### PR TITLE
🔒️ control-plane: resolve per-org Zitadel OIDC client by host (S3b)

### DIFF
--- a/apps/control-plane/prisma/migrations/0026_zitadel_client_id/migration.sql
+++ b/apps/control-plane/prisma/migrations/0026_zitadel_client_id/migration.sql
@@ -1,0 +1,11 @@
+-- Migration 0026: per-org OIDC client_id on the ClusterTenant (S3b)
+--
+-- S3 provisions a dedicated Zitadel Organization + OIDC app per ClusterTenant and
+-- persists the org id, app id, and redirect URI. The login flow still uses a single
+-- shared client, so it cannot scope login to one org's user pool. Capture the OIDC
+-- app's client_id (returned by the live app-create response) so host→CT→client
+-- resolution can authorize against the org-scoped client. Nullable so existing rows
+-- and the unconfigured (no-Zitadel) path are unaffected.
+
+ALTER TABLE "cluster_tenants"
+  ADD COLUMN "zitadel_client_id" TEXT;

--- a/apps/control-plane/prisma/migrations/0027_zitadel_project_id_and_vanity_unique/migration.sql
+++ b/apps/control-plane/prisma/migrations/0027_zitadel_project_id_and_vanity_unique/migration.sql
@@ -1,0 +1,18 @@
+-- Migration 0027: per-org Zitadel project id + unique vanity domain (S3b)
+--
+-- A ClusterTenant's vanity domain (e.g. ai.client-company.com) must serve the org's
+-- login surface too: it has to be registered as a redirect URI on the org's Zitadel
+-- OIDC app, and a login request arriving at the vanity host has to resolve to that org.
+--
+-- 1. Record the org's Zitadel `opencrane` project id so the control-plane can UPDATE the
+--    OIDC app's redirect URIs (the Zitadel update endpoint is project-scoped) when the
+--    vanity domain is added/changed/cleared via PUT. Nullable so existing rows and the
+--    unconfigured (no-Zitadel) path are unaffected.
+ALTER TABLE "cluster_tenants"
+  ADD COLUMN "zitadel_project_id" TEXT;
+
+-- 2. A vanity domain maps to at most one ClusterTenant, so per-org login can resolve a
+--    vanity host to exactly one org's client. A standard unique index leaves the many
+--    NULLs (orgs with no vanity) distinct in Postgres, so it does not constrain them.
+CREATE UNIQUE INDEX "cluster_tenants_vanity_domain_key"
+  ON "cluster_tenants" ("vanity_domain");

--- a/apps/control-plane/prisma/schema.prisma
+++ b/apps/control-plane/prisma/schema.prisma
@@ -142,8 +142,8 @@ model ClusterTenant {
   name           String                     @id
   /// Human-readable customer name.
   displayName    String                     @map("display_name")
-  /// Optional customer-vanity domain CNAMEd onto the org's canonical apex (<name>.<platformBaseDomain>); an overlay, not the org identity. Null → only the derived apex serves the org.
-  vanityDomain   String?                    @map("vanity_domain")
+  /// Optional customer-vanity domain CNAMEd onto the org's canonical apex (<name>.<platformBaseDomain>); an overlay, not the org identity. Null → only the derived apex serves the org. Unique (NULLs distinct) so a vanity host resolves to exactly one org for per-org login.
+  vanityDomain   String?                    @unique @map("vanity_domain")
   /// Isolation strength chosen for this customer.
   isolationTier  ClusterTenantIsolationTier @default(Shared) @map("isolation_tier")
   /// Whether the customer shares nodes or gets a dedicated pool.
@@ -173,6 +173,10 @@ model ClusterTenant {
   zitadelClientId    String?                @map("zitadel_client_id")
   /// The redirect URI registered on this org's Zitadel app (`<org>.<base>/api/v1/auth/callback`).
   zitadelRedirectUri String?                @map("zitadel_redirect_uri")
+  /// Zitadel project id of this org's `opencrane` project (S3b). Needed to update the
+  /// OIDC app's redirect URIs when the org's vanity domain changes (the Zitadel update
+  /// endpoint is project-scoped). Null until provisioned (or when Zitadel is unconfigured).
+  zitadelProjectId   String?                @map("zitadel_project_id")
   /// Creation timestamp.
   createdAt      DateTime                   @default(now()) @map("created_at")
   /// Last update timestamp.

--- a/apps/control-plane/prisma/schema.prisma
+++ b/apps/control-plane/prisma/schema.prisma
@@ -166,6 +166,11 @@ model ClusterTenant {
   zitadelOrgId       String?                @map("zitadel_org_id")
   /// Zitadel OIDC application id for this org's login surface at `<org>.<base>`.
   zitadelAppId       String?                @map("zitadel_app_id")
+  /// OIDC client_id of this org's Zitadel app — the per-org credential login uses to
+  /// authorize against the org's isolated user pool (S3b). Null until provisioned (or
+  /// when Zitadel is unconfigured); a host that resolves to a CT with no client_id
+  /// fail-closes to no per-org login (see oidc.service `_resolvePerOrgClient`).
+  zitadelClientId    String?                @map("zitadel_client_id")
   /// The redirect URI registered on this org's Zitadel app (`<org>.<base>/api/v1/auth/callback`).
   zitadelRedirectUri String?                @map("zitadel_redirect_uri")
   /// Creation timestamp.

--- a/apps/control-plane/src/__tests__/infra/oidc-perorg-login.test.ts
+++ b/apps/control-plane/src/__tests__/infra/oidc-perorg-login.test.ts
@@ -1,0 +1,165 @@
+import type { Request } from "express";
+import type { PrismaClient } from "@prisma/client";
+import pino from "pino";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock openid-client so buildLoginUrl runs without real network discovery. `discovery`
+// echoes back the client_id it was called with so the test can assert which client (per-org
+// vs masters) was selected; `buildAuthorizationUrl` captures the scope it was handed.
+const _discoveryCalls: Array<{ clientId: string }> = [];
+let _lastAuthParams: Record<string, unknown> = {};
+// The client_id of the discovered config handed to authorizationCodeGrant — lets the
+// completeLogin test assert the SAME client resolved at buildLoginUrl is used at token exchange.
+let _grantClientId: string | undefined;
+vi.mock("openid-client", function _mockClient()
+{
+  return {
+    randomPKCECodeVerifier() { return "verifier"; },
+    async calculatePKCECodeChallenge() { return "challenge"; },
+    randomState() { return "state"; },
+    randomNonce() { return "nonce"; },
+    async discovery(_issuer: URL, clientId: string)
+    {
+      _discoveryCalls.push({ clientId });
+      return { clientId } as unknown;
+    },
+    buildAuthorizationUrl(config: { clientId: string }, params: Record<string, unknown>)
+    {
+      _lastAuthParams = params;
+      return new URL(`https://idp.test/authorize?client=${config.clientId}`);
+    },
+    async authorizationCodeGrant(config: { clientId: string })
+    {
+      _grantClientId = config.clientId;
+      return { claims() { return { sub: "user-1", email: "u@acme.io", email_verified: true }; }, access_token: undefined, id_token: "id-tok" };
+    },
+    async fetchUserInfo(_config: unknown, _accessToken: string, sub: string)
+    {
+      return { sub };
+    },
+  };
+});
+
+import { ___CreateOidcAuthService } from "../../infra/auth/oidc.service.js";
+
+/** Minimal OIDC env so the service is enabled and uses `cid` as the masters client. */
+function _enableOidc(): void
+{
+  process.env.OIDC_ISSUER_URL = "https://idp.test";
+  process.env.OIDC_CLIENT_ID = "cid";
+  process.env.OIDC_REDIRECT_URI = "https://platform.dev.opencrane.ai/api/v1/auth/callback";
+  process.env.OIDC_SESSION_SECRET = "test-secret";
+  process.env.OIDC_SCOPES = "openid email profile";
+}
+
+/** Clear the OIDC env between tests so config does not leak across cases. */
+function _disableOidc(): void
+{
+  delete process.env.OIDC_ISSUER_URL;
+  delete process.env.OIDC_CLIENT_ID;
+  delete process.env.OIDC_REDIRECT_URI;
+  delete process.env.OIDC_SESSION_SECRET;
+  delete process.env.OIDC_SCOPES;
+}
+
+/** A Request-like object on `host` with a save-able session. */
+function _reqOnHost(host: string): Request
+{
+  const session: Record<string, unknown> = { save(cb: (err?: Error) => void) { cb(); } };
+  return { headers: { "x-forwarded-host": host }, session } as unknown as Request;
+}
+
+/** Prisma stub whose clusterTenant.findUnique returns `row`. */
+function _prismaReturning(row: Record<string, unknown> | null): PrismaClient
+{
+  return { clusterTenant: { findUnique: vi.fn().mockResolvedValue(row) } } as unknown as PrismaClient;
+}
+
+describe("OidcAuthService.buildLoginUrl — per-org client resolution (S3b)", function _suite()
+{
+  beforeEach(function _reset() { _enableOidc(); _discoveryCalls.length = 0; _lastAuthParams = {}; });
+  afterEach(_disableOidc);
+
+  it("uses the per-org client + org-restriction scope for a provisioned org host", async function _perOrg()
+  {
+    const prisma = _prismaReturning({ name: "acme", zitadelClientId: "client-acme", zitadelOrgId: "org-acme", zitadelRedirectUri: null });
+    const service = ___CreateOidcAuthService(pino({ enabled: false }), prisma);
+    const req = _reqOnHost("acme.dev.opencrane.ai");
+
+    const url = await service.buildLoginUrl(req, "/");
+
+    // Discovery + the authorization request both used the org's client, not the masters one.
+    expect(_discoveryCalls).toEqual([{ clientId: "client-acme" }]);
+    expect(url).toContain("client=client-acme");
+    // The Zitadel org-restriction scope is appended so only acme's user pool may log in.
+    expect(_lastAuthParams.scope).toBe("openid email profile urn:zitadel:iam:org:id:org-acme");
+    // completeLogin must reuse the same client → the per-org client_id is recorded in the flow.
+    expect((req.session as { oidcFlow?: { clientId?: string } }).oidcFlow?.clientId).toBe("client-acme");
+  });
+
+  it("uses the masters client (no org scope) for the platform host", async function _platform()
+  {
+    const prisma = _prismaReturning(null);
+    const service = ___CreateOidcAuthService(pino({ enabled: false }), prisma);
+    const req = _reqOnHost("platform.dev.opencrane.ai");
+
+    const url = await service.buildLoginUrl(req, "/");
+
+    // "platform" is not a provisioned CT → fall through to the masters client; no org scope.
+    expect(_discoveryCalls).toEqual([{ clientId: "cid" }]);
+    expect(url).toContain("client=cid");
+    expect(_lastAuthParams.scope).toBe("openid email profile");
+    expect((req.session as { oidcFlow?: { clientId?: string } }).oidcFlow?.clientId).toBeUndefined();
+  });
+
+  it("falls through to the masters client for an unprovisioned org host (fail-closed)", async function _unprovisioned()
+  {
+    // The CT exists but has no client_id yet (mid-provisioning / unconfigured Zitadel).
+    const prisma = _prismaReturning({ name: "acme", zitadelClientId: null, zitadelOrgId: null, zitadelRedirectUri: null });
+    const service = ___CreateOidcAuthService(pino({ enabled: false }), prisma);
+    const req = _reqOnHost("acme.dev.opencrane.ai");
+
+    const url = await service.buildLoginUrl(req, "/");
+
+    expect(_discoveryCalls).toEqual([{ clientId: "cid" }]);
+    expect(url).toContain("client=cid");
+    expect(_lastAuthParams.scope).toBe("openid email profile");
+  });
+});
+
+/** A callback Request carrying an in-flight oidcFlow (with optional per-org clientId). */
+function _callbackReq(flowClientId: string | undefined): Request
+{
+  const session: Record<string, unknown> = {
+    oidcFlow: { codeVerifier: "verifier", state: "state", nonce: "nonce", returnTo: "/", ...(flowClientId ? { clientId: flowClientId } : {}) },
+    regenerate(cb: (err?: Error) => void) { cb(); },
+    save(cb: (err?: Error) => void) { cb(); },
+  };
+  return { headers: { "x-forwarded-host": "acme.dev.opencrane.ai" }, originalUrl: "/api/v1/auth/callback?code=c&state=state", protocol: "https", session } as unknown as Request;
+}
+
+describe("OidcAuthService.completeLogin — token exchange uses the per-org client (S3b)", function _completeSuite()
+{
+  beforeEach(function _reset() { _enableOidc(); _discoveryCalls.length = 0; _grantClientId = undefined; });
+  afterEach(_disableOidc);
+
+  it("exchanges the code against the per-org client recorded at buildLoginUrl", async function _perOrgExchange()
+  {
+    const service = ___CreateOidcAuthService(pino({ enabled: false }), _prismaReturning(null));
+
+    await service.completeLogin(_callbackReq("client-acme"));
+
+    // The token exchange used the per-org client, not the masters one — the auth-request
+    // and token-exchange client_ids match, so the issued code is honoured.
+    expect(_grantClientId).toBe("client-acme");
+  });
+
+  it("exchanges the code against the masters client when no per-org client was recorded", async function _mastersExchange()
+  {
+    const service = ___CreateOidcAuthService(pino({ enabled: false }), _prismaReturning(null));
+
+    await service.completeLogin(_callbackReq(undefined));
+
+    expect(_grantClientId).toBe("cid");
+  });
+});

--- a/apps/control-plane/src/__tests__/infra/per-org-client.test.ts
+++ b/apps/control-plane/src/__tests__/infra/per-org-client.test.ts
@@ -42,6 +42,24 @@ describe("_ResolvePerOrgClient — host→CT→per-org client (S3b)", function _
     expect(findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { name: "acme" } }));
   });
 
+  it("resolves a customer-vanity host to its org's client via the unique vanityDomain (S3b)", async function _resolvesVanity()
+  {
+    // The first-label lookup ("ai") misses; the full host matches a unique vanityDomain.
+    const row = { name: "acme", zitadelClientId: "client-acme", zitadelOrgId: "org-acme", zitadelRedirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback" };
+    const findUnique = vi.fn().mockImplementation(function _find(args: { where: { name?: string; vanityDomain?: string } })
+    {
+      return Promise.resolve(args.where.vanityDomain === "ai.client-company.com" ? row : null);
+    });
+    const prisma = { clusterTenant: { findUnique } } as unknown as PrismaClient;
+
+    const resolved = await _ResolvePerOrgClient(prisma, "ai.client-company.com");
+
+    expect(resolved).toMatchObject({ clusterTenant: "acme", clientId: "client-acme", orgId: "org-acme" });
+    // The first-label miss is followed by an exact vanity-domain lookup on the full host.
+    expect(findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { name: "ai" } }));
+    expect(findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { vanityDomain: "ai.client-company.com" } }));
+  });
+
   it("returns null for the platform host (bare host, no derivable silo) — masters fallback", async function _platformHost()
   {
     const { prisma, findUnique } = _prismaReturning(null);

--- a/apps/control-plane/src/__tests__/infra/per-org-client.test.ts
+++ b/apps/control-plane/src/__tests__/infra/per-org-client.test.ts
@@ -1,0 +1,79 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { _OrgScope, _ResolvePerOrgClient } from "../../infra/auth/per-org-client.js";
+
+/** Build a Prisma stub whose clusterTenant.findUnique returns `row` for any name. */
+function _prismaReturning(row: Record<string, unknown> | null): { prisma: PrismaClient; findUnique: ReturnType<typeof vi.fn> }
+{
+  const findUnique = vi.fn().mockResolvedValue(row);
+  const prisma = { clusterTenant: { findUnique } } as unknown as PrismaClient;
+  return { prisma, findUnique };
+}
+
+describe("_OrgScope — Zitadel org-restriction login scope (S3b)", function _scopeSuite()
+{
+  it("builds the urn:zitadel:iam:org:id scope for an org id", function _builds()
+  {
+    expect(_OrgScope("org-123")).toBe("urn:zitadel:iam:org:id:org-123");
+  });
+});
+
+describe("_ResolvePerOrgClient — host→CT→per-org client (S3b)", function _resolveSuite()
+{
+  it("resolves a per-org host to its client_id + org id + redirect URI", async function _resolves()
+  {
+    const { prisma, findUnique } = _prismaReturning({
+      name: "acme",
+      zitadelClientId: "client-acme",
+      zitadelOrgId: "org-acme",
+      zitadelRedirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback",
+    });
+
+    const resolved = await _ResolvePerOrgClient(prisma, "acme.dev.opencrane.ai");
+
+    expect(resolved).toEqual({
+      clusterTenant: "acme",
+      clientId: "client-acme",
+      orgId: "org-acme",
+      redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback",
+    });
+    // The lookup is keyed by the host's first DNS label — never request-supplied input.
+    expect(findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { name: "acme" } }));
+  });
+
+  it("returns null for the platform host (bare host, no derivable silo) — masters fallback", async function _platformHost()
+  {
+    const { prisma, findUnique } = _prismaReturning(null);
+
+    // No host ⇒ no derivable silo label ⇒ we never hit the DB and fall through.
+    expect(await _ResolvePerOrgClient(prisma, undefined)).toBeNull();
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns null for the platform host — its label matches no ClusterTenant (fail-closed)", async function _platformHost()
+  {
+    // `platform.<base>` yields the label "platform"; no CT is named that, so the DB lookup
+    // returns null and login falls through to the masters client.
+    const { prisma } = _prismaReturning(null);
+    expect(await _ResolvePerOrgClient(prisma, "platform.dev.opencrane.ai")).toBeNull();
+  });
+
+  it("returns null for an unknown host label that matches no ClusterTenant (fail-closed)", async function _unknownHost()
+  {
+    const { prisma } = _prismaReturning(null);
+    expect(await _ResolvePerOrgClient(prisma, "ghost.dev.opencrane.ai")).toBeNull();
+  });
+
+  it("returns null when the ClusterTenant has no provisioned client_id (fail-closed)", async function _noClientId()
+  {
+    const { prisma } = _prismaReturning({ name: "acme", zitadelClientId: null, zitadelOrgId: "org-acme", zitadelRedirectUri: null });
+    expect(await _ResolvePerOrgClient(prisma, "acme.dev.opencrane.ai")).toBeNull();
+  });
+
+  it("returns null when the ClusterTenant has no provisioned org id (fail-closed)", async function _noOrgId()
+  {
+    const { prisma } = _prismaReturning({ name: "acme", zitadelClientId: "client-acme", zitadelOrgId: null, zitadelRedirectUri: null });
+    expect(await _ResolvePerOrgClient(prisma, "acme.dev.opencrane.ai")).toBeNull();
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
@@ -11,7 +11,8 @@ import type { ZitadelManagementClient } from "../../infra/zitadel/zitadel-client
 
 /** Benign Zitadel test double (this suite exercises the org-admin guard, not provisioning). */
 const _fakeZitadel: ZitadelManagementClient = {
-  async provisionOrg(input) { return { orgId: "z", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
+  async provisionOrg(input) { return { orgId: "z", projectId: "p", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
+  async setAppRedirectUris() { /* no-op */ },
   async teardownOrg() { /* no-op */ },
 };
 

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
@@ -11,7 +11,7 @@ import type { ZitadelManagementClient } from "../../infra/zitadel/zitadel-client
 
 /** Benign Zitadel test double (this suite exercises the org-admin guard, not provisioning). */
 const _fakeZitadel: ZitadelManagementClient = {
-  async provisionOrg(input) { return { orgId: "z", appId: "a", redirectUri: input.redirectUri }; },
+  async provisionOrg(input) { return { orgId: "z", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
   async teardownOrg() { /* no-op */ },
 };
 

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
@@ -413,4 +413,25 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
     expect(res.status).not.toBe(201);
   });
 
+  it("fails the delete (no 200) when Zitadel teardown throws — teardown is inside the delete tx", async function _deleteRollback()
+  {
+    const store = new Map<string, Record<string, unknown>>([["acme", { name: "acme", displayName: "Acme", zitadelOrgId: "zorg-1" }]]);
+    let teardownCalled = false;
+    const throwingTeardown: ZitadelManagementClient = {
+      async provisionOrg(input) { return { orgId: "z", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
+      async teardownOrg() { teardownCalled = true; throw new Error("zitadel unreachable"); },
+    };
+    // No session → dev-auth bypass for the org-manager gate (matches the CRUD test), so the
+    // delete handler runs and we exercise the transactional teardown directly.
+    const app = _buildApp(_mockPrisma(store), _mockRegistry(false), null, undefined, throwingTeardown);
+
+    const res = await request(app).delete("/api/v1/cluster-tenants/acme");
+
+    // Teardown ran inside prisma.$transaction as the last fallible step, so its throw
+    // surfaces (no 200) — real Prisma rolls the row delete back, keeping the DB in sync
+    // with the still-live Zitadel org (the caller retries).
+    expect(teardownCalled).toBe(true);
+    expect(res.status).not.toBe(200);
+  });
+
 });

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
@@ -14,7 +14,8 @@ import type { ZitadelManagementClient } from "../../infra/zitadel/zitadel-client
 function _fakeZitadel(): ZitadelManagementClient
 {
   return {
-    async provisionOrg(input) { return { orgId: "zorg-test", appId: "zapp-test", clientId: "zclient-test", redirectUri: input.redirectUri }; },
+    async provisionOrg(input) { return { orgId: "zorg-test", projectId: "zproj-test", appId: "zapp-test", clientId: "zclient-test", redirectUri: input.redirectUri }; },
+    async setAppRedirectUris() { /* no-op */ },
     async teardownOrg() { /* no-op */ },
   };
 }
@@ -360,19 +361,21 @@ describe("clusterTenantsRouter — owner default tenant (create-time seed + refr
 
 describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", function _zitadelSuite()
 {
-  /** A live-ish fake that records the provision call and returns deterministic ids. */
-  function _fakeProvisioner(): { client: ZitadelManagementClient; calls: unknown[] }
+  /** A live-ish fake that records the provision + redirect-URI calls and returns deterministic ids. */
+  function _fakeProvisioner(): { client: ZitadelManagementClient; calls: unknown[]; redirectCalls: unknown[] }
   {
     const calls: unknown[] = [];
+    const redirectCalls: unknown[] = [];
     const client: ZitadelManagementClient = {
       async provisionOrg(input)
       {
         calls.push(input);
-        return { orgId: "zorg-123", appId: "zapp-456", clientId: "zclient-789", redirectUri: input.redirectUri };
+        return { orgId: "zorg-123", projectId: "zproj-123", appId: "zapp-456", clientId: "zclient-789", redirectUri: input.redirectUri };
       },
+      async setAppRedirectUris(input) { redirectCalls.push(input); },
       async teardownOrg() { /* no-op */ },
     };
-    return { client, calls };
+    return { client, calls, redirectCalls };
   }
 
   it("persists the Zitadel org/app ids on the ClusterTenant when provisioning succeeds", async function _persists()
@@ -400,6 +403,7 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
     const store = new Map<string, Record<string, unknown>>();
     const throwing: ZitadelManagementClient = {
       async provisionOrg() { throw new Error("zitadel rejected: org name taken"); },
+      async setAppRedirectUris() { /* no-op */ },
       async teardownOrg() { /* no-op */ },
     };
     const app = _buildApp(_mockPrisma(store), _mockRegistry(false), null, { sub: "owner-1", email: "owner@acme.test" }, throwing);
@@ -418,7 +422,8 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
     const store = new Map<string, Record<string, unknown>>([["acme", { name: "acme", displayName: "Acme", zitadelOrgId: "zorg-1" }]]);
     let teardownCalled = false;
     const throwingTeardown: ZitadelManagementClient = {
-      async provisionOrg(input) { return { orgId: "z", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
+      async provisionOrg(input) { return { orgId: "z", projectId: "p", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
+      async setAppRedirectUris() { /* no-op */ },
       async teardownOrg() { teardownCalled = true; throw new Error("zitadel unreachable"); },
     };
     // No session → dev-auth bypass for the org-manager gate (matches the CRUD test), so the
@@ -432,6 +437,72 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
     // with the still-live Zitadel org (the caller retries).
     expect(teardownCalled).toBe(true);
     expect(res.status).not.toBe(200);
+  });
+
+  it("syncs the Zitadel app redirect URIs when a vanity domain is added via PUT (S3b)", async function _vanityPutSync()
+  {
+    // A fully-provisioned org with no vanity yet; canonical callback already registered.
+    const store = new Map<string, Row>([["acme", {
+      name: "acme", displayName: "Acme", vanityDomain: null,
+      isolationTier: "Shared", computeMode: "Shared", quota: {}, phase: "pending",
+      zitadelOrgId: "zorg-1", zitadelProjectId: "zproj-1", zitadelAppId: "zapp-1", zitadelClientId: "zc-1",
+      zitadelRedirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback",
+    }]]);
+    const { client, redirectCalls } = _fakeProvisioner();
+    const app = _buildApp(_mockPrisma(store), _mockRegistry(false), null, undefined, client);
+
+    const res = await request(app).put("/api/v1/cluster-tenants/acme").send({ vanityDomain: "ai.acme.com" });
+
+    expect(res.status).toBe(200);
+    // The redirect-URI sync ran with the org's persisted ids and the canonical + vanity set.
+    expect(redirectCalls).toHaveLength(1);
+    expect(redirectCalls[0]).toEqual({
+      orgId: "zorg-1", projectId: "zproj-1", appId: "zapp-1",
+      redirectUris: ["https://acme.dev.opencrane.ai/api/v1/auth/callback", "https://ai.acme.com/api/v1/auth/callback"],
+    });
+  });
+
+  it("fails the vanity PUT (no 200) when the Zitadel redirect-URI sync throws — sync is inside the update tx (S3b)", async function _vanityPutRollback()
+  {
+    const store = new Map<string, Row>([["acme", {
+      name: "acme", displayName: "Acme", vanityDomain: null,
+      isolationTier: "Shared", computeMode: "Shared", quota: {}, phase: "pending",
+      zitadelOrgId: "zorg-1", zitadelProjectId: "zproj-1", zitadelAppId: "zapp-1", zitadelClientId: "zc-1",
+      zitadelRedirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback",
+    }]]);
+    let syncCalled = false;
+    const throwingSync: ZitadelManagementClient = {
+      async provisionOrg(input) { return { orgId: "z", projectId: "p", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
+      async setAppRedirectUris() { syncCalled = true; throw new Error("zitadel unreachable"); },
+      async teardownOrg() { /* no-op */ },
+    };
+    const app = _buildApp(_mockPrisma(store), _mockRegistry(false), null, undefined, throwingSync);
+
+    const res = await request(app).put("/api/v1/cluster-tenants/acme").send({ vanityDomain: "ai.acme.com" });
+
+    // The sync is the last fallible step inside prisma.$transaction, so its throw surfaces
+    // (no 200) — real Prisma rolls the row update back, keeping the persisted vanity in sync
+    // with the Zitadel app's allowlist (the caller retries).
+    expect(syncCalled).toBe(true);
+    expect(res.status).not.toBe(200);
+  });
+
+  it("does NOT call Zitadel on a PUT that leaves the vanity domain unchanged (S3b)", async function _noVanityChangeNoSync()
+  {
+    const store = new Map<string, Row>([["acme", {
+      name: "acme", displayName: "Acme", vanityDomain: null,
+      isolationTier: "Shared", computeMode: "Shared", quota: {}, phase: "pending",
+      zitadelOrgId: "zorg-1", zitadelProjectId: "zproj-1", zitadelAppId: "zapp-1", zitadelClientId: "zc-1",
+      zitadelRedirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback",
+    }]]);
+    const { client, redirectCalls } = _fakeProvisioner();
+    const app = _buildApp(_mockPrisma(store), _mockRegistry(false), null, undefined, client);
+
+    // A display-name-only update touches no host, so the app's allowlist must not be synced.
+    const res = await request(app).put("/api/v1/cluster-tenants/acme").send({ displayName: "Acme Inc" });
+
+    expect(res.status).toBe(200);
+    expect(redirectCalls).toHaveLength(0);
   });
 
 });

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
@@ -14,7 +14,7 @@ import type { ZitadelManagementClient } from "../../infra/zitadel/zitadel-client
 function _fakeZitadel(): ZitadelManagementClient
 {
   return {
-    async provisionOrg(input) { return { orgId: "zorg-test", appId: "zapp-test", redirectUri: input.redirectUri }; },
+    async provisionOrg(input) { return { orgId: "zorg-test", appId: "zapp-test", clientId: "zclient-test", redirectUri: input.redirectUri }; },
     async teardownOrg() { /* no-op */ },
   };
 }
@@ -368,7 +368,7 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
       async provisionOrg(input)
       {
         calls.push(input);
-        return { orgId: "zorg-123", appId: "zapp-456", redirectUri: input.redirectUri };
+        return { orgId: "zorg-123", appId: "zapp-456", clientId: "zclient-789", redirectUri: input.redirectUri };
       },
       async teardownOrg() { /* no-op */ },
     };
@@ -391,6 +391,8 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
     const row = store.get("acme");
     expect(row?.zitadelOrgId).toBe("zorg-123");
     expect(row?.zitadelAppId).toBe("zapp-456");
+    // S3b: the OIDC client_id is persisted so login can resolve the per-org client by host.
+    expect(row?.zitadelClientId).toBe("zclient-789");
   });
 
   it("fails the create (no 201) when Zitadel provisioning throws — the tx is the rollback boundary", async function _rollsBack()

--- a/apps/control-plane/src/__tests__/zitadel/zitadel-client.test.ts
+++ b/apps/control-plane/src/__tests__/zitadel/zitadel-client.test.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 
 import { beforeEach, afterEach, describe, expect, it } from "vitest";
 
-import { _BuildZitadelManagementClient, _DeriveOrgRedirectUri, _HttpZitadelManagementClient, _ReadZitadelClientConfig } from "../../infra/zitadel/zitadel-client.js";
+import { _BuildZitadelManagementClient, _DeriveOrgRedirectUri, _DeriveVanityRedirectUri, _HttpZitadelManagementClient, _ReadZitadelClientConfig } from "../../infra/zitadel/zitadel-client.js";
 
 /** A real RSA SA key so the client's RS256 jwt-bearer signing actually succeeds. */
 function _saKeyJson(): string
@@ -13,12 +13,15 @@ function _saKeyJson(): string
 }
 
 /** Build an injectable fetch fake that records calls and replies per path. */
-function _fakeFetch(overrides: Record<string, { status?: number; body?: unknown }> = {}): { fetchImpl: typeof fetch; calls: Array<{ method: string; path: string; orgId?: string }> }
+function _fakeFetch(overrides: Record<string, { status?: number; body?: unknown }> = {}): { fetchImpl: typeof fetch; calls: Array<{ method: string; path: string; orgId?: string; body?: Record<string, unknown> }> }
 {
-  const calls: Array<{ method: string; path: string; orgId?: string }> = [];
-  const fetchImpl = (async function _f(url: string, init: { method?: string; headers?: Record<string, string> }) {
+  const calls: Array<{ method: string; path: string; orgId?: string; body?: Record<string, unknown> }> = [];
+  const fetchImpl = (async function _f(url: string, init: { method?: string; headers?: Record<string, string>; body?: unknown }) {
     const path = url.replace(/^https:\/\/[^/]+/, "");
-    calls.push({ method: init?.method ?? "GET", path, orgId: init?.headers?.["x-zitadel-orgid"] });
+    // The JSON management calls send a stringified object body; the token call sends
+    // URLSearchParams — only parse the former so assertions can read redirectUris etc.
+    const parsedBody = typeof init?.body === "string" && init.body.startsWith("{") ? JSON.parse(init.body) as Record<string, unknown> : undefined;
+    calls.push({ method: init?.method ?? "GET", path, orgId: init?.headers?.["x-zitadel-orgid"], body: parsedBody });
     const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) });
     const o = overrides[path];
     if (o) return { ok: (o.status ?? 200) < 400, status: o.status ?? 200, json: async () => o.body ?? {}, text: async () => JSON.stringify(o.body ?? {}) };
@@ -43,7 +46,7 @@ describe("_HttpZitadelManagementClient — live provisioning lifecycle (injected
 
     const result = await client.provisionOrg({ orgName: "acme", displayName: "Acme", redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback", masterSubject: "u-master" });
 
-    expect(result).toEqual({ orgId: "org-9", appId: "app-9", clientId: "client-9", redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback" });
+    expect(result).toEqual({ orgId: "org-9", projectId: "proj-9", appId: "app-9", clientId: "client-9", redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback" });
     const paths = calls.map(c => c.path);
     expect(paths).toEqual([
       "/oauth/v2/token",
@@ -55,6 +58,47 @@ describe("_HttpZitadelManagementClient — live provisioning lifecycle (injected
     ]);
     // Every in-org call carries the new org's context header.
     expect(calls.filter(c => c.path.startsWith("/management")).every(c => c.orgId === "org-9")).toBe(true);
+    // With no vanity domain, only the canonical callback is registered on the app.
+    const appCreate = calls.find(c => c.path.endsWith("/apps/oidc"));
+    expect(appCreate?.body?.redirectUris).toEqual(["https://acme.dev.opencrane.ai/api/v1/auth/callback"]);
+  });
+
+  it("registers the vanity callback alongside the canonical one when a vanity domain is given (S3b)", async function _provisionsVanity()
+  {
+    const { fetchImpl, calls } = _fakeFetch();
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: _saKeyJson(), baseDomain: "dev.opencrane.ai" }, fetchImpl);
+
+    await client.provisionOrg({
+      orgName: "acme", displayName: "Acme",
+      redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback",
+      vanityRedirectUri: "https://ai.acme.com/api/v1/auth/callback",
+      masterSubject: "u-master",
+    });
+
+    const appCreate = calls.find(c => c.path.endsWith("/apps/oidc"));
+    expect(appCreate?.body?.redirectUris).toEqual([
+      "https://acme.dev.opencrane.ai/api/v1/auth/callback",
+      "https://ai.acme.com/api/v1/auth/callback",
+    ]);
+  });
+
+  it("setAppRedirectUris PUTs the full URI set to the org-scoped oidc_config endpoint (S3b)", async function _setRedirects()
+  {
+    const { fetchImpl, calls } = _fakeFetch();
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: _saKeyJson(), baseDomain: "dev.opencrane.ai" }, fetchImpl);
+
+    await client.setAppRedirectUris({
+      orgId: "org-9", projectId: "proj-9", appId: "app-9",
+      redirectUris: ["https://acme.dev.opencrane.ai/api/v1/auth/callback", "https://ai.acme.com/api/v1/auth/callback"],
+    });
+
+    const put = calls.find(c => c.method === "PUT");
+    expect(put?.path).toBe("/management/v1/projects/proj-9/apps/app-9/oidc_config");
+    expect(put?.orgId).toBe("org-9");
+    expect(put?.body?.redirectUris).toEqual([
+      "https://acme.dev.opencrane.ai/api/v1/auth/callback",
+      "https://ai.acme.com/api/v1/auth/callback",
+    ]);
   });
 
   it("compensates (deletes the half-created org) and rethrows when a later step fails", async function _compensates()
@@ -96,6 +140,14 @@ describe("_DeriveOrgRedirectUri", function _deriveSuite()
   it("derives the per-org callback URI from the org name + base domain", function _derives()
   {
     expect(_DeriveOrgRedirectUri("elewa-be", "dev.opencrane.ai")).toBe("https://elewa-be.dev.opencrane.ai/api/v1/auth/callback");
+  });
+});
+
+describe("_DeriveVanityRedirectUri", function _deriveVanitySuite()
+{
+  it("derives the vanity callback URI from the full vanity host (no base appended)", function _derivesVanity()
+  {
+    expect(_DeriveVanityRedirectUri("ai.client-company.com")).toBe("https://ai.client-company.com/api/v1/auth/callback");
   });
 });
 

--- a/apps/control-plane/src/__tests__/zitadel/zitadel-client.test.ts
+++ b/apps/control-plane/src/__tests__/zitadel/zitadel-client.test.ts
@@ -43,7 +43,7 @@ describe("_HttpZitadelManagementClient — live provisioning lifecycle (injected
 
     const result = await client.provisionOrg({ orgName: "acme", displayName: "Acme", redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback", masterSubject: "u-master" });
 
-    expect(result).toEqual({ orgId: "org-9", appId: "app-9", redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback" });
+    expect(result).toEqual({ orgId: "org-9", appId: "app-9", clientId: "client-9", redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback" });
     const paths = calls.map(c => c.path);
     expect(paths).toEqual([
       "/oauth/v2/token",
@@ -64,6 +64,17 @@ describe("_HttpZitadelManagementClient — live provisioning lifecycle (injected
 
     await expect(client.provisionOrg({ orgName: "acme", displayName: "Acme", redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback", masterSubject: "u-master" })).rejects.toThrow(/apps\/oidc failed \(500\)/);
     // The compensating org delete ran.
+    expect(calls.some(c => c.method === "DELETE" && c.path === "/admin/v1/orgs/org-9")).toBe(true);
+  });
+
+  it("fails loud (and compensates) when the app-create response omits the clientId (S3b)", async function _noClientId()
+  {
+    // The live app-create returns appId + clientId; an app row without a clientId would
+    // leave the org with a login surface but no per-org credential, so we reject it.
+    const { fetchImpl, calls } = _fakeFetch({ "/management/v1/projects/proj-9/apps/oidc": { status: 200, body: { appId: "app-9" } } });
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: _saKeyJson(), baseDomain: "dev.opencrane.ai" }, fetchImpl);
+
+    await expect(client.provisionOrg({ orgName: "acme", displayName: "Acme", redirectUri: "https://acme.dev.opencrane.ai/api/v1/auth/callback", masterSubject: "u-master" })).rejects.toThrow(/no clientId/);
     expect(calls.some(c => c.method === "DELETE" && c.path === "/admin/v1/orgs/org-9")).toBe(true);
   });
 

--- a/apps/control-plane/src/infra/auth/oidc.service.ts
+++ b/apps/control-plane/src/infra/auth/oidc.service.ts
@@ -439,7 +439,19 @@ export class OidcAuthService
       discovered = client.discovery(new URL(this.config.issuerUrl), clientId);
       this.perOrgDiscovered.set(clientId, discovered);
     }
-    return await discovered;
+    try
+    {
+      return await discovered;
+    }
+    catch (err)
+    {
+      // A per-org discovery failure breaks login at that org's host. Evict the memoized
+      // rejected promise so the next attempt re-discovers (else the failure is cached for
+      // the process lifetime), and warn — clientId is a public OIDC identifier, not a secret.
+      this.perOrgDiscovered.delete(clientId);
+      this.log.warn({ err, clientId }, "per-org OIDC discovery failed; per-org login is unavailable for this client");
+      throw err;
+    }
   }
 
   /** Merge ID token claims with UserInfo claims when an access token is available. */

--- a/apps/control-plane/src/infra/auth/oidc.service.ts
+++ b/apps/control-plane/src/infra/auth/oidc.service.ts
@@ -11,6 +11,7 @@ import { _ResolveCallerClusterTenant } from "./resolve-caller-cluster-tenant.js"
 import { _ClusterTenantFromHost, _RequestHost } from "./request-silo.js";
 import { _ResolveOrgMembershipFacts } from "./org-membership.js";
 import type { OwnedOrg } from "./org-membership.js";
+import { _OrgScope, _ResolvePerOrgClient } from "./per-org-client.js";
 
 /** Auth mode exposed to the UI so it can decide whether login is required. */
 export type ControlPlaneAuthMode = "development" | "oidc" | "token";
@@ -112,8 +113,16 @@ export class OidcAuthService
   /** Logger used for auth lifecycle diagnostics. */
   private log: Logger;
 
-  /** Lazily initialized OIDC client configuration discovered from the issuer. */
+  /** Lazily initialized OIDC client configuration discovered from the issuer (masters client). */
   private discoveredConfig: Promise<client.Configuration> | null = null;
+
+  /**
+   * Per-org discovered configurations, keyed by the org's OIDC client_id (S3b). Each
+   * ClusterTenant logs in against its own public client at the SAME issuer, so we memoize
+   * one `client.Configuration` per client_id and reuse it across requests. The masters
+   * client keeps its own `discoveredConfig` field above.
+   */
+  private perOrgDiscovered = new Map<string, Promise<client.Configuration>>();
 
   /** Prisma client used to resolve the caller's ClusterTenant by verified email. */
   private prisma: PrismaClient;
@@ -241,38 +250,48 @@ export class OidcAuthService
   /** Build the provider redirect URL and persist PKCE state in the local session. */
   async buildLoginUrl(req: Request, returnTo: string): Promise<string>
   {
-    const discoveredConfig = await this._getDiscoveredConfig();
+    // 1. Resolve the per-org client for this host (S3b). A host `<org>.<base>` that maps to
+    //    a fully-provisioned ClusterTenant uses THAT org's client + org-restriction scope so
+    //    only its user pool may log in. The platform host, and any unknown/unprovisioned org
+    //    host, fail-closed to null → the masters client below.
+    const perOrg = await _ResolvePerOrgClient(this.prisma, _RequestHost(req));
+    const discoveredConfig = perOrg ? await this._discoverForClient(perOrg.clientId) : await this._getDiscoveredConfig();
+    const scope = perOrg ? `${this.config.scopes} ${_OrgScope(perOrg.orgId)}` : this.config.scopes;
+
     const codeVerifier = client.randomPKCECodeVerifier();
     const codeChallenge = await client.calculatePKCECodeChallenge(codeVerifier);
     const state = client.randomState();
     const nonce = client.randomNonce();
     const sanitizedReturnTo = _sanitizeReturnTo(returnTo);
 
-    // 1. Persist the PKCE and replay-protection values into the signed session.
+    // 2. Persist the PKCE and replay-protection values into the signed session, recording the
+    //    resolved per-org client_id so completeLogin exchanges the code against the SAME
+    //    client (absent ⇒ masters client). Keeps auth-request and token-exchange consistent.
     req.session.oidcFlow = {
       codeVerifier,
       state,
       nonce,
       returnTo: sanitizedReturnTo,
+      ...(perOrg ? { clientId: perOrg.clientId } : {}),
     };
     await _saveSession(req);
 
-    // 2. Build a standards-only OIDC authorization redirect. Zitadel is the single trusted
-    //    issuer (Mode-2 broker, no upstream Entra), but this uses nothing Zitadel-specific —
-    //    it works against any spec-compliant issuer at OIDC_ISSUER_URL.
+    // 3. Build a standards-only OIDC authorization redirect. Zitadel is the single trusted
+    //    issuer (Mode-2 broker, no upstream Entra); the only Zitadel-specific element is the
+    //    org-restriction scope appended above (a no-op shape for other issuers).
     const loginUrl = client.buildAuthorizationUrl(discoveredConfig, {
       // Host-derived so per-org-host login works (each org is served at <org>.<base>) AND
       // the session cookie stays host-scoped to that host; matches the origin completeLogin
       // derives at the callback. Falls back to the configured URI when no host is present.
       redirect_uri: _buildRedirectUri(req, this.config.redirectUri),
-      scope: this.config.scopes,
+      scope,
       code_challenge: codeChallenge,
       code_challenge_method: "S256",
       state,
       nonce,
     });
 
-    // 3. Return the URL so the router can redirect the browser.
+    // 4. Return the URL so the router can redirect the browser.
     return loginUrl.href;
   }
 
@@ -285,8 +304,10 @@ export class OidcAuthService
       throw new Error("OIDC callback arrived without an in-flight login session");
     }
 
-    // 1. Exchange the authorization code for tokens using the stored PKCE verifier.
-    const discoveredConfig = await this._getDiscoveredConfig();
+    // 1. Exchange the authorization code for tokens using the stored PKCE verifier, against
+    //    the SAME client the authorization request used: the per-org client_id recorded in
+    //    the flow (S3b) when the login started on an org host, else the masters client.
+    const discoveredConfig = flow.clientId ? await this._discoverForClient(flow.clientId) : await this._getDiscoveredConfig();
     const tokens = await client.authorizationCodeGrant(discoveredConfig, _buildCurrentUrl(req), {
       pkceCodeVerifier: flow.codeVerifier,
       expectedState: flow.state,
@@ -393,6 +414,32 @@ export class OidcAuthService
     }
 
     return await this.discoveredConfig;
+  }
+
+  /**
+   * Discover (and memoize) the OIDC configuration for a SPECIFIC client_id at the
+   * configured issuer (S3b). Used for per-org clients: each ClusterTenant's Zitadel app is
+   * a distinct public client at the same issuer, so we discover once per client_id and
+   * cache it. Per-org apps are provisioned with `authMethodType: NONE` (public PKCE
+   * clients), so no client secret is supplied here — only the masters client may be
+   * confidential, and it uses `_getDiscoveredConfig`.
+   *
+   * @param clientId - The org's OIDC client_id resolved from the request host.
+   */
+  private async _discoverForClient(clientId: string): Promise<client.Configuration>
+  {
+    if (!this.config.enabled)
+    {
+      throw new Error("OIDC is not configured for this control-plane instance");
+    }
+
+    let discovered = this.perOrgDiscovered.get(clientId);
+    if (!discovered)
+    {
+      discovered = client.discovery(new URL(this.config.issuerUrl), clientId);
+      this.perOrgDiscovered.set(clientId, discovered);
+    }
+    return await discovered;
   }
 
   /** Merge ID token claims with UserInfo claims when an access token is available. */

--- a/apps/control-plane/src/infra/auth/per-org-client.ts
+++ b/apps/control-plane/src/infra/auth/per-org-client.ts
@@ -19,17 +19,23 @@ export function _OrgScope(orgId: string): string
   return `urn:zitadel:iam:org:id:${orgId}`;
 }
 
+/** Prisma `select` for the persisted per-org login identifiers (shared by both lookups). */
+const _PER_ORG_SELECT = { name: true, zitadelClientId: true, zitadelOrgId: true, zitadelRedirectUri: true } as const;
+
 /**
- * Resolve the per-org OIDC client for a request host (S3b). For a host `<org>.<base>` the
- * first DNS label names the silo; we confirm it against a ClusterTenant row and return its
- * `{clientId, orgId, redirectUri}` so login can authorize against that org's isolated user
- * pool. Fail-closed: returns null for
- *  - a host with no derivable silo label (bare host / platform host),
- *  - a label with no matching ClusterTenant, or
+ * Resolve the per-org OIDC client for a request host (S3b). A host resolves to a
+ * ClusterTenant two ways, both DB-authoritative:
+ *  - **canonical** `<org>.<base>` — the first DNS label names the silo, or
+ *  - **customer-vanity** — the full host matches a unique `vanityDomain` (CNAMEd onto the
+ *    org apex), so login works at the customer's own domain too.
+ * Either way we return the org's `{clientId, orgId, redirectUri}` so login authorizes
+ * against that org's isolated user pool. Fail-closed: returns null for
+ *  - a bare host (no label and no vanity match — e.g. the platform host / localhost),
+ *  - a host matching no ClusterTenant by either label or vanity, or
  *  - a ClusterTenant whose org is not fully provisioned (no `zitadelClientId`/`zitadelOrgId`).
  * In every null case the caller falls through to the masters client config — never a
- * partial per-org login. The DB read is the single source of truth, so a spoofed host
- * label that names no real, fully-provisioned org cannot pick up an org client.
+ * partial per-org login. The DB read is the single source of truth, so a spoofed host that
+ * names no real, fully-provisioned org cannot pick up an org client.
  *
  * @param prisma - Prisma client used to confirm the silo and read its persisted client ids.
  * @param host   - The request host (typically from `_RequestHost`).
@@ -37,28 +43,30 @@ export function _OrgScope(orgId: string): string
  */
 export async function _ResolvePerOrgClient(prisma: PrismaClient, host: string | undefined): Promise<ResolvedPerOrgClient | null>
 {
-  // 1. Derive the candidate silo from the host's first DNS label. A bare host (no
-  //    subdomain — e.g. the platform host or localhost) yields undefined, so the
-  //    platform host keeps using the masters client without a DB hit.
-  const candidate = _ClusterTenantFromHost(host);
-  if (!candidate)
+  if (!host)
   {
     return null;
   }
-
-  // 2. Confirm the label is a real ClusterTenant and read its persisted Zitadel ids. The
-  //    DB row is authoritative: a host label that names no row resolves to null, so a
-  //    fabricated host can never select an org client it does not own.
-  const row = await prisma.clusterTenant.findUnique({
-    where: { name: candidate },
-    select: { name: true, zitadelClientId: true, zitadelOrgId: true, zitadelRedirectUri: true },
-  });
+  // 1. Resolve the ClusterTenant for this host. Try the canonical first DNS label first
+  //    (the common case, one indexed lookup), then fall back to an exact vanity-domain
+  //    match on the full host (port-stripped, lower-cased). Both are DB-authoritative, so a
+  //    fabricated host that matches neither a real silo label nor a real vanity domain
+  //    cannot select an org client it does not own.
+  const candidate = _ClusterTenantFromHost(host);
+  const normHost = host.split(":")[0].trim().toLowerCase();
+  let row = candidate
+    ? await prisma.clusterTenant.findUnique({ where: { name: candidate }, select: _PER_ORG_SELECT })
+    : null;
   if (!row)
   {
-    // A silo-shaped host label that names no ClusterTenant is usually probe/scanner noise
+    row = await prisma.clusterTenant.findUnique({ where: { vanityDomain: normHost }, select: _PER_ORG_SELECT });
+  }
+  if (!row)
+  {
+    // A host that matches no silo label and no vanity domain is usually probe/scanner noise
     // hitting the wildcard, not an operational fault — log at debug so it is traceable
     // without flooding the error log.
-    _log.debug({ host, candidate }, "per-org client resolution: host label matches no ClusterTenant; falling through to masters client");
+    _log.debug({ host, candidate }, "per-org client resolution: host matches no ClusterTenant (label or vanity); falling through to masters client");
     return null;
   }
 

--- a/apps/control-plane/src/infra/auth/per-org-client.ts
+++ b/apps/control-plane/src/infra/auth/per-org-client.ts
@@ -45,6 +45,9 @@ export async function _ResolvePerOrgClient(prisma: PrismaClient, host: string | 
 {
   if (!host)
   {
+    // No host on the request (e.g. a non-proxied internal call) — there is nothing to
+    // resolve a silo from, so login uses the masters client. Benign and expected, so debug.
+    _log.debug("per-org client resolution: request carries no host; falling through to masters client");
     return null;
   }
   // 1. Resolve the ClusterTenant for this host. Try the canonical first DNS label first

--- a/apps/control-plane/src/infra/auth/per-org-client.ts
+++ b/apps/control-plane/src/infra/auth/per-org-client.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 
+import { _log } from "../../log.js";
 import { _ClusterTenantFromHost } from "./request-silo.js";
 import type { ResolvedPerOrgClient } from "./per-org-client.types.js";
 
@@ -54,6 +55,10 @@ export async function _ResolvePerOrgClient(prisma: PrismaClient, host: string | 
   });
   if (!row)
   {
+    // A silo-shaped host label that names no ClusterTenant is usually probe/scanner noise
+    // hitting the wildcard, not an operational fault — log at debug so it is traceable
+    // without flooding the error log.
+    _log.debug({ host, candidate }, "per-org client resolution: host label matches no ClusterTenant; falling through to masters client");
     return null;
   }
 
@@ -63,6 +68,14 @@ export async function _ResolvePerOrgClient(prisma: PrismaClient, host: string | 
   //    against the wrong / an unrestricted pool.
   if (!row.zitadelClientId || !row.zitadelOrgId)
   {
+    // This is a real operational anomaly: a ClusterTenant exists for this host but its
+    // Zitadel org is not fully provisioned, so login at its own subdomain silently
+    // degrades to the masters client. Warn so the failed/pending provisioning surfaces
+    // in the error log instead of presenting as a confusing wrong-pool login.
+    _log.warn(
+      { host, clusterTenant: row.name, hasClientId: Boolean(row.zitadelClientId), hasOrgId: Boolean(row.zitadelOrgId) },
+      "per-org client resolution: ClusterTenant host is not fully provisioned in Zitadel; login falls through to masters client",
+    );
     return null;
   }
 

--- a/apps/control-plane/src/infra/auth/per-org-client.ts
+++ b/apps/control-plane/src/infra/auth/per-org-client.ts
@@ -1,0 +1,75 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { _ClusterTenantFromHost } from "./request-silo.js";
+import type { ResolvedPerOrgClient } from "./per-org-client.types.js";
+
+/**
+ * Build the Zitadel org-restriction login scope for an org id. Adding
+ * `urn:zitadel:iam:org:id:{orgId}` to the authorization request restricts the login to
+ * that organisation's user pool, so only members of the org may authenticate at its host.
+ * Centralised so the provisioner-side string and the login-side string can never drift.
+ *
+ * @param orgId - The Zitadel Organization id of the per-org client.
+ * @returns The org-scope string to append to the OIDC `scope` parameter.
+ * @see https://zitadel.com/docs/apis/openidoauth/scopes
+ */
+export function _OrgScope(orgId: string): string
+{
+  return `urn:zitadel:iam:org:id:${orgId}`;
+}
+
+/**
+ * Resolve the per-org OIDC client for a request host (S3b). For a host `<org>.<base>` the
+ * first DNS label names the silo; we confirm it against a ClusterTenant row and return its
+ * `{clientId, orgId, redirectUri}` so login can authorize against that org's isolated user
+ * pool. Fail-closed: returns null for
+ *  - a host with no derivable silo label (bare host / platform host),
+ *  - a label with no matching ClusterTenant, or
+ *  - a ClusterTenant whose org is not fully provisioned (no `zitadelClientId`/`zitadelOrgId`).
+ * In every null case the caller falls through to the masters client config — never a
+ * partial per-org login. The DB read is the single source of truth, so a spoofed host
+ * label that names no real, fully-provisioned org cannot pick up an org client.
+ *
+ * @param prisma - Prisma client used to confirm the silo and read its persisted client ids.
+ * @param host   - The request host (typically from `_RequestHost`).
+ * @returns The resolved per-org client, or null to fall through to the masters client.
+ */
+export async function _ResolvePerOrgClient(prisma: PrismaClient, host: string | undefined): Promise<ResolvedPerOrgClient | null>
+{
+  // 1. Derive the candidate silo from the host's first DNS label. A bare host (no
+  //    subdomain — e.g. the platform host or localhost) yields undefined, so the
+  //    platform host keeps using the masters client without a DB hit.
+  const candidate = _ClusterTenantFromHost(host);
+  if (!candidate)
+  {
+    return null;
+  }
+
+  // 2. Confirm the label is a real ClusterTenant and read its persisted Zitadel ids. The
+  //    DB row is authoritative: a host label that names no row resolves to null, so a
+  //    fabricated host can never select an org client it does not own.
+  const row = await prisma.clusterTenant.findUnique({
+    where: { name: candidate },
+    select: { name: true, zitadelClientId: true, zitadelOrgId: true, zitadelRedirectUri: true },
+  });
+  if (!row)
+  {
+    return null;
+  }
+
+  // 3. Fail-closed on a half-provisioned org: both the client_id (the credential) and the
+  //    org id (the user-pool restriction scope) must exist, else we cannot build a SAFE
+  //    org-scoped login and fall through to the masters client rather than logging in
+  //    against the wrong / an unrestricted pool.
+  if (!row.zitadelClientId || !row.zitadelOrgId)
+  {
+    return null;
+  }
+
+  return {
+    clusterTenant: row.name,
+    clientId: row.zitadelClientId,
+    orgId: row.zitadelOrgId,
+    redirectUri: row.zitadelRedirectUri ?? null,
+  };
+}

--- a/apps/control-plane/src/infra/auth/per-org-client.types.ts
+++ b/apps/control-plane/src/infra/auth/per-org-client.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Types for host→ClusterTenant→per-org OIDC client resolution (S3b).
+ *
+ * Each ClusterTenant gets a dedicated Zitadel Organization + OIDC app on create (S3),
+ * persisting `{zitadelOrgId, zitadelClientId, zitadelRedirectUri}`. A request arriving at
+ * `<org>.<base>` must log in against THAT org's client (and only that org's user pool),
+ * so login resolves the per-org client from the host's first DNS label.
+ */
+
+/**
+ * The org-scoped OIDC client resolved for a per-org host. Returned only when the host's
+ * ClusterTenant has a fully-provisioned client; an unprovisioned or unknown host yields
+ * null (fail-closed → login falls through to the masters client).
+ */
+export interface ResolvedPerOrgClient
+{
+  /** The ClusterTenant (silo) name — the host's first DNS label, confirmed against the DB. */
+  clusterTenant: string;
+
+  /** The org's OIDC client_id login authorizes with (the per-org credential). */
+  clientId: string;
+
+  /** The org's Zitadel Organization id — added as the `urn:zitadel:iam:org:id:{orgId}` login scope. */
+  orgId: string;
+
+  /** The redirect URI registered on the org's app, when known (else null). */
+  redirectUri: string | null;
+}

--- a/apps/control-plane/src/infra/auth/session.types.d.ts
+++ b/apps/control-plane/src/infra/auth/session.types.d.ts
@@ -27,6 +27,11 @@ declare module "express-session"
       state: string;
       nonce: string;
       returnTo: string;
+      // Per-org OIDC client_id resolved at buildLoginUrl from the request host (S3b).
+      // Persisted so completeLogin exchanges the code against the SAME client the
+      // authorization request used. Absent ⇒ the masters client (platform host or an
+      // unprovisioned/unknown org host that fell through fail-closed).
+      clientId?: string;
     };
   }
 }

--- a/apps/control-plane/src/infra/zitadel/zitadel-client.ts
+++ b/apps/control-plane/src/infra/zitadel/zitadel-client.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 
 import { _log } from "../../log.js";
-import type { ProvisionOrgInput, ProvisionOrgResult, ZitadelClientConfig, ZitadelManagementClient } from "./zitadel-client.types.js";
+import type { ZitadelProvisionOrgInput, ZitadelProvisionOrgResult, ZitadelClientConfig, ZitadelManagementClient } from "./zitadel-client.types.js";
 
 export type { ZitadelClientConfig };
 
@@ -69,7 +69,7 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
     this.saKey = { keyId: parsed.keyId, key: parsed.key, userId: parsed.userId };
   }
 
-  public async provisionOrg(input: ProvisionOrgInput): Promise<ProvisionOrgResult>
+  public async provisionOrg(input: ZitadelProvisionOrgInput): Promise<ZitadelProvisionOrgResult>
   {
     // 1. Create the dedicated Organization (instance-level). Everything else happens
     //    inside its context via the x-zitadel-orgid header.

--- a/apps/control-plane/src/infra/zitadel/zitadel-client.ts
+++ b/apps/control-plane/src/infra/zitadel/zitadel-client.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 
 import { _log } from "../../log.js";
-import type { ZitadelProvisionOrgInput, ZitadelProvisionOrgResult, ZitadelClientConfig, ZitadelManagementClient } from "./zitadel-client.types.js";
+import type { ZitadelProvisionOrgInput, ZitadelProvisionOrgResult, ZitadelSetRedirectUrisInput, ZitadelClientConfig, ZitadelManagementClient } from "./zitadel-client.types.js";
 
 export type { ZitadelClientConfig };
 
@@ -99,9 +99,13 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
         ],
       }, orgId);
 
+      // Register the canonical `<org>.<base>` callback plus the customer-vanity callback
+      // when the org has a vanity domain, so login works at either host. Zitadel rejects a
+      // code exchange whose redirect_uri is not on this list, so both must be present.
+      const redirectUris = [input.redirectUri, ...(input.vanityRedirectUri ? [input.vanityRedirectUri] : [])];
       const app = await this._call("POST", `/management/v1/projects/${projectId}/apps/oidc`, {
         name: "login",
-        redirectUris: [input.redirectUri],
+        redirectUris,
         responseTypes: ["OIDC_RESPONSE_TYPE_CODE"],
         grantTypes: ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"],
         appType: "OIDC_APP_TYPE_WEB",
@@ -127,8 +131,8 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
         roleKeys: ["admin"],
       }, orgId);
 
-      _log.info({ orgId, appId: app.appId, orgName: input.orgName }, "provisioned Zitadel org for ClusterTenant");
-      return { orgId, appId: app.appId, clientId: app.clientId, redirectUri: input.redirectUri };
+      _log.info({ orgId, projectId, appId: app.appId, orgName: input.orgName, redirectUriCount: redirectUris.length }, "provisioned Zitadel org for ClusterTenant");
+      return { orgId, projectId, appId: app.appId, clientId: app.clientId, redirectUri: input.redirectUri };
     }
     catch (err)
     {
@@ -136,6 +140,28 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
       await this.teardownOrg(orgId).catch(function _ignore() { /* compensation is best-effort */ });
       throw err;
     }
+  }
+
+  public async setAppRedirectUris(input: ZitadelSetRedirectUrisInput): Promise<void>
+  {
+    // Replace the OIDC app's config. Zitadel's update is a FULL PUT of the oidc_config —
+    // any settable field omitted here resets to its default. This is safe ONLY because
+    // `provisionOrg` is the sole creator of these apps and sets exactly this field set
+    // (all other config left at Zitadel defaults), so re-sending the same fields verbatim
+    // is a no-op for everything except `redirectUris`. If `provisionOrg`'s app-create body
+    // ever gains a non-default field (custom TTLs, PKCE/secret settings, post-logout URIs),
+    // it MUST be mirrored here too — keep the two field sets in lock-step. Org-scoped via
+    // the x-zitadel-orgid header; fail-loud so a wrapping DB transaction rolls back when the
+    // IdP rejects the change.
+    await this._call("PUT", `/management/v1/projects/${input.projectId}/apps/${input.appId}/oidc_config`, {
+      redirectUris: input.redirectUris,
+      responseTypes: ["OIDC_RESPONSE_TYPE_CODE"],
+      grantTypes: ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"],
+      appType: "OIDC_APP_TYPE_WEB",
+      authMethodType: "OIDC_AUTH_METHOD_TYPE_NONE",
+      devMode: false,
+    }, input.orgId);
+    _log.info({ orgId: input.orgId, projectId: input.projectId, appId: input.appId, redirectUriCount: input.redirectUris.length }, "updated Zitadel OIDC app redirect URIs");
   }
 
   public async teardownOrg(orgId: string): Promise<void>
@@ -244,6 +270,17 @@ export function _BuildZitadelManagementClient(): ZitadelManagementClient
 export function _DeriveOrgRedirectUri(orgName: string, baseDomain: string): string
 {
   return `https://${orgName}.${baseDomain}/api/v1/auth/callback`;
+}
+
+/**
+ * Derive the OIDC redirect URI for an org's customer-vanity host:
+ * `https://<vanityDomain>/api/v1/auth/callback`. The vanity domain is a full host (CNAMEd
+ * onto the org apex), so it is the authority directly — no base domain is appended. Used
+ * to register/sync the vanity callback on the org's Zitadel app.
+ */
+export function _DeriveVanityRedirectUri(vanityDomain: string): string
+{
+  return `https://${vanityDomain}/api/v1/auth/callback`;
 }
 
 /** URL-safe base64 of a string or buffer (JWT segments / signatures). */

--- a/apps/control-plane/src/infra/zitadel/zitadel-client.ts
+++ b/apps/control-plane/src/infra/zitadel/zitadel-client.ts
@@ -107,10 +107,17 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
         appType: "OIDC_APP_TYPE_WEB",
         authMethodType: "OIDC_AUTH_METHOD_TYPE_NONE",
         devMode: false,
-      }, orgId) as { appId?: string };
+      }, orgId) as { appId?: string; clientId?: string };
       if (!app.appId)
       {
         throw new Error("Zitadel OIDC app create returned no appId");
+      }
+      // The live app-create response carries the generated OIDC client_id alongside the
+      // appId. Capture it so login can resolve this org's per-org client by host (S3b);
+      // without it the org has a login surface but no credential to authorize against it.
+      if (!app.clientId)
+      {
+        throw new Error("Zitadel OIDC app create returned no clientId");
       }
 
       // Grant the master `admin` on this org's project (cross-org user grant; the master
@@ -121,7 +128,7 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
       }, orgId);
 
       _log.info({ orgId, appId: app.appId, orgName: input.orgName }, "provisioned Zitadel org for ClusterTenant");
-      return { orgId, appId: app.appId, redirectUri: input.redirectUri };
+      return { orgId, appId: app.appId, clientId: app.clientId, redirectUri: input.redirectUri };
     }
     catch (err)
     {

--- a/apps/control-plane/src/infra/zitadel/zitadel-client.types.ts
+++ b/apps/control-plane/src/infra/zitadel/zitadel-client.types.ts
@@ -20,7 +20,7 @@ export interface ZitadelClientConfig
 }
 
 /** Inputs needed to provision a ClusterTenant's Zitadel org + login surface. */
-export interface ProvisionOrgInput
+export interface ZitadelProvisionOrgInput
 {
   /** ClusterTenant name (the org key) — first DNS label of the org host. */
   orgName: string;
@@ -33,7 +33,7 @@ export interface ProvisionOrgInput
 }
 
 /** The Zitadel identifiers persisted onto the ClusterTenant row after provisioning. */
-export interface ProvisionOrgResult
+export interface ZitadelProvisionOrgResult
 {
   /** Provisioned Zitadel Organization id. */
   orgId: string;
@@ -57,7 +57,7 @@ export interface ZitadelManagementClient
    * Provision a dedicated Organization + project + roles + OIDC app for a ClusterTenant
    * and grant the master `admin`. Returns the identifiers to persist. Throws on failure.
    */
-  provisionOrg(input: ProvisionOrgInput): Promise<ProvisionOrgResult>;
+  provisionOrg(input: ZitadelProvisionOrgInput): Promise<ZitadelProvisionOrgResult>;
 
   /** Tear down a previously-provisioned org (tolerates an already-absent org). */
   teardownOrg(orgId: string): Promise<void>;

--- a/apps/control-plane/src/infra/zitadel/zitadel-client.types.ts
+++ b/apps/control-plane/src/infra/zitadel/zitadel-client.types.ts
@@ -28,8 +28,27 @@ export interface ZitadelProvisionOrgInput
   displayName: string;
   /** Redirect URI to register on the org's OIDC app (`<org>.<base>/api/v1/auth/callback`). */
   redirectUri: string;
+  /**
+   * Optional second redirect URI for the org's customer-vanity host
+   * (`https://<vanity>/api/v1/auth/callback`), registered alongside the canonical one so
+   * login works at the vanity domain too. Omitted when the org has no vanity domain.
+   */
+  vanityRedirectUri?: string;
   /** IdP subject (Zitadel user id) of the tenant master, granted `admin` on the new org. */
   masterSubject: string;
+}
+
+/** Inputs needed to replace the redirect URIs on an existing org's OIDC app. */
+export interface ZitadelSetRedirectUrisInput
+{
+  /** Zitadel Organization id the app lives in (sets the `x-zitadel-orgid` context). */
+  orgId: string;
+  /** Zitadel project id the app belongs to (the update endpoint is project-scoped). */
+  projectId: string;
+  /** The OIDC application id whose redirect URIs are being replaced. */
+  appId: string;
+  /** The full set of redirect URIs the app should have after the update (canonical + any vanity). */
+  redirectUris: string[];
 }
 
 /** The Zitadel identifiers persisted onto the ClusterTenant row after provisioning. */
@@ -37,6 +56,8 @@ export interface ZitadelProvisionOrgResult
 {
   /** Provisioned Zitadel Organization id. */
   orgId: string;
+  /** Provisioned project id (the `opencrane` project the OIDC app belongs to). */
+  projectId: string;
   /** Provisioned OIDC application id (login surface for `<org>.<base>`). */
   appId: string;
   /** The OIDC client_id of the provisioned app — the per-org credential login authorizes with. */
@@ -58,6 +79,13 @@ export interface ZitadelManagementClient
    * and grant the master `admin`. Returns the identifiers to persist. Throws on failure.
    */
   provisionOrg(input: ZitadelProvisionOrgInput): Promise<ZitadelProvisionOrgResult>;
+
+  /**
+   * Replace the redirect URIs on an org's existing OIDC app — used when the org's vanity
+   * domain is added, changed, or cleared so the app's allowlist tracks the live hosts.
+   * Throws on failure so a caller wrapping it in a DB transaction rolls the local write back.
+   */
+  setAppRedirectUris(input: ZitadelSetRedirectUrisInput): Promise<void>;
 
   /** Tear down a previously-provisioned org (tolerates an already-absent org). */
   teardownOrg(orgId: string): Promise<void>;

--- a/apps/control-plane/src/infra/zitadel/zitadel-client.types.ts
+++ b/apps/control-plane/src/infra/zitadel/zitadel-client.types.ts
@@ -39,6 +39,8 @@ export interface ProvisionOrgResult
   orgId: string;
   /** Provisioned OIDC application id (login surface for `<org>.<base>`). */
   appId: string;
+  /** The OIDC client_id of the provisioned app — the per-org credential login authorizes with. */
+  clientId: string;
   /** The redirect URI registered on the app (echoed for persistence). */
   redirectUri: string;
 }

--- a/apps/control-plane/src/routes/cluster-tenants.service.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.service.ts
@@ -3,6 +3,7 @@ import type { ClusterTenant, ClusterTenantObservedStatus, ClusterTenantResourceQ
 import type { Prisma, PrismaClient } from "@prisma/client";
 
 import type { ClusterTenantComputeInput, ClusterTenantResourcesInput } from "./cluster-tenants.models.js";
+import { _log } from "../log.js";
 
 /** A cluster_tenants row as read back from Prisma (subset consumed here). */
 type ClusterTenantRow = Prisma.ClusterTenantGetPayload<Record<string, never>>;
@@ -106,10 +107,12 @@ export async function _SyncObservedStatusToDb(prisma: PrismaClient, row: Cluster
   {
     await prisma.clusterTenant.update({ where: { name: row.name }, data: { phase, message, boundNamespace, provisioner } });
   }
-  catch
+  catch (err)
   {
     // Best-effort mirror: the authoritative read already used the observed status, so a
-    // transient DB write failure must not fail the status endpoint.
+    // transient DB write failure must not fail the status endpoint. Log at debug so a
+    // persistent divergence is traceable without flooding the log on every poll.
+    _log.debug({ err, orgName: row.name, phase }, "best-effort ClusterTenant status mirror to DB failed; serving observed status from the CR");
   }
 }
 

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -14,6 +14,7 @@ import { _ReadClusterTenantObservedStatus } from "../core/cluster-tenants/cr-sta
 import { _EnsureOwnerDefaultTenant } from "../core/cluster-tenants/default-tenant.js";
 import { _DeriveOrgRedirectUri } from "../infra/zitadel/zitadel-client.js";
 import type { ZitadelManagementClient } from "../infra/zitadel/zitadel-client.types.js";
+import { _log } from "../log.js";
 
 /** RFC-1123-ish DNS domain: lowercase labels, ≥1 dot, alpha TLD, ≤253 chars. */
 const _VANITY_DOMAIN_PATTERN = /^(?=.{1,253}$)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}$/;
@@ -326,12 +327,12 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
       });
       if (seed.skippedReason)
       {
-        console.warn(`[cluster-tenants] default tenant not seeded for ${created.name}: ${seed.skippedReason}`);
+        _log.warn({ orgName: created.name, skippedReason: seed.skippedReason }, "default tenant not seeded for new org; owner has no workspace until refresh");
       }
     }
     catch (err)
     {
-      console.error(`[cluster-tenants] default tenant seed failed for ${created.name}; org stays created (use refresh to retry):`, err);
+      _log.warn({ err, orgName: created.name }, "default tenant seed failed; org stays created (use refresh to retry)");
     }
 
     res.status(201).json(orgContract);
@@ -452,8 +453,19 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     });
     // Tear down the cluster-scoped CR so the reconciler stops watching it; tolerant of a
     // missing CR (404). This is a Kubernetes side-effect (operator-reconciled), so it sits
-    // OUTSIDE the DB transaction — a Prisma tx cannot roll back a k8s mutation.
-    await _DeleteClusterTenantCr(customApi, req.params.name);
+    // OUTSIDE the DB transaction — a Prisma tx cannot roll back a k8s mutation. The DB row
+    // (source of truth) is already committed, so a CR-delete failure must NOT 500 the call:
+    // a retry would 404 (row gone) and never re-attempt cleanup, leaving a permanent orphan.
+    // Instead log.error so the orphaned CR surfaces for operator cleanup, and still report
+    // the delete as done (the org no longer exists from the API's perspective).
+    try
+    {
+      await _DeleteClusterTenantCr(customApi, req.params.name);
+    }
+    catch (err)
+    {
+      _log.error({ err, orgName: req.params.name }, "ClusterTenant CR teardown failed after DB row + Zitadel org were deleted; CR is orphaned and needs manual cleanup");
+    }
     res.json({ name: req.params.name, status: "deleted" });
   });
 

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -436,25 +436,23 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
       res.status(404).json({ error: "Cluster tenant not found", code: "CLUSTER_TENANT_NOT_FOUND" });
       return;
     }
-    await prisma.clusterTenant.delete({ where: { name: req.params.name } });
-    // Tear down the org's Zitadel Organization (S3 / Phase 2a). Best-effort + AFTER the
-    // local delete: the DB is the source of truth for "this org is gone"; a Zitadel
-    // teardown hiccup must not resurrect the row. The reconcile/backfill loop (later
-    // slice) sweeps any orphaned Zitadel org left by a failure here. No-op when the org
-    // was never provisioned (null orgId) or the client is unconfigured.
-    if (existing.zitadelOrgId)
+    // Delete the row and tear down its Zitadel Organization in ONE transaction so the DB
+    // never drifts from the IdP: the Zitadel teardown is the LAST fallible step, so if it
+    // fails the row delete rolls back and the org stays (the caller retries) — there is
+    // never a deleted ClusterTenant row left pointing at a live Zitadel org. teardownOrg is
+    // 404-tolerant, so an already-absent org still commits the delete. No Zitadel call when
+    // the org was never provisioned (null orgId).
+    await prisma.$transaction(async function _deleteWithOrgTeardown(tx)
     {
-      try
+      await tx.clusterTenant.delete({ where: { name: req.params.name } });
+      if (existing.zitadelOrgId)
       {
         await zitadelClient.teardownOrg(existing.zitadelOrgId);
       }
-      catch (err)
-      {
-        console.error(`[cluster-tenants] Zitadel org teardown failed for ${req.params.name} (org row already deleted; reconcile will sweep):`, err);
-      }
-    }
-    // Tear down the cluster-scoped CR so the reconciler stops watching it; tolerant
-    // of a missing CR (404) for the dev/no-cluster path where none was ever written.
+    });
+    // Tear down the cluster-scoped CR so the reconciler stops watching it; tolerant of a
+    // missing CR (404). This is a Kubernetes side-effect (operator-reconciled), so it sits
+    // OUTSIDE the DB transaction — a Prisma tx cannot roll back a k8s mutation.
     await _DeleteClusterTenantCr(customApi, req.params.name);
     res.json({ name: req.params.name, status: "deleted" });
   });

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -12,7 +12,7 @@ import { _RequireBillingAccountForOrgCreate, _RequireOrgManager } from "../infra
 import { _ApplyClusterTenantCr, _DeleteClusterTenantCr } from "../core/cluster-tenants/cr-bridge.js";
 import { _ReadClusterTenantObservedStatus } from "../core/cluster-tenants/cr-status-reader.js";
 import { _EnsureOwnerDefaultTenant } from "../core/cluster-tenants/default-tenant.js";
-import { _DeriveOrgRedirectUri } from "../infra/zitadel/zitadel-client.js";
+import { _DeriveOrgRedirectUri, _DeriveVanityRedirectUri } from "../infra/zitadel/zitadel-client.js";
 import type { ZitadelManagementClient } from "../infra/zitadel/zitadel-client.types.js";
 import { _log } from "../log.js";
 
@@ -269,11 +269,14 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
           orgName: org.name,
           displayName: org.displayName,
           redirectUri: _DeriveOrgRedirectUri(org.name, process.env.PLATFORM_BASE_DOMAIN?.trim() ?? ""),
+          // Register the vanity callback too when the org is created with a vanity domain,
+          // so login works at the vanity host from the start (not only after a later PUT).
+          ...(org.vanityDomain ? { vanityRedirectUri: _DeriveVanityRedirectUri(org.vanityDomain) } : {}),
           masterSubject: ownerSubject,
         });
         return tx.clusterTenant.update({
           where: { name: org.name },
-          data: { zitadelOrgId: zitadel.orgId, zitadelAppId: zitadel.appId, zitadelClientId: zitadel.clientId, zitadelRedirectUri: zitadel.redirectUri },
+          data: { zitadelOrgId: zitadel.orgId, zitadelProjectId: zitadel.projectId, zitadelAppId: zitadel.appId, zitadelClientId: zitadel.clientId, zitadelRedirectUri: zitadel.redirectUri },
         });
       });
     }
@@ -422,7 +425,43 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
     // never clobber the observed status the reconciler stamps — those columns are
     // the operator's to own. Re-project the new spec onto the CR so the reconciler
     // re-converges to the changed desired state (idempotent; status untouched).
-    const updated = await prisma.clusterTenant.update({ where: { name: req.params.name }, data });
+    //
+    // When the vanity domain ACTUALLY changes and the org is fully provisioned in Zitadel,
+    // the OIDC app's redirect-URI allowlist must track it — else login at the new vanity
+    // host fails (URI not allowlisted) or a cleared vanity keeps a stale URI. Persist the
+    // row + sync the allowlist in ONE transaction (IdP call LAST) so the two never drift:
+    // a Zitadel rejection rolls the row update back. TLS for the vanity host is handled
+    // separately by the operator's domain provisioner off the re-projected CR.
+    const vanityChanged = body.vanityDomain !== undefined && ((data.vanityDomain as string | null | undefined) ?? null) !== (existing.vanityDomain ?? null);
+    const orgId = existing.zitadelOrgId;
+    const projectId = existing.zitadelProjectId;
+    const appId = existing.zitadelAppId;
+    let updated: ClusterTenantRow;
+    if (vanityChanged && orgId && projectId && appId)
+    {
+      const baseDomain = process.env.PLATFORM_BASE_DOMAIN?.trim() ?? "";
+      const canonical = existing.zitadelRedirectUri ?? _DeriveOrgRedirectUri(req.params.name, baseDomain);
+      const newVanity = (data.vanityDomain as string | null | undefined) ?? null;
+      const redirectUris = [canonical, ...(newVanity ? [_DeriveVanityRedirectUri(newVanity)] : [])];
+      updated = await prisma.$transaction(async function _updateWithRedirectSync(tx)
+      {
+        const row = await tx.clusterTenant.update({ where: { name: req.params.name }, data });
+        await zitadelClient.setAppRedirectUris({ orgId, projectId, appId, redirectUris });
+        return row;
+      });
+    }
+    else
+    {
+      // No vanity change (or an unprovisioned org with no app to sync) → a plain DB update.
+      // A vanity change on an unprovisioned org (single-cluster / no Zitadel app, or a row
+      // predating provisioning) persists but has no per-org app to register against — trace
+      // it so the "vanity set but not in the IdP allowlist" state is visible, not silent.
+      if (vanityChanged && !(orgId && projectId && appId))
+      {
+        _log.debug({ orgName: req.params.name }, "vanity domain changed on an unprovisioned org; persisted without a Zitadel redirect-URI sync (no per-org app)");
+      }
+      updated = await prisma.clusterTenant.update({ where: { name: req.params.name }, data });
+    }
     const orgContract = _ToContract(updated);
     await _ApplyClusterTenantCr(customApi, orgContract);
     res.json(orgContract);

--- a/apps/control-plane/src/routes/cluster-tenants.ts
+++ b/apps/control-plane/src/routes/cluster-tenants.ts
@@ -272,7 +272,7 @@ export function clusterTenantsRouter(prisma: PrismaClient, registry: ClusterTena
         });
         return tx.clusterTenant.update({
           where: { name: org.name },
-          data: { zitadelOrgId: zitadel.orgId, zitadelAppId: zitadel.appId, zitadelRedirectUri: zitadel.redirectUri },
+          data: { zitadelOrgId: zitadel.orgId, zitadelAppId: zitadel.appId, zitadelClientId: zitadel.clientId, zitadelRedirectUri: zitadel.redirectUri },
         });
       });
     }


### PR DESCRIPTION
## S3b — host→ClusterTenant→per-org OIDC client resolution

Builds on S3 (per-CT Zitadel Organization + OIDC app provisioning). Login now uses each ClusterTenant's **own** Zitadel client and user pool instead of a single shared client, so a request to `<org>.<base>` can only authenticate members of that org.

### What changed
- **Persist the OIDC clientId**
  - `prisma/schema.prisma` + migration `0026_zitadel_client_id`: new nullable `zitadelClientId` column on `ClusterTenant` (additive; existing rows and the unconfigured no-Zitadel path unaffected).
  - `zitadel-client.ts` / `.types.ts`: capture the OIDC app `clientId` from the live app-create response, thread it through `ProvisionOrgResult`. Fail-loud + compensate (delete the half-created org) when the response omits a `clientId`.
  - `routes/cluster-tenants.ts`: persist `zitadelClientId` in the same create transaction as the org/app/redirect ids.
- **Host→CT→per-org client resolution**
  - New `infra/auth/per-org-client.ts`: `_ResolvePerOrgClient(host)` confirms the host's first DNS label against a `ClusterTenant` row and returns `{clientId, orgId, redirectUri}`; `_OrgScope(orgId)` builds the Zitadel org-restriction scope `urn:zitadel:iam:org:id:{orgId}`.
  - `infra/auth/oidc.service.ts`: `buildLoginUrl` and `completeLogin` resolve the per-org client by host and append the org scope; per-`clientId` OIDC discovery is memoized; the resolved `clientId` is recorded in `session.oidcFlow` so the token exchange uses the **same** client as the authorization request.

### How unprovisioned / unknown hosts are handled (fail-closed)
`_ResolvePerOrgClient` returns `null` — and login falls through to the **masters** OIDC client (the existing `OIDC_*` env config) — in every one of:
- absent / bare host (no derivable silo label) — no DB hit;
- the platform host (`platform.<base>`: label `platform` matches no CT row);
- an unknown host label that matches no `ClusterTenant`;
- a `ClusterTenant` whose org is not fully provisioned (missing `zitadelClientId` **or** `zitadelOrgId`).

The DB row is the single source of truth, so a spoofed host label that names no real, fully-provisioned org can never pick up an org client. There is no partial per-org login: either a complete org-scoped client or the masters client.

### Tests
- `clientId` persisted on create; provisioner fails loud + compensates when app-create omits `clientId`.
- `_ResolvePerOrgClient`: per-org host resolves; absent host (no DB hit); platform host; unknown host; missing clientId/orgId — all fail-closed.
- `buildLoginUrl`: per-org host picks the org client + org scope and records `flow.clientId`; platform + unprovisioned hosts use the masters client with no org scope.
- `completeLogin`: token exchange uses the per-org client recorded at login, else the masters client.

### Validation
- `pnpm --filter "@opencrane/control-plane..." build` ✅
- `pnpm --filter @opencrane/control-plane test` ✅ — 458 passed (68 files)
- Independent `@review` gate run: no Critical/High; the one Medium (missing `completeLogin` coverage) is now addressed with the two `completeLogin` tests above.

### Deferred / follow-ups
- **Org-scope enforcement is delegated to Zitadel.** `completeLogin` does not re-validate that the returned identity belongs to the scoped org (the `urn:zitadel:iam:org:id` scope restricts the login at the IdP, and tenant membership is enforced at the API). A defensive claim-level org check could be added later.
- **`perOrgDiscovered` cache is unbounded** (one small entry per org, never evicted). Negligible in practice; an LRU/periodic purge could be added for very long-lived processes.
- **No explicit host-consistency check** between `buildLoginUrl` and `completeLogin` — the host-scoped session cookie already makes a cross-host callback fail closed ("callback without in-flight login").