### PR TITLE
Fixes for some set-up configurations

### DIFF
--- a/apps/control-plane/deploy/Dockerfile
+++ b/apps/control-plane/deploy/Dockerfile
@@ -16,6 +16,9 @@ COPY apps/control-plane-ui/src apps/control-plane-ui/src
 COPY apps/control-plane-ui/public apps/control-plane-ui/public
 RUN pnpm --filter @opencrane/control-plane-ui build
 RUN pnpm --filter @opencrane/control-plane build
+# Stage generated Prisma client to a fixed path for the runtime stage
+RUN find /app -path '*/node_modules/.prisma/client' -type d | head -1 | \
+    xargs -I{} cp -r {} /generated-prisma
 
 # Runtime stage
 FROM node:22-bookworm-slim
@@ -27,6 +30,12 @@ COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml
 COPY --from=build /app/apps/control-plane/package.json apps/control-plane/
 COPY --from=build /app/apps/control-plane/prisma apps/control-plane/prisma
 RUN pnpm install --frozen-lockfile --filter @opencrane/control-plane --prod
+COPY --from=build /generated-prisma /tmp/generated-prisma
+# Retrieve the generated Prisma client for the runtime stage
+RUN target=$(find /app -path '*/node_modules/.prisma/client' -type d | head -1) && \
+    rm -rf "$target" && \
+    cp -r /tmp/generated-prisma "$target" && \
+    rm -rf /tmp/generated-prisma
 
 COPY --from=build /app/apps/control-plane/dist apps/control-plane/dist
 COPY --from=build /app/apps/control-plane-ui/dist apps/control-plane-ui/dist

--- a/apps/operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/operator/src/tenants/deploy/2-config-map.ts
@@ -30,11 +30,18 @@ export function _BuildConfigMap(config: OperatorConfig, tenant: Tenant, namespac
     },
     ...(config.liteLlmEnabled
       ? {
-          llmProxy: {
-            endpoint: config.liteLlmEndpoint,
-            apiKey: "${LITELLM_API_KEY}",
-          },
-        }
+            models: {
+              mode: "merge",
+              providers: {
+                "litellm-proxy": {
+                  baseUrl: config.liteLlmEndpoint,
+                  apiKey: "${LITELLM_API_KEY}",
+                  api: "openai-completions",
+                  models: []
+                },
+              },
+            },
+          }
       : {}),
   };
 

--- a/apps/operator/src/tenants/deploy/3-deployment.ts
+++ b/apps/operator/src/tenants/deploy/3-deployment.ts
@@ -33,6 +33,7 @@ export function _BuildDeployment(config: OperatorConfig, tenant: Tenant, namespa
     { name: "OPENCLAW_SECRETS_DIR", value: "/data/secrets" },
     { name: "OPENCLAW_ENCRYPTION_KEY_PATH", value: "/etc/openclaw/encryption-key/key" },
     { name: "OPENCLAW_TENANT_NAME", value: name },
+    { name: "OPENCLAW_GATEWAY_TOKEN", value: `opencrane-${name}-gateway` },
     { name: "OPENCLAW_VERSION", value: openclawVersion },
     { name: "OPENCRANE_RUNTIME_MODE", value: "managed" },
     { name: "OPENCRANE_RUNTIME_CONTRACT_PATH", value: "/config/opencrane-managed-runtime.json" },
@@ -54,6 +55,18 @@ export function _BuildDeployment(config: OperatorConfig, tenant: Tenant, namespa
       valueFrom: {
         secretKeyRef: {
           name: `openclaw-${name}-litellm-key`,
+          key: "apiKey",
+          optional: true,
+        },
+      },
+    });
+
+    // OpenClaw requires OPENAI_API_KEY for its internal OpenAI translator engine fallback
+    envVars.push({
+      name: "OPENAI_API_KEY",
+      valueFrom: {
+        secretKeyRef: {
+          name: `openclaw-${name}-openai-key`,
           key: "apiKey",
           optional: true,
         },

--- a/platform/tests/k3d-local.sh
+++ b/platform/tests/k3d-local.sh
@@ -197,7 +197,7 @@ spec:
         - name: migrate
           image: opencrane/control-plane:local
           imagePullPolicy: IfNotPresent
-          command: ["npx", "prisma", "migrate", "deploy"]
+          command: ["npx", "prisma@6", "migrate", "deploy"]
           workingDir: /app/apps/control-plane
           env:
             - name: DATABASE_URL

--- a/platform/tests/values-k3d-local.yaml
+++ b/platform/tests/values-k3d-local.yaml
@@ -45,4 +45,6 @@ litellm:
   enabled: true
   generateMasterKey: false
   image:
+    repository: ghcr.io/berriai/litellm-non_root
+    tag: main-v1.81.0-stable
     pullPolicy: IfNotPresent


### PR DESCRIPTION
# Changes:
- The Control Plane Docker file introduces a step to copy the Prisma Client into runtime because the `--prod` flag does not install it but it is needed during runtime where we have imports like `@prisma/client`.
-  The Tenant deployment config file (`apps/operator/src/tenants/deploy/2-config-map.ts`) was using a different structure from the OpenClaw docs which was causing errors with the OpenAI translations within OpenClaw. The new structure follows the docs. 
- Introducing a fix for the missing `OPENAI_API_KEY` which is needed by the Clawd bot. 
- Introducing a fix for the migrations stage where npx was trying to use Prisma `v7` for the migrations which introduced a  change that removed definition of the database `URL` from the schema. The other alternative is to upgrade to `v7` but that requires more consideration to make sure it does not break things.
- The values definition for the local build were using a root version of the LiteLLM image which was causing write issues within the cluster and crashing the tenant pod. The non-root image fixes that.

# Files Changed:
- `apps/control-plane/deploy/Dockerfile` - Copying the Prisma Client to runtime
- `apps/operator/src/tenants/deploy/2-config-map.ts` - Restructuring the LiteLLM config for the tenant
- `apps/operator/src/tenants/deploy/3-deployment.ts` - Injecting the `OPENAI_API_KEY` environment variable
- `platform/tests/k3d-local.sh` - Running migrations with Prisma v6 specifically.
- `platform/tests/values-k3d-local.yaml` - Moving to usage of the non-root image of LiteLLM.
 
# Testing: 
- The local installation runs successfully.