### PR TITLE
Added missing ingress template for the Control Plane

### DIFF
--- a/platform/helm/templates/control-plane-ingress.yaml
+++ b/platform/helm/templates/control-plane-ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+{{- $host := printf "admin.%s" .Values.ingress.domain -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "opencrane.fullname" . }}-control-plane
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | default "opencrane-wildcard-tls" }}
+  {{- end }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "opencrane.fullname" . }}-control-plane
+                port:
+                  number: {{ .Values.controlPlane.service.port }}
+{{- end }}


### PR DESCRIPTION
# Changes:
- The Control Plane was missing an ingress template needed for it to route the traffic to `https://admin.{customDomain}` according to the VPS deploy script. This fix adds that.

# Files Changed:
- `platform/helm/templates/control-plane-ingress.yaml`