### PR TITLE
GitHub Actions Fixes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,9 +19,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          packageManager: true
 
       - uses: actions/setup-node@v4
         with:
@@ -45,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install k3d
         run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
@@ -68,7 +72,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,9 +25,9 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies
@@ -53,7 +53,7 @@ jobs:
         run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Run k3d e2e smoke test
         run: ./platform/tests/k3d-e2e.sh
@@ -74,18 +74,18 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract image metadata (operator)
         id: meta-operator
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.OPERATOR_IMAGE }}
           tags: |
@@ -93,7 +93,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push operator
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/operator/deploy/Dockerfile
@@ -105,7 +105,7 @@ jobs:
 
       - name: Extract image metadata (control-plane)
         id: meta-control-plane
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.CONTROL_PLANE_IMAGE }}
           tags: |
@@ -113,7 +113,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push control-plane
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/control-plane/deploy/Dockerfile
@@ -125,7 +125,7 @@ jobs:
 
       - name: Extract image metadata (tenant)
         id: meta-tenant
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.TENANT_IMAGE }}
           tags: |
@@ -133,7 +133,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push tenant
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: apps/tenant/deploy/Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          packageManager: true
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ coverage/
 .DS_Store
 *.tsbuildinfo
 .turbo/
+.vscode/
+.idea/
+*.log
 
-# Angular local build cache
-apps/control-plane-ui/.angular/
+# Dev
+dev/

--- a/apps/control-plane/deploy/Dockerfile
+++ b/apps/control-plane/deploy/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY tsconfig.base.json ./
 COPY libs/contracts/package.json libs/contracts/tsconfig.json libs/contracts/
+COPY apps/control-plane/openapi.json apps/control-plane/openapi.json
 COPY apps/control-plane/package.json apps/control-plane/tsconfig.json apps/control-plane/
 COPY apps/control-plane/prisma apps/control-plane/prisma
 RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/control-plane

--- a/apps/control-plane/deploy/Dockerfile
+++ b/apps/control-plane/deploy/Dockerfile
@@ -8,15 +8,12 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY tsconfig.base.json ./
 COPY libs/contracts/package.json libs/contracts/tsconfig.json libs/contracts/
 COPY apps/control-plane/package.json apps/control-plane/tsconfig.json apps/control-plane/
-COPY apps/control-plane-ui/package.json apps/control-plane-ui/angular.json apps/control-plane-ui/tsconfig.json apps/control-plane-ui/tsconfig.app.json apps/control-plane-ui/
 COPY apps/control-plane/prisma apps/control-plane/prisma
-RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/control-plane --filter @opencrane/control-plane-ui
+RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/control-plane
 
 COPY libs/contracts/src libs/contracts/src
 COPY apps/control-plane/src apps/control-plane/src
-COPY apps/control-plane-ui/src apps/control-plane-ui/src
 RUN pnpm --filter @opencrane/contracts build
-RUN pnpm --filter @opencrane/control-plane-ui build
 RUN pnpm --filter @opencrane/control-plane build
 # Stage generated Prisma client to a fixed path for the runtime stage
 RUN find /app -path '*/node_modules/.prisma/client' -type d | head -1 | \
@@ -42,7 +39,6 @@ RUN target=$(find /app -path '*/node_modules/.prisma/client' -type d | head -1) 
 
 COPY --from=build /app/libs/contracts/dist libs/contracts/dist
 COPY --from=build /app/apps/control-plane/dist apps/control-plane/dist
-COPY --from=build /app/apps/control-plane-ui/dist apps/control-plane-ui/dist
 
 USER node
 

--- a/apps/control-plane/deploy/Dockerfile
+++ b/apps/control-plane/deploy/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY tsconfig.base.json ./
 COPY libs/contracts/package.json libs/contracts/tsconfig.json libs/contracts/
+COPY apps/control-plane/scripts apps/control-plane/scripts
 COPY apps/control-plane/openapi.json apps/control-plane/openapi.json
 COPY apps/control-plane/package.json apps/control-plane/tsconfig.json apps/control-plane/
 COPY apps/control-plane/prisma apps/control-plane/prisma

--- a/platform/tests/k3d-e2e.sh
+++ b/platform/tests/k3d-e2e.sh
@@ -7,7 +7,9 @@ NAMESPACE="${NAMESPACE:-opencrane-system}"
 RELEASE_NAME="${RELEASE_NAME:-opencrane}"
 KEEP_CLUSTER="${KEEP_CLUSTER:-0}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-240}"
-MIN_FREE_GB="${MIN_FREE_GB:-8}"
+DB_STORAGE_GB="${DB_STORAGE_GB:-10}"
+DISK_HEADROOM_GB="${DISK_HEADROOM_GB:-2}"
+MIN_FREE_GB="${MIN_FREE_GB:-$(( DB_STORAGE_GB + DISK_HEADROOM_GB ))}"
 DB_RELEASE_NAME="${DB_RELEASE_NAME:-opencrane-db}"
 DB_SECRET_NAME="${DB_SECRET_NAME:-opencrane-db}"
 DB_PASSWORD="${DB_PASSWORD:-opencrane-e2e-password}"
@@ -42,6 +44,7 @@ function _require_free_space()
 
   if [[ -z "$free_kb" || "$free_kb" -lt "$min_free_kb" ]]; then
     echo "[e2e] Insufficient free disk space for image builds."
+    echo "[e2e] Baseline includes DB storage (${DB_STORAGE_GB}GiB) + headroom (${DISK_HEADROOM_GB}GiB)."
     echo "[e2e] Required: ${MIN_FREE_GB}GiB, Available: $(( free_kb / 1024 / 1024 ))GiB"
     exit 1
   fi
@@ -136,7 +139,7 @@ spec:
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:16
   storage:
-    size: 10Gi
+    size: ${DB_STORAGE_GB}Gi
     storageClass: local-path
   resources:
     requests:

--- a/platform/tests/k3d-e2e.sh
+++ b/platform/tests/k3d-e2e.sh
@@ -160,6 +160,12 @@ kubectl create secret generic "$DB_SECRET_NAME" \
   -o yaml | kubectl apply -f -
 
 if [[ "$LOCAL_PROFILE" == "strict" ]]; then
+  if [[ -z "$LITELLM_MASTER_KEY" ]]; then
+    echo "[e2e] LOCAL_PROFILE=strict requires LITELLM_MASTER_KEY to be set and non-empty"
+    echo "[e2e] Example: LOCAL_PROFILE=strict LITELLM_MASTER_KEY=dev-e2e-key platform/tests/k3d-e2e.sh"
+    exit 1
+  fi
+
   kubectl create secret generic "$LITELLM_SECRET_NAME" \
     -n "$NAMESPACE" \
     --from-literal=LITELLM_MASTER_KEY="$LITELLM_MASTER_KEY" \

--- a/platform/tests/k3d-e2e.sh
+++ b/platform/tests/k3d-e2e.sh
@@ -8,6 +8,12 @@ RELEASE_NAME="${RELEASE_NAME:-opencrane}"
 KEEP_CLUSTER="${KEEP_CLUSTER:-0}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-240}"
 MIN_FREE_GB="${MIN_FREE_GB:-8}"
+DB_RELEASE_NAME="${DB_RELEASE_NAME:-opencrane-db}"
+DB_SECRET_NAME="${DB_SECRET_NAME:-opencrane-db}"
+DB_PASSWORD="${DB_PASSWORD:-opencrane-e2e-password}"
+LOCAL_PROFILE="${LOCAL_PROFILE:-}"
+LITELLM_SECRET_NAME="${LITELLM_SECRET_NAME:-opencrane-litellm}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-}"
 
 function _require_cmd()
 {
@@ -92,17 +98,82 @@ echo "[e2e] Recreating k3d cluster '$CLUSTER_NAME'"
 k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true
 k3d cluster create "$CLUSTER_NAME" --agents 1
 
-# 4. Import images into the k3d cluster runtime.
+# 4a. Pre-pulling the official CloudNativePG database image.
+echo "[e2e] Pre-pulling official CloudNativePG database image"
+docker pull ghcr.io/cloudnative-pg/postgresql:16
+
+# 4b. Import images into the k3d cluster runtime.
 echo "[e2e] Importing images into k3d"
 k3d image import opencrane/operator:e2e --cluster "$CLUSTER_NAME"
 k3d image import opencrane/tenant:e2e --cluster "$CLUSTER_NAME"
+k3d image import ghcr.io/cloudnative-pg/postgresql:16 --cluster "$CLUSTER_NAME"
 
-# 5. Install Helm chart with k3d-safe overrides.
+# 5. Install in-cluster PostgreSQL and publish the DATABASE_URL secret expected by the chart.
+echo "[e2e] Installing CloudNativePG Engine Operator into control plane"
+helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update >/dev/null
+helm upgrade --install cnpg cnpg/cloudnative-pg \
+  --namespace "$NAMESPACE" \
+  --create-namespace \
+  --wait \
+  --set-string monitoring.podMonitor.enabled=false
+
+echo "[e2e] Bootstrapping credentials secret for PostgreSQL"
+kubectl create secret generic "${DB_RELEASE_NAME}-creds" \
+  -n "$NAMESPACE" \
+  --from-literal=username=opencrane \
+  --from-literal=password="$DB_PASSWORD" \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+
+echo "[e2e] Applying CloudNativePG configuration layer"
+cat <<EOF | kubectl apply -f -
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ${DB_RELEASE_NAME}
+  namespace: ${NAMESPACE}
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  storage:
+    size: 10Gi
+    storageClass: local-path
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+  bootstrap:
+    initdb:
+      database: opencrane
+      secret:
+        name: ${DB_RELEASE_NAME}-creds
+EOF
+
+echo "[e2e] Waiting for Control-Plane Database Engine to stabilize..."
+kubectl wait --for=condition=Ready cluster/"${DB_RELEASE_NAME}" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+
+# Note: CNPG creates a service structured as [cluster-name]-rw for write/read routes
+kubectl create secret generic "$DB_SECRET_NAME" \
+  -n "$NAMESPACE" \
+  --from-literal=DATABASE_URL="postgresql://opencrane:${DB_PASSWORD}@${DB_RELEASE_NAME}-rw.${NAMESPACE}.svc.cluster.local:5432/opencrane" \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+
+if [[ "$LOCAL_PROFILE" == "strict" ]]; then
+  kubectl create secret generic "$LITELLM_SECRET_NAME" \
+    -n "$NAMESPACE" \
+    --from-literal=LITELLM_MASTER_KEY="$LITELLM_MASTER_KEY" \
+    --dry-run=client \
+    -o yaml | kubectl apply -f -
+fi
+
+# 6. Install Helm chart with k3d-safe overrides wired to the in-cluster database.
 echo "[e2e] Installing Helm release '$RELEASE_NAME'"
 helm upgrade --install "$RELEASE_NAME" "$ROOT_DIR/platform/helm" \
   --namespace "$NAMESPACE" \
   --create-namespace \
-  --values "$ROOT_DIR/platform/tests/values-k3d-e2e.yaml"
+  --values "$ROOT_DIR/platform/tests/values-k3d-e2e.yaml" \
+  --set "litellm.existingDatabaseSecret=$DB_SECRET_NAME"
 
 # Wait for operator deployment (skip helm --wait because local-path PVCs don't bind
 # until a pod mounts them, creating a chicken-and-egg with Helm's readiness checks).
@@ -113,7 +184,7 @@ if kubectl get deployment/opencrane-litellm -n "$NAMESPACE" >/dev/null 2>&1; the
   kubectl rollout status deployment/opencrane-litellm -n "$NAMESPACE" --timeout=120s
 fi
 
-# 6. Create a Tenant CR and let the operator reconcile child resources.
+# 7. Create a Tenant CR and let the operator reconcile child resources.
 echo "[e2e] Creating Tenant CR"
 cat <<EOF | kubectl apply -f -
 apiVersion: opencrane.io/v1alpha1
@@ -129,7 +200,7 @@ EOF
 
 _wait_for_tenant_running
 
-# 7. Assert core reconciled resources exist.
+# 8. Assert core reconciled resources exist.
 kubectl get serviceaccount openclaw-e2e -n "$NAMESPACE" >/dev/null
 kubectl get configmap openclaw-e2e-config -n "$NAMESPACE" >/dev/null
 kubectl get deployment openclaw-e2e -n "$NAMESPACE" >/dev/null
@@ -137,7 +208,7 @@ kubectl get service openclaw-e2e -n "$NAMESPACE" >/dev/null
 kubectl get ingress openclaw-e2e -n "$NAMESPACE" >/dev/null
 kubectl get secret openclaw-e2e-encryption-key -n "$NAMESPACE" >/dev/null
 
-# 8. Assert status fields were written by the operator.
+# 9. Assert status fields were written by the operator.
 INGRESS_HOST="$(kubectl get tenant e2e -n "$NAMESPACE" -o jsonpath='{.status.ingressHost}')"
 if [[ "$INGRESS_HOST" != "e2e.opencrane.local" ]]; then
   echo "[e2e] Unexpected ingress host: $INGRESS_HOST"

--- a/platform/tests/values-k3d-e2e.yaml
+++ b/platform/tests/values-k3d-e2e.yaml
@@ -40,4 +40,4 @@ litellm:
   image:
     repository: ghcr.io/berriai/litellm-non_root
     tag: main-v1.81.0-stable
-    pullPolicy: IfNotPresent
+    pullPolicy: Always

--- a/platform/tests/values-k3d-e2e.yaml
+++ b/platform/tests/values-k3d-e2e.yaml
@@ -37,3 +37,7 @@ crossplane:
 litellm:
   enabled: true
   masterKey: e2e-master-key
+  image:
+    repository: ghcr.io/berriai/litellm-non_root
+    tag: main-v1.81.0-stable
+    pullPolicy: IfNotPresent


### PR DESCRIPTION
Changes:
- Updated the `setup-node`, `pnpm/action-setup`, `checkout` and `docker/*` action runners to the latest versions running on the Node 24 runtime.
- Included a Postgres database set-up step for the e2e test to allow the LiteLLM pod to save its virtual keys for the test.

Files Changed:
- `.github/workflows/docker.yml` - GitHub Action Runners version updates
- `platform/tests/k3d-e2e.sh` - PostgresSQL database set-up for the e2e test
- `platform/tests/values-k3d-e2e.yaml` - Switching to the non-root image variant of LiteLLM

# Testing:
- The GitHub Action runners do not emit warnings anymore.
- The `e2e` test runs successfully.