### PR TITLE
feat(control-plane): MCP operator API — catalogue, credential-connect, governance

### DIFF
--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -182,6 +182,206 @@
           }
         }
       },
+      "McpCatalogServer": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "description": "A catalogue server as exposed by the operator API (distinct from the registry McpServer). Every field beyond id is optional so the same shape serves the entitled user catalogue and the admin governance view.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "publisher": {
+            "type": "string"
+          },
+          "glyph": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "single-user",
+              "multi-user",
+              "remote-oauth"
+            ],
+            "description": "Consumption shape; decides the credential-connect flow."
+          },
+          "approvalStatus": {
+            "type": "string",
+            "enum": [
+              "pending-review",
+              "approved",
+              "published",
+              "disabled"
+            ],
+            "description": "Governance lifecycle status."
+          },
+          "credentialSchema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CredentialField"
+            }
+          },
+          "entitlementSummary": {
+            "type": "string",
+            "description": "Human-readable summary of who is entitled (admin view)."
+          }
+        }
+      },
+      "CredentialField": {
+        "type": "object",
+        "required": [
+          "key",
+          "label",
+          "required",
+          "sensitive"
+        ],
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "Stable key the value is submitted under."
+          },
+          "label": {
+            "type": "string",
+            "description": "Human-readable field label."
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether the field must be supplied."
+          },
+          "sensitive": {
+            "type": "boolean",
+            "description": "Whether the value is secret (masked, never echoed back)."
+          },
+          "placeholder": {
+            "type": "string",
+            "description": "Optional input placeholder."
+          },
+          "hint": {
+            "type": "string",
+            "description": "Optional helper hint."
+          }
+        }
+      },
+      "McpInstalled": {
+        "type": "object",
+        "required": [
+          "serverId"
+        ],
+        "description": "A server installed by the calling user. Never carries credential material — only the connection status and a non-secret account label.",
+        "properties": {
+          "serverId": {
+            "type": "string"
+          },
+          "connectionStatus": {
+            "type": "string",
+            "enum": [
+              "needs-credential",
+              "activating",
+              "connected",
+              "oauth-connected",
+              "shared-key",
+              "activation-failed"
+            ]
+          },
+          "lastUsed": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO-8601 timestamp of last use, or null when never used."
+          },
+          "connectedAccount": {
+            "type": "string",
+            "description": "Non-secret display label of the connected account."
+          }
+        }
+      },
+      "McpAccessPolicy": {
+        "type": "object",
+        "required": [
+          "serverId"
+        ],
+        "properties": {
+          "serverId": {
+            "type": "string"
+          },
+          "everyoneInOrg": {
+            "type": "boolean",
+            "description": "When true, every caller in the org is entitled (lists ignored)."
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Entitled group identifiers / names."
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntitledUser"
+            }
+          }
+        }
+      },
+      "EntitledUser": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "initials",
+          "color"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Stable user identifier (sub or email)."
+          },
+          "name": {
+            "type": "string",
+            "description": "Display name."
+          },
+          "initials": {
+            "type": "string",
+            "description": "Two-letter initials derived from the name."
+          },
+          "color": {
+            "type": "string",
+            "description": "Deterministic avatar colour derived from the identifier."
+          }
+        }
+      },
+      "McpDirectory": {
+        "type": "object",
+        "required": [
+          "users",
+          "groups"
+        ],
+        "description": "The selectable universe of users and groups for the admin access editor.",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntitledUser"
+            }
+          },
+          "groups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "ClusterTenant": {
         "type": "object",
         "required": [
@@ -3883,6 +4083,768 @@
         }
       }
     },
+    "/mcp/catalog": {
+      "get": {
+        "operationId": "listMcpCatalog",
+        "summary": "List the published MCP servers the calling user is entitled to",
+        "tags": [
+          "MCP Operator"
+        ],
+        "responses": {
+          "200": {
+            "description": "Entitlement-scoped catalogue.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/McpCatalogServer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/installed": {
+      "get": {
+        "operationId": "listMcpInstalled",
+        "summary": "List the servers the calling user has installed",
+        "tags": [
+          "MCP Operator"
+        ],
+        "responses": {
+          "200": {
+            "description": "Install list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/McpInstalled"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "installMcpServer",
+        "summary": "Install a catalogue server for the calling user",
+        "tags": [
+          "MCP Operator"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "serverId"
+                ],
+                "properties": {
+                  "serverId": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Server installed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpInstalled"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "serverId is required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/installed/{serverId}": {
+      "delete": {
+        "operationId": "uninstallMcpServer",
+        "summary": "Uninstall a server for the calling user (clears the stored credential)",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Server uninstalled."
+          },
+          "404": {
+            "description": "MCP install not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/installed/{serverId}/credential": {
+      "put": {
+        "operationId": "setMcpCredential",
+        "summary": "Author a per-user credential (write-only) and mark the install connected",
+        "description": "The submitted values are write-only: stored server-side as an opaque custody handle and NEVER returned by any response.",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "values"
+                ],
+                "properties": {
+                  "values": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Field values keyed by CredentialField.key. Write-only — never echoed back."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Credential connected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpInstalled"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP install not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "clearMcpCredential",
+        "summary": "Clear a per-user credential, returning the install to needs-credential",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Credential cleared.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpInstalled"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP install not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/installed/{serverId}/oauth": {
+      "post": {
+        "operationId": "connectMcpOauth",
+        "summary": "Mark a remote-OAuth install connected after a successful handshake",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OAuth connected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpInstalled"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP install not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "disconnectMcpOauth",
+        "summary": "Disconnect a remote-OAuth install, returning it to needs-credential",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "serverId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OAuth disconnected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpInstalled"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP install not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/servers": {
+      "get": {
+        "operationId": "listMcpGovernanceServers",
+        "summary": "List every catalogue server regardless of status (org-admin governance view)",
+        "tags": [
+          "MCP Operator"
+        ],
+        "responses": {
+          "200": {
+            "description": "All catalogue servers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/McpCatalogServer"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/servers/{id}/approve": {
+      "post": {
+        "operationId": "approveMcpServer",
+        "summary": "Approve a server (pending-review → approved). Org-admin only",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server approved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpCatalogServer"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/servers/{id}/publish": {
+      "post": {
+        "operationId": "publishMcpServer",
+        "summary": "Publish a server (approved → published). Org-admin only",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server published.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpCatalogServer"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/servers/{id}/reject": {
+      "post": {
+        "operationId": "rejectMcpServer",
+        "summary": "Reject a server (→ disabled). Org-admin only",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Server rejected.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpCatalogServer"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/servers/{id}/enabled": {
+      "post": {
+        "operationId": "setMcpServerEnabled",
+        "summary": "Toggle a server's availability (true → published, false → disabled). Org-admin only",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "enabled"
+                ],
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Server availability updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpCatalogServer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "enabled (boolean) is required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/servers/{id}/access": {
+      "get": {
+        "operationId": "getMcpAccessPolicy",
+        "summary": "Read a server's access policy. Org-admin only",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Access policy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpAccessPolicy"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "setMcpAccessPolicy",
+        "summary": "Replace a server's access policy wholesale. Org-admin only",
+        "tags": [
+          "MCP Operator"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "everyoneInOrg",
+                  "groups",
+                  "users"
+                ],
+                "properties": {
+                  "everyoneInOrg": {
+                    "type": "boolean"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "users": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Entitled user identifiers."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access policy updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpAccessPolicy"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "everyoneInOrg (boolean), groups (array), and users (array) are required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "MCP server not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mcp/directory": {
+      "get": {
+        "operationId": "getMcpDirectory",
+        "summary": "List the selectable users and groups for the access editor. Org-admin only",
+        "tags": [
+          "MCP Operator"
+        ],
+        "responses": {
+          "200": {
+            "description": "Directory.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/McpDirectory"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/groups": {
       "get": {
         "operationId": "listGroups",
@@ -6996,36 +7958,28 @@
     },
     "/auth/pod-token": {
       "post": {
-        "operationId": "exchangePodToken",
-        "summary": "Exchange the current OIDC session for a short-lived token to the caller's OpenClaw pod",
-        "description": "Single sign-on across the control plane and the tenant pod: requires an established OIDC session (cookie) and returns a short-lived, audience-bound token minted via the Kubernetes TokenRequest API for the caller's tenant. The token targets the OpenClaw pod's session audience (reachable at `ingressHost`) — it is NOT an `obot-gateway` token; Obot is called only from inside the pod. The tenant is resolved solely from the session's verified email, so a caller cannot obtain a token for another user's pod. Re-call before `expiresAt`; re-login only when the session itself expires. Returns 401 without a session, 403 when no tenant matches the session email, 409 when the pod has no ingress host yet or when the email maps to more than one tenant.",
+        "operationId": "getPodConnection",
+        "summary": "Resolve the caller's OpenClaw pod gateway connection coordinates from their OIDC session",
+        "description": "Single sign-on across the control plane and the tenant pod: requires an established OIDC session (cookie) and returns the `wss://` gateway URL for the caller's own pod. Under trusted-proxy gateway auth the browser holds no credential — the gateway socket is authorised at the ingress against the live session (`/auth/gateway-verify`), so no token is returned. The tenant is resolved solely from the session's verified email, so a caller cannot obtain another user's pod connection. Returns 401 without a session, 403 when no tenant matches the session email, 409 when the pod has no gateway URL / ingress host yet or when the email maps to more than one tenant.",
         "tags": [
           "Auth"
         ],
         "security": [],
         "responses": {
           "200": {
-            "description": "Short-lived pod access token.",
+            "description": "The caller's OpenClaw pod gateway connection coordinates.",
             "content": {
               "application/json": {
                 "schema": {
                   "type": "object",
                   "required": [
-                    "token",
-                    "expiresAt",
-                    "tenant",
-                    "ingressHost",
-                    "audience"
+                    "gatewayUrl",
+                    "tenant"
                   ],
                   "properties": {
-                    "token": {
+                    "gatewayUrl": {
                       "type": "string",
-                      "description": "Short-lived bearer token bound to the OpenClaw pod session audience."
-                    },
-                    "expiresAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "description": "ISO-8601 expiry reported by the API server."
+                      "description": "The `wss://` OpenClaw gateway URL to open."
                     },
                     "tenant": {
                       "type": "string",
@@ -7033,11 +7987,7 @@
                     },
                     "ingressHost": {
                       "type": "string",
-                      "description": "Host to reach the tenant's OpenClaw pod session API."
-                    },
-                    "audience": {
-                      "type": "string",
-                      "description": "Audience the token is bound to (the OpenClaw pod session, not obot-gateway)."
+                      "description": "Host the tenant's OpenClaw pod is reachable at, when known."
                     }
                   }
                 }
@@ -7081,7 +8031,7 @@
             }
           },
           "409": {
-            "description": "The tenant pod has no ingress host yet.",
+            "description": "The tenant pod has no gateway URL / ingress host yet.",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/control-plane/prisma/migrations/0022_mcp_operator_api/migration.sql
+++ b/apps/control-plane/prisma/migrations/0022_mcp_operator_api/migration.sql
@@ -1,0 +1,73 @@
+-- Migration 0022: MCP operator API — catalogue / credential-connect / activation
+-- + admin governance (P1).
+--
+-- Layers the consumption + governance surface the WeOwnAI frontend targets on top
+-- of the existing /mcp-servers admin registry. Additive + backward-compatible:
+-- existing servers default to server_type='single-user', approval_status='pending-review',
+-- and an empty credential_schema, so nothing already registered changes behaviour.
+-- Secret custody is unchanged: per-user installs carry only a write-only credential_ref
+-- handle (the gateway plane / Obot holds the material), never serialised by any response.
+
+-- 1. Closed-set enums (DB values mirror the @map labels in schema.prisma).
+CREATE TYPE "McpServerType" AS ENUM ('single-user', 'multi-user', 'remote-oauth');
+CREATE TYPE "McpApprovalStatus" AS ENUM ('pending-review', 'approved', 'published', 'disabled');
+CREATE TYPE "McpConnectionStatus" AS ENUM ('needs-credential', 'activating', 'connected', 'oauth-connected', 'shared-key', 'activation-failed');
+
+-- 2. Extend the server catalogue row with consumption + governance metadata.
+ALTER TABLE "mcp_servers"
+  ADD COLUMN "publisher"           TEXT,
+  ADD COLUMN "glyph"               TEXT,
+  ADD COLUMN "server_type"         "McpServerType" NOT NULL DEFAULT 'single-user',
+  ADD COLUMN "approval_status"     "McpApprovalStatus" NOT NULL DEFAULT 'pending-review',
+  ADD COLUMN "credential_schema"   JSONB NOT NULL DEFAULT '[]',
+  ADD COLUMN "entitlement_summary" TEXT;
+
+CREATE INDEX "mcp_servers_approval_status_idx" ON "mcp_servers" ("approval_status");
+
+-- 3. Per-user install records. credential_ref is a write-only custody handle; the
+--    unique pair keeps a caller to one install per server.
+CREATE TABLE "mcp_server_installs" (
+  "id"                TEXT NOT NULL,
+  "mcp_server_id"     TEXT NOT NULL,
+  "user_id"           TEXT NOT NULL,
+  "connection_status" "McpConnectionStatus" NOT NULL DEFAULT 'needs-credential',
+  "credential_ref"    TEXT,
+  "connected_account" TEXT,
+  "last_used_at"      TIMESTAMP(3),
+  "created_at"        TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"        TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "mcp_server_installs_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "mcp_server_installs_mcp_server_id_user_id_key" ON "mcp_server_installs" ("mcp_server_id", "user_id");
+CREATE INDEX "mcp_server_installs_user_id_idx" ON "mcp_server_installs" ("user_id");
+ALTER TABLE "mcp_server_installs"
+  ADD CONSTRAINT "mcp_server_installs_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 4. Per-server access policy (one row per server). everyone_in_org short-circuits
+--    the per-user / per-group entitlement lists.
+CREATE TABLE "mcp_server_access_policies" (
+  "id"              TEXT NOT NULL,
+  "mcp_server_id"   TEXT NOT NULL,
+  "everyone_in_org" BOOLEAN NOT NULL DEFAULT false,
+  "groups"          TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  "created_at"      TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"      TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "mcp_server_access_policies_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "mcp_server_access_policies_mcp_server_id_key" ON "mcp_server_access_policies" ("mcp_server_id");
+ALTER TABLE "mcp_server_access_policies"
+  ADD CONSTRAINT "mcp_server_access_policies_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers" ("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 5. Per-user entitlement rows attached to a policy (child of the policy, not a
+--    String[]) so a caller's entitlement can be looked up without scanning.
+CREATE TABLE "mcp_server_access_users" (
+  "id"               TEXT NOT NULL,
+  "access_policy_id" TEXT NOT NULL,
+  "user_id"          TEXT NOT NULL,
+  "created_at"       TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "mcp_server_access_users_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "mcp_server_access_users_access_policy_id_user_id_key" ON "mcp_server_access_users" ("access_policy_id", "user_id");
+CREATE INDEX "mcp_server_access_users_user_id_idx" ON "mcp_server_access_users" ("user_id");
+ALTER TABLE "mcp_server_access_users"
+  ADD CONSTRAINT "mcp_server_access_users_access_policy_id_fkey" FOREIGN KEY ("access_policy_id") REFERENCES "mcp_server_access_policies" ("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/control-plane/prisma/schema.prisma
+++ b/apps/control-plane/prisma/schema.prisma
@@ -277,26 +277,113 @@ enum McpServerStatus {
   Draft    @map("draft")
 }
 
+// Consumption shape advertised to the operator API: how a caller connects a
+// downstream MCP server (single-user secret, org-wide shared key, or remote OAuth).
+enum McpServerType {
+  SingleUser  @map("single-user")
+  MultiUser   @map("multi-user")
+  RemoteOauth @map("remote-oauth")
+}
+
+// Governance lifecycle gated by org admins (P1 catalogue review). Only `published`
+// servers are visible to entitled callers in the user-facing catalogue.
+enum McpApprovalStatus {
+  PendingReview @map("pending-review")
+  Approved      @map("approved")
+  Published     @map("published")
+  Disabled      @map("disabled")
+}
+
+// Per-user install connection state surfaced by the operator API. `credentialRef`
+// custody is never serialised — this enum reports state, never secret material.
+enum McpConnectionStatus {
+  NeedsCredential  @map("needs-credential")
+  Activating       @map("activating")
+  Connected        @map("connected")
+  OauthConnected   @map("oauth-connected")
+  SharedKey        @map("shared-key")
+  ActivationFailed @map("activation-failed")
+}
+
 model McpServer {
-  id            String               @id @default(cuid())
-  name          String               @unique
-  description   String               @default("")
-  endpoint      String
-  scope         GrantScope
-  transport     McpServerTransport
-  status        McpServerStatus      @default(Draft)
-  capabilities  String[]             @default([])
-  sourceId      String?              @map("source_id")
-  lastSyncedAt  DateTime?            @map("last_synced_at")
-  createdAt     DateTime             @default(now()) @map("created_at")
-  updatedAt     DateTime             @updatedAt @map("updated_at")
-  grants        Grant[]
-  scopedGrants  McpServerGrant[]
-  credentials   McpServerCredential[]
-  source        ThirdPartySource?    @relation(fields: [sourceId], references: [id], onDelete: SetNull)
+  id                 String                 @id @default(cuid())
+  name               String                 @unique
+  description        String                 @default("")
+  endpoint           String
+  scope              GrantScope
+  transport          McpServerTransport
+  status             McpServerStatus        @default(Draft)
+  capabilities       String[]               @default([])
+  publisher          String?
+  glyph              String?
+  serverType         McpServerType          @default(SingleUser) @map("server_type")
+  approvalStatus     McpApprovalStatus      @default(PendingReview) @map("approval_status")
+  credentialSchema   Json                   @default("[]") @map("credential_schema")
+  entitlementSummary String?                @map("entitlement_summary")
+  sourceId           String?                @map("source_id")
+  lastSyncedAt       DateTime?              @map("last_synced_at")
+  createdAt          DateTime               @default(now()) @map("created_at")
+  updatedAt          DateTime               @updatedAt @map("updated_at")
+  grants             Grant[]
+  scopedGrants       McpServerGrant[]
+  credentials        McpServerCredential[]
+  installs           McpServerInstall[]
+  accessPolicy       McpServerAccessPolicy?
+  source             ThirdPartySource?      @relation(fields: [sourceId], references: [id], onDelete: SetNull)
 
   @@index([scope])
+  @@index([approvalStatus])
   @@map("mcp_servers")
+}
+
+// Per-user installation of an MCP server (operator API). Holds the caller's
+// connection state and a write-only `credentialRef` custody handle (the actual
+// secret lives in the gateway plane / Obot, never here and never serialised).
+model McpServerInstall {
+  id               String              @id @default(cuid())
+  mcpServerId      String              @map("mcp_server_id")
+  userId           String              @map("user_id")
+  connectionStatus McpConnectionStatus @default(NeedsCredential) @map("connection_status")
+  credentialRef    String?             @map("credential_ref")
+  connectedAccount String?             @map("connected_account")
+  lastUsedAt       DateTime?           @map("last_used_at")
+  createdAt        DateTime            @default(now()) @map("created_at")
+  updatedAt        DateTime            @updatedAt @map("updated_at")
+  mcpServer        McpServer           @relation(fields: [mcpServerId], references: [id], onDelete: Cascade)
+
+  @@unique([mcpServerId, userId])
+  @@index([userId])
+  @@map("mcp_server_installs")
+}
+
+// Org-admin authored access policy deciding which callers may see and install a
+// server in the user-facing catalogue. `everyoneInOrg` short-circuits the per-user
+// / per-group lists; otherwise membership in `users` or `groups` is required.
+model McpServerAccessPolicy {
+  id            String                @id @default(cuid())
+  mcpServerId   String                @unique @map("mcp_server_id")
+  everyoneInOrg Boolean               @default(false) @map("everyone_in_org")
+  groups        String[]              @default([])
+  createdAt     DateTime              @default(now()) @map("created_at")
+  updatedAt     DateTime              @updatedAt @map("updated_at")
+  mcpServer     McpServer             @relation(fields: [mcpServerId], references: [id], onDelete: Cascade)
+  users         McpServerAccessUser[]
+
+  @@map("mcp_server_access_policies")
+}
+
+// A single user entitled to a server via its access policy. Stored as a child row
+// (rather than a String[]) so entitlement can be queried per user without scanning.
+model McpServerAccessUser {
+  id             String                @id @default(cuid())
+  accessPolicyId String                @map("access_policy_id")
+  userId         String                @map("user_id")
+  createdAt      DateTime              @default(now()) @map("created_at")
+  accessPolicy   McpServerAccessPolicy @relation(fields: [accessPolicyId], references: [id], onDelete: Cascade)
+
+  @@unique([accessPolicyId, userId])
+  @@index([userId])
+  @@map("mcp_server_access_users")
 }
 
 model McpServerGrant {

--- a/apps/control-plane/src/__tests__/routes/mcp-operator.test.ts
+++ b/apps/control-plane/src/__tests__/routes/mcp-operator.test.ts
@@ -1,0 +1,284 @@
+import express from "express";
+import type { Express } from "express";
+import type { PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { mcpOperatorRouter } from "../../routes/mcp-operator.js";
+
+/**
+ * Operator-API coverage (`/api/v1/mcp/*`): the org-admin gate on the governance
+ * endpoints, published+entitled filtering of the catalogue, the
+ * install→credential→connected lifecycle, and the custody invariant that NO
+ * response ever serialises credential material.
+ */
+
+/** Auth env that decides `_IsDevAuthMode`; cleared/restored around each test. */
+const _AUTH_ENV = ["OPENCRANE_API_TOKEN", "OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET", "OIDC_REDIRECT_URI", "OIDC_SESSION_SECRET"] as const;
+
+/** Session user shape seeded onto the request (mirrors the OIDC session). */
+interface _SessionUser
+{
+  /** Stable subject identifier. */
+  sub?: string;
+  /** Caller email (used when sub is absent). */
+  email?: string;
+  /** IdP group claims. */
+  groups?: string[];
+  /** Whether the IdP marked the caller an org admin. */
+  isOrgAdmin?: boolean;
+}
+
+/**
+ * Recording Prisma stub: every `prisma.<model>.<method>()` resolves to `[]` and is
+ * a memoised spy, unless an explicit override is supplied for `model.method`.
+ *
+ * @param overrides - Per-`model.method` implementations to install.
+ * @returns The stubbed client plus the spy registry.
+ */
+function _mockPrisma(overrides: Record<string, (...args: unknown[]) => unknown> = {}): { prisma: PrismaClient; spies: Record<string, ReturnType<typeof vi.fn>> }
+{
+  const spies: Record<string, ReturnType<typeof vi.fn>> = {};
+  const prisma = new Proxy({}, {
+    get(_t, model)
+    {
+      return new Proxy({}, {
+        get(_t2, method)
+        {
+          const key = `${String(model)}.${String(method)}`;
+          if (!spies[key])
+          {
+            spies[key] = overrides[key] ? vi.fn(overrides[key]) : vi.fn().mockResolvedValue([]);
+          }
+          return spies[key];
+        },
+      });
+    },
+  }) as unknown as PrismaClient;
+  return { prisma, spies };
+}
+
+/** Mount the operator router, optionally seeding a session user. */
+function _buildApp(prisma: PrismaClient, user?: _SessionUser): Express
+{
+  const app = express();
+  app.use(express.json());
+  if (user)
+  {
+    app.use(function _seedSession(req, _res, next) { (req as unknown as { session: { authUser: _SessionUser } }).session = { authUser: user }; next(); });
+  }
+  app.use("/api/v1/mcp", mcpOperatorRouter(prisma));
+  return app;
+}
+
+describe("mcp-operator router", function _suite()
+{
+  const _saved: Record<string, string | undefined> = {};
+
+  /** Snapshot then clear the auth env so each case controls the dev-mode posture. */
+  beforeEach(function _clearEnv()
+  {
+    for (const key of _AUTH_ENV) { _saved[key] = process.env[key]; delete process.env[key]; }
+  });
+
+  /** Restore the auth env captured in `beforeEach` so cases stay isolated. */
+  afterEach(function _restoreEnv()
+  {
+    for (const key of _AUTH_ENV) { if (_saved[key] === undefined) { delete process.env[key]; } else { process.env[key] = _saved[key]; } }
+  });
+
+  describe("org-admin gate on governance endpoints", function _gate()
+  {
+    it("denies GET /servers for a non-admin session", async function _denyList()
+    {
+      process.env.OPENCRANE_API_TOKEN = "ci-token";
+      const { prisma, spies } = _mockPrisma();
+      const res = await request(_buildApp(prisma, { sub: "u1", isOrgAdmin: false })).get("/api/v1/mcp/servers");
+
+      expect(res.status).toBe(403);
+      expect(res.body).toMatchObject({ code: "FORBIDDEN_NOT_ORG_ADMIN" });
+      expect(spies["mcpServer.findMany"]).toBeUndefined();
+    });
+
+    it("denies PUT /servers/:id/access for a non-admin session", async function _denyAccess()
+    {
+      process.env.OPENCRANE_API_TOKEN = "ci-token";
+      const { prisma, spies } = _mockPrisma();
+      const res = await request(_buildApp(prisma, { sub: "u1", isOrgAdmin: false }))
+        .put("/api/v1/mcp/servers/srv-1/access").send({ everyoneInOrg: true, groups: [], users: [] });
+
+      expect(res.status).toBe(403);
+      expect(spies["mcpServerAccessPolicy.upsert"]).toBeUndefined();
+    });
+
+    it("denies GET /directory for a non-admin session", async function _denyDirectory()
+    {
+      process.env.OPENCRANE_API_TOKEN = "ci-token";
+      const { prisma } = _mockPrisma();
+      const res = await request(_buildApp(prisma, { sub: "u1", isOrgAdmin: false })).get("/api/v1/mcp/directory");
+
+      expect(res.status).toBe(403);
+    });
+
+    it("lets an org-admin session through GET /servers to the handler", async function _allowList()
+    {
+      process.env.OPENCRANE_API_TOKEN = "ci-token";
+      const { prisma, spies } = _mockPrisma();
+      const res = await request(_buildApp(prisma, { sub: "admin", isOrgAdmin: true })).get("/api/v1/mcp/servers");
+
+      expect(res.status).not.toBe(403);
+      expect(spies["mcpServer.findMany"]).toHaveBeenCalled();
+    });
+
+    it("opens the gate under dev mode when no session and no real auth", async function _devOpen()
+    {
+      const { prisma } = _mockPrisma();
+      const res = await request(_buildApp(prisma)).get("/api/v1/mcp/servers");
+
+      expect(res.status).not.toBe(403);
+    });
+  });
+
+  describe("GET /catalog — published + entitled filtering", function _catalog()
+  {
+    /** Two published servers: one org-wide entitled, one only for another user. */
+    const _servers = [
+      { id: "srv-open", name: "Open", description: "", publisher: null, glyph: null, serverType: "MultiUser", approvalStatus: "Published", credentialSchema: [], entitlementSummary: null, createdAt: new Date(), accessPolicy: { everyoneInOrg: true, groups: [], users: [] } },
+      { id: "srv-closed", name: "Closed", description: "", publisher: null, glyph: null, serverType: "SingleUser", approvalStatus: "Published", credentialSchema: [], entitlementSummary: null, createdAt: new Date(), accessPolicy: { everyoneInOrg: false, groups: ["other-group"], users: [{ userId: "someone-else" }] } },
+    ];
+
+    it("returns only the servers the caller is entitled to", async function _filters()
+    {
+      process.env.OPENCRANE_API_TOKEN = "ci-token";
+      const { prisma } = _mockPrisma({ "mcpServer.findMany": function _findMany() { return Promise.resolve(_servers); } });
+      const res = await request(_buildApp(prisma, { sub: "user-1", groups: [], isOrgAdmin: false })).get("/api/v1/mcp/catalog");
+
+      expect(res.status).toBe(200);
+      expect(res.body.map(function _id(s: { id: string }) { return s.id; })).toEqual(["srv-open"]);
+      expect(res.body[0]).toMatchObject({ id: "srv-open", type: "multi-user", approvalStatus: "published" });
+    });
+
+    it("entitles a caller via a matching group claim", async function _group()
+    {
+      process.env.OPENCRANE_API_TOKEN = "ci-token";
+      const { prisma } = _mockPrisma({ "mcpServer.findMany": function _findMany() { return Promise.resolve(_servers); } });
+      const res = await request(_buildApp(prisma, { sub: "user-2", groups: ["other-group"], isOrgAdmin: false })).get("/api/v1/mcp/catalog");
+
+      expect(res.status).toBe(200);
+      expect(res.body.map(function _id(s: { id: string }) { return s.id; }).sort()).toEqual(["srv-closed", "srv-open"]);
+    });
+  });
+
+  describe("install → credential → connected lifecycle", function _lifecycle()
+  {
+    /**
+     * Stateful single-install store backing the connect mutations, so a request can
+     * observe the connection-status transition a real DB would persist.
+     */
+    function _statefulPrisma(serverType: string): { prisma: PrismaClient; store: { install: Record<string, unknown> | null } }
+    {
+      const store: { install: Record<string, unknown> | null } = { install: null };
+      const overrides: Record<string, (...args: unknown[]) => unknown> = {
+        "mcpServer.findUnique": function _serverFind() { return Promise.resolve({ serverType }); },
+        "mcpServerInstall.findUnique": function _installFind() { return Promise.resolve(store.install); },
+        "mcpServerInstall.upsert": function _upsert(arg: unknown) {
+          const create = (arg as { create: Record<string, unknown> }).create;
+          store.install ??= { mcpServerId: create.mcpServerId, userId: create.userId, connectionStatus: create.connectionStatus ?? "NeedsCredential", credentialRef: null, connectedAccount: null, lastUsedAt: null };
+          return Promise.resolve(store.install);
+        },
+        "mcpServerInstall.update": function _update(arg: unknown) {
+          const data = (arg as { data: Record<string, unknown> }).data;
+          store.install = { ...(store.install ?? {}), ...data };
+          return Promise.resolve(store.install);
+        },
+        "auditEntry.create": function _audit() { return Promise.resolve({}); },
+      };
+      const { prisma } = _mockPrisma(overrides);
+      return { prisma, store };
+    }
+
+    it("installs a single-user server as needs-credential", async function _install()
+    {
+      const { prisma } = _statefulPrisma("SingleUser");
+      const res = await request(_buildApp(prisma, { sub: "user-1" })).post("/api/v1/mcp/installed").send({ serverId: "srv-1" });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toMatchObject({ serverId: "srv-1", connectionStatus: "needs-credential" });
+    });
+
+    it("installs a multi-user server as shared-key", async function _installShared()
+    {
+      const { prisma } = _statefulPrisma("MultiUser");
+      const res = await request(_buildApp(prisma, { sub: "user-1" })).post("/api/v1/mcp/installed").send({ serverId: "srv-1" });
+
+      expect(res.status).toBe(201);
+      expect(res.body.connectionStatus).toBe("shared-key");
+    });
+
+    it("transitions to connected when a credential is authored", async function _connect()
+    {
+      const { prisma, store } = _statefulPrisma("SingleUser");
+      store.install = { mcpServerId: "srv-1", userId: "user-1", connectionStatus: "NeedsCredential", credentialRef: null, connectedAccount: null, lastUsedAt: null };
+      const res = await request(_buildApp(prisma, { sub: "user-1" }))
+        .put("/api/v1/mcp/installed/srv-1/credential").send({ values: { apiKey: "SUPER-SECRET-123" } });
+
+      expect(res.status).toBe(200);
+      expect(res.body.connectionStatus).toBe("connected");
+    });
+
+    it("returns 404 when authoring a credential for an uninstalled server", async function _noInstall()
+    {
+      const { prisma } = _statefulPrisma("SingleUser");
+      const res = await request(_buildApp(prisma, { sub: "user-1" }))
+        .put("/api/v1/mcp/installed/srv-1/credential").send({ values: { apiKey: "x" } });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("user-scoping — a caller only sees / acts on their own installs", function _scoping()
+  {
+    it("scopes GET /installed to the calling user's id", async function _listScoped()
+    {
+      const { prisma, spies } = _mockPrisma({ "mcpServerInstall.findMany": function _f() { return Promise.resolve([]); } });
+      await request(_buildApp(prisma, { sub: "caller-9" })).get("/api/v1/mcp/installed");
+
+      expect(spies["mcpServerInstall.findMany"]).toHaveBeenCalledWith(expect.objectContaining({ where: { userId: "caller-9" } }));
+    });
+
+    it("scopes DELETE /installed/:serverId to the calling user's id", async function _deleteScoped()
+    {
+      const { prisma, spies } = _mockPrisma({
+        "mcpServerInstall.deleteMany": function _d() { return Promise.resolve({ count: 1 }); },
+        "auditEntry.create": function _a() { return Promise.resolve({}); },
+      });
+      const res = await request(_buildApp(prisma, { sub: "caller-9" })).delete("/api/v1/mcp/installed/srv-1");
+
+      expect(res.status).toBe(204);
+      expect(spies["mcpServerInstall.deleteMany"]).toHaveBeenCalledWith({ where: { mcpServerId: "srv-1", userId: "caller-9" } });
+    });
+  });
+
+  describe("credential custody — no response serialises secret material", function _custody()
+  {
+    it("never echoes the submitted credential values or the credentialRef", async function _writeOnly()
+    {
+      const store: { install: Record<string, unknown> | null } = { install: { mcpServerId: "srv-1", userId: "user-1", connectionStatus: "NeedsCredential", credentialRef: null, connectedAccount: null, lastUsedAt: null } };
+      const { prisma } = _mockPrisma({
+        "mcpServerInstall.findUnique": function _f() { return Promise.resolve(store.install); },
+        "mcpServerInstall.update": function _u(arg: unknown) { store.install = { ...(store.install ?? {}), ...(arg as { data: Record<string, unknown> }).data }; return Promise.resolve(store.install); },
+        "auditEntry.create": function _a() { return Promise.resolve({}); },
+      });
+      const res = await request(_buildApp(prisma, { sub: "user-1" }))
+        .put("/api/v1/mcp/installed/srv-1/credential").send({ values: { apiKey: "SUPER-SECRET-123", token: "t0ps3cret" } });
+
+      expect(res.status).toBe(200);
+      const serialised = JSON.stringify(res.body);
+      expect(serialised).not.toContain("SUPER-SECRET-123");
+      expect(serialised).not.toContain("t0ps3cret");
+      expect(serialised).not.toContain("credentialRef");
+      expect(serialised).not.toContain("cred_");
+      expect(Object.keys(res.body).sort()).toEqual(["connectionStatus", "lastUsed", "serverId"]);
+    });
+  });
+});

--- a/apps/control-plane/src/features/mcp-operator/mcp-operator.logic.ts
+++ b/apps/control-plane/src/features/mcp-operator/mcp-operator.logic.ts
@@ -1,0 +1,733 @@
+import { randomBytes } from "node:crypto";
+
+import { McpApprovalStatus, McpConnectionStatus, McpServerType, type CredentialField, type Directory, type EntitledUser, type McpAccessPolicy, type McpCatalogServer, type McpInstalled } from "@opencrane/contracts";
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+import { ___SortBy } from "../../core/utils/collections.js";
+import type { McpAccessPolicyRequest } from "../../routes/mcp-operator.types.js";
+
+/** MCP server row joined with the access policy + entitled users used for filtering. */
+type _McpServerWithPolicyRow = Prisma.McpServerGetPayload<{ include: { accessPolicy: { include: { users: true } } } }>;
+
+/** Per-user install row returned by the install/connect mutations. */
+type _McpInstallRow = Prisma.McpServerInstallGetPayload<object>;
+
+/**
+ * Identity + entitlement context of the caller of a user-facing endpoint.
+ *
+ * `devOpen` mirrors the platform's fail-open dev posture: when no session is
+ * established and no real auth is configured, the caller sees the full published
+ * catalogue so a fresh local install / the OPEN dev backend isn't locked out.
+ */
+export interface McpOperatorCaller
+{
+  /** Stable caller identifier (`authUser.sub ?? authUser.email`, or a dev fallback). */
+  userId: string;
+  /** IdP-verified group claims used for group-based entitlement. */
+  groups: string[];
+  /** True only when unauthenticated under dev-auth-mode — bypasses entitlement filtering. */
+  devOpen: boolean;
+}
+
+/** Typed Prisma `McpServerType` values (member names, not the @map'd DB labels). */
+const _PRISMA_SERVER_TYPE = {
+  SingleUser: "SingleUser",
+  MultiUser: "MultiUser",
+  RemoteOauth: "RemoteOauth",
+} as const;
+
+/** Typed Prisma `McpApprovalStatus` values used during runtime lookups. */
+const _PRISMA_APPROVAL_STATUS = {
+  PendingReview: "PendingReview",
+  Approved: "Approved",
+  Published: "Published",
+  Disabled: "Disabled",
+} as const;
+
+/** Typed Prisma `McpConnectionStatus` values used during runtime lookups. */
+const _PRISMA_CONNECTION_STATUS = {
+  NeedsCredential: "NeedsCredential",
+  Activating: "Activating",
+  Connected: "Connected",
+  OauthConnected: "OauthConnected",
+  SharedKey: "SharedKey",
+  ActivationFailed: "ActivationFailed",
+} as const;
+
+/** Contract server-type lookup keyed by Prisma enum values. */
+const _TYPE_BY_PRISMA = {
+  [_PRISMA_SERVER_TYPE.SingleUser]: McpServerType.SingleUser,
+  [_PRISMA_SERVER_TYPE.MultiUser]: McpServerType.MultiUser,
+  [_PRISMA_SERVER_TYPE.RemoteOauth]: McpServerType.RemoteOauth,
+};
+
+/** Contract approval-status lookup keyed by Prisma enum values. */
+const _APPROVAL_BY_PRISMA = {
+  [_PRISMA_APPROVAL_STATUS.PendingReview]: McpApprovalStatus.PendingReview,
+  [_PRISMA_APPROVAL_STATUS.Approved]: McpApprovalStatus.Approved,
+  [_PRISMA_APPROVAL_STATUS.Published]: McpApprovalStatus.Published,
+  [_PRISMA_APPROVAL_STATUS.Disabled]: McpApprovalStatus.Disabled,
+};
+
+/** Contract connection-status lookup keyed by Prisma enum values. */
+const _CONNECTION_BY_PRISMA = {
+  [_PRISMA_CONNECTION_STATUS.NeedsCredential]: McpConnectionStatus.NeedsCredential,
+  [_PRISMA_CONNECTION_STATUS.Activating]: McpConnectionStatus.Activating,
+  [_PRISMA_CONNECTION_STATUS.Connected]: McpConnectionStatus.Connected,
+  [_PRISMA_CONNECTION_STATUS.OauthConnected]: McpConnectionStatus.OauthConnected,
+  [_PRISMA_CONNECTION_STATUS.SharedKey]: McpConnectionStatus.SharedKey,
+  [_PRISMA_CONNECTION_STATUS.ActivationFailed]: McpConnectionStatus.ActivationFailed,
+};
+
+/** Deterministic avatar palette indexed by a stable hash of the user identifier. */
+const _AVATAR_COLORS = ["#1F3B6E", "#2E7D32", "#6A1B9A", "#C62828", "#00838F", "#EF6C00", "#4527A0", "#283593"];
+
+/**
+ * List the catalogue servers the caller may see: published AND entitled.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param caller - Identity + entitlement context of the calling user.
+ * @returns Published, entitlement-scoped catalogue rows.
+ */
+export async function listEntitledCatalog(prisma: PrismaClient, caller: McpOperatorCaller): Promise<McpCatalogServer[]>
+{
+  // 1. Narrow to published servers in the database so disabled/pending rows never
+  //    leave the governance boundary, then load each server's access policy.
+  const servers = await prisma.mcpServer.findMany({
+    where: { approvalStatus: _PRISMA_APPROVAL_STATUS.Published as Prisma.McpServerWhereInput["approvalStatus"] },
+    include: { accessPolicy: { include: { users: true } } },
+    orderBy: { createdAt: "desc" },
+  });
+
+  // 2. Apply the per-caller entitlement filter (everyone-in-org / user / group),
+  //    bypassed only under the dev-open posture, then map to the wire shape.
+  return servers
+    .filter(function _entitled(server) { return _IsEntitled(server, caller); })
+    .map(function _map(server) { return _MapCatalogServer(server); });
+}
+
+/**
+ * List every catalogue server regardless of status — the org-admin governance view.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @returns All catalogue rows in newest-first order.
+ */
+export async function listAllServers(prisma: PrismaClient): Promise<McpCatalogServer[]>
+{
+  const servers = await prisma.mcpServer.findMany({ orderBy: { createdAt: "desc" } });
+  return servers.map(function _map(server) { return _MapCatalogServer(server); });
+}
+
+/**
+ * List the servers the calling user has installed.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param userId - Stable caller identifier.
+ * @returns The caller's install rows in wire shape.
+ */
+export async function listInstalled(prisma: PrismaClient, userId: string): Promise<McpInstalled[]>
+{
+  const installs = await prisma.mcpServerInstall.findMany({ where: { userId }, orderBy: { createdAt: "asc" } });
+  return installs.map(function _map(install) { return _MapInstalled(install); });
+}
+
+/**
+ * Install a catalogue server for the calling user (idempotent per user+server).
+ *
+ * The initial connection state is derived from the server type: a multi-user
+ * server is satisfied by the org-wide shared key immediately (`shared-key`),
+ * while every other type starts out needing a per-user credential.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param userId - Stable caller identifier.
+ * @param serverId - Catalogue server identifier to install.
+ * @returns The install row, or null when the server does not exist.
+ */
+export async function installServer(prisma: PrismaClient, userId: string, serverId: string): Promise<McpInstalled | null>
+{
+  // 1. Confirm the server exists so a bad identifier reads as 404 rather than a
+  //    dangling install row pointing at nothing.
+  const server = await prisma.mcpServer.findUnique({ where: { id: serverId }, select: { serverType: true } });
+  if (!server)
+  {
+    return null;
+  }
+
+  // 2. Multi-user servers are brokered by an org-wide shared key, so the install
+  //    is connected on creation; every other type must author a credential first.
+  const initialStatus = server.serverType === _PRISMA_SERVER_TYPE.MultiUser
+    ? _PRISMA_CONNECTION_STATUS.SharedKey
+    : _PRISMA_CONNECTION_STATUS.NeedsCredential;
+
+  // 3. Upsert so a repeated install is idempotent and never duplicates the row,
+  //    leaving an already-connected install untouched.
+  const install = await prisma.mcpServerInstall.upsert({
+    where: { mcpServerId_userId: { mcpServerId: serverId, userId } },
+    create: { mcpServerId: serverId, userId, connectionStatus: initialStatus as Prisma.McpServerInstallCreateInput["connectionStatus"] },
+    update: {},
+  });
+
+  await _AuditInstall(prisma, "Created", serverId, userId, `MCP server ${serverId} installed for ${userId}`);
+  return _MapInstalled(install);
+}
+
+/**
+ * Uninstall a server for the calling user, clearing any stored credential handle.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param userId - Stable caller identifier.
+ * @param serverId - Installed server identifier.
+ * @returns True when an install was removed, false when none existed.
+ */
+export async function uninstallServer(prisma: PrismaClient, userId: string, serverId: string): Promise<boolean>
+{
+  // 1. Scope the delete to the caller's own install so one user cannot uninstall
+  //    another's; a missing row reads as a no-op 404 at the route.
+  const result = await prisma.mcpServerInstall.deleteMany({ where: { mcpServerId: serverId, userId } });
+  if (result.count === 0)
+  {
+    return false;
+  }
+
+  // 2. Deleting the row drops the credentialRef custody handle with it, so no
+  //    further brokering can occur for this user+server.
+  await _AuditInstall(prisma, "Deleted", serverId, userId, `MCP server ${serverId} uninstalled for ${userId}`);
+  return true;
+}
+
+/**
+ * Store a per-user credential (WRITE-ONLY) and mark the install connected.
+ *
+ * The submitted `values` are never persisted as plaintext and never returned: a
+ * minted opaque `credentialRef` is the only thing kept, standing in for the secret
+ * the gateway plane (Obot) brokers. No response serialises credential material.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param userId - Stable caller identifier.
+ * @param serverId - Installed server identifier.
+ * @returns The updated install row, or null when no install exists for the caller.
+ */
+export async function setCredential(prisma: PrismaClient, userId: string, serverId: string): Promise<McpInstalled | null>
+{
+  // 1. Require an existing install so credential authoring follows install; a
+  //    missing install reads as 404 rather than silently creating one.
+  const existing = await prisma.mcpServerInstall.findUnique({ where: { mcpServerId_userId: { mcpServerId: serverId, userId } }, select: { id: true } });
+  if (!existing)
+  {
+    return null;
+  }
+
+  // 2. Mint an opaque custody handle; the raw values are discarded here and the
+  //    secret is brokered by the gateway plane, so nothing secret touches the DB.
+  const credentialRef = `cred_${randomBytes(18).toString("hex")}`;
+
+  // 3. Flip the install to connected and attach the handle.
+  const install = await prisma.mcpServerInstall.update({
+    where: { mcpServerId_userId: { mcpServerId: serverId, userId } },
+    data: { credentialRef, connectionStatus: _PRISMA_CONNECTION_STATUS.Connected as Prisma.McpServerInstallUpdateInput["connectionStatus"] },
+  });
+
+  await _AuditInstall(prisma, "Updated", serverId, userId, `MCP credential connected for ${userId} on server ${serverId}`);
+  return _MapInstalled(install);
+}
+
+/**
+ * Clear a per-user credential, returning the install to `needs-credential`.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param userId - Stable caller identifier.
+ * @param serverId - Installed server identifier.
+ * @returns The updated install row, or null when no install exists for the caller.
+ */
+export async function clearCredential(prisma: PrismaClient, userId: string, serverId: string): Promise<McpInstalled | null>
+{
+  return _TransitionInstall(prisma, userId, serverId, _PRISMA_CONNECTION_STATUS.NeedsCredential, true, `MCP credential cleared for ${userId} on server ${serverId}`);
+}
+
+/**
+ * Mark a remote-OAuth install connected after a successful OAuth handshake.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param userId - Stable caller identifier.
+ * @param serverId - Installed server identifier.
+ * @returns The updated install row, or null when no install exists for the caller.
+ */
+export async function connectOauth(prisma: PrismaClient, userId: string, serverId: string): Promise<McpInstalled | null>
+{
+  // 1. Require an existing install so the OAuth callback targets a real row.
+  const existing = await prisma.mcpServerInstall.findUnique({ where: { mcpServerId_userId: { mcpServerId: serverId, userId } }, select: { id: true } });
+  if (!existing)
+  {
+    return null;
+  }
+
+  // 2. Mint a custody handle for the brokered OAuth grant and flip to connected;
+  //    the grant material lives in the gateway plane, not here.
+  const credentialRef = `oauth_${randomBytes(18).toString("hex")}`;
+  const install = await prisma.mcpServerInstall.update({
+    where: { mcpServerId_userId: { mcpServerId: serverId, userId } },
+    data: { credentialRef, connectionStatus: _PRISMA_CONNECTION_STATUS.OauthConnected as Prisma.McpServerInstallUpdateInput["connectionStatus"] },
+  });
+
+  await _AuditInstall(prisma, "Updated", serverId, userId, `MCP OAuth connected for ${userId} on server ${serverId}`);
+  return _MapInstalled(install);
+}
+
+/**
+ * Disconnect a remote-OAuth install, returning it to `needs-credential`.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param userId - Stable caller identifier.
+ * @param serverId - Installed server identifier.
+ * @returns The updated install row, or null when no install exists for the caller.
+ */
+export async function disconnectOauth(prisma: PrismaClient, userId: string, serverId: string): Promise<McpInstalled | null>
+{
+  return _TransitionInstall(prisma, userId, serverId, _PRISMA_CONNECTION_STATUS.NeedsCredential, true, `MCP OAuth disconnected for ${userId} on server ${serverId}`);
+}
+
+/**
+ * Move a server through the governance lifecycle by setting its approval status.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param serverId - Catalogue server identifier.
+ * @param target - The Prisma approval-status value to set.
+ * @param message - Audit message describing the transition.
+ * @returns The updated server in wire shape, or null when it does not exist.
+ */
+async function _SetApprovalStatus(prisma: PrismaClient, serverId: string, target: string, message: string): Promise<McpCatalogServer | null>
+{
+  // 1. Confirm the server exists so a bad identifier reads as 404, not a write.
+  const existing = await prisma.mcpServer.findUnique({ where: { id: serverId }, select: { id: true } });
+  if (!existing)
+  {
+    return null;
+  }
+
+  // 2. Set the target status and record an audit entry so governance decisions
+  //    stay traceable in operator history.
+  const server = await prisma.mcpServer.update({
+    where: { id: serverId },
+    data: { approvalStatus: target as Prisma.McpServerUpdateInput["approvalStatus"] },
+  });
+  await prisma.auditEntry.create({ data: { action: "Updated", resource: `McpServer/${serverId}`, message } });
+
+  return _MapCatalogServer(server);
+}
+
+/**
+ * Approve a server (pending-review → approved).
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param serverId - Catalogue server identifier.
+ * @returns The updated server, or null when it does not exist.
+ */
+export async function approveServer(prisma: PrismaClient, serverId: string): Promise<McpCatalogServer | null>
+{
+  return _SetApprovalStatus(prisma, serverId, _PRISMA_APPROVAL_STATUS.Approved, `MCP server ${serverId} approved`);
+}
+
+/**
+ * Publish a server (approved → published) so entitled callers can install it.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param serverId - Catalogue server identifier.
+ * @returns The updated server, or null when it does not exist.
+ */
+export async function publishServer(prisma: PrismaClient, serverId: string): Promise<McpCatalogServer | null>
+{
+  return _SetApprovalStatus(prisma, serverId, _PRISMA_APPROVAL_STATUS.Published, `MCP server ${serverId} published`);
+}
+
+/**
+ * Reject a server (→ disabled), removing it from the user-facing catalogue.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param serverId - Catalogue server identifier.
+ * @returns The updated server, or null when it does not exist.
+ */
+export async function rejectServer(prisma: PrismaClient, serverId: string): Promise<McpCatalogServer | null>
+{
+  return _SetApprovalStatus(prisma, serverId, _PRISMA_APPROVAL_STATUS.Disabled, `MCP server ${serverId} rejected`);
+}
+
+/**
+ * Toggle a server's availability (true → published, false → disabled).
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param serverId - Catalogue server identifier.
+ * @param enabled - True publishes; false disables.
+ * @returns The updated server, or null when it does not exist.
+ */
+export async function setServerEnabled(prisma: PrismaClient, serverId: string, enabled: boolean): Promise<McpCatalogServer | null>
+{
+  const target = enabled ? _PRISMA_APPROVAL_STATUS.Published : _PRISMA_APPROVAL_STATUS.Disabled;
+  return _SetApprovalStatus(prisma, serverId, target, `MCP server ${serverId} ${enabled ? "enabled" : "disabled"}`);
+}
+
+/**
+ * Read a server's access policy, projecting entitled users into the wire shape.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param serverId - Catalogue server identifier.
+ * @returns The access policy (defaults when none is authored), or null when the server is absent.
+ */
+export async function getAccessPolicy(prisma: PrismaClient, serverId: string): Promise<McpAccessPolicy | null>
+{
+  // 1. Confirm the server exists so a bad identifier reads as 404, not an empty policy.
+  const server = await prisma.mcpServer.findUnique({
+    where: { id: serverId },
+    include: { accessPolicy: { include: { users: true } } },
+  });
+  if (!server)
+  {
+    return null;
+  }
+
+  // 2. Project the persisted policy (or empty defaults) into the wire shape.
+  return _MapAccessPolicy(serverId, server.accessPolicy);
+}
+
+/**
+ * Replace a server's access policy wholesale (admin authoritative write).
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param serverId - Catalogue server identifier.
+ * @param body - Full replacement policy (everyoneInOrg + group ids + user ids).
+ * @returns The persisted policy in wire shape, or null when the server is absent.
+ */
+export async function setAccessPolicy(prisma: PrismaClient, serverId: string, body: McpAccessPolicyRequest): Promise<McpAccessPolicy | null>
+{
+  // 1. Confirm the server exists before authoring a policy against it.
+  const server = await prisma.mcpServer.findUnique({ where: { id: serverId }, select: { id: true } });
+  if (!server)
+  {
+    return null;
+  }
+
+  // 2. Normalise the submitted ids so blank/duplicate entries cannot inflate the
+  //    entitlement lists.
+  const groups = _NormalizeIds(body.groups);
+  const userIds = _NormalizeIds(body.users);
+
+  // 3. Upsert the policy parent, then replace its user rows wholesale because the
+  //    submitted payload is treated as authoritative.
+  const policy = await prisma.mcpServerAccessPolicy.upsert({
+    where: { mcpServerId: serverId },
+    create: { mcpServerId: serverId, everyoneInOrg: body.everyoneInOrg, groups },
+    update: { everyoneInOrg: body.everyoneInOrg, groups },
+  });
+  await prisma.mcpServerAccessUser.deleteMany({ where: { accessPolicyId: policy.id } });
+  if (userIds.length > 0)
+  {
+    await prisma.mcpServerAccessUser.createMany({
+      data: userIds.map(function _row(userId) { return { accessPolicyId: policy.id, userId }; }),
+    });
+  }
+
+  // 4. Record an audit entry so access changes stay traceable.
+  await prisma.auditEntry.create({ data: { action: "Updated", resource: `McpServer/${serverId}`, message: `MCP server ${serverId} access policy updated` } });
+
+  return _MapAccessPolicy(serverId, { everyoneInOrg: body.everyoneInOrg, groups, users: userIds.map(function _u(userId) { return { userId }; }) });
+}
+
+/**
+ * Build the selectable universe of users and groups for the admin access editor.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @returns Distinct entitled users plus all group names.
+ */
+export async function getDirectory(prisma: PrismaClient): Promise<Directory>
+{
+  // 1. Load every group (for its name) and its JSON membership list.
+  const groups = await prisma.group.findMany({ orderBy: { name: "asc" }, select: { name: true, members: true } });
+
+  // 2. Also fold in any user already entitled via an access policy so directly
+  //    granted users remain selectable even if not in a group.
+  const accessUsers = await prisma.mcpServerAccessUser.findMany({ select: { userId: true } });
+
+  // 3. Collect distinct principal identifiers from both sources.
+  const userIds = new Set<string>();
+  for (const group of groups)
+  {
+    for (const member of _NormalizeMembers(group.members))
+    {
+      userIds.add(member);
+    }
+  }
+  for (const accessUser of accessUsers)
+  {
+    userIds.add(accessUser.userId);
+  }
+
+  return {
+    users: ___SortBy(Array.from(userIds)).map(function _u(userId) { return _MapEntitledUser(userId); }),
+    groups: groups.map(function _g(group) { return group.name; }),
+  };
+}
+
+/**
+ * Resolve a per-mode install transition, optionally clearing the credential handle.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param userId - Stable caller identifier.
+ * @param serverId - Installed server identifier.
+ * @param status - Target Prisma connection-status value.
+ * @param clearRef - When true, the credentialRef custody handle is dropped.
+ * @param message - Audit message describing the transition.
+ * @returns The updated install row, or null when no install exists for the caller.
+ */
+async function _TransitionInstall(prisma: PrismaClient, userId: string, serverId: string, status: string, clearRef: boolean, message: string): Promise<McpInstalled | null>
+{
+  // 1. Require an existing install so the transition targets a real row.
+  const existing = await prisma.mcpServerInstall.findUnique({ where: { mcpServerId_userId: { mcpServerId: serverId, userId } }, select: { id: true } });
+  if (!existing)
+  {
+    return null;
+  }
+
+  // 2. Apply the status change, dropping the custody handle when the connection
+  //    is being torn down so no stale broker reference survives.
+  const install = await prisma.mcpServerInstall.update({
+    where: { mcpServerId_userId: { mcpServerId: serverId, userId } },
+    data: { connectionStatus: status as Prisma.McpServerInstallUpdateInput["connectionStatus"], ...(clearRef ? { credentialRef: null } : {}) },
+  });
+
+  await _AuditInstall(prisma, "Updated", serverId, userId, message);
+  return _MapInstalled(install);
+}
+
+/**
+ * Append an audit entry for a per-user install mutation.
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @param action - Audit action label.
+ * @param serverId - Installed server identifier.
+ * @param userId - Stable caller identifier.
+ * @param message - Human-readable audit message.
+ */
+async function _AuditInstall(prisma: PrismaClient, action: string, serverId: string, userId: string, message: string): Promise<void>
+{
+  await prisma.auditEntry.create({ data: { action, resource: `McpServerInstall/${serverId}:${userId}`, message } });
+}
+
+/**
+ * Decide whether a caller is entitled to a published server.
+ *
+ * @param server - Server row with its access policy + entitled users loaded.
+ * @param caller - Identity + entitlement context of the calling user.
+ * @returns True when the caller may see / install the server.
+ */
+function _IsEntitled(server: _McpServerWithPolicyRow, caller: McpOperatorCaller): boolean
+{
+  // 1. Dev-open posture bypasses entitlement so a local install isn't locked out.
+  if (caller.devOpen)
+  {
+    return true;
+  }
+
+  // 2. No policy authored → fail closed; an admin must grant access explicitly.
+  const policy = server.accessPolicy;
+  if (!policy)
+  {
+    return false;
+  }
+
+  // 3. Org-wide grant short-circuits the per-user / per-group lists.
+  if (policy.everyoneInOrg)
+  {
+    return true;
+  }
+
+  // 4. Direct user grant, then group-claim intersection.
+  if (policy.users.some(function _u(user) { return user.userId === caller.userId; }))
+  {
+    return true;
+  }
+
+  return policy.groups.some(function _g(group) { return caller.groups.includes(group); });
+}
+
+/**
+ * Map a server row into the operator catalogue wire shape.
+ *
+ * @param server - Persisted server row.
+ * @returns Normalized catalogue server payload.
+ */
+function _MapCatalogServer(server: Prisma.McpServerGetPayload<object>): McpCatalogServer
+{
+  return {
+    id: server.id,
+    name: server.name,
+    description: server.description,
+    publisher: server.publisher ?? undefined,
+    glyph: server.glyph ?? undefined,
+    type: _TYPE_BY_PRISMA[server.serverType],
+    approvalStatus: _APPROVAL_BY_PRISMA[server.approvalStatus],
+    credentialSchema: _NormalizeCredentialSchema(server.credentialSchema),
+    entitlementSummary: server.entitlementSummary ?? undefined,
+  };
+}
+
+/**
+ * Map a per-user install row into the operator wire shape.
+ *
+ * Deliberately omits `credentialRef`: the custody handle is never serialised.
+ *
+ * @param install - Persisted install row.
+ * @returns Normalized install payload.
+ */
+function _MapInstalled(install: _McpInstallRow): McpInstalled
+{
+  return {
+    serverId: install.mcpServerId,
+    connectionStatus: _CONNECTION_BY_PRISMA[install.connectionStatus],
+    lastUsed: install.lastUsedAt ? install.lastUsedAt.toISOString() : null,
+    connectedAccount: install.connectedAccount ?? undefined,
+  };
+}
+
+/**
+ * Project an access policy (or empty defaults) into the wire shape.
+ *
+ * @param serverId - Governed server identifier.
+ * @param policy - Persisted policy with entitled users, or null/partial.
+ * @returns Normalized access-policy payload.
+ */
+function _MapAccessPolicy(serverId: string, policy: { everyoneInOrg: boolean; groups: string[]; users: { userId: string }[] } | null): McpAccessPolicy
+{
+  return {
+    serverId,
+    everyoneInOrg: policy?.everyoneInOrg ?? false,
+    groups: policy?.groups ?? [],
+    users: (policy?.users ?? []).map(function _u(user) { return _MapEntitledUser(user.userId); }),
+  };
+}
+
+/**
+ * Derive an EntitledUser display projection from a stable identifier.
+ *
+ * @param userId - Stable principal identifier (sub or email).
+ * @returns Display name, initials, and a deterministic avatar colour.
+ */
+function _MapEntitledUser(userId: string): EntitledUser
+{
+  // 1. Prefer the local-part of an email for the display name; fall back to the id.
+  const localPart = userId.includes("@") ? userId.slice(0, userId.indexOf("@")) : userId;
+  const name = localPart.length > 0 ? localPart : userId;
+
+  // 2. Build two-letter initials from word boundaries in the name.
+  const words = name.split(/[\s._-]+/).filter(function _nonEmpty(word) { return word.length > 0; });
+  const initials = (words.length >= 2 ? `${words[0][0]}${words[1][0]}` : name.slice(0, 2)).toUpperCase();
+
+  // 3. Pick a stable palette colour from a simple checksum of the identifier.
+  let checksum = 0;
+  for (let index = 0; index < userId.length; index += 1)
+  {
+    checksum = (checksum + userId.charCodeAt(index)) % _AVATAR_COLORS.length;
+  }
+
+  return { id: userId, name, initials, color: _AVATAR_COLORS[checksum] };
+}
+
+/**
+ * Parse the persisted credential-schema JSON into typed fields.
+ *
+ * @param value - Raw JSON value from the server row.
+ * @returns Credential fields, or an empty array when the value is malformed.
+ */
+function _NormalizeCredentialSchema(value: Prisma.JsonValue): CredentialField[]
+{
+  if (!Array.isArray(value))
+  {
+    return [];
+  }
+
+  const fields: CredentialField[] = [];
+  for (const entry of value)
+  {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry))
+    {
+      continue;
+    }
+
+    const record = entry as Record<string, unknown>;
+    if (typeof record.key !== "string" || typeof record.label !== "string")
+    {
+      continue;
+    }
+
+    fields.push({
+      key: record.key,
+      label: record.label,
+      required: record.required === true,
+      sensitive: record.sensitive === true,
+      ...(typeof record.placeholder === "string" ? { placeholder: record.placeholder } : {}),
+      ...(typeof record.hint === "string" ? { hint: record.hint } : {}),
+    });
+  }
+
+  return fields;
+}
+
+/**
+ * Normalize a list of identifiers: trim, drop blanks, de-duplicate, sort.
+ *
+ * @param values - Raw identifier list from a request body.
+ * @returns Canonical identifier list.
+ */
+function _NormalizeIds(values: string[] | undefined): string[]
+{
+  if (!Array.isArray(values))
+  {
+    return [];
+  }
+
+  const unique = new Set<string>();
+  for (const value of values)
+  {
+    if (typeof value !== "string")
+    {
+      continue;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length > 0)
+    {
+      unique.add(trimmed);
+    }
+  }
+
+  return ___SortBy(Array.from(unique));
+}
+
+/**
+ * Normalize a group's JSON membership list into trimmed principal identifiers.
+ *
+ * @param members - Raw JSON value from the group row.
+ * @returns Distinct, sorted principal identifiers.
+ */
+function _NormalizeMembers(members: Prisma.JsonValue): string[]
+{
+  if (!Array.isArray(members))
+  {
+    return [];
+  }
+
+  const unique = new Set<string>();
+  for (const member of members)
+  {
+    if (typeof member !== "string")
+    {
+      continue;
+    }
+
+    const trimmed = member.trim();
+    if (trimmed.length > 0)
+    {
+      unique.add(trimmed);
+    }
+  }
+
+  return Array.from(unique);
+}

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -164,6 +164,80 @@ const McpServerSchema = {
   },
 };
 
+const CredentialFieldSchema = {
+  type: "object" as const,
+  required: ["key", "label", "required", "sensitive"],
+  properties: {
+    key: { type: "string", description: "Stable key the value is submitted under." },
+    label: { type: "string", description: "Human-readable field label." },
+    required: { type: "boolean", description: "Whether the field must be supplied." },
+    sensitive: { type: "boolean", description: "Whether the value is secret (masked, never echoed back)." },
+    placeholder: { type: "string", description: "Optional input placeholder." },
+    hint: { type: "string", description: "Optional helper hint." },
+  },
+};
+
+const McpCatalogServerSchema = {
+  type: "object" as const,
+  required: ["id"],
+  description: "A catalogue server as exposed by the operator API (distinct from the registry McpServer). Every field beyond id is optional so the same shape serves the entitled user catalogue and the admin governance view.",
+  properties: {
+    id: { type: "string" },
+    name: { type: "string" },
+    description: { type: "string" },
+    publisher: { type: "string" },
+    glyph: { type: "string" },
+    type: { type: "string", enum: ["single-user", "multi-user", "remote-oauth"], description: "Consumption shape; decides the credential-connect flow." },
+    approvalStatus: { type: "string", enum: ["pending-review", "approved", "published", "disabled"], description: "Governance lifecycle status." },
+    credentialSchema: { type: "array", items: { $ref: "#/components/schemas/CredentialField" } },
+    entitlementSummary: { type: "string", description: "Human-readable summary of who is entitled (admin view)." },
+  },
+};
+
+const McpInstalledSchema = {
+  type: "object" as const,
+  required: ["serverId"],
+  description: "A server installed by the calling user. Never carries credential material — only the connection status and a non-secret account label.",
+  properties: {
+    serverId: { type: "string" },
+    connectionStatus: { type: "string", enum: ["needs-credential", "activating", "connected", "oauth-connected", "shared-key", "activation-failed"] },
+    lastUsed: { type: ["string", "null"], format: "date-time", description: "ISO-8601 timestamp of last use, or null when never used." },
+    connectedAccount: { type: "string", description: "Non-secret display label of the connected account." },
+  },
+};
+
+const EntitledUserSchema = {
+  type: "object" as const,
+  required: ["id", "name", "initials", "color"],
+  properties: {
+    id: { type: "string", description: "Stable user identifier (sub or email)." },
+    name: { type: "string", description: "Display name." },
+    initials: { type: "string", description: "Two-letter initials derived from the name." },
+    color: { type: "string", description: "Deterministic avatar colour derived from the identifier." },
+  },
+};
+
+const McpAccessPolicySchema = {
+  type: "object" as const,
+  required: ["serverId"],
+  properties: {
+    serverId: { type: "string" },
+    everyoneInOrg: { type: "boolean", description: "When true, every caller in the org is entitled (lists ignored)." },
+    groups: { type: "array", items: { type: "string" }, description: "Entitled group identifiers / names." },
+    users: { type: "array", items: { $ref: "#/components/schemas/EntitledUser" } },
+  },
+};
+
+const McpDirectorySchema = {
+  type: "object" as const,
+  required: ["users", "groups"],
+  description: "The selectable universe of users and groups for the admin access editor.",
+  properties: {
+    users: { type: "array", items: { $ref: "#/components/schemas/EntitledUser" } },
+    groups: { type: "array", items: { type: "string" } },
+  },
+};
+
 const ClusterTenantResourceQuotaSchema = {
   type: "object" as const,
   properties: {
@@ -660,6 +734,12 @@ export const spec = {
       Policy: PolicySchema,
       McpServer: McpServerSchema,
       McpServerCredential: McpServerCredentialSchema,
+      McpCatalogServer: McpCatalogServerSchema,
+      CredentialField: CredentialFieldSchema,
+      McpInstalled: McpInstalledSchema,
+      McpAccessPolicy: McpAccessPolicySchema,
+      EntitledUser: EntitledUserSchema,
+      McpDirectory: McpDirectorySchema,
       ClusterTenant: ClusterTenantSchema,
       ClusterTenantWrite: ClusterTenantWriteSchema,
       ClusterTenantUpdate: ClusterTenantUpdateSchema,
@@ -1463,6 +1543,226 @@ export const spec = {
         responses: {
           200: ok("Credential deleted.", { type: "object", properties: { id: { type: "string" }, status: { type: "string" } } }),
           404: notFound("MCP server or credential not found."),
+        },
+      },
+    },
+
+    // ------------------------------------------------------------------
+    // MCP Operator API — catalogue / install / credential-connect (user-facing)
+    // + governance + access policy (org-admin gated). Layered on /mcp-servers.
+    // ------------------------------------------------------------------
+
+    "/mcp/catalog": {
+      get: {
+        operationId: "listMcpCatalog",
+        summary: "List the published MCP servers the calling user is entitled to",
+        tags: ["MCP Operator"],
+        responses: {
+          200: ok("Entitlement-scoped catalogue.", { type: "array", items: { $ref: "#/components/schemas/McpCatalogServer" } }),
+        },
+      },
+    },
+
+    "/mcp/installed": {
+      get: {
+        operationId: "listMcpInstalled",
+        summary: "List the servers the calling user has installed",
+        tags: ["MCP Operator"],
+        responses: {
+          200: ok("Install list.", { type: "array", items: { $ref: "#/components/schemas/McpInstalled" } }),
+        },
+      },
+      post: {
+        operationId: "installMcpServer",
+        summary: "Install a catalogue server for the calling user",
+        tags: ["MCP Operator"],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["serverId"], properties: { serverId: { type: "string" } } } } },
+        },
+        responses: {
+          201: created("Server installed.", { $ref: "#/components/schemas/McpInstalled" }),
+          400: badRequest("serverId is required."),
+          404: notFound("MCP server not found."),
+        },
+      },
+    },
+
+    "/mcp/installed/{serverId}": {
+      delete: {
+        operationId: "uninstallMcpServer",
+        summary: "Uninstall a server for the calling user (clears the stored credential)",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "serverId", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          204: { description: "Server uninstalled." },
+          404: notFound("MCP install not found."),
+        },
+      },
+    },
+
+    "/mcp/installed/{serverId}/credential": {
+      put: {
+        operationId: "setMcpCredential",
+        summary: "Author a per-user credential (write-only) and mark the install connected",
+        description: "The submitted values are write-only: stored server-side as an opaque custody handle and NEVER returned by any response.",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "serverId", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["values"], properties: { values: { type: "object", additionalProperties: { type: "string" }, description: "Field values keyed by CredentialField.key. Write-only — never echoed back." } } } } },
+        },
+        responses: {
+          200: ok("Credential connected.", { $ref: "#/components/schemas/McpInstalled" }),
+          404: notFound("MCP install not found."),
+        },
+      },
+      delete: {
+        operationId: "clearMcpCredential",
+        summary: "Clear a per-user credential, returning the install to needs-credential",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "serverId", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("Credential cleared.", { $ref: "#/components/schemas/McpInstalled" }),
+          404: notFound("MCP install not found."),
+        },
+      },
+    },
+
+    "/mcp/installed/{serverId}/oauth": {
+      post: {
+        operationId: "connectMcpOauth",
+        summary: "Mark a remote-OAuth install connected after a successful handshake",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "serverId", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("OAuth connected.", { $ref: "#/components/schemas/McpInstalled" }),
+          404: notFound("MCP install not found."),
+        },
+      },
+      delete: {
+        operationId: "disconnectMcpOauth",
+        summary: "Disconnect a remote-OAuth install, returning it to needs-credential",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "serverId", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("OAuth disconnected.", { $ref: "#/components/schemas/McpInstalled" }),
+          404: notFound("MCP install not found."),
+        },
+      },
+    },
+
+    "/mcp/servers": {
+      get: {
+        operationId: "listMcpGovernanceServers",
+        summary: "List every catalogue server regardless of status (org-admin governance view)",
+        tags: ["MCP Operator"],
+        responses: {
+          200: ok("All catalogue servers.", { type: "array", items: { $ref: "#/components/schemas/McpCatalogServer" } }),
+          403: { description: "Caller is not an organisation admin.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+        },
+      },
+    },
+
+    "/mcp/servers/{id}/approve": {
+      post: {
+        operationId: "approveMcpServer",
+        summary: "Approve a server (pending-review → approved). Org-admin only",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("Server approved.", { $ref: "#/components/schemas/McpCatalogServer" }),
+          403: { description: "Caller is not an organisation admin.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          404: notFound("MCP server not found."),
+        },
+      },
+    },
+
+    "/mcp/servers/{id}/publish": {
+      post: {
+        operationId: "publishMcpServer",
+        summary: "Publish a server (approved → published). Org-admin only",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("Server published.", { $ref: "#/components/schemas/McpCatalogServer" }),
+          403: { description: "Caller is not an organisation admin.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          404: notFound("MCP server not found."),
+        },
+      },
+    },
+
+    "/mcp/servers/{id}/reject": {
+      post: {
+        operationId: "rejectMcpServer",
+        summary: "Reject a server (→ disabled). Org-admin only",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("Server rejected.", { $ref: "#/components/schemas/McpCatalogServer" }),
+          403: { description: "Caller is not an organisation admin.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          404: notFound("MCP server not found."),
+        },
+      },
+    },
+
+    "/mcp/servers/{id}/enabled": {
+      post: {
+        operationId: "setMcpServerEnabled",
+        summary: "Toggle a server's availability (true → published, false → disabled). Org-admin only",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["enabled"], properties: { enabled: { type: "boolean" } } } } },
+        },
+        responses: {
+          200: ok("Server availability updated.", { $ref: "#/components/schemas/McpCatalogServer" }),
+          400: badRequest("enabled (boolean) is required."),
+          403: { description: "Caller is not an organisation admin.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          404: notFound("MCP server not found."),
+        },
+      },
+    },
+
+    "/mcp/servers/{id}/access": {
+      get: {
+        operationId: "getMcpAccessPolicy",
+        summary: "Read a server's access policy. Org-admin only",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("Access policy.", { $ref: "#/components/schemas/McpAccessPolicy" }),
+          403: { description: "Caller is not an organisation admin.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          404: notFound("MCP server not found."),
+        },
+      },
+      put: {
+        operationId: "setMcpAccessPolicy",
+        summary: "Replace a server's access policy wholesale. Org-admin only",
+        tags: ["MCP Operator"],
+        parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { type: "object", required: ["everyoneInOrg", "groups", "users"], properties: { everyoneInOrg: { type: "boolean" }, groups: { type: "array", items: { type: "string" } }, users: { type: "array", items: { type: "string" }, description: "Entitled user identifiers." } } } } },
+        },
+        responses: {
+          200: ok("Access policy updated.", { $ref: "#/components/schemas/McpAccessPolicy" }),
+          400: badRequest("everyoneInOrg (boolean), groups (array), and users (array) are required."),
+          403: { description: "Caller is not an organisation admin.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+          404: notFound("MCP server not found."),
+        },
+      },
+    },
+
+    "/mcp/directory": {
+      get: {
+        operationId: "getMcpDirectory",
+        summary: "List the selectable users and groups for the access editor. Org-admin only",
+        tags: ["MCP Operator"],
+        responses: {
+          200: ok("Directory.", { $ref: "#/components/schemas/McpDirectory" }),
+          403: { description: "Caller is not an organisation admin.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
         },
       },
     },

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -10,6 +10,7 @@ import { _RegisterInternalBundles } from "./routes/internal/skill-bundles.js";
 import { _RegisterInternalTenantContract } from "./routes/internal/tenant-contract.js";
 import { _RegisterInternalTenantModels } from "./routes/internal/tenant-models.js";
 import { _RegisterInternalParticipation } from "./routes/internal/participation.js";
+import { mcpOperatorRouter } from "./routes/mcp-operator.js";
 import { mcpServersRouter } from "./routes/mcp-servers.js";
 import { metricsRouter } from "./routes/metrics.js";
 import { openapiRouter } from "./routes/openapi-route.js";
@@ -106,6 +107,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/token-usage", tokenUsageRouter(prisma));
   app.use("/api/v1/groups", groupsRouter(prisma));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
+  app.use("/api/v1/mcp", mcpOperatorRouter(prisma));
   app.use("/api/v1/skills/catalog", skillCatalogRouter(prisma, ociBundleStore));
   app.use("/api/v1/skills/posture", skillModelPostureRouter(prisma));
   app.use("/api/v1/model-routing/defaults", modelRoutingDefaultsRouter(prisma));

--- a/apps/control-plane/src/routes/mcp-operator.ts
+++ b/apps/control-plane/src/routes/mcp-operator.ts
@@ -1,0 +1,254 @@
+import { Router, type Request, type Response } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { approveServer, clearCredential, connectOauth, disconnectOauth, getAccessPolicy, getDirectory, installServer, listAllServers, listEntitledCatalog, listInstalled, publishServer, rejectServer, setAccessPolicy, setCredential, setServerEnabled, uninstallServer, type McpOperatorCaller } from "../features/mcp-operator/mcp-operator.logic.js";
+import { _IsDevAuthMode } from "../infra/auth/auth-mode.js";
+import { _RequireOrgAdmin } from "../infra/middleware/require-org-admin.js";
+import type { McpAccessPolicyRequest, McpEnabledRequest, McpInstallRequest } from "./mcp-operator.types.js";
+
+/**
+ * Operator-API router for the MCP consumption + governance surface (`/api/v1/mcp/*`).
+ *
+ * Layers the entitlement-scoped catalogue, per-user installs / credential connect,
+ * and org-admin governance + access-policy endpoints ON TOP of the existing
+ * `/mcp-servers` admin registry (which stays as-is). Two authorization postures:
+ *
+ * - **User-facing** (`/catalog`, `/installed/*`) — scoped to the calling user via
+ *   {@link _ResolveCaller}; entitlement filtering decides catalogue visibility.
+ * - **Admin** (`/servers/*`, `/directory`) — gated by `_RequireOrgAdmin`, matching
+ *   the registry's curate-is-an-admin-action posture (fail-open dev / fail-closed real auth).
+ *
+ * Custody: no response on any route serialises credential material — a connected
+ * install reports only its connection status (the secret is brokered by the gateway plane).
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @returns Configured Express router.
+ */
+export function mcpOperatorRouter(prisma: PrismaClient): Router
+{
+  const router = Router();
+
+  // -------------------------------------------------------------------------
+  // User-facing — entitlement-scoped catalogue + per-user installs
+  // -------------------------------------------------------------------------
+
+  /** List the published servers the calling user is entitled to. */
+  router.get("/catalog", async function _listCatalog(req, res)
+  {
+    res.json(await listEntitledCatalog(prisma, _ResolveCaller(req)));
+  });
+
+  /** List the servers the calling user has installed. */
+  router.get("/installed", async function _listInstalled(req, res)
+  {
+    res.json(await listInstalled(prisma, _ResolveCaller(req).userId));
+  });
+
+  /** Install a catalogue server for the calling user. */
+  router.post("/installed", async function _install(req, res)
+  {
+    const body = req.body as McpInstallRequest;
+    if (typeof body?.serverId !== "string" || body.serverId.trim().length === 0)
+    {
+      res.status(400).json({ error: "serverId is required", code: "VALIDATION_ERROR" });
+      return;
+    }
+
+    const installed = await installServer(prisma, _ResolveCaller(req).userId, body.serverId.trim());
+    if (!installed)
+    {
+      res.status(404).json({ error: "MCP server not found", code: "MCP_SERVER_NOT_FOUND" });
+      return;
+    }
+
+    res.status(201).json(installed);
+  });
+
+  /** Uninstall a server for the calling user; clears any stored credential. */
+  router.delete("/installed/:serverId", async function _uninstall(req: Request<{ serverId: string }>, res)
+  {
+    const removed = await uninstallServer(prisma, _ResolveCaller(req).userId, req.params.serverId);
+    if (!removed)
+    {
+      res.status(404).json({ error: "MCP install not found", code: "MCP_INSTALL_NOT_FOUND" });
+      return;
+    }
+
+    res.status(204).end();
+  });
+
+  /** Author a per-user credential (WRITE-ONLY) and mark the install connected. */
+  router.put("/installed/:serverId/credential", async function _setCredential(req: Request<{ serverId: string }>, res)
+  {
+    // The submitted `values` are accepted but never persisted as plaintext nor
+    // returned — setCredential mints an opaque custody handle in their place.
+    const installed = await setCredential(prisma, _ResolveCaller(req).userId, req.params.serverId);
+    _sendInstallOrNotFound(res, installed);
+  });
+
+  /** Clear a per-user credential, returning the install to needs-credential. */
+  router.delete("/installed/:serverId/credential", async function _clearCredential(req: Request<{ serverId: string }>, res)
+  {
+    const installed = await clearCredential(prisma, _ResolveCaller(req).userId, req.params.serverId);
+    _sendInstallOrNotFound(res, installed);
+  });
+
+  /** Mark a remote-OAuth install connected after a successful handshake. */
+  router.post("/installed/:serverId/oauth", async function _connectOauth(req: Request<{ serverId: string }>, res)
+  {
+    const installed = await connectOauth(prisma, _ResolveCaller(req).userId, req.params.serverId);
+    _sendInstallOrNotFound(res, installed);
+  });
+
+  /** Disconnect a remote-OAuth install, returning it to needs-credential. */
+  router.delete("/installed/:serverId/oauth", async function _disconnectOauth(req: Request<{ serverId: string }>, res)
+  {
+    const installed = await disconnectOauth(prisma, _ResolveCaller(req).userId, req.params.serverId);
+    _sendInstallOrNotFound(res, installed);
+  });
+
+  // -------------------------------------------------------------------------
+  // Admin — governance + access policy (org-admin gated)
+  // -------------------------------------------------------------------------
+
+  /** List every catalogue server regardless of status (governance view). Org-admin only. */
+  router.get("/servers", _RequireOrgAdmin(), async function _listServers(req, res)
+  {
+    res.json(await listAllServers(prisma));
+  });
+
+  /** Approve a server (pending-review → approved). Org-admin only. */
+  router.post("/servers/:id/approve", _RequireOrgAdmin(), async function _approve(req: Request<{ id: string }>, res)
+  {
+    _sendServerOrNotFound(res, await approveServer(prisma, req.params.id));
+  });
+
+  /** Publish a server (approved → published). Org-admin only. */
+  router.post("/servers/:id/publish", _RequireOrgAdmin(), async function _publish(req: Request<{ id: string }>, res)
+  {
+    _sendServerOrNotFound(res, await publishServer(prisma, req.params.id));
+  });
+
+  /** Reject a server (→ disabled). Org-admin only. */
+  router.post("/servers/:id/reject", _RequireOrgAdmin(), async function _reject(req: Request<{ id: string }>, res)
+  {
+    _sendServerOrNotFound(res, await rejectServer(prisma, req.params.id));
+  });
+
+  /** Toggle a server's availability (true → published, false → disabled). Org-admin only. */
+  router.post("/servers/:id/enabled", _RequireOrgAdmin(), async function _setEnabled(req: Request<{ id: string }>, res)
+  {
+    const body = req.body as McpEnabledRequest;
+    if (typeof body?.enabled !== "boolean")
+    {
+      res.status(400).json({ error: "enabled (boolean) is required", code: "VALIDATION_ERROR" });
+      return;
+    }
+
+    _sendServerOrNotFound(res, await setServerEnabled(prisma, req.params.id, body.enabled));
+  });
+
+  /** Read a server's access policy. Org-admin only. */
+  router.get("/servers/:id/access", _RequireOrgAdmin(), async function _getAccess(req: Request<{ id: string }>, res)
+  {
+    const policy = await getAccessPolicy(prisma, req.params.id);
+    if (!policy)
+    {
+      res.status(404).json({ error: "MCP server not found", code: "MCP_SERVER_NOT_FOUND" });
+      return;
+    }
+
+    res.json(policy);
+  });
+
+  /** Replace a server's access policy wholesale. Org-admin only. */
+  router.put("/servers/:id/access", _RequireOrgAdmin(), async function _setAccess(req: Request<{ id: string }>, res)
+  {
+    const body = req.body as McpAccessPolicyRequest;
+    if (typeof body?.everyoneInOrg !== "boolean" || !Array.isArray(body.groups) || !Array.isArray(body.users))
+    {
+      res.status(400).json({ error: "everyoneInOrg (boolean), groups (array), and users (array) are required", code: "VALIDATION_ERROR" });
+      return;
+    }
+
+    const policy = await setAccessPolicy(prisma, req.params.id, body);
+    if (!policy)
+    {
+      res.status(404).json({ error: "MCP server not found", code: "MCP_SERVER_NOT_FOUND" });
+      return;
+    }
+
+    res.json(policy);
+  });
+
+  /** List the selectable users and groups for the access editor. Org-admin only. */
+  router.get("/directory", _RequireOrgAdmin(), async function _directory(req, res)
+  {
+    res.json(await getDirectory(prisma));
+  });
+
+  return router;
+}
+
+/**
+ * Resolve the calling user's identity + entitlement context from the session.
+ *
+ * Mirrors the platform's fail-open dev posture: an established session uses the
+ * IdP-verified identity; an unauthenticated caller under dev-auth-mode is treated
+ * as dev-open (full catalogue), and otherwise as an unknown caller (fail closed).
+ *
+ * @param req - Incoming request carrying the optional auth session.
+ * @returns The resolved caller context.
+ */
+function _ResolveCaller(req: Request): McpOperatorCaller
+{
+  // 1. Established session — derive the stable id and group claims from the IdP.
+  const authUser = req.session?.authUser;
+  if (authUser)
+  {
+    return { userId: authUser.sub ?? authUser.email ?? "unknown", groups: authUser.groups ?? [], devOpen: false };
+  }
+
+  // 2. No session under dev-auth-mode — open the catalogue so local dev isn't locked out.
+  if (_IsDevAuthMode())
+  {
+    return { userId: "dev-user", groups: [], devOpen: true };
+  }
+
+  // 3. No session under real auth — fail closed (empty groups, not dev-open).
+  return { userId: "unknown", groups: [], devOpen: false };
+}
+
+/**
+ * Send an install response or a 404 when the install / server was absent.
+ *
+ * @param res - Express response.
+ * @param installed - Install payload, or null when not found.
+ */
+function _sendInstallOrNotFound(res: Response, installed: object | null): void
+{
+  if (!installed)
+  {
+    res.status(404).json({ error: "MCP install not found", code: "MCP_INSTALL_NOT_FOUND" });
+    return;
+  }
+
+  res.json(installed);
+}
+
+/**
+ * Send a server response or a 404 when the server was absent.
+ *
+ * @param res - Express response.
+ * @param server - Server payload, or null when not found.
+ */
+function _sendServerOrNotFound(res: Response, server: object | null): void
+{
+  if (!server)
+  {
+    res.status(404).json({ error: "MCP server not found", code: "MCP_SERVER_NOT_FOUND" });
+    return;
+  }
+
+  res.json(server);
+}

--- a/apps/control-plane/src/routes/mcp-operator.types.ts
+++ b/apps/control-plane/src/routes/mcp-operator.types.ts
@@ -1,0 +1,31 @@
+/** Request body for installing a catalogue server for the calling user. */
+export interface McpInstallRequest
+{
+  /** Identifier of the catalogue server to install. */
+  serverId: string;
+}
+
+/** Request body for authoring a per-user credential (write-only). */
+export interface McpCredentialRequest
+{
+  /** Field values keyed by {@link CredentialField.key}; stored server-side only, never returned. */
+  values: Record<string, string>;
+}
+
+/** Request body for the admin enable/disable toggle. */
+export interface McpEnabledRequest
+{
+  /** True publishes the server; false disables it. */
+  enabled: boolean;
+}
+
+/** Request body for replacing a server's access policy (admin). */
+export interface McpAccessPolicyRequest
+{
+  /** When true, every caller in the org is entitled (lists ignored). */
+  everyoneInOrg: boolean;
+  /** Entitled group identifiers / names. */
+  groups: string[];
+  /** Entitled user identifiers. */
+  users: string[];
+}

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -464,6 +464,217 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/mcp/catalog": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the published MCP servers the calling user is entitled to */
+        get: operations["listMcpCatalog"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/installed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the servers the calling user has installed */
+        get: operations["listMcpInstalled"];
+        put?: never;
+        /** Install a catalogue server for the calling user */
+        post: operations["installMcpServer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/installed/{serverId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Uninstall a server for the calling user (clears the stored credential) */
+        delete: operations["uninstallMcpServer"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/installed/{serverId}/credential": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /**
+         * Author a per-user credential (write-only) and mark the install connected
+         * @description The submitted values are write-only: stored server-side as an opaque custody handle and NEVER returned by any response.
+         */
+        put: operations["setMcpCredential"];
+        post?: never;
+        /** Clear a per-user credential, returning the install to needs-credential */
+        delete: operations["clearMcpCredential"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/installed/{serverId}/oauth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark a remote-OAuth install connected after a successful handshake */
+        post: operations["connectMcpOauth"];
+        /** Disconnect a remote-OAuth install, returning it to needs-credential */
+        delete: operations["disconnectMcpOauth"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/servers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List every catalogue server regardless of status (org-admin governance view) */
+        get: operations["listMcpGovernanceServers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/servers/{id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Approve a server (pending-review → approved). Org-admin only */
+        post: operations["approveMcpServer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/servers/{id}/publish": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Publish a server (approved → published). Org-admin only */
+        post: operations["publishMcpServer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/servers/{id}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reject a server (→ disabled). Org-admin only */
+        post: operations["rejectMcpServer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/servers/{id}/enabled": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Toggle a server's availability (true → published, false → disabled). Org-admin only */
+        post: operations["setMcpServerEnabled"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/servers/{id}/access": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read a server's access policy. Org-admin only */
+        get: operations["getMcpAccessPolicy"];
+        /** Replace a server's access policy wholesale. Org-admin only */
+        put: operations["setMcpAccessPolicy"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/directory": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the selectable users and groups for the access editor. Org-admin only */
+        get: operations["getMcpDirectory"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/groups": {
         parameters: {
             query?: never;
@@ -1199,10 +1410,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Exchange the current OIDC session for a short-lived token to the caller's OpenClaw pod
-         * @description Single sign-on across the control plane and the tenant pod: requires an established OIDC session (cookie) and returns a short-lived, audience-bound token minted via the Kubernetes TokenRequest API for the caller's tenant. The token targets the OpenClaw pod's session audience (reachable at `ingressHost`) — it is NOT an `obot-gateway` token; Obot is called only from inside the pod. The tenant is resolved solely from the session's verified email, so a caller cannot obtain a token for another user's pod. Re-call before `expiresAt`; re-login only when the session itself expires. Returns 401 without a session, 403 when no tenant matches the session email, 409 when the pod has no ingress host yet or when the email maps to more than one tenant.
+         * Resolve the caller's OpenClaw pod gateway connection coordinates from their OIDC session
+         * @description Single sign-on across the control plane and the tenant pod: requires an established OIDC session (cookie) and returns the `wss://` gateway URL for the caller's own pod. Under trusted-proxy gateway auth the browser holds no credential — the gateway socket is authorised at the ingress against the live session (`/auth/gateway-verify`), so no token is returned. The tenant is resolved solely from the session's verified email, so a caller cannot obtain another user's pod connection. Returns 401 without a session, 403 when no tenant matches the session email, 409 when the pod has no gateway URL / ingress host yet or when the email maps to more than one tenant.
          */
-        post: operations["exchangePodToken"];
+        post: operations["getPodConnection"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1408,6 +1619,77 @@ export interface components {
             brokeringMode?: "static" | "obo";
             /** @description Secret reference for 'static' brokering; null for 'obo'. */
             secretRef?: string | null;
+        };
+        /** @description A catalogue server as exposed by the operator API (distinct from the registry McpServer). Every field beyond id is optional so the same shape serves the entitled user catalogue and the admin governance view. */
+        McpCatalogServer: {
+            id: string;
+            name?: string;
+            description?: string;
+            publisher?: string;
+            glyph?: string;
+            /**
+             * @description Consumption shape; decides the credential-connect flow.
+             * @enum {string}
+             */
+            type?: "single-user" | "multi-user" | "remote-oauth";
+            /**
+             * @description Governance lifecycle status.
+             * @enum {string}
+             */
+            approvalStatus?: "pending-review" | "approved" | "published" | "disabled";
+            credentialSchema?: components["schemas"]["CredentialField"][];
+            /** @description Human-readable summary of who is entitled (admin view). */
+            entitlementSummary?: string;
+        };
+        CredentialField: {
+            /** @description Stable key the value is submitted under. */
+            key: string;
+            /** @description Human-readable field label. */
+            label: string;
+            /** @description Whether the field must be supplied. */
+            required: boolean;
+            /** @description Whether the value is secret (masked, never echoed back). */
+            sensitive: boolean;
+            /** @description Optional input placeholder. */
+            placeholder?: string;
+            /** @description Optional helper hint. */
+            hint?: string;
+        };
+        /** @description A server installed by the calling user. Never carries credential material — only the connection status and a non-secret account label. */
+        McpInstalled: {
+            serverId: string;
+            /** @enum {string} */
+            connectionStatus?: "needs-credential" | "activating" | "connected" | "oauth-connected" | "shared-key" | "activation-failed";
+            /**
+             * Format: date-time
+             * @description ISO-8601 timestamp of last use, or null when never used.
+             */
+            lastUsed?: string | null;
+            /** @description Non-secret display label of the connected account. */
+            connectedAccount?: string;
+        };
+        McpAccessPolicy: {
+            serverId: string;
+            /** @description When true, every caller in the org is entitled (lists ignored). */
+            everyoneInOrg?: boolean;
+            /** @description Entitled group identifiers / names. */
+            groups?: string[];
+            users?: components["schemas"]["EntitledUser"][];
+        };
+        EntitledUser: {
+            /** @description Stable user identifier (sub or email). */
+            id: string;
+            /** @description Display name. */
+            name: string;
+            /** @description Two-letter initials derived from the name. */
+            initials: string;
+            /** @description Deterministic avatar colour derived from the identifier. */
+            color: string;
+        };
+        /** @description The selectable universe of users and groups for the admin access editor. */
+        McpDirectory: {
+            users: components["schemas"]["EntitledUser"][];
+            groups: string[];
         };
         ClusterTenant: {
             /** @description Stable cluster-scoped identifier (the customer key). */
@@ -3419,6 +3701,583 @@ export interface operations {
             };
             /** @description MCP server or credential not found. */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listMcpCatalog: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Entitlement-scoped catalogue. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpCatalogServer"][];
+                };
+            };
+        };
+    };
+    listMcpInstalled: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Install list. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpInstalled"][];
+                };
+            };
+        };
+    };
+    installMcpServer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    serverId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Server installed. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpInstalled"];
+                };
+            };
+            /** @description serverId is required. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP server not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    uninstallMcpServer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serverId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server uninstalled. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description MCP install not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    setMcpCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serverId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Field values keyed by CredentialField.key. Write-only — never echoed back. */
+                    values: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Credential connected. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpInstalled"];
+                };
+            };
+            /** @description MCP install not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    clearMcpCredential: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serverId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Credential cleared. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpInstalled"];
+                };
+            };
+            /** @description MCP install not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    connectMcpOauth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serverId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OAuth connected. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpInstalled"];
+                };
+            };
+            /** @description MCP install not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    disconnectMcpOauth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                serverId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OAuth disconnected. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpInstalled"];
+                };
+            };
+            /** @description MCP install not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listMcpGovernanceServers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All catalogue servers. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpCatalogServer"][];
+                };
+            };
+            /** @description Caller is not an organisation admin. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    approveMcpServer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server approved. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpCatalogServer"];
+                };
+            };
+            /** @description Caller is not an organisation admin. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP server not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    publishMcpServer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server published. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpCatalogServer"];
+                };
+            };
+            /** @description Caller is not an organisation admin. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP server not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    rejectMcpServer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Server rejected. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpCatalogServer"];
+                };
+            };
+            /** @description Caller is not an organisation admin. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP server not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    setMcpServerEnabled: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    enabled: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Server availability updated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpCatalogServer"];
+                };
+            };
+            /** @description enabled (boolean) is required. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is not an organisation admin. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP server not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getMcpAccessPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Access policy. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpAccessPolicy"];
+                };
+            };
+            /** @description Caller is not an organisation admin. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP server not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    setMcpAccessPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    everyoneInOrg: boolean;
+                    groups: string[];
+                    /** @description Entitled user identifiers. */
+                    users: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Access policy updated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpAccessPolicy"];
+                };
+            };
+            /** @description everyoneInOrg (boolean), groups (array), and users (array) are required. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is not an organisation admin. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP server not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getMcpDirectory: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Directory. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpDirectory"];
+                };
+            };
+            /** @description Caller is not an organisation admin. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -5590,7 +6449,7 @@ export interface operations {
             };
         };
     };
-    exchangePodToken: {
+    getPodConnection: {
         parameters: {
             query?: never;
             header?: never;
@@ -5599,26 +6458,19 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description Short-lived pod access token. */
+            /** @description The caller's OpenClaw pod gateway connection coordinates. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
                     "application/json": {
-                        /** @description Short-lived bearer token bound to the OpenClaw pod session audience. */
-                        token: string;
-                        /**
-                         * Format: date-time
-                         * @description ISO-8601 expiry reported by the API server.
-                         */
-                        expiresAt: string;
+                        /** @description The `wss://` OpenClaw gateway URL to open. */
+                        gatewayUrl: string;
                         /** @description Resolved tenant (pod) name. */
                         tenant: string;
-                        /** @description Host to reach the tenant's OpenClaw pod session API. */
-                        ingressHost: string;
-                        /** @description Audience the token is bound to (the OpenClaw pod session, not obot-gateway). */
-                        audience: string;
+                        /** @description Host the tenant's OpenClaw pod is reachable at, when known. */
+                        ingressHost?: string;
                     };
                 };
             };
@@ -5646,7 +6498,7 @@ export interface operations {
                     };
                 };
             };
-            /** @description The tenant pod has no ingress host yet. */
+            /** @description The tenant pod has no gateway URL / ingress host yet. */
             409: {
                 headers: {
                     [name: string]: unknown;

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -18,6 +18,17 @@ export { GrantAccess, GrantScope, GrantSubjectType, type Grant } from "./grant.t
 export { type Group } from "./group.types.js";
 export { McpCredentialBrokeringMode, McpServerStatus, McpServerTransport, type McpServer, type McpServerCredential } from "./mcp-server.types.js";
 export {
+  McpApprovalStatus,
+  McpConnectionStatus,
+  McpServerType,
+  type CredentialField,
+  type Directory,
+  type EntitledUser,
+  type McpAccessPolicy,
+  type McpCatalogServer,
+  type McpInstalled,
+} from "./mcp-operator.types.js";
+export {
   AutoRoutingObjective,
   ModelRoutingScope,
   RoutingProposalStatus,

--- a/libs/contracts/src/mcp-operator.types.ts
+++ b/libs/contracts/src/mcp-operator.types.ts
@@ -1,0 +1,167 @@
+/**
+ * Operator-API contracts for the MCP consumption + governance surface.
+ *
+ * These shapes back the `/api/v1/mcp/*` API the WeOwnAI frontend targets: the
+ * entitlement-scoped catalogue, per-user installs / credential connect, and the
+ * org-admin governance + access-policy endpoints. They sit ON TOP of the existing
+ * `/mcp-servers` admin registry (whose source-of-truth shape is {@link McpServer}
+ * in `mcp-server.types.ts`) rather than replacing it.
+ *
+ * Custody contract: NO type here ever carries credential material. A connected
+ * install reports only its {@link McpConnectionStatus}; the secret lives in the
+ * gateway plane (Obot) and the agent only ever receives a connection URL.
+ */
+
+/**
+ * How a caller consumes a downstream MCP server. Surfaced as the `type` field on
+ * {@link McpCatalogServer} and decides the initial install connection state.
+ */
+export enum McpServerType
+{
+  /** Each caller authors their own credential (per-user secret). */
+  SingleUser = "single-user",
+  /** One org-wide shared key brokered for every caller (no per-user secret). */
+  MultiUser = "multi-user",
+  /** Remote OAuth — the caller authorises via an OAuth handshake. */
+  RemoteOauth = "remote-oauth",
+}
+
+/**
+ * Org-admin governance lifecycle of a catalogue server. Only
+ * {@link McpApprovalStatus.Published} servers reach the user-facing catalogue.
+ */
+export enum McpApprovalStatus
+{
+  /** Newly registered; awaiting an org-admin review. */
+  PendingReview = "pending-review",
+  /** Reviewed and approved, not yet visible to callers. */
+  Approved = "approved",
+  /** Live in the user-facing catalogue for entitled callers. */
+  Published = "published",
+  /** Withdrawn — hidden from the catalogue and not installable. */
+  Disabled = "disabled",
+}
+
+/**
+ * Per-user install connection state. Reports custody state only — never the
+ * underlying secret material.
+ */
+export enum McpConnectionStatus
+{
+  /** Installed but no credential authored yet. */
+  NeedsCredential = "needs-credential",
+  /** Credential submitted; the gateway is establishing the connection. */
+  Activating = "activating",
+  /** Connected via a per-user credential. */
+  Connected = "connected",
+  /** Connected via a remote OAuth handshake. */
+  OauthConnected = "oauth-connected",
+  /** Connected via the org-wide shared key (multi-user servers). */
+  SharedKey = "shared-key",
+  /** The gateway failed to establish the connection. */
+  ActivationFailed = "activation-failed",
+}
+
+/**
+ * One field a caller must supply to connect a {@link McpServerType.SingleUser}
+ * server. Describes the input only — the submitted value is write-only.
+ */
+export interface CredentialField
+{
+  /** Stable key the value is submitted under. */
+  key: string;
+  /** Human-readable field label. */
+  label: string;
+  /** Whether the field must be supplied. */
+  required: boolean;
+  /** Whether the value is secret (masked input, never echoed back). */
+  sensitive: boolean;
+  /** Optional input placeholder. */
+  placeholder?: string;
+  /** Optional helper hint shown under the field. */
+  hint?: string;
+}
+
+/**
+ * A catalogue server as exposed by the operator API (distinct from the registry
+ * {@link McpServer}). Every field beyond `id` is optional so the same shape serves
+ * both the entitled user catalogue and the richer admin governance view.
+ */
+export interface McpCatalogServer
+{
+  /** Stable server identifier. */
+  id: string;
+  /** Display name shown in the catalogue. */
+  name?: string;
+  /** Short caller-facing summary. */
+  description?: string;
+  /** Publishing organisation or author label. */
+  publisher?: string;
+  /** Glyph / icon key rendered by the frontend. */
+  glyph?: string;
+  /** Consumption shape; decides the credential-connect flow. */
+  type?: McpServerType;
+  /** Governance lifecycle status. */
+  approvalStatus?: McpApprovalStatus;
+  /** Credential fields a caller must supply to connect (single-user servers). */
+  credentialSchema?: CredentialField[];
+  /** Human-readable summary of who is entitled (admin governance view). */
+  entitlementSummary?: string;
+}
+
+/**
+ * A server installed by the calling user, with its connection state. Never carries
+ * credential material — `connectedAccount` is a non-secret display label only.
+ */
+export interface McpInstalled
+{
+  /** Identifier of the installed server. */
+  serverId: string;
+  /** Current connection state of this install. */
+  connectionStatus?: McpConnectionStatus;
+  /** ISO-8601 timestamp of last use, or null when never used. */
+  lastUsed?: string | null;
+  /** Non-secret display label of the connected account (e.g. an email). */
+  connectedAccount?: string;
+}
+
+/**
+ * A user entitled to a server, rendered for the admin access editor and directory.
+ */
+export interface EntitledUser
+{
+  /** Stable user identifier (sub or email). */
+  id: string;
+  /** Display name. */
+  name: string;
+  /** Two-letter initials derived from the name. */
+  initials: string;
+  /** Deterministic avatar colour derived from the identifier. */
+  color: string;
+}
+
+/**
+ * Org-admin access policy deciding which callers may see and install a server.
+ */
+export interface McpAccessPolicy
+{
+  /** Identifier of the governed server. */
+  serverId: string;
+  /** When true, every caller in the org is entitled (lists are ignored). */
+  everyoneInOrg?: boolean;
+  /** Entitled group identifiers / names. */
+  groups?: string[];
+  /** Entitled individual users. */
+  users?: EntitledUser[];
+}
+
+/**
+ * The selectable universe of users and groups for the admin access editor.
+ */
+export interface Directory
+{
+  /** All known users that can be entitled. */
+  users: EntitledUser[];
+  /** All known group identifiers / names that can be entitled. */
+  groups: string[];
+}


### PR DESCRIPTION
## Summary

Adds the `/api/v1/mcp/*` operator API the WeOwnAI frontend targets, layered on top of the existing `/mcp-servers` admin registry (registry routes unchanged). 16 endpoints across two authorization postures.

**User-facing (entitlement-scoped, per-caller):**
- `GET /mcp/catalog` — published **and** entitled servers only
- `GET/POST /mcp/installed`, `DELETE /mcp/installed/{serverId}` — per-user installs
- `PUT/DELETE /mcp/installed/{serverId}/credential` — **write-only** secret custody
- `POST/DELETE /mcp/installed/{serverId}/oauth` — remote-OAuth connect

**Admin (org-admin gated via `_RequireOrgAdmin`):**
- `GET /mcp/servers` — governance view (all statuses)
- `POST /mcp/servers/{id}/{approve,publish,reject,enabled}` — lifecycle
- `GET/PUT /mcp/servers/{id}/access` — access policy
- `GET /mcp/directory` — selectable users + groups

## Security contract

No response on any route serialises credential material. Per-user installs hold only a write-only `credentialRef` custody handle (the secret is brokered server-side / Obot); the submitted credential `values` are never persisted as plaintext nor echoed back. A dedicated test asserts the secret strings, `credentialRef`, and the `cred_` prefix never appear in any response, and that `_MapInstalled` emits exactly `{serverId, connectionStatus, lastUsed, connectedAccount}`.

## Schema / migration

- New enums `McpServerType`, `McpApprovalStatus`, `McpConnectionStatus` (DB `@map` labels = the verbatim wire strings).
- `McpServer` extended with `publisher`, `glyph`, `serverType`, `approvalStatus`, `credentialSchema`, `entitlementSummary`.
- New models `McpServerInstall`, `McpServerAccessPolicy`, `McpServerAccessUser`.
- Migration `0022_mcp_operator_api` — **additive + backward-compatible** (existing rows default to `single-user` / `pending-review` / empty schema).

## Contracts / OpenAPI

New `mcp-operator.types.ts` in `@opencrane/contracts` + barrel export; hand-authored OpenAPI extended and `openapi.json` regenerated (the contracts typed client regenerated from it). Frontend regenerates its client via `./scripts/sync-spec.sh --local`.

## Deviations from the original contract (with reasons)

1. **OpenAPI schema named `McpCatalogServer`, not `McpServer`** — the registry already owns the `McpServer` schema name and OpenAPI keys must be unique. Field names match the spec exactly. (`Directory` → `McpDirectory` for the same reason.)
2. **Credential `values` are accepted then discarded; an opaque `credentialRef` is minted** — live gateway/Obot brokering isn't wired in this slice, so this mirrors the existing `secretRef` reference-only custody model and satisfies the write-only invariant.
3. **Catalogue entitlement fails closed when a published server has no access policy**; an unauthenticated caller under dev-auth-mode is treated as `devOpen` (sees all published), matching the platform's fail-open-in-dev / fail-closed-under-real-auth posture.

## Verification

- `pnpm -C apps/control-plane build` ✅, `lint` (tsc --noEmit) ✅
- Full suite **379 passed (58 files)**, incl. 14 new operator tests (org-admin gate, published+entitled filtering, install→credential→connected lifecycle, per-user scoping, no-credential-in-response invariant)
- `/mcp/*` paths present in `openapi.json` (12 path items / 16 operations)
- Independent review: no correctness bugs or regressions; credential-custody invariant verified across all 16 response paths
