### PR TITLE
🐛 operator: build @opencrane/contracts in the image (fixes container build / k3d-e2e)

### DIFF
--- a/apps/operator/deploy/Dockerfile
+++ b/apps/operator/deploy/Dockerfile
@@ -7,12 +7,18 @@ WORKDIR /app
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY tsconfig.base.json ./
 COPY libs/observability/package.json libs/observability/tsconfig.json libs/observability/
+COPY libs/contracts/package.json libs/contracts/tsconfig.json libs/contracts/
 COPY apps/operator/package.json apps/operator/tsconfig.json apps/operator/
-RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/operator
+RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/contracts --filter @opencrane/operator
 
 COPY libs/observability/src libs/observability/src
+COPY libs/contracts/src libs/contracts/src
+# @opencrane/contracts' build regenerates its typed client from the control-plane
+# OpenAPI spec (`pnpm generate` → openapi-typescript), so the spec must be present.
+COPY apps/control-plane/openapi.json apps/control-plane/openapi.json
 COPY apps/operator/src apps/operator/src
 RUN pnpm --filter @opencrane/observability build
+RUN pnpm --filter @opencrane/contracts build
 RUN pnpm --filter @opencrane/operator build
 
 # Runtime stage
@@ -23,10 +29,12 @@ RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
 WORKDIR /app
 COPY --from=build /app/package.json /app/pnpm-workspace.yaml /app/pnpm-lock.yaml ./
 COPY --from=build /app/libs/observability/package.json libs/observability/
+COPY --from=build /app/libs/contracts/package.json libs/contracts/
 COPY --from=build /app/apps/operator/package.json apps/operator/
-RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/operator --prod
+RUN pnpm install --frozen-lockfile --filter @opencrane/observability --filter @opencrane/contracts --filter @opencrane/operator --prod
 
 COPY --from=build /app/libs/observability/dist libs/observability/dist
+COPY --from=build /app/libs/contracts/dist libs/contracts/dist
 COPY --from=build /app/apps/operator/dist apps/operator/dist
 
 USER node


### PR DESCRIPTION
The merged #50 relocated the per-org domain provisioner into the operator, which imports `@opencrane/contracts` (`_BuildOrgDomain`/`_BuildOrgWildcard`). But `apps/operator/deploy/Dockerfile` only wires `@opencrane/observability`, so the operator **image build** fails:

```
src/cluster-tenants/internal/org-domain.provisioner.ts(1,52): error TS2307: Cannot find module '@opencrane/contracts'
```

(Local `tsc`/unit tests passed because the workspace resolves it; only the dependency-restricted container build broke — surfaced by `platform/tests/k3d-e2e.sh`.)

**Fix:** mirror the `observability` wiring for `contracts` in both build + runtime stages, and copy `apps/control-plane/openapi.json` (contracts' `build` regenerates its typed client from the spec via `openapi-typescript`).

**Validation:** built `@opencrane/contracts` then `@opencrane/operator` in sequence (the Dockerfile's build-stage order) — the TS2307 is gone and the operator compiles clean. (Full `docker build` not run here — local Docker daemon was down; the e2e will confirm the container layer.)