### PR TITLE
fix(auth): scope all email→tenant resolution by silo so multi-silo owners resolve

### DIFF
--- a/apps/control-plane/src/__tests__/connections/gateway-resolve.test.ts
+++ b/apps/control-plane/src/__tests__/connections/gateway-resolve.test.ts
@@ -93,4 +93,19 @@ describe("_ResolveGatewayTarget (DOMAIN.T4 routing authority)", function _suite(
 			take: 2,
 		});
 	});
+
+	it("scopes the lookup to the given silo so a multi-silo owner routes to one pod", async function ()
+	{
+		// Globally ambiguous, but scoping to the connecting silo resolves to exactly its pod.
+		const { prisma, findMany } = _buildPrisma([{ name: "elewa-be-default", clusterTenantRef: "elewa-be" }]);
+
+		const outcome = await _ResolveGatewayTarget(prisma, "default", "jente@elewa.ke", "sub-1", "elewa-be");
+
+		expect(outcome.ok).toBe(true);
+		expect(findMany).toHaveBeenCalledWith({
+			where: { email: { equals: "jente@elewa.ke", mode: "insensitive" }, clusterTenantRef: "elewa-be" },
+			select: { name: true, clusterTenantRef: true },
+			take: 2,
+		});
+	});
 });

--- a/apps/control-plane/src/__tests__/infra/oidc-getstatus.test.ts
+++ b/apps/control-plane/src/__tests__/infra/oidc-getstatus.test.ts
@@ -23,10 +23,11 @@ function _disableOidc(): void
   delete process.env.OIDC_SESSION_SECRET;
 }
 
-/** Build a Request-like object carrying a logged-in session user. */
-function _reqWithUser(email: string | undefined): Request
+/** Build a Request-like object carrying a logged-in session user (and an optional org host). */
+function _reqWithUser(email: string | undefined, host?: string): Request
 {
   return {
+    headers: host ? { "x-forwarded-host": host } : {},
     session: {
       authUser: {
         sub: "user-1",
@@ -80,6 +81,23 @@ describe("OidcAuthService.getStatus — /auth/me identity surface (WOI.1)", func
     const status = await service.getStatus(_reqWithUser("dup@acme.io"));
 
     expect(status.user?.clusterTenant).toBeNull();
+  });
+
+  it("scopes the lookup to the silo in the request host so a multi-silo owner resolves (WOI.1)", async function _hostScoped()
+  {
+    // The owner has a workspace in three silos; the host says which one they are viewing.
+    // The where clause must carry clusterTenantRef so the email match is no longer ambiguous.
+    const findMany = vi.fn().mockResolvedValue([{ clusterTenantRef: "elewa-be" }]);
+    const prisma = { tenant: { findMany } } as unknown as PrismaClient;
+    const service = ___CreateOidcAuthService(pino({ enabled: false }), prisma);
+
+    const status = await service.getStatus(_reqWithUser("jente@elewa.ke", "elewa-be.dev.opencrane.ai"));
+
+    expect(status.user?.clusterTenant).toBe("elewa-be");
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { email: { equals: "jente@elewa.ke", mode: "insensitive" }, clusterTenantRef: "elewa-be" },
+      take: 2,
+    }));
   });
 
   it("returns clusterTenant null when the tenant has no parent ref", async function _noParent()

--- a/apps/control-plane/src/__tests__/middleware/cluster-tenant-scope.test.ts
+++ b/apps/control-plane/src/__tests__/middleware/cluster-tenant-scope.test.ts
@@ -1,0 +1,118 @@
+import type { Request, Response } from "express";
+import type { PrismaClient } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _ClusterTenantScopeGuard } from "../../infra/middleware/cluster-tenant-scope.js";
+import type { ClusterTenantScopedResource } from "../../infra/middleware/cluster-tenant-scope.types.js";
+
+/** Minimal OIDC env so the guard runs in real-auth mode (no dev-mode fail-open). */
+function _enableOidc(): void
+{
+  process.env.OIDC_ISSUER_URL = "https://idp.test";
+  process.env.OIDC_CLIENT_ID = "cid";
+  process.env.OIDC_REDIRECT_URI = "https://cp.test/api/v1/auth/callback";
+  process.env.OIDC_SESSION_SECRET = "test-secret";
+}
+
+/** Clear the OIDC env between tests so config does not leak across cases. */
+function _disableOidc(): void
+{
+  delete process.env.OIDC_ISSUER_URL;
+  delete process.env.OIDC_CLIENT_ID;
+  delete process.env.OIDC_REDIRECT_URI;
+  delete process.env.OIDC_SESSION_SECRET;
+}
+
+/** Build a Request carrying the given session user (or none). */
+function _req(authUser: Record<string, unknown> | undefined): Request
+{
+  return { session: authUser ? { authUser } : {} } as unknown as Request;
+}
+
+/** A non-operator human session. */
+function _human(email: string): Record<string, unknown>
+{
+  return { sub: "u-1", issuer: "https://idp.test", groups: [], isPlatformOperator: false, isOrgAdmin: false, email };
+}
+
+/** Run the guard and resolve to the decision it took (`allow` via next, `deny` via 403 json). */
+function _decide(
+  prisma: PrismaClient,
+  resource: ClusterTenantScopedResource | null,
+  req: Request,
+): Promise<{ decision: "allow" | "deny"; status?: number }>
+{
+  return new Promise(function _exec(resolve)
+  {
+    const handler = _ClusterTenantScopeGuard(prisma, async function _resolve() { return resource; });
+    let statusCode: number | undefined;
+    const res = {
+      status(code: number) { statusCode = code; return res; },
+      json() { resolve({ decision: "deny", status: statusCode }); return res; },
+    } as unknown as Response;
+    handler(req, res, function _next() { resolve({ decision: "allow" }); });
+  });
+}
+
+/** Prisma stub whose tenant.findMany echoes a configurable row set. */
+function _prismaWith(rows: { clusterTenantRef: string | null }[]): { prisma: PrismaClient; findMany: ReturnType<typeof vi.fn> }
+{
+  const findMany = vi.fn().mockResolvedValue(rows);
+  return { prisma: { tenant: { findMany } } as unknown as PrismaClient, findMany };
+}
+
+describe("_ClusterTenantScopeGuard — silo-scoped mutation authz (AIR.0b)", function _suite()
+{
+  beforeEach(_enableOidc);
+  afterEach(function _reset() { _disableOidc(); vi.restoreAllMocks(); });
+
+  it("allows a platform operator without resolving any tenant", async function _operator()
+  {
+    const { prisma, findMany } = _prismaWith([]);
+    const result = await _decide(prisma, { scope: "clusterTenant", clusterTenant: "acme" }, _req({ isPlatformOperator: true, email: "op@x.io" }));
+
+    expect(result.decision).toBe("allow");
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("fails closed (deny) for a missing session under real auth", async function _noSession()
+  {
+    const { prisma } = _prismaWith([]);
+    const result = await _decide(prisma, { scope: "clusterTenant", clusterTenant: "acme" }, _req(undefined));
+
+    expect(result.decision).toBe("deny");
+    expect(result.status).toBe(403);
+  });
+
+  it("denies a non-operator a global-scoped mutation", async function _global()
+  {
+    const { prisma, findMany } = _prismaWith([{ clusterTenantRef: "acme" }]);
+    const result = await _decide(prisma, { scope: "global", clusterTenant: null }, _req(_human("owner@acme.io")));
+
+    expect(result.decision).toBe("deny");
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("allows a multi-silo owner to mutate a resource in a silo they own, scoping the lookup to it", async function _ownerScoped()
+  {
+    // Owner of several silos: an unscoped email match would be ambiguous, but the guard scopes the
+    // lookup to the targeted silo so exactly the owned row matches.
+    const { prisma, findMany } = _prismaWith([{ clusterTenantRef: "elewa-be" }]);
+    const result = await _decide(prisma, { scope: "clusterTenant", clusterTenant: "elewa-be" }, _req(_human("jente@elewa.ke")));
+
+    expect(result.decision).toBe("allow");
+    expect(findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { email: { equals: "jente@elewa.ke", mode: "insensitive" }, clusterTenantRef: "elewa-be" },
+      take: 2,
+    }));
+  });
+
+  it("denies a non-owner whose scoped lookup yields no row in the targeted silo", async function _foreign()
+  {
+    const { prisma } = _prismaWith([]);
+    const result = await _decide(prisma, { scope: "clusterTenant", clusterTenant: "northwind" }, _req(_human("jente@elewa.ke")));
+
+    expect(result.decision).toBe("deny");
+    expect(result.status).toBe(403);
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/auth-pod-token.test.ts
+++ b/apps/control-plane/src/__tests__/routes/auth-pod-token.test.ts
@@ -110,6 +110,22 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 		expect(res.body.code).toBe("AMBIGUOUS_TENANT");
 	});
 
+	it("scopes the tenant lookup to the silo in the request host so a multi-silo owner resolves", async function _hostScoped()
+	{
+		// A multi-silo owner: an unscoped lookup would be ambiguous (409). The request host
+		// (`<clusterTenant>.<base>`) scopes the query to the silo being connected through.
+		const prisma = _buildPrisma([{ name: "elewa-be-default", ingressHost: "elewa-be.dev.opencrane.ai", configOverrides: null }]);
+		const app = _buildApp({ authUser: { sub: "u1", email: "jente@elewa.ke" } }, prisma);
+
+		const res = await request(app).post("/auth/pod-token").set("x-forwarded-host", "elewa-be.dev.opencrane.ai");
+
+		expect(res.status).toBe(200);
+		expect(res.body.tenant).toBe("elewa-be-default");
+		expect((prisma.tenant.findMany as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(expect.objectContaining({
+			where: { email: { equals: "jente@elewa.ke", mode: "insensitive" }, clusterTenantRef: "elewa-be" },
+		}));
+	});
+
 	it("returns 409 when the pod is neither paired nor has an ingress host", async function _notReady()
 	{
 		const prisma = _buildPrisma([{ name: "alex.oc", ingressHost: null, configOverrides: null }]);

--- a/apps/control-plane/src/core/connections/gateway-resolve.ts
+++ b/apps/control-plane/src/core/connections/gateway-resolve.ts
@@ -34,14 +34,21 @@ export type GatewayResolveOutcome =
  * resolves to a forbidden outcome, never an arbitrary pick. This is the routing-level
  * half of cross-tenant safety; the pod-level half is per-pod owner pinning (CONN.10).
  *
+ * `scopeClusterTenant` narrows the lookup to the silo the connection is coming in on
+ * (derived from the request host by the caller). A human who owns a workspace in more
+ * than one silo would otherwise be ambiguous (>1) and fail closed everywhere; scoping
+ * routes them to the pod for the host they are connecting through. Self-validating: a
+ * foreign/unknown silo yields zero rows → NO_TENANT, never a foreign pod.
+ *
  * The pod's namespace is re-derived from the tenant's owning org
  * (`opencrane-<clusterTenantRef>`); a tenant with no org ref (legacy single-namespace
  * install) falls back to the control plane's own namespace.
  *
- * @param prisma           - Prisma client for the email→tenant lookup.
- * @param defaultNamespace - Namespace for tenants with no org ref (the CP's own ns).
- * @param email            - The session's verified email claim.
- * @param sub              - The session subject (logged identity); falls back to email.
+ * @param prisma             - Prisma client for the email→tenant lookup.
+ * @param defaultNamespace   - Namespace for tenants with no org ref (the CP's own ns).
+ * @param email              - The session's verified email claim.
+ * @param sub                - The session subject (logged identity); falls back to email.
+ * @param scopeClusterTenant - Optional silo to scope the lookup to; omit for a global match.
  * @returns A forward target, or a fail-closed reason.
  */
 export async function _ResolveGatewayTarget(
@@ -49,6 +56,7 @@ export async function _ResolveGatewayTarget(
   defaultNamespace: string,
   email: string | undefined,
   sub: string,
+  scopeClusterTenant?: string | undefined,
 ): Promise<GatewayResolveOutcome>
 {
   const normalized = typeof email === "string" ? email.toLowerCase().trim() : "";
@@ -60,8 +68,9 @@ export async function _ResolveGatewayTarget(
   // Fail closed: at most one tenant may match. `take: 2` is enough to detect ambiguity
   // without scanning the whole table — an ambiguous email must never silently route the
   // caller to one of several pods (which could be another user's).
+  const scope = typeof scopeClusterTenant === "string" ? scopeClusterTenant.trim() : "";
   const matches = await prisma.tenant.findMany({
-    where: { email: { equals: normalized, mode: "insensitive" } },
+    where: { email: { equals: normalized, mode: "insensitive" }, ...(scope ? { clusterTenantRef: scope } : {}) },
     select: { name: true, clusterTenantRef: true },
     take: 2,
   });

--- a/apps/control-plane/src/infra/auth/auth.router.ts
+++ b/apps/control-plane/src/infra/auth/auth.router.ts
@@ -83,7 +83,10 @@ export function ___AuthRouter(authService: OidcAuthService, prisma: PrismaClient
 
       const email = typeof authUser.email === "string" ? authUser.email : "";
       const sub = typeof authUser.sub === "string" ? authUser.sub : "";
-      const outcome = await _ResolveGatewayTarget(prisma, namespace, email, sub);
+      // Scope to the silo the WebSocket is connecting through so a multi-silo owner routes
+      // to the pod for this host (mirrors /pod-token); foreign silo fails closed.
+      const silo = _ClusterTenantFromHost(_RequestHost(req));
+      const outcome = await _ResolveGatewayTarget(prisma, namespace, email, sub, silo);
 
       if (!outcome.ok)
       {

--- a/apps/control-plane/src/infra/auth/auth.router.ts
+++ b/apps/control-plane/src/infra/auth/auth.router.ts
@@ -7,6 +7,7 @@ import { _log } from "../../log.js";
 import type { OidcAuthService } from "./oidc.service.js";
 import { _AuthorizeDeviceGrant, _CreateDeviceGrant, _FindGrantByUserCode, _PollDeviceGrant } from "./device-grant.js";
 import { _ResolveOpenClawPairing } from "./openclaw-pairing.js";
+import { _ClusterTenantFromHost, _RequestHost } from "./request-silo.js";
 import { _RecordBrokeredDevice } from "./brokered-device.js";
 import { _CutTenant } from "../../core/connections/cut-tenant.js";
 import type { OpenClawGatewayAdmin } from "../../core/connections/gateway-admin.types.js";
@@ -140,7 +141,11 @@ export function ___AuthRouter(authService: OidcAuthService, prisma: PrismaClient
         return;
       }
 
-      // 2. Resolve the caller's tenant by their verified email (one pod per user).
+      // 2. Resolve the caller's tenant by their verified email (one pod per user PER silo).
+      //    Scope the lookup to the silo the caller is on — each org is served at
+      //    `<clusterTenant>.<base>`, so a user who owns a workspace in more than one silo
+      //    resolves to the pod for the host they are connecting through. Without a derivable
+      //    silo the lookup stays global (and still fail-closes on ambiguity below).
       const email = typeof authUser.email === "string" ? authUser.email.toLowerCase() : "";
       if (!email)
       {
@@ -148,8 +153,9 @@ export function ___AuthRouter(authService: OidcAuthService, prisma: PrismaClient
         return;
       }
 
+      const silo = _ClusterTenantFromHost(_RequestHost(req));
       const matches = await prisma.tenant.findMany({
-        where: { email: { equals: email, mode: "insensitive" } },
+        where: { email: { equals: email, mode: "insensitive" }, ...(silo ? { clusterTenantRef: silo } : {}) },
         select: { name: true, ingressHost: true, configOverrides: true },
       });
 
@@ -227,9 +233,9 @@ export function ___AuthRouter(authService: OidcAuthService, prisma: PrismaClient
         return;
       }
 
-      // 2. Resolve the caller's tenant by their verified email (one pod per user),
-      //    failing closed on a missing or ambiguous mapping — never cut another
-      //    user's connections.
+      // 2. Resolve the caller's tenant by their verified email (one pod per user per silo),
+      //    scoped to the silo the caller is on, failing closed on a missing or ambiguous
+      //    mapping — never cut another user's connections. Mirrors `/pod-token`.
       const email = typeof authUser.email === "string" ? authUser.email.toLowerCase() : "";
       if (!email)
       {
@@ -237,8 +243,9 @@ export function ___AuthRouter(authService: OidcAuthService, prisma: PrismaClient
         return;
       }
 
+      const silo = _ClusterTenantFromHost(_RequestHost(req));
       const matches = await prisma.tenant.findMany({
-        where: { email: { equals: email, mode: "insensitive" } },
+        where: { email: { equals: email, mode: "insensitive" }, ...(silo ? { clusterTenantRef: silo } : {}) },
         select: { name: true },
       });
 

--- a/apps/control-plane/src/infra/auth/oidc.service.ts
+++ b/apps/control-plane/src/infra/auth/oidc.service.ts
@@ -8,6 +8,7 @@ import type { PrismaClient } from "@prisma/client";
 
 import { ___LoadOidcAuthConfig } from "./oidc.config.js";
 import { _ResolveCallerClusterTenant } from "./resolve-caller-cluster-tenant.js";
+import { _ClusterTenantFromHost, _RequestHost } from "./request-silo.js";
 import { _ResolveOrgMembershipFacts } from "./org-membership.js";
 import type { OwnedOrg } from "./org-membership.js";
 
@@ -187,7 +188,7 @@ export class OidcAuthService
       //    OR-s the login-time flag (groups/operator) with membership-derived authority,
       //    so a user who just created an org is an org admin without re-logging-in.
       const [clusterTenant, membership] = await Promise.all([
-        this._resolveClusterTenant(authUser.email, _requestHost(req)),
+        this._resolveClusterTenant(authUser.email, _RequestHost(req)),
         _ResolveOrgMembershipFacts(this.prisma, authUser.sub),
       ]);
       return {
@@ -234,7 +235,7 @@ export class OidcAuthService
    */
   private async _resolveClusterTenant(email: string | undefined, host: string | undefined): Promise<string | null>
   {
-    return _ResolveCallerClusterTenant(this.prisma, email, _clusterTenantFromHost(host));
+    return _ResolveCallerClusterTenant(this.prisma, email, _ClusterTenantFromHost(host));
   }
 
   /** Build the provider redirect URL and persist PKCE state in the local session. */
@@ -576,34 +577,6 @@ export function ___CreateOidcAuthService(log: Logger, prisma: PrismaClient): Oid
 }
 
 /**
- * The request's effective host, honouring the `x-forwarded-host` set by the ingress proxy
- * (first value when comma-joined) and falling back to the `Host` header. Undefined when the
- * request carries no host. Shared by every per-org-host helper so they read the host one way.
- */
-function _requestHost(req: Request): string | undefined
-{
-  const forwardedHost = req.headers?.["x-forwarded-host"];
-  if (typeof forwardedHost === "string") return forwardedHost.split(",")[0].trim();
-  return typeof req.get === "function" ? req.get("host") : undefined;
-}
-
-/**
- * Derive the ClusterTenant (silo) the caller is currently on from the request host. Each org is
- * served at `<clusterTenant>.<base>`, so the first DNS label names the silo (port and case are
- * stripped). Returns undefined for a bare host with no subdomain (e.g. localhost) so the caller
- * falls back to an unscoped lookup. The label is only a candidate: the email→tenant query filters
- * on it and yields zero rows for a host whose first label is not a real silo, so a wrong guess
- * fail-closes rather than mis-resolving. Custom org domains that do not follow `<org>.<base>` are
- * not matched here (a future ingressHost-based lookup would cover them).
- */
-function _clusterTenantFromHost(host: string | undefined): string | undefined
-{
-  if (!host) return undefined;
-  const firstLabel = host.split(":")[0].trim().toLowerCase().split(".")[0];
-  return firstLabel || undefined;
-}
-
-/**
  * Build the OIDC redirect_uri for THIS request's host (DOMAIN.T4 multi-host). Each org is
  * served at its own host `<org>.<base>`, so login/callback must happen there for the
  * session cookie to be host-scoped to it. We take the callback PATH from the configured
@@ -616,7 +589,7 @@ function _buildRedirectUri(req: Request, configuredRedirect: string): string
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = _requestHost(req);
+  const host = _RequestHost(req);
   if (!host) return configuredRedirect;
   const callbackPath = new URL(configuredRedirect).pathname;
   return `${protocol}://${host}${callbackPath}`;
@@ -633,7 +606,7 @@ function _buildPostLogoutRedirectUri(req: Request, configuredRedirect: string): 
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = _requestHost(req);
+  const host = _RequestHost(req);
   if (!host) return configuredRedirect;
   const parsed = new URL(configuredRedirect);
   return `${protocol}://${host}${parsed.pathname}${parsed.search}`;
@@ -644,7 +617,7 @@ function _buildCurrentUrl(req: Request): URL
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = _requestHost(req);
+  const host = _RequestHost(req);
 
   return new URL(`${protocol}://${host}${req.originalUrl}`);
 }

--- a/apps/control-plane/src/infra/auth/oidc.service.ts
+++ b/apps/control-plane/src/infra/auth/oidc.service.ts
@@ -7,6 +7,7 @@ import type { Logger } from "pino";
 import type { PrismaClient } from "@prisma/client";
 
 import { ___LoadOidcAuthConfig } from "./oidc.config.js";
+import { _ResolveCallerClusterTenant } from "./resolve-caller-cluster-tenant.js";
 import { _ResolveOrgMembershipFacts } from "./org-membership.js";
 import type { OwnedOrg } from "./org-membership.js";
 
@@ -186,7 +187,7 @@ export class OidcAuthService
       //    OR-s the login-time flag (groups/operator) with membership-derived authority,
       //    so a user who just created an org is an org admin without re-logging-in.
       const [clusterTenant, membership] = await Promise.all([
-        this._resolveClusterTenant(authUser.email),
+        this._resolveClusterTenant(authUser.email, _RequestHost(req)),
         _ResolveOrgMembershipFacts(this.prisma, authUser.sub),
       ]);
       return {
@@ -218,42 +219,22 @@ export class OidcAuthService
   }
 
   /**
-   * Resolve the caller's ClusterTenant from their IdP-verified email, reusing the
-   * pod-token broker's fail-closed rule: resolve the tenant by email, then read its
-   * `clusterTenantRef`. Returns null when the email is missing, matches no tenant,
-   * matches more than one (ambiguous), the tenant has no parent, or the lookup
-   * fails — never an arbitrary pick, and never taken from request input.
+   * Resolve the caller's ClusterTenant for `/auth/me`, delegating to the shared fail-closed
+   * resolver so the rule cannot drift from the mutation guard and read-time scope filters.
+   *
+   * The lookup is SCOPED to the silo the caller is currently viewing — derived from the request
+   * host (each org is served at `<clusterTenant>.<base>`). Without that scope a human who owns
+   * workspaces in more than one ClusterTenant is ambiguous (>1 email match) and fail-closes to
+   * null, which is exactly the "No tenant yet" state for a multi-silo owner. With it, they resolve
+   * to the silo whose host they are on. When no silo can be derived (no host) the resolver falls
+   * back to a global email match, preserving the single-tenant behaviour.
    *
    * @param email - The session's verified email claim, if any.
+   * @param host  - The request host, used to scope the lookup to one silo.
    */
-  private async _resolveClusterTenant(email: string | undefined): Promise<string | null>
+  private async _resolveClusterTenant(email: string | undefined, host: string | undefined): Promise<string | null>
   {
-    const normalized = typeof email === "string" ? email.toLowerCase().trim() : "";
-    if (!normalized)
-    {
-      return null;
-    }
-
-    try
-    {
-      // Fail closed on an ambiguous email→tenant mapping: take at most two rows so a
-      // duplicate is detected without silently adopting one tenant's parent.
-      const matches = await this.prisma.tenant.findMany({
-        where: { email: { equals: normalized, mode: "insensitive" } },
-        select: { clusterTenantRef: true },
-        take: 2,
-      });
-      if (matches.length !== 1)
-      {
-        return null;
-      }
-      return matches[0].clusterTenantRef ?? null;
-    }
-    catch (err)
-    {
-      this.log.warn({ err }, "failed to resolve clusterTenant for /auth/me; returning null");
-      return null;
-    }
+    return _ResolveCallerClusterTenant(this.prisma, email, _ClusterTenantFromHost(host));
   }
 
   /** Build the provider redirect URL and persist PKCE state in the local session. */
@@ -595,6 +576,34 @@ export function ___CreateOidcAuthService(log: Logger, prisma: PrismaClient): Oid
 }
 
 /**
+ * The request's effective host, honouring the `x-forwarded-host` set by the ingress proxy
+ * (first value when comma-joined) and falling back to the `Host` header. Undefined when the
+ * request carries no host. Shared by every per-org-host helper so they read the host one way.
+ */
+function _RequestHost(req: Request): string | undefined
+{
+  const forwardedHost = req.headers?.["x-forwarded-host"];
+  if (typeof forwardedHost === "string") return forwardedHost.split(",")[0].trim();
+  return typeof req.get === "function" ? req.get("host") : undefined;
+}
+
+/**
+ * Derive the ClusterTenant (silo) the caller is currently on from the request host. Each org is
+ * served at `<clusterTenant>.<base>`, so the first DNS label names the silo (port and case are
+ * stripped). Returns undefined for a bare host with no subdomain (e.g. localhost) so the caller
+ * falls back to an unscoped lookup. The label is only a candidate: the email→tenant query filters
+ * on it and yields zero rows for a host whose first label is not a real silo, so a wrong guess
+ * fail-closes rather than mis-resolving. Custom org domains that do not follow `<org>.<base>` are
+ * not matched here (a future ingressHost-based lookup would cover them).
+ */
+function _ClusterTenantFromHost(host: string | undefined): string | undefined
+{
+  if (!host) return undefined;
+  const firstLabel = host.split(":")[0].trim().toLowerCase().split(".")[0];
+  return firstLabel || undefined;
+}
+
+/**
  * Build the OIDC redirect_uri for THIS request's host (DOMAIN.T4 multi-host). Each org is
  * served at its own host `<org>.<base>`, so login/callback must happen there for the
  * session cookie to be host-scoped to it. We take the callback PATH from the configured
@@ -606,9 +615,8 @@ export function ___CreateOidcAuthService(log: Logger, prisma: PrismaClient): Oid
 function _buildRedirectUri(req: Request, configuredRedirect: string): string
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
-  const forwardedHost = req.headers["x-forwarded-host"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = typeof forwardedHost === "string" ? forwardedHost.split(",")[0].trim() : req.get("host");
+  const host = _RequestHost(req);
   if (!host) return configuredRedirect;
   const callbackPath = new URL(configuredRedirect).pathname;
   return `${protocol}://${host}${callbackPath}`;
@@ -624,9 +632,8 @@ function _buildRedirectUri(req: Request, configuredRedirect: string): string
 function _buildPostLogoutRedirectUri(req: Request, configuredRedirect: string): string
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
-  const forwardedHost = req.headers["x-forwarded-host"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = typeof forwardedHost === "string" ? forwardedHost.split(",")[0].trim() : req.get("host");
+  const host = _RequestHost(req);
   if (!host) return configuredRedirect;
   const parsed = new URL(configuredRedirect);
   return `${protocol}://${host}${parsed.pathname}${parsed.search}`;
@@ -636,9 +643,8 @@ function _buildPostLogoutRedirectUri(req: Request, configuredRedirect: string): 
 function _buildCurrentUrl(req: Request): URL
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
-  const forwardedHost = req.headers["x-forwarded-host"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = typeof forwardedHost === "string" ? forwardedHost.split(",")[0].trim() : req.get("host");
+  const host = _RequestHost(req);
 
   return new URL(`${protocol}://${host}${req.originalUrl}`);
 }

--- a/apps/control-plane/src/infra/auth/oidc.service.ts
+++ b/apps/control-plane/src/infra/auth/oidc.service.ts
@@ -187,7 +187,7 @@ export class OidcAuthService
       //    OR-s the login-time flag (groups/operator) with membership-derived authority,
       //    so a user who just created an org is an org admin without re-logging-in.
       const [clusterTenant, membership] = await Promise.all([
-        this._resolveClusterTenant(authUser.email, _RequestHost(req)),
+        this._resolveClusterTenant(authUser.email, _requestHost(req)),
         _ResolveOrgMembershipFacts(this.prisma, authUser.sub),
       ]);
       return {
@@ -234,7 +234,7 @@ export class OidcAuthService
    */
   private async _resolveClusterTenant(email: string | undefined, host: string | undefined): Promise<string | null>
   {
-    return _ResolveCallerClusterTenant(this.prisma, email, _ClusterTenantFromHost(host));
+    return _ResolveCallerClusterTenant(this.prisma, email, _clusterTenantFromHost(host));
   }
 
   /** Build the provider redirect URL and persist PKCE state in the local session. */
@@ -580,7 +580,7 @@ export function ___CreateOidcAuthService(log: Logger, prisma: PrismaClient): Oid
  * (first value when comma-joined) and falling back to the `Host` header. Undefined when the
  * request carries no host. Shared by every per-org-host helper so they read the host one way.
  */
-function _RequestHost(req: Request): string | undefined
+function _requestHost(req: Request): string | undefined
 {
   const forwardedHost = req.headers?.["x-forwarded-host"];
   if (typeof forwardedHost === "string") return forwardedHost.split(",")[0].trim();
@@ -596,7 +596,7 @@ function _RequestHost(req: Request): string | undefined
  * fail-closes rather than mis-resolving. Custom org domains that do not follow `<org>.<base>` are
  * not matched here (a future ingressHost-based lookup would cover them).
  */
-function _ClusterTenantFromHost(host: string | undefined): string | undefined
+function _clusterTenantFromHost(host: string | undefined): string | undefined
 {
   if (!host) return undefined;
   const firstLabel = host.split(":")[0].trim().toLowerCase().split(".")[0];
@@ -616,7 +616,7 @@ function _buildRedirectUri(req: Request, configuredRedirect: string): string
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = _RequestHost(req);
+  const host = _requestHost(req);
   if (!host) return configuredRedirect;
   const callbackPath = new URL(configuredRedirect).pathname;
   return `${protocol}://${host}${callbackPath}`;
@@ -633,7 +633,7 @@ function _buildPostLogoutRedirectUri(req: Request, configuredRedirect: string): 
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = _RequestHost(req);
+  const host = _requestHost(req);
   if (!host) return configuredRedirect;
   const parsed = new URL(configuredRedirect);
   return `${protocol}://${host}${parsed.pathname}${parsed.search}`;
@@ -644,7 +644,7 @@ function _buildCurrentUrl(req: Request): URL
 {
   const forwardedProto = req.headers["x-forwarded-proto"];
   const protocol = typeof forwardedProto === "string" ? forwardedProto.split(",")[0].trim() : req.protocol;
-  const host = _RequestHost(req);
+  const host = _requestHost(req);
 
   return new URL(`${protocol}://${host}${req.originalUrl}`);
 }

--- a/apps/control-plane/src/infra/auth/request-silo.ts
+++ b/apps/control-plane/src/infra/auth/request-silo.ts
@@ -1,0 +1,35 @@
+import type { Request } from "express";
+
+/**
+ * The request's effective host, honouring the `x-forwarded-host` set by the ingress proxy
+ * (first value when comma-joined) and falling back to the `Host` header. Undefined when the
+ * request carries no host. Shared by every per-org-host path so they read the host one way.
+ *
+ * @param req - The incoming Express request.
+ * @returns The host (no scheme), or undefined when none is present.
+ */
+export function _RequestHost(req: Request): string | undefined
+{
+  const forwardedHost = req.headers?.["x-forwarded-host"];
+  if (typeof forwardedHost === "string") return forwardedHost.split(",")[0].trim();
+  return typeof req.get === "function" ? req.get("host") : undefined;
+}
+
+/**
+ * Derive the ClusterTenant (silo) the caller is currently on from the request host. Each org is
+ * served at `<clusterTenant>.<base>`, so the first DNS label names the silo (port and case are
+ * stripped). Returns undefined for a bare host with no subdomain (e.g. localhost) so the caller
+ * falls back to an unscoped lookup. The label is only a candidate: the email→tenant query filters
+ * on it and yields zero rows for a host whose first label is not a real silo, so a wrong guess
+ * fail-closes rather than mis-resolving. Custom org domains that do not follow `<org>.<base>` are
+ * not matched here (a future ingressHost-based lookup would cover them).
+ *
+ * @param host - The request host, typically from {@link _RequestHost}.
+ * @returns The silo (first DNS label), or undefined when none can be derived.
+ */
+export function _ClusterTenantFromHost(host: string | undefined): string | undefined
+{
+  if (!host) return undefined;
+  const firstLabel = host.split(":")[0].trim().toLowerCase().split(".")[0];
+  return firstLabel || undefined;
+}

--- a/apps/control-plane/src/infra/auth/resolve-caller-cluster-tenant.ts
+++ b/apps/control-plane/src/infra/auth/resolve-caller-cluster-tenant.ts
@@ -5,15 +5,31 @@ import type { PrismaClient } from "@prisma/client";
  * may match, and its `clusterTenantRef` is returned; null on a missing/ambiguous email or any lookup
  * failure — never an arbitrary pick, never taken from request input.
  *
- * Single source of truth (Track AIR) for the ClusterTenant scope guard (mutation authz) and the
- * read-time scope filters (the savings-recommendation feed + the metrics proxy). Keep these on one
- * implementation so the fail-closed rule cannot drift between call sites.
+ * Single source of truth (Track AIR) for the ClusterTenant scope guard (mutation authz), the
+ * read-time scope filters (the savings-recommendation feed + the metrics proxy), and `/auth/me`
+ * introspection. Keep these on one implementation so the fail-closed rule cannot drift between
+ * call sites.
  *
- * @param prisma - Prisma client for the email→tenant→clusterTenantRef lookup.
- * @param email  - The session's verified email claim, if any.
+ * `scopeClusterTenant` narrows the lookup to a single silo BEFORE the at-most-one rule is applied.
+ * Without it the lookup is global, so a human who legitimately owns workspaces in more than one
+ * ClusterTenant is ambiguous (>1 match) and fail-closes to null. Callers that already know which
+ * silo is in play pass it so that human resolves correctly:
+ *  - `/auth/me` derives it from the request host (the org the caller is currently viewing);
+ *  - the mutation guard passes the targeted resource's owning ClusterTenant (a membership check:
+ *    "does the caller own a workspace in this silo?").
+ * The filter is self-validating — an unknown or foreign silo simply yields zero rows (null/deny),
+ * never an arbitrary pick.
+ *
+ * @param prisma             - Prisma client for the email→tenant→clusterTenantRef lookup.
+ * @param email              - The session's verified email claim, if any.
+ * @param scopeClusterTenant - Optional silo to scope the lookup to; omit for a global email match.
  * @returns The caller's owning ClusterTenant ref, or null when unresolved/ambiguous.
  */
-export async function _ResolveCallerClusterTenant(prisma: PrismaClient, email: string | undefined): Promise<string | null>
+export async function _ResolveCallerClusterTenant(
+  prisma: PrismaClient,
+  email: string | undefined,
+  scopeClusterTenant?: string | undefined,
+): Promise<string | null>
 {
   const normalized = typeof email === "string" ? email.toLowerCase().trim() : "";
   if (!normalized)
@@ -21,10 +37,15 @@ export async function _ResolveCallerClusterTenant(prisma: PrismaClient, email: s
     return null;
   }
 
+  const scope = typeof scopeClusterTenant === "string" ? scopeClusterTenant.trim() : "";
+
   try
   {
     const matches = await prisma.tenant.findMany({
-      where: { email: { equals: normalized, mode: "insensitive" } },
+      where: {
+        email: { equals: normalized, mode: "insensitive" },
+        ...(scope ? { clusterTenantRef: scope } : {}),
+      },
       select: { clusterTenantRef: true },
       take: 2,
     });

--- a/apps/control-plane/src/infra/middleware/cluster-tenant-scope.ts
+++ b/apps/control-plane/src/infra/middleware/cluster-tenant-scope.ts
@@ -11,13 +11,13 @@ import { _IsDevAuthMode } from "../auth/auth-mode.js";
  *
  * The rule (AIR.0b), in priority order:
  *   1. A platform operator (session `isPlatformOperator`) may mutate any resource at any scope.
- *   2. A non-operator may mutate only a `clusterTenant`-scoped resource whose owning
- *      ClusterTenant equals the caller's own resolved ClusterTenant. Global-scoped mutations
- *      are operator-only.
+ *   2. A non-operator may mutate only a `clusterTenant`-scoped resource in a silo they own a
+ *      workspace in. Global-scoped mutations are operator-only.
  *
- * `clusterTenant` is resolved fresh from the caller's IdP-verified email (email → tenant →
- * `clusterTenantRef`), mirroring `OidcAuthService._resolveClusterTenant` — never taken from a
- * self-asserted claim or request input.
+ * Ownership is resolved fresh from the caller's IdP-verified email via the shared
+ * `_ResolveCallerClusterTenant`, scoped to the resource's own silo so a human who owns workspaces
+ * in more than one ClusterTenant is authorised for each — never taken from a self-asserted claim
+ * or request input. `/auth/me` uses the same resolver (scoped by request host instead).
  *
  * The guard is applied per-router and reads the *resource* scope/clusterTenant from the request
  * via the supplied `resolveResource` callback, which is run after the request body / params are
@@ -94,9 +94,11 @@ async function _enforce(
     return "deny";
   }
 
-  // 5. ClusterTenant-scoped: allow only when the caller's own resolved ClusterTenant
-  //    matches the resource owner. Resolve fresh from the verified email (fail-closed).
-  const callerClusterTenant = await _ResolveCallerClusterTenant(prisma, authUser.email);
+  // 5. ClusterTenant-scoped: allow only when the caller owns a workspace in the resource's
+  //    silo. Scope the fail-closed lookup to that silo so a human who owns workspaces in more
+  //    than one ClusterTenant is authorised for each (an unscoped email match would be ambiguous
+  //    and deny them everywhere). A non-owner yields zero rows → null → deny.
+  const callerClusterTenant = await _ResolveCallerClusterTenant(prisma, authUser.email, resource.clusterTenant);
   if (callerClusterTenant && callerClusterTenant === resource.clusterTenant)
   {
     return "allow";


### PR DESCRIPTION
## Problem

A human who owns workspaces in more than one `ClusterTenant` (e.g. `jente@elewa.ke`, owner of `elewa`, `elewa-be`, `northwind` on the dev backend) is blocked everywhere despite being signed in with a `Running` Tenant on the host they're visiting:

- **Operator UI** → "No tenant yet"
- **WeOwnAI frontend** → "No workspace for this account … or it maps to more than one"

Root cause: **four** independent `email → tenant` resolution paths each do a **global, host-blind** lookup that fail-closes on `> 1` match. An owner of multiple silos is *legitimately* ambiguous, so every path resolves to null / 403:

1. `/auth/me` — `OidcAuthService._resolveClusterTenant` (operator UI gate)
2. ClusterTenant **mutation scope guard** — `_ResolveCallerClusterTenant`
3. `POST /auth/pod-token` (+ `/pod-token/cut`) — the WeOwnAI OpenClaw connection broker
4. `GET /auth/gateway-resolve` — `_ResolveGatewayTarget`, the gateway-proxy WebSocket routing authority (data-plane path)

## Fix

Scope each lookup to the silo the caller is currently in, **before** the at-most-one rule, so an owner resolves to the workspace for the context they're in:

- **`/auth/me`** and the **pod-token / gateway-resolve** paths derive the silo from the **request host** (`<clusterTenant>.<base>`, first DNS label).
- The **mutation guard** scopes by the **targeted resource's** owning ClusterTenant (a membership check).

Mechanics:
- `_ResolveCallerClusterTenant` and `_ResolveGatewayTarget` gain an optional `scopeClusterTenant` added to the `where` clause; the two `/pod-token` queries add the same filter inline.
- Omitting the scope preserves the prior global, fail-closed behaviour (no-host / token callers).
- Host helpers extracted to a shared `infra/auth/request-silo` module (`_RequestHost`, `_ClusterTenantFromHost`) so all four paths share one implementation; the duplicate resolver in `oidc.service` is collapsed into the shared helper.

**Self-validating / fail-closed preserved:** a foreign or unknown silo yields zero rows → null / `NO_TENANT` / deny — never an arbitrary or foreign pod. The host is advisory only (it can never widen access, only narrow the email match the caller already owns). Operator/super-admin paths unchanged. Aligns with the silo multi-tenant model.

## Tests

- `/auth/me`: multi-silo owner on `elewa-be.dev.opencrane.ai` resolves to `elewa-be`, `where` carries `clusterTenantRef`.
- Scope guard: operator bypass, fail-closed no-session, global-scope deny, multi-silo owner allowed (scoped), foreign-silo deny.
- `/pod-token`: host-scoped lookup resolves a multi-silo owner.
- `_ResolveGatewayTarget`: scoped lookup routes a multi-silo owner to one pod.
- Existing fail-closed cases unchanged. `tsc` clean; **full control-plane suite green (435)**.

## Live dev backend note

Independently, the `tenants` DB table had drifted **empty** (CRD/DB desync after a CNPG reset) while the Tenant CRDs persisted — a second cause of the same screens. Those 3 rows have been re-seeded to match the CRDs. This PR is the durable fix that makes all silos resolve by host once `:latest` rolls out.