### PR TITLE
GitHub Docker Build Action Fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
         run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Run k3d e2e smoke test
         run: ./platform/tests/k3d-e2e.sh
@@ -74,18 +74,18 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract image metadata (operator)
         id: meta-operator
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.OPERATOR_IMAGE }}
           tags: |
@@ -93,7 +93,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push operator
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/operator/deploy/Dockerfile
@@ -105,7 +105,7 @@ jobs:
 
       - name: Extract image metadata (control-plane)
         id: meta-control-plane
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.CONTROL_PLANE_IMAGE }}
           tags: |
@@ -113,7 +113,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push control-plane
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/control-plane/deploy/Dockerfile
@@ -125,7 +125,7 @@ jobs:
 
       - name: Extract image metadata (tenant)
         id: meta-tenant
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.TENANT_IMAGE }}
           tags: |
@@ -133,7 +133,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push tenant
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/tenant/deploy/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,11 +19,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
         with:
-          version: 10
+          packageManager: true
 
       - uses: actions/setup-node@v4
         with:
@@ -47,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install k3d
         run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
@@ -70,7 +72,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          packageManager: true
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage/
 
 # Angular local build cache
 apps/control-plane-ui/.angular/
+
+# Dev Scripts
+dev/

--- a/apps/control-plane/deploy/Dockerfile
+++ b/apps/control-plane/deploy/Dockerfile
@@ -16,6 +16,9 @@ COPY apps/control-plane-ui/src apps/control-plane-ui/src
 COPY apps/control-plane-ui/public apps/control-plane-ui/public
 RUN pnpm --filter @opencrane/control-plane-ui build
 RUN pnpm --filter @opencrane/control-plane build
+# Stage generated Prisma client to a fixed path for the runtime stage
+RUN find /app -path '*/node_modules/.prisma/client' -type d | head -1 | \
+    xargs -I{} cp -r {} /generated-prisma
 
 # Runtime stage
 FROM node:22-bookworm-slim
@@ -27,6 +30,12 @@ COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml
 COPY --from=build /app/apps/control-plane/package.json apps/control-plane/
 COPY --from=build /app/apps/control-plane/prisma apps/control-plane/prisma
 RUN pnpm install --frozen-lockfile --filter @opencrane/control-plane --prod
+COPY --from=build /generated-prisma /tmp/generated-prisma
+# Retrieve the generated Prisma client for the runtime stage
+RUN target=$(find /app -path '*/node_modules/.prisma/client' -type d | head -1) && \
+    rm -rf "$target" && \
+    cp -r /tmp/generated-prisma "$target" && \
+    rm -rf /tmp/generated-prisma
 
 COPY --from=build /app/apps/control-plane/dist apps/control-plane/dist
 COPY --from=build /app/apps/control-plane-ui/dist apps/control-plane-ui/dist

--- a/apps/control-plane/deploy/Dockerfile
+++ b/apps/control-plane/deploy/Dockerfile
@@ -30,6 +30,8 @@ RUN pnpm install --frozen-lockfile --filter @opencrane/control-plane --prod
 
 COPY --from=build /app/apps/control-plane/dist apps/control-plane/dist
 COPY --from=build /app/apps/control-plane-ui/dist apps/control-plane-ui/dist
+COPY --from=build /app/apps/control-plane-ui/public apps/control-plane-ui/public
+
 
 USER node
 

--- a/platform/tests/k3d-local.sh
+++ b/platform/tests/k3d-local.sh
@@ -142,6 +142,26 @@ kubectl create secret generic "$DB_SECRET_NAME" \
   --dry-run=client \
   -o yaml | kubectl apply -f -
 
+# 7b. Run Prisma migrations locally before deploying the application.
+echo "[local] Running Prisma migrations"
+
+# 7c. Wait for postgres pod to be ready
+echo "[local] Waiting for PostgreSQL pod to be ready..."
+kubectl wait --for=condition=Ready pod -l app=postgres -n "$NAMESPACE" --timeout=300s
+
+# 7d. Port-forward postgres to localhost so migrations can reach it
+echo "[local] Setting up port-forward to PostgreSQL"
+kubectl port-forward -n "$NAMESPACE" svc/opencrane-db-postgresql 5432:5432 >/dev/null 2>&1 &
+PF_PID=$!
+sleep 2
+
+# 7e. Run migrations against localhost (port-forwarded)
+export DATABASE_URL="postgresql://opencrane:${DB_PASSWORD}@localhost:5432/opencrane"
+pnpm --filter @opencrane/control-plane run db:migrate
+
+# 7f. Clean up port-forward
+kill $PF_PID 2>/dev/null || true
+
 if [[ "$LOCAL_PROFILE" == "strict" ]]; then
   kubectl create secret generic "$LITELLM_SECRET_NAME" \
     -n "$NAMESPACE" \
@@ -150,7 +170,7 @@ if [[ "$LOCAL_PROFILE" == "strict" ]]; then
     -o yaml | kubectl apply -f -
 fi
 
-# 7. Install the OpenCrane chart with local-strict overrides wired to the in-cluster database.
+# 8. Install the OpenCrane chart with local-strict overrides wired to the in-cluster database.
 echo "[local] Installing Helm release '$RELEASE_NAME'"
 helm_args=(
   upgrade
@@ -175,36 +195,6 @@ else
 fi
 
 helm "${helm_args[@]}"
-
-# 8. Run schema migrations so the control-plane and LiteLLM share an initialized database.
-echo "[local] Running Prisma migrations"
-cat <<EOF | kubectl apply -f -
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: opencrane-db-migrate
-  namespace: ${NAMESPACE}
-spec:
-  ttlSecondsAfterFinished: 300
-  backoffLimit: 3
-  template:
-    spec:
-      restartPolicy: OnFailure
-      containers:
-        - name: migrate
-          image: opencrane/control-plane:local
-          imagePullPolicy: IfNotPresent
-          command: ["npx", "prisma", "migrate", "deploy"]
-          workingDir: /app/apps/control-plane
-          env:
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: ${DB_SECRET_NAME}
-                  key: DATABASE_URL
-EOF
-
-_wait_for_job "opencrane-db-migrate"
 
 # 9. Wait for the platform workloads that depend on the database.
 _wait_for_rollout "deployment/opencrane-operator"

--- a/platform/tests/k3d-local.sh
+++ b/platform/tests/k3d-local.sh
@@ -122,12 +122,17 @@ k3d image import opencrane/operator:local --cluster "$CLUSTER_NAME"
 k3d image import opencrane/tenant:local --cluster "$CLUSTER_NAME"
 k3d image import opencrane/control-plane:local --cluster "$CLUSTER_NAME"
 
+# 5. Pre-pull PostgreSQL image for k3d
+echo "[local] Pre-pulling PostgreSQL image"
+docker pull postgres:16-alpine
+k3d image import postgres:16-alpine --cluster "$CLUSTER_NAME"
+
 echo "[local] Using profile '$LOCAL_PROFILE' with values '$VALUES_FILE'"
 
-# 5. Creating the namespace early so the PostgreSQL chart can reference it for its service discovery.
+# 6. Creating the namespace early so the PostgreSQL chart can reference it for its service discovery.
 kubectl create namespace opencrane-system --dry-run=client -o yaml | kubectl apply -f -
 
-# 6. Install in-cluster PostgreSQL using the configuration file
+# 7. Install in-cluster PostgreSQL using the configuration file
 echo "[local] Installing PostgreSQL release '$DB_RELEASE_NAME'"
 kubectl apply -f "$ROOT_DIR/platform/tests/postgres.yaml"
 

--- a/platform/tests/k3d-local.sh
+++ b/platform/tests/k3d-local.sh
@@ -124,20 +124,12 @@ k3d image import opencrane/control-plane:local --cluster "$CLUSTER_NAME"
 
 echo "[local] Using profile '$LOCAL_PROFILE' with values '$VALUES_FILE'"
 
-# 5. Install in-cluster PostgreSQL and publish the DATABASE_URL secret expected by the chart.
+# 5. Creating the namespace early so the PostgreSQL chart can reference it for its service discovery.
+kubectl create namespace opencrane-system --dry-run=client -o yaml | kubectl apply -f -
+
+# 6. Install in-cluster PostgreSQL using the configuration file
 echo "[local] Installing PostgreSQL release '$DB_RELEASE_NAME'"
-helm upgrade --install "$DB_RELEASE_NAME" oci://registry-1.docker.io/bitnamicharts/postgresql \
-  --version 16.4.1 \
-  --namespace "$NAMESPACE" \
-  --create-namespace \
-  --wait \
-  --set auth.username=opencrane \
-  --set auth.password="$DB_PASSWORD" \
-  --set auth.database=opencrane \
-  --set primary.persistence.size=10Gi \
-  --set primary.persistence.storageClass=local-path \
-  --set primary.resources.requests.cpu=250m \
-  --set primary.resources.requests.memory=256Mi
+kubectl apply -f "$ROOT_DIR/platform/tests/postgres.yaml"
 
 kubectl create secret generic "$DB_SECRET_NAME" \
   -n "$NAMESPACE" \
@@ -153,7 +145,7 @@ if [[ "$LOCAL_PROFILE" == "strict" ]]; then
     -o yaml | kubectl apply -f -
 fi
 
-# 6. Install the OpenCrane chart with local-strict overrides wired to the in-cluster database.
+# 7. Install the OpenCrane chart with local-strict overrides wired to the in-cluster database.
 echo "[local] Installing Helm release '$RELEASE_NAME'"
 helm_args=(
   upgrade
@@ -179,7 +171,7 @@ fi
 
 helm "${helm_args[@]}"
 
-# 7. Run schema migrations so the control-plane and LiteLLM share an initialized database.
+# 8. Run schema migrations so the control-plane and LiteLLM share an initialized database.
 echo "[local] Running Prisma migrations"
 cat <<EOF | kubectl apply -f -
 apiVersion: batch/v1
@@ -209,7 +201,7 @@ EOF
 
 _wait_for_job "opencrane-db-migrate"
 
-# 8. Wait for the platform workloads that depend on the database.
+# 9. Wait for the platform workloads that depend on the database.
 _wait_for_rollout "deployment/opencrane-operator"
 _wait_for_rollout "deployment/opencrane-control-plane"
 

--- a/platform/tests/postgres.yaml
+++ b/platform/tests/postgres.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-data
+  namespace: opencrane-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: opencrane-db-postgresql
+  namespace: opencrane-system
+spec:
+  type: ClusterIP
+  selector:
+    app: postgres
+  ports:
+  - protocol: TCP
+    port: 5432
+    targetPort: 5432
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: opencrane-system
+spec:
+  serviceName: opencrane-db-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:16-alpine
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_USER
+          value: opencrane
+        - name: POSTGRES_PASSWORD
+          value: opencrane-local-password
+        - name: POSTGRES_DB
+          value: opencrane
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -U opencrane
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - pg_isready -U opencrane
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: postgres-data

--- a/platform/tests/values-k3d-e2e.yaml
+++ b/platform/tests/values-k3d-e2e.yaml
@@ -35,5 +35,5 @@ crossplane:
   enabled: false
 
 litellm:
-  enabled: true
+  enabled: false
   masterKey: e2e-master-key

--- a/platform/tests/values-k3d-local.yaml
+++ b/platform/tests/values-k3d-local.yaml
@@ -45,4 +45,6 @@ litellm:
   enabled: true
   generateMasterKey: false
   image:
+    repository: ghcr.io/berriai/litellm-non_root
+    tag: main-v1.81.0-stable
     pullPolicy: IfNotPresent


### PR DESCRIPTION
# Changes:
- Updated the `checkout` and `pnpm/setup-action` runners to `v6` since GitHub is depreciating runners relying on older versions of Node below 24.
- Fixed the resolution of the `pnpm` version within the runner to point to the `package.json` version which avoids the hardcoded value that might be forgotten during updates.

# Files changed:
- `.github/workflows/docker.yml`

# Testing:
- Tested the action locally using  the `act` package and specifically ran the `test` job which completed successfully.