### PR TITLE
Operator Fixes

### DIFF
--- a/apps/control-plane/src/core/spend/spend.logic.ts
+++ b/apps/control-plane/src/core/spend/spend.logic.ts
@@ -25,7 +25,7 @@ export class SpendLogic
   {
     const endpoint = process.env.LITELLM_ENDPOINT ?? "http://litellm:4000";
     const masterKey = process.env.LITELLM_MASTER_KEY ?? "";
-    const pathTemplate = process.env.LITELLM_SPEND_PATH_TEMPLATE ?? "/spend/tenant/{tenant}";
+    const pathTemplate = process.env.LITELLM_SPEND_PATH_TEMPLATE ?? "/team/info?team_id={tenant}";
 
     if (!masterKey)
     {

--- a/apps/operator/src/tenants/internal/tenant-litellm-keys.ts
+++ b/apps/operator/src/tenants/internal/tenant-litellm-keys.ts
@@ -73,8 +73,11 @@ export class TenantLiteLlmKeys
       // Continue to create key and secret when missing.
     }
 
-    // 3. Provision key in LiteLLM and persist as a namespaced Secret for tenant env injection.
+    // 3. Ensure team exists in LiteLLM — required for per-tenant spend tracking.
     const budget = tenant.spec.monthlyBudgetUsd ?? this.config.liteLlmDefaultMonthlyBudgetUsd;
+    await this._ensureLiteLlmTeam(name, budget);
+
+    // 4. Provision key in LiteLLM and persist as a namespaced Secret for tenant env injection.
     const issuedAt = new Date().toISOString();
     const keyAlias = `opencrane-${name}`;
     const apiKey = await this._generateLiteLlmVirtualKey(name, budget);
@@ -102,6 +105,50 @@ export class TenantLiteLlmKeys
   }
 
   /**
+   * Ensure a LiteLLM team exists for the tenant, creating it if absent.
+   * Teams enable per-tenant budget tracking and spend attribution in LiteLLM.
+   */
+  private async _ensureLiteLlmTeam(tenantName: string, monthlyBudgetUsd: number): Promise<void>
+  {
+    // 1. Check if team already exists — avoid duplicates on re-reconcile.
+    const infoResponse = await fetch(
+      `${this.config.liteLlmEndpoint}/team/info?team_id=${encodeURIComponent(tenantName)}`,
+      {
+        headers: { Authorization: `Bearer ${this.config.liteLlmMasterKey}` },
+      },
+    );
+
+    if (infoResponse.ok)
+    {
+      this.log.debug({ tenantName }, "litellm team already exists");
+      return;
+    }
+
+    // 2. Create team — establishes the tenant identity in LiteLLM for spend tracking.
+    const createResponse = await fetch(`${this.config.liteLlmEndpoint}/team/new`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${this.config.liteLlmMasterKey}`,
+      },
+      body: JSON.stringify({
+        team_id: tenantName,
+        team_alias: `opencrane-${tenantName}`,
+        max_budget: monthlyBudgetUsd,
+        metadata: { managed_by: "opencrane-operator" },
+      }),
+    });
+
+    if (!createResponse.ok)
+    {
+      const body = await createResponse.text();
+      throw new Error(`LiteLLM team creation failed (${createResponse.status}): ${body}`);
+    }
+
+    this.log.info({ tenantName, monthlyBudgetUsd }, "created litellm team");
+  }
+
+  /**
    * Request a new LiteLLM virtual key for the tenant from the LiteLLM API.
    */
   private async _generateLiteLlmVirtualKey(tenantName: string, monthlyBudgetUsd: number): Promise<string>
@@ -114,6 +161,7 @@ export class TenantLiteLlmKeys
       },
       body: JSON.stringify({
         key_alias: `opencrane-${tenantName}`,
+        team_id: tenantName,
         metadata: { tenant: tenantName },
         max_budget: monthlyBudgetUsd,
       }),


### PR DESCRIPTION
# Changes:
- The operator was missing a step to create the LiteLLM team during tenant creation which is needed to track per tenant spending. This was causing an error within the `{CONTROL_PLANE_BASE_URL}/api/ai-budget/{tenant-name}/spend` endpoint where it could not track the tenant team via the `{LITELLM_BASE_URL}/team/info?team_id={tenant-name}` endpoint which runs under the hood within the `.../control-plane/src/core/spend/spend.logic.ts` file in the `getTenantSpend` function.

# Files changed:
- `apps/operator/src/tenants/internal/tenant-litellm-keys.ts` - The LiteLLM tenant team creation function.
- `apps/control-plane/src/core/spend/spend.logic.ts` - The Tenant spend endpoint fallback correction.

# Testing:
- The `/ai-budget/{tenant-name}/spend` endpoint within the control plane executes successfully.