### PR TITLE
fix(control-plane): run Prisma migrations via pre-upgrade hook Job

### DIFF
--- a/platform/helm/templates/control-plane-deployment.yaml
+++ b/platform/helm/templates/control-plane-deployment.yaml
@@ -22,7 +22,11 @@ spec:
         # Apply pending Prisma migrations before the server starts (prisma migrate
         # deploy). Runs the same image so the schema/migrations match the binary;
         # the server never boots against an un-migrated database. Idempotent — a
-        # no-op when the DB is already at the latest migration.
+        # no-op when the DB is already at the latest migration. This is a
+        # belt-and-suspenders guard for pod (re)creation BETWEEN deploys: the
+        # deploy-time migration authority is the pre-upgrade hook Job
+        # (control-plane-migration-job.yaml), which an unchanged `helm upgrade`
+        # cannot skip the way it skips an unchanged pod template.
         - name: db-migrate
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}

--- a/platform/helm/templates/control-plane-migration-job.yaml
+++ b/platform/helm/templates/control-plane-migration-job.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.controlPlane.migrationJob.enabled }}
+# Run Prisma migrations on EVERY install/upgrade, independent of the control-plane
+# pod template. The control-plane also carries a `db-migrate` initContainer, but an
+# initContainer only fires when the pod is (re)created — so a `helm upgrade` whose
+# control-plane values are unchanged never rolls the pod and never re-runs migrations.
+# That left the schema silently behind whenever the database was recreated under a
+# still-running pod (e.g. a CNPG cluster rebuild). This pre-upgrade hook closes that
+# gap: it blocks the rollout until `prisma migrate deploy` succeeds against the live
+# database, so every deploy reconciles the schema. Idempotent — a no-op when the DB is
+# already at the latest migration.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "opencrane.fullname" . }}-control-plane-migrate
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ .Values.controlPlane.migrationJob.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "opencrane.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: control-plane-migrate
+    spec:
+      serviceAccountName: {{ include "opencrane.fullname" . }}-control-plane
+      restartPolicy: Never
+      containers:
+        - name: db-migrate
+          image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
+          imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
+          command: ["node", "apps/control-plane/dist/scripts/migrate.js"]
+          env:
+            {{- if .Values.controlPlane.database.existingSecret }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.controlPlane.database.existingSecret }}
+                  key: {{ .Values.controlPlane.database.secretKey }}
+            {{- else if .Values.controlPlane.database.url }}
+            - name: DATABASE_URL
+              value: {{ .Values.controlPlane.database.url | quote }}
+            {{- end }}
+{{- end }}

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -139,6 +139,16 @@ controlPlane:
     existingSecret: ""
     # -- Key within the Secret that holds the connection string
     secretKey: DATABASE_URL
+  # -- Prisma migration Helm hook. Runs `prisma migrate deploy` as a
+  #    pre-install/pre-upgrade Job so EVERY deploy reconciles the schema, even when
+  #    the control-plane pod template is unchanged (a plain `helm upgrade` won't roll
+  #    the pod, so the db-migrate initContainer alone can leave the schema behind when
+  #    the database is recreated under a running pod). The initContainer remains a
+  #    belt-and-suspenders guard so a pod never serves an un-migrated database.
+  migrationJob:
+    enabled: true
+    # -- Retries before the migration hook is considered failed (fails the deploy).
+    backoffLimit: 3
   # -- Cognee integration for control-plane permission synchronization
   cognee:
     # -- Install an in-cluster Cognee as part of this release. Cognee is a REQUIRED

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -712,10 +712,13 @@ helm_args+=("${EXTRA_SET[@]}")
 helm "${helm_args[@]}"
 
 # 4. Wait for the core workloads.
-# Database migrations run automatically in the control-plane's `db-migrate`
-# initContainer (prisma migrate deploy) before the server starts — so the
-# rollout below also gates on a successful migration. Any `helm upgrade` or
-# pod restart re-runs it idempotently; no separate migration Job needed.
+# Database migrations run via the control-plane's pre-upgrade hook Job
+# (prisma migrate deploy), which `helm upgrade` above blocks on before the
+# rollout — so EVERY deploy reconciles the schema, even when the control-plane
+# pod template is unchanged (a plain `helm upgrade` won't roll an unchanged pod,
+# so the db-migrate initContainer alone could leave the schema behind when the
+# database was recreated under a running pod). The initContainer remains a
+# belt-and-suspenders guard for pod (re)creation between deploys. Idempotent.
 kubectl rollout status "deployment/${RELEASE}-operator" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
 kubectl rollout status "deployment/${RELEASE}-control-plane" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
 


### PR DESCRIPTION
## Problem

\"Manage customers\" on the WeOwnAI control-plane returned a 500: `The table public.tenants does not exist in the current database` (`prisma.tenant.findMany()`).

Root cause was a **migration ordering gap**, not a code bug. The control-plane ran migrations **only** from its `db-migrate` initContainer, which fires solely on pod (re)creation:

- The control-plane pod ran all migrations against the DB that existed at pod-creation time.
- The CNPG database was later bootstrapped fresh (empty schema) under the still-running pod.
- A subsequent `helm upgrade` left the control-plane deployment at `generation=1` (unchanged pod template), so the pod was **never recreated** → the initContainer never re-ran → the schema stayed empty.

The deploy script even asserted *\"any helm upgrade re-runs it idempotently; no separate migration Job needed\"* — which is wrong: `helm upgrade` only recreates a pod when its template changes.

## Fix

- Add a **`pre-install,pre-upgrade` Helm hook Job** (`control-plane-migration-job.yaml`) that runs `prisma migrate deploy` on **every** deploy, blocking the rollout until the schema reconciles — independent of the pod template.
- Keep the `db-migrate` initContainer as a belt-and-suspenders guard so a pod never serves an un-migrated DB on recreation between deploys.
- Toggle via `controlPlane.migrationJob.enabled` (default on), `controlPlane.migrationJob.backoffLimit` (default 3).
- Correct the now-inaccurate comments in `control-plane-deployment.yaml` and `k8s-deploy.sh`.

## Verification

- `helm template` renders the Job with the correct hook annotations; full chart renders cleanly; the `enabled=false` toggle suppresses it.
- Live opencrane-dev was unblocked separately via `kubectl rollout restart` (forced the initContainer to re-run `prisma migrate deploy`); new pod is ready and serving. This PR ensures the failure mode cannot recur on future deploys.