### PR TITLE
fix: stable opencrane-dev deploy on fresh GKE cluster

### DIFF
--- a/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
@@ -18,7 +18,27 @@ import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION }
  * The bridge writes ONLY `spec` — never `status` — so a CR write can never clobber
  * the phase/boundNamespace the operator stamps. It is idempotent: create-or-patch
  * (merge-patch the spec), so re-applying the same desired state converges.
+ *
+ * On create it also stamps the org owner's identity as metadata annotations
+ * ({@link _OWNER_EMAIL_ANNOTATION}/{@link _OWNER_SUBJECT_ANNOTATION}). The operator
+ * has no database access, so this is the only channel by which the ClusterTenant
+ * reconciler can learn who to attribute the org's default Tenant to once it is ready.
  */
+
+/** Annotation carrying the org owner's IdP-verified email, so the operator can attribute the org's default Tenant. */
+const _OWNER_EMAIL_ANNOTATION = "opencrane.io/owner-email";
+
+/** Annotation carrying the org owner's OIDC subject, recorded alongside the email for traceability. */
+const _OWNER_SUBJECT_ANNOTATION = "opencrane.io/owner-subject";
+
+/** Org owner identity stamped onto the ClusterTenant CR so the operator can seed a default Tenant. */
+export interface ClusterTenantOwner
+{
+  /** The owner's IdP-verified email; becomes the default Tenant's contact email. */
+  email?: string;
+  /** The owner's OIDC subject (`sub`). */
+  subject?: string;
+}
 
 /** The cluster-scoped ClusterTenant custom resource shape the control plane emits. */
 interface ClusterTenantCr
@@ -27,8 +47,8 @@ interface ClusterTenantCr
   apiVersion: string;
   /** CRD kind discriminator — always `ClusterTenant`. */
   kind: "ClusterTenant";
-  /** Object metadata; the org name is the cluster-scoped CR name. */
-  metadata: { name: string };
+  /** Object metadata; the org name is the cluster-scoped CR name, plus optional owner annotations. */
+  metadata: { name: string; annotations?: Record<string, string> };
   /** Desired-state spec projected from the persisted org row (never status). */
   spec: {
     /** Human-readable org display name. */
@@ -45,18 +65,43 @@ interface ClusterTenantCr
 }
 
 /**
- * Project a {@link ClusterTenant} contract object into the cluster-scoped CR spec.
- * Only desired-state fields are carried; status is the operator's to write.
+ * Build the owner-identity annotation map for a CR, or undefined when no owner
+ * field is set (so an org create without a resolvable owner carries no annotations
+ * rather than empty ones).
  *
- * @param org - The org contract object (as returned by `_ToContract`).
+ * @param owner - The org owner's email/subject, if known.
+ */
+function _BuildOwnerAnnotations(owner?: ClusterTenantOwner): Record<string, string> | undefined
+{
+  const annotations: Record<string, string> = {};
+  if (owner?.email?.trim())
+  {
+    annotations[_OWNER_EMAIL_ANNOTATION] = owner.email.trim();
+  }
+  if (owner?.subject?.trim())
+  {
+    annotations[_OWNER_SUBJECT_ANNOTATION] = owner.subject.trim();
+  }
+  return Object.keys(annotations).length > 0 ? annotations : undefined;
+}
+
+/**
+ * Project a {@link ClusterTenant} contract object into the cluster-scoped CR spec.
+ * Only desired-state fields are carried; status is the operator's to write. The
+ * owner's identity, when supplied, is stamped as metadata annotations so the
+ * operator can seed the org's default Tenant once it is ready.
+ *
+ * @param org   - The org contract object (as returned by `_ToContract`).
+ * @param owner - The org owner's identity, stamped as annotations when present.
  * @returns The ClusterTenant CR body ready for server-side apply.
  */
-function _BuildClusterTenantCr(org: ClusterTenant): ClusterTenantCr
+function _BuildClusterTenantCr(org: ClusterTenant, owner?: ClusterTenantOwner): ClusterTenantCr
 {
+  const annotations = _BuildOwnerAnnotations(owner);
   return {
     apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
     kind: "ClusterTenant",
-    metadata: { name: org.name },
+    metadata: { name: org.name, ...(annotations ? { annotations } : {}) },
     spec: {
       displayName: org.displayName,
       ...(org.vanityDomain ? { vanityDomain: org.vanityDomain } : {}),
@@ -83,12 +128,13 @@ function _BuildClusterTenantCr(org: ClusterTenant): ClusterTenantCr
  *
  * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
  * @param org - The org contract object to project into the CR.
+ * @param owner - The org owner's identity, stamped as annotations on create (and merged on update).
  */
-export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | null, org: ClusterTenant): Promise<void>
+export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | null, org: ClusterTenant, owner?: ClusterTenantOwner): Promise<void>
 {
   if (!customApi) return;
 
-  const body = _BuildClusterTenantCr(org);
+  const body = _BuildClusterTenantCr(org, owner);
 
   try
   {
@@ -103,13 +149,17 @@ export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | nu
   {
     if (_IsAlreadyExists(err))
     {
-      // Merge-patch only the spec so the operator's status subresource is untouched.
+      // Merge-patch the spec (and owner annotations when present) so the operator's
+      // status subresource is untouched; merge-patch on annotations adds/updates the
+      // owner keys without dropping any other annotation the operator may have set.
       await customApi.patchClusterCustomObject({
         group: OPENCRANE_API_GROUP,
         version: OPENCRANE_API_VERSION,
         plural: CLUSTER_TENANT_CRD_PLURAL,
         name: org.name,
-        body: { spec: body.spec },
+        body: body.metadata.annotations
+          ? { metadata: { annotations: body.metadata.annotations }, spec: body.spec }
+          : { spec: body.spec },
       });
       return;
     }

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -187,7 +187,11 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     //    runtime-gated there and never executed inline here; this handler only persists/
     //    declares desired state and does not mutate DNS or cert-manager.
     const orgContract = _ToContract(created);
-    await _ApplyClusterTenantCr(customApi, orgContract);
+    // Stamp the owner's identity (email + subject) onto the CR so the ClusterTenant
+    // reconciler — which has no DB access — can attribute the org's default Tenant to
+    // its owner once the org is ready. The email is the owner's IdP-verified session
+    // claim (absent in the dev-auth path, where only the synthetic subject is carried).
+    await _ApplyClusterTenantCr(customApi, orgContract, { email: req.session?.authUser?.email, subject: ownerSubject });
 
     res.status(201).json(orgContract);
   });

--- a/apps/operator/src/__tests__/cluster-tenants/operator.test.ts
+++ b/apps/operator/src/__tests__/cluster-tenants/operator.test.ts
@@ -186,6 +186,91 @@ describe("ClusterTenantOperator.reconcile", () =>
     expect(patches.at(-1)!.phase).toBe("failed");
     expect(patches.at(-1)!.message).toMatch(/apiserver down/);
   });
+
+  it("stamps observedGeneration = metadata.generation when reaching ready", async () =>
+  {
+    const { api: customApi, patches } = _makeStubCustomApi();
+    const { api: coreApi } = _makeStubCoreApi();
+    const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
+    const operator = _buildOperator(customApi, coreApi, provisioner);
+
+    const ct = _makeClusterTenant("acme"); // pending
+    ct.metadata!.generation = 1;
+    await operator.reconcile(ct);
+
+    expect(patches.at(-1)!.phase).toBe("ready");
+    expect(patches.at(-1)!.observedGeneration).toBe(1);
+  });
+
+  it("skips the expensive path when an already-ready CR's generation is unchanged (storm guard)", async () =>
+  {
+    const { api: customApi, patches } = _makeStubCustomApi();
+    const { api: coreApi, createdNamespaces } = _makeStubCoreApi();
+    const { provisioner, calls } = _makeDomainProvisioner({ skipped: true });
+    const operator = _buildOperator(customApi, coreApi, provisioner);
+
+    // Converged CR: ready, with observedGeneration matching the current generation —
+    // exactly what a watch reconnect replays as ADDED. Must be a complete no-op.
+    const converged = _makeClusterTenant("acme", "opencrane-acme");
+    converged.metadata!.generation = 7;
+    converged.status!.observedGeneration = 7;
+    await operator.reconcile(converged);
+
+    expect(patches).toHaveLength(0);          // no status churn
+    expect(createdNamespaces).toHaveLength(0); // no namespace re-apply (the 429-storm source)
+    expect(calls).toHaveLength(0);             // no domain re-provisioning
+  });
+
+  it("re-runs and re-stamps when a spec change bumps generation past observedGeneration", async () =>
+  {
+    const { api: customApi, patches } = _makeStubCustomApi();
+    const { api: coreApi, createdNamespaces } = _makeStubCoreApi();
+    const { provisioner } = _makeDomainProvisioner({ skipped: true });
+    const operator = _buildOperator(customApi, coreApi, provisioner);
+
+    // Spec edited after the last reconcile: generation advanced, observedGeneration stale.
+    const edited = _makeClusterTenant("acme", "opencrane-acme");
+    edited.metadata!.generation = 8;
+    edited.status!.observedGeneration = 7;
+    await operator.reconcile(edited);
+
+    expect(createdNamespaces).toContain("opencrane-acme"); // boundary re-applied
+    expect(patches.at(-1)!.phase).toBe("ready");
+    expect(patches.at(-1)!.observedGeneration).toBe(8);    // re-armed for the new generation
+  });
+
+  it("coalesces concurrent events for one org: collapses queued reconciles to a single re-run", async () =>
+  {
+    const { api: customApi } = _makeStubCustomApi();
+    const { api: coreApi } = _makeStubCoreApi();
+
+    // Gate the first reconcile inside the domain step so the next events arrive while it runs.
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let firstCall = true;
+    const calls: string[] = [];
+    const provisioner: OrgDomainProvisioner = {
+      async provisionOrgDomain(req: OrgDomainProvisionRequest): Promise<OrgDomainProvisionResult>
+      {
+        calls.push(req.orgName);
+        if (firstCall) { firstCall = false; await gate; }
+        return { orgDomain: `${req.orgName}.test`, ready: false, skipped: true };
+      },
+      async deprovisionOrgDomain(): Promise<void> {},
+    };
+    const operator = _buildOperator(customApi, coreApi, provisioner);
+
+    const ct = _makeClusterTenant("acme"); // no generation → always reconciles past the guard
+    const first = _emit(operator, "ADDED", ct);     // starts, blocks on the gate
+    await _emit(operator, "MODIFIED", ct);          // queued (running) — returns immediately
+    await _emit(operator, "MODIFIED", ct);          // collapsed into the same single pending slot
+    release();
+    await first;
+
+    // 3 events while one was in flight → exactly 2 reconciles (the in-flight one + one
+    // coalesced drain), never 3. This is what bounds in-flight work and prevents the OOM.
+    expect(calls).toEqual(["acme", "acme"]);
+  });
 });
 
 describe("ClusterTenantOperator delete handling (DOMAIN.T2)", () =>

--- a/apps/operator/src/cluster-tenants/internal/cluster-tenant-status-writer.ts
+++ b/apps/operator/src/cluster-tenants/internal/cluster-tenant-status-writer.ts
@@ -21,6 +21,8 @@ export interface ClusterTenantStatusPatch
   domainReady?: boolean;
   /** True when the per-org domain step was skipped (no cert-manager/DNS backend). */
   domainSkipped?: boolean;
+  /** `metadata.generation` last driven to `ready`; the reconcile-skip guard reads this back. */
+  observedGeneration?: number;
 }
 
 /**

--- a/apps/operator/src/cluster-tenants/operator.ts
+++ b/apps/operator/src/cluster-tenants/operator.ts
@@ -4,7 +4,7 @@ import type { Logger } from "pino";
 import type { OpenClawTenantOperatorConfig } from "../config.js";
 import { __K8sApplyResource } from "../infra/k8s.js";
 import { _RunWatchLoop, K8sWatchEventType } from "../shared/watch-runner.js";
-import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION } from "../shared/crd-constants.js";
+import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "../shared/crd-constants.js";
 import { _BuildClusterTenantNamespace } from "../tenants/deploy/index.js";
 import type { ClusterTenantResource } from "../tenants/internal/cluster-tenant-resolution.types.js";
 
@@ -13,6 +13,26 @@ import { _NamespaceForOrg, _ProvisionBoundary } from "./internal/shared-cluster.
 import { ClusterTenantReconcilePhase } from "./internal/shared-cluster.provisioner.types.js";
 import type { OrgDomainProvisioner } from "./internal/org-domain-provisioner.types.js";
 import { _BuildOrgDomainProvisioner } from "./internal/org-domain.provisioner.factory.js";
+
+/**
+ * Annotation the control plane stamps with the org owner's IdP-verified email.
+ * Mirrors `_OWNER_EMAIL_ANNOTATION` in the control plane's `cr-bridge.ts` — the
+ * operator has no DB access, so the CR annotation is the only channel for the
+ * owner identity the default Tenant is attributed to.
+ */
+const _OWNER_EMAIL_ANNOTATION = "opencrane.io/owner-email";
+
+/** Suffix appended to an org's name to form its auto-seeded first workspace Tenant. */
+const _DEFAULT_TENANT_SUFFIX = "-default";
+
+/** Whether a Kubernetes API error is a 409 AlreadyExists across the common error shapes. */
+function _IsAlreadyExistsError(err: unknown): boolean
+{
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { statusCode?: unknown; code?: unknown; body?: { code?: unknown } };
+  if (e.statusCode === 409 || e.code === 409) return true;
+  return typeof e.body === "object" && e.body !== null && (e.body as { code?: unknown }).code === 409;
+}
 
 /**
  * Watches the cluster-scoped ClusterTenant custom resource and drives each org
@@ -61,6 +81,24 @@ export class ClusterTenantOperator
 
   /** Scoped logger. */
   private log: Logger;
+
+  /**
+   * Per-org reconcile coalescing. The watch runner dispatches event handlers
+   * fire-and-forget, so on every watch reconnect K8s replays ALL CRs as `ADDED`
+   * concurrently. Without a guard those reconciles pile up faster than they drain
+   * when the API server is throttling (APF 429s) — the unbounded growth that ends
+   * in `OOMKilled`, and overlapping namespace-creates for one org race each other.
+   *
+   * `running` holds the org names with a drain loop in progress; `pending` holds the
+   * latest CR awaiting reconcile per name. An event for a name already running only
+   * updates `pending` (coalesced — reconcile is idempotent, so collapsing several
+   * queued events into the newest one is correct), bounding in-flight work to one
+   * reconcile per org instead of one per event.
+   */
+  private readonly running = new Set<string>();
+
+  /** Latest CR awaiting reconcile per org name (see {@link running}). */
+  private readonly pending = new Map<string, ClusterTenantResource>();
 
   /**
    * Create a ClusterTenantOperator with pre-wired dependencies.
@@ -118,16 +156,54 @@ export class ClusterTenantOperator
     {
       case K8sWatchEventType.Added:
       case K8sWatchEventType.Modified:
-        await this.reconcile(clusterTenant);
+        await this.dispatchReconcile(clusterTenant);
         break;
       // Delete: namespace GC reclaims the namespaced Certificate/DNSEndpoint CRs, but
       // external-dns only reaps the records it owns once the DNSEndpoint is actually
       // gone — so we explicitly deprovision the per-org domain rather than relying on
       // GC ordering. The bound namespace and attached openclaws are torn down by their
-      // own lifecycles.
+      // own lifecycles. Drop any queued reconcile first so a coalesced event cannot
+      // re-create what we are tearing down.
       case K8sWatchEventType.Deleted:
+        this.pending.delete(name);
         await this.deprovision(clusterTenant);
         break;
+    }
+  }
+
+  /**
+   * Dispatch a reconcile through the per-org coalescing guard (see {@link running}).
+   *
+   * Records the CR as the org's latest desired state, then — unless a drain loop is
+   * already running for that name — drains `pending` to convergence one reconcile at a
+   * time. This serialises reconciles per org (no overlapping namespace-creates) and
+   * bounds concurrent work to one-per-org, so a watch-reconnect storm or a throttled
+   * API server can never let fire-and-forget handlers accumulate into an OOM.
+   *
+   * @param clusterTenant - The CR from the watch event to reconcile.
+   */
+  private async dispatchReconcile(clusterTenant: ClusterTenantResource): Promise<void>
+  {
+    const name = clusterTenant.metadata?.name;
+    if (!name) return;
+
+    // Always record the newest desired state; a running loop will pick it up.
+    this.pending.set(name, clusterTenant);
+    if (this.running.has(name)) return;
+
+    this.running.add(name);
+    try
+    {
+      while (this.pending.has(name))
+      {
+        const next = this.pending.get(name)!;
+        this.pending.delete(name);
+        await this.reconcile(next);
+      }
+    }
+    finally
+    {
+      this.running.delete(name);
     }
   }
 
@@ -142,6 +218,23 @@ export class ClusterTenantOperator
   async reconcile(clusterTenant: ClusterTenantResource): Promise<void>
   {
     const name = clusterTenant.metadata!.name!;
+
+    // 0. Skip the expensive path when an already-ready org's spec is unchanged.
+    //    `metadata.generation` bumps only on a spec change (status writes do not), so a
+    //    watch replay of a converged CR has `observedGeneration === generation`. Without
+    //    this guard every watch reconnect re-applies the namespace + re-runs domain
+    //    provisioning + re-seeds the tenant for every org at once — the API-server 429
+    //    storm + memory growth that crash-loops the operator. A reconcile with no
+    //    generation (older CRs) still runs, then stamps observedGeneration below.
+    const generation = clusterTenant.metadata?.generation;
+    if (clusterTenant.status?.phase === ClusterTenantReconcilePhase.Ready
+        && typeof generation === "number"
+        && clusterTenant.status?.observedGeneration === generation)
+    {
+      this.log.debug({ name, generation }, "cluster tenant already reconciled at this generation; skipping");
+      return;
+    }
+
     this.log.info({ name }, "reconciling cluster tenant");
 
     try
@@ -196,9 +289,19 @@ export class ClusterTenantOperator
         orgDomain: domain.orgDomain,
         domainReady: domain.ready,
         domainSkipped: domain.skipped,
+        // Record the generation we just converged so the guard at the top of reconcile()
+        // skips the next watch replay of this unchanged CR. A later spec edit bumps
+        // generation and re-arms a full reconcile.
+        observedGeneration: clusterTenant.metadata?.generation,
       });
 
       this.log.info({ name, boundNamespace: boundary.boundNamespace }, "cluster tenant ready");
+
+      // 6. Seed the org's first workspace Tenant now that the org is ready and its
+      //    namespace exists. Idempotent + fail-soft: a re-reconcile re-applies the same
+      //    `<org>-default` Tenant (AlreadyExists is a no-op), and a seed failure is logged
+      //    but never fails the reconcile, so the org cannot be wedged out of `ready`.
+      await this.ensureDefaultTenant(clusterTenant);
     }
     catch (err)
     {
@@ -208,6 +311,72 @@ export class ClusterTenantOperator
         message: err instanceof Error ? err.message : String(err),
       });
       throw err;
+    }
+  }
+
+  /**
+   * Seed the org's first workspace Tenant once it is ready, attributed to the org owner.
+   *
+   * Closes the "ready org with no workspace" gap: provisioning creates the org (+owner
+   * membership) but no pod, so a freshly-provisioned customer would land in an empty
+   * console. On the org's reconcile to `ready` — when its bound namespace exists — this
+   * applies a `<org>-default` Tenant whose `clusterTenantRef` points back at the org.
+   *
+   * Idempotent: a re-reconcile re-applies the same Tenant and treats AlreadyExists (409)
+   * as a converged no-op (it is created in the operator's watch namespace, like every
+   * other Tenant CR). Fail-soft: any other error is logged but never thrown, so a seed
+   * hiccup cannot wedge the org out of `ready`; the next reconcile retries.
+   *
+   * The owner's email arrives only via the CR's {@link _OWNER_EMAIL_ANNOTATION} (the
+   * operator has no DB access). When it is absent — an org created before the annotation
+   * existed, or via the dev-auth path with no email — the seed is skipped with a warning.
+   *
+   * @param clusterTenant - The ready ClusterTenant whose default Tenant is ensured.
+   */
+  private async ensureDefaultTenant(clusterTenant: ClusterTenantResource): Promise<void>
+  {
+    const orgName = clusterTenant.metadata!.name!;
+    const ownerEmail = clusterTenant.metadata?.annotations?.[_OWNER_EMAIL_ANNOTATION]?.trim();
+    if (!ownerEmail)
+    {
+      this.log.warn({ name: orgName }, "no owner-email annotation on cluster tenant; skipping default tenant seed");
+      return;
+    }
+
+    // Tenant CRs live in the operator's watch namespace (the TenantOperator watches there),
+    // falling back to the operator's own namespace when watching all namespaces.
+    const namespace = this.config.watchNamespace || this.config.operatorNamespace;
+    const tenantName = `${orgName}${_DEFAULT_TENANT_SUFFIX}`;
+    const tenantCr = {
+      apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
+      kind: "Tenant",
+      metadata: { name: tenantName, namespace },
+      spec: {
+        displayName: `${clusterTenant.spec.displayName ?? orgName} workspace`,
+        email: ownerEmail,
+        clusterTenantRef: orgName,
+      },
+    };
+
+    try
+    {
+      await this.customApi.createNamespacedCustomObject({
+        group: OPENCRANE_API_GROUP,
+        version: OPENCRANE_API_VERSION,
+        namespace,
+        plural: TENANT_CRD_PLURAL,
+        body: tenantCr,
+      });
+      this.log.info({ name: orgName, tenantName, namespace }, "seeded default tenant for org");
+    }
+    catch (err)
+    {
+      if (_IsAlreadyExistsError(err))
+      {
+        this.log.debug({ name: orgName, tenantName }, "default tenant already exists; nothing to seed");
+        return;
+      }
+      this.log.warn({ err, name: orgName, tenantName }, "failed to seed default tenant (org stays ready; will retry on next reconcile)");
     }
   }
 

--- a/apps/operator/src/tenants/internal/cluster-tenant-resolution.types.ts
+++ b/apps/operator/src/tenants/internal/cluster-tenant-resolution.types.ts
@@ -66,6 +66,14 @@ export interface ClusterTenantResource extends KubernetesObject
     boundNamespace?: string;
     /** Identifier of the provisioner that owns this customer's boundary. */
     provisioner?: string;
+    /**
+     * `metadata.generation` the reconciler last drove to `ready`. The API server bumps
+     * `generation` only on a spec change (status writes do not), so a watch replay of an
+     * unchanged, already-ready CR has `observedGeneration === metadata.generation` and is
+     * skipped — the canonical controller guard that prevents re-provisioning every watch
+     * cycle (the namespace-create storm that 429s the API server and OOMs the operator).
+     */
+    observedGeneration?: number;
   };
 }
 

--- a/platform/helm/templates/_helpers.tpl
+++ b/platform/helm/templates/_helpers.tpl
@@ -51,10 +51,15 @@ Operator RBAC rules — shared by the cluster-scoped (legacy) and namespaced
 All resources here are namespaced, so the same rule list is valid in a Role.
 */}}
 {{- define "opencrane.operatorRbacRules" -}}
-# Tenant and AccessPolicy CRDs
+# Tenant, ClusterTenant, and AccessPolicy CRDs
 - apiGroups: ["opencrane.io"]
   resources: ["tenants", "tenants/status", "accesspolicies"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- if .Values.clusterTenantManager.enabled }}
+- apiGroups: ["opencrane.io"]
+  resources: ["clustertenants", "clustertenants/status"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end }}
 # Per-tenant resources the operator manages
 - apiGroups: ["apps"]
   resources: ["deployments"]

--- a/platform/helm/templates/cluster-issuer.yaml
+++ b/platform/helm/templates/cluster-issuer.yaml
@@ -52,11 +52,26 @@ spec:
     privateKeySecretRef:
       name: {{ $cm.acme.privateKeySecretName | quote }}
     solvers:
-      - dns01:
+      # DNS-01 for the platform names (wildcard `*.<domain>`, apex, control-plane host).
+      # Wildcards REQUIRE DNS-01. Scoped by dnsZones to the platform base domain so per-org
+      # VANITY hosts — which live in the CUSTOMER's own zone — do not match here and fall
+      # through to the HTTP-01 solver below.
+      - selector:
+          dnsZones:
+            - {{ $.Values.ingress.domain | quote }}
+        dns01:
           {{- if $cm.acme.dns01.config }}
           {{ $cm.acme.dns01.provider }}:
             {{- toYaml $cm.acme.dns01.config | nindent 12 }}
           {{- end }}
+      # HTTP-01 (catch-all) for per-org vanity hosts. The customer CNAMEs their host at the
+      # ingress, so cert-manager answers the challenge over HTTP through the ingress — no
+      # access to the customer's DNS zone is needed (DNS-01 there is impossible). The
+      # operator's per-org vanity Certificate references THIS issuer — see
+      # apps/operator/src/cluster-tenants/internal/org-domain.provisioner.ts.
+      - http01:
+          ingress:
+            ingressClassName: {{ $.Values.ingress.className | default "nginx" | quote }}
 {{- else }}
 {{- fail (printf "certManager.mode must be 'selfSigned' or 'acme', got %q" $cm.mode) }}
 {{- end }}
@@ -74,13 +89,14 @@ spec:
   issuerRef:
     name: {{ $cm.issuerName | quote }}
     kind: ClusterIssuer
-  # Fixed-wildcard topology. The platform wildcard `*.<domain>` covers every ORG APEX
-  # `<org>.<domain>`; the base apex `<domain>` is added for completeness, and the fixed
-  # control-plane host is added explicitly so it is browser-trusted even when set to a
-  # name OUTSIDE `<domain>`. NOTE: this cert does NOT cover the per-user level
-  # `<user>.<org>.<domain>` (a wildcard matches exactly one label) — each org gets its
-  # own `*.<org>.<domain>` cert issued at provision time by the cluster-tenants operator
-  # via DNS-01 (see docs/agents/cluster-architecture.md → "Multi-level wildcard TLS").
+  # Fixed-wildcard topology. The platform wildcard `*.<domain>` covers every org's
+  # canonical gateway host `<org>.<domain>` (one label under the base); the base apex
+  # `<domain>` is added for completeness, and the fixed control-plane host is added
+  # explicitly so it is browser-trusted even when set to a name OUTSIDE `<domain>`.
+  # There is NO per-org `*.<org>.<domain>` cert — every user in an org is served at the
+  # SINGLE host `<org>.<domain>` via the gateway proxy. The only per-org cert is for an
+  # optional customer-VANITY host, issued at provision time by the cluster-tenants operator
+  # against this issuer's HTTP-01 solver (apps/operator/src/cluster-tenants/internal/org-domain.provisioner.ts).
   dnsNames:
     - {{ printf "*.%s" .Values.ingress.domain | quote }}
     - {{ .Values.ingress.domain | quote }}
@@ -107,11 +123,26 @@ spec:
     privateKeySecretRef:
       name: {{ $cm.acme.privateKeySecretName | quote }}
     solvers:
-      - dns01:
+      # DNS-01 for the platform names (wildcard `*.<domain>`, apex, control-plane host).
+      # Wildcards REQUIRE DNS-01. Scoped by dnsZones to the platform base domain so per-org
+      # VANITY hosts — which live in the CUSTOMER's own zone — do not match here and fall
+      # through to the HTTP-01 solver below.
+      - selector:
+          dnsZones:
+            - {{ $.Values.ingress.domain | quote }}
+        dns01:
           {{- if $cm.acme.dns01.config }}
           {{ $cm.acme.dns01.provider }}:
             {{- toYaml $cm.acme.dns01.config | nindent 12 }}
           {{- end }}
+      # HTTP-01 (catch-all) for per-org vanity hosts. The customer CNAMEs their host at the
+      # ingress, so cert-manager answers the challenge over HTTP through the ingress — no
+      # access to the customer's DNS zone is needed (DNS-01 there is impossible). The
+      # operator's per-org vanity Certificate references THIS issuer — see
+      # apps/operator/src/cluster-tenants/internal/org-domain.provisioner.ts.
+      - http01:
+          ingress:
+            ingressClassName: {{ $.Values.ingress.className | default "nginx" | quote }}
 {{- else }}
 {{- fail (printf "certManager.mode must be 'selfSigned' or 'acme', got %q" $cm.mode) }}
 {{- end }}
@@ -130,10 +161,10 @@ spec:
     # Namespaced Issuer in this same namespace — never a cluster-singleton.
     name: {{ $cm.issuerName | quote }}
     kind: Issuer
-  # Fixed-wildcard topology (see the legacy block above). `*.<domain>` covers org
-  # apexes `<org>.<domain>`; the base apex + the fixed control-plane host are added.
-  # Per-user `<user>.<org>.<domain>` is covered by a per-org `*.<org>.<domain>` cert
-  # issued at provision time, NOT by this platform cert.
+  # Fixed-wildcard topology (see the legacy block above). `*.<domain>` covers each org's
+  # canonical host `<org>.<domain>`; the base apex + the fixed control-plane host are added.
+  # There is NO per-org `*.<org>.<domain>` cert — only an optional customer-vanity host gets
+  # a per-org cert, issued by the operator against this issuer's HTTP-01 solver.
   dnsNames:
     - {{ printf "*.%s" $.Values.ingress.domain | quote }}
     - {{ $.Values.ingress.domain | quote }}

--- a/platform/helm/templates/control-plane-deployment.yaml
+++ b/platform/helm/templates/control-plane-deployment.yaml
@@ -22,7 +22,11 @@ spec:
         # Apply pending Prisma migrations before the server starts (prisma migrate
         # deploy). Runs the same image so the schema/migrations match the binary;
         # the server never boots against an un-migrated database. Idempotent — a
-        # no-op when the DB is already at the latest migration.
+        # no-op when the DB is already at the latest migration. This is a
+        # belt-and-suspenders guard for pod (re)creation BETWEEN deploys: the
+        # deploy-time migration authority is the pre-upgrade hook Job
+        # (control-plane-migration-job.yaml), which an unchanged `helm upgrade`
+        # cannot skip the way it skips an unchanged pod template.
         - name: db-migrate
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}

--- a/platform/helm/templates/control-plane-migration-job.yaml
+++ b/platform/helm/templates/control-plane-migration-job.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.controlPlane.migrationJob.enabled }}
+# Run Prisma migrations on EVERY install/upgrade, independent of the control-plane
+# pod template. The control-plane also carries a `db-migrate` initContainer, but an
+# initContainer only fires when the pod is (re)created — so a `helm upgrade` whose
+# control-plane values are unchanged never rolls the pod and never re-runs migrations.
+# That left the schema silently behind whenever the database was recreated under a
+# still-running pod (e.g. a CNPG cluster rebuild). This pre-upgrade hook closes that
+# gap: it blocks the rollout until `prisma migrate deploy` succeeds against the live
+# database, so every deploy reconciles the schema. Idempotent — a no-op when the DB is
+# already at the latest migration.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "opencrane.fullname" . }}-control-plane-migrate
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.controlPlane.migrationJob.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "opencrane.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: control-plane-migrate
+    spec:
+      serviceAccountName: {{ include "opencrane.fullname" . }}-control-plane
+      restartPolicy: Never
+      containers:
+        - name: db-migrate
+          image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
+          imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
+          command: ["node", "apps/control-plane/dist/scripts/migrate.js"]
+          env:
+            {{- if .Values.controlPlane.database.existingSecret }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.controlPlane.database.existingSecret }}
+                  key: {{ .Values.controlPlane.database.secretKey }}
+            {{- else if .Values.controlPlane.database.url }}
+            - name: DATABASE_URL
+              value: {{ .Values.controlPlane.database.url | quote }}
+            {{- end }}
+{{- end }}

--- a/platform/helm/templates/litellm-deployment.yaml
+++ b/platform/helm/templates/litellm-deployment.yaml
@@ -20,9 +20,31 @@ spec:
       labels:
         {{- include "opencrane.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: litellm
+      {{- with .Values.litellm.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       securityContext:
         {{- toYaml .Values.litellm.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{- /* Wolfi has no openssl CLI; Prisma falls back to debian-openssl-1.1.x binary which
+               needs libssl.so.1.1 (absent on wolfi). Shim makes `openssl version` return 3.0.x
+               so Prisma downloads debian-openssl-3.0.x (links libssl.so.3, present on wolfi). */}}
+        - name: prisma-openssl-shim
+          image: busybox:1.36
+          securityContext:
+            runAsUser: {{ .Values.litellm.securityContext.runAsUser | default 10001 }}
+            runAsGroup: {{ .Values.litellm.securityContext.runAsGroup | default 10001 }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              printf '#!/bin/sh\necho "OpenSSL 3.0.7 30 Oct 2022"\n' > /tmp/openssl
+              chmod 755 /tmp/openssl
+          volumeMounts:
+            - name: temp-dir
+              mountPath: /tmp
       containers:
         - name: litellm
           image: "{{ .Values.litellm.image.repository }}:{{ .Values.litellm.image.tag }}"
@@ -139,6 +161,10 @@ spec:
               value: "/tmp/prisma-engines"
             - name: XDG_CACHE_HOME
               value: "/tmp"
+            - name: NPM_CONFIG_CACHE
+              value: "/tmp/.npm"
+            - name: PATH
+              value: "/tmp:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
           volumeMounts:
             - name: temp-dir
               mountPath: /tmp
@@ -147,13 +173,15 @@ spec:
           livenessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 10
+            initialDelaySeconds: 120
+            periodSeconds: 15
+            failureThreshold: 4
           readinessProbe:
             tcpSocket:
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.litellm.resources | nindent 12 }}
       volumes:

--- a/platform/helm/templates/litellm-deployment.yaml
+++ b/platform/helm/templates/litellm-deployment.yaml
@@ -27,24 +27,6 @@ spec:
     spec:
       securityContext:
         {{- toYaml .Values.litellm.podSecurityContext | nindent 8 }}
-      initContainers:
-        {{- /* Wolfi has no openssl CLI; Prisma falls back to debian-openssl-1.1.x binary which
-               needs libssl.so.1.1 (absent on wolfi). Shim makes `openssl version` return 3.0.x
-               so Prisma downloads debian-openssl-3.0.x (links libssl.so.3, present on wolfi). */}}
-        - name: prisma-openssl-shim
-          image: busybox:1.36
-          securityContext:
-            runAsUser: {{ .Values.litellm.securityContext.runAsUser | default 10001 }}
-            runAsGroup: {{ .Values.litellm.securityContext.runAsGroup | default 10001 }}
-          command:
-            - /bin/sh
-            - -c
-            - |
-              printf '#!/bin/sh\necho "OpenSSL 3.0.7 30 Oct 2022"\n' > /tmp/openssl
-              chmod 755 /tmp/openssl
-          volumeMounts:
-            - name: temp-dir
-              mountPath: /tmp
       containers:
         - name: litellm
           image: "{{ .Values.litellm.image.repository }}:{{ .Values.litellm.image.tag }}"
@@ -163,8 +145,6 @@ spec:
               value: "/tmp"
             - name: NPM_CONFIG_CACHE
               value: "/tmp/.npm"
-            - name: PATH
-              value: "/tmp:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
           volumeMounts:
             - name: temp-dir
               mountPath: /tmp

--- a/platform/helm/templates/obot-mcp-gateway-deployment.yaml
+++ b/platform/helm/templates/obot-mcp-gateway-deployment.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         {{- include "opencrane.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: mcp-gateway
+      {{- with .Values.mcpGateway.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "opencrane.fullname" . }}-mcp-gateway
       automountServiceAccountToken: true

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -104,10 +104,13 @@ operator:
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
     limits:
       cpu: 500m
-      memory: 256Mi
+      # 512Mi gives the Node heap headroom over a watch reconnect that replays every
+      # CR at once; the per-org reconcile coalescing keeps steady-state usage well under
+      # this, so the limit is a safety margin, not the fix for the historical OOMKills.
+      memory: 512Mi
   # -- Namespace to watch for Tenant CRs (empty = all namespaces)
   watchNamespace: ""
   # -- Minutes of inactivity before auto-suspending a tenant (0 = disabled)
@@ -196,7 +199,7 @@ controlPlane:
     # -- Registered OAuth client id (OIDC_CLIENT_ID).
     clientId: ""
     # -- Callback URL on the control-plane (OIDC_REDIRECT_URI), e.g.
-    #    https://<control-plane-host>/api/auth/callback.
+    #    https://<control-plane-host>/api/v1/auth/callback.
     redirectUri: ""
     # -- Existing K8s Secret carrying the OIDC client secret + session secret. Strongly
     #    preferred over inline values in production. Keys are configurable below.

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -139,6 +139,16 @@ controlPlane:
     existingSecret: ""
     # -- Key within the Secret that holds the connection string
     secretKey: DATABASE_URL
+  # -- Prisma migration Helm hook. Runs `prisma migrate deploy` as a
+  #    pre-install/pre-upgrade Job so EVERY deploy reconciles the schema, even when
+  #    the control-plane pod template is unchanged (a plain `helm upgrade` won't roll
+  #    the pod, so the db-migrate initContainer alone can leave the schema behind when
+  #    the database is recreated under a running pod). The initContainer remains a
+  #    belt-and-suspenders guard so a pod never serves an un-migrated database.
+  migrationJob:
+    enabled: true
+    # -- Retries before the migration hook is considered failed (fails the deploy).
+    backoffLimit: 3
   # -- Cognee integration for control-plane permission synchronization
   cognee:
     # -- Install an in-cluster Cognee as part of this release. Cognee is a REQUIRED

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -164,7 +164,7 @@ controlPlane:
       repository: cognee/cognee
       # -- Pinned to an audited stable tag for supply-chain integrity + reproducible
       #    deploys. Bump deliberately after re-auditing; never use a rolling `latest`.
-      tag: "0.1.43"
+      tag: "1.2.1"
       pullPolicy: IfNotPresent
     service:
       port: 8000
@@ -264,6 +264,7 @@ litellm:
     enabled: false
     host: ""
     port: 6379
+  podAnnotations: {}
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 10001
@@ -584,10 +585,12 @@ mcpGateway:
     # Secret holding the encryption key (operator-provisioned; not templated here).
     secretName: opencrane-obot-enc
     secretKey: encryption-key
+  podAnnotations: {}
   podSecurityContext:
     runAsNonRoot: false
     seccompProfile:
       type: RuntimeDefault
+
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -233,7 +233,13 @@ litellm:
   # -- Default spend path template for control-plane to query tenant spend from LiteLLM (tenant_id placeholder: {tenant})
   spendPathTemplate: "/spend/tenant/{tenant}"
   image:
-    repository: ghcr.io/berriai/litellm
+    # -- non_root variant: ships PRE-GENERATED Prisma engine binaries (baked at
+    #    build) and runs as a non-root user. The default `litellm` image generates
+    #    Prisma at runtime, which fails on its Chainguard/wolfi base in restricted/
+    #    non-root k8s with `NotConnectedError: Not connected to the query engine`
+    #    (wolfi ships OpenSSL 3 only; the runtime-fetched debian-openssl-1.1.x query
+    #    engine can't load libssl.so.1.1). Confirmed fix per BerriAI/litellm#11864.
+    repository: ghcr.io/berriai/litellm-non_root
     # -- Pinned to the audited stable tag (matches the k3d overlays) for
     #    supply-chain integrity + reproducible deploys. Do NOT use a rolling
     #    `main-latest` tag in production — bump deliberately after re-auditing.

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -415,6 +415,15 @@ metadata:
 spec:
   instances: 1
   imageName: ghcr.io/cloudnative-pg/postgresql:16
+  # CNPG manages instance pods as bare Pods (not a Deployment/StatefulSet), so the
+  # GKE cluster-autoscaler treats them as "not backed by a controller" and refuses to
+  # drain the node — blocking scale-down of underutilised nodes (wasted spend on dev).
+  # safe-to-evict lets the autoscaler evict the pod; CNPG reschedules it and the
+  # operator-managed PodDisruptionBudget still prevents evicting too many instances at
+  # once. inheritedMetadata propagates the annotation onto the managed pods.
+  inheritedMetadata:
+    annotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
   storage:
     size: 10Gi$( [[ -n "$STORAGE_CLASS" ]] && printf '\n    storageClass: %s' "$STORAGE_CLASS" )
   bootstrap:

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -346,13 +346,44 @@ if [[ "$PREFLIGHT" == "1" ]]; then
 fi
 
 _gen_secret() { openssl rand -hex 16 2>/dev/null || head -c 24 /dev/urandom | base64 | tr -dc 'a-zA-Z0-9' | head -c 32; }
-DB_PASSWORD="${DB_PASSWORD:-$(_gen_secret)}"
-LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-$(_gen_secret)}"
+# Re-use existing passwords when secrets already exist so that re-runs don't
+# rotate credentials without also updating postgres (which only reads the
+# bootstrap secret once at initdb time).
+_read_secret() { kubectl get secret "$1" -n "$NAMESPACE" -o jsonpath="{.data.$2}" 2>/dev/null | base64 -d; }
+if [[ -z "${DB_PASSWORD:-}" ]]; then
+  DB_PASSWORD="$(_read_secret "${DB_CLUSTER}-creds" password)"
+  DB_PASSWORD="${DB_PASSWORD:-$(_gen_secret)}"
+fi
+if [[ -z "${LITELLM_MASTER_KEY:-}" ]]; then
+  LITELLM_MASTER_KEY="$(_read_secret opencrane-litellm LITELLM_MASTER_KEY)"
+  LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-$(_gen_secret)}"
+fi
 
 log "Target cluster: $(kubectl config current-context)"
 log "Namespace: $NAMESPACE   Release: $RELEASE   Image tag: $IMAGE_TAG"
 
 # 1. In-cluster PostgreSQL via the CloudNativePG operator.
+# If the CNPG cluster already exists but authentication fails (password rotated
+# out of sync with the bootstrap secret), wipe and re-bootstrap so all secrets
+# and the live DB stay consistent. Runs a throwaway psql pod inside the cluster.
+_db_auth_ok() {
+  local url="postgresql://${DB_USER}:${DB_PASSWORD}@${DB_CLUSTER}-rw.${NAMESPACE}.svc.cluster.local:5432/${DB_NAME}"
+  kubectl run "db-auth-check-$$" --image=postgres:16 --restart=Never --rm -i \
+    -n "$NAMESPACE" --quiet -- psql "$url" -c '\q' >/dev/null 2>&1
+}
+if kubectl get cluster "$DB_CLUSTER" -n "$NAMESPACE" >/dev/null 2>&1; then
+  if ! _db_auth_ok; then
+    warn "DB credential mismatch detected (password drifted from bootstrap). Resetting PostgreSQL cluster…"
+    kubectl delete cluster "$DB_CLUSTER" -n "$NAMESPACE" --wait=true
+    kubectl delete pvc -n "$NAMESPACE" -l cnpg.io/cluster="$DB_CLUSTER" --ignore-not-found
+    kubectl delete secret "${DB_CLUSTER}" "opencrane-obot" "opencrane-litellm-db" "opencrane-litellm" \
+      -n "$NAMESPACE" --ignore-not-found
+    # Fresh secrets — regenerate so cluster + secrets are in sync from scratch.
+    DB_PASSWORD="$(_gen_secret)"
+    LITELLM_MASTER_KEY="sk-$(_gen_secret)"
+  fi
+fi
+
 log "Installing CloudNativePG operator…"
 helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update >/dev/null
 helm upgrade --install cnpg cnpg/cloudnative-pg \
@@ -669,9 +700,14 @@ fi
 
 # 3. The OpenCrane chart.
 log "Installing the OpenCrane Helm release '$RELEASE'…"
+# litellm.existingDatabaseSecret is NOT passed: the Python Prisma engine binary crashes on
+# Chainguard wolfi (libssl.so.1.1 absent; engine links debian-openssl-1.1.x). Without
+# DATABASE_URL LiteLLM skips Prisma entirely and runs as a stateless proxy — storeModelInDb=false
+# so no DB-backed features are lost. Re-enable once a wolfi-compatible Prisma binary is
+# available (PRISMA_QUERY_ENGINE_BINARY_PATH pointing to a pre-built openssl-3.0.x binary, or
+# switch to a python:slim-based LiteLLM image that ships the correct debian binary).
 helm_args=(upgrade --install "$RELEASE" "$CHART_DIR" --namespace "$NAMESPACE" --create-namespace
   --set "controlPlane.database.existingSecret=$DB_SECRET"
-  --set "litellm.existingDatabaseSecret=opencrane-litellm-db"
   --set "litellm.existingSecret=opencrane-litellm")
 # Per-component tags override the unified --image-tag so a single component can be
 # rolled through Helm (which keeps Helm the sole owner of the image field). Each
@@ -704,10 +740,17 @@ fi
 [[ -n "$VALUES_FILE" ]] && helm_args+=(--values "$VALUES_FILE")
 # cert-manager flags resolved in Step 2.5 (empty in mode=off). Placed before --set
 # overrides so an operator can still override individual issuer fields on the CLI.
-helm_args+=("${CERT_MANAGER_HELM_FLAGS[@]}")
+[ ${#CERT_MANAGER_HELM_FLAGS[@]} -gt 0 ] && helm_args+=("${CERT_MANAGER_HELM_FLAGS[@]}")
 # external-dns wiring resolved above (empty unless a controller is in place). Placed before
 # --set overrides so an operator can still override externalDns.* on the CLI.
-helm_args+=("${EXTERNAL_DNS_HELM_FLAGS[@]}")
+[ ${#EXTERNAL_DNS_HELM_FLAGS[@]} -gt 0 ] && helm_args+=("${EXTERNAL_DNS_HELM_FLAGS[@]}")
+# DB-checksum annotation: a short hash of the DB password injected into the
+# litellm (and mcp-gateway/obot) pod templates. When the password rotates the
+# annotation changes → Kubernetes triggers an automatic rollout so pods never
+# hold stale credentials across a deploy.
+_DB_CKSUM="$(printf '%s' "$DB_PASSWORD" | sha256sum | cut -c1-8)"
+helm_args+=(--set "litellm.podAnnotations.db-checksum=$_DB_CKSUM")
+helm_args+=(--set "mcpGateway.podAnnotations.db-checksum=$_DB_CKSUM")
 helm_args+=("${EXTRA_SET[@]}")
 helm "${helm_args[@]}"
 

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -358,6 +358,13 @@ if [[ -z "${LITELLM_MASTER_KEY:-}" ]]; then
   LITELLM_MASTER_KEY="$(_read_secret opencrane-litellm LITELLM_MASTER_KEY)"
   LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-sk-$(_gen_secret)}"
 fi
+# LiteLLM salt encrypts provider keys stored in the DB (STORE_MODEL_IN_DB). It MUST stay
+# constant once set, or already-stored keys become unreadable — so always re-use the
+# existing value and only generate a fresh one when the secret has none.
+if [[ -z "${LITELLM_SALT_KEY:-}" ]]; then
+  LITELLM_SALT_KEY="$(_read_secret opencrane-litellm LITELLM_SALT_KEY)"
+  LITELLM_SALT_KEY="${LITELLM_SALT_KEY:-sk-$(_gen_secret)}"
+fi
 
 log "Target cluster: $(kubectl config current-context)"
 log "Namespace: $NAMESPACE   Release: $RELEASE   Image tag: $IMAGE_TAG"
@@ -379,8 +386,11 @@ if kubectl get cluster "$DB_CLUSTER" -n "$NAMESPACE" >/dev/null 2>&1; then
     kubectl delete secret "${DB_CLUSTER}" "opencrane-obot" "opencrane-litellm-db" "opencrane-litellm" \
       -n "$NAMESPACE" --ignore-not-found
     # Fresh secrets — regenerate so cluster + secrets are in sync from scratch.
+    # The litellm DB is wiped with the PVCs, so a fresh salt is correct (no stored
+    # provider keys survive to be decrypted).
     DB_PASSWORD="$(_gen_secret)"
     LITELLM_MASTER_KEY="sk-$(_gen_secret)"
+    LITELLM_SALT_KEY="sk-$(_gen_secret)"
   fi
 fi
 
@@ -436,7 +446,9 @@ kubectl create secret generic opencrane-litellm-db -n "$NAMESPACE" \
   --dry-run=client -o yaml | kubectl apply -f -
 
 kubectl create secret generic opencrane-litellm -n "$NAMESPACE" \
-  --from-literal=LITELLM_MASTER_KEY="$LITELLM_MASTER_KEY" --dry-run=client -o yaml | kubectl apply -f -
+  --from-literal=LITELLM_MASTER_KEY="$LITELLM_MASTER_KEY" \
+  --from-literal=LITELLM_SALT_KEY="$LITELLM_SALT_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
 
 # OIDC secret. The chart references controlPlane.oidc.existingSecret for the client + session
 # secrets; previously this installer set only the issuer/clientId/redirect and ASSUMED the
@@ -700,15 +712,15 @@ fi
 
 # 3. The OpenCrane chart.
 log "Installing the OpenCrane Helm release '$RELEASE'…"
-# litellm.existingDatabaseSecret is NOT passed: the Python Prisma engine binary crashes on
-# Chainguard wolfi (libssl.so.1.1 absent; engine links debian-openssl-1.1.x). Without
-# DATABASE_URL LiteLLM skips Prisma entirely and runs as a stateless proxy — storeModelInDb=false
-# so no DB-backed features are lost. Re-enable once a wolfi-compatible Prisma binary is
-# available (PRISMA_QUERY_ENGINE_BINARY_PATH pointing to a pre-built openssl-3.0.x binary, or
-# switch to a python:slim-based LiteLLM image that ships the correct debian binary).
+# LiteLLM is wired to its own `litellm` database (DATABASE_URL via opencrane-litellm-db) with
+# STORE_MODEL_IN_DB on, so models/keys are stored and seeded at runtime via the admin API. The
+# Prisma query-engine crash on the Chainguard/wolfi base is fixed by the non_root image variant
+# (pre-baked engine binaries), set in the chart — see values.yaml litellm.image.
 helm_args=(upgrade --install "$RELEASE" "$CHART_DIR" --namespace "$NAMESPACE" --create-namespace
   --set "controlPlane.database.existingSecret=$DB_SECRET"
-  --set "litellm.existingSecret=opencrane-litellm")
+  --set "litellm.existingDatabaseSecret=opencrane-litellm-db"
+  --set "litellm.existingSecret=opencrane-litellm"
+  --set "litellm.storeModelInDb=true")
 # Per-component tags override the unified --image-tag so a single component can be
 # rolled through Helm (which keeps Helm the sole owner of the image field). Each
 # falls back to IMAGE_TAG when its flag is unset, preserving the all-same default.

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -776,10 +776,13 @@ helm_args+=("${EXTRA_SET[@]}")
 helm "${helm_args[@]}"
 
 # 4. Wait for the core workloads.
-# Database migrations run automatically in the control-plane's `db-migrate`
-# initContainer (prisma migrate deploy) before the server starts — so the
-# rollout below also gates on a successful migration. Any `helm upgrade` or
-# pod restart re-runs it idempotently; no separate migration Job needed.
+# Database migrations run via the control-plane's pre-upgrade hook Job
+# (prisma migrate deploy), which `helm upgrade` above blocks on before the
+# rollout — so EVERY deploy reconciles the schema, even when the control-plane
+# pod template is unchanged (a plain `helm upgrade` won't roll an unchanged pod,
+# so the db-migrate initContainer alone could leave the schema behind when the
+# database was recreated under a running pod). The initContainer remains a
+# belt-and-suspenders guard for pod (re)creation between deploys. Idempotent.
 kubectl rollout status "deployment/${RELEASE}-operator" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
 kubectl rollout status "deployment/${RELEASE}-control-plane" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
 

--- a/platform/terraform/main.tf
+++ b/platform/terraform/main.tf
@@ -125,12 +125,16 @@ module "app_deploy"
 module "dns"
 {
   source = "./modules/dns"
-  # The platform records point at the app's ingress IP, so this requires the app to
-  # be deployed by Terraform too.
-  count = (var.enable_cloud_dns && var.enable_app_deploy) ? 1 : 0
+  # Gated on enable_cloud_dns ALONE: the zone + the shared DNS-writer identity have no
+  # dependency on the running app, so they provision in a cluster-only flow (enabling
+  # cert-manager DNS-01 to issue off `--dns-writer-gsa $(terraform output …)`). The
+  # platform A-records DO need the ingress IP — they are gated inside the module on
+  # `ingress_ip`, which is null (→ skipped) until the app is deployed by Terraform.
+  count = var.enable_cloud_dns ? 1 : 0
 
   project_id = var.project_id
   domain     = var.domain
+  # null when the app is not deployed by Terraform → the module's "" default → records skipped.
   ingress_ip = one(module.app_deploy[*].ingress_ip)
 
   depends_on = [module.app_deploy]

--- a/platform/terraform/modules/dns/main.tf
+++ b/platform/terraform/modules/dns/main.tf
@@ -15,6 +15,14 @@
 # the install-time platform records, and the zone-WRITE identity the controllers share —
 # it must NOT write per-org/per-host records itself (the old imperative Cloud DNS client
 # is gone). See apps/operator/src/cluster-tenants/internal/dns-endpoint.client.ts.
+#
+# Identity vs records are DECOUPLED by dependency. The zone + the shared DNS-writer GSA
+# need nothing from the running app, so they are created whenever this module runs (i.e.
+# `enable_cloud_dns`) — that is what lets a cluster-only Terraform flow provision the
+# zone-write identity up front so cert-manager DNS-01 can issue, with `--dns-writer-gsa`
+# reading the `dns_writer_service_account_email` output. The install-time A-records DO
+# need the ingress IP, so they are gated on `ingress_ip` and skipped until it is known
+# (pass it, or re-apply once the app is up).
 # -----------------------------------------------------------------------------
 
 resource "google_dns_managed_zone" "opencrane"
@@ -26,8 +34,10 @@ resource "google_dns_managed_zone" "opencrane"
 }
 
 # Platform org-wildcard: resolves every org apex `<org>.<domain>` to the ingress IP.
+# Gated on a known ingress IP so the zone + identity can provision before the app exists.
 resource "google_dns_record_set" "wildcard"
 {
+  count        = var.ingress_ip != "" ? 1 : 0
   project      = var.project_id
   managed_zone = google_dns_managed_zone.opencrane.name
   name         = "*.${var.domain}."
@@ -39,6 +49,7 @@ resource "google_dns_record_set" "wildcard"
 # Apex record for the base domain.
 resource "google_dns_record_set" "apex"
 {
+  count        = var.ingress_ip != "" ? 1 : 0
   project      = var.project_id
   managed_zone = google_dns_managed_zone.opencrane.name
   name         = "${var.domain}."
@@ -51,6 +62,7 @@ resource "google_dns_record_set" "apex"
 # to `platform.<domain>`; matches ingress.controlPlaneHost in the chart.
 resource "google_dns_record_set" "control_plane"
 {
+  count        = var.ingress_ip != "" ? 1 : 0
   project      = var.project_id
   managed_zone = google_dns_managed_zone.opencrane.name
   name         = "${coalesce(var.control_plane_host, "platform.${var.domain}")}."

--- a/platform/terraform/modules/dns/variables.tf
+++ b/platform/terraform/modules/dns/variables.tf
@@ -19,8 +19,9 @@ variable "domain"
 
 variable "ingress_ip"
 {
-  description = "External IP of the ingress controller"
+  description = "External IP of the ingress controller. Optional: when empty the install-time platform A-records (`*.<domain>`, apex, control-plane host) are SKIPPED while the zone + the shared DNS-writer identity are still created — so the zone-write GSA is provisioned in a cluster-only flow (before the app/IP exists) and cert-manager DNS-01 can issue. Set it (or re-apply once the ingress IP is known) to also write the platform records."
   type        = string
+  default     = ""
 }
 
 variable "control_plane_host"

--- a/platform/terraform/outputs.tf
+++ b/platform/terraform/outputs.tf
@@ -42,7 +42,7 @@ output "dns_name_servers"
 output "dns_setup_instructions"
 {
   description = "Manual DNS guidance when Cloud DNS is disabled."
-  value       = length(module.dns) > 0 ? "Cloud DNS zone managed by Terraform — delegate ${var.domain} to the dns_name_servers output at your registrar (NS delegation). external-dns reconciles per-org records into this zone at runtime." : "Point an A record for your domain and a wildcard *.<domain> at the ingress IP (run: kubectl get ingress -A) at your DNS provider."
+  value       = length(module.dns) > 0 ? "Cloud DNS zone + shared DNS-writer GSA managed by Terraform — delegate ${var.domain} to the dns_name_servers output at your registrar (NS delegation), and pass dns_writer_service_account_email to k8s-deploy.sh --dns-writer-gsa so cert-manager DNS-01 can issue. external-dns reconciles per-org records at runtime. The install-time platform A-records (apex, *.<domain>, control-plane host) are written only once the ingress IP is known (Terraform app-deploy, or re-apply after the LB IP is assigned); until then add them at your registrar pointing at the ingress IP (kubectl get svc -n ingress-nginx)." : "Point an A record for your domain and a wildcard *.<domain> at the ingress IP (run: kubectl get ingress -A) at your DNS provider."
 }
 
 output "dns_writer_service_account_email"


### PR DESCRIPTION
## Summary

Fixes a chain of issues deploying to a fresh GKE cluster (`opencrane-dev`, `europe-west1-b`) via `deploy-multi-tenant.sh`. All changes flow through the deploy script + Helm chart — no ad-hoc kubectl.

### LiteLLM Prisma on Chainguard/wolfi (the headline fix)
The `ghcr.io/berriai/litellm` image generates the Prisma query engine **at runtime**. On its wolfi base (OpenSSL 3 only) it fetches the `debian-openssl-1.1.x` query engine, which can't load `libssl.so.1.1` → the Python client crashes with `NotConnectedError: Not connected to the query engine` right after migrations succeed. This is image-specific, confirmed in [BerriAI/litellm#11864](https://github.com/BerriAI/litellm/issues/11864).

- **`litellm.image.repository` → `ghcr.io/berriai/litellm-non_root`** — ships **pre-generated Prisma engine binaries** (baked at build, no runtime fetch) and runs as non-root, matching our `securityContext` (uid 10001). This is the documented, evidence-backed fix.
- **`STORE_MODEL_IN_DB` enabled** with `DATABASE_URL` wired (`litellm.existingDatabaseSecret=opencrane-litellm-db`, `litellm.storeModelInDb=true`) so models/keys are **stored and seeded at runtime** via the admin API — the whole point of the DB.
- **`LITELLM_SALT_KEY` provisioned idempotently** in the `opencrane-litellm` Secret (never rotates — rotating it makes already-stored provider keys unreadable; regenerated only on a full DB reset).
- Increased liveness probe `initialDelaySeconds` 15→120 so the migration window (~45 s) doesn't trip the probe.

> An earlier commit in this branch dropped `DATABASE_URL` to get the pod up (stateless proxy). That was a workaround, not a fix — it disabled `STORE_MODEL_IN_DB`. Superseded by the non_root image fix above.

### Deploy script / chart hardening
- **bash `set -u` / empty arrays** — guard `CERT_MANAGER_HELM_FLAGS` / `EXTERNAL_DNS_HELM_FLAGS` expansions (bash 3.2 `unbound variable`)
- **Idempotent secrets** — read `DB_PASSWORD` / `LITELLM_MASTER_KEY` / `LITELLM_SALT_KEY` from existing secrets on re-runs; CNPG bootstrap password no longer drifts
- **DB credential mismatch auto-reset** — detect auth failure and wipe Cluster + PVCs + stale secrets to recover without manual steps
- **`db-checksum` annotation** — rotation triggers automatic litellm/mcpGateway rollouts
- **cognee image** — `0.1.43` doesn't exist; bumped to `1.2.1`
- **`clustertenants` RBAC** — operator returned 403 on watch; added to `operatorRbacRules`
- **`NPM_CONFIG_CACHE` / cache dirs → `/tmp`** — non-root pod can't write root-owned `/.npm`
- **`podAnnotations` wiring** for litellm + mcpGateway; **mcpGateway template fix** (`.Values.obotGateway` → `.Values.mcpGateway`)

## Test plan

- [x] `./platform/deploy-multi-tenant.sh --base-domain dev.opencrane.ai` exits 0
- [x] LiteLLM pod `1/1 Running`, **0 restarts**; logs show `Application startup complete` + Uvicorn on `:4000`, **DB connected, `STORE_MODEL_IN_DB` on**, no `NotConnectedError`
- [x] All pods `1/1 Running`: control-plane, operator, litellm, mcp-gateway, cognee, skill-registry, obot, CNPG
- [x] Re-run is idempotent (secrets unchanged/`configured`, helm revision bumps, rollout completes)