### PR TITLE
🔒 pin Obot image to v0.23.1 + verify encryption/DSN config

### DIFF
--- a/platform/helm/templates/obot-mcp-gateway-deployment.yaml
+++ b/platform/helm/templates/obot-mcp-gateway-deployment.yaml
@@ -66,12 +66,16 @@ spec:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
             {{- if .Values.mcpGateway.encryptionAtRest.enabled }}
-            # Encryption-at-rest ENABLED (P4D.1).
-            # ⚠️ ASSUMED knob — provider=custom + key-from-Secret are NOT verified
-            # against a live Obot; this whole block is gated behind
-            # mcpGateway.encryptionAtRest.enabled (default OFF). Confirm the valid
-            # provider value and the exact key env var against the pinned Obot
-            # version before enabling anywhere real.
+            # Encryption-at-rest (P4D.1), gated behind mcpGateway.encryptionAtRest.enabled (default OFF).
+            # VERIFIED against obot v0.23.x source: `custom` is a valid OBOT_SERVER_ENCRYPTION_PROVIDER
+            # value (alongside aws/gcp/azure/none) and OBOT_SERVER_DSN is correct.
+            # INCOMPLETE: the obot binary does NOT read OBOT_SERVER_ENCRYPTION_KEY directly — `custom`
+            # requires an apiserver-style EncryptionConfiguration file referenced by
+            # OBOT_SERVER_ENCRYPTION_CONFIG_FILE, which the upstream Obot Helm chart materialises from
+            # the key via an `encryptionsetup` init container (with Obot's exact encrypted-resource
+            # list). That init container is NOT yet replicated here, so the vars below are necessary
+            # but NOT sufficient — do not rely on encryption-at-rest until the init container lands
+            # (follow-up).
             - name: OBOT_SERVER_ENCRYPTION_PROVIDER
               value: "custom"
             - name: OBOT_SERVER_ENCRYPTION_KEY
@@ -84,9 +88,15 @@ spec:
             - name: OBOT_SERVER_ENCRYPTION_PROVIDER
               value: "none"
             {{- end }}
-            # Control-plane registry — Obot polls this endpoint to sync the MCP server catalog
-            # with OpenCrane McpServer rows. The control-plane exposes /api/internal/obot-registry
-            # in Obot's /v0.1/servers format.
+            # MCP-catalog sync — KNOWN-SUSPECT, do not trust as-is (tracked follow-up). This points
+            # Obot at the control-plane /api/internal/obot-registry endpoint, but research against obot
+            # source indicates OBOT_SERVER_PROVIDER_REGISTRIES is for LLM model-provider *filesystem
+            # directories*, NOT MCP server catalogs — the MCP catalog mechanism is
+            # OBOT_SERVER_DEFAULT_MCPCATALOG_PATH (a GIT catalog URL). So this likely does NOT sync the
+            # catalog, and Obot may hold no OpenCrane MCP servers (which would also block routing tenant
+            # MCP through Obot). Left in place (the operator drift-repairer in apps/operator/src/
+            # runtime-planes/drift-repairer.ts also enforces it) pending independent confirmation and a
+            # coordinated fix across the deployment, drift-repairer + test, and this endpoint.
             - name: OBOT_SERVER_PROVIDER_REGISTRIES
               value: "http://{{ include "opencrane.fullname" . }}-control-plane:{{ .Values.controlPlane.service.port }}/api/internal/obot-registry"
           livenessProbe:

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -384,12 +384,15 @@ certManager:
 # key `dsn` containing the PostgreSQL DSN for Obot's own database. The release prefix
 # stops two instances in one cluster colliding on a fixed `opencrane-obot` name (B5).
 # Authentication is disabled; access is controlled by NetworkPolicy (in-cluster only).
-# Obot polls the control-plane /api/internal/obot-registry endpoint to sync the MCP catalog.
+# NOTE: external MCP-catalog sync into Obot is NOT wired up correctly yet (see the deployment
+# template). Obot's catalog mechanism is OBOT_SERVER_DEFAULT_MCPCATALOG_PATH (a git catalog URL),
+# not a dynamic HTTP endpoint — tracked as a follow-up.
 mcpGateway:
   enabled: true
   image:
     repository: ghcr.io/obot-platform/obot
-    tag: latest
+    # Pinned to a verified stable Obot release that exists on ghcr — never `latest`/`main`.
+    tag: v0.23.1
     pullPolicy: IfNotPresent
   replicas: 1
   service:


### PR DESCRIPTION
## What & why

Addresses two of the deferred hardening items from #36 (Obot image pin + encryption/DSN verification), and surfaces a real catalog-sync misconfiguration found while verifying. **No behaviour change except the version pin** — the rest is accurate documentation of verified findings.

## Changes

- **Pin the Obot image** `mcpGateway.image.tag: latest → v0.23.1`. Verified the tag exists on ghcr (anonymous manifest pull → HTTP 200; a bogus tag → 404). `v0.23.1` is the latest stable Obot release (2026-06-18).
- **Encryption-at-rest — verified, comment corrected.** Confirmed against obot v0.23.x source: `OBOT_SERVER_ENCRYPTION_PROVIDER=custom` is valid (with aws/gcp/azure/none) and `OBOT_SERVER_DSN` is the correct Postgres var. **But** the obot binary does **not** read `OBOT_SERVER_ENCRYPTION_KEY` directly — `custom` requires an apiserver-style `EncryptionConfiguration` file referenced by `OBOT_SERVER_ENCRYPTION_CONFIG_FILE`, which the upstream Obot Helm chart materialises from the key via an `encryptionsetup` init container. That init container (with Obot's exact encrypted-resource list) is **not yet replicated here**, so the knob is necessary-but-insufficient and stays **default-off**. The comment now says so (was an "ASSUMED, unverified" guess).

## Verified but NOT fixed here (flagged for follow-up)

- **MCP-catalog sync is mis-wired.** `OBOT_SERVER_PROVIDER_REGISTRIES` (set in this deployment **and enforced by the operator drift-repairer**) is, per obot source, for LLM model-provider *filesystem directories* — **not** MCP server catalogs. The MCP mechanism is `OBOT_SERVER_DEFAULT_MCPCATALOG_PATH` (a **git** catalog URL), which doesn't fit the dynamic `/api/internal/obot-registry` HTTP endpoint OpenCrane exposes. So Obot likely holds **no** OpenCrane MCP servers — which also blocks routing tenant MCP through Obot. Left in place (removing it cleanly spans the template + drift-repairer + its test + the endpoint, and needs independent confirmation + a real catalog mechanism). The deployment comment now flags it as known-suspect.

## Testing
- `helm template` renders `image: "ghcr.io/obot-platform/obot:v0.23.1"` and the deployment still renders cleanly.
- ghcr tag existence confirmed by anonymous manifest pull.

## Remaining hardening (separate)
- The `encryptionsetup` init container (to make encryption-at-rest actually work).
- A real MCP-catalog sync (git catalog or alternative), replacing the suspect `PROVIDER_REGISTRIES` across deployment + drift-repairer + endpoint.
- Chart-wide tag pinning off `latest` for first-party images (a release-versioning decision — see discussion).
