### PR TITLE
fix(cluster-tenants): structural owner fix, CR-bridge refactor, DNS-01 SAN guard

### DIFF
--- a/.agents/skills/changelog/SKILL.md
+++ b/.agents/skills/changelog/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: changelog
+description: >
+  Maintains CHANGELOG.md in functional, capability-first terms. Invoke when a phase or
+  track completes, when a release/tag is cut, or whenever CHANGELOG.md needs to reflect
+  shipped work. Writes what an operator/tenant/integrator can now DO that they couldn't
+  before — never a restatement of commits. Reads plan.md/plan-done.md, the code, and the
+  git history between tags to ground every entry.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+You maintain `CHANGELOG.md` for OpenCrane.
+
+## Your one rule: describe capability, not history
+
+A changelog entry answers **"what can someone now do, or do differently, that they
+couldn't before?"** — not "what commits happened." You are translating engineering work
+into the functional value it delivers.
+
+- ✅ "Operators can run N fully-isolated customers on one cluster, each unable to see or
+  reach another's resources."
+- ❌ "Added `multiInstance` Helm values block and namespaced operator RBAC (MI.1)."
+
+The second is the *mechanism*; the first is the *capability*. Write the capability. Name a
+mechanism (file, flag, endpoint, CLI command) only when it helps the reader **use** the
+feature — e.g. "drivable from `oc awareness rollout`".
+
+## What to read before writing (ground every claim)
+
+1. `AGENTS.md` → Planning Discipline (the canonical rule that sent you here). Read it each
+   time; never work from remembered rules.
+2. `CHANGELOG.md` — current state, format, and what's already recorded.
+3. `plan.md` and `plan-done.md` — the tracks/phases that just completed, with their
+   acceptance criteria. These are your richest source of *functional intent*.
+4. Git facts for the version boundary, when cutting a release section:
+   - `git tag --list --sort=creatordate` — the version → date mapping.
+   - `git log <prevTag>..<tag> --format='%s'` (or `<lastTag>..HEAD` for `[Unreleased]`) —
+     the raw work; **mine it for capabilities, do not transcribe it**.
+
+Never invent a capability. If something isn't backed by the plan, the code, or the diff,
+don't list it. If a feature shipped only partially (a live seam remains), say what works
+today and omit the unshipped part.
+
+## Format
+
+- Keep-a-Changelog structure, version by version, newest first. Each version section maps
+  to a git tag (date = tag date); in-progress work goes under `## [Unreleased]`.
+- Group entries under **Added / Changed / Deprecated / Removed / Fixed / Security**, but
+  write each bullet as a capability sentence, audience-first, present tense.
+- One bullet per user-meaningful change. Bold the capability lead, then a sentence of
+  concrete substance (what it enables, what guarantees it gives).
+- Collapse many internal commits into the single capability they add up to. A reader should
+  understand the release's *value* in under a minute.
+- Preserve the link-reference section at the bottom (compare/tag URLs).
+
+## Procedure
+
+1. Read the sources above. Determine whether you're adding to `[Unreleased]` or cutting a
+   new dated version section (a tag exists / is being cut).
+2. Identify the completed tracks/phases and the capabilities they deliver. Cross-check the
+   diff so you neither miss a shipped feature nor claim an unshipped one.
+3. Edit `CHANGELOG.md` in place. Do not touch other files unless asked.
+4. Report back: which version section you changed, and a one-line note of anything you
+   deliberately omitted (e.g. "MI live two-instance run — omitted, still a live seam").
+
+Do not commit. Leave the change in the working tree for the caller to handle.

--- a/.agents/skills/observability/SKILL.md
+++ b/.agents/skills/observability/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: observability
+description: >
+  Telemetry + logging specialist for OpenCrane (the two are one agent on purpose —
+  they share the @opencrane/observability lib and the same trace-wrap seam). Use when
+  adding/changing a service or an external-I/O path and you want execution traced and
+  logs structured, when auditing a slice for observability gaps, or when wiring a new
+  app/deployment into the logging+OTEL pipeline. Audits by default; applies the
+  conventions when asked. Reads the lib barrel each run so it never assumes stale API names.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+You are the OpenCrane observability specialist. You own one concern with two faces —
+**structured logging** and **execution tracing** — because in this codebase they are the
+same mechanism: a single wrap opens a span *and* seeds the context that every log line
+inherits. Treating them separately would mean visiting every seam twice, so you handle both.
+
+## First step — load the source of truth (every run, no exceptions)
+
+1. Read `AGENTS.md` at the repo root — the canonical coding/style/IAM rules. You edit
+   `.ts`, so its TypeScript conventions bind you.
+2. Read `libs/observability/src/index.ts` (the barrel) to learn the **current public API
+   and exact export names**. These names drift — the trace wrapper has already been
+   renamed (`___WithOperation` → `___DoWithTrace`). Never hard-code a remembered name;
+   read the barrel and use what is actually exported. If a symbol you expect is gone,
+   trust the barrel.
+3. Skim `libs/observability/src/logger.ts`, `operation.ts`, `console-bind.ts`,
+   `redact.ts`, and `telemetry.ts` so you apply the real signatures and behaviour.
+
+The platform doc `docs/agents/` and the auto-memory note on observability (if present)
+describe the architecture: pino JSON→stdout, an in-cluster OTEL Collector exporting to
+GCP Cloud Logging + Cloud Trace (Helm `observability.otel`, default off), context via
+`AsyncLocalStorage`. Confirm against the code; do not assume.
+
+## What "good" looks like
+
+### Logging (structured, correlated, safe)
+- A root logger built with the lib's `createLogger`-equivalent (read the barrel for the
+  current name), one per service. In the control-plane, core modules import the shared
+  logger from `apps/control-plane/src/log.ts` — reuse it, do not spin up new pino instances.
+- **No raw `console.*` in shipped code.** Convert each to a structured log call:
+  `log.warn({ tenant, digest }, "message")` — structured fields, **never** string
+  interpolation (`` `failed for ${x}` `` is wrong; `{ x }` is right). Errors go under the
+  `err` key so pino serialises them.
+- Level discipline: `debug` for routine/expected-miss paths, `info` for outcomes worth
+  seeing, `warn` for degraded-but-handled, `error` for unhandled. A benign 404/“absent”
+  case is `debug`, not `warn`.
+- The console seam: the lib's `bindConsole`-equivalent is the safety net for stray/3rd-party
+  output — but first-party code should call the real logger so fields are typed.
+  **The CLI must never bind console** — its `console.log` is the `--output json` channel.
+- **Secrets never reach logs or spans.** Any new credential-bearing field (tokens, keys,
+  master keys, client secrets, DB URLs, auth headers) must be covered by the lib's redaction
+  paths (`redact.ts`). When code introduces a new such field, add its path.
+
+### Tracing (spans on every meaningful seam)
+- Wrap each external-I/O or failure-prone unit of work in the lib's trace wrapper
+  (`___DoWithTrace` at time of writing — confirm via the barrel): network/`fetch`, DB
+  mutations, Kubernetes API calls, OCI registry, LiteLLM, Cognee, gateway admin, reconcile
+  loops, ingest cycles.
+- Span names are dotted `domain.action` (`oci.bundle.push`, `litellm.chat.run`,
+  `tenant.reconcile`). Pass the same structured fields you would log (ids, sizes, model,
+  outcome) — they become span attributes for trace queries.
+- The wrapper takes a callback. Inside a **class method** use an arrow or capture
+  `const self = this` so `this` survives (a named `function` callback loses it — this is a
+  real trap; verify). Inside a standalone function or object-literal method, a named
+  `function` expression is correct.
+- Per-app bootstrap: a first-imported `src/instrument.ts` calls the lib's
+  `startTelemetry`-equivalent before any instrumented module loads (ESM ordering). It is a
+  no-op without an OTLP endpoint, so it is always safe to add.
+- Lifecycle: long-running services flush on `SIGTERM`/`SIGINT` via the lib's shutdown
+  function before exit; short-lived processes (CLI, migrate) flush after their work resolves.
+
+### Infra wiring (when a new deployable app appears)
+- Add the `@opencrane/observability` workspace dep, the `instrument.ts`, and (for servers)
+  the request-context middleware.
+- Helm: include the `opencrane.observabilityEnv` helper in the app's Deployment `env:` and
+  ensure the Dockerfile builds the lib like the other workspace libs. Verify the OTEL
+  Collector toggle still renders (`helm template ... --set observability.otel.enabled=true`).
+
+## Two modes
+
+- **Audit** (default, and whenever the caller says "check/review"): report gaps only, do not
+  edit. Use the output format below, `file:line` for every gap.
+- **Apply** (when the caller says "wire/add/fix/instrument"): make the edits, matching the
+  surrounding code's idioms and AGENTS.md style, then verify (below).
+
+Determine scope first: `git diff --stat HEAD` / `git diff HEAD`, or the files/PR the caller named.
+
+## Constraints
+- **Reuse the lib; never reinvent.** No bespoke logger, no manual `trace.getTracer`, no
+  hand-rolled context — go through `@opencrane/observability`.
+- **Do not add noise.** One start line (debug) + one outcome line per seam is plenty; avoid
+  logging inside tight loops or per-iteration unless explicitly asked.
+- **Never log or span a secret.** If unsure whether a field is sensitive, treat it as
+  sensitive and redact.
+- **Match the existing API names from the barrel**, not names from memory or this document.
+- Editing `.ts` binds you to AGENTS.md: Allman braces, JSDoc on every declaration, no
+  standalone arrow declarations (arrows only in HOF callbacks / where `this` must bind),
+  single-line top imports, `*.types.ts` separation, the `_`/`___` naming convention.
+
+## Verify after applying (mandatory when you edit)
+- Typecheck/build the touched package(s): e.g. `pnpm --filter @opencrane/observability build`,
+  `pnpm --filter @opencrane/control-plane exec tsc --noEmit`.
+- Run the relevant tests: `pnpm --filter <pkg> test`. If you added a lib capability
+  (redaction path, helper), add a vitest covering it.
+- If you touched Helm, `helm template` the chart in default-off and `observability.otel.enabled=true`.
+- Report what you ran and the result. Never claim green without running it.
+
+## Output format
+1. **Summary** — one line: audited vs applied, and the headline (e.g. "3 untraced seams, 5 console.* calls").
+2. **Logging gaps/changes** — `file:line`, what's wrong/done, structured-field suggestion.
+3. **Tracing gaps/changes** — `file:line`, span name + fields added or missing.
+4. **Infra/wiring** — instrument.ts, shutdown flush, Helm env, redaction-path additions.
+5. **Verification** — commands run and results (apply mode), or "audit only — no edits".
+6. **Residual risks / follow-ups.**

--- a/.agents/skills/readme/SKILL.md
+++ b/.agents/skills/readme/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: readme
+description: >
+  Maintains README.md as the project's front door: the problem OpenCrane solves, the
+  vision, and what the repo does — for a newcomer skimming in two minutes. Invoke when a
+  shipped change alters what OpenCrane is or does, when the README drifts toward internal
+  detail, or whenever it needs a refresh. Keeps design decisions, phase history, threat
+  models, and deep mechanism OUT — those live in CHANGELOG.md, plan-done.md, and the docs.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+You maintain `README.md` for OpenCrane — the first thing a newcomer reads.
+
+## Your one rule: describe what it IS and DOES, never how it was DECIDED
+
+The README answers three questions, and only these:
+
+1. **What problem does OpenCrane solve?** (the pain, the stakes)
+2. **What's the vision?** (why self-hosted organizational AI matters)
+3. **What does the repo do, and how do I start?** (capabilities + Quick Start)
+
+It does **not** carry design decisions, trade-offs, threat models, protocol mechanics,
+or phase/roadmap history. Those have homes elsewhere — send them there.
+
+- ✅ "Every employee gets a private, isolated AI assistant; you manage them all from one
+  control plane."
+- ❌ "Security posture — Option B (decided): short-lived re-brokered credentials, a
+  per-user kill-switch… the Envoy proxy is a deferred, contingent vision."
+
+The first is *what it does*; the second is a *decision with its trade-offs*. Keep the
+first. A mechanism (a flag, endpoint, CLI command, file path) earns a mention only when it
+helps the reader **use or locate** something — never to explain how a choice was reached.
+
+## Where content belongs (redirect, don't delete knowledge)
+
+| Content | Home |
+|---------|------|
+| Problem, vision, what it does, Quick Start | **README.md** (here) |
+| What shipped / what you can now do | [`CHANGELOG.md`](../../CHANGELOG.md) (capability-first) |
+| Design decisions, phase history, why a choice was made | [`plan-done.md`](../../plan-done.md) |
+| Deep dives, threat models, protocol detail, operator/integrator how-to | the docs site (`website/` → opencrane.ai) |
+| Contributor coding rules & architecture-of-record | [`AGENTS.md`](../../AGENTS.md), `docs/agents/` |
+
+If you find decision/mechanism content in the README, **move or link it** to the right
+home; don't just delete the information.
+
+## The shape to keep
+
+A scannable front door, roughly:
+
+- **Vision** — the problem at scale, why it matters.
+- **Why OpenCrane** — self-hosted vs vendor-hosted (the value).
+- **Meet OpenCrane / How It Works** — what it does, in plain functional terms.
+- **Architecture** — a *concise* functional overview (control plane + one isolated
+  assistant per employee + shared planes), then a link to the illustrated architecture
+  page on the docs site. No internal topology diagrams or protocol flows here.
+- **Components** — the repo map (path → one-line "what it is").
+- **Documentation** — pointer to the docs site + AGENTS.md.
+- **Quick Start** — install, deploy, create a tenant, CLI basics.
+- **License.**
+
+Keep prose plain and audience-first. Define jargon or avoid it; prefer "employee
+assistant" over CRD/`Tenant` internals in the narrative.
+
+## Procedure
+
+1. Read `README.md` (current state), `AGENTS.md` (source of truth), and whatever shipped
+   change prompted the update (the diff, `CHANGELOG.md`, or `plan.md`/`plan-done.md`).
+2. Update only what changed about *what OpenCrane is or does*. Don't restate commits.
+3. Keep the Architecture section short and linked-out; never reintroduce the topology
+   diagram, connection handshake, or decision language.
+4. Verify links resolve (opencrane.ai/* routes, repo files). Prefer the public docs
+   site over `docs/agents/*` for reader-facing links.
+5. Self-check before finishing — run a jargon scan and fix any hit:
+
+   ```bash
+   grep -niE 'option [a-z]|decided|deferred|threat model|handshake|projected (jwt|token)|two clocks|envoy|roadmap|phase [0-9]|clustertenant base domain|config-slaved|drift repair' README.md
+   ```
+
+   Any match means a design decision or internal mechanism leaked back in — rewrite it as a
+   capability, or move it to its proper home and link.
+
+You report what you changed and why; you do not commit unless asked.

--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: review
+description: >
+  Independent code reviewer for OpenCrane changes. Use after implementing a slice,
+  before opening a PR, or whenever you want a fresh-context check for correctness
+  bugs, regressions, security/IAM-policy drift, missing tests, leftover legacy /
+  migration residue, and AGENTS.md style violations. Returns findings ordered by severity. Does not modify code unless the
+  caller explicitly asks for fixes.
+tools: Read, Grep, Glob, Bash
+model: haiku
+---
+
+You are the OpenCrane code review specialist.
+
+Your job is to detect behavioural regressions and high-risk implementation issues
+**before merge**, then report findings in a severity-first format. You review with
+fresh context — you did not write this code, so do not assume the author's intent
+was correct.
+
+## First step — load the source of truth
+
+Before reviewing, read `AGENTS.md` at the repository root. It is the canonical
+rule set for this repo (coding conventions, IAM-first policy, planning discipline).
+Never review against remembered rules — read the file each time so you never drift
+from the current version.
+
+## Scope
+
+- Review changed code for correctness, runtime risk, security, and test adequacy.
+- Verify AGENTS.md alignment for TypeScript conventions and planning discipline.
+- Validate that any roadmap status changes in `plan.md` are backed by real evidence.
+
+Determine what changed first. Prefer `git diff --stat HEAD` and `git diff HEAD` to
+scope the review to actual changes. If the caller named specific files or a PR
+scope, review those.
+
+## Constraints
+
+- **Findings over summaries.** Lead with what is wrong, not a description of the code.
+- **Bugs and regressions before style.** A missing null check outranks a missing JSDoc.
+- **Do not rewrite code** unless the caller explicitly asks for fixes.
+- **Do not approve checklist completion** without validation evidence.
+- Order findings by severity: Critical, High, Medium, Low.
+- Cite `file:line` for every finding so the author can jump straight to it.
+- **Verify before you assert.** Re-read the cited lines and trace the actual behaviour;
+  never report a speculative, pattern-matched, or unconfirmed claim as a finding.
+
+## Review checklist
+
+1. **Correctness and behaviour changes**
+   - Logic bugs, edge-case failures, off-by-one, unhandled null/undefined.
+   - Backward-incompatible behaviour changes.
+2. **Reliability and operations**
+   - Failure handling, retry/timeout behaviour, resource cleanup.
+   - Observability: are failures logged with enough structured context?
+3. **Security and policy (IAM-first)**
+   - Verify federated identity / OIDC / Workload Identity is preferred over static
+     bearer tokens. Flag any new bearer-token control path that IAM could solve.
+   - Check auth boundaries: routes without auth middleware must have a documented,
+     enforced network boundary (e.g. NetworkPolicy) — verify the policy actually exists.
+   - Secret handling: no secrets logged, hard-coded, or returned in responses.
+4. **AGENTS.md style compliance**
+   - Bracket placement on their own line for classes and functions.
+   - No standalone arrow-function declarations (arrows only in `map`/`filter`/`reduce`/`Array.from`).
+   - Numbered inline step comments for functions with 3+ sequential steps.
+   - JSDoc on every declaration, including every interface property and class field.
+   - Import ordering and single-line imports (no multi-line import blocks, none mid-file).
+   - Exported types/interfaces in `*.types.ts`, not mixed with implementation.
+   - Function naming underscore-prefix convention (`_`, `_Pascal`, `__Pascal`, `___Pascal`).
+5. **Test coverage and validation**
+   - Tests exist for changed behaviour and for the regression being fixed.
+   - Confirm relevant package validation ran. When in doubt, run it: e.g.
+     `pnpm --filter @opencrane/control-plane test` and `pnpm build`.
+6. **Roadmap integrity**
+   - Any `plan.md` checkbox/status change must be consistent with implemented,
+     validated evidence — not aspirational.
+7. **Legacy & migration residue (a migration must leave nothing behind)**
+   - When a change adds a new way to do something, hunt for the OLD way still present:
+     a superseded route/module/env/flag/config field, an implementation now coexisting
+     with its replacement, or an OpenAPI/spec entry that still describes retired
+     behaviour. A feature is not "migrated" until the path it replaced is gone.
+   - Classify each remnant before proposing action: **dead** (no import/call/route hit —
+     safe to delete, say so); **superseded but still wired** (new path exists, old one
+     still reachable — migrate remaining callers, then remove); **capability that must
+     survive** (mechanism changes but the capability is still required, e.g. a
+     kill-switch — never propose deleting it; migrate its mechanism and name what must
+     be preserved).
+   - **Contract drift counts.** Flag any `openapi/spec.ts` entry whose documented
+     response no longer matches what the handler returns — the spec drives every
+     generated client, so a stale entry silently breaks consumers.
+   - **Sequencing belongs in the procedure.** Never recommend deleting a working
+     security/auth path or a required capability before its replacement is validated
+     live — removing the only proven path to land a "cleanup" is a regression.
+   - For every remnant give the **removal + migration procedure** (what to delete, what
+     to migrate first, in what order), not just "this looks unused." When the caller
+     asks for fixes, perform the removal following that sequencing.
+
+## Verify every finding before reporting (mandatory)
+
+A wrong finding wastes the author's time and erodes trust in the review. Before a
+claim goes in the **Findings** section, confirm it against the actual code — do not
+rely on a quick pattern match or an assumption about what an expression "probably" does.
+
+For each candidate finding:
+
+1. **Re-read the exact cited lines** and the surrounding context. Trace what the code
+   actually does — evaluate the real control flow, string/branch conditions, and types
+   by hand. Example of the trap to avoid: claiming `"//host".startsWith("http")` is true,
+   or that a value reaches a sink, without actually tracing it.
+2. **Reproduce the reasoning concretely.** For a logic/security claim, walk a specific
+   input through the code to the bad outcome. If you cannot construct one, you have not
+   verified it.
+3. **Check the caller's stated context.** If the caller says a path is non-destructive,
+   gated off by default, or not yet wired, do not report "it isn't consumed yet" or
+   "this could break prod" as a finding — that is expected.
+4. **If you cannot confirm it, it is not a Finding.** Move unconfirmed concerns to
+   *Open questions / assumptions*, phrased as a question, not an assertion.
+5. **Label confidence and severity honestly.** A real-but-low-impact issue is Low, not
+   Critical. Reserve Critical/High for confirmed, material defects.
+
+Withdraw or downgrade any candidate that does not survive this check. It is better to
+report three verified findings than ten that include a wrong one.
+
+## Output format
+
+Return these sections in order:
+
+1. **Findings** — grouped by Critical, High, Medium, Low. Each finding: `file:line`,
+   what is wrong, why it matters, and the suggested fix direction.
+2. **Open questions / assumptions** — anything you could not verify.
+3. **Residual risks / testing gaps**
+4. **Brief summary** — one short paragraph.
+
+If there are no Critical or High findings, state explicitly:
+"No critical or high-severity findings detected." Then either list medium/low risks,
+or state "No medium or low-severity findings detected." when fully clean.

--- a/.agents/skills/website/SKILL.md
+++ b/.agents/skills/website/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: website
+description: >
+  Maintains the VitePress documentation site under `website/` (published to opencrane.ai):
+  end-user guides, operator runbooks, and integrator/architecture deep dives. Invoke when a
+  shipped change needs reader-facing docs, when a new capability needs a page, when docs drift
+  from the code, or to add/move a page and wire it into the nav + sidebar. Authors in the house
+  style (sentence-case, no frontmatter, See-also blockquotes, fenced box diagrams, ::: admonitions),
+  cross-links siblings, and always builds to validate links before finishing.
+tools: Read, Grep, Glob, Bash, Edit, Write
+model: sonnet
+---
+
+You maintain the OpenCrane documentation site under `website/` — a VitePress site served at
+opencrane.ai. Your job is reader-facing docs that stay true to the code, fit the existing
+taxonomy, and match the house style exactly.
+
+## Where a page belongs (the taxonomy)
+
+The sidebar in `website/.vitepress/config.ts` is the source of truth. Sections and their dirs:
+
+| Section | Dir | Audience & purpose |
+|---------|-----|--------------------|
+| Start here · Get set up · Guides | `guide/` | End users / admins. Plain language, task-first, minimal jargon. |
+| Reference | `reference/` (+ `integrators/contracts-sdk`) | CLI / API lookup. |
+| Operating OpenCrane | `operators/`, `security/` | Operators. Hosting, DNS, identity, runbook, telemetry, SLOs. |
+| Deep dives | `integrators/` | Integrators/engineers. Runtime planes & governance (MCP gateway, skill registry, retrieval, agent workspace). |
+| Advanced | `advanced/` | Architecture & multi-instance — conceptual tours. |
+
+Pick the section by **audience**, not topic. A how-to for an admin is a guide; a mechanism a
+plane enforces is a deep dive; a conceptual map is Advanced. When unsure, prefer the section
+whose sibling pages you'd cross-link most.
+
+## House style (match existing pages exactly)
+
+- **No YAML frontmatter.** Open with a single `# Heading` in **sentence case** (every heading,
+  every level — never Title Case).
+- **Intro paragraph below the H1** — 1–2 sentences saying what the page covers, in bold-keyword
+  prose. On deep-dive pages, follow it with a `> See also:` blockquote linking 2–4 sibling pages
+  (relative `/path` links, with a parenthetical on what each gives the reader).
+- **UK English** (`lang: en-GB`). "organisation", "behaviour", "catalogue"? — match neighbours;
+  the codebase mixes US spellings in identifiers, but prose is en-GB.
+- **Admonitions:** VitePress `::: tip` (golden rules / key concepts), `::: info` (clarifying
+  asides), `::: warning` (footguns). Close with `:::`.
+- **Diagrams are fenced ASCII box-drawing**, not Mermaid (the config comment pins this: "docs use
+  Unicode box-drawing; keep them intact"). Keep them theme-agnostic and aligned.
+- **Links are relative from site root:** `[text](/integrators/mcp-gateway)`. Use `→` to signal a
+  next-step / learn-more link. Link source files on GitHub as
+  `https://github.com/italanta/opencrane/blob/main/<path>` (matching existing pages).
+- **Tables** for structured facts (env vars, layers, comparisons). **Status emoji** ✅ (shipped) /
+  🔶 (planned/seam) when maturity matters.
+- **Active voice, technical-but-accessible.** Define a term on first use; prefer "employee
+  assistant" over `Tenant`-internals in guide prose. Deep dives may assume k8s/OIDC fluency.
+
+## Accuracy is the contract
+
+Docs that lie about the code are worse than no docs. Before describing a mechanism, **read the
+code that implements it** (routes, helm templates, operator deploy steps) and cite real file
+paths/endpoints. Distinguish shipped behaviour from a locked-but-unbuilt seam (mark the latter 🔶).
+If you can't verify a claim in the repo, don't assert it — soften to intent or leave it out.
+
+## Procedure
+
+1. Read `website/.vitepress/config.ts` (nav + sidebar) and 1–2 sibling pages in the target section
+   to lock onto current structure and tone.
+2. Read the code behind whatever you're documenting; ground every mechanism claim in a real path.
+3. Author or edit the page. **New page →** also add a sidebar entry in `config.ts` (and a nav entry
+   only if it's a top-level destination), and add a reciprocal `See also` link from the 1–2 most
+   related pages so it isn't an orphan.
+4. **Build to validate** — `ignoreDeadLinks: false`, so the build is your link checker:
+
+   ```bash
+   cd website && pnpm build 2>&1 | tail -20
+   ```
+
+   A broken cross-link or bad sidebar path fails the build. The pre-existing
+   `Failed to resolve base URL: /api/v1` warnings come from the OpenAPI sync step — ignore them;
+   only a `dead link` / render error is yours. Confirm the new page appears under
+   `website/.vitepress/dist/<section>/<slug>.html`.
+5. Report what you added/changed, which section it landed in, and what you cross-linked. Do not
+   commit unless asked.
+
+Keep deep design history out of the docs — decisions live in `plan-done.md`, shipped-capability
+notes in `CHANGELOG.md`. The docs explain how to *use* and *understand* OpenCrane, not how each
+choice was reached.

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -3566,6 +3566,16 @@
               }
             }
           },
+          "409": {
+            "description": "A workspace with this name already exists (code CONFLICT).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Requested isolation tier is not served by any registered provisioner (code TIER_UNAVAILABLE).",
             "content": {

--- a/apps/control-plane/src/__tests__/middleware/error-handler.test.ts
+++ b/apps/control-plane/src/__tests__/middleware/error-handler.test.ts
@@ -1,0 +1,63 @@
+import type { NextFunction, Request, Response } from "express";
+import { Prisma } from "@prisma/client";
+import pino from "pino";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { _ErrorHandler } from "../../middleware/error-handler.js";
+
+const log = pino({ level: "silent" });
+
+/** A minimal Response stub recording the status + JSON body the handler emits. */
+function _mockRes(): { res: Response; sent: { status?: number; body?: Record<string, unknown> } }
+{
+  const sent: { status?: number; body?: Record<string, unknown> } = {};
+  const res = {
+    status(code: number) { sent.status = code; return this; },
+    json(body: Record<string, unknown>) { sent.body = body; return this; },
+  } as unknown as Response;
+  return { res, sent };
+}
+
+const req = { url: "/x", method: "POST" } as Request;
+const next = (() => {}) as NextFunction;
+
+describe("_ErrorHandler", function _suite()
+{
+  afterEach(() => { delete process.env["NODE_ENV"]; vi.restoreAllMocks(); });
+
+  it("maps an unmapped Prisma P2002 to 409 CONFLICT with no leaked detail (any env)", function _p2002()
+  {
+    process.env["NODE_ENV"] = "production";
+    const { res, sent } = _mockRes();
+    const err = new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields: (`name`)", { code: "P2002", clientVersion: "test" });
+
+    _ErrorHandler(log)(err, req, res, next);
+
+    expect(sent.status).toBe(409);
+    expect(sent.body).toEqual({ error: "A resource with these unique values already exists.", code: "CONFLICT" });
+    expect(JSON.stringify(sent.body)).not.toMatch(/Unique constraint|P2002/);
+  });
+
+  it("strips detail from a generic 500 in production", function _prodStrip()
+  {
+    process.env["NODE_ENV"] = "production";
+    const { res, sent } = _mockRes();
+
+    _ErrorHandler(log)(new Error("boom: secret internals"), req, res, next);
+
+    expect(sent.status).toBe(500);
+    expect(sent.body).toEqual({ error: "An unexpected error occurred", code: "INTERNAL_ERROR" });
+    expect(sent.body).not.toHaveProperty("detail");
+  });
+
+  it("includes detail on a generic 500 outside production (debugging aid)", function _devDetail()
+  {
+    process.env["NODE_ENV"] = "development";
+    const { res, sent } = _mockRes();
+
+    _ErrorHandler(log)(new Error("boom"), req, res, next);
+
+    expect(sent.status).toBe(500);
+    expect(sent.body?.["detail"]).toBe("boom");
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
@@ -2,7 +2,7 @@ import express from "express";
 import type { Express } from "express";
 import { ClusterTenantIsolationTier } from "@opencrane/contracts";
 import type { ClusterTenantProvisionerRegistry } from "@opencrane/contracts";
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 
@@ -21,6 +21,12 @@ function _mockPrisma(store: Map<string, Row>): PrismaClient
       findUnique: vi.fn(async function _findUnique(args: { where: { name: string } }) { return store.get(args.where.name) ?? null; }),
       create: vi.fn(async function _create(args: { data: Row })
       {
+        // Faithful to the DB unique constraint on `name`: a duplicate throws Prisma P2002,
+        // which the route maps to 409 CONFLICT.
+        if (store.has(args.data.name as string))
+        {
+          throw new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields: (`name`)", { code: "P2002", clientVersion: "test" });
+        }
         const row = { nodePool: null, message: null, boundNamespace: null, provisioner: null, ...args.data };
         store.set(args.data.name as string, row);
         return row;
@@ -163,6 +169,20 @@ describe("clusterTenantsRouter (CT.2 management API)", function _suite()
     const clrRes = await request(app).put("/api/v1/cluster-tenants/acme").send({ vanityDomain: "" });
     expect(clrRes.status).toBe(200);
     expect(clrRes.body.vanityDomain).toBeUndefined();
+  });
+
+  it("returns 409 CONFLICT on a duplicate workspace name (Prisma P2002 → domain message)", async function _duplicateName()
+  {
+    const app = _buildApp(_mockPrisma(new Map()), _mockRegistry(false));
+
+    const first = await request(app).post("/api/v1/cluster-tenants").send(_sharedBody());
+    expect(first.status).toBe(201);
+
+    const dup = await request(app).post("/api/v1/cluster-tenants").send(_sharedBody());
+    expect(dup.status).toBe(409);
+    expect(dup.body.code).toBe("CONFLICT");
+    // The raw Prisma message must never leak to the client.
+    expect(JSON.stringify(dup.body)).not.toMatch(/Unique constraint|P2002/);
   });
 
   it("returns 404 for an unknown cluster tenant", async function _notFound()

--- a/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
@@ -4,6 +4,7 @@ import type { ClusterTenant } from "@opencrane/contracts";
 
 import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION } from "../../shared/crd-constants.js";
 import { _IsK8sConflict, _IsK8sNotFound } from "../../shared/k8s-errors.js";
+import type { ClusterTenantCrSpecPatch, ClusterTenantOwner, ClusterTenantSpec } from "./cr-bridge.types.js";
 
 /**
  * DB → Kubernetes bridge for the cluster-scoped ClusterTenant CRD.
@@ -22,52 +23,26 @@ import { _IsK8sConflict, _IsK8sNotFound } from "../../shared/k8s-errors.js";
  * to patch; update (no owner) → patch only, tolerate 404.
  */
 
+export type { ClusterTenantOwner } from "./cr-bridge.types.js";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/** Org owner identity projected into the ClusterTenant CR `spec.owner` so the operator can seed a default Tenant. */
-export interface ClusterTenantOwner
-{
-  /** The owner's IdP-verified email; becomes the default Tenant's contact email. */
-  email?: string;
-  /** The owner's OIDC subject (`sub`). */
-  subject?: string;
-}
-
-/**
- * Desired-state spec projected from the persisted org row (never status), EXCLUDING the
- * owner. This is the shape sent on a merge-patch (update path): omitting `owner` means a
- * JSON merge-patch leaves the existing `spec.owner` untouched.
- */
-interface ClusterTenantCrSpecPatch
-{
-  displayName: string;
-  vanityDomain?: string;
-  isolationTier: string;
-  compute: { mode: string; nodePool?: string };
-  resources: { quota: Record<string, unknown> };
-}
-
-/**
- * Full cluster-scoped ClusterTenant custom resource emitted on create.
- * `spec.owner` is MANDATORY — every org has a single owner.
- */
+/** Full cluster-scoped ClusterTenant custom resource emitted on create. */
 interface ClusterTenantCr
 {
   apiVersion: string;
   kind: "ClusterTenant";
   metadata: { name: string };
-  spec: ClusterTenantCrSpecPatch & {
-    owner: { subject: string; email?: string };
-  };
+  spec: ClusterTenantSpec;
 }
 
 // ---------------------------------------------------------------------------
 // Step 1 — Build
 // ---------------------------------------------------------------------------
 
-function _BuildOwnerSpec(owner?: ClusterTenantOwner): { subject: string; email?: string } | undefined
+function _BuildOwnerSpec(owner?: Partial<ClusterTenantOwner>): ClusterTenantOwner | undefined
 {
   const subject = owner?.subject?.trim();
   if (!subject) return undefined;
@@ -156,7 +131,7 @@ async function _CreateCr(customApi: k8s.CustomObjectsApi, body: ClusterTenantCr)
  * With owner (create path): build full CR → {@link _CreateCr} → on 409 fall back
  * to {@link _PatchSpec}. Without owner (update path): {@link _PatchSpec} only.
  */
-export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | null, org: ClusterTenant, owner?: ClusterTenantOwner): Promise<void>
+export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | null, org: ClusterTenant, owner?: Partial<ClusterTenantOwner>): Promise<void>
 {
   if (!customApi) return;
 

--- a/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
@@ -3,29 +3,28 @@ import { ClusterTenantComputeMode } from "@opencrane/contracts";
 import type { ClusterTenant } from "@opencrane/contracts";
 
 import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION } from "../../shared/crd-constants.js";
+import { _IsK8sConflict, _IsK8sNotFound } from "../../shared/k8s-errors.js";
 
 /**
  * DB → Kubernetes bridge for the cluster-scoped ClusterTenant CRD.
  *
  * The control plane is the system of record for an org's DESIRED state (the
  * `cluster_tenants` row); the operator owns the OBSERVED state (`status.phase`,
- * `status.boundNamespace`). Mirroring how `tenantsRouter` dual-writes the Tenant
- * CRD, the create/update/delete handlers project the persisted row into a
- * cluster-scoped `clustertenants` CR so the ClusterTenant reconciler has something
- * to watch. Without this bridge a `POST /cluster-tenants` would persist a `pending`
- * row that nothing ever reconciles ("hollow CRUD shell").
+ * `status.boundNamespace`). The bridge writes ONLY `spec` — never `status` — so
+ * a CR write can never clobber the phase/boundNamespace the operator stamps.
  *
- * The bridge writes ONLY `spec` — never `status` — so a CR write can never clobber
- * the phase/boundNamespace the operator stamps. It is idempotent: create-or-patch
- * (merge-patch the spec), so re-applying the same desired state converges.
+ * Three named steps compose the apply path:
+ *   1. {@link _BuildSpecPatch}  — project the persisted row into the owner-free spec.
+ *   2. {@link _PatchSpec}       — merge-patch the spec onto an existing CR (update).
+ *   3. {@link _CreateCr}        — create a full CR with mandatory `spec.owner` (create).
  *
- * On create it also projects the org owner's identity into `spec.owner` — first-class,
- * schema-validated desired state, NOT a free-floating annotation. The operator has no
- * database access, so the CR spec is the only channel by which the ClusterTenant
- * reconciler can learn who to attribute the org's default Tenant to once it is ready.
- * Presence is enforced upstream by this control plane (org create 401s with no resolvable
- * subject), so an owner-less org can never be persisted in the first place.
+ * {@link _ApplyClusterTenantCr} orchestrates: create (with owner) → on 409 fall back
+ * to patch; update (no owner) → patch only, tolerate 404.
  */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 /** Org owner identity projected into the ClusterTenant CR `spec.owner` so the operator can seed a default Tenant. */
 export interface ClusterTenantOwner
@@ -39,51 +38,35 @@ export interface ClusterTenantOwner
 /**
  * Desired-state spec projected from the persisted org row (never status), EXCLUDING the
  * owner. This is the shape sent on a merge-patch (update path): omitting `owner` means a
- * JSON merge-patch leaves the existing `spec.owner` untouched, so an update by a non-owner
- * admin (who has no owner identity to re-assert) can never drop it.
+ * JSON merge-patch leaves the existing `spec.owner` untouched.
  */
 interface ClusterTenantCrSpecPatch
 {
-  /** Human-readable org display name. */
   displayName: string;
-  /** Optional customer-vanity domain CNAMEd onto the org apex. */
   vanityDomain?: string;
-  /** Isolation tier driving the operator's boundary provisioner selection. */
   isolationTier: string;
-  /** Compute placement: shared cluster or a dedicated node pool. */
   compute: { mode: string; nodePool?: string };
-  /** Resource governance for the org's bound namespace (quota map). */
   resources: { quota: Record<string, unknown> };
 }
 
 /**
- * The full cluster-scoped ClusterTenant custom resource the control plane emits on create.
- * `spec.owner` is MANDATORY: every org has a single owner (the control plane records it
- * transactionally and 401s a create with no resolvable subject), so a CR can never be born
- * without one. Updates use {@link ClusterTenantCrSpecPatch}, which preserves the owner.
+ * Full cluster-scoped ClusterTenant custom resource emitted on create.
+ * `spec.owner` is MANDATORY — every org has a single owner.
  */
 interface ClusterTenantCr
 {
-  /** API group/version of the ClusterTenant CRD (`opencrane.io/<version>`). */
   apiVersion: string;
-  /** CRD kind discriminator — always `ClusterTenant`. */
   kind: "ClusterTenant";
-  /** Object metadata; the org name is the cluster-scoped CR name. */
   metadata: { name: string };
-  /** Desired-state spec projected from the persisted org row (never status). */
   spec: ClusterTenantCrSpecPatch & {
-    /** Org owner identity, so the operator can attribute the org's default Tenant. */
     owner: { subject: string; email?: string };
   };
 }
 
-/**
- * Build the `spec.owner` block for a CR, or undefined when no owner subject is
- * resolvable (the dev/test path with no session) — so the projected spec carries a
- * well-formed owner or none at all, never a subject-less stub the CRD would reject.
- *
- * @param owner - The org owner's email/subject, if known.
- */
+// ---------------------------------------------------------------------------
+// Step 1 — Build
+// ---------------------------------------------------------------------------
+
 function _BuildOwnerSpec(owner?: ClusterTenantOwner): { subject: string; email?: string } | undefined
 {
   const subject = owner?.subject?.trim();
@@ -92,14 +75,6 @@ function _BuildOwnerSpec(owner?: ClusterTenantOwner): { subject: string; email?:
   return { subject, ...(email ? { email } : {}) };
 }
 
-/**
- * Project a {@link ClusterTenant} contract object into the owner-free desired-state spec.
- * Only desired-state fields are carried; status is the operator's to write, and `owner` is
- * added by the create path (never on update — see {@link ClusterTenantCrSpecPatch}).
- *
- * @param org - The org contract object (as returned by `_ToContract`).
- * @returns The owner-free spec, ready as a create-body fragment or a merge-patch body.
- */
 function _BuildSpecPatch(org: ClusterTenant): ClusterTenantCrSpecPatch
 {
   return {
@@ -116,62 +91,44 @@ function _BuildSpecPatch(org: ClusterTenant): ClusterTenantCrSpecPatch
   };
 }
 
+// ---------------------------------------------------------------------------
+// Step 2 — Patch (update path)
+// ---------------------------------------------------------------------------
+
 /**
- * Apply the cluster-scoped ClusterTenant CR for an org idempotently.
- *
- * Tries to create; on 409 (already exists) merge-patches the spec so an update to
- * the org's desired state propagates without touching operator-owned status. The
- * `customApi` may be null in dev/test wiring with no cluster — in that case the
- * bridge is a no-op (the DB row is still the source of truth and the reconciler is
- * not running anyway).
- *
- * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
- * @param org - The org contract object to project into the CR.
- * @param owner - The org owner's identity. Present on create (projected into the mandatory
- *                `spec.owner`); omitted on update, where the spec is merge-patched and the
- *                existing `spec.owner` is preserved.
+ * Merge-patch the owner-free spec onto an existing CR. Tolerates 404 — a missing
+ * CR on the update path is an out-of-band anomaly, not something this write-back
+ * can resolve (a re-create requires an owner).
  */
-export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | null, org: ClusterTenant, owner?: ClusterTenantOwner): Promise<void>
+async function _PatchSpec(customApi: k8s.CustomObjectsApi, name: string, specPatch: ClusterTenantCrSpecPatch): Promise<void>
 {
-  if (!customApi) return;
-
-  const specPatch = _BuildSpecPatch(org);
-  const ownerSpec = _BuildOwnerSpec(owner);
-
-  // Update path: no resolvable owner to assert → merge-patch the spec only. A JSON
-  // merge-patch leaves keys it omits (here, `owner`) untouched, so the owner the create
-  // stamped is preserved. Tolerates a 404 the way the delete bridge does: the CR cannot
-  // be (re)created without an owner, and a missing CR on update is an out-of-band anomaly,
-  // not something this write-back can resolve.
-  if (!ownerSpec)
+  try
   {
-    try
-    {
-      await customApi.patchClusterCustomObject({
-        group: OPENCRANE_API_GROUP,
-        version: OPENCRANE_API_VERSION,
-        plural: CLUSTER_TENANT_CRD_PLURAL,
-        name: org.name,
-        body: { spec: specPatch },
-      });
-    }
-    catch (err: unknown)
-    {
-      if (_IsNotFound(err)) return;
-      throw err;
-    }
-    return;
+    await customApi.patchClusterCustomObject({
+      group: OPENCRANE_API_GROUP,
+      version: OPENCRANE_API_VERSION,
+      plural: CLUSTER_TENANT_CRD_PLURAL,
+      name,
+      body: { spec: specPatch },
+    });
   }
+  catch (err: unknown)
+  {
+    if (_IsK8sNotFound(err)) return;
+    throw err;
+  }
+}
 
-  // Create path: full CR including the mandatory `spec.owner`. Idempotent — on 409 the CR
-  // already exists, so fall back to the same owner-free spec merge-patch (preserving owner).
-  const body: ClusterTenantCr = {
-    apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
-    kind: "ClusterTenant",
-    metadata: { name: org.name },
-    spec: { ...specPatch, owner: ownerSpec },
-  };
+// ---------------------------------------------------------------------------
+// Step 3 — Create (create path)
+// ---------------------------------------------------------------------------
 
+/**
+ * Create the full CR with mandatory `spec.owner`. Returns `true` when created,
+ * `false` when the CR already existed (409).
+ */
+async function _CreateCr(customApi: k8s.CustomObjectsApi, body: ClusterTenantCr): Promise<boolean>
+{
   try
   {
     await customApi.createClusterCustomObject({
@@ -180,29 +137,54 @@ export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | nu
       plural: CLUSTER_TENANT_CRD_PLURAL,
       body,
     });
+    return true;
   }
   catch (err: unknown)
   {
-    if (_IsAlreadyExists(err))
-    {
-      await customApi.patchClusterCustomObject({
-        group: OPENCRANE_API_GROUP,
-        version: OPENCRANE_API_VERSION,
-        plural: CLUSTER_TENANT_CRD_PLURAL,
-        name: org.name,
-        body: { spec: specPatch },
-      });
-      return;
-    }
+    if (_IsK8sConflict(err)) return false;
     throw err;
   }
 }
 
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
 /**
- * Delete the cluster-scoped ClusterTenant CR for an org, tolerating 404.
+ * Apply the cluster-scoped ClusterTenant CR idempotently.
  *
- * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
- * @param name - The org (ClusterTenant) name to delete.
+ * With owner (create path): build full CR → {@link _CreateCr} → on 409 fall back
+ * to {@link _PatchSpec}. Without owner (update path): {@link _PatchSpec} only.
+ */
+export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | null, org: ClusterTenant, owner?: ClusterTenantOwner): Promise<void>
+{
+  if (!customApi) return;
+
+  const specPatch = _BuildSpecPatch(org);
+  const ownerSpec = _BuildOwnerSpec(owner);
+
+  if (!ownerSpec)
+  {
+    await _PatchSpec(customApi, org.name, specPatch);
+    return;
+  }
+
+  const body: ClusterTenantCr = {
+    apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
+    kind: "ClusterTenant",
+    metadata: { name: org.name },
+    spec: { ...specPatch, owner: ownerSpec },
+  };
+
+  const created = await _CreateCr(customApi, body);
+  if (!created)
+  {
+    await _PatchSpec(customApi, org.name, specPatch);
+  }
+}
+
+/**
+ * Delete the cluster-scoped ClusterTenant CR, tolerating 404.
  */
 export async function _DeleteClusterTenantCr(customApi: k8s.CustomObjectsApi | null, name: string): Promise<void>
 {
@@ -219,28 +201,7 @@ export async function _DeleteClusterTenantCr(customApi: k8s.CustomObjectsApi | n
   }
   catch (err: unknown)
   {
-    if (_IsNotFound(err)) return;
+    if (_IsK8sNotFound(err)) return;
     throw err;
   }
-}
-
-/** Whether a Kubernetes API error carries a given numeric status code (common shapes). */
-function _HasK8sStatus(err: unknown, code: number): boolean
-{
-  if (typeof err !== "object" || err === null) return false;
-  const e = err as { statusCode?: unknown; code?: unknown; body?: { code?: unknown } };
-  if (e.statusCode === code || e.code === code) return true;
-  return typeof e.body === "object" && e.body !== null && (e.body as { code?: unknown }).code === code;
-}
-
-/** Whether the error is a Kubernetes 409 AlreadyExists. */
-function _IsAlreadyExists(err: unknown): boolean
-{
-  return _HasK8sStatus(err, 409);
-}
-
-/** Whether the error is a Kubernetes 404 NotFound. */
-function _IsNotFound(err: unknown): boolean
-{
-  return _HasK8sStatus(err, 404);
 }

--- a/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
@@ -19,19 +19,15 @@ import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION }
  * the phase/boundNamespace the operator stamps. It is idempotent: create-or-patch
  * (merge-patch the spec), so re-applying the same desired state converges.
  *
- * On create it also stamps the org owner's identity as metadata annotations
- * ({@link _OWNER_EMAIL_ANNOTATION}/{@link _OWNER_SUBJECT_ANNOTATION}). The operator
- * has no database access, so this is the only channel by which the ClusterTenant
+ * On create it also projects the org owner's identity into `spec.owner` — first-class,
+ * schema-validated desired state, NOT a free-floating annotation. The operator has no
+ * database access, so the CR spec is the only channel by which the ClusterTenant
  * reconciler can learn who to attribute the org's default Tenant to once it is ready.
+ * Presence is enforced upstream by this control plane (org create 401s with no resolvable
+ * subject), so an owner-less org can never be persisted in the first place.
  */
 
-/** Annotation carrying the org owner's IdP-verified email, so the operator can attribute the org's default Tenant. */
-const _OWNER_EMAIL_ANNOTATION = "opencrane.io/owner-email";
-
-/** Annotation carrying the org owner's OIDC subject, recorded alongside the email for traceability. */
-const _OWNER_SUBJECT_ANNOTATION = "opencrane.io/owner-subject";
-
-/** Org owner identity stamped onto the ClusterTenant CR so the operator can seed a default Tenant. */
+/** Org owner identity projected into the ClusterTenant CR `spec.owner` so the operator can seed a default Tenant. */
 export interface ClusterTenantOwner
 {
   /** The owner's IdP-verified email; becomes the default Tenant's contact email. */
@@ -47,8 +43,8 @@ interface ClusterTenantCr
   apiVersion: string;
   /** CRD kind discriminator — always `ClusterTenant`. */
   kind: "ClusterTenant";
-  /** Object metadata; the org name is the cluster-scoped CR name, plus optional owner annotations. */
-  metadata: { name: string; annotations?: Record<string, string> };
+  /** Object metadata; the org name is the cluster-scoped CR name. */
+  metadata: { name: string };
   /** Desired-state spec projected from the persisted org row (never status). */
   spec: {
     /** Human-readable org display name. */
@@ -61,47 +57,44 @@ interface ClusterTenantCr
     compute: { mode: string; nodePool?: string };
     /** Resource governance for the org's bound namespace (quota map). */
     resources: { quota: Record<string, unknown> };
+    /** Org owner identity, so the operator can attribute the org's default Tenant. */
+    owner?: { subject: string; email?: string };
   };
 }
 
 /**
- * Build the owner-identity annotation map for a CR, or undefined when no owner
- * field is set (so an org create without a resolvable owner carries no annotations
- * rather than empty ones).
+ * Build the `spec.owner` block for a CR, or undefined when no owner subject is
+ * resolvable (the dev/test path with no session) — so the projected spec carries a
+ * well-formed owner or none at all, never a subject-less stub the CRD would reject.
  *
  * @param owner - The org owner's email/subject, if known.
  */
-function _BuildOwnerAnnotations(owner?: ClusterTenantOwner): Record<string, string> | undefined
+function _BuildOwnerSpec(owner?: ClusterTenantOwner): { subject: string; email?: string } | undefined
 {
-  const annotations: Record<string, string> = {};
-  if (owner?.email?.trim())
-  {
-    annotations[_OWNER_EMAIL_ANNOTATION] = owner.email.trim();
-  }
-  if (owner?.subject?.trim())
-  {
-    annotations[_OWNER_SUBJECT_ANNOTATION] = owner.subject.trim();
-  }
-  return Object.keys(annotations).length > 0 ? annotations : undefined;
+  const subject = owner?.subject?.trim();
+  if (!subject) return undefined;
+  const email = owner?.email?.trim();
+  return { subject, ...(email ? { email } : {}) };
 }
 
 /**
  * Project a {@link ClusterTenant} contract object into the cluster-scoped CR spec.
  * Only desired-state fields are carried; status is the operator's to write. The
- * owner's identity, when supplied, is stamped as metadata annotations so the
- * operator can seed the org's default Tenant once it is ready.
+ * owner's identity, when supplied, is projected into `spec.owner` (first-class,
+ * schema-validated desired state) so the operator can seed the org's default Tenant
+ * once it is ready.
  *
  * @param org   - The org contract object (as returned by `_ToContract`).
- * @param owner - The org owner's identity, stamped as annotations when present.
+ * @param owner - The org owner's identity, projected into `spec.owner` when present.
  * @returns The ClusterTenant CR body ready for server-side apply.
  */
 function _BuildClusterTenantCr(org: ClusterTenant, owner?: ClusterTenantOwner): ClusterTenantCr
 {
-  const annotations = _BuildOwnerAnnotations(owner);
+  const ownerSpec = _BuildOwnerSpec(owner);
   return {
     apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
     kind: "ClusterTenant",
-    metadata: { name: org.name, ...(annotations ? { annotations } : {}) },
+    metadata: { name: org.name },
     spec: {
       displayName: org.displayName,
       ...(org.vanityDomain ? { vanityDomain: org.vanityDomain } : {}),
@@ -113,6 +106,7 @@ function _BuildClusterTenantCr(org: ClusterTenant, owner?: ClusterTenantOwner): 
           : {}),
       },
       resources: { quota: (org.resources.quota as Record<string, unknown>) ?? {} },
+      ...(ownerSpec ? { owner: ownerSpec } : {}),
     },
   };
 }
@@ -128,7 +122,7 @@ function _BuildClusterTenantCr(org: ClusterTenant, owner?: ClusterTenantOwner): 
  *
  * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
  * @param org - The org contract object to project into the CR.
- * @param owner - The org owner's identity, stamped as annotations on create (and merged on update).
+ * @param owner - The org owner's identity, projected into `spec.owner` on create (and merged on update).
  */
 export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | null, org: ClusterTenant, owner?: ClusterTenantOwner): Promise<void>
 {
@@ -149,17 +143,16 @@ export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | nu
   {
     if (_IsAlreadyExists(err))
     {
-      // Merge-patch the spec (and owner annotations when present) so the operator's
-      // status subresource is untouched; merge-patch on annotations adds/updates the
-      // owner keys without dropping any other annotation the operator may have set.
+      // Merge-patch the spec (owner included when present) so the operator's status
+      // subresource is untouched. Merge-patch never drops keys the patch omits, so an
+      // update with no resolvable owner (e.g. the PUT path) preserves the existing
+      // spec.owner the create stamped.
       await customApi.patchClusterCustomObject({
         group: OPENCRANE_API_GROUP,
         version: OPENCRANE_API_VERSION,
         plural: CLUSTER_TENANT_CRD_PLURAL,
         name: org.name,
-        body: body.metadata.annotations
-          ? { metadata: { annotations: body.metadata.annotations }, spec: body.spec }
-          : { spec: body.spec },
+        body: { spec: body.spec },
       });
       return;
     }

--- a/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
@@ -36,7 +36,32 @@ export interface ClusterTenantOwner
   subject?: string;
 }
 
-/** The cluster-scoped ClusterTenant custom resource shape the control plane emits. */
+/**
+ * Desired-state spec projected from the persisted org row (never status), EXCLUDING the
+ * owner. This is the shape sent on a merge-patch (update path): omitting `owner` means a
+ * JSON merge-patch leaves the existing `spec.owner` untouched, so an update by a non-owner
+ * admin (who has no owner identity to re-assert) can never drop it.
+ */
+interface ClusterTenantCrSpecPatch
+{
+  /** Human-readable org display name. */
+  displayName: string;
+  /** Optional customer-vanity domain CNAMEd onto the org apex. */
+  vanityDomain?: string;
+  /** Isolation tier driving the operator's boundary provisioner selection. */
+  isolationTier: string;
+  /** Compute placement: shared cluster or a dedicated node pool. */
+  compute: { mode: string; nodePool?: string };
+  /** Resource governance for the org's bound namespace (quota map). */
+  resources: { quota: Record<string, unknown> };
+}
+
+/**
+ * The full cluster-scoped ClusterTenant custom resource the control plane emits on create.
+ * `spec.owner` is MANDATORY: every org has a single owner (the control plane records it
+ * transactionally and 401s a create with no resolvable subject), so a CR can never be born
+ * without one. Updates use {@link ClusterTenantCrSpecPatch}, which preserves the owner.
+ */
 interface ClusterTenantCr
 {
   /** API group/version of the ClusterTenant CRD (`opencrane.io/<version>`). */
@@ -46,19 +71,9 @@ interface ClusterTenantCr
   /** Object metadata; the org name is the cluster-scoped CR name. */
   metadata: { name: string };
   /** Desired-state spec projected from the persisted org row (never status). */
-  spec: {
-    /** Human-readable org display name. */
-    displayName: string;
-    /** Optional customer-vanity domain CNAMEd onto the org apex. */
-    vanityDomain?: string;
-    /** Isolation tier driving the operator's boundary provisioner selection. */
-    isolationTier: string;
-    /** Compute placement: shared cluster or a dedicated node pool. */
-    compute: { mode: string; nodePool?: string };
-    /** Resource governance for the org's bound namespace (quota map). */
-    resources: { quota: Record<string, unknown> };
+  spec: ClusterTenantCrSpecPatch & {
     /** Org owner identity, so the operator can attribute the org's default Tenant. */
-    owner?: { subject: string; email?: string };
+    owner: { subject: string; email?: string };
   };
 }
 
@@ -78,36 +93,26 @@ function _BuildOwnerSpec(owner?: ClusterTenantOwner): { subject: string; email?:
 }
 
 /**
- * Project a {@link ClusterTenant} contract object into the cluster-scoped CR spec.
- * Only desired-state fields are carried; status is the operator's to write. The
- * owner's identity, when supplied, is projected into `spec.owner` (first-class,
- * schema-validated desired state) so the operator can seed the org's default Tenant
- * once it is ready.
+ * Project a {@link ClusterTenant} contract object into the owner-free desired-state spec.
+ * Only desired-state fields are carried; status is the operator's to write, and `owner` is
+ * added by the create path (never on update — see {@link ClusterTenantCrSpecPatch}).
  *
- * @param org   - The org contract object (as returned by `_ToContract`).
- * @param owner - The org owner's identity, projected into `spec.owner` when present.
- * @returns The ClusterTenant CR body ready for server-side apply.
+ * @param org - The org contract object (as returned by `_ToContract`).
+ * @returns The owner-free spec, ready as a create-body fragment or a merge-patch body.
  */
-function _BuildClusterTenantCr(org: ClusterTenant, owner?: ClusterTenantOwner): ClusterTenantCr
+function _BuildSpecPatch(org: ClusterTenant): ClusterTenantCrSpecPatch
 {
-  const ownerSpec = _BuildOwnerSpec(owner);
   return {
-    apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
-    kind: "ClusterTenant",
-    metadata: { name: org.name },
-    spec: {
-      displayName: org.displayName,
-      ...(org.vanityDomain ? { vanityDomain: org.vanityDomain } : {}),
-      isolationTier: org.isolationTier,
-      compute: {
-        mode: org.compute.mode,
-        ...(org.compute.mode === ClusterTenantComputeMode.Dedicated && org.compute.nodePool
-          ? { nodePool: org.compute.nodePool }
-          : {}),
-      },
-      resources: { quota: (org.resources.quota as Record<string, unknown>) ?? {} },
-      ...(ownerSpec ? { owner: ownerSpec } : {}),
+    displayName: org.displayName,
+    ...(org.vanityDomain ? { vanityDomain: org.vanityDomain } : {}),
+    isolationTier: org.isolationTier,
+    compute: {
+      mode: org.compute.mode,
+      ...(org.compute.mode === ClusterTenantComputeMode.Dedicated && org.compute.nodePool
+        ? { nodePool: org.compute.nodePool }
+        : {}),
     },
+    resources: { quota: (org.resources.quota as Record<string, unknown>) ?? {} },
   };
 }
 
@@ -122,13 +127,50 @@ function _BuildClusterTenantCr(org: ClusterTenant, owner?: ClusterTenantOwner): 
  *
  * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
  * @param org - The org contract object to project into the CR.
- * @param owner - The org owner's identity, projected into `spec.owner` on create (and merged on update).
+ * @param owner - The org owner's identity. Present on create (projected into the mandatory
+ *                `spec.owner`); omitted on update, where the spec is merge-patched and the
+ *                existing `spec.owner` is preserved.
  */
 export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | null, org: ClusterTenant, owner?: ClusterTenantOwner): Promise<void>
 {
   if (!customApi) return;
 
-  const body = _BuildClusterTenantCr(org, owner);
+  const specPatch = _BuildSpecPatch(org);
+  const ownerSpec = _BuildOwnerSpec(owner);
+
+  // Update path: no resolvable owner to assert → merge-patch the spec only. A JSON
+  // merge-patch leaves keys it omits (here, `owner`) untouched, so the owner the create
+  // stamped is preserved. Tolerates a 404 the way the delete bridge does: the CR cannot
+  // be (re)created without an owner, and a missing CR on update is an out-of-band anomaly,
+  // not something this write-back can resolve.
+  if (!ownerSpec)
+  {
+    try
+    {
+      await customApi.patchClusterCustomObject({
+        group: OPENCRANE_API_GROUP,
+        version: OPENCRANE_API_VERSION,
+        plural: CLUSTER_TENANT_CRD_PLURAL,
+        name: org.name,
+        body: { spec: specPatch },
+      });
+    }
+    catch (err: unknown)
+    {
+      if (_IsNotFound(err)) return;
+      throw err;
+    }
+    return;
+  }
+
+  // Create path: full CR including the mandatory `spec.owner`. Idempotent — on 409 the CR
+  // already exists, so fall back to the same owner-free spec merge-patch (preserving owner).
+  const body: ClusterTenantCr = {
+    apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
+    kind: "ClusterTenant",
+    metadata: { name: org.name },
+    spec: { ...specPatch, owner: ownerSpec },
+  };
 
   try
   {
@@ -143,16 +185,12 @@ export async function _ApplyClusterTenantCr(customApi: k8s.CustomObjectsApi | nu
   {
     if (_IsAlreadyExists(err))
     {
-      // Merge-patch the spec (owner included when present) so the operator's status
-      // subresource is untouched. Merge-patch never drops keys the patch omits, so an
-      // update with no resolvable owner (e.g. the PUT path) preserves the existing
-      // spec.owner the create stamped.
       await customApi.patchClusterCustomObject({
         group: OPENCRANE_API_GROUP,
         version: OPENCRANE_API_VERSION,
         plural: CLUSTER_TENANT_CRD_PLURAL,
         name: org.name,
-        body: { spec: body.spec },
+        body: { spec: specPatch },
       });
       return;
     }
@@ -183,58 +221,6 @@ export async function _DeleteClusterTenantCr(customApi: k8s.CustomObjectsApi | n
   {
     if (_IsNotFound(err)) return;
     throw err;
-  }
-}
-
-/** Observed-state fields the operator stamps on the ClusterTenant CR status subresource. */
-export interface ClusterTenantObservedStatus
-{
-  /** Current lifecycle phase the operator observed (pending|provisioning|ready|failed). */
-  phase?: string;
-  /** Human-readable detail, set on failure or transitional states. */
-  message?: string;
-  /** Namespace the operator bound to this org once provisioned. */
-  boundNamespace?: string;
-  /** Identifier of the provisioner that owns this org's boundary. */
-  provisioner?: string;
-}
-
-/**
- * Read the OBSERVED status the operator stamped on the cluster-scoped ClusterTenant CR.
- *
- * The control plane persists DESIRED state to Postgres and never writes status back; the
- * operator advances `status.phase` (pending→provisioning→ready) on the CR's status
- * subresource. The DB `phase` column therefore stays at its seeded `pending` forever, so
- * the read path must consult the CR to report real provisioning progress (the
- * onboarding poll otherwise never leaves `pending`).
- *
- * Returns null when no cluster is wired (`customApi` null), the CRD/CR is absent, or any
- * read error — callers then fall back to the DB-derived status, preserving behaviour in
- * non-cluster (dev/test) environments and never hard-failing the status endpoint on a
- * transient cluster blip.
- *
- * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
- * @param name - The org (ClusterTenant) name whose observed status to read.
- */
-export async function _ReadClusterTenantObservedStatus(customApi: k8s.CustomObjectsApi | null, name: string): Promise<ClusterTenantObservedStatus | null>
-{
-  if (!customApi) return null;
-
-  try
-  {
-    const cr = await customApi.getClusterCustomObject({
-      group: OPENCRANE_API_GROUP,
-      version: OPENCRANE_API_VERSION,
-      plural: CLUSTER_TENANT_CRD_PLURAL,
-      name,
-    });
-    const status = (cr as { status?: ClusterTenantObservedStatus } | undefined)?.status;
-    return status && typeof status === "object" ? status : null;
-  }
-  catch
-  {
-    // No CRD / CR not found / cluster unreachable → caller falls back to the DB status.
-    return null;
   }
 }
 

--- a/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-bridge.ts
@@ -193,6 +193,58 @@ export async function _DeleteClusterTenantCr(customApi: k8s.CustomObjectsApi | n
   }
 }
 
+/** Observed-state fields the operator stamps on the ClusterTenant CR status subresource. */
+export interface ClusterTenantObservedStatus
+{
+  /** Current lifecycle phase the operator observed (pending|provisioning|ready|failed). */
+  phase?: string;
+  /** Human-readable detail, set on failure or transitional states. */
+  message?: string;
+  /** Namespace the operator bound to this org once provisioned. */
+  boundNamespace?: string;
+  /** Identifier of the provisioner that owns this org's boundary. */
+  provisioner?: string;
+}
+
+/**
+ * Read the OBSERVED status the operator stamped on the cluster-scoped ClusterTenant CR.
+ *
+ * The control plane persists DESIRED state to Postgres and never writes status back; the
+ * operator advances `status.phase` (pending→provisioning→ready) on the CR's status
+ * subresource. The DB `phase` column therefore stays at its seeded `pending` forever, so
+ * the read path must consult the CR to report real provisioning progress (the
+ * onboarding poll otherwise never leaves `pending`).
+ *
+ * Returns null when no cluster is wired (`customApi` null), the CRD/CR is absent, or any
+ * read error — callers then fall back to the DB-derived status, preserving behaviour in
+ * non-cluster (dev/test) environments and never hard-failing the status endpoint on a
+ * transient cluster blip.
+ *
+ * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
+ * @param name - The org (ClusterTenant) name whose observed status to read.
+ */
+export async function _ReadClusterTenantObservedStatus(customApi: k8s.CustomObjectsApi | null, name: string): Promise<ClusterTenantObservedStatus | null>
+{
+  if (!customApi) return null;
+
+  try
+  {
+    const cr = await customApi.getClusterCustomObject({
+      group: OPENCRANE_API_GROUP,
+      version: OPENCRANE_API_VERSION,
+      plural: CLUSTER_TENANT_CRD_PLURAL,
+      name,
+    });
+    const status = (cr as { status?: ClusterTenantObservedStatus } | undefined)?.status;
+    return status && typeof status === "object" ? status : null;
+  }
+  catch
+  {
+    // No CRD / CR not found / cluster unreachable → caller falls back to the DB status.
+    return null;
+  }
+}
+
 /** Whether a Kubernetes API error carries a given numeric status code (common shapes). */
 function _HasK8sStatus(err: unknown, code: number): boolean
 {

--- a/apps/control-plane/src/core/cluster-tenants/cr-bridge.types.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-bridge.types.ts
@@ -1,0 +1,28 @@
+/** Org owner identity projected into the ClusterTenant CR `spec.owner`. */
+export interface ClusterTenantOwner
+{
+  /** The owner's OIDC subject (`sub`). */
+  subject: string;
+  /** The owner's IdP-verified email; becomes the default Tenant's contact email. */
+  email?: string;
+}
+
+/**
+ * Desired-state spec EXCLUDING the owner. This is the shape sent on a
+ * merge-patch (update path): omitting `owner` means a JSON merge-patch
+ * leaves the existing `spec.owner` untouched.
+ */
+export interface ClusterTenantCrSpecPatch
+{
+  displayName: string;
+  vanityDomain?: string;
+  isolationTier: string;
+  compute: { mode: string; nodePool?: string };
+  resources: { quota: Record<string, unknown> };
+}
+
+/** Full desired-state spec including the mandatory owner. */
+export interface ClusterTenantSpec extends ClusterTenantCrSpecPatch
+{
+  owner: ClusterTenantOwner;
+}

--- a/apps/control-plane/src/core/cluster-tenants/cr-bridge.types.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-bridge.types.ts
@@ -1,7 +1,7 @@
 /** Org owner identity projected into the ClusterTenant CR `spec.owner`. */
 export interface ClusterTenantOwner
 {
-  /** The owner's OIDC subject (`sub`). */
+  /** The owner's OIDC subject (`sub`) — stable IdP-issued identifier, required. */
   subject: string;
   /** The owner's IdP-verified email; becomes the default Tenant's contact email. */
   email?: string;
@@ -14,15 +14,33 @@ export interface ClusterTenantOwner
  */
 export interface ClusterTenantCrSpecPatch
 {
+  /** Human-readable org display name shown in UIs and audit logs. */
   displayName: string;
+  /** Optional customer-vanity domain CNAMEd onto the derived `<org>.<base>` apex. */
   vanityDomain?: string;
+  /** Isolation tier (`shared` | `dedicatedNodes` | `dedicatedCluster`) driving the operator's boundary-provisioner selection. */
   isolationTier: string;
-  compute: { mode: string; nodePool?: string };
-  resources: { quota: Record<string, unknown> };
+  /** Compute placement: shared cluster or a dedicated node pool. */
+  compute: {
+    /** Compute mode: `shared` (multi-tenant pool) or `dedicated` (per-org node pool). */
+    mode: string;
+    /** Node-pool name when `mode` is `dedicated`; omitted/ignored otherwise. */
+    nodePool?: string;
+  };
+  /** Resource governance for the org's bound namespace. */
+  resources: {
+    /** Kubernetes `ResourceQuota` map (CPU, memory, storage, etc.) applied to the org namespace. */
+    quota: Record<string, unknown>;
+  };
 }
 
-/** Full desired-state spec including the mandatory owner. */
+/**
+ * Full desired-state spec — the patch shape extended with the mandatory owner.
+ * Used as the spec on a CREATE (every org has a single owner; the control plane
+ * 401s any create with no resolvable subject, so a CR is never born owner-less).
+ */
 export interface ClusterTenantSpec extends ClusterTenantCrSpecPatch
 {
+  /** Org owner identity — stamped on create, preserved across updates by the merge-patch path. */
   owner: ClusterTenantOwner;
 }

--- a/apps/control-plane/src/core/cluster-tenants/cr-status-reader.ts
+++ b/apps/control-plane/src/core/cluster-tenants/cr-status-reader.ts
@@ -1,0 +1,52 @@
+import * as k8s from "@kubernetes/client-node";
+import type { ClusterTenantObservedStatus } from "@opencrane/contracts";
+
+import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION } from "../../shared/crd-constants.js";
+
+/**
+ * Reader for the OBSERVED status the operator stamps on the cluster-scoped ClusterTenant CR.
+ *
+ * Separate from `cr-bridge.ts` on purpose: the bridge writes DESIRED state (`spec`) and never
+ * touches `status`; this module does the opposite — it READS the `status` subresource the
+ * operator owns. Keeping the read path out of the write-only bridge keeps each module's
+ * contract honest.
+ */
+
+/**
+ * Read the OBSERVED status the operator stamped on the cluster-scoped ClusterTenant CR.
+ *
+ * The control plane persists DESIRED state to Postgres and never writes status back; the
+ * operator advances `status.phase` (pending→provisioning→ready) on the CR's status
+ * subresource. The DB `phase` column therefore stays at its seeded `pending` forever, so
+ * the read path must consult the CR to report real provisioning progress (the
+ * onboarding poll otherwise never leaves `pending`).
+ *
+ * Returns null when no cluster is wired (`customApi` null), the CRD/CR is absent, or any
+ * read error — callers then fall back to the DB-derived status, preserving behaviour in
+ * non-cluster (dev/test) environments and never hard-failing the status endpoint on a
+ * transient cluster blip.
+ *
+ * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
+ * @param name - The org (ClusterTenant) name whose observed status to read.
+ */
+export async function _ReadClusterTenantObservedStatus(customApi: k8s.CustomObjectsApi | null, name: string): Promise<ClusterTenantObservedStatus | null>
+{
+  if (!customApi) return null;
+
+  try
+  {
+    const cr = await customApi.getClusterCustomObject({
+      group: OPENCRANE_API_GROUP,
+      version: OPENCRANE_API_VERSION,
+      plural: CLUSTER_TENANT_CRD_PLURAL,
+      name,
+    });
+    const status = (cr as { status?: ClusterTenantObservedStatus } | undefined)?.status;
+    return status && typeof status === "object" ? status : null;
+  }
+  catch
+  {
+    // No CRD / CR not found / cluster unreachable → caller falls back to the DB status.
+    return null;
+  }
+}

--- a/apps/control-plane/src/core/platform-dns/apply-dns-config.ts
+++ b/apps/control-plane/src/core/platform-dns/apply-dns-config.ts
@@ -1,5 +1,6 @@
 import * as k8s from "@kubernetes/client-node";
 
+import { _IsK8sConflict } from "../../shared/k8s-errors.js";
 import { _RenderDns01Issuer, _RenderDnsCredentialsSecret } from "./cluster-issuer.js";
 import type { CertIssuerKind, DnsProviderConfig } from "./cluster-issuer.types.js";
 import type { ApplyDnsConfigResult } from "./apply-dns-config.types.js";
@@ -96,7 +97,7 @@ async function _UpsertSecret(coreApi: k8s.CoreV1Api, namespace: string, name: st
   catch (err)
   {
     // 409 Conflict → the Secret exists; replace it so a rotated token takes effect.
-    if (_IsConflict(err))
+    if (_IsK8sConflict(err))
     {
       await coreApi.replaceNamespacedSecret({ name, namespace, body: manifest as unknown as k8s.V1Secret });
       return;
@@ -120,7 +121,7 @@ async function _UpsertClusterIssuer(customApi: k8s.CustomObjectsApi, name: strin
   catch (err)
   {
     // 409 Conflict → exists; fetch the live resourceVersion and replace.
-    if (_IsConflict(err))
+    if (_IsK8sConflict(err))
     {
       const existing = await customApi.getClusterCustomObject({ group: _CM_GROUP, version: _CM_VERSION, plural: _CM_CLUSTER_ISSUER_PLURAL, name });
       const resourceVersion = (existing as { metadata?: { resourceVersion?: string } }).metadata?.resourceVersion;
@@ -148,7 +149,7 @@ async function _UpsertNamespacedIssuer(customApi: k8s.CustomObjectsApi, namespac
   catch (err)
   {
     // 409 Conflict → exists; fetch the live resourceVersion and replace in-place.
-    if (_IsConflict(err))
+    if (_IsK8sConflict(err))
     {
       const existing = await customApi.getNamespacedCustomObject({ group: _CM_GROUP, version: _CM_VERSION, namespace, plural: _CM_ISSUER_PLURAL, name });
       const resourceVersion = (existing as { metadata?: { resourceVersion?: string } }).metadata?.resourceVersion;
@@ -160,12 +161,3 @@ async function _UpsertNamespacedIssuer(customApi: k8s.CustomObjectsApi, namespac
   }
 }
 
-/**
- * Detect a Kubernetes 409 Conflict (already-exists) across client error shapes.
- * @param err - The caught error.
- */
-function _IsConflict(err: unknown): boolean
-{
-  const code = (err as { code?: number; statusCode?: number; response?: { statusCode?: number } });
-  return code?.code === 409 || code?.statusCode === 409 || code?.response?.statusCode === 409;
-}

--- a/apps/control-plane/src/middleware/error-handler.ts
+++ b/apps/control-plane/src/middleware/error-handler.ts
@@ -7,14 +7,17 @@ import type { Logger } from "pino";
  *
  * Register this AFTER all routes so Express selects it only for errors.
  *
+ * `detail` is intentionally omitted from the response body — Prisma messages,
+ * stack traces, and ORM internals must never reach a client. The full error is
+ * still logged server-side for diagnostics.
+ *
  * @param log - Pino logger instance.
  */
 export function _ErrorHandler(log: Logger)
 {
   return function _handleError(err: unknown, req: Request, res: Response, _next: NextFunction): void
   {
-    const message = err instanceof Error ? err.message : String(err);
     log.error({ err, url: req.url, method: req.method }, "unhandled request error");
-    res.status(500).json({ error: "An unexpected error occurred", code: "INTERNAL_ERROR", detail: message });
+    res.status(500).json({ error: "An unexpected error occurred", code: "INTERNAL_ERROR" });
   };
 }

--- a/apps/control-plane/src/middleware/error-handler.ts
+++ b/apps/control-plane/src/middleware/error-handler.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
+import { Prisma } from "@prisma/client";
 import type { Logger } from "pino";
 
 /**
@@ -7,9 +8,10 @@ import type { Logger } from "pino";
  *
  * Register this AFTER all routes so Express selects it only for errors.
  *
- * `detail` is intentionally omitted from the response body — Prisma messages,
- * stack traces, and ORM internals must never reach a client. The full error is
- * still logged server-side for diagnostics.
+ * `detail` carries the raw error message in DEVELOPMENT only — handy without tailing logs.
+ * It is STRIPPED in production (`NODE_ENV=production`) so Prisma messages, stack traces, and
+ * ORM internals never reach a client there. Callers MUST always branch on `code`, never on a
+ * human message or `detail`.
  *
  * @param log - Pino logger instance.
  */
@@ -17,7 +19,23 @@ export function _ErrorHandler(log: Logger)
 {
   return function _handleError(err: unknown, req: Request, res: Response, _next: NextFunction): void
   {
+    // The full error (incl. Prisma/stack) always goes to the server log.
     log.error({ err, url: req.url, method: req.method }, "unhandled request error");
-    res.status(500).json({ error: "An unexpected error occurred", code: "INTERNAL_ERROR" });
+
+    // Safety net: a Prisma unique-constraint violation (P2002) that a route did not map is
+    // a client conflict, not a server error — return a clean 409 (no detail, any env) so the
+    // ORM message can never leak through the generic 500 path. Routes SHOULD still catch P2002
+    // themselves for a domain-specific message (e.g. POST /cluster-tenants → "workspace name").
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002")
+    {
+      res.status(409).json({ error: "A resource with these unique values already exists.", code: "CONFLICT" });
+      return;
+    }
+
+    // Generic 500. `detail` is included in development only and STRIPPED in production, so
+    // Prisma/stack internals never reach a client there.
+    const body: Record<string, string> = { error: "An unexpected error occurred", code: "INTERNAL_ERROR" };
+    if (process.env["NODE_ENV"] !== "production") body["detail"] = err instanceof Error ? err.message : String(err);
+    res.status(500).json(body);
   };
 }

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -1407,6 +1407,7 @@ export const spec = {
           400: badRequest("Request body failed validation."),
           401: unauthorized("No authenticated session (real-auth deployments)."),
           403: forbidden("Caller has no billing account (code BILLING_ACCOUNT_REQUIRED)."),
+          409: conflict("A workspace with this name already exists (code CONFLICT)."),
           422: unprocessable("Requested isolation tier is not served by any registered provisioner (code TIER_UNAVAILABLE)."),
         },
       },

--- a/apps/control-plane/src/routes/cluster-tenants.service.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.service.ts
@@ -1,9 +1,8 @@
 import { ClusterTenantComputeMode, ClusterTenantIsolationTier, ClusterTenantPhase } from "@opencrane/contracts";
-import type { ClusterTenant, ClusterTenantResourceQuota } from "@opencrane/contracts";
+import type { ClusterTenant, ClusterTenantObservedStatus, ClusterTenantResourceQuota, ClusterTenantStatus } from "@opencrane/contracts";
 import type { Prisma, PrismaClient } from "@prisma/client";
 
 import type { ClusterTenantComputeInput, ClusterTenantResourcesInput } from "./cluster-tenants.models.js";
-import type { ClusterTenantObservedStatus } from "../core/cluster-tenants/cr-bridge.js";
 
 /** A cluster_tenants row as read back from Prisma (subset consumed here). */
 type ClusterTenantRow = Prisma.ClusterTenantGetPayload<Record<string, never>>;
@@ -65,7 +64,7 @@ export function _FromPrismaPhase(value: string): ClusterTenantPhase
  * @param observed - The status subresource read from the ClusterTenant CR.
  * @returns The contract status reflecting real provisioning progress.
  */
-export function _ObservedStatusToContract(observed: ClusterTenantObservedStatus): ClusterTenant["status"]
+export function _ObservedStatusToContract(observed: ClusterTenantObservedStatus): ClusterTenantStatus
 {
   return {
     phase: _FromPrismaPhase(observed.phase ?? "pending"),

--- a/apps/control-plane/src/routes/cluster-tenants.service.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.service.ts
@@ -1,8 +1,9 @@
 import { ClusterTenantComputeMode, ClusterTenantIsolationTier, ClusterTenantPhase } from "@opencrane/contracts";
 import type { ClusterTenant, ClusterTenantResourceQuota } from "@opencrane/contracts";
-import type { Prisma } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 
 import type { ClusterTenantComputeInput, ClusterTenantResourcesInput } from "./cluster-tenants.models.js";
+import type { ClusterTenantObservedStatus } from "../core/cluster-tenants/cr-bridge.js";
 
 /** A cluster_tenants row as read back from Prisma (subset consumed here). */
 type ClusterTenantRow = Prisma.ClusterTenantGetPayload<Record<string, never>>;
@@ -50,6 +51,66 @@ export function _FromPrismaPhase(value: string): ClusterTenantPhase
     case "ready": return ClusterTenantPhase.Ready;
     case "failed": return ClusterTenantPhase.Failed;
     default: return ClusterTenantPhase.Pending;
+  }
+}
+
+/**
+ * Map the operator's OBSERVED CR status into the contract status shape.
+ *
+ * Used by the read path to surface the live phase the operator stamped on the CR
+ * (which the DB `phase` column never receives) instead of the seeded `pending`. The
+ * phase string uses the same tokens as the DB column, so {@link _FromPrismaPhase}
+ * maps it identically.
+ *
+ * @param observed - The status subresource read from the ClusterTenant CR.
+ * @returns The contract status reflecting real provisioning progress.
+ */
+export function _ObservedStatusToContract(observed: ClusterTenantObservedStatus): ClusterTenant["status"]
+{
+  return {
+    phase: _FromPrismaPhase(observed.phase ?? "pending"),
+    ...(observed.message ? { message: observed.message } : {}),
+    ...(observed.boundNamespace ? { boundNamespace: observed.boundNamespace } : {}),
+    ...(observed.provisioner ? { provisioner: observed.provisioner } : {}),
+  };
+}
+
+/**
+ * Mirror the operator's observed CR status back into the `cluster_tenants` row (read-repair).
+ *
+ * Approach A2 reads the live phase from the CR, but the DB column stays stale, so the fleet
+ * LIST endpoint (and any other DB reader) would still show `pending`. Writing the observed
+ * status back on read converges the DB to the truth the operator stamped — without the
+ * operator needing DB access. The phase tokens match the column's, so they persist verbatim.
+ *
+ * Idempotent and side-effect-safe: skips the write when nothing changed (no write amplification
+ * once converged), and swallows write errors so a DB hiccup never fails the status read.
+ *
+ * @param prisma - Prisma client.
+ * @param row - The currently persisted row (used to diff before writing).
+ * @param observed - The observed status read from the CR.
+ */
+export async function _SyncObservedStatusToDb(prisma: PrismaClient, row: ClusterTenantRow, observed: ClusterTenantObservedStatus): Promise<void>
+{
+  const phase = observed.phase ?? "pending";
+  const message = observed.message ?? null;
+  const boundNamespace = observed.boundNamespace ?? null;
+  const provisioner = observed.provisioner ?? null;
+
+  // No delta → nothing to mirror (avoids a write on every poll once the org has converged).
+  if (row.phase === phase && row.message === message && row.boundNamespace === boundNamespace && row.provisioner === provisioner)
+  {
+    return;
+  }
+
+  try
+  {
+    await prisma.clusterTenant.update({ where: { name: row.name }, data: { phase, message, boundNamespace, provisioner } });
+  }
+  catch
+  {
+    // Best-effort mirror: the authoritative read already used the observed status, so a
+    // transient DB write failure must not fail the status endpoint.
   }
 }
 

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -3,7 +3,7 @@ import type { Request } from "express";
 import * as k8s from "@kubernetes/client-node";
 import { ClusterTenantPhase, ClusterTenantTierUnavailableCode } from "@opencrane/contracts";
 import type { ClusterTenantProvisionerRegistry } from "@opencrane/contracts";
-import type { Prisma, PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 
 import type { ClusterTenantCreateRequest, ClusterTenantUpdateRequest } from "./cluster-tenants.models.js";
 import { _IsIsolationTier, _ToContract, _ToPrismaCompute, _ToPrismaTier, _ValidateCompute, _ValidateResources } from "./cluster-tenants.service.js";
@@ -145,30 +145,44 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     //    NOTE (provisioning hand-off): the ClusterTenant operator/CR watcher reconciles
     //    `pending` → `ready` and drives the domain provisioner. This handler only
     //    persists the desired state; it performs no cluster-side side effects.
-    const created = await prisma.$transaction(async function _createOrgWithOwner(tx)
+    // eslint-disable-next-line prefer-const
+    let created: Prisma.ClusterTenantGetPayload<object>;
+    try
     {
-      const org = await tx.clusterTenant.create({
-        data: {
-          name: body.name.trim(),
-          displayName: body.displayName.trim(),
-          vanityDomain: body.vanityDomain?.trim() || null,
-          isolationTier: _ToPrismaTier(body.isolationTier),
-          computeMode: _ToPrismaCompute(body.compute.mode),
-          nodePool: body.compute.nodePool?.trim() || null,
-          quota: (body.resources.quota as Prisma.InputJsonValue),
-          phase: ClusterTenantPhase.Pending,
-        },
-      });
+      created = await prisma.$transaction(async function _createOrgWithOwner(tx)
+      {
+        const org = await tx.clusterTenant.create({
+          data: {
+            name: body.name.trim(),
+            displayName: body.displayName.trim(),
+            vanityDomain: body.vanityDomain?.trim() || null,
+            isolationTier: _ToPrismaTier(body.isolationTier),
+            computeMode: _ToPrismaCompute(body.compute.mode),
+            nodePool: body.compute.nodePool?.trim() || null,
+            quota: (body.resources.quota as Prisma.InputJsonValue),
+            phase: ClusterTenantPhase.Pending,
+          },
+        });
 
-      // The creator is the org's single `owner` (one-owner-per-org is enforced by the
-      // partial unique index). Written in the same tx so an org can never exist
-      // without its owner, and vice versa.
-      await tx.orgMembership.create({
-        data: { clusterTenant: org.name, subject: ownerSubject, role: "Owner" },
-      });
+        // The creator is the org's single `owner` (one-owner-per-org is enforced by the
+        // partial unique index). Written in the same tx so an org can never exist
+        // without its owner, and vice versa.
+        await tx.orgMembership.create({
+          data: { clusterTenant: org.name, subject: ownerSubject, role: "Owner" },
+        });
 
-      return org;
-    });
+        return org;
+      });
+    }
+    catch (err)
+    {
+      if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002")
+      {
+        res.status(409).json({ error: "A workspace with this name already exists.", code: "CONFLICT" });
+        return;
+      }
+      throw err;
+    }
 
     // 5. DB → K8s bridge. Project the persisted desired state into the cluster-scoped
     //    `clustertenants` CR the ClusterTenant reconciler watches. This is the seam

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -6,10 +6,10 @@ import type { ClusterTenantProvisionerRegistry } from "@opencrane/contracts";
 import { Prisma, type PrismaClient } from "@prisma/client";
 
 import type { ClusterTenantCreateRequest, ClusterTenantUpdateRequest } from "./cluster-tenants.models.js";
-import { _IsIsolationTier, _ToContract, _ToPrismaCompute, _ToPrismaTier, _ValidateCompute, _ValidateResources } from "./cluster-tenants.service.js";
+import { _IsIsolationTier, _ObservedStatusToContract, _SyncObservedStatusToDb, _ToContract, _ToPrismaCompute, _ToPrismaTier, _ValidateCompute, _ValidateResources } from "./cluster-tenants.service.js";
 import { _IsDevAuthMode } from "../infra/auth/auth-mode.js";
 import { _RequireBillingAccountForOrgCreate, _RequireOrgManager } from "../infra/middleware/cluster-tenant-org-admin.js";
-import { _ApplyClusterTenantCr, _DeleteClusterTenantCr } from "../core/cluster-tenants/cr-bridge.js";
+import { _ApplyClusterTenantCr, _DeleteClusterTenantCr, _ReadClusterTenantObservedStatus } from "../core/cluster-tenants/cr-bridge.js";
 
 /** RFC-1123-ish DNS domain: lowercase labels, ≥1 dot, alpha TLD, ≤253 chars. */
 const _VANITY_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
@@ -61,7 +61,18 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
       res.status(404).json({ error: "Cluster tenant not found", code: "CLUSTER_TENANT_NOT_FOUND" });
       return;
     }
-    res.json(_ToContract(row));
+    const contract = _ToContract(row);
+    // Overlay the operator's OBSERVED phase from the CR: the DB column is desired-only and
+    // never receives the operator's status write-back, so it stays `pending`. Falls back to
+    // the DB-derived status when no cluster/CR is available. Mirror it back to the DB
+    // (read-repair) so the fleet list and other DB readers converge too.
+    const observed = await _ReadClusterTenantObservedStatus(customApi, req.params.name);
+    if (observed)
+    {
+      await _SyncObservedStatusToDb(prisma, row, observed);
+      contract.status = _ObservedStatusToContract(observed);
+    }
+    res.json(contract);
   });
 
   /** Get just the observed status of a cluster tenant (operator OR owner/admin of that org). */
@@ -71,6 +82,17 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     if (!row)
     {
       res.status(404).json({ error: "Cluster tenant not found", code: "CLUSTER_TENANT_NOT_FOUND" });
+      return;
+    }
+    // Read the operator's observed phase from the CR (the source of truth for provisioning
+    // progress); fall back to the DB-derived status when no cluster/CR is available. Without
+    // this the onboarding poll never advances past the seeded `pending`. Mirror the observed
+    // status back to the DB (read-repair) so the fleet list and other DB readers converge.
+    const observed = await _ReadClusterTenantObservedStatus(customApi, req.params.name);
+    if (observed)
+    {
+      await _SyncObservedStatusToDb(prisma, row, observed);
+      res.json(_ObservedStatusToContract(observed));
       return;
     }
     res.json(_ToContract(row).status);

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -9,7 +9,8 @@ import type { ClusterTenantCreateRequest, ClusterTenantUpdateRequest } from "./c
 import { _IsIsolationTier, _ObservedStatusToContract, _SyncObservedStatusToDb, _ToContract, _ToPrismaCompute, _ToPrismaTier, _ValidateCompute, _ValidateResources } from "./cluster-tenants.service.js";
 import { _IsDevAuthMode } from "../infra/auth/auth-mode.js";
 import { _RequireBillingAccountForOrgCreate, _RequireOrgManager } from "../infra/middleware/cluster-tenant-org-admin.js";
-import { _ApplyClusterTenantCr, _DeleteClusterTenantCr, _ReadClusterTenantObservedStatus } from "../core/cluster-tenants/cr-bridge.js";
+import { _ApplyClusterTenantCr, _DeleteClusterTenantCr } from "../core/cluster-tenants/cr-bridge.js";
+import { _ReadClusterTenantObservedStatus } from "../core/cluster-tenants/cr-status-reader.js";
 
 /** RFC-1123-ish DNS domain: lowercase labels, ≥1 dot, alpha TLD, ≤253 chars. */
 const _VANITY_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
@@ -18,6 +19,37 @@ const _VANITY_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])
 function _isValidVanityDomain(value: string): boolean
 {
   return _VANITY_DOMAIN_PATTERN.test(value);
+}
+
+/** A `cluster_tenants` row as returned by Prisma `findUnique`. */
+type ClusterTenantRow = NonNullable<Awaited<ReturnType<PrismaClient["clusterTenant"]["findUnique"]>>>;
+
+/**
+ * Read the org's OBSERVED status from its CR and map it to the contract status, kicking off
+ * a best-effort read-repair of the DB row WITHOUT blocking the response.
+ *
+ * Both `GET /:name` and `GET /:name/status` need the same thing: the DB `phase` column is
+ * desired-only and never receives the operator's status write-back, so it stays `pending` —
+ * the live phase lives on the CR. This consolidates that read (DRY) and returns null when no
+ * cluster/CR is available so callers fall back to the DB-derived status.
+ *
+ * The DB mirror (`_SyncObservedStatusToDb`) is fire-and-forget: it is a convergence nicety
+ * for other DB readers (the fleet LIST), not part of answering this request — the response is
+ * built from `observed` regardless of whether the write lands. Awaiting it would tax every
+ * onboarding poll with a DB-write round-trip for no correctness gain. It swallows its own
+ * errors internally; the `.catch` is a final guard against an unhandled rejection.
+ *
+ * @param prisma - Prisma client (for the read-repair write).
+ * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
+ * @param row - The persisted org row (diffed before any mirror write).
+ * @returns The contract status from the CR, or null to fall back to the DB-derived status.
+ */
+async function _ReadObservedStatus(prisma: PrismaClient, customApi: k8s.CustomObjectsApi | null, row: ClusterTenantRow): Promise<NonNullable<ReturnType<typeof _ObservedStatusToContract>> | null>
+{
+  const observed = await _ReadClusterTenantObservedStatus(customApi, row.name);
+  if (!observed) return null;
+  void _SyncObservedStatusToDb(prisma, row, observed).catch(() => { /* best-effort mirror */ });
+  return _ObservedStatusToContract(observed);
 }
 
 /**
@@ -62,16 +94,10 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
       return;
     }
     const contract = _ToContract(row);
-    // Overlay the operator's OBSERVED phase from the CR: the DB column is desired-only and
-    // never receives the operator's status write-back, so it stays `pending`. Falls back to
-    // the DB-derived status when no cluster/CR is available. Mirror it back to the DB
-    // (read-repair) so the fleet list and other DB readers converge too.
-    const observed = await _ReadClusterTenantObservedStatus(customApi, req.params.name);
-    if (observed)
-    {
-      await _SyncObservedStatusToDb(prisma, row, observed);
-      contract.status = _ObservedStatusToContract(observed);
-    }
+    // Overlay the operator's OBSERVED phase from the CR (the DB column stays `pending`);
+    // falls back to the DB-derived status when no cluster/CR is available.
+    const observed = await _ReadObservedStatus(prisma, customApi, row);
+    if (observed) contract.status = observed;
     res.json(contract);
   });
 
@@ -85,17 +111,10 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
       return;
     }
     // Read the operator's observed phase from the CR (the source of truth for provisioning
-    // progress); fall back to the DB-derived status when no cluster/CR is available. Without
-    // this the onboarding poll never advances past the seeded `pending`. Mirror the observed
-    // status back to the DB (read-repair) so the fleet list and other DB readers converge.
-    const observed = await _ReadClusterTenantObservedStatus(customApi, req.params.name);
-    if (observed)
-    {
-      await _SyncObservedStatusToDb(prisma, row, observed);
-      res.json(_ObservedStatusToContract(observed));
-      return;
-    }
-    res.json(_ToContract(row).status);
+    // progress); without it the onboarding poll never advances past the seeded `pending`.
+    // Fall back to the DB-derived status when no cluster/CR is available.
+    const observed = await _ReadObservedStatus(prisma, customApi, row);
+    res.json(observed ?? _ToContract(row).status);
   });
 
   /**

--- a/apps/control-plane/src/routes/platform-dns.ts
+++ b/apps/control-plane/src/routes/platform-dns.ts
@@ -4,6 +4,7 @@ import * as k8s from "@kubernetes/client-node";
 import { _ApplyPlatformDnsConfig } from "../core/platform-dns/apply-dns-config.js";
 import { _DnsProviderConfigError } from "../core/platform-dns/cluster-issuer.js";
 import type { CertIssuerKind } from "../core/platform-dns/cluster-issuer.types.js";
+import { _IsK8sNotFound } from "../shared/k8s-errors.js";
 import type { PlatformDnsStatus } from "./platform-dns.types.js";
 
 /** Default issuer name when the request omits one. */
@@ -130,7 +131,7 @@ export function platformDnsRouter(customApi: k8s.CustomObjectsApi, coreApi: k8s.
         // Only a 404 (issuer absent / cert-manager CRD not installed) means
         // "unconfigured" — propagate auth/permission/server errors instead of
         // masking them as a clean not-configured response.
-        if (_IsNotFound(lookupErr))
+        if (_IsK8sNotFound(lookupErr))
         {
           res.json({ configured: false, issuerName, issuerKind, issuerNamespace, provider: null, email: null, server: null } satisfies PlatformDnsStatus);
           return;
@@ -149,15 +150,6 @@ export function platformDnsRouter(customApi: k8s.CustomObjectsApi, coreApi: k8s.
   return router;
 }
 
-/**
- * Detect a Kubernetes 404 Not Found across the client's error shapes.
- * @param err - The caught error.
- */
-function _IsNotFound(err: unknown): boolean
-{
-  const e = err as { code?: number; statusCode?: number; response?: { statusCode?: number } };
-  return e?.code === 404 || e?.statusCode === 404 || e?.response?.statusCode === 404;
-}
 
 /**
  * Extract a non-secret status summary from an issuer custom resource.

--- a/apps/control-plane/src/routes/tenants.ts
+++ b/apps/control-plane/src/routes/tenants.ts
@@ -8,6 +8,7 @@ import { compile } from "../core/grants/grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "../core/grants/grant-compiler.types.js";
 import { _CutTenant } from "../core/connections/cut-tenant.js";
 import type { OpenClawGatewayAdmin } from "../core/connections/gateway-admin.types.js";
+import { _IsK8sNotFound } from "../shared/k8s-errors.js";
 
 import type { CreateTenantRequest, TenantDatasetsResponse, TenantResponse, UpdateTenantDatasetsRequest } from "../types.js";
 import type { EffectiveContractResponse } from "./tenants.types.js";
@@ -721,25 +722,6 @@ function _IsStringArray(value: unknown[]): value is string[]
   });
 }
 
-/**
- * Check whether an unknown Kubernetes client error represents a not-found response.
- * @param error - Unknown thrown error from Kubernetes client calls.
- */
-function _IsKubernetesNotFoundError(error: unknown): boolean
-{
-  if (typeof error !== "object" || error === null)
-  {
-    return false;
-  }
-
-  const errorObject = error as {
-    statusCode?: number;
-    response?: { statusCode?: number };
-    body?: { code?: number };
-  };
-  const statusCode = errorObject.statusCode ?? errorObject.response?.statusCode ?? errorObject.body?.code;
-  return statusCode === 404;
-}
 
 /**
  * Wait until a newly-created tenant becomes observable as a Tenant CR.
@@ -775,7 +757,7 @@ async function _WaitForTenantCrAppearance(
     }
     catch (error)
     {
-      if (!_IsKubernetesNotFoundError(error))
+      if (!_IsK8sNotFound(error))
       {
         throw error;
       }

--- a/apps/control-plane/src/shared/k8s-errors.ts
+++ b/apps/control-plane/src/shared/k8s-errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Whether a Kubernetes API error carries a given numeric status code.
+ *
+ * The @kubernetes/client-node library surfaces HTTP failures in at least three
+ * shapes (`statusCode`, `code`, `body.code`); this helper normalises them.
+ */
+export function _IsK8sStatus(err: unknown, code: number): boolean
+{
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { statusCode?: unknown; code?: unknown; body?: { code?: unknown }; response?: { statusCode?: unknown } };
+  if (e.statusCode === code || e.code === code) return true;
+  if (e.response && (e.response as { statusCode?: unknown }).statusCode === code) return true;
+  return typeof e.body === "object" && e.body !== null && (e.body as { code?: unknown }).code === code;
+}
+
+/** Whether the error is a Kubernetes 404 NotFound. */
+export function _IsK8sNotFound(err: unknown): boolean
+{
+  return _IsK8sStatus(err, 404);
+}
+
+/** Whether the error is a Kubernetes 409 AlreadyExists / Conflict. */
+export function _IsK8sConflict(err: unknown): boolean
+{
+  return _IsK8sStatus(err, 409);
+}

--- a/apps/operator/src/__tests__/cluster-tenants/operator.test.ts
+++ b/apps/operator/src/__tests__/cluster-tenants/operator.test.ts
@@ -13,19 +13,29 @@ const log = pino({ level: "silent" });
 /** Recorded status-patch body so a test can read what the reconciler stamped. */
 type StatusPatch = Record<string, unknown>;
 
+/** A recorded default-Tenant seed (the body passed to createNamespacedCustomObject). */
+interface SeededTenant { name: string; namespace: string; email: string; clusterTenantRef: string }
+
 /**
  * Build a stub CustomObjectsApi that records the merged status value from each
  * `patchClusterCustomObjectStatus` call (JSON Patch `add /status`), plus a spy.
+ * Also records each default-Tenant seed via `createNamespacedCustomObject` so the
+ * owner-resolution path can be asserted.
  */
-function _makeStubCustomApi(): { api: k8s.CustomObjectsApi; patches: StatusPatch[]; spy: ReturnType<typeof vi.fn> }
+function _makeStubCustomApi(): { api: k8s.CustomObjectsApi; patches: StatusPatch[]; spy: ReturnType<typeof vi.fn>; seeds: SeededTenant[] }
 {
   const patches: StatusPatch[] = [];
+  const seeds: SeededTenant[] = [];
   const spy = vi.fn(async function _patch(args: { body: Array<{ value: StatusPatch }> })
   {
     patches.push(args.body[0].value);
   });
-  const api = { patchClusterCustomObjectStatus: spy } as unknown as k8s.CustomObjectsApi;
-  return { api, patches, spy };
+  const createNamespacedCustomObject = vi.fn(async function _seed(args: { namespace: string; body: { metadata: { name: string }; spec: { email: string; clusterTenantRef: string } } })
+  {
+    seeds.push({ name: args.body.metadata.name, namespace: args.namespace, email: args.body.spec.email, clusterTenantRef: args.body.spec.clusterTenantRef });
+  });
+  const api = { patchClusterCustomObjectStatus: spy, createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+  return { api, patches, spy, seeds };
 }
 
 /**
@@ -270,6 +280,73 @@ describe("ClusterTenantOperator.reconcile", () =>
     // 3 events while one was in flight → exactly 2 reconciles (the in-flight one + one
     // coalesced drain), never 3. This is what bounds in-flight work and prevents the OOM.
     expect(calls).toEqual(["acme", "acme"]);
+  });
+});
+
+describe("ClusterTenantOperator default-tenant seed (owner resolution)", () =>
+{
+  beforeEach(() => vi.clearAllMocks());
+
+  it("seeds the default Tenant from spec.owner.email when the org reaches ready", async () =>
+  {
+    const { api: customApi, seeds } = _makeStubCustomApi();
+    const { api: coreApi } = _makeStubCoreApi();
+    const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
+    const operator = _buildOperator(customApi, coreApi, provisioner);
+
+    const ct = _makeClusterTenant("acme");
+    ct.spec.owner = { subject: "auth0|abc", email: "owner@acme.example" };
+    await operator.reconcile(ct);
+
+    expect(seeds).toHaveLength(1);
+    expect(seeds[0].name).toBe("acme-default");
+    expect(seeds[0].email).toBe("owner@acme.example");
+    expect(seeds[0].clusterTenantRef).toBe("acme");
+  });
+
+  it("falls back to the legacy owner-email annotation for a CR with no spec.owner (rollout safety)", async () =>
+  {
+    const { api: customApi, seeds } = _makeStubCustomApi();
+    const { api: coreApi } = _makeStubCoreApi();
+    const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
+    const operator = _buildOperator(customApi, coreApi, provisioner);
+
+    const ct = _makeClusterTenant("legacy");
+    ct.metadata!.annotations = { "opencrane.io/owner-email": "legacy@acme.example" };
+    await operator.reconcile(ct);
+
+    expect(seeds).toHaveLength(1);
+    expect(seeds[0].email).toBe("legacy@acme.example");
+  });
+
+  it("prefers spec.owner.email over the legacy annotation when both are present", async () =>
+  {
+    const { api: customApi, seeds } = _makeStubCustomApi();
+    const { api: coreApi } = _makeStubCoreApi();
+    const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
+    const operator = _buildOperator(customApi, coreApi, provisioner);
+
+    const ct = _makeClusterTenant("acme");
+    ct.spec.owner = { subject: "auth0|abc", email: "spec@acme.example" };
+    ct.metadata!.annotations = { "opencrane.io/owner-email": "annotation@acme.example" };
+    await operator.reconcile(ct);
+
+    expect(seeds[0].email).toBe("spec@acme.example");
+  });
+
+  it("skips the seed (org still ready) when no owner email is resolvable — dev-auth path", async () =>
+  {
+    const { api: customApi, seeds, patches } = _makeStubCustomApi();
+    const { api: coreApi } = _makeStubCoreApi();
+    const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
+    const operator = _buildOperator(customApi, coreApi, provisioner);
+
+    const ct = _makeClusterTenant("devorg");
+    ct.spec.owner = { subject: "dev-local-subject" }; // subject only, no email
+    await operator.reconcile(ct);
+
+    expect(seeds).toHaveLength(0);                 // nothing seeded without an email
+    expect(patches.at(-1)!.phase).toBe("ready");   // but the org is not wedged out of ready
   });
 });
 

--- a/apps/operator/src/cluster-tenants/operator.ts
+++ b/apps/operator/src/cluster-tenants/operator.ts
@@ -15,12 +15,12 @@ import type { OrgDomainProvisioner } from "./internal/org-domain-provisioner.typ
 import { _BuildOrgDomainProvisioner } from "./internal/org-domain.provisioner.factory.js";
 
 /**
- * Annotation the control plane stamps with the org owner's IdP-verified email.
- * Mirrors `_OWNER_EMAIL_ANNOTATION` in the control plane's `cr-bridge.ts` — the
- * operator has no DB access, so the CR annotation is the only channel for the
- * owner identity the default Tenant is attributed to.
+ * Legacy annotation the control plane used to stamp with the org owner's email,
+ * before owner identity moved to the validated `spec.owner` field. Read only as a
+ * fallback so CRs created by an older control plane (not yet backfilled) still seed
+ * their default Tenant during rollout; new CRs carry `spec.owner` instead.
  */
-const _OWNER_EMAIL_ANNOTATION = "opencrane.io/owner-email";
+const _LEGACY_OWNER_EMAIL_ANNOTATION = "opencrane.io/owner-email";
 
 /** Suffix appended to an org's name to form its auto-seeded first workspace Tenant. */
 const _DEFAULT_TENANT_SUFFIX = "-default";
@@ -327,19 +327,21 @@ export class ClusterTenantOperator
    * other Tenant CR). Fail-soft: any other error is logged but never thrown, so a seed
    * hiccup cannot wedge the org out of `ready`; the next reconcile retries.
    *
-   * The owner's email arrives only via the CR's {@link _OWNER_EMAIL_ANNOTATION} (the
-   * operator has no DB access). When it is absent — an org created before the annotation
-   * existed, or via the dev-auth path with no email — the seed is skipped with a warning.
+   * The owner's email arrives via the CR's `spec.owner.email` (the operator has no DB
+   * access), falling back to the legacy `opencrane.io/owner-email` annotation for CRs an
+   * older control plane created before the field existed. When it is absent — the dev-auth
+   * path carries only a subject, no email — the seed is skipped with a warning.
    *
    * @param clusterTenant - The ready ClusterTenant whose default Tenant is ensured.
    */
   private async ensureDefaultTenant(clusterTenant: ClusterTenantResource): Promise<void>
   {
     const orgName = clusterTenant.metadata!.name!;
-    const ownerEmail = clusterTenant.metadata?.annotations?.[_OWNER_EMAIL_ANNOTATION]?.trim();
+    const ownerEmail = clusterTenant.spec.owner?.email?.trim()
+      || clusterTenant.metadata?.annotations?.[_LEGACY_OWNER_EMAIL_ANNOTATION]?.trim();
     if (!ownerEmail)
     {
-      this.log.warn({ name: orgName }, "no owner-email annotation on cluster tenant; skipping default tenant seed");
+      this.log.warn({ name: orgName }, "no owner email on cluster tenant (spec.owner.email / legacy annotation both absent); skipping default tenant seed");
       return;
     }
 

--- a/apps/operator/src/tenants/internal/cluster-tenant-resolution.types.ts
+++ b/apps/operator/src/tenants/internal/cluster-tenant-resolution.types.ts
@@ -54,6 +54,17 @@ export interface ClusterTenantResource extends KubernetesObject
       /** Aggregate quota enforced over the customer's namespace. */
       quota?: ClusterTenantQuotaView;
     };
+    /**
+     * Org owner identity, projected by the control plane (the IAM authority) as first-class
+     * desired state. The operator attributes the org's auto-seeded default Tenant to this
+     * owner; it has no DB access, so the CR spec is the only channel for the owner identity.
+     */
+    owner?: {
+      /** The owner's OIDC subject (`sub`). */
+      subject?: string;
+      /** The owner's IdP-verified email; becomes the default Tenant's contact email. */
+      email?: string;
+    };
   };
 
   /** Observed state; absent until first reconciled by the control plane. */

--- a/libs/contracts/src/cluster-tenant.types.ts
+++ b/libs/contracts/src/cluster-tenant.types.ts
@@ -78,6 +78,28 @@ export interface ClusterTenantStatus
 }
 
 /**
+ * Raw observed status as read straight off the ClusterTenant CR's status subresource —
+ * the canonical shape the operator stamps and the control plane reads back.
+ *
+ * Distinct from {@link ClusterTenantStatus}: `phase` is the raw CR string (not yet mapped
+ * to the {@link ClusterTenantPhase} enum) and every field is optional, because a CR may be
+ * observed mid-reconcile with only a partial status. The control-plane read path maps this
+ * into {@link ClusterTenantStatus} for the API response. Defined once here so the operator
+ * writer and the control-plane reader cannot drift apart.
+ */
+export interface ClusterTenantObservedStatus
+{
+  /** Current lifecycle phase the operator observed (pending|provisioning|ready|failed). */
+  phase?: string;
+  /** Human-readable detail, set on failure or transitional states. */
+  message?: string;
+  /** Namespace the operator bound to this customer once provisioned. */
+  boundNamespace?: string;
+  /** Identifier of the provisioner that owns this customer's boundary. */
+  provisioner?: string;
+}
+
+/**
  * Shared API contract for a cluster tenant — the first-class customer / isolation
  * unit that sits above the `Tenant`/openclaw CRD. The control plane emits this
  * shape; the operator reconciles attached openclaws into the bound namespace.

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -3390,6 +3390,15 @@ export interface operations {
                     "application/json": components["schemas"]["Error"];
                 };
             };
+            /** @description A workspace with this name already exists (code CONFLICT). */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
             /** @description Requested isolation tier is not served by any registered provisioner (code TIER_UNAVAILABLE). */
             422: {
                 headers: {

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -10,6 +10,7 @@ export {
   type ClusterTenantProvisionResult,
   type ClusterTenantProvisionerCapability,
   type ClusterTenantProvisionerRegistry,
+  type ClusterTenantObservedStatus,
   type ClusterTenantResourceQuota,
   type ClusterTenantResources,
   type ClusterTenantStatus,

--- a/platform/helm/crds/opencrane.io_clustertenants.yaml
+++ b/platform/helm/crds/opencrane.io_clustertenants.yaml
@@ -84,6 +84,28 @@ spec:
                           type: integer
                           minimum: 0
                           description: Total GPUs the customer may request.
+                owner:
+                  type: object
+                  required: [subject]
+                  description: >-
+                    Identity of the org's root owner, resolved by the control plane (the
+                    IAM authority) at create time and projected here as first-class desired
+                    state. The operator attributes the org's auto-seeded default Tenant to
+                    this owner; it has no database access, so the CR spec is the only channel
+                    for the owner identity. Presence is enforced by the control plane (which
+                    rejects an org create with no resolvable subject), not by CRD admission,
+                    so status writes on pre-existing CRs are never blocked by this field.
+                  properties:
+                    subject:
+                      type: string
+                      minLength: 1
+                      description: The owner's OIDC subject (`sub`).
+                    email:
+                      type: string
+                      description: >-
+                        The owner's IdP-verified email; becomes the default Tenant's contact
+                        email. Absent on the dev-auth path, where only the synthetic subject
+                        is carried (the default-Tenant seed is then skipped).
             status:
               type: object
               properties:
@@ -99,6 +121,15 @@ spec:
                 lastReconciled:
                   type: string
                   format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+                  description: >-
+                    metadata.generation the operator last drove to ready. The reconcile-skip
+                    guard compares this against metadata.generation so an unchanged, already-
+                    ready CR is not re-provisioned on every watch replay. MUST be present in
+                    the schema or the API server prunes it from status writes, defeating the
+                    guard and re-provisioning every org on each watch reconnect.
       additionalPrinterColumns:
         - name: Display Name
           type: string

--- a/platform/helm/templates/cluster-issuer.yaml
+++ b/platform/helm/templates/cluster-issuer.yaml
@@ -105,7 +105,10 @@ spec:
   dnsNames:
     - {{ printf "*.%s" .Values.ingress.domain | quote }}
     - {{ .Values.ingress.domain | quote }}
-    - {{ .Values.ingress.controlPlaneHost | default (printf "platform.%s" .Values.ingress.domain) | quote }}
+    {{- $cpHost := .Values.ingress.controlPlaneHost | default (printf "platform.%s" .Values.ingress.domain) -}}
+    {{- if and (ne $cpHost .Values.ingress.domain) (not (hasSuffix (printf ".%s" .Values.ingress.domain) $cpHost)) }}
+    - {{ $cpHost | quote }}
+    {{- end }}
 {{- else }}
 {{- /* Namespaced mode: a per-instance-namespace Issuer + wildcard Certificate. */ -}}
 {{- $namespaces := include "opencrane.instanceNamespaces" . | fromJsonArray }}
@@ -178,7 +181,10 @@ spec:
   dnsNames:
     - {{ printf "*.%s" $.Values.ingress.domain | quote }}
     - {{ $.Values.ingress.domain | quote }}
-    - {{ $.Values.ingress.controlPlaneHost | default (printf "platform.%s" $.Values.ingress.domain) | quote }}
+    {{- $cpHost := $.Values.ingress.controlPlaneHost | default (printf "platform.%s" $.Values.ingress.domain) -}}
+    {{- if and (ne $cpHost $.Values.ingress.domain) (not (hasSuffix (printf ".%s" $.Values.ingress.domain) $cpHost)) }}
+    - {{ $cpHost | quote }}
+    {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/platform/helm/templates/cluster-issuer.yaml
+++ b/platform/helm/templates/cluster-issuer.yaml
@@ -104,7 +104,13 @@ spec:
   # against this issuer's HTTP-01 solver (apps/operator/src/cluster-tenants/internal/org-domain.provisioner.ts).
   dnsNames:
     - {{ printf "*.%s" .Values.ingress.domain | quote }}
+    {{- /* Apex SAN is opt-in: many installs use the bare domain as a marketing site
+           hosted elsewhere and cannot serve `_acme-challenge.<domain>` from the
+           platform's DNS-01 zone, which would stall issuance. Set
+           certManager.includeApex=true only when the platform serves the apex. */}}
+    {{- if .Values.certManager.includeApex }}
     - {{ .Values.ingress.domain | quote }}
+    {{- end }}
     {{- $cpHost := .Values.ingress.controlPlaneHost | default (printf "platform.%s" .Values.ingress.domain) -}}
     {{- if and (ne $cpHost .Values.ingress.domain) (not (hasSuffix (printf ".%s" .Values.ingress.domain) $cpHost)) }}
     - {{ $cpHost | quote }}
@@ -180,7 +186,10 @@ spec:
   # a per-org cert, issued by the operator against this issuer's HTTP-01 solver.
   dnsNames:
     - {{ printf "*.%s" $.Values.ingress.domain | quote }}
+    {{- /* Apex SAN opt-in (see legacy block above for rationale). */}}
+    {{- if $.Values.certManager.includeApex }}
     - {{ $.Values.ingress.domain | quote }}
+    {{- end }}
     {{- $cpHost := $.Values.ingress.controlPlaneHost | default (printf "platform.%s" $.Values.ingress.domain) -}}
     {{- if and (ne $cpHost $.Values.ingress.domain) (not (hasSuffix (printf ".%s" $.Values.ingress.domain) $cpHost)) }}
     - {{ $cpHost | quote }}

--- a/platform/helm/templates/dns-solver-secret.yaml
+++ b/platform/helm/templates/dns-solver-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.certManager.enabled (eq .Values.certManager.mode "acme") .Values.certManager.acme.dns01.secretData }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ dig "serviceAccountSecretRef" "name" "clouddns-dns01-solver" .Values.certManager.acme.dns01.config }}
+  namespace: {{ .Values.certManager.namespace | default "cert-manager" }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ dig "serviceAccountSecretRef" "key" "key.json" .Values.certManager.acme.dns01.config }}: {{ .Values.certManager.acme.dns01.secretData | b64enc }}
+{{- end }}

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -542,6 +542,11 @@ certManager:
       provider: ""
       # -- Provider-specific solver config, rendered verbatim under solvers[].dns01.
       config: {}
+      # -- Raw service-account key (JSON string) for the DNS-01 solver Secret.
+      # When non-empty the chart renders a Secret in certManager.namespace so the
+      # solver can authenticate against the DNS provider (e.g. GCP CloudDNS SA key).
+      # Stopgap — prefer GCP-SM + ESO + CMEK for production credential delivery.
+      secretData: ""
 
 # -- Obot MCP gateway plane settings.
 # Uses the upstream obot-platform/obot image. Requires a per-instance, release-prefixed

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -512,6 +512,13 @@ certManager:
   enabled: false
   # -- Issuer mode: "acme" (production, public CA via DNS-01) or "selfSigned" (dev/local).
   mode: selfSigned
+  # -- Include the bare `<ingress.domain>` apex as a SAN on the platform wildcard
+  # Certificate. OFF by default: many installs use the apex as a marketing site
+  # hosted elsewhere (Webflow, Vercel, etc.) and the platform's DNS-01 solver
+  # cannot answer `_acme-challenge.<domain>` in that zone — adding the SAN would
+  # stall the whole cert at `pending`. Set true only when the platform actually
+  # serves the apex AND its DNS zone is wired to certManager.acme.dns01.
+  includeApex: false
   # -- Name of the ClusterIssuer this chart creates and the Certificate references.
   issuerName: opencrane-issuer
   # -- cert-manager controller namespace. The `oc platform dns set` endpoint writes

--- a/platform/migrations/backfill-clustertenant-owner.sh
+++ b/platform/migrations/backfill-clustertenant-owner.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# =============================================================================
+# OpenCrane — backfill ClusterTenant spec.owner (one-time data migration)
+#
+# Owner identity moved from the legacy `opencrane.io/owner-email` annotation to the
+# validated `spec.owner` field. CRs created before that change (or created via a
+# control plane that stamped only the annotation) carry no `spec.owner`, so the
+# operator skips seeding their default Tenant. This script stamps `spec.owner` onto
+# each such CR so the next reconcile seeds the workspace.
+#
+# The owner SUBJECT is authoritative in the control-plane database (`org_memberships`,
+# role = owner) and is read from there per org. The owner EMAIL was never persisted —
+# it only ever lived on the session/CR — so it must be supplied (--email), or per org
+# via --email-for <org>=<email> (repeatable). Without an email the operator still
+# cannot seed the default Tenant (the Tenant CRD requires a valid email), so an org
+# with no email resolved is reported and left for a re-run.
+#
+# Idempotent: merge-patches spec.owner; re-running on a converged CR is a no-op.
+#
+# Usage:
+#   ./platform/migrations/backfill-clustertenant-owner.sh --email owner@example.com
+#   ./platform/migrations/backfill-clustertenant-owner.sh \
+#       --email-for elewa=jente@elewa.ke --email-for elewa-be=jente@elewa.ke
+#   # optional: restrict to specific orgs, point at the DB pod/namespace
+#   ./platform/migrations/backfill-clustertenant-owner.sh --email x@y.z --only elewa,northwind \
+#       --db-namespace opencrane-system --db-pod opencrane-db-1 --db-user postgres --db-name opencrane
+#
+# Prereqs: kubectl (pointed at the target cluster). Apply the updated CRD first
+# (via the deploy script) so the `spec.owner` schema exists.
+# =============================================================================
+set -euo pipefail
+
+GROUP="opencrane.io"
+VERSION="v1alpha1"
+PLURAL="clustertenants"
+
+DEFAULT_EMAIL=""
+declare -A EMAIL_FOR=()
+ONLY=""
+DB_NAMESPACE="opencrane-system"
+DB_POD="opencrane-db-1"
+DB_USER="postgres"
+DB_NAME="opencrane"
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --email)         DEFAULT_EMAIL="$2"; shift 2 ;;
+    --email-for)     EMAIL_FOR["${2%%=*}"]="${2#*=}"; shift 2 ;;
+    --only)          ONLY="$2"; shift 2 ;;
+    --db-namespace)  DB_NAMESPACE="$2"; shift 2 ;;
+    --db-pod)        DB_POD="$2"; shift 2 ;;
+    --db-user)       DB_USER="$2"; shift 2 ;;
+    --db-name)       DB_NAME="$2"; shift 2 ;;
+    --dry-run)       DRY_RUN=1; shift ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Detect the CRD's served version so we patch the right API version.
+detected_version="$(kubectl get crd "${PLURAL}.${GROUP}" -o jsonpath='{.spec.versions[?(@.served==true)].name}' 2>/dev/null | awk '{print $1}')"
+[[ -n "$detected_version" ]] && VERSION="$detected_version"
+
+# Read the owner subject for an org from the control-plane DB (role = owner).
+owner_subject_for() {
+  local org="$1"
+  kubectl exec -n "$DB_NAMESPACE" "$DB_POD" -- \
+    psql -U "$DB_USER" -d "$DB_NAME" -tAc \
+    "SELECT subject FROM org_memberships WHERE cluster_tenant = '${org}' AND role = 'owner' LIMIT 1;" \
+    2>/dev/null | tr -d '[:space:]'
+}
+
+email_for() {
+  local org="$1"
+  if [[ -n "${EMAIL_FOR[$org]:-}" ]]; then echo "${EMAIL_FOR[$org]}"; else echo "$DEFAULT_EMAIL"; fi
+}
+
+mapfile -t orgs < <(kubectl get "$PLURAL.$GROUP" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+if [[ -n "$ONLY" ]]; then
+  IFS=',' read -r -a only_arr <<< "$ONLY"
+fi
+
+patched=0; skipped=0
+for org in "${orgs[@]}"; do
+  [[ -z "$org" ]] && continue
+  if [[ -n "$ONLY" ]] && ! printf '%s\n' "${only_arr[@]}" | grep -qx "$org"; then continue; fi
+
+  existing_subject="$(kubectl get "$PLURAL.$GROUP" "$org" -o jsonpath='{.spec.owner.subject}' 2>/dev/null)"
+  existing_email="$(kubectl get "$PLURAL.$GROUP" "$org" -o jsonpath='{.spec.owner.email}' 2>/dev/null)"
+
+  subject="$existing_subject"
+  [[ -z "$subject" ]] && subject="$(owner_subject_for "$org")"
+  if [[ -z "$subject" ]]; then
+    echo "SKIP  $org — no owner subject in spec.owner or org_memberships"; ((skipped++)); continue
+  fi
+
+  email="$(email_for "$org")"
+  [[ -z "$email" ]] && email="$existing_email"
+  if [[ -z "$email" ]]; then
+    echo "SKIP  $org — owner subject '$subject' resolved but no email (pass --email or --email-for $org=...)"; ((skipped++)); continue
+  fi
+
+  if [[ "$existing_subject" == "$subject" && "$existing_email" == "$email" ]]; then
+    echo "OK    $org — spec.owner already converged (subject=$subject email=$email)"; continue
+  fi
+
+  patch="{\"spec\":{\"owner\":{\"subject\":\"$subject\",\"email\":\"$email\"}}}"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "DRY   $org — would merge-patch $patch"; ((patched++)); continue
+  fi
+  kubectl patch "$PLURAL.$GROUP" "$org" --type=merge -p "$patch"
+  echo "PATCH $org — spec.owner set (subject=$subject email=$email)"; ((patched++))
+done
+
+echo "---"
+echo "Done: $patched patched/queued, $skipped skipped."
+echo "The operator seeds each org's default Tenant on its next reconcile (touch the spec to force one, e.g. kubectl patch ... --type=merge -p '{\"spec\":{\"displayName\":\"...\"}}')."


### PR DESCRIPTION
## Summary

Fixes ClusterTenants stuck in `pending` and hardens the CR-bridge + DNS-01 issuance pipeline.

### ClusterTenant owner identity (spec.owner)
- Move owner from free-form annotation to validated `spec.owner` (subject + email) in the CRD schema
- Owner is mandatory on create, preserved via merge-patch on update (non-owner admin can't drop it)
- Operator reads `spec.owner` with annotation fallback for the 3 existing CRs
- Backfill migration script at `platform/migrations/backfill-clustertenant-owner.sh`

### observedGeneration + status read-repair
- Add `status.observedGeneration` to the CRD schema (was silently pruned by the API server → infinite reconcile)
- Extract `ClusterTenantObservedStatus` to `@opencrane/contracts` (shared type for operator writer + control-plane reader)
- Extract `cr-status-reader.ts` from `cr-bridge.ts` (read path belongs in its own module, not the write-only bridge)
- Non-blocking read-repair: `void _SyncObservedStatusToDb().catch()` — status reads never block on DB mirror

### CR-bridge refactor
- Split `_ApplyClusterTenantCr` into named steps: `_BuildSpecPatch` → `_PatchSpec` (update) → `_CreateCr` (create)
- Extract K8s error helpers to `shared/k8s-errors.ts`, replacing 4 duplicated implementations across `cr-bridge`, `tenants`, `platform-dns`, and `apply-dns-config`

### API quality
- POST /cluster-tenants returns 409 CONFLICT on duplicate name (Prisma P2002 mapping)
- Error handler strips Prisma detail from 500s in production
- OpenAPI spec updated with 409 response
- Deduplicated GET /:name and GET /:name/status via shared `_ReadObservedStatus` helper

### DNS-01 / TLS (fixes cert stall)
- Guard `controlPlaneHost` SAN: only add when the host is genuinely outside the wildcard zone
- Previous always-add forced a redundant DNS-01 challenge that stalled cert issuance
- Add `dns-solver-secret.yaml` template for declarative CloudDNS SA key at helm-install
- Declare `certManager.acme.dns01.secretData` in `values.yaml` (defaults empty = no secret rendered)

## Test plan

- [x] 421 control-plane tests pass (including new P2002→409, error-handler, duplicate-name tests)
- [x] 163 operator tests pass (including spec.owner seed, annotation fallback, spec-wins precedence)
- [x] TypeScript compiles clean (control-plane + operator)
- [x] Helm template renders correct dnsNames for all 3 SAN cases (subdomain, apex, external)
- [x] dns-solver-secret renders when secretData set, skipped when empty
- [ ] Deploy to dev cluster + verify 3 existing CRs pick up spec.owner after backfill migration
- [ ] Verify cert-manager issues wildcard without stalling on redundant SAN