### PR TITLE
Control Plane Deployment Fixes 

### DIFF
--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -22,14 +22,12 @@
     "@types/express-session": "^1.19.0",
     "express": "^5.1.0",
     "express-session": "^1.19.0",
-    "lodash": "^4.18.1",
     "openid-client": "^6.8.4",
     "pino": "^9.6.0",
     "pino-http": "^10.0.0"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
-    "@types/lodash": "^4.17.24",
     "@types/node": "^22.0.0",
     "@types/supertest": "^6.0.0",
     "prisma": "^6.0.0",

--- a/apps/control-plane/src/__tests__/routes/metrics.test.ts
+++ b/apps/control-plane/src/__tests__/routes/metrics.test.ts
@@ -46,26 +46,22 @@ describe("metrics routes", function ()
         if (args.plural === "tenants")
         {
           return {
-            body: {
-              items: [
-                {
-                  metadata: { name: "alpha" },
-                  spec: { displayName: "Alpha", email: "alpha@example.com", team: "platform" },
-                },
-              ],
-            },
+            items: [
+              {
+                metadata: { name: "alpha" },
+                spec: { displayName: "Alpha", email: "alpha@example.com", team: "platform" },
+              },
+            ],
           };
         }
 
         return {
-          body: {
-            items: [
-              {
-                metadata: { name: "default-deny" },
-                spec: { description: "Default deny", domains: { deny: ["*"] } },
-              },
-            ],
-          },
+          items: [
+            {
+              metadata: { name: "default-deny" },
+              spec: { description: "Default deny", domains: { deny: ["*"] } },
+            },
+          ],
         };
       }),
     } as unknown as k8s.CustomObjectsApi;
@@ -130,26 +126,22 @@ describe("metrics routes", function ()
         if (args.plural === "tenants")
         {
           return {
-            body: {
-              items: [
-                {
-                  metadata: { name: "alpha" },
-                  spec: { displayName: "Alpha", email: "alpha@example.com", team: "platform" },
-                },
-              ],
-            },
+            items: [
+              {
+                metadata: { name: "alpha" },
+                spec: { displayName: "Alpha", email: "alpha@example.com", team: "platform" },
+              },
+            ],
           };
         }
 
         return {
-          body: {
-            items: [
-              {
-                metadata: { name: "default-deny" },
-                spec: { description: "Default deny", domains: { deny: ["*"] } },
-              },
-            ],
-          },
+          items: [
+            {
+              metadata: { name: "default-deny" },
+              spec: { description: "Default deny", domains: { deny: ["*"] } },
+            },
+          ],
         };
       }),
     } as unknown as k8s.CustomObjectsApi;

--- a/apps/control-plane/src/__tests__/routes/projection-drift.test.ts
+++ b/apps/control-plane/src/__tests__/routes/projection-drift.test.ts
@@ -35,18 +35,16 @@ describe("projection drift routes", function ()
   {
     const customApi = {
       listNamespacedCustomObject: vi.fn().mockResolvedValue({
-        body: {
-          items: [
-            {
-              metadata: { name: "alpha" },
-              spec: {
-                displayName: "Alpha From CRD",
-                email: "alpha@example.com",
-                team: "platform",
-              },
+        items: [
+          {
+            metadata: { name: "alpha" },
+            spec: {
+              displayName: "Alpha From CRD",
+              email: "alpha@example.com",
+              team: "platform",
             },
-          ],
-        },
+          },
+        ],
       }),
     } as unknown as k8s.CustomObjectsApi;
 
@@ -86,17 +84,15 @@ describe("projection drift routes", function ()
   {
     const customApi = {
       listNamespacedCustomObject: vi.fn().mockResolvedValue({
-        body: {
-          items: [
-            {
-              metadata: { name: "default-deny" },
-              spec: {
-                description: "Default deny policy",
-                domains: { deny: ["*"] },
-              },
+        items: [
+          {
+            metadata: { name: "default-deny" },
+            spec: {
+              description: "Default deny policy",
+              domains: { deny: ["*"] },
             },
-          ],
-        },
+          },
+        ],
       }),
     } as unknown as k8s.CustomObjectsApi;
 

--- a/apps/control-plane/src/__tests__/routes/projection-repair.test.ts
+++ b/apps/control-plane/src/__tests__/routes/projection-repair.test.ts
@@ -31,14 +31,12 @@ describe("projection repair routes", function ()
   {
     const customApi = {
       listNamespacedCustomObject: vi.fn().mockResolvedValue({
-        body: {
-          items: [
-            {
-              metadata: { name: "alpha" },
-              spec: { displayName: "Alpha Fixed", email: "alpha@example.com", team: "platform" },
-            },
-          ],
-        },
+        items: [
+          {
+            metadata: { name: "alpha" },
+            spec: { displayName: "Alpha Fixed", email: "alpha@example.com", team: "platform" },
+          },
+        ],
       }),
     } as unknown as k8s.CustomObjectsApi;
 
@@ -69,14 +67,12 @@ describe("projection repair routes", function ()
   {
     const customApi = {
       listNamespacedCustomObject: vi.fn().mockResolvedValue({
-        body: {
-          items: [
-            {
-              metadata: { name: "beta" },
-              spec: { displayName: "Beta", email: "beta@example.com", team: null },
-            },
-          ],
-        },
+        items: [
+          {
+            metadata: { name: "beta" },
+            spec: { displayName: "Beta", email: "beta@example.com", team: null },
+          },
+        ],
       }),
     } as unknown as k8s.CustomObjectsApi;
 
@@ -105,14 +101,12 @@ describe("projection repair routes", function ()
   {
     const customApi = {
       listNamespacedCustomObject: vi.fn().mockResolvedValue({
-        body: {
-          items: [
-            {
-              metadata: { name: "gamma" },
-              spec: { displayName: "Gamma", email: "gamma@example.com", team: "eng" },
-            },
-          ],
-        },
+        items: [
+          {
+            metadata: { name: "gamma" },
+            spec: { displayName: "Gamma", email: "gamma@example.com", team: "eng" },
+          },
+        ],
       }),
     } as unknown as k8s.CustomObjectsApi;
 
@@ -137,7 +131,7 @@ describe("projection repair routes", function ()
   it("skips a tenant projection row that has no matching CRD source", async function ()
   {
     const customApi = {
-      listNamespacedCustomObject: vi.fn().mockResolvedValue({ body: { items: [] } }),
+      listNamespacedCustomObject: vi.fn().mockResolvedValue({ items: [] }),
     } as unknown as k8s.CustomObjectsApi;
 
     const prisma = {
@@ -162,20 +156,18 @@ describe("projection repair routes", function ()
   {
     const customApi = {
       listNamespacedCustomObject: vi.fn().mockResolvedValue({
-        body: {
-          items: [
-            {
-              metadata: { name: "egress-policy" },
-              spec: {
-                description: "Updated description",
-                tenantSelector: null,
-                domains: null,
-                egressRules: null,
-                mcpServers: { allow: ["skills"] },
-              },
+        items: [
+          {
+            metadata: { name: "egress-policy" },
+            spec: {
+              description: "Updated description",
+              tenantSelector: null,
+              domains: null,
+              egressRules: null,
+              mcpServers: { allow: ["skills"] },
             },
-          ],
-        },
+          },
+        ],
       }),
     } as unknown as k8s.CustomObjectsApi;
 

--- a/apps/control-plane/src/core/grants/grant-compiler.ts
+++ b/apps/control-plane/src/core/grants/grant-compiler.ts
@@ -1,7 +1,7 @@
 import {
   type PrismaClient,
 } from "@prisma/client";
-import { some as ___some, sortBy as ___sortBy } from "lodash";
+import { ___SomeArray, ___SomeRecord, ___SortBy } from "../utils/collections.js";
 
 import {
   GrantCompilerAccess,
@@ -181,7 +181,7 @@ export async function compile(
   }
 
   // 5. Emit a stable payload ordering so callers can cache and diff compiled contracts deterministically.
-  return ___sortBy(Array.from(winnerByPayloadId.values()), "payloadId");
+  return ___SortBy(Array.from(winnerByPayloadId.values()), "payloadId");
 }
 
 /**
@@ -238,7 +238,7 @@ function _GroupHasPrincipal(members: unknown, principalId: string): boolean
 {
   if (Array.isArray(members))
   {
-    return ___some(members, function _matchMember(member)
+    return ___SomeArray(members, function _matchMember(member)
     {
       return _MemberMatchesPrincipal(member, principalId);
     });
@@ -250,13 +250,13 @@ function _GroupHasPrincipal(members: unknown, principalId: string): boolean
 
     if (Array.isArray(record.items))
     {
-      return ___some(record.items, function _matchRecordItem(member)
+      return ___SomeArray(record.items, function _matchRecordItem(member)
       {
         return _MemberMatchesPrincipal(member, principalId);
       });
     }
 
-    return ___some(record, function _matchRecordValue(value, key)
+    return ___SomeRecord(record, function _matchRecordValue(value, key)
     {
       return key === principalId || _MemberMatchesPrincipal(value, principalId);
     });
@@ -287,7 +287,7 @@ function _MemberMatchesPrincipal(member: unknown, principalId: string): boolean
   const record = member as Record<string, unknown>;
   const candidateValues = [record.id, record.principalId, record.tenant, record.userId, record.name];
 
-  return ___some(candidateValues, function _matchValue(candidateValue)
+  return ___SomeArray(candidateValues, function _matchValue(candidateValue)
   {
     return typeof candidateValue === "string" && candidateValue === principalId;
   });

--- a/apps/control-plane/src/core/utils/collections.ts
+++ b/apps/control-plane/src/core/utils/collections.ts
@@ -1,0 +1,75 @@
+/**
+ * Native collection utilities replacing lodash helpers for ESM compatibility.
+ *
+ * Each function mirrors the lodash signature it replaces so call-sites
+ * need only swap the import path.
+ */
+
+/**
+ * Sort an array of items by a string key or by natural string comparison.
+ *
+ * When called without a key the elements themselves are compared via
+ * `String.prototype.localeCompare`, matching `_.sortBy(array)` for
+ * string arrays.
+ *
+ * @param items - Source array (not mutated).
+ * @param key - Optional property name to sort by.
+ * @returns A new sorted array.
+ */
+export function ___SortBy<T>(items: T[], key?: keyof T): T[]
+{
+	const copy = [...items];
+
+	if (key)
+	{
+		return copy.sort(function _compare(a, b)
+		{
+			const aVal = String(a[key] ?? "");
+			const bVal = String(b[key] ?? "");
+			return aVal.localeCompare(bVal);
+		});
+	}
+
+	return copy.sort(function _compare(a, b)
+	{
+		return String(a).localeCompare(String(b));
+	});
+}
+
+/**
+ * Test whether any element in an array satisfies a predicate.
+ *
+ * This is a thin wrapper around `Array.prototype.some` that matches the
+ * lodash `_.some(collection, predicate)` call signature for arrays.
+ *
+ * @param items - Array to test.
+ * @param predicate - Callback invoked per element.
+ * @returns True when at least one element passes.
+ */
+export function ___SomeArray<T>(items: T[], predicate: (item: T) => boolean): boolean
+{
+	return items.some(predicate);
+}
+
+/**
+ * Test whether any entry in a plain object satisfies a predicate.
+ *
+ * Mirrors the lodash `_.some(object, iteratee)` overload that passes
+ * `(value, key)` to the callback.
+ *
+ * @param record - Plain object to iterate.
+ * @param predicate - Callback invoked with `(value, key)`.
+ * @returns True when at least one entry passes.
+ */
+export function ___SomeRecord<V>(record: Record<string, V>, predicate: (value: V, key: string) => boolean): boolean
+{
+	for (const key of Object.keys(record))
+	{
+		if (predicate(record[key], key))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/apps/control-plane/src/features/groups/groups.logic.ts
+++ b/apps/control-plane/src/features/groups/groups.logic.ts
@@ -1,6 +1,6 @@
 import { GrantAccess, GrantScope, GrantSubjectType, type Grant, type Group } from "@opencrane/contracts";
 import { Prisma, type PrismaClient } from "@prisma/client";
-import { sortBy as ___sortBy, uniq as ___uniq } from "lodash";
+import { ___SortBy } from "../../core/utils/collections.js";
 
 import type {
   GroupGrantInput,
@@ -285,7 +285,7 @@ function _NormalizeMembers(members: unknown): string[]
     uniqueMembers.add(normalizedMember);
   }
 
-  return ___sortBy(Array.from(uniqueMembers));
+  return ___SortBy(Array.from(uniqueMembers));
 }
 
 /**

--- a/apps/control-plane/src/routes/internal/projection-drift.ts
+++ b/apps/control-plane/src/routes/internal/projection-drift.ts
@@ -54,14 +54,16 @@ interface NamedSnapshot
   fields: Record<string, unknown>;
 }
 
-/** Minimal Kubernetes list payload shape returned by the client. */
+/**
+ * Minimal Kubernetes list payload shape returned by the client.
+ *
+ * @see https://github.com/kubernetes-client/javascript/releases/tag/v1.0.0 — release
+ *   specifying the removal of the request/response body wrapper.
+ */
 interface KubernetesList<TItem>
 {
-  /** List body returned by the generated client. */
-  body?: {
-    /** Items present in the list response. */
-    items?: TItem[];
-  };
+  /** Items present in the list response. */
+  items: TItem[];
 }
 
 /** Minimal Tenant CRD shape needed for drift comparison. */
@@ -304,10 +306,12 @@ function _BuildSnapshotMap(items: NamedSnapshot[]): Map<string, NamedSnapshot>
 
 /**
  * Extract list items from the Kubernetes client response payload.
+ *
+ * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#collections - API reference
  */
 function _ReadKubernetesListItems<TItem>(response: KubernetesList<TItem>): TItem[]
 {
-  return response.body?.items ?? [];
+  return response.items;
 }
 
 /**

--- a/apps/control-plane/src/routes/internal/projection-repair.ts
+++ b/apps/control-plane/src/routes/internal/projection-repair.ts
@@ -4,14 +4,15 @@ import type { PrismaClient } from "@prisma/client";
 import { OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL, POLICY_CRD_PLURAL } from "./crd-constants.js";
 import type { ProjectionRepairEntry, ProjectionRepairReport } from "./projection-repair.types.js";
 
-/** Minimal Kubernetes list payload shape returned by the client. */
+/**
+ * Minimal Kubernetes list payload shape returned by the client.
+ *
+ * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#collections - API reference
+ */
 interface KubernetesList<TItem>
 {
-  /** List body from the generated client. */
-  body?: {
-    /** Items present in the list response. */
-    items?: TItem[];
-  };
+  /** Items present in the list response. */
+  items: TItem[];
 }
 
 /** Minimal Tenant CRD shape needed for repair. */
@@ -239,8 +240,12 @@ export async function _RepairPolicyProjection(customApi: k8s.CustomObjectsApi, p
   };
 }
 
-/** Extract items from a Kubernetes list response, defaulting to empty. */
+/**
+ * Extract items from a Kubernetes list response.
+ *
+ * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#collections - API reference
+ */
 function _readItems<T>(response: KubernetesList<T>): T[]
 {
-  return response.body?.items ?? [];
+  return response.items;
 }

--- a/apps/operator/src/__tests__/tenants/policy-resolution.test.ts
+++ b/apps/operator/src/__tests__/tenants/policy-resolution.test.ts
@@ -26,11 +26,13 @@ function _makePolicy(name: string, options?: { matchTeam?: string; matchLabels?:
 
 /**
  * Build a custom API mock that returns the provided policy list.
+ *
+ * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#collections - API reference
  */
 function _makeCustomApi(policies: AccessPolicy[]): k8s.CustomObjectsApi
 {
   return {
-    listNamespacedCustomObject: vi.fn().mockResolvedValue({ body: { items: policies } }),
+    listNamespacedCustomObject: vi.fn().mockResolvedValue({ items: policies }),
   } as unknown as k8s.CustomObjectsApi;
 }
 

--- a/apps/operator/src/infra/k8s.ts
+++ b/apps/operator/src/infra/k8s.ts
@@ -148,20 +148,19 @@ async function _replaceResource(client: any, resource: k8s.KubernetesObject, nam
 /**
  * Extract response body returned by typed API calls; fallback to original
  * resource for generic object API return shapes.
+ *
+ * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#collections - API reference
  */
 function _extractBody<T extends k8s.KubernetesObject>(response: unknown, fallback: T): T
 {
-  if (typeof response === "object" && response !== null && "body" in response)
-  {
-    return (response as { body: T }).body;
-  }
-
   return (response as T) ?? fallback;
 }
 
 /**
- * Pull metadata.resourceVersion from API responses that may be wrapped
- * ({ body }) or returned as raw Kubernetes objects.
+ * Pull metadata.resourceVersion from API responses that are returned as
+ * raw Kubernetes objects.
+ *
+ * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#collections - API reference
  */
 function _extractResourceVersion(response: unknown): string
 {
@@ -170,16 +169,7 @@ function _extractResourceVersion(response: unknown): string
     throw new Error("unable to read current resource version from API response");
   }
 
-  const candidate = ("body" in response)
-    ? (response as { body?: unknown }).body
-    : response;
-
-  if (typeof candidate !== "object" || candidate === null)
-  {
-    throw new Error("unable to read current resource version from API response body");
-  }
-
-  const metadata = (candidate as { metadata?: unknown }).metadata;
+  const metadata = (response as { metadata?: unknown }).metadata;
   if (typeof metadata !== "object" || metadata === null)
   {
     throw new Error("resource metadata missing in current API object");

--- a/apps/operator/src/tenants/internal/policy-resolution.ts
+++ b/apps/operator/src/tenants/internal/policy-resolution.ts
@@ -15,6 +15,8 @@ import { TenantPolicyResolutionState } from "../models/tenant-status.interface.j
  * 2) Exactly one selector match
  * 3) Optional configured default policy
  * 4) No policy
+ *
+ * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#collections - API reference
  */
 export async function _ResolveTenantPolicy(customApi: k8s.CustomObjectsApi, config: OpenClawTenantOperatorConfig,
                                            tenant: Tenant, namespace: string): Promise<TenantPolicyResolutionResult>
@@ -25,9 +27,9 @@ export async function _ResolveTenantPolicy(customApi: k8s.CustomObjectsApi, conf
         version: OPENCRANE_API_VERSION,
         namespace,
         plural: ACCESS_POLICY_CRD_PLURAL,
-      }) as { body?: { items?: AccessPolicy[] } };
+      }) as { items: AccessPolicy[] };
 
-  const policies = policyListResponse.body?.items ?? [];
+  const policies = policyListResponse.items;
   const policiesByName = new Map(policies.map(function _toPolicyEntry(policy)
   {
     return [policy.metadata?.name ?? "", policy] as const;

--- a/apps/operator/src/tenants/runtime/idle-checker.ts
+++ b/apps/operator/src/tenants/runtime/idle-checker.ts
@@ -94,6 +94,8 @@ export class IdleChecker
    * 5. The operator's existing watch loop picks up the MODIFIED event
    *    and scales the Deployment to 0 replicas.
    * 6. On GKE Autopilot the now-idle node is automatically reclaimed.
+   *
+   * @see https://kubernetes.io/docs/reference/using-api/api-concepts/#collections - API reference
    */
   private async _checkAll(): Promise<void>
   {
@@ -103,7 +105,7 @@ export class IdleChecker
       ? await this.customApi.listNamespacedCustomObject({ group: OPENCRANE_API_GROUP, version: OPENCRANE_API_VERSION, namespace: ns, plural: TENANT_CRD_PLURAL })
       : await this.customApi.listClusterCustomObject({ group: OPENCRANE_API_GROUP, version: OPENCRANE_API_VERSION, plural: TENANT_CRD_PLURAL });
 
-    const tenants = ((response as Record<string, unknown>).items ?? []) as Tenant[];
+    const tenants = (response as { items: Tenant[] }).items;
     const now = Date.now();
     const thresholdMs = this.config.idleTimeoutMinutes * 60 * 1000;
 

--- a/platform/helm/templates/control-plane-deployment.yaml
+++ b/platform/helm/templates/control-plane-deployment.yaml
@@ -42,6 +42,8 @@ spec:
               value: {{ ternary "true" "false" .Values.controlPlane.cognee.backendAccessControl | quote }}
             - name: LITELLM_ENDPOINT
               value: {{ .Values.litellm.endpoint | quote }}
+            - name: LITELLM_SPEND_PATH_TEMPLATE
+              value: {{ .Values.litellm.spendPathTemplate | quote }}
             {{- if .Values.litellm.enabled }}
             - name: LITELLM_MASTER_KEY
               valueFrom:

--- a/platform/helm/templates/control-plane-deployment.yaml
+++ b/platform/helm/templates/control-plane-deployment.yaml
@@ -26,6 +26,10 @@ spec:
             - name: http
               containerPort: {{ .Values.controlPlane.service.port }}
           env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: PORT
               value: {{ .Values.controlPlane.service.port | quote }}
             - name: INGRESS_DOMAIN

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -71,6 +71,8 @@ litellm:
   generateMasterKey: true
   # -- Default budget used by operator when tenant does not define monthlyBudgetUsd
   defaultMonthlyBudgetUsd: 50
+  # -- Default spend path template for control-plane to query tenant spend from LiteLLM (tenant_id placeholder: {tenant})
+  spendPathTemplate: "/spend/tenant/{tenant}"
   image:
     repository: ghcr.io/berriai/litellm
     tag: main-latest

--- a/platform/install.sh
+++ b/platform/install.sh
@@ -150,7 +150,7 @@ function _run_local()
   _require_cmd k3d
 
   echo "[install] Running local full-stack install on k3d..."
-  KEEP_CLUSTER="$keep_cluster" CLUSTER_NAME="$cluster_name" NAMESPACE="$namespace" LOCAL_PROFILE="$profile" "$ROOT_DIR/platform/tests/k3d-local.sh"
+  KEEP_CLUSTER="$keep_cluster" CLUSTER_NAME="$cluster_name" NAMESPACE="$namespace" LOCAL_PROFILE="$profile" bash "$ROOT_DIR/platform/tests/k3d-local.sh"
   echo "[install] Local install complete."
   echo "[install] Cluster: $cluster_name, Namespace: $namespace, Profile: $profile"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       express-session:
         specifier: ^1.19.0
         version: 1.19.0
-      lodash:
-        specifier: ^4.18.1
-        version: 4.18.1
       openid-client:
         specifier: ^6.8.4
         version: 6.8.4
@@ -63,9 +60,6 @@ importers:
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.6
-      '@types/lodash':
-        specifier: ^4.17.24
-        version: 4.17.24
       '@types/node':
         specifier: ^22.0.0
         version: 22.15.31
@@ -698,9 +692,6 @@ packages:
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
-
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -1482,9 +1473,6 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
-
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -2671,8 +2659,6 @@ snapshots:
 
   '@types/js-yaml@4.0.9': {}
 
-  '@types/lodash@4.17.24': {}
-
   '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
@@ -2928,7 +2914,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -3041,6 +3027,10 @@ snapshots:
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -3238,7 +3228,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -3314,7 +3304,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -3617,8 +3607,6 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
     optional: true
-
-  lodash@4.18.1: {}
 
   loupe@3.2.1: {}
 
@@ -3977,7 +3965,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -4020,7 +4008,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -4089,7 +4077,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -4163,7 +4151,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       fast-safe-stringify: 2.1.1
       form-data: 4.0.5
       formidable: 3.5.4
@@ -4360,7 +4348,7 @@ snapshots:
   vite-node@3.2.4(@types/node@22.15.31)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.1(@types/node@22.15.31)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)
@@ -4460,7 +4448,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3


### PR DESCRIPTION
# Changes:
- The `kubernetes/client-node` api changed which introduced a breaking change where the response items are served in the top level instead of the older under `body` response. Fixed that to match the new API.
- The Control Plane deployment was missing the `NAMESPACE` env var which is needed during the Kubernetes API calls  within the Control Plane API so that it can target the right `namespace`. The missing var meant the `NAMESPACE` var was falling back to `default` which is the wrong namespace.
- Corrected the missing `LITELLM_SPEND_PATH_TEMPLATE` env var that I had earlier omitted from the Helm Chart
- Replaced the Lodash import within the Control Plane with local custom utilities that mirror those exact functions.

# Files Changed:
- `apps/control-plane/src/routes/internal/projection-drift.ts` - KubernetesList interface changes
- `apps/control-plane/src/routes/internal/projection-repair.ts` - KubernetesList interface changes
- `apps/control-plane/src/__tests__/routes/metrics.test.ts` - Tests for the KubernenetesList interface changes
- `apps/control-plane/src/__tests__/routes/projection-drift.test.ts`- Tests for the KubernenetesList interface changes
- `apps/control-plane/src/__tests__/routes/projection-repair.test.ts` - Tests for the KubernenetesList interface changes
- `apps/operator/src/tenants/internal/policy-resolution.ts` - KubernetesList interface changes
- `apps/operator/src/__tests__/tenants/policy-resolution.test.ts` - Tests for the KubernetesList interface changes
- `apps/operator/src/infra/k8s.ts` - KubernetesList interface changes
- `apps/operator/src/tenants/runtime/idle-checker.ts` - KubernetesList interface changes
- `platform/helm/templates/control-plane-deployment.yaml` - Added missing NAMESPACE and LITELLM_SPEND_PATH_TEMPLATE env variables.
- `platform/helm/values.yaml` - Addition of the `litellm.spendPathTemplate` value
- `platform/install.sh` - Added `bash` command to running of the local install script
- `apps/control-plane/src/core/utils/collections.ts` - Common utilities mirroring the Lodash functions.
- `apps/control-plane/src/features/groups/groups.logic.ts` - Replacing lodash utilities with custom utilities.
- `apps/control-plane/src/core/grants/grant-compiler.ts` - Replacing lodash utilities with custom utilities.
- `apps/control-plane/package.json` - Dropping the lodash package.
- `pnpm-lock.yaml` - Dropping the lodash package.