### PR TITLE
📝 DOCS: ADR 0001 (silo substrate = Linkerd) + networking page drift fix

### DIFF
--- a/docs/adr/0001-cluster-tenant-virtual-network-isolation.md
+++ b/docs/adr/0001-cluster-tenant-virtual-network-isolation.md
@@ -1,0 +1,128 @@
+# ADR 0001 — ClusterTenant-as-virtual-network strict isolation
+
+- **Status:** Accepted
+- **Date:** 2026-06-25
+- **Task:** `task_5164276f` (Phase 3 / S6 of the strict-multi-tenancy program)
+- **Supersedes / superseded by:** none
+- **Related:** [`silo-multi-tenant-plan.md`](../../silo-multi-tenant-plan.md) (§2 identity loop, §4 phases) · [`website/operators/networking.md`](../../website/operators/networking.md) (the north-south edge + the L3/4 floor this layers on)
+
+## Context
+
+Every ClusterTenant (a customer org) is modelled as a strictly isolated **silo / virtual
+network**. All silos feed a single **main network** (`opencrane-system`) that hosts the
+super-admin control plane. The goal is east-west default-deny: no silo→silo traffic ever,
+and the control-plane/operator super-admin identity as the **only** cross-silo principal.
+
+The live system has already shipped the L3/4 floor of this model in S2 (`task_08734d58` +
+`task_d6404452`): the operator emits a per-silo default-deny `NetworkPolicy`
+(`_BuildSiloBaselineNetworkPolicy`) in each ClusterTenant namespace. That floor is keyed on
+namespaces and ports — it is correct and necessary, but it is **not** workload-identity-aware,
+it does not give us mTLS, and it cannot express L7 (per-route) authorization.
+
+The open question this ADR settles: **what substrate carries workload identity and L7
+authorization on top of that floor**, given two hard constraints:
+
+1. The org is going **k8s-native and portable** — actively moving off GCP-managed bits.
+   A substrate that only works on GKE (or that hard-couples isolation to a managed Google
+   product) is a non-starter for the shared/dedicated tiers.
+2. Identity must be **cryptographic and robust to pod churn**, not a CIDR/IP allow-list
+   (the live bug — policies present, enforcement off, zero isolation — is exactly the
+   failure mode of coupling isolation to addressing).
+
+## Decision
+
+### Substrate = Linkerd service mesh
+
+**Linkerd** is the chosen substrate for workload identity and L7 authorization across silos:
+
+- **Workload identity via mTLS.** Linkerd issues each meshed workload a per-service-account
+  identity and establishes mutual TLS between them automatically. This is the cryptographic,
+  auto-rotating, churn-robust identity the silo model requires — keyed on the workload, not
+  its IP.
+- **L7 `AuthorizationPolicy`.** Linkerd `Server` + `AuthorizationPolicy` resources let the
+  operator express "only the super-admin/control-plane identity may reach into this silo" at
+  the request layer, on top of the namespace floor.
+- **Portable / no cloud lock-in.** Linkerd runs on any conformant Kubernetes — GKE, and
+  whatever the org moves to. This is the deciding factor: it keeps the isolation substrate
+  portable as the org goes k8s-native and off GCP-managed networking.
+
+### GKE Dataplane V2 = interim L3/4 NetworkPolicy floor only
+
+The per-silo default-deny `NetworkPolicy` that S2 shipped **stays** as a defense-in-depth
+L3/4 floor. It is expressed in **standard Kubernetes `NetworkPolicy`**, which is portable;
+the enforcer is whatever CNI the cluster runs — **GKE Dataplane V2** today, Calico/Cilium
+elsewhere. We depend on DV2 only as a *NetworkPolicy enforcer*, not for any GKE-specific
+isolation feature. Linkerd layers identity + L7 on top; the NetworkPolicy floor is never
+removed.
+
+### Per-CT operator + per-CT planes is the target the substrate enables
+
+The substrate exists to make the **Phase 3 silo architecture** safe: moving the operator and
+the data/runtime planes (Obot/MCP, skill-registry, LiteLLM, Cognee, tenant DB) *into* each
+silo, with the control plane remaining the only shared, cross-silo plane. Linkerd identity is
+what lets a silo-local plane trust a caller without falling back to network position.
+
+### Mesh rollout is additive (S5)
+
+Adopting the mesh does not require a flag-day. The operator:
+
+1. annotates each silo namespace `linkerd.io/inject: enabled` so silo workloads join the mesh
+   and get an identity + mTLS;
+2. emits a Linkerd `Server` + `AuthorizationPolicy` per silo expressing the same
+   default-deny + allow-super-admin posture at L7.
+
+The DV2 / `NetworkPolicy` floor stays in place throughout. The two compose: NetworkPolicy
+drops anything not allowed at L3/4; Linkerd authorization drops anything not allowed at L7.
+A silo gains identity/L7 isolation incrementally as it is annotated, with no window where it
+is *less* isolated than the S2 floor.
+
+### Substrate scales with `isolationTier`
+
+The substrate is not one-size-fits-all; it tracks `ClusterTenant.spec.isolationTier`:
+
+| Tier | Substrate |
+|------|-----------|
+| `shared` | DV2/CNI NetworkPolicy floor **+ Linkerd identity & L7** in one cluster |
+| `dedicatedNodes` | same as `shared`, pinned to dedicated nodes |
+| `dedicatedCluster` | vcluster / Kamaji — a separate control plane per silo (strongest isolation) |
+
+## Alternatives considered
+
+- **Self-managed Cilium (BYO CNI) with `CiliumNetworkPolicy` + SPIFFE mTLS** — richest
+  identity-aware L3/4/L7 and the original front-runner in the plan. **Deferred.** It is the
+  fallback **only if** full `CiliumNetworkPolicy` + SPIFFE mutual-auth turns out to be
+  required *and* we are willing to leave GKE Autopilot and run our own CNI (significantly more
+  ops). Linkerd delivers the workload-identity + L7 we need today with far less operational
+  surface and no Autopilot exit.
+- **vcluster / Kamaji per silo** — strongest possible isolation (a separate Kubernetes
+  control plane per silo). **Reserved for the `dedicatedCluster` tier**, where the customer is
+  buying that level and footprint. It is also the AGPL / WeOwnAI enterprise seam, so it stays
+  an arm's-length, out-of-process provisioner rather than the default substrate.
+- **GKE Dataplane V2 as the *whole* isolation story** — rejected as a complete answer: the
+  GKE-managed surface exposes standard `NetworkPolicy` + GKE FQDN policy, but **not** full
+  `CiliumNetworkPolicy` or SPIFFE mutual-auth, and leaning on it for identity would re-couple
+  isolation to the managed Google product we are moving away from. Kept strictly as the
+  portable L3/4 floor.
+- **Istio (ambient or sidecar)** — comparable L7 identity authorization, but heavier to run
+  than Linkerd for the posture we need. Not chosen.
+
+## Consequences
+
+- **Portable by construction.** Both layers we own — standard `NetworkPolicy` and Linkerd —
+  run on any conformant Kubernetes. The only cloud-specific dependency is "a CNI that enforces
+  NetworkPolicy," which every target platform provides.
+- **Two-layer defense in depth.** L3/4 floor (NetworkPolicy) + L7 identity authorization
+  (Linkerd) are independent; a gap or misconfiguration in one does not open the silo, because
+  the other still has to pass.
+- **Cryptographic, churn-robust identity.** mTLS identities are short-lived and auto-rotating,
+  bound to the workload's service account — no shared secret, no IP allow-list to drift.
+- **New operational dependency.** The cluster now runs Linkerd (control plane + per-workload
+  proxies); this is added build/run surface (S5) and a new failure domain to monitor. The
+  NetworkPolicy floor remaining in place bounds the blast radius if the mesh is unhealthy.
+- **Autopilot stays viable.** Because we did not choose self-managed Cilium, GKE Autopilot
+  remains an option for the shared/dedicated-node tiers; the Cilium/SPIFFE path is held in
+  reserve behind an explicit "we need full CiliumNetworkPolicy + SPIFFE" trigger.
+- **The crown jewel is unchanged and reinforced.** The super-admin (control-plane/operator)
+  identity is still the only cross-silo principal; Linkerd authorization now enforces that at
+  L7 in addition to the namespace floor, making its issuance/rotation/audit even more
+  load-bearing.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+Long-lived design decisions for the OpenCrane platform. An ADR captures **why** a
+decision was made, the alternatives that were weighed, and the consequences we accepted —
+so a later reader (or a later agent) does not relitigate a settled question.
+
+These records are engineering history: they sit next to the agent guidance in
+[`docs/agents/`](../agents/) and complement the forward plans at the repo root
+(`plan.md`, `silo-multi-tenant-plan.md`). Reader-facing operator and integrator docs live
+in [`website/`](../../website); an ADR may be the source a website page summarises, but it
+is not itself published.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-cluster-tenant-virtual-network-isolation.md) | ClusterTenant-as-virtual-network strict isolation (substrate) | Accepted |
+
+## Writing a new ADR
+
+- Number sequentially (`NNNN-short-slug.md`); never reuse or renumber.
+- Keep the shape: **Status · Context · Decision · Alternatives considered · Consequences**.
+- Record the **decided** outcome. Open questions belong in a plan file, not an ADR.
+- When a decision changes, write a new ADR that supersedes the old one and flip the old
+  one's status to `Superseded by NNNN` — never rewrite history in place.
+- Reference the originating task ID (e.g. `task_5164276f`) so the record traces back to the
+  roadmap that requested it.

--- a/website/operators/networking.md
+++ b/website/operators/networking.md
@@ -164,9 +164,31 @@ Tenant-to-plane calls carry **audience-bound projected-identity tokens** mounted
 
 ---
 
-## Egress
+## The per-silo default-deny baseline
 
-The intended baseline for tenant egress is **DNS port 53 + HTTPS port 443**, plus optional per-tenant extensions. The chart's `networkpolicy.yaml` renders a `*-tenant-default` policy with egress rules for DNS and HTTPS (and any additional CIDRs listed in `networkPolicy.egressAllowCIDRs`). Operators can bind an `AccessPolicy` with `egressRules` to add or restrict what a specific tenant can reach. For fine-grained FQDN filtering (e.g. allowing only `api.openai.com`), Cilium's `CiliumNetworkPolicy` with `spec.domains.allow` is the intended mechanism.
+Each ClusterTenant (org) is modelled as a strictly isolated **silo**. The operator now emits a per-silo default-deny baseline `NetworkPolicy` in **every** ClusterTenant namespace as it provisions the silo — `_BuildSiloBaselineNetworkPolicy` (see [`apps/operator/src/tenants/deploy/silo-baseline-network-policy.ts`](https://github.com/italanta/opencrane/blob/main/apps/operator/src/tenants/deploy/silo-baseline-network-policy.ts)), named `opencrane-<cluster-tenant>-silo-baseline`.
+
+The policy uses an **empty `podSelector`** (it selects every pod in the silo namespace) and names both `Ingress` and `Egress` in `policyTypes`, which flips the namespace to **default-deny**: anything not explicitly allowed below is dropped. The allow-list is the minimum a silo needs to function while staying isolated from every *other* silo — there is no silo→silo path because no rule ever names another silo namespace:
+
+| Direction | Allowed | Why |
+|-----------|---------|-----|
+| Ingress | the same silo namespace (intra-silo) | pods within one org talk to each other |
+| Ingress | the control-plane / operator namespace | the super-admin plane is the only principal allowed to reach inward (it brokers the gateway connection) |
+| Egress | cluster DNS (`kube-system`, UDP/TCP 53) | without this every name lookup fails and the pod is dead |
+| Egress | the same silo namespace + the control-plane / operator namespace | reach the shared planes (control-plane, Obot/MCP, skill-registry, LiteLLM, Cognee) in the shared tier |
+| Egress | external HTTPS (TCP 443) | the agent legitimately calls out to LLM / MCP / Git endpoints |
+
+This **replaces the retired `opencrane-tenant-default` policy**, which sat in the install namespace (`opencrane-system`) and selected tenant pods cluster-wide by `app.kubernetes.io/component=tenant` — so it governed nothing in the per-org namespaces where tenant pods actually run, leaving egress unrestricted there. The operator now emits one correctly-scoped policy per silo namespace it provisions, so egress (DNS + HTTPS only) and east-west default-deny are enforced in the right place. The companion per-tenant gateway policy (`openclaw-<tenant>-gateway`, [Layer 1](#the-authenticated-operator-seam) above) narrows the gateway *port* to the operator on top of this baseline; `NetworkPolicy` rules are additive, so the two compose.
+
+::: tip Enforcement is CNI-dependent
+This baseline is an **L3/L4** floor — a namespace-scoped, port-keyed allow-list. It only takes effect on a `NetworkPolicy`-enforcing CNI: GKE Dataplane V2 (and Autopilot) enforce it inherently; Calico/Cilium do elsewhere. On a CNI that does not enforce `NetworkPolicy`, the floor is inert.
+:::
+
+### Identity-aware L7 isolation is coming (Linkerd)
+
+The baseline above is keyed on namespaces and ports, not on **workload identity**, and it cannot express L7 (per-route) authorization. The next layer of the silo model adds a [Linkerd](https://linkerd.io) service mesh on top of this floor: the operator will annotate each silo namespace `linkerd.io/inject: enabled` (giving every silo workload an mTLS identity bound to its service account) and emit a Linkerd `Server` + `AuthorizationPolicy` per silo expressing the same default-deny + allow-super-admin posture at the request layer. The rollout is **additive** — the `NetworkPolicy` floor stays in place as defence-in-depth, and a silo gains identity/L7 isolation as it is meshed, never going below the floor described here. See [ADR 0001 — ClusterTenant-as-virtual-network strict isolation](https://github.com/italanta/opencrane/blob/main/docs/adr/0001-cluster-tenant-virtual-network-isolation.md) for the substrate decision and why Linkerd (portable, no cloud lock-in) was chosen.
+
+For fine-grained egress FQDN filtering (e.g. allowing only `api.openai.com`), an operator can additionally bind an `AccessPolicy` with `egressRules`, or apply a `CiliumNetworkPolicy` with `spec.domains.allow` on a Cilium-enabled cluster.
 
 ---
 
@@ -174,15 +196,11 @@ The intended baseline for tenant egress is **DNS port 53 + HTTPS port 443**, plu
 
 The following gaps are honest assessments verified against the live codebase. They do not undermine the overall isolation model but operators should be aware of them.
 
-**Tenant egress is not currently enforced for per-org-namespace tenants.** The chart's `*-tenant-default` egress policy (`networkpolicy.yaml`) selects pods by `app.kubernetes.io/component=tenant` but is rendered only into the release namespace (`opencrane-system`). Tenant pods run in per-org namespaces (`opencrane-<org>`), so the policy governs nothing there. Until this is fixed, tenant egress is unrestricted at the network layer unless an `AccessPolicy` with `egressRules` is bound. A fix is tracked separately. The ingress isolation (the three-layer gateway seam) is unaffected.
-
 **litellm, langfuse, and the otel-collector have no ingress NetworkPolicy.** The plane ingress policies cover the control plane, mcp-gateway, skill-registry, and OCI store. LiteLLM, Langfuse, and the OTEL collector are not yet covered by a corresponding ingress policy — a defence-in-depth gap. Application-level auth still applies on those services.
 
 **Plane ingress rules use tenant podSelectors without a namespaceSelector.** The rules admitting tenant pods to the control plane and plane services select by `app.kubernetes.io/component=tenant` without scoping to the correct namespace. In a multi-instance cluster, a tenant pod from a different instance's namespace could match. This is a multi-instance hygiene gap; the fix is to also add a `namespaceSelector` that constrains to the instance's own org namespaces.
 
-::: warning Egress is open until the per-org policy gap is fixed
-Until the egress enforcement gap is resolved, treat tenant pods as having unrestricted internet egress at the network layer. If your threat model requires egress restriction before that fix lands, apply manual `NetworkPolicy` or `CiliumNetworkPolicy` resources to the per-org namespaces directly.
-:::
+**Identity-aware L7 enforcement is not yet live.** Until the Linkerd layer lands, cross-silo isolation rests on the L3/L4 baseline alone — robust against routing position but not yet expressing per-workload identity or per-route authorization. The super-admin namespace is trusted as a whole at L3/L4; L7 will narrow that to the super-admin *identity*.
 
 ---
 
@@ -192,3 +210,4 @@ Until the egress enforcement gap is resolved, treat tenant pods as having unrest
 - [Connection security](/security/connection-security) — the full CONN.9/CONN.10 threat model, the trusted-proxy auth decision record, and the transport hardening posture
 - [DNS configuration](/operators/dns-config) — external-dns setup, cert-manager issuers, and the zone-write identity model
 - [Hosting & deployment](/operators/hosting) — ingress class, TLS cert modes, cloud hosting adapters
+- [ADR 0001 — ClusterTenant-as-virtual-network strict isolation](https://github.com/italanta/opencrane/blob/main/docs/adr/0001-cluster-tenant-virtual-network-isolation.md) — the substrate decision behind the per-silo baseline and the coming Linkerd L7 layer


### PR DESCRIPTION
DOCS track of the strong-siloes roadmap. Two changes.

## 1. ADR 0001 — ClusterTenant-as-virtual-network strict isolation (\`task_5164276f\`)

New \`docs/adr/\` directory (with an index README) as the canonical ADR home, co-located with the engineering guidance in \`docs/agents/\` and the root plan files. Records the **decided** substrate for the silo model:

- **Substrate = Linkerd** service mesh — workload identity (mTLS) + L7 \`AuthorizationPolicy\`. Chosen for **portability / no GCP lock-in** as the org goes k8s-native.
- **GKE Dataplane V2 = interim L3/4 NetworkPolicy floor only** (what S2 shipped). Standard, portable \`NetworkPolicy\`; the CNI is the enforcer (DV2 on GKE, Calico/Cilium elsewhere). Stays as defence-in-depth.
- **Self-managed Cilium/SPIFFE** and **vcluster/Kamaji** captured as deferred alternatives (Cilium only if full CiliumNetworkPolicy+SPIFFE is needed and willing to leave Autopilot; vcluster/Kamaji reserved for the \`dedicatedCluster\` tier — AGPL/WeOwnAI seam).
- **Per-CT operator + per-CT planes** is the Phase-3 target the substrate enables.
- **Mesh rollout is additive (S5):** operator annotates each silo namespace \`linkerd.io/inject: enabled\` and emits Linkerd \`Server\` + \`AuthorizationPolicy\` per silo; the NetworkPolicy floor stays.
- **Substrate scales with \`isolationTier\`:** shared/dedicatedNodes → DV2 floor + Linkerd identity; dedicatedCluster → vcluster/Kamaji.

## 2. Fix networking page drift (C2)

\`website/operators/networking.md\` still described the retired install-namespace \`opencrane-tenant-default\` NetworkPolicy. Updated the egress + known-gaps sections to the S2 reality: the operator emits a per-silo default-deny baseline (\`_BuildSiloBaselineNetworkPolicy\`) in each ClusterTenant namespace (allow-list = intra-silo + control-plane/operator namespace + DNS + external HTTPS; no silo→silo path), noted the L3/4 enforcement is CNI-dependent, and pointed forward to the coming Linkerd L7 layer (ADR 0001).

## Validation

\`pnpm build\` (vitepress build, \`ignoreDeadLinks: false\`) passes — build complete, exit 0, no dead links. Remaining warnings (\`env\` highlighter, \`/api/v1\` base URL, chunk size) are pre-existing and unrelated.