### PR TITLE
fix(operator): unblock image build — drift-repair patch content-type (TS2353)

### DIFF
--- a/apps/operator/src/runtime-planes/drift-repairer.ts
+++ b/apps/operator/src/runtime-planes/drift-repairer.ts
@@ -247,14 +247,19 @@ export class RuntimePlaneDriftRepairer
       },
     } as unknown as k8s.V1Deployment;
 
-    await this._appsApi.patchNamespacedDeployment({
-      name: plane.deploymentName,
-      namespace: this._namespace,
-      body: patch,
-      // Must be explicit — without it the client defaults to json-patch+json,
-      // which expects an array; the server rejects our object with a 400.
-      contentType: "application/strategic-merge-patch+json",
-    });
+    // Content-Type must be explicit — without it the client defaults to
+    // json-patch+json, which expects an array; the server rejects our object
+    // with a 400. The @kubernetes/client-node@1.x request object has no
+    // `contentType` field; the strategy is set via the ConfigurationOptions
+    // second argument (same idiom as idle-checker / policies operator).
+    await this._appsApi.patchNamespacedDeployment(
+      {
+        name: plane.deploymentName,
+        namespace: this._namespace,
+        body: patch,
+      },
+      k8s.setHeaderOptions("Content-Type", k8s.PatchStrategy.StrategicMergePatch),
+    );
 
     this._log.info(
       { plane: plane.label, repairedVars: drifted.map(function _name(d) { return d.name; }) },


### PR DESCRIPTION
## What landed
`apps/operator/src/runtime-planes/drift-repairer.ts` passed `contentType` as a field on the `patchNamespacedDeployment` **request object**. `@kubernetes/client-node@1.x` (`AppsV1ApiPatchNamespacedDeploymentRequest`) has no such field, so `tsc` failed with **TS2353** — breaking `pnpm -r build`, which the `docker.yml` `test` job runs before `build-and-push`. Net effect: **no images publish for any app** (operator, control-plane, tenant, skill-registry), blocking all deploys.

Fix: set the patch strategy via the **`ConfigurationOptions` second argument** — `setHeaderOptions("Content-Type", PatchStrategy.StrategicMergePatch)` — the idiom already used across the codebase (`idle-checker`, `policies/operator`, `tenant-update-with-canary-strategy`). The on-the-wire `Content-Type` (`application/strategic-merge-patch+json`) is unchanged, so drift-repair runtime behaviour is preserved.

## Why it matters
This break is pre-existing on `main` (failed on `bb47516` and the `#43` merge `6bcf177`) and unrelated to any feature — it is the single thing gating image publishing today.

## Validation
- `pnpm -C apps/operator build` — green (was TS2353).
- Full `pnpm -r build` — all packages green (operator + control-plane included).

## Scope
One-line behavioural change (call shape only); no other 