### PR TITLE
Correcting the misdefined `providers/keys/{provider}` endpoint

### DIFF
--- a/apps/cli/src/commands/providers.ts
+++ b/apps/cli/src/commands/providers.ts
@@ -29,8 +29,9 @@ export function _RegisterProviders(parent: Command, getConfig: () => CliConfig):
     .action(async function _set(provider: string, key: string)
     {
       const client = _MakeClient(getConfig());
-      const { error } = await client.PUT("/providers/keys", {
-        body: { provider, apiKey: key },
+      const { error } = await client.PUT("/providers/keys/{provider}", {
+        params: { path: { provider } },
+        body: { apiKey: key },
       });
       if (error) _PrintApiError("providers set", error);
       _PrintSuccess(`Provider key for "${provider}" updated`);

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -2148,12 +2148,24 @@
             }
           }
         }
-      },
+      }
+    },
+    "/providers/keys/{provider}": {
       "put": {
         "operationId": "upsertProviderKey",
         "summary": "Create or update a provider API key",
         "tags": [
           "Provider Keys"
+        ],
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -2162,13 +2174,9 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "provider",
                   "apiKey"
                 ],
                 "properties": {
-                  "provider": {
-                    "type": "string"
-                  },
                   "apiKey": {
                     "type": "string"
                   }
@@ -2189,9 +2197,7 @@
             }
           }
         }
-      }
-    },
-    "/providers/keys/{provider}": {
+      },
       "delete": {
         "operationId": "deleteProviderKey",
         "summary": "Delete a configured provider API key",

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -921,18 +921,24 @@ export const spec = {
           200: ok("Provider key status list.", { type: "array", items: { $ref: "#/components/schemas/ProviderKey" } }),
         },
       },
+    },
+
+    // @see https://datatracker.ietf.org/doc/html/rfc9110#name-put
+    // The RFC spec which specifies that PUT requires the full resource representation, which in this case is just the provider name 
+    "/providers/keys/{provider}": {
       put: {
         operationId: "upsertProviderKey",
         summary: "Create or update a provider API key",
         tags: ["Provider Keys"],
+        parameters: [{ name: "provider", in: "path", required: true, schema: { type: "string" } }],
         requestBody: {
           required: true,
           content: {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["provider", "apiKey"],
-                properties: { provider: { type: "string" }, apiKey: { type: "string" } },
+                required: ["apiKey"],
+                properties: { apiKey: { type: "string" } },
               },
             },
           },
@@ -941,9 +947,6 @@ export const spec = {
           200: ok("Key updated.", { $ref: "#/components/schemas/ProviderKey" }),
         },
       },
-    },
-
-    "/providers/keys/{provider}": {
       delete: {
         operationId: "deleteProviderKey",
         summary: "Delete a configured provider API key",

--- a/apps/control-plane/src/routes/provider-keys.ts
+++ b/apps/control-plane/src/routes/provider-keys.ts
@@ -39,7 +39,7 @@ export function providerKeysRouter(prisma: PrismaClient): Router
   router.put("/:provider", async function _putProviderKey(req, res)
   {
     const provider = String(req.params.provider ?? "").toLowerCase();
-    const keyValue = String(req.body.value ?? "").trim();
+    const keyValue = String(req.body.apiKey ?? "").trim();
 
     if (!provider || !keyValue)
     {

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -407,8 +407,7 @@ export interface paths {
         };
         /** List configured provider API keys (configured status only, never the key value) */
         get: operations["listProviderKeys"];
-        /** Create or update a provider API key */
-        put: operations["upsertProviderKey"];
+        put?: never;
         post?: never;
         delete?: never;
         options?: never;
@@ -424,7 +423,8 @@ export interface paths {
             cookie?: never;
         };
         get?: never;
-        put?: never;
+        /** Create or update a provider API key */
+        put: operations["upsertProviderKey"];
         post?: never;
         /** Delete a configured provider API key */
         delete: operations["deleteProviderKey"];
@@ -619,6 +619,26 @@ export interface paths {
         get: operations["getAuthStatus"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/pod-token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Exchange the current OIDC session for a short-lived token to the caller's OpenClaw pod
+         * @description Single sign-on across the control plane and the tenant pod: requires an established OIDC session (cookie) and returns a short-lived, audience-bound token minted via the Kubernetes TokenRequest API for the caller's tenant. The token targets the OpenClaw pod's session audience (reachable at `ingressHost`) — it is NOT an `obot-gateway` token; Obot is called only from inside the pod. The tenant is resolved solely from the session's verified email, so a caller cannot obtain a token for another user's pod. Re-call before `expiresAt`; re-login only when the session itself expires. Returns 401 without a session, 403 when no tenant matches the session email, 409 when the pod has no ingress host yet or when the email maps to more than one tenant.
+         */
+        post: operations["exchangePodToken"];
         delete?: never;
         options?: never;
         head?: never;
@@ -2103,13 +2123,14 @@ export interface operations {
         parameters: {
             query?: never;
             header?: never;
-            path?: never;
+            path: {
+                provider: string;
+            };
             cookie?: never;
         };
         requestBody: {
             content: {
                 "application/json": {
-                    provider: string;
                     apiKey: string;
                 };
             };
@@ -2498,6 +2519,76 @@ export interface operations {
                             email?: string;
                             name?: string;
                         } | null;
+                    };
+                };
+            };
+        };
+    };
+    exchangePodToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Short-lived pod access token. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Short-lived bearer token bound to the OpenClaw pod session audience. */
+                        token: string;
+                        /**
+                         * Format: date-time
+                         * @description ISO-8601 expiry reported by the API server.
+                         */
+                        expiresAt: string;
+                        /** @description Resolved tenant (pod) name. */
+                        tenant: string;
+                        /** @description Host to reach the tenant's OpenClaw pod session API. */
+                        ingressHost: string;
+                        /** @description Audience the token is bound to (the OpenClaw pod session, not obot-gateway). */
+                        audience: string;
+                    };
+                };
+            };
+            /** @description No authenticated session. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        code?: string;
+                    };
+                };
+            };
+            /** @description Session has no email claim, or no tenant is provisioned for it. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        code?: string;
+                    };
+                };
+            };
+            /** @description The tenant pod has no ingress host yet. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        code?: string;
                     };
                 };
             };


### PR DESCRIPTION
# Changes:
- The `providers/keys/{provider}` endpoint had been defined as `providers/keys` in the Control Plane API spec which was wrong and misaligned with what the Control Plane routes were serving. The [RFC spec](https://datatracker.ietf.org/doc/html/rfc9110#name-put) also recommends the approach the Control Plane routes were using. This change just fixes that on the spec and the CLI.

# Files changed:
- `apps/control-plane/src/openapi/spec.ts` - Spec endpoint fix
- `apps/cli/src/commands/providers.ts` - CLI endpoint fix
- `apps/control-plane/openapi.json` - Generated Spec
- `apps/control-plane/src/routes/provider-keys.ts` - Fixing the Control Plane to match the expected body shape from the spec
- `libs/contracts/src/generated/api.ts` - Generated Contract

# Testing:
- The PUT operation for provider keys routes correctly via the CLI