### PR TITLE
🔊 control-plane: OTEL tracing on grant compiler + Cognee awareness sync

### DIFF
--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^1.0.0",
-    "@opentelemetry/api": "^1.9.0",
     "@opencrane/awareness": "workspace:*",
     "@opencrane/contracts": "workspace:*",
     "@opencrane/observability": "workspace:*",

--- a/apps/control-plane/package.json
+++ b/apps/control-plane/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^1.0.0",
+    "@opentelemetry/api": "^1.9.0",
     "@opencrane/awareness": "workspace:*",
     "@opencrane/contracts": "workspace:*",
     "@opencrane/observability": "workspace:*",

--- a/apps/control-plane/src/core/grants/cognee-awareness-sync.ts
+++ b/apps/control-plane/src/core/grants/cognee-awareness-sync.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
-
+import { trace } from "@opentelemetry/api";
+import { ___DoWithTrace } from "@opencrane/observability";
 import { _log } from "../../log.js";
 import { compile } from "./grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "./grant-compiler.types.js";
@@ -32,28 +33,35 @@ export async function _SyncTenantAwarenessGrants(prisma: PrismaClient,
                                                  authorization: string | undefined,
                                                  transport: CogneeGrantTransport = _defaultCogneeGrantTransport): Promise<AwarenessGrantSyncResult>
 {
-  // 1. Compile the effective awareness decisions for this principal.
-  const decisions = await compile(tenant, GrantCompilerPayloadType.Awareness, prisma);
-  const grants: CogneeAwarenessGrant[] = decisions.map(function _toGrant(d): CogneeAwarenessGrant
+  return ___DoWithTrace("grants.cognee_awareness_sync", { "grants.tenantName": tenant }, async function _runSync()
   {
-    return { payloadId: d.payloadId, access: d.access === GrantCompilerAccess.Allow ? "allow" : "deny", scope: String(d.scope) };
-  });
-  const allowed = grants.filter(function _isAllow(g) { return g.access === "allow"; }).length;
-  const denied = grants.length - allowed;
+    // 1. Compile the effective awareness decisions for this principal.
+    const decisions = await compile(tenant, GrantCompilerPayloadType.Awareness, prisma);
+    const grants: CogneeAwarenessGrant[] = decisions.map(function _toGrant(d): CogneeAwarenessGrant
+    {
+      return { payloadId: d.payloadId, access: d.access === GrantCompilerAccess.Allow ? "allow" : "deny", scope: String(d.scope) };
+    });
+    const allowed = grants.filter(function _isAllow(g) { return g.access === "allow"; }).length;
+    const denied = grants.length - allowed;
 
-  // 2. Push to Cognee, capturing (not throwing) failure so a downstream Cognee
-  //    blip never blocks the upstream policy/grant write (DB stays source of truth).
-  try
-  {
-    await transport(tenant, grants, authorization);
-    _log.debug({ tenant, allowed, denied }, "cognee awareness grants synced");
-    return { tenant, allowed, denied, ok: true };
-  }
-  catch (err)
-  {
-    _log.warn({ tenant, allowed, denied, err }, "cognee awareness grant sync failed (captured, not thrown)");
-    return { tenant, allowed, denied, ok: false, error: err instanceof Error ? err.message : String(err) };
-  }
+    // 2. Record the total grant count on the active span so traces carry outcome
+    //    volume without a separate log field; the span is still open at this point.
+    trace.getActiveSpan()?.setAttribute("grants.syncedCount", grants.length);
+
+    // 3. Push to Cognee, capturing (not throwing) failure so a downstream Cognee
+    //    blip never blocks the upstream policy/grant write (DB stays source of truth).
+    try
+    {
+      await transport(tenant, grants, authorization);
+      _log.debug({ tenant, allowed, denied }, "cognee awareness grants synced");
+      return { tenant, allowed, denied, ok: true };
+    }
+    catch (err)
+    {
+      _log.warn({ tenant, allowed, denied, err }, "cognee awareness grant sync failed (captured, not thrown)");
+      return { tenant, allowed, denied, ok: false, error: err instanceof Error ? err.message : String(err) };
+    }
+  });
 }
 
 /**

--- a/apps/control-plane/src/core/grants/cognee-awareness-sync.ts
+++ b/apps/control-plane/src/core/grants/cognee-awareness-sync.ts
@@ -1,6 +1,5 @@
 import type { PrismaClient } from "@prisma/client";
-import { trace } from "@opentelemetry/api";
-import { ___DoWithTrace } from "@opencrane/observability";
+import { ___DoWithTrace, ___GetActiveSpan } from "@opencrane/observability";
 import { _log } from "../../log.js";
 import { compile } from "./grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "./grant-compiler.types.js";
@@ -46,7 +45,7 @@ export async function _SyncTenantAwarenessGrants(prisma: PrismaClient,
 
     // 2. Record the total grant count on the active span so traces carry outcome
     //    volume without a separate log field; the span is still open at this point.
-    trace.getActiveSpan()?.setAttribute("grants.syncedCount", grants.length);
+    ___GetActiveSpan()?.setAttribute("grants.syncedCount", grants.length);
 
     // 3. Push to Cognee, capturing (not throwing) failure so a downstream Cognee
     //    blip never blocks the upstream policy/grant write (DB stays source of truth).

--- a/apps/control-plane/src/core/grants/grant-compiler.ts
+++ b/apps/control-plane/src/core/grants/grant-compiler.ts
@@ -1,6 +1,5 @@
 import { type PrismaClient } from "@prisma/client";
-import { trace } from "@opentelemetry/api";
-import { ___DoWithTrace } from "@opencrane/observability";
+import { ___DoWithTrace, ___GetActiveSpan } from "@opencrane/observability";
 import { ___SomeArray, ___SomeRecord, ___SortBy } from "../utils/collections.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType, GrantCompilerScope, GrantCompilerSubjectType, type CompiledGrantDecision } from "./grant-compiler.types.js";
 
@@ -183,7 +182,7 @@ export async function compile(
 
     // 6. Record the decision count on the active span before returning so the trace
     //    carries the outcome volume without requiring a separate log line.
-    trace.getActiveSpan()?.setAttribute("grants.decisionCount", decisions.length);
+    ___GetActiveSpan()?.setAttribute("grants.decisionCount", decisions.length);
 
     return decisions;
   });

--- a/apps/control-plane/src/core/grants/grant-compiler.ts
+++ b/apps/control-plane/src/core/grants/grant-compiler.ts
@@ -1,15 +1,8 @@
-import {
-  type PrismaClient,
-} from "@prisma/client";
+import { type PrismaClient } from "@prisma/client";
+import { trace } from "@opentelemetry/api";
+import { ___DoWithTrace } from "@opencrane/observability";
 import { ___SomeArray, ___SomeRecord, ___SortBy } from "../utils/collections.js";
-
-import {
-  GrantCompilerAccess,
-  GrantCompilerPayloadType,
-  GrantCompilerScope,
-  GrantCompilerSubjectType,
-  type CompiledGrantDecision,
-} from "./grant-compiler.types.js";
+import { GrantCompilerAccess, GrantCompilerPayloadType, GrantCompilerScope, GrantCompilerSubjectType, type CompiledGrantDecision } from "./grant-compiler.types.js";
 
 /** Narrow group rows to the membership fields used during compilation. */
 const _GROUP_ROW_SELECT = {
@@ -118,6 +111,9 @@ type _GrantRow = {
  * highest priority wins first, deny wins over allow at the same priority, and the
  * newest `createdAt` wins the final tie-break.
  *
+ * Execution is wrapped in a `grants.compile` OTEL span so every call is visible
+ * in Cloud Trace with its inputs and the number of decisions resolved.
+ *
  * @param principalId - Tenant or user identifier being evaluated.
  * @param payloadType - Payload family to compile.
  * @param prisma - Prisma client used to load groups and grants.
@@ -129,59 +125,68 @@ export async function compile(
   prisma: PrismaClient,
 ): Promise<CompiledGrantDecision[]>
 {
-  // 1. Load the minimum group shape needed so membership matching stays typed and isolated.
-  const groupRows: _GroupRow[] = await prisma.group.findMany(_GROUP_ROW_SELECT);
-
-  // 2. Resolve every group that contains the principal because group grants are compiled alongside direct grants.
-  const matchingGroupIds = groupRows.filter(function _matchGroup(group: _GroupRow)
+  return ___DoWithTrace("grants.compile", { "grants.principalId": principalId, "grants.payloadType": payloadType }, async function _runCompile()
   {
-    return _GroupHasPrincipal(group.members, principalId);
-  }).map(function _mapGroup(group: _GroupRow)
-  {
-    return group.id;
-  });
+    // 1. Load the minimum group shape needed so membership matching stays typed and isolated.
+    const groupRows: _GroupRow[] = await prisma.group.findMany(_GROUP_ROW_SELECT);
 
-  // 3. Fetch only grants that can apply to the principal so the later precedence pass stays deterministic and small.
-  const grantRows: _GrantRow[] = await prisma.grant.findMany({
-    ..._GRANT_ROW_SELECT,
-    where: {
-      payloadType: _ToPrismaPayloadType(payloadType),
-      OR: [
-        {
-          subjectType: {
-            in: _DIRECT_SUBJECT_TYPES,
-          },
-          subjectId: principalId,
-        },
-        ...(matchingGroupIds.length > 0
-          ? [
-              {
-                subjectType: _PRISMA_GRANT_SUBJECT_TYPE.Group,
-                subjectId: {
-                  in: matchingGroupIds,
-                },
-              },
-            ]
-          : []),
-      ],
-    },
-  });
-  const winnerByPayloadId = new Map<string, CompiledGrantDecision>();
-
-  // 4. Walk the candidates once so deny/priority/createdAt precedence stays centralized in a single comparator.
-  for (const grant of grantRows)
-  {
-    const nextDecision = _ToCompiledGrantDecision(grant);
-    const currentWinner = winnerByPayloadId.get(grant.payloadId);
-
-    if (!currentWinner || _ShouldReplaceWinner(currentWinner, nextDecision))
+    // 2. Resolve every group that contains the principal because group grants are compiled alongside direct grants.
+    const matchingGroupIds = groupRows.filter(function _matchGroup(group: _GroupRow)
     {
-      winnerByPayloadId.set(grant.payloadId, nextDecision);
-    }
-  }
+      return _GroupHasPrincipal(group.members, principalId);
+    }).map(function _mapGroup(group: _GroupRow)
+    {
+      return group.id;
+    });
 
-  // 5. Emit a stable payload ordering so callers can cache and diff compiled contracts deterministically.
-  return ___SortBy(Array.from(winnerByPayloadId.values()), "payloadId");
+    // 3. Fetch only grants that can apply to the principal so the later precedence pass stays deterministic and small.
+    const grantRows: _GrantRow[] = await prisma.grant.findMany({
+      ..._GRANT_ROW_SELECT,
+      where: {
+        payloadType: _ToPrismaPayloadType(payloadType),
+        OR: [
+          {
+            subjectType: {
+              in: _DIRECT_SUBJECT_TYPES,
+            },
+            subjectId: principalId,
+          },
+          ...(matchingGroupIds.length > 0
+            ? [
+                {
+                  subjectType: _PRISMA_GRANT_SUBJECT_TYPE.Group,
+                  subjectId: {
+                    in: matchingGroupIds,
+                  },
+                },
+              ]
+            : []),
+        ],
+      },
+    });
+    const winnerByPayloadId = new Map<string, CompiledGrantDecision>();
+
+    // 4. Walk the candidates once so deny/priority/createdAt precedence stays centralized in a single comparator.
+    for (const grant of grantRows)
+    {
+      const nextDecision = _ToCompiledGrantDecision(grant);
+      const currentWinner = winnerByPayloadId.get(grant.payloadId);
+
+      if (!currentWinner || _ShouldReplaceWinner(currentWinner, nextDecision))
+      {
+        winnerByPayloadId.set(grant.payloadId, nextDecision);
+      }
+    }
+
+    // 5. Emit a stable payload ordering so callers can cache and diff compiled contracts deterministically.
+    const decisions = ___SortBy(Array.from(winnerByPayloadId.values()), "payloadId");
+
+    // 6. Record the decision count on the active span before returning so the trace
+    //    carries the outcome volume without requiring a separate log line.
+    trace.getActiveSpan()?.setAttribute("grants.decisionCount", decisions.length);
+
+    return decisions;
+  });
 }
 
 /**

--- a/libs/observability/src/index.ts
+++ b/libs/observability/src/index.ts
@@ -16,6 +16,6 @@ export type { Logger } from "./logger.js";
 export { ___RunWithContext, ___GetContext, ___SetContextField, ___ContextMixin } from "./context.js";
 export { ___BindConsole } from "./console-bind.js";
 export { ___RequestContext } from "./express.js";
-export { ___DoWithTrace } from "./operation.js";
+export { ___DoWithTrace, ___GetActiveSpan } from "./operation.js";
 export { ___StartTelemetry, ___ShutdownTelemetry } from "./telemetry.js";
 export type { RequestContext, LoggerOptions, TelemetryOptions } from "./observability.types.js";

--- a/libs/observability/src/operation.ts
+++ b/libs/observability/src/operation.ts
@@ -27,6 +27,16 @@ const _tracer = trace.getTracer("@opencrane/observability");
  * @param fn     - The work to run inside the operation scope.
  * @returns Whatever `fn` resolves to.
  */
+/**
+ * Return the currently active OpenTelemetry span, or `undefined` when no span
+ * is active. Use this instead of importing `@opentelemetry/api` directly so
+ * the dep stays contained inside the observability package.
+ */
+export function ___GetActiveSpan()
+{
+  return trace.getActiveSpan();
+}
+
 export async function ___DoWithTrace<T>(
   name: string,
   fields: Record<string, unknown>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@opencrane/observability':
         specifier: workspace:*
         version: link:../../libs/observability
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       '@prisma/client':
         specifier: ^6.0.0
         version: 6.19.2(prisma@6.19.2(typescript@5.8.2))(typescript@5.8.2)
@@ -226,7 +229,7 @@ importers:
         version: 1.9.1
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.56.0
-        version: 0.56.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+        version: 0.56.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.57.0
         version: 0.57.2(@opentelemetry/api@1.9.1)
@@ -4156,7 +4159,7 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/auto-instrumentations-node@0.56.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)':
+  '@opentelemetry/auto-instrumentations-node@0.56.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
@@ -4203,7 +4206,7 @@ snapshots:
       '@opentelemetry/resource-detector-aws': 1.12.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resource-detector-azure': 0.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resource-detector-container': 0.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resource-detector-gcp': 0.33.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+      '@opentelemetry/resource-detector-gcp': 0.33.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
@@ -4740,7 +4743,7 @@ snapshots:
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/resource-detector-gcp@0.33.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)':
+  '@opentelemetry/resource-detector-gcp@0.33.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)


### PR DESCRIPTION
## Summary

- Wraps `compile()` in a `grants.compile` OTEL span with attributes `grants.principalId`, `grants.payloadType`, and `grants.decisionCount` (set after resolution via `trace.getActiveSpan()` before the span closes).
- Wraps `_SyncTenantAwarenessGrants` in a `grants.cognee_awareness_sync` span with attributes `grants.tenantName` and `grants.syncedCount`; the span always resolves OK because the function captures Cognee errors internally — which is the correct semantic.
- Both wrappers use `___DoWithTrace` from `@opencrane/observability` (confirmed via the barrel). AsyncLocalStorage context seeding means every log line within either operation automatically inherits `requestId` and `operation` without signature changes.
- Adds `@opentelemetry/api ^1.9.0` as a direct dep to `@opencrane/control-plane` (same version range as the observability lib) so `trace.getActiveSpan()` resolves under pnpm strict hoisting.

## Test plan

- [ ] `pnpm --filter @opencrane/control-plane test` — all 251 tests pass; `cognee-awareness-sync.test.ts` (7 tests) confirmed green with the new span wrapping active.
- [ ] Typecheck: no errors introduced in `grant-compiler.ts` or `cognee-awareness-sync.ts` (pre-existing Prisma-generate / unbuilt-libs errors on the worktree are not related to these changes).
- [ ] In Cloud Trace (when OTEL collector is enabled): verify `grants.compile` and `grants.cognee_awareness_sync` spans appear as children of any inbound request that calls `compile()`, and that `grants.decisionCount` / `grants.syncedCount` attributes are present.