### PR TITLE
✨ Seed the model registry on startup (opt-in, custom endpoints)

### DIFF
--- a/apps/control-plane/src/__tests__/model-routing/seed-models.test.ts
+++ b/apps/control-plane/src/__tests__/model-routing/seed-models.test.ts
@@ -1,0 +1,217 @@
+import type { PrismaClient } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _SeedModels } from "../../core/model-routing/seed-models.js";
+
+/** An in-memory row in either backing store. */
+type Row = Record<string, unknown>;
+
+/** A no-op logger satisfying the subset of the pino Logger surface _SeedModels uses. */
+function _silentLog(): { info: () => void; warn: () => void; debug: () => void }
+{
+  return { info: function _i() {}, warn: function _w() {}, debug: function _d() {} };
+}
+
+/**
+ * Build a Prisma stub over two in-memory maps (model_definitions + model_routing_defaults) with
+ * just the methods _SeedModels touches: modelDefinition.findFirst/create and
+ * modelRoutingDefault.findFirst/create/update. Keyed for deterministic assertions.
+ *
+ * @param models   - Pre-seeded model_definitions store (keyed by id).
+ * @param defaults - Pre-seeded model_routing_defaults store (keyed by `scope:clusterTenant`).
+ * @returns A Prisma-shaped stub plus the two backing maps.
+ */
+function _mockPrisma(models: Map<string, Row> = new Map(), defaults: Map<string, Row> = new Map()): PrismaClient
+{
+  let modelSeq = 0;
+  let defaultSeq = 0;
+  function _key(scope: string, clusterTenant: string | null): string { return `${scope}:${clusterTenant ?? ""}`; }
+  return {
+    modelDefinition: {
+      findFirst: async function _findFirst(args: { where: { scope: string; publicModelName: string } })
+      {
+        return Array.from(models.values()).find(function _match(r) { return r.scope === args.where.scope && r.publicModelName === args.where.publicModelName; }) ?? null;
+      },
+      create: async function _create(args: { data: Row })
+      {
+        const id = `model-${++modelSeq}`;
+        const now = new Date("2026-06-19T00:00:00.000Z");
+        const row: Row = { id, apiBase: null, isDefault: false, providerCredentialId: null, clusterTenant: null, createdAt: now, updatedAt: now, ...args.data };
+        models.set(id, row);
+        return row;
+      },
+    },
+    modelRoutingDefault: {
+      findFirst: async function _findFirst(args: { where: { scope: string; clusterTenant: string | null } })
+      {
+        return defaults.get(_key(args.where.scope, args.where.clusterTenant)) ?? null;
+      },
+      create: async function _create(args: { data: Row })
+      {
+        const row: Row = { id: `default-${++defaultSeq}`, ...args.data };
+        defaults.set(_key(String(row.scope), (row.clusterTenant as string | null) ?? null), row);
+        return row;
+      },
+      update: async function _update(args: { where: { id: string }; data: Row })
+      {
+        for (const [k, v] of defaults)
+        {
+          if (v.id === args.where.id)
+          {
+            const row = { ...v, ...args.data };
+            defaults.set(k, row);
+            return row;
+          }
+        }
+        return null;
+      },
+    },
+  } as unknown as PrismaClient;
+}
+
+describe("_SeedModels", function _suite()
+{
+  const original = process.env.MODEL_REGISTRY_SEED;
+
+  beforeEach(function _resetEnv()
+  {
+    delete process.env.MODEL_REGISTRY_SEED;
+    delete process.env.LITELLM_ENDPOINT;
+    delete process.env.LITELLM_MASTER_KEY;
+  });
+
+  afterEach(function _restoreEnv()
+  {
+    if (original !== undefined) { process.env.MODEL_REGISTRY_SEED = original; } else { delete process.env.MODEL_REGISTRY_SEED; }
+    vi.restoreAllMocks();
+  });
+
+  it("seeds a new Global model with apiBase passed through and a placeholder id", async function _seedsNew()
+  {
+    process.env.MODEL_REGISTRY_SEED = JSON.stringify([
+      { publicModelName: "local/llama-3.3-70b", upstreamModel: "openai/llama-3.3-70b", apiKeyEnvRef: "LOCAL_LLM_API_KEY", apiBase: "http://my-vllm.internal:8000/v1" },
+    ]);
+    const models = new Map<string, Row>();
+    await _SeedModels(_mockPrisma(models), _silentLog() as never);
+
+    expect(models.size).toBe(1);
+    const row = Array.from(models.values())[0];
+    expect(row.scope).toBe("Global");
+    expect(row.publicModelName).toBe("local/llama-3.3-70b");
+    expect(row.apiBase).toBe("http://my-vllm.internal:8000/v1");
+    expect(row.providerCredentialId).toBeNull();
+    // Unconfigured LiteLLM → deterministic Global placeholder id.
+    expect(row.litellmModelId).toBe("placeholder:global-local-llama-3-3-70b");
+  });
+
+  it("registers the api_key as an os.environ reference + the apiBase when LiteLLM is configured", async function _registersLiteLlm()
+  {
+    process.env.LITELLM_ENDPOINT = "http://litellm:4000";
+    process.env.LITELLM_MASTER_KEY = "master-key";
+    process.env.MODEL_REGISTRY_SEED = JSON.stringify([
+      { publicModelName: "openai/gpt-5", upstreamModel: "openai/gpt-5", apiKeyEnvRef: "OPENAI_API_KEY" },
+    ]);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async function _json() { return { model_id: "deploy-xyz" }; } });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const models = new Map<string, Row>();
+    await _SeedModels(_mockPrisma(models), _silentLog() as never);
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const body = JSON.parse((fetchSpy.mock.calls[0][1] as { body: string }).body);
+    expect(body.model_name).toBe("openai/gpt-5");
+    expect(body.litellm_params.api_key).toBe("os.environ/OPENAI_API_KEY");
+    expect(Array.from(models.values())[0].litellmModelId).toBe("deploy-xyz");
+  });
+
+  it("skips an entry whose publicModelName already exists at Global scope", async function _skipsExisting()
+  {
+    process.env.MODEL_REGISTRY_SEED = JSON.stringify([
+      { publicModelName: "openai/gpt-5", upstreamModel: "openai/gpt-5", apiKeyEnvRef: "OPENAI_API_KEY" },
+    ]);
+    const models = new Map<string, Row>([
+      ["existing", { id: "existing", scope: "Global", publicModelName: "openai/gpt-5", upstreamModel: "openai/gpt-5-old", litellmModelId: "x", apiBase: null, isDefault: false, providerCredentialId: null }],
+    ]);
+    await _SeedModels(_mockPrisma(models), _silentLog() as never);
+
+    // No new row created; the existing one is untouched.
+    expect(models.size).toBe(1);
+    expect(models.get("existing")!.upstreamModel).toBe("openai/gpt-5-old");
+  });
+
+  it("sets the Global ModelRoutingDefault for an isDefault entry", async function _setsDefault()
+  {
+    process.env.MODEL_REGISTRY_SEED = JSON.stringify([
+      { publicModelName: "anthropic/claude-sonnet-4-6", upstreamModel: "anthropic/claude-sonnet-4-6", apiKeyEnvRef: "ANTHROPIC_API_KEY", isDefault: true },
+    ]);
+    const defaults = new Map<string, Row>();
+    await _SeedModels(_mockPrisma(new Map(), defaults), _silentLog() as never);
+
+    expect(defaults.size).toBe(1);
+    const row = defaults.get("Global:");
+    expect(row?.defaultModel).toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  it("applies last-isDefault-wins when several entries are flagged default", async function _lastDefaultWins()
+  {
+    process.env.MODEL_REGISTRY_SEED = JSON.stringify([
+      { publicModelName: "a/first", upstreamModel: "a/first", apiKeyEnvRef: "K", isDefault: true },
+      { publicModelName: "a/second", upstreamModel: "a/second", apiKeyEnvRef: "K", isDefault: true },
+    ]);
+    const defaults = new Map<string, Row>();
+    await _SeedModels(_mockPrisma(new Map(), defaults), _silentLog() as never);
+
+    expect(defaults.get("Global:")?.defaultModel).toBe("a/second");
+  });
+
+  it("no-ops when MODEL_REGISTRY_SEED is unset, blank, or malformed", async function _noOps()
+  {
+    for (const value of [undefined, "", "   ", "{not json", "{\"not\":\"array\"}"])
+    {
+      if (value === undefined) { delete process.env.MODEL_REGISTRY_SEED; } else { process.env.MODEL_REGISTRY_SEED = value; }
+      const models = new Map<string, Row>();
+      const defaults = new Map<string, Row>();
+      // Must resolve (never throw) and create nothing.
+      await expect(_SeedModels(_mockPrisma(models, defaults), _silentLog() as never)).resolves.toBeUndefined();
+      expect(models.size).toBe(0);
+      expect(defaults.size).toBe(0);
+    }
+  });
+
+  it("one bad entry does not abort the rest", async function _badEntryIsolated()
+  {
+    process.env.MODEL_REGISTRY_SEED = JSON.stringify([
+      { upstreamModel: "missing/public-name", apiKeyEnvRef: "K" }, // invalid: no publicModelName → coerced out
+      { publicModelName: "good/model", upstreamModel: "good/model", apiKeyEnvRef: "K" }, // valid
+    ]);
+    const models = new Map<string, Row>();
+    await _SeedModels(_mockPrisma(models), _silentLog() as never);
+
+    expect(models.size).toBe(1);
+    expect(Array.from(models.values())[0].publicModelName).toBe("good/model");
+  });
+
+  it("isolates a runtime failure on one entry so siblings still seed", async function _runtimeFailureIsolated()
+  {
+    process.env.MODEL_REGISTRY_SEED = JSON.stringify([
+      { publicModelName: "boom/model", upstreamModel: "boom/model", apiKeyEnvRef: "K" },
+      { publicModelName: "ok/model", upstreamModel: "ok/model", apiKeyEnvRef: "K" },
+    ]);
+    const models = new Map<string, Row>();
+    const prisma = _mockPrisma(models);
+    // Make the first create throw; the per-entry guard must catch it and continue. The second
+    // call (the "ok/model" entry) falls through to the in-memory store.
+    const realCreate = prisma.modelDefinition.create.bind(prisma.modelDefinition) as unknown as (args: { data: Row }) => Promise<Row>;
+    let calls = 0;
+    vi.spyOn(prisma.modelDefinition, "create").mockImplementation((function _create(args: { data: Row }): Promise<Row>
+    {
+      calls += 1;
+      if (calls === 1) { throw new Error("db down"); }
+      return realCreate(args);
+    }) as never);
+
+    await expect(_SeedModels(prisma, _silentLog() as never)).resolves.toBeUndefined();
+    expect(models.size).toBe(1);
+    expect(Array.from(models.values())[0].publicModelName).toBe("ok/model");
+  });
+});

--- a/apps/control-plane/src/core/model-routing/seed-models.ts
+++ b/apps/control-plane/src/core/model-routing/seed-models.ts
@@ -1,0 +1,224 @@
+import { ModelRoutingScope } from "@opencrane/contracts";
+import type { PrismaClient } from "@prisma/client";
+
+import type { Logger } from "pino";
+
+import { _RegisterLiteLlmModel } from "./litellm-model-registration.js";
+import type { ModelSeedEntry } from "./seed-models.types.js";
+
+/**
+ * Idempotently seed global {@link import("@opencrane/contracts").ModelDefinition}s from the
+ * `MODEL_REGISTRY_SEED` env var (a JSON array of {@link ModelSeedEntry}). Reuses the existing
+ * registration path: each new model is persisted at Global scope and best-effort registered in
+ * LiteLLM via {@link _RegisterLiteLlmModel}, exactly like the model-registry route.
+ *
+ * Everything is best-effort and non-fatal — an unset/blank/malformed env var is a no-op, and a
+ * single bad entry never aborts the rest. This function NEVER throws, so it cannot block or crash
+ * control-plane startup; it logs and returns instead.
+ *
+ * When an entry has `isDefault: true`, the Global {@link import("@opencrane/contracts").ModelRoutingDefault}
+ * is upserted to that slug so inherit-posture skills resolve to it. Only one Global default exists
+ * (`@@unique([scope, clusterTenant])`); last-isDefault-wins — the final `isDefault` entry in array
+ * order is the one that sticks.
+ *
+ * @param prisma - Prisma client used for persistence + the default upsert.
+ * @param log    - Logger for the best-effort diagnostics.
+ */
+export async function _SeedModels(prisma: PrismaClient, log: Logger): Promise<void>
+{
+  // 1. Decode the env var defensively — unset/blank/malformed must no-op, never throw, so a bad
+  //    operator value can never block startup.
+  const entries = _parseSeed(process.env.MODEL_REGISTRY_SEED, log);
+  if (entries.length === 0)
+  {
+    return;
+  }
+
+  log.info({ count: entries.length }, "model-registry seed: processing entries");
+
+  // 2. Process each entry in isolation so one failure cannot abort the rest of the seed.
+  let lastDefault: string | null = null;
+  for (const entry of entries)
+  {
+    try
+    {
+      const seeded = await _seedOne(prisma, log, entry);
+      // 2a. Track the last isDefault slug that was successfully seeded (last-isDefault-wins).
+      if (seeded && entry.isDefault === true)
+      {
+        lastDefault = entry.publicModelName.trim();
+      }
+    }
+    catch (err)
+    {
+      log.warn({ err, publicModelName: entry.publicModelName }, "model-registry seed: entry failed (non-fatal)");
+    }
+  }
+
+  // 3. Upsert the Global ModelRoutingDefault once, for the last isDefault entry, so inherit-posture
+  //    skills resolve to the platform default. Best-effort — a failure here is also non-fatal.
+  if (lastDefault)
+  {
+    await _upsertGlobalDefault(prisma, log, lastDefault);
+  }
+}
+
+/**
+ * Parse and validate the raw `MODEL_REGISTRY_SEED` value into clean seed entries. Returns an empty
+ * array for unset/blank input and for malformed JSON (logging a warn in the latter case). Entries
+ * missing the required `publicModelName`, `upstreamModel`, or `apiKeyEnvRef` are skipped with a warn.
+ *
+ * @param raw - The raw env var value (possibly undefined).
+ * @param log - Logger for malformed-input + skipped-entry diagnostics.
+ * @returns The validated, trimmed seed entries (possibly empty).
+ */
+function _parseSeed(raw: string | undefined, log: Logger): ModelSeedEntry[]
+{
+  // 1. Treat unset / blank as an explicit no-op (opt-in: empty default = no seeding).
+  const trimmed = raw?.trim() ?? "";
+  if (!trimmed)
+  {
+    return [];
+  }
+
+  // 2. Parse defensively — malformed JSON is logged and no-ops rather than throwing.
+  let decoded: unknown;
+  try
+  {
+    decoded = JSON.parse(trimmed);
+  }
+  catch (err)
+  {
+    log.warn({ err }, "model-registry seed: MODEL_REGISTRY_SEED is not valid JSON; skipping seed");
+    return [];
+  }
+
+  // 3. The top level must be an array; anything else is a misconfiguration we skip.
+  if (!Array.isArray(decoded))
+  {
+    log.warn("model-registry seed: MODEL_REGISTRY_SEED is not a JSON array; skipping seed");
+    return [];
+  }
+
+  // 4. Keep only entries carrying the three required string fields; drop the rest with a warn.
+  const valid: ModelSeedEntry[] = [];
+  for (const candidate of decoded)
+  {
+    const entry = _coerceEntry(candidate);
+    if (!entry)
+    {
+      log.warn({ candidate }, "model-registry seed: skipping invalid entry (needs publicModelName, upstreamModel, apiKeyEnvRef)");
+      continue;
+    }
+    valid.push(entry);
+  }
+  return valid;
+}
+
+/**
+ * Coerce one untrusted array element into a {@link ModelSeedEntry}, or null when it lacks any of
+ * the required string fields. Trims strings and normalises the optional `apiBase`/`isDefault`.
+ *
+ * @param candidate - One untrusted element of the decoded seed array.
+ * @returns A clean seed entry, or null when required fields are absent.
+ */
+function _coerceEntry(candidate: unknown): ModelSeedEntry | null
+{
+  if (typeof candidate !== "object" || candidate === null)
+  {
+    return null;
+  }
+  const obj = candidate as Record<string, unknown>;
+  const publicModelName = typeof obj.publicModelName === "string" ? obj.publicModelName.trim() : "";
+  const upstreamModel = typeof obj.upstreamModel === "string" ? obj.upstreamModel.trim() : "";
+  const apiKeyEnvRef = typeof obj.apiKeyEnvRef === "string" ? obj.apiKeyEnvRef.trim() : "";
+  if (!publicModelName || !upstreamModel || !apiKeyEnvRef)
+  {
+    return null;
+  }
+  const apiBase = typeof obj.apiBase === "string" && obj.apiBase.trim() ? obj.apiBase.trim() : null;
+  return { publicModelName, upstreamModel, apiKeyEnvRef, apiBase, isDefault: obj.isDefault === true };
+}
+
+/**
+ * Seed a single entry idempotently at Global scope. Skips when a Global `ModelDefinition` already
+ * owns the slug; otherwise best-effort registers it in LiteLLM and persists the row.
+ *
+ * @param prisma - Prisma client used for the existence check + create.
+ * @param log    - Logger for skip / seed diagnostics.
+ * @param entry  - The validated seed entry.
+ * @returns True when a new row was created; false when the slug already existed (skipped).
+ */
+async function _seedOne(prisma: PrismaClient, log: Logger, entry: ModelSeedEntry): Promise<boolean>
+{
+  const publicModelName = entry.publicModelName.trim();
+
+  // 1. Idempotency: a Global model already owning this slug is left untouched so re-runs are no-ops
+  //    and an operator's later edits via the API are never clobbered by the seed.
+  const existing = await prisma.modelDefinition.findFirst({ where: { scope: "Global", publicModelName } });
+  if (existing)
+  {
+    log.debug({ publicModelName }, "model-registry seed: slug already present at Global scope; skipping");
+    return false;
+  }
+
+  // 2. Best-effort LiteLLM registration — api_key is an os.environ/<ref> so the raw key never
+  //    transits OpenCrane; returns a deterministic placeholder when LiteLLM is unconfigured.
+  const apiBase = entry.apiBase?.trim() || null;
+  const litellmModelId = await _RegisterLiteLlmModel({
+    publicModelName,
+    upstreamModel: entry.upstreamModel.trim(),
+    scope: ModelRoutingScope.Global,
+    clusterTenant: null,
+    apiBase,
+    apiKeyEnvRef: entry.apiKeyEnvRef.trim(),
+  });
+
+  // 3. Persist the Global row with the resolved deployment id; providerCredentialId stays null
+  //    since the seed binds the key purely via the os.environ reference above.
+  await prisma.modelDefinition.create({
+    data: {
+      scope: "Global",
+      clusterTenant: null,
+      publicModelName,
+      litellmModelId,
+      upstreamModel: entry.upstreamModel.trim(),
+      apiBase,
+      isDefault: entry.isDefault === true,
+      providerCredentialId: null,
+    },
+  });
+  log.info({ publicModelName, litellmModelId, apiBase }, "model-registry seed: registered Global model");
+  return true;
+}
+
+/**
+ * Upsert the single Global `ModelRoutingDefault` to the given slug so inherit-posture skills
+ * resolve to it. Best-effort — logs and swallows any failure so it cannot block startup.
+ *
+ * @param prisma       - Prisma client used for the upsert.
+ * @param log          - Logger for the diagnostic.
+ * @param defaultModel - The `publicModelName` to set as the Global default.
+ */
+async function _upsertGlobalDefault(prisma: PrismaClient, log: Logger, defaultModel: string): Promise<void>
+{
+  try
+  {
+    // Resolve-then-branch keeps only one Global default. Prisma's compound-unique selector cannot
+    // express a null clusterTenant (Global scope), so findFirst + update/create as the route does.
+    const existing = await prisma.modelRoutingDefault.findFirst({ where: { scope: "Global", clusterTenant: null } });
+    if (existing)
+    {
+      await prisma.modelRoutingDefault.update({ where: { id: existing.id }, data: { defaultModel } });
+    }
+    else
+    {
+      await prisma.modelRoutingDefault.create({ data: { scope: "Global", clusterTenant: null, defaultModel } });
+    }
+    log.info({ defaultModel }, "model-registry seed: set Global ModelRoutingDefault");
+  }
+  catch (err)
+  {
+    log.warn({ err, defaultModel }, "model-registry seed: failed to set Global ModelRoutingDefault (non-fatal)");
+  }
+}

--- a/apps/control-plane/src/core/model-routing/seed-models.types.ts
+++ b/apps/control-plane/src/core/model-routing/seed-models.types.ts
@@ -1,0 +1,19 @@
+/**
+ * A single declarative model-registry seed entry, decoded from the `MODEL_REGISTRY_SEED`
+ * JSON array. Each entry registers ONE Global {@link import("@opencrane/contracts").ModelDefinition}
+ * idempotently on control-plane startup. Supports user-defined models + custom endpoints: any
+ * `apiKeyEnvRef` and any `apiBase` are accepted so operators can point at their own provider.
+ */
+export interface ModelSeedEntry
+{
+  /** The routable public slug callers request, e.g. `anthropic/claude-sonnet-4-6`. */
+  publicModelName: string;
+  /** The upstream model the LiteLLM deployment targets, e.g. `anthropic/claude-sonnet-4-6`. */
+  upstreamModel: string;
+  /** Env var name LiteLLM reads the provider key from — becomes `os.environ/<apiKeyEnvRef>`. */
+  apiKeyEnvRef: string;
+  /** Optional non-default API base for OSS / self-hosted / proxied endpoints. */
+  apiBase?: string | null;
+  /** When true, also marks this slug as the Global `ModelRoutingDefault.defaultModel`. */
+  isDefault?: boolean;
+}

--- a/apps/control-plane/src/index.ts
+++ b/apps/control-plane/src/index.ts
@@ -15,6 +15,7 @@ import { _TransportSecurity } from "./infra/middleware/transport-security.middle
 import { _ErrorHandler } from "./middleware/error-handler.js";
 
 import { _RegisterRoutes } from "./routes.js";
+import { _SeedModels } from "./core/model-routing/seed-models.js";
 
 /** Application logger instance. */
 const log = pino({ name: "ctrl" });
@@ -88,4 +89,12 @@ log.info({ port }, "starting opencrane control plane");
 app.listen(port, function _onListen()
 {
   log.info({ port }, "control plane listening");
+});
+
+// Idempotently seed the global model registry from MODEL_REGISTRY_SEED (opt-in; empty by
+// default). Best-effort and non-fatal — a seed failure must never block the control plane
+// from serving, so we log and continue rather than crash on startup.
+void _SeedModels(prisma, log).catch(function _onSeedError(err: unknown)
+{
+  log.warn({ err }, "model registry seed failed (non-fatal)");
 });

--- a/plan.md
+++ b/plan.md
@@ -522,6 +522,14 @@ With one agent per lane, wall-clock ≈ 4 sequential slices instead of 7.
   per `3-deployment.ts:81`) — needs an **OpenClaw image change** (configurable translator backend) to point it
   at LiteLLM. **(C)** deleting the orphaned `ProviderApiKey` table + `/providers/keys` route needs WeOwnAI
   confirmed off the legacy endpoint first. Both deferred to a coordinated cutover.
+- [x] **AIR.1b Model-registry seeding (opt-in). — LANDED 2026-06-19.** Declarative seed of global
+  `ModelDefinition`s registered idempotently on control-plane startup (`core/model-routing/seed-models.ts`,
+  best-effort/non-fatal, skips existing slugs, `isDefault` upserts the Global `ModelRoutingDefault`). Helm
+  `controlPlane.modelRegistry.seed` (empty default; commented recommended tiered block — Anthropic
+  Opus/Sonnet[default]/Haiku, OpenAI gpt-5/mini, Gemini pro/flash, + an OSS template) → `MODEL_REGISTRY_SEED`
+  env (JSON). Each entry supports a custom `apiBase` + `apiKeyEnvRef` (`api_key: os.environ/<ref>`) so operators
+  define their own models/endpoints. Seeded models route only once the matching key env reaches LiteLLM +
+  `storeModelInDb` is on. Model ids are unverified (verify-against-catalog note in values).
 - [x] **AIR.1 Model registry (BYOM) — control-plane + LiteLLM. — LANDED 2026-06-18.** Prisma
   `ModelDefinition` + `ProviderCredential` (scope `global|clusterTenant`, **stores `secretRef` — never a raw
   key**) + enum `ModelRoutingScope` + migration `0017_model_routing`; contract types in `libs/contracts`;

--- a/platform/helm/templates/control-plane-deployment.yaml
+++ b/platform/helm/templates/control-plane-deployment.yaml
@@ -78,6 +78,13 @@ spec:
             - name: SKILL_OCI_REPOSITORY
               value: {{ .Values.skillRegistry.ociStore.repository | quote }}
             {{- end }}
+            {{- with .Values.controlPlane.modelRegistry.seed }}
+            # Opt-in model-registry seeding: a JSON array the control plane registers
+            # ONCE at Global scope on startup (idempotent, best-effort, never blocks boot).
+            # Empty seed → this env is omitted entirely (no seeding).
+            - name: MODEL_REGISTRY_SEED
+              value: {{ toJson . | quote }}
+            {{- end }}
             - name: COGNEE_ENDPOINT
               value: {{ .Values.controlPlane.cognee.endpoint | quote }}
             - name: COGNEE_PERMISSIONS_TIMEOUT_MS

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -145,6 +145,69 @@ controlPlane:
     backendAccessControl: true
     # -- Permission sync timeout in milliseconds
     permissionsTimeoutMs: 5000
+  # -- Declarative, idempotent model-registry seeding (opt-in). Rendered to the
+  #    control-plane Deployment as the MODEL_REGISTRY_SEED env (a JSON array). On
+  #    startup the control plane registers each entry ONCE at Global scope, reusing
+  #    the normal model-registry path (persist ModelDefinition + best-effort LiteLLM
+  #    `POST /model/new`). Re-runs are no-ops; an entry whose publicModelName already
+  #    exists at Global scope is skipped, so your later edits via the API are never
+  #    clobbered. Everything is best-effort — a bad entry is skipped, malformed input
+  #    no-ops, and seeding NEVER blocks or crashes control-plane startup.
+  #
+  #    Seed entry shape (supports user-defined models + custom endpoints):
+  #      { publicModelName, upstreamModel, apiKeyEnvRef, apiBase?, isDefault? }
+  #      - apiKeyEnvRef  → LiteLLM api_key becomes `os.environ/<apiKeyEnvRef>` (the
+  #                        raw key never transits OpenCrane; LiteLLM reads it from
+  #                        its own env). e.g. ANTHROPIC_API_KEY / OPENAI_API_KEY.
+  #      - apiBase       → optional; passed through to the deployment so you can
+  #                        point at your OWN OSS / self-hosted / proxied endpoint.
+  #      - isDefault     → optional; marks the platform default. Sets the Global
+  #                        ModelRoutingDefault so inherit-posture skills resolve to
+  #                        it. Only one Global default — last isDefault wins.
+  #
+  #    IMPORTANT: a seeded model only ROUTES once (a) the matching key env reaches the
+  #    LiteLLM pod (e.g. via `orgSecrets.envMappings`) AND (b) `litellm.storeModelInDb`
+  #    is true (STORE_MODEL_IN_DB, AIR.0). Seeding the registry alone does not ship keys.
+  #
+  #    Empty default = no seeding. Uncomment the recommended block below and trim to
+  #    the providers you have keys for. Model ids are dated snapshots where the
+  #    provider offers them; otherwise floating aliases.
+  #    # verify ids against the current provider catalog before relying on them.
+  modelRegistry:
+    seed: []
+    # seed:
+    #   # --- Anthropic ---
+    #   - publicModelName: anthropic/claude-opus-4-8           # frontier
+    #     upstreamModel: anthropic/claude-opus-4-8
+    #     apiKeyEnvRef: ANTHROPIC_API_KEY
+    #   - publicModelName: anthropic/claude-sonnet-4-6         # balanced (platform default)
+    #     upstreamModel: anthropic/claude-sonnet-4-6
+    #     apiKeyEnvRef: ANTHROPIC_API_KEY
+    #     isDefault: true
+    #   - publicModelName: anthropic/claude-haiku-4-5-20251001 # cheap (dated snapshot)
+    #     upstreamModel: anthropic/claude-haiku-4-5-20251001
+    #     apiKeyEnvRef: ANTHROPIC_API_KEY
+    #   # --- OpenAI ---
+    #   - publicModelName: openai/gpt-5                        # frontier
+    #     upstreamModel: openai/gpt-5
+    #     apiKeyEnvRef: OPENAI_API_KEY
+    #   - publicModelName: openai/gpt-5-mini                   # cheap
+    #     upstreamModel: openai/gpt-5-mini
+    #     apiKeyEnvRef: OPENAI_API_KEY
+    #   # --- Google Gemini ---
+    #   - publicModelName: gemini/gemini-2.5-pro               # frontier
+    #     upstreamModel: gemini/gemini-2.5-pro
+    #     apiKeyEnvRef: GEMINI_API_KEY
+    #   - publicModelName: gemini/gemini-2.5-flash             # cheap
+    #     upstreamModel: gemini/gemini-2.5-flash
+    #     apiKeyEnvRef: GEMINI_API_KEY
+    #   # --- OSS / self-hosted template ---
+    #   # apiBase lets you point at your OWN endpoint (vLLM, Ollama, TGI, a proxy);
+    #   # upstreamModel uses the openai/ provider prefix for an OpenAI-compatible API.
+    #   - publicModelName: local/llama-3.3-70b
+    #     upstreamModel: openai/llama-3.3-70b
+    #     apiKeyEnvRef: LOCAL_LLM_API_KEY
+    #     apiBase: http://my-vllm.internal:8000/v1
 
 # -- LiteLLM integration settings
 litellm:


### PR DESCRIPTION
## What

Adds opt-in, idempotent **model-registry seeding** on control-plane startup. Operators declare a list of models in Helm; the control plane registers each one **once at Global scope** on boot.

`_SeedModels(prisma, log)` reads `MODEL_REGISTRY_SEED` (a JSON array), and for each entry:
- persists a global `ModelDefinition` and best-effort registers it with LiteLLM (`POST /model/new`) via the existing model-registry path;
- skips any entry whose `publicModelName` already exists at Global scope (so later edits via the API are never clobbered);
- if `isDefault`, upserts the Global `ModelRoutingDefault`.

It is **best-effort and non-fatal** — a bad entry is skipped, malformed input no-ops, and a seed failure logs a warning but never blocks or crashes startup.

## Seed entry shape

`{ publicModelName, upstreamModel, apiKeyEnvRef, apiBase?, isDefault? }`

- `apiKeyEnvRef` → LiteLLM `api_key` becomes `os.environ/<ref>` — **the raw key never transits OpenCrane**; LiteLLM reads it from its own env.
- `apiBase` → optional; point at your **own** OSS / self-hosted / proxied endpoint (vLLM, Ollama, TGI, …).
- `isDefault` → optional; sets the Global routing default (last one wins).

## Helm

`controlPlane.modelRegistry.seed` defaults to `[]` (no seeding). A commented, recommended tiered block ships in `values.yaml` — Anthropic Opus/Sonnet[default]/Haiku, OpenAI gpt-5/mini, Gemini pro/flash, plus an OSS `apiBase` template — to uncomment and trim. Rendered to the Deployment as `MODEL_REGISTRY_SEED`; an empty seed omits the env entirely.

> A seeded model only **routes** once (a) the matching key env reaches the LiteLLM pod and (b) `litellm.storeModelInDb` is on. Seeding the registry alone does not ship keys. Model ids are unverified — verify against the current provider catalogue.

## Tests

`pnpm --filter @opencrane/control-plane build` + `test` → **360/360 green**. New `seed-models.test.ts` covers idempotency, skip-existing, `isDefault` upsert, custom `apiBase`, and malformed/non-fatal input.

## Note for reviewers

Clean-split from the in-flight observability branch: this PR touches `index.ts`, `control-plane-deployment.yaml`, and `values.yaml` with seeding hunks **only** (no OTEL/observability). The observability PR will resolve the overlap on those three files when it lands. `seed-models.ts` uses pino's `Logger` type (not `@opencrane/observability`).