### PR TITLE
:bug: :package: build & publish the skill-registry image in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ env:
   OPERATOR_IMAGE: ghcr.io/${{ github.repository_owner }}/opencrane-operator
   CONTROL_PLANE_IMAGE: ghcr.io/${{ github.repository_owner }}/opencrane-control-plane
   TENANT_IMAGE: ghcr.io/${{ github.repository_owner }}/opencrane-tenant
+  SKILL_REGISTRY_IMAGE: ghcr.io/${{ github.repository_owner }}/opencrane-skill-registry
 
 jobs:
   test:
@@ -41,6 +42,9 @@ jobs:
 
       - name: Test control-plane
         run: pnpm --filter @opencrane/control-plane test
+
+      - name: Test skill-registry
+        run: pnpm --filter @opencrane/skill-registry test
 
   e2e-k3d:
     name: k3d e2e smoke test
@@ -140,5 +144,25 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta-tenant.outputs.tags }}
           labels: ${{ steps.meta-tenant.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Extract image metadata (skill-registry)
+        id: meta-skill-registry
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.SKILL_REGISTRY_IMAGE }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+
+      - name: Build and push skill-registry
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/skill-registry/deploy/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta-skill-registry.outputs.tags }}
+          labels: ${{ steps.meta-skill-registry.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -427,7 +427,9 @@ mcpGateway:
 skillRegistry:
   enabled: true
   image:
-    repository: ghcr.io/italanta/skill-registry
+    # Built and published by .github/workflows/docker.yml (SKILL_REGISTRY_IMAGE), matching
+    # the opencrane-<service> naming of the other first-party images.
+    repository: ghcr.io/italanta/opencrane-skill-registry
     tag: latest
     pullPolicy: IfNotPresent
   replicas: 1


### PR DESCRIPTION
## What & why

The skill-registry plane had source code (`apps/skill-registry`), a Dockerfile, and Helm templates — but **no published image**:

- `.github/workflows/docker.yml` built only operator / control-plane / tenant.
- The Helm default `ghcr.io/italanta/skill-registry` **404s** on ghcr (never published) and is **misnamed** vs the `opencrane-<service>` convention used by every other first-party image.

Net: the skill-registry plane was not actually deployable, which also blocks the per-tenant skill **pull** added in #34 (the registry pod can't start without its image).

## Changes

- **CI** (`docker.yml`): add a `skill-registry` build-and-push job mirroring the tenant job — `SKILL_REGISTRY_IMAGE = ghcr.io/<owner>/opencrane-skill-registry`, `sha-` + `latest` tags, build context = repo root, `apps/skill-registry/deploy/Dockerfile`. Also run the skill-registry vitest suite in the `test` job (it wasn't covered before).
- **Helm** (`values.yaml`): point `skillRegistry.image.repository` at the corrected `ghcr.io/italanta/opencrane-skill-registry`.

## Testing
- `docker.yml` validated as YAML; new env/test/build steps present and well-formed.
- `pnpm --filter @opencrane/skill-registry test` → 6/6.
- `helm template` renders `image: "ghcr.io/italanta/opencrane-skill-registry:latest"` for the skill-registry Deployment.

## Out of scope (remaining hardening, flagged for follow-up)
- Pin image tags off `latest` chart-wide (a release-versioning decision; CI already emits immutable `sha-` tags to pin to).
- Pin the upstream Obot image (`ghcr.io/obot-platform/obot:latest`) to a known-good version — needs `read:packages` / a chosen version.
- Live-verify Obot's encryption-at-rest knob and out-of-band Postgres DSN provisioning — needs a live Obot of the pinned version.
