### PR TITLE
Tenant Drift Fixes

### DIFF
--- a/apps/control-plane/src/__tests__/routes/projection-drift.test.ts
+++ b/apps/control-plane/src/__tests__/routes/projection-drift.test.ts
@@ -57,6 +57,8 @@ describe("projection drift routes", function ()
             displayName: "Alpha From DB",
             email: "alpha@example.com",
             team: "platform",
+            phase: "Pending",
+            ingressHost: null,
           },
         ]),
       },
@@ -116,6 +118,54 @@ describe("projection drift routes", function ()
       {
         name: "default-deny",
         issue: "missing-projection",
+      },
+    ]);
+  });
+
+  it("detects tenant status drift for phase and ingressHost", async function ()
+  {
+    const customApi = {
+      listNamespacedCustomObject: vi.fn().mockResolvedValue({
+        items: [
+          {
+            metadata: { name: "delta" },
+            spec: {
+              displayName: "Delta",
+              email: "delta@example.com",
+              team: "platform",
+            },
+            status: {
+              phase: "Running",
+              ingressHost: "delta.opencrane.local",
+            },
+          },
+        ],
+      }),
+    } as unknown as k8s.CustomObjectsApi;
+
+    const prisma = {
+      tenant: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            name: "delta",
+            displayName: "Delta",
+            email: "delta@example.com",
+            team: "platform",
+            phase: "Pending",
+            ingressHost: null,
+          },
+        ]),
+      },
+    } as unknown as PrismaClient;
+
+    const res = await request(_BuildTenantDriftApp(customApi, prisma)).get("/drift");
+
+    expect(res.status).toBe(200);
+    expect(res.body.mismatches).toEqual([
+      {
+        name: "delta",
+        issue: "field-mismatch",
+        fields: ["phase", "ingressHost"],
       },
     ]);
   });

--- a/apps/control-plane/src/__tests__/routes/projection-repair.test.ts
+++ b/apps/control-plane/src/__tests__/routes/projection-repair.test.ts
@@ -199,4 +199,53 @@ describe("projection repair routes", function ()
     expect(res.body.entries[0]).toMatchObject({ name: "egress-policy", action: "updated", dryRun: true });
     expect(update).not.toHaveBeenCalled();
   });
+
+  it("applies tenant status projection updates for phase and ingressHost", async function ()
+  {
+    const customApi = {
+      listNamespacedCustomObject: vi.fn().mockResolvedValue({
+        items: [
+          {
+            metadata: { name: "epsilon" },
+            spec: { displayName: "Epsilon", email: "epsilon@example.com", team: "eng" },
+            status: { phase: "Running", ingressHost: "epsilon.opencrane.local" },
+          },
+        ],
+      }),
+    } as unknown as k8s.CustomObjectsApi;
+
+    const update = vi.fn().mockResolvedValue({});
+    const prisma = {
+      tenant: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            name: "epsilon",
+            displayName: "Epsilon",
+            email: "epsilon@example.com",
+            team: "eng",
+            phase: "Pending",
+            ingressHost: null,
+          },
+        ]),
+        create: vi.fn(),
+        update,
+      },
+    } as unknown as PrismaClient;
+
+    const res = await request(_BuildTenantRepairApp(customApi, prisma)).post("/repair?dryRun=false");
+
+    expect(res.status).toBe(200);
+    expect(res.body.mode).toBe("apply");
+    expect(res.body.repairedCount).toBe(1);
+    expect(update).toHaveBeenCalledWith({
+      where: { name: "epsilon" },
+      data: {
+        displayName: "Epsilon",
+        email: "epsilon@example.com",
+        team: "eng",
+        phase: "Running",
+        ingressHost: "epsilon.opencrane.local",
+      },
+    });
+  });
 });

--- a/apps/control-plane/src/__tests__/routes/tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/tenants.test.ts
@@ -314,3 +314,129 @@ describe("tenantsRouter create endpoint — Tenant CR appearance validation", ()
     expect(auditCreateSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("tenantsRouter status projection refresh on reads", () =>
+{
+  it("refreshes projected phase and ingress host on tenant list", async () =>
+  {
+    const tenantFindManySpy = vi.fn().mockResolvedValue([
+      {
+        name: "acme",
+        displayName: "Acme",
+        email: "owner@acme.io",
+        team: "engineering",
+        phase: "Pending",
+        ingressHost: null,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ]);
+    const tenantUpdateSpy = vi.fn().mockResolvedValue({});
+    const customApi = {
+      listNamespacedCustomObject: vi.fn().mockResolvedValue({
+        items: [
+          {
+            metadata: { name: "acme" },
+            status: {
+              phase: "Running",
+              ingressHost: "acme.opencrane.local",
+            },
+          },
+        ],
+      }),
+    } as unknown as k8s.CustomObjectsApi;
+    const prisma = {
+      tenant: {
+        findMany: tenantFindManySpy,
+        update: tenantUpdateSpy,
+      },
+    } as unknown as PrismaClient;
+
+    const app = _buildTenantsApp(customApi, prisma);
+    const response = await request(app).get("/api/tenants");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      {
+        name: "acme",
+        displayName: "Acme",
+        email: "owner@acme.io",
+        team: "engineering",
+        phase: "Running",
+        ingressHost: "acme.opencrane.local",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    expect(tenantUpdateSpy).toHaveBeenCalledOnce();
+  });
+
+  it("returns SQL projection when Kubernetes status refresh fails", async () =>
+  {
+    const tenantFindManySpy = vi.fn().mockResolvedValue([
+      {
+        name: "acme",
+        displayName: "Acme",
+        email: "owner@acme.io",
+        team: "engineering",
+        phase: "Pending",
+        ingressHost: null,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ]);
+    const tenantUpdateSpy = vi.fn().mockResolvedValue({});
+    const customApi = {
+      listNamespacedCustomObject: vi.fn().mockRejectedValue(new Error("k8s unavailable")),
+    } as unknown as k8s.CustomObjectsApi;
+    const prisma = {
+      tenant: {
+        findMany: tenantFindManySpy,
+        update: tenantUpdateSpy,
+      },
+    } as unknown as PrismaClient;
+
+    const app = _buildTenantsApp(customApi, prisma);
+    const response = await request(app).get("/api/tenants");
+
+    expect(response.status).toBe(200);
+    expect(response.body[0].phase).toBe("Pending");
+    expect(tenantUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it("refreshes projected phase and ingress host on tenant detail", async () =>
+  {
+    const tenantFindUniqueSpy = vi.fn().mockResolvedValue(
+      {
+        name: "acme",
+        displayName: "Acme",
+        email: "owner@acme.io",
+        team: "engineering",
+        phase: "Pending",
+        ingressHost: null,
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    );
+    const tenantUpdateSpy = vi.fn().mockResolvedValue({});
+    const customApi = {
+      getNamespacedCustomObject: vi.fn().mockResolvedValue({
+        metadata: { name: "acme" },
+        status: {
+          phase: "Running",
+          ingressHost: "acme.opencrane.local",
+        },
+      }),
+    } as unknown as k8s.CustomObjectsApi;
+    const prisma = {
+      tenant: {
+        findUnique: tenantFindUniqueSpy,
+        update: tenantUpdateSpy,
+      },
+    } as unknown as PrismaClient;
+
+    const app = _buildTenantsApp(customApi, prisma);
+    const response = await request(app).get("/api/tenants/acme");
+
+    expect(response.status).toBe(200);
+    expect(response.body.phase).toBe("Running");
+    expect(response.body.ingressHost).toBe("acme.opencrane.local");
+    expect(tenantUpdateSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/control-plane/src/routes/internal/projection-drift.ts
+++ b/apps/control-plane/src/routes/internal/projection-drift.ts
@@ -86,6 +86,15 @@ interface TenantCustomResource
     /** Optional team ownership label. */
     team?: string;
   };
+
+  /** Observed tenant runtime status written by the operator. */
+  status?: {
+    /** Current lifecycle phase derived from reconciliation outcomes. */
+    phase?: string;
+
+    /** External ingress host assigned to the tenant gateway. */
+    ingressHost?: string;
+  };
 }
 
 /** Minimal AccessPolicy CRD shape needed for drift comparison. */
@@ -119,9 +128,8 @@ interface AccessPolicyCustomResource
 /**
  * Compare Tenant CRDs against their PostgreSQL projection rows.
  *
- * This intentionally compares only the fields that are already dual-written
- * by the request path today. Runtime-driven status fields such as ingress host
- * are excluded until a dedicated status projector exists.
+ * This compares desired-state fields and status fields that should be mirrored
+ * in the SQL projection so API reads do not drift from Kubernetes status.
  */
 export async function _DetectTenantProjectionDrift(
   customApi: k8s.CustomObjectsApi,
@@ -129,7 +137,7 @@ export async function _DetectTenantProjectionDrift(
   namespace: string,
 ): Promise<ProjectionDriftReport>
 {
-  const comparedFields = ["displayName", "email", "team"];
+  const comparedFields = ["displayName", "email", "team", "phase", "ingressHost"];
 
   // 1. Read the CRDs that remain the desired-state source of truth.
   const sourceResponse = await customApi.listNamespacedCustomObject({
@@ -156,6 +164,8 @@ export async function _DetectTenantProjectionDrift(
           displayName: item.spec?.displayName,
           email: item.spec?.email,
           team: item.spec?.team,
+          phase: item.status?.phase ?? "Pending",
+          ingressHost: item.status?.ingressHost ?? null,
         },
       };
     }),
@@ -167,6 +177,8 @@ export async function _DetectTenantProjectionDrift(
           displayName: item.displayName,
           email: item.email,
           team: item.team,
+          phase: item.phase,
+          ingressHost: item.ingressHost,
         },
       };
     }),

--- a/apps/control-plane/src/routes/internal/projection-repair.ts
+++ b/apps/control-plane/src/routes/internal/projection-repair.ts
@@ -27,6 +27,15 @@ interface TenantCrd
     email?: string;
     team?: string;
   };
+
+  /** Tenant runtime status written by the operator reconcile loop. */
+  status?: {
+    /** Lifecycle phase currently observed by the operator. */
+    phase?: string;
+
+    /** Ingress host currently assigned to this tenant. */
+    ingressHost?: string;
+  };
 }
 
 /** Minimal AccessPolicy CRD shape needed for repair. */
@@ -85,6 +94,8 @@ export async function _RepairTenantProjection(customApi: k8s.CustomObjectsApi, p
     const displayName = crd.spec?.displayName ?? "";
     const email = crd.spec?.email ?? "";
     const team = crd.spec?.team ?? null;
+    const phase = crd.status?.phase ?? "Pending";
+    const ingressHost = crd.status?.ingressHost ?? null;
     const existing = rowByName.get(name);
 
     if (!existing)
@@ -92,7 +103,16 @@ export async function _RepairTenantProjection(customApi: k8s.CustomObjectsApi, p
       // 3a. Projection row is missing — insert from CRD state.
       if (!dryRun)
       {
-        await prisma.tenant.create({ data: { name, displayName, email, team: team ?? undefined } });
+        await prisma.tenant.create({
+          data: {
+            name,
+            displayName,
+            email,
+            team: team ?? undefined,
+            phase,
+            ingressHost: ingressHost ?? undefined,
+          },
+        });
       }
 
       entries.push({ name, action: "created", reason: "missing projection row created from CRD", dryRun });
@@ -102,13 +122,24 @@ export async function _RepairTenantProjection(customApi: k8s.CustomObjectsApi, p
     // 3b. Both sides exist — check for field drift and update if needed.
     const drifted = existing.displayName !== displayName
       || existing.email !== email
-      || (existing.team ?? null) !== team;
+      || (existing.team ?? null) !== team
+      || existing.phase !== phase
+      || (existing.ingressHost ?? null) !== ingressHost;
 
     if (drifted)
     {
       if (!dryRun)
       {
-        await prisma.tenant.update({ where: { name }, data: { displayName, email, team: team ?? undefined } });
+        await prisma.tenant.update({
+          where: { name },
+          data: {
+            displayName,
+            email,
+            team: team ?? undefined,
+            phase,
+            ingressHost: ingressHost ?? undefined,
+          },
+        });
       }
 
       entries.push({ name, action: "updated", reason: "field drift corrected from CRD", dryRun });

--- a/apps/control-plane/src/routes/tenants.ts
+++ b/apps/control-plane/src/routes/tenants.ts
@@ -62,7 +62,9 @@ export function tenantsRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCli
       orderBy: { createdAt: "desc" },
     });
 
-    const response: TenantResponse[] = tenants.map(function _mapTenant(t)
+    const syncedTenants = await _SyncTenantStatusesForRows(customApi, prisma, namespace, tenants);
+
+    const response: TenantResponse[] = syncedTenants.map(function _mapTenant(t)
     {
       return {
         name: t.name,
@@ -331,14 +333,16 @@ export function tenantsRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCli
       return;
     }
 
+    const syncedTenant = await _SyncSingleTenantStatusForRow(customApi, prisma, namespace, tenant);
+
     const response: TenantResponse = {
-      name: tenant.name,
-      displayName: tenant.displayName,
-      email: tenant.email,
-      team: tenant.team ?? undefined,
-      phase: tenant.phase,
-      ingressHost: tenant.ingressHost ?? undefined,
-      createdAt: tenant.createdAt.toISOString(),
+      name: syncedTenant.name,
+      displayName: syncedTenant.displayName,
+      email: syncedTenant.email,
+      team: syncedTenant.team ?? undefined,
+      phase: syncedTenant.phase,
+      ingressHost: syncedTenant.ingressHost ?? undefined,
+      createdAt: syncedTenant.createdAt.toISOString(),
     };
 
     res.json(response);
@@ -796,6 +800,239 @@ async function _Sleep(durationMs: number): Promise<void>
   {
     setTimeout(resolve, durationMs);
   });
+}
+
+/** Minimal Tenant CR status shape for projection synchronization. */
+interface TenantCustomResourceStatus
+{
+  /** Current lifecycle phase observed by the operator. */
+  phase?: string;
+
+  /** External ingress host assigned to the tenant. */
+  ingressHost?: string;
+}
+
+/** Minimal Tenant CR shape needed to read status from the Kubernetes client payloads. */
+interface TenantCustomResource
+{
+  /** Standard Kubernetes metadata. */
+  metadata?: { name?: string };
+
+  /** Runtime status fields written by the operator. */
+  status?: TenantCustomResourceStatus;
+}
+
+/** Minimal SQL projection row shape needed for tenant API responses and status sync. */
+interface TenantProjectionRow
+{
+  /** Tenant resource name. */
+  name: string;
+
+  /** Display name reflected by the API. */
+  displayName: string;
+
+  /** Tenant owner contact email. */
+  email: string;
+
+  /** Optional team ownership label. */
+  team: string | null;
+
+  /** Current projected lifecycle phase. */
+  phase: string;
+
+  /** Current projected ingress host. */
+  ingressHost: string | null;
+
+  /** Tenant creation timestamp. */
+  createdAt: Date;
+}
+
+/** Kubernetes list payload shape returned by the custom objects client. */
+interface KubernetesListResponse<TItem>
+{
+  /** Newer client payload shape where items exist at top-level. */
+  items?: TItem[];
+
+  /** Legacy payload shape where items are nested in body. */
+  body?: {
+    /** List items from legacy payloads. */
+    items?: TItem[];
+  };
+}
+
+/** Kubernetes object payload shape returned by getNamespacedCustomObject. */
+interface KubernetesObjectResponse
+{
+  /** Newer client payload shape where object fields exist at top-level. */
+  metadata?: { name?: string };
+  status?: TenantCustomResourceStatus;
+
+  /** Legacy payload shape where object fields are nested in body. */
+  body?: TenantCustomResource;
+}
+
+/**
+ * Synchronize projection statuses for a list of tenant rows from Kubernetes CR status.
+ * Best-effort only: API responses still succeed even if Kubernetes sync fails.
+ * @param customApi - Kubernetes custom objects API client.
+ * @param prisma - Prisma ORM client.
+ * @param namespace - Kubernetes namespace.
+ * @param rows - Existing tenant projection rows loaded from SQL.
+ */
+async function _SyncTenantStatusesForRows(
+  customApi: k8s.CustomObjectsApi,
+  prisma: PrismaClient,
+  namespace: string,
+  rows: TenantProjectionRow[],
+): Promise<TenantProjectionRow[]>
+{
+  try
+  {
+    const response = await customApi.listNamespacedCustomObject({
+      group: OPENCRANE_API_GROUP,
+      version: OPENCRANE_API_VERSION,
+      namespace,
+      plural: TENANT_CRD_PLURAL,
+    }) as KubernetesListResponse<TenantCustomResource>;
+
+    const items = response.items ?? response.body?.items ?? [];
+    const statusByName = new Map<string, { phase: string; ingressHost: string | null }>();
+
+    for (const item of items)
+    {
+      const name = item.metadata?.name ?? "";
+      if (!name)
+      {
+        continue;
+      }
+
+      statusByName.set(name, {
+        phase: item.status?.phase ?? "Pending",
+        ingressHost: item.status?.ingressHost ?? null,
+      });
+    }
+
+    const updates: Array<Promise<unknown>> = [];
+    const syncedRows = rows.map(function _mapRow(row)
+    {
+      const status = statusByName.get(row.name);
+      if (!status)
+      {
+        return row;
+      }
+
+      const ingressHost = status.ingressHost;
+      if (row.phase === status.phase && (row.ingressHost ?? null) === ingressHost)
+      {
+        return row;
+      }
+
+      updates.push(prisma.tenant.update({
+        where: { name: row.name },
+        data: {
+          phase: status.phase,
+          ingressHost,
+        },
+      }));
+
+      return {
+        ...row,
+        phase: status.phase,
+        ingressHost,
+      };
+    });
+
+    if (updates.length > 0)
+    {
+      await Promise.all(updates);
+    }
+
+    return syncedRows;
+  }
+  catch
+  {
+    return rows;
+  }
+}
+
+/**
+ * Synchronize one tenant projection row from Kubernetes CR status.
+ * Best-effort only: returns the original row when sync cannot be completed.
+ * @param customApi - Kubernetes custom objects API client.
+ * @param prisma - Prisma ORM client.
+ * @param namespace - Kubernetes namespace.
+ * @param row - Existing tenant projection row loaded from SQL.
+ */
+async function _SyncSingleTenantStatusForRow(
+  customApi: k8s.CustomObjectsApi,
+  prisma: PrismaClient,
+  namespace: string,
+  row: TenantProjectionRow,
+): Promise<TenantProjectionRow>
+{
+  try
+  {
+    const response = await customApi.getNamespacedCustomObject({
+      group: OPENCRANE_API_GROUP,
+      version: OPENCRANE_API_VERSION,
+      namespace,
+      plural: TENANT_CRD_PLURAL,
+      name: row.name,
+    }) as KubernetesObjectResponse;
+
+    const resource = _ReadTenantCustomObject(response);
+    if (!resource)
+    {
+      return row;
+    }
+
+    const nextPhase = resource.status?.phase ?? "Pending";
+    const nextIngressHost = resource.status?.ingressHost ?? null;
+    if (row.phase === nextPhase && (row.ingressHost ?? null) === nextIngressHost)
+    {
+      return row;
+    }
+
+    await prisma.tenant.update({
+      where: { name: row.name },
+      data: {
+        phase: nextPhase,
+        ingressHost: nextIngressHost,
+      },
+    });
+
+    return {
+      ...row,
+      phase: nextPhase,
+      ingressHost: nextIngressHost,
+    };
+  }
+  catch
+  {
+    return row;
+  }
+}
+
+/**
+ * Read a Tenant custom object from either modern or legacy client payload shapes.
+ * @param response - Raw Kubernetes client response for getNamespacedCustomObject.
+ */
+function _ReadTenantCustomObject(response: KubernetesObjectResponse): TenantCustomResource | null
+{
+  if (response.body)
+  {
+    return response.body;
+  }
+
+  if (response.metadata || response.status)
+  {
+    return {
+      metadata: response.metadata,
+      status: response.status,
+    };
+  }
+
+  return null;
 }
 
 /**

--- a/apps/operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts
+++ b/apps/operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts
@@ -33,6 +33,16 @@ function _makeRecordingClient(): RecordingClient
       get(target, prop: string): unknown
       {
         if (prop === "created") return target.created;
+        if (prop === "readNamespacedDeployment")
+        {
+          return async function readNamespacedDeployment(): Promise<unknown>
+          {
+            return {
+              spec: { replicas: 1 },
+              status: { readyReplicas: 1 },
+            };
+          };
+        }
         // The generic KubernetesObjectApi methods (`create`/`read`/`replace`) must
         // stay absent so `_K8sApplyResource` falls through to the typed switch,
         // which is the production CoreV1/AppsV1 client surface.

--- a/apps/operator/src/tenants/operator.ts
+++ b/apps/operator/src/tenants/operator.ts
@@ -12,13 +12,18 @@ import { _RunWatchLoop, K8sWatchEventType } from "../shared/watch-runner.js";
 import { OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "../shared/crd-constants.js";
 import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildIngress, _BuildIngressHost, _BuildService, _BuildServiceAccount, _BuildStatePvc } from "./deploy/index.js";
 import { TenantCleanup } from "./destroy/tenant-cleanup.js";
-
 import { TenantEncryptionKeys } from "./internal/tenant-encryption-keys.js";
 import { TenantLiteLlmKeys } from "./internal/tenant-litellm-keys.js";
 import { _ResolveTenantPolicy } from "./internal/policy-resolution.js";
 import { _ResolveClusterTenant } from "./internal/cluster-tenant-resolution.js";
 import type { ClusterTenantResource } from "./internal/cluster-tenant-resolution.types.js";
 import { TenantStatusWriter } from "./internal/tenant-status-writer.js";
+import type { DeploymentStatusSnapshot } from "./operator.types.js";
+
+/** Deployment readiness wait defaults used before marking tenant Running. */
+const TENANT_DEPLOYMENT_READY_TIMEOUT_MS = 120_000;
+/** Poll interval between readiness checks. */
+const TENANT_DEPLOYMENT_READY_POLL_INTERVAL_MS = 2_000;
 
 /**
  * Watches Tenant custom resources and reconciles the corresponding
@@ -71,17 +76,17 @@ export class TenantOperator
    * Prefer {@link _CreateTenantOperator} in production entry-points.
    */
   constructor(watch: k8s.Watch,
-              customApi: k8s.CustomObjectsApi,
-              coreApi: k8s.CoreV1Api,
-              appsApi: k8s.AppsV1Api,
-              networkingApi: k8s.NetworkingV1Api,
-              log: Logger,
-              config: OpenClawTenantOperatorConfig,
-              hosting: HostingAdapter,
-              cleanup: TenantCleanup,
-              statusWriter: TenantStatusWriter,
-              encryptionKeys: TenantEncryptionKeys,
-              liteLlmKeys: TenantLiteLlmKeys)
+			  customApi: k8s.CustomObjectsApi,
+			  coreApi: k8s.CoreV1Api,
+			  appsApi: k8s.AppsV1Api,
+			  networkingApi: k8s.NetworkingV1Api,
+			  log: Logger,
+			  config: OpenClawTenantOperatorConfig,
+			  hosting: HostingAdapter,
+			  cleanup: TenantCleanup,
+			  statusWriter: TenantStatusWriter,
+			  encryptionKeys: TenantEncryptionKeys,
+			  liteLlmKeys: TenantLiteLlmKeys)
   {
     this.watch = watch;
     this.customApi = customApi;
@@ -108,6 +113,7 @@ export class TenantOperator
       ? `/apis/${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}/namespaces/${ns}/${TENANT_CRD_PLURAL}`
       : `/apis/${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}/${TENANT_CRD_PLURAL}`;
 
+    const self = this;
     await _RunWatchLoop<Tenant>({
       watch: this.watch,
       path,
@@ -115,14 +121,16 @@ export class TenantOperator
       startMessage: "starting tenant watch",
       reconnectMessage: "watch connection lost, reconnecting...",
       failedMessage: "watch failed, retrying...",
-      onEvent: async (type: K8sWatchEventType | string, tenant: Tenant) => {
-        await this.handleEvent(type, tenant);
+      async onEvent(type: K8sWatchEventType | string, tenant: Tenant)
+      {
+        await self.handleEvent(type, tenant);
       },
     });
   }
 
   /**
-   * Route a watch event to the appropriate reconciliation handler.
+   * Route a watch event to the appropriate handler: provisioning for new
+   * tenants, reconciliation for updates, and cleanup for deletions.
    */
   private async handleEvent(type: K8sWatchEventType | string, tenant: Tenant): Promise<void>
   {
@@ -134,6 +142,16 @@ export class TenantOperator
     switch (type)
     {
       case K8sWatchEventType.Added:
+        if (tenant.spec.suspended)
+        {
+          await this.suspendTenant(tenant);
+        }
+        else
+        {
+          await this.provisionTenant(tenant);
+          await this.reconcileTenant(tenant);
+        }
+        break;
       case K8sWatchEventType.Modified:
         if (tenant.spec.suspended)
         {
@@ -147,6 +165,30 @@ export class TenantOperator
       case K8sWatchEventType.Deleted:
         await this.cleanupTenant(tenant);
         break;
+    }
+  }
+
+  /**
+   * Run one-time provisioning steps for a newly observed tenant.
+   * Idempotent — each step short-circuits when its target resource already exists,
+   * so operator restarts that replay ADDED events are safe.
+   */
+  private async provisionTenant(tenant: Tenant): Promise<void>
+  {
+    const name = tenant.metadata!.name!;
+    const namespace = tenant.metadata!.namespace ?? "default";
+
+    // 1. LiteLLM team + virtual key — creates the team for spend tracking and
+    //    materialises the API key as a Secret. Skipped when LiteLLM is disabled
+    //    or the Secret already exists. Best-effort so transient LiteLLM issues
+    //    do not block tenant startup.
+    try
+    {
+      await this.liteLlmKeys.ensureLiteLlmKeySecret(tenant, namespace);
+    }
+    catch (err)
+    {
+      this.log.warn({ err, name }, "litellm key provisioning failed; tenant will reconcile without a key");
     }
   }
 
@@ -237,42 +279,54 @@ export class TenantOperator
       //    and stores it as a K8s Secret. Idempotent: existing secrets are not rotated.
       await this.encryptionKeys.ensureEncryptionKeySecret(name, namespace);
 
-      // 4. LiteLLM key Secret — creates a per-tenant virtual key in LiteLLM and stores
-      //    it in a tenant Secret mounted through env var. Skipped when LiteLLM is disabled.
-      //    Best-effort so transient LiteLLM backend issues do not block tenant startup.
-      try
-      {
-        await this.liteLlmKeys.ensureLiteLlmKeySecret(effectiveTenant, namespace);
-      }
-      catch (err)
-      {
-        this.log.warn({ err, name }, "litellm key provisioning failed; continuing reconcile");
-      }
-
-      // 5. ConfigMap — serialises the base OpenClaw JSON config merged with any
+      // 4. ConfigMap — serialises the base OpenClaw JSON config merged with any
       //    spec.configOverrides the tenant author provided.
       await __K8sApplyResource(this.coreApi, _BuildConfigMap(this.config, effectiveTenant, namespace, policyResolution.effectivePolicy), this.log);
 
-      // 6. State volume — adapter decides CSI mount (cloud) vs PVC (on-prem).
-      //    Create the PVC only when the adapter requests it (on-prem path).
-      const stateVolume = this.hosting.buildStateVolume(name);
-      if (stateVolume.requiresPvc)
-      {
-        await __K8sApplyResource(this.coreApi, _BuildStatePvc(name, namespace), this.log);
-      }
+	  // 5. State volume — adapter decides CSI mount (cloud) vs PVC (on-prem).
+	  //    Create the PVC only when the adapter requests it (on-prem path).
+	  const stateVolume = this.hosting.buildStateVolume(name);
+	  if (stateVolume.requiresPvc)
+	  {
+		await __K8sApplyResource(this.coreApi, _BuildStatePvc(name, namespace), this.log);
+	  }
 
-      // 7. Deployment — single-replica pod running the tenant's OpenClaw gateway.
+      // 6. Deployment — single-replica pod running the tenant's OpenClaw gateway.
       //    Mounts the ConfigMap, encryption key, state volume, and projected identity tokens.
       await __K8sApplyResource(this.appsApi, _BuildDeployment(this.config, stateVolume, effectiveTenant, namespace, compute), this.log);
 
-      // 8. Service — ClusterIP that makes the gateway reachable inside the cluster
+      // 7. Service — ClusterIP that makes the gateway reachable inside the cluster
       //    on the configured gateway port.
       await __K8sApplyResource(this.coreApi, _BuildService(this.config, effectiveTenant, namespace), this.log);
 
-      // 9. Ingress — routes external HTTPS traffic for {tenant}.{domain} to the Service.
+      // 8. Ingress — routes external HTTPS traffic for {tenant}.{domain} to the Service.
       //    Ingress class and annotations come from the adapter (nginx on-prem, gce on GKE).
       const ingressBinding = this.hosting.buildIngressBinding();
       await __K8sApplyResource(this.networkingApi, _BuildIngress(this.config, ingressBinding, effectiveTenant, namespace, ingressDomain), this.log);
+
+      // 9. Deployment readiness — avoid optimistic Running states when pods still fail to start.
+      const deploymentReady = await _WaitForTenantDeploymentReady(
+        this.appsApi,
+        name,
+        namespace,
+        _ReadPositiveIntEnv("TENANT_DEPLOYMENT_READY_TIMEOUT_MS", TENANT_DEPLOYMENT_READY_TIMEOUT_MS),
+        _ReadPositiveIntEnv("TENANT_DEPLOYMENT_READY_POLL_INTERVAL_MS", TENANT_DEPLOYMENT_READY_POLL_INTERVAL_MS),
+      );
+
+      if (!deploymentReady)
+      {
+        await this.statusWriter.patchStatus(tenant, crNamespace, {
+          phase: TenantStatusPhase.Pending,
+          podName: `openclaw-${name}`,
+          ingressHost: _BuildIngressHost(name, ingressDomain),
+          message: "Deployment is not ready yet",
+          effectivePolicyRef,
+          policyResolutionSource: policyResolution.source,
+          policyResolutionState: policyResolution.state,
+          lastReconciled: new Date().toISOString(),
+        });
+        return;
+      }
 
       // 10. Status — write the observed Running state back to the Tenant CR so that
       //    kubectl, the control-plane API, and the UI all see the current phase.
@@ -360,9 +414,11 @@ export class TenantOperator
     const stateVolume = this.hosting.buildStateVolume(name);
     const deployment = _BuildDeployment(this.config, stateVolume, tenant, namespace, compute);
     deployment.spec!.replicas = 0;
+
+    // 3. Apply — server-side apply the zero-replica deployment to the cluster.
     await __K8sApplyResource(this.appsApi, deployment, this.log);
 
-    // 3. Record the suspended phase against the CR namespace.
+    // 4. Status — mark the tenant as Suspended so controllers and the UI reflect the change.
     await this.statusWriter.patchStatus(tenant, crNamespace, {
       phase: TenantStatusPhase.Suspended,
       lastReconciled: new Date().toISOString(),
@@ -378,13 +434,81 @@ export class TenantOperator
     const name = tenant.metadata!.name!;
     const namespace = tenant.metadata!.namespace ?? "default";
 
+    // 1. Log — emit a structured log before cleanup begins for traceability.
     this.log.info({ name }, "cleaning up tenant resources");
 
+    // 2. Cleanup — remove tenant-owned K8s resources (Deployment, Service, Ingress, etc.).
+    //    External storage and encryption key Secrets are intentionally retained.
     await this.cleanup.cleanupTenant(name, namespace);
 
+    // 3. Log — confirm completion so operators can distinguish partial from full teardown.
     this.log.info({ name }, "tenant cleanup complete (storage + encryption key retained)");
   }
 
+}
+
+/**
+ * Wait until a tenant deployment reports all desired replicas as ready.
+ */
+async function _WaitForTenantDeploymentReady(appsApi: k8s.AppsV1Api, tenantName: string, namespace: string, timeoutMs: number, pollIntervalMs: number): Promise<boolean>
+{
+  const deploymentName = `openclaw-${tenantName}`;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() <= deadline)
+  {
+    try
+    {
+      const response = await appsApi.readNamespacedDeployment({
+        name: deploymentName,
+        namespace,
+      }) as DeploymentStatusSnapshot;
+
+      if (_IsDeploymentReady(response))
+      {
+        return true;
+      }
+    }
+    catch
+    {
+      // Ignore transient read errors while the deployment is settling.
+    }
+
+    await _Sleep(pollIntervalMs);
+  }
+
+  return false;
+}
+
+/**
+ * Decide whether the deployment has reached ready state.
+ */
+function _IsDeploymentReady(deployment: DeploymentStatusSnapshot): boolean
+{
+  const desiredReplicas = deployment.spec?.replicas ?? 1;
+  const readyReplicas = deployment.status?.readyReplicas ?? 0;
+  return readyReplicas >= desiredReplicas && desiredReplicas > 0;
+}
+
+/**
+ * Parse positive integer env vars with fallback values.
+ */
+function _ReadPositiveIntEnv(key: string, fallback: number): number
+{
+  const raw = process.env[key];
+  const parsed = raw ? Number(raw) : Number.NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+/**
+ * Sleep for the provided duration.
+ */
+async function _Sleep(durationMs: number): Promise<void>
+{
+  await new Promise(function _resolveAfterSleep(resolve)
+  {
+    setTimeout(resolve, durationMs);
+  });
 }
 
 /**

--- a/apps/operator/src/tenants/operator.types.ts
+++ b/apps/operator/src/tenants/operator.types.ts
@@ -1,0 +1,17 @@
+/** Minimal Deployment shape required for readiness checks. */
+export interface DeploymentStatusSnapshot
+{
+  /** Desired replica configuration. */
+  spec?:
+  {
+    /** Number of desired replicas. */
+    replicas?: number;
+  };
+
+  /** Current deployment status from the cluster. */
+  status?:
+  {
+    /** Number of pods that have passed readiness probes. */
+    readyReplicas?: number;
+  };
+}


### PR DESCRIPTION
# Changes:
- The Tenant drift detection and reconciliation was not working which left the Control Plane API Tenant Status and the CR Status diverged. As a result, the Control Plane API was always stuck in a pending state for any tenant that was created.

# Files Changed:
- `apps/control-plane/src/__tests__/routes/projection-drift.test.ts` - Tests to assert addition of `phase` and `ingressHost` fields to tenant drift detection.
- `apps/control-plane/src/routes/internal/projection-drift.ts` - Addition of `phase` and `ingressHost` fields to drift detection.
- `apps/control-plane/src/__tests__/routes/projection-repair.test.ts` - Tests to assert drift repair for `phase` and `ingressHost` fields.
- `apps/control-plane/src/routes/internal/projection-repair.ts` - Addition of `phase` and `ingressHost` fields to drift repair.
- `apps/control-plane/src/__tests__/routes/tenants.test.ts` - Tests to assert dynamic update of DB values on tenants list operations.
- `apps/control-plane/src/routes/tenants.ts` - Querying the Kubernetes API for the live CR status and dynamically updating the DB values for phase and ingressHost if they differ
- `apps/operator/src/tenants/operator.ts`:
    - Moved LiteLLM key Secret creation to step 1 (one-time provisioning block provisionTenant) to avoid redundant checks during standard reconciliation iterations.
    - Introduced `_WaitForTenantDeploymentReady` inside `reconcileTenant()`. The reconcile loop now polls the deployment status for a configurable period (`TENANT_DEPLOYMENT_READY_TIMEOUT_MS`) before updating the Custom Resource status to `Running`.
- `apps/operator/src/tenants/operator.types.ts` - Created to house the `DeploymentStatusSnapshot` interface.
- `apps/operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts` - Updated mock object recording client (`_makeRecordingClient`) to provide mock responses for `readNamespacedDeployment` calls to prevent test failures during operator execution checks. 