### PR TITLE
✨ domain: fixed platform wildcard + CNAME topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   (`*.<base>` + apex + control-plane host) at install, and each org gets its own `*.<org>.<base>`
   certificate at provision time (cert-manager DNS-01) — because a single wildcard cannot reach the
   per-user `<user>.<org>.<base>` level. New users under an existing org get HTTPS automatically.
+- **Per-org domain serving + TLS is now actually provisioned, not just specified.** OpenCrane carries a
+  working `OrgDomainProvisioner` that, for a given org, applies the per-org wildcard `Certificate`
+  (`*.<org>.<base>` + the org apex, plus any vanity domain) through cert-manager and ensures the
+  matching `*.<org>.<base>` / `<org>.<base>` A records in the platform's Cloud DNS zone — so every user
+  under the org both resolves and is browser-trusted with no per-user setup. It is idempotent and
+  fail-closed: on a cluster without cert-manager it reports the org as not-yet-ready with a clear reason
+  instead of failing, and the Cloud DNS integration is an optional dependency that on-prem installs never
+  load. As before, this runs only from the org reconciler — creating an org over the API never touches
+  DNS or cert-manager directly.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,27 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   or an owner/admin member of that specific org. Anonymous callers are rejected (401) in any real
   deployment.
 
+- **One fixed platform domain serves every org and user — no customer DNS delegation required.** The
+  platform now owns a single wildcard base (`ingress.domain`, e.g. `weownai.eu`) and a fixed
+  super-operator/control-plane host (`ingress.controlPlaneHost`, default `platform.<base>`). Each
+  organisation is automatically reachable at `<org>.<base>` (e.g. `acme.weownai.eu`) and each user at
+  `<user>.<org>.<base>` (e.g. `mike.acme.weownai.eu`) — derived names, created with zero per-name DNS
+  work once the org's wildcard exists. A customer who wants their own brand adds a single `CNAME` from
+  their domain onto `<org>.<base>` and sets the org's `vanityDomain` (`oc cluster-tenant update <org>
+  --vanity-domain …`); OpenCrane adds it to the org's TLS so it is browser-trusted, while the canonical
+  `<org>.<base>` keeps working.
+- **TLS now covers the full two-level hierarchy.** The chart issues the platform wildcard certificate
+  (`*.<base>` + apex + control-plane host) at install, and each org gets its own `*.<org>.<base>`
+  certificate at provision time (cert-manager DNS-01) — because a single wildcard cannot reach the
+  per-user `<user>.<org>.<base>` level. New users under an existing org get HTTPS automatically.
+
 ### Changed
+
+- **A ClusterTenant's `baseDomain` is replaced by `vanityDomain`.** Under the fixed-wildcard topology an
+  org no longer brings its own base domain (its serving domain is derived as `<org>.<base>`); the field is
+  repurposed as an OPTIONAL customer-vanity domain CNAMEd onto that apex. The API, `oc cluster-tenant`
+  CLI (`--vanity-domain`), and the ClusterTenant CRD use the new name; existing values are carried over by
+  the migration as vanity overlays.
 
 - **The control-plane Helm chart now wires human-login OIDC end to end.** A new
   `controlPlane.oidc.*` values block (issuer/client/redirect, client+session secret via an

--- a/apps/cli/src/commands/cluster-tenants.ts
+++ b/apps/cli/src/commands/cluster-tenants.ts
@@ -91,7 +91,7 @@ export function _RegisterClusterTenants(parent: Command, getConfig: () => CliCon
     .command("create <name>")
     .description("Create a new cluster tenant")
     .requiredOption("--display-name <displayName>", "Human-readable customer name")
-    .option("--base-domain <domain>", "Customer-owned base domain for UserTenant gateways (e.g. ai.client-company.com)")
+    .option("--vanity-domain <domain>", "Optional customer-vanity domain CNAMEd onto the org apex (e.g. ai.client-company.com)")
     .requiredOption("--tier <tier>", "Isolation tier: shared|dedicatedNodes|dedicatedCluster")
     .option("--compute <mode>", "Compute placement: shared|dedicated", "shared")
     .option("--node-pool <nodePool>", "Dedicated node pool name (required when --compute dedicated)")
@@ -108,7 +108,7 @@ export function _RegisterClusterTenants(parent: Command, getConfig: () => CliCon
       const body = {
         name,
         displayName: opts.displayName,
-        ...(opts.baseDomain ? { baseDomain: opts.baseDomain } : {}),
+        ...(opts.vanityDomain ? { vanityDomain: opts.vanityDomain } : {}),
         isolationTier: opts.tier as "shared" | "dedicatedNodes" | "dedicatedCluster",
         compute: _buildComputeBody(opts.compute, opts.nodePool),
         resources: { quota: _BuildQuotaBody(opts) },
@@ -128,7 +128,7 @@ export function _RegisterClusterTenants(parent: Command, getConfig: () => CliCon
     .command("update <name>")
     .description("Update a cluster tenant (only the supplied fields change)")
     .option("--display-name <displayName>", "New human-readable customer name")
-    .option("--base-domain <domain>", "New customer-owned base domain (e.g. ai.client-company.com)")
+    .option("--vanity-domain <domain>", "New customer-vanity domain CNAMEd onto the org apex (e.g. ai.client-company.com)")
     .option("--tier <tier>", "New isolation tier: shared|dedicatedNodes|dedicatedCluster")
     .option("--compute <mode>", "New compute placement: shared|dedicated")
     .option("--node-pool <nodePool>", "New dedicated node pool name")
@@ -145,7 +145,7 @@ export function _RegisterClusterTenants(parent: Command, getConfig: () => CliCon
       const quota = _BuildQuotaBody(opts);
       const body = {
         ...(opts.displayName ? { displayName: opts.displayName } : {}),
-        ...(opts.baseDomain !== undefined ? { baseDomain: opts.baseDomain } : {}),
+        ...(opts.vanityDomain !== undefined ? { vanityDomain: opts.vanityDomain } : {}),
         ...(opts.tier ? { isolationTier: opts.tier as "shared" | "dedicatedNodes" | "dedicatedCluster" } : {}),
         ...(opts.compute ? { compute: _buildComputeBody(opts.compute, opts.nodePool) } : {}),
         ...(Object.keys(quota).length > 0 ? { resources: { quota } } : {}),

--- a/apps/cli/src/commands/cluster-tenants.types.ts
+++ b/apps/cli/src/commands/cluster-tenants.types.ts
@@ -27,8 +27,8 @@ export interface ClusterTenantCreateOptions extends ClusterTenantQuotaOptions
 {
   /** Human-readable customer name. */
   displayName: string;
-  /** Customer-owned base domain for UserTenant gateways (e.g. ai.client-company.com). */
-  baseDomain?: string;
+  /** Optional customer-vanity domain CNAMEd onto the org apex (e.g. ai.client-company.com). */
+  vanityDomain?: string;
   /** Isolation strength: shared | dedicatedNodes | dedicatedCluster. */
   tier: string;
   /** Compute placement mode: shared | dedicated. */
@@ -44,8 +44,8 @@ export interface ClusterTenantUpdateOptions extends ClusterTenantQuotaOptions
 {
   /** New human-readable customer name. */
   displayName?: string;
-  /** New customer-owned base domain (empty string clears it). */
-  baseDomain?: string;
+  /** New customer-vanity domain CNAMEd onto the org apex (empty string clears it). */
+  vanityDomain?: string;
   /** New isolation tier: shared | dedicatedNodes | dedicatedCluster. */
   tier?: string;
   /** New compute placement mode: shared | dedicated. */

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -400,9 +400,9 @@
             "type": "string",
             "description": "Human-readable customer name."
           },
-          "baseDomain": {
+          "vanityDomain": {
             "type": "string",
-            "description": "Customer-owned base domain serving this tenant's UserTenant gateways (<user>.<baseDomain>); falls back to the per-instance ingress.domain when unset."
+            "description": "Optional customer-vanity domain CNAMEd onto the org's derived apex (<name>.<platformBaseDomain>); an overlay, not the org identity. When unset, only the derived apex serves the org."
           },
           "isolationTier": {
             "type": "string",
@@ -486,9 +486,9 @@
             "type": "string",
             "description": "Human-readable customer name."
           },
-          "baseDomain": {
+          "vanityDomain": {
             "type": "string",
-            "description": "Customer-owned base domain (e.g. ai.client-company.com); optional, falls back to the per-instance ingress.domain."
+            "description": "Optional customer-vanity domain CNAMEd onto the org's derived apex (<name>.<platformBaseDomain>); an overlay, not the org identity."
           },
           "isolationTier": {
             "type": "string",
@@ -537,9 +537,9 @@
             "type": "string",
             "description": "New human-readable customer name (must be non-blank when present)."
           },
-          "baseDomain": {
+          "vanityDomain": {
             "type": "string",
-            "description": "New customer-owned base domain; an empty string clears it (back to the per-instance ingress.domain fallback)."
+            "description": "New customer-vanity domain CNAMEd onto the org apex; an empty string clears it (back to the derived <name>.<base> apex only)."
           },
           "isolationTier": {
             "type": "string",

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -29,6 +29,9 @@
     "pino-http": "^10.0.0",
     "prisma": "^6.0.0"
   },
+  "optionalDependencies": {
+    "@google-cloud/dns": "^4.0.0"
+  },
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",

--- a/apps/control-plane/prisma/migrations/0024_cluster_tenant_vanity_domain/migration.sql
+++ b/apps/control-plane/prisma/migrations/0024_cluster_tenant_vanity_domain/migration.sql
@@ -1,0 +1,12 @@
+-- Migration 0024: ClusterTenant vanity domain (fixed wildcard topology)
+--
+-- The platform now owns ONE fixed wildcard base; an org's serving domain is DERIVED
+-- as <name>.<platformBaseDomain> (and its users at <user>.<name>.<base>), so the org
+-- no longer brings its own base domain. The old customer-owned `base_domain` column
+-- is repurposed as `vanity_domain`: an OPTIONAL customer-vanity domain CNAMEd onto
+-- the derived org apex (an overlay, not the org identity). Existing values carry over
+-- unchanged (a rename preserves data), so any previously-set domain is retained as a
+-- vanity overlay until reviewed.
+
+ALTER TABLE "cluster_tenants"
+  RENAME COLUMN "base_domain" TO "vanity_domain";

--- a/apps/control-plane/prisma/schema.prisma
+++ b/apps/control-plane/prisma/schema.prisma
@@ -137,8 +137,8 @@ model ClusterTenant {
   name           String                     @id
   /// Human-readable customer name.
   displayName    String                     @map("display_name")
-  /// Customer-owned base domain serving this tenant's UserTenant gateways (<user>.<baseDomain>); null falls back to the per-instance ingress.domain.
-  baseDomain     String?                    @map("base_domain")
+  /// Optional customer-vanity domain CNAMEd onto the org's canonical apex (<name>.<platformBaseDomain>); an overlay, not the org identity. Null → only the derived apex serves the org.
+  vanityDomain   String?                    @map("vanity_domain")
   /// Isolation strength chosen for this customer.
   isolationTier  ClusterTenantIsolationTier @default(Shared) @map("isolation_tier")
   /// Whether the customer shares nodes or gets a dedicated pool.

--- a/apps/control-plane/src/__tests__/cluster-tenants/cert-manager.client.test.ts
+++ b/apps/control-plane/src/__tests__/cluster-tenants/cert-manager.client.test.ts
@@ -3,7 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { CertManagerClient } from "../../core/cluster-tenants/cert-manager.client.js";
 
-/** A 404 error matching the client's not-found / CRD-absent shape. */
+/** A 404 the API server returns when the cert-manager CRD type is NOT served. */
+const _CRD_ABSENT = Object.assign(new Error("the server could not find the requested resource"), { code: 404, body: { message: "the server could not find the requested resource" } });
+/** A 404 the API server returns when the TARGET NAMESPACE is missing (CRD present). */
+const _NAMESPACE_MISSING = Object.assign(new Error("namespaces \"opencrane-acme\" not found"), { code: 404, body: { reason: "NotFound", message: "namespaces \"opencrane-acme\" not found", details: { kind: "namespaces", name: "opencrane-acme" } } });
+/** A plain 404 (already-gone) for delete idempotency. */
 const _NOT_FOUND = Object.assign(new Error("not found"), { code: 404 });
 /** A 409 error matching the client's conflict shape. */
 const _CONFLICT = Object.assign(new Error("already exists"), { code: 409 });
@@ -23,9 +27,9 @@ describe("CertManagerClient — Certificate CR apply (fail-closed on absent cert
     expect(result).toEqual({ ready: true, certManagerInstalled: true });
   });
 
-  it("gates ready:false + certManagerInstalled:false when the Certificate CRD is absent (404 on create) — never throws", async function _crdAbsent()
+  it("gates ready:false + certManagerInstalled:false when the Certificate CRD is absent (unserved-type 404) — never throws", async function _crdAbsent()
   {
-    const createNamespacedCustomObject = vi.fn().mockRejectedValue(_NOT_FOUND);
+    const createNamespacedCustomObject = vi.fn().mockRejectedValue(_CRD_ABSENT);
     const customApi = { createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
 
     const result = await new CertManagerClient(customApi).applyCertificate("opencrane-acme", _MANIFEST);
@@ -33,6 +37,16 @@ describe("CertManagerClient — Certificate CR apply (fail-closed on absent cert
     expect(result.ready).toBe(false);
     expect(result.certManagerInstalled).toBe(false);
     expect(result.reason).toContain("cert-manager is not installed");
+  });
+
+  it("RE-THROWS a namespace-missing 404 rather than misattributing it as cert-manager-absent", async function _namespaceMissing()
+  {
+    const createNamespacedCustomObject = vi.fn().mockRejectedValue(_NAMESPACE_MISSING);
+    const customApi = { createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    // A missing target namespace is a real precondition fault — it must NOT be masked
+    // as "cert-manager is not installed" (which would mislead operators).
+    await expect(new CertManagerClient(customApi).applyCertificate("opencrane-acme", _MANIFEST)).rejects.toThrow(/not found/);
   });
 
   it("replaces the Certificate on 409 carrying the live resourceVersion (idempotent re-apply)", async function _conflict()

--- a/apps/control-plane/src/__tests__/cluster-tenants/cert-manager.client.test.ts
+++ b/apps/control-plane/src/__tests__/cluster-tenants/cert-manager.client.test.ts
@@ -1,0 +1,72 @@
+import type * as k8s from "@kubernetes/client-node";
+import { describe, expect, it, vi } from "vitest";
+
+import { CertManagerClient } from "../../core/cluster-tenants/cert-manager.client.js";
+
+/** A 404 error matching the client's not-found / CRD-absent shape. */
+const _NOT_FOUND = Object.assign(new Error("not found"), { code: 404 });
+/** A 409 error matching the client's conflict shape. */
+const _CONFLICT = Object.assign(new Error("already exists"), { code: 409 });
+
+const _MANIFEST = { apiVersion: "cert-manager.io/v1", kind: "Certificate", metadata: { name: "org-wildcard-tls-acme", namespace: "opencrane-acme" }, spec: {} };
+
+describe("CertManagerClient — Certificate CR apply (fail-closed on absent cert-manager)", function _suite()
+{
+  it("creates the Certificate as a namespaced custom object and reads the Ready condition", async function _create()
+  {
+    const createNamespacedCustomObject = vi.fn().mockResolvedValue({ status: { conditions: [{ type: "Ready", status: "True" }] } });
+    const customApi = { createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    const result = await new CertManagerClient(customApi).applyCertificate("opencrane-acme", _MANIFEST);
+
+    expect(createNamespacedCustomObject).toHaveBeenCalledWith(expect.objectContaining({ group: "cert-manager.io", version: "v1", namespace: "opencrane-acme", plural: "certificates" }));
+    expect(result).toEqual({ ready: true, certManagerInstalled: true });
+  });
+
+  it("gates ready:false + certManagerInstalled:false when the Certificate CRD is absent (404 on create) — never throws", async function _crdAbsent()
+  {
+    const createNamespacedCustomObject = vi.fn().mockRejectedValue(_NOT_FOUND);
+    const customApi = { createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    const result = await new CertManagerClient(customApi).applyCertificate("opencrane-acme", _MANIFEST);
+
+    expect(result.ready).toBe(false);
+    expect(result.certManagerInstalled).toBe(false);
+    expect(result.reason).toContain("cert-manager is not installed");
+  });
+
+  it("replaces the Certificate on 409 carrying the live resourceVersion (idempotent re-apply)", async function _conflict()
+  {
+    const createNamespacedCustomObject = vi.fn().mockRejectedValue(_CONFLICT);
+    const getNamespacedCustomObject = vi.fn().mockResolvedValue({ metadata: { resourceVersion: "99" } });
+    const replaceNamespacedCustomObject = vi.fn().mockResolvedValue({ status: { conditions: [{ type: "Ready", status: "False", message: "pending" }] } });
+    const customApi = { createNamespacedCustomObject, getNamespacedCustomObject, replaceNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    const result = await new CertManagerClient(customApi).applyCertificate("opencrane-acme", _MANIFEST);
+
+    const body = replaceNamespacedCustomObject.mock.calls[0][0].body as { metadata: { resourceVersion?: string } };
+    expect(body.metadata.resourceVersion).toBe("99");
+    expect(result).toEqual({ ready: false, certManagerInstalled: true, reason: "pending" });
+  });
+
+  it("reports ready:false with a default reason when the Ready condition is absent (issuance in flight)", async function _noCondition()
+  {
+    const createNamespacedCustomObject = vi.fn().mockResolvedValue({ status: { conditions: [] } });
+    const customApi = { createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    const result = await new CertManagerClient(customApi).applyCertificate("opencrane-acme", _MANIFEST);
+
+    expect(result.ready).toBe(false);
+    expect(result.certManagerInstalled).toBe(true);
+    expect(result.reason).toContain("in flight");
+  });
+
+  it("deletes the Certificate; a 404 (already gone) and an absent CRD are both no-ops", async function _delete()
+  {
+    const deleteNamespacedCustomObject = vi.fn().mockRejectedValue(_NOT_FOUND);
+    const customApi = { deleteNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    await expect(new CertManagerClient(customApi).deleteCertificate("opencrane-acme", "org-wildcard-tls-acme")).resolves.toBeUndefined();
+    expect(deleteNamespacedCustomObject).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/control-plane/src/__tests__/cluster-tenants/cloud-dns.client.test.ts
+++ b/apps/control-plane/src/__tests__/cluster-tenants/cloud-dns.client.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CloudDnsClient } from "../../core/cluster-tenants/cloud-dns.client.js";
+
+/**
+ * Build a CloudDnsClient whose lazy SDK loader is stubbed with a fake DNS surface,
+ * so the record-change logic is exercised without the real @google-cloud/dns SDK.
+ */
+function _clientWithFakeZone(existing: Array<{ metadata: { data: string | string[]; ttl: number } }>)
+{
+  const createChange = vi.fn().mockResolvedValue([{}]);
+  const getRecords = vi.fn().mockResolvedValue([existing]);
+  const record = vi.fn().mockImplementation((type: string, metadata: unknown) => ({ type, metadata }));
+  const zone = { getRecords, createChange, record };
+  const dns = { zone: vi.fn().mockReturnValue(zone) };
+
+  const client = new CloudDnsClient("proj", "opencrane-zone");
+  // Inject the fake DNS into the memoised slot, bypassing the dynamic import.
+  (client as unknown as { dns: unknown }).dns = dns;
+
+  return { client, getRecords, createChange, record, zone };
+}
+
+describe("CloudDnsClient — per-org A record provisioning (idempotent)", function _suite()
+{
+  it("creates the A record (with a trailing-dot FQDN) when none exists", async function _create()
+  {
+    const { client, getRecords, createChange, record } = _clientWithFakeZone([]);
+
+    await client.ensureARecord("*.acme.weownai.eu", ["203.0.113.10"], 300);
+
+    expect(getRecords).toHaveBeenCalledWith({ name: "*.acme.weownai.eu.", type: "A" });
+    expect(record).toHaveBeenCalledWith("A", { name: "*.acme.weownai.eu.", ttl: 300, data: ["203.0.113.10"] });
+    expect(createChange).toHaveBeenCalledWith(expect.objectContaining({ add: expect.anything() }));
+    expect(createChange.mock.calls[0][0]).not.toHaveProperty("delete");
+  });
+
+  it("is a no-op when the same record data already exists", async function _noop()
+  {
+    const { client, createChange } = _clientWithFakeZone([{ metadata: { data: ["203.0.113.10"], ttl: 300 } }]);
+
+    await client.ensureARecord("*.acme.weownai.eu", ["203.0.113.10"], 300);
+
+    expect(createChange).not.toHaveBeenCalled();
+  });
+
+  it("replaces the record (delete + add) when the existing data differs", async function _replace()
+  {
+    const { client, createChange } = _clientWithFakeZone([{ metadata: { data: ["198.51.100.1"], ttl: 300 } }]);
+
+    await client.ensureARecord("*.acme.weownai.eu", ["203.0.113.10"], 300);
+
+    expect(createChange).toHaveBeenCalledWith(expect.objectContaining({ delete: expect.anything(), add: expect.anything() }));
+  });
+
+  it("deletes the record when present, and is a no-op when absent", async function _delete()
+  {
+    const present = _clientWithFakeZone([{ metadata: { data: ["203.0.113.10"], ttl: 300 } }]);
+    await present.client.deleteARecord("*.acme.weownai.eu");
+    expect(present.createChange).toHaveBeenCalledWith(expect.objectContaining({ delete: expect.anything() }));
+
+    const absent = _clientWithFakeZone([]);
+    await absent.client.deleteARecord("*.acme.weownai.eu");
+    expect(absent.createChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/control-plane/src/__tests__/cluster-tenants/org-domain.provisioner.test.ts
+++ b/apps/control-plane/src/__tests__/cluster-tenants/org-domain.provisioner.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import { DefaultOrgDomainProvisioner } from "../../core/cluster-tenants/org-domain.provisioner.js";
+import type { OrgDomainProvisionerConfig } from "../../core/cluster-tenants/org-domain.provisioner.js";
+import type { CertManagerOperations, CertificateReadiness } from "../../core/cluster-tenants/cert-manager.client.js";
+import type { CloudDnsOperations } from "../../core/cluster-tenants/cloud-dns.client.js";
+
+/** Records a cert-manager apply for assertion; returns a scripted readiness. */
+function _fakeCerts(readiness: CertificateReadiness): CertManagerOperations & { applied: Array<{ namespace: string; manifest: Record<string, unknown> }>; deleted: Array<{ namespace: string; name: string }> }
+{
+  return {
+    applied: [],
+    deleted: [],
+    async applyCertificate(namespace, manifest)
+    {
+      this.applied.push({ namespace, manifest });
+      return readiness;
+    },
+    async deleteCertificate(namespace, name)
+    {
+      this.deleted.push({ namespace, name });
+    },
+  };
+}
+
+/** Records DNS ensures/deletes for assertion. */
+function _fakeDns(): CloudDnsOperations & { ensured: Array<{ name: string; rrdatas: string[]; ttl: number }>; deleted: string[] }
+{
+  return {
+    ensured: [],
+    deleted: [],
+    async ensureARecord(name, rrdatas, ttl)
+    {
+      this.ensured.push({ name, rrdatas, ttl });
+    },
+    async deleteARecord(name)
+    {
+      this.deleted.push(name);
+    },
+  };
+}
+
+const _CONFIG: OrgDomainProvisionerConfig = { issuerName: "opencrane-issuer", issuerKind: "ClusterIssuer", namespacePrefix: "opencrane-" };
+
+const _REQ = { orgName: "acme", platformBaseDomain: "weownai.eu", ingressIp: "203.0.113.10" };
+
+describe("DefaultOrgDomainProvisioner — per-org wildcard cert + Cloud DNS", function _suite()
+{
+  it("applies a Certificate CR with the *.<org>.<base> SAN, apex SAN, issuer ref, and per-org secret", async function _certShape()
+  {
+    const certs = _fakeCerts({ ready: true, certManagerInstalled: true });
+    const dns = _fakeDns();
+    const provisioner = new DefaultOrgDomainProvisioner(certs, dns, _CONFIG);
+
+    const result = await provisioner.provisionOrgDomain(_REQ);
+
+    expect(certs.applied).toHaveLength(1);
+    const { namespace, manifest } = certs.applied[0];
+    expect(namespace).toBe("opencrane-acme");
+    expect(manifest.apiVersion).toBe("cert-manager.io/v1");
+    expect(manifest.kind).toBe("Certificate");
+    expect((manifest.metadata as Record<string, unknown>).name).toBe("org-wildcard-tls-acme");
+    expect((manifest.metadata as Record<string, unknown>).namespace).toBe("opencrane-acme");
+    const spec = manifest.spec as { secretName: string; issuerRef: { name: string; kind: string }; dnsNames: string[] };
+    expect(spec.secretName).toBe("org-wildcard-tls-acme");
+    expect(spec.issuerRef).toEqual({ name: "opencrane-issuer", kind: "ClusterIssuer" });
+    expect(spec.dnsNames).toEqual(["*.acme.weownai.eu", "acme.weownai.eu"]);
+
+    expect(result).toEqual({
+      orgDomain: "acme.weownai.eu",
+      wildcardDnsName: "*.acme.weownai.eu",
+      tlsSecretName: "org-wildcard-tls-acme",
+      ready: true,
+    });
+  });
+
+  it("ensures the per-org wildcard AND apex A records point at the ingress IP", async function _dnsShape()
+  {
+    const certs = _fakeCerts({ ready: true, certManagerInstalled: true });
+    const dns = _fakeDns();
+    const provisioner = new DefaultOrgDomainProvisioner(certs, dns, _CONFIG);
+
+    await provisioner.provisionOrgDomain(_REQ);
+
+    expect(dns.ensured).toEqual([
+      { name: "*.acme.weownai.eu", rrdatas: ["203.0.113.10"], ttl: 300 },
+      { name: "acme.weownai.eu", rrdatas: ["203.0.113.10"], ttl: 300 },
+    ]);
+  });
+
+  it("appends the vanity domain (and its wildcard) to the cert SANs when set", async function _vanity()
+  {
+    const certs = _fakeCerts({ ready: true, certManagerInstalled: true });
+    const dns = _fakeDns();
+    const provisioner = new DefaultOrgDomainProvisioner(certs, dns, _CONFIG);
+
+    await provisioner.provisionOrgDomain({ ..._REQ, vanityDomain: "acme.com" });
+
+    const spec = certs.applied[0].manifest.spec as { dnsNames: string[] };
+    expect(spec.dnsNames).toEqual(["*.acme.weownai.eu", "acme.weownai.eu", "*.acme.com", "acme.com"]);
+  });
+
+  it("is idempotent — a re-apply issues the SAME cert + DNS requests (clients absorb the no-op)", async function _idempotent()
+  {
+    const certs = _fakeCerts({ ready: true, certManagerInstalled: true });
+    const dns = _fakeDns();
+    const provisioner = new DefaultOrgDomainProvisioner(certs, dns, _CONFIG);
+
+    const first = await provisioner.provisionOrgDomain(_REQ);
+    const second = await provisioner.provisionOrgDomain(_REQ);
+
+    expect(second).toEqual(first);
+    // Same request shape both times — idempotency is the client's job (create-or-replace
+    // / same-data no-op), and the provisioner emits a stable, repeatable request.
+    expect(certs.applied[0].manifest).toEqual(certs.applied[1].manifest);
+    expect(dns.ensured.slice(0, 2)).toEqual(dns.ensured.slice(2, 4));
+  });
+
+  it("gates ready:false when the cluster has NO cert-manager — DNS still lands, no crash", async function _gatedNoCertManager()
+  {
+    const certs = _fakeCerts({ ready: false, certManagerInstalled: false, reason: "cert-manager is not installed" });
+    const dns = _fakeDns();
+    const provisioner = new DefaultOrgDomainProvisioner(certs, dns, _CONFIG);
+
+    const result = await provisioner.provisionOrgDomain(_REQ);
+
+    // Fail-closed: not ready, but the call returns cleanly (never throws).
+    expect(result.ready).toBe(false);
+    // The Certificate apply WAS attempted (real path, not a no-op stub).
+    expect(certs.applied).toHaveLength(1);
+    // Serving DNS still landed so the org resolves; only browser-trusted TLS waits.
+    expect(dns.ensured.map(e => e.name)).toEqual(["*.acme.weownai.eu", "acme.weownai.eu"]);
+  });
+
+  it("reports ready:false while DNS-01 issuance is still in flight (cert-manager present)", async function _inFlight()
+  {
+    const certs = _fakeCerts({ ready: false, certManagerInstalled: true, reason: "issuance in flight" });
+    const dns = _fakeDns();
+    const provisioner = new DefaultOrgDomainProvisioner(certs, dns, _CONFIG);
+
+    const result = await provisioner.provisionOrgDomain(_REQ);
+
+    expect(result.ready).toBe(false);
+    expect(result.tlsSecretName).toBe("org-wildcard-tls-acme");
+  });
+
+  it("deprovisions by deleting the Certificate and both A records (idempotent teardown)", async function _deprovision()
+  {
+    const certs = _fakeCerts({ ready: true, certManagerInstalled: true });
+    const dns = _fakeDns();
+    const provisioner = new DefaultOrgDomainProvisioner(certs, dns, _CONFIG);
+
+    await provisioner.deprovisionOrgDomain("acme", "weownai.eu");
+
+    expect(certs.deleted).toEqual([{ namespace: "opencrane-acme", name: "org-wildcard-tls-acme" }]);
+    expect(dns.deleted).toEqual(["*.acme.weownai.eu", "acme.weownai.eu"]);
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
@@ -145,24 +145,24 @@ describe("clusterTenantsRouter (CT.2 management API)", function _suite()
     expect(res.body.code).toBe("VALIDATION_ERROR");
   });
 
-  it("persists and returns a valid baseDomain, and rejects a malformed one (CT.8)", async function _baseDomain()
+  it("persists and returns a valid vanityDomain, and rejects a malformed one", async function _vanityDomain()
   {
     const app = _buildApp(_mockPrisma(new Map()), _mockRegistry(false));
 
-    // 1. A valid customer domain round-trips on create.
-    const okRes = await request(app).post("/api/v1/cluster-tenants").send({ ..._sharedBody(), baseDomain: "ai.client-company.com" });
+    // 1. A valid customer-vanity domain round-trips on create.
+    const okRes = await request(app).post("/api/v1/cluster-tenants").send({ ..._sharedBody(), vanityDomain: "ai.client-company.com" });
     expect(okRes.status).toBe(201);
-    expect(okRes.body.baseDomain).toBe("ai.client-company.com");
+    expect(okRes.body.vanityDomain).toBe("ai.client-company.com");
 
     // 2. A malformed domain is rejected before persistence.
-    const badRes = await request(app).post("/api/v1/cluster-tenants").send({ ..._sharedBody(), name: "bad", baseDomain: "not a domain" });
+    const badRes = await request(app).post("/api/v1/cluster-tenants").send({ ..._sharedBody(), name: "bad", vanityDomain: "not a domain" });
     expect(badRes.status).toBe(400);
     expect(badRes.body.code).toBe("VALIDATION_ERROR");
 
-    // 3. Update can clear the domain with an empty string (falls back to ingress.domain).
-    const clrRes = await request(app).put("/api/v1/cluster-tenants/acme").send({ baseDomain: "" });
+    // 3. Update can clear the vanity domain with an empty string (back to the derived apex only).
+    const clrRes = await request(app).put("/api/v1/cluster-tenants/acme").send({ vanityDomain: "" });
     expect(clrRes.status).toBe(200);
-    expect(clrRes.body.baseDomain).toBeUndefined();
+    expect(clrRes.body.vanityDomain).toBeUndefined();
   });
 
   it("returns 404 for an unknown cluster tenant", async function _notFound()

--- a/apps/control-plane/src/core/cluster-tenants/cert-manager.client.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cert-manager.client.ts
@@ -1,0 +1,179 @@
+import type * as k8s from "@kubernetes/client-node";
+
+/** cert-manager API group/version for the Certificate custom resource. */
+const _CM_GROUP = "cert-manager.io";
+const _CM_VERSION = "v1";
+/** Plural for the namespaced `Certificate` custom resource. */
+const _CM_CERTIFICATE_PLURAL = "certificates";
+
+/** The readiness a cert-manager Certificate reports once issuance completes. */
+export interface CertificateReadiness
+{
+  /** Whether the Certificate's `Ready` condition is `True` (issuance complete). */
+  ready: boolean;
+  /** Whether cert-manager is installed (the Certificate CRD is served). */
+  certManagerInstalled: boolean;
+  /** Human-readable reason when not ready (condition message, or CRD-absent note). */
+  reason?: string;
+}
+
+/**
+ * Minimal interface over the cert-manager Certificate operations the
+ * OrgDomainProvisioner needs. Injected so unit tests can substitute a fake
+ * without a live cluster or the CustomObjectsApi.
+ */
+export interface CertManagerOperations
+{
+  /**
+   * Apply (create-or-replace) a Certificate CR, idempotently. A re-apply carries
+   * the live resourceVersion so it never conflicts. Surfaces `certManagerInstalled:
+   * false` (fail-closed, never throws) when the Certificate CRD is absent.
+   *
+   * @param namespace - Namespace the Certificate (and its Secret) live in.
+   * @param manifest  - The Certificate manifest to apply.
+   */
+  applyCertificate(namespace: string, manifest: Record<string, unknown>): Promise<CertificateReadiness>;
+
+  /**
+   * Delete the named Certificate if present; absence (404) and a missing CRD are
+   * both no-ops (idempotent teardown).
+   *
+   * @param namespace - Namespace the Certificate lives in.
+   * @param name      - Certificate name.
+   */
+  deleteCertificate(namespace: string, name: string): Promise<void>;
+}
+
+/**
+ * Production cert-manager client over the Kubernetes custom-objects API. Mirrors
+ * the proven create-then-replace-on-409 pattern in
+ * `core/platform-dns/apply-dns-config.ts`, and reads the Certificate's `Ready`
+ * condition back so the caller can reflect issuance state.
+ *
+ * Fail-closed: when the dev/target cluster has NO cert-manager (the Certificate
+ * CRD is not served), apply does NOT crash — it returns `certManagerInstalled:
+ * false` so the provisioner can surface a clear `ready:false` + reason. The
+ * resource-authoring path is real (not a no-op stub): the exact manifest that
+ * WOULD be applied is built and the API call IS issued; only an absent CRD short-
+ * circuits it.
+ */
+export class CertManagerClient implements CertManagerOperations
+{
+  /** Kubernetes custom-objects client (Certificate CRDs). */
+  private readonly customApi: k8s.CustomObjectsApi;
+
+  /**
+   * @param customApi - Kubernetes custom-objects client.
+   */
+  public constructor(customApi: k8s.CustomObjectsApi)
+  {
+    this.customApi = customApi;
+  }
+
+  /** @inheritdoc */
+  public async applyCertificate(namespace: string, manifest: Record<string, unknown>): Promise<CertificateReadiness>
+  {
+    const name = ((manifest.metadata as Record<string, unknown>)?.name) as string;
+
+    let applied: unknown;
+    try
+    {
+      applied = await this.customApi.createNamespacedCustomObject({
+        group: _CM_GROUP, version: _CM_VERSION, namespace, plural: _CM_CERTIFICATE_PLURAL, body: manifest,
+      });
+    }
+    catch (err)
+    {
+      // No cert-manager → the Certificate CRD is not served. Fail closed, never crash.
+      if (_IsCrdAbsent(err))
+      {
+        return { ready: false, certManagerInstalled: false, reason: "cert-manager is not installed (certificates.cert-manager.io CRD is absent); no Certificate was created." };
+      }
+
+      // 409 Conflict → already exists; fetch live resourceVersion and replace in-place.
+      if (_IsConflict(err))
+      {
+        const existing = await this.customApi.getNamespacedCustomObject({ group: _CM_GROUP, version: _CM_VERSION, namespace, plural: _CM_CERTIFICATE_PLURAL, name });
+        const resourceVersion = (existing as { metadata?: { resourceVersion?: string } }).metadata?.resourceVersion;
+        const body = { ...manifest, metadata: { ...(manifest.metadata as Record<string, unknown>), resourceVersion } };
+        applied = await this.customApi.replaceNamespacedCustomObject({ group: _CM_GROUP, version: _CM_VERSION, namespace, plural: _CM_CERTIFICATE_PLURAL, name, body });
+        return _readReadiness(applied);
+      }
+      throw err;
+    }
+
+    return _readReadiness(applied);
+  }
+
+  /** @inheritdoc */
+  public async deleteCertificate(namespace: string, name: string): Promise<void>
+  {
+    try
+    {
+      await this.customApi.deleteNamespacedCustomObject({ group: _CM_GROUP, version: _CM_VERSION, namespace, plural: _CM_CERTIFICATE_PLURAL, name });
+    }
+    catch (err)
+    {
+      // 404 (already gone) and an absent CRD are both no-ops.
+      if (_IsNotFound(err) || _IsCrdAbsent(err))
+      {
+        return;
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Read the `Ready` condition off a Certificate object. cert-manager stamps
+ * `status.conditions[type=Ready].status` once DNS-01 issuance completes; absent or
+ * `False` means issuance is still in flight (the gated `ready:false` case).
+ */
+function _readReadiness(obj: unknown): CertificateReadiness
+{
+  const conditions = (obj as { status?: { conditions?: Array<{ type?: string; status?: string; message?: string }> } })?.status?.conditions ?? [];
+  const ready = conditions.find(c => c.type === "Ready");
+  if (ready?.status === "True")
+  {
+    return { ready: true, certManagerInstalled: true };
+  }
+  return { ready: false, certManagerInstalled: true, reason: ready?.message ?? "Certificate issuance is still in flight (DNS-01 challenge not yet complete)." };
+}
+
+/** Detect a Kubernetes 409 Conflict (already-exists) across client error shapes. */
+function _IsConflict(err: unknown): boolean
+{
+  return _statusOf(err) === 409;
+}
+
+/** Detect a Kubernetes 404 Not Found across client error shapes. */
+function _IsNotFound(err: unknown): boolean
+{
+  return _statusOf(err) === 404;
+}
+
+/**
+ * Detect an absent CRD — the cluster has no cert-manager. The API server answers a
+ * request against an unserved group/version with 404 NotFound (and the body kind is
+ * `Status` with reason `NotFound`), so a 404 on a CREATE (which can never be an
+ * already-gone delete) signals the CRD is not installed.
+ */
+function _IsCrdAbsent(err: unknown): boolean
+{
+  if (_statusOf(err) !== 404)
+  {
+    return false;
+  }
+  // A create returning 404 means the resource TYPE (CRD) is not served — there is no
+  // object to be "not found" on a create otherwise.
+  const reason = (err as { body?: { reason?: string }; reason?: string })?.body?.reason
+    ?? (err as { reason?: string })?.reason;
+  return reason === undefined || reason === "NotFound";
+}
+
+/** Extract a Kubernetes API status code from common client error shapes. */
+function _statusOf(err: unknown): number | undefined
+{
+  const e = err as { code?: number; statusCode?: number; response?: { statusCode?: number }; body?: { code?: number } };
+  return e?.code ?? e?.statusCode ?? e?.response?.statusCode ?? e?.body?.code;
+}

--- a/apps/control-plane/src/core/cluster-tenants/cert-manager.client.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cert-manager.client.ts
@@ -153,10 +153,20 @@ function _IsNotFound(err: unknown): boolean
 }
 
 /**
- * Detect an absent CRD — the cluster has no cert-manager. The API server answers a
- * request against an unserved group/version with 404 NotFound (and the body kind is
- * `Status` with reason `NotFound`), so a 404 on a CREATE (which can never be an
- * already-gone delete) signals the CRD is not installed.
+ * Detect an absent CRD — the cluster has no cert-manager — and ONLY that.
+ *
+ * A 404 on a CREATE is ambiguous: it can mean either (a) the resource TYPE is not
+ * served (the `certificates.cert-manager.io` CRD is not installed) OR (b) the target
+ * NAMESPACE does not exist. We must not conflate the two — reporting "cert-manager is
+ * not installed" when the real fault is a missing namespace would mislead operators.
+ *
+ * The API server discriminates them in the Status body: an unserved type returns the
+ * discovery-style message "the server could not find the requested resource" with no
+ * resource-specific `details.name`; a missing namespace returns reason `NotFound` with
+ * `details.kind == "namespaces"` (and a namespace name). So we treat a 404 as CRD-absent
+ * ONLY when it carries the unserved-type signature (group cert-manager.io, or the
+ * discovery message, or no `details.kind`/`details.name` pinning it to another object).
+ * Any other 404 returns false here and is re-thrown by the caller (fail-loud).
  */
 function _IsCrdAbsent(err: unknown): boolean
 {
@@ -164,11 +174,30 @@ function _IsCrdAbsent(err: unknown): boolean
   {
     return false;
   }
-  // A create returning 404 means the resource TYPE (CRD) is not served — there is no
-  // object to be "not found" on a create otherwise.
-  const reason = (err as { body?: { reason?: string }; reason?: string })?.body?.reason
-    ?? (err as { reason?: string })?.reason;
-  return reason === undefined || reason === "NotFound";
+
+  const body = (err as { body?: { message?: string; details?: { group?: string; kind?: string; name?: string } }; message?: string }).body
+    ?? (err as { message?: string; details?: { group?: string; kind?: string; name?: string } });
+  const message = (body as { message?: string })?.message ?? (err as { message?: string })?.message ?? "";
+  const details = (body as { details?: { group?: string; kind?: string; name?: string } })?.details;
+
+  // (a) The Status names the cert-manager group/Certificate type as the missing TYPE.
+  if (details?.group === _CM_GROUP && !details?.name)
+  {
+    return true;
+  }
+  // (b) The discovery-layer message for an unserved group/version/kind.
+  if (/could not find the requested resource/i.test(message))
+  {
+    return true;
+  }
+  // (c) The 404 is pinned to a DIFFERENT object (e.g. a missing namespace) — NOT a CRD
+  //     absence. Return false so the caller re-throws rather than misattributing it.
+  if (details?.kind && details.kind !== _CM_CERTIFICATE_PLURAL && details.kind !== "certificates")
+  {
+    return false;
+  }
+  // (d) No details at all and no discovery message → too ambiguous to claim CRD-absent.
+  return false;
 }
 
 /** Extract a Kubernetes API status code from common client error shapes. */

--- a/apps/control-plane/src/core/cluster-tenants/cloud-dns.client.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cloud-dns.client.ts
@@ -1,0 +1,163 @@
+// Type-only import — erased at compile time, so it creates NO runtime dependency
+// on @google-cloud/dns. The actual module is loaded lazily in _getDns().
+import type { DNS } from "@google-cloud/dns";
+
+/**
+ * Minimal interface over the Cloud DNS record operations the OrgDomainProvisioner
+ * needs. Injected so unit tests can substitute a fake without importing the SDK.
+ */
+export interface CloudDnsOperations
+{
+  /**
+   * Ensure an A record exists for `name` pointing at `rrdatas`, idempotently. A
+   * re-apply with the same data is a no-op; an existing record with different data
+   * is replaced. `name` is the fully-qualified record name WITHOUT a trailing dot
+   * (e.g. `*.acme.weownai.eu`); implementations append the dot Cloud DNS requires.
+   *
+   * @param name    - FQDN of the record (no trailing dot).
+   * @param rrdatas - Record data (the ingress IP for an A record).
+   * @param ttl     - Record TTL in seconds.
+   */
+  ensureARecord(name: string, rrdatas: string[], ttl: number): Promise<void>;
+
+  /**
+   * Delete the A record `name` if present; absence is a no-op (idempotent teardown).
+   *
+   * @param name - FQDN of the record (no trailing dot).
+   */
+  deleteARecord(name: string): Promise<void>;
+}
+
+/**
+ * Production Cloud DNS client wrapper, scoped to a single managed zone.
+ *
+ * The `@google-cloud/dns` SDK is an OPTIONAL dependency loaded lazily via dynamic
+ * import only when a DNS operation actually runs. This keeps the on-prem default
+ * (and any non-GCP install) free of the cloud SDK at install and runtime — an
+ * on-prem image can omit the package entirely and the control-plane still starts,
+ * because this code path is never taken there. Mirrors the operator's
+ * `GcpBucketClient` posture.
+ *
+ * Uses Application Default Credentials (Workload Identity on GKE); no static
+ * credentials are read.
+ */
+export class CloudDnsClient implements CloudDnsOperations
+{
+  /** GCP project that owns the managed zone. */
+  private readonly projectId: string;
+
+  /** Cloud DNS managed-zone resource name (the terraform-created `<zone>-zone`). */
+  private readonly managedZone: string;
+
+  /** Lazily-initialised SDK client; null until the first DNS operation. */
+  private dns: DNS | null = null;
+
+  /**
+   * @param projectId   - GCP project that owns the managed zone.
+   * @param managedZone - Cloud DNS managed-zone resource name (terraform `<zone>-zone`).
+   */
+  public constructor(projectId: string, managedZone: string)
+  {
+    this.projectId = projectId;
+    this.managedZone = managedZone;
+  }
+
+  /** @inheritdoc */
+  public async ensureARecord(name: string, rrdatas: string[], ttl: number): Promise<void>
+  {
+    const dns = await this._getDns();
+    const zone = dns.zone(this.managedZone);
+    const fqdn = _withTrailingDot(name);
+
+    // 1. Look up any existing A record at this name (zone records are keyed by
+    //    name+type). A re-apply with identical data converges to a no-op.
+    const [records] = await zone.getRecords({ name: fqdn, type: "A" });
+    const desired = zone.record("A", { name: fqdn, ttl, data: rrdatas });
+
+    if (records.length === 0)
+    {
+      await zone.createChange({ add: desired });
+      return;
+    }
+
+    // 2. Same data already present → idempotent no-op (don't churn the zone).
+    const current = records[0];
+    if (_sameRecordData(_recordData(current.metadata?.data), rrdatas) && current.metadata?.ttl === ttl)
+    {
+      return;
+    }
+
+    // 3. Different data → atomic replace (delete old, add new in one change).
+    await zone.createChange({ delete: current, add: desired });
+  }
+
+  /** @inheritdoc */
+  public async deleteARecord(name: string): Promise<void>
+  {
+    const dns = await this._getDns();
+    const zone = dns.zone(this.managedZone);
+    const fqdn = _withTrailingDot(name);
+
+    const [records] = await zone.getRecords({ name: fqdn, type: "A" });
+    if (records.length === 0)
+    {
+      return; // Already gone — idempotent.
+    }
+    await zone.createChange({ delete: records[0] });
+  }
+
+  /**
+   * Lazily import @google-cloud/dns and memoise the client. Throws a precise,
+   * actionable error if the optional dependency is missing.
+   */
+  private async _getDns(): Promise<DNS>
+  {
+    if (this.dns)
+    {
+      return this.dns;
+    }
+
+    try
+    {
+      const sdk = await import("@google-cloud/dns");
+      this.dns = new sdk.DNS({ projectId: this.projectId });
+      return this.dns;
+    }
+    catch (err)
+    {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        "@google-cloud/dns is required for Cloud DNS per-org record provisioning but could not be loaded. "
+        + "Install the optional GCP DNS dependency (pnpm install, without --no-optional). "
+        + `Original error: ${detail}`,
+      );
+    }
+  }
+}
+
+/** Append the trailing dot Cloud DNS requires on FQDNs, idempotently. */
+function _withTrailingDot(name: string): string
+{
+  return name.endsWith(".") ? name : `${name}.`;
+}
+
+/** Normalise a record's `data` (string | string[] | undefined) to a string array. */
+function _recordData(data: string | string[] | undefined): string[]
+{
+  if (data === undefined)
+  {
+    return [];
+  }
+  return Array.isArray(data) ? data : [data];
+}
+
+/** Compare two record-data arrays as sets (order-insensitive). */
+function _sameRecordData(a: string[], b: string[]): boolean
+{
+  if (a.length !== b.length)
+  {
+    return false;
+  }
+  const setB = new Set(b);
+  return a.every(item => setB.has(item));
+}

--- a/apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts
+++ b/apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts
@@ -10,17 +10,19 @@
  *      because the platform `*.<base>` cert does NOT cover the extra label
  *      `<user>.<name>.<base>` (DNS wildcards match exactly one label).
  *
- * This module defines ONLY the interface. The concrete implementation — and the
- * ClusterTenant operator/CR watcher that CALLS it on the `pending → ready` reconcile
- * — is a SEPARATE workstream (the cluster-tenants operator track) and is intentionally
- * NOT built here. The control-plane create flow
- * (`routes/cluster-tenants.ts → _createClusterTenant`) persists desired state and
- * hands off to that reconciler; the reconciler invokes `provisionOrgDomain(...)`.
+ * This module defines the interface. The concrete implementation is
+ * `DefaultOrgDomainProvisioner` (org-domain.provisioner.js), wired from env via
+ * `_BuildOrgDomainProvisioner`: it applies the per-org wildcard Certificate through
+ * cert-manager (DNS-01) and the per-org A records through the terraform-managed
+ * Cloud DNS zone. The ClusterTenant operator/CR watcher that CALLS it on the
+ * `pending → ready` reconcile lands with that reconciler. The control-plane create
+ * flow (`routes/cluster-tenants.ts → _createClusterTenant`) persists desired state
+ * and hands off to that reconciler; the reconciler invokes `provisionOrgDomain(...)`.
  *
- * Keeping this an interface (no live cert-manager / Cloud DNS calls in the create
- * path) preserves the API-first, fail-closed posture: a malformed or unauthorised
- * create never reaches DNS or TLS issuance, and the side effects are idempotent and
- * separately ownable.
+ * Keeping the create path free of live cert-manager / Cloud DNS calls (they run only
+ * from the reconciler, behind this interface) preserves the API-first, fail-closed
+ * posture: a malformed or unauthorised create never reaches DNS or TLS issuance, and
+ * the side effects are idempotent and separately ownable.
  */
 
 /** Inputs the reconciler passes when provisioning an org's domain + TLS. */
@@ -56,9 +58,9 @@ export interface OrgDomainProvisionResult
 
 /**
  * Backend that materialises an org's DNS record + wildcard TLS certificate. The
- * concrete implementation is provided by the cluster-tenants operator workstream;
- * the control plane only depends on this signature so the two can be built and
- * tested independently (mirrors the `ClusterTenantProvisioner` seam).
+ * concrete implementation is `DefaultOrgDomainProvisioner`; callers depend only on
+ * this signature so the provisioner and the reconciler that drives it can be built
+ * and tested independently (mirrors the `ClusterTenantProvisioner` seam).
  */
 export interface OrgDomainProvisioner
 {

--- a/apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts
+++ b/apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts
@@ -1,0 +1,82 @@
+/**
+ * Per-org domain provisioning seam (fixed-wildcard topology).
+ *
+ * When an org (ClusterTenant) is created, it becomes addressable at its derived apex
+ * `<name>.<platformBaseDomain>` and its users at `<user>.<name>.<base>`. Two
+ * cluster-side side effects must follow:
+ *   1. DNS — a per-org wildcard record `*.<name>.<base>` → the cluster ingress IP, so
+ *      every UserTenant gateway host under the org resolves with no per-user record.
+ *   2. TLS — a per-org wildcard Certificate `*.<name>.<base>` (cert-manager DNS-01),
+ *      because the platform `*.<base>` cert does NOT cover the extra label
+ *      `<user>.<name>.<base>` (DNS wildcards match exactly one label).
+ *
+ * This module defines ONLY the interface. The concrete implementation — and the
+ * ClusterTenant operator/CR watcher that CALLS it on the `pending → ready` reconcile
+ * — is a SEPARATE workstream (the cluster-tenants operator track) and is intentionally
+ * NOT built here. The control-plane create flow
+ * (`routes/cluster-tenants.ts → _createClusterTenant`) persists desired state and
+ * hands off to that reconciler; the reconciler invokes `provisionOrgDomain(...)`.
+ *
+ * Keeping this an interface (no live cert-manager / Cloud DNS calls in the create
+ * path) preserves the API-first, fail-closed posture: a malformed or unauthorised
+ * create never reaches DNS or TLS issuance, and the side effects are idempotent and
+ * separately ownable.
+ */
+
+/** Inputs the reconciler passes when provisioning an org's domain + TLS. */
+export interface OrgDomainProvisionRequest
+{
+  /** Org (ClusterTenant) name — the single DNS label, e.g. `acme`. */
+  orgName: string;
+  /** Platform wildcard base the org hangs off, e.g. `weownai.eu`. */
+  platformBaseDomain: string;
+  /**
+   * Optional customer-vanity domain CNAMEd onto the org apex (`<name>.<base>`). When
+   * present, the implementation SHOULD add it to the issued certificate's SANs so the
+   * org is browser-trusted under the vanity name too. DNS for the vanity name itself
+   * is the customer's CNAME at their own provider — never created here.
+   */
+  vanityDomain?: string;
+  /** Cluster ingress external IP the per-org wildcard A record must point at. */
+  ingressIp: string;
+}
+
+/** Result reported back to the reconciler so it can stamp the org's status. */
+export interface OrgDomainProvisionResult
+{
+  /** Canonical org apex the record + cert were provisioned for (`<name>.<base>`). */
+  orgDomain: string;
+  /** The per-org wildcard DNS name created (`*.<name>.<base>`). */
+  wildcardDnsName: string;
+  /** Name of the cert-manager-managed TLS Secret holding the issued wildcard cert. */
+  tlsSecretName: string;
+  /** Whether issuance has completed (false while DNS-01 is still in flight). */
+  ready: boolean;
+}
+
+/**
+ * Backend that materialises an org's DNS record + wildcard TLS certificate. The
+ * concrete implementation is provided by the cluster-tenants operator workstream;
+ * the control plane only depends on this signature so the two can be built and
+ * tested independently (mirrors the `ClusterTenantProvisioner` seam).
+ */
+export interface OrgDomainProvisioner
+{
+  /**
+   * Provision (idempotently) the per-org wildcard DNS record and TLS certificate.
+   * Called by the ClusterTenant reconciler on the `pending → ready` transition; safe
+   * to re-invoke on every reconcile.
+   *
+   * @param req - The org coordinates, platform base, optional vanity domain, ingress IP.
+   * @returns The provisioned apex, wildcard name, TLS Secret name, and readiness.
+   */
+  provisionOrgDomain(req: OrgDomainProvisionRequest): Promise<OrgDomainProvisionResult>;
+
+  /**
+   * Tear down the per-org DNS record + certificate when the org is deleted.
+   *
+   * @param orgName - The org (ClusterTenant) name being deprovisioned.
+   * @param platformBaseDomain - The platform wildcard base the org hung off.
+   */
+  deprovisionOrgDomain(orgName: string, platformBaseDomain: string): Promise<void>;
+}

--- a/apps/control-plane/src/core/cluster-tenants/org-domain.provisioner.factory.ts
+++ b/apps/control-plane/src/core/cluster-tenants/org-domain.provisioner.factory.ts
@@ -1,0 +1,45 @@
+import type * as k8s from "@kubernetes/client-node";
+
+import { CertManagerClient } from "./cert-manager.client.js";
+import { CloudDnsClient } from "./cloud-dns.client.js";
+import { DefaultOrgDomainProvisioner } from "./org-domain.provisioner.js";
+import type { OrgDomainProvisioner } from "./org-domain-provisioner.types.js";
+
+/**
+ * Build the concrete {@link OrgDomainProvisioner} from the environment, wiring the
+ * real cert-manager (custom-objects) and Cloud DNS clients.
+ *
+ * Env (all optional; sensible defaults match the chart values):
+ * - `GCP_PROJECT_ID`           — project owning the Cloud DNS managed zone (required for DNS).
+ * - `DNS_MANAGED_ZONE`         — managed-zone resource name (terraform `<zone>-zone`); required for DNS.
+ * - `CERT_MANAGER_ISSUER_NAME` — issuer the Certificate references (default `opencrane-issuer`).
+ * - `CERT_MANAGER_ISSUER_KIND` — `ClusterIssuer` (default) or `Issuer`.
+ * - `CLUSTER_TENANT_NAMESPACE_PREFIX` — org→namespace prefix (default `opencrane-`).
+ *
+ * Returns null when the DNS coordinates are absent (no GCP project/zone) — the
+ * platform is not on a Cloud DNS install, so per-org domain provisioning is
+ * unavailable and the reconciler must treat the org as not-yet-served (fail-closed),
+ * NOT silently succeed.
+ *
+ * @param customApi - Kubernetes custom-objects client (Certificate CRDs).
+ * @returns A wired provisioner, or null when Cloud DNS coordinates are unset.
+ */
+export function _BuildOrgDomainProvisioner(customApi: k8s.CustomObjectsApi): OrgDomainProvisioner | null
+{
+  const projectId = process.env.GCP_PROJECT_ID?.trim();
+  const managedZone = process.env.DNS_MANAGED_ZONE?.trim();
+  if (!projectId || !managedZone)
+  {
+    return null;
+  }
+
+  const issuerName = process.env.CERT_MANAGER_ISSUER_NAME?.trim() || "opencrane-issuer";
+  const issuerKind = process.env.CERT_MANAGER_ISSUER_KIND?.trim() === "Issuer" ? "Issuer" : "ClusterIssuer";
+  const namespacePrefix = process.env.CLUSTER_TENANT_NAMESPACE_PREFIX?.trim() || "opencrane-";
+
+  return new DefaultOrgDomainProvisioner(
+    new CertManagerClient(customApi),
+    new CloudDnsClient(projectId, managedZone),
+    { issuerName, issuerKind, namespacePrefix },
+  );
+}

--- a/apps/control-plane/src/core/cluster-tenants/org-domain.provisioner.ts
+++ b/apps/control-plane/src/core/cluster-tenants/org-domain.provisioner.ts
@@ -1,0 +1,145 @@
+import { _BuildOrgDomain, _BuildOrgWildcard } from "@opencrane/contracts";
+
+import type { OrgDomainProvisioner, OrgDomainProvisionRequest, OrgDomainProvisionResult } from "./org-domain-provisioner.types.js";
+import type { CertManagerOperations } from "./cert-manager.client.js";
+import type { CloudDnsOperations } from "./cloud-dns.client.js";
+
+/** TTL (seconds) for the per-org A records — matches the terraform DNS module. */
+const _RECORD_TTL = 300;
+
+/**
+ * Static config the provisioner needs to author the per-org Certificate, supplied
+ * from the chart's `certManager` values (issuerName / issuer kind) and the org's
+ * bound namespace prefix. Injected so the provisioner carries no environment reads.
+ */
+export interface OrgDomainProvisionerConfig
+{
+  /** cert-manager issuer name the Certificate references (chart `certManager.issuerName`). */
+  issuerName: string;
+  /** Issuer kind: a cluster-singleton `ClusterIssuer` (default) or namespaced `Issuer`. */
+  issuerKind: "ClusterIssuer" | "Issuer";
+  /** Prefix applied to the org name to derive its bound namespace (`opencrane-<org>`). */
+  namespacePrefix: string;
+}
+
+/**
+ * Concrete {@link OrgDomainProvisioner} for the fixed-wildcard topology. Given an
+ * org, it materialises the two cluster-side side effects the topology requires:
+ *
+ *   1. A per-org wildcard TLS Certificate `*.<org>.<base>` (+ the `<org>.<base>`
+ *      apex SAN, and the vanity domain when present) via cert-manager DNS-01, into
+ *      the org's bound namespace — because the platform `*.<base>` cert does NOT
+ *      cover the extra label `<user>.<org>.<base>`.
+ *   2. A per-org serving DNS record `*.<org>.<base>` (and the `<org>.<base>` apex)
+ *      → the cluster ingress IP, via the terraform-managed Cloud DNS zone — so every
+ *      UserTenant gateway host under the org resolves with no per-user record.
+ *
+ * Both side effects are idempotent (re-apply is a no-op) so the reconciler can call
+ * `provisionOrgDomain` on every reconcile. It is FAIL-CLOSED and GATED: when the
+ * cluster has no cert-manager (the dev cluster currently does not), it returns a
+ * clear `ready:false` + reason rather than crashing — but the code path that WOULD
+ * create the resources is real, not a no-op stub. This is invoked by the
+ * ClusterTenant reconciler (PR #50); the create HTTP path never calls it directly,
+ * preserving the API-first posture.
+ */
+export class DefaultOrgDomainProvisioner implements OrgDomainProvisioner
+{
+  /** cert-manager Certificate operations (injected; fake in tests). */
+  private readonly certs: CertManagerOperations;
+
+  /** Cloud DNS record operations (injected; fake in tests). */
+  private readonly dns: CloudDnsOperations;
+
+  /** Static issuer + namespace config from the chart values. */
+  private readonly config: OrgDomainProvisionerConfig;
+
+  /**
+   * @param certs  - cert-manager Certificate operations.
+   * @param dns    - Cloud DNS record operations.
+   * @param config - Issuer name/kind + namespace prefix from the chart values.
+   */
+  public constructor(certs: CertManagerOperations, dns: CloudDnsOperations, config: OrgDomainProvisionerConfig)
+  {
+    this.certs = certs;
+    this.dns = dns;
+    this.config = config;
+  }
+
+  /** @inheritdoc */
+  public async provisionOrgDomain(req: OrgDomainProvisionRequest): Promise<OrgDomainProvisionResult>
+  {
+    const orgDomain = _BuildOrgDomain(req.orgName, req.platformBaseDomain);
+    const wildcardDnsName = _BuildOrgWildcard(orgDomain); // `*.<org>.<base>`
+    const namespace = `${this.config.namespacePrefix}${req.orgName}`;
+    const tlsSecretName = `org-wildcard-tls-${req.orgName}`;
+
+    // 1. DNS first — the wildcard A record `*.<org>.<base>` and the org apex
+    //    `<org>.<base>`, both → the ingress IP. DNS-01 issuance below also needs the
+    //    zone reachable, and serving must resolve regardless of cert state. Idempotent.
+    await this.dns.ensureARecord(wildcardDnsName, [req.ingressIp], _RECORD_TTL);
+    await this.dns.ensureARecord(orgDomain, [req.ingressIp], _RECORD_TTL);
+
+    // 2. The per-org wildcard Certificate. Built to the exact shape of the WS5
+    //    reference manifest (platform/helm/examples/per-org-wildcard-cert.yaml).
+    const certificate = this._buildCertificate(req, orgDomain, wildcardDnsName, namespace, tlsSecretName);
+    const readiness = await this.certs.applyCertificate(namespace, certificate);
+
+    // 3. Gated: cert-manager absent → ready:false + reason, never a crash. Serving
+    //    DNS still landed above, so the org resolves; only browser-trusted TLS waits.
+    return { orgDomain, wildcardDnsName, tlsSecretName, ready: readiness.ready };
+  }
+
+  /** @inheritdoc */
+  public async deprovisionOrgDomain(orgName: string, platformBaseDomain: string): Promise<void>
+  {
+    const orgDomain = _BuildOrgDomain(orgName, platformBaseDomain);
+    const wildcardDnsName = _BuildOrgWildcard(orgDomain);
+    const namespace = `${this.config.namespacePrefix}${orgName}`;
+    const tlsSecretName = `org-wildcard-tls-${orgName}`;
+
+    // Idempotent teardown: missing records / Certificate / CRD are all no-ops.
+    await this.certs.deleteCertificate(namespace, tlsSecretName);
+    await this.dns.deleteARecord(wildcardDnsName);
+    await this.dns.deleteARecord(orgDomain);
+  }
+
+  /**
+   * Build the per-org wildcard Certificate CR — the exact shape WS5's reference
+   * manifest defines: `*.<org>.<base>` + the `<org>.<base>` apex SAN, the org's
+   * vanity domain (and its wildcard) appended when set, the configured issuer ref,
+   * and the per-org TLS Secret name.
+   */
+  private _buildCertificate(req: OrgDomainProvisionRequest, orgDomain: string, wildcardDnsName: string, namespace: string, tlsSecretName: string): Record<string, unknown>
+  {
+    const dnsNames: string[] = [wildcardDnsName, orgDomain];
+    const vanity = req.vanityDomain?.trim();
+    if (vanity)
+    {
+      // The customer CNAMEs the vanity onto <org>.<base>; add it (and its wildcard)
+      // so the org is browser-trusted under the vanity name too.
+      dnsNames.push(_BuildOrgWildcard(vanity), vanity);
+    }
+
+    return {
+      apiVersion: "cert-manager.io/v1",
+      kind: "Certificate",
+      metadata: {
+        name: tlsSecretName,
+        namespace,
+        labels: {
+          "app.kubernetes.io/part-of": "opencrane",
+          "app.kubernetes.io/component": "org-wildcard-cert",
+          "opencrane.io/cluster-tenant": req.orgName,
+        },
+      },
+      spec: {
+        secretName: tlsSecretName,
+        issuerRef: {
+          name: this.config.issuerName,
+          kind: this.config.issuerKind,
+        },
+        dnsNames,
+      },
+    };
+  }
+}

--- a/apps/control-plane/src/core/cluster-tenants/org-domain.provisioner.ts
+++ b/apps/control-plane/src/core/cluster-tenants/org-domain.provisioner.ts
@@ -41,6 +41,12 @@ export interface OrgDomainProvisionerConfig
  * create the resources is real, not a no-op stub. This is invoked by the
  * ClusterTenant reconciler (PR #50); the create HTTP path never calls it directly,
  * preserving the API-first posture.
+ *
+ * PRECONDITION: the org's bound namespace (`<namespacePrefix><org>`) must already
+ * exist — the reconciler fences it (the same step that binds the ClusterTenant)
+ * BEFORE calling this. A missing namespace is a precondition fault: the cert-manager
+ * client re-throws that 404 (it is NOT masked as "cert-manager absent"), so the
+ * reconciler surfaces it as an error rather than a silent not-ready.
  */
 export class DefaultOrgDomainProvisioner implements OrgDomainProvisioner
 {

--- a/apps/control-plane/src/core/cluster-tenants/provisioner.ts
+++ b/apps/control-plane/src/core/cluster-tenants/provisioner.ts
@@ -1,3 +1,10 @@
 export { SHARED_PROVISIONER_ID, SharedClusterProvisioner } from "./shared-cluster.provisioner.js";
 export { ExternalWebhookProvisioner } from "./external-webhook.provisioner.js";
 export { _ReadExternalWebhookConfig } from "./external-webhook.config.js";
+export { DefaultOrgDomainProvisioner } from "./org-domain.provisioner.js";
+export type { OrgDomainProvisionerConfig } from "./org-domain.provisioner.js";
+export { _BuildOrgDomainProvisioner } from "./org-domain.provisioner.factory.js";
+export { CertManagerClient } from "./cert-manager.client.js";
+export type { CertManagerOperations, CertificateReadiness } from "./cert-manager.client.js";
+export { CloudDnsClient } from "./cloud-dns.client.js";
+export type { CloudDnsOperations } from "./cloud-dns.client.js";

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -271,7 +271,7 @@ const ClusterTenantSchema = {
   properties: {
     name: { type: "string", description: "Stable cluster-scoped identifier (the customer key)." },
     displayName: { type: "string", description: "Human-readable customer name." },
-    baseDomain: { type: "string", description: "Customer-owned base domain serving this tenant's UserTenant gateways (<user>.<baseDomain>); falls back to the per-instance ingress.domain when unset." },
+    vanityDomain: { type: "string", description: "Optional customer-vanity domain CNAMEd onto the org's derived apex (<name>.<platformBaseDomain>); an overlay, not the org identity. When unset, only the derived apex serves the org." },
     isolationTier: { type: "string", enum: ["shared", "dedicatedNodes", "dedicatedCluster"], description: "Isolation strength chosen for this customer." },
     compute: {
       type: "object",
@@ -304,7 +304,7 @@ const ClusterTenantWriteSchema = {
   properties: {
     name: { type: "string", description: "Stable cluster-scoped identifier (the customer key)." },
     displayName: { type: "string", description: "Human-readable customer name." },
-    baseDomain: { type: "string", description: "Customer-owned base domain (e.g. ai.client-company.com); optional, falls back to the per-instance ingress.domain." },
+    vanityDomain: { type: "string", description: "Optional customer-vanity domain CNAMEd onto the org's derived apex (<name>.<platformBaseDomain>); an overlay, not the org identity." },
     isolationTier: { type: "string", enum: ["shared", "dedicatedNodes", "dedicatedCluster"] },
     compute: {
       type: "object",
@@ -348,7 +348,7 @@ const ClusterTenantUpdateSchema = {
   description: "Partial cluster-tenant update; the immutable name comes from the path. Every field is optional — only those present are changed.",
   properties: {
     displayName: { type: "string", description: "New human-readable customer name (must be non-blank when present)." },
-    baseDomain: { type: "string", description: "New customer-owned base domain; an empty string clears it (back to the per-instance ingress.domain fallback)." },
+    vanityDomain: { type: "string", description: "New customer-vanity domain CNAMEd onto the org apex; an empty string clears it (back to the derived <name>.<base> apex only)." },
     isolationTier: { type: "string", enum: ["shared", "dedicatedNodes", "dedicatedCluster"], description: "New isolation strength; re-gated against the provisioner registry when changed." },
     compute: {
       type: "object",

--- a/apps/control-plane/src/routes/cluster-tenants.models.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.models.ts
@@ -23,8 +23,8 @@ export interface ClusterTenantCreateRequest
   name: string;
   /** Human-readable customer name. */
   displayName: string;
-  /** Customer-owned base domain serving this tenant's UserTenant gateways; optional. */
-  baseDomain?: string;
+  /** Optional customer-vanity domain CNAMEd onto the org's derived apex; an overlay, not the org identity. */
+  vanityDomain?: string;
   /** Isolation strength chosen for this customer. */
   isolationTier: ClusterTenantIsolationTier;
   /** Compute placement policy. */
@@ -38,8 +38,8 @@ export interface ClusterTenantUpdateRequest
 {
   /** New human-readable customer name. */
   displayName?: string;
-  /** New customer-owned base domain (empty string clears it). */
-  baseDomain?: string;
+  /** New customer-vanity domain CNAMEd onto the org apex (empty string clears it). */
+  vanityDomain?: string;
   /** New isolation strength. */
   isolationTier?: ClusterTenantIsolationTier;
   /** New compute placement policy. */

--- a/apps/control-plane/src/routes/cluster-tenants.service.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.service.ts
@@ -112,7 +112,7 @@ export function _ToContract(row: ClusterTenantRow): ClusterTenant
   return {
     name: row.name,
     displayName: row.displayName,
-    ...(row.baseDomain ? { baseDomain: row.baseDomain } : {}),
+    ...(row.vanityDomain ? { vanityDomain: row.vanityDomain } : {}),
     isolationTier: _FromPrismaTier(row.isolationTier as unknown as string),
     compute: {
       mode: _FromPrismaCompute(row.computeMode as unknown as string),

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -10,12 +10,12 @@ import { _IsDevAuthMode } from "../infra/auth/auth-mode.js";
 import { _RequireBillingAccountForOrgCreate, _RequireOrgManager } from "../infra/middleware/cluster-tenant-org-admin.js";
 
 /** RFC-1123-ish DNS domain: lowercase labels, ≥1 dot, alpha TLD, ≤253 chars. */
-const _BASE_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
+const _VANITY_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
 
-/** Whether a string is a syntactically valid customer base domain. */
-function _isValidBaseDomain(value: string): boolean
+/** Whether a string is a syntactically valid customer-vanity domain. */
+function _isValidVanityDomain(value: string): boolean
 {
-  return _BASE_DOMAIN_PATTERN.test(value);
+  return _VANITY_DOMAIN_PATTERN.test(value);
 }
 
 /**
@@ -104,9 +104,9 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
       res.status(400).json({ error: "isolationTier must be 'shared', 'dedicatedNodes', or 'dedicatedCluster'.", code: "VALIDATION_ERROR" });
       return;
     }
-    if (body.baseDomain !== undefined && body.baseDomain.trim() && !_isValidBaseDomain(body.baseDomain.trim()))
+    if (body.vanityDomain !== undefined && body.vanityDomain.trim() && !_isValidVanityDomain(body.vanityDomain.trim()))
     {
-      res.status(400).json({ error: "baseDomain must be a valid lowercase DNS domain (e.g. ai.client-company.com).", code: "VALIDATION_ERROR" });
+      res.status(400).json({ error: "vanityDomain must be a valid lowercase DNS domain (e.g. ai.client-company.com).", code: "VALIDATION_ERROR" });
       return;
     }
 
@@ -145,7 +145,7 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
         data: {
           name: body.name.trim(),
           displayName: body.displayName.trim(),
-          baseDomain: body.baseDomain?.trim() || null,
+          vanityDomain: body.vanityDomain?.trim() || null,
           isolationTier: _ToPrismaTier(body.isolationTier),
           computeMode: _ToPrismaCompute(body.compute.mode),
           nodePool: body.compute.nodePool?.trim() || null,
@@ -163,6 +163,17 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
 
       return org;
     });
+
+    // 5. Domain provisioning hand-off (fixed-wildcard topology). The org is now
+    //    addressable at its derived apex `<name>.<platformBaseDomain>` and its users
+    //    at `<user>.<name>.<base>`. Two cluster-side side effects must follow — the
+    //    per-org DNS record (`*.<org>.<base>` → ingress IP) and the per-org wildcard
+    //    TLS cert — but BOTH are owned by the ClusterTenant operator/CR watcher (the
+    //    same WS4 hand-off seam that reconciles `pending` → `ready`), never executed
+    //    inline here. The reconciler calls the single typed interface
+    //    `OrgDomainProvisioner.provisionOrgDomain(...)` (see
+    //    core/cluster-tenants/org-domain-provisioner.types.ts). This handler only
+    //    persists desired state; it does not mutate DNS or cert-manager.
     res.status(201).json(_ToContract(created));
   });
 
@@ -190,17 +201,17 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
       data.displayName = body.displayName.trim();
     }
 
-    // 1b. Apply base-domain change when present; an empty string clears it (back to
-    //     the per-instance ingress.domain fallback), a non-empty value must be valid.
-    if (body.baseDomain !== undefined)
+    // 1b. Apply vanity-domain change when present; an empty string clears it (back to
+    //     the derived `<name>.<base>` apex only), a non-empty value must be valid.
+    if (body.vanityDomain !== undefined)
     {
-      const trimmed = body.baseDomain.trim();
-      if (trimmed && !_isValidBaseDomain(trimmed))
+      const trimmed = body.vanityDomain.trim();
+      if (trimmed && !_isValidVanityDomain(trimmed))
       {
-        res.status(400).json({ error: "baseDomain must be a valid lowercase DNS domain (e.g. ai.client-company.com).", code: "VALIDATION_ERROR" });
+        res.status(400).json({ error: "vanityDomain must be a valid lowercase DNS domain (e.g. ai.client-company.com).", code: "VALIDATION_ERROR" });
         return;
       }
-      data.baseDomain = trimmed || null;
+      data.vanityDomain = trimmed || null;
     }
 
     // 2. Re-validate and re-gate the isolation tier when it changes — a customer

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -136,9 +136,9 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     // 4. Persist the org and its single owner membership in ONE transaction: the
     //    caller becomes the org's root admin (owner) atomically with the org row.
     //    Dual-write the org in `pending`; the operator reconciles it to `ready`.
-    //    NOTE (provisioning hand-off): a separate workstream owns the ClusterTenant
-    //    operator/CR watcher that reconciles `pending` → `ready`. This handler only
-    //    persists the desired state; see the cluster-tenants operator track.
+    //    NOTE (provisioning hand-off): the ClusterTenant operator/CR watcher reconciles
+    //    `pending` → `ready` and drives the domain provisioner. This handler only
+    //    persists the desired state; it performs no cluster-side side effects.
     const created = await prisma.$transaction(async function _createOrgWithOwner(tx)
     {
       const org = await tx.clusterTenant.create({
@@ -168,9 +168,9 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     //    addressable at its derived apex `<name>.<platformBaseDomain>` and its users
     //    at `<user>.<name>.<base>`. Two cluster-side side effects must follow — the
     //    per-org DNS record (`*.<org>.<base>` → ingress IP) and the per-org wildcard
-    //    TLS cert — but BOTH are owned by the ClusterTenant operator/CR watcher (the
-    //    same WS4 hand-off seam that reconciles `pending` → `ready`), never executed
-    //    inline here. The reconciler calls the single typed interface
+    //    TLS cert — both implemented by `DefaultOrgDomainProvisioner` and driven by
+    //    the ClusterTenant operator/CR watcher on the `pending` → `ready` reconcile,
+    //    never executed inline here. The reconciler calls the single typed interface
     //    `OrgDomainProvisioner.provisionOrgDomain(...)` (see
     //    core/cluster-tenants/org-domain-provisioner.types.ts). This handler only
     //    persists desired state; it does not mutate DNS or cert-manager.

--- a/apps/control-plane/src/routes/tenants.ts
+++ b/apps/control-plane/src/routes/tenants.ts
@@ -435,7 +435,7 @@ export function tenantsRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCli
 
     // Normalise the parent ClusterTenant ref so a present-but-empty value clears
     // it (stored null, field deleted from the CRD spec via merge-patch), mirroring
-    // how baseDomain is cleared on cluster-tenants. Absent → field left untouched.
+    // how vanityDomain is cleared on cluster-tenants. Absent → field left untouched.
     const clusterTenantRefProvided = body.clusterTenantRef !== undefined;
     const normalizedClusterTenantRef = clusterTenantRefProvided && body.clusterTenantRef!.trim() ? body.clusterTenantRef!.trim() : null;
 

--- a/apps/operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts
+++ b/apps/operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts
@@ -168,19 +168,45 @@ describe("ClusterTenant isolation enforcement (CT.5 reconcile flow)", () =>
     expect(podSpec?.tolerations?.[0]?.key).toBe("opencrane.io/dedicated");
   });
 
-  it("derives the UserTenant ingress host from the ClusterTenant baseDomain (CT.8)", async () =>
+  it("derives the UserTenant host from the org's apex under the platform base (<user>.<org>.<base>)", async () =>
   {
     const clusterTenant = _makeClusterTenant("acme", "ct-acme");
-    clusterTenant.spec.baseDomain = "ai.client-company.com";
     const tenant = _makeTenant("mike", { clusterTenantRef: "acme" });
 
     const operator = _makeOperator(core, apps, networking, clusterTenant);
     await operator.reconcileTenant(tenant);
 
-    // The Ingress host comes from the parent's customer-owned base domain, not the
-    // per-instance ingress.domain.
+    // No vanity domain: the org is served at its DERIVED apex <org>.<base>
+    // (acme.opencrane.local), so the user lands at <user>.<org>.<base>.
+    const ingress = networking.created.find((r) => r.kind === "Ingress") as k8s.V1Ingress | undefined;
+    expect(ingress?.spec?.rules?.[0]?.host).toBe("mike.acme.opencrane.local");
+  });
+
+  it("a customer-vanity domain CNAMEd onto the org apex overrides the derived apex", async () =>
+  {
+    const clusterTenant = _makeClusterTenant("acme", "ct-acme");
+    clusterTenant.spec.vanityDomain = "ai.client-company.com";
+    const tenant = _makeTenant("mike", { clusterTenantRef: "acme" });
+
+    const operator = _makeOperator(core, apps, networking, clusterTenant);
+    await operator.reconcileTenant(tenant);
+
+    // With a vanity overlay set, the user serves under the vanity name.
     const ingress = networking.created.find((r) => r.kind === "Ingress") as k8s.V1Ingress | undefined;
     expect(ingress?.spec?.rules?.[0]?.host).toBe("mike.ai.client-company.com");
+  });
+
+  it("a ref-less openclaw derives its host at the bare platform base (<user>.<base>)", async () =>
+  {
+    // No parent org → no apex to derive; the user serves directly under the platform
+    // base (config.ingressDomain), so the single-install default path is unchanged.
+    const tenant = _makeTenant("plain");
+
+    const operator = _makeOperator(core, apps, networking);
+    await operator.reconcileTenant(tenant);
+
+    const ingress = networking.created.find((r) => r.kind === "Ingress") as k8s.V1Ingress | undefined;
+    expect(ingress?.spec?.rules?.[0]?.host).toBe("plain.opencrane.local");
   });
 
   it("default (ref-less) openclaw renders no namespace/quota/limitrange and no scheduling", async () =>

--- a/apps/operator/src/tenants/deploy/ingress-host.ts
+++ b/apps/operator/src/tenants/deploy/ingress-host.ts
@@ -1,9 +1,10 @@
 /**
  * Build the fully-qualified ingress hostname for a UserTenant gateway:
- * `<tenantName>.<ingressDomain>`, where `ingressDomain` is the ClusterTenant base
- * domain. So the host is a per-user UserTenant gateway under the customer's
- * (ClusterTenant's) own domain — e.g. `mike.ai.client-company.com`. See
- * docs/agents/cluster-architecture.md → "Tenancy Model — ClusterTenant vs UserTenant".
+ * `<tenantName>.<ingressDomain>`. Under the fixed-wildcard topology `ingressDomain`
+ * is the org's serving domain `<org>.<base>` (so the user lands at
+ * `<user>.<org>.<base>`, e.g. `mike.acme.weownai.eu`), or a customer-vanity domain
+ * CNAMEd onto that apex; ref-less openclaws fall back to the bare platform base
+ * `<base>`. See docs/agents/cluster-architecture.md → "Tenancy Model".
  */
 export function _BuildIngressHost(tenantName: string, ingressDomain: string): string
 {

--- a/apps/operator/src/tenants/internal/cluster-tenant-resolution.types.ts
+++ b/apps/operator/src/tenants/internal/cluster-tenant-resolution.types.ts
@@ -43,8 +43,8 @@ export interface ClusterTenantResource extends KubernetesObject
   spec: {
     /** Human-readable customer name. */
     displayName?: string;
-    /** Customer-owned base domain; UserTenant gateway hosts are `<name>.<baseDomain>`. */
-    baseDomain?: string;
+    /** Optional customer-vanity domain CNAMEd onto the org apex (`<name>.<platformBase>`); an overlay, not the org identity. */
+    vanityDomain?: string;
     /** Isolation strength chosen for this customer. */
     isolationTier?: string;
     /** Compute placement policy stamped onto attached openclaw pods. */

--- a/apps/operator/src/tenants/internal/org-serving-domain.ts
+++ b/apps/operator/src/tenants/internal/org-serving-domain.ts
@@ -1,0 +1,32 @@
+/**
+ * Resolve the domain a UserTenant gateway host hangs off, under the fixed-wildcard
+ * topology.
+ *
+ * Precedence:
+ *   1. A customer-vanity domain CNAMEd onto the org apex, when set — the org is
+ *      reachable under that name, so its users serve there too.
+ *   2. The org's DERIVED apex `<org>.<platformBaseDomain>` — the canonical home,
+ *      used when a parent org is resolved with no vanity overlay.
+ *   3. The bare `platformBaseDomain` — for ref-less openclaws with no parent org, so
+ *      the single-install default path (`<user>.<base>`) is byte-for-byte unchanged.
+ *
+ * @param orgName - The parent ClusterTenant name, or undefined for a ref-less openclaw.
+ * @param vanityDomain - Optional customer-vanity domain CNAMEd onto the org apex.
+ * @param platformBaseDomain - The platform wildcard base (operator `INGRESS_DOMAIN`).
+ * @returns The serving domain to derive the UserTenant host from.
+ */
+export function _ResolveOrgServingDomain(orgName: string | undefined, vanityDomain: string | undefined, platformBaseDomain: string): string
+{
+  if (vanityDomain && vanityDomain.trim())
+  {
+    return vanityDomain.trim();
+  }
+  if (orgName && orgName.trim())
+  {
+    // Mirrors @opencrane/contracts `_BuildOrgDomain`; inlined because the operator
+    // intentionally carries no dependency on the contracts package (operator-local
+    // types only), keeping the reconcile path free of cross-package coupling.
+    return `${orgName.trim()}.${platformBaseDomain}`;
+  }
+  return platformBaseDomain;
+}

--- a/apps/operator/src/tenants/operator.ts
+++ b/apps/operator/src/tenants/operator.ts
@@ -19,6 +19,7 @@ import { _ResolveTenantPolicy } from "./internal/policy-resolution.js";
 import { _FetchTenantModels } from "./internal/tenant-models.js";
 import { _ResolveClusterTenant } from "./internal/cluster-tenant-resolution.js";
 import type { ClusterTenantResource } from "./internal/cluster-tenant-resolution.types.js";
+import { _ResolveOrgServingDomain } from "./internal/org-serving-domain.js";
 import { TenantStatusWriter } from "./internal/tenant-status-writer.js";
 
 /**
@@ -194,10 +195,18 @@ export class TenantOperator
         await this.enforceClusterTenantIsolation(clusterTenantResolution.clusterTenant, namespace);
       }
       const compute = clusterTenantResolution.clusterTenant?.spec.compute;
-      // CT.8 — derive UserTenant ingress hosts from the parent ClusterTenant's
-      // customer-owned base domain when set; ref-less openclaws fall back to the
-      // per-instance ingress.domain so the default path is byte-for-byte unchanged.
-      const ingressDomain = clusterTenantResolution.clusterTenant?.spec.baseDomain ?? this.config.ingressDomain;
+      // Fixed-wildcard topology — derive the UserTenant ingress host from the org's
+      // domain under the platform wildcard base (`config.ingressDomain`). An org
+      // (ClusterTenant) is served at its DERIVED apex `<org>.<base>`, so its users
+      // land at `<user>.<org>.<base>` — handled by `_ResolveOrgServingDomain`, which
+      // also lets a customer-vanity domain (CNAMEd onto the apex) override the apex.
+      // Ref-less openclaws have no parent org → they stay at the bare
+      // `<user>.<base>` per-instance host, so the default path is unchanged.
+      const ingressDomain = _ResolveOrgServingDomain(
+        clusterTenantResolution.clusterTenant?.metadata?.name,
+        clusterTenantResolution.clusterTenant?.spec.vanityDomain,
+        this.config.ingressDomain,
+      );
 
       // 0b. Effective policy — resolve policyRef deterministically so runtime behavior
       //    is predictable even when selectors or default policies are configured.

--- a/docs/agents/cluster-architecture.md
+++ b/docs/agents/cluster-architecture.md
@@ -164,11 +164,17 @@ authorised on the zone.
 
 When an org is created (`POST /api/v1/cluster-tenants`), the control plane persists desired state and
 hands off the cluster-side side effects (per-org DNS record + per-org wildcard TLS cert) to the
-cluster-tenants operator/CR watcher (a **separate workstream**). The interface the reconciler calls is
+ClusterTenant operator/CR watcher. The interface the reconciler calls is
 `OrgDomainProvisioner.provisionOrgDomain(...)`
-(`apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts`) — the same `pending →
-ready` hand-off seam already documented in the create flow. The create path itself never mutates DNS or
-cert-manager (fail-closed, API-first).
+(`apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts`), implemented by
+`DefaultOrgDomainProvisioner` (`org-domain.provisioner.ts`): it applies the per-org wildcard
+`Certificate` (`*.<org>.<base>` + apex/vanity SANs) via cert-manager DNS-01 and ensures the
+`*.<org>.<base>` / `<org>.<base>` A records in the terraform-managed Cloud DNS zone. Both side effects
+are idempotent. It is **fail-closed + gated**: when the cluster has no cert-manager (the dev cluster
+currently does not), it returns `ready:false` with a reason and never crashes, while the
+resource-authoring path stays real. The Cloud DNS SDK is an optional dependency loaded lazily, so
+on-prem installs never pull it. The create path itself never mutates DNS or cert-manager — only the
+reconciler does (fail-closed, API-first).
 
 ## Isolation Tiers
 

--- a/docs/agents/cluster-architecture.md
+++ b/docs/agents/cluster-architecture.md
@@ -34,47 +34,59 @@ strength is a per-customer choice (`isolationTier`).
 │  │   · Secrets(enc-key, litellm-key) · SA · (CT) ResourceQuota+LimitRange │
 │  └─────────────────────────────────────────────────────────────────────┘ │
 │         ▲ external traffic: GCE LB (GCP) / ingress-nginx (on-prem)       │
-│  platform domain → control-plane:8080 · *.<clustertenant-domain> → UserTenant │
+│  control-plane host → control-plane:8080 · *.<org>.<base> → UserTenant   │
 └────────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Tenancy Model — ClusterTenant vs UserTenant
 
-OpenCrane has **two distinct tenant concepts**. Keep them straight — they live on **separate,
-independent domains** and serve different roles:
+OpenCrane has **two distinct tenant concepts**. Keep them straight. Under the **fixed-wildcard
+topology** the platform owns ONE wildcard base domain and every org/user name is **derived** under it
+— customers no longer bring their own domain (a vanity domain is an optional overlay, see below):
 
 | Term | What it is | Scope | Domain |
 |------|-----------|-------|--------|
-| **ClusterTenant** | The **customer / isolation unit** — owns a namespace, a `ResourceQuota`/`LimitRange`, a compute `isolationTier`, and **its own base domain** (typically the customer's own company domain). One ClusterTenant ≈ one multi-instance OpenCrane instance. | Cluster-scoped CRD `clustertenants.opencrane.io`. | Owns its base domain (the instance's `ingress.domain`, customer-owned, e.g. `ai.client-company.com`); the wildcard `*.<clustertenant-domain>` is this customer's ingress space. |
-| **UserTenant** | A **per-user OpenClaw agent gateway** — the workload a person connects to. This is the `Tenant`/openclaw CRD; **"UserTenant" is the canonical name**, "`Tenant`" is the legacy CRD kind in code. | Namespaced CRD `tenant.opencrane.io`, runs inside its ClusterTenant's namespace. | A single host `<user>.<clustertenant-domain>`, e.g. `mike.ai.client-company.com`. |
+| **ClusterTenant** | The **customer / isolation unit (org)** — owns a namespace, a `ResourceQuota`/`LimitRange`, and a compute `isolationTier`. | Cluster-scoped CRD `clustertenants.opencrane.io`. | **Derived** apex `<org>.<base>` under the platform wildcard `*.<base>` (e.g. `acme.weownai.eu`). NOT customer-owned. An optional `vanityDomain` CNAMEd onto that apex is an overlay. |
+| **UserTenant** | A **per-user OpenClaw agent gateway** — the workload a person connects to. This is the `Tenant`/openclaw CRD; **"UserTenant" is the canonical name**, "`Tenant`" is the legacy CRD kind in code. | Namespaced CRD `tenant.opencrane.io`, runs inside its ClusterTenant's namespace. | A single host `<user>.<org>.<base>`, e.g. `mike.acme.weownai.eu`. |
 
 ### DNS hierarchy
 
-These are **three independent domains**, not one nested DNS tree — the platform and each customer bring
-their own domains:
+There are exactly **two platform-owned domains** — a fixed super-operator/control-plane host, and one
+fixed org-wildcard base — under which every org and user name is **derived** (one nested DNS tree, not
+per-customer domains):
 
 ```
-example.com                  → control plane (platform management API)   [platform's own domain]
-ai.client-company.com        → ClusterTenant "client-company" base domain [per-customer, customer-owned]
-  mike.ai.client-company.com → UserTenant "mike" gateway   (wildcard      [per-user]
-  sara.ai.client-company.com → UserTenant "sara" gateway    *.ai.client-company.com)
+platform.weownai.eu             → control plane (the FIXED super-operator host)   [platform-owned, distinct]
+*.weownai.eu                    → resolves every ORG APEX                          [platform org-wildcard base]
+  acme.weownai.eu               → ClusterTenant "acme" (org apex)                  [derived <org>.<base>]
+    mike.acme.weownai.eu        → UserTenant "mike" gateway   (per-org wildcard    [derived <user>.<org>.<base>]
+    sara.acme.weownai.eu        → UserTenant "sara" gateway    *.acme.weownai.eu)
+  globex.weownai.eu             → ClusterTenant "globex" (org apex)
+    bob.globex.weownai.eu       → UserTenant "bob" gateway
+
+  ai.client-company.com         → OPTIONAL customer-vanity domain, CNAMEd by the customer onto acme.weownai.eu
 ```
 
-- **Control plane** → runs on the **platform's own domain** (e.g. `example.com`), separate from any
-  customer. It is one management API above every customer — logically, not as a DNS parent.
-- **ClusterTenant base domain** → **customer-owned and independent** (e.g. `ai.client-company.com`); each
-  instance sets its own `ingress.domain`. The wildcard cert + ingress live at this level.
-- **UserTenant host** → a single OpenClaw gateway; the operator builds **one `Ingress` per UserTenant** at
-  `<name>.<ingress.domain>`, i.e. a subdomain of that ClusterTenant's base domain.
+- **Control plane** → the **fixed super-operator host** (`ingress.controlPlaneHost`, defaults to
+  `platform.<base>`). It is one management API above every org — a distinct host, **never** an org under
+  `*.<base>`. Wired by `control-plane-ingress.yaml`.
+- **Org apex** → **derived** `<org>.<base>` from the org (ClusterTenant) name and the platform base
+  (`ingress.domain`). Resolved by the platform wildcard `*.<base>`.
+- **UserTenant host** → the operator builds **one `Ingress` per UserTenant** at `<user>.<org>.<base>`.
+  The org's serving domain is derived as `<org>.<base>`; if a `vanityDomain` is set it overrides the apex
+  so users serve under the vanity name too.
+- **Customer vanity domain** → OPTIONAL. The customer adds a `CNAME` at their own provider pointing
+  their domain at the org apex `<org>.<base>` (see [DNS config](/operators/dns-config) for the exact
+  instruction). It is an overlay added to the org's TLS SANs, not the org's identity.
 
-> **Validated against the tree (June 2026):** the operator builds the UserTenant ingress at
-> `<name>.<ingress.domain>` (`apps/operator/.../5-ingress.ts`) and cert-manager issues
-> `*.<ingress.domain>` + that base domain's own apex (`cluster-issuer.yaml`). `ingress.domain` is already
-> per-instance, so it **is** the ClusterTenant base domain — set it to the customer's domain. Two things
-> to keep straight: (1) the wildcard `*.<domain>` maps to **UserTenant** gateways, *not* the
-> ClusterTenant — the ClusterTenant owns the domain, its UserTenants get the hosts; (2) the **control
-> plane's own domain is not wired by an Ingress in the chart** — its cert/SAN may be covered but routing
-> the platform domain to the control-plane Service is currently an installer/out-of-chart step.
+> **Validated against the tree (June 2026):** the operator derives the UserTenant ingress host via
+> `_ResolveOrgServingDomain` → `<user>.<org>.<base>` (`apps/operator/.../internal/org-serving-domain.ts`
+> + `5-ingress.ts`); the platform cert-manager `Certificate` covers `*.<base>` + apex + the control-plane
+> host (`cluster-issuer.yaml`); the control-plane host is wired by `control-plane-ingress.yaml`. Two
+> things to keep straight: (1) `*.<base>` matches **org apexes** `<org>.<base>`, *not* the per-user
+> level — `<user>.<org>.<base>` is a second label and needs a **per-org** `*.<org>.<base>` cert (see
+> [Multi-level wildcard TLS](#multi-level-wildcard-tls)); (2) the control-plane host is its own fixed
+> host, never an org.
 
 ## Physical Cluster
 
@@ -123,10 +135,40 @@ All planes are **ClusterIP-only** (no external LB) — external traffic arrives 
 
 ## Network Topology
 
-- **Ingress:** GCE Ingress (GCP) or ingress-nginx (on-prem). The **control plane** is reached on the **platform's own domain** (e.g. `example.com`); each **UserTenant** (OpenClaw gateway) is exposed at `<user>.<clustertenant-domain>` → its Service, under the customer-owned wildcard `*.<clustertenant-domain>`. See [Tenancy Model](#tenancy-model--clustertenant-vs-usertenant).
+- **Ingress:** GCE Ingress (GCP) or ingress-nginx (on-prem). The **control plane** is reached on the **fixed super-operator host** (`ingress.controlPlaneHost`, default `platform.<base>`); each **UserTenant** (OpenClaw gateway) is exposed at `<user>.<org>.<base>` → its Service, under the per-org wildcard `*.<org>.<base>`. See [Tenancy Model](#tenancy-model--clustertenant-vs-usertenant).
 - **`networkpolicy-planes.yaml`** restricts control-plane ingress to: ingress controller, operator, mcp-gateway, skill-registry, and tenant pods (contract re-pull). The Zot OCI store accepts the control-plane only. Because `/api/internal/*` has **no auth middleware**, this policy is its only boundary — see [`k8s.md`](./k8s.md#internal-routes-without-auth-middleware).
 - **Tenant egress** is default-DNS + the CIDR/FQDN allow-lists compiled from the tenant's AccessPolicy (standard NetworkPolicy always; optional CiliumNetworkPolicy for FQDN filtering).
-- **TLS:** cert-manager issues a wildcard cert for the **ClusterTenant base domain** (`*.<clustertenant-domain>` + that base domain's own apex `<clustertenant-domain>`; ACME DNS-01 in prod, selfSigned in dev), so every UserTenant host under it is covered without per-UserTenant issuance. Issuance is driven API-first via control-plane `/api/v1/platform/dns`, not raw `kubectl`.
+- **TLS:** see [Multi-level wildcard TLS](#multi-level-wildcard-tls) below. In short: one **platform**
+  cert (`*.<base>` + apex + control-plane host) plus a **per-org** cert (`*.<org>.<base>`) issued at
+  org-provision time. Issuance is k8s-native via cert-manager DNS-01; the platform cert is rendered by
+  the chart and the per-org cert by the cluster-tenants operator hook.
+
+### Multi-level wildcard TLS
+
+DNS wildcards match **exactly one label**, so a single platform wildcard cannot cover the whole tree:
+
+| Cert | Covers | Does NOT cover | Issued by |
+|------|--------|----------------|-----------|
+| **Platform** `*.<base>` (+ `<base>` + control-plane host) | org apexes `<org>.<base>`, the apex, the fixed control-plane host | `<user>.<org>.<base>` (a second label) | the chart (`cluster-issuer.yaml`) at install |
+| **Per-org** `*.<org>.<base>` (+ `<org>.<base>`, + vanity SANs) | every UserTenant gateway host `<user>.<org>.<base>` under the org | other orgs | the cluster-tenants operator at org-provision, via cert-manager DNS-01 (see `platform/helm/examples/per-org-wildcard-cert.yaml`) |
+
+The per-org cert is the decided strategy: a per-org `*.<org>.<base>` `Certificate` issued at
+org-provision via cert-manager DNS-01 against Cloud DNS, written into the org's bound namespace (an
+Ingress can only reference a TLS Secret in its own namespace). The control plane persists the org and
+hands off to the operator, which calls the
+[`OrgDomainProvisioner`](#org-provisioning-hand-off) seam to issue the cert + DNS record (never inline
+in the create path). A wildcard cert **requires** the ACME DNS-01 challenge, so the issuer must be
+authorised on the zone.
+
+### Org provisioning hand-off
+
+When an org is created (`POST /api/v1/cluster-tenants`), the control plane persists desired state and
+hands off the cluster-side side effects (per-org DNS record + per-org wildcard TLS cert) to the
+cluster-tenants operator/CR watcher (a **separate workstream**). The interface the reconciler calls is
+`OrgDomainProvisioner.provisionOrgDomain(...)`
+(`apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts`) — the same `pending →
+ready` hand-off seam already documented in the create flow. The create path itself never mutates DNS or
+cert-manager (fail-closed, API-first).
 
 ## Isolation Tiers
 

--- a/libs/contracts/src/cluster-tenant.types.ts
+++ b/libs/contracts/src/cluster-tenant.types.ts
@@ -89,12 +89,14 @@ export interface ClusterTenant
   /** Human-readable customer name. */
   displayName: string;
   /**
-   * Customer-owned base domain this ClusterTenant serves its UserTenant gateways
-   * under (e.g. `ai.client-company.com`). UserTenant hosts are derived as
-   * `<user>.<baseDomain>`. Optional: when unset, the operator falls back to the
-   * per-instance `ingress.domain` Helm value, so existing installs are unchanged.
+   * Optional customer-vanity domain CNAMEd onto this org's canonical apex
+   * `<name>.<platformBaseDomain>` (e.g. `ai.client-company.com`). This is an OVERLAY,
+   * not the org's identity: the org is always served at its derived `<name>.<base>`
+   * apex (and users at `<user>.<name>.<base>`); a vanity domain is an additional name
+   * the customer points at that apex. When unset, only the platform-derived apex
+   * serves the org. See docs/agents/cluster-architecture.md → "Tenancy Model".
    */
-  baseDomain?: string;
+  vanityDomain?: string;
   /** Isolation strength chosen for this customer. */
   isolationTier: ClusterTenantIsolationTier;
   /** Compute placement policy. */

--- a/libs/contracts/src/domain-topology.types.ts
+++ b/libs/contracts/src/domain-topology.types.ts
@@ -1,0 +1,63 @@
+/**
+ * Platform domain topology — the single source of truth for how OpenCrane derives
+ * org and user hostnames from one fixed platform wildcard base.
+ *
+ * The platform owns ONE wildcard base (`<base>`, e.g. `weownai.eu`) under which:
+ *   - each org (ClusterTenant) is served at `<org>.<base>`     (the org apex)
+ *   - each user (UserTenant) is served at `<user>.<org>.<base>` (the per-user gateway)
+ * The fixed super-operator / control-plane host (e.g. `platform.weownai.eu`) is a
+ * SEPARATE host, never derived from this base — it is the management API above every
+ * org. A customer may optionally CNAME a vanity domain ONTO their `<org>.<base>` apex;
+ * the vanity name is an overlay, not the canonical identity.
+ *
+ * Because DNS wildcards match exactly one label, `*.<base>` covers `<org>.<base>` but
+ * NOT `<user>.<org>.<base>`. The per-user level needs its own `*.<org>.<base>`
+ * wildcard certificate, issued per org at provision time (see
+ * docs/agents/cluster-architecture.md → "Multi-level wildcard TLS").
+ */
+
+/** Lowercased, single-label DNS name (an org name or user/tenant name). */
+type DnsLabel = string;
+
+/**
+ * Derive the canonical org-serving domain (the org apex) for a ClusterTenant under
+ * the platform wildcard base: `<org>.<base>`. This is the domain the org's UserTenant
+ * gateway hosts hang off, and the apex a customer CNAMEs a vanity domain onto.
+ *
+ * @param orgName - The ClusterTenant name (single DNS label, e.g. `acme`).
+ * @param platformBaseDomain - The platform wildcard base (e.g. `weownai.eu`).
+ * @returns The org apex domain `<org>.<base>` (e.g. `acme.weownai.eu`).
+ */
+export function _BuildOrgDomain(orgName: DnsLabel, platformBaseDomain: string): string
+{
+  return `${orgName}.${platformBaseDomain}`;
+}
+
+/**
+ * Derive a UserTenant gateway host under an org domain: `<user>.<orgDomain>`. The
+ * org domain is normally `<org>.<base>` (so the user lands at `<user>.<org>.<base>`),
+ * but a customer-vanity domain CNAMEd onto the org apex can be passed instead so the
+ * user is reachable under the vanity name too.
+ *
+ * @param userName - The UserTenant name (single DNS label, e.g. `mike`).
+ * @param orgDomain - The org-serving domain (`<org>.<base>` or a vanity domain).
+ * @returns The UserTenant host `<user>.<orgDomain>` (e.g. `mike.acme.weownai.eu`).
+ */
+export function _BuildUserHost(userName: DnsLabel, orgDomain: string): string
+{
+  return `${userName}.${orgDomain}`;
+}
+
+/**
+ * Derive the per-org wildcard DNS name whose certificate covers every UserTenant
+ * gateway host under the org: `*.<orgDomain>`. cert-manager issues this per org at
+ * provision time via DNS-01, because the platform `*.<base>` cert does NOT reach the
+ * extra label `<user>.<org>.<base>`.
+ *
+ * @param orgDomain - The org-serving domain (`<org>.<base>`).
+ * @returns The per-org wildcard name `*.<orgDomain>` (e.g. `*.acme.weownai.eu`).
+ */
+export function _BuildOrgWildcard(orgDomain: string): string
+{
+  return `*.${orgDomain}`;
+}

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1739,8 +1739,8 @@ export interface components {
             name: string;
             /** @description Human-readable customer name. */
             displayName: string;
-            /** @description Customer-owned base domain serving this tenant's UserTenant gateways (<user>.<baseDomain>); falls back to the per-instance ingress.domain when unset. */
-            baseDomain?: string;
+            /** @description Optional customer-vanity domain CNAMEd onto the org's derived apex (<name>.<platformBaseDomain>); an overlay, not the org identity. When unset, only the derived apex serves the org. */
+            vanityDomain?: string;
             /**
              * @description Isolation strength chosen for this customer.
              * @enum {string}
@@ -1768,8 +1768,8 @@ export interface components {
             name: string;
             /** @description Human-readable customer name. */
             displayName: string;
-            /** @description Customer-owned base domain (e.g. ai.client-company.com); optional, falls back to the per-instance ingress.domain. */
-            baseDomain?: string;
+            /** @description Optional customer-vanity domain CNAMEd onto the org's derived apex (<name>.<platformBaseDomain>); an overlay, not the org identity. */
+            vanityDomain?: string;
             /** @enum {string} */
             isolationTier: "shared" | "dedicatedNodes" | "dedicatedCluster";
             compute: {
@@ -1785,8 +1785,8 @@ export interface components {
         ClusterTenantUpdate: {
             /** @description New human-readable customer name (must be non-blank when present). */
             displayName?: string;
-            /** @description New customer-owned base domain; an empty string clears it (back to the per-instance ingress.domain fallback). */
-            baseDomain?: string;
+            /** @description New customer-vanity domain CNAMEd onto the org apex; an empty string clears it (back to the derived <name>.<base> apex only). */
+            vanityDomain?: string;
             /**
              * @description New isolation strength; re-gated against the provisioner registry when changed.
              * @enum {string}

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -14,6 +14,7 @@ export {
   type ClusterTenantResources,
   type ClusterTenantStatus,
 } from "./cluster-tenant.types.js";
+export { _BuildOrgDomain, _BuildOrgWildcard, _BuildUserHost } from "./domain-topology.types.js";
 export { GrantAccess, GrantScope, GrantSubjectType, type Grant } from "./grant.types.js";
 export { type Group } from "./group.types.js";
 export { McpCredentialBrokeringMode, McpServerStatus, McpServerTransport, type McpServer, type McpServerCredential } from "./mcp-server.types.js";

--- a/plan.md
+++ b/plan.md
@@ -112,15 +112,23 @@ Stacked on `feat/org-admin-billing`.
   cert-manager DNS-01 (reference manifest `platform/helm/examples/per-org-wildcard-cert.yaml`).
 - **DNS automation:** `modules/dns` extended — platform wildcard + apex + control-plane-host records, and a
   `var.org_wildcards`-driven per-org `*.<org>.<base>` record matching the operator hook's shape.
-- **Per-org provisioning hook (interface only):** `OrgDomainProvisioner.provisionOrgDomain(...)`
-  (`core/cluster-tenants/org-domain-provisioner.types.ts`), wired to the same WS4 `pending → ready` hand-off
-  the create flow leaves in place; the create path never mutates DNS/cert-manager (fail-closed, API-first).
+- **Per-org provisioning — IMPLEMENTED:** `DefaultOrgDomainProvisioner`
+  (`core/cluster-tenants/org-domain.provisioner.ts`) behind the `OrgDomainProvisioner` interface. It applies
+  the per-org wildcard `Certificate` (`*.<org>.<base>` + apex/vanity SANs) via cert-manager DNS-01
+  (`CertManagerClient` over the custom-objects API, mirroring `apply-dns-config.ts`) and ensures the
+  `*.<org>.<base>`/`<org>.<base>` A records in the terraform-managed Cloud DNS zone (`CloudDnsClient`, a thin
+  wrapper over `@google-cloud/dns` as an **optional** dep, lazy-loaded like the operator's `GcsBucketClient`).
+  Both side effects idempotent. **Fail-closed + gated:** an absent cert-manager CRD yields `ready:false` + a
+  reason and never crashes, while the resource-authoring path stays real (not a no-op stub). Wired from env via
+  `_BuildOrgDomainProvisioner`; the create path never mutates DNS/cert-manager — only the reconciler does
+  (fail-closed, API-first).
 - **Docs:** `docs/agents/cluster-architecture.md` + `website/operators/dns-config.md` rewritten to the new
   topology with the exact customer CNAME instruction.
-- **Deferred to the cluster-tenants operator workstream:** the CR watcher that CALLS the hook to create the
-  live per-org DNS record + wildcard cert. Live cert/DNS apply prepared (not executed) for human authorisation.
-- Validation: `helm template` + `kubectl --dry-run=server` (control-plane Ingress) green; operator (104),
-  control-plane (407), cli (4) suites green; touched-package build + lint clean.
+- **Remaining (PR #50):** the CR watcher that CALLS `provisionOrgDomain(...)` on the `pending → ready`
+  reconcile. The provisioner itself is done; live cert/DNS apply remains the batched human-authorised step
+  (cert-manager is not installed on the shared dev cluster) — prepared, not executed.
+- Validation: `helm template` + `kubectl --dry-run=server` (control-plane Ingress) green; operator (105),
+  control-plane (424; +17 provisioner/cert/DNS unit tests), cli (4) suites green; touched-package build + lint clean.
 
 ### Track P5 — Close Phase 5 — ✅ COMPLETE · full history: plan-done.md § Completed Tracks (archived 2026-06-15)
 

--- a/plan.md
+++ b/plan.md
@@ -92,6 +92,36 @@ creates a billing account, then creates an org and becomes its root admin.
 - Tests: billing-account create, create-records-owner, the full guard matrix, membership-derived `isOrgAdmin`
   (+20; control-plane suite 407 green).
 
+### Track DOMAIN — Fixed wildcard + CNAME domain topology — LANDED 2026-06-22
+
+Replaced the "each customer brings their own domain + delegated DNS-01" model with a **fixed-wildcard
+topology**: ONE platform org-wildcard base + a fixed super-operator/control-plane host; orgs are derived at
+`<org>.<base>`, users at `<user>.<org>.<base>`; customers optionally CNAME a vanity domain onto `<org>.<base>`.
+Stacked on `feat/org-admin-billing`.
+- **Chart values:** `ingress.controlPlaneHost` (fixed super-operator host, defaults `platform.<base>`,
+  distinct from the wildcard) + `ingress.domain` reframed as the platform org-wildcard base.
+  `control-plane-ingress.yaml` serves the fixed host; the platform `Certificate` SANs are
+  `*.<base>` + apex + control-plane host (operator/control-plane deployment templates untouched to keep merges trivial).
+- **Host derivation:** `_BuildOrgDomain`/`_BuildUserHost`/`_BuildOrgWildcard` in `libs/contracts`
+  (`domain-topology.types.ts`); operator `_ResolveOrgServingDomain` derives `<user>.<org>.<base>` with the
+  vanity domain as an overlay (ref-less openclaws unchanged at `<user>.<base>`).
+- **Schema:** ClusterTenant `base_domain` → `vanity_domain` (`migrations/0024`), repurposed as the optional
+  CNAME overlay; mirrored through contracts, openapi, CLI (`--vanity-domain`), and the CRD.
+- **Multi-level wildcard TLS (decided):** `*.<base>` covers org apexes but NOT `<user>.<org>.<base>` (a
+  wildcard matches one label) → a **per-org** `*.<org>.<base>` `Certificate` issued at org-provision via
+  cert-manager DNS-01 (reference manifest `platform/helm/examples/per-org-wildcard-cert.yaml`).
+- **DNS automation:** `modules/dns` extended — platform wildcard + apex + control-plane-host records, and a
+  `var.org_wildcards`-driven per-org `*.<org>.<base>` record matching the operator hook's shape.
+- **Per-org provisioning hook (interface only):** `OrgDomainProvisioner.provisionOrgDomain(...)`
+  (`core/cluster-tenants/org-domain-provisioner.types.ts`), wired to the same WS4 `pending → ready` hand-off
+  the create flow leaves in place; the create path never mutates DNS/cert-manager (fail-closed, API-first).
+- **Docs:** `docs/agents/cluster-architecture.md` + `website/operators/dns-config.md` rewritten to the new
+  topology with the exact customer CNAME instruction.
+- **Deferred to the cluster-tenants operator workstream:** the CR watcher that CALLS the hook to create the
+  live per-org DNS record + wildcard cert. Live cert/DNS apply prepared (not executed) for human authorisation.
+- Validation: `helm template` + `kubectl --dry-run=server` (control-plane Ingress) green; operator (104),
+  control-plane (407), cli (4) suites green; touched-package build + lint clean.
+
 ### Track P5 — Close Phase 5 — ✅ COMPLETE · full history: plan-done.md § Completed Tracks (archived 2026-06-15)
 
 ### Track P4-A — Finish Phase 4 runtime-plane enforcement gaps — ✅ COMPLETE · full history: plan-done.md § Completed Tracks (archived 2026-06-15)

--- a/platform/helm/crds/opencrane.io_clustertenants.yaml
+++ b/platform/helm/crds/opencrane.io_clustertenants.yaml
@@ -31,14 +31,16 @@ spec:
                   type: string
                   minLength: 1
                   description: Human-readable customer name.
-                baseDomain:
+                vanityDomain:
                   type: string
                   maxLength: 253
                   pattern: '^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$'
                   description: >-
-                    Customer-owned base domain this ClusterTenant serves its UserTenant gateways
-                    under (e.g. ai.client-company.com). UserTenant hosts are <user>.<baseDomain>.
-                    Optional — when unset the operator falls back to the per-instance ingress.domain.
+                    Optional customer-vanity domain CNAMEd onto this org's canonical apex
+                    <name>.<platformBaseDomain> (e.g. ai.client-company.com). An OVERLAY, not the
+                    org identity: the org is always served at its derived <name>.<base> apex (and
+                    users at <user>.<name>.<base>); a vanity domain is an additional name pointed at
+                    that apex. When unset, only the derived apex serves the org.
                 isolationTier:
                   type: string
                   enum: [shared, dedicatedNodes, dedicatedCluster]

--- a/platform/helm/examples/per-org-wildcard-cert.yaml
+++ b/platform/helm/examples/per-org-wildcard-cert.yaml
@@ -7,13 +7,13 @@
 # `*.<org>.<base>`, issued at org-provision time via cert-manager DNS-01 against
 # Cloud DNS.
 #
-# This file is the exact shape the cluster-tenants operator (a SEPARATE workstream)
-# renders per org through the `OrgDomainProvisioner.provisionOrgDomain(...)` seam
-# (apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts). It is
+# This file is the exact shape `DefaultOrgDomainProvisioner` emits per org through the
+# `OrgDomainProvisioner.provisionOrgDomain(...)` seam
+# (apps/control-plane/src/core/cluster-tenants/org-domain.provisioner.ts). It is
 # NOT a chart template and is NOT installed by `helm install` — issuing a cert is a
-# live, authorised action. To provision a single org by hand (until the operator owns
-# it), substitute the placeholders and apply under human authorisation. See the
-# PREPARED commands in the PR / docs/agents/cluster-architecture.md.
+# live, authorised action. To provision a single org by hand (before the reconciler
+# runs in a given cluster), substitute the placeholders and apply under human
+# authorisation. See the PREPARED commands in the PR / docs/agents/cluster-architecture.md.
 #
 # Placeholders:
 #   <ORG>   — the org (ClusterTenant) name, e.g. acme

--- a/platform/helm/examples/per-org-wildcard-cert.yaml
+++ b/platform/helm/examples/per-org-wildcard-cert.yaml
@@ -1,0 +1,54 @@
+# -----------------------------------------------------------------------------
+# Per-org wildcard TLS Certificate — REFERENCE MANIFEST (NOT auto-applied)
+#
+# Fixed-wildcard topology: the platform wildcard cert `*.<base>` covers org apexes
+# `<org>.<base>` but NOT the per-user level `<user>.<org>.<base>` (a DNS wildcard
+# matches exactly one label). Each org therefore needs its OWN wildcard cert
+# `*.<org>.<base>`, issued at org-provision time via cert-manager DNS-01 against
+# Cloud DNS.
+#
+# This file is the exact shape the cluster-tenants operator (a SEPARATE workstream)
+# renders per org through the `OrgDomainProvisioner.provisionOrgDomain(...)` seam
+# (apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts). It is
+# NOT a chart template and is NOT installed by `helm install` — issuing a cert is a
+# live, authorised action. To provision a single org by hand (until the operator owns
+# it), substitute the placeholders and apply under human authorisation. See the
+# PREPARED commands in the PR / docs/agents/cluster-architecture.md.
+#
+# Placeholders:
+#   <ORG>   — the org (ClusterTenant) name, e.g. acme
+#   <BASE>  — the platform wildcard base (ingress.domain), e.g. weownai.eu
+#   <NS>    — the org's bound namespace (status.boundNamespace), e.g. opencrane-acme
+#   <ISSUER> / <ISSUER_KIND> — the cert-manager issuer (certManager.issuerName;
+#             ClusterIssuer in single-install, namespaced Issuer in multi-instance)
+# -----------------------------------------------------------------------------
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: org-wildcard-tls-<ORG>
+  # MUST be the org's bound namespace: an Ingress can only reference a TLS Secret in
+  # its OWN namespace, and per-user UserTenant Ingresses live in <NS>.
+  namespace: <NS>
+  labels:
+    app.kubernetes.io/part-of: opencrane
+    app.kubernetes.io/component: org-wildcard-cert
+    opencrane.io/cluster-tenant: <ORG>
+spec:
+  # The Secret per-org UserTenant Ingresses reference (set the operator's
+  # INGRESS_TLS_SECRET_NAME / the org's tenants' ingress.tls.secretName to this).
+  secretName: org-wildcard-tls-<ORG>
+  issuerRef:
+    name: <ISSUER>
+    kind: <ISSUER_KIND>
+  # Covers EVERY UserTenant gateway host under the org: <user>.<ORG>.<BASE>. The org
+  # apex itself (<ORG>.<BASE>) is already covered by the platform `*.<BASE>` cert, but
+  # we add it here too so an org's TLS is self-contained. A wildcard cert REQUIRES the
+  # ACME DNS-01 challenge (cert-manager briefly writes `_acme-challenge.<ORG>.<BASE>`
+  # TXT), so the issuer above must be a DNS-01 ACME issuer authorised on the zone.
+  dnsNames:
+    - "*.<ORG>.<BASE>"
+    - "<ORG>.<BASE>"
+  # When the customer CNAMEs a vanity domain onto <ORG>.<BASE>, ALSO add (the operator
+  # appends these when ClusterTenant.vanityDomain is set):
+  #   - "*.<VANITY_DOMAIN>"
+  #   - "<VANITY_DOMAIN>"

--- a/platform/helm/templates/cluster-issuer.yaml
+++ b/platform/helm/templates/cluster-issuer.yaml
@@ -74,12 +74,17 @@ spec:
   issuerRef:
     name: {{ $cm.issuerName | quote }}
     kind: ClusterIssuer
-  # Wildcard covers every UserTenant gateway host (<user>.<domain>) under the
-  # ClusterTenant base domain; the apex is added so the control plane served at the
-  # bare base domain is also covered (a wildcard does not match the apex).
+  # Fixed-wildcard topology. The platform wildcard `*.<domain>` covers every ORG APEX
+  # `<org>.<domain>`; the base apex `<domain>` is added for completeness, and the fixed
+  # control-plane host is added explicitly so it is browser-trusted even when set to a
+  # name OUTSIDE `<domain>`. NOTE: this cert does NOT cover the per-user level
+  # `<user>.<org>.<domain>` (a wildcard matches exactly one label) — each org gets its
+  # own `*.<org>.<domain>` cert issued at provision time by the cluster-tenants operator
+  # via DNS-01 (see docs/agents/cluster-architecture.md → "Multi-level wildcard TLS").
   dnsNames:
     - {{ printf "*.%s" .Values.ingress.domain | quote }}
     - {{ .Values.ingress.domain | quote }}
+    - {{ .Values.ingress.controlPlaneHost | default (printf "platform.%s" .Values.ingress.domain) | quote }}
 {{- else }}
 {{- /* Namespaced mode: a per-instance-namespace Issuer + wildcard Certificate. */ -}}
 {{- $namespaces := include "opencrane.instanceNamespaces" . | fromJsonArray }}
@@ -125,12 +130,14 @@ spec:
     # Namespaced Issuer in this same namespace — never a cluster-singleton.
     name: {{ $cm.issuerName | quote }}
     kind: Issuer
-  # Wildcard covers every UserTenant gateway host (<user>.<domain>) under the
-  # ClusterTenant base domain; the apex is added so the control plane served at the
-  # bare base domain is also covered (a wildcard does not match the apex).
+  # Fixed-wildcard topology (see the legacy block above). `*.<domain>` covers org
+  # apexes `<org>.<domain>`; the base apex + the fixed control-plane host are added.
+  # Per-user `<user>.<org>.<domain>` is covered by a per-org `*.<org>.<domain>` cert
+  # issued at provision time, NOT by this platform cert.
   dnsNames:
     - {{ printf "*.%s" $.Values.ingress.domain | quote }}
     - {{ $.Values.ingress.domain | quote }}
+    - {{ $.Values.ingress.controlPlaneHost | default (printf "platform.%s" $.Values.ingress.domain) | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/helm/templates/control-plane-ingress.yaml
+++ b/platform/helm/templates/control-plane-ingress.yaml
@@ -1,5 +1,11 @@
 {{- if .Values.ingress.enabled -}}
-{{- $host := .Values.ingress.domain -}}
+{{- /*
+Fixed-wildcard topology: the control plane is the FIXED super-operator host, distinct
+from the org-wildcard base (`ingress.domain`). It serves at `ingress.controlPlaneHost`
+when set, else the derived default `platform.<ingress.domain>` — never under the org
+wildcard `*.<ingress.domain>`. See docs/agents/cluster-architecture.md → "Tenancy Model".
+*/ -}}
+{{- $host := .Values.ingress.controlPlaneHost | default (printf "platform.%s" .Values.ingress.domain) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -332,15 +332,27 @@ ingress:
   enabled: true
   # -- Ingress class is set by the hosting adapter; override here only for custom setups.
   className: nginx
-  # -- The ClusterTenant base domain for this instance. Per-user UserTenant gateways
-  #    are exposed as subdomains under it (<usertenant>.domain). See
-  #    docs/agents/cluster-architecture.md → "Tenancy Model — ClusterTenant vs UserTenant".
+  # -- The platform org-wildcard BASE domain for this install (fixed-wildcard topology).
+  #    Orgs (ClusterTenants) are served at `<org>.<domain>` and their users at
+  #    `<user>.<org>.<domain>`; the platform wildcard `*.<domain>` covers the org apexes.
+  #    This is wired to the operator as INGRESS_DOMAIN (the wildcard base it derives
+  #    UserTenant hosts from). See docs/agents/cluster-architecture.md → "Tenancy Model".
   domain: opencrane.local
+  # -- The FIXED super-operator / control-plane host (the management API above every
+  #    org). DISTINCT from the org-wildcard base above — it is its own host, never an
+  #    org under `*.<domain>`. Defaults to `platform.<domain>` when left empty so a
+  #    default render still produces a sane, separate host. Set it to a dedicated name
+  #    (e.g. `platform.weownai.eu`) in production.
+  controlPlaneHost: ""
   annotations: {}
   tls:
     enabled: false
-    # -- Secret name for the wildcard TLS cert (*.domain) covering every UserTenant
-    #    gateway host under the ClusterTenant base domain.
+    # -- Secret name for the platform wildcard TLS cert (`*.<domain>`, covering every
+    #    org apex `<org>.<domain>`) that per-UserTenant Ingresses reference by default.
+    #    NOTE: this wildcard does NOT cover the per-user level `<user>.<org>.<domain>`
+    #    (DNS wildcards match one label) — each org gets its own `*.<org>.<domain>`
+    #    cert at provision time. See docs/agents/cluster-architecture.md → "Multi-level
+    #    wildcard TLS".
     secretName: opencrane-wildcard-tls
 
 # -- Documentation site (optional). When enabled, serves the VitePress docs build

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -13,7 +13,17 @@
 # Usage:
 #   ./platform/k8s-deploy.sh [--domain DOMAIN] [--namespace NS] [--release NAME]
 #                            [--image-tag TAG] [--storage-class SC]
+#                            [--control-plane-tag TAG] [--operator-tag TAG]
+#                            [--tenant-tag TAG]
 #                            [--values FILE] [--set k=v ...]
+#
+# --image-tag pins all three platform images (control-plane, operator, tenant)
+# to the same tag. To roll a SINGLE component to a different build, pass the
+# matching per-component flag (e.g. --control-plane-tag sha-abc123); it overrides
+# --image-tag for that component only. ALWAYS bump component images this way —
+# never `kubectl set image` / `kubectl patch` a managed deployment. An imperative
+# patch creates a `kubectl-*` field manager that owns the image field on the live
+# object and makes every later `helm upgrade` fail with a field-ownership conflict.
 #
 # Prereqs: kubectl (pointed at the target cluster) and helm.
 # =============================================================================
@@ -25,6 +35,9 @@ CHART_DIR="$SCRIPT_DIR/helm"
 NAMESPACE="opencrane-system"
 RELEASE="opencrane"
 IMAGE_TAG="latest"
+CONTROL_PLANE_TAG=""    # empty → falls back to IMAGE_TAG
+OPERATOR_TAG=""         # empty → falls back to IMAGE_TAG
+TENANT_TAG=""           # empty → falls back to IMAGE_TAG
 DOMAIN=""
 STORAGE_CLASS=""        # empty → cluster default StorageClass
 VALUES_FILE=""
@@ -45,7 +58,10 @@ while [[ $# -gt 0 ]]; do
     --domain)        DOMAIN="$2"; shift 2 ;;
     --namespace)     NAMESPACE="$2"; shift 2 ;;
     --release)       RELEASE="$2"; shift 2 ;;
-    --image-tag)     IMAGE_TAG="$2"; shift 2 ;;
+    --image-tag)        IMAGE_TAG="$2"; shift 2 ;;
+    --control-plane-tag) CONTROL_PLANE_TAG="$2"; shift 2 ;;
+    --operator-tag)     OPERATOR_TAG="$2"; shift 2 ;;
+    --tenant-tag)       TENANT_TAG="$2"; shift 2 ;;
     --storage-class) STORAGE_CLASS="$2"; shift 2 ;;
     --values)        VALUES_FILE="$2"; shift 2 ;;
     --set)           EXTRA_SET+=(--set "$2"); shift 2 ;;
@@ -125,7 +141,15 @@ helm_args=(upgrade --install "$RELEASE" "$CHART_DIR" --namespace "$NAMESPACE" --
   --set "controlPlane.database.existingSecret=$DB_SECRET"
   --set "litellm.existingDatabaseSecret=opencrane-litellm-db"
   --set "litellm.existingSecret=opencrane-litellm")
-[[ -n "$IMAGE_TAG" ]] && helm_args+=(--set "controlPlane.image.tag=$IMAGE_TAG" --set "operator.image.tag=$IMAGE_TAG" --set "tenant.image.tag=$IMAGE_TAG")
+# Per-component tags override the unified --image-tag so a single component can be
+# rolled through Helm (which keeps Helm the sole owner of the image field). Each
+# falls back to IMAGE_TAG when its flag is unset, preserving the all-same default.
+CP_TAG="${CONTROL_PLANE_TAG:-$IMAGE_TAG}"
+OP_TAG="${OPERATOR_TAG:-$IMAGE_TAG}"
+TN_TAG="${TENANT_TAG:-$IMAGE_TAG}"
+[[ -n "$CP_TAG" ]] && helm_args+=(--set "controlPlane.image.tag=$CP_TAG")
+[[ -n "$OP_TAG" ]] && helm_args+=(--set "operator.image.tag=$OP_TAG")
+[[ -n "$TN_TAG" ]] && helm_args+=(--set "tenant.image.tag=$TN_TAG")
 [[ -n "$DOMAIN" ]]    && helm_args+=(--set "ingress.domain=$DOMAIN")
 [[ -n "$VALUES_FILE" ]] && helm_args+=(--values "$VALUES_FILE")
 helm_args+=("${EXTRA_SET[@]}")

--- a/platform/terraform/modules/dns/main.tf
+++ b/platform/terraform/modules/dns/main.tf
@@ -1,9 +1,19 @@
 # -----------------------------------------------------------------------------
-# Cloud DNS module
+# Cloud DNS module — fixed-wildcard topology
 #
-# Creates a Cloud DNS managed zone and a wildcard A record pointing to
-# the ingress controller's external IP. All tenant subdomains resolve
-# automatically via the wildcard.
+# Owns the platform's managed zone and the FIXED, install-time records:
+#   - `*.<domain>`          → ingress IP  (resolves every ORG APEX `<org>.<domain>`)
+#   - `<domain>` (apex)     → ingress IP
+#   - control-plane host    → ingress IP  (the fixed super-operator host, distinct
+#                                           from the org wildcard)
+#
+# Per-ORG records (`*.<org>.<domain>`, which resolve the per-user level
+# `<user>.<org>.<domain>`) are NOT created here at install — they are added at
+# org-provision time by the cluster-tenants operator through the `OrgDomainProvisioner`
+# seam (apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts).
+# `google_dns_record_set.org_wildcard` below is the exact shape that hook emits, and
+# can also be driven from `var.org_wildcards` to pre-provision specific orgs from
+# Terraform. The platform `*.<domain>` record alone does NOT cover that extra label.
 # -----------------------------------------------------------------------------
 
 resource "google_dns_managed_zone" "opencrane"
@@ -11,9 +21,10 @@ resource "google_dns_managed_zone" "opencrane"
   name        = "${var.zone_name}-zone"
   project     = var.project_id
   dns_name    = "${var.domain}."
-  description = "OpenCrane platform DNS zone"
+  description = "OpenCrane platform DNS zone (fixed-wildcard topology)"
 }
 
+# Platform org-wildcard: resolves every org apex `<org>.<domain>` to the ingress IP.
 resource "google_dns_record_set" "wildcard"
 {
   project      = var.project_id
@@ -24,12 +35,44 @@ resource "google_dns_record_set" "wildcard"
   rrdatas      = [var.ingress_ip]
 }
 
-# Also create an A record for the apex domain (control-plane UI)
+# Apex record for the base domain.
 resource "google_dns_record_set" "apex"
 {
   project      = var.project_id
   managed_zone = google_dns_managed_zone.opencrane.name
   name         = "${var.domain}."
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [var.ingress_ip]
+}
+
+# Fixed super-operator / control-plane host (distinct from the org wildcard). Defaults
+# to `platform.<domain>`; matches ingress.controlPlaneHost in the chart.
+resource "google_dns_record_set" "control_plane"
+{
+  project      = var.project_id
+  managed_zone = google_dns_managed_zone.opencrane.name
+  name         = "${coalesce(var.control_plane_host, "platform.${var.domain}")}."
+  type         = "A"
+  ttl          = 300
+  rrdatas      = [var.ingress_ip]
+}
+
+# -----------------------------------------------------------------------------
+# Per-org wildcard records — the SHAPE the operator's DNS hook emits per org.
+#
+# Driven by `var.org_wildcards` (a set of org names). LEFT EMPTY by default so this
+# module does not pre-empt the operator; populate it only to pre-provision specific
+# orgs from Terraform. For each org `<org>` it creates `*.<org>.<domain>` → ingress IP,
+# which resolves every `<user>.<org>.<domain>` UserTenant gateway under that org.
+# -----------------------------------------------------------------------------
+resource "google_dns_record_set" "org_wildcard"
+{
+  for_each = var.org_wildcards
+
+  project      = var.project_id
+  managed_zone = google_dns_managed_zone.opencrane.name
+  name         = "*.${each.value}.${var.domain}."
   type         = "A"
   ttl          = 300
   rrdatas      = [var.ingress_ip]

--- a/platform/terraform/modules/dns/variables.tf
+++ b/platform/terraform/modules/dns/variables.tf
@@ -13,7 +13,7 @@ variable "zone_name"
 
 variable "domain"
 {
-  description = "Base domain for tenant subdomains (e.g. opencrane.example.com)"
+  description = "Platform org-wildcard base domain. Orgs are <org>.<domain>, users <user>.<org>.<domain> (e.g. weownai.eu)."
   type        = string
 }
 
@@ -21,4 +21,18 @@ variable "ingress_ip"
 {
   description = "External IP of the ingress controller"
   type        = string
+}
+
+variable "control_plane_host"
+{
+  description = "Fixed super-operator / control-plane host (distinct from the org wildcard). Empty → defaults to platform.<domain>."
+  type        = string
+  default     = ""
+}
+
+variable "org_wildcards"
+{
+  description = "Org names to pre-provision a per-org wildcard record (*.<org>.<domain>) for. Empty by default — the cluster-tenants operator owns per-org records at provision time."
+  type        = set(string)
+  default     = []
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,10 @@ importers:
       vitest:
         specifier: ^3.1.0
         version: 3.2.4(@types/node@22.15.31)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)
+    optionalDependencies:
+      '@google-cloud/dns':
+        specifier: ^4.0.0
+        version: 4.0.0(encoding@0.1.13)
 
   apps/harvesting-agent:
     dependencies:
@@ -684,6 +688,14 @@ packages:
 
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
+
+  '@google-cloud/common@5.0.2':
+    resolution: {integrity: sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA==}
+    engines: {node: '>=14.0.0'}
+
+  '@google-cloud/dns@4.0.0':
+    resolution: {integrity: sha512-cqwq8rNalRl7gxEVV2w2WITCq7tx4Sk4j+4qfS+ZIPn1yu0Xe4ZxyuthP1KB2IrZDSKZtzRtoYpAA8PrDVmRNw==}
+    engines: {node: '>=14.0.0'}
 
   '@google-cloud/paginator@5.0.2':
     resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
@@ -2190,6 +2202,10 @@ packages:
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
+  dns-zonefile@0.2.10:
+    resolution: {integrity: sha512-YXs0T8EjhwI3YFpL4l7n9Uy+g/ufmd3WyDSQsI4mrMNlrrdgK6aN0AbNjOkKoHyF59l/x4Y3/z64F3aJWCKWpg==}
+    hasBin: true
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -2650,6 +2666,9 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.groupby@4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
@@ -3242,6 +3261,9 @@ packages:
 
   streamx@2.23.0:
     resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
+
+  string-format-obj@1.1.1:
+    resolution: {integrity: sha512-Mm+sROy+pHJmx0P/0Bs1uxIX6UhGJGj6xDGQZ5zh9v/SZRmLGevp+p0VJxV7lirrkAmQ2mvva/gHKpnF/pTb+Q==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3988,6 +4010,36 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+
+  '@google-cloud/common@5.0.2(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.0.0
+      arrify: 2.0.1
+      duplexify: 4.1.3
+      extend: 3.0.2
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      html-entities: 2.6.0
+      retry-request: 7.0.2(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  '@google-cloud/dns@4.0.0(encoding@0.1.13)':
+    dependencies:
+      '@google-cloud/common': 5.0.2(encoding@0.1.13)
+      '@google-cloud/paginator': 5.0.2
+      '@google-cloud/promisify': 4.0.0
+      arrify: 2.0.1
+      dns-zonefile: 0.2.10
+      lodash.groupby: 4.6.0
+      string-format-obj: 1.1.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
 
   '@google-cloud/paginator@5.0.2':
     dependencies:
@@ -5768,6 +5820,9 @@ snapshots:
       asap: 2.0.6
       wrappy: 1.0.2
 
+  dns-zonefile@0.2.10:
+    optional: true
+
   dotenv@16.6.1: {}
 
   dunder-proto@1.0.1:
@@ -6395,6 +6450,9 @@ snapshots:
     optional: true
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.groupby@4.6.0:
+    optional: true
 
   long@5.3.2: {}
 
@@ -7086,6 +7144,9 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
+
+  string-format-obj@1.1.1:
+    optional: true
 
   string-width@4.2.3:
     dependencies:

--- a/website/operators/dns-config.md
+++ b/website/operators/dns-config.md
@@ -5,46 +5,58 @@ walks an admin through the happy path; this page documents the model, the full A
 surface, the cert-manager resources OpenCrane creates, and the per-provider and
 multi-instance options.
 
-## The model: delegate once, manage from the platform
+## The model: one fixed platform wildcard, orgs and users derived under it
 
-OpenCrane is designed so DNS is a **one-time delegation** at your provider, after which
-every assistant is reachable with no further record changes:
+OpenCrane uses a **fixed wildcard topology**. The platform owns **one base domain**
+(`<base>`, e.g. `weownai.eu`) and a **fixed super-operator / control-plane host**
+(`platform.<base>`). Every org and user name is **derived** under the base — customers do
+not bring their own domain:
 
-| Step | Where | How often |
-|------|-------|-----------|
-| Apex `A`/`CNAME` → ingress address | your DNS provider | once |
-| Wildcard `*.<zone>` `A`/`CNAME` → ingress address | your DNS provider | once |
-| `oc platform dns set …` (provider token for DNS-01) | the platform | once |
-| New assistant `alice.<zone>` resolves **and** gets HTTPS | automatic | every assistant, zero touch |
+| Name | Where it points | Set how often |
+|------|-----------------|---------------|
+| Control-plane host `platform.<base>` → ingress | platform DNS | once, at install |
+| Apex `<base>` → ingress | platform DNS | once, at install |
+| Platform wildcard `*.<base>` → ingress (resolves every **org apex** `<org>.<base>`) | platform DNS | once, at install |
+| Per-org wildcard `*.<org>.<base>` → ingress (resolves every **user** `<user>.<org>.<base>`) | platform DNS | automatic, per org at provision time |
+| New user `alice.<org>.<base>` resolves **and** gets HTTPS | — | automatic, zero touch |
 
-Two records and one token, set once. The provider stays the source of truth for the
-*delegation*; the platform owns everything underneath it.
+So an org is served at `<org>.<base>` (e.g. `acme.weownai.eu`) and its users at
+`<user>.<org>.<base>` (e.g. `mike.acme.weownai.eu`).
 
-### Why a wildcard
+### Why two wildcard levels
 
-A wildcard record (`*.<zone>`) resolves **every** name at that level to the cluster
-ingress address, so `alice.<zone>`, `bob.<zone>` and any future assistant resolve the
-moment they are created — without adding a record per assistant. All names land on the
-same ingress; the ingress controller then routes by the HTTP `Host:` header to the right
-tenant. DNS gets the request to the cluster; the ingress decides *which* assistant.
+A DNS wildcard matches **exactly one label**. `*.<base>` resolves every org apex
+`<org>.<base>`, but it does **not** reach the extra label in `<user>.<org>.<base>`. So each
+org gets its **own** wildcard `*.<org>.<base>` (record + certificate), created when the org
+is provisioned. Once an org exists, every user under it resolves and gets HTTPS the moment
+they are created — no per-user record. All names land on the same ingress; the ingress
+controller routes by the HTTP `Host:` header to the right gateway.
 
 ### Why a provider token is still needed
 
-The wildcard solves **routing**, but HTTPS needs a certificate valid for the name in the
-browser. OpenCrane issues a single wildcard certificate (`*.<zone>`) via Let's Encrypt,
-and a wildcard certificate can only be validated with the **ACME DNS-01 challenge** —
-cert-manager must briefly create a `_acme-challenge.<zone>` `TXT` record. The provider
-token you supply is used for **exactly that, and only that**: writing and removing that
-temporary validation record. cert-manager then auto-renews the certificate (~every 60
-days) using the same token. Per-assistant Ingresses reference the shared wildcard cert
-Secret, so adding an assistant needs no new issuance.
+Wildcards solve **routing**; HTTPS needs a certificate valid for the name in the browser.
+OpenCrane issues wildcard certificates via Let's Encrypt — the **platform** cert
+(`*.<base>` + apex + control-plane host) and, per org, a `*.<org>.<base>` cert. A wildcard
+certificate can only be validated with the **ACME DNS-01 challenge** — cert-manager briefly
+creates a `_acme-challenge.<zone>` `TXT` record. The provider token you supply is used for
+**exactly that, and only that**: writing and removing that temporary validation record.
+cert-manager then auto-renews (~every 60 days) using the same token.
 
-::: tip This page is about the wildcard model
-Programmatic, record-level management (real per-host `A`/`CNAME` records, custom/vanity
-domains, dropping the wildcard) is an `external-dns` extension that reuses the same
-provider token. It is an open decision — see the DNS-ownership item in
-[Hosting & deployment](/operators/hosting).
-:::
+### Optional: a customer-vanity domain (CNAME)
+
+A customer who wants their **own** domain (e.g. `ai.client-company.com`) does **not**
+delegate or transfer it — they add a single `CNAME` at their own provider pointing it at
+their org apex:
+
+```
+# At the customer's DNS provider, for org "acme" on base "weownai.eu":
+ai.client-company.com.   CNAME   acme.weownai.eu.
+```
+
+Then set the org's `vanityDomain` (`oc cluster-tenant update acme --vanity-domain
+ai.client-company.com`, or the `vanityDomain` field on the API). OpenCrane adds the vanity
+name to the org's TLS SANs so it is browser-trusted. The vanity domain is an **overlay**:
+the org is always also reachable at its canonical `<org>.<base>` apex.
 
 ## Configure it
 
@@ -61,7 +73,7 @@ oc platform dns set \
 | Flag | Required | Meaning |
 |------|----------|---------|
 | `--provider` | yes | DNS-01 solver provider key (`cloudflare`, `digitalocean`, `route53`, `rfc2136`, …) |
-| `--zone` | yes | Base/delegated zone the wildcard cert covers (e.g. `ai.example.com`) |
+| `--zone` | yes | The platform wildcard **base** the certs cover (e.g. `weownai.eu`) — orgs are `<org>.<base>`, users `<user>.<org>.<base>` |
 | `--email` | yes | ACME account contact address (renewal notices) |
 | `--server` | no | ACME directory URL (defaults to Let's Encrypt production) |
 | `--issuer-name` | no | Issuer name to create/update (defaults to `opencrane-issuer`) |
@@ -173,12 +185,16 @@ token takes effect on re-apply):
 1. **A credentials Secret** — `opencrane-dns01-<provider>` (token-based providers only),
    holding the provider token under the `api-token` key.
 2. **A cert-manager issuer** — an ACME DNS-01 issuer referencing that Secret (or the raw
-   solver block). cert-manager then issues/renews the wildcard `*.<zone>` certificate
-   into the Secret that per-tenant Ingresses reference (`ingress.tls.secretName`,
-   default `opencrane-wildcard-tls`).
+   solver block). cert-manager then issues/renews the **platform** wildcard `*.<base>`
+   certificate (plus the apex and the control-plane host) into the Secret the chart
+   references (`ingress.tls.secretName`, default `opencrane-wildcard-tls`).
 
-The certificate appearing in the wildcard Secret happens on a live cluster with real DNS;
-this endpoint's job is to author and apply the two resources correctly.
+This authorises the issuer **on the zone**. Per **org** the cluster-tenants operator then
+issues a `*.<org>.<base>` certificate at provision time, reusing the same issuer/token (see
+[Multi-level wildcard TLS](/agents/cluster-architecture#multi-level-wildcard-tls) and
+`platform/helm/examples/per-org-wildcard-cert.yaml`). The certificate appearing in a Secret
+happens on a live cluster with real DNS; this endpoint's job is to author and apply the
+issuer + Secret correctly.
 
 ## Issuer kind: single vs multi-instance
 


### PR DESCRIPTION
## What landed

Replaces the old **"each customer brings their own domain + delegated DNS-01"** model with a **fixed wildcard + CNAME topology** (product decision):

- **One fixed platform org-wildcard base** (`ingress.domain`, e.g. `opencrane.ai`) + a **fixed super-operator/control-plane host** (`ingress.controlPlaneHost`, default `platform.<base>`) — distinct, never an org under `*.<base>`.
- **Orgs** (ClusterTenants) are derived at `<org>.<base>` (e.g. `acme.opencrane.ai`); **users** (UserTenants) at `<user>.<org>.<base>` (e.g. `mike.acme.opencrane.ai`).
- **Customer vanity domain** is an optional CNAME overlay onto the org apex (`ClusterTenant.baseDomain` → `vanityDomain`).

### Topology

```
platform.opencrane.ai        → control plane (FIXED super-operator host)
*.opencrane.ai               → every ORG APEX <org>.opencrane.ai        (platform wildcard)
  acme.opencrane.ai          → ClusterTenant "acme" (org apex)
    mike.acme.opencrane.ai   → UserTenant "mike"   (per-org wildcard *.acme.opencrane.ai)
  ai.client-company.com    → OPTIONAL vanity CNAME → acme.opencrane.ai
```

### Wildcard-cert strategy decision

A DNS wildcard matches **exactly one label**, so `*.<base>` covers org apexes but **not** `<user>.<org>.<base>`. **Decision:** two cert levels —
| Cert | Covers | Issued by |
|------|--------|-----------|
| **Platform** `*.<base>` + apex + control-plane host | org apexes, control plane | the chart (`cluster-issuer.yaml`) at install |
| **Per-org** `*.<org>.<base>` (+ org apex, + vanity SANs) | every `<user>.<org>.<base>` | the cluster-tenants operator at org-provision, cert-manager DNS-01 (ref manifest `platform/helm/examples/per-org-wildcard-cert.yaml`) |

### Per-org provisioning hook interface (and WS4 tie-in)

`OrgDomainProvisioner.provisionOrgDomain(req)` (`apps/control-plane/src/core/cluster-tenants/org-domain-provisioner.types.ts`) — **interface only**. The control-plane create flow (`routes/cluster-tenants.ts → _createClusterTenant`) persists desired state and hands off to the **same WS4 `pending → ready` reconcile seam** already noted in the create flow; the reconciler (separate cluster-tenants operator workstream) calls this hook to create the per-org DNS record + wildcard cert. The create path **never** mutates DNS or cert-manager (fail-closed, API-first).

## Files changed

- **Contracts:** `domain-topology.types.ts` (`_BuildOrgDomain`/`_BuildUserHost`/`_BuildOrgWildcard`), `cluster-tenant.types.ts` (`vanityDomain`), barrel + regenerated `generated/api.ts`.
- **Schema:** migration `0024_cluster_tenant_vanity_domain` (rename `base_domain` → `vanity_domain`), `schema.prisma`.
- **Control-plane:** `cluster-tenants.{ts,models.ts,service.ts}`, `openapi/spec.ts` + `openapi.json`, `org-domain-provisioner.types.ts`, `tenants.ts` (comment).
- **Operator:** `org-serving-domain.ts` (`_ResolveOrgServingDomain`), `operator.ts`, `ingress-host.ts`, `cluster-tenant-resolution.types.ts`, isolation tests (+ref-less host test).
- **CLI:** `cluster-tenants.{ts,types.ts}` (`--vanity-domain`).
- **Helm:** `values.yaml` (controlPlaneHost + reframed domain), `control-plane-ingress.yaml`, `cluster-issuer.yaml` (control-plane SAN), CRD, `examples/per-org-wildcard-cert.yaml`. (operator-deployment + control-plane-deployment intentionally untouched.)
- **Terraform:** `modules/dns` (control-plane-host + per-org wildcard records).
- **Docs:** `docs/agents/cluster-architecture.md`, `website/operators/dns-config.md`; `plan.md`, `CHANGELOG.md`.

## Validation

- `helm template` (default, prod-domain, multi-instance namespaced) renders correctly; control-plane host = `platform.<base>`, platform cert SANs `*.<base>` + apex + control-plane host.
- `kubectl --dry-run=server` on the rendered control-plane Ingress: created (server dry-run, no mutation).
- Suites green: operator **105**, control-plane **407**, cli **4**; touched-package `build` + `tsc --noEmit` clean. Static multi-instance conformance: PASS.
- Independent review (auth/infra gate): **no Critical/High**; one Medium (ref-less host test) resolved in this PR.

## Prepared (NOT applied) live cert + DNS commands

Per the strict read-only cloud rule, these are prepared for human authorisation against the shared `gke_weownai-proto_europe-west1_weownai-dev` cluster (ingress IP **35.205.225.244**, live base `dev.opencrane.ai`). **Do not run unattended.** They assume cert-manager + a DNS-01-authorised issuer are installed (cert-manager is currently NOT installed on the cluster — that is a prerequisite).

**1. Platform wildcard cert (chart-rendered; review before apply):**
```bash
helm template oc platform/helm \
  --set ingress.domain=dev.opencrane.ai \
  --set ingress.controlPlaneHost=platform.dev.opencrane.ai \
  --set ingress.tls.enabled=true \
  --set certManager.enabled=true --set certManager.mode=acme \
  --set certManager.acme.email=ops@opencrane.ai \
  --set certManager.acme.dns01.provider=clouddns \
  --set certManager.acme.dns01.config.project=weownai-proto \
  --show-only templates/cluster-issuer.yaml | kubectl apply -f -
# SANs: *.dev.opencrane.ai, dev.opencrane.ai, platform.dev.opencrane.ai
```

**2. Per-org wildcard cert for org `acme` (substitute placeholders, then apply):**
```bash
sed 's/<ORG>/acme/g; s/<BASE>/dev.opencrane.ai/g; s/<NS>/opencrane-acme/g; \
     s/<ISSUER>/opencrane-issuer/g; s/<ISSUER_KIND>/ClusterIssuer/g' \
  platform/helm/examples/per-org-wildcard-cert.yaml | kubectl apply -f -
# dnsNames: *.acme.dev.opencrane.ai, acme.dev.opencrane.ai
```

**3. DNS records (Cloud DNS) — platform + per-org. Run via Terraform (preferred) or gcloud:**
```bash
# Terraform (preferred — module already extended):
#   in platform/terraform/cloud/gcp, set domain=dev.opencrane.ai and
#   org_wildcards (via the dns module) = ["acme"], then: terraform plan / apply

# Equivalent gcloud (manual), against the platform managed zone <ZONE>:
gcloud dns record-sets create 'platform.dev.opencrane.ai' --zone=<ZONE> \
  --type=A --ttl=300 --rrdatas=35.205.225.244 --project=weownai-proto
gcloud dns record-sets create '*.dev.opencrane.ai.' --zone=<ZONE> \
  --type=A --ttl=300 --rrdatas=35.205.225.244 --project=weownai-proto
gcloud dns record-sets create '*.acme.dev.opencrane.ai.' --zone=<ZONE> \
  --type=A --ttl=300 --rrdatas=35.205.225.244 --project=weownai-proto
```
> NOTE: the only Cloud DNS zone visible in `weownai-proto` is the private GKE `cluster.local` zone — the public `opencrane.ai` zone is managed elsewhere, so `<ZONE>` must be the actual public managed zone name (confirm before applying).

**Customer vanity CNAME (the customer runs this at their own provider):**
```
ai.client-company.com.   CNAME   acme.dev.opencrane.ai.
# then: oc cluster-tenant update acme --vanity-domain ai.client-company.com
```

## Deferred

- The cluster-tenants **operator/CR watcher** that *calls* `OrgDomainProvisioner` to create the live per-org DNS record + wildcard cert (separate workstream; interface + reference manifest provided here).
- Live cert/DNS apply (prepared above, not executed).