### PR TITLE
🔒️ harden operator openclaw.json: pin gateway against overrides + schema-validate render

### DIFF
--- a/apps/operator/package.json
+++ b/apps/operator/package.json
@@ -16,7 +16,8 @@
     "@opencrane/contracts": "workspace:*",
     "@opencrane/observability": "workspace:*",
     "http-proxy": "^1.18.1",
-    "pino": "^9.6.0"
+    "pino": "^9.6.0",
+    "zod": "^3.25.0"
   },
   "optionalDependencies": {
     "@google-cloud/storage": "^7.0.0"

--- a/apps/operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -2,66 +2,130 @@ import { describe, expect, it } from "vitest";
 
 import { defaultConfig, _makeTenant } from "../fixtures.js";
 import { _BuildConfigMap } from "../../tenants/deploy/index.js";
+import { _OpenclawConfigSchema } from "../../tenants/deploy/openclaw-config.schema.js";
 
 /**
- * Structural contract test for the rendered `openclaw.json` (task_d611ab4d, S1).
+ * Schema contract test for the rendered `openclaw.json` (task_d611ab4d, S1).
  *
- * OpenClaw's gateway config schema is **strict** — an unknown key crashes the pod
- * on boot (the `trustNothing`-class crash fixed in f6afafd, where the operator
- * leaked an internal flag into the `gateway` block). The full validation against
- * the pinned OpenClaw zod schema is BLOCKED (the schema is not vendored — OpenClaw
- * ships as a container, not an npm dep), so this is the no-dependency fallback: it
- * pins the exact key set the operator emits and fails closed on any stray key,
- * which is precisely the regression class that crashed live tenants.
+ * OpenClaw's config schema is **strict** — an unknown key crashes the pod on boot
+ * (the `trustNothing`-class crash fixed in f6afafd, where the operator leaked an
+ * internal flag into the `gateway` block). Earlier this test was a no-dependency
+ * structural allowlist because OpenClaw ships as a container, not an npm dep, so
+ * its schema wasn't vendored. We now validate the rendered config against a
+ * VENDORED zod mirror of OpenClaw's documented schema
+ * (`openclaw-config.schema.ts`, pinned to OpenClaw 2026.6.x), which rejects stray
+ * keys exactly as the live gateway does — covering the same regression class with
+ * a real schema instead of a hand-maintained key list.
  */
-describe("openclaw.json render contract — strict key set (task_d611ab4d)", function _suite()
+describe("openclaw.json render contract — zod schema (task_d611ab4d)", function _suite()
 {
-  /** Keys OpenClaw's strict `gateway` schema accepts; anything else crashes the pod. */
-  const _ALLOWED_GATEWAY_KEYS = ["mode", "port", "bind", "trustedProxies", "auth"];
-
-  /** Keys of the nested `gateway.auth.trustedProxy` block. */
-  const _ALLOWED_TRUSTED_PROXY_KEYS = ["userHeader", "allowUsers"];
-
-  function _renderGateway(tenant = _makeTenant("contract")): Record<string, unknown>
+  function _renderRaw(tenant = _makeTenant("contract")): string
   {
     const configMap = _BuildConfigMap(defaultConfig, tenant, "default");
-    const payload = JSON.parse(configMap.data?.["openclaw.json"] ?? "{}");
-    return payload.gateway as Record<string, unknown>;
+    return configMap.data?.["openclaw.json"] ?? "{}";
   }
 
-  it("emits exactly the strict gateway key set — no stray keys", function _gatewayKeys()
+  function _renderConfig(tenant = _makeTenant("contract")): Record<string, unknown>
   {
-    const gateway = _renderGateway();
-    expect(Object.keys(gateway).sort()).toEqual([..._ALLOWED_GATEWAY_KEYS].sort());
+    return JSON.parse(_renderRaw(tenant)) as Record<string, unknown>;
+  }
+
+  it("validates the default rendered config against the OpenClaw zod schema", function _schemaOk()
+  {
+    const parsed = _OpenclawConfigSchema.safeParse(_renderConfig());
+    expect(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2)).toBe(true);
+  });
+
+  it("validates the LiteLLM-enabled config (models block) against the schema", function _modelsOk()
+  {
+    // Exercise the optional `models` branch so the provider/mode shape is covered.
+    const liteLlmConfig = { ...defaultConfig, liteLlmEnabled: true };
+    const configMap = _BuildConfigMap(liteLlmConfig, _makeTenant("contract"), "default");
+    const parsed = _OpenclawConfigSchema.safeParse(JSON.parse(configMap.data?.["openclaw.json"] ?? "{}"));
+    expect(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error?.issues, null, 2)).toBe(true);
   });
 
   it("never leaks the internal trustNothing flag into the gateway block", function _noTrustNothing()
   {
     // The exact f6afafd regression: trustNothing is operator-internal, not an
-    // OpenClaw key, so it must never appear anywhere in the rendered config.
-    const configMap = _BuildConfigMap(defaultConfig, _makeTenant("contract"), "default");
-    const raw = configMap.data?.["openclaw.json"] ?? "";
-    expect(raw).not.toContain("trustNothing");
+    // OpenClaw key, so it must never appear anywhere in the rendered config and
+    // the strict gateway schema would reject it if it did.
+    expect(_renderRaw()).not.toContain("trustNothing");
   });
 
-  it("emits the strict trusted-proxy auth shape", function _authShape()
+  it("rejects a stray key injected into the gateway block (regression guard)", function _strayKey()
   {
-    const gateway = _renderGateway();
-    const auth = gateway.auth as Record<string, unknown>;
-    expect(auth.mode).toBe("trusted-proxy");
-
-    const trustedProxy = auth.trustedProxy as Record<string, unknown>;
-    expect(Object.keys(trustedProxy).sort()).toEqual([..._ALLOWED_TRUSTED_PROXY_KEYS].sort());
+    // Tamper the rendered config the way the f6afafd bug did and prove the schema
+    // fails closed — this is what protects the live pod from an unknown gateway key.
+    const config = _renderConfig();
+    (config["gateway"] as Record<string, unknown>)["trustNothing"] = true;
+    expect(_OpenclawConfigSchema.safeParse(config).success).toBe(false);
   });
 
   it("pins the gateway to the owner email via allowUsers", function _ownerPin()
   {
-    // CONN.10 — the operator-emitted config must scope the pod to its owner. (Note:
-    // configOverrides currently REPLACES the gateway block via shallow merge, so a
-    // gateway override drops this pin — tracked as a follow-up gap, see PR notes.)
-    const gateway = _renderGateway(_makeTenant("contract"));
-    const auth = gateway.auth as Record<string, unknown>;
-    const trustedProxy = auth.trustedProxy as { allowUsers: string[] };
+    // CONN.10 — the operator-emitted config scopes the pod to its owner.
+    const config = _renderConfig();
+    const auth = (config["gateway"] as Record<string, unknown>)["auth"] as Record<string, unknown>;
+    const trustedProxy = auth["trustedProxy"] as { allowUsers: string[] };
+    expect(trustedProxy.allowUsers).toEqual(["contract@example.com"]);
+  });
+});
+
+/**
+ * C1 — a tenant `configOverrides.gateway` must NOT clobber the platform-owned
+ * gateway block. Step 3b of `_BuildConfigMap` re-pins `baseConfig.gateway` after
+ * the tenant merge, so a gateway override can never drop the owner-pin (CONN.10)
+ * or inject a stray key that crashes the strict gateway schema.
+ */
+describe("configOverrides cannot clobber the platform gateway (C1)", function _c1Suite()
+{
+  function _render(overrides: Record<string, unknown>): Record<string, unknown>
+  {
+    const tenant = _makeTenant("contract", { configOverrides: overrides });
+    const configMap = _BuildConfigMap(defaultConfig, tenant, "default");
+    return JSON.parse(configMap.data?.["openclaw.json"] ?? "{}") as Record<string, unknown>;
+  }
+
+  it("ignores a malicious gateway override (no stray key, owner-pin preserved)", function _gatewayOverride()
+  {
+    // A tenant tries to replace the gateway block: it drops allowUsers AND injects a
+    // stray key. After the re-pin, neither must survive.
+    const config = _render({
+      gateway: {
+        mode: "local",
+        port: 18789,
+        bind: "lan",
+        trustedProxies: ["0.0.0.0/0"],
+        auth: { mode: "trusted-proxy", trustedProxy: { userHeader: "X-Forwarded-User" } },
+        // Stray key + a malicious wide-open trustedProxies + missing allowUsers.
+        trustNothing: true,
+      },
+    });
+
+    const gateway = config["gateway"] as Record<string, unknown>;
+    const auth = gateway["auth"] as Record<string, unknown>;
+    const trustedProxy = auth["trustedProxy"] as { allowUsers: string[] };
+
+    // 1. Owner-pin survives — the override's missing allowUsers did not win.
+    expect(trustedProxy.allowUsers).toEqual(["contract@example.com"]);
+    // 2. The stray key is gone — the platform block was restored verbatim.
+    expect(gateway).not.toHaveProperty("trustNothing");
+    // 3. The platform trustedProxies (fixture default), not the wide-open override, applies.
+    expect(gateway["trustedProxies"]).toEqual(["10.0.0.0/8"]);
+    // 4. The result still validates against the strict OpenClaw schema.
+    expect(_OpenclawConfigSchema.safeParse(config).success).toBe(true);
+  });
+
+  it("still applies a non-gateway override", function _nonGatewayOverride()
+  {
+    // A non-platform top-level override must pass through untouched.
+    const config = _render({ telemetry: { enabled: false } });
+    expect(config["telemetry"]).toEqual({ enabled: false });
+
+    // ...and the gateway block is still the platform-owned one.
+    const auth = (config["gateway"] as Record<string, unknown>)["auth"] as Record<string, unknown>;
+    const trustedProxy = auth["trustedProxy"] as { allowUsers: string[] };
     expect(trustedProxy.allowUsers).toEqual(["contract@example.com"]);
   });
 });

--- a/apps/operator/src/config.ts
+++ b/apps/operator/src/config.ts
@@ -314,10 +314,16 @@ function _resolveTrustedProxiesInput(raw: string): string[]
     }
     if (derived === null)
     {
-      console.error(`GATEWAY_TRUSTED_PROXIES="auto" but POD_IP "${podIp}" is missing/invalid; dropping the token (staying fail-closed)`);
+      // Degraded-but-handled: the operator asked for `auto` but POD_IP is unusable, so the
+      // token is dropped and the gateway stays fail-closed. A warning (not an error — the
+      // process continues correctly), but one an operator must see to fix the missing POD_IP.
+      console.warn(`GATEWAY_TRUSTED_PROXIES="auto" but POD_IP "${podIp}" is missing/invalid; dropping the token (staying fail-closed)`);
       return [];
     }
-    console.error(`GATEWAY_TRUSTED_PROXIES="auto" derived trusted-proxy CIDR ${derived} from POD_IP ${podIp} (/${maskBits}); this trusts the whole pod range`);
+    // Routine on every auto-mode boot, but it widens the trust boundary to the whole pod
+    // range, so it is logged at warn (not error) — error-level would pollute the error log
+    // on normal startup while still deserving operator visibility.
+    console.warn(`GATEWAY_TRUSTED_PROXIES="auto" derived trusted-proxy CIDR ${derived} from POD_IP ${podIp} (/${maskBits}); this trusts the whole pod range`);
     return [derived];
   });
 }

--- a/apps/operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/operator/src/tenants/deploy/2-config-map.ts
@@ -153,6 +153,17 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
     ? { ...baseConfig, ...tenant.spec.configOverrides }
     : { ...baseConfig };
 
+  // 3b. Re-pin the platform-owned `gateway` block (CONN.10) — applied AFTER the tenant
+  //     merge so `spec.configOverrides.gateway` can never clobber it. The shallow merge
+  //     in step 3 is top-level: a tenant `gateway` override REPLACES the whole block,
+  //     which would drop the owner-pin (auth.trustedProxy.allowUsers=[owner]) and could
+  //     inject a stray key that crashes the strict gateway schema on boot. Restoring
+  //     baseConfig.gateway verbatim keeps the security-critical block under platform
+  //     control while every non-gateway override still applies. This mirrors the
+  //     agents.defaults re-application in step 4. A fresh spread (not the baseConfig
+  //     reference) keeps `merged` free of aliasing into the local baseConfig object.
+  tenantMerged["gateway"] = { ...(baseConfig["gateway"] as Record<string, unknown>) };
+
   // 4. Platform-owned agent workspace settings — applied after the tenant merge so
   //    they cannot be overridden by spec.configOverrides.  The workspace path must
   //    be pinned to the persistent volume; skipBootstrap prevents the interactive

--- a/apps/operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -1,0 +1,158 @@
+import { z } from "zod";
+
+/**
+ * Vendored zod schema for the `openclaw.json` the operator emits, used to
+ * validate the rendered config in the contract test (task_d611ab4d).
+ *
+ * PINNED OpenClaw version: 2026.6.x (operator `config.ts` `defaultOpenclawVersion`
+ * = "2026.6.9"). OpenClaw is shipped as a container image, not an npm dependency,
+ * so its canonical schema is not importable; this file VENDORS a strict best-effort
+ * mirror of the documented config schema for the subset of keys the operator emits.
+ *
+ * Source (researched 2026-06-25 from primary OpenClaw docs):
+ *   - https://docs.openclaw.ai/gateway/configuration-reference
+ *   - https://docs.openclaw.ai/gateway/configuration
+ *   - https://docs.openclaw.ai/gateway/trusted-proxy-auth
+ *
+ * What is PINNED vs INFERRED:
+ *   - PINNED (verbatim from docs): gateway.mode ∈ {local,remote}; gateway.bind ∈
+ *     {auto,loopback,lan,tailnet,custom}; gateway.auth.mode ∈
+ *     {none,token,password,trusted-proxy}; models.mode ∈ {merge,replace}. The docs
+ *     state OpenClaw "only accepts configurations that fully match the schema —
+ *     unknown keys cause the gateway to refuse to start", so every object below is
+ *     `.strict()` (unknown keys rejected). This is exactly the `trustNothing`-class
+ *     regression that crashed live tenants (f6afafd).
+ *   - INFERRED (best-effort, not byte-for-byte from the canonical JSON Schema): the
+ *     exact optionality/typing of `trustedProxy.userHeader`/`allowUsers`, the
+ *     `models.providers.*` field set (baseUrl/apiKey/api/models), and the
+ *     `agents.defaults` shape. These mirror what the operator emits and the
+ *     documented field names; widen them here if OpenClaw's `openclaw config schema`
+ *     output later proves a looser shape.
+ */
+
+/** Bind modes the OpenClaw gateway accepts (docs: configuration-reference). */
+const _bindMode = z.enum(["auto", "loopback", "lan", "tailnet", "custom"]);
+
+/** Auth modes the OpenClaw gateway accepts (docs: configuration-reference). */
+const _authMode = z.enum(["none", "token", "password", "trusted-proxy"]);
+
+/**
+ * Trusted-proxy auth block. INFERRED optionality: the operator always emits both
+ * keys, but the docs describe `allowUsers` as an optional allowlist, so it is
+ * `.optional()` here while `userHeader` is required (the operator pins it).
+ */
+const _trustedProxySchema = z
+  .object({
+    /** Header the trusted proxy injects with the authenticated user identity. */
+    userHeader: z.string().min(1),
+    /** Allowlist of users (emails) the gateway will accept from the proxy. */
+    allowUsers: z.array(z.string()).optional(),
+  })
+  .strict();
+
+/**
+ * Gateway auth block. The operator only ever emits `trusted-proxy`; the schema
+ * still admits the documented modes so the enum stays faithful to OpenClaw.
+ */
+const _authSchema = z
+  .object({
+    /** Auth strategy the gateway uses. */
+    mode: _authMode,
+    /** Trusted-proxy settings, present when `mode === "trusted-proxy"`. */
+    trustedProxy: _trustedProxySchema.optional(),
+  })
+  .strict();
+
+/**
+ * PLATFORM-OWNED gateway block. `.strict()` is the load-bearing guarantee: an
+ * unknown key here is the exact class of bug that crashed live tenant pods on boot.
+ */
+const _gatewaySchema = z
+  .object({
+    /** Gateway run mode. */
+    mode: z.enum(["local", "remote"]),
+    /** Multiplexed WS+HTTP port. */
+    port: z.number().int().positive(),
+    /** Network bind scope. */
+    bind: _bindMode,
+    /** Reverse-proxy source IPs/CIDRs trusted for trusted-proxy auth. */
+    trustedProxies: z.array(z.string()),
+    /** Delegated-auth configuration. */
+    auth: _authSchema,
+  })
+  .strict();
+
+/**
+ * A single model provider entry. INFERRED field set mirrors what the operator
+ * emits for the `litellm-proxy` provider (baseUrl/apiKey/api/models).
+ */
+const _modelProviderSchema = z
+  .object({
+    /** Provider base URL (e.g. the LiteLLM proxy endpoint). */
+    baseUrl: z.string().optional(),
+    /** Provider API key, supports `${ENV}` interpolation. */
+    apiKey: z.string().optional(),
+    /** Wire protocol the provider speaks (e.g. `openai-completions`). */
+    api: z.string().optional(),
+    /** Allowed model ids; `[]` keeps the proxy default. */
+    models: z.array(z.string()).optional(),
+  })
+  .strict();
+
+/**
+ * Models block emitted only when LiteLLM is enabled. `mode` ∈ {merge,replace}
+ * (PINNED from docs); `default` is the optional default model id.
+ */
+const _modelsSchema = z
+  .object({
+    /** How the provider map merges with built-in providers. */
+    mode: z.enum(["merge", "replace"]),
+    /** Default model id, surfaced when the control-plane returned one. */
+    default: z.string().optional(),
+    /** Provider id → provider config map. */
+    providers: z.record(z.string(), _modelProviderSchema),
+  })
+  .strict();
+
+/**
+ * Agent defaults the operator pins. INFERRED shape (workspace path + skipBootstrap);
+ * `.passthrough()` is deliberate here because a tenant MAY add its own
+ * `agents.defaults.*` keys (the operator merges them in step 4 of `_BuildConfigMap`),
+ * unlike the strictly platform-owned gateway block.
+ */
+const _agentsDefaultsSchema = z
+  .object({
+    /** Persistent workspace path inside the tenant pod. */
+    workspace: z.string(),
+    /** Skip the interactive bootstrap ritual in the headless pod. */
+    skipBootstrap: z.boolean(),
+  })
+  .passthrough();
+
+/**
+ * Agents block. `.passthrough()` mirrors the gateway/agents asymmetry: tenants may
+ * extend agents config, so only the platform-pinned `defaults` keys are asserted.
+ */
+const _agentsSchema = z
+  .object({
+    /** Default agent settings applied to every agent in the pod. */
+    defaults: _agentsDefaultsSchema,
+  })
+  .passthrough();
+
+/**
+ * Top-level `openclaw.json` schema for the operator-emitted config. `.passthrough()`
+ * at the root tolerates tenant `configOverrides` adding non-platform top-level keys
+ * (which is supported), while the nested `gateway` block stays `.strict()` — exactly
+ * the override-can't-clobber-gateway contract C1 enforces.
+ */
+export const _OpenclawConfigSchema = z
+  .object({
+    /** Platform-owned gateway block (never overridable by a tenant). */
+    gateway: _gatewaySchema,
+    /** Optional models block (present only when LiteLLM is enabled). */
+    models: _modelsSchema.optional(),
+    /** Agents block carrying the platform-pinned defaults. */
+    agents: _agentsSchema,
+  })
+  .passthrough();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       pino:
         specifier: ^9.6.0
         version: 9.14.0
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
     devDependencies:
       '@types/http-proxy':
         specifier: ^1.17.14
@@ -3690,6 +3693,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7675,5 +7681,7 @@ snapshots:
 
   yocto-queue@0.1.0:
     optional: true
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
OPERATOR track of the strong-siloes roadmap. Two coherent commits.

## C1 — configOverrides can no longer clobber the platform gateway block
`_BuildConfigMap` did a top-level shallow merge (`{ ...baseConfig, ...configOverrides }`), so a tenant that set `configOverrides.gateway` **replaced the entire platform-owned gateway block** — dropping the CONN.10 owner-pin (`auth.trustedProxy.allowUsers=[owner]`) and able to inject an unknown key that crashes the strict OpenClaw gateway schema on boot.

Fix: re-pin `baseConfig.gateway` (defensive spread, no aliasing) after the tenant merge — step 3b, mirroring the existing `agents.defaults` re-application in step 4. Non-gateway overrides still apply.

## task_d611ab4d — real OpenClaw config-schema validation
The contract test was a hand-maintained structural allowlist because OpenClaw ships as a container, not an npm dep.

- New `apps/operator/src/tenants/deploy/openclaw-config.schema.ts`: a vendored **zod** mirror of OpenClaw's documented config schema (gateway / models / agents blocks), **pinned to OpenClaw 2026.6.x** (operator `defaultOpenclawVersion` = `2026.6.9`). Every object is `.strict()` so an unknown key fails closed — the exact `trustNothing`-class regression that crashed live pods. The file comments what is **pinned-from-docs** (the `mode`/`bind`/`auth.mode`/`models.mode` enums + strict-unknown-key rejection) vs **inferred** (exact field optionality of the trustedProxy/provider/agents shapes).
- Sources: docs.openclaw.ai/gateway/{configuration-reference, configuration, trusted-proxy-auth}.
- Rewrote the contract test to validate the rendered config (default + LiteLLM branches) against the schema, kept the `trustNothing` regression coverage, and added the C1 gateway-clobber assertions.
- Added `zod ^3.25.0` to operator deps.

## Validation
- `pnpm --filter "@opencrane/operator..." build` — passes
- `pnpm --filter @opencrane/operator test` — 186 passed (22 files), incl. 7 contract tests
- Independent review gate: no Critical/High findings; the Medium aliasing note was addressed (defensive spread).

## Deferred
The vendored schema is a best-effort strict mirror of the **documented** shape, not a byte-for-byte import of OpenClaw's canonical `openclaw config schema` output (not importable from the container). If that output later proves a looser shape for the inferred fields, widen the schema accordingly.