### PR TITLE
Minor fixes to add missing steps needed for cluster set-up

### DIFF
--- a/apps/control-plane/deploy/Dockerfile
+++ b/apps/control-plane/deploy/Dockerfile
@@ -7,15 +7,18 @@ WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY tsconfig.base.json ./
 COPY libs/contracts/package.json libs/contracts/tsconfig.json libs/contracts/
+COPY libs/awareness/package.json libs/awareness/tsconfig.json libs/awareness/
 COPY apps/control-plane/scripts apps/control-plane/scripts
 COPY apps/control-plane/openapi.json apps/control-plane/openapi.json
 COPY apps/control-plane/package.json apps/control-plane/tsconfig.json apps/control-plane/
 COPY apps/control-plane/prisma apps/control-plane/prisma
-RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/control-plane
+RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/awareness --filter @opencrane/control-plane
 
 COPY libs/contracts/src libs/contracts/src
+COPY libs/awareness/src libs/awareness/src
 COPY apps/control-plane/src apps/control-plane/src
 RUN pnpm --filter @opencrane/contracts build
+RUN pnpm --filter @opencrane/awareness build
 RUN pnpm --filter @opencrane/control-plane build
 # Stage generated Prisma client to a fixed path for the runtime stage
 RUN find /app -path '*/node_modules/.prisma/client' -type d | head -1 | \
@@ -29,9 +32,10 @@ RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
 WORKDIR /app
 COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml ./
 COPY --from=build /app/libs/contracts/package.json libs/contracts/
+COPY --from=build /app/libs/awareness/package.json libs/awareness/
 COPY --from=build /app/apps/control-plane/package.json apps/control-plane/
 COPY --from=build /app/apps/control-plane/prisma apps/control-plane/prisma
-RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/control-plane --prod
+RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/awareness --filter @opencrane/control-plane --prod
 COPY --from=build /generated-prisma /tmp/generated-prisma
 # Retrieve the generated Prisma client for the runtime stage
 RUN target=$(find /app -path '*/node_modules/.prisma/client' -type d | head -1) && \
@@ -40,6 +44,7 @@ RUN target=$(find /app -path '*/node_modules/.prisma/client' -type d | head -1) 
     rm -rf /tmp/generated-prisma
 
 COPY --from=build /app/libs/contracts/dist libs/contracts/dist
+COPY --from=build /app/libs/awareness/dist libs/awareness/dist
 COPY --from=build /app/apps/control-plane/dist apps/control-plane/dist
 
 USER node

--- a/apps/operator/src/tenants/internal/tenant-encryption-keys.ts
+++ b/apps/operator/src/tenants/internal/tenant-encryption-keys.ts
@@ -3,7 +3,7 @@ import { randomBytes } from "node:crypto";
 import * as k8s from "@kubernetes/client-node";
 import type { Logger } from "pino";
 
-import { ___K8sApplyResource } from "../../infra/k8s.js";
+import { __K8sApplyResource } from "../../infra/k8s.js";
 import { _BuildTenantLabels } from "../deploy/tenant-labels.js";
 
 /**

--- a/apps/operator/src/tenants/operator.ts
+++ b/apps/operator/src/tenants/operator.ts
@@ -2,13 +2,12 @@ import * as k8s from "@kubernetes/client-node";
 import type { Logger } from "pino";
 
 import type { OpenClawTenantOperatorConfig } from "../config.js";
-import type { HostingAdapter } from "../hosting/index.js";
-import { _BuildHostingAdapter } from "../hosting/index.js";
+import { _BuildHostingAdapter, type HostingAdapter } from "../hosting/index.js";
 
 import type { Tenant } from "./models/tenant.interface.js";
 import { TenantPolicyResolutionState, TenantStatusPhase } from "./models/tenant-status.interface.js";
 
-import { ___K8sApplyResource } from "../infra/k8s.js";
+import { __K8sApplyResource } from "../infra/k8s.js";
 import { _RunWatchLoop, K8sWatchEventType } from "../shared/watch-runner.js";
 import { OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "../shared/crd-constants.js";
 import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildIngress, _BuildIngressHost, _BuildService, _BuildServiceAccount, _BuildStatePvc } from "./deploy/index.js";

--- a/platform/helm/templates/litellm-deployment.yaml
+++ b/platform/helm/templates/litellm-deployment.yaml
@@ -61,6 +61,19 @@ spec:
                   name: {{ include "opencrane.fullname" . }}-litellm
                   key: {{ .Values.litellm.databaseSecretKey }}
             {{- end }}
+            - name: LITELLM_MIGRATION_DIR
+              value: "/tmp/litellm/migrations"
+            - name: LITELLM_NON_ROOT
+              value: "true"
+            - name: PRISMA_BINARY_CACHE_DIR
+              value: "/tmp/prisma-engines"
+            - name: XDG_CACHE_HOME
+              value: "/tmp"
+          volumeMounts:
+            - name: temp-dir
+              mountPath: /tmp
+            - name: var-lib-litellm
+              mountPath: /var/lib/litellm
           livenessProbe:
             tcpSocket:
               port: http
@@ -73,4 +86,9 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.litellm.resources | nindent 12 }}
+      volumes:
+        - name: temp-dir
+          emptyDir: {}
+        - name: var-lib-litellm
+          emptyDir: {}
 {{- end }}

--- a/platform/helm/templates/mcp-gateway-rbac.yaml
+++ b/platform/helm/templates/mcp-gateway-rbac.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.mcpGateway.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "opencrane.fullname" . }}-mcp-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-gateway
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "opencrane.fullname" . }}-mcp-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-gateway
+rules:
+  # Obot needs to manage pods, services, PVCs, configmaps, deployments, replicasets, etc.
+  # for the MCP servers it dynamically provisions.
+  - apiGroups: [""]
+    resources: ["secrets", "services", "persistentvolumeclaims", "configmaps", "serviceaccounts"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log", "events"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "opencrane.fullname" . }}-mcp-gateway
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mcp-gateway
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "opencrane.fullname" . }}-mcp-gateway
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "opencrane.fullname" . }}-mcp-gateway
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/helm/templates/obot-mcp-gateway-deployment.yaml
+++ b/platform/helm/templates/obot-mcp-gateway-deployment.yaml
@@ -21,7 +21,8 @@ spec:
         {{- include "opencrane.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: mcp-gateway
     spec:
-      automountServiceAccountToken: false
+      serviceAccountName: {{ include "opencrane.fullname" . }}-mcp-gateway
+      automountServiceAccountToken: true
       securityContext:
         {{- toYaml .Values.mcpGateway.podSecurityContext | nindent 8 }}
       containers:
@@ -54,6 +55,16 @@ spec:
               value: "kubernetes"
             - name: OBOT_SERVER_MCPCLUSTER_DOMAIN
               value: "cluster.local"
+            - name: OBOT_SERVER_MCPNAMESPACE
+              value: "{{ .Release.Namespace }}"
+            - name: OBOT_SERVER_SERVICE_NAME
+              value: "{{ include "opencrane.fullname" . }}-mcp-gateway"
+            - name: OBOT_SERVER_SERVICE_NAMESPACE
+              value: "{{ .Release.Namespace }}"
+            - name: OBOT_SERVER_SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
             {{- if .Values.mcpGateway.encryptionAtRest.enabled }}
             # Encryption-at-rest ENABLED (P4D.1).
             # ⚠️ ASSUMED knob — provider=custom + key-from-Secret are NOT verified
@@ -77,17 +88,17 @@ spec:
             # with OpenCrane McpServer rows. The control-plane exposes /api/internal/obot-registry
             # in Obot's /v0.1/servers format.
             - name: OBOT_SERVER_PROVIDER_REGISTRIES
-              value: "http://{{ include "opencrane.fullname" . }}-control-plane.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.controlPlane.service.port }}/api/internal/obot-registry"
+              value: "http://{{ include "opencrane.fullname" . }}-control-plane:{{ .Values.controlPlane.service.port }}/api/internal/obot-registry"
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /api/healthz
               port: http
             initialDelaySeconds: 20
             periodSeconds: 15
             failureThreshold: 4
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /api/healthz
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10

--- a/platform/terraform/modules/app-deploy/main.tf
+++ b/platform/terraform/modules/app-deploy/main.tf
@@ -1,12 +1,12 @@
 # -----------------------------------------------------------------------------
 # App Deploy module
 #
-# Deploys in-cluster PostgreSQL (Bitnami), the OpenCrane Helm chart, and
+# Deploys in-cluster PostgreSQL (CloudNativePG), the OpenCrane Helm chart, and
 # a Kubernetes Job for Prisma database migrations. This is the final step
 # that brings the application online after infrastructure provisioning.
 # -----------------------------------------------------------------------------
 
-# ---- In-cluster PostgreSQL via Bitnami Helm chart ----
+# ---- In-cluster PostgreSQL via CloudNativePG Operator ----
 
 resource "random_password" "db_password"
 {
@@ -14,52 +14,75 @@ resource "random_password" "db_password"
   special = false
 }
 
-resource "helm_release" "postgresql"
+resource "helm_release" "cnpg"
 {
-  name             = "opencrane-db"
+  name             = "cnpg"
   namespace        = var.namespace
   create_namespace = true
-  repository       = "oci://registry-1.docker.io/bitnamicharts"
-  chart            = "postgresql"
-  version          = "16.4.1"
+  repository       = "https://cloudnative-pg.github.io/charts"
+  chart            = "cloudnative-pg"
+  version          = "0.22.0"
   wait             = true
   timeout          = 600
 
   set
   {
-    name  = "auth.username"
-    value = "opencrane"
+    name  = "monitoring.podMonitor.enabled"
+    value = "false"
+  }
+}
+
+resource "kubernetes_secret" "db_creds"
+{
+  metadata
+  {
+    name      = "opencrane-db-creds"
+    namespace = var.namespace
   }
 
-  set_sensitive
+  data =
   {
-    name  = "auth.password"
-    value = random_password.db_password.result
+    username = "opencrane"
+    password = random_password.db_password.result
+  }
+}
+
+resource "kubernetes_manifest" "postgresql_cluster"
+{
+  manifest = {
+    apiVersion = "postgresql.cnpg.io/v1"
+    kind       = "Cluster"
+    metadata = {
+      name      = "opencrane-db"
+      namespace = var.namespace
+    }
+    spec = {
+      instances = 1
+      imageName = "ghcr.io/cloudnative-pg/postgresql:16"
+      storage = {
+        size = "10Gi"
+      }
+      resources = {
+        requests = {
+          cpu    = "250m"
+          memory = "256Mi"
+        }
+      }
+      bootstrap = {
+        initdb = {
+          database = "opencrane"
+          secret = {
+            name = kubernetes_secret.db_creds.metadata[0].name
+          }
+        }
+      }
+    }
   }
 
-  set
-  {
-    name  = "auth.database"
-    value = "opencrane"
-  }
-
-  set
-  {
-    name  = "primary.persistence.size"
-    value = "10Gi"
-  }
-
-  set
-  {
-    name  = "primary.resources.requests.cpu"
-    value = "250m"
-  }
-
-  set
-  {
-    name  = "primary.resources.requests.memory"
-    value = "256Mi"
-  }
+  depends_on = [
+    helm_release.cnpg,
+    kubernetes_secret.db_creds,
+  ]
 }
 
 # ---- Kubernetes Secret with DATABASE_URL for the control-plane ----
@@ -74,10 +97,10 @@ resource "kubernetes_secret" "database_url"
 
   data =
   {
-    DATABASE_URL = "postgresql://opencrane:${random_password.db_password.result}@opencrane-db-postgresql.${var.namespace}.svc.cluster.local:5432/opencrane"
+    DATABASE_URL = "postgresql://opencrane:${random_password.db_password.result}@opencrane-db-rw.${var.namespace}.svc.cluster.local:5432/opencrane"
   }
 
-  depends_on = [helm_release.postgresql]
+  depends_on = [kubernetes_manifest.postgresql_cluster]
 }
 
 # ---- Static ingress IP (reserved so DNS can point to it) ----
@@ -230,7 +253,7 @@ resource "helm_release" "opencrane"
 
   depends_on = [
     kubernetes_secret.database_url,
-    helm_release.postgresql,
+    kubernetes_manifest.postgresql_cluster,
     helm_release.cert_manager,
   ]
 }
@@ -296,7 +319,7 @@ resource "kubernetes_job" "db_migrate"
   }
 
   depends_on = [
-    helm_release.postgresql,
+    kubernetes_manifest.postgresql_cluster,
     kubernetes_secret.database_url,
   ]
 }

--- a/platform/terraform/modules/app-deploy/main.tf
+++ b/platform/terraform/modules/app-deploy/main.tf
@@ -103,6 +103,24 @@ resource "kubernetes_secret" "database_url"
   depends_on = [kubernetes_manifest.postgresql_cluster]
 }
 
+# ---- Kubernetes Secret with dsn for the Obot MCP Gateway ----
+
+resource "kubernetes_secret" "opencrane_obot"
+{
+  metadata
+  {
+    name      = "opencrane-obot"
+    namespace = var.namespace
+  }
+
+  data =
+  {
+    dsn = "postgresql://opencrane:${random_password.db_password.result}@opencrane-db-rw.${var.namespace}.svc.cluster.local:5432/opencrane"
+  }
+
+  depends_on = [kubernetes_manifest.postgresql_cluster]
+}
+
 # ---- Static ingress IP (reserved so DNS can point to it) ----
 
 resource "google_compute_global_address" "ingress_ip"
@@ -253,6 +271,7 @@ resource "helm_release" "opencrane"
 
   depends_on = [
     kubernetes_secret.database_url,
+    kubernetes_secret.opencrane_obot,
     kubernetes_manifest.postgresql_cluster,
     helm_release.cert_manager,
   ]

--- a/platform/terraform/modules/app-deploy/main.tf
+++ b/platform/terraform/modules/app-deploy/main.tf
@@ -88,6 +88,26 @@ resource "google_compute_global_address" "ingress_ip"
   project = var.project_id
 }
 
+# ---- cert-manager via Helm chart (CONN.8) ----
+
+resource "helm_release" "cert_manager"
+{
+  name             = "cert-manager"
+  namespace        = "cert-manager"
+  create_namespace = true
+  repository       = "https://charts.jetstack.io"
+  chart            = "cert-manager"
+  version          = "v1.15.1"
+  wait             = true
+  timeout          = 600
+
+  set
+  {
+    name  = "crds.enabled"
+    value = "true"
+  }
+}
+
 # ---- OpenCrane Helm chart ----
 
 resource "helm_release" "opencrane"
@@ -211,6 +231,7 @@ resource "helm_release" "opencrane"
   depends_on = [
     kubernetes_secret.database_url,
     helm_release.postgresql,
+    helm_release.cert_manager,
   ]
 }
 

--- a/platform/terraform/modules/app-deploy/outputs.tf
+++ b/platform/terraform/modules/app-deploy/outputs.tf
@@ -7,11 +7,18 @@ output "ingress_ip"
 output "database_host"
 {
   description = "In-cluster PostgreSQL service hostname"
-  value       = "opencrane-db-postgresql.${var.namespace}.svc.cluster.local"
+  value       = "opencrane-db-rw.${var.namespace}.svc.cluster.local"
 }
 
 output "control_plane_url"
 {
   description = "URL for the OpenCrane control-plane UI"
   value       = "https://${var.domain}"
+}
+
+output "database_password"
+{
+  description = "In-cluster PostgreSQL database password"
+  value       = random_password.db_password.result
+  sensitive   = true
 }

--- a/platform/terraform/outputs.tf
+++ b/platform/terraform/outputs.tf
@@ -42,7 +42,7 @@ output "dns_name_servers"
 output "database_url"
 {
   description = "PostgreSQL connection string"
-  value       = module.cloudsql.database_url
+  value       = "postgresql://opencrane:${module.app_deploy.database_password}@${module.app_deploy.database_host}:5432/opencrane"
   sensitive   = true
 }
 

--- a/platform/tests/k3d-e2e.sh
+++ b/platform/tests/k3d-e2e.sh
@@ -162,6 +162,14 @@ kubectl create secret generic "$DB_SECRET_NAME" \
   --dry-run=client \
   -o yaml | kubectl apply -f -
 
+echo "[e2e] Bootstrapping credentials secret for Obot MCP Gateway"
+kubectl create secret generic "opencrane-obot" \
+  -n "$NAMESPACE" \
+  --from-literal=dsn="postgresql://opencrane:${DB_PASSWORD}@${DB_RELEASE_NAME}-rw.${NAMESPACE}.svc.cluster.local:5432/opencrane" \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+
+
 if [[ "$LOCAL_PROFILE" == "strict" ]]; then
   if [[ -z "$LITELLM_MASTER_KEY" ]]; then
     echo "[e2e] LOCAL_PROFILE=strict requires LITELLM_MASTER_KEY to be set and non-empty"
@@ -190,7 +198,7 @@ kubectl rollout status deployment/opencrane-operator -n "$NAMESPACE" --timeout=1
 
 # Wait for LiteLLM when cost routing is enabled by chart values.
 if kubectl get deployment/opencrane-litellm -n "$NAMESPACE" >/dev/null 2>&1; then
-  kubectl rollout status deployment/opencrane-litellm -n "$NAMESPACE" --timeout=120s
+  kubectl rollout status deployment/opencrane-litellm -n "$NAMESPACE" --timeout=240s
 fi
 
 # 7. Create a Tenant CR and let the operator reconcile child resources.

--- a/platform/tests/k3d-local.sh
+++ b/platform/tests/k3d-local.sh
@@ -188,6 +188,17 @@ if [[ "$LOCAL_PROFILE" == "strict" ]]; then
     -o yaml | kubectl apply -f -
 fi
 
+# 5b. Install cert-manager if enabled in the resolved values file to support in-cluster TLS certificate generation.
+if grep -A 5 "certManager:" "$VALUES_FILE" 2>/dev/null | grep -q "enabled: true"; then
+  echo "[local] Installing cert-manager"
+  helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
+  helm upgrade --install cert-manager jetstack/cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --set crds.enabled=true \
+    --wait
+fi
+
 # 6. Install the OpenCrane chart with local-strict overrides wired to the in-cluster database.
 echo "[local] Installing Helm release '$RELEASE_NAME'"
 helm_args=(

--- a/platform/tests/k3d-local.sh
+++ b/platform/tests/k3d-local.sh
@@ -180,6 +180,14 @@ kubectl create secret generic "$DB_SECRET_NAME" \
   --dry-run=client \
   -o yaml | kubectl apply -f -
 
+echo "[local] Bootstrapping credentials secret for Obot MCP Gateway"
+kubectl create secret generic "opencrane-obot" \
+  -n "$NAMESPACE" \
+  --from-literal=dsn="postgresql://opencrane:${DB_PASSWORD}@${DB_RELEASE_NAME}-rw.${NAMESPACE}.svc.cluster.local:5432/opencrane" \
+  --dry-run=client \
+  -o yaml | kubectl apply -f -
+
+
 if [[ "$LOCAL_PROFILE" == "strict" ]]; then
   kubectl create secret generic "$LITELLM_SECRET_NAME" \
     -n "$NAMESPACE" \


### PR DESCRIPTION
# Changes:
- The `control-plane` docker build file was missing the `@opencrane/awareness` library imports which was causing crashes. I added that. The failing GitHub build action should also be resolved by that fix.
- The local install script was missing an installation step for the `cert-manager` which is enabled. The GCP deployment script has been updated to match that too.
- The GCP deployment script was yet to be updated to match the CloudNativePG set-up for the database. The fix corrects that parity.
- The just changed `K8sApplyResource` import had not been updated to match the change within the operator files.
- The LiteLLM service was hitting permission errors during the restructuring of UI files and directories. This fix granted those permissions.
- As a Kubernetes-native platform, the Obot gateway needs to know; which namespace it is running in `OBOT_SERVER_SERVICE_NAMESPACE`, the name of its own service `OBOT_SERVER_SERVICE_NAME` the name of its own service account `OBOT_SERVER_SERVICE_ACCOUNT_NAME` and which namespace it should deploy MCP servers in (`OBOT_SERVER_MCPNAMESPACE`). This fix adds those which fixes the ContainerCrashConfig errors.

# Files Changed:
- `apps/control-plane/deploy/Dockerfile` - Control Plane build fixes for `@opencrane/awareness` package.
- `platform/tests/k3d-local.sh` - Addition of missing `cert-manager` for local install.
- `platform/tests/k3d-e2e.sh` - Addition of a secret creation step for Obot MCP Gateway.
- `platform/terraform/modules/app-deploy/main.tf` - Postgres set-up parity fix.
- `platform/terraform/modules/app-deploy/outputs.tf` - Postgres database references fix.
- `platform/terraform/outputs.tf` - Postgres database URL reference fix.
- `apps/operator/src/tenants/internal/tenant-encryption-keys.ts` - correction of `K8sApplyResource` import.
- `apps/operator/src/tenants/operator.ts` - correction of `K8sApplyResource` import.
- `platform/helm/templates/litellm-deployment.yaml` - LiteLLM non-root variant permissions.
- `platform/helm/templates/mcp-gateway-rbac.yaml` - Obot MCP permissions config.
- `platform/helm/templates/obot-mcp-gateway-deployment.yaml` - Addition of missing Obot MCP environment variables.

# Testing:
- The local cluster deployment executes cleanly