### PR TITLE
📝 Documentation website (VitePress): branding, journey-driven content, deploy split

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -63,7 +63,14 @@ export default defineConfig({
       {
         text: 'Get set up',
         items: [
-          { text: '1. Install OpenCrane', link: '/guide/getting-started' },
+          {
+            text: '1. Install OpenCrane',
+            link: '/guide/getting-started',
+            items: [
+              { text: 'Local, VM or VPS', link: '/guide/deploy-local' },
+              { text: 'Cluster deployment', link: '/guide/deploy-cluster' },
+            ],
+          },
           { text: '2. Set up your domain', link: '/guide/dns' },
           { text: '3. Create your first assistant', link: '/guide/first-tenant' },
           { text: '4. Connect to OpenClaw', link: '/guide/connect' },

--- a/website/guide/deploy-cluster.md
+++ b/website/guide/deploy-cluster.md
@@ -1,0 +1,78 @@
+# Cluster deployment
+
+For production, run OpenCrane on a managed Kubernetes cluster. Because OpenCrane is
+**plain Kubernetes** — standard storage (PVC), standard ingress, in-cluster
+PostgreSQL, Kubernetes Secrets — **any conformant cluster works the same way**:
+
+```bash
+helm install opencrane platform/helm --set ingress.domain=<your-domain>
+```
+
+There are no required cloud-specific features. A managed cluster is just a Kubernetes
+cluster someone else runs the nodes for.
+
+## Provider support
+
+| Provider | Managed Kubernetes | Status |
+|----------|--------------------|--------|
+| **Google Cloud** | GKE | ✅ Supported |
+| **AWS** | EKS | 🚧 TODO |
+| **Azure** | AKS | 🚧 TODO |
+| **Alibaba Cloud** | ACK | 🙌 Looking for contributors |
+
+"Supported" means there's a documented, tested path below. The others are plain
+Kubernetes too, so OpenCrane should run on them today — they just don't have a
+first-class guide yet. Contributions welcome.
+
+## The shape of any cluster deploy
+
+1. **Have a cluster** — create one with your provider, or use an existing one. Make
+   sure `kubectl` points at it.
+2. **Make images reachable** — pull OpenCrane's images from a registry your cluster
+   can read (the public images, your own mirror, or your provider's registry).
+3. **Install** — `helm install opencrane platform/helm --set ingress.domain=<your-domain>`.
+4. **Point your domain** at the ingress — see [Set up your domain](/guide/dns).
+
+## Google Cloud (GKE) ✅
+
+GKE is treated as a standard Kubernetes cluster — no GCP-only features required.
+
+```bash
+# 1. Create a cluster (Autopilot manages the nodes for you)
+gcloud container clusters create-auto opencrane --region <region>
+gcloud container clusters get-credentials opencrane --region <region>
+
+# 2. Install OpenCrane
+helm install opencrane platform/helm --set ingress.domain=<your-domain>
+```
+
+Then [point your domain](/guide/dns) at the ingress IP. That's it — same chart,
+standard Kubernetes.
+
+::: details Optional GCP-native extras
+If you *want* deeper GCP integration — GCS-backed tenant storage with Workload
+Identity, Secret Manager via External Secrets, or Cloud DNS for automatic records —
+those are available as opt-in overlays. They aren't required, and the default GKE
+deploy stays plain Kubernetes. See [Hosting & deployment](/operators/hosting).
+:::
+
+## AWS (EKS) 🚧
+
+**TODO.** A first-class EKS guide isn't written yet. Since OpenCrane is plain
+Kubernetes, a standard EKS cluster with an ingress controller and a default
+StorageClass should work with the same `helm install`. Tried it? A write-up
+contribution would land you in the table above.
+
+## Azure (AKS) 🚧
+
+**TODO.** No first-class AKS guide yet — same story as EKS: standard cluster,
+standard `helm install`. Contributions welcome.
+
+## Alibaba Cloud (ACK) 🙌
+
+**Looking for contributors.** We'd love a tested ACK path. If you run OpenCrane on
+Alibaba Cloud Container Service for Kubernetes, please open a PR with the steps.
+
+## Next
+
+→ **[Set up your domain](/guide/dns)** → **[Create your first assistant](/guide/first-tenant)**

--- a/website/guide/deploy-local.md
+++ b/website/guide/deploy-local.md
@@ -1,0 +1,45 @@
+# Local, VM or VPS
+
+Run all of OpenCrane on a **single machine** — your laptop, a VM, or a VPS. This is
+the fastest way to try it, demo it, or serve a small team. Everything (control plane,
+operator, assistants, database) runs in one lightweight Kubernetes node.
+
+## On your laptop
+
+The bundled installer spins up a local [k3d](https://k3d.io) cluster and installs the
+full stack:
+
+```bash
+./platform/install.sh local
+```
+
+That's enough to create assistants and explore the `oc` CLI. Tear it down anytime;
+nothing leaves your machine.
+
+## On a VM or VPS
+
+For an always-on single server (a cloud VM, or a box under your desk), use
+[k3s](https://k3s.io) — a tiny, production-grade Kubernetes that's perfect for one
+node:
+
+```bash
+# 1. Install k3s (gives you a one-node cluster + kubectl)
+curl -sfL https://get.k3s.io | sh -
+export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+
+# 2. Install OpenCrane with your domain
+helm install opencrane platform/helm --set ingress.domain=<your-domain>
+```
+
+Point your domain at the server's IP (see [Set up your domain](/guide/dns)) and you
+have a real, public deployment on a single host.
+
+::: tip When to move to a cluster
+A single machine is great up to a point. When you need high availability, more
+capacity, or auto-scaling, the **exact same `helm install`** works on a managed
+Kubernetes cluster — see [Cluster deployment](/guide/deploy-cluster).
+:::
+
+## Next
+
+→ **[Set up your domain](/guide/dns)** → **[Create your first assistant](/guide/first-tenant)**

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -1,47 +1,30 @@
 # Install OpenCrane
 
-OpenCrane runs on a Kubernetes cluster you control. This page gets it running. Don't
-worry if you're not a Kubernetes expert — the defaults do the heavy lifting.
+OpenCrane is **plain Kubernetes**. If you can run a Kubernetes cluster, you can run
+OpenCrane — there's no special cloud dependency. Pick the path that fits you:
 
-## Try it on your laptop first
+| Path | Best for | Guide |
+|------|----------|-------|
+| **Local, VM or VPS** | Trying it out, a demo, or a small team on a single machine | [Local, VM or VPS →](/guide/deploy-local) |
+| **Cluster** | Production, scale, high availability | [Cluster deployment →](/guide/deploy-cluster) |
 
-The quickest way to kick the tyres, with everything bundled in:
-
-```bash
-./platform/install.sh local
-```
-
-That's enough to create assistants and explore the `oc` command-line tool locally.
-When you're ready for real users, install it on a cluster.
-
-## Install on a cluster
-
-```bash
-helm install opencrane platform/helm \
-  --set ingress.domain=opencrane.example.com \
-  --set controlPlane.database.existingSecret=opencrane-db
-```
-
-`ingress.domain` is **your OpenCrane address**. Your control plane lives at the top
-(`admin.opencrane.example.com`) and each person's assistant gets its own subdomain,
-like `alice.opencrane.example.com`.
-
-For storage, cloud, and other options, see [Hosting & deployment](/operators/hosting).
+Both install the same way — the only difference is the size and shape of the
+Kubernetes underneath.
 
 ## Connect the command-line tool
 
-Everything in these guides uses `oc`. Point it at your control plane:
+However you deploy, everything in these guides uses the `oc` CLI. Point it at your
+control plane:
 
 ```bash
-export OPENCRANE_URL=https://admin.opencrane.example.com
+export OPENCRANE_URL=https://admin.<your-domain>
 export OPENCRANE_TOKEN=<your-access-token>
 
 oc auth me        # confirms you're connected
 ```
 
-## Next: set up your domain
+## Then
 
-Because every assistant gets its own subdomain, the next step is pointing your domain
-name at OpenCrane and turning on HTTPS.
-
-→ **[Set up your domain](/guide/dns)**
+1. **[Set up your domain](/guide/dns)** — point DNS at OpenCrane and turn on HTTPS.
+2. **[Create your first assistant](/guide/first-tenant)**.
+3. **[Connect to OpenClaw](/guide/connect)**.


### PR DESCRIPTION
A first-class documentation site for OpenCrane.

- **VitePress site** under `website/` (served at opencrane.ai via CNAME), interactive API reference generated from `openapi.json`, GitHub Pages deploy workflow (+ self-host container/Helm).
- **Branding**: OpenCrane palette + crane logo; illustrated, theme-aware architecture diagrams.
- **Journey-driven, plain-language** content; concept explainers; design decisions kept out of reader-facing pages.
- **Deployment split**: Local/VM/VPS vs Cluster, with a provider table — GCP ✅, AWS/Azure 🚧 TODO, Alibaba 🙌 looking for contributors.
- **README** trimmed to vision / what-it-does (status & design → CHANGELOG/plan-done); adds a `readme` maintainer agent.

Build passes the dead-link gate. Pairs with the GKE-only-standard infra PR.