### PR TITLE
♻️ auth: rename broker route /auth/pod-token → /auth/pod-connection

### DIFF
--- a/apps/control-plane/src/__tests__/routes/auth-pod-connection.test.ts
+++ b/apps/control-plane/src/__tests__/routes/auth-pod-connection.test.ts
@@ -9,7 +9,7 @@ import { ___AuthRouter } from "../../infra/auth/auth.router.js";
 import type { OidcAuthService } from "../../infra/auth/oidc.service.js";
 import { _NoopGatewayAdmin } from "../../core/connections/gateway-admin.js";
 
-/** Session shape the pod-token route reads. */
+/** Session shape the pod-connection route reads. */
 interface TestSession
 {
 	/** Authenticated user, or undefined for an anonymous request. */
@@ -42,7 +42,7 @@ function _buildApp(session: TestSession, prisma: PrismaClient): Express
 	return app;
 }
 
-describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
+describe("POST /auth/pod-connection (OpenClaw connection broker)", function _suite()
 {
 	it("returns the gateway connection coordinates for the caller's tenant", async function _ok()
 	{
@@ -53,7 +53,7 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 		}]);
 		const app = _buildApp({ authUser: { sub: "u1", email: "Alex@acme.com" } }, prisma);
 
-		const res = await request(app).post("/auth/pod-token");
+		const res = await request(app).post("/auth/pod-connection");
 
 		expect(res.status).toBe(200);
 		expect(res.body).toMatchObject({
@@ -70,7 +70,7 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 		const prisma = _buildPrisma([{ name: "alex.oc", ingressHost: "alex.oc.example.com", configOverrides: null }]);
 		const app = _buildApp({ authUser: { sub: "u1", email: "alex@acme.com" } }, prisma);
 
-		const res = await request(app).post("/auth/pod-token");
+		const res = await request(app).post("/auth/pod-connection");
 
 		expect(res.status).toBe(200);
 		expect(res.body.gatewayUrl).toBe("wss://alex.oc.example.com");
@@ -80,7 +80,7 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 	it("returns 401 without a session", async function _noSession()
 	{
 		const app = _buildApp({}, _buildPrisma([]));
-		const res = await request(app).post("/auth/pod-token");
+		const res = await request(app).post("/auth/pod-connection");
 		expect(res.status).toBe(401);
 		expect(res.body.code).toBe("UNAUTHORIZED");
 	});
@@ -88,7 +88,7 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 	it("returns 403 when the session has no email", async function _noEmail()
 	{
 		const app = _buildApp({ authUser: { sub: "u1" } }, _buildPrisma([]));
-		const res = await request(app).post("/auth/pod-token");
+		const res = await request(app).post("/auth/pod-connection");
 		expect(res.status).toBe(403);
 		expect(res.body.code).toBe("FORBIDDEN");
 	});
@@ -96,7 +96,7 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 	it("returns 403 when no tenant matches the session email", async function _noTenant()
 	{
 		const app = _buildApp({ authUser: { sub: "u1", email: "ghost@acme.com" } }, _buildPrisma([]));
-		const res = await request(app).post("/auth/pod-token");
+		const res = await request(app).post("/auth/pod-connection");
 		expect(res.status).toBe(403);
 		expect(res.body.code).toBe("NO_TENANT");
 	});
@@ -108,7 +108,7 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 			{ name: "alex2.oc", ingressHost: "b.example.com", configOverrides: null },
 		]);
 		const app = _buildApp({ authUser: { sub: "u1", email: "alex@acme.com" } }, prisma);
-		const res = await request(app).post("/auth/pod-token");
+		const res = await request(app).post("/auth/pod-connection");
 		expect(res.status).toBe(409);
 		expect(res.body.code).toBe("AMBIGUOUS_TENANT");
 	});
@@ -117,7 +117,7 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 	{
 		const prisma = _buildPrisma([{ name: "alex.oc", ingressHost: null, configOverrides: null }]);
 		const app = _buildApp({ authUser: { sub: "u1", email: "alex@acme.com" } }, prisma);
-		const res = await request(app).post("/auth/pod-token");
+		const res = await request(app).post("/auth/pod-connection");
 		expect(res.status).toBe(409);
 		expect(res.body.code).toBe("POD_NOT_READY");
 	});

--- a/apps/control-plane/src/infra/auth/auth.router.ts
+++ b/apps/control-plane/src/infra/auth/auth.router.ts
@@ -14,7 +14,7 @@ import type { OpenClawGatewayAdmin } from "../../core/connections/gateway-admin.
 /**
  * Build the auth router covering:
  *  - Session introspection (GET /me)
- *  - OpenClaw connection broker (POST /pod-token)
+ *  - OpenClaw connection broker (POST /pod-connection)
  *  - OIDC browser flow (GET /login, GET /callback, POST /logout)
  *  - Device authorization grant for CLI (POST /device, GET /device/activate, GET /device/token)
  *
@@ -103,7 +103,7 @@ export function ___AuthRouter(authService: OidcAuthService, prisma: PrismaClient
    * **This route is mounted before `___AuthMiddleware`** (the whole auth router
    * is public), so it enforces the session check inline.
    */
-  router.post("/pod-token", async function _podToken(req, res, next)
+  router.post("/pod-connection", async function _podConnection(req, res, next)
   {
     try
     {
@@ -185,12 +185,12 @@ export function ___AuthRouter(authService: OidcAuthService, prisma: PrismaClient
    * so it revokes the caller's device tokens/pairings at the gateway and marks
    * their registry rows cut **without** deleting the shared per-tenant pod (which
    * would sign out everyone). The target tenant is resolved from the session's
-   * IdP-verified email exactly as `/pod-token` — no request-supplied tenant input.
+   * IdP-verified email exactly as `/pod-connection` — no request-supplied tenant input.
    *
    * **This route is mounted before `___AuthMiddleware`** (the whole auth router is
    * public), so it enforces the session check inline.
    */
-  router.post("/pod-token/cut", async function _podTokenCut(req, res, next)
+  router.post("/pod-connection/cut", async function _podConnectionCut(req, res, next)
   {
     try
     {

--- a/apps/control-plane/src/infra/auth/brokered-device.ts
+++ b/apps/control-plane/src/infra/auth/brokered-device.ts
@@ -5,7 +5,7 @@ import type { RecordBrokeredDeviceParams } from "./brokered-device.types.js";
 /**
  * Record (or refresh) a brokered OpenClaw connection in the device registry.
  *
- * Called on every successful `/auth/pod-token` broker so the per-user
+ * Called on every successful `/auth/pod-connection` broker so the per-user
  * kill-switch (`_CutTenant`, CONN.5) has an authoritative list of which
  * (tenant, subject) connections to revoke. Re-brokering an existing
  * (tenant, subject) bumps `lastBrokeredAt` and clears any prior `revokedAt`

--- a/apps/control-plane/src/infra/auth/oidc.service.ts
+++ b/apps/control-plane/src/infra/auth/oidc.service.ts
@@ -184,7 +184,7 @@ export class OidcAuthService
 
   /**
    * Resolve the caller's ClusterTenant from their IdP-verified email, reusing the
-   * pod-token broker's fail-closed rule: resolve the tenant by email, then read its
+   * pod-connection broker's fail-closed rule: resolve the tenant by email, then read its
    * `clusterTenantRef`. Returns null when the email is missing, matches no tenant,
    * matches more than one (ambiguous), the tenant has no parent, or the lookup
    * fails — never an arbitrary pick, and never taken from request input.

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -2496,7 +2496,7 @@ export const spec = {
       },
     },
 
-    "/auth/pod-token": {
+    "/auth/pod-connection": {
       post: {
         operationId: "getPodConnection",
         summary: "Resolve the caller's OpenClaw pod gateway connection coordinates from their OIDC session",


### PR DESCRIPTION
## What landed

Renames the OpenClaw connection broker route to drop the last bit of "token" vocabulary — the endpoint returns connection coordinates (`{ gatewayUrl, tenant, ingressHost }`) under trusted-proxy, **no token**, so the `/pod-token` path name was stale residue.

- Route `POST /auth/pod-token` → `POST /auth/pod-connection`, and its sibling `/auth/pod-token/cut` → `/auth/pod-connection/cut`.
- Handler fns `_podToken` / `_podTokenCut` → `_podConnection` / `_podConnectionCut`.
- OpenAPI path key in `spec.ts` (the `operationId` was already `getPodConnection`).
- Test file `auth-pod-token.test.ts` → `auth-pod-connection.test.ts` (+ its request paths/describe).
- Doc-comment references in `oidc.service.ts` and `brokered-device.ts`.

The **central cut** (`/auth/pod-connection/cut` → `_CutTenant`) is unchanged in behaviour — only its path/handler name moved.

## Validation

- `tsc --noEmit` clean.
- Control-plane suite: **353 tests / 56 files pass**, incl. the renamed auth-route suite.
- `git grep "pod-token\|_podToken"` on the committed tree: **none**.

## Deferred / Open items

- **Stacked on [#38](https://github.com/italanta/opencrane/pull/38)** (base branch `oc2-gateway-broker`) — merge after it.
- WeOwnAI counterpart (the `POST` caller + pinned `opencrane.json`) ships as a sibling PR; both must deploy together, but chat is dark pre-validation so ordering is not load-bearing.

## Commits

- `♻️ auth: rename broker route /auth/pod-token → /auth/pod-connection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
