### PR TITLE
fix(crd): add observedGeneration to Tenant CRD status — stops the reconcile hot-loop

### DIFF
--- a/platform/helm/crds/tenant.opencrane.io_tenants.yaml
+++ b/platform/helm/crds/tenant.opencrane.io_tenants.yaml
@@ -128,9 +128,26 @@ spec:
                   type: string
                 message:
                   type: string
+                effectivePolicyRef:
+                  type: string
+                policyResolutionSource:
+                  type: string
+                policyResolutionState:
+                  type: string
                 lastReconciled:
                   type: string
                   format: date-time
+                observedGeneration:
+                  type: integer
+                  format: int64
+                  description: >-
+                    metadata.generation the operator last drove to Running. The reconcile-skip
+                    guard compares this against metadata.generation so an unchanged, already-
+                    running Tenant is not re-provisioned on every watch replay. MUST be present
+                    in the schema or the API server prunes it from status writes, defeating the
+                    guard and re-reconciling on every watch cycle — which, because each reconcile
+                    writes status (lastReconciled), self-triggers an endless MODIFIED → reconcile
+                    loop.
       additionalPrinterColumns:
         - name: Display Name
           type: string


### PR DESCRIPTION
## Symptom

The operator reconciles every running Tenant **~once per second forever** (observed live: 76 reconciles / 30s across 3 tenants), each cycle hammering LiteLLM `/key/update` (→ `404 Team doesn't exist`) and the control-plane tenant-models API. Pure churn — nothing is changing.

## Root cause

`reconcileTenant` has a convergence guard (`operator.ts:240-246`) that skips the full reconcile when `status.phase === Running && status.observedGeneration === metadata.generation`. The success path writes `observedGeneration` back (`operator.ts:378`).

But the **Tenant CRD status schema was missing `observedGeneration`**. With a structural schema + the `status` subresource enabled, Kubernetes **prunes** unknown fields on write — so `observedGeneration` never persists (verified live: `phase=Running` but `status.observedGeneration` empty, `generation=1`). The guard is therefore never satisfied → every watch event re-runs the reconcile → each reconcile writes `status` (`lastReconciled = now()`) → that write emits another `MODIFIED` → **endless self-triggered loop**.

The ClusterTenant CRD already carries `observedGeneration` and its description literally documents this pruning trap — the lesson was never applied to the Tenant CRD.

## Fix

Add to the Tenant CRD `status` schema:
- `observedGeneration` (integer/int64) — **the loop fix**.
- `effectivePolicyRef`, `policyResolutionSource`, `policyResolutionState` — also written by the operator (`operator.ts:290-292,371-373`) but absent from the schema, so silently pruned → invisible to the API/UI. Same class of bug; added for correctness.

No operator code change. No image rebuild.

## Deploy note

Helm applies `crds/` **on install only** — `helm upgrade` will NOT update an existing CRD, and the deploy scripts don't apply the dir explicitly. So this lands via an explicit `kubectl apply -f platform/helm/crds/tenant.opencrane.io_tenants.yaml`. The operator's next status write then persists `observedGeneration` and the guard converges (one reconcile, then quiescent).

## Out of scope (separate follow-ups)
- **LiteLLM `404 Team doesn't exist`**: the operator sets `team_id=<clusterTenantRef>` on tenant keys but nothing ever calls `/team/new` to create the LiteLLM team. The key still works (it exists); only team-scoped budget/limits don't apply. The hot-loop just made it spam.
- **tenant-models `401`**: the operator's best-effort fetch of the control-plane tenant-models API returns 401 (falls back to unrestricted models) — likely an internal-auth gap.