### PR TITLE
🏷️ prefix model-routing telemetry tables with mrl_

### DIFF
--- a/apps/control-plane/prisma/migrations/0021_mrl_table_prefix/migration.sql
+++ b/apps/control-plane/prisma/migrations/0021_mrl_table_prefix/migration.sql
@@ -1,0 +1,21 @@
+-- Migration 0021: Prefix the model-routing telemetry tables with `mrl_` (model routing logic).
+--
+-- Draws the measurements-vs-decisions seam in the schema. The shadow-mode measurement table and
+-- the eval-case table are append-heavy, FK-free telemetry (version-stamped by value, no relations)
+-- and are the splittable half of Track AIR — they may later move to an isolated analytical store.
+-- The `mrl_` prefix marks that boundary now so the eventual extraction is a config change, not a
+-- rename-everything migration. Routing *decisions* (routing_proposals) and the model registry stay
+-- as-is: they are transactional control-plane state, FK-coupled, and never leave this database.
+--
+-- Pure rename — no column or data changes. Constraints and indexes are renamed to keep the `mrl_`
+-- convention consistent (Postgres keeps the old names on a bare table rename otherwise).
+
+-- routing_measurements -> mrl_measurements
+ALTER TABLE "routing_measurements" RENAME TO "mrl_measurements";
+ALTER TABLE "mrl_measurements" RENAME CONSTRAINT "routing_measurements_pkey" TO "mrl_measurements_pkey";
+ALTER INDEX "routing_measurements_skill_idx" RENAME TO "mrl_measurements_skill_idx";
+
+-- routing_eval_cases -> mrl_eval_cases
+ALTER TABLE "routing_eval_cases" RENAME TO "mrl_eval_cases";
+ALTER TABLE "mrl_eval_cases" RENAME CONSTRAINT "routing_eval_cases_pkey" TO "mrl_eval_cases_pkey";
+ALTER INDEX "routing_eval_cases_skill_idx" RENAME TO "mrl_eval_cases_skill_idx";

--- a/apps/control-plane/prisma/schema.prisma
+++ b/apps/control-plane/prisma/schema.prisma
@@ -643,7 +643,7 @@ model RoutingEvalCase {
   updatedAt  DateTime @updatedAt @map("updated_at")
 
   @@index([skillName, skillScope, skillTeam])
-  @@map("routing_eval_cases")
+  @@map("mrl_eval_cases")
 }
 
 /// A shadow-mode savings measurement for one skill (AIR.6 output): what routing WOULD save at
@@ -671,7 +671,7 @@ model RoutingMeasurement {
   runAt               DateTime @default(now()) @map("run_at")
 
   @@index([skillName, skillScope, skillTeam])
-  @@map("routing_measurements")
+  @@map("mrl_measurements")
 }
 
 /// A human-gated routing-change proposal (AIR.7). Emitted only when the savings CI excludes zero;


### PR DESCRIPTION
Rename routing_measurements -> mrl_measurements and routing_eval_cases -> mrl_eval_cases (+ their pkey/index) to mark the measurements-vs-decisions seam: the FK-free, append-heavy telemetry that may later move to an isolated analytical store. Routing decisions (routing_proposals) and the model registry stay put — transactional control-plane state. Pure rename, no data change. Migration 0021. 352 control-plane tests green.