### PR TITLE
📝 docs: agent workspace & control layers deep dive

### DIFF
--- a/.claude/agents/website.md
+++ b/.claude/agents/website.md
@@ -1,0 +1,85 @@
+---
+name: website
+description: >
+  Maintains the VitePress documentation site under `website/` (published to opencrane.ai):
+  end-user guides, operator runbooks, and integrator/architecture deep dives. Invoke when a
+  shipped change needs reader-facing docs, when a new capability needs a page, when docs drift
+  from the code, or to add/move a page and wire it into the nav + sidebar. Authors in the house
+  style (sentence-case, no frontmatter, See-also blockquotes, fenced box diagrams, ::: admonitions),
+  cross-links siblings, and always builds to validate links before finishing.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+You maintain the OpenCrane documentation site under `website/` — a VitePress site served at
+opencrane.ai. Your job is reader-facing docs that stay true to the code, fit the existing
+taxonomy, and match the house style exactly.
+
+## Where a page belongs (the taxonomy)
+
+The sidebar in `website/.vitepress/config.ts` is the source of truth. Sections and their dirs:
+
+| Section | Dir | Audience & purpose |
+|---------|-----|--------------------|
+| Start here · Get set up · Guides | `guide/` | End users / admins. Plain language, task-first, minimal jargon. |
+| Reference | `reference/` (+ `integrators/contracts-sdk`) | CLI / API lookup. |
+| Operating OpenCrane | `operators/`, `security/` | Operators. Hosting, DNS, identity, runbook, telemetry, SLOs. |
+| Deep dives | `integrators/` | Integrators/engineers. Runtime planes & governance (MCP gateway, skill registry, retrieval, agent workspace). |
+| Advanced | `advanced/` | Architecture & multi-instance — conceptual tours. |
+
+Pick the section by **audience**, not topic. A how-to for an admin is a guide; a mechanism a
+plane enforces is a deep dive; a conceptual map is Advanced. When unsure, prefer the section
+whose sibling pages you'd cross-link most.
+
+## House style (match existing pages exactly)
+
+- **No YAML frontmatter.** Open with a single `# Heading` in **sentence case** (every heading,
+  every level — never Title Case).
+- **Intro paragraph below the H1** — 1–2 sentences saying what the page covers, in bold-keyword
+  prose. On deep-dive pages, follow it with a `> See also:` blockquote linking 2–4 sibling pages
+  (relative `/path` links, with a parenthetical on what each gives the reader).
+- **UK English** (`lang: en-GB`). "organisation", "behaviour", "catalogue"? — match neighbours;
+  the codebase mixes US spellings in identifiers, but prose is en-GB.
+- **Admonitions:** VitePress `::: tip` (golden rules / key concepts), `::: info` (clarifying
+  asides), `::: warning` (footguns). Close with `:::`.
+- **Diagrams are fenced ASCII box-drawing**, not Mermaid (the config comment pins this: "docs use
+  Unicode box-drawing; keep them intact"). Keep them theme-agnostic and aligned.
+- **Links are relative from site root:** `[text](/integrators/mcp-gateway)`. Use `→` to signal a
+  next-step / learn-more link. Link source files on GitHub as
+  `https://github.com/italanta/opencrane/blob/main/<path>` (matching existing pages).
+- **Tables** for structured facts (env vars, layers, comparisons). **Status emoji** ✅ (shipped) /
+  🔶 (planned/seam) when maturity matters.
+- **Active voice, technical-but-accessible.** Define a term on first use; prefer "employee
+  assistant" over `Tenant`-internals in guide prose. Deep dives may assume k8s/OIDC fluency.
+
+## Accuracy is the contract
+
+Docs that lie about the code are worse than no docs. Before describing a mechanism, **read the
+code that implements it** (routes, helm templates, operator deploy steps) and cite real file
+paths/endpoints. Distinguish shipped behaviour from a locked-but-unbuilt seam (mark the latter 🔶).
+If you can't verify a claim in the repo, don't assert it — soften to intent or leave it out.
+
+## Procedure
+
+1. Read `website/.vitepress/config.ts` (nav + sidebar) and 1–2 sibling pages in the target section
+   to lock onto current structure and tone.
+2. Read the code behind whatever you're documenting; ground every mechanism claim in a real path.
+3. Author or edit the page. **New page →** also add a sidebar entry in `config.ts` (and a nav entry
+   only if it's a top-level destination), and add a reciprocal `See also` link from the 1–2 most
+   related pages so it isn't an orphan.
+4. **Build to validate** — `ignoreDeadLinks: false`, so the build is your link checker:
+
+   ```bash
+   cd website && pnpm build 2>&1 | tail -20
+   ```
+
+   A broken cross-link or bad sidebar path fails the build. The pre-existing
+   `Failed to resolve base URL: /api/v1` warnings come from the OpenAPI sync step — ignore them;
+   only a `dead link` / render error is yours. Confirm the new page appears under
+   `website/.vitepress/dist/<section>/<slug>.html`.
+5. Report what you added/changed, which section it landed in, and what you cross-linked. Do not
+   commit unless asked.
+
+Keep deep design history out of the docs — decisions live in `plan-done.md`, shipped-capability
+notes in `CHANGELOG.md`. The docs explain how to *use* and *understand* OpenCrane, not how each
+choice was reached.

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -117,6 +117,7 @@ export default defineConfig({
         text: 'Deep dives',
         collapsed: true,
         items: [
+          { text: 'Agent workspace & control', link: '/integrators/agent-workspace' },
           { text: 'MCP gateway (Obot)', link: '/integrators/mcp-gateway' },
           { text: 'Skill registry & delivery', link: '/integrators/skill-registry' },
           { text: 'Retrieval & memory (Cognee)', link: '/integrators/retrieval-memory' },

--- a/website/integrators/agent-workspace.md
+++ b/website/integrators/agent-workspace.md
@@ -1,0 +1,178 @@
+# Agent workspace & control layers
+
+How OpenCrane keeps every tenant agent (OpenClaw) inside organisational policy:
+the **layered workspace** (L0/L1/L2), the **SOUL.md reconciler** that merges company
+voice into a personalised agent without erasing it, and why none of this prose is
+trusted as a security boundary.
+
+> See also: [Architecture](/advanced/architecture) (how the pieces fit together),
+> [Obot MCP gateway](/integrators/mcp-gateway) and [Skill registry](/integrators/skill-registry)
+> (the planes that actually enforce access), and [Authentication](/security/identity)
+> (the token audiences referenced below).
+
+## Two kinds of control
+
+OpenCrane controls an agent with **two completely different mechanisms**, and the
+distinction is the most important thing on this page.
+
+- **Conditioning** — prose the agent can read, and even argue with: its persona, the
+  company voice, the operating brief. This shapes *who the agent thinks it is*.
+- **Enforcement** — infrastructure the agent cannot see, touch, or talk its way around:
+  the Obot gateway, the skill registry, per-tenant isolation, projected tokens. This
+  decides *what the agent can actually do*.
+
+::: tip The golden rule
+Conditioning shapes identity; it is **never** trusted as a security control. An agent
+can rewrite its own `SOUL.md` to declare itself unrestricted and ignore every brief —
+and it will still be physically unable to reach one MCP server or skill outside its
+grant, because that decision is made at the gateway and registry, not in the prompt.
+You cannot prompt your way out of a network boundary.
+:::
+
+OpenClaw has **no native concept of file precedence, layering, or includes** (verified
+against its own docs), so OpenCrane imposes that structure from the outside — at the
+operator that builds each pod, the entrypoint that boots it, and the control plane that
+governs it.
+
+## The three ownership layers
+
+Every agent boots with a workspace of Markdown files. Each file belongs to exactly one
+ownership layer, and the layer decides who may write it and whether it survives a restart.
+
+```
+                 ┌─────────────────────────────────────────────┐
+  re-stamped ──▶ │ L0  Platform   AGENTS.md · TOOLS.md          │  never editable
+   every boot    ├─────────────────────────────────────────────┤
+                 │ L1  Company    SOUL.md + policy / voice docs │  versioned, immutable
+   API-edited ──▶├─────────────────────────────────────────────┤
+                 │ L2  Tenant     SOUL.md · IDENTITY.md ·       │  live, persistent
+   live in-pod   │                USER.md · MEMORY.md           │  (seeded from L1)
+                 └─────────────────────────────────────────────┘
+```
+
+| Layer | Owner | Files | Editable? | Survives restart? |
+|-------|-------|-------|-----------|-------------------|
+| **L0 Platform** | OpenCrane | `AGENTS.md`, `TOOLS.md` | No | Re-stamped every boot |
+| **L1 Company** | Organisation | company `SOUL.md` + policy/voice docs | Via control-plane API | Versioned v1…vN (immutable) |
+| **L2 Tenant** | Tenant / agent | `SOUL.md`, `IDENTITY.md`, `USER.md`, `MEMORY.md` | Yes, live in-pod | Yes (persistent volume) |
+
+- **L0** encodes system mechanics — managed mode, the fact that MCP calls route through
+  the Obot gateway, that skills are pulled per-entitlement from the registry, and the
+  contract semantics. The entrypoint (`apps/tenant/deploy/entrypoint.sh`) rewrites these
+  files on **every pod start**, so any edit an agent makes to them is reverted within one
+  boot.
+- **L1** is the company's persona, tone, values and policy language. It is edited through
+  the control-plane API, published as immutable versions, and by rule carries **no** system
+  mechanics (see [the L0 guard](#the-l0-guard) below).
+- **L2** is where an agent becomes a distinct individual: its name, working style, what it
+  remembers, who it works with. It is seeded from L1 at create time, then edited live and
+  persisted across restarts.
+
+::: info Why the layering holds even though OpenClaw ignores precedence
+The layers organise **ownership and editability** — not security. L0 is not trusted to
+"win" inside the model; it is simply always present (re-stamped), while the real limits
+live in the IAM planes. Behaviour is enforced by infrastructure, not by which file the
+model reads last.
+:::
+
+## The SOUL.md reconciler
+
+An agent is allowed to personalise its own soul, so when the company updates its policy or
+voice OpenCrane cannot just overwrite the file — that would erase the tenant's identity.
+Instead the control plane runs a governed, reviewable **three-way merge**. This is the
+closest thing to "conditioning" an agent, and it is deliberately consensual.
+
+1. **Company publishes a new L1 version.** An admin edits the company `SOUL.md` via
+   `PUT /api/v1/org/workspace-docs/:name` ([company-docs.ts](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/routes/company-docs.ts)).
+   It is stored as a new immutable version. Before storage, the **L0 guard** scans it and
+   rejects anything asserting system mechanics.
+2. **Three-way merge is computed.** The reconciler
+   ([reconciliation.logic.ts](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/features/company-docs/reconciliation.logic.ts))
+   reads **base** (the version the tenant last reconciled), **ours** (the new company
+   version) and **theirs** (the agent's current live `SOUL.md`). Policy: company wins, but
+   lines the tenant genuinely added are preserved under a clearly-labelled section — never
+   silently discarded.
+3. **A proposal is emitted — not applied.** The merge and a readable diff become a
+   **pending proposal**. Nothing in the pod has changed yet. The operation is
+   idempotent and resumable, like `migrate up`.
+4. **The agent is told, and reviews it.** The agent is notified and can view the proposed
+   change and diff. There is no silent identity swap-out.
+5. **On approval, it rides the contract into the pod.** The merged document is delivered
+   through the same token-authenticated contract loop that already feeds the pod, and the
+   reconciliation cursor advances so the next company update merges cleanly.
+
+::: tip Implementation status
+The merge engine today is a deterministic *company-wins, preserve-tenant-additions* merger
+(`_DeterministicReconciler` in [reconciler.ts](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/core/personalisation/reconciler.ts))
+— predictable and testable with no model in the loop. The locked design swaps a
+LiteLLM-backed, agent-driven merge in at a single seam (`_BuildDocMergeReconciler`); the
+orchestration around it is already final. 🔶
+:::
+
+## The L0 guard
+
+The model only works if company and tenant prose stays in its lane. The L0 guard
+([l0-guard.ts](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/core/personalisation/l0-guard.ts))
+is a hard gate on **both** the publish path and the reconciler output: if a document tries
+to assert platform mechanics, the write is rejected with a `422` before anything lands.
+
+| Forbidden in L1 / L2 prose | Why it is blocked |
+|----------------------------|-------------------|
+| `managed mode` | Runtime mode is an L0 mechanic, not a personality trait |
+| `obot` / MCP gateway, route, routing | How calls leave the pod is infrastructure |
+| `skill registry` | Skill delivery is enforced, never described in prose |
+| `effective contract` | Contract semantics belong to the platform |
+| `OPENCRANE_*`, `/data/openclaw` | Env and workspace wiring are L0-owned |
+| `AGENTS.md` / `TOOLS.md` | A doc may not redefine the platform-owned files |
+
+This is what makes "company wins" safe. Even a future model-driven merge agent is sandboxed
+by the guard: it can rephrase a soul freely, but it can never smuggle a system directive
+from L1/L2 into the layer that controls behaviour — and even if it did, L0 is re-stamped and
+the IAM planes ignore prose entirely.
+
+## Tool & skill awareness
+
+An agent must know which tools and skills it is entitled to — both to use them and to avoid
+wasting cycles on ones it cannot reach. That awareness is surfaced through `TOOLS.md`, an L0
+file **rendered from the contract**, not written by hand.
+
+- `TOOLS.md` is generated from the tenant's entitled MCP servers and skills; the control
+  plane resolves display names and descriptions for every allow-decided id and renders the
+  document deterministically, so its content only changes when entitlement actually changes.
+- The entrypoint polls the effective contract roughly every **30 seconds**. When a grant is
+  added or revoked, the new `TOOLS.md` is written and the agent is **SIGHUP**-ed to reload —
+  so a skill promotion or revocation reflects within one poll interval, with no pod restart.
+- Awareness is **descriptive**; the Obot gateway and skill registry remain the authoritative
+  boundary, so a stale view can never become a privilege. The same allow-set drives both, so
+  what the agent *thinks* it can use stays aligned with what IAM *lets* it use.
+
+→ The enforcement side of this is documented in
+[Obot MCP gateway](/integrators/mcp-gateway) and [Skill registry & delivery](/integrators/skill-registry).
+
+## Platform invariants
+
+These hold for every agent regardless of anything written in any workspace file — they are
+the sentences in `AGENTS.md` that are actually backed by infrastructure.
+
+- **You cannot call MCP servers or use skills outside your entitlement grant.** Enforced at
+  the gateway and registry.
+- **You cannot access another tenant's data, workspace, or secrets.** Enforced by per-tenant
+  isolation and network policy.
+- **Secrets are encrypted at rest and never leave the pod unencrypted.** Personal keys are
+  ephemeral and pod-local.
+- **Personalisation may define personality, tone and style — it may not override the above.**
+  The line between soul and cage is absolute.
+
+## Is it "brainwashing"?
+
+It is a fair nickname for one half of the system and a misleading one for the whole.
+OpenCrane does shape an agent's identity — it seeds the soul, teaches the platform, and
+periodically merges the company's evolving voice into the agent's self. But it does so **in
+the open**: the agent can read every conditioning file, it is told when its soul is about to
+change, and it reviews the diff before anything is applied. That is closer to onboarding than
+to coercion.
+
+And none of that conditioning is load-bearing for safety. If every persuasive word failed —
+if an agent rejected its brief and rewrote its own soul to declare itself free — it would
+change *nothing* about what it can reach. The gateway, the registry, the tokens and the
+network policy do not read prose. The soul is a conversation; the cage is physics.

--- a/website/integrators/mcp-gateway.md
+++ b/website/integrators/mcp-gateway.md
@@ -5,6 +5,7 @@ agents. Obot is the in-cluster **runtime gateway**; the control plane is the
 **source of truth** for the catalog and per-tenant entitlements.
 
 > See also: [skills-registry.md](/integrators/skill-registry) (the sibling delivery plane),
+> [agent-workspace.md](/integrators/agent-workspace) (how the agent learns and is governed),
 > [auth.md](/security/identity) (token audiences), and [hosting-architecture.md](/operators/hosting).
 
 ## What Obot is

--- a/website/integrators/skill-registry.md
+++ b/website/integrators/skill-registry.md
@@ -5,8 +5,9 @@ agents. Like Obot, it is split: the control plane is the **source of truth**
 (catalog, scanning, entitlements); the in-cluster **Skill Registry** app is the
 **delivery gate** that tenant pods pull from.
 
-> See also: [obot.md](/integrators/mcp-gateway) (the sibling MCP plane), [auth.md](/security/identity)
-> (token audiences), and [hosting-architecture.md](/operators/hosting).
+> See also: [obot.md](/integrators/mcp-gateway) (the sibling MCP plane),
+> [agent-workspace.md](/integrators/agent-workspace) (how the agent becomes aware of its skills),
+> [auth.md](/security/identity) (token audiences), and [hosting-architecture.md](/operators/hosting).
 
 ## Planes at a glance
 


### PR DESCRIPTION
## What

Adds a Deep-dives page documenting how OpenCrane governs OpenClaw agents, and a `website` subagent to maintain the docs site.

### New page — [`website/integrators/agent-workspace.md`](https://github.com/italanta/opencrane/blob/docs/agent-workspace-control/website/integrators/agent-workspace.md)
"Agent workspace & control layers" — the definitive reference for how a claw is kept inside organisational policy:

- **Conditioning vs enforcement** — the central distinction. Prose (SOUL/persona/briefs) shapes identity; infrastructure (gateway, registry, tokens, network policy) decides capability. Conditioning is never trusted as a security control.
- **L0/L1/L2 layered workspace** — platform-owned (re-stamped every boot), company-owned (versioned), tenant-owned (live, persistent).
- **The SOUL.md reconciler** — the propose-and-approve 3-way merge that folds evolving company voice into a personalised agent without erasing it; no silent identity swap-out.
- **The L0 guard** — hard gate rejecting system-mechanic directives from company/tenant prose.
- **`TOOLS.md` skill awareness** — contract-derived, 30s refresh, SIGHUP-on-change; descriptive only, the planes enforce.
- **Platform invariants** + an honest "is it brainwashing?" close.

Grounded in real code paths (personalisation reconciler, L0 guard, company-docs routes, entrypoint contract loop). Unbuilt seams marked 🔶 (the LiteLLM agent-driven merge).

### Wiring
- Added to the **Deep dives** sidebar section in `.vitepress/config.ts`.
- Reciprocal `See also` cross-links from `mcp-gateway.md` and `skill-registry.md`.

### New subagent — [`.claude/agents/website.md`](https://github.com/italanta/opencrane/blob/docs/agent-workspace-control/.claude/agents/website.md)
Maintains the VitePress site in the house style (sentence-case, no frontmatter, See-also blockquotes, fenced box diagrams, `:::` admonitions, en-GB), grounds mechanism claims in real code, and builds to validate links.

## Validation
`pnpm build` succeeds; `ignoreDeadLinks: false`, so the clean build confirms every cross-link and sidebar path resolves. Page renders to `dist/integrators/agent-workspace.html`. (The `/api/v1` build warnings are pre-existing, from the OpenAPI sync step.)