### PR TITLE
🔧 GKE-only standard cloud deploy (plain k8s) + fix GCP value-path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,9 @@ coverage/
 .idea/
 *.log
 
-# Dev
-dev/
+# Dev (root-level scratch dir only; anchored so it doesn't swallow nested dirs
+# like platform/terraform/environments/dev/)
+/dev/
 
 # Claude Code local review-gate state
 .claude/.last-review-hash

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ terraform init && terraform apply
 # 2. Install the platform
 helm install opencrane platform/helm \
   -f platform/helm/values/gcp.yaml \
-  --set tenant.storage.gcpProject=my-project \
+  --set hosting.gcp.projectId=my-project \
   --set ingress.domain=opencrane.ai \
   --set controlPlane.database.existingSecret=opencrane-cloudsql
 

--- a/platform/deploy.sh
+++ b/platform/deploy.sh
@@ -293,11 +293,16 @@ docker push "${REGISTRY_URL}/operator:${IMAGE_TAG}"
 docker push "${REGISTRY_URL}/operator:latest"
 
 # ---- Step 6: Terraform apply (full — App + DNS) ----
+#
+# enable_app_deploy=true switches on the Helm-chart install (off by default so a
+# manual `terraform apply` only ever provisions the cluster). The cluster already
+# exists from Step 4, so the kubernetes/helm providers bootstrap cleanly here.
 
 log "Step 6/7 — Deploying platform (PostgreSQL, OpenCrane, DNS)..."
 cd "$TF_DIR"
 terraform apply \
   -var-file="environments/${ENVIRONMENT}/terraform.tfvars" \
+  -var enable_app_deploy=true \
   -auto-approve
 
 # ---- Step 7: Output summary ----

--- a/platform/deploy.sh
+++ b/platform/deploy.sh
@@ -115,6 +115,19 @@ for cmd in gcloud terraform docker pnpm; do
   fi
 done
 
+# ---- GCP feature toggles (all GCP-only extras default OFF → plain-k8s on GKE) ----
+#
+# Override any of these via environment variable before running, e.g.
+#   ENABLE_CLOUD_DNS=1 ENABLE_CUSTOM_VPC=1 ./deploy.sh gcp
+ENABLE_CUSTOM_VPC="${ENABLE_CUSTOM_VPC:-0}"
+ENABLE_CLOUD_DNS="${ENABLE_CLOUD_DNS:-0}"
+ENABLE_ARTIFACT_REGISTRY="${ENABLE_ARTIFACT_REGISTRY:-0}"
+ENABLE_GCS_STORAGE="${ENABLE_GCS_STORAGE:-0}"
+# Default registry for images when Artifact Registry is disabled.
+REGISTRY_URL="${REGISTRY_URL:-ghcr.io/opencrane}"
+
+_tf_bool() { [[ "$1" == "1" ]] && echo "true" || echo "false"; }
+
 # ---- Interactive prompts ----
 
 echo ""
@@ -134,14 +147,24 @@ IMAGE_TAG="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo 'lat
 VPC_NAME="opencrane-${ENVIRONMENT}-vpc"
 CLUSTER_NAME="opencrane-${ENVIRONMENT}-cluster"
 
+# When Artifact Registry is enabled, images live in the regional AR repo.
+if [[ "$ENABLE_ARTIFACT_REGISTRY" == "1" ]]; then
+  REGISTRY_URL="${REGION}-docker.pkg.dev/${PROJECT_ID}/opencrane"
+fi
+
 echo ""
 log "Configuration:"
-echo "  Project:       $PROJECT_ID"
-echo "  Region:        $REGION"
-echo "  Domain:        $DOMAIN"
-echo "  Environment:   $ENVIRONMENT"
-echo "  GKE mode:      Autopilot (auto-managed nodes)"
-echo "  Image tag:     $IMAGE_TAG"
+echo "  Project:            $PROJECT_ID"
+echo "  Region:             $REGION"
+echo "  Domain:             $DOMAIN"
+echo "  Environment:        $ENVIRONMENT"
+echo "  GKE mode:           Autopilot (auto-managed nodes)"
+echo "  Image tag:          $IMAGE_TAG"
+echo "  Registry:           $REGISTRY_URL"
+echo "  Custom VPC/NAT:     $([[ "$ENABLE_CUSTOM_VPC" == 1 ]] && echo enabled || echo 'disabled (default VPC)')"
+echo "  Artifact Registry:  $([[ "$ENABLE_ARTIFACT_REGISTRY" == 1 ]] && echo enabled || echo 'disabled (external registry)')"
+echo "  Cloud DNS:          $([[ "$ENABLE_CLOUD_DNS" == 1 ]] && echo enabled || echo 'disabled (manual DNS)')"
+echo "  GCS tenant storage: $([[ "$ENABLE_GCS_STORAGE" == 1 ]] && echo enabled || echo 'disabled (PVC storage)')"
 echo ""
 read -rp "Proceed? [Y/n]: " CONFIRM
 CONFIRM="${CONFIRM:-Y}"
@@ -157,15 +180,16 @@ log "Step 1/7 — Configuring gcloud..."
 gcloud config set project "$PROJECT_ID"
 gcloud config set compute/region "$REGION"
 
-# Enable required APIs
+# Enable required APIs. Only the core set is needed for a plain-k8s GKE deploy;
+# Artifact Registry / Cloud DNS APIs are added only when those extras are enabled.
 APIS=(
   container.googleapis.com
   compute.googleapis.com
-  artifactregistry.googleapis.com
-  dns.googleapis.com
   iam.googleapis.com
   cloudresourcemanager.googleapis.com
 )
+[[ "$ENABLE_ARTIFACT_REGISTRY" == "1" ]] && APIS+=(artifactregistry.googleapis.com)
+[[ "$ENABLE_CLOUD_DNS" == "1" ]] && APIS+=(dns.googleapis.com)
 
 log "Enabling GCP APIs..."
 gcloud services enable "${APIS[@]}" --quiet
@@ -192,33 +216,44 @@ environment = "${ENVIRONMENT}"
 domain      = "${DOMAIN}"
 image_tag   = "${IMAGE_TAG}"
 
-# Networking
-vpc_name = "${VPC_NAME}"
-
 # GKE (Autopilot — Google manages nodes)
 cluster_name = "${CLUSTER_NAME}"
+
+# Registry for OpenCrane images (used when Artifact Registry is disabled).
+registry_url = "${REGISTRY_URL}"
+
+# GCP-only extras — all default OFF → plain-k8s on GKE.
+enable_custom_vpc        = $(_tf_bool "$ENABLE_CUSTOM_VPC")
+enable_artifact_registry = $(_tf_bool "$ENABLE_ARTIFACT_REGISTRY")
+enable_cloud_dns         = $(_tf_bool "$ENABLE_CLOUD_DNS")
+enable_gcs_storage       = $(_tf_bool "$ENABLE_GCS_STORAGE")
+vpc_name                 = "${VPC_NAME}"
 EOF
 
 log "Wrote $ENV_DIR/terraform.tfvars"
 
-# ---- Step 4: Terraform apply (infra only — networking + GKE + registry) ----
+# ---- Step 4: Terraform apply (cluster + optional infra) ----
 
-log "Step 4/7 — Provisioning cloud infrastructure (VPC, GKE, Artifact Registry)..."
+log "Step 4/7 — Provisioning the GKE cluster (and any enabled extras)..."
+TF_TARGETS=(-target=module.gke)
+[[ "$ENABLE_CUSTOM_VPC" == "1" ]] && TF_TARGETS+=(-target=module.networking)
+[[ "$ENABLE_ARTIFACT_REGISTRY" == "1" ]] && TF_TARGETS+=(-target=module.artifact_registry)
 terraform apply \
   -var-file="environments/${ENVIRONMENT}/terraform.tfvars" \
-  -target=module.networking \
-  -target=module.gke \
-  -target=module.artifact_registry \
+  "${TF_TARGETS[@]}" \
   -auto-approve
 
 # ---- Step 5: Build & push Docker images ----
 
-log "Step 5/7 — Building and pushing Docker images..."
+log "Step 5/7 — Building and pushing Docker images to ${REGISTRY_URL}..."
 
-REGISTRY_URL=$(terraform output -raw registry_url)
-
-# Authenticate Docker with Artifact Registry
-gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+# Authenticate Docker with the target registry.
+if [[ "$ENABLE_ARTIFACT_REGISTRY" == "1" ]]; then
+  gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+else
+  warn "Using external registry ${REGISTRY_URL}. Ensure 'docker login' is already done"
+  warn "(e.g. for ghcr.io: echo \$GHCR_TOKEN | docker login ghcr.io -u USER --password-stdin)."
+fi
 
 # Get GKE credentials for kubectl
 gcloud container clusters get-credentials "$CLUSTER_NAME" \
@@ -275,16 +310,25 @@ echo ""
 
 INGRESS_IP=$(terraform output -raw ingress_ip)
 CONTROL_PLANE_URL=$(terraform output -raw control_plane_url)
-DNS_NS=$(terraform output -json dns_name_servers)
 
 log "Ingress IP:           $INGRESS_IP"
 log "Control-plane URL:    $CONTROL_PLANE_URL"
 log "Registry:             $REGISTRY_URL"
 echo ""
-warn "ACTION REQUIRED — Delegate your domain's NS records:"
-echo "  Domain: $DOMAIN"
-echo "  Name servers:"
-echo "$DNS_NS" | tr -d '[]"' | tr ',' '\n' | sed 's/^ */    /'
+
+if [[ "$ENABLE_CLOUD_DNS" == "1" ]]; then
+  DNS_NS=$(terraform output -json dns_name_servers)
+  warn "ACTION REQUIRED — Delegate your domain's NS records:"
+  echo "  Domain: $DOMAIN"
+  echo "  Name servers:"
+  echo "$DNS_NS" | tr -d '[]"' | tr ',' '\n' | sed 's/^ */    /'
+else
+  warn "ACTION REQUIRED — Point DNS at the ingress IP at your DNS provider:"
+  echo "  A     ${DOMAIN}        -> ${INGRESS_IP}"
+  echo "  A     *.${DOMAIN}      -> ${INGRESS_IP}"
+  echo ""
+  echo "  (Or re-run with ENABLE_CLOUD_DNS=1 to let Terraform manage Cloud DNS.)"
+fi
 echo ""
 log "Once DNS propagates, your platform is live at: $CONTROL_PLANE_URL"
 log "Create tenants via: kubectl apply -f <tenant-cr.yaml>"

--- a/platform/deploy.sh
+++ b/platform/deploy.sh
@@ -1,340 +1,44 @@
 #!/usr/bin/env bash
 # =============================================================================
-# OpenCrane Platform — GCP Bootstrap Script
+# OpenCrane — deploy dispatcher
 #
-# Interactive script that deploys a local k3d stack or a full GCP environment.
+# Thin menu that routes to the focused deploy scripts. Pick the one that matches
+# your target and run it directly for the full set of flags:
 #
-# Usage:
-#   ./deploy.sh
-#   ./deploy.sh local
-#   ./deploy.sh gcp
+#   ./platform/vps-deploy.sh   — single machine (VM / VPS) via k3s
+#   ./platform/k8s-deploy.sh   — an existing Kubernetes cluster (any provider)
+#   ./platform/gke-deploy.sh   — provision + deploy on Google Kubernetes Engine
 #
-# Prerequisites (by mode):
-#   - local: docker, kubectl, helm, k3d
-#   - gcp: gcloud, terraform >= 1.5, docker, pnpm
+# For laptop/dev: ./platform/install.sh local  (k3d).
 # =============================================================================
-
 set -euo pipefail
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-CYAN='\033[0;36m'
-NC='\033[0m'
-
-log()   { echo -e "${GREEN}[opencrane]${NC} $1"; }
-warn()  { echo -e "${YELLOW}[opencrane]${NC} $1"; }
-err()   { echo -e "${RED}[opencrane]${NC} $1" >&2; }
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-TF_DIR="$SCRIPT_DIR/terraform"
+CYAN='\033[0;36m'; NC='\033[0m'
 
-# ---- Mode selection ----
-
-DEPLOY_MODE="${1:-}"
-
-if [[ -z "$DEPLOY_MODE" ]]; then
-  if [[ -t 0 ]]; then
-    echo ""
-    echo -e "${CYAN}╔══════════════════════════════════════════╗${NC}"
-    echo -e "${CYAN}║   OpenCrane Platform — Deploy Target     ║${NC}"
-    echo -e "${CYAN}╚══════════════════════════════════════════╝${NC}"
-    echo ""
-    echo "1) Local (k3d)"
-    echo "2) Cloud (GCP)"
-    read -rp "Choose [1/2, default 2]: " mode_choice
-    mode_choice="${mode_choice:-2}"
-    case "$mode_choice" in
-      1)
-        DEPLOY_MODE="local"
-        ;;
-      2)
-        DEPLOY_MODE="gcp"
-        ;;
-      *)
-        err "Invalid choice: $mode_choice"
-        exit 1
-        ;;
-    esac
-  else
-    # Preserve backwards compatibility for piped/non-interactive GCP runs.
-    DEPLOY_MODE="gcp"
-  fi
+target="${1:-}"
+if [[ -z "$target" ]]; then
+  echo -e "${CYAN}OpenCrane — where do you want to deploy?${NC}"
+  echo "  1) VM / VPS         (single machine, installs k3s)"
+  echo "  2) Existing cluster (helm install onto your kubectl context)"
+  echo "  3) GKE              (provision a cluster on Google Cloud)"
+  echo "  4) Local            (laptop, k3d)"
+  read -rp "Choose [1-4]: " choice
+  case "$choice" in
+    1) target="vps" ;;
+    2) target="k8s" ;;
+    3) target="gke" ;;
+    4) target="local" ;;
+    *) echo "Invalid choice"; exit 1 ;;
+  esac
+else
+  shift
 fi
 
-case "$DEPLOY_MODE" in
-  local)
-    for cmd in docker kubectl helm k3d; do
-      if ! command -v "$cmd" &>/dev/null; then
-        err "Required command not found for local mode: $cmd"
-        exit 1
-      fi
-    done
-
-    CLUSTER_NAME="opencrane-local"
-    NAMESPACE="opencrane-system"
-    KEEP_CLUSTER="1"
-    LOCAL_PROFILE="default"
-
-    read -rp "Cluster name [opencrane-local]: " CLUSTER_NAME
-    CLUSTER_NAME="${CLUSTER_NAME:-opencrane-local}"
-    read -rp "Namespace [opencrane-system]: " NAMESPACE
-    NAMESPACE="${NAMESPACE:-opencrane-system}"
-    read -rp "Local profile [default/strict, default default]: " LOCAL_PROFILE
-    LOCAL_PROFILE="${LOCAL_PROFILE:-default}"
-    read -rp "Keep cluster after install? [Y/n]: " KEEP_INPUT
-    KEEP_INPUT="${KEEP_INPUT:-Y}"
-    if [[ ! "$KEEP_INPUT" =~ ^[Yy]$ ]]; then
-      KEEP_CLUSTER="0"
-    fi
-
-    echo ""
-    log "Starting local full-stack install"
-    log "Cluster: $CLUSTER_NAME"
-    log "Namespace: $NAMESPACE"
-    log "Profile: $LOCAL_PROFILE"
-    KEEP_CLUSTER="$KEEP_CLUSTER" CLUSTER_NAME="$CLUSTER_NAME" NAMESPACE="$NAMESPACE" LOCAL_PROFILE="$LOCAL_PROFILE" "$SCRIPT_DIR/tests/k3d-local.sh"
-    exit 0
-    ;;
-  gcp|cloud)
-    ;;
-  *)
-    err "Unknown deploy mode: $DEPLOY_MODE"
-    err "Use 'local' or 'gcp'."
-    exit 1
-    ;;
+case "$target" in
+  vps)        exec "$SCRIPT_DIR/vps-deploy.sh" "$@" ;;
+  k8s)        exec "$SCRIPT_DIR/k8s-deploy.sh" "$@" ;;
+  gke|cloud)  exec "$SCRIPT_DIR/gke-deploy.sh" "$@" ;;
+  local)      exec "$SCRIPT_DIR/install.sh" local "$@" ;;
+  *)          echo "Unknown target '$target' (use: vps | k8s | gke | local)"; exit 1 ;;
 esac
-
-# ---- Pre-flight checks ----
-
-for cmd in gcloud terraform docker pnpm; do
-  if ! command -v "$cmd" &>/dev/null; then
-    err "Required command not found: $cmd"
-    exit 1
-  fi
-done
-
-# ---- GCP feature toggles (all GCP-only extras default OFF → plain-k8s on GKE) ----
-#
-# Override any of these via environment variable before running, e.g.
-#   ENABLE_CLOUD_DNS=1 ENABLE_CUSTOM_VPC=1 ./deploy.sh gcp
-ENABLE_CUSTOM_VPC="${ENABLE_CUSTOM_VPC:-0}"
-ENABLE_CLOUD_DNS="${ENABLE_CLOUD_DNS:-0}"
-ENABLE_ARTIFACT_REGISTRY="${ENABLE_ARTIFACT_REGISTRY:-0}"
-ENABLE_GCS_STORAGE="${ENABLE_GCS_STORAGE:-0}"
-# Default registry for images when Artifact Registry is disabled.
-REGISTRY_URL="${REGISTRY_URL:-ghcr.io/opencrane}"
-
-_tf_bool() { [[ "$1" == "1" ]] && echo "true" || echo "false"; }
-
-# ---- Interactive prompts ----
-
-echo ""
-echo -e "${CYAN}╔══════════════════════════════════════════╗${NC}"
-echo -e "${CYAN}║     OpenCrane Platform — GCP Deploy      ║${NC}"
-echo -e "${CYAN}╚══════════════════════════════════════════╝${NC}"
-echo ""
-
-read -rp "GCP Project ID: " PROJECT_ID
-read -rp "GCP Region [europe-west1]: " REGION
-REGION="${REGION:-europe-west1}"
-read -rp "Base domain (e.g. opencrane.example.com): " DOMAIN
-read -rp "Environment [dev]: " ENVIRONMENT
-ENVIRONMENT="${ENVIRONMENT:-dev}"
-
-IMAGE_TAG="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo 'latest')"
-VPC_NAME="opencrane-${ENVIRONMENT}-vpc"
-CLUSTER_NAME="opencrane-${ENVIRONMENT}-cluster"
-
-# When Artifact Registry is enabled, images live in the regional AR repo.
-if [[ "$ENABLE_ARTIFACT_REGISTRY" == "1" ]]; then
-  REGISTRY_URL="${REGION}-docker.pkg.dev/${PROJECT_ID}/opencrane"
-fi
-
-echo ""
-log "Configuration:"
-echo "  Project:            $PROJECT_ID"
-echo "  Region:             $REGION"
-echo "  Domain:             $DOMAIN"
-echo "  Environment:        $ENVIRONMENT"
-echo "  GKE mode:           Autopilot (auto-managed nodes)"
-echo "  Image tag:          $IMAGE_TAG"
-echo "  Registry:           $REGISTRY_URL"
-echo "  Custom VPC/NAT:     $([[ "$ENABLE_CUSTOM_VPC" == 1 ]] && echo enabled || echo 'disabled (default VPC)')"
-echo "  Artifact Registry:  $([[ "$ENABLE_ARTIFACT_REGISTRY" == 1 ]] && echo enabled || echo 'disabled (external registry)')"
-echo "  Cloud DNS:          $([[ "$ENABLE_CLOUD_DNS" == 1 ]] && echo enabled || echo 'disabled (manual DNS)')"
-echo "  GCS tenant storage: $([[ "$ENABLE_GCS_STORAGE" == 1 ]] && echo enabled || echo 'disabled (PVC storage)')"
-echo ""
-read -rp "Proceed? [Y/n]: " CONFIRM
-CONFIRM="${CONFIRM:-Y}"
-if [[ ! "$CONFIRM" =~ ^[Yy]$ ]]; then
-  echo "Aborted."
-  exit 0
-fi
-
-# ---- Step 1: Configure gcloud ----
-
-log "Step 1/7 — Configuring gcloud..."
-
-gcloud config set project "$PROJECT_ID"
-gcloud config set compute/region "$REGION"
-
-# Enable required APIs. Only the core set is needed for a plain-k8s GKE deploy;
-# Artifact Registry / Cloud DNS APIs are added only when those extras are enabled.
-APIS=(
-  container.googleapis.com
-  compute.googleapis.com
-  iam.googleapis.com
-  cloudresourcemanager.googleapis.com
-)
-[[ "$ENABLE_ARTIFACT_REGISTRY" == "1" ]] && APIS+=(artifactregistry.googleapis.com)
-[[ "$ENABLE_CLOUD_DNS" == "1" ]] && APIS+=(dns.googleapis.com)
-
-log "Enabling GCP APIs..."
-gcloud services enable "${APIS[@]}" --quiet
-
-# ---- Step 2: Terraform init ----
-
-log "Step 2/7 — Initialising Terraform..."
-cd "$TF_DIR"
-terraform init -upgrade
-
-# ---- Step 3: Write tfvars ----
-
-log "Step 3/7 — Writing terraform.tfvars..."
-
-ENV_DIR="$TF_DIR/environments/${ENVIRONMENT}"
-mkdir -p "$ENV_DIR"
-
-cat > "$ENV_DIR/terraform.tfvars" <<EOF
-# Auto-generated by deploy.sh on $(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-project_id  = "${PROJECT_ID}"
-region      = "${REGION}"
-environment = "${ENVIRONMENT}"
-domain      = "${DOMAIN}"
-image_tag   = "${IMAGE_TAG}"
-
-# GKE (Autopilot — Google manages nodes)
-cluster_name = "${CLUSTER_NAME}"
-
-# Registry for OpenCrane images (used when Artifact Registry is disabled).
-registry_url = "${REGISTRY_URL}"
-
-# GCP-only extras — all default OFF → plain-k8s on GKE.
-enable_custom_vpc        = $(_tf_bool "$ENABLE_CUSTOM_VPC")
-enable_artifact_registry = $(_tf_bool "$ENABLE_ARTIFACT_REGISTRY")
-enable_cloud_dns         = $(_tf_bool "$ENABLE_CLOUD_DNS")
-enable_gcs_storage       = $(_tf_bool "$ENABLE_GCS_STORAGE")
-vpc_name                 = "${VPC_NAME}"
-EOF
-
-log "Wrote $ENV_DIR/terraform.tfvars"
-
-# ---- Step 4: Terraform apply (cluster + optional infra) ----
-
-log "Step 4/7 — Provisioning the GKE cluster (and any enabled extras)..."
-TF_TARGETS=(-target=module.gke)
-[[ "$ENABLE_CUSTOM_VPC" == "1" ]] && TF_TARGETS+=(-target=module.networking)
-[[ "$ENABLE_ARTIFACT_REGISTRY" == "1" ]] && TF_TARGETS+=(-target=module.artifact_registry)
-terraform apply \
-  -var-file="environments/${ENVIRONMENT}/terraform.tfvars" \
-  "${TF_TARGETS[@]}" \
-  -auto-approve
-
-# ---- Step 5: Build & push Docker images ----
-
-log "Step 5/7 — Building and pushing Docker images to ${REGISTRY_URL}..."
-
-# Authenticate Docker with the target registry.
-if [[ "$ENABLE_ARTIFACT_REGISTRY" == "1" ]]; then
-  gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
-else
-  warn "Using external registry ${REGISTRY_URL}. Ensure 'docker login' is already done"
-  warn "(e.g. for ghcr.io: echo \$GHCR_TOKEN | docker login ghcr.io -u USER --password-stdin)."
-fi
-
-# Get GKE credentials for kubectl
-gcloud container clusters get-credentials "$CLUSTER_NAME" \
-  --region "$REGION" \
-  --project "$PROJECT_ID"
-
-cd "$REPO_ROOT"
-
-# Generate Prisma migration files before building images
-log "Generating Prisma migration..."
-cd apps/control-plane
-pnpm install --frozen-lockfile 2>/dev/null || pnpm install
-npx prisma generate
-npx prisma migrate dev --name init --create-only 2>/dev/null || true
-cd "$REPO_ROOT"
-
-# Build control-plane (includes UI)
-log "Building control-plane image..."
-docker build \
-  -f apps/control-plane/deploy/Dockerfile \
-  -t "${REGISTRY_URL}/control-plane:${IMAGE_TAG}" \
-  -t "${REGISTRY_URL}/control-plane:latest" \
-  .
-
-docker push "${REGISTRY_URL}/control-plane:${IMAGE_TAG}"
-docker push "${REGISTRY_URL}/control-plane:latest"
-
-# Build operator
-log "Building operator image..."
-docker build \
-  -f apps/operator/deploy/Dockerfile \
-  -t "${REGISTRY_URL}/operator:${IMAGE_TAG}" \
-  -t "${REGISTRY_URL}/operator:latest" \
-  .
-
-docker push "${REGISTRY_URL}/operator:${IMAGE_TAG}"
-docker push "${REGISTRY_URL}/operator:latest"
-
-# ---- Step 6: Terraform apply (full — App + DNS) ----
-#
-# enable_app_deploy=true switches on the Helm-chart install (off by default so a
-# manual `terraform apply` only ever provisions the cluster). The cluster already
-# exists from Step 4, so the kubernetes/helm providers bootstrap cleanly here.
-
-log "Step 6/7 — Deploying platform (PostgreSQL, OpenCrane, DNS)..."
-cd "$TF_DIR"
-terraform apply \
-  -var-file="environments/${ENVIRONMENT}/terraform.tfvars" \
-  -var enable_app_deploy=true \
-  -auto-approve
-
-# ---- Step 7: Output summary ----
-
-echo ""
-echo -e "${CYAN}╔══════════════════════════════════════════════════════╗${NC}"
-echo -e "${CYAN}║             OpenCrane Platform — Deployed!           ║${NC}"
-echo -e "${CYAN}╚══════════════════════════════════════════════════════╝${NC}"
-echo ""
-
-INGRESS_IP=$(terraform output -raw ingress_ip)
-CONTROL_PLANE_URL=$(terraform output -raw control_plane_url)
-
-log "Ingress IP:           $INGRESS_IP"
-log "Control-plane URL:    $CONTROL_PLANE_URL"
-log "Registry:             $REGISTRY_URL"
-echo ""
-
-if [[ "$ENABLE_CLOUD_DNS" == "1" ]]; then
-  DNS_NS=$(terraform output -json dns_name_servers)
-  warn "ACTION REQUIRED — Delegate your domain's NS records:"
-  echo "  Domain: $DOMAIN"
-  echo "  Name servers:"
-  echo "$DNS_NS" | tr -d '[]"' | tr ',' '\n' | sed 's/^ */    /'
-else
-  warn "ACTION REQUIRED — Point DNS at the ingress IP at your DNS provider:"
-  echo "  A     ${DOMAIN}        -> ${INGRESS_IP}"
-  echo "  A     *.${DOMAIN}      -> ${INGRESS_IP}"
-  echo ""
-  echo "  (Or re-run with ENABLE_CLOUD_DNS=1 to let Terraform manage Cloud DNS.)"
-fi
-echo ""
-log "Once DNS propagates, your platform is live at: $CONTROL_PLANE_URL"
-log "Create tenants via: kubectl apply -f <tenant-cr.yaml>"
-echo ""

--- a/platform/gke-deploy.sh
+++ b/platform/gke-deploy.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# =============================================================================
+# OpenCrane — Google Kubernetes Engine (GKE) deploy
+#
+# Provisions a standard GKE cluster with Terraform (cluster only — on the project
+# default VPC, no GCP-specific extras), then installs OpenCrane onto it with the
+# published images. GKE is treated as plain Kubernetes; GCP-native extras (GCS
+# storage, Cloud DNS, Artifact Registry, custom VPC) stay opt-in in Terraform.
+#
+# Usage:
+#   ./platform/gke-deploy.sh --project-id ID [--region R] [--cluster NAME]
+#                            [--domain D] [--yes]
+#
+# Prereqs: gcloud, terraform, kubectl, helm.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TF_DIR="$SCRIPT_DIR/terraform"
+
+PROJECT_ID=""
+REGION="europe-west1"
+CLUSTER="opencrane-cluster"
+DOMAIN=""
+ASSUME_YES=0
+
+log()  { echo -e "\033[0;32m[gke-deploy]\033[0m $1"; }
+warn() { echo -e "\033[1;33m[gke-deploy]\033[0m $1"; }
+err()  { echo -e "\033[0;31m[gke-deploy]\033[0m $1" >&2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project-id) PROJECT_ID="$2"; shift 2 ;;
+    --region)     REGION="$2"; shift 2 ;;
+    --cluster)    CLUSTER="$2"; shift 2 ;;
+    --domain)     DOMAIN="$2"; shift 2 ;;
+    --yes)        ASSUME_YES=1; shift ;;
+    -h|--help)    grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)            err "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+for c in gcloud terraform kubectl helm; do command -v "$c" >/dev/null 2>&1 || { err "Missing required command: $c"; exit 1; }; done
+if [[ -z "$PROJECT_ID" && -t 0 ]]; then read -rp "GCP Project ID: " PROJECT_ID; fi
+[[ -n "$PROJECT_ID" ]] || { err "--project-id is required (flag or interactive prompt)."; exit 1; }
+
+log "Project: $PROJECT_ID   Region: $REGION   Cluster: $CLUSTER"
+if [[ "$ASSUME_YES" != "1" ]]; then
+  read -rp "Provision this GKE cluster and install OpenCrane? [Y/n]: " c; [[ "${c:-Y}" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+fi
+
+# 1. Enable the only APIs a plain cluster needs.
+log "Enabling GCP APIs (container, compute)…"
+gcloud services enable container.googleapis.com compute.googleapis.com --project "$PROJECT_ID" --quiet
+
+# 2. Terraform: create the cluster ONLY (default flow — no provider bootstrap problem).
+log "Provisioning the GKE cluster with Terraform…"
+terraform -chdir="$TF_DIR" init -upgrade -input=false
+terraform -chdir="$TF_DIR" apply -input=false -auto-approve \
+  -var "project_id=$PROJECT_ID" -var "region=$REGION" -var "cluster_name=$CLUSTER"
+
+# 3. Point kubectl at the new cluster.
+log "Fetching cluster credentials…"
+gcloud container clusters get-credentials "$CLUSTER" --region "$REGION" --project "$PROJECT_ID"
+
+# 4. Install OpenCrane (published images, GKE default StorageClass).
+log "Installing OpenCrane…"
+"$SCRIPT_DIR/k8s-deploy.sh" ${DOMAIN:+--domain "$DOMAIN"}
+
+# 5. Next steps.
+warn "GKE has no ingress controller by default — install one (e.g. ingress-nginx) if you haven't,"
+warn "then point your domain at its external IP:  kubectl get ingress -A"
+log "Done."

--- a/platform/helm/templates/external-secrets-store.yaml
+++ b/platform/helm/templates/external-secrets-store.yaml
@@ -16,7 +16,11 @@ the install binds to an externally-managed ClusterSecretStore
 {{- if and .Values.externalSecrets.enabled (ne (include "opencrane.externalSecretsShared" .) "true") }}
 {{- if eq .Values.externalSecrets.provider "gcp-secret-manager" }}
 {{- $namespaced := eq (include "opencrane.namespacedSecretStore" .) "true" }}
-{{- $projectID := required "tenant.storage.gcpProject is required for gcp-secret-manager" .Values.tenant.storage.gcpProject }}
+{{- $projectID := required "hosting.gcp.projectId is required for gcp-secret-manager" .Values.hosting.gcp.projectId }}
+{{- /* GKE cluster location (region or zone) for the Workload Identity binding.
+       Optional: when empty, external-secrets falls back to GKE metadata-server
+       discovery, which works for in-cluster Workload Identity. */ -}}
+{{- $clusterLocation := .Values.hosting.gcp.clusterLocation | default "" }}
 {{- $saName := printf "%s-external-secrets" (include "opencrane.fullname" .) }}
 {{- if not $namespaced }}
 apiVersion: external-secrets.io/v1beta1
@@ -31,7 +35,7 @@ spec:
       projectID: {{ $projectID }}
       auth:
         workloadIdentity:
-          clusterLocation: {{ .Values.tenant.storage.gcpProject }}
+          clusterLocation: {{ $clusterLocation | quote }}
           clusterName: ""
           serviceAccountRef:
             name: {{ $saName }}
@@ -53,7 +57,7 @@ spec:
       projectID: {{ $projectID }}
       auth:
         workloadIdentity:
-          clusterLocation: {{ $.Values.tenant.storage.gcpProject }}
+          clusterLocation: {{ $clusterLocation | quote }}
           clusterName: ""
           serviceAccountRef:
             # A namespaced SecretStore can only reference a SA in its own namespace.

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -223,6 +223,10 @@ hosting:
     bucketPrefix: ""
     # -- CSI driver for GCS Fuse mounts; defaults to the standard GKE driver.
     csiDriver: gcsfuse.csi.storage.gke.io
+    # -- GKE cluster location (region or zone) for the External Secrets Workload
+    #    Identity binding. Optional: when empty, external-secrets discovers it from
+    #    the GKE metadata server. Only consumed when externalSecrets is enabled.
+    clusterLocation: ""
 
 # -- Ingress settings
 ingress:

--- a/platform/helm/values/gcp-extras.yaml
+++ b/platform/helm/values/gcp-extras.yaml
@@ -1,0 +1,45 @@
+# GCP-native EXTRAS overlay (OPT-IN) for OpenCrane on GKE.
+#
+# Layer this ON TOP of values/gcp.yaml to enable GCP-specific features that go
+# beyond a plain-Kubernetes deploy. None of these are required for a working
+# GKE install — the baseline in values/gcp.yaml runs as standard k8s.
+#
+# Usage:
+#   helm install opencrane platform/helm \
+#     -f platform/helm/values/gcp.yaml \
+#     -f platform/helm/values/gcp-extras.yaml \
+#     --set hosting.gcp.projectId=YOUR_PROJECT_ID
+#
+# This overlay enables:
+#   - GCS-backed tenant storage (GCS Fuse CSI + Workload Identity)
+#   - GCE ingress (Google Cloud Load Balancer) instead of the default ingress
+#   - External Secrets backed by GCP Secret Manager
+#   - Cloud Logging / Error Reporting integration
+
+# GCS-backed tenant storage via Workload Identity + GCS Fuse CSI driver.
+hosting:
+  provider: gcp
+  gcp:
+    # projectId MUST be supplied (e.g. --set hosting.gcp.projectId=...).
+    projectId: "replace-with-gcp-project-id"
+    bucketPrefix: opencrane
+    csiDriver: gcsfuse.csi.storage.gke.io
+    # Optional GKE cluster location for the External Secrets Workload Identity
+    # binding. Leave empty to let external-secrets discover it from the metadata
+    # server (region or zone, e.g. "europe-west1").
+    clusterLocation: ""
+
+# Google Cloud Load Balancer ingress.
+ingress:
+  className: gce
+
+# External Secrets Operator backed by GCP Secret Manager. Requires the
+# External Secrets Operator CRDs installed in-cluster.
+externalSecrets:
+  enabled: true
+  provider: gcp-secret-manager
+
+# Cloud-native observability (GKE auto-ingests structured logs).
+observability:
+  cloudLogging: true
+  cloudErrorReporting: true

--- a/platform/helm/values/gcp.yaml
+++ b/platform/helm/values/gcp.yaml
@@ -1,20 +1,26 @@
-# GCP-specific value overrides for OpenCrane on GKE.
+# GCP / GKE values for OpenCrane — PLAIN-KUBERNETES baseline.
+#
 # Usage: helm install opencrane platform/helm -f platform/helm/values/gcp.yaml
 #
-# Set GCP_PROJECT_ID, GCP_BUCKET_PREFIX per environment.
+# This file deliberately keeps a GKE deploy identical to a plain Kubernetes
+# cluster: standard PVC storage (GKE default StorageClass), in-cluster
+# PostgreSQL, k8s Secrets, and standard ingress. NONE of the GCP-only features
+# (GCS-backed tenant storage, Workload Identity, External Secrets / Secret
+# Manager, Cloud DNS) are enabled here.
+#
+# To opt in to the GCP-native extras, layer the optional overlay ON TOP:
+#   helm install opencrane platform/helm \
+#     -f platform/helm/values/gcp.yaml \
+#     -f platform/helm/values/gcp-extras.yaml \
+#     --set hosting.gcp.projectId=YOUR_PROJECT_ID
 
 global:
   environment: prod
 
+# Hosting stays on-prem semantics by default: tenant storage uses standard PVCs,
+# no GCS/Workload-Identity coupling. The gcp-extras overlay flips this to `gcp`.
 hosting:
-  provider: gcp
-  gcp:
-    projectId: "replace-with-gcp-project-id"
-    bucketPrefix: opencrane
-    csiDriver: gcsfuse.csi.storage.gke.io
-
-ingress:
-  className: gce
+  provider: onprem
 
 controlPlane:
   database:
@@ -28,11 +34,3 @@ litellm:
   generateMasterKey: false
   existingDatabaseSecret: opencrane-db
   databaseSecretKey: DATABASE_URL
-
-externalSecrets:
-  enabled: true
-  provider: gcp-secret-manager
-
-observability:
-  cloudLogging: true
-  cloudErrorReporting: true

--- a/platform/install.sh
+++ b/platform/install.sh
@@ -21,7 +21,7 @@ Examples:
 Notes:
   - local mode uses k3d + Helm full-stack install and keeps cluster by default.
   - local profiles: `default` (fast dev) and `strict` (prod-like validation + explicit LiteLLM secret flow).
-  - gcp mode delegates to ./platform/deploy.sh (interactive unless --yes with all required flags).
+  - gcp mode delegates to ./platform/gke-deploy.sh (interactive unless --yes with --project-id).
 EOF
 }
 
@@ -197,29 +197,24 @@ function _run_gcp()
     esac
   done
 
-  # Default to interactive deploy script if required values are not provided.
-  if [[ -z "$project_id" || -z "$domain" ]]; then
-    echo "[install] Running interactive GCP deploy..."
-    "$ROOT_DIR/platform/deploy.sh"
+  # Interactive GKE deploy when no project is given (gke-deploy.sh prompts).
+  if [[ -z "$project_id" ]]; then
+    echo "[install] Running interactive GKE deploy..."
+    "$ROOT_DIR/platform/gke-deploy.sh" ${domain:+--domain "$domain"}
     return
   fi
 
   region="${region:-europe-west1}"
-  environment="${environment:-dev}"
 
   if [[ "$auto_yes" != "1" ]]; then
     echo "[install] Missing --yes for non-interactive run."
-    echo "[install] Re-run with --yes or use interactive mode (omit --project-id/--domain)."
+    echo "[install] Re-run with --yes, or omit --project-id for interactive mode."
     exit 1
   fi
 
-  _require_cmd gcloud
-  _require_cmd terraform
-  _require_cmd docker
-  _require_cmd pnpm
-
-  echo "[install] Running non-interactive GCP deploy..."
-  printf "%s\n%s\n%s\n%s\nY\n" "$project_id" "$region" "$domain" "$environment" | "$ROOT_DIR/platform/deploy.sh"
+  echo "[install] Running non-interactive GKE deploy..."
+  "$ROOT_DIR/platform/gke-deploy.sh" \
+    --project-id "$project_id" --region "$region" ${domain:+--domain "$domain"} --yes
 }
 
 if [[ $# -lt 1 ]]; then

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# =============================================================================
+# OpenCrane — install onto ANY Kubernetes cluster
+#
+# Installs OpenCrane onto the cluster your current kubectl context points at:
+# CloudNativePG (in-cluster PostgreSQL) → secrets → the OpenCrane Helm chart →
+# DB migrations. Uses the published ghcr.io/opencrane images and the cluster's
+# default StorageClass — pure, provider-agnostic Kubernetes.
+#
+# This is the shared core. vps-deploy.sh and gke-deploy.sh provision a cluster
+# and then call this script.
+#
+# Usage:
+#   ./platform/k8s-deploy.sh [--domain DOMAIN] [--namespace NS] [--release NAME]
+#                            [--image-tag TAG] [--storage-class SC]
+#                            [--values FILE] [--set k=v ...]
+#
+# Prereqs: kubectl (pointed at the target cluster) and helm.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$SCRIPT_DIR/helm"
+
+NAMESPACE="opencrane-system"
+RELEASE="opencrane"
+IMAGE_TAG="latest"
+DOMAIN=""
+STORAGE_CLASS=""        # empty → cluster default StorageClass
+VALUES_FILE=""
+EXTRA_SET=()
+
+DB_CLUSTER="opencrane-db"
+DB_SECRET="opencrane-db"
+DB_USER="opencrane"
+DB_NAME="opencrane"
+TIMEOUT="${TIMEOUT_SECONDS:-300}"
+
+log()  { echo -e "\033[0;32m[k8s-deploy]\033[0m $1"; }
+warn() { echo -e "\033[1;33m[k8s-deploy]\033[0m $1"; }
+err()  { echo -e "\033[0;31m[k8s-deploy]\033[0m $1" >&2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --domain)        DOMAIN="$2"; shift 2 ;;
+    --namespace)     NAMESPACE="$2"; shift 2 ;;
+    --release)       RELEASE="$2"; shift 2 ;;
+    --image-tag)     IMAGE_TAG="$2"; shift 2 ;;
+    --storage-class) STORAGE_CLASS="$2"; shift 2 ;;
+    --values)        VALUES_FILE="$2"; shift 2 ;;
+    --set)           EXTRA_SET+=(--set "$2"); shift 2 ;;
+    -h|--help)       grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)               err "Unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+for c in kubectl helm; do command -v "$c" >/dev/null 2>&1 || { err "Missing required command: $c"; exit 1; }; done
+kubectl cluster-info >/dev/null 2>&1 || { err "kubectl can't reach a cluster. Point your context at the target cluster first."; exit 1; }
+
+_gen_secret() { openssl rand -hex 16 2>/dev/null || head -c 24 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 32; }
+DB_PASSWORD="${DB_PASSWORD:-$(_gen_secret)}"
+LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-$(_gen_secret)}"
+
+log "Target cluster: $(kubectl config current-context)"
+log "Namespace: $NAMESPACE   Release: $RELEASE   Image tag: $IMAGE_TAG"
+
+# 1. In-cluster PostgreSQL via the CloudNativePG operator.
+log "Installing CloudNativePG operator…"
+helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update >/dev/null
+helm upgrade --install cnpg cnpg/cloudnative-pg \
+  --namespace "$NAMESPACE" --create-namespace --wait \
+  --set-string monitoring.podMonitor.enabled=false
+
+log "Creating database credentials…"
+kubectl create secret generic "${DB_CLUSTER}-creds" -n "$NAMESPACE" \
+  --from-literal=username="$DB_USER" --from-literal=password="$DB_PASSWORD" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+log "Provisioning the PostgreSQL cluster…"
+kubectl apply -f - <<EOF
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: ${DB_CLUSTER}
+  namespace: ${NAMESPACE}
+spec:
+  instances: 1
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  storage:
+    size: 10Gi$( [[ -n "$STORAGE_CLASS" ]] && printf '\n    storageClass: %s' "$STORAGE_CLASS" )
+  bootstrap:
+    initdb:
+      database: ${DB_NAME}
+      secret:
+        name: ${DB_CLUSTER}-creds
+EOF
+
+log "Waiting for the database to become ready…"
+kubectl wait --for=condition=Ready "cluster/${DB_CLUSTER}" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+
+# 2. Connection + LiteLLM secrets the chart expects.
+DB_URL="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_CLUSTER}-rw.${NAMESPACE}.svc.cluster.local:5432/${DB_NAME}"
+for name in "$DB_SECRET" opencrane-obot; do
+  key=DATABASE_URL; [[ "$name" == "opencrane-obot" ]] && key=dsn
+  kubectl create secret generic "$name" -n "$NAMESPACE" \
+    --from-literal="$key=$DB_URL" --dry-run=client -o yaml | kubectl apply -f -
+done
+kubectl create secret generic opencrane-litellm -n "$NAMESPACE" \
+  --from-literal=LITELLM_MASTER_KEY="$LITELLM_MASTER_KEY" --dry-run=client -o yaml | kubectl apply -f -
+
+# 3. The OpenCrane chart.
+log "Installing the OpenCrane Helm release '$RELEASE'…"
+helm_args=(upgrade --install "$RELEASE" "$CHART_DIR" --namespace "$NAMESPACE" --create-namespace
+  --set "controlPlane.database.existingSecret=$DB_SECRET"
+  --set "litellm.existingDatabaseSecret=$DB_SECRET"
+  --set "litellm.existingSecret=opencrane-litellm")
+[[ -n "$IMAGE_TAG" ]] && helm_args+=(--set "controlPlane.image.tag=$IMAGE_TAG" --set "operator.image.tag=$IMAGE_TAG" --set "tenant.image.tag=$IMAGE_TAG")
+[[ -n "$DOMAIN" ]]    && helm_args+=(--set "ingress.domain=$DOMAIN")
+[[ -n "$VALUES_FILE" ]] && helm_args+=(--values "$VALUES_FILE")
+helm_args+=("${EXTRA_SET[@]}")
+helm "${helm_args[@]}"
+
+# 4. Database schema migration.
+log "Running database migrations…"
+kubectl apply -f - <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: opencrane-db-migrate
+  namespace: ${NAMESPACE}
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: migrate
+          image: ghcr.io/opencrane/control-plane:${IMAGE_TAG}
+          command: ["npx", "prisma@6", "migrate", "deploy"]
+          workingDir: /app/apps/control-plane
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef: { name: ${DB_SECRET}, key: DATABASE_URL }
+EOF
+kubectl wait --for=condition=complete "job/opencrane-db-migrate" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+
+# 5. Wait for the core workloads.
+kubectl rollout status "deployment/${RELEASE}-operator" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+kubectl rollout status "deployment/${RELEASE}-control-plane" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+
+log "Done. OpenCrane is installed in namespace '$NAMESPACE'."
+[[ -n "$DOMAIN" ]] && log "Point your DNS at the ingress, then visit https://admin.${DOMAIN}"
+log "Ingress: kubectl get ingress -n $NAMESPACE"

--- a/platform/terraform/environments/dev/terraform.tfvars
+++ b/platform/terraform/environments/dev/terraform.tfvars
@@ -1,22 +1,10 @@
 # -----------------------------------------------------------------------------
-# Dev environment values
-# (auto-overwritten by deploy.sh — edit there or here before manual apply)
+# Dev environment values. The only required value is project_id — everything else
+# has a sensible default (see ../../variables.tf). deploy.sh overwrites this file;
+# for a manual apply, copy terraform.tfvars.example and set your project.
 # -----------------------------------------------------------------------------
 
-project_id  = "opencrane-dev"
-region      = "europe-west1"
-environment = "dev"
-domain      = "opencrane.example.com"
-image_tag   = "latest"
+project_id = "opencrane-dev"
+region     = "europe-west1"
 
-# Networking
-vpc_name = "opencrane-dev-vpc"
-
-# GKE
 cluster_name = "opencrane-dev-cluster"
-
-# Cloud SQL
-db_instance_name     = "opencrane-dev-db"
-db_name              = "opencrane"
-db_tier              = "db-f1-micro"
-db_high_availability = false

--- a/platform/terraform/environments/dev/terraform.tfvars.example
+++ b/platform/terraform/environments/dev/terraform.tfvars.example
@@ -1,0 +1,27 @@
+# -----------------------------------------------------------------------------
+# Copy this file and set your project — that's the only required value:
+#
+#   cp terraform.tfvars.example terraform.tfvars
+#   terraform -chdir=../.. init
+#   terraform -chdir=../.. apply -var-file=environments/dev/terraform.tfvars
+#
+# A bare apply provisions a GKE cluster on the project's default VPC. Install
+# OpenCrane the standard way afterwards:
+#
+#   eval "$(terraform -chdir=../.. output -raw kubeconfig_command)"
+#   helm install opencrane ../../helm --set ingress.domain=YOUR_DOMAIN
+# -----------------------------------------------------------------------------
+
+project_id = "your-gcp-project-id"
+
+# --- Optional (defaults shown) -----------------------------------------------
+# region       = "europe-west1"
+# cluster_name = "opencrane-cluster"
+# domain       = ""                 # e.g. "opencrane.example.com"
+
+# --- Opt-in cloud extras (all default false → plain Kubernetes when off) ------
+# enable_app_deploy        = false  # also install the Helm chart via Terraform
+# enable_custom_vpc        = false  # dedicated VPC + Cloud NAT (else default VPC)
+# enable_artifact_registry = false  # GCP Artifact Registry (else ghcr.io images)
+# enable_cloud_dns         = false  # managed Cloud DNS records (needs app deploy)
+# enable_gcs_storage       = false  # GCS tenant storage + Workload Identity

--- a/platform/terraform/main.tf
+++ b/platform/terraform/main.tf
@@ -1,8 +1,10 @@
 # -----------------------------------------------------------------------------
 # OpenCrane GCP Infrastructure
 #
-# Provisions networking, GKE, Artifact Registry, in-cluster PostgreSQL,
-# the OpenCrane platform, and Cloud DNS for wildcard routing.
+# DEFAULT FLOW (plain-k8s on GKE): ensure a GKE cluster on the project's default
+# VPC, deploy in-cluster PostgreSQL + the OpenCrane Helm chart, and print the
+# ingress IP for manual DNS. Custom VPC/NAT, Artifact Registry, Cloud DNS, and
+# GCS-backed tenant storage are all OPT-IN (see variables.tf).
 #
 # Usage:
 #   cd platform/terraform
@@ -12,11 +14,15 @@
 
 data "google_client_config" "default" {}
 
-# ---- Phase 1: Networking ----
+# ---- Phase 1: Networking (OPT-IN) ----
+#
+# When enable_custom_vpc=false (default) GKE runs on the project default VPC and
+# no networking resources are created.
 
 module "networking"
 {
   source = "./modules/networking"
+  count  = var.enable_custom_vpc ? 1 : 0
 
   project_id = var.project_id
   region     = var.region
@@ -32,8 +38,13 @@ module "gke"
   project_id   = var.project_id
   region       = var.region
   cluster_name = var.cluster_name
-  vpc_id       = module.networking.vpc_id
-  subnet_id    = module.networking.subnet_id
+
+  # Empty strings → the GKE module falls back to the project default VPC.
+  vpc_id    = var.enable_custom_vpc ? module.networking[0].vpc_id : ""
+  subnet_id = var.enable_custom_vpc ? module.networking[0].subnet_id : ""
+
+  # Private nodes + Cloud NAT only make sense with a custom VPC.
+  enable_private_nodes = var.enable_custom_vpc
 
   depends_on = [module.networking]
 }
@@ -56,15 +67,24 @@ provider "helm"
   }
 }
 
-# ---- Phase 3: Artifact Registry ----
+# ---- Phase 3: Artifact Registry (OPT-IN) ----
+#
+# Default flow pushes images to an external registry (e.g. ghcr.io). Enable to
+# provision a GCP Artifact Registry instead.
 
 module "artifact_registry"
 {
   source = "./modules/artifact-registry"
+  count  = var.enable_artifact_registry ? 1 : 0
 
   project_id    = var.project_id
   region        = var.region
   repository_id = "opencrane"
+}
+
+locals
+{
+  registry_url = var.enable_artifact_registry ? module.artifact_registry[0].repository_url : var.registry_url
 }
 
 # ---- Phase 4: Application (PostgreSQL + OpenCrane + DB migration) ----
@@ -73,20 +93,25 @@ module "app_deploy"
 {
   source = "./modules/app-deploy"
 
-  project_id   = var.project_id
-  registry_url = module.artifact_registry.repository_url
-  image_tag    = var.image_tag
-  domain       = var.domain
-  namespace    = "opencrane"
+  project_id         = var.project_id
+  registry_url       = local.registry_url
+  image_tag          = var.image_tag
+  domain             = var.domain
+  namespace          = "opencrane"
+  enable_gcs_storage = var.enable_gcs_storage
 
   depends_on = [module.gke]
 }
 
-# ---- Phase 6: Cloud DNS (wildcard → ingress IP) ----
+# ---- Phase 5: Cloud DNS (OPT-IN: wildcard → ingress IP) ----
+#
+# Default flow prints the ingress IP and you point DNS at it manually. Enable to
+# have Terraform manage a Cloud DNS zone + records.
 
 module "dns"
 {
   source = "./modules/dns"
+  count  = var.enable_cloud_dns ? 1 : 0
 
   project_id = var.project_id
   domain     = var.domain

--- a/platform/terraform/main.tf
+++ b/platform/terraform/main.tf
@@ -1,15 +1,19 @@
 # -----------------------------------------------------------------------------
 # OpenCrane GCP Infrastructure
 #
-# DEFAULT FLOW (plain-k8s on GKE): ensure a GKE cluster on the project's default
-# VPC, deploy in-cluster PostgreSQL + the OpenCrane Helm chart, and print the
-# ingress IP for manual DNS. Custom VPC/NAT, Artifact Registry, Cloud DNS, and
-# GCS-backed tenant storage are all OPT-IN (see variables.tf).
+# DEFAULT FLOW (plain-k8s on GKE): a single `terraform apply` provisions just a
+# GKE cluster on the project's default VPC — nothing else required. You then
+# install OpenCrane the standard way: `helm install opencrane platform/helm`.
+# Custom VPC/NAT, Artifact Registry, Cloud DNS, GCS-backed storage, and even
+# installing the Helm chart via Terraform (enable_app_deploy) are all OPT-IN
+# (see variables.tf).
 #
-# Usage:
+# Easiest start — only the project id is required:
 #   cd platform/terraform
 #   terraform init
-#   terraform apply -var-file=environments/dev/terraform.tfvars
+#   terraform apply -var project_id=YOUR_GCP_PROJECT
+#   eval "$(terraform output -raw kubeconfig_command)"
+#   helm install opencrane ../helm --set ingress.domain=YOUR_DOMAIN
 # -----------------------------------------------------------------------------
 
 data "google_client_config" "default" {}
@@ -87,11 +91,17 @@ locals
   registry_url = var.enable_artifact_registry ? module.artifact_registry[0].repository_url : var.registry_url
 }
 
-# ---- Phase 4: Application (PostgreSQL + OpenCrane + DB migration) ----
+# ---- Phase 4: Application (OPT-IN: PostgreSQL + OpenCrane + DB migration) ----
+#
+# Disabled by default so a bare `terraform apply` provisions only the cluster and
+# never has to bootstrap the kubernetes/helm providers from a cluster created in
+# the same run. Install the app afterwards with `helm install` (recommended), or
+# set enable_app_deploy=true to have Terraform install the chart too.
 
 module "app_deploy"
 {
   source = "./modules/app-deploy"
+  count  = var.enable_app_deploy ? 1 : 0
 
   project_id         = var.project_id
   registry_url       = local.registry_url
@@ -111,11 +121,13 @@ module "app_deploy"
 module "dns"
 {
   source = "./modules/dns"
-  count  = var.enable_cloud_dns ? 1 : 0
+  # Cloud DNS records point at the app's ingress IP, so this requires the app to
+  # be deployed by Terraform too.
+  count = (var.enable_cloud_dns && var.enable_app_deploy) ? 1 : 0
 
   project_id = var.project_id
   domain     = var.domain
-  ingress_ip = module.app_deploy.ingress_ip
+  ingress_ip = one(module.app_deploy[*].ingress_ip)
 
   depends_on = [module.app_deploy]
 }

--- a/platform/terraform/modules/app-deploy/main.tf
+++ b/platform/terraform/modules/app-deploy/main.tf
@@ -230,29 +230,28 @@ resource "helm_release" "opencrane"
     value = google_compute_global_address.ingress_ip.name
   }
 
-  # Storage
+  # Hosting provider. Default is plain-k8s on GKE: standard PVC tenant storage,
+  # k8s Secrets, GKE default StorageClass. The GCS-backed tenant storage extras
+  # (GCS Fuse CSI + Workload Identity) are opt-in via enable_gcs_storage.
   set
   {
-    name  = "tenant.storage.provider"
-    value = "gcs"
+    name  = "hosting.provider"
+    value = var.enable_gcs_storage ? "gcp" : "onprem"
   }
 
-  set
+  # GCP-only tenant storage settings — rendered only when enable_gcs_storage=true.
+  dynamic "set"
   {
-    name  = "tenant.storage.bucketPrefix"
-    value = "opencrane"
-  }
-
-  set
-  {
-    name  = "tenant.storage.csiDriver"
-    value = "gcsfuse.csi.storage.gke.io"
-  }
-
-  set
-  {
-    name  = "tenant.storage.gcpProject"
-    value = var.project_id
+    for_each = var.enable_gcs_storage ? {
+      "hosting.gcp.projectId"   = var.project_id
+      "hosting.gcp.bucketPrefix" = var.bucket_prefix
+      "hosting.gcp.csiDriver"   = "gcsfuse.csi.storage.gke.io"
+    } : {}
+    content
+    {
+      name  = set.key
+      value = set.value
+    }
   }
 
   # Observability

--- a/platform/terraform/modules/app-deploy/variables.tf
+++ b/platform/terraform/modules/app-deploy/variables.tf
@@ -36,3 +36,20 @@ variable "domain"
   description = "Base domain for tenant subdomains"
   type        = string
 }
+
+# -- GCP extras (opt-in). When false (default) the deploy is plain-k8s on GKE:
+#    standard PVC tenant storage, k8s Secrets, no GCS / Workload Identity / External
+#    Secrets specialness. Flip to true to enable GCS-backed tenant storage.
+variable "enable_gcs_storage"
+{
+  description = "Enable GCS-backed tenant storage (Workload Identity + GCS Fuse CSI). Plain k8s PVC storage when false."
+  type        = bool
+  default     = false
+}
+
+variable "bucket_prefix"
+{
+  description = "Bucket name prefix for GCS-backed tenant storage (only used when enable_gcs_storage=true)"
+  type        = string
+  default     = "opencrane"
+}

--- a/platform/terraform/modules/gke/main.tf
+++ b/platform/terraform/modules/gke/main.tf
@@ -3,7 +3,17 @@
 #
 # GKE Autopilot cluster — Google manages nodes, bin-packing, and scaling.
 # Nodes scale to zero when no pods are scheduled. You pay per pod resource.
+#
+# By default (vpc_id/subnet_id empty) the cluster runs on the project's default
+# VPC with Google-managed IP allocation — no custom networking required. Supply
+# vpc_id/subnet_id (and enable_private_nodes) for a dedicated VPC with private
+# nodes.
 # -----------------------------------------------------------------------------
+
+locals
+{
+  use_custom_vpc = var.vpc_id != "" && var.subnet_id != ""
+}
 
 resource "google_container_cluster" "cluster"
 {
@@ -13,18 +23,23 @@ resource "google_container_cluster" "cluster"
   project  = var.project_id
   location = var.region
 
-  network    = var.vpc_id
-  subnetwork = var.subnet_id
+  # Omitted (null) when on the default VPC so GKE picks the default network.
+  network    = local.use_custom_vpc ? var.vpc_id : null
+  subnetwork = local.use_custom_vpc ? var.subnet_id : null
 
   # Autopilot mode — no node pools to manage
   enable_autopilot = true
 
-  # Private cluster configuration
-  private_cluster_config
+  # Private cluster configuration — only when a custom VPC provides Cloud NAT.
+  dynamic "private_cluster_config"
   {
-    enable_private_nodes    = true
-    enable_private_endpoint = false
-    master_ipv4_cidr_block  = "172.16.0.0/28"
+    for_each = var.enable_private_nodes ? [1] : []
+    content
+    {
+      enable_private_nodes    = true
+      enable_private_endpoint = false
+      master_ipv4_cidr_block  = "172.16.0.0/28"
+    }
   }
 
   # Master authorized networks -- restrict API access
@@ -37,11 +52,22 @@ resource "google_container_cluster" "cluster"
     }
   }
 
-  # IP allocation policy for VPC-native cluster
-  ip_allocation_policy
+  # IP allocation policy. With a custom VPC use the named secondary ranges; on
+  # the default VPC let GKE auto-allocate (empty block).
+  dynamic "ip_allocation_policy"
   {
-    cluster_secondary_range_name  = "pods"
-    services_secondary_range_name = "services"
+    for_each = local.use_custom_vpc ? [1] : []
+    content
+    {
+      cluster_secondary_range_name  = "pods"
+      services_secondary_range_name = "services"
+    }
+  }
+
+  dynamic "ip_allocation_policy"
+  {
+    for_each = local.use_custom_vpc ? [] : [1]
+    content {}
   }
 
   # Release channel for automatic upgrades

--- a/platform/terraform/modules/gke/variables.tf
+++ b/platform/terraform/modules/gke/variables.tf
@@ -18,12 +18,21 @@ variable "cluster_name"
 
 variable "vpc_id"
 {
-  description = "Self-link of the VPC network"
+  description = "Self-link of the VPC network. Empty → use the project default VPC."
   type        = string
+  default     = ""
 }
 
 variable "subnet_id"
 {
-  description = "Self-link of the subnet"
+  description = "Self-link of the subnet. Empty → use the project default subnet."
   type        = string
+  default     = ""
+}
+
+variable "enable_private_nodes"
+{
+  description = "Provision private nodes (requires a custom VPC with Cloud NAT for egress)."
+  type        = bool
+  default     = false
 }

--- a/platform/terraform/outputs.tf
+++ b/platform/terraform/outputs.tf
@@ -17,8 +17,8 @@ output "cluster_endpoint"
 
 output "registry_url"
 {
-  description = "Artifact Registry URL for Docker images"
-  value       = module.artifact_registry.repository_url
+  description = "Registry URL for OpenCrane images (Artifact Registry when enabled, else the external registry)"
+  value       = local.registry_url
 }
 
 output "ingress_ip"
@@ -35,8 +35,14 @@ output "control_plane_url"
 
 output "dns_name_servers"
 {
-  description = "Name servers — delegate your domain to these"
-  value       = module.dns.name_servers
+  description = "Cloud DNS name servers (empty unless enable_cloud_dns=true). Delegate your domain to these."
+  value       = var.enable_cloud_dns ? module.dns[0].name_servers : []
+}
+
+output "dns_setup_instructions"
+{
+  description = "Manual DNS guidance when Cloud DNS is disabled."
+  value = var.enable_cloud_dns ? "Cloud DNS managed by Terraform — delegate ${var.domain} to the dns_name_servers output." : "Create an A record for ${var.domain} and a wildcard *.${var.domain} pointing at the ingress_ip output at your DNS provider."
 }
 
 output "database_url"

--- a/platform/terraform/outputs.tf
+++ b/platform/terraform/outputs.tf
@@ -23,32 +23,32 @@ output "registry_url"
 
 output "ingress_ip"
 {
-  description = "External IP for the ingress controller"
-  value       = module.app_deploy.ingress_ip
+  description = "External IP for the ingress controller (null until the app is deployed)"
+  value       = one(module.app_deploy[*].ingress_ip)
 }
 
 output "control_plane_url"
 {
-  description = "URL for the OpenCrane control-plane UI"
-  value       = module.app_deploy.control_plane_url
+  description = "URL for the OpenCrane control plane (null until the app is deployed)"
+  value       = one(module.app_deploy[*].control_plane_url)
 }
 
 output "dns_name_servers"
 {
-  description = "Cloud DNS name servers (empty unless enable_cloud_dns=true). Delegate your domain to these."
-  value       = var.enable_cloud_dns ? module.dns[0].name_servers : []
+  description = "Cloud DNS name servers (empty unless enable_cloud_dns is on). Delegate your domain to these."
+  value       = length(module.dns) > 0 ? module.dns[0].name_servers : []
 }
 
 output "dns_setup_instructions"
 {
   description = "Manual DNS guidance when Cloud DNS is disabled."
-  value = var.enable_cloud_dns ? "Cloud DNS managed by Terraform — delegate ${var.domain} to the dns_name_servers output." : "Create an A record for ${var.domain} and a wildcard *.${var.domain} pointing at the ingress_ip output at your DNS provider."
+  value = length(module.dns) > 0 ? "Cloud DNS managed by Terraform — delegate ${var.domain} to the dns_name_servers output." : "Point an A record for your domain and a wildcard *.<domain> at the ingress IP (run: kubectl get ingress -A) at your DNS provider."
 }
 
 output "database_url"
 {
-  description = "PostgreSQL connection string"
-  value       = "postgresql://opencrane:${module.app_deploy.database_password}@${module.app_deploy.database_host}:5432/opencrane"
+  description = "PostgreSQL connection string (null until the app is deployed)"
+  value       = try("postgresql://opencrane:${module.app_deploy[0].database_password}@${module.app_deploy[0].database_host}:5432/opencrane", null)
   sensitive   = true
 }
 

--- a/platform/terraform/variables.tf
+++ b/platform/terraform/variables.tf
@@ -23,11 +23,60 @@ variable "environment"
 }
 
 # Networking
+#
+# By default the GKE cluster runs on the project's existing `default` VPC, so a
+# bare apply needs no custom networking. Set enable_custom_vpc=true to provision
+# a dedicated VPC + subnet + Cloud Router + Cloud NAT (e.g. for private nodes).
+variable "enable_custom_vpc"
+{
+  description = "Provision a dedicated VPC + subnet + Cloud NAT. When false, GKE uses the project default VPC."
+  type        = bool
+  default     = false
+}
+
 variable "vpc_name"
 {
-  description = "Name for the VPC network"
+  description = "Name for the VPC network (only used when enable_custom_vpc=true)"
   type        = string
   default     = "opencrane-vpc"
+}
+
+# Cloud DNS is optional. By default the deploy prints the ingress IP and you set
+# DNS manually at your registrar. Set enable_cloud_dns=true to have Terraform
+# create a managed zone + wildcard/apex records.
+variable "enable_cloud_dns"
+{
+  description = "Create a Cloud DNS managed zone and wildcard/apex records pointing at the ingress IP."
+  type        = bool
+  default     = false
+}
+
+# Artifact Registry is optional. By default images are expected on an external
+# registry (e.g. ghcr.io). Set enable_artifact_registry=true to provision a GCP
+# Artifact Registry and push images there.
+variable "enable_artifact_registry"
+{
+  description = "Provision a GCP Artifact Registry repository for OpenCrane images."
+  type        = bool
+  default     = false
+}
+
+# Container registry base URL used for image references when Artifact Registry is
+# disabled. Defaults to the public ghcr.io OpenCrane org.
+variable "registry_url"
+{
+  description = "Registry base URL for OpenCrane images when enable_artifact_registry=false (e.g. ghcr.io/opencrane)."
+  type        = string
+  default     = "ghcr.io/opencrane"
+}
+
+# Enable GCS-backed tenant storage (Workload Identity + GCS Fuse). When false
+# (default) tenant storage uses standard k8s PVCs, keeping the deploy plain-k8s.
+variable "enable_gcs_storage"
+{
+  description = "Enable GCS-backed tenant storage extras. Plain k8s PVC storage when false."
+  type        = bool
+  default     = false
 }
 
 # GKE

--- a/platform/terraform/variables.tf
+++ b/platform/terraform/variables.tf
@@ -79,6 +79,18 @@ variable "enable_gcs_storage"
   default     = false
 }
 
+# Install the OpenCrane Helm chart with Terraform. When false (default), Terraform
+# provisions the cluster ONLY — so a single `terraform apply` always succeeds (no
+# provider bootstrap problem) and you install the app afterwards with the standard
+# `helm install` (k8s-native). Set true to also deploy the chart via Terraform; the
+# guided deploy.sh handles the required two-step bootstrap automatically.
+variable "enable_app_deploy"
+{
+  description = "Also install the OpenCrane Helm chart via Terraform. When false (default), Terraform creates the cluster only — run `helm install` afterwards."
+  type        = bool
+  default     = false
+}
+
 # GKE
 variable "cluster_name"
 {
@@ -87,11 +99,13 @@ variable "cluster_name"
   default     = "opencrane-cluster"
 }
 
-# Domain & DNS
+# Domain & DNS. Optional — bring the cluster up first and wire DNS later. Used for
+# ingress hostnames and, when enable_cloud_dns=true, the managed DNS records.
 variable "domain"
 {
-  description = "Base domain for tenant subdomains (e.g. opencrane.example.com)"
+  description = "Base domain for tenant subdomains (e.g. opencrane.example.com). Optional."
   type        = string
+  default     = ""
 }
 
 # Container images

--- a/platform/tests/multi-instance-conformance.sh
+++ b/platform/tests/multi-instance-conformance.sh
@@ -53,7 +53,7 @@ render()
     --skip-tests \
     --set certManager.enabled=true --set certManager.email=ops@example.com \
     --set externalSecrets.enabled=true --set externalSecrets.provider=gcp-secret-manager \
-    --set tenant.storage.gcpProject=demo-project \
+    --set hosting.gcp.projectId=demo-project \
     -f "$values" > "$out"
 }
 

--- a/platform/tests/values-k3d-e2e.yaml
+++ b/platform/tests/values-k3d-e2e.yaml
@@ -13,11 +13,6 @@ tenant:
     repository: opencrane/tenant
     tag: e2e
     pullPolicy: IfNotPresent
-  storage:
-    provider: ""
-    bucketPrefix: ""
-    csiDriver: ""
-    gcpProject: ""
 
 sharedSkills:
   enabled: true

--- a/platform/tests/values-k3d-local.yaml
+++ b/platform/tests/values-k3d-local.yaml
@@ -17,11 +17,6 @@ tenant:
     repository: opencrane/tenant
     tag: local
     pullPolicy: IfNotPresent
-  storage:
-    provider: ""
-    bucketPrefix: ""
-    csiDriver: ""
-    gcpProject: ""
 
 sharedSkills:
   enabled: true

--- a/platform/tests/values-k3d-strict.yaml
+++ b/platform/tests/values-k3d-strict.yaml
@@ -20,11 +20,6 @@ tenant:
     repository: opencrane/tenant
     tag: local
     pullPolicy: IfNotPresent
-  storage:
-    provider: ""
-    bucketPrefix: ""
-    csiDriver: ""
-    gcpProject: ""
 
 sharedSkills:
   enabled: true

--- a/platform/vps-deploy.sh
+++ b/platform/vps-deploy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# =============================================================================
+# OpenCrane — single machine (VM / VPS) deploy
+#
+# Stands up a one-node Kubernetes cluster on THIS Linux host using k3s, then
+# installs OpenCrane onto it. Ideal for a VM, a VPS, or a single server.
+#
+# Usage:
+#   sudo ./platform/vps-deploy.sh [--domain DOMAIN]
+#
+# Prereqs: a Linux host with curl + helm (this script installs k3s for you).
+# For laptop/dev on macOS or Windows, use ./platform/install.sh local (k3d).
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOMAIN=""
+PASSTHROUGH=()
+
+log()  { echo -e "\033[0;32m[vps-deploy]\033[0m $1"; }
+err()  { echo -e "\033[0;31m[vps-deploy]\033[0m $1" >&2; }
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --domain) DOMAIN="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) PASSTHROUGH+=("$1"); shift ;;
+  esac
+done
+
+[[ "$(uname -s)" == "Linux" ]] || { err "k3s needs Linux. On a laptop use ./platform/install.sh local (k3d)."; exit 1; }
+command -v helm >/dev/null 2>&1 || { err "Missing required command: helm (https://helm.sh/docs/intro/install/)"; exit 1; }
+
+# 1. Install k3s (idempotent — skips if already present) → a one-node cluster.
+if ! command -v k3s >/dev/null 2>&1 && ! command -v kubectl >/dev/null 2>&1; then
+  log "Installing k3s…"
+  curl -sfL https://get.k3s.io | sh -
+fi
+export KUBECONFIG="${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml}"
+[[ -r "$KUBECONFIG" ]] || { err "Cannot read $KUBECONFIG (run with sudo, or set KUBECONFIG)."; exit 1; }
+
+log "Cluster ready. Installing OpenCrane…"
+# k3s ships the 'local-path' default StorageClass and a Traefik ingress out of the box.
+exec "$SCRIPT_DIR/k8s-deploy.sh" ${DOMAIN:+--domain "$DOMAIN"} "${PASSTHROUGH[@]}"


### PR DESCRIPTION
Make cloud deployment "just Kubernetes on GKE" — no extra cloud features by default; GCP-native extras become opt-in.

- **Fixes the value-path bug**: unify on `hosting.gcp.*` (was split with `tenant.storage.*` in `external-secrets-store.yaml`, the Terraform `app-deploy` module, and the README flag).
- **Default GKE = plain k8s**: `values/gcp.yaml` renders plain (0 SecretStores, PVC storage, in-cluster Postgres, k8s Secrets). New `values/gcp-extras.yaml` overlay restores GCS storage / Workload Identity / External Secrets / GCE ingress when wanted.
- **Simplified flow**: `deploy.sh` defaults to GKE-on-default-VPC → push to ghcr.io → `helm install` → manual DNS. Custom VPC, Artifact Registry, Cloud DNS, GCS gated behind Terraform toggles (default off). Added `terraform.tfvars.example`.

**Validated:** `helm lint` clean; `gcp.yaml` renders plain-k8s, `+gcp-extras` renders the GCP features; `bash -n` clean. (`terraform validate` not run — terraform absent in CI sandbox.)