### PR TITLE
Moving the 'OPENAI_API_KEY' to the Control Plane

### DIFF
--- a/apps/control-plane/src/__tests__/routes/provider-keys.test.ts
+++ b/apps/control-plane/src/__tests__/routes/provider-keys.test.ts
@@ -1,0 +1,171 @@
+import type * as k8s from "@kubernetes/client-node";
+import express from "express";
+import type { Express } from "express";
+import type { PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { providerKeysRouter } from "../../routes/provider-keys.js";
+
+/** Build a minimal app containing only the provider-keys route. */
+function _buildProviderKeysApp(prisma: PrismaClient, coreApi: k8s.CoreV1Api): Express
+{
+  const app = express();
+  app.use(express.json());
+  app.use("/api/providers/keys", providerKeysRouter(prisma, coreApi, "opencrane", "org-shared-secrets"));
+  return app;
+}
+
+describe("providerKeysRouter", () =>
+{
+  it("upserts openai key and projects it into org shared Secret", async () =>
+  {
+    const prisma = {
+      providerApiKey: {
+        upsert: vi.fn().mockResolvedValue({ provider: "openai" }),
+      },
+    } as unknown as PrismaClient;
+
+    const coreApi = {
+      readNamespacedSecret: vi.fn().mockResolvedValue({
+        metadata: {
+          name: "org-shared-secrets",
+          namespace: "opencrane",
+          resourceVersion: "12",
+        },
+        data: {
+          ANTHROPIC_API_KEY: Buffer.from("claude-token").toString("base64"),
+        },
+      }),
+      replaceNamespacedSecret: vi.fn().mockResolvedValue({}),
+    } as unknown as k8s.CoreV1Api;
+
+    const app = _buildProviderKeysApp(prisma, coreApi);
+    const res = await request(app)
+      .put("/api/providers/keys/openai")
+      .send({ value: "openai-token" });
+
+    expect(res.status).toBe(204);
+    expect(prisma.providerApiKey.upsert).toHaveBeenCalledWith({
+      where: { provider: "openai" },
+      update: { keyValue: "openai-token" },
+      create: { provider: "openai", keyValue: "openai-token" },
+    });
+    expect(coreApi.replaceNamespacedSecret).toHaveBeenCalledWith({
+      name: "org-shared-secrets",
+      namespace: "opencrane",
+      body: expect.objectContaining({
+        metadata: expect.objectContaining({
+          resourceVersion: "12",
+        }),
+        stringData: {
+          ANTHROPIC_API_KEY: "claude-token",
+          OPENAI_API_KEY: "openai-token",
+        },
+      }),
+    });
+  });
+
+  it("creates org shared Secret when provider key projection runs for first time", async () =>
+  {
+    const prisma = {
+      providerApiKey: {
+        upsert: vi.fn().mockResolvedValue({ provider: "openai" }),
+      },
+    } as unknown as PrismaClient;
+
+    const notFound = Object.assign(new Error("Not Found"), { statusCode: 404 });
+    const coreApi = {
+      readNamespacedSecret: vi.fn().mockRejectedValue(notFound),
+      createNamespacedSecret: vi.fn().mockResolvedValue({}),
+    } as unknown as k8s.CoreV1Api;
+
+    const app = _buildProviderKeysApp(prisma, coreApi);
+    const res = await request(app)
+      .put("/api/providers/keys/openai")
+      .send({ value: "openai-token" });
+
+    expect(res.status).toBe(204);
+    expect(coreApi.createNamespacedSecret).toHaveBeenCalledWith({
+      namespace: "opencrane",
+      body: expect.objectContaining({
+        metadata: expect.objectContaining({
+          name: "org-shared-secrets",
+          namespace: "opencrane",
+        }),
+        stringData: {
+          OPENAI_API_KEY: "openai-token",
+        },
+      }),
+    });
+  });
+
+  it("treats Kubernetes ApiException code=404 as not found and creates org secret", async () =>
+  {
+    const prisma = {
+      providerApiKey: {
+        upsert: vi.fn().mockResolvedValue({ provider: "openai" }),
+      },
+    } as unknown as PrismaClient;
+
+    const notFoundApiError = Object.assign(new Error("Not Found"), {
+      code: 404,
+      body: JSON.stringify({ code: 404, reason: "NotFound" }),
+    });
+
+    const coreApi = {
+      readNamespacedSecret: vi.fn().mockRejectedValue(notFoundApiError),
+      createNamespacedSecret: vi.fn().mockResolvedValue({}),
+    } as unknown as k8s.CoreV1Api;
+
+    const app = _buildProviderKeysApp(prisma, coreApi);
+    const res = await request(app)
+      .put("/api/providers/keys/openai")
+      .send({ value: "openai-token" });
+
+    expect(res.status).toBe(204);
+    expect(coreApi.createNamespacedSecret).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes openai key projection while keeping other org secret entries", async () =>
+  {
+    const prisma = {
+      providerApiKey: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    } as unknown as PrismaClient;
+
+    const coreApi = {
+      readNamespacedSecret: vi.fn().mockResolvedValue({
+        metadata: {
+          name: "org-shared-secrets",
+          namespace: "opencrane",
+          resourceVersion: "15",
+        },
+        data: {
+          OPENAI_API_KEY: Buffer.from("openai-token").toString("base64"),
+          ANTHROPIC_API_KEY: Buffer.from("claude-token").toString("base64"),
+        },
+      }),
+      replaceNamespacedSecret: vi.fn().mockResolvedValue({}),
+    } as unknown as k8s.CoreV1Api;
+
+    const app = _buildProviderKeysApp(prisma, coreApi);
+    const res = await request(app).delete("/api/providers/keys/openai");
+
+    expect(res.status).toBe(204);
+    expect(prisma.providerApiKey.deleteMany).toHaveBeenCalledWith({ where: { provider: "openai" } });
+    expect(coreApi.replaceNamespacedSecret).toHaveBeenCalledWith({
+      name: "org-shared-secrets",
+      namespace: "opencrane",
+      body: expect.objectContaining({
+        metadata: expect.objectContaining({
+          resourceVersion: "15",
+        }),
+        stringData: {
+          ANTHROPIC_API_KEY: "claude-token",
+        },
+      }),
+    });
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/provider-keys.test.ts
+++ b/apps/control-plane/src/__tests__/routes/provider-keys.test.ts
@@ -16,9 +16,9 @@ function _buildProviderKeysApp(prisma: PrismaClient, coreApi: k8s.CoreV1Api): Ex
   return app;
 }
 
-describe("providerKeysRouter", () =>
+describe("providerKeysRouter", function _suite()
 {
-  it("upserts openai key and projects it into org shared Secret", async () =>
+  it("upserts openai key and projects it into org shared Secret", async function _upsertOpenaiKey()
   {
     const prisma = {
       providerApiKey: {
@@ -43,7 +43,7 @@ describe("providerKeysRouter", () =>
     const app = _buildProviderKeysApp(prisma, coreApi);
     const res = await request(app)
       .put("/api/providers/keys/openai")
-      .send({ value: "openai-token" });
+      .send({ apiKey: "openai-token" });
 
     expect(res.status).toBe(204);
     expect(prisma.providerApiKey.upsert).toHaveBeenCalledWith({
@@ -66,7 +66,7 @@ describe("providerKeysRouter", () =>
     });
   });
 
-  it("creates org shared Secret when provider key projection runs for first time", async () =>
+  it("creates org shared Secret when provider key projection runs for first time", async function _createOrgSecretFirstTime()
   {
     const prisma = {
       providerApiKey: {
@@ -83,7 +83,7 @@ describe("providerKeysRouter", () =>
     const app = _buildProviderKeysApp(prisma, coreApi);
     const res = await request(app)
       .put("/api/providers/keys/openai")
-      .send({ value: "openai-token" });
+      .send({ apiKey: "openai-token" });
 
     expect(res.status).toBe(204);
     expect(coreApi.createNamespacedSecret).toHaveBeenCalledWith({
@@ -100,7 +100,7 @@ describe("providerKeysRouter", () =>
     });
   });
 
-  it("treats Kubernetes ApiException code=404 as not found and creates org secret", async () =>
+  it("treats Kubernetes ApiException code=404 as not found and creates org secret", async function _treats404AsNotFound()
   {
     const prisma = {
       providerApiKey: {
@@ -121,13 +121,13 @@ describe("providerKeysRouter", () =>
     const app = _buildProviderKeysApp(prisma, coreApi);
     const res = await request(app)
       .put("/api/providers/keys/openai")
-      .send({ value: "openai-token" });
+      .send({ apiKey: "openai-token" });
 
     expect(res.status).toBe(204);
     expect(coreApi.createNamespacedSecret).toHaveBeenCalledTimes(1);
   });
 
-  it("deletes openai key projection while keeping other org secret entries", async () =>
+  it("deletes openai key projection while keeping other org secret entries", async function _deletesOpenaiKey()
   {
     const prisma = {
       providerApiKey: {

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -61,8 +61,10 @@ function _BuildOciBundleStore(): OciBundleStore | null
  * @param authApi   - Kubernetes Authentication API for tenant contract TokenReview validation.
  * @returns The Express application instance with registered routes.
  */
-export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k8s.CustomObjectsApi, coreApi: k8s.CoreV1Api, authApi: k8s.AuthenticationV1Api): Express
-{
+export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k8s.CustomObjectsApi, coreApi: k8s.CoreV1Api, authApi: k8s.AuthenticationV1Api) {
+  const namespace = process.env.NAMESPACE ?? "default";
+  const orgSharedSecretsName = process.env.ORG_SHARED_SECRETS_NAME ?? "org-shared-secrets";
+
   // Internal routes — mounted before ___AuthMiddleware and not behind any token check.
   // Access is enforced by Kubernetes NetworkPolicy: only the Obot, skill-registry, and
   // tenant pods can reach the control-plane service on the cluster network.
@@ -103,7 +105,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/awareness/participation", awarenessParticipationRouter(prisma));
   app.use("/api/v1/sessions", sessionsRouter(prisma));
   app.use("/api/v1/access-tokens", accessTokensRouter(prisma));
-  app.use("/api/v1/providers/keys", providerKeysRouter(prisma));
+  app.use("/api/v1/providers/keys", providerKeysRouter(prisma, coreApi, namespace, orgSharedSecretsName));
   app.use("/api/v1/openapi.json", openapiRouter());
   app.get("/healthz", _CheckDbHealth(prisma));
   app.use("/prom", prometheusMetricsRouter(prisma, customApi));

--- a/apps/control-plane/src/routes/provider-keys.ts
+++ b/apps/control-plane/src/routes/provider-keys.ts
@@ -1,13 +1,17 @@
 import { Router } from "express";
+import type * as k8s from "@kubernetes/client-node";
 import type { PrismaClient } from "@prisma/client";
 
 /**
  * Creates router for global provider API key management.
  * 
  * @param prisma - Prisma ORM client
+ * @param coreApi - Kubernetes Core V1 API for org secret projection
+ * @param namespace - Namespace where the shared org Secret lives
+ * @param orgSecretName - Name of the shared org Secret
  * @returns Configured Express router
  */
-export function providerKeysRouter(prisma: PrismaClient): Router
+export function providerKeysRouter(prisma: PrismaClient, coreApi: k8s.CoreV1Api, namespace: string, orgSecretName: string): Router
 {
   const router = Router();
 
@@ -53,6 +57,8 @@ export function providerKeysRouter(prisma: PrismaClient): Router
       create: { provider, keyValue },
     });
 
+    await _upsertOrgProviderSecret(coreApi, namespace, orgSecretName, provider, keyValue);
+
     res.status(204).send();
   });
 
@@ -68,9 +74,169 @@ export function providerKeysRouter(prisma: PrismaClient): Router
     }
 
     await prisma.providerApiKey.deleteMany({ where: { provider } });
+    await _deleteOrgProviderSecretKey(coreApi, namespace, orgSecretName, provider);
 
     res.status(204).send();
   });
 
   return router;
+}
+
+/** Map provider name to the org-shared secret key used by tenant envFrom. */
+function _providerToSecretKey(provider: string): string {
+  if (provider === "openai") {
+    return "OPENAI_API_KEY";
+  }
+
+  if (provider === "claude") {
+    return "ANTHROPIC_API_KEY";
+  }
+
+  return provider.toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+}
+
+/** Build a plain-text map from Secret data (base64) so keys can be merged safely. */
+function _decodeSecretData(secret: k8s.V1Secret): Record<string, string> {
+  const decoded: Record<string, string> = {};
+  const data = secret.data ?? {};
+
+  for (const [key, value] of Object.entries(data)) {
+    decoded[key] = Buffer.from(value, "base64").toString("utf8");
+  }
+
+  return decoded;
+}
+
+/** Returns true when the Kubernetes error indicates a missing resource (HTTP 404). */
+function _isNotFoundError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  const maybeStatus = err as Error & { code?: number; statusCode?: number; body?: { code?: number } | string };
+  if (maybeStatus.statusCode === 404 || maybeStatus.code === 404) {
+    return true;
+  }
+
+  if (typeof maybeStatus.body === "object" && maybeStatus.body?.code === 404) {
+    return true;
+  }
+
+  if (typeof maybeStatus.body === "string") {
+    try {
+      const parsedBody = JSON.parse(maybeStatus.body) as { code?: number };
+      return parsedBody.code === 404;
+    }
+    catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Upsert the shared org Secret entry for a provider key.
+ */
+async function _upsertOrgProviderSecret(
+  coreApi: k8s.CoreV1Api,
+  namespace: string,
+  secretName: string,
+  provider: string,
+  keyValue: string,
+): Promise<void> {
+  const secretKey = _providerToSecretKey(provider);
+
+  try {
+    // 1. Read the existing Secret so we can preserve unrelated provider keys.
+    const existing = await coreApi.readNamespacedSecret({ name: secretName, namespace });
+    const mergedData = _decodeSecretData(existing);
+    mergedData[secretKey] = keyValue;
+
+    // 2. Replace the Secret with merged keys so updates remain atomic per write.
+    await coreApi.replaceNamespacedSecret({
+      name: secretName,
+      namespace,
+      body: {
+        apiVersion: "v1",
+        kind: "Secret",
+        type: existing.type ?? "Opaque",
+        metadata: {
+          name: secretName,
+          namespace,
+          resourceVersion: existing.metadata?.resourceVersion,
+          labels: existing.metadata?.labels,
+          annotations: existing.metadata?.annotations,
+        },
+        stringData: mergedData,
+      },
+    });
+  }
+  catch (err) {
+    if (!_isNotFoundError(err)) {
+      throw err;
+    }
+
+    // 3. Create the Secret on first write so control-plane ownership is explicit.
+    await coreApi.createNamespacedSecret({
+      namespace,
+      body: {
+        apiVersion: "v1",
+        kind: "Secret",
+        type: "Opaque",
+        metadata: {
+          name: secretName,
+          namespace,
+        },
+        stringData: {
+          [secretKey]: keyValue,
+        },
+      },
+    });
+  }
+}
+
+/**
+ * Remove a provider key from the shared org Secret without deleting other keys.
+ */
+async function _deleteOrgProviderSecretKey(
+  coreApi: k8s.CoreV1Api,
+  namespace: string,
+  secretName: string,
+  provider: string,
+): Promise<void> {
+  const secretKey = _providerToSecretKey(provider);
+
+  try {
+    // 1. Read the existing Secret and decode all keys to preserve unrelated entries.
+    const existing = await coreApi.readNamespacedSecret({ name: secretName, namespace });
+    const mergedData = _decodeSecretData(existing);
+
+    // 2. Remove only this provider key so other provider credentials remain available.
+    delete mergedData[secretKey];
+
+    // 3. Replace the Secret with the reduced key set.
+    await coreApi.replaceNamespacedSecret({
+      name: secretName,
+      namespace,
+      body: {
+        apiVersion: "v1",
+        kind: "Secret",
+        type: existing.type ?? "Opaque",
+        metadata: {
+          name: secretName,
+          namespace,
+          resourceVersion: existing.metadata?.resourceVersion,
+          labels: existing.metadata?.labels,
+          annotations: existing.metadata?.annotations,
+        },
+        stringData: mergedData,
+      },
+    });
+  }
+  catch (err) {
+    if (!_isNotFoundError(err)) {
+      throw err;
+    }
+  }
 }

--- a/apps/control-plane/src/routes/provider-keys.ts
+++ b/apps/control-plane/src/routes/provider-keys.ts
@@ -83,12 +83,15 @@ export function providerKeysRouter(prisma: PrismaClient, coreApi: k8s.CoreV1Api,
 }
 
 /** Map provider name to the org-shared secret key used by tenant envFrom. */
-function _providerToSecretKey(provider: string): string {
-  if (provider === "openai") {
+function _providerToSecretKey(provider: string): string
+{
+  if (provider === "openai")
+  {
     return "OPENAI_API_KEY";
   }
 
-  if (provider === "claude") {
+  if (provider === "claude")
+  {
     return "ANTHROPIC_API_KEY";
   }
 
@@ -96,11 +99,13 @@ function _providerToSecretKey(provider: string): string {
 }
 
 /** Build a plain-text map from Secret data (base64) so keys can be merged safely. */
-function _decodeSecretData(secret: k8s.V1Secret): Record<string, string> {
+function _decodeSecretData(secret: k8s.V1Secret): Record<string, string>
+{
   const decoded: Record<string, string> = {};
   const data = secret.data ?? {};
 
-  for (const [key, value] of Object.entries(data)) {
+  for (const [key, value] of Object.entries(data))
+  {
     decoded[key] = Buffer.from(value, "base64").toString("utf8");
   }
 
@@ -108,26 +113,33 @@ function _decodeSecretData(secret: k8s.V1Secret): Record<string, string> {
 }
 
 /** Returns true when the Kubernetes error indicates a missing resource (HTTP 404). */
-function _isNotFoundError(err: unknown): boolean {
-  if (!(err instanceof Error)) {
+function _isNotFoundError(err: unknown): boolean
+{
+  if (!(err instanceof Error))
+  {
     return false;
   }
 
   const maybeStatus = err as Error & { code?: number; statusCode?: number; body?: { code?: number } | string };
-  if (maybeStatus.statusCode === 404 || maybeStatus.code === 404) {
+  if (maybeStatus.statusCode === 404 || maybeStatus.code === 404)
+  {
     return true;
   }
 
-  if (typeof maybeStatus.body === "object" && maybeStatus.body?.code === 404) {
+  if (typeof maybeStatus.body === "object" && maybeStatus.body?.code === 404)
+  {
     return true;
   }
 
-  if (typeof maybeStatus.body === "string") {
-    try {
+  if (typeof maybeStatus.body === "string")
+  {
+    try
+    {
       const parsedBody = JSON.parse(maybeStatus.body) as { code?: number };
       return parsedBody.code === 404;
     }
-    catch {
+    catch
+    {
       return false;
     }
   }
@@ -144,10 +156,12 @@ async function _upsertOrgProviderSecret(
   secretName: string,
   provider: string,
   keyValue: string,
-): Promise<void> {
+): Promise<void>
+{
   const secretKey = _providerToSecretKey(provider);
 
-  try {
+  try
+  {
     // 1. Read the existing Secret so we can preserve unrelated provider keys.
     const existing = await coreApi.readNamespacedSecret({ name: secretName, namespace });
     const mergedData = _decodeSecretData(existing);
@@ -172,8 +186,10 @@ async function _upsertOrgProviderSecret(
       },
     });
   }
-  catch (err) {
-    if (!_isNotFoundError(err)) {
+  catch (err)
+  {
+    if (!_isNotFoundError(err))
+    {
       throw err;
     }
 
@@ -204,10 +220,12 @@ async function _deleteOrgProviderSecretKey(
   namespace: string,
   secretName: string,
   provider: string,
-): Promise<void> {
+): Promise<void>
+{
   const secretKey = _providerToSecretKey(provider);
 
-  try {
+  try
+  {
     // 1. Read the existing Secret and decode all keys to preserve unrelated entries.
     const existing = await coreApi.readNamespacedSecret({ name: secretName, namespace });
     const mergedData = _decodeSecretData(existing);
@@ -234,9 +252,12 @@ async function _deleteOrgProviderSecretKey(
       },
     });
   }
-  catch (err) {
-    if (!_isNotFoundError(err)) {
+  catch (err)
+  {
+    if (!_isNotFoundError(err))
+    {
       throw err;
     }
   }
 }
+

--- a/apps/operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -174,6 +174,10 @@ describe("TenantResourceBuilder", () =>
     const podSpec = deployment.spec?.template?.spec;
     const container = podSpec?.containers?.[0];
     const envVars = Object.fromEntries((container?.env ?? []).map((entry) => [entry.name ?? "", entry.value ?? ""]));
+    const envVarNames = (container?.env ?? []).map((entry) => entry.name);
+    const envFromSecretNames = (container?.envFrom ?? [])
+      .map((entry) => entry.secretRef?.name)
+      .filter((name): name is string => name !== undefined);
     const volumeMounts = container?.volumeMounts ?? [];
     const volumes = podSpec?.volumes ?? [];
 
@@ -193,7 +197,8 @@ describe("TenantResourceBuilder", () =>
     expect(envVars.OPENCRANE_ALLOWED_SKILLS).toBeUndefined();
     expect(envVars.HOME).toBe("/tmp/opencrane-home");
     expect(envVars.NPM_CONFIG_CACHE).toBe("/tmp/npm-cache");
-    expect(envVars.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
+    expect(envVarNames).not.toContain("OPENAI_API_KEY");
+    expect(envFromSecretNames).toContain("org-shared-secrets");
     expect(volumeMounts.some((mount) => mount.name === "tmp" && mount.mountPath === "/tmp")).toBe(true);
     expect(volumeMounts.some((mount) => mount.name === "projected-identity" && mount.mountPath === "/var/run/opencrane/tokens")).toBe(true);
     expect(volumes.some((volume) => volume.name === "tmp" && volume.emptyDir !== undefined)).toBe(true);

--- a/apps/operator/src/tenants/deploy/3-deployment.ts
+++ b/apps/operator/src/tenants/deploy/3-deployment.ts
@@ -77,18 +77,6 @@ export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolu
         },
       },
     });
-
-    // OpenClaw requires OPENAI_API_KEY for its internal OpenAI translator engine fallback
-    envVars.push({
-      name: "OPENAI_API_KEY",
-      valueFrom: {
-        secretKeyRef: {
-          name: `openclaw-${name}-openai-key`,
-          key: "apiKey",
-          optional: true,
-        },
-      },
-    });
   }
 
   // 2. Volume mounts — the state volume mount comes from the adapter;
@@ -187,6 +175,8 @@ export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolu
               ports: [{ name: "gateway", containerPort: config.gatewayPort }],
               env: envVars,
               envFrom: [
+                // OPENAI_API_KEY is delivered through org-shared-secrets so
+                // provider-key ownership can remain in the control plane.
                 { secretRef: { name: "org-shared-secrets", optional: true } },
               ],
               volumeMounts,

--- a/platform/helm/templates/control-plane-rbac.yaml
+++ b/platform/helm/templates/control-plane-rbac.yaml
@@ -114,6 +114,34 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "opencrane.fullname" . }}-control-plane
     namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "opencrane.fullname" . }}-control-plane-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "opencrane.fullname" . }}-control-plane-secrets
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "opencrane.fullname" . }}-control-plane-secrets
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "opencrane.fullname" . }}-control-plane
+    namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- if .Values.certManager.enabled }}
 {{- if eq (include "opencrane.namespacedCertIssuer" .) "true" }}

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -448,7 +448,8 @@ networkPolicy:
 
 # -- Org-wide secrets injected into all tenant pods
 orgSecrets:
-  # -- Name of the Kubernetes Secret containing org-wide API keys
+  # -- Name of the Kubernetes Secret containing org-wide API keys.
+  # -- Control-plane provider-key updates project OPENAI/ANTHROPIC keys into this Secret.
   secretName: org-shared-secrets
   # -- Keys to inject as env vars (key in Secret -> env var name)
   envMappings: {}


### PR DESCRIPTION
# Changes:
- This series of fixes just moves the 'OPEN_AI_API' from the Tenant Deployment into the Control Plane and Grants the Control Plane the permissions needed to manage the API keys in the `org-shared-secrets` through a ServiceAccount.
 
# Files Changed:
- `apps/control-plane/src/__tests__/routes/provider-keys.test.ts` - Tests to assert the saving and deleting of provider API keys from the database.
- `apps/control-plane/src/routes.ts` - Passing the environment variables for the namespace and org shared secrets name via downward API.
- `apps/control-plane/src/routes/provider-keys.ts` - Saving and deleting of the provider keys to the database.
- `apps/operator/src/__tests__/tenants/tenant-resource-builder.test.ts` - Tests to assert API_KEY removal.
- `apps/operator/src/tenants/deploy/3-deployment.ts` - Removing the Direct provider key injection from the tenant deployment.
-  `platform/helm/templates/control-plane-rbac.yaml` - Granting the Control Plane the necessary permission to manage the provider keys.
- `platform/helm/values.yaml` - Comments update to explain new behaviour.