### PR TITLE
✨ S4a: openclaw Tenant inherits its bound user's rights

### DIFF
--- a/apps/control-plane/src/__tests__/grants/grant-compiler-inheritance.test.ts
+++ b/apps/control-plane/src/__tests__/grants/grant-compiler-inheritance.test.ts
@@ -1,0 +1,118 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { compile, compileForPrincipals } from "../../core/grants/grant-compiler.js";
+import { GrantCompilerAccess, GrantCompilerPayloadType } from "../../core/grants/grant-compiler.types.js";
+
+/** A grant row in the shape the compiler selects (Prisma enum string values). */
+interface _GrantRow
+{
+  id: string;
+  payloadType: string;
+  payloadId: string;
+  access: string;
+  priority: number;
+  scope: string;
+  subjectType: string;
+  subjectId: string;
+  createdAt: Date;
+}
+
+/** A group row in the shape the compiler selects. */
+interface _GroupRow
+{
+  id: string;
+  members: unknown;
+}
+
+/** One clause of the compiler's grant `where.OR` (direct-subject or group). */
+interface _WhereClause
+{
+  subjectType: { in: string[] } | string;
+  subjectId: { in: string[] };
+}
+
+/**
+ * Build a Prisma stub that HONOURS the compiler's group + grant filters, so the test
+ * exercises the real candidate-selection (not just the precedence pass). `group.findMany`
+ * returns all groups; `grant.findMany` filters the fixed grant set by the `where` the
+ * compiler builds (payloadType + the direct-subject/group OR clauses).
+ *
+ * @param groups - The group rows the compiler sees.
+ * @param grants - The full grant set to filter against the compiler's where.
+ * @returns A Prisma-typed stub exposing only `group`/`grant` findMany.
+ */
+function _prismaStub(groups: _GroupRow[], grants: _GrantRow[]): PrismaClient
+{
+  return {
+    group: {
+      findMany: async function _groupFindMany() { return groups; },
+    },
+    grant: {
+      findMany: async function _grantFindMany(args: { where: { payloadType: string; OR: _WhereClause[] } })
+      {
+        const { payloadType, OR } = args.where;
+        return grants.filter(function _match(grant)
+        {
+          if (grant.payloadType !== payloadType) return false;
+          return OR.some(function _clause(clause)
+          {
+            const types = typeof clause.subjectType === "string" ? [clause.subjectType] : clause.subjectType.in;
+            return types.includes(grant.subjectType) && clause.subjectId.in.includes(grant.subjectId);
+          });
+        });
+      },
+    },
+  } as unknown as PrismaClient;
+}
+
+/** Shorthand builder for an McpServer grant row. */
+function _grant(id: string, payloadId: string, access: "Allow" | "Deny", subjectType: string, subjectId: string, isoDate: string): _GrantRow
+{
+  return { id, payloadType: "McpServer", payloadId, access, priority: 0, scope: "Org", subjectType, subjectId, createdAt: new Date(isoDate) };
+}
+
+describe("grant compiler — openclaw Tenant inherits its user's rights (S4)", function _inheritanceSuite()
+{
+  // A group the USER (not the tenant) belongs to, and grants spread across all three
+  // subject types — including a user-level Deny that collides with a tenant-level Allow.
+  const groups: _GroupRow[] = [{ id: "grp-eng", members: ["user-sub"] }];
+  const grants: _GrantRow[] = [
+    _grant("g1", "mcp-user",  "Allow", "User",   "user-sub",   "2026-01-01T00:00:00Z"),
+    _grant("g2", "mcp-both",  "Allow", "Tenant", "team-alpha", "2026-01-01T00:00:00Z"),
+    _grant("g3", "mcp-both",  "Deny",  "User",   "user-sub",   "2026-01-02T00:00:00Z"),
+    _grant("g4", "mcp-group", "Allow", "Group",  "grp-eng",    "2026-01-01T00:00:00Z"),
+    _grant("g5", "mcp-tenant","Allow", "Tenant", "team-alpha", "2026-01-01T00:00:00Z"),
+  ];
+
+  it("tenant-only compile sees only the tenant's own grants (no user/user-group inheritance)", async function _tenantOnly()
+  {
+    const decisions = await compile("team-alpha", GrantCompilerPayloadType.McpServer, _prismaStub(groups, grants));
+
+    // Only the two Tenant-subject grants resolve; the user grant, the user's group grant,
+    // and the user Deny are all invisible when compiling the tenant principal alone.
+    expect(decisions.map(d => d.payloadId)).toEqual(["mcp-both", "mcp-tenant"]);
+    expect(decisions.find(d => d.payloadId === "mcp-both")?.access).toBe(GrantCompilerAccess.Allow);
+  });
+
+  it("compiling over {tenant, subject} inherits the user's grants + the user's group grant", async function _inherits()
+  {
+    const decisions = await compileForPrincipals(["team-alpha", "user-sub"], GrantCompilerPayloadType.McpServer, _prismaStub(groups, grants));
+    const byId = new Map(decisions.map(d => [d.payloadId, d.access]));
+
+    // The user's direct grant and the grant on the user's group are now inherited.
+    expect(byId.get("mcp-user")).toBe(GrantCompilerAccess.Allow);
+    expect(byId.get("mcp-group")).toBe(GrantCompilerAccess.Allow);
+    expect(byId.get("mcp-tenant")).toBe(GrantCompilerAccess.Allow);
+    // Deny>Allow holds ACROSS principals: the user-level Deny overrides the tenant-level
+    // Allow at equal priority — inheritance stays least-privilege-capable.
+    expect(byId.get("mcp-both")).toBe(GrantCompilerAccess.Deny);
+  });
+
+  it("an empty principal set compiles to nothing (no DB-wide grant leak)", async function _empty()
+  {
+    expect(await compileForPrincipals([], GrantCompilerPayloadType.McpServer, _prismaStub(groups, grants))).toEqual([]);
+    // A bound subject that is null/empty collapses to the tenant-only set, never a leak.
+    expect(await compileForPrincipals(["", ""], GrantCompilerPayloadType.McpServer, _prismaStub(groups, grants))).toEqual([]);
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/tenant-contract.test.ts
+++ b/apps/control-plane/src/__tests__/routes/tenant-contract.test.ts
@@ -6,7 +6,7 @@ import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 
 import { _RegisterInternalTenantContract } from "../../routes/internal/tenant-contract.js";
-import { compile } from "../../core/grants/grant-compiler.js";
+import { compileForPrincipals } from "../../core/grants/grant-compiler.js";
 import { GrantCompilerAccess } from "../../core/grants/grant-compiler.types.js";
 
 // Mock the grant compiler at the module boundary so tests can drive Allow/Deny
@@ -14,6 +14,7 @@ import { GrantCompilerAccess } from "../../core/grants/grant-compiler.types.js";
 // which keeps every existing test's empty-contract expectations intact.
 vi.mock("../../core/grants/grant-compiler.js", () => ({
   compile: vi.fn().mockResolvedValue([]),
+  compileForPrincipals: vi.fn().mockResolvedValue([]),
 }));
 
 // Per-skill model resolution is exercised by its own suite; stub it to [] here so
@@ -224,8 +225,8 @@ describe("_RegisterInternalTenantContract GET /:name", () =>
     // The route compiles MCP grants first, then skill grants. Allow one skill bundle.
     // The route only reads `payloadId` + `access`, so cast a minimal decision rather
     // than fabricate every CompiledGrantDecision field.
-    const _allowBundle1 = [{ payloadId: "bundle-1", access: GrantCompilerAccess.Allow }] as unknown as Awaited<ReturnType<typeof compile>>;
-    vi.mocked(compile)
+    const _allowBundle1 = [{ payloadId: "bundle-1", access: GrantCompilerAccess.Allow }] as unknown as Awaited<ReturnType<typeof compileForPrincipals>>;
+    vi.mocked(compileForPrincipals)
       .mockResolvedValueOnce([]) // McpServer decisions
       .mockResolvedValueOnce(_allowBundle1); // SkillBundle decisions
     // The entitled-bundle metadata the contract must surface (digest is what addresses the registry).

--- a/apps/control-plane/src/__tests__/routes/tenant-contract.test.ts
+++ b/apps/control-plane/src/__tests__/routes/tenant-contract.test.ts
@@ -42,7 +42,7 @@ function _buildAuthApi(opts: {
 
 /** Build a mock Prisma client for contract endpoint tests. */
 function _buildPrismaStub(overrides: {
-  tenant?: { name: string; team: string | null; awarenessWave?: string | null } | null;
+  tenant?: { name: string; team: string | null; awarenessWave?: string | null; subject?: string | null } | null;
   rollout?: Record<string, unknown> | null;
 } = {}): PrismaClient
 {
@@ -243,5 +243,38 @@ describe("_RegisterInternalTenantContract GET /:name", () =>
     expect(res.body.skills.entitled).toEqual([
       { id: "bundle-1", name: "company-policy", digest: "sha256:abc123" },
     ]);
+  });
+
+  it("compiles the contract over the tenant's principal SET {name, subject} when bound (S4 inheritance)", async () =>
+  {
+    vi.mocked(compileForPrincipals).mockClear();
+    const prisma = _buildPrismaStub({ tenant: { name: "team-alpha", team: null, subject: "user-sub" } });
+    const app = _buildApp(prisma, _validAuthApi);
+
+    const res = await request(app)
+      .get("/api/internal/contract/team-alpha")
+      .set("Authorization", "Bearer valid");
+
+    expect(res.status).toBe(200);
+    // The route must pass BOTH the tenant name and its bound subject so the openclaw Tenant
+    // inherits the user's grants — guards the principal-set construction (a typo collapsing
+    // it to tenant-only would otherwise pass every other test).
+    expect(vi.mocked(compileForPrincipals)).toHaveBeenCalledWith(["team-alpha", "user-sub"], expect.anything(), expect.anything());
+    // Never called with the tenant alone when a subject is bound.
+    expect(vi.mocked(compileForPrincipals)).not.toHaveBeenCalledWith(["team-alpha"], expect.anything(), expect.anything());
+  });
+
+  it("collapses to the tenant principal alone for a legacy/unbound tenant (subject null)", async () =>
+  {
+    vi.mocked(compileForPrincipals).mockClear();
+    const prisma = _buildPrismaStub({ tenant: { name: "team-alpha", team: null, subject: null } });
+    const app = _buildApp(prisma, _validAuthApi);
+
+    const res = await request(app)
+      .get("/api/internal/contract/team-alpha")
+      .set("Authorization", "Bearer valid");
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(compileForPrincipals)).toHaveBeenCalledWith(["team-alpha"], expect.anything(), expect.anything());
   });
 });

--- a/apps/control-plane/src/core/grants/grant-compiler.ts
+++ b/apps/control-plane/src/core/grants/grant-compiler.ts
@@ -111,12 +111,10 @@ type _GrantRow = {
 };
 
 /**
- * Compile effective grant decisions for a principal and payload family.
+ * Compile effective grant decisions for a single principal and payload family.
  *
- * The compiler resolves direct tenant/user grants plus any group grants where the
- * principal is listed in `groups.members`. Precedence rules are deterministic:
- * highest priority wins first, deny wins over allow at the same priority, and the
- * newest `createdAt` wins the final tie-break.
+ * Thin wrapper over {@link compileForPrincipals} for the common single-principal case
+ * (a user session, an awareness lookup). Preserved so existing callers are unchanged.
  *
  * @param principalId - Tenant or user identifier being evaluated.
  * @param payloadType - Payload family to compile.
@@ -129,19 +127,53 @@ export async function compile(
   prisma: PrismaClient,
 ): Promise<CompiledGrantDecision[]>
 {
+  return compileForPrincipals([principalId], payloadType, prisma);
+}
+
+/**
+ * Compile effective grant decisions over a SET of principals (S4 inheritance).
+ *
+ * An openclaw Tenant is 1:1 with one ClusterTenant user and must act with that user's
+ * entitlements, so its contract is compiled over `{tenant-name, subject}` — the union of
+ * direct grants on any principal in the set PLUS group grants for every group that
+ * contains any principal. The precedence pass is unchanged and deterministic: highest
+ * priority wins, deny beats allow at equal priority, newest `createdAt` breaks the tie —
+ * so a user-level Deny still overrides a tenant-level Allow regardless of which principal
+ * carried it. Duplicate/empty ids are dropped so the set is minimal.
+ *
+ * @param principalIds - Tenant and/or user identifiers whose grants are unioned.
+ * @param payloadType - Payload family to compile.
+ * @param prisma - Prisma client used to load groups and grants.
+ * @returns Final decision per payload identifier.
+ */
+export async function compileForPrincipals(
+  principalIds: string[],
+  payloadType: GrantCompilerPayloadType,
+  prisma: PrismaClient,
+): Promise<CompiledGrantDecision[]>
+{
+  // 0. Normalise to a minimal, distinct principal set (drop empties + duplicates). An empty
+  //    set has nothing to compile, so short-circuit before touching the DB.
+  const principals = Array.from(new Set(principalIds.filter(function _present(id) { return Boolean(id); })));
+  if (principals.length === 0)
+  {
+    return [];
+  }
+
   // 1. Load the minimum group shape needed so membership matching stays typed and isolated.
   const groupRows: _GroupRow[] = await prisma.group.findMany(_GROUP_ROW_SELECT);
 
-  // 2. Resolve every group that contains the principal because group grants are compiled alongside direct grants.
+  // 2. Resolve every group that contains ANY principal in the set, because a group grant is
+  //    inherited when the user OR the tenant is a member.
   const matchingGroupIds = groupRows.filter(function _matchGroup(group: _GroupRow)
   {
-    return _GroupHasPrincipal(group.members, principalId);
+    return _GroupHasAnyPrincipal(group.members, principals);
   }).map(function _mapGroup(group: _GroupRow)
   {
     return group.id;
   });
 
-  // 3. Fetch only grants that can apply to the principal so the later precedence pass stays deterministic and small.
+  // 3. Fetch only grants that can apply to the principal set so the later precedence pass stays deterministic and small.
   const grantRows: _GrantRow[] = await prisma.grant.findMany({
     ..._GRANT_ROW_SELECT,
     where: {
@@ -151,7 +183,9 @@ export async function compile(
           subjectType: {
             in: _DIRECT_SUBJECT_TYPES,
           },
-          subjectId: principalId,
+          subjectId: {
+            in: principals,
+          },
         },
         ...(matchingGroupIds.length > 0
           ? [
@@ -225,6 +259,21 @@ function _ToCompiledGrantDecision(grant: _GrantRow): CompiledGrantDecision
     subjectId: grant.subjectId,
     createdAt: grant.createdAt.toISOString(),
   };
+}
+
+/**
+ * Check whether a group membership JSON document contains ANY of the principals.
+ *
+ * @param members - Raw JSON stored on the group record.
+ * @param principalIds - Distinct principal identifiers being matched.
+ * @returns True when at least one principal is present.
+ */
+function _GroupHasAnyPrincipal(members: unknown, principalIds: string[]): boolean
+{
+  return ___SomeArray(principalIds, function _anyMatch(principalId)
+  {
+    return _GroupHasPrincipal(members, principalId);
+  });
 }
 
 /**

--- a/apps/control-plane/src/routes/internal/tenant-contract.ts
+++ b/apps/control-plane/src/routes/internal/tenant-contract.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import * as k8s from "@kubernetes/client-node";
 import type { PrismaClient } from "@prisma/client";
 
-import { compile } from "../../core/grants/grant-compiler.js";
+import { compileForPrincipals } from "../../core/grants/grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "../../core/grants/grant-compiler.types.js";
 import { _RenderToolsMarkdown } from "../../core/contract/tools-markdown.js";
 import { _LoadAwarenessRollout } from "../../core/awareness/rollout-store.js";
@@ -121,7 +121,7 @@ export function _RegisterInternalTenantContract(prisma: PrismaClient, authApi: k
       // 4. Verify the tenant exists before compiling grants.
       const tenant = await prisma.tenant.findUnique({
         where: { name },
-        select: { name: true, team: true, awarenessWave: true, clusterTenantRef: true },
+        select: { name: true, team: true, awarenessWave: true, clusterTenantRef: true, subject: true },
       });
 
       if (!tenant)
@@ -130,9 +130,14 @@ export function _RegisterInternalTenantContract(prisma: PrismaClient, authApi: k
         return;
       }
 
-      // 5. Compile MCP server and skill grants for this tenant.
-      const mcpDecisions = await compile(name, GrantCompilerPayloadType.McpServer, prisma);
-      const skillDecisions = await compile(name, GrantCompilerPayloadType.SkillBundle, prisma);
+      // 5. Compile MCP server and skill grants over the tenant's principal SET (S4 inheritance):
+      //    the openclaw Tenant inherits the rights of its 1:1 ClusterTenant user, so we compile
+      //    over { tenant-name, bound subject } — the union of both principals' direct + group
+      //    grants. A user-level Deny still beats a tenant-level Allow (Deny>Allow precedence).
+      //    The subject is absent for legacy/unbound tenants, which collapses to tenant-only.
+      const principals = [name, ...(tenant.subject ? [tenant.subject] : [])];
+      const mcpDecisions = await compileForPrincipals(principals, GrantCompilerPayloadType.McpServer, prisma);
+      const skillDecisions = await compileForPrincipals(principals, GrantCompilerPayloadType.SkillBundle, prisma);
 
       const allowedMcp = mcpDecisions
         .filter(function _isAllow(d) { return d.access === GrantCompilerAccess.Allow; })

--- a/apps/control-plane/src/routes/tenants.ts
+++ b/apps/control-plane/src/routes/tenants.ts
@@ -4,7 +4,7 @@ import * as k8s from "@kubernetes/client-node";
 import { Router } from "express";
 import type { Prisma, PrismaClient } from "@prisma/client";
 
-import { compile } from "../core/grants/grant-compiler.js";
+import { compile, compileForPrincipals } from "../core/grants/grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "../core/grants/grant-compiler.types.js";
 import { _CutTenant } from "../core/connections/cut-tenant.js";
 import type { OpenClawGatewayAdmin } from "../core/connections/gateway-admin.types.js";
@@ -210,6 +210,7 @@ export function tenantsRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCli
       select: {
         name: true,
         team: true,
+        subject: true,
       },
     });
 
@@ -227,8 +228,13 @@ export function tenantsRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCli
       },
     });
     const awarenessMemberships = _BuildTenantDatasetMembershipResponse(memberships);
+    // Awareness is a fleet-participation property of the tenant itself, so it stays keyed on
+    // the tenant name. MCP + skills are user ENTITLEMENTS, so they compile over the tenant's
+    // principal set { tenant-name, bound subject } (S4 inheritance) — the openclaw Tenant
+    // inherits its 1:1 user's tool/skill rights; Deny>Allow keeps it least-privilege-capable.
+    const principals = [req.params.name, ...(tenant.subject ? [tenant.subject] : [])];
     const awarenessDecisions = await compile(req.params.name, GrantCompilerPayloadType.Awareness, prisma);
-    const mcpDecisions = await compile(req.params.name, GrantCompilerPayloadType.McpServer, prisma);
+    const mcpDecisions = await compileForPrincipals(principals, GrantCompilerPayloadType.McpServer, prisma);
     const allowedMcpIds = mcpDecisions.filter(function _isAllowed(decision)
     {
       return decision.access === GrantCompilerAccess.Allow;
@@ -236,7 +242,7 @@ export function tenantsRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCli
     {
       return decision.payloadId;
     });
-    const allowedSkillIds = (await compile(req.params.name, GrantCompilerPayloadType.SkillBundle, prisma)).filter(function _isAllowed(decision)
+    const allowedSkillIds = (await compileForPrincipals(principals, GrantCompilerPayloadType.SkillBundle, prisma)).filter(function _isAllowed(decision)
     {
       return decision.access === GrantCompilerAccess.Allow;
     }).map(function _mapDecision(decision)


### PR DESCRIPTION
**S4 (silo Phase 2b) — keystone slice.** An openclaw Tenant is 1:1 with one ClusterTenant user and must act with that user's entitlements. The grant machinery already unioned User+Tenant+Group grants with Deny>Allow → priority → recency, but the contract was compiled with the **tenant name as the sole principal** — so a Tenant inherited the *tenant's* groups, never its *user's* rights.

## What changed
- **grant-compiler**: new `compileForPrincipals(principalIds[], …)` unions direct grants on any principal + group grants for any group containing any principal. `compile(id)` delegates to it (all existing single-principal callers unchanged). Empty/duplicate ids dropped + early `[]` return → an unbound tenant can never leak DB-wide grants.
- **contract routes**: the pod-polled enforcement surface (`internal/tenant-contract.ts`) and the public projection (`routes/tenants.ts`) now compile **MCP + skills** over `{ tenant-name, Tenant.subject }`. Awareness stays tenant-keyed (fleet-participation property, not a user entitlement). Legacy/unbound tenants (subject null) collapse to tenant-only.
- A **user-level Deny still overrides a tenant-level Allow** across principals (least-privilege-capable, per the silo plan's security-tension note). The subject is read from the persisted `Tenant.subject` (IdP-verified at create), never a request-carried claim.

## Tests
471 control-plane (+5): real-compiler inheritance (user grant + group-via-user + Deny-across-principals + empty/falsy-set leak guard) and route-level guards asserting `compileForPrincipals` is called with both principals (bound) / tenant-only (unbound). Build + OpenAPI clean.

## Reviewed
Fresh-context review (security-sensitive): no Critical/High. Principal-set filtering airtight; Deny>Allow precedence unchanged; no token-carried principal path. Medium gap (untested route principal-set construction) folded in.

## Follow-up S4 slices (not in this PR)
Zitadel groups → `Group.members` mirror; derive Cognee dataset scopes from the same expansion; inter-user sharing API + `oc share` (a least-privilege-bounded Grant).