### PR TITLE
feat(model-routing): model catalog discovery layer

### DIFF
--- a/apps/control-plane/prisma/migrations/0025_model_catalog_entry/migration.sql
+++ b/apps/control-plane/prisma/migrations/0025_model_catalog_entry/migration.sql
@@ -1,0 +1,42 @@
+-- Migration 0025: ModelCatalogEntry (discovery layer)
+--
+-- Adds the model_catalog_entries table: the "available but not enabled"
+-- discovery layer.  Populated by the catalog-reconcile cron (LiteLLM cost
+-- map as the billing spine + models.dev for enrichment).  No entries here
+-- are callable; enablement stays in model_definitions.
+
+CREATE TABLE "model_catalog_entries" (
+    "id"                    TEXT            NOT NULL,
+    "litellm_key"           TEXT            NOT NULL,
+    "provider"              TEXT            NOT NULL,
+    "mode"                  TEXT,
+    "input_cost_per_token"  DECIMAL(20,12),
+    "output_cost_per_token" DECIMAL(20,12),
+    "max_input_tokens"      INTEGER,
+    "max_output_tokens"     INTEGER,
+    "models_dev_id"         TEXT,
+    "modalities_in"         TEXT[]          NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "modalities_out"        TEXT[]          NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "capabilities"          JSONB,
+    "cache_read_cost"       DECIMAL(20,12),
+    "cache_write_cost"      DECIMAL(20,12),
+    "release_date"          TEXT,
+    "knowledge_cutoff"      TEXT,
+    "open_weights"          BOOLEAN,
+    "hosting_regions"       TEXT[]          NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "pricing_updated_at"    TIMESTAMP(3),
+    "first_seen_at"         TIMESTAMP(3)    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_seen_at"          TIMESTAMP(3)    NOT NULL,
+    "deprecated_at"         TIMESTAMP(3),
+
+    CONSTRAINT "model_catalog_entries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "model_catalog_entries_litellm_key_key"
+    ON "model_catalog_entries"("litellm_key");
+
+CREATE INDEX "model_catalog_entries_provider_idx"
+    ON "model_catalog_entries"("provider");
+
+CREATE INDEX "model_catalog_entries_deprecated_at_idx"
+    ON "model_catalog_entries"("deprecated_at");

--- a/apps/control-plane/prisma/schema.prisma
+++ b/apps/control-plane/prisma/schema.prisma
@@ -1126,3 +1126,73 @@ model DocMergeProposal {
   @@index([status])
   @@map("doc_merge_proposals")
 }
+
+/// A model discovered from the LiteLLM cost map (billing spine) and enriched
+/// from models.dev.  Represents a model that *exists* (available for
+/// enablement), NOT one that is callable.  Distinct from ModelDefinition
+/// (a registered LiteLLM deployment).  Populated by the catalog-reconcile
+/// cron; never directly callable.
+///
+/// Canonical identity: `litellmKey` (the LiteLLM cost-map key).
+/// Billable pricing: re-read from the LiteLLM map on every reconcile run;
+/// changes stamp `pricingUpdatedAt` and write an AuditEntry.
+/// Enrichment: modalities + capability flags from models.dev, joined on key.
+model ModelCatalogEntry {
+  /// Surrogate key.
+  id                 String    @id @default(cuid())
+  /// Canonical identity = LiteLLM cost-map key (e.g. "gpt-4o", "claude-3-5-sonnet-20241022").
+  litellmKey         String    @unique @map("litellm_key")
+  /// LiteLLM provider string (e.g. "openai", "anthropic", "vertex_ai").
+  provider           String
+  /// Inference mode: "chat" | "embedding" | "rerank" | null when unclassified.
+  mode               String?
+
+  // --- Billable pricing — from the LiteLLM map, re-read every reconcile ---
+  /// Input cost per token in USD (billing spine).
+  inputCostPerToken  Decimal?  @map("input_cost_per_token") @db.Decimal(20, 12)
+  /// Output cost per token in USD (billing spine).
+  outputCostPerToken Decimal?  @map("output_cost_per_token") @db.Decimal(20, 12)
+  /// Maximum input context tokens.
+  maxInputTokens     Int?      @map("max_input_tokens")
+  /// Maximum output tokens.
+  maxOutputTokens    Int?      @map("max_output_tokens")
+
+  // --- Enrichment — from models.dev, joined on litellmKey ---
+  /// models.dev model id (e.g. "openai/gpt-4o"); null when unmatched.
+  modelsDevId        String?   @map("models_dev_id")
+  /// Input modalities (e.g. ["text", "image"]).
+  modalitiesIn       String[]  @map("modalities_in")
+  /// Output modalities (e.g. ["text"]).
+  modalitiesOut      String[]  @map("modalities_out")
+  /// Capability flags: {tool_call, reasoning, attachment, structured_output}.
+  capabilities       Json?
+  /// Cache-read cost per token (from models.dev, display-only).
+  cacheReadCost      Decimal?  @map("cache_read_cost") @db.Decimal(20, 12)
+  /// Cache-write cost per token (from models.dev, display-only).
+  cacheWriteCost     Decimal?  @map("cache_write_cost") @db.Decimal(20, 12)
+  /// Model release date string (e.g. "2024-10-22").
+  releaseDate        String?   @map("release_date")
+  /// Training knowledge cutoff date string.
+  knowledgeCutoff    String?   @map("knowledge_cutoff")
+  /// Whether the model weights are public/open.
+  openWeights        Boolean?  @map("open_weights")
+
+  // --- Data residency ---
+  /// Provider hosting regions for data-residency gating (e.g. ["eu-west"]).
+  /// Empty = unknown / not yet classified.
+  hostingRegions     String[]  @map("hosting_regions")
+
+  // --- Lifecycle ---
+  /// When billable rates last changed (used by the audit trail).
+  pricingUpdatedAt   DateTime? @map("pricing_updated_at")
+  /// When this entry was first discovered.
+  firstSeenAt        DateTime  @default(now()) @map("first_seen_at")
+  /// Bumped on every reconcile run; drift signals the entry may be gone.
+  lastSeenAt         DateTime  @map("last_seen_at")
+  /// Set when the key drops out of the LiteLLM map (soft-delete).
+  deprecatedAt       DateTime? @map("deprecated_at")
+
+  @@index([provider])
+  @@index([deprecatedAt])
+  @@map("model_catalog_entries")
+}

--- a/apps/control-plane/src/core/model-routing/catalog-reconcile.ts
+++ b/apps/control-plane/src/core/model-routing/catalog-reconcile.ts
@@ -1,0 +1,242 @@
+import type { PrismaClient } from "@prisma/client";
+import { _log } from "../../log.js";
+import type {
+  CatalogReconcileRunResult,
+  LiteLlmCostMap,
+  LiteLlmCostMapEntry,
+  ModelsDevApiJson,
+  ModelsDevModel,
+} from "./catalog-reconcile.types.js";
+
+const LITELLM_COST_MAP_URL =
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const MODELS_DEV_URL = "https://models.dev/api.json";
+const FETCH_TIMEOUT_MS = 30_000;
+
+/** Fetch JSON from `url`; returns null on any error (network, timeout, non-2xx). */
+async function _fetchJson<T>(url: string, label: string): Promise<T | null>
+{
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try
+  {
+    const res = await fetch(url, { signal: ctrl.signal });
+    if (!res.ok)
+    {
+      _log.warn({ url, status: res.status }, `catalog-reconcile: ${label} fetch failed`);
+      return null;
+    }
+    return (await res.json()) as T;
+  }
+  catch (err)
+  {
+    _log.warn({ url, err }, `catalog-reconcile: ${label} fetch error`);
+    return null;
+  }
+  finally
+  {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Build a lookup from models.dev entry identifiers → enrichment payload.
+ *
+ * Indexes each model under two keys so the join succeeds for both the
+ * "provider/model-id" form (e.g. "openai/gpt-4o") and the bare model-id
+ * form (e.g. "gpt-4o") that LiteLLM uses as its canonical key.
+ * Full-id entries are written first so they take priority on exact match.
+ */
+function _buildModelsDevIndex(
+  data: ModelsDevApiJson,
+): Map<string, ModelsDevModel & { modelsDevId: string }>
+{
+  const index = new Map<string, ModelsDevModel & { modelsDevId: string }>();
+  for (const [provider, providerData] of Object.entries(data))
+  {
+    for (const [modelId, model] of Object.entries(providerData.models ?? {}))
+    {
+      const fullId = `${provider}/${modelId}`;
+      const entry = { ...model, modelsDevId: fullId };
+      if (!index.has(fullId)) index.set(fullId, entry);
+      if (!index.has(modelId)) index.set(modelId, entry);
+    }
+  }
+  return index;
+}
+
+/** True when `next` differs from `prev` (both null counts as no change). */
+function _rateChanged(
+  prev: { toString(): string } | null | undefined,
+  next: number | null | undefined,
+): boolean
+{
+  const p = prev != null ? prev.toString() : null;
+  const n = next != null ? String(next) : null;
+  return p !== n;
+}
+
+/** Convert a per-million-token cost (models.dev convention) to per-token. */
+function _perToken(perMillion: number | null | undefined): number | null
+{
+  return perMillion != null ? perMillion / 1_000_000 : null;
+}
+
+/**
+ * Reconcile the model catalog from the LiteLLM cost map + models.dev.
+ *
+ * Design (see model-registry-discovery-design.md):
+ * - LiteLLM map = spine: every key becomes/updates a ModelCatalogEntry; its
+ *   rates are the BILLABLE pricing, re-read each run.
+ * - models.dev = enrichment: modalities, capability flags, display-only cache
+ *   pricing, release / knowledge dates — joined onto the LiteLLM key.
+ * - Pricing changes stamp `pricingUpdatedAt` and write an AuditEntry.
+ * - Keys that vanish from the LiteLLM map are soft-deprecated (`deprecatedAt`).
+ *
+ * Called from POST /api/internal/catalog-reconcile (triggered by a
+ * Kubernetes CronJob; also callable manually by operators).
+ */
+export async function _ReconcileCatalog(prisma: PrismaClient): Promise<CatalogReconcileRunResult>
+{
+  const startedAt = Date.now();
+  const runTs = new Date(startedAt);
+
+  // 1. Fetch both sources in parallel; models.dev is best-effort.
+  const [litellmMap, modelsDevData] = await Promise.all([
+    _fetchJson<LiteLlmCostMap>(LITELLM_COST_MAP_URL, "LiteLLM cost map"),
+    _fetchJson<ModelsDevApiJson>(MODELS_DEV_URL, "models.dev"),
+  ]);
+
+  if (!litellmMap)
+  {
+    throw new Error("catalog-reconcile: LiteLLM cost map unavailable — aborting");
+  }
+
+  const modelsDevIndex = modelsDevData
+    ? _buildModelsDevIndex(modelsDevData)
+    : new Map<string, ModelsDevModel & { modelsDevId: string }>();
+
+  if (!modelsDevData)
+  {
+    _log.warn("catalog-reconcile: models.dev unavailable — enrichment skipped this run");
+  }
+
+  // 2. Load all existing entries for diff comparison (pricing change detection).
+  const existing = await prisma.modelCatalogEntry.findMany();
+  const existingByKey = new Map(existing.map(e => [e.litellmKey, e]));
+
+  let added = 0, updated = 0, deprecated = 0, pricingChanges = 0;
+  const seenKeys = new Set<string>();
+
+  // 3. Upsert one entry per LiteLLM map key.
+  for (const [litellmKey, rawEntry] of Object.entries(litellmMap))
+  {
+    // "sample_spec" is a schema-documentation entry that ships inside the map.
+    if (litellmKey === "sample_spec") continue;
+    if (typeof rawEntry !== "object" || !rawEntry) continue;
+
+    const entry = rawEntry as LiteLlmCostMapEntry;
+    seenKeys.add(litellmKey);
+
+    const provider = entry.litellm_provider
+      ?? (litellmKey.includes("/") ? litellmKey.split("/")[0] : "unknown")
+      ?? "unknown";
+    const mode = entry.mode ?? null;
+    const inputCost = entry.input_cost_per_token ?? null;
+    const outputCost = entry.output_cost_per_token ?? null;
+    const maxIn = entry.max_input_tokens ?? entry.max_tokens ?? null;
+    const maxOut = entry.max_output_tokens ?? null;
+
+    const enrichment = modelsDevIndex.get(litellmKey) ?? null;
+    const capabilities = enrichment
+      ? {
+          tool_call: enrichment.tool_call ?? null,
+          reasoning: enrichment.reasoning ?? null,
+          attachment: enrichment.attachment ?? null,
+          structured_output: enrichment.structured_output ?? null,
+        }
+      : null;
+
+    const prev = existingByKey.get(litellmKey);
+    const isPriceChanged =
+      prev != null &&
+      (_rateChanged(prev.inputCostPerToken, inputCost) ||
+        _rateChanged(prev.outputCostPerToken, outputCost));
+
+    const sharedData = {
+      provider,
+      mode,
+      inputCostPerToken: inputCost,
+      outputCostPerToken: outputCost,
+      maxInputTokens: maxIn,
+      maxOutputTokens: maxOut,
+      modelsDevId: enrichment?.modelsDevId ?? null,
+      modalitiesIn: enrichment?.modalities?.input ?? [],
+      modalitiesOut: enrichment?.modalities?.output ?? [],
+      capabilities,
+      cacheReadCost: _perToken(enrichment?.cost?.cache_read),
+      cacheWriteCost: _perToken(enrichment?.cost?.cache_write),
+      releaseDate: enrichment?.release_date ?? null,
+      knowledgeCutoff: enrichment?.knowledge ?? null,
+      openWeights: enrichment?.open_weights ?? null,
+      lastSeenAt: runTs,
+      deprecatedAt: null,
+      ...(isPriceChanged ? { pricingUpdatedAt: runTs } : {}),
+    };
+
+    if (!prev)
+    {
+      await prisma.modelCatalogEntry.create({
+        data: { litellmKey, firstSeenAt: runTs, ...sharedData },
+      });
+      added++;
+    }
+    else
+    {
+      await prisma.modelCatalogEntry.update({ where: { litellmKey }, data: sharedData });
+      updated++;
+    }
+
+    if (isPriceChanged)
+    {
+      pricingChanges++;
+      await prisma.auditEntry.create({
+        data: {
+          action: "catalog.pricing.changed",
+          resource: `model_catalog_entries/${litellmKey}`,
+          message: `Billable pricing updated for ${litellmKey}`,
+          metadata: {
+            litellmKey,
+            prev: {
+              input: prev!.inputCostPerToken?.toString() ?? null,
+              output: prev!.outputCostPerToken?.toString() ?? null,
+            },
+            next: { input: inputCost, output: outputCost },
+          },
+        },
+      });
+    }
+  }
+
+  // 4. Soft-deprecate entries whose key has vanished from the LiteLLM map.
+  const toDeprecate = existing.filter(e => !seenKeys.has(e.litellmKey) && !e.deprecatedAt);
+  if (toDeprecate.length > 0)
+  {
+    await prisma.modelCatalogEntry.updateMany({
+      where: { litellmKey: { in: toDeprecate.map(e => e.litellmKey) } },
+      data: { deprecatedAt: runTs },
+    });
+    deprecated = toDeprecate.length;
+  }
+
+  const result: CatalogReconcileRunResult = {
+    added,
+    updated,
+    deprecated,
+    pricingChanges,
+    total: seenKeys.size,
+    durationMs: Date.now() - startedAt,
+  };
+  _log.info(result, "catalog-reconcile: run complete");
+  return result;
+}

--- a/apps/control-plane/src/core/model-routing/catalog-reconcile.types.ts
+++ b/apps/control-plane/src/core/model-routing/catalog-reconcile.types.ts
@@ -1,0 +1,51 @@
+/** One entry in the LiteLLM model_prices_and_context_window.json. */
+export interface LiteLlmCostMapEntry
+{
+  litellm_provider?: string;
+  mode?: string;
+  max_tokens?: number;
+  max_input_tokens?: number;
+  max_output_tokens?: number;
+  input_cost_per_token?: number;
+  output_cost_per_token?: number;
+  [key: string]: unknown;
+}
+
+/** The full LiteLLM cost map — an object keyed by model name (e.g. "gpt-4o"). */
+export type LiteLlmCostMap = Record<string, LiteLlmCostMapEntry>;
+
+/** One model entry from the models.dev api.json. */
+export interface ModelsDevModel
+{
+  id?: string;
+  name?: string;
+  limit?: { context?: number; output?: number };
+  /** Per-million-token costs (models.dev convention). */
+  cost?: { input?: number; output?: number; cache_read?: number; cache_write?: number };
+  modalities?: { input?: string[]; output?: string[] };
+  attachment?: boolean;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  structured_output?: boolean;
+  release_date?: string;
+  knowledge?: string;
+  open_weights?: boolean;
+}
+
+/**
+ * models.dev api.json shape.
+ * Top-level keys are provider names ("openai", "anthropic", …).
+ * Each provider has a `models` record keyed by model id.
+ */
+export type ModelsDevApiJson = Record<string, { models?: Record<string, ModelsDevModel>; [k: string]: unknown }>;
+
+/** Stats returned from a single catalog-reconcile run. */
+export interface CatalogReconcileRunResult
+{
+  added: number;
+  updated: number;
+  deprecated: number;
+  pricingChanges: number;
+  total: number;
+  durationMs: number;
+}

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -20,6 +20,7 @@ import { prometheusMetricsRouter } from "./routes/prometheus-metrics.js";
 import { providerKeysRouter } from "./routes/provider-keys.js";
 import { providerCredentialsRouter } from "./routes/provider-credentials.js";
 import { modelRegistryRouter } from "./routes/model-registry.js";
+import { internalCatalogRouter, modelCatalogRouter } from "./routes/model-catalog.js";
 import { modelRoutingDefaultsRouter } from "./routes/model-routing-defaults.js";
 import { modelRoutingRecommendationsRouter } from "./routes/model-routing-recommendations.js";
 import { modelRoutingMetricsRouter } from "./routes/model-routing-metrics.js";
@@ -110,6 +111,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   // API to gate which isolation tiers a customer may request.
   const clusterTenantRegistry = _BuildClusterTenantProvisionerRegistry();
 
+  app.use("/api/internal/catalog-reconcile", internalCatalogRouter(prisma));
   app.use("/api/internal/bundles", _RegisterInternalBundles(prisma, ociBundleStore));
   // NetworkPolicy-only (no auth/TokenReview): the operator fetches a tenant's
   // allowed model set + effective default at reconcile. Best-effort — never 404/500.
@@ -157,6 +159,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/providers/keys", providerKeysRouter(prisma));
   app.use("/api/v1/providers/credentials", providerCredentialsRouter(prisma));
   app.use("/api/v1/models", modelRegistryRouter(prisma));
+  app.use("/api/v1/model-catalog", modelCatalogRouter(prisma));
   app.use("/api/v1/openapi.json", openapiRouter());
   app.get("/healthz", _CheckDbHealth(prisma));
   app.use("/prom", prometheusMetricsRouter(prisma, customApi));

--- a/apps/control-plane/src/routes/model-catalog.ts
+++ b/apps/control-plane/src/routes/model-catalog.ts
@@ -1,0 +1,124 @@
+import { Router } from "express";
+import type { PrismaClient, ModelCatalogEntry as PrismaModelCatalogEntry } from "@prisma/client";
+import type { ModelCatalogEntry } from "@opencrane/contracts";
+import { _ReconcileCatalog } from "../core/model-routing/catalog-reconcile.js";
+import { _log } from "../log.js";
+
+/**
+ * Project a persisted ModelCatalogEntry row into its contract DTO.
+ * Decimal fields are serialised as strings (Prisma's Decimal.toString()).
+ */
+function _toContract(row: PrismaModelCatalogEntry): ModelCatalogEntry
+{
+  return {
+    id: row.id,
+    litellmKey: row.litellmKey,
+    provider: row.provider,
+    mode: row.mode,
+    inputCostPerToken: row.inputCostPerToken?.toString() ?? null,
+    outputCostPerToken: row.outputCostPerToken?.toString() ?? null,
+    maxInputTokens: row.maxInputTokens,
+    maxOutputTokens: row.maxOutputTokens,
+    modelsDevId: row.modelsDevId,
+    modalitiesIn: row.modalitiesIn,
+    modalitiesOut: row.modalitiesOut,
+    capabilities: row.capabilities as Record<string, boolean | null> | null,
+    cacheReadCost: row.cacheReadCost?.toString() ?? null,
+    cacheWriteCost: row.cacheWriteCost?.toString() ?? null,
+    releaseDate: row.releaseDate,
+    knowledgeCutoff: row.knowledgeCutoff,
+    openWeights: row.openWeights,
+    hostingRegions: row.hostingRegions,
+    pricingUpdatedAt: row.pricingUpdatedAt?.toISOString() ?? null,
+    firstSeenAt: row.firstSeenAt.toISOString(),
+    lastSeenAt: row.lastSeenAt.toISOString(),
+    deprecatedAt: row.deprecatedAt?.toISOString() ?? null,
+  };
+}
+
+/**
+ * Public (authenticated) router for browsing the model catalog.
+ *
+ * GET /api/v1/model-catalog         — list entries (filter: provider, deprecated)
+ * GET /api/v1/model-catalog/:id     — get one entry by id
+ *
+ * @param prisma - Prisma client.
+ */
+export function modelCatalogRouter(prisma: PrismaClient): Router
+{
+  const router = Router();
+
+  /**
+   * List catalog entries.
+   * Query params:
+   *   provider     — filter by provider string (exact match)
+   *   deprecated   — "true" to include deprecated entries (default: exclude)
+   *   mode         — filter by mode ("chat", "embedding", …)
+   */
+  router.get("/", async function _listCatalog(req, res)
+  {
+    const provider = typeof req.query.provider === "string" ? req.query.provider : undefined;
+    const mode = typeof req.query.mode === "string" ? req.query.mode : undefined;
+    const includeDeprecated = req.query.deprecated === "true";
+
+    const rows = await prisma.modelCatalogEntry.findMany({
+      where: {
+        ...(provider ? { provider } : {}),
+        ...(mode ? { mode } : {}),
+        ...(!includeDeprecated ? { deprecatedAt: null } : {}),
+      },
+      orderBy: [{ provider: "asc" }, { litellmKey: "asc" }],
+    });
+    res.json(rows.map(_toContract));
+  });
+
+  /** Get a single catalog entry by id. */
+  router.get("/:id", async function _getCatalogEntry(req, res)
+  {
+    const row = await prisma.modelCatalogEntry.findUnique({ where: { id: req.params.id } });
+    if (!row)
+    {
+      res.status(404).json({ error: "Catalog entry not found", code: "CATALOG_ENTRY_NOT_FOUND" });
+      return;
+    }
+    res.json(_toContract(row));
+  });
+
+  return router;
+}
+
+/**
+ * Internal (network-policy-guarded) router for catalog management.
+ * Mounted at /api/internal/catalog-reconcile — no auth middleware.
+ * Access is enforced by the Kubernetes NetworkPolicy that restricts
+ * this path to the catalog-reconcile CronJob pod only.
+ *
+ * POST /api/internal/catalog-reconcile — trigger a reconcile run.
+ *
+ * @param prisma - Prisma client.
+ */
+export function internalCatalogRouter(prisma: PrismaClient): Router
+{
+  const router = Router();
+
+  router.post("/", async function _triggerReconcile(req, res)
+  {
+    _log.info("catalog-reconcile: triggered via internal endpoint");
+    try
+    {
+      const result = await _ReconcileCatalog(prisma);
+      res.json(result);
+    }
+    catch (err)
+    {
+      _log.error({ err }, "catalog-reconcile: run failed");
+      res.status(500).json({
+        error: "Catalog reconcile failed",
+        code: "CATALOG_RECONCILE_FAILED",
+        detail: err instanceof Error ? err.message : String(err),
+      });
+    }
+  });
+
+  return router;
+}

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -47,6 +47,7 @@ export {
   type RoutingProposal,
   type SavingsRecommendation,
 } from "./model-routing.types.js";
+export { type CatalogReconcileResult, type ModelCatalogEntry } from "./model-catalog.types.js";
 export { SkillBundleStatus, SkillPromotionStatus, type SkillBundle, type SkillPromotion } from "./skill-bundle.types.js";
 export {
   ThirdPartySourceItemKind,

--- a/libs/contracts/src/model-catalog.types.ts
+++ b/libs/contracts/src/model-catalog.types.ts
@@ -1,0 +1,89 @@
+/**
+ * Contract types for the model catalog (discovery layer).
+ *
+ * A ModelCatalogEntry represents a model that *exists* (available for
+ * enablement), NOT one that is callable.  Distinct from ModelDefinition
+ * (a registered LiteLLM deployment).  Populated by the catalog-reconcile
+ * cron; never directly callable.
+ *
+ * Canonical identity: the LiteLLM cost-map key (`litellmKey`).
+ * Billing rates: from the LiteLLM map (re-read every reconcile, audited on change).
+ * Enrichment: modalities + capability flags from models.dev, joined on litellmKey.
+ */
+
+/** A discovered catalog entry — available but not yet enabled. */
+export interface ModelCatalogEntry
+{
+  /** Stable surrogate key. */
+  id: string;
+  /** Canonical identity = LiteLLM cost-map key (e.g. "gpt-4o", "claude-3-5-sonnet-20241022"). */
+  litellmKey: string;
+  /** LiteLLM provider string (e.g. "openai", "anthropic", "vertex_ai"). */
+  provider: string;
+  /** Inference mode: "chat" | "embedding" | "rerank" | null when unclassified. */
+  mode: string | null;
+
+  // Billable pricing — from the LiteLLM map, re-read every reconcile.
+  /** Input cost per token in USD (billing spine from LiteLLM map). */
+  inputCostPerToken: string | null;
+  /** Output cost per token in USD (billing spine from LiteLLM map). */
+  outputCostPerToken: string | null;
+  /** Maximum input context tokens. */
+  maxInputTokens: number | null;
+  /** Maximum output tokens. */
+  maxOutputTokens: number | null;
+
+  // Enrichment — from models.dev, joined on litellmKey; null when unmatched.
+  /** models.dev model id (e.g. "openai/gpt-4o"); null when unmatched. */
+  modelsDevId: string | null;
+  /** Input modalities, e.g. ["text", "image"]. */
+  modalitiesIn: string[];
+  /** Output modalities, e.g. ["text"]. */
+  modalitiesOut: string[];
+  /** Capability flags: { tool_call, reasoning, attachment, structured_output }; null when unmatched. */
+  capabilities: Record<string, boolean | null> | null;
+  /** Cache-read cost per token (from models.dev, display-only). */
+  cacheReadCost: string | null;
+  /** Cache-write cost per token (from models.dev, display-only). */
+  cacheWriteCost: string | null;
+  /** Model release date string (e.g. "2024-10-22"); null when unknown. */
+  releaseDate: string | null;
+  /** Training knowledge cutoff date string; null when unknown. */
+  knowledgeCutoff: string | null;
+  /** Whether the model weights are public/open; null when unknown. */
+  openWeights: boolean | null;
+
+  // Data residency.
+  /**
+   * Provider hosting regions, e.g. ["eu-west", "eu-central"].
+   * Empty array = unknown / not yet classified.
+   */
+  hostingRegions: string[];
+
+  // Lifecycle.
+  /** When billable rates last changed; null until first change after discovery. */
+  pricingUpdatedAt: string | null;
+  /** When this entry was first discovered (ISO-8601). */
+  firstSeenAt: string;
+  /** When the entry was last seen in the LiteLLM map (ISO-8601). */
+  lastSeenAt: string;
+  /** Set when the key dropped out of the LiteLLM map (soft-delete); null while active. */
+  deprecatedAt: string | null;
+}
+
+/** Stats returned from a single catalog-reconcile run. */
+export interface CatalogReconcileResult
+{
+  /** Number of new entries added. */
+  added: number;
+  /** Number of existing entries whose metadata was updated. */
+  updated: number;
+  /** Number of entries soft-deprecated (dropped out of the LiteLLM map). */
+  deprecated: number;
+  /** Number of pricing-change audit entries written. */
+  pricingChanges: number;
+  /** Total LiteLLM map keys processed (= added + updated). */
+  total: number;
+  /** Wall-clock duration of the run in milliseconds. */
+  durationMs: number;
+}

--- a/model-registry-discovery-design.md
+++ b/model-registry-discovery-design.md
@@ -1,0 +1,199 @@
+# Model registry: discovery, enablement, and naming
+
+Design note for keeping OpenCrane's model registry current as new models ship constantly,
+without a hand-maintained `model_list`. Slots into the existing `model-routing` core
+(`apps/control-plane/src/core/model-routing/`). Status: proposal, not built.
+
+## Problem
+
+New models are published weekly. Each one needs an identity, specs (context window,
+pricing, modalities, capabilities), a provider route, and a credential. A frozen,
+hand-edited list rots immediately; auto-registering everything creates orphan models
+pointing at missing keys and surprise spend. We want "new models show up ready to enable"
+without "patch the list every week."
+
+## The three layers (keep them separate)
+
+Conflating these is what creates the maintenance treadmill. Each moves on its own cadence.
+
+| Layer | Question | Cadence | Today in OpenCrane |
+|---|---|---|---|
+| **Discovery** | What models exist + their specs? | Automatic, frequent | **MISSING** |
+| **Enablement** | Which are callable here, with which key? | Deliberate, key-gated | `ModelDefinition` → `ProviderCredential` |
+| **Naming / routing** | What does the app request? | Rare (policy change) | `ModelRoutingDefault` + `Skill` posture |
+
+The naming layer is the treadmill-killer: apps request a stable slug (`publicModelName`) or a
+scope/skill **floor** (`ModelRoutingDefault.defaultModel`), never a pinned upstream ID. A new
+model next week is a mapping change, not a code change. OpenCrane already has this indirection
+— `publicModelName`, per-skill `modelMode`/`pinnedModel`/`autoConfig`, scope defaults, and the
+AIR.7 safe-rollout spine (routing proposals are never auto-applied). The enablement layer also
+exists: `ModelDefinition` records a registered LiteLLM deployment (`litellmModelId` from
+`POST /model/new`, via `_RegisterLiteLlmModel`) wired to a `ProviderCredential` (a reference to
+an External-Secrets-synced k8s Secret — the raw key is never stored).
+
+**The only missing layer is discovery.** We're missing a catalog of *available* models with
+specs, decoupled from whether they're enabled.
+
+## How other systems solve discovery
+
+- **Maintained metadata catalog (crowdsourced static file).** LiteLLM's own
+  `model_prices_and_context_window.json` — PR-updated, shipped per release **plus** a live raw
+  URL with a bundled backup. Pull live, fall back to bundled. Lags new models by days; pricing
+  can be stale. Metadata only (no keys, no endpoints).
+- **Vendor-run live registry API.** OpenRouter `/api/v1/models`; gateways (Portkey, Vercel AI
+  Gateway, Cloudflare AI Gateway, Kong, Databricks) maintain a server-side catalog as a product.
+- **Provider list APIs.** OpenAI/Anthropic `GET /v1/models`, Bedrock `ListFoundationModels`,
+  Vertex Model Garden, Azure AI catalog, HF Hub. Authoritative for *availability with your key*,
+  but usually return IDs only — no pricing/capabilities. Join with a metadata catalog.
+- **GitOps + automation.** `model_list` in version control; a Renovate-style watcher diffs the
+  cost-map and opens a PR. Humans decide; automation surfaces.
+
+**Robust pattern: a periodic reconcile.** Sync the metadata catalog (∪ provider list APIs) into
+a local catalog table, marking new entries "available, not enabled." Discovery automatic;
+nothing callable or billable by surprise.
+
+## Sources we can sync with (assessed 2026-06-23)
+
+| Source | Endpoint | License | Coverage | Richness | Role |
+|---|---|---|---|---|---|
+| **models.dev** | `https://models.dev/api.json` (also `/models.json`, `/catalog.json`) | **MIT** | ~1,675 models | modalities in/out, `tool_call`/`reasoning`/`attachment`/`structured_output`, `limit.context`/`output`, cost incl. `cache_read`/`cache_write`, `release_date`, `knowledge`, `open_weights` | **Primary metadata catalog** |
+| **LiteLLM cost map** | `model_prices_and_context_window.json` (live URL + bundled backup in the litellm pkg) | **MIT** | ~1000s | `max_input/output_tokens`, `input/output_cost_per_token`, `mode`, `supports_*`, `litellm_provider` | **Pricing-for-billing truth** (what the gateway meters against) |
+| **Provider list APIs** | OpenAI/Anthropic `GET /v1/models`, Bedrock `ListFoundationModels`, Vertex, Azure | provider ToS | only what the key sees | sparse (IDs, sometimes context) | **Reachability gate** (needs BYOK key; optional v1) |
+| **OpenRouter** | `/api/v1/models` | commercial ToS | 400+ | rich | **AVOID as a data source** (ToS + inspiration-only stance) |
+
+models.dev JSON is keyed `provider → models → { id, name, family, limit{context,output}, cost{input,output,cache_read,cache_write} (per-million), modalities{input[],output[]}, attachment, reasoning, tool_call, structured_output, release_date, knowledge, open_weights }`. Maintained by sst/OpenCode (TOML source, schema-validated PRs); other registries (e.g. `llm-registry`) already sync from it weekly.
+
+**Chosen approach: a two-source join (both MIT, AGPL-safe), keyed on LiteLLM.**
+- **LiteLLM cost map is the spine.** Its model keys are the **canonical identity** of a catalog
+  entry, and its rates are the **billable** pricing — both because LiteLLM is what actually routes
+  and meters, so enablement (`POST /model/new`) and billing line up with the catalog by
+  construction ("follow LiteLLM keys"). The LiteLLM map therefore defines the *universe* of
+  catalog entries.
+- **models.dev enriches** each entry (richer modalities + capability flags + cache pricing +
+  release/knowledge dates), joined onto the canonical LiteLLM key. Where models.dev has no match,
+  the entry still exists from the LiteLLM map; the enrichment fields are just null.
+- **Id normalization** is the join step: normalize models.dev `xai/grok-4` and provider-native ids
+  onto the LiteLLM key. Unmatched models.dev rows are ignored in v1 (not invented as entries).
+- **Provider list APIs are out of scope for v1** ("map-only first") — added later as a reachability
+  gate per BYOK key.
+
+## Proposal
+
+### 1. `ModelCatalogEntry` table (the discovery/catalog layer)
+
+A row per *known* model — distinct from `ModelDefinition` (a *callable* deployment). Reconciled
+from a source; never directly callable.
+
+The canonical identity is the **LiteLLM map key** (`litellmKey`); models.dev fills the enrichment
+fields. Pricing is reconciled on every run (it drifts), so billable rates track the LiteLLM map
+over time — material price changes are audited (see reconcile job).
+
+```
+model ModelCatalogEntry {
+  id              String   @id @default(cuid())
+  litellmKey      String   @unique          // CANONICAL id = LiteLLM cost-map key ("follow LiteLLM keys")
+  provider        String                    // litellm_provider
+  mode            String?                    // chat | embedding | rerank | ...
+  // --- billable pricing: from the LiteLLM map, re-read every reconcile ---
+  inputCostPerToken  Decimal? @db.Decimal(20, 12)
+  outputCostPerToken Decimal? @db.Decimal(20, 12)
+  maxInputTokens  Int?
+  maxOutputTokens Int?
+  // --- enrichment: from models.dev, joined on litellmKey (null when unmatched) ---
+  modelsDevId     String?                    // e.g. "xai/grok-4"
+  modalitiesIn    String[]                   // ["text","image"]
+  modalitiesOut   String[]
+  capabilities    Json?                      // {tool_call, reasoning, attachment, structured_output, ...}
+  cacheReadCost   Decimal? @db.Decimal(20, 12)
+  cacheWriteCost  Decimal? @db.Decimal(20, 12)
+  releaseDate     String?
+  knowledgeCutoff String?
+  openWeights     Boolean?
+  // --- data residency: where this provider hosts inference (data-residency gate input) ---
+  hostingRegions  String[]                   // one or more, e.g. ["eu-west","eu-central"] | ["us-east"]; empty = unknown
+  // --- lifecycle ---
+  pricingUpdatedAt DateTime?                 // last time a rate actually changed
+  firstSeenAt     DateTime @default(now())
+  lastSeenAt      DateTime                   // bumped each reconcile; staleness = lastSeenAt drift
+  deprecatedAt    DateTime?                  // set when it drops out of the LiteLLM map
+}
+```
+
+### 2. Reconcile job (discovery)
+
+A **control-plane cron** (not the operator reconcile loop — decided) that each run:
+1. Fetches the **LiteLLM cost map** (live URL → bundled backup on failure — cache + fallback).
+   This is the spine: every key becomes/updates a `ModelCatalogEntry`, and its rates set the
+   **billable** pricing.
+2. Fetches **models.dev `/api.json`** and joins it onto the LiteLLM keys (id-normalized) to fill
+   the enrichment fields. Unmatched models.dev rows are skipped in v1.
+3. **Reconciles pricing over time** — not just discovery of new models. Re-reads rates every run;
+   when a rate actually changes, updates the entry, stamps `pricingUpdatedAt`, and writes an
+   `AuditEntry` (price drift is billing-relevant, so the change is recorded, not silent).
+4. Upserts entries; bumps `lastSeenAt`; sets `deprecatedAt` for keys that dropped out of the
+   LiteLLM map. New models appear automatically as *available, not enabled*.
+
+**Provider list APIs are out of scope for v1 (map-only first — decided);** added later as a
+reachability gate per BYOK key.
+
+Lives alongside the routing core, e.g. `model-routing/catalog-reconcile.ts`, scheduled as a
+control-plane cron.
+
+### 3. Enablement gate — fully opt-in, attach key at enable (decided)
+
+**No model is enabled by default** — nothing is registered on deploy. The catalog is purely
+*available*; an operator explicitly opts a model in. Enablement = today's flow:
+`_RegisterLiteLlmModel` → `POST /model/new` → record a `ModelDefinition` wired to a
+`ProviderCredential`. The credential is **attached at enable time** (BYOK), not pre-provisioned.
+**Fail-closed**: refuse to enable an entry whose provider has no `ProviderCredential` in scope (no
+orphan models pointing at missing keys). A `ModelRoutingDefault.defaultModel` (floor) may only
+reference an *enabled* `publicModelName`.
+
+### Layer wiring summary
+
+```
+LiteLLM cost map (spine: keys + billable pricing)  ⨝  models.dev (enrichment)
+   │  control-plane cron reconcile (automatic; pricing re-read + audited each run)
+   ▼
+ModelCatalogEntry        ── available, NOT enabled
+   │  opt-in enable (deliberate; attach BYOK ProviderCredential; fail-closed)
+   ▼
+ModelDefinition          ── callable LiteLLM deployment (existing)
+   │  referenced by
+   ▼
+ModelRoutingDefault / Skill posture   ── stable names + floors (existing)
+```
+
+## Principles carried from the field
+
+- **Metadata source ≠ access source.** Specs/pricing from the maps; reachability from provider
+  APIs + our keys. Join them — though reachability is deferred past v1 (map-only first).
+- **Don't trust crowdsourced pricing for billing.** Verify/pin the prices we actually bill on
+  rather than trusting `ModelCatalogEntry.*CostPerToken` blindly.
+- **Cache + fallback** (LiteLLM's live-URL-with-bundled-backup shape): current, not down.
+- **Enablement is fail-closed and key-gated.**
+- **Avoid OpenRouter as a *data* source** here, consistent with the "OpenRouter = inspiration
+  only" stance; use LiteLLM's own map.
+
+## Decisions (locked 2026-06-23)
+
+- **Reconcile transport: control-plane cron.** Not the operator reconcile loop.
+- **No default-enabled set.** Fully opt-in; the operator attaches a BYOK credential at enable time.
+- **v1 is map-only.** No provider list-API reachability checks; add later as a reachability gate.
+- **Pricing: LiteLLM map for billing, reconciled over time.** Rates are re-read every run and
+  audited on change (`pricingUpdatedAt` + `AuditEntry`); models.dev pricing is display-only.
+- **Canonical id = LiteLLM map keys** ("follow LiteLLM keys"). models.dev is joined onto them;
+  unmatched models.dev rows are ignored in v1.
+
+### Still open
+
+- Cron cadence (e.g. hourly vs. daily) and where the schedule is configured.
+- Threshold for what counts as a "material" price change worth an `AuditEntry`.
+- When provider list-API reachability lands (v1.5) and how it gates enablement.
+
+## See also
+
+- `litellm-byok-byom-research.md`, `litellm-router-autonomous-improvement-research.md` (router + BYOK)
+- `apps/control-plane/src/core/model-routing/` (registration, skill resolution, shadow measure)
+- `apps/control-plane/prisma/schema.prisma` — `ModelDefinition`, `ProviderCredential`,
+  `ModelRoutingDefault`, `Skill`, `ModelRoutingScope`

--- a/platform/helm/templates/catalog-reconcile-cronjob.yaml
+++ b/platform/helm/templates/catalog-reconcile-cronjob.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.catalogReconcile.enabled }}
+{{- /*
+  CronJob that triggers the model catalog reconcile by POSTing to the
+  control-plane's network-policy-guarded /api/internal/catalog-reconcile
+  endpoint.  No auth token is required; access is enforced at the network
+  layer (see networkpolicy-planes.yaml — the catalog-reconcile podSelector).
+
+  The job fetches the LiteLLM cost map + models.dev, upserts ModelCatalogEntry
+  rows, and audits any billable pricing changes.  Failures are logged but do
+  not affect the serving path (catalog entries are advisory; model_definitions
+  are the callable set).
+*/ -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "opencrane.fullname" . }}-catalog-reconcile
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: catalog-reconcile
+spec:
+  schedule: {{ .Values.catalogReconcile.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 300
+      template:
+        metadata:
+          labels:
+            {{- include "opencrane.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: catalog-reconcile
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: reconcile
+              image: {{ .Values.catalogReconcile.image | quote }}
+              imagePullPolicy: IfNotPresent
+              command:
+                - sh
+                - -c
+                - |
+                  set -e
+                  ENDPOINT="http://{{ include "opencrane.fullname" . }}-control-plane:{{ .Values.controlPlane.service.port }}/api/internal/catalog-reconcile"
+                  echo "Triggering catalog reconcile: $ENDPOINT"
+                  curl --silent --show-error --fail \
+                       --max-time 270 \
+                       -X POST "$ENDPOINT" \
+                       -H "Content-Type: application/json" | tee /dev/stderr | grep -q '"total"'
+                  echo "Catalog reconcile complete."
+              resources:
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+                limits:
+                  cpu: 100m
+                  memory: 64Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                capabilities:
+                  drop: ["ALL"]
+{{- end }}

--- a/platform/helm/templates/networkpolicy-planes.yaml
+++ b/platform/helm/templates/networkpolicy-planes.yaml
@@ -74,6 +74,16 @@ spec:
       ports:
         - protocol: TCP
           port: {{ .Values.controlPlane.service.port }}
+    # Allow the catalog-reconcile CronJob pod to POST to
+    # /api/internal/catalog-reconcile (network-policy-only; no auth token).
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "opencrane.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: catalog-reconcile
+      ports:
+        - protocol: TCP
+          port: {{ .Values.controlPlane.service.port }}
 ---
 {{- end }}
 {{- if and .Values.networkPolicy.enabled .Values.mcpGateway.enabled }}

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -817,3 +817,16 @@ clusterTenant:
     existingSecret: ""
     # -- Key within that Secret holding the token.
     secretKey: CLUSTER_TENANT_PROVISIONER_WEBHOOK_TOKEN
+
+# -- Model catalog reconcile CronJob.
+# Periodically syncs ModelCatalogEntry rows from the LiteLLM cost map
+# (billing spine) and models.dev (enrichment) via a POST to the control-plane's
+# /api/internal/catalog-reconcile endpoint.  The CronJob pod is allowed through
+# the NetworkPolicy by the catalog-reconcile podSelector rule.
+catalogReconcile:
+  # -- Enable the CronJob. Set to false to disable automatic catalog sync.
+  enabled: true
+  # -- Cron schedule (UTC). Default: daily at 03:00.
+  schedule: "0 3 * * *"
+  # -- Minimal curl image used by the reconcile Job pod.
+  image: curlimages/curl:8.6.0


### PR DESCRIPTION
## Summary

Implements the model catalog discovery layer designed in `model-registry-discovery-design.md`.

- **`ModelCatalogEntry` table** (migration 0025) — rows represent models that *exist* (available for enablement), not callable deployments. Distinct from `ModelDefinition`. Canonical key = LiteLLM cost-map key.
- **`_ReconcileCatalog()` core** (`catalog-reconcile.ts`) — fetches LiteLLM cost map + models.dev in parallel, joins on a normalised key index, upserts entries. Pricing changes stamp `pricingUpdatedAt` + write an `AuditEntry`. Keys that vanish are soft-deprecated (`deprecatedAt` set).
- **API endpoints** — `GET /api/v1/model-catalog` (list, filterable by provider/mode/deprecated) and `GET /api/v1/model-catalog/:id`. Internal trigger `POST /api/internal/catalog-reconcile` (network-policy guarded, no auth token).
- **Kubernetes CronJob** (`catalog-reconcile-cronjob.yaml`) — calls the internal endpoint on a configurable schedule (default: daily 03:00 UTC). NetworkPolicy updated with `catalog-reconcile` podSelector rule.
- **`@opencrane/contracts`** — `ModelCatalogEntry` and `CatalogReconcileResult` exported.

## Design decisions carried from the locked design doc

- LiteLLM cost map = billing spine (its keys are canonical identity; its rates are billable)
- models.dev = enrichment only (display pricing + modalities + capability flags)
- No model is enabled by default — `ModelCatalogEntry` is advisory; enablement stays in `ModelDefinition`
- Pricing reconciled and audited on every run (not just on first discovery)
- Keys that vanish from the LiteLLM map are soft-deprecated, never hard-deleted
- Fail-closed enablement: existing `_resolveCredential` in model-registry already enforces this

## Files changed

| File | What |
|---|---|
| `model-registry-discovery-design.md` | Design note (committed earlier) |
| `prisma/migrations/0025_model_catalog_entry/migration.sql` | New table DDL |
| `prisma/schema.prisma` | `ModelCatalogEntry` model |
| `src/core/model-routing/catalog-reconcile.ts` | `_ReconcileCatalog()` |
| `src/core/model-routing/catalog-reconcile.types.ts` | LiteLLM + models.dev wire shapes |
| `src/routes/model-catalog.ts` | Public + internal routers |
| `src/routes.ts` | Mount both routers |
| `libs/contracts/src/model-catalog.types.ts` | `ModelCatalogEntry`, `CatalogReconcileResult` |
| `libs/contracts/src/index.ts` | Re-export |
| `platform/helm/templates/catalog-reconcile-cronjob.yaml` | CronJob |
| `platform/helm/templates/networkpolicy-planes.yaml` | catalog-reconcile ingress rule |
| `platform/helm/values.yaml` | `catalogReconcile.*` values |

## Still open (from design doc)

- `hostingRegions` population: neither source provides it reliably — needs operator-curated static map per provider
- Provider list-API reachability gate (v1.5, deferred)

## Test plan

- [ ] `POST /api/internal/catalog-reconcile` returns `{ added, updated, deprecated, pricingChanges, total, durationMs }`
- [ ] `GET /api/v1/model-catalog` returns active entries only by default
- [ ] `GET /api/v1/model-catalog?deprecated=true` includes deprecated entries
- [ ] `GET /api/v1/model-catalog?provider=openai` filters correctly
- [ ] Second run on unchanged data: `added=0`, `updated>0`, `deprecated=0`, `pricingChanges=0`
- [ ] CronJob pod starts, curl POST succeeds, job completes with exit 0