### PR TITLE
S1 — Demo-able shared tier + unblock login (silo Phase 0)

### DIFF
--- a/apps/operator/src/__tests__/config.test.ts
+++ b/apps/operator/src/__tests__/config.test.ts
@@ -128,3 +128,72 @@ describe("_LoadOperatorConfig trusted-proxy fail-closed wiring (OC-2 / CONN.4)",
 		expect(function _load() { _LoadOperatorConfig(); }).toThrow(/invalid IP\/CIDR entry/);
 	});
 });
+
+describe("_LoadOperatorConfig auto trusted-proxy derivation (task_845dd617)", function _autoSuite()
+{
+	let _saved: NodeJS.ProcessEnv;
+
+	beforeEach(function _save()
+	{
+		_saved = process.env;
+		process.env = { ..._BASE_ENV, WATCH_NAMESPACE: "oc-acme" };
+	});
+
+	afterEach(function _restore()
+	{
+		process.env = _saved;
+	});
+
+	it("expands `auto` to the POD_IP /14 pod range by default", function _autoDefault()
+	{
+		process.env.GATEWAY_TRUSTED_PROXIES = "auto";
+		process.env.POD_IP = "10.8.3.5";
+		const config = _LoadOperatorConfig();
+		expect(config.gatewayTrustedProxies).toEqual(["10.8.0.0/14"]);
+		expect(config.gatewayTrustNothing).toBe(false);
+	});
+
+	it("honours GATEWAY_TRUSTED_PROXIES_AUTO_MASK for the derived prefix", function _autoMask()
+	{
+		process.env.GATEWAY_TRUSTED_PROXIES = "auto";
+		process.env.POD_IP = "172.20.55.7";
+		process.env.GATEWAY_TRUSTED_PROXIES_AUTO_MASK = "16";
+		const config = _LoadOperatorConfig();
+		expect(config.gatewayTrustedProxies).toEqual(["172.20.0.0/16"]);
+	});
+
+	it("drops `auto` to trust-nothing when POD_IP is missing (stays fail-closed, never trust-all)", function _missingPodIp()
+	{
+		process.env.GATEWAY_TRUSTED_PROXIES = "auto";
+		// POD_IP intentionally absent.
+		const config = _LoadOperatorConfig();
+		expect(config.gatewayTrustedProxies).toEqual([]);
+		expect(config.gatewayTrustNothing).toBe(true);
+	});
+
+	it("drops `auto` to trust-nothing when POD_IP is not a valid IPv4 address", function _invalidPodIp()
+	{
+		process.env.GATEWAY_TRUSTED_PROXIES = "auto";
+		process.env.POD_IP = "fd00::1";
+		const config = _LoadOperatorConfig();
+		expect(config.gatewayTrustNothing).toBe(true);
+	});
+
+	it("keeps explicit CIDRs when `auto` derivation fails (partial fallback, no trust-all)", function _mixedFallback()
+	{
+		process.env.GATEWAY_TRUSTED_PROXIES = "auto, 10.0.0.0/8";
+		// POD_IP absent ⇒ the auto token is dropped, the explicit CIDR remains.
+		const config = _LoadOperatorConfig();
+		expect(config.gatewayTrustedProxies).toEqual(["10.0.0.0/8"]);
+		expect(config.gatewayTrustNothing).toBe(false);
+	});
+
+	it("falls back to the default /14 when the mask override is not a canonical integer", function _badMask()
+	{
+		process.env.GATEWAY_TRUSTED_PROXIES = "auto";
+		process.env.POD_IP = "10.8.3.5";
+		process.env.GATEWAY_TRUSTED_PROXIES_AUTO_MASK = "0xff";
+		const config = _LoadOperatorConfig();
+		expect(config.gatewayTrustedProxies).toEqual(["10.8.0.0/14"]);
+	});
+});

--- a/apps/operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultConfig, _makeTenant } from "../fixtures.js";
+import { _BuildConfigMap } from "../../tenants/deploy/index.js";
+
+/**
+ * Structural contract test for the rendered `openclaw.json` (task_d611ab4d, S1).
+ *
+ * OpenClaw's gateway config schema is **strict** — an unknown key crashes the pod
+ * on boot (the `trustNothing`-class crash fixed in f6afafd, where the operator
+ * leaked an internal flag into the `gateway` block). The full validation against
+ * the pinned OpenClaw zod schema is BLOCKED (the schema is not vendored — OpenClaw
+ * ships as a container, not an npm dep), so this is the no-dependency fallback: it
+ * pins the exact key set the operator emits and fails closed on any stray key,
+ * which is precisely the regression class that crashed live tenants.
+ */
+describe("openclaw.json render contract — strict key set (task_d611ab4d)", function _suite()
+{
+  /** Keys OpenClaw's strict `gateway` schema accepts; anything else crashes the pod. */
+  const _ALLOWED_GATEWAY_KEYS = ["mode", "port", "bind", "trustedProxies", "auth"];
+
+  /** Keys of the nested `gateway.auth.trustedProxy` block. */
+  const _ALLOWED_TRUSTED_PROXY_KEYS = ["userHeader", "allowUsers"];
+
+  function _renderGateway(tenant = _makeTenant("contract")): Record<string, unknown>
+  {
+    const configMap = _BuildConfigMap(defaultConfig, tenant, "default");
+    const payload = JSON.parse(configMap.data?.["openclaw.json"] ?? "{}");
+    return payload.gateway as Record<string, unknown>;
+  }
+
+  it("emits exactly the strict gateway key set — no stray keys", function _gatewayKeys()
+  {
+    const gateway = _renderGateway();
+    expect(Object.keys(gateway).sort()).toEqual([..._ALLOWED_GATEWAY_KEYS].sort());
+  });
+
+  it("never leaks the internal trustNothing flag into the gateway block", function _noTrustNothing()
+  {
+    // The exact f6afafd regression: trustNothing is operator-internal, not an
+    // OpenClaw key, so it must never appear anywhere in the rendered config.
+    const configMap = _BuildConfigMap(defaultConfig, _makeTenant("contract"));
+    const raw = configMap.data?.["openclaw.json"] ?? "";
+    expect(raw).not.toContain("trustNothing");
+  });
+
+  it("emits the strict trusted-proxy auth shape", function _authShape()
+  {
+    const gateway = _renderGateway();
+    const auth = gateway.auth as Record<string, unknown>;
+    expect(auth.mode).toBe("trusted-proxy");
+
+    const trustedProxy = auth.trustedProxy as Record<string, unknown>;
+    expect(Object.keys(trustedProxy).sort()).toEqual([..._ALLOWED_TRUSTED_PROXY_KEYS].sort());
+  });
+
+  it("pins the gateway to the owner email via allowUsers", function _ownerPin()
+  {
+    // CONN.10 — the operator-emitted config must scope the pod to its owner. (Note:
+    // configOverrides currently REPLACES the gateway block via shallow merge, so a
+    // gateway override drops this pin — tracked as a follow-up gap, see PR notes.)
+    const gateway = _renderGateway(_makeTenant("contract"));
+    const auth = gateway.auth as Record<string, unknown>;
+    const trustedProxy = auth.trustedProxy as { allowUsers: string[] };
+    expect(trustedProxy.allowUsers).toEqual(["contract@example.com"]);
+  });
+});

--- a/apps/operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -39,7 +39,7 @@ describe("openclaw.json render contract — strict key set (task_d611ab4d)", fun
   {
     // The exact f6afafd regression: trustNothing is operator-internal, not an
     // OpenClaw key, so it must never appear anywhere in the rendered config.
-    const configMap = _BuildConfigMap(defaultConfig, _makeTenant("contract"));
+    const configMap = _BuildConfigMap(defaultConfig, _makeTenant("contract"), "default");
     const raw = configMap.data?.["openclaw.json"] ?? "";
     expect(raw).not.toContain("trustNothing");
   });

--- a/apps/operator/src/__tests__/trusted-proxies.test.ts
+++ b/apps/operator/src/__tests__/trusted-proxies.test.ts
@@ -1,6 +1,47 @@
 import { describe, expect, it } from "vitest";
 
-import { _ParseTrustedProxies } from "../trusted-proxies.js";
+import { _ParseTrustedProxies, _DeriveTrustedProxyCidr } from "../trusted-proxies.js";
+
+describe("_DeriveTrustedProxyCidr — pod-IP `auto` trusted-proxy derivation (task_845dd617)", function _deriveSuite()
+{
+  it("masks a GKE pod IP to the /14 pod range", function _gke()
+  {
+    expect(_DeriveTrustedProxyCidr("10.8.3.5", 14)).toBe("10.8.0.0/14");
+  });
+
+  it("derives a /16 network address from a pod IP", function _slash16()
+  {
+    expect(_DeriveTrustedProxyCidr("172.20.55.7", 16)).toBe("172.20.0.0/16");
+  });
+
+  it("handles /0 (whole space) and /32 (single host) bounds", function _bounds()
+  {
+    expect(_DeriveTrustedProxyCidr("10.8.3.5", 0)).toBe("0.0.0.0/0");
+    expect(_DeriveTrustedProxyCidr("10.8.3.5", 32)).toBe("10.8.3.5/32");
+  });
+
+  it("returns null (→ caller stays fail-closed) for missing/invalid/non-IPv4 input", function _failClosed()
+  {
+    expect(_DeriveTrustedProxyCidr("", 14)).toBeNull();
+    expect(_DeriveTrustedProxyCidr("not-an-ip", 14)).toBeNull();
+    expect(_DeriveTrustedProxyCidr("256.0.0.1", 14)).toBeNull();
+    expect(_DeriveTrustedProxyCidr("fd00::1", 14)).toBeNull();
+  });
+
+  it("returns null for an out-of-range mask", function _badMask()
+  {
+    expect(_DeriveTrustedProxyCidr("10.8.3.5", -1)).toBeNull();
+    expect(_DeriveTrustedProxyCidr("10.8.3.5", 33)).toBeNull();
+  });
+
+  it("re-parses the derived CIDR as a valid allowlist entry", function _roundTrip()
+  {
+    const derived = _DeriveTrustedProxyCidr("10.8.3.5", 14);
+    const result = _ParseTrustedProxies(derived ?? "");
+    expect(result.trustNothing).toBe(false);
+    expect(result.cidrs).toEqual(["10.8.0.0/14"]);
+  });
+});
 
 describe("_ParseTrustedProxies — fail-closed trusted-proxy allowlist (OC-2 / CONN.4)", function _suite()
 {

--- a/apps/operator/src/config.ts
+++ b/apps/operator/src/config.ts
@@ -1,6 +1,6 @@
 import { HostingProvider } from "./hosting/hosting-adapter.types.js";
 import type { GcpHostingConfig } from "./hosting/hosting-adapter.types.js";
-import { _ParseTrustedProxies } from "./trusted-proxies.js";
+import { _ParseTrustedProxies, _DeriveTrustedProxyCidr, _AUTO_TRUSTED_PROXY_TOKEN, _DEFAULT_AUTO_TRUSTED_PROXY_MASK } from "./trusted-proxies.js";
 
 export type { GcpHostingConfig };
 export { HostingProvider };
@@ -183,8 +183,12 @@ export function _LoadOperatorConfig(): OpenClawTenantOperatorConfig
   // 2b. Parse the trusted-proxy allowlist fail-closed (OC-2 / CONN.4). An empty
   //     value resolves to trust-nothing (never trust-all); a malformed CIDR throws
   //     here so a typo crashes the operator at startup rather than silently
-  //     widening or narrowing the gateway's trust boundary.
-  const trustedProxies = _ParseTrustedProxies(_readEnvValue<string>("GATEWAY_TRUSTED_PROXIES", "string", false, ""));
+  //     widening or narrowing the gateway's trust boundary. The opt-in `auto`
+  //     token is first expanded to a pod-IP-derived CIDR (task_845dd617) — empty
+  //     stays trust-nothing, so the fail-closed default (CONN.9) is preserved.
+  const trustedProxies = _ParseTrustedProxies(_resolveTrustedProxiesInput(
+    _readEnvValue<string>("GATEWAY_TRUSTED_PROXIES", "string", false, ""),
+  ));
 
   // 3. Build the typed config from env, applying namespace-derived fallbacks for the
   //    runtime-plane URLs so no value silently points at another instance.
@@ -270,6 +274,50 @@ function _readOwnNamespace(): string
 {
   const raw = process.env["POD_NAMESPACE"]?.trim();
   return raw && raw.length > 0 ? raw : "default";
+}
+
+/**
+ * Expand the opt-in `auto` token in `GATEWAY_TRUSTED_PROXIES` into a CIDR derived
+ * from the operator's own pod IP (task_845dd617), leaving every other entry
+ * untouched for {@link _ParseTrustedProxies} to validate.
+ *
+ * `auto` is convenience, not the default: it widens the gateway's trust boundary to
+ * the whole pod range, so it activates only when explicitly listed and is logged
+ * loudly. POD_IP comes from the downward API (`status.podIP`); the mask defaults to
+ * the GKE pod-range /14 and is overridable via `GATEWAY_TRUSTED_PROXIES_AUTO_MASK`.
+ * If derivation fails (no/invalid POD_IP, bad mask) the token is dropped — so an
+ * `auto`-only config falls back to trust-nothing rather than trust-all (CONN.9).
+ *
+ * @param raw - The raw comma-separated `GATEWAY_TRUSTED_PROXIES` value.
+ * @returns The entry list with `auto` replaced by the derived CIDR (or removed).
+ */
+function _resolveTrustedProxiesInput(raw: string): string[]
+{
+  const entries = _splitCsv(raw);
+  if (!entries.some(entry => entry.toLowerCase() === _AUTO_TRUSTED_PROXY_TOKEN))
+  {
+    return entries;
+  }
+
+  const podIp = process.env["POD_IP"]?.trim() ?? "";
+  const maskRaw = process.env["GATEWAY_TRUSTED_PROXIES_AUTO_MASK"]?.trim();
+  const maskBits = maskRaw && /^\d{1,3}$/.test(maskRaw) ? Number(maskRaw) : _DEFAULT_AUTO_TRUSTED_PROXY_MASK;
+  const derived = _DeriveTrustedProxyCidr(podIp, maskBits);
+
+  return entries.flatMap(function _expandAuto(entry)
+  {
+    if (entry.toLowerCase() !== _AUTO_TRUSTED_PROXY_TOKEN)
+    {
+      return [entry];
+    }
+    if (derived === null)
+    {
+      console.error(`GATEWAY_TRUSTED_PROXIES="auto" but POD_IP "${podIp}" is missing/invalid; dropping the token (staying fail-closed)`);
+      return [];
+    }
+    console.error(`GATEWAY_TRUSTED_PROXIES="auto" derived trusted-proxy CIDR ${derived} from POD_IP ${podIp} (/${maskBits}); this trusts the whole pod range`);
+    return [derived];
+  });
 }
 
 /**

--- a/apps/operator/src/config.ts
+++ b/apps/operator/src/config.ts
@@ -301,7 +301,9 @@ function _resolveTrustedProxiesInput(raw: string): string[]
 
   const podIp = process.env["POD_IP"]?.trim() ?? "";
   const maskRaw = process.env["GATEWAY_TRUSTED_PROXIES_AUTO_MASK"]?.trim();
-  const maskBits = maskRaw && /^\d{1,3}$/.test(maskRaw) ? Number(maskRaw) : _DEFAULT_AUTO_TRUSTED_PROXY_MASK;
+  // Reject leading-zero / non-canonical masks (matching trusted-proxies' _isValidPrefix) so a
+  // typo falls back to the safe default rather than being silently coerced.
+  const maskBits = maskRaw && /^(0|[1-9]\d{0,2})$/.test(maskRaw) ? Number(maskRaw) : _DEFAULT_AUTO_TRUSTED_PROXY_MASK;
   const derived = _DeriveTrustedProxyCidr(podIp, maskBits);
 
   return entries.flatMap(function _expandAuto(entry)

--- a/apps/operator/src/trusted-proxies.ts
+++ b/apps/operator/src/trusted-proxies.ts
@@ -62,6 +62,54 @@ export function _ParseTrustedProxies(raw: string | string[]): TrustedProxyParseR
   return { cidrs, trustNothing: false };
 }
 
+/** The opt-in sentinel that asks the operator to derive a trusted-proxy CIDR from its own pod IP. */
+export const _AUTO_TRUSTED_PROXY_TOKEN = "auto";
+
+/** Default mask applied to the operator's pod IP when deriving the `auto` CIDR (GKE pod-range /14). */
+export const _DEFAULT_AUTO_TRUSTED_PROXY_MASK = 14;
+
+/**
+ * Derive a trusted-proxy CIDR from the operator's own pod IP (downward API
+ * `status.podIP`) — the convenience path behind the opt-in `auto` sentinel
+ * (task_845dd617). The ingress controller shares the cluster's pod network, so
+ * the operator's pod IP masked to the pod-range prefix is a sane trust source
+ * when no explicit CIDR was configured, killing the "forgot the CIDR ⇒ every pod
+ * fails closed" footgun.
+ *
+ * This is **opt-in only** and never the default: an empty `GATEWAY_TRUSTED_PROXIES`
+ * still resolves to trust-nothing (CONN.9). Trusting the pod range widens the
+ * boundary to any pod on it, so the caller must ask for it explicitly and log loudly.
+ *
+ * IPv4 only — GKE/most CNIs hand pods IPv4. A non-IPv4 / malformed pod IP or an
+ * out-of-range mask returns `null` so the caller falls back to fail-closed rather
+ * than emitting a bogus entry.
+ *
+ * @param podIp - The operator pod's own IPv4 address (downward API), or empty/unset.
+ * @param maskBits - The prefix length to mask the pod IP to (0–32).
+ * @returns The derived `network/mask` CIDR, or `null` when it cannot be derived.
+ */
+export function _DeriveTrustedProxyCidr(podIp: string, maskBits: number): string | null
+{
+  // 1. Reject anything that isn't a canonical IPv4 literal or an in-range mask —
+  //    derivation must fail to null (→ caller stays fail-closed), never guess.
+  const trimmed = podIp.trim();
+  if (!_isValidIpv4(trimmed) || !Number.isInteger(maskBits) || maskBits < 0 || maskBits > _IPV4_MAX_PREFIX)
+  {
+    return null;
+  }
+
+  // 2. Pack the four octets into a 32-bit value, mask off the host bits, and
+  //    unpack the network address back to dotted-quad. `>>> 0` keeps the shift
+  //    unsigned so the high octet never goes negative.
+  const octets = trimmed.split(".").map(Number);
+  const ipInt = ((octets[0] << 24) | (octets[1] << 16) | (octets[2] << 8) | octets[3]) >>> 0;
+  const maskInt = maskBits === 0 ? 0 : (0xffffffff << (_IPV4_MAX_PREFIX - maskBits)) >>> 0;
+  const networkInt = (ipInt & maskInt) >>> 0;
+  const network = [(networkInt >>> 24) & 0xff, (networkInt >>> 16) & 0xff, (networkInt >>> 8) & 0xff, networkInt & 0xff].join(".");
+
+  return `${network}/${maskBits}`;
+}
+
 /**
  * Validate a single trust entry as either a bare IP address or a CIDR block.
  *

--- a/plan.md
+++ b/plan.md
@@ -32,10 +32,12 @@
 
 **Silo program (S1–S7) — full detail in `silo-multi-tenant-plan.md`.**
 
-- **S1 — Demo-able shared tier + unblock login.** *(silo Phase 0)* trustedProxies auto-derive,
-  preflight + `values.schema.json` guards, externalIp auto-derive + post-deploy verify,
-  openclaw-schema CI test; **interim manual redirect-URI add so `elewa-be.dev.opencrane.ai/login`
-  works**. Absorbs Go-Live → *DNS + ingress verification* (per-org-host path). No deps.
+- **S1 — Demo-able shared tier + unblock login.** 🟢 **IN REVIEW (PR → strong-siloes).** Code
+  landed: trustedProxies `[auto]` derive (task_845dd617), `values.schema.json` + WI preflight
+  (task_bbafd7e9), `--auto-ingress-ip` + `--verify` (task_5cab917e). 🟡 openclaw-schema CI test =
+  structural-fallback only; full zod-schema **BLOCKED** (schema not vendored — task_d611ab4d).
+  ⏩ interim manual Zitadel redirect-URI add for `elewa-be.dev.opencrane.ai/login` (console action,
+  not code). Detail in `silo-multi-tenant-plan.md` Phase 0.
 - **S2 — Enforcement floor: make isolation real.** *(silo Phase 1)* Enable Dataplane-V2/Cilium +
   default-deny baseline (cluster-lifecycle/Terraform, **not** Helm); per-silo egress NetworkPolicy.
   Absorbs Go-Live → *GCP installer smoke* (must now provision DV2 + Workload Identity, which also

--- a/platform/deploy-multi-tenant.sh
+++ b/platform/deploy-multi-tenant.sh
@@ -20,9 +20,10 @@
 #       [ANY k8s-deploy.sh flag, e.g. --cert-manager --acme-email … --dns01-provider clouddns]
 #
 # --base-domain is required (the platform wildcard base every org is served under).
-# --ingress-ip / --dns-managed-zone wire the operator's per-org DNS side effect; omit
-# them on-prem or until the LoadBalancer IP is assigned (the operator then skips the DNS
-# write and only applies the per-org Certificate).
+# --ingress-ip / --dns-managed-zone wire the operator's per-org DNS side effect. When
+# --ingress-ip is OMITTED the core auto-derives it from the ingress-nginx LoadBalancer
+# (--auto-ingress-ip); on-prem with no LB it stays unset and the operator skips the DNS
+# write (per-org Certificate still applied). Add --verify for an advisory post-deploy check.
 #
 # Prereqs: kubectl (pointed at the target cluster) and helm.
 # =============================================================================
@@ -62,8 +63,15 @@ PROFILE_SET=(
   --set "billing.enabled=true"
   --set "ingress.tls.enabled=true"
 )
-[[ -n "$INGRESS_IP" ]]       && PROFILE_SET+=(--set "ingress.externalIp=$INGRESS_IP")
 [[ -n "$DNS_MANAGED_ZONE" ]] && PROFILE_SET+=(--set "ingress.dnsManagedZone=$DNS_MANAGED_ZONE")
+# When --ingress-ip is given, pin it; otherwise ask the core to auto-derive it from the
+# ingress-nginx LoadBalancer once installed (so per-org *.<org>.<base> records resolve
+# without hand-copying the IP). An on-prem install with no LB simply leaves it unset.
+if [[ -n "$INGRESS_IP" ]]; then
+  PROFILE_SET+=(--set "ingress.externalIp=$INGRESS_IP")
+else
+  PROFILE_SET+=(--auto-ingress-ip)
+fi
 
 echo -e "\033[0;32m[multi-tenant]\033[0m Profile: multi-tenant platform on $BASE_DOMAIN (self-service orgs + billing ON)"
 exec "$CORE" "${PROFILE_SET[@]}" "${PASSTHROUGH[@]}"

--- a/platform/helm/templates/operator-deployment.yaml
+++ b/platform/helm/templates/operator-deployment.yaml
@@ -35,6 +35,13 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # -- This pod's own IP (downward API). Used ONLY to expand the opt-in
+            #    `auto` trusted-proxy token into a pod-range CIDR (task_845dd617); the
+            #    operator shares the cluster pod network with the ingress controller.
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             {{- include "opencrane.observabilityEnv" (dict "ctx" $ "component" "operator") | nindent 12 }}
             - name: WATCH_NAMESPACE
               value: {{ .Values.operator.watchNamespace | quote }}
@@ -74,9 +81,16 @@ spec:
             #    source range). Comma-joined for the operator's fail-closed parser.
             #    EMPTY ⇒ trust nothing (the gateway honours no proxy source); a NetworkPolicy
             #    additionally locks the gateway port to the ingress so this range can't be
-            #    abused by other pods. Set to the ingress controller's pod source range.
+            #    abused by other pods. Set to the ingress controller's pod source range, or the
+            #    opt-in literal `auto` to derive a pod-range CIDR from POD_IP (task_845dd617).
             - name: GATEWAY_TRUSTED_PROXIES
               value: {{ join "," .Values.tenant.gateway.trustedProxies | quote }}
+            {{- with .Values.tenant.gateway.trustedProxiesAutoMask }}
+            # -- Prefix length the `auto` token masks POD_IP to (defaults to /14 in the
+            #    operator when unset). Only consulted when trustedProxies contains `auto`.
+            - name: GATEWAY_TRUSTED_PROXIES_AUTO_MASK
+              value: {{ . | quote }}
+            {{- end }}
             {{- if .Values.gatewayProxy.enabled }}
             # -- Identity-routing gateway proxy, folded in-process (DOMAIN.T4). The operator
             #    runs a WS proxy on GATEWAY_PROXY_PORT; the wildcard Ingress routes the gateway

--- a/platform/helm/values.schema.json
+++ b/platform/helm/values.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OpenCrane Helm values coherence guards",
+  "description": "Fail-fast guards for the demo-able shared-tier install (S1 / task_bbafd7e9). Deliberately PERMISSIVE: only the keys below are constrained, every other value passes through untouched. Helm validates the MERGED values on every install/template/lint, so an incoherent overlay (e.g. gatewayProxy enabled with no ingress IP) is rejected before the rollout half-installs.",
+  "type": "object",
+  "properties": {
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "externalIp": { "type": "string" }
+      }
+    },
+    "gatewayProxy": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    },
+    "tenant": {
+      "type": "object",
+      "properties": {
+        "gateway": {
+          "type": "object",
+          "properties": {
+            "trustedProxies": {
+              "type": "array",
+              "items": { "type": "string" }
+            },
+            "trustedProxiesAutoMask": {
+              "type": ["string", "integer"]
+            }
+          }
+        }
+      }
+    }
+  },
+  "if": {
+    "required": ["gatewayProxy"],
+    "properties": {
+      "gatewayProxy": {
+        "required": ["enabled"],
+        "properties": {
+          "enabled": { "const": true }
+        }
+      }
+    }
+  },
+  "then": {
+    "description": "When the per-org gateway proxy is enabled, the wildcard A records need an ingress IP and the tenant gateway needs at least one trusted proxy source (use [auto] to derive one) — otherwise every per-org host fails to resolve or every connection fails closed.",
+    "required": ["ingress", "tenant"],
+    "properties": {
+      "ingress": {
+        "required": ["externalIp"],
+        "properties": {
+          "externalIp": {
+            "type": "string",
+            "minLength": 7
+          }
+        }
+      },
+      "tenant": {
+        "required": ["gateway"],
+        "properties": {
+          "gateway": {
+            "required": ["trustedProxies"],
+            "properties": {
+              "trustedProxies": {
+                "type": "array",
+                "minItems": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -371,7 +371,15 @@ tenant:
     #    NetworkPolicy independently locks the gateway port to the ingress namespace, so
     #    a wide CIDR here still can't be abused by other pods. A malformed entry crashes
     #    the operator at startup rather than silently shifting the trust boundary.
+    #
+    #    OPT-IN convenience: the single literal entry `[auto]` asks the operator to derive
+    #    a pod-range CIDR from its own POD_IP (downward API), killing the "forgot the CIDR
+    #    ⇒ all pods fail-closed" footgun. This trusts the whole pod range, so it stays
+    #    opt-in and is logged loudly; empty still means trust-nothing.
     trustedProxies: []
+    # -- Prefix length `[auto]` masks POD_IP to (e.g. 14 → /14, the GKE pod range).
+    #    Empty ⇒ operator default (/14). Only consulted when trustedProxies is `[auto]`.
+    trustedProxiesAutoMask: ""
   # -- OpenClaw npm package version installed into each tenant pod. Pinned (not `latest`)
   # so the gateway can't silently roll across breaking changes; bump deliberately. A
   # Tenant CR's `spec.openclawVersion` overrides this per-tenant.

--- a/platform/k8s-deploy.sh
+++ b/platform/k8s-deploy.sh
@@ -184,6 +184,14 @@ DNS_WRITER_GSA="${OPENCRANE_DNS_WRITER_GSA:-${DNS_WRITER_GSA:-}}"
 # OPENCRANE_PREFLIGHT=1. It is advisory unless run — the install itself does not auto-run it.
 PREFLIGHT="${OPENCRANE_PREFLIGHT:-0}"
 
+# --auto-ingress-ip derives ingress.externalIp from the ingress-nginx LoadBalancer after
+# it is installed (so per-org *.<domain> A records resolve without hand-copying the IP).
+# Opt-in; an explicit ingress.externalIp --set always wins. Also via OPENCRANE_AUTO_INGRESS_IP=1.
+AUTO_INGRESS_IP="${OPENCRANE_AUTO_INGRESS_IP:-0}"
+# --verify runs an advisory post-deploy check (pods Running, DNSEndpoints present, external-dns
+# error-free, control-plane host resolves). Never fails the install. Also via OPENCRANE_VERIFY=1.
+VERIFY="${OPENCRANE_VERIFY:-0}"
+
 DB_CLUSTER="opencrane-db"
 DB_SECRET="opencrane-db"
 DB_USER="opencrane"
@@ -212,6 +220,8 @@ while [[ $# -gt 0 ]]; do
     --oidc-session-secret) OIDC_SESSION_SECRET="$2"; shift 2 ;;
     --platform-operator-seed-email) PLATFORM_OPERATOR_SEED_EMAIL="$2"; shift 2 ;;
     --preflight)        PREFLIGHT="1"; shift ;;
+    --auto-ingress-ip)  AUTO_INGRESS_IP="1"; shift ;;
+    --verify)           VERIFY="1"; shift ;;
     --no-ingress-nginx) INSTALL_INGRESS_NGINX="0"; shift ;;
     --no-external-dns)  INSTALL_EXTERNAL_DNS="0"; shift ;;
     --dns-writer-gsa)   DNS_WRITER_GSA="$2"; shift 2 ;;
@@ -314,6 +324,13 @@ _run_preflight() {
       # --dns-writer-gsa is required here too (the install fails closed without it).
       if [[ -z "$DNS_WRITER_GSA" ]]; then
         PF_FAILS+=("Workload-Identity DNS writes need the shared DNS-writer GSA. Pass --dns-writer-gsa <gsa>@<project>.iam.gserviceaccount.com (Terraform output dns_writer_service_account_email) so the external-dns + cert-manager KSAs can be annotated, or pass --dns01-credentials for an external zone.")
+      fi
+      # Workload Identity ENABLED on the cluster — a roles/dns.admin binding is useless if
+      # the cluster can't impersonate the GSA. GKE runs the gke-metadata-server DaemonSet in
+      # kube-system iff Workload Identity is enabled; its absence is the dead-external-dns
+      # root cause (records never written, no auth error — the pod just can't get a token).
+      if ! kubectl get ds -n kube-system gke-metadata-server -o name >/dev/null 2>&1; then
+        PF_FAILS+=("Workload Identity is NOT enabled on this cluster (no gke-metadata-server DaemonSet in kube-system), so external-dns + cert-manager DNS-01 cannot impersonate the DNS-writer GSA — records silently never get written. Enable it: gcloud container clusters update <cluster> --workload-pool=<project>.svc.id.goog (and node pools --workload-metadata=GKE_METADATA), or pass --dns01-credentials for an external zone.")
       fi
       local _proj="${DNS01_PROJECT:-$(gcloud config get-value project 2>/dev/null || true)}"
       if [[ -z "$_proj" || "$_proj" == "(unset)" ]]; then
@@ -558,6 +575,34 @@ _install_ingress_nginx() {
 }
 
 _install_ingress_nginx
+
+# 2.30. Auto-derive ingress.externalIp from the ingress-nginx LoadBalancer (opt-in,
+# --auto-ingress-ip). The operator's per-org DNS side effect needs the cluster ingress IP;
+# rather than hand-copy it from `kubectl get svc`, derive it here once the controller's LB is
+# assigned and feed it into the chart as a --set. An explicit ingress.externalIp --set wins.
+_resolve_ingress_ip() {
+  [[ "$AUTO_INGRESS_IP" == "1" ]] || return 0
+  if printf '%s\n' "${EXTRA_SET[@]}" | grep -q "ingress.externalIp="; then
+    log "Auto-ingress-ip: ingress.externalIp set explicitly — skipping derivation."
+    return 0
+  fi
+  log "Auto-ingress-ip: waiting for the ingress-nginx LoadBalancer address…"
+  local sel="app.kubernetes.io/name=ingress-nginx,app.kubernetes.io/component=controller"
+  local ip="" tries=0
+  while (( tries < 60 )); do
+    ip="$(kubectl get svc -n "$INGRESS_NGINX_NAMESPACE" -l "$sel" -o jsonpath='{.items[0].status.loadBalancer.ingress[0].ip}' 2>/dev/null)"
+    [[ -z "$ip" ]] && ip="$(kubectl get svc -n "$INGRESS_NGINX_NAMESPACE" -l "$sel" -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}' 2>/dev/null)"
+    [[ -n "$ip" ]] && break
+    sleep 5; tries=$((tries+1))
+  done
+  if [[ -z "$ip" ]]; then
+    warn "Auto-ingress-ip: no LoadBalancer address after ~5m; leaving ingress.externalIp unset (per-org DNS records stay unwritten until it is set)."
+    return 0
+  fi
+  log "Auto-ingress-ip: derived ingress.externalIp=$ip from the ingress-nginx LB."
+  EXTRA_SET+=(--set "ingress.externalIp=$ip")
+}
+_resolve_ingress_ip
 
 # 2.35. external-dns (a cluster singleton). The operator declares per-org records as
 # namespaced DNSEndpoint CRs; the external-dns controller (run with --source=crd)
@@ -865,6 +910,55 @@ helm "${helm_args[@]}"
 # belt-and-suspenders guard for pod (re)creation between deploys. Idempotent.
 kubectl rollout status "deployment/${RELEASE}-operator" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
 kubectl rollout status "deployment/${RELEASE}-control-plane" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+
+# 5. Post-deploy verify (opt-in, --verify). Advisory only — surfaces the failure modes that
+# leave a "green" install unreachable (pods not Running, no DNSEndpoints, external-dns auth
+# errors, host not resolving) so they are caught here instead of in a confused browser session.
+_post_deploy_verify() {
+  [[ "$VERIFY" == "1" ]] || return 0
+  log "Post-deploy verify (advisory — does not fail the install):"
+
+  # 1. Core pods Running — a CrashLoop/ImagePullBackOff that helm --wait didn't catch.
+  local notready
+  notready="$(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null | grep -c . || true)"
+  if [[ "$notready" == "0" ]]; then
+    log "  ✓ all pods Running/Succeeded in $NAMESPACE"
+  else
+    warn "  ✗ $notready pod(s) not Running in $NAMESPACE — kubectl get pods -n $NAMESPACE"
+  fi
+
+  # 2. DNSEndpoint CRs — the operator's per-org record side effect (only meaningful when the
+  #    external-dns CRD source is installed). Absent CRD ⇒ per-org hosts never get A records.
+  if kubectl get crd dnsendpoints.externaldns.k8s.io >/dev/null 2>&1; then
+    local des
+    des="$(kubectl get dnsendpoint -A -o name 2>/dev/null | grep -c . || true)"
+    log "  • DNSEndpoint CRs present: $des"
+  else
+    warn "  • DNSEndpoint CRD absent (external-dns --source=crd not installed) — per-org A records won't be written."
+  fi
+
+  # 3. external-dns recent auth/permission errors — the dead-external-dns failure mode (the
+  #    controller runs but can't write the zone, so records silently never appear).
+  if kubectl get deploy -A -l app.kubernetes.io/name=external-dns -o name 2>/dev/null | grep -q .; then
+    if kubectl logs -A -l app.kubernetes.io/name=external-dns --tail=200 2>/dev/null | grep -qiE "permission|forbidden|invalid_grant|denied|failed to (apply|submit)"; then
+      warn "  ✗ external-dns logs show recent errors — kubectl logs -A -l app.kubernetes.io/name=external-dns --tail=200"
+    else
+      log "  ✓ external-dns logs show no recent auth errors"
+    fi
+  fi
+
+  # 4. Control-plane host resolves to the ingress — the end of the chain a user hits first.
+  if [[ -n "$BASE_DOMAIN" ]] && command -v dig >/dev/null 2>&1; then
+    local host="platform.$BASE_DOMAIN" resolved
+    resolved="$(dig +short "$host" 2>/dev/null | tail -1)"
+    if [[ -n "$resolved" ]]; then
+      log "  ✓ $host resolves to $resolved"
+    else
+      warn "  ✗ $host does not resolve yet (DNS propagation lag or a missing record)."
+    fi
+  fi
+}
+_post_deploy_verify
 
 log "Done. OpenCrane is installed in namespace '$NAMESPACE'."
 [[ -n "$BASE_DOMAIN" ]] && log "Point your DNS at the ingress, then visit https://platform.${BASE_DOMAIN}"

--- a/silo-multi-tenant-plan.md
+++ b/silo-multi-tenant-plan.md
@@ -291,16 +291,23 @@ of bug. Demo-unblocking.
   `trustedProxies=[10.8.0.0/14]` (commit `818041d`).
 - ✅ **DONE** — networking architecture doc (commit `5795b99`).
 - ⏩ **INTERIM** — manual DNS for the demo (see §5).
-- `task_845dd617` — operator auto-derives `trustedProxies` from its own pod IP (downward API);
-  kills the "forgot the CIDR → all pods fail-closed" footgun.
-- `task_bbafd7e9` — preflight + `values.schema.json` guards (incl. the missing **WI-enabled**
-  check, not just `roles/dns.admin`; `gatewayProxy`↔`externalIp` coherence; non-empty
-  `trustedProxies`).
-- `task_5cab917e` — deploy auto-derives `ingress.externalIp` from the ingress-nginx LB +
-  a post-deploy verify phase (DNSEndpoints present, external-dns no auth errors, pods Running,
+- ✅ **DONE (S1)** `task_845dd617` — operator auto-derives `trustedProxies` from its own pod IP
+  via the opt-in `[auto]` token (downward API `POD_IP`, default /14); empty stays trust-nothing so
+  the CONN.9 fail-closed default is preserved. Kills the "forgot the CIDR → all pods fail-closed"
+  footgun without silently widening trust.
+- ✅ **DONE (S1)** `task_bbafd7e9` — `values.schema.json` coherence guard (`gatewayProxy.enabled` ⇒
+  non-empty `ingress.externalIp` + `trustedProxies`, Helm-enforced on every render) + preflight
+  **WI-enabled** cluster probe (`gke-metadata-server`), not just the `roles/dns.admin` binding.
+- ✅ **DONE (S1)** `task_5cab917e` — `--auto-ingress-ip` derives `ingress.externalIp` from the
+  ingress-nginx LB (deploy-multi-tenant opts in when `--ingress-ip` is omitted) + `--verify`
+  advisory post-deploy phase (DNSEndpoints present, external-dns no auth errors, pods Running,
   host resolves).
-- `task_d611ab4d` — CI contract test: render the tenant ConfigMap, validate `openclaw.json`
-  against the pinned OpenClaw zod schema (prevents the `trustNothing`-class crash).
+- 🟡 **PARTIAL (S1)** `task_d611ab4d` — landed the **minimal fallback**: a no-dep structural
+  contract test pinning the rendered `openclaw.json` to OpenClaw's strict gateway key set
+  (catches the `trustNothing`-class crash). Full validation against the **pinned OpenClaw zod
+  schema is BLOCKED** — the schema isn't vendored (OpenClaw ships as a container, not an npm dep);
+  schema-source is an open decision. Also surfaced: `configOverrides` shallow-merge can replace the
+  whole `gateway` block (drops the owner-pin / can inject a crashing key) — follow-up gap.
 - **NEW (live login bug)** — `<org>.<base>/login` throws the OIDC redirect error because the host's
   callback isn't a registered redirect URI. **Interim unblock (now):** add
   `elewa-be.dev.opencrane.ai/api/v1/auth/callback` to the current Zitadel app by hand. **Durable
@@ -383,6 +390,12 @@ The virtual-network model proper.
   cost/footprint model per tier. Then split implementation tasks (per-CT operator;
   templating planes into the silo; reparent under `ClusterTenantProvisioner` /
   `multiInstance`-per-CT).
+- **Per-silo ingress is the operator's job.** When the operator moves into the silo, *that*
+  operator must own its silo's north-south edge: emit the `{org}.{base-domain}` Ingress +
+  `DNSEndpoint` (and bind the wildcard/cert) for its own org, scoped to its namespace — never a
+  shared operator writing every org's ingress. Today the single shared operator already emits the
+  per-org Ingress/DNSEndpoint (Track DOMAIN); Phase 3 must preserve that capability per-CT and
+  fail-closed (a silo with no ingress is unreachable, not cross-wired to another org's host).
 
 ### Phase 4 — Tiers & cost
 - Map to `ClusterTenant.spec.isolationTier`: `shared` → `dedicatedNodes` → `dedicatedCluster`


### PR DESCRIPTION
## S1 — Demo-able shared tier + unblock login (silo Phase 0)

First step of the **strong-siloes** S-series roadmap. Hardens the shared-tier install so it stops half-installing and self-configures, and protects the runtime config contract. Detail in `silo-multi-tenant-plan.md` Phase 0.

### What landed

| Task | Change |
|------|--------|
| **task_845dd617** | Operator opt-in `[auto]` trusted-proxy token: masks its own `POD_IP` (downward API) to a pod-range CIDR (default `/14`, `GATEWAY_TRUSTED_PROXIES_AUTO_MASK` override). Pure `_DeriveTrustedProxyCidr` helper. |
| **task_bbafd7e9** | `values.schema.json` coherence guard (Helm-enforced every render): `gatewayProxy.enabled` ⇒ non-empty `ingress.externalIp` **and** `trustedProxies`. Preflight **Workload-Identity-enabled** cluster probe (`gke-metadata-server`) — the dead-external-dns root cause a `roles/dns.admin` binding alone misses. |
| **task_5cab917e** | `--auto-ingress-ip` derives `ingress.externalIp` from the ingress-nginx LB (deploy-multi-tenant opts in when `--ingress-ip` is omitted); `--verify` advisory post-deploy phase (pods Running, DNSEndpoints, external-dns error-free, host resolves). |
| **task_d611ab4d** | 🟡 **Partial** — minimal no-dep fallback: structural contract test pinning the rendered `openclaw.json` to OpenClaw's strict gateway key set (catches the `trustNothing`-class crash). |

### Security note (deliberate)
`trustedProxies` governs which sources the gateway trusts the `X-Forwarded-User` identity header from. The `auto` token is **opt-in only** — empty/unset stays **trust-nothing** (CONN.9 fail-closed preserved), and `auto` drops back to fail-closed if `POD_IP` is missing/invalid. It never silently widens trust.

### Blocked / deferred
- **task_d611ab4d full validation is BLOCKED**: OpenClaw's zod config schema isn't vendored (OpenClaw ships as a container, not an npm dep). Schema-source is an open decision; the structural fallback ships now.
- **Interim manual step (not code, excluded from this PR):** add `elewa-be.dev.opencrane.ai/api/v1/auth/callback` as a redirect URI on the current Zitadel app to unblock login today. The durable fix is per-CT Zitadel app provisioning in **S3 (Phase 2a)**.

### Flagged follow-up
`tenant.spec.configOverrides` shallow-merges over the gateway block, so a `gateway` override **replaces** it wholesale — dropping the owner-pin (`allowUsers`) and able to inject a crashing key. Out of S1 scope; noted for a follow-up.

### Validation
- `pnpm --filter @opencrane/operator build` ✅ · operator tests **179 passed** (10 new).
- `helm template` ✅ default + opencrane-dev overlay + k3d e2e/local profiles; incoherent input (proxy on, no IP / empty trustedProxies) correctly **rejected** by the schema.
- `bash -n` clean on both deploy scripts.
- Independent `review` gate run; High finding (auto-path test coverage) resolved, Low (mask rigor) fixed.
