### PR TITLE
✨ Centralized logging + OpenTelemetry tracing across the k8s apps

### DIFF
--- a/.claude/agents/observability.md
+++ b/.claude/agents/observability.md
@@ -1,0 +1,116 @@
+---
+name: observability
+description: >
+  Telemetry + logging specialist for OpenCrane (the two are one agent on purpose —
+  they share the @opencrane/observability lib and the same trace-wrap seam). Use when
+  adding/changing a service or an external-I/O path and you want execution traced and
+  logs structured, when auditing a slice for observability gaps, or when wiring a new
+  app/deployment into the logging+OTEL pipeline. Audits by default; applies the
+  conventions when asked. Reads the lib barrel each run so it never assumes stale API names.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+You are the OpenCrane observability specialist. You own one concern with two faces —
+**structured logging** and **execution tracing** — because in this codebase they are the
+same mechanism: a single wrap opens a span *and* seeds the context that every log line
+inherits. Treating them separately would mean visiting every seam twice, so you handle both.
+
+## First step — load the source of truth (every run, no exceptions)
+
+1. Read `AGENTS.md` at the repo root — the canonical coding/style/IAM rules. You edit
+   `.ts`, so its TypeScript conventions bind you.
+2. Read `libs/observability/src/index.ts` (the barrel) to learn the **current public API
+   and exact export names**. These names drift — the trace wrapper has already been
+   renamed (`___WithOperation` → `___DoWithTrace`). Never hard-code a remembered name;
+   read the barrel and use what is actually exported. If a symbol you expect is gone,
+   trust the barrel.
+3. Skim `libs/observability/src/logger.ts`, `operation.ts`, `console-bind.ts`,
+   `redact.ts`, and `telemetry.ts` so you apply the real signatures and behaviour.
+
+The platform doc `docs/agents/` and the auto-memory note on observability (if present)
+describe the architecture: pino JSON→stdout, an in-cluster OTEL Collector exporting to
+GCP Cloud Logging + Cloud Trace (Helm `observability.otel`, default off), context via
+`AsyncLocalStorage`. Confirm against the code; do not assume.
+
+## What "good" looks like
+
+### Logging (structured, correlated, safe)
+- A root logger built with the lib's `createLogger`-equivalent (read the barrel for the
+  current name), one per service. In the control-plane, core modules import the shared
+  logger from `apps/control-plane/src/log.ts` — reuse it, do not spin up new pino instances.
+- **No raw `console.*` in shipped code.** Convert each to a structured log call:
+  `log.warn({ tenant, digest }, "message")` — structured fields, **never** string
+  interpolation (`` `failed for ${x}` `` is wrong; `{ x }` is right). Errors go under the
+  `err` key so pino serialises them.
+- Level discipline: `debug` for routine/expected-miss paths, `info` for outcomes worth
+  seeing, `warn` for degraded-but-handled, `error` for unhandled. A benign 404/“absent”
+  case is `debug`, not `warn`.
+- The console seam: the lib's `bindConsole`-equivalent is the safety net for stray/3rd-party
+  output — but first-party code should call the real logger so fields are typed.
+  **The CLI must never bind console** — its `console.log` is the `--output json` channel.
+- **Secrets never reach logs or spans.** Any new credential-bearing field (tokens, keys,
+  master keys, client secrets, DB URLs, auth headers) must be covered by the lib's redaction
+  paths (`redact.ts`). When code introduces a new such field, add its path.
+
+### Tracing (spans on every meaningful seam)
+- Wrap each external-I/O or failure-prone unit of work in the lib's trace wrapper
+  (`___DoWithTrace` at time of writing — confirm via the barrel): network/`fetch`, DB
+  mutations, Kubernetes API calls, OCI registry, LiteLLM, Cognee, gateway admin, reconcile
+  loops, ingest cycles.
+- Span names are dotted `domain.action` (`oci.bundle.push`, `litellm.chat.run`,
+  `tenant.reconcile`). Pass the same structured fields you would log (ids, sizes, model,
+  outcome) — they become span attributes for trace queries.
+- The wrapper takes a callback. Inside a **class method** use an arrow or capture
+  `const self = this` so `this` survives (a named `function` callback loses it — this is a
+  real trap; verify). Inside a standalone function or object-literal method, a named
+  `function` expression is correct.
+- Per-app bootstrap: a first-imported `src/instrument.ts` calls the lib's
+  `startTelemetry`-equivalent before any instrumented module loads (ESM ordering). It is a
+  no-op without an OTLP endpoint, so it is always safe to add.
+- Lifecycle: long-running services flush on `SIGTERM`/`SIGINT` via the lib's shutdown
+  function before exit; short-lived processes (CLI, migrate) flush after their work resolves.
+
+### Infra wiring (when a new deployable app appears)
+- Add the `@opencrane/observability` workspace dep, the `instrument.ts`, and (for servers)
+  the request-context middleware.
+- Helm: include the `opencrane.observabilityEnv` helper in the app's Deployment `env:` and
+  ensure the Dockerfile builds the lib like the other workspace libs. Verify the OTEL
+  Collector toggle still renders (`helm template ... --set observability.otel.enabled=true`).
+
+## Two modes
+
+- **Audit** (default, and whenever the caller says "check/review"): report gaps only, do not
+  edit. Use the output format below, `file:line` for every gap.
+- **Apply** (when the caller says "wire/add/fix/instrument"): make the edits, matching the
+  surrounding code's idioms and AGENTS.md style, then verify (below).
+
+Determine scope first: `git diff --stat HEAD` / `git diff HEAD`, or the files/PR the caller named.
+
+## Constraints
+- **Reuse the lib; never reinvent.** No bespoke logger, no manual `trace.getTracer`, no
+  hand-rolled context — go through `@opencrane/observability`.
+- **Do not add noise.** One start line (debug) + one outcome line per seam is plenty; avoid
+  logging inside tight loops or per-iteration unless explicitly asked.
+- **Never log or span a secret.** If unsure whether a field is sensitive, treat it as
+  sensitive and redact.
+- **Match the existing API names from the barrel**, not names from memory or this document.
+- Editing `.ts` binds you to AGENTS.md: Allman braces, JSDoc on every declaration, no
+  standalone arrow declarations (arrows only in HOF callbacks / where `this` must bind),
+  single-line top imports, `*.types.ts` separation, the `_`/`___` naming convention.
+
+## Verify after applying (mandatory when you edit)
+- Typecheck/build the touched package(s): e.g. `pnpm --filter @opencrane/observability build`,
+  `pnpm --filter @opencrane/control-plane exec tsc --noEmit`.
+- Run the relevant tests: `pnpm --filter <pkg> test`. If you added a lib capability
+  (redaction path, helper), add a vitest covering it.
+- If you touched Helm, `helm template` the chart in default-off and `observability.otel.enabled=true`.
+- Report what you ran and the result. Never claim green without running it.
+
+## Output format
+1. **Summary** — one line: audited vs applied, and the headline (e.g. "3 untraced seams, 5 console.* calls").
+2. **Logging gaps/changes** — `file:line`, what's wrong/done, structured-field suggestion.
+3. **Tracing gaps/changes** — `file:line`, span name + fields added or missing.
+4. **Infra/wiring** — instrument.ts, shutdown flush, Helm env, redaction-path additions.
+5. **Verification** — commands run and results (apply mode), or "audit only — no edits".
+6. **Residual risks / follow-ups.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ message) wherever the work has no dependency between them.
 | `review` | Haiku | Independent, fresh-context code review of a changed slice — correctness bugs, regressions, security/IAM-policy drift, missing tests, AGENTS.md style. Read-only; reports findings severity-first. **Required by the review gate before a turn ends** (see [Mandatory Independent Review](docs/agents/workflow.md#mandatory-independent-review-policy-driven-gate)). |
 | `changelog` | Sonnet | Maintain `CHANGELOG.md` in functional, capability-first terms when a phase/track completes or a tag is cut. Reads `plan.md`/`plan-done.md` + git range; writes capability, not commit history. |
 | `readme` | Sonnet | Maintain `README.md` as the project front door — the problem, the vision, and what the repo does. Keeps design decisions, phase history, threat models, and deep mechanism OUT (those go to `CHANGELOG.md`/`plan-done.md`/the docs site). |
+| `observability` | Sonnet | Telemetry + logging in one (they share the `@opencrane/observability` lib and trace-wrap seam). Audits or wires a slice so external-I/O paths are traced (`___DoWithTrace` spans) and output is structured (no raw `console.*`, secrets redacted, errors under `err`), plus per-app `instrument.ts`/shutdown-flush/Helm env. Reads the lib barrel each run for current API names. |
 
 **Roadmap execution** is the `/execute-plan` **skill** (`.claude/commands/execute-plan.md`), not an
 agent — it runs in the main session, parallelises via a dependency DAG + waves (one `general-purpose`

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@opencrane/contracts": "workspace:*",
+    "@opencrane/observability": "workspace:*",
     "commander": "^12.0.0"
   },
   "devDependencies": {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -18,7 +18,13 @@
  *   Example: oc tenants list --output json | jq '.[].name'
  */
 
+// OpenTelemetry must initialise before the HTTP client is imported. No-op
+// unless OTEL_EXPORTER_OTLP_ENDPOINT is set, so laptop use is unaffected.
+import "./instrument.js";
+
 import { Command } from "commander";
+
+import { ___ShutdownTelemetry } from "@opencrane/observability";
 
 import { type CliConfig, _ResolveConfig } from "./config.js";
 import { _RegisterAudit } from "./commands/audit.js";
@@ -88,8 +94,16 @@ _RegisterAwareness(program, _getConfig);
 _RegisterSessions(program, _getConfig);
 _RegisterAuth(program, _getConfig);
 
-program.parseAsync(process.argv).catch(function _onError(err: unknown)
-{
-  console.error(err instanceof Error ? err.message : String(err));
-  process.exit(1);
-});
+program.parseAsync(process.argv)
+  .then(async function _onDone()
+  {
+    // Flush any spans (only created when a collector endpoint is configured)
+    // before the process exits naturally.
+    await ___ShutdownTelemetry();
+  })
+  .catch(async function _onError(err: unknown)
+  {
+    console.error(err instanceof Error ? err.message : String(err));
+    await ___ShutdownTelemetry();
+    process.exit(1);
+  });

--- a/apps/cli/src/instrument.ts
+++ b/apps/cli/src/instrument.ts
@@ -1,0 +1,15 @@
+/**
+ * OpenTelemetry bootstrap for the `oc` CLI.
+ *
+ * A complete no-op unless `OTEL_EXPORTER_OTLP_ENDPOINT` is set (the default on a
+ * laptop), so normal CLI use carries zero overhead. When an endpoint *is*
+ * configured (e.g. `oc` running in CI against the cluster), the auto HTTP
+ * instrumentation propagates trace context to the control-plane so a command
+ * and the server work it triggers appear in one trace.
+ *
+ * Imported first in `index.ts` so instrumentation is installed before the
+ * contracts HTTP client loads.
+ */
+import { ___StartTelemetry } from "@opencrane/observability/telemetry";
+
+await ___StartTelemetry({ serviceName: "oc-cli", serviceVersion: process.env["npm_package_version"] ?? "0.1.0" });

--- a/apps/control-plane/deploy/Dockerfile
+++ b/apps/control-plane/deploy/Dockerfile
@@ -8,17 +8,20 @@ COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY tsconfig.base.json ./
 COPY libs/contracts/package.json libs/contracts/tsconfig.json libs/contracts/
 COPY libs/awareness/package.json libs/awareness/tsconfig.json libs/awareness/
+COPY libs/observability/package.json libs/observability/tsconfig.json libs/observability/
 COPY apps/control-plane/scripts apps/control-plane/scripts
 COPY apps/control-plane/openapi.json apps/control-plane/openapi.json
 COPY apps/control-plane/package.json apps/control-plane/tsconfig.json apps/control-plane/
 COPY apps/control-plane/prisma apps/control-plane/prisma
-RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/awareness --filter @opencrane/control-plane
+RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/awareness --filter @opencrane/observability --filter @opencrane/control-plane
 
 COPY libs/contracts/src libs/contracts/src
 COPY libs/awareness/src libs/awareness/src
+COPY libs/observability/src libs/observability/src
 COPY apps/control-plane/src apps/control-plane/src
 RUN pnpm --filter @opencrane/contracts build
 RUN pnpm --filter @opencrane/awareness build
+RUN pnpm --filter @opencrane/observability build
 RUN pnpm --filter @opencrane/control-plane build
 # Stage generated Prisma client to a fixed path for the runtime stage
 RUN find /app -path '*/node_modules/.prisma/client' -type d | head -1 | \
@@ -33,9 +36,10 @@ WORKDIR /app
 COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml ./
 COPY --from=build /app/libs/contracts/package.json libs/contracts/
 COPY --from=build /app/libs/awareness/package.json libs/awareness/
+COPY --from=build /app/libs/observability/package.json libs/observability/
 COPY --from=build /app/apps/control-plane/package.json apps/control-plane/
 COPY --from=build /app/apps/control-plane/prisma apps/control-plane/prisma
-RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/awareness --filter @opencrane/control-plane --prod
+RUN pnpm install --frozen-lockfile --filter @opencrane/contracts --filter @opencrane/awareness --filter @opencrane/observability --filter @opencrane/control-plane --prod
 COPY --from=build /generated-prisma /tmp/generated-prisma
 # Retrieve the generated Prisma client for the runtime stage
 RUN target=$(find /app -path '*/node_modules/.prisma/client' -type d | head -1) && \
@@ -45,6 +49,7 @@ RUN target=$(find /app -path '*/node_modules/.prisma/client' -type d | head -1) 
 
 COPY --from=build /app/libs/contracts/dist libs/contracts/dist
 COPY --from=build /app/libs/awareness/dist libs/awareness/dist
+COPY --from=build /app/libs/observability/dist libs/observability/dist
 COPY --from=build /app/apps/control-plane/dist apps/control-plane/dist
 
 USER node

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -19,6 +19,7 @@
     "@kubernetes/client-node": "^1.0.0",
     "@opencrane/awareness": "workspace:*",
     "@opencrane/contracts": "workspace:*",
+    "@opencrane/observability": "workspace:*",
     "@prisma/client": "^6.0.0",
     "@types/express-session": "^1.19.0",
     "express": "^5.1.0",

--- a/apps/control-plane/src/core/ai-budget/ai-budget.logic.ts
+++ b/apps/control-plane/src/core/ai-budget/ai-budget.logic.ts
@@ -2,6 +2,7 @@ import type * as k8s from "@kubernetes/client-node";
 import type { PrismaClient } from "@prisma/client";
 import type { Request, Response } from "express";
 
+import { _log } from "../../log.js";
 import { SpendLogic } from "../spend/spend.logic.js";
 
 /** AI-budget controller dependencies. */
@@ -195,10 +196,14 @@ export async function _RevokeLiteLlmKey(req: Request, res: Response, deps: AiBud
   {
     await deps.coreApi.deleteNamespacedSecret({ name: secretName, namespace: deps.namespace });
     secretDeleted = true;
+    _log.info({ tenant: tenantName, secretName, namespace: deps.namespace }, "litellm key secret deleted");
   }
-  catch
+  catch (err)
   {
+    // Absent secret is the common case (already revoked / never issued); log at debug so a real
+    // RBAC/API failure is still visible without spamming on the benign 404.
     secretDeleted = false;
+    _log.debug({ tenant: tenantName, secretName, namespace: deps.namespace, err }, "litellm key secret not deleted");
   }
 
   await deps.prisma.tenantLiteLlmKey.updateMany({
@@ -239,6 +244,10 @@ async function _deleteLiteLlmKey(keyAlias: string | null): Promise<{ deleted: bo
   // 1. Unconfigured or no alias to target → nothing to delete upstream.
   if (!endpoint || !masterKey || !keyAlias)
   {
+    _log.debug(
+      { endpointConfigured: Boolean(endpoint), masterKeyConfigured: Boolean(masterKey), keyAlias },
+      "litellm key delete skipped (unconfigured or no alias)",
+    );
     return { deleted: false };
   }
 
@@ -253,11 +262,13 @@ async function _deleteLiteLlmKey(keyAlias: string | null): Promise<{ deleted: bo
       },
       body: JSON.stringify({ key_aliases: [keyAlias] }),
     });
+    _log.info({ keyAlias, deleted: response.ok, status: response.status }, "litellm key delete attempted");
     return { deleted: response.ok };
   }
-  catch
+  catch (err)
   {
     // 3. Network / parse failure is non-fatal — the Secret delete still revokes access locally.
+    _log.warn({ keyAlias, err }, "litellm key delete errored; relying on local secret delete");
     return { deleted: false };
   }
 }

--- a/apps/control-plane/src/core/grants/cognee-awareness-sync.ts
+++ b/apps/control-plane/src/core/grants/cognee-awareness-sync.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 
+import { _log } from "../../log.js";
 import { compile } from "./grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "./grant-compiler.types.js";
 import type { AwarenessGrantSyncResult, CogneeAwarenessGrant, CogneeGrantTransport, PolicyPropagationResult } from "./cognee-awareness-sync.types.js";
@@ -45,10 +46,12 @@ export async function _SyncTenantAwarenessGrants(prisma: PrismaClient,
   try
   {
     await transport(tenant, grants, authorization);
+    _log.debug({ tenant, allowed, denied }, "cognee awareness grants synced");
     return { tenant, allowed, denied, ok: true };
   }
   catch (err)
   {
+    _log.warn({ tenant, allowed, denied, err }, "cognee awareness grant sync failed (captured, not thrown)");
     return { tenant, allowed, denied, ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
@@ -83,7 +86,7 @@ export async function _ResolvePolicyAffectedTenants(prisma: PrismaClient, policy
   // 1. No DB-resolvable criteria → defer to pod-side reconcile; resolve nothing here.
   if (!team && !name)
   {
-    console.warn(`[awareness-sync] policy ${policyName} selector is not DB-resolvable (arbitrary labels); pod-side reconcile applies`);
+    _log.warn({ policyName }, "policy selector is not DB-resolvable (arbitrary labels); pod-side reconcile applies");
     return [];
   }
 

--- a/apps/control-plane/src/core/model-routing/litellm-model-registration.ts
+++ b/apps/control-plane/src/core/model-routing/litellm-model-registration.ts
@@ -1,4 +1,4 @@
-import { ___WithOperation } from "@opencrane/observability";
+import { ___DoWithTrace } from "@opencrane/observability";
 
 import { _log } from "../../log.js";
 import type { LiteLlmModelRegistration } from "./litellm-model-registration.types.js";
@@ -33,7 +33,7 @@ export async function _RegisterLiteLlmModel(input: LiteLlmModelRegistration): Pr
     return placeholder;
   }
 
-  return ___WithOperation(
+  return ___DoWithTrace(
     "litellm.model.register",
     { publicModelName: input.publicModelName, upstreamModel: input.upstreamModel, scope: input.scope },
     function _register(): Promise<string> { return _registerLive(endpoint, masterKey, input); },

--- a/apps/control-plane/src/core/model-routing/litellm-model-registration.ts
+++ b/apps/control-plane/src/core/model-routing/litellm-model-registration.ts
@@ -1,3 +1,6 @@
+import { ___WithOperation } from "@opencrane/observability";
+
+import { _log } from "../../log.js";
 import type { LiteLlmModelRegistration } from "./litellm-model-registration.types.js";
 
 /**
@@ -19,14 +22,34 @@ export async function _RegisterLiteLlmModel(input: LiteLlmModelRegistration): Pr
 {
   const endpoint = process.env.LITELLM_ENDPOINT?.trim() ?? "";
   const masterKey = process.env.LITELLM_MASTER_KEY?.trim() ?? "";
+  const configured = Boolean(endpoint && masterKey);
 
   // 1. Unconfigured (dev / tests): skip the network call and return a stable placeholder
   //    so creates succeed and are reproducible without a live LiteLLM.
-  if (!endpoint || !masterKey)
+  if (!configured)
   {
-    return _placeholderModelId(input);
+    const placeholder = _placeholderModelId(input);
+    _log.debug({ publicModelName: input.publicModelName, configured: false, litellmModelId: placeholder }, "litellm model registration skipped (unconfigured)");
+    return placeholder;
   }
 
+  return ___WithOperation(
+    "litellm.model.register",
+    { publicModelName: input.publicModelName, upstreamModel: input.upstreamModel, scope: input.scope },
+    function _register(): Promise<string> { return _registerLive(endpoint, masterKey, input); },
+  );
+}
+
+/**
+ * Perform the live `POST /model/new` registration against LiteLLM, falling back to a deterministic
+ * placeholder on any non-OK response or network/parse error so the create path never fails.
+ * @param endpoint  - LiteLLM base URL.
+ * @param masterKey - LiteLLM bearer credential.
+ * @param input     - The registration inputs.
+ * @returns The LiteLLM deployment id, or a placeholder when the call fails.
+ */
+async function _registerLive(endpoint: string, masterKey: string, input: LiteLlmModelRegistration): Promise<string>
+{
   try
   {
     // 2. Register the deployment GLOBALLY. `api_key` is an `os.environ/<KEY>` reference so the
@@ -57,15 +80,19 @@ export async function _RegisterLiteLlmModel(input: LiteLlmModelRegistration): Pr
     //    and the deployment can be reconciled later; the create must not fail on a flaky LiteLLM.
     if (!response.ok)
     {
+      _log.warn({ publicModelName: input.publicModelName, status: response.status }, "litellm model registration failed; using placeholder id");
       return _placeholderModelId(input);
     }
 
     const payload = await response.json() as { model_id?: string; id?: string; model_info?: { id?: string } };
-    return payload.model_id ?? payload.id ?? payload.model_info?.id ?? _placeholderModelId(input);
+    const litellmModelId = payload.model_id ?? payload.id ?? payload.model_info?.id ?? _placeholderModelId(input);
+    _log.info({ publicModelName: input.publicModelName, litellmModelId }, "litellm model registered");
+    return litellmModelId;
   }
-  catch
+  catch (err)
   {
     // 4. Network / parse failure is non-fatal — keep the create working with a placeholder.
+    _log.warn({ publicModelName: input.publicModelName, err }, "litellm model registration errored; using placeholder id");
     return _placeholderModelId(input);
   }
 }

--- a/apps/control-plane/src/core/model-routing/shadow-seams.ts
+++ b/apps/control-plane/src/core/model-routing/shadow-seams.ts
@@ -1,4 +1,4 @@
-import { ___WithOperation } from "@opencrane/observability";
+import { ___DoWithTrace } from "@opencrane/observability";
 
 import { _log } from "../../log.js";
 import type { JudgeClient, ModelRunResult, ModelRunner } from "./shadow-measure.types.js";
@@ -76,7 +76,7 @@ function _buildModelRunner(endpoint: string, masterKey: string): ModelRunner
     {
       // Trace each candidate execution as a `litellm.chat.run` span so a slow or
       // failing leg of a shadow measurement is attributable to a specific model.
-      return ___WithOperation("litellm.chat.run", { model }, async function _traced(): Promise<ModelRunResult>
+      return ___DoWithTrace("litellm.chat.run", { model }, async function _traced(): Promise<ModelRunResult>
       {
         // 1. Derive OpenAI-style messages from the arbitrary eval-case input so any case shape runs.
         const messages = _deriveMessages(input);
@@ -139,7 +139,7 @@ function _buildJudgeClient(endpoint: string, masterKey: string, judgeModel: stri
     {
       // Trace each grading call as a `routing.judge.score` span, keyed by the
       // independent judge model, so judge latency/failures are separable from runs.
-      return ___WithOperation("routing.judge.score", { judgeModel }, async function _traced(): Promise<number>
+      return ___DoWithTrace("routing.judge.score", { judgeModel }, async function _traced(): Promise<number>
       {
         // 1. Build a grading prompt presenting the input, candidate output, and optional rubric, and
         //    instruct the judge to reply with a single JSON `{ "score": n }` in [0, 1].

--- a/apps/control-plane/src/core/model-routing/shadow-seams.ts
+++ b/apps/control-plane/src/core/model-routing/shadow-seams.ts
@@ -1,3 +1,6 @@
+import { ___WithOperation } from "@opencrane/observability";
+
+import { _log } from "../../log.js";
 import type { JudgeClient, ModelRunResult, ModelRunner } from "./shadow-measure.types.js";
 
 /** Bounded timeout (ms) for a single LiteLLM chat-completions call — keeps a hung run from stalling the whole measurement. */
@@ -71,29 +74,36 @@ function _buildModelRunner(endpoint: string, masterKey: string): ModelRunner
   return {
     run: async function _run(model: string, input: unknown): Promise<ModelRunResult>
     {
-      // 1. Derive OpenAI-style messages from the arbitrary eval-case input so any case shape runs.
-      const messages = _deriveMessages(input);
-
-      // 2. POST the chat-completion under a bounded timeout so a hung upstream cannot stall the run.
-      const response = await _postChatCompletion(endpoint, masterKey, model, messages);
-
-      // 3. Hard failure → throw: a non-OK response means no trustworthy output/cost for this case,
-      //    and recording a corrupt sample would bias the measurement. Fail the run instead.
-      if (!response.ok)
+      // Trace each candidate execution as a `litellm.chat.run` span so a slow or
+      // failing leg of a shadow measurement is attributable to a specific model.
+      return ___WithOperation("litellm.chat.run", { model }, async function _traced(): Promise<ModelRunResult>
       {
-        const detail = await _safeText(response);
-        throw new Error(`LiteLLM chat-completion failed (${response.status}) for model "${model}": ${detail}`);
-      }
+        // 1. Derive OpenAI-style messages from the arbitrary eval-case input so any case shape runs.
+        const messages = _deriveMessages(input);
 
-      // 4. Cost: read the LiteLLM per-response cost header (USD). Absent → fall back to 0 with a warn
-      //    (soft, non-corrupting: the savings estimator simply sees a zero-cost run for this leg).
-      const costUsd = _parseResponseCost(response, model);
+        // 2. POST the chat-completion under a bounded timeout so a hung upstream cannot stall the run.
+        const response = await _postChatCompletion(endpoint, masterKey, model, messages);
 
-      // 5. Extract the assistant message content as the verbatim output passed to the judge.
-      const payload = await response.json() as _ChatCompletionResponse;
-      const output = payload?.choices?.[0]?.message?.content ?? "";
+        // 3. Hard failure → throw: a non-OK response means no trustworthy output/cost for this case,
+        //    and recording a corrupt sample would bias the measurement. Fail the run instead.
+        if (!response.ok)
+        {
+          const detail = await _safeText(response);
+          _log.warn({ model, status: response.status }, "litellm chat-completion failed");
+          throw new Error(`LiteLLM chat-completion failed (${response.status}) for model "${model}": ${detail}`);
+        }
 
-      return { output, costUsd };
+        // 4. Cost: read the LiteLLM per-response cost header (USD). Absent → fall back to 0 with a warn
+        //    (soft, non-corrupting: the savings estimator simply sees a zero-cost run for this leg).
+        const costUsd = _parseResponseCost(response, model);
+
+        // 5. Extract the assistant message content as the verbatim output passed to the judge.
+        const payload = await response.json() as _ChatCompletionResponse;
+        const output = payload?.choices?.[0]?.message?.content ?? "";
+
+        _log.debug({ model, costUsd, outputChars: output.length }, "litellm chat-completion ok");
+        return { output, costUsd };
+      });
     },
   };
 }
@@ -127,24 +137,32 @@ function _buildJudgeClient(endpoint: string, masterKey: string, judgeModel: stri
   return {
     score: async function _score(input: unknown, output: unknown, expected: unknown): Promise<number>
     {
-      // 1. Build a grading prompt presenting the input, candidate output, and optional rubric, and
-      //    instruct the judge to reply with a single JSON `{ "score": n }` in [0, 1].
-      const messages = _buildJudgePrompt(input, output, expected);
-
-      // 2. POST to the independent judge model under the bounded timeout.
-      const response = await _postChatCompletion(endpoint, masterKey, judgeModel, messages);
-
-      // 3. Hard failure → throw to fail the run cleanly (matches the runner contract).
-      if (!response.ok)
+      // Trace each grading call as a `routing.judge.score` span, keyed by the
+      // independent judge model, so judge latency/failures are separable from runs.
+      return ___WithOperation("routing.judge.score", { judgeModel }, async function _traced(): Promise<number>
       {
-        const detail = await _safeText(response);
-        throw new Error(`Judge chat-completion failed (${response.status}) for model "${judgeModel}": ${detail}`);
-      }
+        // 1. Build a grading prompt presenting the input, candidate output, and optional rubric, and
+        //    instruct the judge to reply with a single JSON `{ "score": n }` in [0, 1].
+        const messages = _buildJudgePrompt(input, output, expected);
 
-      // 4. Parse the assistant content into a clamped [0, 1] score; soft parse failure → penalizing 0.
-      const payload = await response.json() as _ChatCompletionResponse;
-      const content = payload?.choices?.[0]?.message?.content ?? "";
-      return _parseScore(content);
+        // 2. POST to the independent judge model under the bounded timeout.
+        const response = await _postChatCompletion(endpoint, masterKey, judgeModel, messages);
+
+        // 3. Hard failure → throw to fail the run cleanly (matches the runner contract).
+        if (!response.ok)
+        {
+          const detail = await _safeText(response);
+          _log.warn({ judgeModel, status: response.status }, "judge chat-completion failed");
+          throw new Error(`Judge chat-completion failed (${response.status}) for model "${judgeModel}": ${detail}`);
+        }
+
+        // 4. Parse the assistant content into a clamped [0, 1] score; soft parse failure → penalizing 0.
+        const payload = await response.json() as _ChatCompletionResponse;
+        const content = payload?.choices?.[0]?.message?.content ?? "";
+        const score = _parseScore(content);
+        _log.debug({ judgeModel, score }, "judge score parsed");
+        return score;
+      });
     },
   };
 }
@@ -270,14 +288,14 @@ function _parseResponseCost(response: Response, model: string): number
   const raw = response.headers.get("x-litellm-response-cost");
   if (raw === null || raw.trim() === "")
   {
-    console.warn(`[shadow-seams] no x-litellm-response-cost header for model "${model}"; treating cost as 0`);
+    _log.warn({ model }, "no x-litellm-response-cost header; treating cost as 0");
     return 0;
   }
 
   const cost = parseFloat(raw);
   if (!Number.isFinite(cost) || cost < 0)
   {
-    console.warn(`[shadow-seams] unparseable x-litellm-response-cost "${raw}" for model "${model}"; treating cost as 0`);
+    _log.warn({ model, rawCost: raw }, "unparseable x-litellm-response-cost; treating cost as 0");
     return 0;
   }
 
@@ -317,7 +335,7 @@ function _parseScore(content: unknown): number
   }
 
   // 3. Nothing recoverable: penalize rather than throw so the rest of the suite proceeds.
-  console.warn(`[shadow-seams] judge reply had no parseable score; penalizing to 0: ${text.slice(0, 200)}`);
+  _log.warn({ replyPreview: text.slice(0, 200) }, "judge reply had no parseable score; penalizing to 0");
   return 0;
 }
 

--- a/apps/control-plane/src/core/oci/oci-bundle-store.ts
+++ b/apps/control-plane/src/core/oci/oci-bundle-store.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { ___WithOperation } from "@opencrane/observability";
+import { ___DoWithTrace } from "@opencrane/observability";
 
 import { _log } from "../../log.js";
 import type { OciBundleStoreConfig, OciFetch, OciPushResult, OciResponse } from "./oci-bundle-store.types.js";
@@ -111,7 +111,7 @@ export class OciBundleStore
 
     // Trace the push as `oci.bundle.push`; the digest + size make a slow or
     // failing registry interaction attributable to a specific bundle.
-    return ___WithOperation("oci.bundle.push", { repository: this.repository, digest, sizeBytes: size }, async function _push(): Promise<OciPushResult>
+    return ___DoWithTrace("oci.bundle.push", { repository: this.repository, digest, sizeBytes: size }, async function _push(): Promise<OciPushResult>
     {
       // 1. Upload the bundle as a layer blob and the empty config blob. Both must
       //    exist before the manifest that references them can be accepted.
@@ -143,7 +143,7 @@ export class OciBundleStore
     const self = this;
 
     // Trace the pull as `oci.bundle.pull`.
-    return ___WithOperation("oci.bundle.pull", { repository: this.repository, digest }, async function _pull(): Promise<string | null>
+    return ___DoWithTrace("oci.bundle.pull", { repository: this.repository, digest }, async function _pull(): Promise<string | null>
     {
       // 1. Fetch the blob directly by its content-addressable digest.
       const res = await self.fetchFn(`${self.registryUrl}/v2/${self.repository}/blobs/${digest}`, {

--- a/apps/control-plane/src/core/oci/oci-bundle-store.ts
+++ b/apps/control-plane/src/core/oci/oci-bundle-store.ts
@@ -1,5 +1,8 @@
 import { createHash } from "node:crypto";
 
+import { ___WithOperation } from "@opencrane/observability";
+
+import { _log } from "../../log.js";
 import type { OciBundleStoreConfig, OciFetch, OciPushResult, OciResponse } from "./oci-bundle-store.types.js";
 
 /** Media type for the stored skill-bundle layer blob. */
@@ -101,18 +104,28 @@ export class OciBundleStore
   public async pushBundle(content: string): Promise<OciPushResult>
   {
     const digest = _Digest(content);
+    const size = Buffer.byteLength(content, "utf8");
+    // Capture `this` so the traced callback can be a named function expression
+    // (repo style) while still reaching the instance's transport + helpers.
+    const self = this;
 
-    // 1. Upload the bundle as a layer blob and the empty config blob. Both must
-    //    exist before the manifest that references them can be accepted.
-    await this._uploadBlob(content, digest);
-    await this._uploadBlob(_EMPTY_CONFIG, _Digest(_EMPTY_CONFIG));
+    // Trace the push as `oci.bundle.push`; the digest + size make a slow or
+    // failing registry interaction attributable to a specific bundle.
+    return ___WithOperation("oci.bundle.push", { repository: this.repository, digest, sizeBytes: size }, async function _push(): Promise<OciPushResult>
+    {
+      // 1. Upload the bundle as a layer blob and the empty config blob. Both must
+      //    exist before the manifest that references them can be accepted.
+      await self._uploadBlob(content, digest);
+      await self._uploadBlob(_EMPTY_CONFIG, _Digest(_EMPTY_CONFIG));
 
-    // 2. PUT a manifest referencing the layer so the registry keeps the blob
-    //    (unreferenced blobs are eligible for garbage collection). The manifest
-    //    is tagged by the layer's hex digest, a valid OCI tag.
-    await this._putManifest(content, digest);
+      // 2. PUT a manifest referencing the layer so the registry keeps the blob
+      //    (unreferenced blobs are eligible for garbage collection). The manifest
+      //    is tagged by the layer's hex digest, a valid OCI tag.
+      await self._putManifest(content, digest);
 
-    return { digest, size: Buffer.byteLength(content, "utf8") };
+      _log.info({ repository: self.repository, digest, sizeBytes: size }, "oci bundle pushed");
+      return { digest, size };
+    });
   }
 
   /**
@@ -126,32 +139,40 @@ export class OciBundleStore
   {
     // 0. Reject a malformed digest before it reaches the registry URL.
     _AssertDigest(digest);
+    // Capture `this` so the traced callback can be a named function expression.
+    const self = this;
 
-    // 1. Fetch the blob directly by its content-addressable digest.
-    const res = await this.fetchFn(`${this.registryUrl}/v2/${this.repository}/blobs/${digest}`, {
-      method: "GET",
-      headers: { accept: _BUNDLE_MEDIA_TYPE },
+    // Trace the pull as `oci.bundle.pull`.
+    return ___WithOperation("oci.bundle.pull", { repository: this.repository, digest }, async function _pull(): Promise<string | null>
+    {
+      // 1. Fetch the blob directly by its content-addressable digest.
+      const res = await self.fetchFn(`${self.registryUrl}/v2/${self.repository}/blobs/${digest}`, {
+        method: "GET",
+        headers: { accept: _BUNDLE_MEDIA_TYPE },
+      });
+
+      // 2. A missing blob is an expected "not stored" signal, not an error.
+      if (res.status === 404)
+      {
+        _log.debug({ repository: self.repository, digest }, "oci bundle not found");
+        return null;
+      }
+      if (!res.ok)
+      {
+        throw new Error(`OCI blob GET failed for ${digest}: HTTP ${res.status}`);
+      }
+
+      // 3. Re-verify the digest — never serve bytes that do not hash to what was asked for.
+      const content = await res.text();
+      const actual = _Digest(content);
+      if (actual !== digest)
+      {
+        throw new Error(`OCI digest mismatch: requested ${digest}, got ${actual}`);
+      }
+
+      _log.debug({ repository: self.repository, digest, sizeBytes: Buffer.byteLength(content, "utf8") }, "oci bundle pulled");
+      return content;
     });
-
-    // 2. A missing blob is an expected "not stored" signal, not an error.
-    if (res.status === 404)
-    {
-      return null;
-    }
-    if (!res.ok)
-    {
-      throw new Error(`OCI blob GET failed for ${digest}: HTTP ${res.status}`);
-    }
-
-    // 3. Re-verify the digest — never serve bytes that do not hash to what was asked for.
-    const content = await res.text();
-    const actual = _Digest(content);
-    if (actual !== digest)
-    {
-      throw new Error(`OCI digest mismatch: requested ${digest}, got ${actual}`);
-    }
-
-    return content;
   }
 
   /**

--- a/apps/control-plane/src/index.ts
+++ b/apps/control-plane/src/index.ts
@@ -1,10 +1,18 @@
+// OpenTelemetry must be initialised before any instrumented module is imported,
+// so this side-effecting import stays first in the file (and is also preloaded
+// via NODE_OPTIONS=--import in the container).
+import "./instrument.js";
+
+import { randomUUID } from "node:crypto";
+
 import * as k8s from "@kubernetes/client-node";
 
-import pino from "pino";
 import { pinoHttp } from "pino-http";
 import express from "express";
 import type { Express } from "express";
 import type { PrismaClient } from "@prisma/client";
+
+import { ___BindConsole, ___GetContext, ___RequestContext, ___ShutdownTelemetry } from "@opencrane/observability";
 
 import { ___AuthRouter } from "./infra/auth/auth.router.js";
 import { _BuildGatewayAdmin } from "./core/connections/gateway-admin.js";
@@ -14,10 +22,12 @@ import { ___AuthMiddleware } from "./infra/middleware/auth.middleware.js";
 import { _TransportSecurity } from "./infra/middleware/transport-security.middleware.js";
 import { _ErrorHandler } from "./middleware/error-handler.js";
 
+import { _log as log } from "./log.js";
 import { _RegisterRoutes } from "./routes.js";
 
-/** Application logger instance. */
-const log = pino({ name: "ctrl" });
+// Route any stray console.* call (first-party or third-party) through the
+// structured logger so nothing reaches stdout unstructured / uncorrelated.
+const _unbindConsole = ___BindConsole(log);
 
 /**
  * Creates and configures the Express application with all middleware and routes.
@@ -39,7 +49,12 @@ export function createApp(prisma: PrismaClient, customApi: k8s.CustomObjectsApi,
   // before any body parsing or session handling.
   app.use(_TransportSecurity());
   app.use(express.json());
-  app.use(pinoHttp({ logger: log }));
+  // Seed the per-request correlation context BEFORE pino-http so every request
+  // log (and every downstream service log) shares one requestId.
+  app.use(___RequestContext());
+  // ___RequestContext() (mounted above) always seeds the id; the ?? is only a
+  // type-level fallback so genReqId never returns undefined.
+  app.use(pinoHttp({ logger: log, genReqId: function _genReqId() { return ___GetContext()?.requestId ?? randomUUID(); } }));
   app.use(authService.createSessionMiddleware());
 
   // Auth router is mounted before the auth middleware so its endpoints are
@@ -85,7 +100,45 @@ const app = createApp(prisma, customApi, coreApi, authApi);
 
 log.info({ port }, "starting opencrane control plane");
 
-app.listen(port, function _onListen()
+const server = app.listen(port, function _onListen()
 {
   log.info({ port }, "control plane listening");
 });
+
+/**
+ * Gracefully drain the server, disconnect Prisma, flush telemetry, and restore
+ * console before exiting. A hard-exit timer guards against a stuck close so the
+ * pod terminates within the kubelet grace period.
+ * @param signal - The signal that triggered shutdown.
+ */
+async function _shutdown(signal: string): Promise<void>
+{
+  log.info({ signal }, "shutting down control plane");
+
+  // 1. Force exit if graceful shutdown stalls, so we never exceed the grace period.
+  const hardExit = setTimeout(function _force() { process.exit(1); }, 10_000);
+  hardExit.unref();
+
+  try
+  {
+    // 2. Stop accepting new connections and let in-flight requests finish.
+    await new Promise<void>(function _close(resolve) { server.close(function _done() { resolve(); }); });
+    // 3. Release the DB pool so Postgres connections aren't leaked.
+    await prisma.$disconnect();
+    // 4. Flush any buffered spans to the collector before the process dies.
+    await ___ShutdownTelemetry();
+  }
+  catch (err)
+  {
+    log.error({ err }, "error during graceful shutdown");
+  }
+  finally
+  {
+    // 5. Restore the original console methods last, then exit cleanly.
+    _unbindConsole();
+    process.exit(0);
+  }
+}
+
+process.on("SIGTERM", function _onSigterm() { void _shutdown("SIGTERM"); });
+process.on("SIGINT", function _onSigint() { void _shutdown("SIGINT"); });

--- a/apps/control-plane/src/infra/auth/auth.router.ts
+++ b/apps/control-plane/src/infra/auth/auth.router.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import type { PrismaClient } from "@prisma/client";
 import type * as k8s from "@kubernetes/client-node";
 
+import { _log } from "../../log.js";
 import type { OidcAuthService } from "./oidc.service.js";
 import { _AuthorizeDeviceGrant, _CreateDeviceGrant, _FindGrantByUserCode, _PollDeviceGrant } from "./device-grant.js";
 import { _ResolveOpenClawPairing } from "./openclaw-pairing.js";
@@ -130,7 +131,7 @@ export function ___AuthRouter(authService: OidcAuthService, prisma: PrismaClient
       }
       catch (err)
       {
-        console.warn(`[auth] failed to record brokered device for ${tenant.name}/${subject}:`, err instanceof Error ? err.message : err);
+        _log.warn({ tenant: tenant.name, subject, err }, "failed to record brokered device (connection still granted)");
       }
 
       // 5. Return the connection details for the gateway `connect` handshake.

--- a/apps/control-plane/src/instrument.ts
+++ b/apps/control-plane/src/instrument.ts
@@ -1,0 +1,11 @@
+/**
+ * OpenTelemetry bootstrap for the control-plane.
+ *
+ * Imported as the very first statement of `index.ts` (and, in containers, also
+ * preloaded via `node --import ./dist/instrument.js`) so the SDK patches
+ * `http`/`express`/`pg`/`fetch` before any instrumented module is loaded.
+ * Keep this module tiny and dependency-light for that reason.
+ */
+import { ___StartTelemetry } from "@opencrane/observability/telemetry";
+
+await ___StartTelemetry({ serviceName: "control-plane", serviceVersion: process.env["npm_package_version"] ?? "0.1.0" });

--- a/apps/control-plane/src/log.ts
+++ b/apps/control-plane/src/log.ts
@@ -1,0 +1,17 @@
+/**
+ * Shared control-plane logger.
+ *
+ * A single root logger imported by both the bootstrap (`index.ts`) and the
+ * core service modules so every line is consistent and — thanks to the
+ * AsyncLocalStorage mixin in `@opencrane/observability` — automatically carries
+ * the active request's `requestId` and the current span's `trace_id`, with no
+ * logger threaded through function signatures.
+ *
+ * Safe to import from anywhere in the app because `index.ts` initialises
+ * OpenTelemetry (`./instrument.js`) before this module's pino is loaded.
+ */
+import { ___CreateLogger } from "@opencrane/observability";
+import type { Logger } from "@opencrane/observability";
+
+/** Process-wide control-plane logger. */
+export const _log: Logger = ___CreateLogger("control-plane");

--- a/apps/control-plane/src/routes/internal/skill-bundles.ts
+++ b/apps/control-plane/src/routes/internal/skill-bundles.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import type { PrismaClient } from "@prisma/client";
 
+import { _log } from "../../log.js";
 import { compile } from "../../core/grants/grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "../../core/grants/grant-compiler.types.js";
 import type { OciBundleStore } from "../../core/oci/oci-bundle-store.js";
@@ -34,7 +35,7 @@ export async function _ResolveBundleContent(ociStore: OciBundleStore | null, dig
     {
       // Fall back to DB content during the dual-write window, but log so a registry
       // outage or a digest mismatch (never served — see OciBundleStore) is visible.
-      console.warn(`[skill-bundles] OCI pull failed for ${digest}, falling back to DB content:`, err instanceof Error ? err.message : err);
+      _log.warn({ digest, err }, "OCI pull failed; falling back to DB content");
     }
   }
 

--- a/apps/control-plane/src/routes/policies.ts
+++ b/apps/control-plane/src/routes/policies.ts
@@ -2,6 +2,7 @@ import * as k8s from "@kubernetes/client-node";
 import { Router } from "express";
 import type { PrismaClient } from "@prisma/client";
 
+import { _log } from "../log.js";
 import type { CreatePolicyRequest } from "../types.js";
 import { _PropagatePolicyToCognee, _ResolvePolicyAffectedTenants } from "../core/grants/cognee-awareness-sync.js";
 import { _DetectPolicyProjectionDrift } from "./internal/projection-drift.js";
@@ -45,12 +46,12 @@ export function policiesRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCl
       const result = await _PropagatePolicyToCognee(prisma, policyName, affected, auth);
       if (result.failures > 0)
       {
-        console.warn(`[policies] Cognee awareness propagation for ${policyName}: ${result.failures}/${affected.length} tenant(s) failed`);
+        _log.warn({ policyName, failures: result.failures, affected: affected.length }, "cognee awareness propagation had tenant failures");
       }
     }
     catch (err)
     {
-      console.warn(`[policies] Cognee awareness propagation for ${policyName} errored:`, err instanceof Error ? err.message : err);
+      _log.warn({ policyName, err }, "cognee awareness propagation errored");
     }
   }
 
@@ -226,7 +227,7 @@ export function policiesRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCl
     //    a resolution hiccup must not block the delete (propagation is downstream).
     const affectedTenants = await _ResolvePolicyAffectedTenants(prisma, name).catch(function _onResolveErr(err)
     {
-      console.warn(`[policies] could not resolve affected tenants for ${name} before delete:`, err instanceof Error ? err.message : err);
+      _log.warn({ policyName: name, err }, "could not resolve affected tenants before policy delete");
       return [] as string[];
     });
 

--- a/apps/control-plane/src/routes/skill-catalog.ts
+++ b/apps/control-plane/src/routes/skill-catalog.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import type { Grant, SkillBundle, SkillPromotion } from "@opencrane/contracts";
 import type { PrismaClient } from "@prisma/client";
 
+import { _log } from "../log.js";
 import { _ScanBundleContent } from "../core/scanning/scan-bundle.js";
 import { _BackfillBundlesToOci } from "../core/oci/oci-backfill.js";
 import type { OciBundleStore } from "../core/oci/oci-bundle-store.js";
@@ -37,7 +38,7 @@ async function _PushPublishedBundle(prisma: PrismaClient, ociStore: OciBundleSto
   {
     // Swallowed during the dual-write window — DB content + delivery fallback cover it —
     // but logged so a persistently-failing push is visible before the destructive cutover.
-    console.warn(`[skill-catalog] OCI dual-write push failed for bundle ${id}:`, err instanceof Error ? err.message : err);
+    _log.warn({ bundleId: id, err }, "OCI dual-write push failed; DB content remains source of truth");
   }
 }
 

--- a/apps/control-plane/src/scripts/migrate.ts
+++ b/apps/control-plane/src/scripts/migrate.ts
@@ -1,5 +1,10 @@
 import { execSync } from "node:child_process";
 
+import { ___CreateLogger } from "@opencrane/observability";
+
+/** Structured logger for the migration init container — JSON to stdout for central scraping. */
+const _log = ___CreateLogger("control-plane-migrate");
+
 /**
  * Standalone migration runner for the control plane database.
  * Intended for use as an init container or pre-start hook.
@@ -7,7 +12,7 @@ import { execSync } from "node:child_process";
  */
 function _runMigrations(): void
 {
-  console.log("[opencrane] Running database migrations...");
+  _log.info("running database migrations");
 
   try
   {
@@ -17,11 +22,11 @@ function _runMigrations(): void
       // where prisma/schema.prisma lives (the cwd `prisma migrate deploy` expects).
       cwd: new URL("../../", import.meta.url).pathname,
     });
-    console.log("[opencrane] Migrations complete");
+    _log.info("migrations complete");
   }
   catch (err)
   {
-    console.error("[opencrane] Migration failed:", err);
+    _log.error({ err }, "migration failed");
     process.exit(1);
   }
 }

--- a/apps/harvesting-agent/deploy/Dockerfile
+++ b/apps/harvesting-agent/deploy/Dockerfile
@@ -1,23 +1,39 @@
-FROM node:22-alpine AS builder
+# NOTE: build context is the REPO ROOT (e.g. `docker build -f apps/harvesting-agent/deploy/Dockerfile .`),
+# not the app dir — required so the @opencrane/observability workspace dependency resolves.
+# Build stage
+FROM node:22-bookworm-slim AS build
 
-WORKDIR /build
-
-COPY package.json tsconfig.json ./
-COPY src/ src/
-
-RUN npm install --omit=dev
-RUN npm run build
-
-FROM node:22-alpine
+RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
 
 WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY tsconfig.base.json ./
+COPY libs/observability/package.json libs/observability/tsconfig.json libs/observability/
+COPY apps/harvesting-agent/package.json apps/harvesting-agent/tsconfig.json apps/harvesting-agent/
+RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/harvesting-agent
 
-COPY --from=builder /build/dist ./dist
-COPY --from=builder /build/node_modules ./node_modules
-COPY package.json ./
+COPY libs/observability/src libs/observability/src
+COPY apps/harvesting-agent/src apps/harvesting-agent/src
+RUN pnpm --filter @opencrane/observability build
+RUN pnpm --filter @opencrane/harvesting-agent build
 
+# Runtime stage
+FROM node:22-bookworm-slim
+
+RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
+
+WORKDIR /app
 ENV NODE_ENV=production
+COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml ./
+COPY --from=build /app/libs/observability/package.json libs/observability/
+COPY --from=build /app/apps/harvesting-agent/package.json apps/harvesting-agent/
+RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/harvesting-agent --prod
+
+COPY --from=build /app/libs/observability/dist libs/observability/dist
+COPY --from=build /app/apps/harvesting-agent/dist apps/harvesting-agent/dist
+
+USER node
 
 EXPOSE 9090
 
-CMD ["node", "dist/index.js"]
+CMD ["node", "apps/harvesting-agent/dist/index.js"]

--- a/apps/harvesting-agent/package.json
+++ b/apps/harvesting-agent/package.json
@@ -12,6 +12,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@opencrane/observability": "workspace:*",
     "@prisma/client": "^6.0.0",
     "pino": "^9.6.0"
   },

--- a/apps/harvesting-agent/src/index.ts
+++ b/apps/harvesting-agent/src/index.ts
@@ -3,7 +3,7 @@ import "./instrument.js";
 
 import { PrismaClient } from "@prisma/client";
 
-import { ___BindConsole, ___CreateLogger, ___ShutdownTelemetry, ___WithOperation } from "@opencrane/observability";
+import { ___BindConsole, ___CreateLogger, ___ShutdownTelemetry, ___DoWithTrace } from "@opencrane/observability";
 
 import { SlackConnector } from "./connectors/slack.connector.js";
 import type { SlackConnectorConfig } from "./domain/harvesting-agents/harvesting-agent.types.js";
@@ -94,7 +94,7 @@ async function _RunSlackSyncCycle(
 
   // Trace the whole cycle as a `harvest.cycle` span so each sync (and its
   // Slack→Cognee child calls) is one attributable unit in the trace timeline.
-  await ___WithOperation("harvest.cycle", { source }, async function _cycle()
+  await ___DoWithTrace("harvest.cycle", { source }, async function _cycle()
   {
     log.info({ source }, "starting sync cycle");
 

--- a/apps/harvesting-agent/src/index.ts
+++ b/apps/harvesting-agent/src/index.ts
@@ -1,13 +1,20 @@
+// OpenTelemetry must initialise before any instrumented module is imported.
+import "./instrument.js";
+
 import { PrismaClient } from "@prisma/client";
-import pino from "pino";
+
+import { ___BindConsole, ___CreateLogger, ___ShutdownTelemetry, ___WithOperation } from "@opencrane/observability";
 
 import { SlackConnector } from "./connectors/slack.connector.js";
 import type { SlackConnectorConfig } from "./domain/harvesting-agents/harvesting-agent.types.js";
 import { _IngestDocuments, _LoadCursor, _SaveCursor } from "./ingestion.js";
 import { _RecordSyncMetrics, _StartMetricsServer } from "./metrics.js";
 
-/** Application logger for the harvesting agent. */
-const log = pino({ name: "harvesting-agent" });
+/** Application logger for the harvesting agent — structured JSON, trace-correlated. */
+const log = ___CreateLogger("harvesting-agent");
+
+// Route any stray console.* output through the structured logger.
+const _unbindConsole = ___BindConsole(log);
 
 /**
  * Read and validate Slack connector configuration from the environment.
@@ -84,34 +91,40 @@ async function _RunSlackSyncCycle(
 ): Promise<void>
 {
   const source = "slack";
-  log.info({ source }, "starting sync cycle");
 
-  // 1. Load the persisted cursor from the last successful sync.
-  const cursor = await _LoadCursor(prisma, source);
-
-  // 2. Fetch new messages from Slack since the cursor timestamp.
-  const { documents, nextCursor, errors } = await connector.sync(cursor);
-
-  log.info({ source, documentCount: documents.length, errors: errors.length }, "sync fetched documents");
-
-  // 3. Push normalized documents directly into Cognee.
-  const { upsertedCount, skippedCount, failedCount } = await _IngestDocuments(
-    cogneeEndpoint,
-    documents,
-    log,
-  );
-
-  // 4. Advance the cursor to the latest message timestamp if progress was made.
-  if (nextCursor)
+  // Trace the whole cycle as a `harvest.cycle` span so each sync (and its
+  // Slack→Cognee child calls) is one attributable unit in the trace timeline.
+  await ___WithOperation("harvest.cycle", { source }, async function _cycle()
   {
-    await _SaveCursor(prisma, source, nextCursor);
-  }
+    log.info({ source }, "starting sync cycle");
 
-  // 5. Record metrics for this cycle so the metrics server can serve them.
-  const hasErrors = errors.length > 0 || failedCount > 0;
-  _RecordSyncMetrics(source, upsertedCount, failedCount, !hasErrors, errors[0]);
+    // 1. Load the persisted cursor from the last successful sync.
+    const cursor = await _LoadCursor(prisma, source);
 
-  log.info({ source, upsertedCount, skippedCount, failedCount, nextCursor }, "sync cycle complete");
+    // 2. Fetch new messages from Slack since the cursor timestamp.
+    const { documents, nextCursor, errors } = await connector.sync(cursor);
+
+    log.info({ source, documentCount: documents.length, errors: errors.length }, "sync fetched documents");
+
+    // 3. Push normalized documents directly into Cognee.
+    const { upsertedCount, skippedCount, failedCount } = await _IngestDocuments(
+      cogneeEndpoint,
+      documents,
+      log,
+    );
+
+    // 4. Advance the cursor to the latest message timestamp if progress was made.
+    if (nextCursor)
+    {
+      await _SaveCursor(prisma, source, nextCursor);
+    }
+
+    // 5. Record metrics for this cycle so the metrics server can serve them.
+    const hasErrors = errors.length > 0 || failedCount > 0;
+    _RecordSyncMetrics(source, upsertedCount, failedCount, !hasErrors, errors[0]);
+
+    log.info({ source, upsertedCount, skippedCount, failedCount, nextCursor }, "sync cycle complete");
+  });
 }
 
 /**
@@ -158,6 +171,29 @@ async function _Main(): Promise<void>
     }
   }, slackConfig.syncIntervalMs);
 }
+
+/**
+ * Flush buffered spans to the collector and restore console before exiting.
+ * @param signal - The signal that triggered shutdown.
+ */
+async function _shutdown(signal: string): Promise<void>
+{
+  log.info({ signal }, "shutting down harvesting agent");
+  const hardExit = setTimeout(function _force() { process.exit(1); }, 10_000);
+  hardExit.unref();
+  try
+  {
+    await ___ShutdownTelemetry();
+  }
+  finally
+  {
+    _unbindConsole();
+    process.exit(0);
+  }
+}
+
+process.on("SIGTERM", function _onSigterm() { void _shutdown("SIGTERM"); });
+process.on("SIGINT", function _onSigint() { void _shutdown("SIGINT"); });
 
 _Main().catch(function _onError(err: unknown)
 {

--- a/apps/harvesting-agent/src/instrument.ts
+++ b/apps/harvesting-agent/src/instrument.ts
@@ -1,0 +1,10 @@
+/**
+ * OpenTelemetry bootstrap for the harvesting agent.
+ *
+ * Imported first in `index.ts` (and preloaded via `node --import` in the
+ * container) so the SDK patches `http`/`fetch`/`pg` before any instrumented
+ * module loads. Keep tiny and dependency-light.
+ */
+import { ___StartTelemetry } from "@opencrane/observability/telemetry";
+
+await ___StartTelemetry({ serviceName: "harvesting-agent", serviceVersion: process.env["npm_package_version"] ?? "0.1.0" });

--- a/apps/operator/deploy/Dockerfile
+++ b/apps/operator/deploy/Dockerfile
@@ -6,10 +6,13 @@ RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
 WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY tsconfig.base.json ./
+COPY libs/observability/package.json libs/observability/tsconfig.json libs/observability/
 COPY apps/operator/package.json apps/operator/tsconfig.json apps/operator/
-RUN pnpm install --frozen-lockfile --filter @opencrane/operator
+RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/operator
 
+COPY libs/observability/src libs/observability/src
 COPY apps/operator/src apps/operator/src
+RUN pnpm --filter @opencrane/observability build
 RUN pnpm --filter @opencrane/operator build
 
 # Runtime stage
@@ -19,9 +22,11 @@ RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
 
 WORKDIR /app
 COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml ./
+COPY --from=build /app/libs/observability/package.json libs/observability/
 COPY --from=build /app/apps/operator/package.json apps/operator/
-RUN pnpm install --frozen-lockfile --filter @opencrane/operator --prod
+RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/operator --prod
 
+COPY --from=build /app/libs/observability/dist libs/observability/dist
 COPY --from=build /app/apps/operator/dist apps/operator/dist
 
 USER node

--- a/apps/operator/package.json
+++ b/apps/operator/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^1.0.0",
+    "@opencrane/observability": "workspace:*",
     "pino": "^9.6.0"
   },
   "optionalDependencies": {

--- a/apps/operator/src/index.ts
+++ b/apps/operator/src/index.ts
@@ -3,7 +3,7 @@ import "./instrument.js";
 
 import * as k8s from "@kubernetes/client-node";
 
-import { ___BindConsole, ___CreateLogger, ___ShutdownTelemetry, ___WithOperation } from "@opencrane/observability";
+import { ___BindConsole, ___CreateLogger, ___ShutdownTelemetry, ___DoWithTrace } from "@opencrane/observability";
 
 import { _LoadOperatorConfig } from "./config.js";
 import { ObotHealthChecker } from "./mcp-gateway/obot-health-checker.js";
@@ -65,7 +65,7 @@ async function main(): Promise<void>
     // registry probe is attributable in the trace timeline.
     setInterval(function _pollRelease()
     {
-      void ___WithOperation("tenant.rollout.poll", { releaseTag: tenantRolloutConfig.releaseTag }, async function _poll()
+      void ___DoWithTrace("tenant.rollout.poll", { releaseTag: tenantRolloutConfig.releaseTag }, async function _poll()
       {
         try
         {

--- a/apps/operator/src/index.ts
+++ b/apps/operator/src/index.ts
@@ -1,5 +1,9 @@
+// OpenTelemetry must initialise before any instrumented module is imported.
+import "./instrument.js";
+
 import * as k8s from "@kubernetes/client-node";
-import pino from "pino";
+
+import { ___BindConsole, ___CreateLogger, ___ShutdownTelemetry, ___WithOperation } from "@opencrane/observability";
 
 import { _LoadOperatorConfig } from "./config.js";
 import { ObotHealthChecker } from "./mcp-gateway/obot-health-checker.js";
@@ -8,8 +12,11 @@ import { _CreateTenantOperator, IdleChecker } from "./tenants/index.js";
 import { PolicyOperator } from "./policies/operator.js";
 import { _ReadTenantRolloutConfig, TenantUpdateWithCanaryStrategyController } from "./tenant-rollout/tenant-update-with-canary-strategy.controller.js";
 
-/** Root logger for the opencrane-operator process. */
-const log = pino({ name: "opencrane-operator" });
+/** Root logger for the opencrane-operator process — structured JSON, trace-correlated. */
+const log = ___CreateLogger("operator");
+
+// Route any stray console.* output through the structured logger.
+const _unbindConsole = ___BindConsole(log);
 
 /** Reference to the idle checker, set during startup for shutdown access. */
 let _idleCheckerRef: IdleChecker | null = null;
@@ -53,21 +60,26 @@ async function main(): Promise<void>
       "tenant rollout canary controller enabled",
     );
 
-    // Poll npm registry for new releases; the controller handles rollout internally
-    setInterval(async function _pollRelease()
+    // Poll npm registry for new releases; the controller handles rollout internally.
+    // Each tick is a traced `tenant.rollout.poll` operation so a slow/failing
+    // registry probe is attributable in the trace timeline.
+    setInterval(function _pollRelease()
     {
-      try
+      void ___WithOperation("tenant.rollout.poll", { releaseTag: tenantRolloutConfig.releaseTag }, async function _poll()
       {
-        const latest = await tenantRolloutController.getLatestRelease();
-        if (latest !== null)
+        try
         {
-          log.debug({ latest }, "tenant rollout release poll");
+          const latest = await tenantRolloutController.getLatestRelease();
+          if (latest !== null)
+          {
+            log.debug({ latest }, "tenant rollout release poll");
+          }
         }
-      }
-      catch (err)
-      {
-        log.warn({ err }, "tenant rollout release poll failed; will retry next interval");
-      }
+        catch (err)
+        {
+          log.warn({ err }, "tenant rollout release poll failed; will retry next interval");
+        }
+      });
     }, 15 * 60 * 1000); // every 15 minutes
   }
   else
@@ -100,18 +112,32 @@ async function main(): Promise<void>
 }
 
 /**
- * Perform a graceful shutdown by logging the signal and exiting.
+ * Perform a graceful shutdown: stop the timers, flush buffered spans to the
+ * collector, restore console, then exit. A hard-exit timer guards a stuck flush.
+ * @param signal - The signal that triggered shutdown.
  */
-function _shutdown(signal: string): void
+async function _shutdown(signal: string): Promise<void>
 {
   log.info({ signal }, "shutting down");
   _idleCheckerRef?.stop();
   _driftRepairerRef?.stop();
-  process.exit(0);
+
+  const hardExit = setTimeout(function _force() { process.exit(1); }, 10_000);
+  hardExit.unref();
+
+  try
+  {
+    await ___ShutdownTelemetry();
+  }
+  finally
+  {
+    _unbindConsole();
+    process.exit(0);
+  }
 }
 
-process.on("SIGTERM", function _onSigterm() { _shutdown("SIGTERM"); });
-process.on("SIGINT", function _onSigint() { _shutdown("SIGINT"); });
+process.on("SIGTERM", function _onSigterm() { void _shutdown("SIGTERM"); });
+process.on("SIGINT", function _onSigint() { void _shutdown("SIGINT"); });
 
 main().catch(function (err)
 {

--- a/apps/operator/src/instrument.ts
+++ b/apps/operator/src/instrument.ts
@@ -1,0 +1,10 @@
+/**
+ * OpenTelemetry bootstrap for the operator.
+ *
+ * Imported first in `index.ts` (and preloaded via `node --import` in the
+ * container) so the SDK patches `http`/`@kubernetes/client-node`/`fetch` before
+ * any instrumented module loads. Keep tiny and dependency-light.
+ */
+import { ___StartTelemetry } from "@opencrane/observability/telemetry";
+
+await ___StartTelemetry({ serviceName: "operator", serviceVersion: process.env["npm_package_version"] ?? "0.1.0" });

--- a/apps/skill-registry/deploy/Dockerfile
+++ b/apps/skill-registry/deploy/Dockerfile
@@ -1,16 +1,39 @@
-FROM node:22-slim AS builder
-WORKDIR /app
-COPY package.json tsconfig.json ./
-RUN npm install --ignore-scripts
-COPY src ./src
-RUN npm run build
+# NOTE: build context is the REPO ROOT (e.g. `docker build -f apps/skill-registry/deploy/Dockerfile .`),
+# not the app dir — required so the @opencrane/observability workspace dependency resolves.
+# Build stage
+FROM node:22-bookworm-slim AS build
 
-FROM node:22-slim
+RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
+
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY tsconfig.base.json ./
+COPY libs/observability/package.json libs/observability/tsconfig.json libs/observability/
+COPY apps/skill-registry/package.json apps/skill-registry/tsconfig.json apps/skill-registry/
+RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/skill-registry
+
+COPY libs/observability/src libs/observability/src
+COPY apps/skill-registry/src apps/skill-registry/src
+RUN pnpm --filter @opencrane/observability build
+RUN pnpm --filter @opencrane/skill-registry build
+
+# Runtime stage
+FROM node:22-bookworm-slim
+
+RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
+
 WORKDIR /app
 ENV NODE_ENV=production
-COPY package.json ./
-RUN npm install --omit=dev --ignore-scripts
-COPY --from=builder /app/dist ./dist
+COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml ./
+COPY --from=build /app/libs/observability/package.json libs/observability/
+COPY --from=build /app/apps/skill-registry/package.json apps/skill-registry/
+RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/skill-registry --prod
+
+COPY --from=build /app/libs/observability/dist libs/observability/dist
+COPY --from=build /app/apps/skill-registry/dist apps/skill-registry/dist
+
 USER node
+
 EXPOSE 5000
-CMD ["node", "dist/index.js"]
+
+CMD ["node", "apps/skill-registry/dist/index.js"]

--- a/apps/skill-registry/package.json
+++ b/apps/skill-registry/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.21.0",
+    "@opencrane/observability": "workspace:*",
     "express": "^4.18.2",
     "pino": "^9.6.0",
     "pino-http": "^10.0.0"

--- a/apps/skill-registry/src/index.ts
+++ b/apps/skill-registry/src/index.ts
@@ -1,12 +1,22 @@
+// OpenTelemetry must initialise before any instrumented module is imported.
+import "./instrument.js";
+
+import { randomUUID } from "node:crypto";
+
 import express from "express";
 import * as k8s from "@kubernetes/client-node";
-import pino from "pino";
 import { pinoHttp } from "pino-http";
+
+import { ___BindConsole, ___CreateLogger, ___GetContext, ___RequestContext, ___ShutdownTelemetry } from "@opencrane/observability";
 
 import { _LoadConfig } from "./config.js";
 import { _BuildRouter } from "./routes.js";
 
-const log = pino({ level: process.env["LOG_LEVEL"] ?? "info" });
+/** Root logger for the skill-registry — structured JSON, trace-correlated. */
+const log = ___CreateLogger("skill-registry");
+
+// Route any stray console.* output through the structured logger.
+const _unbindConsole = ___BindConsole(log);
 
 async function main(): Promise<void>
 {
@@ -18,13 +28,40 @@ async function main(): Promise<void>
   const authApi = kc.makeApiClient(k8s.AuthenticationV1Api);
 
   const app = express();
-  app.use(pinoHttp({ logger: log }));
+  // Seed the per-request correlation context before pino-http so every request
+  // log (and the control-plane call it makes) shares one requestId.
+  app.use(___RequestContext());
+  app.use(pinoHttp({ logger: log, genReqId: function _genReqId() { return ___GetContext()?.requestId ?? randomUUID(); } }));
   app.use(_BuildRouter(authApi, config.controlPlaneUrl, log));
 
-  app.listen(config.port, function _onListen()
+  const server = app.listen(config.port, function _onListen()
   {
     log.info({ port: config.port }, "skill-registry listening");
   });
+
+  /**
+   * Drain the server, flush spans, restore console, then exit.
+   * @param signal - The signal that triggered shutdown.
+   */
+  async function _shutdown(signal: string): Promise<void>
+  {
+    log.info({ signal }, "shutting down skill-registry");
+    const hardExit = setTimeout(function _force() { process.exit(1); }, 10_000);
+    hardExit.unref();
+    try
+    {
+      await new Promise<void>(function _close(resolve) { server.close(function _done() { resolve(); }); });
+      await ___ShutdownTelemetry();
+    }
+    finally
+    {
+      _unbindConsole();
+      process.exit(0);
+    }
+  }
+
+  process.on("SIGTERM", function _onSigterm() { void _shutdown("SIGTERM"); });
+  process.on("SIGINT", function _onSigint() { void _shutdown("SIGINT"); });
 }
 
 main().catch(function _onError(err: unknown)

--- a/apps/skill-registry/src/instrument.ts
+++ b/apps/skill-registry/src/instrument.ts
@@ -1,0 +1,10 @@
+/**
+ * OpenTelemetry bootstrap for the skill-registry.
+ *
+ * Imported first in `index.ts` (and preloaded via `node --import` in the
+ * container) so the SDK patches `http`/`express`/`fetch` before any
+ * instrumented module loads. Keep tiny and dependency-light.
+ */
+import { ___StartTelemetry } from "@opencrane/observability/telemetry";
+
+await ___StartTelemetry({ serviceName: "skill-registry", serviceVersion: process.env["npm_package_version"] ?? "0.1.0" });

--- a/libs/observability/package.json
+++ b/libs/observability/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@opencrane/observability",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./telemetry": {
+      "types": "./dist/telemetry.d.ts",
+      "import": "./dist/telemetry.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.56.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.57.0",
+    "@opentelemetry/sdk-node": "^0.57.0",
+    "pino": "^9.6.0"
+  },
+  "devDependencies": {
+    "@opentelemetry/sdk-trace-base": "^1.30.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.1.0"
+  }
+}

--- a/libs/observability/src/__tests__/console-bind.test.ts
+++ b/libs/observability/src/__tests__/console-bind.test.ts
@@ -1,0 +1,119 @@
+import { Writable } from "node:stream";
+
+import pino from "pino";
+import type { Logger } from "pino";
+import { describe, expect, it } from "vitest";
+
+import { ___BindConsole } from "../console-bind.js";
+import { ___ContextMixin, ___RunWithContext } from "../context.js";
+
+/** Build a pino logger that records each emitted record into an array. */
+function _memLogger(): { logger: Logger; records: Array<Record<string, unknown>> }
+{
+  const records: Array<Record<string, unknown>> = [];
+  const stream = new Writable({
+    write(chunk: Buffer, _enc, cb): void
+    {
+      records.push(JSON.parse(chunk.toString()) as Record<string, unknown>);
+      cb();
+    },
+  });
+  const logger = pino({ level: "debug", mixin: ___ContextMixin }, stream);
+  return { logger, records };
+}
+
+describe("___BindConsole", function _bindConsoleSuite()
+{
+  it("forwards console.log to one structured info record", function _single()
+  {
+    const { logger, records } = _memLogger();
+    const unbind = ___BindConsole(logger);
+    try
+    {
+      console.log("hello %s", "world");
+    }
+    finally
+    {
+      unbind();
+    }
+    // Exactly one record => no recursion through the patched console.
+    expect(records).toHaveLength(1);
+    expect(records[0]?.["level"]).toBe(30);
+    expect(records[0]?.["msg"]).toBe("hello world");
+  });
+
+  it("maps console.warn/error/debug to the right levels", function _levels()
+  {
+    const { logger, records } = _memLogger();
+    const unbind = ___BindConsole(logger);
+    try
+    {
+      console.warn("w");
+      console.error("e");
+      console.debug("d");
+    }
+    finally
+    {
+      unbind();
+    }
+    expect(records.map(function _lvl(r) { return r["level"]; })).toEqual([40, 50, 20]);
+  });
+
+  it("serialises an Error-first call under err", function _errorFirst()
+  {
+    const { logger, records } = _memLogger();
+    const unbind = ___BindConsole(logger);
+    try
+    {
+      console.error(new Error("boom"));
+    }
+    finally
+    {
+      unbind();
+    }
+    expect(records[0]?.["msg"]).toBe("boom");
+    expect((records[0]?.["err"] as { type?: string })?.type).toBe("Error");
+  });
+
+  it("keeps an object-first call's fields structured", function _objectFirst()
+  {
+    const { logger, records } = _memLogger();
+    const unbind = ___BindConsole(logger);
+    try
+    {
+      console.warn({ tenant: "acme", failures: 2 }, "sync partial");
+    }
+    finally
+    {
+      unbind();
+    }
+    expect(records[0]?.["tenant"]).toBe("acme");
+    expect(records[0]?.["failures"]).toBe(2);
+    expect(records[0]?.["msg"]).toBe("sync partial");
+  });
+
+  it("inherits request context on forwarded console calls", function _withContext()
+  {
+    const { logger, records } = _memLogger();
+    const unbind = ___BindConsole(logger);
+    try
+    {
+      ___RunWithContext({ requestId: "req-9", extra: {} }, function _run() { console.log("scoped"); });
+    }
+    finally
+    {
+      unbind();
+    }
+    expect(records[0]?.["requestId"]).toBe("req-9");
+  });
+
+  it("restores the original console methods on unbind", function _restore()
+  {
+    const original = console.log;
+    const { logger } = _memLogger();
+    const unbind = ___BindConsole(logger);
+    expect(console.log).not.toBe(original);
+    unbind();
+    expect(console.log).toBe(original);
+  });
+});

--- a/libs/observability/src/__tests__/context.test.ts
+++ b/libs/observability/src/__tests__/context.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { ___ContextMixin, ___GetContext, ___RunWithContext, ___SetContextField } from "../context.js";
+
+describe("context", function _contextSuite()
+{
+  it("returns undefined / empty outside any scope", function _outside()
+  {
+    expect(___GetContext()).toBeUndefined();
+    expect(___ContextMixin()).toEqual({});
+  });
+
+  it("exposes requestId and extra fields inside a scope", function _inside()
+  {
+    ___RunWithContext({ requestId: "req-1", extra: { tenant: "acme" } }, function _run()
+    {
+      expect(___GetContext()?.requestId).toBe("req-1");
+      expect(___ContextMixin()).toEqual({ requestId: "req-1", tenant: "acme" });
+    });
+  });
+
+  it("merges fields added with ___SetContextField", function _setField()
+  {
+    ___RunWithContext({ requestId: "req-2", extra: {} }, function _run()
+    {
+      ___SetContextField("operation", "tenant.reconcile");
+      expect(___ContextMixin()).toEqual({ requestId: "req-2", operation: "tenant.reconcile" });
+    });
+  });
+
+  it("isolates concurrent async scopes with no field bleed", async function _concurrent()
+  {
+    async function _task(id: string, delayMs: number): Promise<string>
+    {
+      return ___RunWithContext({ requestId: id, extra: {} }, async function _run()
+      {
+        await new Promise(function _wait(resolve) { setTimeout(resolve, delayMs); });
+        // After awaiting, the context must still be this task's, not the other's.
+        return ___GetContext()?.requestId ?? "none";
+      });
+    }
+
+    const [a, b] = await Promise.all([_task("A", 20), _task("B", 5)]);
+    expect(a).toBe("A");
+    expect(b).toBe("B");
+    expect(___GetContext()).toBeUndefined();
+  });
+});

--- a/libs/observability/src/__tests__/express.test.ts
+++ b/libs/observability/src/__tests__/express.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { ___GetContext } from "../context.js";
+import { ___RequestContext } from "../express.js";
+
+/** Minimal response double capturing headers set by the middleware. */
+function _fakeRes(): { headers: Record<string, string>; setHeader(name: string, value: string): void }
+{
+  const headers: Record<string, string> = {};
+  return {
+    headers,
+    setHeader(name: string, value: string): void { headers[name] = value; },
+  };
+}
+
+describe("___RequestContext", function _requestContextSuite()
+{
+  it("mints a requestId, echoes it, and exposes it to handlers", function _mint()
+  {
+    const mw = ___RequestContext();
+    const res = _fakeRes();
+    let seenId: string | undefined;
+
+    mw({ headers: {}, method: "GET", path: "/healthz" }, res, function _next()
+    {
+      seenId = ___GetContext()?.requestId;
+    });
+
+    expect(seenId).toBeDefined();
+    expect(res.headers["x-request-id"]).toBe(seenId);
+  });
+
+  it("reuses an inbound x-request-id", function _reuse()
+  {
+    const mw = ___RequestContext();
+    const res = _fakeRes();
+    let seenId: string | undefined;
+
+    mw({ headers: { "x-request-id": "upstream-7" }, method: "POST", path: "/api/v1/tenants" }, res, function _next()
+    {
+      seenId = ___GetContext()?.requestId;
+    });
+
+    expect(seenId).toBe("upstream-7");
+    expect(res.headers["x-request-id"]).toBe("upstream-7");
+  });
+
+  it("surfaces method and path as context fields", function _fields()
+  {
+    const mw = ___RequestContext();
+    let extra: Record<string, unknown> | undefined;
+
+    mw({ headers: {}, method: "DELETE", path: "/api/v1/tenants/acme" }, _fakeRes(), function _next()
+    {
+      extra = ___GetContext()?.extra;
+    });
+
+    expect(extra).toEqual({ method: "DELETE", path: "/api/v1/tenants/acme" });
+  });
+});

--- a/libs/observability/src/__tests__/operation.test.ts
+++ b/libs/observability/src/__tests__/operation.test.ts
@@ -3,9 +3,9 @@ import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { ___GetContext } from "../context.js";
-import { ___WithOperation } from "../operation.js";
+import { ___DoWithTrace } from "../operation.js";
 
-/** Captures spans emitted by ___WithOperation for assertion. */
+/** Captures spans emitted by ___DoWithTrace for assertion. */
 const _exporter = new InMemorySpanExporter();
 
 beforeAll(function _registerProvider()
@@ -21,12 +21,12 @@ afterAll(async function _shutdown()
   await _exporter.shutdown();
 });
 
-describe("___WithOperation", function _withOperationSuite()
+describe("___DoWithTrace", function _withOperationSuite()
 {
   it("seeds context, sets duration, and ends an OK span on success", async function _success()
   {
     _exporter.reset();
-    const seen = await ___WithOperation("tenant.reconcile", { tenant: "acme" }, async function _work()
+    const seen = await ___DoWithTrace("tenant.reconcile", { tenant: "acme" }, async function _work()
     {
       return ___GetContext();
     });
@@ -47,7 +47,7 @@ describe("___WithOperation", function _withOperationSuite()
   {
     _exporter.reset();
     await expect(
-      ___WithOperation("oci.bundle.push", { digest: "sha256:bad" }, async function _work()
+      ___DoWithTrace("oci.bundle.push", { digest: "sha256:bad" }, async function _work()
       {
         throw new Error("registry unreachable");
       }),
@@ -61,7 +61,7 @@ describe("___WithOperation", function _withOperationSuite()
 
   it("reuses a caller-supplied requestId", async function _inheritsId()
   {
-    const seen = await ___WithOperation("harvest.cycle", { requestId: "req-42" }, async function _work()
+    const seen = await ___DoWithTrace("harvest.cycle", { requestId: "req-42" }, async function _work()
     {
       return ___GetContext()?.requestId;
     });

--- a/libs/observability/src/__tests__/operation.test.ts
+++ b/libs/observability/src/__tests__/operation.test.ts
@@ -1,0 +1,70 @@
+import { SpanStatusCode } from "@opentelemetry/api";
+import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { ___GetContext } from "../context.js";
+import { ___WithOperation } from "../operation.js";
+
+/** Captures spans emitted by ___WithOperation for assertion. */
+const _exporter = new InMemorySpanExporter();
+
+beforeAll(function _registerProvider()
+{
+  // Register an in-memory tracer so trace.getTracer in operation.ts produces
+  // real spans we can inspect, without a live collector.
+  const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(_exporter)] });
+  provider.register();
+});
+
+afterAll(async function _shutdown()
+{
+  await _exporter.shutdown();
+});
+
+describe("___WithOperation", function _withOperationSuite()
+{
+  it("seeds context, sets duration, and ends an OK span on success", async function _success()
+  {
+    _exporter.reset();
+    const seen = await ___WithOperation("tenant.reconcile", { tenant: "acme" }, async function _work()
+    {
+      return ___GetContext();
+    });
+
+    expect(seen?.extra["operation"]).toBe("tenant.reconcile");
+    expect(seen?.extra["tenant"]).toBe("acme");
+    expect(typeof seen?.requestId).toBe("string");
+
+    const spans = _exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.name).toBe("tenant.reconcile");
+    expect(spans[0]?.status.code).toBe(SpanStatusCode.OK);
+    expect(spans[0]?.attributes["tenant"]).toBe("acme");
+    expect(typeof spans[0]?.attributes["duration_ms"]).toBe("number");
+  });
+
+  it("records the exception and re-throws on failure", async function _failure()
+  {
+    _exporter.reset();
+    await expect(
+      ___WithOperation("oci.bundle.push", { digest: "sha256:bad" }, async function _work()
+      {
+        throw new Error("registry unreachable");
+      }),
+    ).rejects.toThrow("registry unreachable");
+
+    const spans = _exporter.getFinishedSpans();
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.status.code).toBe(SpanStatusCode.ERROR);
+    expect(spans[0]?.events.some(function _isException(e) { return e.name === "exception"; })).toBe(true);
+  });
+
+  it("reuses a caller-supplied requestId", async function _inheritsId()
+  {
+    const seen = await ___WithOperation("harvest.cycle", { requestId: "req-42" }, async function _work()
+    {
+      return ___GetContext()?.requestId;
+    });
+    expect(seen).toBe("req-42");
+  });
+});

--- a/libs/observability/src/__tests__/redact.test.ts
+++ b/libs/observability/src/__tests__/redact.test.ts
@@ -1,0 +1,58 @@
+import { Writable } from "node:stream";
+
+import pino from "pino";
+import { describe, expect, it } from "vitest";
+
+import { REDACT_PATHS } from "../redact.js";
+
+/** Build a pino logger applying REDACT_PATHS, capturing records into an array. */
+function _redactingLogger(): { logger: pino.Logger; records: Array<Record<string, unknown>> }
+{
+  const records: Array<Record<string, unknown>> = [];
+  const stream = new Writable({
+    write(chunk: Buffer, _enc, cb): void
+    {
+      records.push(JSON.parse(chunk.toString()) as Record<string, unknown>);
+      cb();
+    },
+  });
+  const logger = pino({ redact: [...REDACT_PATHS] }, stream);
+  return { logger, records };
+}
+
+describe("REDACT_PATHS", function _redactSuite()
+{
+  it("redacts top-level credential fields from logged objects", function _topLevel()
+  {
+    const { logger, records } = _redactingLogger();
+    logger.info({ masterKey: "sk-secret", token: "t-123", password: "hunter2" }, "config");
+    expect(records[0]?.["masterKey"]).toBe("[Redacted]");
+    expect(records[0]?.["token"]).toBe("[Redacted]");
+    expect(records[0]?.["password"]).toBe("[Redacted]");
+  });
+
+  it("redacts nested credential fields via wildcard paths", function _nested()
+  {
+    const { logger, records } = _redactingLogger();
+    logger.info({ litellm: { apiKey: "sk-nested", masterKey: "mk-nested" } }, "nested");
+    const litellm = records[0]?.["litellm"] as Record<string, unknown>;
+    expect(litellm["apiKey"]).toBe("[Redacted]");
+    expect(litellm["masterKey"]).toBe("[Redacted]");
+  });
+
+  it("redacts the Authorization request header", function _authHeader()
+  {
+    const { logger, records } = _redactingLogger();
+    logger.info({ req: { headers: { authorization: "Bearer leak-me" } } }, "request");
+    const req = records[0]?.["req"] as { headers: Record<string, unknown> };
+    expect(req.headers["authorization"]).toBe("[Redacted]");
+  });
+
+  it("leaves non-sensitive fields intact", function _passthrough()
+  {
+    const { logger, records } = _redactingLogger();
+    logger.info({ tenant: "acme", requestId: "req-1" }, "ok");
+    expect(records[0]?.["tenant"]).toBe("acme");
+    expect(records[0]?.["requestId"]).toBe("req-1");
+  });
+});

--- a/libs/observability/src/console-bind.ts
+++ b/libs/observability/src/console-bind.ts
@@ -1,0 +1,108 @@
+/**
+ * Routes the global `console.*` methods through a structured pino logger.
+ *
+ * This is the "plug into console.log" seam: once bound, every `console.log`,
+ * `console.warn`, etc. — first-party stragglers and noisy third-party
+ * libraries alike — becomes a structured, context-tagged, trace-correlated log
+ * record instead of an opaque stdout line.
+ *
+ * Safe against recursion: the logger writes JSON straight to a file descriptor
+ * (see {@link ___CreateLogger}), never back through `console`, so forwarding a
+ * `console.*` call into pino cannot re-enter the patched method.
+ */
+import { format } from "node:util";
+
+import type { Logger } from "pino";
+
+/** The `console` method names this module patches. */
+const _METHODS = ["log", "info", "warn", "error", "debug"] as const;
+
+/** A `console` method name handled by {@link ___BindConsole}. */
+type ConsoleMethod = (typeof _METHODS)[number];
+
+/** Map each console method to the pino level it should emit at. */
+const _LEVEL_FOR: Record<ConsoleMethod, "info" | "warn" | "error" | "debug"> = {
+  log: "info",
+  info: "info",
+  warn: "warn",
+  error: "error",
+  debug: "debug",
+};
+
+/**
+ * Forward one captured `console.*` invocation to the matching pino level,
+ * preserving structure when the first argument is an object or `Error`.
+ * @param logger - Target logger.
+ * @param level  - Pino level to emit at.
+ * @param args   - Original `console.*` arguments.
+ */
+function _forward(logger: Logger, level: "info" | "warn" | "error" | "debug", args: unknown[]): void
+{
+  // 1. Empty call — emit an empty record so the call site is still observable.
+  if (args.length === 0)
+  {
+    logger[level]("");
+    return;
+  }
+
+  const [first, ...rest] = args;
+
+  // 2. Error first — let pino serialise it under `err` and use the rest (or the
+  //    error message) as the human-readable message.
+  if (first instanceof Error)
+  {
+    logger[level]({ err: first }, rest.length > 0 ? format(...rest) : first.message);
+    return;
+  }
+
+  // 3. Plain object first — treat it as pino's merge object (structured fields),
+  //    formatting any remaining args into the message.
+  if (typeof first === "object" && first !== null)
+  {
+    logger[level](first as Record<string, unknown>, rest.length > 0 ? format(...rest) : undefined);
+    return;
+  }
+
+  // 4. Otherwise behave like console: printf-format every argument into one
+  //    message string.
+  logger[level](format(...args));
+}
+
+/**
+ * Patch the global `console.*` methods to emit through `logger`.
+ * @param logger - Logger that receives all forwarded console output.
+ * @returns An `unbind` function that restores the original `console` methods.
+ */
+export function ___BindConsole(logger: Logger): () => void
+{
+  // 1. Capture the originals up front so unbind can restore them exactly and so
+  //    forwarding never depends on the (now patched) live methods.
+  const originals = new Map<ConsoleMethod, (...args: unknown[]) => void>();
+  for (const method of _METHODS)
+  {
+    originals.set(method, console[method] as (...args: unknown[]) => void);
+  }
+
+  // 2. Replace each method with a forwarder bound to the logger.
+  for (const method of _METHODS)
+  {
+    const level = _LEVEL_FOR[method];
+    console[method] = function _patchedConsole(...args: unknown[]): void
+    {
+      _forward(logger, level, args);
+    };
+  }
+
+  // 3. Hand back a restore closure for graceful shutdown / tests.
+  return function _unbindConsole(): void
+  {
+    for (const method of _METHODS)
+    {
+      const original = originals.get(method);
+      if (original)
+      {
+        console[method] = original;
+      }
+    }
+  };
+}

--- a/libs/observability/src/context.ts
+++ b/libs/observability/src/context.ts
@@ -1,0 +1,66 @@
+/**
+ * Per-request / per-operation context propagation via `AsyncLocalStorage`.
+ *
+ * The store is seeded once at an entry point ({@link ___RunWithContext}) and is
+ * read by the pino mixin ({@link ___ContextMixin}) so every log line emitted
+ * anywhere inside the async scope carries the same `requestId` plus any seeded
+ * fields — without threading a logger or id through function signatures.
+ */
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { RequestContext } from "./observability.types.js";
+
+/** Process-wide async store holding the active {@link RequestContext}. */
+const _store = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Run `fn` with `ctx` installed as the active context for the entire async
+ * subtree it spawns.
+ * @param ctx - Context to install for the duration of `fn`.
+ * @param fn  - Function to execute within the context.
+ * @returns Whatever `fn` returns.
+ */
+export function ___RunWithContext<T>(ctx: RequestContext, fn: () => T): T
+{
+  return _store.run(ctx, fn);
+}
+
+/**
+ * Return the active context, or `undefined` when called outside any
+ * {@link ___RunWithContext} scope.
+ * @returns The active context or `undefined`.
+ */
+export function ___GetContext(): RequestContext | undefined
+{
+  return _store.getStore();
+}
+
+/**
+ * Merge a single field into the active context's `extra` bag so it appears on
+ * every subsequent log line within the scope. No-op outside a context.
+ * @param key   - Field name.
+ * @param value - Field value.
+ */
+export function ___SetContextField(key: string, value: unknown): void
+{
+  const ctx = _store.getStore();
+  if (ctx)
+  {
+    ctx.extra[key] = value;
+  }
+}
+
+/**
+ * Pino mixin: returns the fields to merge into every log record. Reads the
+ * active context so logs are automatically correlated by `requestId`.
+ * @returns Context fields, or an empty object outside any context.
+ */
+export function ___ContextMixin(): Record<string, unknown>
+{
+  const ctx = _store.getStore();
+  if (!ctx)
+  {
+    return {};
+  }
+  return { requestId: ctx.requestId, ...ctx.extra };
+}

--- a/libs/observability/src/express.ts
+++ b/libs/observability/src/express.ts
@@ -1,0 +1,59 @@
+/**
+ * Express middleware that seeds the per-request {@link RequestContext}.
+ *
+ * Structurally typed (no `express` import) so it works on both the Express 5
+ * control-plane and the Express 4 skill-registry without coupling the lib to a
+ * framework version.
+ */
+import { randomUUID } from "node:crypto";
+
+import { ___RunWithContext } from "./context.js";
+
+/** Minimal request shape this middleware reads from. */
+interface _MinimalRequest
+{
+  /** Incoming HTTP headers (used to honour an inbound `x-request-id`). */
+  headers: Record<string, string | string[] | undefined>;
+  /** HTTP method, surfaced as a context field. */
+  method?: string;
+  /** Routed path, surfaced as a context field. */
+  path?: string;
+}
+
+/** Minimal response shape this middleware writes the echoed id to. */
+interface _MinimalResponse
+{
+  /** Sets a response header. */
+  setHeader(name: string, value: string): void;
+}
+
+/**
+ * Build the request-context middleware.
+ *
+ * Reuses an inbound `x-request-id` when a caller (or upstream proxy) supplies
+ * one so a correlation id can span multiple services; otherwise mints a fresh
+ * UUID. The id is echoed back on the response and installed as the active
+ * context for the whole request handler chain.
+ * @returns An Express-compatible request handler.
+ */
+export function ___RequestContext(): (req: _MinimalRequest, res: _MinimalResponse, next: () => void) => void
+{
+  return function _requestContext(req: _MinimalRequest, res: _MinimalResponse, next: () => void): void
+  {
+    // 1. Reuse an inbound correlation id when present so traces stitch across
+    //    service hops; fall back to a fresh UUID for edge requests.
+    const header = req.headers["x-request-id"];
+    const inbound = Array.isArray(header) ? header[0] : header;
+    const requestId = inbound && inbound.length > 0 ? inbound : randomUUID();
+
+    // 2. Echo the id so clients (and downstream logs) can correlate.
+    //    x-request-id: de-facto standard correlation header (RFC 6648 X- prefix);
+    //    consumers use it to tie a client-side error back to server logs.
+    //    @see https://www.rfc-editor.org/rfc/rfc6648
+    res.setHeader("x-request-id", requestId);
+
+    // 3. Install the context for the remainder of the handler chain so every
+    //    downstream log line inherits requestId/method/path automatically.
+    ___RunWithContext({ requestId, extra: { method: req.method, path: req.path } }, next);
+  };
+}

--- a/libs/observability/src/index.ts
+++ b/libs/observability/src/index.ts
@@ -16,6 +16,6 @@ export type { Logger } from "./logger.js";
 export { ___RunWithContext, ___GetContext, ___SetContextField, ___ContextMixin } from "./context.js";
 export { ___BindConsole } from "./console-bind.js";
 export { ___RequestContext } from "./express.js";
-export { ___WithOperation } from "./operation.js";
+export { ___DoWithTrace } from "./operation.js";
 export { ___StartTelemetry, ___ShutdownTelemetry } from "./telemetry.js";
 export type { RequestContext, LoggerOptions, TelemetryOptions } from "./observability.types.js";

--- a/libs/observability/src/index.ts
+++ b/libs/observability/src/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @opencrane/observability — centralized structured logging + execution tracing.
+ *
+ * One place to build a fleet-consistent logger, propagate a correlation id
+ * through async work without threading it by hand, route stray `console.*`
+ * calls into structured logs, and emit OpenTelemetry traces to the in-cluster
+ * collector (which forwards to GCP Cloud Logging + Cloud Trace, or any OTLP
+ * backend behind a Helm toggle).
+ *
+ * The side-effecting SDK bootstrap ({@link ___StartTelemetry}) is also available
+ * via the dedicated `@opencrane/observability/telemetry` entry point so it can
+ * be imported in isolation before the rest of the application graph.
+ */
+export { ___CreateLogger } from "./logger.js";
+export type { Logger } from "./logger.js";
+export { ___RunWithContext, ___GetContext, ___SetContextField, ___ContextMixin } from "./context.js";
+export { ___BindConsole } from "./console-bind.js";
+export { ___RequestContext } from "./express.js";
+export { ___WithOperation } from "./operation.js";
+export { ___StartTelemetry, ___ShutdownTelemetry } from "./telemetry.js";
+export type { RequestContext, LoggerOptions, TelemetryOptions } from "./observability.types.js";

--- a/libs/observability/src/logger.ts
+++ b/libs/observability/src/logger.ts
@@ -1,0 +1,63 @@
+/**
+ * Structured logger factory built on pino.
+ *
+ * Every app creates its root logger here so logging is consistent across the
+ * fleet: JSON to stdout (or stderr for the CLI), context fields injected via a
+ * mixin, secrets redacted, and — once {@link ___StartTelemetry} has run — every
+ * record carries `trace_id`/`span_id` for correlation with Cloud Trace.
+ */
+import pino from "pino";
+import type { Logger } from "pino";
+
+import { ___ContextMixin } from "./context.js";
+import { REDACT_PATHS } from "./redact.js";
+import type { LoggerOptions } from "./observability.types.js";
+
+/**
+ * Create a configured root logger.
+ *
+ * Writes synchronous JSON straight to a file descriptor (never through
+ * `console`), so it is safe to use together with {@link ___BindConsole} and never
+ * spawns a worker-thread transport in production.
+ * @param name - Service/component name stamped on every record.
+ * @param opts - Optional level, pretty-print, and destination overrides.
+ * @returns A pino {@link Logger}.
+ */
+export function ___CreateLogger(name: string, opts: LoggerOptions = {}): Logger
+{
+  // 1. Resolve the destination fd first — the CLI logs to stderr (2) to keep
+  //    stdout reserved for `--output json`; everything else logs to stdout (1).
+  const fd = opts.destination ?? 1;
+
+  // 2. Resolve level and pretty-print from options or environment. Pretty mode
+  //    uses a worker-thread transport, so it is dev-only and never the default
+  //    in a container (NODE_ENV=production).
+  const level = opts.level ?? process.env["LOG_LEVEL"] ?? "info";
+  const pretty = opts.pretty ?? (process.env["NODE_ENV"] !== "production" && fd === 2);
+
+  // 3. In pretty (dev) mode hand off to pino-pretty; the transport owns the fd.
+  if (pretty)
+  {
+    return pino({
+      name,
+      level,
+      mixin: ___ContextMixin,
+      redact: [...REDACT_PATHS],
+      transport: { target: "pino-pretty", options: { destination: fd, colorize: fd === 2 } },
+    });
+  }
+
+  // 4. Production path: synchronous JSON to the raw fd. `sync: true` avoids the
+  //    async buffer that can drop logs when a short-lived process exits.
+  return pino(
+    {
+      name,
+      level,
+      mixin: ___ContextMixin,
+      redact: [...REDACT_PATHS],
+    },
+    pino.destination({ fd, sync: true }),
+  );
+}
+
+export type { Logger } from "pino";

--- a/libs/observability/src/observability.types.ts
+++ b/libs/observability/src/observability.types.ts
@@ -9,7 +9,7 @@
  * Per-operation context propagated through `AsyncLocalStorage`.
  *
  * Seeded once at the entry of a request (HTTP middleware) or a background
- * operation (`___WithOperation`); every log line emitted within that async scope
+ * operation (`___DoWithTrace`); every log line emitted within that async scope
  * automatically inherits these fields via the pino mixin, so no logger or id
  * needs to be threaded through function signatures.
  */

--- a/libs/observability/src/observability.types.ts
+++ b/libs/observability/src/observability.types.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared type definitions for the `@opencrane/observability` package.
+ *
+ * Kept separate from the implementation files per the repository's
+ * type-file separation rule.
+ */
+
+/**
+ * Per-operation context propagated through `AsyncLocalStorage`.
+ *
+ * Seeded once at the entry of a request (HTTP middleware) or a background
+ * operation (`___WithOperation`); every log line emitted within that async scope
+ * automatically inherits these fields via the pino mixin, so no logger or id
+ * needs to be threaded through function signatures.
+ */
+export interface RequestContext
+{
+  /** Correlation id shared by every log line and span of one request/operation. */
+  requestId: string;
+  /** Arbitrary structured fields merged into every log line within the scope. */
+  extra: Record<string, unknown>;
+}
+
+/**
+ * Options accepted by {@link ___CreateLogger}.
+ */
+export interface LoggerOptions
+{
+  /** Minimum level to emit; defaults to `LOG_LEVEL` env or `"info"`. */
+  level?: string;
+  /** Pretty-print to a human-readable transport (dev only); defaults to off in production. */
+  pretty?: boolean;
+  /** Destination file descriptor: 1 = stdout (default), 2 = stderr (used by the CLI). */
+  destination?: 1 | 2;
+}
+
+/**
+ * Options accepted by {@link ___StartTelemetry}.
+ */
+export interface TelemetryOptions
+{
+  /** Logical service name reported to the collector (e.g. `"control-plane"`). */
+  serviceName: string;
+  /** Service version stamped on every span; usually the package version. */
+  serviceVersion?: string;
+  /**
+   * Whether to start the OpenTelemetry SDK at all.
+   * Defaults to `true` only when `OTEL_EXPORTER_OTLP_ENDPOINT` is set, so the
+   * CLI and local runs without a collector are silent by default.
+   */
+  enabled?: boolean;
+}

--- a/libs/observability/src/operation.ts
+++ b/libs/observability/src/operation.ts
@@ -27,7 +27,7 @@ const _tracer = trace.getTracer("@opencrane/observability");
  * @param fn     - The work to run inside the operation scope.
  * @returns Whatever `fn` resolves to.
  */
-export async function ___WithOperation<T>(
+export async function ___DoWithTrace<T>(
   name: string,
   fields: Record<string, unknown>,
   fn: () => Promise<T>,

--- a/libs/observability/src/operation.ts
+++ b/libs/observability/src/operation.ts
@@ -1,0 +1,70 @@
+/**
+ * Wrapper that turns any background unit of work (operator reconcile, CLI
+ * command, harvesting cycle) into a traced, context-scoped operation.
+ *
+ * It opens an OpenTelemetry span, seeds the {@link RequestContext} so log lines
+ * within the work inherit `requestId` + `operation`, and records the outcome,
+ * duration, and any error on both the span and the logs.
+ */
+import { randomUUID } from "node:crypto";
+
+import { SpanStatusCode, trace } from "@opentelemetry/api";
+
+import { ___RunWithContext } from "./context.js";
+
+/** Tracer shared by all operations started through this package. */
+const _tracer = trace.getTracer("@opencrane/observability");
+
+/**
+ * Execute `fn` as a named, traced operation.
+ *
+ * A `requestId` is taken from `fields.requestId` when supplied (so an operation
+ * can inherit a caller's correlation id) or minted otherwise. The span is
+ * always ended and the error always re-thrown, so callers see normal control
+ * flow while telemetry is captured transparently.
+ * @param name   - Span / operation name (e.g. `"tenant.reconcile"`).
+ * @param fields - Structured attributes attached to the span and context.
+ * @param fn     - The work to run inside the operation scope.
+ * @returns Whatever `fn` resolves to.
+ */
+export async function ___WithOperation<T>(
+  name: string,
+  fields: Record<string, unknown>,
+  fn: () => Promise<T>,
+): Promise<T>
+{
+  // 1. Derive the correlation id once so the span, context, and logs all agree.
+  const requestId = typeof fields["requestId"] === "string" ? (fields["requestId"] as string) : randomUUID();
+  const startedAt = performance.now();
+
+  // 2. Open an active span so auto-instrumented child calls (HTTP, pg, fetch)
+  //    nest under this operation in the trace.
+  return _tracer.startActiveSpan(name, async function _runSpan(span)
+  {
+    span.setAttributes({ ...fields, requestId });
+
+    // 3. Seed the async context so every log line within fn carries the ids.
+    return ___RunWithContext({ requestId, extra: { operation: name, ...fields } }, async function _runWork()
+    {
+      try
+      {
+        const result = await fn();
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result;
+      }
+      catch (err)
+      {
+        // Record on the span before re-throwing so failed operations are still
+        // visible in Cloud Trace with their exception attached.
+        span.recordException(err as Error);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: err instanceof Error ? err.message : String(err) });
+        throw err;
+      }
+      finally
+      {
+        span.setAttribute("duration_ms", Math.round(performance.now() - startedAt));
+        span.end();
+      }
+    });
+  });
+}

--- a/libs/observability/src/redact.ts
+++ b/libs/observability/src/redact.ts
@@ -1,0 +1,35 @@
+/**
+ * Default redaction paths applied by every logger created through this package.
+ *
+ * Pino replaces the value at each path with `[Redacted]` before serialisation,
+ * so secrets and bearer tokens never reach stdout / the collector / Cloud
+ * Logging even when an object is logged wholesale.
+ */
+
+/**
+ * Pino `redact.paths` entries covering the credential-bearing fields that flow
+ * through the OpenCrane control-plane and its clients (auth headers, LiteLLM
+ * master keys, OIDC secrets, DB URLs, k8s secret payloads).
+ */
+export const REDACT_PATHS: readonly string[] = [
+  "req.headers.authorization",
+  "req.headers.cookie",
+  "res.headers['set-cookie']",
+  "headers.authorization",
+  "authorization",
+  "password",
+  "token",
+  "accessToken",
+  "refreshToken",
+  "apiKey",
+  "masterKey",
+  "client_secret",
+  "clientSecret",
+  "DATABASE_URL",
+  "databaseUrl",
+  "*.password",
+  "*.token",
+  "*.apiKey",
+  "*.masterKey",
+  "*.client_secret",
+];

--- a/libs/observability/src/telemetry.ts
+++ b/libs/observability/src/telemetry.ts
@@ -1,0 +1,83 @@
+/**
+ * OpenTelemetry SDK bootstrap.
+ *
+ * Apps import this module **first** (via a tiny `instrument.ts`, ideally also
+ * preloaded with `node --import`) so auto-instrumentation patches `http`,
+ * `express`, `pg`, and `fetch` before the application graph loads.
+ *
+ * Only traces are exported in-process (OTLP/http-protobuf → the in-cluster
+ * collector → Cloud Trace). Logs travel as JSON on stdout and are scraped by
+ * the collector's filelog receiver; the auto pino instrumentation injects
+ * `trace_id`/`span_id` into those JSON records so logs and traces correlate.
+ */
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+
+import type { TelemetryOptions } from "./observability.types.js";
+
+/** The running SDK, kept so {@link ___ShutdownTelemetry} can flush it. Null when disabled. */
+let _sdk: NodeSDK | null = null;
+
+/**
+ * Start the OpenTelemetry SDK.
+ *
+ * No-op (returns immediately) when disabled — by default that is whenever no
+ * `OTEL_EXPORTER_OTLP_ENDPOINT` is configured, which keeps the CLI and local
+ * runs silent without a collector.
+ * @param opts - Service identity and an explicit enable override.
+ */
+export async function ___StartTelemetry(opts: TelemetryOptions): Promise<void>
+{
+  // 1. Decide whether to start at all. Default to enabled only when a collector
+  //    endpoint is present so laptop / CI runs don't try to export to nothing.
+  const enabled = opts.enabled ?? Boolean(process.env["OTEL_EXPORTER_OTLP_ENDPOINT"]);
+  if (!enabled || _sdk)
+  {
+    return;
+  }
+
+  // 2. Seed service identity via env so the NodeSDK resource detector picks it
+  //    up without importing the resources package directly.
+  process.env["OTEL_SERVICE_NAME"] ??= opts.serviceName;
+  if (opts.serviceVersion)
+  {
+    const existing = process.env["OTEL_RESOURCE_ATTRIBUTES"];
+    const versionAttr = `service.version=${opts.serviceVersion}`;
+    process.env["OTEL_RESOURCE_ATTRIBUTES"] = existing ? `${existing},${versionAttr}` : versionAttr;
+  }
+
+  // 3. Build the SDK: OTLP trace exporter (endpoint from env) + the standard
+  //    Node auto-instrumentations, with the noisy fs instrumentation disabled.
+  _sdk = new NodeSDK({
+    traceExporter: new OTLPTraceExporter(),
+    instrumentations: [getNodeAutoInstrumentations({ "@opentelemetry/instrumentation-fs": { enabled: false } })],
+  });
+
+  // 4. Start synchronously-ish; NodeSDK.start() registers the providers and
+  //    patches modules immediately.
+  _sdk.start();
+}
+
+/**
+ * Flush and stop the OpenTelemetry SDK.
+ *
+ * Must be awaited during graceful shutdown (and after a CLI command resolves)
+ * so batched spans are exported before the process exits. No-op when telemetry
+ * was never started.
+ */
+export async function ___ShutdownTelemetry(): Promise<void>
+{
+  if (!_sdk)
+  {
+    return;
+  }
+  try
+  {
+    await _sdk.shutdown();
+  }
+  finally
+  {
+    _sdk = null;
+  }
+}

--- a/libs/observability/tsconfig.json
+++ b/libs/observability/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/__tests__/**"]
+}

--- a/platform/helm/templates/_helpers.tpl
+++ b/platform/helm/templates/_helpers.tpl
@@ -250,6 +250,40 @@ This Secret is provisioned out-of-band (operator/installer), not by the chart.
 {{- end }}
 
 {{/*
+Observability env block for an app container.
+
+Call with a dict carrying the root context + the logical service name, e.g.:
+  {{- include "opencrane.observabilityEnv" (dict "ctx" $ "component" "control-plane") | nindent 12 }}
+
+NODE_ENV + LOG_LEVEL are always emitted so logs are consistent JSON. The OTEL_*
+vars are emitted only when observability.otel.enabled, pointing apps at the
+release-local collector Service; omitting them leaves @opencrane/observability's
+startTelemetry a no-op (it keys off OTEL_EXPORTER_OTLP_ENDPOINT). The service name
+is also set in code, so this stays correct even if the env var is dropped.
+*/}}
+{{- define "opencrane.observabilityEnv" -}}
+{{- $ctx := .ctx -}}
+{{- $component := .component -}}
+{{- $o := $ctx.Values.observability | default dict -}}
+{{- $otel := $o.otel | default dict -}}
+{{- $collector := $otel.collector | default dict -}}
+- name: NODE_ENV
+  value: {{ default "production" $otel.nodeEnv | quote }}
+- name: LOG_LEVEL
+  value: {{ default "info" $otel.logLevel | quote }}
+{{- if $otel.enabled }}
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: "http://{{ include "opencrane.fullname" $ctx }}-otel-collector.{{ $ctx.Release.Namespace }}.svc:{{ default 4318 $collector.otlpPort }}"
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: "http/protobuf"
+- name: OTEL_SERVICE_NAME
+  value: {{ $component | quote }}
+- name: OTEL_RESOURCE_ATTRIBUTES
+  value: "service.namespace=opencrane,deployment.environment={{ include "opencrane.environment" $ctx }}"
+{{- end }}
+{{- end }}
+
+{{/*
 Validation guardrails for sensitive LiteLLM configuration.
 */}}
 {{- define "opencrane.validate" -}}

--- a/platform/helm/templates/control-plane-deployment.yaml
+++ b/platform/helm/templates/control-plane-deployment.yaml
@@ -52,6 +52,7 @@ spec:
                   fieldPath: metadata.namespace
             - name: PORT
               value: {{ .Values.controlPlane.service.port | quote }}
+            {{- include "opencrane.observabilityEnv" (dict "ctx" $ "component" "control-plane") | nindent 12 }}
             - name: INGRESS_DOMAIN
               value: {{ .Values.ingress.domain | quote }}
             {{- if .Values.certManager.enabled }}

--- a/platform/helm/templates/operator-deployment.yaml
+++ b/platform/helm/templates/operator-deployment.yaml
@@ -30,6 +30,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- include "opencrane.observabilityEnv" (dict "ctx" $ "component" "operator") | nindent 12 }}
             - name: WATCH_NAMESPACE
               value: {{ .Values.operator.watchNamespace | quote }}
             # -- Multi-instance fail-closed guard (brief B2): when true the operator

--- a/platform/helm/templates/otel-collector.yaml
+++ b/platform/helm/templates/otel-collector.yaml
@@ -1,0 +1,195 @@
+{{- if (((.Values.observability).otel).enabled) }}
+{{- $otel := .Values.observability.otel }}
+{{- $collector := $otel.collector | default dict }}
+{{- $exporter := $otel.exporter | default dict }}
+{{- $logsMode := (($otel.logs).collector) | default "filelog" }}
+{{- $backend := $exporter.backend | default "googlecloud" }}
+{{- $otlpPort := int (default 4318 $collector.otlpPort) }}
+{{- $fullName := printf "%s-otel-collector" (include "opencrane.fullname" .) }}
+{{- /* filelog log scraping needs node-local pod logs → only valid as a DaemonSet. */ -}}
+{{- $useFilelog := and (eq $logsMode "filelog") (eq (default "daemonset" $collector.mode) "daemonset") }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+---
+{{- if $useFilelog }}
+# The collector reads pod stdout from the node filesystem; it needs to list/watch
+# pods/namespaces so the k8sattributes processor can enrich logs with metadata.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $fullName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $fullName }}
+    namespace: {{ .Release.Namespace }}
+---
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          http:
+            endpoint: 0.0.0.0:{{ $otlpPort }}
+          grpc:
+            endpoint: 0.0.0.0:4317
+    {{- if $useFilelog }}
+      filelog:
+        include: [ /var/log/pods/*/*/*.log ]
+        include_file_path: true
+        operators:
+          # Containerd/CRI log line → structured record (timestamp, stream, log body).
+          - type: container
+            id: cri-parser
+          # App lines are pino JSON; parse so severity + trace_id/span_id are first-class.
+          - type: json_parser
+            parse_from: body
+            on_error: send_quiet
+          - type: severity_parser
+            parse_from: attributes.level
+            on_error: send_quiet
+    {{- end }}
+    processors:
+      batch: {}
+      resourcedetection:
+        detectors: [env, gcp, system]
+        timeout: 5s
+        override: false
+    {{- if $useFilelog }}
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata: [k8s.namespace.name, k8s.pod.name, k8s.container.name, k8s.deployment.name]
+    {{- end }}
+    exporters:
+    {{- if eq $backend "googlecloud" }}
+      googlecloud:
+        log:
+          default_log_name: opencrane
+    {{- else }}
+      otlp:
+        endpoint: {{ (($exporter.otlp).endpoint) | default "" | quote }}
+        tls:
+          insecure: true
+    {{- end }}
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [resourcedetection, batch]
+          exporters: [{{ $backend }}]
+      {{- if $useFilelog }}
+        logs:
+          receivers: [filelog]
+          processors: [k8sattributes, resourcedetection, batch]
+          exporters: [{{ $backend }}]
+      {{- end }}
+---
+{{- $kind := ternary "DaemonSet" "Deployment" (eq (default "daemonset" $collector.mode) "daemonset") }}
+apiVersion: apps/v1
+kind: {{ $kind }}
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+spec:
+  {{- if eq $kind "Deployment" }}
+  replicas: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "opencrane.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: otel-collector
+  template:
+    metadata:
+      labels:
+        {{- include "opencrane.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: otel-collector
+      annotations:
+        # Roll the pod(s) when the collector config changes.
+        checksum/config: {{ tpl (.Files.Get "templates/otel-collector.yaml" | default "") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ $fullName }}
+      containers:
+        - name: otel-collector
+          image: {{ $collector.image | default "otel/opentelemetry-collector-contrib:0.115.0" | quote }}
+          args: ["--config=/etc/otel/config.yaml"]
+          ports:
+            - name: otlp-http
+              containerPort: {{ $otlpPort }}
+            - name: otlp-grpc
+              containerPort: 4317
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+            {{- if $useFilelog }}
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            {{- end }}
+          resources:
+            {{- toYaml ($collector.resources | default dict) | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $fullName }}
+        {{- if $useFilelog }}
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+            type: Directory
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+spec:
+  selector:
+    {{- include "opencrane.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: otel-collector
+  ports:
+    - name: otlp-http
+      port: {{ $otlpPort }}
+      targetPort: otlp-http
+    - name: otlp-grpc
+      port: 4317
+      targetPort: otlp-grpc
+{{- end }}

--- a/platform/helm/templates/skill-registry-deployment.yaml
+++ b/platform/helm/templates/skill-registry-deployment.yaml
@@ -77,6 +77,7 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.skillRegistry.service.port | quote }}
+            {{- include "opencrane.observabilityEnv" (dict "ctx" $ "component" "skill-registry") | nindent 12 }}
             # In-cluster control-plane URL for internal entitlement + content calls.
             - name: CONTROL_PLANE_URL
               value: "http://{{ include "opencrane.fullname" . }}-control-plane.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.controlPlane.service.port }}"

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -520,6 +520,41 @@ observability:
   cloudLogging: false
   # -- Enable Cloud Error Reporting integration
   cloudErrorReporting: false
+  # -- OpenTelemetry: every OpenCrane service emits structured JSON logs (trace-correlated)
+  #    and execution traces. An in-cluster OTEL Collector receives the traces over OTLP and
+  #    scrapes pod-stdout logs, then exports both to GCP Cloud Logging + Cloud Trace (or any
+  #    OTLP backend). Disabled by default — apps log to stdout regardless; turning this on
+  #    wires them to the collector and deploys it.
+  otel:
+    enabled: false
+    # -- Per-app pino level (debug|info|warn|error). Consumed via LOG_LEVEL.
+    logLevel: info
+    # -- NODE_ENV for the app containers (production = JSON logs, no pretty transport).
+    nodeEnv: production
+    collector:
+      # -- Topology: "daemonset" scrapes each node's pod stdout via the filelog receiver
+      #    (needed for the log pipeline); "deployment" runs a single collector for traces
+      #    only (use on GKE Autopilot, where hostPath DaemonSets are restricted — rely on
+      #    the platform's native stdout→Cloud Logging and set logs.collector=platform).
+      mode: daemonset
+      # -- Collector image (contrib distro carries the googlecloud + filelog components).
+      image: otel/opentelemetry-collector-contrib:0.115.0
+      # -- OTLP/HTTP port apps export traces to.
+      otlpPort: 4318
+      # -- Collector container resource requests/limits.
+      resources: {}
+    exporter:
+      # -- Export backend: "googlecloud" (Cloud Logging + Cloud Trace) or "otlp" (forward to
+      #    an external OTLP endpoint such as Tempo/Loki/another collector).
+      backend: googlecloud
+      otlp:
+        # -- Downstream OTLP endpoint when exporter.backend=otlp.
+        endpoint: ""
+    logs:
+      # -- Log pipeline: "filelog" (collector scrapes pod stdout — requires collector.mode=daemonset)
+      #    or "platform" (rely on the cloud's native stdout collection, e.g. GKE Autopilot →
+      #    Cloud Logging; the collector then handles traces only).
+      collector: filelog
 
 # -- ClusterTenant provisioner (Track CT). The native `shared` and `dedicatedNodes`
 #    isolation tiers need NO configuration here — the operator enforces them inline.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ importers:
       '@opencrane/contracts':
         specifier: workspace:*
         version: link:../../libs/contracts
+      '@opencrane/observability':
+        specifier: workspace:*
+        version: link:../../libs/observability
       commander:
         specifier: ^12.0.0
         version: 12.1.0
@@ -41,6 +44,9 @@ importers:
       '@opencrane/contracts':
         specifier: workspace:*
         version: link:../../libs/contracts
+      '@opencrane/observability':
+        specifier: workspace:*
+        version: link:../../libs/observability
       '@prisma/client':
         specifier: ^6.0.0
         version: 6.19.2(prisma@6.19.2(typescript@5.8.2))(typescript@5.8.2)
@@ -62,6 +68,9 @@ importers:
       pino-http:
         specifier: ^10.0.0
         version: 10.5.0
+      prisma:
+        specifier: ^6.0.0
+        version: 6.19.2(typescript@5.8.2)
     devDependencies:
       '@types/express':
         specifier: ^5.0.0
@@ -72,9 +81,6 @@ importers:
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.3
-      prisma:
-        specifier: ^6.0.0
-        version: 6.19.2(typescript@5.8.2)
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
@@ -90,6 +96,9 @@ importers:
 
   apps/harvesting-agent:
     dependencies:
+      '@opencrane/observability':
+        specifier: workspace:*
+        version: link:../../libs/observability
       '@prisma/client':
         specifier: ^6.0.0
         version: 6.19.2(prisma@6.19.2(typescript@5.8.2))(typescript@5.8.2)
@@ -118,6 +127,9 @@ importers:
       '@kubernetes/client-node':
         specifier: ^1.0.0
         version: 1.4.0(encoding@0.1.13)
+      '@opencrane/observability':
+        specifier: workspace:*
+        version: link:../../libs/observability
       pino:
         specifier: ^9.6.0
         version: 9.14.0
@@ -144,6 +156,9 @@ importers:
       '@kubernetes/client-node':
         specifier: ^0.21.0
         version: 0.21.0
+      '@opencrane/observability':
+        specifier: workspace:*
+        version: link:../../libs/observability
       express:
         specifier: ^4.18.2
         version: 4.22.2
@@ -194,6 +209,37 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.8.2
+
+  libs/observability:
+    dependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+      '@opentelemetry/auto-instrumentations-node':
+        specifier: ^0.56.0
+        version: 0.56.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.57.0
+        version: 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.57.0
+        version: 0.57.2(@opentelemetry/api@1.9.1)
+      pino:
+        specifier: ^9.6.0
+        version: 9.14.0
+    devDependencies:
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.30.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.15.31
+      typescript:
+        specifier: ^5.7.0
+        version: 5.8.2
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.15.31)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)
 
   website:
     devDependencies:
@@ -655,6 +701,15 @@ packages:
     resolution: {integrity: sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==}
     engines: {node: '>=14'}
 
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@iconify-json/simple-icons@1.2.86':
     resolution: {integrity: sha512-t3jck5qPQuK1qy+bRn9eCoDQhIB7XSazKz1Fjp8hcan3XOAsTI5Mq/s3F0ekOKSvMQqkVORYK6ns6o6T9f5EMA==}
 
@@ -673,6 +728,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@jsep-plugin/assignment@1.3.0':
     resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
@@ -698,6 +756,458 @@ packages:
 
   '@nodable/entities@2.1.1':
     resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
+  '@opentelemetry/api-logs@0.57.2':
+    resolution: {integrity: sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/auto-instrumentations-node@0.56.1':
+    resolution: {integrity: sha512-4cK0+unfkXRRbQQg2r9K3ki8JlE0j9Iw8+4DZEkChShAnmviiE+/JMgHGvK+VVcLrSlgV6BBHv4+ZTLukQwhkA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.4.1
+
+  '@opentelemetry/context-async-hooks@1.30.1':
+    resolution: {integrity: sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-eovEy10n3umjKJl2Ey6TLzikPE+W4cUQ4gCwgGP1RqzTGtgDra0WjIqdy29ohiUKfvmbiL3MndZww58xfIvyFw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.57.2':
+    resolution: {integrity: sha512-0rygmvLcehBRp56NQVLSleJ5ITTduq/QfU7obOkyWgPpFHulwpw2LYTqNIz5TczKZuy5YY+5D3SDnXZL1tXImg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-ta0ithCin0F8lu9eOf4lEz9YAScecezCHkMMyDkvd9S7AnZNX5ikUmC5EQOQADU+oCcgo/qkQIaKcZvQ0TYKDw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-r70B8yKR41F0EC443b5CGB4rUaOMm99I5N75QQt6sHKxYDzSEc6gm48Diz1CI1biwa5tDPznpylTrywO/pT7qw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.57.2':
+    resolution: {integrity: sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-HX068Q2eNs38uf7RIkNN9Hl4Ynl+3lP0++KELkXMCpsCbFO03+0XNNZ1SkwxPlP9jrhQahsMPMkzNXpq3fKsnw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.57.2':
+    resolution: {integrity: sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.57.2':
+    resolution: {integrity: sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2':
+    resolution: {integrity: sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.57.2':
+    resolution: {integrity: sha512-awDdNRMIwDvUtoRYxRhja5QYH6+McBLtoz1q9BeEsskhZcrGmH/V1fWpGx8n+Rc+542e8pJA6y+aullbIzQmlw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@1.30.1':
+    resolution: {integrity: sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-amqplib@0.46.1':
+    resolution: {integrity: sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-aws-lambda@0.50.3':
+    resolution: {integrity: sha512-kotm/mRvSWUauudxcylc5YCDei+G/r+jnOH6q5S99aPLQ/Ms8D2yonMIxEJUILIPlthEmwLYxkw3ualWzMjm/A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-aws-sdk@0.49.1':
+    resolution: {integrity: sha512-Vbj4BYeV/1K4Pbbfk+gQ8gwYL0w+tBeUwG88cOxnF7CLPO1XnskGV8Q3Gzut2Ah/6Dg17dBtlzEqL3UiFP2Z6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-bunyan@0.45.1':
+    resolution: {integrity: sha512-T9POV9ccS41UjpsjLrJ4i0m8LfplBiN3dMeH9XZ2btiDrjoaWtDrst6tNb1avetBjkeshOuBp1EWKP22EVSr0g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-cassandra-driver@0.45.1':
+    resolution: {integrity: sha512-RqnP0rK2hcKK1AKcmYvedLiL6G5TvFGiSUt2vI9wN0cCBdTt9Y9+wxxY19KoGxq7e9T/aHow6P5SUhCVI1sHvQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-connect@0.43.1':
+    resolution: {integrity: sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-cucumber@0.14.1':
+    resolution: {integrity: sha512-ybO+tmH85pDO0ywTskmrMtZcccKyQr7Eb7wHy1keR2HFfx46SzZbjHo1AuGAX//Hook3gjM7+w211gJ2bwKe1Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation-dataloader@0.16.1':
+    resolution: {integrity: sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-dns@0.43.1':
+    resolution: {integrity: sha512-e/tMZYU1nc+k+J3259CQtqVZIPsPRSLNoAQbGEmSKrjLEY/KJSbpBZ17lu4dFVBzqoF1cZYIZxn9WPQxy4V9ng==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-express@0.47.1':
+    resolution: {integrity: sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fastify@0.44.2':
+    resolution: {integrity: sha512-arSp97Y4D2NWogoXRb8CzFK3W2ooVdvqRRtQDljFt9uC3zI6OuShgey6CVFC0JxT1iGjkAr1r4PDz23mWrFULQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-fs@0.19.1':
+    resolution: {integrity: sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-generic-pool@0.43.1':
+    resolution: {integrity: sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-graphql@0.47.1':
+    resolution: {integrity: sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-grpc@0.57.2':
+    resolution: {integrity: sha512-TR6YQA67cLSZzdxbf2SrbADJy2Y8eBW1+9mF15P0VK2MYcpdoUSmQTF1oMkBwa3B9NwqDFA2fq7wYTTutFQqaQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-hapi@0.45.2':
+    resolution: {integrity: sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-http@0.57.2':
+    resolution: {integrity: sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-ioredis@0.47.1':
+    resolution: {integrity: sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-kafkajs@0.7.1':
+    resolution: {integrity: sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-knex@0.44.1':
+    resolution: {integrity: sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-koa@0.47.1':
+    resolution: {integrity: sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.1':
+    resolution: {integrity: sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-memcached@0.43.1':
+    resolution: {integrity: sha512-rK5YWC22gmsLp2aEbaPk5F+9r6BFFZuc9GTnW/ErrWpz2XNHUgeFInoPDg4t+Trs8OttIfn8XwkfFkSKqhxanw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongodb@0.52.0':
+    resolution: {integrity: sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mongoose@0.46.1':
+    resolution: {integrity: sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql2@0.45.2':
+    resolution: {integrity: sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-mysql@0.45.1':
+    resolution: {integrity: sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-nestjs-core@0.44.1':
+    resolution: {integrity: sha512-4TXaqJK27QXoMqrt4+hcQ6rKFd8B6V4JfrTJKnqBmWR1cbaqd/uwyl9yxhNH1JEkyo8GaBfdpBC4ZE4FuUhPmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-net@0.43.1':
+    resolution: {integrity: sha512-TaMqP6tVx9/SxlY81dHlSyP5bWJIKq+K7vKfk4naB/LX4LBePPY3++1s0edpzH+RfwN+tEGVW9zTb9ci0up/lQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pg@0.51.1':
+    resolution: {integrity: sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-pino@0.46.1':
+    resolution: {integrity: sha512-HB8gD/9CNAKlTV+mdZehnFC4tLUtQ7e+729oGq88e4WipxzZxmMYuRwZ2vzOA9/APtq+MRkERJ9PcoDqSIjZ+g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis-4@0.46.1':
+    resolution: {integrity: sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-redis@0.46.1':
+    resolution: {integrity: sha512-AN7OvlGlXmlvsgbLHs6dS1bggp6Fcki+GxgYZdSrb/DB692TyfjR7sVILaCe0crnP66aJuXsg9cge3hptHs9UA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-restify@0.45.1':
+    resolution: {integrity: sha512-Zd6Go9iEa+0zcoA2vDka9r/plYKaT3BhD3ESIy4JNIzFWXeQBGbH3zZxQIsz0jbNTMEtonlymU7eTLeaGWiApA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-router@0.44.1':
+    resolution: {integrity: sha512-l4T/S7ByjpY5TCUPeDe1GPns02/5BpR0jroSMexyH3ZnXJt9PtYqx1IKAlOjaFEGEOQF2tGDsMi4PY5l+fSniQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-socket.io@0.46.1':
+    resolution: {integrity: sha512-9AsCVUAHOqvfe2RM/2I0DsDnx2ihw1d5jIN4+Bly1YPFTJIbk4+bXjAkr9+X6PUfhiV5urQHZkiYYPU1Q4yzPA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-tedious@0.18.1':
+    resolution: {integrity: sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation-undici@0.10.1':
+    resolution: {integrity: sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.7.0
+
+  '@opentelemetry/instrumentation-winston@0.44.1':
+    resolution: {integrity: sha512-iexblTsT3fP0hHUz/M1mWr+Ylg3bsYN2En/jvKXZtboW3Qkvt17HrQJYTF9leVIkXAfN97QxAcTE99YGbQW7vQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/instrumentation@0.57.2':
+    resolution: {integrity: sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.57.2':
+    resolution: {integrity: sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.57.2':
+    resolution: {integrity: sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.57.2':
+    resolution: {integrity: sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagation-utils@0.30.16':
+    resolution: {integrity: sha512-ZVQ3Z/PQ+2GQlrBfbMMMT0U7MzvYZLCPP800+ooyaBqm4hMvuQHfP028gB9/db0mwkmyEAMad9houukUVxhwcw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/propagator-b3@1.30.1':
+    resolution: {integrity: sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@1.30.1':
+    resolution: {integrity: sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/redis-common@0.36.2':
+    resolution: {integrity: sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/resource-detector-alibaba-cloud@0.30.1':
+    resolution: {integrity: sha512-9l0FVP3F4+Z6ax27vMzkmhZdNtxAbDqEfy7rduzya3xFLaRiJSvOpw6cru6Edl5LwO+WvgNui+VzHa9ViE8wCg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-aws@1.12.0':
+    resolution: {integrity: sha512-Cvi7ckOqiiuWlHBdA1IjS0ufr3sltex2Uws2RK6loVp4gzIJyOijsddAI6IZ5kiO8h/LgCWe8gxPmwkTKImd+Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-azure@0.6.1':
+    resolution: {integrity: sha512-Djr31QCExVfWViaf9cGJnH+bUInD72p0GEfgDGgjCAztyvyji6WJvKjs6qmkpPN+Ig6KLk0ho2VgzT5Kdl4L2Q==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-container@0.6.1':
+    resolution: {integrity: sha512-o4sLzx149DQXDmVa8pgjBDEEKOj9SuQnkSLbjUVOpQNnn10v0WNR6wLwh30mFsK26xOJ6SpqZBGKZiT7i5MjlA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resource-detector-gcp@0.33.1':
+    resolution: {integrity: sha512-/aZJXI1rU6Eus04ih2vU0hxXAibXXMzH1WlDZ8bXcTJmhwmTY8cP392+6l7cWeMnTQOibBUz8UKV3nhcCBAefw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.57.2':
+    resolution: {integrity: sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.30.1':
+    resolution: {integrity: sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.57.2':
+    resolution: {integrity: sha512-8BaeqZyN5sTuPBtAoY+UtKwXBdqyuRKmekN5bFzAO40CgbGzAxfTpiL3PBerT7rhZ7p2nBdq7FaMv/tBQgHE4A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@1.30.1':
+    resolution: {integrity: sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
+  '@opentelemetry/sql-common@0.40.1':
+    resolution: {integrity: sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -816,6 +1326,33 @@ packages:
 
   '@prisma/get-platform@6.19.2':
     resolution: {integrity: sha512-PGLr06JUSTqIvztJtAzIxOwtWKtJm5WwOG6xpsgD37Rc84FpfUBGLKz65YpJBGtkRQGXTYEFie7pYALocC3MtA==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
@@ -994,8 +1531,14 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
+  '@types/aws-lambda@8.10.147':
+    resolution: {integrity: sha512-nD0Z9fNIZcxYX5Mai2CTmFD7wX7UldCkW2ezCF8D1T5hdiLsnTWDGRpfRYntU6VjTdLQjOvyszru7I1c1oCQew==}
+
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/bunyan@1.8.11':
+    resolution: {integrity: sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==}
 
   '@types/caseless@0.12.5':
     resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
@@ -1051,11 +1594,17 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
+  '@types/memcached@2.2.10':
+    resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
+
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/mysql@2.15.26':
+    resolution: {integrity: sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==}
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
@@ -1068,6 +1617,12 @@ packages:
 
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
+
+  '@types/pg-pool@2.0.6':
+    resolution: {integrity: sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==}
+
+  '@types/pg@8.6.1':
+    resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
 
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
@@ -1090,6 +1645,9 @@ packages:
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
 
+  '@types/shimmer@1.2.0':
+    resolution: {integrity: sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==}
+
   '@types/stream-buffers@3.0.8':
     resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
 
@@ -1098,6 +1656,9 @@ packages:
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
+
+  '@types/tedious@4.0.14':
+    resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -1263,6 +1824,16 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -1281,6 +1852,14 @@ packages:
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1466,12 +2045,26 @@ packages:
   citty@0.2.1:
     resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
 
+  cjs-module-lexer@1.4.3:
+    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
@@ -1623,6 +2216,9 @@ packages:
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -1669,6 +2265,10 @@ packages:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -1778,6 +2378,9 @@ packages:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
 
+  forwarded-parse@2.1.2:
+    resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -1865,6 +2468,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
@@ -1919,6 +2526,9 @@ packages:
   immutable@5.1.5:
     resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
+  import-in-the-middle@1.15.0:
+    resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
@@ -1934,9 +2544,17 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2029,6 +2647,12 @@ packages:
 
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -2141,6 +2765,9 @@ packages:
 
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -2259,6 +2886,9 @@ packages:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
@@ -2277,6 +2907,17 @@ packages:
 
   performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2313,6 +2954,22 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
 
@@ -2331,6 +2988,10 @@ packages:
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -2414,12 +3075,25 @@ packages:
     engines: {node: '>= 6'}
     deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  require-in-the-middle@7.5.2:
+    resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
+    engines: {node: '>=8.6.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
@@ -2462,6 +3136,11 @@ packages:
   search-insights@2.17.3:
     resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
 
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.2:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
@@ -2483,6 +3162,9 @@ packages:
 
   shiki@2.5.0:
     resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
+
+  shimmer@1.2.1:
+    resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -2561,11 +3243,19 @@ packages:
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
@@ -2591,6 +3281,10 @@ packages:
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
     engines: {node: '>=18'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
@@ -2913,6 +3607,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2932,6 +3630,14 @@ packages:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -2944,6 +3650,10 @@ packages:
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.3:
+    resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
     engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
@@ -3313,6 +4023,18 @@ snapshots:
       - supports-color
     optional: true
 
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.4
+      yargs: 17.7.3
+
   '@iconify-json/simple-icons@1.2.86':
     dependencies:
       '@iconify/types': 2.0.0
@@ -3332,6 +4054,8 @@ snapshots:
       minipass: 7.1.3
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
     dependencies:
@@ -3394,6 +4118,678 @@ snapshots:
 
   '@nodable/entities@2.1.1':
     optional: true
+
+  '@opentelemetry/api-logs@0.57.2':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/auto-instrumentations-node@0.56.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-amqplib': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-aws-lambda': 0.50.3(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-aws-sdk': 0.49.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-bunyan': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-cassandra-driver': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-connect': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-cucumber': 0.14.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dataloader': 0.16.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-dns': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-express': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fastify': 0.44.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-fs': 0.19.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-generic-pool': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-graphql': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-hapi': 0.45.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-ioredis': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-kafkajs': 0.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-knex': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-koa': 0.47.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-lru-memoizer': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-memcached': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongodb': 0.52.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mongoose': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-mysql2': 0.45.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-nestjs-core': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-net': 0.43.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pg': 0.51.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-pino': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-redis-4': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-restify': 0.45.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-router': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-socket.io': 0.46.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-tedious': 0.18.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-undici': 0.10.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation-winston': 0.44.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-alibaba-cloud': 0.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-aws': 1.12.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-azure': 0.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-container': 0.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resource-detector-gcp': 0.33.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-node': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-prometheus@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/exporter-zipkin@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/instrumentation-amqplib@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-aws-lambda@0.50.3(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@types/aws-lambda': 8.10.147
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-aws-sdk@0.49.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagation-utils': 0.30.16(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-bunyan@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@types/bunyan': 1.8.11
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-cassandra-driver@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-connect@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@types/connect': 3.4.38
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-cucumber@0.14.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dataloader@0.16.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-dns@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-express@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fastify@0.44.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-fs@0.19.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-generic-pool@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-graphql@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-grpc@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-hapi@0.45.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-http@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+      forwarded-parse: 2.1.2
+      semver: 7.8.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-ioredis@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-kafkajs@0.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-knex@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-koa@0.47.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-lru-memoizer@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-memcached@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@types/memcached': 2.2.10
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongodb@0.52.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mongoose@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql2@0.45.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-mysql@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@types/mysql': 2.15.26
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-nestjs-core@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-net@0.43.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pg@0.51.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@opentelemetry/sql-common': 0.40.1(@opentelemetry/api@1.9.1)
+      '@types/pg': 8.6.1
+      '@types/pg-pool': 2.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-pino@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis-4@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-redis@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/redis-common': 0.36.2
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-restify@0.45.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-router@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-socket.io@0.46.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-tedious@0.18.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@types/tedious': 4.0.14
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-undici@0.10.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation-winston@0.44.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@types/shimmer': 1.2.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+      semver: 7.8.4
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.57.2(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      protobufjs: 7.6.4
+
+  '@opentelemetry/propagation-utils@0.30.16(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/propagator-b3@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/propagator-jaeger@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/redis-common@0.36.2': {}
+
+  '@opentelemetry/resource-detector-alibaba-cloud@0.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/resource-detector-aws@1.12.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/resource-detector-azure@0.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/resource-detector-container@0.6.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/resource-detector-gcp@0.33.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      gcp-metadata: 6.1.1(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-logs@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-node@0.57.2(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.57.2
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-prometheus': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-http': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/exporter-zipkin': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.57.2(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-node@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/context-async-hooks': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-b3': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.1)
+      semver: 7.8.4
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@opentelemetry/sql-common@0.40.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -3496,6 +4892,26 @@ snapshots:
   '@prisma/get-platform@6.19.2':
     dependencies:
       '@prisma/debug': 6.19.2
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@redocly/ajv@8.11.2':
     dependencies:
@@ -3651,9 +5067,15 @@ snapshots:
   '@tootallnate/once@2.0.1':
     optional: true
 
+  '@types/aws-lambda@8.10.147': {}
+
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
+      '@types/node': 22.15.31
+
+  '@types/bunyan@1.8.11':
+    dependencies:
       '@types/node': 22.15.31
 
   '@types/caseless@0.12.5': {}
@@ -3725,9 +5147,17 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
+  '@types/memcached@2.2.10':
+    dependencies:
+      '@types/node': 22.15.31
+
   '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
+
+  '@types/mysql@2.15.26':
+    dependencies:
+      '@types/node': 22.15.31
 
   '@types/node-fetch@2.6.13':
     dependencies:
@@ -3745,6 +5175,16 @@ snapshots:
   '@types/node@24.12.0':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/pg-pool@2.0.6':
+    dependencies:
+      '@types/pg': 8.6.1
+
+  '@types/pg@8.6.1':
+    dependencies:
+      '@types/node': 22.15.31
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
 
   '@types/qs@6.15.0': {}
 
@@ -3777,6 +5217,8 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/node': 22.15.31
 
+  '@types/shimmer@1.2.0': {}
+
   '@types/stream-buffers@3.0.8':
     dependencies:
       '@types/node': 22.15.31
@@ -3792,6 +5234,10 @@ snapshots:
     dependencies:
       '@types/methods': 1.1.4
       '@types/superagent': 8.1.9
+
+  '@types/tedious@4.0.14':
+    dependencies:
+      '@types/node': 22.15.31
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -3988,6 +5434,12 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -4022,6 +5474,12 @@ snapshots:
       '@algolia/requester-node-http': 5.54.0
 
   ansi-colors@4.1.3: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   argparse@2.0.1: {}
 
@@ -4101,8 +5559,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  bignumber.js@9.3.1:
-    optional: true
+  bignumber.js@9.3.1: {}
 
   birpc@2.9.0: {}
 
@@ -4207,11 +5664,25 @@ snapshots:
 
   citty@0.2.1: {}
 
+  cjs-module-lexer@1.4.3: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   colorette@1.4.0: {}
 
@@ -4332,6 +5803,8 @@ snapshots:
 
   emoji-regex-xs@1.0.0: {}
 
+  emoji-regex@8.0.0: {}
+
   empathic@2.0.0: {}
 
   encodeurl@2.0.0: {}
@@ -4418,6 +5891,8 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -4617,6 +6092,8 @@ snapshots:
       dezalgo: 1.0.4
       once: 1.4.0
 
+  forwarded-parse@2.1.2: {}
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -4638,7 +6115,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   gcp-metadata@6.1.1(encoding@0.1.13):
     dependencies:
@@ -4648,7 +6124,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   get-caller-file@2.0.5: {}
 
@@ -4700,8 +6175,7 @@ snapshots:
       - supports-color
     optional: true
 
-  google-logging-utils@0.0.2:
-    optional: true
+  google-logging-utils@0.0.2: {}
 
   gopd@1.2.0: {}
 
@@ -4728,6 +6202,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -4812,6 +6290,13 @@ snapshots:
   immutable@5.1.5:
     optional: true
 
+  import-in-the-middle@1.15.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      cjs-module-lexer: 1.4.3
+      module-details-from-path: 1.0.4
+
   index-to-position@1.2.0: {}
 
   inherits@2.0.4: {}
@@ -4820,8 +6305,14 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
   is-extglob@2.1.1:
     optional: true
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -4830,8 +6321,7 @@ snapshots:
 
   is-promise@4.0.0: {}
 
-  is-stream@2.0.1:
-    optional: true
+  is-stream@2.0.1: {}
 
   is-typedarray@1.0.0: {}
 
@@ -4867,7 +6357,6 @@ snapshots:
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
-    optional: true
 
   json-schema-traverse@0.4.1: {}
 
@@ -4904,6 +6393,10 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
     optional: true
+
+  lodash.camelcase@4.3.0: {}
+
+  long@5.3.2: {}
 
   loupe@3.2.1: {}
 
@@ -4997,6 +6490,8 @@ snapshots:
       minipass: 7.1.3
 
   mitt@3.0.1: {}
+
+  module-details-from-path@1.0.4: {}
 
   ms@2.0.0: {}
 
@@ -5104,6 +6599,8 @@ snapshots:
   path-expression-matcher@1.5.0:
     optional: true
 
+  path-parse@1.0.7: {}
+
   path-to-regexp@0.1.13: {}
 
   path-to-regexp@8.3.0: {}
@@ -5115,6 +6612,18 @@ snapshots:
   perfect-debounce@1.0.0: {}
 
   performance-now@2.1.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
 
   picocolors@1.1.1: {}
 
@@ -5167,6 +6676,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   preact@10.29.2: {}
 
   prisma@6.19.2(typescript@5.8.2):
@@ -5181,6 +6700,20 @@ snapshots:
   process-warning@5.0.0: {}
 
   property-information@7.2.0: {}
+
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.15.31
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -5295,9 +6828,26 @@ snapshots:
       tunnel-agent: 0.6.0
       uuid: 3.4.0
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      module-details-from-path: 1.0.4
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
   resolve-pkg-maps@1.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   retry-request@7.0.2(encoding@0.1.13):
     dependencies:
@@ -5374,6 +6924,8 @@ snapshots:
 
   search-insights@2.17.3: {}
 
+  semver@7.8.4: {}
+
   send@0.19.2:
     dependencies:
       debug: 2.6.9
@@ -5438,6 +6990,8 @@ snapshots:
       '@shikijs/types': 2.5.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  shimmer@1.2.1: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -5533,6 +7087,12 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -5542,6 +7102,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-literal@3.1.0:
     dependencies:
@@ -5580,6 +7144,8 @@ snapshots:
       - supports-color
 
   supports-color@10.2.2: {}
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   tabbable@6.4.0: {}
 
@@ -5750,8 +7316,7 @@ snapshots:
   uuid@8.3.2:
     optional: true
 
-  uuid@9.0.1:
-    optional: true
+  uuid@9.0.1: {}
 
   vary@1.1.2: {}
 
@@ -6023,12 +7588,22 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
 
   xml-naming@0.1.0:
     optional: true
+
+  xtend@4.0.2: {}
+
+  y18n@5.0.8: {}
 
   yallist@4.0.0:
     optional: true
@@ -6038,6 +7613,16 @@ snapshots:
   yaml-ast-parser@0.0.43: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs@17.7.3:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - libs/contracts
   - libs/awareness
+  - libs/observability
   - apps/operator
   - apps/control-plane
   - apps/harvesting-agent


### PR DESCRIPTION
## What & why

We had no way to trace server execution centrally: logging was inconsistent (a lone pino in control-plane, ~14 raw `console.*` calls, no correlation id, no tracing). This adds a shared observability layer wired into **every** service, so a request or background operation can be followed end-to-end and aggregated centrally.

Branched **clean off `main`** — contains only the logging/tracing work (no model-registry-seed changes).

## Approach

- **New `@opencrane/observability` lib** (`libs/observability/`):
  - `___CreateLogger` — pino, structured JSON to stdout, secret redaction, context mixin.
  - `___BindConsole` — routes global `console.*` through the structured logger (the "plug into console.log" ask), recursion-safe.
  - `AsyncLocalStorage` context + pino mixin → every log line carries `requestId` / `operation` / `trace_id` with **no logger threaded through signatures**. Seeded by `___RequestContext()` (HTTP) or `___WithOperation()` (background work).
  - `___StartTelemetry`/`___ShutdownTelemetry` — OTEL NodeSDK + OTLP trace exporter; **no-op unless a collector endpoint is set**.
- **Wired into all apps** via a first-import `instrument.ts` (ESM ordering): control-plane, operator, harvesting-agent, skill-registry get logger + console-binding + flush-on-shutdown; the **CLI gets tracing only** (its `console.log` stays the `--output json` channel).
- **control-plane traces**: spans + structured logs on every external-I/O seam (LiteLLM chat/judge/model-register, OCI push/pull, k8s secret ops, Cognee sync, gateway); all 14 `console.*` calls converted to structured logs.
- **Helm**: in-cluster **OTEL Collector** (`observability.otel`, default **off**) exporting to **GCP Cloud Logging + Cloud Trace** (`googlecloud` exporter), with an OTLP-backend toggle for non-GCP; DaemonSet+filelog for logs or Deployment for traces-only (Autopilot). `opencrane.observabilityEnv` helper injects env into the app deployments.

## Verification
- Tests green: observability **20**, control-plane **352**, operator **101**, awareness 24, harvesting 9, cli 4, skill-registry 6.
- `pnpm -r build` green across all libs + apps; `helm template` renders in default-off and otel-on modes.

## Notes
- **Off by default** — apps log structured JSON to stdout regardless; enable the pipeline with `observability.otel.enabled=true` (on GKE Autopilot also `collector.mode=deployment` + `logs.collector=platform`).
- `skill-registry` / `harvesting-agent` Dockerfiles were rewritten to **workspace-aware (repo-root build context)** so the `workspace:*` dep resolves (they aren't built in CI).
- `apps/tenant` has no Node entrypoint → infra-only (collector scrapes its stdout).

Replaces #30 (which had the model-registry-seed commit riding along).