### PR TITLE
fix: configmap authority on boot + drift-repairer patch content-type

### DIFF
--- a/apps/operator/src/runtime-planes/drift-repairer.ts
+++ b/apps/operator/src/runtime-planes/drift-repairer.ts
@@ -251,6 +251,9 @@ export class RuntimePlaneDriftRepairer
       name: plane.deploymentName,
       namespace: this._namespace,
       body: patch,
+      // Must be explicit — without it the client defaults to json-patch+json,
+      // which expects an array; the server rejects our object with a 400.
+      contentType: "application/strategic-merge-patch+json",
     });
 
     this._log.info(

--- a/apps/operator/src/tenants/deploy/3-deployment.ts
+++ b/apps/operator/src/tenants/deploy/3-deployment.ts
@@ -154,6 +154,11 @@ export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolu
     },
     spec: {
       replicas: 1,
+      // Recreate is required because the state PVC is ReadWriteOnce — only one
+      // pod can mount it at a time. RollingUpdate (the default) would deadlock:
+      // new pod can't attach the disk until old pod releases it, but old pod
+      // isn't terminated until new pod is Ready.
+      strategy: { type: "Recreate" },
       selector: {
         matchLabels: { "opencrane.io/tenant": name },
       },

--- a/apps/tenant/deploy/entrypoint.sh
+++ b/apps/tenant/deploy/entrypoint.sh
@@ -427,10 +427,16 @@ function _main()
   # Add runtime bin to PATH
   export PATH="$RUNTIME_DIR/node_modules/.bin:$PATH"
 
-  # Copy base config if not already present (preserves tenant customizations)
-  if [ ! -f "$STATE_DIR/openclaw.json" ] && [ -f "$CONFIG_SOURCE" ]; then
-    cp "$CONFIG_SOURCE" "$STATE_DIR/openclaw.json"
-    echo "[opencrane] Initialized config from base template"
+  # Always apply the operator-managed config on boot — the configmap is the
+  # authoritative source for platform settings (auth, port, bind, MCP servers).
+  # Tenant customisations arrive via spec.configOverrides, which the operator
+  # merges before mounting, so the mounted file is always the fully-merged config.
+  # Skipping this copy was the original design intent (to "preserve customisations")
+  # but it caused operator config updates (e.g. auth-mode changes) to be silently
+  # ignored on pod restart when the state-volume file already existed.
+  if [ -f "$CONFIG_SOURCE" ]; then
+    cp -f "$CONFIG_SOURCE" "$STATE_DIR/openclaw.json"
+    echo "[opencrane] Applied operator config from configmap"
   fi
 
   # L0 workspace files — platform-managed, re-stamped on every boot so operator edits


### PR DESCRIPTION
## Summary

- **Recreate strategy** (`6f02bf1`): tenant Deployments now use `strategy: Recreate` instead of the default `RollingUpdate`. With a ReadWriteOnce PVC the rolling strategy deadlocks: the new pod can't attach the disk until the old pod releases it, but the old pod waits for the new pod to be Ready first.

- **Entrypoint configmap authority** (`95b7d2c`): the operator-managed `openclaw.json` is now copied from the mounted configmap on *every* pod boot, not only when the state-volume file is absent. Operator config changes (e.g. switching auth mode to `trusted-proxy`) were silently ignored on pod restart because the stale state-dir copy was left in place. Tenant customisations arrive via `spec.configOverrides`, which the operator merges before mounting, so the mounted file is always the fully-merged config.

- **Drift-repairer patch type** (`95b7d2c`): `patchNamespacedDeployment` now sets `contentType: "application/strategic-merge-patch+json"` explicitly. Without it the kubernetes client defaulted to `json-patch+json`, causing a 400 `"cannot unmarshal object into Go value of type []handlers.jsonPatchOp"` from the apiserver every time the drift-repairer tried to repair env-var drift on a runtime plane.

## Live cluster impact

Both code fixes require a new tenant image build (entrypoint.sh) and a new operator build (drift-repairer.ts). After merging and deploying:

- A pod restart will automatically pick up any future operator config changes (no more manual state-dir surgery).
- The drift-repairer will successfully repair the `CONTROL_PLANE_URL` env drift on the skill-registry without erroring.

**Immediate workaround for openclaw-alex** (run in Cloud Shell while waiting for the build):
```bash
kubectl scale deployment openclaw-alex -n opencrane-system --replicas=0
kubectl wait --for=delete pod -l opencrane.io/tenant=alex -n opencrane-system --timeout=60s
kubectl run -n opencrane-system fix-openclaw-config --rm -i --restart=Never \
  --image=busybox \
  --overrides='{"spec":{"volumes":[{"name":"state","persistentVolumeClaim":{"claimName":"openclaw-alex-state"}}],"containers":[{"name":"fix","image":"busybox","command":["sh","-c","rm -f /data/openclaw/openclaw.json && echo done"],"volumeMounts":[{"name":"state","mountPath":"/data"}]}],"securityContext":{"runAsUser":1000,"runAsGroup":1000,"fsGroup":1000}}}' -- /bin/sh
kubectl scale deployment openclaw-alex -n opencrane-system --replicas=1
```

## Test plan

- [ ] CI passes (operator tsc + tests, tenant image build)
- [ ] After deploy: restart `openclaw-alex` pod — it should start without the "Refusing to bind gateway to lan without auth" error
- [ ] After deploy: verify drift-repairer logs no longer show 400 BadRequest when repairing skill-registry env drift