### PR TITLE
Control Plane ingress fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   (`clusterTenant.provisionerWebhook.url`); `dedicatedCluster` is rejected `422
   TIER_UNAVAILABLE` until a backend advertises it (fail-closed).
 
+### Changed
+
+- **Expose the control plane ingress at the root domain instead of the `admin` subdomain.** The control plane ingress host maps directly to the base `ingress.domain` configured in Helm (e.g. `opencrane.local`), rather than prepending `admin.`.
+
 ### Security
 
 - **The provisioner webhook refuses a non-`https://` URL at startup**, so the bearer token

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ helm install opencrane platform/helm \
   --set controlPlane.database.existingSecret=opencrane-cloudsql
 
 # 3. Create a tenant via the oc CLI
-export OPENCRANE_URL=https://admin.opencrane.ai
+export OPENCRANE_URL=https://opencrane.ai
 export OPENCRANE_TOKEN=<your-access-token>
 
 oc tenants create \
@@ -196,7 +196,7 @@ The operator provisions everything the tenant needs — storage, identity, an en
 
 ```bash
 # Point the CLI at your control plane
-export OPENCRANE_URL=https://admin.opencrane.ai
+export OPENCRANE_URL=https://opencrane.ai
 export OPENCRANE_TOKEN=<your-access-token>
 
 oc tenants list                         # list all tenants

--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "docs:dev": "pnpm --filter @opencrane/website dev",
     "docs:build": "pnpm --filter @opencrane/website build",
     "docs:preview": "pnpm --filter @opencrane/website preview",
-    "docker:build:tenant": "docker build -f apps/tenant/deploy/Dockerfile -t ghcr.io/opencrane/tenant:latest .",
-    "docker:build:operator": "docker build -f apps/operator/deploy/Dockerfile -t ghcr.io/opencrane/operator:latest .",
-    "docker:build:control-plane": "docker build -f apps/control-plane/deploy/Dockerfile -t ghcr.io/opencrane/control-plane:latest .",
-    "docker:build:docs": "docker build -f website/Dockerfile -t ghcr.io/opencrane/docs:latest ."
+    "docker:build:tenant": "docker build -f apps/tenant/deploy/Dockerfile -t ghcr.io/italanta/opencrane-tenant:latest .",
+    "docker:build:operator": "docker build -f apps/operator/deploy/Dockerfile -t ghcr.io/italanta/opencrane-operator:latest .",
+    "docker:build:control-plane": "docker build -f apps/control-plane/deploy/Dockerfile -t ghcr.io/italanta/opencrane-control-plane:latest .",
+    "docker:build:docs": "docker build -f website/Dockerfile -t ghcr.io/italanta/docs:latest ."
   }
 }

--- a/platform/helm/templates/control-plane-ingress.yaml
+++ b/platform/helm/templates/control-plane-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $host := printf "admin.%s" .Values.ingress.domain -}}
+{{- $host := .Values.ingress.domain -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -95,7 +95,7 @@ sharedPlatform:
 # -- Operator settings
 operator:
   image:
-    repository: ghcr.io/opencrane/operator
+    repository: ghcr.io/italanta/opencrane-operator
     tag: latest
     pullPolicy: IfNotPresent
   replicas: 1
@@ -116,7 +116,7 @@ operator:
 # -- Control plane settings
 controlPlane:
   image:
-    repository: ghcr.io/opencrane/control-plane
+    repository: ghcr.io/italanta/opencrane-control-plane
     tag: latest
     pullPolicy: IfNotPresent
   replicas: 1
@@ -199,7 +199,7 @@ litellm:
 # -- Default tenant pod settings (can be overridden per Tenant CR)
 tenant:
   defaultImage:
-    repository: ghcr.io/opencrane/tenant
+    repository: ghcr.io/italanta/opencrane-tenant
     tag: latest
     pullPolicy: IfNotPresent
   defaultResources:
@@ -250,7 +250,7 @@ ingress:
 docs:
   enabled: false
   image:
-    repository: ghcr.io/opencrane/docs
+    repository: ghcr.io/italanta/docs
     tag: latest
     pullPolicy: IfNotPresent
   replicas: 1
@@ -374,7 +374,7 @@ mcpGateway:
 skillRegistry:
   enabled: true
   image:
-    repository: ghcr.io/opencrane/skill-registry
+    repository: ghcr.io/italanta/skill-registry
     tag: latest
     pullPolicy: IfNotPresent
   replicas: 1

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -147,7 +147,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: ghcr.io/opencrane/control-plane:${IMAGE_TAG}
+          image: ghcr.io/italanta/opencrane-control-plane:${IMAGE_TAG}
           command: ["npx", "prisma@6", "migrate", "deploy"]
           workingDir: /app/apps/control-plane
           env:

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -162,5 +162,5 @@ kubectl rollout status "deployment/${RELEASE}-operator" -n "$NAMESPACE" --timeou
 kubectl rollout status "deployment/${RELEASE}-control-plane" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
 
 log "Done. OpenCrane is installed in namespace '$NAMESPACE'."
-[[ -n "$DOMAIN" ]] && log "Point your DNS at the ingress, then visit https://admin.${DOMAIN}"
+[[ -n "$DOMAIN" ]] && log "Point your DNS at the ingress, then visit https://${DOMAIN}"
 log "Ingress: kubectl get ingress -n $NAMESPACE"

--- a/platform/terraform/variables.tf
+++ b/platform/terraform/variables.tf
@@ -65,9 +65,9 @@ variable "enable_artifact_registry"
 # disabled. Defaults to the public ghcr.io OpenCrane org.
 variable "registry_url"
 {
-  description = "Registry base URL for OpenCrane images when enable_artifact_registry=false (e.g. ghcr.io/opencrane)."
+  description = "Registry base URL for OpenCrane images when enable_artifact_registry=false (e.g. ghcr.io/italanta)."
   type        = string
-  default     = "ghcr.io/opencrane"
+  default     = "ghcr.io/italanta"
 }
 
 # Enable GCS-backed tenant storage (Workload Identity + GCS Fuse). When false

--- a/platform/vps-deploy.sh
+++ b/platform/vps-deploy.sh
@@ -50,4 +50,4 @@ fi
 
 log "Cluster ready. Installing OpenCrane…"
 # k3s ships the 'local-path' default StorageClass and a Traefik ingress out of the box.
-exec "$SCRIPT_DIR/k8s-deploy.sh" ${DOMAIN:+--domain "$DOMAIN"} "${PASSTHROUGH[@]}"
+exec "$SCRIPT_DIR/k8s-deploy.sh" ${DOMAIN:+--domain "$DOMAIN"} --set ingress.className=traefik --set networkPolicy.ingressNamespace=kube-system "${PASSTHROUGH[@]}"

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -17,7 +17,7 @@ However you deploy, everything in these guides uses the `oc` CLI. Point it at yo
 control plane:
 
 ```bash
-export OPENCRANE_URL=https://admin.<your-domain>
+export OPENCRANE_URL=https://<your-domain>
 export OPENCRANE_TOKEN=<your-access-token>
 
 oc auth me        # confirms you're connected


### PR DESCRIPTION
# Changes:
- Mapping the base domain to the Control Plane instead of `admin.{custom-domain}`.

# Files Changed:
- `CHANGELOG.md` - Updating references.
- `README.md` - Updating references.
- `platform/helm/templates/control-plane-ingress.yaml` - Removing the `admin` prefix from the Control Plane Ingress.
- `platform/k8s-deploy.sh` - Updating references.
- `website/guide/getting-started.md` - Updating references.