### PR TITLE
✨ pull entitled skills into tenant pods + fix Obot healthz probe

### DIFF
--- a/apps/control-plane/src/__tests__/routes/tenant-contract.test.ts
+++ b/apps/control-plane/src/__tests__/routes/tenant-contract.test.ts
@@ -6,6 +6,21 @@ import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 
 import { _RegisterInternalTenantContract } from "../../routes/internal/tenant-contract.js";
+import { compile } from "../../core/grants/grant-compiler.js";
+import { GrantCompilerAccess } from "../../core/grants/grant-compiler.types.js";
+
+// Mock the grant compiler at the module boundary so tests can drive Allow/Deny
+// decisions directly without constructing grant rows. Default: no entitlements,
+// which keeps every existing test's empty-contract expectations intact.
+vi.mock("../../core/grants/grant-compiler.js", () => ({
+  compile: vi.fn().mockResolvedValue([]),
+}));
+
+// Per-skill model resolution is exercised by its own suite; stub it to [] here so
+// the contract-shaping assertions stay focused on entitlement enrichment.
+vi.mock("../../core/model-routing/resolve-contract-skill-models.js", () => ({
+  _ResolveContractSkillModels: vi.fn().mockResolvedValue([]),
+}));
 
 /** Build a mock AuthenticationV1Api that returns a controlled TokenReview response. */
 function _buildAuthApi(opts: {
@@ -201,5 +216,31 @@ describe("_RegisterInternalTenantContract GET /:name", () =>
     expect(tools).toContain("# TOOLS");
     // With no entitlements the section renders an explicit "none" note rather than vanishing.
     expect(tools).toContain("No MCP servers are currently entitled.");
+  });
+
+  it("enriches skills.entitled with the name + digest the pod needs to pull each bundle", async () =>
+  {
+    const prisma = _buildPrismaStub({ tenant: { name: "team-alpha", team: null } });
+    // The route compiles MCP grants first, then skill grants. Allow one skill bundle.
+    // The route only reads `payloadId` + `access`, so cast a minimal decision rather
+    // than fabricate every CompiledGrantDecision field.
+    const _allowBundle1 = [{ payloadId: "bundle-1", access: GrantCompilerAccess.Allow }] as unknown as Awaited<ReturnType<typeof compile>>;
+    vi.mocked(compile)
+      .mockResolvedValueOnce([]) // McpServer decisions
+      .mockResolvedValueOnce(_allowBundle1); // SkillBundle decisions
+    // The entitled-bundle metadata the contract must surface (digest is what addresses the registry).
+    (prisma.skillBundle.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "bundle-1", name: "company-policy", description: "Org policy", digest: "sha256:abc123" },
+    ]);
+    const app = _buildApp(prisma, _validAuthApi);
+
+    const res = await request(app)
+      .get("/api/internal/contract/team-alpha")
+      .set("Authorization", "Bearer valid");
+
+    expect(res.status).toBe(200);
+    expect(res.body.skills.entitled).toEqual([
+      { id: "bundle-1", name: "company-policy", digest: "sha256:abc123" },
+    ]);
   });
 });

--- a/apps/control-plane/src/routes/internal/tenant-contract.ts
+++ b/apps/control-plane/src/routes/internal/tenant-contract.ts
@@ -153,7 +153,7 @@ export function _RegisterInternalTenantContract(prisma: PrismaClient, authApi: k
         ? await prisma.mcpServer.findMany({ where: { id: { in: allowedMcp } }, select: { id: true, name: true, description: true } })
         : [];
       const skillBundles = allowedSkills.length > 0
-        ? await prisma.skillBundle.findMany({ where: { id: { in: allowedSkills } }, select: { id: true, name: true, description: true } })
+        ? await prisma.skillBundle.findMany({ where: { id: { in: allowedSkills } }, select: { id: true, name: true, description: true, digest: true } })
         : [];
 
       // 6b. Resolve the effective model for each entitled skill by the locked precedence chain
@@ -206,7 +206,14 @@ export function _RegisterInternalTenantContract(prisma: PrismaClient, authApi: k
           },
         },
         skills: {
-          entitled: allowedSkills,
+          // Entitled bundles carry the digest + name the pod needs to PULL each skill
+          // from the skill-registry (`GET /bundles/:digest`) and lay it down on disk as
+          // `<skills-dir>/<name>/SKILL.md` (see apps/tenant/deploy/entrypoint.sh).
+          // Bundles whose row no longer exists are dropped here — they cannot be pulled.
+          entitled: skillBundles.map(function _toEntitledSkill(bundle)
+          {
+            return { id: bundle.id, name: bundle.name, digest: bundle.digest };
+          }),
           // Per-skill resolved model (AIR.2). One entry per entitled skill: `{ skillId, model, auto }`.
           // `model` is null when nothing in the precedence chain resolves, in which case the pod
           // falls back to its own configured default. `auto` flags an auto-routing posture.

--- a/apps/operator/src/mcp-gateway/obot-health-checker.ts
+++ b/apps/operator/src/mcp-gateway/obot-health-checker.ts
@@ -84,7 +84,12 @@ export class ObotHealthChecker
   }
 
   /**
-   * Perform a single health-check request against the gateway's `/healthz` endpoint.
+   * Perform a single health-check request against the gateway's `/api/healthz` endpoint.
+   *
+   * The path must match the liveness/readiness probe in the Obot Deployment
+   * (`platform/helm/templates/obot-mcp-gateway-deployment.yaml`), which Obot
+   * serves at `/api/healthz` — NOT `/healthz`. A mismatch here would make every
+   * poll report the gateway as unhealthy even when it is fine.
    *
    * On success the consecutive-failure counter is reset (and a recovery log line
    * is emitted if the gateway had previously been unhealthy).  On failure the
@@ -93,7 +98,7 @@ export class ObotHealthChecker
    */
   private async _check(): Promise<void>
   {
-    const url = `${this._gatewayUrl}/healthz`;
+    const url = `${this._gatewayUrl}/api/healthz`;
 
     try
     {

--- a/apps/tenant/README.md
+++ b/apps/tenant/README.md
@@ -13,8 +13,10 @@ Pod starts
            └── not found → npm install openclaw@$OPENCLAW_VERSION into GCS bucket
            └── found     → reuse existing install (fast restart)
         4. Copy /config/openclaw.json to state dir if not already present
-        5. Symlink /shared-skills/{org,team} into state dir only when the resolved MCP policy allows the `skills` server
-        6. exec openclaw gateway run --bind lan --port 18789
+        5. Symlink /shared-skills/{org,team} into state dir, when that volume is present, if the resolved MCP policy allows the `skills` server
+        6. Pull entitled skill bundles by digest from the skill-registry → $STATE_DIR/agents/main/skills/<name>/SKILL.md
+        7. Start `openclaw gateway run --bind lan --port 18789` in the background, plus a contract re-pull loop:
+           every 30s it polls the control-plane; on a change it re-renders TOOLS.md, re-pulls entitled skills, then SIGHUPs OpenClaw
 ```
 
 ## Storage layout (inside the pod)
@@ -69,13 +71,14 @@ This is the baseline hardening layer only. It still needs end-to-end runtime val
 
 ## Managed runtime policy behavior
 
-The tenant entrypoint now reads `opencrane-managed-runtime.json` before startup and applies the resolved MCP policy to shared-skill linking.
+The tenant entrypoint reads `opencrane-managed-runtime.json` before startup, applies the resolved MCP policy to shared-skill linking, and pulls entitled skill bundles from the skill-registry.
 
 Today this means:
 - when the `skills` MCP server is denied, org and team shared skills are not linked into the tenant runtime
 - when the `skills` MCP server is allowed or no MCP policy is enforced, existing shared-skill linking behavior is preserved
+- entitled skill bundles named in the contract's `skills.entitled` (each `{ id, name, digest }`) are pulled from `OPENCRANE_SKILL_REGISTRY_URL` using the `skill-registry`-audience projected token and written to `<state>/agents/main/skills/<name>/SKILL.md`, at boot and on every contract change. The registry enforces entitlement (a non-entitled or unknown digest returns 404); `Tenant.spec.skillAllowlist` (`OPENCRANE_ALLOWED_SKILLS`) narrows further. Delivery is additive — a de-entitled skill stops being advertised in TOOLS.md and 404s at the registry, but its on-disk copy is not yet pruned.
 
-This is only the first enforcement slice. Broader MCP tool blocking and deny/audit events are still deferred.
+This is an early enforcement slice. Broader MCP tool blocking, deny/audit events, and pruning of de-entitled skills are still deferred.
 
 ## Files
 

--- a/apps/tenant/deploy/entrypoint.sh
+++ b/apps/tenant/deploy/entrypoint.sh
@@ -26,6 +26,10 @@ OPENCRANE_MCP_POLICY_ENFORCED="${OPENCRANE_MCP_POLICY_ENFORCED:-false}"
 # MCP policy from Tenant CRD spec (tenant-level governance override, injected by operator)
 OPENCRANE_TENANT_MCP_ALLOW="${OPENCRANE_TENANT_MCP_ALLOW:-}"
 OPENCRANE_TENANT_MCP_DENY="${OPENCRANE_TENANT_MCP_DENY:-}"
+# Skill-registry delivery: pull entitled skill bundles by digest from the in-cluster
+# skill-registry, authenticating with the audience-bound projected SA token.
+OPENCRANE_SKILL_REGISTRY_URL="${OPENCRANE_SKILL_REGISTRY_URL:-}"
+OPENCRANE_SKILL_REGISTRY_TOKEN_PATH="${OPENCRANE_SKILL_REGISTRY_TOKEN_PATH:-/var/run/opencrane/tokens/skill-registry.token}"
 
 function _csv_contains()
 {
@@ -138,6 +142,96 @@ for (const doc of docs) {
   fs.writeFileSync(markerPath, String(version));
   process.stderr.write(`[opencrane] Delivered managed doc ${doc.file} v${version} to workspace\n`);
 }
+EOF
+}
+
+function _pull_entitled_skills()
+{
+  local contract_file="$1"
+
+  # Need a registry URL, a readable projected token, and a contract to do anything.
+  # On a cold boot the bootstrap contract has skills.entitled=[], so this is a no-op
+  # until the first control-plane poll lands the live contract (mirrors TOOLS.md).
+  if [ -z "$OPENCRANE_SKILL_REGISTRY_URL" ] || [ ! -f "$contract_file" ] || [ ! -r "$OPENCRANE_SKILL_REGISTRY_TOKEN_PATH" ]; then
+    return 0
+  fi
+
+  # Node owns the fetch+write so JSON parsing, the Bearer call, and the exact bytes
+  # stay in one place. Entitlement is already enforced by the registry + control-plane
+  # (a non-entitled digest 404s); OPENCRANE_ALLOWED_SKILLS is the optional tenant-level
+  # (Tenant.spec.skillAllowlist) narrowing applied on top.
+  node - "$contract_file" "$OPENCRANE_SKILL_REGISTRY_URL" "$OPENCRANE_SKILL_REGISTRY_TOKEN_PATH" "$SKILLS_DIR" "${OPENCRANE_ALLOWED_SKILLS:-}" <<'EOF' || true
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [, , contractPath, registryUrl, tokenPath, skillsDir, allowedCsv] = process.argv;
+
+let contract;
+try { contract = JSON.parse(fs.readFileSync(contractPath, "utf8")); } catch { process.exit(0); }
+
+const entitled = Array.isArray(contract?.skills?.entitled) ? contract.skills.entitled : [];
+if (entitled.length === 0) { process.exit(0); }
+
+let token;
+try { token = fs.readFileSync(tokenPath, "utf8").trim(); } catch { process.exit(0); }
+if (!token) { process.exit(0); }
+
+// Optional tenant-level allowlist; empty/unset => deliver everything the contract entitles.
+const allowed = (allowedCsv || "").split(",").map((s) => s.trim()).filter(Boolean);
+const base = registryUrl.replace(/\/+$/, "");
+
+async function _pull()
+{
+  for (const skill of entitled)
+  {
+    // Tolerate both the enriched object shape {id,name,digest} and a legacy bare-id string.
+    const name = typeof skill === "string" ? skill : skill?.name;
+    const digest = typeof skill === "string" ? null : skill?.digest;
+    if (!name || !digest) { continue; }
+    // Keep the on-disk name a single safe path segment so a write can never escape the skills dir.
+    if (name.includes("/") || name.includes("..")) { continue; }
+    if (allowed.length > 0 && !allowed.includes(name)) { continue; }
+
+    let res;
+    try
+    {
+      res = await fetch(`${base}/bundles/${encodeURIComponent(digest)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(10_000),
+      });
+    }
+    catch (err)
+    {
+      process.stderr.write(`[opencrane] skill '${name}' fetch failed: ${err && err.message ? err.message : "error"}\n`);
+      continue;
+    }
+
+    if (!res.ok)
+    {
+      // 404 = not entitled / not found (existence-hiding at the registry); other codes are transient.
+      process.stderr.write(`[opencrane] skill '${name}' not delivered (status ${res.status})\n`);
+      continue;
+    }
+
+    const body = await res.text();
+    try
+    {
+      const dir = path.join(skillsDir, name);
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(path.join(dir, "SKILL.md"), body);
+    }
+    catch (err)
+    {
+      // A write failure (permissions, disk full) must surface and must not abort the
+      // remaining entitled skills — log and move on to the next bundle.
+      process.stderr.write(`[opencrane] skill '${name}' write failed: ${err && err.message ? err.message : "error"}\n`);
+      continue;
+    }
+    process.stderr.write(`[opencrane] Delivered skill '${name}' (${digest}) to workspace\n`);
+  }
+}
+
+_pull().catch(() => process.exit(0));
 EOF
 }
 
@@ -262,6 +356,12 @@ function _contract_poll_loop()
         # agent sees the new tool list as soon as it restarts.
         _apply_workspace_docs "$writable_path"
 
+        # Pull any newly-entitled skill bundles from the registry before the reload so
+        # the agent can use them on restart. Additive: a de-entitled skill stops being
+        # advertised in TOOLS.md and 404s at the registry, but its on-disk copy is left
+        # in place (pruning de-entitled skills is a separate follow-up).
+        _pull_entitled_skills "$writable_path"
+
         # Re-source the updated policy into local variables, then signal OpenClaw
         # to restart so the new policy takes effect without a full pod restart.
         # SIGHUP is used for graceful reload; if OpenClaw exits, the outer wait
@@ -358,8 +458,10 @@ function _main()
   # copy; fall back to the ConfigMap-mounted original.
   if [ -f "$RUNTIME_CONTRACT_WRITABLE" ]; then
     _apply_workspace_docs "$RUNTIME_CONTRACT_WRITABLE"
+    _pull_entitled_skills "$RUNTIME_CONTRACT_WRITABLE"
   else
     _apply_workspace_docs "$RUNTIME_CONTRACT_PATH"
+    _pull_entitled_skills "$RUNTIME_CONTRACT_PATH"
   fi
 
   echo "[opencrane] Starting OpenClaw gateway"


### PR DESCRIPTION
## What & why

Closes two runtime-plane **consumption** gaps. The Obot MCP gateway and the skill-registry are deployed and wired, but the tenant pod did not fully consume them:

1. **Skills gated but never delivered.** The skill-registry enforces entitlement, but the tenant pod never pulled skills — the old `/shared-skills` symlink path reads a volume the Deployment no longer mounts, and nothing fetched from the registry.
2. **Obot health check pointed at the wrong path.** `ObotHealthChecker` probed `/healthz`; the Obot Deployment serves `/api/healthz`, so the operator would report the gateway perpetually unhealthy.

## Changes

**Skills**
- `GET /api/internal/contract/:name` `skills.entitled` enriched from `string[]` → `Array<{id,name,digest}>` so the pod can address the registry by digest (`apps/control-plane/src/routes/internal/tenant-contract.ts`).
- `entrypoint.sh` `_pull_entitled_skills`: fetches each entitled bundle from `OPENCRANE_SKILL_REGISTRY_URL/bundles/:digest` with the `skill-registry`-audience projected token and writes `$STATE_DIR/agents/main/skills/<name>/SKILL.md` — at boot and on every contract change (before SIGHUP). Path-segment-sanitised; honours the `OPENCRANE_ALLOWED_SKILLS` narrowing; per-skill write failures log and continue.

**Obot**
- `ObotHealthChecker` now probes `/api/healthz` to match the Deployment liveness probe.

**Docs / tests**
- New enriched-shape test in `tenant-contract.test.ts`; `apps/tenant/README.md` updated to the new boot/poll flow.

## Testing
- control-plane + operator `tsc --noEmit` clean; `tenant-contract.test.ts` 9/9; operator suite 101/101; `bash -n` + `node --check` on the entrypoint and its embedded script.
- Independent review gate: no critical/high findings; applied the one actionable note (per-skill write resilience).

## Deliberately deferred (noted in code + README)
- Pruning **de-entitled** skills from disk (delivery is currently additive).
- Pointing OpenClaw's MCP client at Obot + confirming per-tenant MCP entitlement enforcement (the remaining "advisory → enforced" step).
