### PR TITLE
org: billing-gated org creation + creator-becomes-root-admin + membership-derived isOrgAdmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   group mapping exists in the IdP, remove the seed. It is fail-closed — an empty/unset
   seed grants operator to nobody, and an email the IdP marks unverified never matches.
 
+- **Any signed-in user can create an organisation and instantly becomes its root admin.**
+  A user first creates a billing account (`POST /api/v1/billing-accounts`), then creating a
+  ClusterTenant (`POST /api/v1/cluster-tenants`) records them as the org's single `owner` in the
+  same transaction — so an organisation always has exactly one root admin. `isOrgAdmin` and the
+  caller's owned/administered orgs are now derived from real per-org `OrgMembership` (not a global
+  flag) and surface on `/auth/me` as `ownedOrgs`. The cluster-tenants API is no longer unguarded:
+  creating requires an authenticated session **with** a billing account (not pre-existing admin — a
+  user becomes admin *by* creating); reading and destructive operations require a platform operator
+  or an owner/admin member of that specific org. Anonymous callers are rejected (401) in any real
+  deployment.
+
 ### Changed
 
 - **The control-plane Helm chart now wires human-login OIDC end to end.** A new

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -607,6 +607,57 @@
           }
         }
       },
+      "BillingAccount": {
+        "type": "object",
+        "required": [
+          "id",
+          "subject",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Surrogate identifier."
+          },
+          "subject": {
+            "type": "string",
+            "description": "IdP-verified subject (OIDC sub) that owns this billing account."
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The caller's verified email at create time (for human reconciliation; not the key)."
+          },
+          "displayName": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional human-readable billing name (company / individual)."
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "BillingAccountWrite": {
+        "type": "object",
+        "description": "Create payload for the caller's own billing account. The subject and email come from the session (never the body); only an optional displayName is accepted.",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "description": "Optional human-readable billing name (company / individual)."
+          }
+        }
+      },
       "Group": {
         "type": "object",
         "properties": {
@@ -3416,7 +3467,8 @@
     "/cluster-tenants": {
       "get": {
         "operationId": "listClusterTenants",
-        "summary": "List all cluster tenants",
+        "summary": "List all cluster tenants (fleet view — platform-operator only)",
+        "description": "Fleet-wide list. Restricted to platform operators; a per-org owner/admin reads only their own org via GET /cluster-tenants/{name}.",
         "tags": [
           "Cluster Tenants"
         ],
@@ -3433,12 +3485,33 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not a platform operator.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       },
       "post": {
         "operationId": "createClusterTenant",
-        "summary": "Create a cluster tenant (rejects an isolation tier no provisioner can serve)",
+        "summary": "Create a cluster tenant (organisation) and become its owner",
+        "description": "Any authenticated user WITH an existing billing account may create an organisation; the caller is recorded as the org's single owner transactionally. Requires a billing account first (POST /billing-accounts), NOT pre-existing org-admin — a user becomes an org admin by creating their first org. Rejects an isolation tier no provisioner can serve.",
         "tags": [
           "Cluster Tenants"
         ],
@@ -3454,7 +3527,7 @@
         },
         "responses": {
           "201": {
-            "description": "Cluster tenant created.",
+            "description": "Cluster tenant created; caller recorded as owner.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3465,6 +3538,26 @@
           },
           "400": {
             "description": "Request body failed validation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller has no billing account (code BILLING_ACCOUNT_REQUIRED).",
             "content": {
               "application/json": {
                 "schema": {
@@ -3489,7 +3582,7 @@
     "/cluster-tenants/{name}": {
       "get": {
         "operationId": "getClusterTenant",
-        "summary": "Get a single cluster tenant by name",
+        "summary": "Get a single cluster tenant by name (operator OR owner/admin of that org)",
         "tags": [
           "Cluster Tenants"
         ],
@@ -3514,6 +3607,26 @@
               }
             }
           },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is neither a platform operator nor an owner/admin of this org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Cluster tenant not found.",
             "content": {
@@ -3528,7 +3641,7 @@
       },
       "put": {
         "operationId": "updateClusterTenant",
-        "summary": "Update a cluster tenant (re-gates the isolation tier when it changes)",
+        "summary": "Update a cluster tenant (operator OR owner/admin of that org); re-gates the isolation tier when it changes",
         "tags": [
           "Cluster Tenants"
         ],
@@ -3573,6 +3686,26 @@
               }
             }
           },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is neither a platform operator nor an owner/admin of this org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Cluster tenant not found.",
             "content": {
@@ -3597,7 +3730,7 @@
       },
       "delete": {
         "operationId": "deleteClusterTenant",
-        "summary": "Delete a cluster tenant",
+        "summary": "Delete a cluster tenant (operator OR owner/admin of that org)",
         "tags": [
           "Cluster Tenants"
         ],
@@ -3630,6 +3763,26 @@
               }
             }
           },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is neither a platform operator nor an owner/admin of this org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Cluster tenant not found.",
             "content": {
@@ -3646,7 +3799,7 @@
     "/cluster-tenants/{name}/status": {
       "get": {
         "operationId": "getClusterTenantStatus",
-        "summary": "Get the observed status of a cluster tenant",
+        "summary": "Get the observed status of a cluster tenant (operator OR owner/admin of that org)",
         "tags": [
           "Cluster Tenants"
         ],
@@ -3691,8 +3844,121 @@
               }
             }
           },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is neither a platform operator nor an owner/admin of this org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "404": {
             "description": "Cluster tenant not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/billing-accounts": {
+      "post": {
+        "operationId": "createBillingAccount",
+        "summary": "Create the caller's own billing account (idempotent per subject)",
+        "description": "Any authenticated user creates their OWN billing account, keyed to their IdP-verified subject (never request input). Idempotent: a repeat call returns the existing account (200) instead of failing. Having a billing account is the gate for creating an organisation (POST /cluster-tenants).",
+        "tags": [
+          "Billing"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BillingAccountWrite"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Billing account already existed (idempotent).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingAccount"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Billing account created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingAccount"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/billing-accounts/me": {
+      "get": {
+        "operationId": "getMyBillingAccount",
+        "summary": "Return the caller's own billing account",
+        "tags": [
+          "Billing"
+        ],
+        "responses": {
+          "200": {
+            "description": "Billing account detail.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BillingAccount"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Caller has no billing account (code BILLING_ACCOUNT_NOT_FOUND).",
             "content": {
               "application/json": {
                 "schema": {
@@ -7929,6 +8195,31 @@
                             "null"
                           ],
                           "description": "The caller's ClusterTenant (customer) key, resolved server-side from their IdP-verified email → tenant → clusterTenantRef. Null when unresolved or ambiguous."
+                        },
+                        "ownedOrgs": {
+                          "type": "array",
+                          "description": "Organisations the caller owns or administers, derived fresh from their OrgMembership rows (owner/admin only; members excluded). Empty when the caller administers no org. The org-scope half of the membership-derived isOrgAdmin. Introspection only — never taken from request input.",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "clusterTenant",
+                              "role"
+                            ],
+                            "properties": {
+                              "clusterTenant": {
+                                "type": "string",
+                                "description": "The organisation (ClusterTenant) key."
+                              },
+                              "role": {
+                                "type": "string",
+                                "enum": [
+                                  "owner",
+                                  "admin"
+                                ],
+                                "description": "The administering role the caller holds in this org."
+                              }
+                            }
+                          }
                         },
                         "email": {
                           "type": "string"

--- a/apps/control-plane/prisma/migrations/0023_org_admin_billing/migration.sql
+++ b/apps/control-plane/prisma/migrations/0023_org_admin_billing/migration.sql
@@ -1,0 +1,51 @@
+-- Migration 0023: org-admin model — BillingAccount + OrgMembership (ORG-ADMIN.1)
+--
+-- Implements the self-serve org-admin flow: a normal authenticated user creates a
+-- billing account, then creates an organisation (ClusterTenant) and becomes its
+-- root owner. Org-admin authority is DERIVED from membership rows, never a global
+-- flag. Both tables are additive; existing cluster_tenants rows are untouched.
+
+-- 1. Closed-set role enum (DB values mirror the @map labels on OrgRole in schema.prisma).
+CREATE TYPE "OrgRole" AS ENUM ('owner', 'admin', 'member');
+
+-- 2. Billing account: the prerequisite for creating an org. Keyed to the caller's
+--    IdP-verified subject (one account per subject); email is recorded for human
+--    reconciliation only (a subject's email can change while its `sub` is stable).
+CREATE TABLE "billing_accounts" (
+  "id"           TEXT NOT NULL,
+  "subject"      TEXT NOT NULL,
+  "email"        TEXT,
+  "display_name" TEXT,
+  "created_at"   TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"   TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "billing_accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- One billing account per subject; the create is idempotent on this constraint.
+CREATE UNIQUE INDEX "billing_accounts_subject_key" ON "billing_accounts"("subject");
+CREATE INDEX "billing_accounts_subject_idx" ON "billing_accounts"("subject");
+
+-- 3. Org membership: binds a subject to a ClusterTenant with a role. Authority is
+--    derived from these rows. Cascades on org delete so memberships never linger.
+CREATE TABLE "org_memberships" (
+  "id"             TEXT NOT NULL,
+  "cluster_tenant" TEXT NOT NULL,
+  "subject"        TEXT NOT NULL,
+  "role"           "OrgRole" NOT NULL,
+  "created_at"     TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at"     TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "org_memberships_pkey" PRIMARY KEY ("id")
+);
+
+-- One membership per (org, subject).
+CREATE UNIQUE INDEX "org_memberships_cluster_tenant_subject_key" ON "org_memberships"("cluster_tenant", "subject");
+CREATE INDEX "org_memberships_subject_idx" ON "org_memberships"("subject");
+CREATE INDEX "org_memberships_cluster_tenant_idx" ON "org_memberships"("cluster_tenant");
+
+-- At most one `owner` per org: a partial unique index over the org for owner rows
+-- only. The creator becomes that single owner transactionally with the org create.
+CREATE UNIQUE INDEX "org_memberships_one_owner_per_org" ON "org_memberships"("cluster_tenant") WHERE "role" = 'owner';
+
+ALTER TABLE "org_memberships"
+  ADD CONSTRAINT "org_memberships_cluster_tenant_fkey"
+  FOREIGN KEY ("cluster_tenant") REFERENCES "cluster_tenants"("name") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/control-plane/prisma/schema.prisma
+++ b/apps/control-plane/prisma/schema.prisma
@@ -159,8 +159,75 @@ model ClusterTenant {
   createdAt      DateTime                   @default(now()) @map("created_at")
   /// Last update timestamp.
   updatedAt      DateTime                   @updatedAt @map("updated_at")
+  /// Membership rows binding subjects to this org with a role; cascades on delete.
+  memberships    OrgMembership[]
 
   @@map("cluster_tenants")
+}
+
+/// Role a subject holds within one organisation (ClusterTenant). `owner` is the
+/// org's root admin created transactionally with the org; `admin` is a delegated
+/// administrator; `member` is a plain participant. Owner and admin both confer
+/// org-admin authority over that org (see `_ResolveIdentityClaims`).
+enum OrgRole {
+  Owner  @map("owner")
+  Admin  @map("admin")
+  Member @map("member")
+}
+
+/// A user's billing account, the prerequisite for creating an organisation.
+///
+/// Org creation is gated on the caller HAVING a billing account, breaking the
+/// chicken-and-egg deadlock (a user becomes an org admin BY creating an org, so
+/// the create cannot itself require pre-existing org-admin). Keyed to the caller's
+/// IdP-verified subject (one account per subject, idempotent on create); the
+/// verified email is recorded for human reconciliation but is NOT the key, since a
+/// subject's email can change while its `sub` is stable.
+model BillingAccount {
+  /// Surrogate key.
+  id        String   @id @default(cuid())
+  /// IdP-verified subject (OIDC `sub`) that owns this billing account; unique.
+  subject   String   @unique
+  /// The caller's IdP-verified email at create time (for human reconciliation; not the key).
+  email     String?
+  /// Optional human-readable billing name (company / individual).
+  displayName String? @map("display_name")
+  /// Creation timestamp.
+  createdAt DateTime @default(now()) @map("created_at")
+  /// Last update timestamp.
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@index([subject])
+  @@map("billing_accounts")
+}
+
+/// Binds a subject to an organisation (ClusterTenant) with a role. Authority is
+/// DERIVED from these rows, never from a global flag: a subject who owns/administers
+/// ≥1 org is an org admin, scoped to exactly the orgs they hold owner/admin on.
+///
+/// One membership per (clusterTenant, subject). At most ONE `owner` per org is
+/// enforced by a partial unique index (see the migration) — the creator becomes
+/// that single owner transactionally with `clusterTenant.create`.
+model OrgMembership {
+  /// Surrogate key.
+  id            String        @id @default(cuid())
+  /// Organisation (ClusterTenant) this membership is in.
+  clusterTenant String        @map("cluster_tenant")
+  /// IdP-verified subject (OIDC `sub`) holding the membership.
+  subject       String
+  /// Role held within the organisation.
+  role          OrgRole
+  /// Creation timestamp.
+  createdAt     DateTime      @default(now()) @map("created_at")
+  /// Last update timestamp.
+  updatedAt     DateTime      @updatedAt @map("updated_at")
+  /// Owning organisation; cascades on org delete so memberships never linger.
+  org           ClusterTenant @relation(fields: [clusterTenant], references: [name], onDelete: Cascade)
+
+  @@unique([clusterTenant, subject])
+  @@index([subject])
+  @@index([clusterTenant])
+  @@map("org_memberships")
 }
 
 model AuditEntry {

--- a/apps/control-plane/src/__tests__/infra/oidc-getstatus.test.ts
+++ b/apps/control-plane/src/__tests__/infra/oidc-getstatus.test.ts
@@ -33,11 +33,21 @@ function _reqWithUser(email: string | undefined): Request
         issuer: "https://idp.test",
         groups: ["acme-users"],
         isPlatformOperator: false,
+        isOrgAdmin: false,
         ...(email ? { email } : {}),
         authenticatedAt: "2026-01-01T00:00:00.000Z",
       },
     },
   } as unknown as Request;
+}
+
+/** Prisma stub for getStatus: tenant.findMany (email→ref) + orgMembership.findMany (owned orgs). */
+function _prismaWith(tenantRows: { clusterTenantRef: string | null }[], membershipRows: { clusterTenant: string; role: string }[]): PrismaClient
+{
+  return {
+    tenant: { findMany: vi.fn().mockResolvedValue(tenantRows) },
+    orgMembership: { findMany: vi.fn().mockResolvedValue(membershipRows) },
+  } as unknown as PrismaClient;
 }
 
 describe("OidcAuthService.getStatus — /auth/me identity surface (WOI.1)", function _suite()
@@ -94,5 +104,29 @@ describe("OidcAuthService.getStatus — /auth/me identity surface (WOI.1)", func
     expect(status.authenticated).toBe(false);
     expect(status.user).toBeNull();
     expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("derives isOrgAdmin + ownedOrgs from OrgMembership at read time, even with no org-admin group (ORG-ADMIN.5)", async function _membershipDerived()
+  {
+    // The session was established with isOrgAdmin=false (no group/operator), but the
+    // user later created an org and became its owner — /auth/me must reflect that.
+    const prisma = _prismaWith([{ clusterTenantRef: null }], [{ clusterTenant: "acme", role: "Owner" }]);
+    const service = ___CreateOidcAuthService(pino({ enabled: false }), prisma);
+
+    const status = await service.getStatus(_reqWithUser("owner@acme.io"));
+
+    expect(status.user?.isOrgAdmin).toBe(true);
+    expect(status.user?.ownedOrgs).toEqual([{ clusterTenant: "acme", role: "owner" }]);
+  });
+
+  it("reports isOrgAdmin false + empty ownedOrgs for a user who administers no org", async function _notAdmin()
+  {
+    const prisma = _prismaWith([{ clusterTenantRef: "acme" }], []);
+    const service = ___CreateOidcAuthService(pino({ enabled: false }), prisma);
+
+    const status = await service.getStatus(_reqWithUser("member@acme.io"));
+
+    expect(status.user?.isOrgAdmin).toBe(false);
+    expect(status.user?.ownedOrgs).toEqual([]);
   });
 });

--- a/apps/control-plane/src/__tests__/infra/org-membership.test.ts
+++ b/apps/control-plane/src/__tests__/infra/org-membership.test.ts
@@ -1,0 +1,63 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { _ResolveOrgMembershipFacts } from "../../infra/auth/org-membership.js";
+
+/**
+ * Unit coverage for the membership-derived org-admin facts (ORG-ADMIN.5): authority
+ * is derived purely from OrgMembership rows (owner/admin), keyed on the verified
+ * subject, and fails closed on a missing subject or a lookup error.
+ */
+describe("_ResolveOrgMembershipFacts (ORG-ADMIN.5)", function _suite()
+{
+  it("derives isOrgAdmin + ownedOrgs from owner/admin rows", async function _derives()
+  {
+    const findMany = vi.fn().mockResolvedValue([
+      { clusterTenant: "acme", role: "Owner" },
+      { clusterTenant: "globex", role: "Admin" },
+    ]);
+    const prisma = { orgMembership: { findMany } } as unknown as PrismaClient;
+
+    const facts = await _ResolveOrgMembershipFacts(prisma, "user-1");
+
+    expect(facts.isOrgAdmin).toBe(true);
+    expect(facts.ownedOrgs).toEqual([
+      { clusterTenant: "acme", role: "owner" },
+      { clusterTenant: "globex", role: "admin" },
+    ]);
+    // Only owner/admin rows are queried — plain members confer no admin authority.
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { subject: "user-1", role: { in: ["Owner", "Admin"] } } }));
+  });
+
+  it("returns empty facts (not an admin) when the caller administers no org", async function _noOrgs()
+  {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const prisma = { orgMembership: { findMany } } as unknown as PrismaClient;
+
+    const facts = await _ResolveOrgMembershipFacts(prisma, "user-2");
+
+    expect(facts.isOrgAdmin).toBe(false);
+    expect(facts.ownedOrgs).toEqual([]);
+  });
+
+  it("fails closed on a missing subject — never hits the DB", async function _noSubject()
+  {
+    const findMany = vi.fn();
+    const prisma = { orgMembership: { findMany } } as unknown as PrismaClient;
+
+    const facts = await _ResolveOrgMembershipFacts(prisma, undefined);
+
+    expect(facts).toEqual({ isOrgAdmin: false, ownedOrgs: [] });
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (no authority) on a lookup error", async function _dbError()
+  {
+    const findMany = vi.fn().mockRejectedValue(new Error("db down"));
+    const prisma = { orgMembership: { findMany } } as unknown as PrismaClient;
+
+    const facts = await _ResolveOrgMembershipFacts(prisma, "user-3");
+
+    expect(facts).toEqual({ isOrgAdmin: false, ownedOrgs: [] });
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/billing-accounts.test.ts
+++ b/apps/control-plane/src/__tests__/routes/billing-accounts.test.ts
@@ -1,0 +1,132 @@
+import express from "express";
+import type { Express } from "express";
+import type { PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { billingAccountsRouter } from "../../routes/billing-accounts.js";
+
+/**
+ * Covers the self-serve billing-account endpoint (ORG-ADMIN.2): a user creates their
+ * OWN account keyed to the session subject (never request input), idempotently, and
+ * the fail-closed / dev-mode posture matches the rest of the platform.
+ */
+
+/** Auth env that decides `_IsDevAuthMode`; cleared/restored around each test. */
+const _AUTH_ENV = ["OPENCRANE_API_TOKEN", "OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET", "OIDC_REDIRECT_URI", "OIDC_SESSION_SECRET"] as const;
+
+/** Minimal in-memory billing-account stub keyed by subject. */
+function _mockPrisma(): { prisma: PrismaClient; store: Map<string, Record<string, unknown>> }
+{
+  const store = new Map<string, Record<string, unknown>>();
+  const prisma = {
+    billingAccount: {
+      findUnique: vi.fn(async function _findUnique(args: { where: { subject: string } }) { return store.get(args.where.subject) ?? null; }),
+      upsert: vi.fn(async function _upsert(args: { where: { subject: string }; create: Record<string, unknown> })
+      {
+        const existing = store.get(args.where.subject);
+        if (existing)
+        {
+          // Mirror Prisma's @updatedAt: an upsert that hits an existing row bumps
+          // updatedAt, so createdAt !== updatedAt marks it as pre-existing (200).
+          existing.updatedAt = new Date(Date.now() + 1000);
+          return existing;
+        }
+        const now = new Date();
+        const row = { id: `ba_${args.where.subject}`, email: null, displayName: null, ...args.create, createdAt: now, updatedAt: now };
+        store.set(args.where.subject, row);
+        return row;
+      }),
+    },
+  } as unknown as PrismaClient;
+  return { prisma, store };
+}
+
+/** Mount the router, optionally seeding a session user. */
+function _buildApp(prisma: PrismaClient, user?: { sub: string; email?: string }): Express
+{
+  const app = express();
+  app.use(express.json());
+  if (user)
+  {
+    app.use(function _seedSession(req, _res, next) { (req as unknown as { session: { authUser: typeof user } }).session = { authUser: user }; next(); });
+  }
+  app.use("/api/v1/billing-accounts", billingAccountsRouter(prisma));
+  return app;
+}
+
+describe("billingAccountsRouter (ORG-ADMIN.2)", function _suite()
+{
+  const _saved: Record<string, string | undefined> = {};
+
+  /** Force REAL-auth mode by default so the fail-closed posture is exercised. */
+  beforeEach(function _enableAuth()
+  {
+    for (const key of _AUTH_ENV) { _saved[key] = process.env[key]; delete process.env[key]; }
+    process.env.OPENCRANE_API_TOKEN = "ci-token";
+  });
+
+  afterEach(function _restoreEnv()
+  {
+    for (const key of _AUTH_ENV) { if (_saved[key] === undefined) { delete process.env[key]; } else { process.env[key] = _saved[key]; } }
+  });
+
+  it("creates the caller's own account keyed to the session subject (201)", async function _create()
+  {
+    const { prisma, store } = _mockPrisma();
+    const res = await request(_buildApp(prisma, { sub: "user-1", email: "user@acme.io" })).post("/api/v1/billing-accounts").send({ displayName: "Acme" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.subject).toBe("user-1");
+    expect(res.body.displayName).toBe("Acme");
+    // The account is keyed to the session subject, never request input.
+    expect(store.get("user-1")).toBeTruthy();
+  });
+
+  it("is idempotent per subject — a repeat create returns 200 with the existing account", async function _idempotent()
+  {
+    const { prisma } = _mockPrisma();
+    const app = _buildApp(prisma, { sub: "user-1" });
+
+    const first = await request(app).post("/api/v1/billing-accounts").send({});
+    expect(first.status).toBe(201);
+    const second = await request(app).post("/api/v1/billing-accounts").send({});
+    expect(second.status).toBe(200);
+    expect(second.body.subject).toBe("user-1");
+  });
+
+  it("rejects an anonymous create with 401 in a real-auth deployment (fail-closed)", async function _anon()
+  {
+    const { prisma, store } = _mockPrisma();
+    const res = await request(_buildApp(prisma)).post("/api/v1/billing-accounts").send({});
+
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe("UNAUTHORIZED");
+    expect(store.size).toBe(0);
+  });
+
+  it("GET /me returns 404 when the caller has no account, 200 once created", async function _getMe()
+  {
+    const { prisma } = _mockPrisma();
+    const app = _buildApp(prisma, { sub: "user-1" });
+
+    const missing = await request(app).get("/api/v1/billing-accounts/me");
+    expect(missing.status).toBe(404);
+    expect(missing.body.code).toBe("BILLING_ACCOUNT_NOT_FOUND");
+
+    await request(app).post("/api/v1/billing-accounts").send({});
+    const found = await request(app).get("/api/v1/billing-accounts/me");
+    expect(found.status).toBe(200);
+    expect(found.body.subject).toBe("user-1");
+  });
+
+  it("allows an anonymous create under the dev-mode bypass (no real auth configured)", async function _dev()
+  {
+    delete process.env.OPENCRANE_API_TOKEN; // no OIDC, no token ⇒ dev mode
+    const { prisma, store } = _mockPrisma();
+    const res = await request(_buildApp(prisma)).post("/api/v1/billing-accounts").send({});
+
+    expect(res.status).toBe(201);
+    expect(store.get("dev-local-subject")).toBeTruthy();
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
@@ -1,0 +1,208 @@
+import express from "express";
+import type { Express } from "express";
+import { ClusterTenantIsolationTier } from "@opencrane/contracts";
+import type { ClusterTenantProvisionerRegistry } from "@opencrane/contracts";
+import type { PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clusterTenantsRouter } from "../../routes/cluster-tenants.js";
+
+/**
+ * Security-critical guard matrix for the org-admin model (ORG-ADMIN.3/4):
+ *   - CREATE requires an authenticated session WITH a billing account (NOT pre-existing
+ *     org-admin); anonymous/billing-less is rejected; the creator is recorded as owner.
+ *   - Destructive mutations + fleet list/get require platform-operator OR the caller's
+ *     owner/admin membership of that org; a non-member is rejected; an operator manages any.
+ */
+
+type Row = Record<string, unknown>;
+
+/** Seed shape for the in-memory fixtures. */
+interface Seed
+{
+  orgs?: string[];
+  billing?: string[];                                   // subjects WITH a billing account
+  memberships?: { clusterTenant: string; subject: string; role: "Owner" | "Admin" | "Member" }[];
+}
+
+/** Build a Prisma stub backed by in-memory arrays for the org-admin tables. */
+function _mockPrisma(seed: Seed = {}): { prisma: PrismaClient; orgs: Map<string, Row>; memberships: Row[] }
+{
+  const orgs = new Map<string, Row>((seed.orgs ?? []).map(n => [n, { name: n, displayName: n, phase: "pending" }]));
+  const billing = new Set(seed.billing ?? []);
+  const memberships: Row[] = (seed.memberships ?? []).map(m => ({ ...m }));
+
+  const prisma = {
+    clusterTenant: {
+      findMany: vi.fn(async function _findMany() { return Array.from(orgs.values()); }),
+      findUnique: vi.fn(async function _findUnique(args: { where: { name: string } }) { return orgs.get(args.where.name) ?? null; }),
+      create: vi.fn(async function _create(args: { data: Row })
+      {
+        const row = { nodePool: null, message: null, boundNamespace: null, provisioner: null, ...args.data };
+        orgs.set(args.data.name as string, row);
+        return row;
+      }),
+      update: vi.fn(async function _update(args: { where: { name: string }; data: Row }) { const row = { ...(orgs.get(args.where.name) as Row), ...args.data }; orgs.set(args.where.name, row); return row; }),
+      delete: vi.fn(async function _delete(args: { where: { name: string } }) { orgs.delete(args.where.name); return {}; }),
+    },
+    billingAccount: {
+      findUnique: vi.fn(async function _findUnique(args: { where: { subject: string } }) { return billing.has(args.where.subject) ? { id: `ba_${args.where.subject}` } : null; }),
+    },
+    orgMembership: {
+      findUnique: vi.fn(async function _findUnique(args: { where: { clusterTenant_subject: { clusterTenant: string; subject: string } } })
+      {
+        const { clusterTenant, subject } = args.where.clusterTenant_subject;
+        return memberships.find(m => m.clusterTenant === clusterTenant && m.subject === subject) ?? null;
+      }),
+      create: vi.fn(async function _create(args: { data: Row }) { memberships.push(args.data); return args.data; }),
+    },
+    $transaction: vi.fn(async function _tx(fn: (tx: PrismaClient) => Promise<unknown>) { return fn(prisma); }),
+  } as unknown as PrismaClient;
+
+  return { prisma, orgs, memberships };
+}
+
+/** Registry stub: every tier available (tier-gating is covered elsewhere). */
+function _mockRegistry(): ClusterTenantProvisionerRegistry
+{
+  return { isTierAvailable(_tier: ClusterTenantIsolationTier) { return true; }, capabilities() { return []; } } as unknown as ClusterTenantProvisionerRegistry;
+}
+
+/** Session user shape (subset of the OIDC session user). */
+interface User { sub: string; isPlatformOperator: boolean; email?: string }
+
+/** Mount the router, optionally seeding a session user. */
+function _buildApp(prisma: PrismaClient, user?: User): Express
+{
+  const app = express();
+  app.use(express.json());
+  if (user)
+  {
+    app.use(function _seedSession(req, _res, next) { (req as unknown as { session: { authUser: User } }).session = { authUser: user }; next(); });
+  }
+  app.use("/api/v1/cluster-tenants", clusterTenantsRouter(prisma, _mockRegistry()));
+  return app;
+}
+
+/** A valid shared-tier create body. */
+function _body(name = "acme"): Row
+{
+  return { name, displayName: "Acme Corp", isolationTier: "shared", compute: { mode: "shared" }, resources: { quota: { cpu: "4", memory: "8Gi" } } };
+}
+
+describe("clusterTenantsRouter — org-admin guard matrix (ORG-ADMIN.3/4)", function _suite()
+{
+  const _AUTH_ENV = ["OPENCRANE_API_TOKEN", "OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET", "OIDC_REDIRECT_URI", "OIDC_SESSION_SECRET"] as const;
+  const _saved: Record<string, string | undefined> = {};
+
+  /** Force REAL-auth mode so every case exercises the fail-closed posture. */
+  beforeEach(function _enableAuth()
+  {
+    for (const key of _AUTH_ENV) { _saved[key] = process.env[key]; delete process.env[key]; }
+    process.env.OPENCRANE_API_TOKEN = "ci-token";
+  });
+
+  afterEach(function _restoreEnv()
+  {
+    for (const key of _AUTH_ENV) { if (_saved[key] === undefined) { delete process.env[key]; } else { process.env[key] = _saved[key]; } }
+  });
+
+  // --- CREATE gate ---------------------------------------------------------
+
+  it("rejects an anonymous create with 401 (fail-closed, never reaches the DB)", async function _anonCreate()
+  {
+    const { prisma, orgs } = _mockPrisma();
+    const res = await request(_buildApp(prisma)).post("/api/v1/cluster-tenants").send(_body());
+
+    expect(res.status).toBe(401);
+    expect(orgs.size).toBe(0);
+  });
+
+  it("rejects a create from a user with NO billing account (403 BILLING_ACCOUNT_REQUIRED)", async function _noBilling()
+  {
+    const { prisma, orgs } = _mockPrisma({ billing: [] });
+    const res = await request(_buildApp(prisma, { sub: "user-1", isPlatformOperator: false })).post("/api/v1/cluster-tenants").send(_body());
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("BILLING_ACCOUNT_REQUIRED");
+    expect(orgs.size).toBe(0);
+  });
+
+  it("allows a create from a billing-account holder and records the caller as owner", async function _createRecordsOwner()
+  {
+    const { prisma, orgs, memberships } = _mockPrisma({ billing: ["user-1"] });
+    const res = await request(_buildApp(prisma, { sub: "user-1", isPlatformOperator: false })).post("/api/v1/cluster-tenants").send(_body());
+
+    expect(res.status).toBe(201);
+    expect(orgs.has("acme")).toBe(true);
+    // The creator is written as the org's single owner, in the same transaction.
+    expect(memberships).toContainEqual(expect.objectContaining({ clusterTenant: "acme", subject: "user-1", role: "Owner" }));
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
+
+  // --- MANAGE gate (PUT/DELETE/:name + list/get) ---------------------------
+
+  it("lets an owner manage (PUT/DELETE) their own org", async function _ownerManages()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "user-1", role: "Owner" }] });
+    const app = _buildApp(prisma, { sub: "user-1", isPlatformOperator: false });
+
+    const put = await request(app).put("/api/v1/cluster-tenants/acme").send({ displayName: "Acme Inc" });
+    expect(put.status).toBe(200);
+    const del = await request(app).delete("/api/v1/cluster-tenants/acme");
+    expect(del.status).toBe(200);
+  });
+
+  it("lets an admin member read their own org via GET /:name", async function _adminReads()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "user-2", role: "Admin" }] });
+    const res = await request(_buildApp(prisma, { sub: "user-2", isPlatformOperator: false })).get("/api/v1/cluster-tenants/acme");
+
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe("acme");
+  });
+
+  it("denies a non-member managing or reading someone else's org (403)", async function _nonMember()
+  {
+    const { prisma, orgs } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "owner", role: "Owner" }] });
+    const app = _buildApp(prisma, { sub: "stranger", isPlatformOperator: false });
+
+    const get = await request(app).get("/api/v1/cluster-tenants/acme");
+    expect(get.status).toBe(403);
+    expect(get.body.code).toBe("FORBIDDEN_ORG_SCOPE");
+
+    const del = await request(app).delete("/api/v1/cluster-tenants/acme");
+    expect(del.status).toBe(403);
+    // The org must still exist — the denied delete never reached the handler.
+    expect(orgs.has("acme")).toBe(true);
+  });
+
+  it("denies a plain member (role=member) managing the org — member confers no admin authority", async function _memberDenied()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "user-3", role: "Member" }] });
+    const res = await request(_buildApp(prisma, { sub: "user-3", isPlatformOperator: false })).put("/api/v1/cluster-tenants/acme").send({ displayName: "x" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("lets a platform operator manage ANY org and list the fleet", async function _operatorAny()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme", "globex"] });
+    const app = _buildApp(prisma, { sub: "op", isPlatformOperator: true });
+
+    const list = await request(app).get("/api/v1/cluster-tenants");
+    expect(list.status).toBe(200);
+    expect(list.body).toHaveLength(2);
+    const del = await request(app).delete("/api/v1/cluster-tenants/globex");
+    expect(del.status).toBe(200);
+  });
+
+  it("denies a per-org owner the fleet list — collection routes are operator-only", async function _ownerNoFleet()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "user-1", role: "Owner" }] });
+    const res = await request(_buildApp(prisma, { sub: "user-1", isPlatformOperator: false })).get("/api/v1/cluster-tenants");
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
@@ -129,6 +129,17 @@ describe("clusterTenantsRouter — org-admin guard matrix (ORG-ADMIN.3/4)", func
     expect(orgs.size).toBe(0);
   });
 
+  it("allows the platform operator (superadmin) to create WITHOUT a billing account", async function _operatorNoBilling()
+  {
+    const { prisma, orgs } = _mockPrisma({ billing: [] });
+    const res = await request(_buildApp(prisma, { sub: "op", isPlatformOperator: true })).post("/api/v1/cluster-tenants").send(_body());
+
+    expect(res.status).toBe(201);
+    expect(orgs.has("acme")).toBe(true);
+    // The billing lookup must be bypassed entirely for the operator.
+    expect(prisma.billingAccount.findUnique).not.toHaveBeenCalled();
+  });
+
   it("allows a create from a billing-account holder and records the caller as owner", async function _createRecordsOwner()
   {
     const { prisma, orgs, memberships } = _mockPrisma({ billing: ["user-1"] });

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
@@ -14,7 +14,8 @@ type Row = Record<string, unknown>;
 /** Build a Prisma stub over an in-memory map keyed by tenant name. */
 function _mockPrisma(store: Map<string, Row>): PrismaClient
 {
-  return {
+  const memberships: Row[] = [];
+  const prisma = {
     clusterTenant: {
       findMany: vi.fn(async function _findMany() { return Array.from(store.values()); }),
       findUnique: vi.fn(async function _findUnique(args: { where: { name: string } }) { return store.get(args.where.name) ?? null; }),
@@ -32,7 +33,14 @@ function _mockPrisma(store: Map<string, Row>): PrismaClient
       }),
       delete: vi.fn(async function _delete(args: { where: { name: string } }) { store.delete(args.where.name); return {}; }),
     },
+    orgMembership: {
+      create: vi.fn(async function _createMembership(args: { data: Row }) { memberships.push(args.data); return args.data; }),
+    },
+    // Run the callback inline against the same stub — the in-memory store has no real
+    // transaction boundary, which is fine for these unit tests.
+    $transaction: vi.fn(async function _tx(fn: (tx: PrismaClient) => Promise<unknown>) { return fn(prisma); }),
   } as unknown as PrismaClient;
+  return prisma;
 }
 
 /** Registry stub: serves shared + dedicatedNodes; dedicatedCluster gated by flag. */

--- a/apps/control-plane/src/infra/auth/oidc.service.ts
+++ b/apps/control-plane/src/infra/auth/oidc.service.ts
@@ -7,6 +7,8 @@ import type { Logger } from "pino";
 import type { PrismaClient } from "@prisma/client";
 
 import { ___LoadOidcAuthConfig } from "./oidc.config.js";
+import { _ResolveOrgMembershipFacts } from "./org-membership.js";
+import type { OwnedOrg } from "./org-membership.js";
 
 /** Auth mode exposed to the UI so it can decide whether login is required. */
 export type ControlPlaneAuthMode = "development" | "oidc" | "token";
@@ -37,10 +39,12 @@ export interface ControlPlaneAuthUser
   isPlatformOperator: boolean;
 
   /**
-   * Whether the caller is an organisation admin — the role allowed to curate the MCP
-   * catalogue and approve servers (`requireOrgAdmin`, P0.5). Derived from the caller's
-   * groups intersecting `OPENCRANE_ORG_ADMIN_GROUPS`; platform operators are always org
-   * admins (superset). Empty/unset config ⇒ false for everyone (fail-closed). Enforcement
+   * Whether the caller is an organisation admin. This session-cached value is the
+   * value resolved AT LOGIN (groups intersecting `OPENCRANE_ORG_ADMIN_GROUPS`, or
+   * platform-operator superset). `/auth/me` re-derives the EFFECTIVE flag fresh at
+   * read time by OR-ing this with membership (owner/admin of ≥1 org via
+   * `OrgMembership`), so a user who creates an org becomes an org admin without
+   * re-logging-in. Empty config + no membership ⇒ false (fail-closed). Enforcement
    * stays at the API; a federated frontend uses this only to decide what UI to hide.
    */
   isOrgAdmin: boolean;
@@ -74,6 +78,14 @@ export interface ControlPlaneAuthStatusUser extends ControlPlaneAuthUser
    * (fail-closed; never taken from request input or a self-asserted claim).
    */
   clusterTenant: string | null;
+
+  /**
+   * The organisations the caller owns or administers, derived fresh from their
+   * `OrgMembership` rows (owner/admin only; members excluded). Empty when the caller
+   * administers no org. The org-scope half of the membership-derived `isOrgAdmin`.
+   * Introspection only — never taken from request input.
+   */
+  ownedOrgs: OwnedOrg[];
 }
 
 /** Session auth status returned to the SPA bootstrap logic. */
@@ -152,9 +164,11 @@ export class OidcAuthService
    * Return the auth mode and current human session details for the SPA.
    *
    * Surfaces introspection-only authorization facts: the caller's `groups`,
-   * the derived `isPlatformOperator`, and their `clusterTenant`. The first two
-   * come from the session (resolved at login); `clusterTenant` is resolved fresh
-   * here from the IdP-verified email so a post-login reparent is reflected.
+   * the derived `isPlatformOperator`, their `clusterTenant`, and their
+   * membership-derived `isOrgAdmin` + `ownedOrgs`. `groups`/`isPlatformOperator`
+   * come from the session (resolved at login); `clusterTenant`, `isOrgAdmin`, and
+   * `ownedOrgs` are resolved FRESH here so a post-login change (a reparent, or the
+   * caller creating an org and becoming its owner) is reflected without re-login.
    */
   async getStatus(req: Request): Promise<ControlPlaneAuthStatus>
   {
@@ -167,13 +181,23 @@ export class OidcAuthService
         return { mode: "oidc", authenticated: false, user: null };
       }
 
-      // 2. Resolve the ClusterTenant from the session's verified email (fail-closed)
-      //    and return it alongside the cached identity facts.
-      const clusterTenant = await this._resolveClusterTenant(authUser.email);
+      // 2. Resolve the ClusterTenant (from the verified email) and the org-admin facts
+      //    (from OrgMembership) fresh — both fail-closed. The effective `isOrgAdmin`
+      //    OR-s the login-time flag (groups/operator) with membership-derived authority,
+      //    so a user who just created an org is an org admin without re-logging-in.
+      const [clusterTenant, membership] = await Promise.all([
+        this._resolveClusterTenant(authUser.email),
+        _ResolveOrgMembershipFacts(this.prisma, authUser.sub),
+      ]);
       return {
         mode: "oidc",
         authenticated: true,
-        user: { ...authUser, clusterTenant },
+        user: {
+          ...authUser,
+          isOrgAdmin: authUser.isOrgAdmin || membership.isOrgAdmin,
+          clusterTenant,
+          ownedOrgs: membership.ownedOrgs,
+        },
       };
     }
 
@@ -460,8 +484,12 @@ export function _ResolveIdentityClaims(
 
   const isPlatformOperator = operatorViaGroup || operatorViaSeed;
 
-  // 4. Org admin iff a group matches the org-admin set (fail-closed when unset).
-  //    Platform operators are always org admins — operator is the broader role.
+  // 4. Org admin (login-time component) iff a group matches the org-admin set
+  //    (fail-closed when unset). Platform operators are always org admins — operator
+  //    is the broader role. NOTE: this is only the GROUP-derived half; `/auth/me`
+  //    OR-s it with the MEMBERSHIP-derived half (owner/admin of ≥1 org via
+  //    `OrgMembership`, resolved fresh at read time), so a user who creates an org is
+  //    an org admin even with no org-admin group claim.
   const orgAdminSet = new Set(config.orgAdminGroups);
   const isOrgAdmin = isPlatformOperator || (orgAdminSet.size > 0 && lowered.some(value => orgAdminSet.has(value)));
 

--- a/apps/control-plane/src/infra/auth/org-membership.ts
+++ b/apps/control-plane/src/infra/auth/org-membership.ts
@@ -1,0 +1,82 @@
+import type { PrismaClient } from "@prisma/client";
+
+/** One organisation the caller administers, with the role they hold there. */
+export interface OwnedOrg
+{
+  /** The organisation (ClusterTenant) key. */
+  clusterTenant: string;
+
+  /** The administering role the caller holds — `owner` or `admin`. */
+  role: "owner" | "admin";
+}
+
+/**
+ * The caller's membership-derived org-admin facts. Authority is derived purely
+ * from {@link OrgMembership} rows, never from a global flag or a self-asserted claim.
+ */
+export interface OrgMembershipFacts
+{
+  /**
+   * True iff the caller owns or administers ≥1 organisation — i.e. {@link ownedOrgs}
+   * is non-empty. This is the membership-derived half of a session's `isOrgAdmin`
+   * (platform operators are org admins by derivation, OR'd in by the caller).
+   */
+  isOrgAdmin: boolean;
+
+  /**
+   * The organisations the caller owns or administers (the org scope). Members
+   * (role `member`) confer no admin authority and are excluded. Empty when the
+   * caller administers no org.
+   */
+  ownedOrgs: OwnedOrg[];
+}
+
+/** Empty (fail-closed) facts: no admin authority, no org scope. */
+const _EMPTY: OrgMembershipFacts = { isOrgAdmin: false, ownedOrgs: [] };
+
+/**
+ * Resolve the caller's org-admin facts from their `OrgMembership` rows, fail-closed.
+ *
+ * The single source of truth for membership-derived authority, so the rule cannot
+ * drift between `/auth/me` (introspection) and the cluster-tenant guard (enforcement):
+ *
+ *   - A subject who holds `owner` or `admin` on ≥1 org IS an org admin, scoped to
+ *     exactly those orgs.
+ *   - `member` rows confer no admin authority and are excluded from the scope.
+ *   - A missing subject, no rows, or any lookup failure ⇒ empty facts (no authority).
+ *
+ * Keyed on the IdP-verified subject (OIDC `sub`), never request input.
+ *
+ * @param prisma  - Prisma client for the membership lookup.
+ * @param subject - The caller's IdP-verified subject; empty/undefined ⇒ empty facts.
+ * @returns The derived org-admin flag and the owned/administered org set.
+ */
+export async function _ResolveOrgMembershipFacts(prisma: PrismaClient, subject: string | undefined): Promise<OrgMembershipFacts>
+{
+  const normalized = typeof subject === "string" ? subject.trim() : "";
+  if (!normalized)
+  {
+    return _EMPTY;
+  }
+
+  try
+  {
+    const rows = await prisma.orgMembership.findMany({
+      where: { subject: normalized, role: { in: ["Owner", "Admin"] } },
+      select: { clusterTenant: true, role: true },
+      orderBy: { clusterTenant: "asc" },
+    });
+
+    const ownedOrgs: OwnedOrg[] = rows.map(function _toOwned(row)
+    {
+      return { clusterTenant: row.clusterTenant, role: row.role === "Owner" ? "owner" : "admin" };
+    });
+
+    return { isOrgAdmin: ownedOrgs.length > 0, ownedOrgs };
+  }
+  catch
+  {
+    // Fail closed: a lookup failure must never silently grant org-admin authority.
+    return _EMPTY;
+  }
+}

--- a/apps/control-plane/src/infra/middleware/cluster-tenant-org-admin.ts
+++ b/apps/control-plane/src/infra/middleware/cluster-tenant-org-admin.ts
@@ -1,0 +1,156 @@
+import type { Request, RequestHandler } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { _IsDevAuthMode } from "../auth/auth-mode.js";
+
+/**
+ * Resolve the caller's subject from the session, fail-closed. Under the dev-mode
+ * bypass (no real auth configured) a missing session yields a stable synthetic
+ * subject; otherwise the empty string (caller is unauthenticated).
+ */
+function _callerSubject(req: Request): string
+{
+  const sub = typeof req.session?.authUser?.sub === "string" ? req.session.authUser.sub.trim() : "";
+  if (sub)
+  {
+    return sub;
+  }
+  return _IsDevAuthMode() ? "dev-local-subject" : "";
+}
+
+/**
+ * Guard for **creating** a cluster tenant (organisation): the caller must be an
+ * authenticated user who ALREADY has a billing account. It deliberately does NOT
+ * require pre-existing org-admin — that would be a chicken-and-egg deadlock, since a
+ * user becomes an org admin BY creating their first org. The billing account is the
+ * gate that replaces it.
+ *
+ * Posture:
+ *   1. No session — FAIL OPEN under the dev-mode bypass (no OIDC, no env token), so a
+ *      fresh local install / the OPEN dev backend still works; FAIL CLOSED otherwise
+ *      (401) — an anonymous caller in a real deployment must never create an org.
+ *   2. Session present — allow iff a billing account exists for the caller's subject;
+ *      otherwise 403 with a code the SPA can use to route the user to billing first.
+ *
+ * @param prisma - Prisma client for the billing-account lookup.
+ * @returns Express middleware enforcing the billing gate (401/403 on denial).
+ */
+export function _RequireBillingAccountForOrgCreate(prisma: PrismaClient): RequestHandler
+{
+  return function _billingGate(req, res, next)
+  {
+    const authUser = req.session?.authUser;
+
+    // 1. No session — honour the auth posture (dev opens the bypass, real auth denies).
+    if (!authUser)
+    {
+      if (_IsDevAuthMode())
+      {
+        next();
+        return;
+      }
+      res.status(401).json({ error: "Authentication required", code: "UNAUTHORIZED" });
+      return;
+    }
+
+    // 2. Established session — require an existing billing account for this subject.
+    const subject = _callerSubject(req);
+    prisma.billingAccount.findUnique({ where: { subject }, select: { id: true } })
+      .then(function _onAccount(account)
+      {
+        if (account)
+        {
+          next();
+          return;
+        }
+        res.status(403).json({ error: "A billing account is required before creating an organisation.", code: "BILLING_ACCOUNT_REQUIRED" });
+      })
+      .catch(next);
+  };
+}
+
+/**
+ * Guard for **managing** an existing cluster tenant — destructive mutations
+ * (PUT/DELETE on `/:name`) and the fleet list/get reads. The caller must be EITHER:
+ *   - a platform operator (manages any org), OR
+ *   - an `owner`/`admin` member of the specific org named in `req.params.name`.
+ *
+ * For the collection routes (list at `/`, with no `:name`) only a platform operator
+ * passes — a per-org member has no business reading the whole fleet. Per-org members
+ * reach their own org via `GET /:name`.
+ *
+ * Authority is derived purely from `OrgMembership` (owner/admin) and the session's
+ * `isPlatformOperator` — never request input beyond the resource name in the path.
+ *
+ * Posture:
+ *   1. No session — FAIL OPEN under the dev-mode bypass, FAIL CLOSED otherwise (401).
+ *   2. Platform operator — allow.
+ *   3. Owner/admin membership of the named org — allow; else 403.
+ *
+ * @param prisma - Prisma client for the membership lookup.
+ * @returns Express middleware enforcing operator-or-owner/admin (401/403 on denial).
+ */
+export function _RequireOrgManager(prisma: PrismaClient): RequestHandler
+{
+  return function _orgManagerGate(req, res, next)
+  {
+    const authUser = req.session?.authUser;
+
+    // 1. No session — honour the auth posture.
+    if (!authUser)
+    {
+      if (_IsDevAuthMode())
+      {
+        next();
+        return;
+      }
+      res.status(401).json({ error: "Authentication required", code: "UNAUTHORIZED" });
+      return;
+    }
+
+    // 2. Platform operators manage any org at any scope.
+    if (authUser.isPlatformOperator)
+    {
+      next();
+      return;
+    }
+
+    // 3. Collection-scoped routes (no `:name`) are operator-only — a per-org member
+    //    must not read the whole fleet. Deny here (operator already returned above).
+    const orgName = typeof req.params.name === "string" ? req.params.name.trim() : "";
+    if (!orgName)
+    {
+      _denyScope(res);
+      return;
+    }
+
+    // 4. Resource-scoped: allow only an owner/admin member of the named org.
+    const subject = _callerSubject(req);
+    if (!subject)
+    {
+      _denyScope(res);
+      return;
+    }
+
+    prisma.orgMembership.findUnique({
+      where: { clusterTenant_subject: { clusterTenant: orgName, subject } },
+      select: { role: true },
+    })
+      .then(function _onMembership(membership)
+      {
+        if (membership && (membership.role === "Owner" || membership.role === "Admin"))
+        {
+          next();
+          return;
+        }
+        _denyScope(res);
+      })
+      .catch(next);
+  };
+}
+
+/** Emit the canonical 403 envelope; never leak which specific check failed. */
+function _denyScope(res: Parameters<RequestHandler>[1]): void
+{
+  res.status(403).json({ error: "Not authorized to manage this organisation.", code: "FORBIDDEN_ORG_SCOPE" });
+}

--- a/apps/control-plane/src/infra/middleware/cluster-tenant-org-admin.ts
+++ b/apps/control-plane/src/infra/middleware/cluster-tenant-org-admin.ts
@@ -29,8 +29,10 @@ function _callerSubject(req: Request): string
  *   1. No session — FAIL OPEN under the dev-mode bypass (no OIDC, no env token), so a
  *      fresh local install / the OPEN dev backend still works; FAIL CLOSED otherwise
  *      (401) — an anonymous caller in a real deployment must never create an org.
- *   2. Session present — allow iff a billing account exists for the caller's subject;
- *      otherwise 403 with a code the SPA can use to route the user to billing first.
+ *   2. Platform operator (env-seeded superadmin) — always allowed, no billing account
+ *      required (they operate the fleet, not a customer billing relationship).
+ *   3. Other established session — allow iff a billing account exists for the caller's
+ *      subject; otherwise 403 with a code the SPA can use to route the user to billing.
  *
  * @param prisma - Prisma client for the billing-account lookup.
  * @returns Express middleware enforcing the billing gate (401/403 on denial).
@@ -53,7 +55,16 @@ export function _RequireBillingAccountForOrgCreate(prisma: PrismaClient): Reques
       return;
     }
 
-    // 2. Established session — require an existing billing account for this subject.
+    // 2. Exception: the platform operator (the env-seeded superadmin) bootstraps and
+    //    operates the fleet, not a customer billing relationship, so they may create
+    //    organisations without a billing account.
+    if (authUser.isPlatformOperator === true)
+    {
+      next();
+      return;
+    }
+
+    // 3. Established non-operator session — require an existing billing account.
     const subject = _callerSubject(req);
     prisma.billingAccount.findUnique({ where: { subject }, select: { id: true } })
       .then(function _onAccount(account)

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -66,6 +66,22 @@ function unprocessable(description: string)
   };
 }
 
+function unauthorized(description: string)
+{
+  return {
+    description,
+    content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+  };
+}
+
+function forbidden(description: string)
+{
+  return {
+    description,
+    content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } },
+  };
+}
+
 function upstreamError()
 {
   return {
@@ -303,6 +319,27 @@ const ClusterTenantWriteSchema = {
       required: ["quota"],
       properties: { quota: { $ref: "#/components/schemas/ClusterTenantResourceQuota" } },
     },
+  },
+};
+
+const BillingAccountSchema = {
+  type: "object" as const,
+  required: ["id", "subject", "createdAt", "updatedAt"],
+  properties: {
+    id: { type: "string", description: "Surrogate identifier." },
+    subject: { type: "string", description: "IdP-verified subject (OIDC sub) that owns this billing account." },
+    email: { type: ["string", "null"], description: "The caller's verified email at create time (for human reconciliation; not the key)." },
+    displayName: { type: ["string", "null"], description: "Optional human-readable billing name (company / individual)." },
+    createdAt: { type: "string", format: "date-time" },
+    updatedAt: { type: "string", format: "date-time" },
+  },
+};
+
+const BillingAccountWriteSchema = {
+  type: "object" as const,
+  description: "Create payload for the caller's own billing account. The subject and email come from the session (never the body); only an optional displayName is accepted.",
+  properties: {
+    displayName: { type: "string", description: "Optional human-readable billing name (company / individual)." },
   },
 };
 
@@ -744,6 +781,8 @@ export const spec = {
       ClusterTenantWrite: ClusterTenantWriteSchema,
       ClusterTenantUpdate: ClusterTenantUpdateSchema,
       ClusterTenantResourceQuota: ClusterTenantResourceQuotaSchema,
+      BillingAccount: BillingAccountSchema,
+      BillingAccountWrite: BillingAccountWriteSchema,
       Group: GroupSchema,
       SkillBundle: SkillBundleSchema,
       AuditEntry: AuditEntrySchema,
@@ -1345,23 +1384,29 @@ export const spec = {
     "/cluster-tenants": {
       get: {
         operationId: "listClusterTenants",
-        summary: "List all cluster tenants",
+        summary: "List all cluster tenants (fleet view — platform-operator only)",
+        description: "Fleet-wide list. Restricted to platform operators; a per-org owner/admin reads only their own org via GET /cluster-tenants/{name}.",
         tags: ["Cluster Tenants"],
         responses: {
           200: ok("Cluster tenant list.", { type: "array", items: { $ref: "#/components/schemas/ClusterTenant" } }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is not a platform operator."),
         },
       },
       post: {
         operationId: "createClusterTenant",
-        summary: "Create a cluster tenant (rejects an isolation tier no provisioner can serve)",
+        summary: "Create a cluster tenant (organisation) and become its owner",
+        description: "Any authenticated user WITH an existing billing account may create an organisation; the caller is recorded as the org's single owner transactionally. Requires a billing account first (POST /billing-accounts), NOT pre-existing org-admin — a user becomes an org admin by creating their first org. Rejects an isolation tier no provisioner can serve.",
         tags: ["Cluster Tenants"],
         requestBody: {
           required: true,
           content: { "application/json": { schema: { $ref: "#/components/schemas/ClusterTenantWrite" } } },
         },
         responses: {
-          201: created("Cluster tenant created.", { $ref: "#/components/schemas/ClusterTenant" }),
+          201: created("Cluster tenant created; caller recorded as owner.", { $ref: "#/components/schemas/ClusterTenant" }),
           400: badRequest("Request body failed validation."),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller has no billing account (code BILLING_ACCOUNT_REQUIRED)."),
           422: unprocessable("Requested isolation tier is not served by any registered provisioner (code TIER_UNAVAILABLE)."),
         },
       },
@@ -1370,17 +1415,19 @@ export const spec = {
     "/cluster-tenants/{name}": {
       get: {
         operationId: "getClusterTenant",
-        summary: "Get a single cluster tenant by name",
+        summary: "Get a single cluster tenant by name (operator OR owner/admin of that org)",
         tags: ["Cluster Tenants"],
         parameters: [{ name: "name", in: "path", required: true, schema: { type: "string" } }],
         responses: {
           200: ok("Cluster tenant detail.", { $ref: "#/components/schemas/ClusterTenant" }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
           404: notFound("Cluster tenant not found."),
         },
       },
       put: {
         operationId: "updateClusterTenant",
-        summary: "Update a cluster tenant (re-gates the isolation tier when it changes)",
+        summary: "Update a cluster tenant (operator OR owner/admin of that org); re-gates the isolation tier when it changes",
         tags: ["Cluster Tenants"],
         parameters: [{ name: "name", in: "path", required: true, schema: { type: "string" } }],
         requestBody: {
@@ -1390,17 +1437,21 @@ export const spec = {
         responses: {
           200: ok("Cluster tenant updated.", { $ref: "#/components/schemas/ClusterTenant" }),
           400: badRequest("Request body failed validation."),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
           404: notFound("Cluster tenant not found."),
           422: unprocessable("Requested isolation tier is not served by any registered provisioner (code TIER_UNAVAILABLE)."),
         },
       },
       delete: {
         operationId: "deleteClusterTenant",
-        summary: "Delete a cluster tenant",
+        summary: "Delete a cluster tenant (operator OR owner/admin of that org)",
         tags: ["Cluster Tenants"],
         parameters: [{ name: "name", in: "path", required: true, schema: { type: "string" } }],
         responses: {
           200: ok("Cluster tenant deleted.", { type: "object", properties: { name: { type: "string" }, status: { type: "string" } } }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
           404: notFound("Cluster tenant not found."),
         },
       },
@@ -1409,7 +1460,7 @@ export const spec = {
     "/cluster-tenants/{name}/status": {
       get: {
         operationId: "getClusterTenantStatus",
-        summary: "Get the observed status of a cluster tenant",
+        summary: "Get the observed status of a cluster tenant (operator OR owner/admin of that org)",
         tags: ["Cluster Tenants"],
         parameters: [{ name: "name", in: "path", required: true, schema: { type: "string" } }],
         responses: {
@@ -1422,7 +1473,44 @@ export const spec = {
               provisioner: { type: "string" },
             },
           }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
           404: notFound("Cluster tenant not found."),
+        },
+      },
+    },
+
+    // ------------------------------------------------------------------
+    // Billing accounts — the prerequisite for creating an organisation
+    // ------------------------------------------------------------------
+
+    "/billing-accounts": {
+      post: {
+        operationId: "createBillingAccount",
+        summary: "Create the caller's own billing account (idempotent per subject)",
+        description: "Any authenticated user creates their OWN billing account, keyed to their IdP-verified subject (never request input). Idempotent: a repeat call returns the existing account (200) instead of failing. Having a billing account is the gate for creating an organisation (POST /cluster-tenants).",
+        tags: ["Billing"],
+        requestBody: {
+          required: false,
+          content: { "application/json": { schema: { $ref: "#/components/schemas/BillingAccountWrite" } } },
+        },
+        responses: {
+          201: created("Billing account created.", { $ref: "#/components/schemas/BillingAccount" }),
+          200: ok("Billing account already existed (idempotent).", { $ref: "#/components/schemas/BillingAccount" }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+        },
+      },
+    },
+
+    "/billing-accounts/me": {
+      get: {
+        operationId: "getMyBillingAccount",
+        summary: "Return the caller's own billing account",
+        tags: ["Billing"],
+        responses: {
+          200: ok("Billing account detail.", { $ref: "#/components/schemas/BillingAccount" }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          404: notFound("Caller has no billing account (code BILLING_ACCOUNT_NOT_FOUND)."),
         },
       },
     },
@@ -2786,6 +2874,18 @@ export const spec = {
                   clusterTenant: {
                     type: ["string", "null"],
                     description: "The caller's ClusterTenant (customer) key, resolved server-side from their IdP-verified email → tenant → clusterTenantRef. Null when unresolved or ambiguous.",
+                  },
+                  ownedOrgs: {
+                    type: "array",
+                    description: "Organisations the caller owns or administers, derived fresh from their OrgMembership rows (owner/admin only; members excluded). Empty when the caller administers no org. The org-scope half of the membership-derived isOrgAdmin. Introspection only — never taken from request input.",
+                    items: {
+                      type: "object",
+                      required: ["clusterTenant", "role"],
+                      properties: {
+                        clusterTenant: { type: "string", description: "The organisation (ClusterTenant) key." },
+                        role: { type: "string", enum: ["owner", "admin"], description: "The administering role the caller holds in this org." },
+                      },
+                    },
                   },
                   email: { type: "string" },
                   emailVerified: { type: "boolean" },

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -5,6 +5,7 @@ import type { PrismaClient } from "@prisma/client";
 import { accessTokensRouter } from "./routes/access-tokens.js";
 import { aiBudgetRouter } from "./routes/ai-budget.js";
 import { auditRouter } from "./routes/audit.js";
+import { billingAccountsRouter } from "./routes/billing-accounts.js";
 import { groupsRouter } from "./routes/groups.js";
 import { _RegisterInternalBundles } from "./routes/internal/skill-bundles.js";
 import { _RegisterInternalTenantContract } from "./routes/internal/tenant-contract.js";
@@ -119,6 +120,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/third-party-sources", thirdPartySourcesRouter(prisma));
   app.use("/api/v1/org/workspace-docs", companyDocsRouter(prisma, _BuildDocMergeReconciler()));
   app.use("/api/v1/platform/dns", platformDnsRouter(customApi, coreApi));
+  app.use("/api/v1/billing-accounts", billingAccountsRouter(prisma));
   app.use("/api/v1/cluster-tenants", clusterTenantsRouter(prisma, clusterTenantRegistry));
   app.use("/api/v1/awareness/rollout", awarenessRolloutRouter(prisma));
   app.use("/api/v1/awareness/participation", awarenessParticipationRouter(prisma));

--- a/apps/control-plane/src/routes/billing-accounts.ts
+++ b/apps/control-plane/src/routes/billing-accounts.ts
@@ -1,0 +1,139 @@
+import { Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { _IsDevAuthMode } from "../infra/auth/auth-mode.js";
+
+/** Shape accepted on `POST /` — only an optional human-readable billing name. */
+interface BillingAccountCreateRequest
+{
+  /** Optional human-readable billing name (company / individual). */
+  displayName?: string;
+}
+
+/**
+ * Router for the caller's own billing account — the prerequisite for creating an
+ * organisation (ClusterTenant). Org creation is gated on HAVING a billing account,
+ * which breaks the chicken-and-egg deadlock: a user becomes an org admin BY creating
+ * an org, so the create cannot itself require pre-existing org-admin.
+ *
+ * IAM-first: the account is always keyed to the caller's OWN IdP-verified subject
+ * (OIDC `sub`) taken from the session — never from request input — so a caller can
+ * only ever create/read their own account. Create is idempotent on the subject.
+ *
+ * Posture (mirrors the platform's other guards):
+ *   - No session under the dev-mode bypass (no OIDC, no env token) ⇒ a synthetic
+ *     local subject so a fresh local install / the OPEN dev backend works.
+ *   - No session in a real auth deployment ⇒ 401 (fail-closed).
+ *
+ * @param prisma - Prisma client used for persistence.
+ * @returns Configured Express router.
+ */
+export function billingAccountsRouter(prisma: PrismaClient): Router
+{
+  const router = Router();
+
+  /** Return the caller's own billing account, or 404 when they have none. */
+  router.get("/me", async function _getMyBillingAccount(req, res, next)
+  {
+    try
+    {
+      const subject = _resolveSubject(req);
+      if (!subject)
+      {
+        res.status(401).json({ error: "Authentication required", code: "UNAUTHORIZED" });
+        return;
+      }
+
+      const account = await prisma.billingAccount.findUnique({ where: { subject } });
+      if (!account)
+      {
+        res.status(404).json({ error: "No billing account for this account", code: "BILLING_ACCOUNT_NOT_FOUND" });
+        return;
+      }
+
+      res.json(_toContract(account));
+    }
+    catch (err)
+    {
+      next(err);
+    }
+  });
+
+  /**
+   * Create the caller's own billing account, idempotently. Keyed to the session's
+   * IdP-verified subject; a repeat call returns the existing account (200) rather
+   * than failing on the unique constraint, so the client can call it unconditionally.
+   */
+  router.post("/", async function _createBillingAccount(req, res, next)
+  {
+    try
+    {
+      const subject = _resolveSubject(req);
+      if (!subject)
+      {
+        res.status(401).json({ error: "Authentication required", code: "UNAUTHORIZED" });
+        return;
+      }
+
+      const body = (req.body ?? {}) as BillingAccountCreateRequest;
+      const displayName = typeof body.displayName === "string" && body.displayName.trim() ? body.displayName.trim() : null;
+      const email = _resolveEmail(req);
+
+      // Idempotent per subject: upsert so a repeat create is a no-op update, never a
+      // unique-constraint 500. The subject is taken from the session, never the body.
+      const account = await prisma.billingAccount.upsert({
+        where: { subject },
+        update: {},
+        create: { subject, email, displayName },
+      });
+
+      // 201 when freshly created (created_at === updated_at), 200 when it already existed.
+      const created = account.createdAt.getTime() === account.updatedAt.getTime();
+      res.status(created ? 201 : 200).json(_toContract(account));
+    }
+    catch (err)
+    {
+      next(err);
+    }
+  });
+
+  return router;
+}
+
+/** Contract projection of a billing-account row (stable field shapes). */
+function _toContract(account: { id: string; subject: string; email: string | null; displayName: string | null; createdAt: Date; updatedAt: Date }): Record<string, unknown>
+{
+  return {
+    id: account.id,
+    subject: account.subject,
+    email: account.email,
+    displayName: account.displayName,
+    createdAt: account.createdAt.toISOString(),
+    updatedAt: account.updatedAt.toISOString(),
+  };
+}
+
+/**
+ * Resolve the caller's subject from the session, fail-closed. Under the dev-mode
+ * bypass (no real auth configured) a missing session yields a stable synthetic
+ * subject so a fresh local install works; otherwise a missing session yields the
+ * empty string and the caller is rejected with 401.
+ */
+function _resolveSubject(req: Parameters<Parameters<Router["post"]>[1]>[0]): string
+{
+  const authUser = (req as { session?: { authUser?: { sub?: string } } }).session?.authUser;
+  const sub = typeof authUser?.sub === "string" ? authUser.sub.trim() : "";
+  if (sub)
+  {
+    return sub;
+  }
+  return _IsDevAuthMode() ? "dev-local-subject" : "";
+}
+
+/** Resolve the caller's verified email from the session, if any (for reconciliation only). */
+function _resolveEmail(req: Parameters<Parameters<Router["post"]>[1]>[0]): string | null
+{
+  const authUser = (req as { session?: { authUser?: { email?: string } } }).session?.authUser;
+  const email = typeof authUser?.email === "string" ? authUser.email.trim().toLowerCase() : "";
+  return email || null;
+}

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -1,10 +1,13 @@
 import { Router } from "express";
+import type { Request } from "express";
 import { ClusterTenantPhase, ClusterTenantTierUnavailableCode } from "@opencrane/contracts";
 import type { ClusterTenantProvisionerRegistry } from "@opencrane/contracts";
 import type { Prisma, PrismaClient } from "@prisma/client";
 
 import type { ClusterTenantCreateRequest, ClusterTenantUpdateRequest } from "./cluster-tenants.models.js";
 import { _IsIsolationTier, _ToContract, _ToPrismaCompute, _ToPrismaTier, _ValidateCompute, _ValidateResources } from "./cluster-tenants.service.js";
+import { _IsDevAuthMode } from "../infra/auth/auth-mode.js";
+import { _RequireBillingAccountForOrgCreate, _RequireOrgManager } from "../infra/middleware/cluster-tenant-org-admin.js";
 
 /** RFC-1123-ish DNS domain: lowercase labels, ≥1 dot, alpha TLD, ≤253 chars. */
 const _BASE_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
@@ -30,15 +33,21 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
 {
   const router = Router();
 
-  /** List all cluster tenants. */
-  router.get("/", async function _listClusterTenants(req, res)
+  // Org-management guards (operator OR owner/admin member of the named org). Applied
+  // to the fleet list/get reads and the destructive mutations below; the create path
+  // uses the billing gate instead (a user becomes admin BY creating, so create cannot
+  // require pre-existing org-admin).
+  const requireOrgManager = _RequireOrgManager(prisma);
+
+  /** List all cluster tenants (fleet view — platform-operator only via the guard). */
+  router.get("/", requireOrgManager, async function _listClusterTenants(req, res)
   {
     const rows = await prisma.clusterTenant.findMany({ orderBy: { createdAt: "asc" } });
     res.json(rows.map(_ToContract));
   });
 
-  /** Get a single cluster tenant by name. */
-  router.get("/:name", async function _getClusterTenant(req, res)
+  /** Get a single cluster tenant by name (operator OR owner/admin of that org). */
+  router.get("/:name", requireOrgManager, async function _getClusterTenant(req: Request<{ name: string }>, res)
   {
     const row = await prisma.clusterTenant.findUnique({ where: { name: req.params.name } });
     if (!row)
@@ -49,8 +58,8 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     res.json(_ToContract(row));
   });
 
-  /** Get just the observed status of a cluster tenant. */
-  router.get("/:name/status", async function _getClusterTenantStatus(req, res)
+  /** Get just the observed status of a cluster tenant (operator OR owner/admin of that org). */
+  router.get("/:name/status", requireOrgManager, async function _getClusterTenantStatus(req: Request<{ name: string }>, res)
   {
     const row = await prisma.clusterTenant.findUnique({ where: { name: req.params.name } });
     if (!row)
@@ -61,10 +70,27 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     res.json(_ToContract(row).status);
   });
 
-  /** Create a cluster tenant, gating the requested isolation tier on the registry. */
-  router.post("/", async function _createClusterTenant(req, res)
+  /**
+   * Create a cluster tenant (organisation), gating on the caller's billing account
+   * and recording the caller as the org's single `owner` membership transactionally.
+   * The billing gate (not pre-existing org-admin) is what authorises create — a user
+   * becomes an org admin BY creating their first org.
+   */
+  router.post("/", _RequireBillingAccountForOrgCreate(prisma), async function _createClusterTenant(req, res)
   {
     const body = req.body as ClusterTenantCreateRequest;
+
+    // 0. Resolve the caller's subject — the future owner. The billing gate ahead has
+    //    already established an authenticated session (or the dev-mode bypass), so a
+    //    missing subject here can only be the dev-mode path: stamp a synthetic owner.
+    const ownerSubject = (typeof req.session?.authUser?.sub === "string" && req.session.authUser.sub.trim())
+      ? req.session.authUser.sub.trim()
+      : (_IsDevAuthMode() ? "dev-local-subject" : "");
+    if (!ownerSubject)
+    {
+      res.status(401).json({ error: "Authentication required", code: "UNAUTHORIZED" });
+      return;
+    }
 
     // 1. Validate identity + isolation tier up front so a malformed request never
     //    reaches the database or the tier-availability gate.
@@ -107,24 +133,41 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
       return;
     }
 
-    // 4. Dual-write the row in `pending`; the operator reconciles it to `ready`.
-    const created = await prisma.clusterTenant.create({
-      data: {
-        name: body.name.trim(),
-        displayName: body.displayName.trim(),
-        baseDomain: body.baseDomain?.trim() || null,
-        isolationTier: _ToPrismaTier(body.isolationTier),
-        computeMode: _ToPrismaCompute(body.compute.mode),
-        nodePool: body.compute.nodePool?.trim() || null,
-        quota: (body.resources.quota as Prisma.InputJsonValue),
-        phase: ClusterTenantPhase.Pending,
-      },
+    // 4. Persist the org and its single owner membership in ONE transaction: the
+    //    caller becomes the org's root admin (owner) atomically with the org row.
+    //    Dual-write the org in `pending`; the operator reconciles it to `ready`.
+    //    NOTE (provisioning hand-off): a separate workstream owns the ClusterTenant
+    //    operator/CR watcher that reconciles `pending` → `ready`. This handler only
+    //    persists the desired state; see the cluster-tenants operator track.
+    const created = await prisma.$transaction(async function _createOrgWithOwner(tx)
+    {
+      const org = await tx.clusterTenant.create({
+        data: {
+          name: body.name.trim(),
+          displayName: body.displayName.trim(),
+          baseDomain: body.baseDomain?.trim() || null,
+          isolationTier: _ToPrismaTier(body.isolationTier),
+          computeMode: _ToPrismaCompute(body.compute.mode),
+          nodePool: body.compute.nodePool?.trim() || null,
+          quota: (body.resources.quota as Prisma.InputJsonValue),
+          phase: ClusterTenantPhase.Pending,
+        },
+      });
+
+      // The creator is the org's single `owner` (one-owner-per-org is enforced by the
+      // partial unique index). Written in the same tx so an org can never exist
+      // without its owner, and vice versa.
+      await tx.orgMembership.create({
+        data: { clusterTenant: org.name, subject: ownerSubject, role: "Owner" },
+      });
+
+      return org;
     });
     res.status(201).json(_ToContract(created));
   });
 
-  /** Update a cluster tenant, re-gating the isolation tier when it changes. */
-  router.put("/:name", async function _updateClusterTenant(req, res)
+  /** Update a cluster tenant (operator OR owner/admin of that org), re-gating the isolation tier when it changes. */
+  router.put("/:name", requireOrgManager, async function _updateClusterTenant(req: Request<{ name: string }>, res)
   {
     const body = req.body as ClusterTenantUpdateRequest;
     const existing = await prisma.clusterTenant.findUnique({ where: { name: req.params.name } });
@@ -206,8 +249,8 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     res.json(_ToContract(updated));
   });
 
-  /** Delete a cluster tenant. */
-  router.delete("/:name", async function _deleteClusterTenant(req, res)
+  /** Delete a cluster tenant (operator OR owner/admin of that org). */
+  router.delete("/:name", requireOrgManager, async function _deleteClusterTenant(req: Request<{ name: string }>, res)
   {
     const existing = await prisma.clusterTenant.findUnique({ where: { name: req.params.name } });
     if (!existing)

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -345,10 +345,16 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List all cluster tenants */
+        /**
+         * List all cluster tenants (fleet view — platform-operator only)
+         * @description Fleet-wide list. Restricted to platform operators; a per-org owner/admin reads only their own org via GET /cluster-tenants/{name}.
+         */
         get: operations["listClusterTenants"];
         put?: never;
-        /** Create a cluster tenant (rejects an isolation tier no provisioner can serve) */
+        /**
+         * Create a cluster tenant (organisation) and become its owner
+         * @description Any authenticated user WITH an existing billing account may create an organisation; the caller is recorded as the org's single owner transactionally. Requires a billing account first (POST /billing-accounts), NOT pre-existing org-admin — a user becomes an org admin by creating their first org. Rejects an isolation tier no provisioner can serve.
+         */
         post: operations["createClusterTenant"];
         delete?: never;
         options?: never;
@@ -363,12 +369,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get a single cluster tenant by name */
+        /** Get a single cluster tenant by name (operator OR owner/admin of that org) */
         get: operations["getClusterTenant"];
-        /** Update a cluster tenant (re-gates the isolation tier when it changes) */
+        /** Update a cluster tenant (operator OR owner/admin of that org); re-gates the isolation tier when it changes */
         put: operations["updateClusterTenant"];
         post?: never;
-        /** Delete a cluster tenant */
+        /** Delete a cluster tenant (operator OR owner/admin of that org) */
         delete: operations["deleteClusterTenant"];
         options?: never;
         head?: never;
@@ -382,8 +388,45 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Get the observed status of a cluster tenant */
+        /** Get the observed status of a cluster tenant (operator OR owner/admin of that org) */
         get: operations["getClusterTenantStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/billing-accounts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create the caller's own billing account (idempotent per subject)
+         * @description Any authenticated user creates their OWN billing account, keyed to their IdP-verified subject (never request input). Idempotent: a repeat call returns the existing account (200) instead of failing. Having a billing account is the gate for creating an organisation (POST /cluster-tenants).
+         */
+        post: operations["createBillingAccount"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/billing-accounts/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return the caller's own billing account */
+        get: operations["getMyBillingAccount"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1770,6 +1813,25 @@ export interface components {
             storage?: string;
             /** @description Total GPUs the customer may request. */
             gpu?: number;
+        };
+        BillingAccount: {
+            /** @description Surrogate identifier. */
+            id: string;
+            /** @description IdP-verified subject (OIDC sub) that owns this billing account. */
+            subject: string;
+            /** @description The caller's verified email at create time (for human reconciliation; not the key). */
+            email?: string | null;
+            /** @description Optional human-readable billing name (company / individual). */
+            displayName?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+        };
+        /** @description Create payload for the caller's own billing account. The subject and email come from the session (never the body); only an optional displayName is accepted. */
+        BillingAccountWrite: {
+            /** @description Optional human-readable billing name (company / individual). */
+            displayName?: string;
         };
         Group: {
             id?: string;
@@ -3259,6 +3321,24 @@ export interface operations {
                     "application/json": components["schemas"]["ClusterTenant"][];
                 };
             };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is not a platform operator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
         };
     };
     createClusterTenant: {
@@ -3274,7 +3354,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Cluster tenant created. */
+            /** @description Cluster tenant created; caller recorded as owner. */
             201: {
                 headers: {
                     [name: string]: unknown;
@@ -3285,6 +3365,24 @@ export interface operations {
             };
             /** @description Request body failed validation. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller has no billing account (code BILLING_ACCOUNT_REQUIRED). */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3321,6 +3419,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ClusterTenant"];
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is neither a platform operator nor an owner/admin of this org. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
             /** @description Cluster tenant not found. */
@@ -3360,6 +3476,24 @@ export interface operations {
             };
             /** @description Request body failed validation. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is neither a platform operator nor an owner/admin of this org. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -3410,6 +3544,24 @@ export interface operations {
                     };
                 };
             };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is neither a platform operator nor an owner/admin of this org. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Cluster tenant not found. */
             404: {
                 headers: {
@@ -3447,7 +3599,105 @@ export interface operations {
                     };
                 };
             };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is neither a platform operator nor an owner/admin of this org. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Cluster tenant not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createBillingAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["BillingAccountWrite"];
+            };
+        };
+        responses: {
+            /** @description Billing account already existed (idempotent). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingAccount"];
+                };
+            };
+            /** @description Billing account created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingAccount"];
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getMyBillingAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Billing account detail. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BillingAccount"];
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller has no billing account (code BILLING_ACCOUNT_NOT_FOUND). */
             404: {
                 headers: {
                     [name: string]: unknown;
@@ -6437,6 +6687,16 @@ export interface operations {
                             isOrgAdmin: boolean;
                             /** @description The caller's ClusterTenant (customer) key, resolved server-side from their IdP-verified email → tenant → clusterTenantRef. Null when unresolved or ambiguous. */
                             clusterTenant?: string | null;
+                            /** @description Organisations the caller owns or administers, derived fresh from their OrgMembership rows (owner/admin only; members excluded). Empty when the caller administers no org. The org-scope half of the membership-derived isOrgAdmin. Introspection only — never taken from request input. */
+                            ownedOrgs?: {
+                                /** @description The organisation (ClusterTenant) key. */
+                                clusterTenant: string;
+                                /**
+                                 * @description The administering role the caller holds in this org.
+                                 * @enum {string}
+                                 */
+                                role: "owner" | "admin";
+                            }[];
                             email?: string;
                             emailVerified?: boolean;
                             name?: string;

--- a/plan.md
+++ b/plan.md
@@ -70,6 +70,28 @@ isolation model).
 
 **Track WOI complete (2026-06-21).** WeOwnAI can re-sync the spec (its LIVE.8) and drop the three stopgaps; a fresh cluster can now seed its first platform operator at install (WOI.5).
 
+### Track ORG-ADMIN — Organisation creation, billing gate & membership-derived admin — LANDED 2026-06-21
+
+Closed the org-creation authz + ownership gaps the WOI fact-check surfaced: `POST /cluster-tenants` was an
+unguarded, persist-only shell with no owner and a flat global `isOrgAdmin`. Now a normal authenticated user
+creates a billing account, then creates an org and becomes its root admin.
+- **Schema (`migrations/0023_org_admin_billing`):** `BillingAccount` (keyed to the OIDC subject) + `OrgMembership`
+  `{clusterTenant, subject, role: owner|admin|member}` with one-owner-per-org uniqueness.
+- **Billing:** `POST /api/v1/billing-accounts` (idempotent per subject).
+- **Create flow:** the caller is recorded as the org's single `owner` in the SAME `$transaction` as the
+  ClusterTenant row — atomic root-admin assignment.
+- **Guards:** create requires an authenticated session WITH a billing account (a user becomes admin BY creating,
+  so create cannot require pre-existing org-admin — chicken-and-egg); read + destructive ops require
+  platform-operator OR owner/admin membership of the named org. Anonymous ⇒ 401 in real deployments (fail-closed;
+  the dev-mode bypass posture is unchanged).
+- **Derivation:** `isOrgAdmin` + the caller's `ownedOrgs` are derived from `OrgMembership` (per-org) and surfaced
+  on `/auth/me` (additive — existing `isOrgAdmin`/`clusterTenant` fields unchanged so WeOwnAI keeps working). The
+  platform-operator seed path stays intact + fail-closed.
+- **Deferred to the cluster-tenants operator track:** create still only persists `pending`; the provisioner/CR
+  watcher that reconciles `pending → ready` is a separate workstream (a named hand-off hook is left in place).
+- Tests: billing-account create, create-records-owner, the full guard matrix, membership-derived `isOrgAdmin`
+  (+20; control-plane suite 407 green).
+
 ### Track P5 — Close Phase 5 — ✅ COMPLETE · full history: plan-done.md § Completed Tracks (archived 2026-06-15)
 
 ### Track P4-A — Finish Phase 4 runtime-plane enforcement gaps — ✅ COMPLETE · full history: plan-done.md § Completed Tracks (archived 2026-06-15)


### PR DESCRIPTION
> **Stacked on `feat/platform-operator-seed` (#46).** Review/merge that first; this branch's diff is only the org-admin work. Rebase to `main` after #46 lands.

## Why

The WeOwnAI integration fact-check found `POST /cluster-tenants` was an **unguarded, persist-only shell**: it wrote a `pending` row and stopped — no owner recorded, no route guard (anonymous could create/delete under the dev-auth posture), and `isOrgAdmin` was a flat global flag. This implements the intended model: **a normal authenticated user creates a billing account, then creates an organisation and instantly becomes its root admin.**

## What

- **Schema (`migrations/0023_org_admin_billing`):** `BillingAccount` (keyed to the OIDC subject) + `OrgMembership {clusterTenant, subject, role: owner|admin|member}` with one-owner-per-org uniqueness.
- **Billing:** `POST /api/v1/billing-accounts` — idempotent per subject.
- **Create → owner, atomically:** `_createClusterTenant` records the caller as the org's single `owner` membership in the **same `$transaction`** as the ClusterTenant row, so an org always has exactly one root admin.
- **Guards** on the previously-unguarded router:
  - **Create** requires an authenticated session **with a billing account** — *not* pre-existing org-admin (a user becomes admin by creating; requiring it first is a chicken-and-egg deadlock).
  - **Read + destructive** ops require a platform operator **or** an owner/admin member of that specific org.
  - Anonymous ⇒ **401 in any real deployment** (fail-closed); the existing dev-mode bypass posture is unchanged.
- **Derivation:** `isOrgAdmin` and the caller's `ownedOrgs` are now derived from per-org `OrgMembership`, surfaced on `/auth/me`. **Additive only** — the existing `isOrgAdmin`/`clusterTenant` fields keep their shape so WeOwnAI's pinned client keeps working. The platform-operator seed path (from #46) stays intact + fail-closed.

## Validation

- Build clean (prisma + tsc + emit-openapi); contracts client regenerated from the fresh spec (no drift).
- **Control-plane suite: 407 passed** (+20 over #46) — billing-account create, create-records-owner, the full guard matrix (anon rejected, billing-less rejected, owner manages own org, non-member denied, platform-operator manages any), and membership-derived `isOrgAdmin`.

## Deferred (separate workstream)

Create still only persists `pending` — the provisioner / `clustertenants` CR-watcher that reconciles `pending → ready` is the cluster-tenants operator track. A named hand-off hook is left in place. The Prisma migration is **prepared, not applied** to any live DB (`prisma migrate deploy` is left for an authorized run).
