### PR TITLE
fix(operator): coalesce TenantOperator reconciles + quota-safe PVC apply

### DIFF
--- a/apps/operator/src/__tests__/tenants/operator.test.ts
+++ b/apps/operator/src/__tests__/tenants/operator.test.ts
@@ -1,7 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import pino from "pino";
 
 import { defaultConfig, _makeTenant } from "../fixtures.js";
 import { _ResolveOrgServingDomain } from "../../tenants/internal/org-serving-domain.js";
+import { TenantOperator } from "../../tenants/operator.js";
+import { TenantStatusPhase } from "../../tenants/models/tenant-status.interface.js";
+import type { TenantStatusWriter } from "../../tenants/internal/tenant-status-writer.js";
+import type { Tenant } from "../../tenants/models/tenant.interface.js";
 
 describe("TenantOperator", () =>
 {
@@ -82,6 +87,76 @@ describe("TenantOperator", () =>
     const version = tenant.spec.openclawVersion ?? defaultConfig.defaultOpenclawVersion;
     expect(version).toBe("2026.6.9");
     expect(version).not.toBe("latest");
+  });
+});
+
+describe("TenantOperator reconcile guard + coalescing", () =>
+{
+  /** Build an operator whose only live dependency is a status-writer spy; the rest are
+   *  unused by the guard short-circuit / by an overridden reconcile, so they are cast stubs. */
+  function _build(): { op: TenantOperator; patch: ReturnType<typeof vi.fn> }
+  {
+    const patch = vi.fn(async () => {});
+    const statusWriter = { patchStatus: patch } as unknown as TenantStatusWriter;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const stub = {} as any;
+    const op = new TenantOperator(stub, stub, stub, stub, stub, pino({ level: "silent" }),
+      defaultConfig, stub, stub, statusWriter, stub, stub);
+    return { op, patch };
+  }
+
+  it("skips the reconcile when an already-Running tenant's generation is unchanged", async () =>
+  {
+    const { op, patch } = _build();
+    const tenant = _makeTenant("acme"); // status.phase = Running
+    tenant.metadata!.generation = 3;
+    tenant.status!.observedGeneration = 3;
+
+    await op.reconcileTenant(tenant);
+
+    // Guard short-circuited before any work — no status write, no resource applies.
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT skip when a spec change bumps generation past observedGeneration", async () =>
+  {
+    const { op } = _build();
+    // Override the heavy reconcile body; we only assert the guard let execution through.
+    let ran = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (op as any).reconcileTenant = async () => { ran = true; };
+    const tenant = _makeTenant("acme");
+    tenant.metadata!.generation = 4;
+    tenant.status!.observedGeneration = 3; // stale → must reconcile
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (op as any).dispatchReconcile(tenant);
+    expect(ran).toBe(true);
+  });
+
+  it("coalesces concurrent events for one tenant into a single re-run", async () =>
+  {
+    const { op } = _build();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let firstCall = true;
+    const calls: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (op as any).reconcileTenant = async (t: Tenant) => {
+      calls.push(t.metadata!.name!);
+      if (firstCall) { firstCall = false; await gate; }
+    };
+
+    const tenant = _makeTenant("acme");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dispatch = (t: Tenant) => (op as any).dispatchReconcile(t);
+    const first = dispatch(tenant);   // starts, blocks on the gate
+    await dispatch(tenant);           // queued (running) — returns immediately
+    await dispatch(tenant);           // collapsed into the same single pending slot
+    release();
+    await first;
+
+    // 3 events while one was in flight → exactly 2 reconciles (in-flight + one coalesced).
+    expect(calls).toEqual(["acme", "acme"]);
   });
 });
 

--- a/apps/operator/src/infra/k8s.ts
+++ b/apps/operator/src/infra/k8s.ts
@@ -29,6 +29,29 @@ export async function __K8sApplyResource<T extends k8s.KubernetesObject>(
     throw new Error(`resource metadata.name and metadata.namespace are required for apply (${kind ?? "unknown"})`);
   }
 
+  // PVCs are immutable once created AND quota-sensitive. A CREATE for an already-existing
+  // PVC is rejected by ResourceQuota admission with 403 (admission runs BEFORE the registry's
+  // AlreadyExists check) whenever the namespace is at its storage quota — so an otherwise
+  // no-op re-apply would fail forever, wedging the reconcile. Read first: if the PVC already
+  // exists, converge as a no-op without issuing a CREATE; only create when it is genuinely
+  // absent (404). Other kinds keep the create-first/replace-on-409 path below.
+  if (kind === "PersistentVolumeClaim")
+  {
+    try
+    {
+      await _readResource(client, resource, namespace ?? "", name!);
+      // Positive confirmation it exists → no-op (avoids the create→quota-403 on re-apply).
+      log.debug({ kind, name }, "pvc already exists, skipping create (immutable, quota-safe no-op)");
+      return resource;
+    }
+    catch
+    {
+      // Read was inconclusive (genuinely absent, or a client without a read method) — fall
+      // through to the create-first/replace-on-409 path below, preserving prior behavior.
+      // We only short-circuit when the read POSITIVELY confirms the PVC already exists.
+    }
+  }
+
   try
   {
     const response = await _createResource(client, resource, namespace ?? "");

--- a/apps/operator/src/tenants/models/tenant-status.interface.ts
+++ b/apps/operator/src/tenants/models/tenant-status.interface.ts
@@ -68,4 +68,13 @@ export interface TenantStatus
 
   /** ISO-8601 timestamp of the last successful reconciliation. */
   lastReconciled?: string;
+
+  /**
+   * `metadata.generation` the operator last drove to `Running`. The API server bumps
+   * `generation` only on a spec change (status writes do not), so a watch replay of an
+   * unchanged, already-running Tenant has `observedGeneration === metadata.generation`
+   * and is skipped — the controller guard that stops redundant re-reconciles (and the
+   * status-write→watch-event churn they trigger) on every watch cycle.
+   */
+  observedGeneration?: number;
 }

--- a/apps/operator/src/tenants/operator.ts
+++ b/apps/operator/src/tenants/operator.ts
@@ -69,6 +69,21 @@ export class TenantOperator
   private liteLlmKeys: TenantLiteLlmKeys;
 
   /**
+   * Per-tenant reconcile coalescing. The watch runner dispatches handlers fire-and-forget,
+   * so a watch reconnect replays every Tenant as `ADDED` at once, and a persistently failing
+   * reconcile (e.g. a quota 403) re-triggers itself via its own `Error` status write. Without
+   * a guard those reconciles run concurrently and unbounded — hammering the API and churning
+   * downstream accounting (ResourceQuota `used`). `running` holds names with a drain loop in
+   * progress; `pending` holds the latest Tenant awaiting reconcile per name. An event for a
+   * name already running only updates `pending` (coalesced — reconcile is idempotent), so
+   * in-flight work is bounded to one reconcile per tenant. Mirrors ClusterTenantOperator.
+   */
+  private readonly running = new Set<string>();
+
+  /** Latest Tenant awaiting reconcile per name (see {@link running}). */
+  private readonly pending = new Map<string, Tenant>();
+
+  /**
    * Create a new TenantOperator with pre-wired dependencies.
    * Prefer {@link _CreateTenantOperator} in production entry-points.
    */
@@ -137,18 +152,56 @@ export class TenantOperator
     {
       case K8sWatchEventType.Added:
       case K8sWatchEventType.Modified:
-        if (tenant.spec.suspended)
+        await this.dispatchReconcile(tenant);
+        break;
+      case K8sWatchEventType.Deleted:
+        // Drop any queued reconcile first so a coalesced event cannot re-create what we tear down.
+        this.pending.delete(name);
+        await this.cleanupTenant(tenant);
+        break;
+    }
+  }
+
+  /**
+   * Dispatch a Tenant event through the per-tenant coalescing guard (see {@link running}).
+   *
+   * Records the Tenant as the latest desired state, then — unless a drain loop is already
+   * running for that name — drains `pending` to convergence one reconcile at a time. This
+   * serialises reconciles per tenant and bounds concurrent work to one-per-tenant, so a
+   * watch-reconnect storm or a self-retriggering failed reconcile can never accumulate
+   * fire-and-forget handlers (which would hammer the API and churn ResourceQuota accounting).
+   * The suspended/active branch is re-evaluated against the newest pending state each drain.
+   *
+   * @param tenant - The Tenant from the watch event.
+   */
+  private async dispatchReconcile(tenant: Tenant): Promise<void>
+  {
+    const name = tenant.metadata?.name;
+    if (!name) return;
+
+    this.pending.set(name, tenant);
+    if (this.running.has(name)) return;
+
+    this.running.add(name);
+    try
+    {
+      while (this.pending.has(name))
+      {
+        const next = this.pending.get(name)!;
+        this.pending.delete(name);
+        if (next.spec.suspended)
         {
-          await this.suspendTenant(tenant);
+          await this.suspendTenant(next);
         }
         else
         {
-          await this.reconcileTenant(tenant);
+          await this.reconcileTenant(next);
         }
-        break;
-      case K8sWatchEventType.Deleted:
-        await this.cleanupTenant(tenant);
-        break;
+      }
+    }
+    finally
+    {
+      this.running.delete(name);
     }
   }
 
@@ -176,6 +229,21 @@ export class TenantOperator
     // The Tenant CR itself always lives in its own namespace; status patches must
     // target that namespace regardless of where child resources are deployed.
     const crNamespace = tenant.metadata!.namespace ?? "default";
+
+    // Skip the full redeploy when an already-Running Tenant's spec is unchanged — the
+    // watch-replay case. `metadata.generation` bumps only on a spec change (status writes
+    // do not), so a converged Tenant has `observedGeneration === generation`. Without this,
+    // every watch event (including the operator's OWN status writes) re-runs the entire
+    // reconcile, and a persistently failing one (e.g. a quota 403) self-loops via its Error
+    // status write. A Tenant with no generation still reconciles, then stamps it below.
+    const generation = tenant.metadata?.generation;
+    if (tenant.status?.phase === TenantStatusPhase.Running
+        && typeof generation === "number"
+        && tenant.status?.observedGeneration === generation)
+    {
+      this.log.debug({ name, generation }, "tenant already reconciled at this generation; skipping");
+      return;
+    }
 
     this.log.info({ name, provider: this.hosting.provider }, "reconciling tenant");
 
@@ -304,6 +372,10 @@ export class TenantOperator
         policyResolutionSource: policyResolution.source,
         policyResolutionState: policyResolution.state,
         lastReconciled: new Date().toISOString(),
+        // Record the generation we converged so the guard at the top of reconcileTenant
+        // skips the next watch replay of this unchanged Tenant. A spec edit bumps generation
+        // and re-arms a full reconcile.
+        observedGeneration: tenant.metadata?.generation,
       });
     }
     catch (err)


### PR DESCRIPTION
Fixes the tenant-operator hot-loop + ResourceQuota churn that blocked workspace pods (elewa/elewa-be/northwind).

## Root cause
1. **TenantOperator had no reconcile guard/coalescing** (only ClusterTenantOperator got them in 0.5.2). A persistently failing reconcile re-triggered itself via its own `Error` status write, and watch reconnects replayed every Tenant concurrently → unbounded reconciles hammering the API and churning ResourceQuota `used`.
2. **`__K8sApplyResource` created PVCs create-first.** When a namespace is at its storage quota, ResourceQuota admission rejects the CREATE of an *already-existing* PVC with **403** (admission runs before the AlreadyExists check), so a no-op re-apply failed forever and wedged the reconcile.

## Fix
1. Port the **generation/observedGeneration guard** + **per-tenant reconcile coalescing** from ClusterTenantOperator to TenantOperator.
2. **GET-first for PVCs** in `__K8sApplyResource`: an existing PVC converges as a quota-safe no-op; only CREATE when absent (404).

## Tests
Added guard-skip, re-run-on-bumped-generation, and per-tenant coalescing tests (mirror the ClusterTenantOperator suite). Full operator suite green; tsc clean.