### PR TITLE
fix(cluster-tenants): own default-tenant creation in the control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
 
 ## [Unreleased]
 
+## [0.5.3] — 2026-06-23
+
+Tenant operator stability: eliminates the status-write hot-loop that inflated ResourceQuota usage and blocked workspace provisioning under high tenant counts.
+
 ### Added
 
 - **Signing out via the API now ends the IdP session, not just the local cookie.** `POST /auth/logout` calls Zitadel's `end_session_endpoint` so the user's token is invalidated at the identity provider — a subsequent sign-in requires a fresh Zitadel authentication rather than silently reusing the existing IdP session.

--- a/apps/cli/src/commands/cluster-tenants.ts
+++ b/apps/cli/src/commands/cluster-tenants.ts
@@ -49,7 +49,7 @@ export function _RegisterClusterTenants(parent: Command, getConfig: () => CliCon
 {
   const clusterTenant = parent
     .command("cluster-tenant")
-    .description("Manage cluster tenants — the first-class customer / isolation unit (create, list, show, update, delete, status)");
+    .description("Manage cluster tenants — the first-class customer / isolation unit (create, list, show, update, delete, status, refresh)");
 
   clusterTenant
     .command("list")
@@ -84,6 +84,18 @@ export function _RegisterClusterTenants(parent: Command, getConfig: () => CliCon
       const client = _MakeClient(getConfig());
       const { data, error } = await client.GET("/cluster-tenants/{name}/status", { params: { path: { name } } });
       if (error) _PrintApiError("cluster-tenant status", error);
+      _Print(data, opts.output);
+    });
+
+  clusterTenant
+    .command("refresh <name>")
+    .description("Refresh a cluster tenant's status and seed its owner workspace tenant if the org is ready but has none")
+    .option("-o, --output <format>", "Output format: table|json", "table")
+    .action(async function _refresh(name: string, opts: { output: OutputFormat })
+    {
+      const client = _MakeClient(getConfig());
+      const { data, error } = await client.POST("/cluster-tenants/{name}/refresh", { params: { path: { name } } });
+      if (error) _PrintApiError("cluster-tenant refresh", error);
       _Print(data, opts.output);
     });
 

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -3887,6 +3887,108 @@
         }
       }
     },
+    "/cluster-tenants/{name}/refresh": {
+      "post": {
+        "operationId": "refreshClusterTenant",
+        "summary": "Refresh a cluster tenant's status and reconcile its owner workspace tenant",
+        "description": "Re-reads the operator's observed phase from the CR (mirroring it to the DB), then — when the org is fully `ready` but has no workspace Tenant projected — seeds the owner's `<org>-default` Tenant via the same dual-write (CRD + DB row) the create path uses. Idempotent: a ready org that already has its tenant just returns the current status.",
+        "tags": [
+          "Cluster Tenants"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Refreshed status, plus the default-tenant reconcile outcome (null when the org is not yet ready).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "object",
+                      "properties": {
+                        "phase": {
+                          "type": "string",
+                          "enum": [
+                            "pending",
+                            "provisioning",
+                            "ready",
+                            "failed"
+                          ]
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "boundNamespace": {
+                          "type": "string"
+                        },
+                        "provisioner": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "defaultTenant": {
+                      "type": "object",
+                      "nullable": true,
+                      "properties": {
+                        "tenantName": {
+                          "type": "string"
+                        },
+                        "created": {
+                          "type": "boolean"
+                        },
+                        "skippedReason": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is neither a platform operator nor an owner/admin of this org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Cluster tenant not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/billing-accounts": {
       "post": {
         "operationId": "createBillingAccount",

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
@@ -1,5 +1,6 @@
 import express from "express";
-import type { Express } from "express";
+import type { Express, Request, Response, NextFunction } from "express";
+import * as k8s from "@kubernetes/client-node";
 import { ClusterTenantIsolationTier } from "@opencrane/contracts";
 import type { ClusterTenantProvisionerRegistry } from "@opencrane/contracts";
 import { Prisma, type PrismaClient } from "@prisma/client";
@@ -11,8 +12,8 @@ import { clusterTenantsRouter } from "../../routes/cluster-tenants.js";
 /** In-memory cluster_tenants store backing the mock Prisma client. */
 type Row = Record<string, unknown>;
 
-/** Build a Prisma stub over an in-memory map keyed by tenant name. */
-function _mockPrisma(store: Map<string, Row>): PrismaClient
+/** Build a Prisma stub over in-memory maps keyed by name (cluster_tenants + tenants). */
+function _mockPrisma(store: Map<string, Row>, tenants: Map<string, Row> = new Map()): PrismaClient
 {
   const memberships: Row[] = [];
   const prisma = {
@@ -39,6 +40,25 @@ function _mockPrisma(store: Map<string, Row>): PrismaClient
       }),
       delete: vi.fn(async function _delete(args: { where: { name: string } }) { store.delete(args.where.name); return {}; }),
     },
+    tenant: {
+      findUnique: vi.fn(async function _tFindUnique(args: { where: { name: string } }) { return tenants.get(args.where.name) ?? null; }),
+      create: vi.fn(async function _tCreate(args: { data: Row })
+      {
+        if (tenants.has(args.data.name as string))
+        {
+          throw new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields: (`name`)", { code: "P2002", clientVersion: "test" });
+        }
+        tenants.set(args.data.name as string, args.data);
+        return args.data;
+      }),
+    },
+    auditEntry: {
+      create: vi.fn(async function _aCreate(args: { data: Row }) { return args.data; }),
+    },
+    // The org-create billing gate requires the caller to already have a billing account.
+    billingAccount: {
+      findUnique: vi.fn(async function _baFindUnique() { return { id: "ba_test" }; }),
+    },
     orgMembership: {
       create: vi.fn(async function _createMembership(args: { data: Row }) { memberships.push(args.data); return args.data; }),
     },
@@ -47,6 +67,30 @@ function _mockPrisma(store: Map<string, Row>): PrismaClient
     $transaction: vi.fn(async function _tx(fn: (tx: PrismaClient) => Promise<unknown>) { return fn(prisma); }),
   } as unknown as PrismaClient;
   return prisma;
+}
+
+/**
+ * Minimal CustomObjectsApi stub for the default-tenant seam: serves a cluster-scoped
+ * ClusterTenant status (for the observed-phase read), the namespaced Tenant CRD lookup
+ * (email recovery), and a create spy. `crdEmail` undefined → the Tenant CRD is absent (404).
+ */
+function _mockCustomApi(opts: { phase: string; crdEmail?: string }): { api: k8s.CustomObjectsApi; created: Row[] }
+{
+  const created: Row[] = [];
+  const notFound = Object.assign(new Error("not found"), { code: 404 });
+  const api = {
+    getClusterCustomObject: vi.fn(async function _getCluster() { return { status: { phase: opts.phase, boundNamespace: "opencrane-acme" } }; }),
+    getNamespacedCustomObject: vi.fn(async function _getNs()
+    {
+      if (opts.crdEmail === undefined) throw notFound;
+      return { spec: { email: opts.crdEmail, clusterTenantRef: "acme" } };
+    }),
+    createNamespacedCustomObject: vi.fn(async function _createNs(args: { body: Row }) { created.push(args.body); return args.body; }),
+    // ClusterTenant CR dual-write seam used by the create path (_ApplyClusterTenantCr).
+    patchClusterCustomObject: vi.fn(async function _patchCluster(args: { body: Row }) { return args.body; }),
+    createClusterCustomObject: vi.fn(async function _createCluster(args: { body: Row }) { return args.body; }),
+  } as unknown as k8s.CustomObjectsApi;
+  return { api, created };
 }
 
 /** Registry stub: serves shared + dedicatedNodes; dedicatedCluster gated by flag. */
@@ -66,11 +110,32 @@ function _mockRegistry(dedicatedClusterAvailable: boolean): ClusterTenantProvisi
 }
 
 /** Build a minimal app mounting only the cluster-tenants router. */
-function _buildApp(prisma: PrismaClient, registry: ClusterTenantProvisionerRegistry): Express
+function _buildApp(prisma: PrismaClient, registry: ClusterTenantProvisionerRegistry,
+                   customApi: k8s.CustomObjectsApi | null = null, session?: { sub: string; email?: string }): Express
 {
   const app = express();
   app.use(express.json());
-  app.use("/api/v1/cluster-tenants", clusterTenantsRouter(prisma, registry));
+  // Inject an authenticated session when provided, so the create path can attribute the
+  // org's owner + default tenant (mirrors what the auth middleware would set upstream).
+  if (session)
+  {
+    app.use(function _injectSession(req: Request, _res: Response, next: NextFunction)
+    {
+      // Stamp a partial authUser; the route only reads `sub`/`email`, so the full session
+      // shape is not needed for these unit tests.
+      (req as unknown as { session: { authUser: unknown } }).session = { authUser: session };
+      next();
+    });
+  }
+  app.use("/api/v1/cluster-tenants", clusterTenantsRouter(prisma, registry, customApi));
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  app.use(function _err(err: Error, _req: Request, res: Response, _next: NextFunction)
+  {
+    // Surface the thrown error in test output instead of an opaque 500.
+    // eslint-disable-next-line no-console
+    console.error("TEST_ROUTE_ERROR:", err?.stack ?? err);
+    res.status(500).json({ error: String(err?.message ?? err) });
+  });
   return app;
 }
 
@@ -189,6 +254,90 @@ describe("clusterTenantsRouter (CT.2 management API)", function _suite()
   {
     const app = _buildApp(_mockPrisma(new Map()), _mockRegistry(false));
     const res = await request(app).get("/api/v1/cluster-tenants/missing");
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("CLUSTER_TENANT_NOT_FOUND");
+  });
+});
+
+describe("clusterTenantsRouter — owner default tenant (create-time seed + refresh)", function _seedSuite()
+{
+  it("seeds the owner's <org>-default tenant (CRD + DB row) as part of create", async function _seedOnCreate()
+  {
+    const tenants = new Map<string, Row>();
+    const { api, created } = _mockCustomApi({ phase: "pending" }); // CRD absent → helper creates it
+    const app = _buildApp(_mockPrisma(new Map(), tenants), _mockRegistry(false), api, { sub: "owner-sub", email: "owner@acme.com" });
+
+    const res = await request(app).post("/api/v1/cluster-tenants").send(_sharedBody());
+    expect(res.status).toBe(201);
+
+    // DB projection row written for the owner's workspace (the bit the operator-only path missed).
+    const row = tenants.get("acme-default");
+    expect(row).toMatchObject({ name: "acme-default", email: "owner@acme.com", clusterTenantRef: "acme", displayName: "Acme Corp workspace" });
+    // CRD dual-written too.
+    expect(created.some((c) => (c.metadata as Row)?.name === "acme-default")).toBe(true);
+  });
+
+  it("does not fail org create when no owner email is available (dev-auth path)", async function _noEmail()
+  {
+    const tenants = new Map<string, Row>();
+    const { api } = _mockCustomApi({ phase: "pending" });
+    // Session carries only a subject (no email) and the CRD is absent → seed is skipped, org still created.
+    const app = _buildApp(_mockPrisma(new Map(), tenants), _mockRegistry(false), api, { sub: "dev-sub" });
+
+    const res = await request(app).post("/api/v1/cluster-tenants").send(_sharedBody());
+    expect(res.status).toBe(201);
+    expect(tenants.has("acme-default")).toBe(false);
+  });
+
+  it("refresh on a ready org with no tenant row seeds it, recovering the email from the CRD", async function _refreshSeeds()
+  {
+    const store = new Map<string, Row>([["acme", { name: "acme", displayName: "Acme Corp", isolationTier: "Shared", computeMode: "Shared", phase: "ready", nodePool: null, message: null, boundNamespace: "opencrane-acme", provisioner: "shared" }]]);
+    const tenants = new Map<string, Row>(); // no tenant row yet — the broken state we are repairing
+    const { api, created } = _mockCustomApi({ phase: "ready", crdEmail: "owner@acme.com" }); // CRD already exists
+
+    const app = _buildApp(_mockPrisma(store, tenants), _mockRegistry(false), api);
+    const res = await request(app).post("/api/v1/cluster-tenants/acme/refresh");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status.phase).toBe("ready");
+    expect(res.body.defaultTenant).toMatchObject({ tenantName: "acme-default", created: true });
+    // DB row created from the existing CRD's email; the CRD is NOT recreated (AlreadyExists path).
+    expect(tenants.get("acme-default")).toMatchObject({ name: "acme-default", email: "owner@acme.com", clusterTenantRef: "acme" });
+    expect(created.length).toBe(0);
+  });
+
+  it("refresh is idempotent: a ready org that already has its tenant creates nothing", async function _refreshIdempotent()
+  {
+    const store = new Map<string, Row>([["acme", { name: "acme", displayName: "Acme Corp", isolationTier: "Shared", computeMode: "Shared", phase: "ready", nodePool: null, message: null, boundNamespace: "opencrane-acme", provisioner: "shared" }]]);
+    const tenants = new Map<string, Row>([["acme-default", { name: "acme-default", email: "owner@acme.com", clusterTenantRef: "acme" }]]);
+    const { api } = _mockCustomApi({ phase: "ready", crdEmail: "owner@acme.com" });
+
+    const app = _buildApp(_mockPrisma(store, tenants), _mockRegistry(false), api);
+    const res = await request(app).post("/api/v1/cluster-tenants/acme/refresh");
+
+    expect(res.status).toBe(200);
+    expect(res.body.defaultTenant).toMatchObject({ tenantName: "acme-default", created: false });
+  });
+
+  it("refresh does not seed a tenant while the org is not yet ready", async function _refreshNotReady()
+  {
+    const store = new Map<string, Row>([["acme", { name: "acme", displayName: "Acme Corp", isolationTier: "Shared", computeMode: "Shared", phase: "pending", nodePool: null, message: null, boundNamespace: null, provisioner: null }]]);
+    const tenants = new Map<string, Row>();
+    const { api } = _mockCustomApi({ phase: "provisioning", crdEmail: "owner@acme.com" });
+
+    const app = _buildApp(_mockPrisma(store, tenants), _mockRegistry(false), api);
+    const res = await request(app).post("/api/v1/cluster-tenants/acme/refresh");
+
+    expect(res.status).toBe(200);
+    expect(res.body.defaultTenant).toBeNull();
+    expect(tenants.has("acme-default")).toBe(false);
+  });
+
+  it("returns 404 when refreshing an unknown org", async function _refreshNotFound()
+  {
+    const app = _buildApp(_mockPrisma(new Map()), _mockRegistry(false));
+    const res = await request(app).post("/api/v1/cluster-tenants/missing/refresh");
 
     expect(res.status).toBe(404);
     expect(res.body.code).toBe("CLUSTER_TENANT_NOT_FOUND");

--- a/apps/control-plane/src/core/cluster-tenants/default-tenant.ts
+++ b/apps/control-plane/src/core/cluster-tenants/default-tenant.ts
@@ -1,0 +1,136 @@
+import * as k8s from "@kubernetes/client-node";
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+import { OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "../../shared/crd-constants.js";
+import { _IsK8sConflict, _IsK8sNotFound } from "../../shared/k8s-errors.js";
+
+/** Suffix appended to an org name to form its first workspace Tenant's name. */
+export const _DEFAULT_TENANT_SUFFIX = "-default";
+
+/** Outcome of an {@link _EnsureOwnerDefaultTenant} call. */
+export interface EnsureDefaultTenantResult
+{
+  /** The `<org>-default` tenant name that was ensured. */
+  tenantName: string;
+  /** Whether a new DB projection row was created on this call (false = already present). */
+  created: boolean;
+  /** When nothing was created and the row was not already present, why it was skipped. */
+  skippedReason?: string;
+}
+
+/**
+ * Ensure an org's first workspace Tenant (`<org>-default`, attributed to the owner)
+ * exists as a control-plane dual-write: the Tenant CRD AND its DB projection row.
+ *
+ * This is the single authority for default-tenant creation. The org create handler calls
+ * it so a freshly-provisioned customer has a workspace row immediately (the TenantOperator
+ * reconciles it to Running once the org's namespace is bound), and the refresh endpoint
+ * calls it to self-heal an org that reached ready without a tenant row.
+ *
+ * Idempotent and recovery-safe:
+ *  - returns early when the DB row already exists (the steady-state path);
+ *  - tolerates a pre-existing CRD (AlreadyExists) and still writes the missing DB row,
+ *    recovering an org whose CRD was seeded out-of-band without its projection;
+ *  - tolerates a P2002 row race.
+ *
+ * The owner email is taken from `ownerEmail` when provided, else recovered from an existing
+ * CRD's `spec.email`. Absent both (the dev-auth path carries only a subject), the seed is
+ * skipped with a reason rather than creating an email-less Tenant.
+ *
+ * @returns Whether a DB row was created, and a skip reason when it was not.
+ */
+export async function _EnsureOwnerDefaultTenant(opts: {
+  customApi: k8s.CustomObjectsApi | null;
+  prisma: PrismaClient;
+  namespace: string;
+  orgName: string;
+  orgDisplayName: string;
+  ownerEmail?: string | undefined;
+}): Promise<EnsureDefaultTenantResult>
+{
+  const { customApi, prisma, namespace, orgName, orgDisplayName, ownerEmail } = opts;
+  const tenantName = `${orgName}${_DEFAULT_TENANT_SUFFIX}`;
+
+  // 1. Already projected → nothing to do (idempotent steady state). The unique key is the
+  //    tenant name, so this also collapses a concurrent caller down to a single create.
+  const existingRow = await prisma.tenant.findUnique({ where: { name: tenantName } });
+  if (existingRow)
+  {
+    return { tenantName, created: false };
+  }
+
+  // 2. Resolve the owner email: the caller's value wins; otherwise recover it from an
+  //    already-seeded CRD (the path we are repairing). The CRD read also tells us whether
+  //    to skip the create-CRD step below.
+  let email = ownerEmail?.trim() ?? "";
+  let crdExists = false;
+  if (customApi)
+  {
+    try
+    {
+      const cr = await customApi.getNamespacedCustomObject({
+        group: OPENCRANE_API_GROUP, version: OPENCRANE_API_VERSION, namespace, plural: TENANT_CRD_PLURAL, name: tenantName,
+      }) as { spec?: { email?: string } };
+      crdExists = true;
+      if (!email) email = cr.spec?.email?.trim() ?? "";
+    }
+    catch (err)
+    {
+      if (!_IsK8sNotFound(err)) throw err;
+    }
+  }
+
+  if (!email)
+  {
+    return { tenantName, created: false, skippedReason: "no owner email available (caller session and CRD both absent)" };
+  }
+
+  // 3. Dual-write. Create the CRD first (skip when no cluster is wired or it already
+  //    exists; tolerate a create-time AlreadyExists race), then the DB projection row —
+  //    the write the operator-only path was missing.
+  const displayName = `${orgDisplayName} workspace`;
+  if (customApi && !crdExists)
+  {
+    try
+    {
+      await customApi.createNamespacedCustomObject({
+        group: OPENCRANE_API_GROUP, version: OPENCRANE_API_VERSION, namespace, plural: TENANT_CRD_PLURAL,
+        body: {
+          apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
+          kind: "Tenant",
+          metadata: { name: tenantName, namespace },
+          spec: { displayName, email, clusterTenantRef: orgName },
+        },
+      });
+    }
+    catch (err)
+    {
+      if (!_IsK8sConflict(err)) throw err;
+    }
+  }
+
+  try
+  {
+    await prisma.tenant.create({
+      data: { name: tenantName, displayName, email, clusterTenantRef: orgName },
+    });
+  }
+  catch (err)
+  {
+    // Lost a create race against a concurrent caller — the row now exists, which is the
+    // desired end state; treat as already-present rather than an error.
+    if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002")
+    {
+      return { tenantName, created: false };
+    }
+    throw err;
+  }
+
+  // Best-effort audit; the FK target (the tenant row) now exists. A failed audit write
+  // must never undo or fail the seed itself.
+  await prisma.auditEntry.create({
+    data: { tenant: tenantName, action: "Created", resource: `Tenant/${tenantName}`, message: `Default workspace tenant ${tenantName} created for org ${orgName}` },
+  }).catch(() => { /* audit is non-critical */ });
+
+  return { tenantName, created: true };
+}

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -1481,6 +1481,44 @@ export const spec = {
       },
     },
 
+    "/cluster-tenants/{name}/refresh": {
+      post: {
+        operationId: "refreshClusterTenant",
+        summary: "Refresh a cluster tenant's status and reconcile its owner workspace tenant",
+        description: "Re-reads the operator's observed phase from the CR (mirroring it to the DB), then — when the org is fully `ready` but has no workspace Tenant projected — seeds the owner's `<org>-default` Tenant via the same dual-write (CRD + DB row) the create path uses. Idempotent: a ready org that already has its tenant just returns the current status.",
+        tags: ["Cluster Tenants"],
+        parameters: [{ name: "name", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("Refreshed status, plus the default-tenant reconcile outcome (null when the org is not yet ready).", {
+            type: "object",
+            properties: {
+              status: {
+                type: "object",
+                properties: {
+                  phase: { type: "string", enum: ["pending", "provisioning", "ready", "failed"] },
+                  message: { type: "string" },
+                  boundNamespace: { type: "string" },
+                  provisioner: { type: "string" },
+                },
+              },
+              defaultTenant: {
+                type: "object",
+                nullable: true,
+                properties: {
+                  tenantName: { type: "string" },
+                  created: { type: "boolean" },
+                  skippedReason: { type: "string" },
+                },
+              },
+            },
+          }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
+          404: notFound("Cluster tenant not found."),
+        },
+      },
+    },
+
     // ------------------------------------------------------------------
     // Billing accounts — the prerequisite for creating an organisation
     // ------------------------------------------------------------------

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -11,7 +11,7 @@ import { _IsDevAuthMode } from "../infra/auth/auth-mode.js";
 import { _RequireBillingAccountForOrgCreate, _RequireOrgManager } from "../infra/middleware/cluster-tenant-org-admin.js";
 import { _ApplyClusterTenantCr, _DeleteClusterTenantCr } from "../core/cluster-tenants/cr-bridge.js";
 import { _ReadClusterTenantObservedStatus } from "../core/cluster-tenants/cr-status-reader.js";
-import { _RepairTenantProjection } from "./internal/projection-repair.js";
+import { _EnsureOwnerDefaultTenant } from "../core/cluster-tenants/default-tenant.js";
 
 /** RFC-1123-ish DNS domain: lowercase labels, ≥1 dot, alpha TLD, ≤253 chars. */
 const _VANITY_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
@@ -50,20 +50,6 @@ async function _ReadObservedStatus(prisma: PrismaClient, customApi: k8s.CustomOb
   const observed = await _ReadClusterTenantObservedStatus(customApi, row.name);
   if (!observed) return null;
   void _SyncObservedStatusToDb(prisma, row, observed).catch(() => { /* best-effort mirror */ });
-
-  // The operator seeds a default Tenant CRD directly when an org reaches ready, bypassing
-  // the control-plane API dual-write (CRD + DB). When the org is ready and the DB has no
-  // tenants yet, fire a projection repair to sync any operator-seeded CRDs into the DB.
-  // A count check before the repair avoids the CRD list call on every poll once converged.
-  // Fire-and-forget — a failure here never blocks the status read.
-  if (observed.phase === ClusterTenantPhase.Ready && customApi)
-  {
-    const tenantNamespace = process.env["NAMESPACE"] ?? "default";
-    void prisma.tenant.count({ where: { clusterTenantRef: row.name } })
-      .then((n) => n === 0 ? _RepairTenantProjection(customApi!, prisma, tenantNamespace, false) : undefined)
-      .catch(() => { /* best-effort */ });
-  }
-
   return _ObservedStatusToContract(observed);
 }
 
@@ -85,6 +71,10 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
                                      customApi: k8s.CustomObjectsApi | null = null): Router
 {
   const router = Router();
+
+  // Tenant CRDs live in the control-plane's namespace (the TenantOperator watches there);
+  // the same value the tenants router uses for its dual-writes.
+  const namespace = process.env.NAMESPACE ?? "default";
 
   // Org-management guards (operator OR owner/admin member of the named org). Applied
   // to the fleet list/get reads and the destructive mutations below; the create path
@@ -130,6 +120,46 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     // Fall back to the DB-derived status when no cluster/CR is available.
     const observed = await _ReadObservedStatus(prisma, customApi, row);
     res.json(observed ?? _ToContract(row).status);
+  });
+
+  /**
+   * Refresh a cluster tenant's status and reconcile its workspace tenant (operator OR
+   * owner/admin of that org).
+   *
+   * Re-reads the operator's observed phase from the CR (mirroring it to the DB), then —
+   * when the org is fully `ready` but has no workspace Tenant projected — seeds the owner's
+   * `<org>-default` Tenant via the same dual-write the create path uses. This is the
+   * explicit, user-triggered recovery for an org that reached ready without a tenant row
+   * (e.g. an org provisioned before the create-time seed existed). Idempotent: a ready org
+   * that already has its tenant simply returns the current status.
+   */
+  router.post("/:name/refresh", requireOrgManager, async function _refreshClusterTenant(req: Request<{ name: string }>, res)
+  {
+    const row = await prisma.clusterTenant.findUnique({ where: { name: req.params.name } });
+    if (!row)
+    {
+      res.status(404).json({ error: "Cluster tenant not found", code: "CLUSTER_TENANT_NOT_FOUND" });
+      return;
+    }
+
+    // Re-read the live phase from the CR (also mirrors it to the DB row); fall back to the
+    // DB-derived status when no cluster/CR is wired.
+    const observed = await _ReadObservedStatus(prisma, customApi, row);
+    const status = observed ?? _ToContract(row).status;
+
+    // Only seed once the org is fully provisioned — a tenant created before its namespace
+    // is bound would churn the TenantOperator with retries until ready. The owner email is
+    // recovered from the existing CRD when present (the org's CR carried it at create).
+    let defaultTenant: Awaited<ReturnType<typeof _EnsureOwnerDefaultTenant>> | null = null;
+    if (status?.phase === ClusterTenantPhase.Ready)
+    {
+      defaultTenant = await _EnsureOwnerDefaultTenant({
+        customApi, prisma, namespace,
+        orgName: row.name, orgDisplayName: row.displayName,
+      });
+    }
+
+    res.json({ status, defaultTenant });
   });
 
   /**
@@ -262,6 +292,30 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     // its owner once the org is ready. The email is the owner's IdP-verified session
     // claim (absent in the dev-auth path, where only the synthetic subject is carried).
     await _ApplyClusterTenantCr(customApi, orgContract, { email: req.session?.authUser?.email, subject: ownerSubject });
+
+    // 6. Seed the org's first workspace Tenant for the owner as part of create — a
+    //    control-plane dual-write (CRD + DB row) so the owner has a workspace from the
+    //    moment the org exists. It sits `Pending` until the TenantOperator reconciles it
+    //    to `Running` once the org's namespace is bound. Best-effort: a seed hiccup must
+    //    not fail org creation (the org row + CR are already committed); the refresh
+    //    endpoint is the explicit recovery path. Skipped in the dev-auth path when no
+    //    owner email is carried.
+    try
+    {
+      const seed = await _EnsureOwnerDefaultTenant({
+        customApi, prisma, namespace,
+        orgName: created.name, orgDisplayName: created.displayName,
+        ownerEmail: req.session?.authUser?.email,
+      });
+      if (seed.skippedReason)
+      {
+        console.warn(`[cluster-tenants] default tenant not seeded for ${created.name}: ${seed.skippedReason}`);
+      }
+    }
+    catch (err)
+    {
+      console.error(`[cluster-tenants] default tenant seed failed for ${created.name}; org stays created (use refresh to retry):`, err);
+    }
 
     res.status(201).json(orgContract);
   });

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -11,6 +11,7 @@ import { _IsDevAuthMode } from "../infra/auth/auth-mode.js";
 import { _RequireBillingAccountForOrgCreate, _RequireOrgManager } from "../infra/middleware/cluster-tenant-org-admin.js";
 import { _ApplyClusterTenantCr, _DeleteClusterTenantCr } from "../core/cluster-tenants/cr-bridge.js";
 import { _ReadClusterTenantObservedStatus } from "../core/cluster-tenants/cr-status-reader.js";
+import { _RepairTenantProjection } from "./internal/projection-repair.js";
 
 /** RFC-1123-ish DNS domain: lowercase labels, ≥1 dot, alpha TLD, ≤253 chars. */
 const _VANITY_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
@@ -49,6 +50,20 @@ async function _ReadObservedStatus(prisma: PrismaClient, customApi: k8s.CustomOb
   const observed = await _ReadClusterTenantObservedStatus(customApi, row.name);
   if (!observed) return null;
   void _SyncObservedStatusToDb(prisma, row, observed).catch(() => { /* best-effort mirror */ });
+
+  // The operator seeds a default Tenant CRD directly when an org reaches ready, bypassing
+  // the control-plane API dual-write (CRD + DB). When the org is ready and the DB has no
+  // tenants yet, fire a projection repair to sync any operator-seeded CRDs into the DB.
+  // A count check before the repair avoids the CRD list call on every poll once converged.
+  // Fire-and-forget — a failure here never blocks the status read.
+  if (observed.phase === ClusterTenantPhase.Ready && customApi)
+  {
+    const tenantNamespace = process.env["NAMESPACE"] ?? "default";
+    void prisma.tenant.count({ where: { clusterTenantRef: row.name } })
+      .then((n) => n === 0 ? _RepairTenantProjection(customApi!, prisma, tenantNamespace, false) : undefined)
+      .catch(() => { /* best-effort */ });
+  }
+
   return _ObservedStatusToContract(observed);
 }
 

--- a/apps/operator/src/__tests__/cluster-tenants/operator.test.ts
+++ b/apps/operator/src/__tests__/cluster-tenants/operator.test.ts
@@ -283,13 +283,18 @@ describe("ClusterTenantOperator.reconcile", () =>
   });
 });
 
-describe("ClusterTenantOperator default-tenant seed (owner resolution)", () =>
+describe("ClusterTenantOperator default-tenant seed (owned by the control plane)", () =>
 {
   beforeEach(() => vi.clearAllMocks());
 
-  it("seeds the default Tenant from spec.owner.email when the org reaches ready", async () =>
+  it("does NOT seed a default Tenant on reconcile — the control plane dual-writes it", async () =>
   {
-    const { api: customApi, seeds } = _makeStubCustomApi();
+    // The org's first workspace Tenant is created by the control plane as a dual-write
+    // (CRD + DB row) at org-create time, with POST /cluster-tenants/:name/refresh as the
+    // explicit recovery. The operator must never create a Tenant CRD here: a CRD without
+    // the matching DB projection row is invisible to the management API (the "ready org,
+    // no workspace tenant" bug). This guards against re-introducing operator-side seeding.
+    const { api: customApi, seeds, patches } = _makeStubCustomApi();
     const { api: coreApi } = _makeStubCoreApi();
     const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
     const operator = _buildOperator(customApi, coreApi, provisioner);
@@ -298,55 +303,8 @@ describe("ClusterTenantOperator default-tenant seed (owner resolution)", () =>
     ct.spec.owner = { subject: "auth0|abc", email: "owner@acme.example" };
     await operator.reconcile(ct);
 
-    expect(seeds).toHaveLength(1);
-    expect(seeds[0].name).toBe("acme-default");
-    expect(seeds[0].email).toBe("owner@acme.example");
-    expect(seeds[0].clusterTenantRef).toBe("acme");
-  });
-
-  it("falls back to the legacy owner-email annotation for a CR with no spec.owner (rollout safety)", async () =>
-  {
-    const { api: customApi, seeds } = _makeStubCustomApi();
-    const { api: coreApi } = _makeStubCoreApi();
-    const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
-    const operator = _buildOperator(customApi, coreApi, provisioner);
-
-    const ct = _makeClusterTenant("legacy");
-    ct.metadata!.annotations = { "opencrane.io/owner-email": "legacy@acme.example" };
-    await operator.reconcile(ct);
-
-    expect(seeds).toHaveLength(1);
-    expect(seeds[0].email).toBe("legacy@acme.example");
-  });
-
-  it("prefers spec.owner.email over the legacy annotation when both are present", async () =>
-  {
-    const { api: customApi, seeds } = _makeStubCustomApi();
-    const { api: coreApi } = _makeStubCoreApi();
-    const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
-    const operator = _buildOperator(customApi, coreApi, provisioner);
-
-    const ct = _makeClusterTenant("acme");
-    ct.spec.owner = { subject: "auth0|abc", email: "spec@acme.example" };
-    ct.metadata!.annotations = { "opencrane.io/owner-email": "annotation@acme.example" };
-    await operator.reconcile(ct);
-
-    expect(seeds[0].email).toBe("spec@acme.example");
-  });
-
-  it("skips the seed (org still ready) when no owner email is resolvable — dev-auth path", async () =>
-  {
-    const { api: customApi, seeds, patches } = _makeStubCustomApi();
-    const { api: coreApi } = _makeStubCoreApi();
-    const { provisioner } = _makeDomainProvisioner({ skipped: true, ready: false });
-    const operator = _buildOperator(customApi, coreApi, provisioner);
-
-    const ct = _makeClusterTenant("devorg");
-    ct.spec.owner = { subject: "dev-local-subject" }; // subject only, no email
-    await operator.reconcile(ct);
-
-    expect(seeds).toHaveLength(0);                 // nothing seeded without an email
-    expect(patches.at(-1)!.phase).toBe("ready");   // but the org is not wedged out of ready
+    expect(seeds).toHaveLength(0);                 // operator creates no Tenant CRD
+    expect(patches.at(-1)!.phase).toBe("ready");   // org still reconciles to ready
   });
 });
 

--- a/apps/operator/src/cluster-tenants/operator.ts
+++ b/apps/operator/src/cluster-tenants/operator.ts
@@ -4,7 +4,7 @@ import type { Logger } from "pino";
 import type { OpenClawTenantOperatorConfig } from "../config.js";
 import { __K8sApplyResource } from "../infra/k8s.js";
 import { _RunWatchLoop, K8sWatchEventType } from "../shared/watch-runner.js";
-import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "../shared/crd-constants.js";
+import { CLUSTER_TENANT_CRD_PLURAL, OPENCRANE_API_GROUP, OPENCRANE_API_VERSION } from "../shared/crd-constants.js";
 import { _BuildClusterTenantNamespace } from "../tenants/deploy/index.js";
 import type { ClusterTenantResource } from "../tenants/internal/cluster-tenant-resolution.types.js";
 
@@ -13,26 +13,6 @@ import { _NamespaceForOrg, _ProvisionBoundary } from "./internal/shared-cluster.
 import { ClusterTenantReconcilePhase } from "./internal/shared-cluster.provisioner.types.js";
 import type { OrgDomainProvisioner } from "./internal/org-domain-provisioner.types.js";
 import { _BuildOrgDomainProvisioner } from "./internal/org-domain.provisioner.factory.js";
-
-/**
- * Legacy annotation the control plane used to stamp with the org owner's email,
- * before owner identity moved to the validated `spec.owner` field. Read only as a
- * fallback so CRs created by an older control plane (not yet backfilled) still seed
- * their default Tenant during rollout; new CRs carry `spec.owner` instead.
- */
-const _LEGACY_OWNER_EMAIL_ANNOTATION = "opencrane.io/owner-email";
-
-/** Suffix appended to an org's name to form its auto-seeded first workspace Tenant. */
-const _DEFAULT_TENANT_SUFFIX = "-default";
-
-/** Whether a Kubernetes API error is a 409 AlreadyExists across the common error shapes. */
-function _IsAlreadyExistsError(err: unknown): boolean
-{
-  if (typeof err !== "object" || err === null) return false;
-  const e = err as { statusCode?: unknown; code?: unknown; body?: { code?: unknown } };
-  if (e.statusCode === 409 || e.code === 409) return true;
-  return typeof e.body === "object" && e.body !== null && (e.body as { code?: unknown }).code === 409;
-}
 
 /**
  * Watches the cluster-scoped ClusterTenant custom resource and drives each org
@@ -297,11 +277,12 @@ export class ClusterTenantOperator
 
       this.log.info({ name, boundNamespace: boundary.boundNamespace }, "cluster tenant ready");
 
-      // 6. Seed the org's first workspace Tenant now that the org is ready and its
-      //    namespace exists. Idempotent + fail-soft: a re-reconcile re-applies the same
-      //    `<org>-default` Tenant (AlreadyExists is a no-op), and a seed failure is logged
-      //    but never fails the reconcile, so the org cannot be wedged out of `ready`.
-      await this.ensureDefaultTenant(clusterTenant);
+      // The org's first workspace Tenant is seeded by the control plane as a dual-write
+      // (CRD + DB row) at org-create time, with its `POST /cluster-tenants/:name/refresh`
+      // endpoint as the explicit recovery. The operator deliberately does NOT seed it here:
+      // a CRD created without the matching DB projection is invisible to the management API
+      // (the "ready org, no workspace tenant" bug). The TenantOperator reconciles whatever
+      // default Tenant the control plane declared, once this org's namespace is bound.
     }
     catch (err)
     {
@@ -311,74 +292,6 @@ export class ClusterTenantOperator
         message: err instanceof Error ? err.message : String(err),
       });
       throw err;
-    }
-  }
-
-  /**
-   * Seed the org's first workspace Tenant once it is ready, attributed to the org owner.
-   *
-   * Closes the "ready org with no workspace" gap: provisioning creates the org (+owner
-   * membership) but no pod, so a freshly-provisioned customer would land in an empty
-   * console. On the org's reconcile to `ready` — when its bound namespace exists — this
-   * applies a `<org>-default` Tenant whose `clusterTenantRef` points back at the org.
-   *
-   * Idempotent: a re-reconcile re-applies the same Tenant and treats AlreadyExists (409)
-   * as a converged no-op (it is created in the operator's watch namespace, like every
-   * other Tenant CR). Fail-soft: any other error is logged but never thrown, so a seed
-   * hiccup cannot wedge the org out of `ready`; the next reconcile retries.
-   *
-   * The owner's email arrives via the CR's `spec.owner.email` (the operator has no DB
-   * access), falling back to the legacy `opencrane.io/owner-email` annotation for CRs an
-   * older control plane created before the field existed. When it is absent — the dev-auth
-   * path carries only a subject, no email — the seed is skipped with a warning.
-   *
-   * @param clusterTenant - The ready ClusterTenant whose default Tenant is ensured.
-   */
-  private async ensureDefaultTenant(clusterTenant: ClusterTenantResource): Promise<void>
-  {
-    const orgName = clusterTenant.metadata!.name!;
-    const ownerEmail = clusterTenant.spec.owner?.email?.trim()
-      || clusterTenant.metadata?.annotations?.[_LEGACY_OWNER_EMAIL_ANNOTATION]?.trim();
-    if (!ownerEmail)
-    {
-      this.log.warn({ name: orgName }, "no owner email on cluster tenant (spec.owner.email / legacy annotation both absent); skipping default tenant seed");
-      return;
-    }
-
-    // Tenant CRs live in the operator's watch namespace (the TenantOperator watches there),
-    // falling back to the operator's own namespace when watching all namespaces.
-    const namespace = this.config.watchNamespace || this.config.operatorNamespace;
-    const tenantName = `${orgName}${_DEFAULT_TENANT_SUFFIX}`;
-    const tenantCr = {
-      apiVersion: `${OPENCRANE_API_GROUP}/${OPENCRANE_API_VERSION}`,
-      kind: "Tenant",
-      metadata: { name: tenantName, namespace },
-      spec: {
-        displayName: `${clusterTenant.spec.displayName ?? orgName} workspace`,
-        email: ownerEmail,
-        clusterTenantRef: orgName,
-      },
-    };
-
-    try
-    {
-      await this.customApi.createNamespacedCustomObject({
-        group: OPENCRANE_API_GROUP,
-        version: OPENCRANE_API_VERSION,
-        namespace,
-        plural: TENANT_CRD_PLURAL,
-        body: tenantCr,
-      });
-      this.log.info({ name: orgName, tenantName, namespace }, "seeded default tenant for org");
-    }
-    catch (err)
-    {
-      if (_IsAlreadyExistsError(err))
-      {
-        this.log.debug({ name: orgName, tenantName }, "default tenant already exists; nothing to seed");
-        return;
-      }
-      this.log.warn({ err, name: orgName, tenantName }, "failed to seed default tenant (org stays ready; will retry on next reconcile)");
     }
   }
 

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -398,6 +398,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/cluster-tenants/{name}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Refresh a cluster tenant's status and reconcile its owner workspace tenant
+         * @description Re-reads the operator's observed phase from the CR (mirroring it to the DB), then — when the org is fully `ready` but has no workspace Tenant projected — seeds the owner's `<org>-default` Tenant via the same dual-write (CRD + DB row) the create path uses. Idempotent: a ready org that already has its tenant just returns the current status.
+         */
+        post: operations["refreshClusterTenant"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/billing-accounts": {
         parameters: {
             query?: never;
@@ -3605,6 +3625,68 @@ export interface operations {
                         message?: string;
                         boundNamespace?: string;
                         provisioner?: string;
+                    };
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is neither a platform operator nor an owner/admin of this org. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Cluster tenant not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    refreshClusterTenant: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Refreshed status, plus the default-tenant reconcile outcome (null when the org is not yet ready). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        status?: {
+                            /** @enum {string} */
+                            phase?: "pending" | "provisioning" | "ready" | "failed";
+                            message?: string;
+                            boundNamespace?: string;
+                            provisioner?: string;
+                        };
+                        defaultTenant?: {
+                            tenantName?: string;
+                            created?: boolean;
+                            skippedReason?: string;
+                        } | null;
                     };
                 };
             };

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -107,6 +107,7 @@ TENANT_TAG=""           # empty → falls back to IMAGE_TAG
 BASE_DOMAIN="${OPENCRANE_BASE_DOMAIN:-}"
 STORAGE_CLASS=""        # empty → cluster default StorageClass
 VALUES_FILE=""
+REUSE_VALUES=""      # "--reuse-values" mode: inherit current helm values; add only overrides
 EXTRA_SET=()
 
 # OIDC + per-cluster operator bootstrap. All default empty (OIDC stays disabled and the
@@ -220,6 +221,7 @@ while [[ $# -gt 0 ]]; do
     --dns01-credentials) DNS01_CREDENTIALS="$2"; shift 2 ;;
     --dns01-project)     DNS01_PROJECT="$2"; shift 2 ;;
     --values)        VALUES_FILE="$2"; shift 2 ;;
+    --reuse-values)  REUSE_VALUES="1"; shift ;;
     --set)           EXTRA_SET+=(--set "$2"); shift 2 ;;
     -h|--help)       grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *)               err "Unknown flag: $1"; exit 1 ;;
@@ -774,6 +776,9 @@ _DB_CKSUM="$(printf '%s' "$DB_PASSWORD" | sha256sum | cut -c1-8)"
 helm_args+=(--set "litellm.podAnnotations.db-checksum=$_DB_CKSUM")
 helm_args+=(--set "mcpGateway.podAnnotations.db-checksum=$_DB_CKSUM")
 helm_args+=("${EXTRA_SET[@]}")
+# When --reuse-values is set, inherit all previously-supplied values from the live release
+# and apply only the overrides passed on this invocation (e.g. a pure image-tag rollout).
+[[ -n "$REUSE_VALUES" ]] && helm_args+=(--reuse-values)
 helm "${helm_args[@]}"
 
 # 4. Wait for the core workloads.


### PR DESCRIPTION
## Problem

ClusterTenants reached ready with a running workspace pod but no row in the tenants table, so GET /tenants returned empty and the Fleet UI showed 'No user tenants yet for this customer.'

Root cause: the operator's ensureDefaultTenant() created the Tenant CRD only, bypassing the control-plane dual-write (CRD + Postgres). The management API reads Postgres, so the tenant was invisible.

## Fix — control plane is now the single authority for the owner's first tenant

1. Create-time seed: POST /cluster-tenants dual-writes the owner's <org>-default Tenant (CRD + DB row) as part of org creation. It sits Pending until the TenantOperator reconciles it to Running once the org namespace is bound. Best-effort — a seed hiccup never fails org creation.

2. Refresh endpoint: POST /cluster-tenants/:name/refresh re-reads the observed phase from the CR (mirrors it to the DB) and, when the org is ready but has no tenant row, seeds it via the same dual-write — recovering the owner email from the existing CRD. Idempotent. Explicit recovery for orgs already ready without a tenant (current elewa / elewa-be / northwind state).

Shared helper _EnsureOwnerDefaultTenant tolerates a pre-existing CRD (AlreadyExists then writes the missing DB row) and a P2002 race.

Operator: ensureDefaultTenant() + dead helpers removed; regression test asserts the operator no longer creates a Tenant CRD on reconcile. Surfaces: adds 'oc cluster-tenant refresh' and the OpenAPI path (client types regenerated).

## Test plan
- pnpm lint clean (all packages)
- control-plane: 427 passed (new create-seed, dev-auth no-email skip, 4 refresh-path tests)
- operator: 163 passed (obsolete seed tests replaced with no-seed guard)
- CLI: 4 passed
- TODO deploy to dev; refresh elewa/elewa-be/northwind, verify rows + UI
- TODO create a fresh org, verify default tenant appears immediately