### PR TITLE
fix(gateway-proxy): forward org host to gateway-resolve so the WS upgrade resolves

### DIFF
--- a/apps/operator/src/__tests__/gateway-proxy/proxy.test.ts
+++ b/apps/operator/src/__tests__/gateway-proxy/proxy.test.ts
@@ -72,7 +72,7 @@ describe("_HandleUpgrade (in-operator gateway proxy)", () =>
     const resolve = vi.fn().mockResolvedValue(okTarget);
     const { deps, proxy } = _deps(resolve);
     const socket = _fakeSocket();
-    const req = _req({ origin: "https://acme.opencrane.ai", cookie: "sid=x", "x-forwarded-user": "attacker@evil.com" });
+    const req = _req({ origin: "https://acme.opencrane.ai", host: "acme.opencrane.ai", cookie: "sid=x", "x-forwarded-user": "attacker@evil.com" });
 
     await _HandleUpgrade(deps, req, socket, Buffer.alloc(0));
 
@@ -80,7 +80,19 @@ describe("_HandleUpgrade (in-operator gateway proxy)", () =>
     expect(proxy.headers[0]?.["X-Forwarded-User"]).toBe("alice@example.com");
     expect(req.headers["x-forwarded-user"]).toBeUndefined();
     expect(socket.destroyed).toBe(false);
-    expect(resolve).toHaveBeenCalledWith("http://cp:3000", "sid=x", expect.any(AbortSignal));
+    // The org host is forwarded so the control plane can scope resolution to this silo.
+    expect(resolve).toHaveBeenCalledWith("http://cp:3000", "sid=x", "acme.opencrane.ai", expect.any(AbortSignal));
+  });
+
+  it("forwards x-forwarded-host (first value) over the Host header when both are present", async () =>
+  {
+    const resolve = vi.fn().mockResolvedValue(okTarget);
+    const { deps } = _deps(resolve);
+    const req = _req({ origin: "https://acme.opencrane.ai", host: "internal:8090", "x-forwarded-host": "acme.opencrane.ai, proxy.internal", cookie: "sid=x" });
+
+    await _HandleUpgrade(deps, req, _fakeSocket(), Buffer.alloc(0));
+
+    expect(resolve).toHaveBeenCalledWith("http://cp:3000", "sid=x", "acme.opencrane.ai", expect.any(AbortSignal));
   });
 
   it("refuses (403) a non-allowlisted origin without calling the control plane (CSWSH)", async () =>

--- a/apps/operator/src/gateway-proxy/auth-client.ts
+++ b/apps/operator/src/gateway-proxy/auth-client.ts
@@ -16,10 +16,16 @@ export type ResolveOutcome =
 
 /**
  * Ask the control plane who a gateway socket belongs to and where it should go, by
- * replaying ONLY the upgrade request's `Cookie` header to
+ * replaying the upgrade request's `Cookie` header — and the org host it arrived on — to
  * `GET /api/v1/auth/gateway-resolve`. The proxy holds no session state — the control
  * plane is the sole auth authority (delegate-auth), so the session store is never
  * shared. Even folded into the operator, the proxy makes no auth decision locally.
+ *
+ * The original org host (`<clusterTenant>.<base>`) is forwarded as `x-forwarded-host` so
+ * the control plane can scope the email→tenant resolution to the silo the socket is for.
+ * This internal call targets `opencrane-control-plane:8080`, so without it the control
+ * plane would see the internal host and fail to resolve a multi-silo owner (no/ambiguous
+ * tenant → 403).
  *
  * Fail closed on anything that is not a clean 200 with a well-formed body:
  *  - 401/403            → propagate (no session / no-or-ambiguous tenant).
@@ -28,19 +34,24 @@ export type ResolveOutcome =
  *
  * @param controlPlaneUrl - Internal control-plane base URL.
  * @param cookie          - The upgrade request's raw `Cookie` header, if any.
+ * @param host            - The org host the upgrade arrived on, forwarded for silo scoping.
  * @param signal          - Abort signal bounding the call (upgrade timeout).
  * @returns A forward target, or a fail-closed status + reason.
  */
-export async function _ResolveTarget(controlPlaneUrl: string, cookie: string | undefined, signal: AbortSignal): Promise<ResolveOutcome>
+export async function _ResolveTarget(controlPlaneUrl: string, cookie: string | undefined, host: string | undefined, signal: AbortSignal): Promise<ResolveOutcome>
 {
   const url = `${controlPlaneUrl.replace(/\/+$/, "")}${GATEWAY_RESOLVE_PATH}`;
+
+  const headers: Record<string, string> = {};
+  if (cookie) headers["cookie"] = cookie;
+  if (host) headers["x-forwarded-host"] = host;
 
   let res: Response;
   try
   {
     res = await fetch(url, {
       method: "GET",
-      headers: cookie ? { cookie } : {},
+      headers,
       signal,
       redirect: "error",
     });

--- a/apps/operator/src/gateway-proxy/proxy.ts
+++ b/apps/operator/src/gateway-proxy/proxy.ts
@@ -39,7 +39,7 @@ export interface UpgradeDeps
   limiter: FixedWindowRateLimiter;
   log: Logger;
   /** Delegated-auth resolver; defaults to the live control-plane call. */
-  resolve?: (controlPlaneUrl: string, cookie: string | undefined, signal: AbortSignal) => Promise<ResolveOutcome>;
+  resolve?: (controlPlaneUrl: string, cookie: string | undefined, host: string | undefined, signal: AbortSignal) => Promise<ResolveOutcome>;
 }
 
 /** Bound on the delegated-auth call so a slow control plane can't pin a socket open. */
@@ -80,13 +80,18 @@ export async function _HandleUpgrade(deps: UpgradeDeps, req: IncomingMessage, so
     return;
   }
 
-  // 2. Delegated auth — the control plane is the sole authority.
+  // 2. Delegated auth — the control plane is the sole authority. Forward the org host the
+  //    upgrade arrived on (x-forwarded-host from the ingress, else Host) so the control plane
+  //    scopes the email→tenant resolution to this silo; the internal call's own host is
+  //    `opencrane-control-plane`, which would otherwise resolve nothing for a multi-silo owner.
+  const forwardedHost = typeof req.headers["x-forwarded-host"] === "string" ? req.headers["x-forwarded-host"].split(",")[0].trim() : undefined;
+  const host = forwardedHost ?? (typeof req.headers.host === "string" ? req.headers.host : undefined);
   const ac = new AbortController();
   const timer = setTimeout(() => ac.abort(), _RESOLVE_TIMEOUT_MS);
   let outcome: ResolveOutcome;
   try
   {
-    outcome = await resolve(config.controlPlaneUrl, req.headers.cookie, ac.signal);
+    outcome = await resolve(config.controlPlaneUrl, req.headers.cookie, host, ac.signal);
   }
   finally
   {


### PR DESCRIPTION
## Problem

After the silo-scoping fix (#68) deployed, the operator UI / WeOwnAI frontend resolves (login + `/auth/me` + `/pod-token` all 200), but the **OpenClaw gateway WebSocket upgrade hangs** — socket pending, 0 bytes, never completes.

Traced live on `opencrane-dev`:
- Browser opens `wss://elewa-be.dev.opencrane.ai/` → ingress → `opencrane-gateway-proxy:8090` (in-operator) → `_HandleUpgrade` → calls control-plane `/auth/gateway-resolve`.
- That call returns **403 "forbidden (no or ambiguous tenant)"**, so the proxy refuses and the socket closes/hangs.
- Yet calling `/auth/gateway-resolve` *through the public ingress* with the same cookie returns **200** with the correct pod target.

Cause: the proxy calls gateway-resolve **internally** at `http://opencrane-control-plane:8080`, forwarding only the `Cookie`. `#68` made gateway-resolve derive the silo from the request host — but on the internal call that host is `opencrane-control-plane`, not the org host. So it scoped to a silo that doesn't exist → 0 rows → 403. (Pre-#68 it did a global match, which still 403'd for a multi-silo owner; #68's scoping then regressed single-silo users on this path too.)

## Fix

The proxy already has the org host on the upgrade request (`x-forwarded-host` from the ingress, else `Host`). Forward it as `x-forwarded-host` on the internal `gateway-resolve` call so the control plane scopes resolution to the correct silo and returns the pod target. No control-plane change needed — it already reads `x-forwarded-host` first.

## Tests
- `_HandleUpgrade` forwards the org host to the resolver; prefers `x-forwarded-host` (first value) over `Host`.
- `tsc` clean; full operator suite green (164).

## Deploy
Operator-only image change. After merge + CI, roll with `deploy-multi-tenant.sh --operator-tag sha-<merge>`.