### PR TITLE
✨ S4c.1: sync grant/dataset scope vocabularies (Team + Department)

### DIFF
--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -1931,6 +1931,7 @@
         "required": [
           "org",
           "team",
+          "department",
           "project",
           "personal"
         ],
@@ -1942,6 +1943,12 @@
             }
           },
           "team": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "department": {
             "type": "array",
             "items": {
               "type": "string"

--- a/apps/control-plane/prisma/migrations/0029_scope_enum_sync/migration.sql
+++ b/apps/control-plane/prisma/migrations/0029_scope_enum_sync/migration.sql
@@ -1,0 +1,28 @@
+-- Migration 0029: sync the GrantScope and DatasetScope levels (S4c)
+--
+-- The grant/group scope vocabulary (org/department/project/personal) and the Cognee
+-- dataset scope vocabulary (org/team/project/personal) diverged on the middle tier
+-- (department vs team). S4c derives dataset memberships from the group/grant expansion, so
+-- the two vocabularies must align 1:1. Give EACH the level it was missing: grants gain
+-- `team`, datasets gain `department`. Additive only — no existing row changes.
+--
+-- NOTE: the two scopes are stored differently in the DB:
+--   * grant scope  → a real Postgres enum type `grant_scope` (ALTER TYPE … ADD VALUE)
+--   * dataset scope → a TEXT column on `tenant_dataset_memberships` guarded by a CHECK
+--     constraint (migration 0003) — widened here, not an enum.
+
+-- 1. grant_scope enum: add `team`. Idempotent; safe to re-run.
+ALTER TYPE "grant_scope" ADD VALUE IF NOT EXISTS 'team';
+
+-- 2. dataset scope CHECK: allow `department` alongside the existing team/project/personal
+--    (org still pins to the singleton `default` subject). Re-create the constraint verbatim
+--    from migration 0003 with `department` added to the non-org set.
+ALTER TABLE "tenant_dataset_memberships"
+  DROP CONSTRAINT "tenant_dataset_memberships_scope_subject_check";
+
+ALTER TABLE "tenant_dataset_memberships"
+  ADD CONSTRAINT "tenant_dataset_memberships_scope_subject_check"
+  CHECK (
+    ("scope" IN ('team', 'department', 'project', 'personal') AND LENGTH(BTRIM("subject")) > 0)
+    OR ("scope" = 'org' AND "subject" = 'default')
+  );

--- a/apps/control-plane/prisma/schema.prisma
+++ b/apps/control-plane/prisma/schema.prisma
@@ -82,10 +82,11 @@ model TenantDatasetMembership {
 }
 
 enum DatasetScope {
-  Org      @map("org")
-  Team     @map("team")
-  Project  @map("project")
-  Personal @map("personal")
+  Org        @map("org")
+  Team       @map("team")
+  Department @map("department")
+  Project    @map("project")
+  Personal   @map("personal")
 }
 
 model TenantLiteLlmKey {
@@ -307,6 +308,7 @@ model Group {
 enum GrantScope {
   Org        @map("org")
   Department @map("department")
+  Team       @map("team")
   Project    @map("project")
   Personal   @map("personal")
 }

--- a/apps/control-plane/src/__tests__/routes/tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/tenants.test.ts
@@ -121,6 +121,7 @@ describe("tenantsRouter dataset membership endpoints", () =>
       .send({
         org: ["default"],
         team: ["engineering"],
+        department: ["platform"],
         project: ["apollo"],
         personal: ["owner@example.com"],
       });
@@ -145,6 +146,7 @@ describe("tenantsRouter dataset membership endpoints", () =>
       .send({
         org: ["default"],
         team: [],
+        department: [],
         project: [],
         personal: [],
       });
@@ -161,12 +163,13 @@ describe("tenantsRouter dataset membership endpoints", () =>
       .send({
         org: "default",
         team: [],
+        department: [],
         project: [],
         personal: [],
       });
 
     expect(response.status).toBe(400);
-    expect(response.body.error).toBe("org, team, project, and personal must all be string arrays, and org may only contain 'default'");
+    expect(response.body.error).toBe("org, team, department, project, and personal must all be string arrays, and org may only contain 'default'");
   });
 
   it("returns 502 when applying dataset updates in Cognee fails", async () =>
@@ -185,6 +188,7 @@ describe("tenantsRouter dataset membership endpoints", () =>
       .send({
         org: ["default"],
         team: [],
+        department: [],
         project: [],
         personal: [],
       });
@@ -209,6 +213,7 @@ describe("tenantsRouter dataset membership endpoints", () =>
       .send({
         org: ["default"],
         team: [],
+        department: [],
         project: [],
         personal: [],
       });
@@ -232,6 +237,7 @@ describe("tenantsRouter dataset membership endpoints", () =>
       .send({
         org: ["default"],
         team: [],
+        department: [],
         project: [],
         personal: [],
       });

--- a/apps/control-plane/src/core/grants/grant-compiler.ts
+++ b/apps/control-plane/src/core/grants/grant-compiler.ts
@@ -51,6 +51,7 @@ const _PRISMA_GRANT_ACCESS = {
 const _PRISMA_GRANT_SCOPE = {
   Org: "Org",
   Department: "Department",
+  Team: "Team",
   Project: "Project",
   Personal: "Personal",
 } as const;
@@ -82,6 +83,7 @@ const _COMPILER_PAYLOAD_BY_PRISMA_PAYLOAD = {
 const _COMPILER_SCOPE_BY_PRISMA_SCOPE = {
   [_PRISMA_GRANT_SCOPE.Org]: GrantCompilerScope.Org,
   [_PRISMA_GRANT_SCOPE.Department]: GrantCompilerScope.Department,
+  [_PRISMA_GRANT_SCOPE.Team]: GrantCompilerScope.Team,
   [_PRISMA_GRANT_SCOPE.Project]: GrantCompilerScope.Project,
   [_PRISMA_GRANT_SCOPE.Personal]: GrantCompilerScope.Personal,
 };

--- a/apps/control-plane/src/core/grants/grant-compiler.types.ts
+++ b/apps/control-plane/src/core/grants/grant-compiler.types.ts
@@ -26,6 +26,7 @@ export enum GrantCompilerScope
 {
   Org = "org",
   Department = "department",
+  Team = "team",
   Project = "project",
   Personal = "personal",
 }

--- a/apps/control-plane/src/domain/retrieval/retrieval.types.ts
+++ b/apps/control-plane/src/domain/retrieval/retrieval.types.ts
@@ -8,6 +8,7 @@ export enum DatasetScope
 {
   Org = "org",
   Team = "team",
+  Department = "department",
   Project = "project",
   Personal = "personal",
 }

--- a/apps/control-plane/src/features/groups/groups.logic.ts
+++ b/apps/control-plane/src/features/groups/groups.logic.ts
@@ -31,6 +31,7 @@ export interface GroupMutationResponse
 const _PRISMA_GRANT_SCOPE = {
   Org: "Org",
   Department: "Department",
+  Team: "Team",
   Project: "Project",
   Personal: "Personal",
 } as const;
@@ -55,6 +56,7 @@ const _PRISMA_AWARENESS_PAYLOAD_TYPE = "Awareness";
 const _ROUTE_SCOPE_BY_PRISMA_SCOPE = {
   [_PRISMA_GRANT_SCOPE.Org]: GrantScope.Org,
   [_PRISMA_GRANT_SCOPE.Department]: GrantScope.Department,
+  [_PRISMA_GRANT_SCOPE.Team]: GrantScope.Team,
   [_PRISMA_GRANT_SCOPE.Project]: GrantScope.Project,
   [_PRISMA_GRANT_SCOPE.Personal]: GrantScope.Personal,
 };

--- a/apps/control-plane/src/features/mcp-servers/mcp-servers.logic.ts
+++ b/apps/control-plane/src/features/mcp-servers/mcp-servers.logic.ts
@@ -27,6 +27,7 @@ export interface McpServerMutationResponse
 const _PRISMA_GRANT_SCOPE = {
   Org: "Org",
   Department: "Department",
+  Team: "Team",
   Project: "Project",
   Personal: "Personal",
 } as const;
@@ -83,6 +84,7 @@ const _PRISMA_MCP_SERVER_PAYLOAD_TYPE = "McpServer";
 const _ROUTE_SCOPE_BY_PRISMA_SCOPE = {
   [_PRISMA_GRANT_SCOPE.Org]: GrantScope.Org,
   [_PRISMA_GRANT_SCOPE.Department]: GrantScope.Department,
+  [_PRISMA_GRANT_SCOPE.Team]: GrantScope.Team,
   [_PRISMA_GRANT_SCOPE.Project]: GrantScope.Project,
   [_PRISMA_GRANT_SCOPE.Personal]: GrantScope.Personal,
 };

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -669,10 +669,11 @@ const DeviceGrantSchema = {
 
 const DatasetMembershipSchema = {
   type: "object" as const,
-  required: ["org", "team", "project", "personal"],
+  required: ["org", "team", "department", "project", "personal"],
   properties: {
     org: { type: "array", items: { type: "string" } },
     team: { type: "array", items: { type: "string" } },
+    department: { type: "array", items: { type: "string" } },
     project: { type: "array", items: { type: "string" } },
     personal: { type: "array", items: { type: "string" } },
   },

--- a/apps/control-plane/src/routes/internal/tenant-datasets.types.ts
+++ b/apps/control-plane/src/routes/internal/tenant-datasets.types.ts
@@ -9,6 +9,8 @@ export interface TenantDatasetMembership
   org: string[];
   /** Team-scoped datasets a tenant can query. */
   team: string[];
+  /** Department-scoped datasets a tenant can query (S4c — mirrors the group/grant `department` tier). */
+  department: string[];
   /** Project-scoped datasets a tenant can query. */
   project: string[];
   /** Personal datasets a tenant can query. */

--- a/apps/control-plane/src/routes/tenants.ts
+++ b/apps/control-plane/src/routes/tenants.ts
@@ -129,7 +129,7 @@ export function tenantsRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCli
 
     if (!membership)
     {
-      res.status(400).json({ error: "org, team, project, and personal must all be string arrays, and org may only contain 'default'", code: "VALIDATION_ERROR" });
+      res.status(400).json({ error: "org, team, department, project, and personal must all be string arrays, and org may only contain 'default'", code: "VALIDATION_ERROR" });
       return;
     }
 
@@ -692,12 +692,12 @@ export function tenantsRouter(customApi: k8s.CustomObjectsApi, prisma: PrismaCli
  */
 function _ValidateTenantDatasetUpdate(body: Partial<UpdateTenantDatasetsRequest>): UpdateTenantDatasetsRequest | null
 {
-  if (!Array.isArray(body.org) || !Array.isArray(body.team) || !Array.isArray(body.project) || !Array.isArray(body.personal))
+  if (!Array.isArray(body.org) || !Array.isArray(body.team) || !Array.isArray(body.department) || !Array.isArray(body.project) || !Array.isArray(body.personal))
   {
     return null;
   }
 
-  if (!_IsStringArray(body.org) || !_IsStringArray(body.team) || !_IsStringArray(body.project) || !_IsStringArray(body.personal))
+  if (!_IsStringArray(body.org) || !_IsStringArray(body.team) || !_IsStringArray(body.department) || !_IsStringArray(body.project) || !_IsStringArray(body.personal))
   {
     return null;
   }
@@ -711,6 +711,7 @@ function _ValidateTenantDatasetUpdate(body: Partial<UpdateTenantDatasetsRequest>
   return {
     org: ["default"],
     team: _NormalizeSubjectList(body.team),
+    department: _NormalizeSubjectList(body.department),
     project: _NormalizeSubjectList(body.project),
     personal: _NormalizeSubjectList(body.personal),
   };
@@ -807,6 +808,7 @@ function _DefaultTenantDatasetMembership(): TenantDatasetsResponse
   return {
     org: ["default"],
     team: [],
+    department: [],
     project: [],
     personal: [],
   };
@@ -835,7 +837,7 @@ function _NormalizeSubjectList(values: string[]): string[]
  */
 function _BuildTenantDatasetMembershipRows(tenant: string, membership: TenantDatasetsResponse): Array<{
   tenant: string;
-  scope: "Org" | "Team" | "Project" | "Personal";
+  scope: "Org" | "Team" | "Department" | "Project" | "Personal";
   subject: string;
 }>
 {
@@ -847,6 +849,10 @@ function _BuildTenantDatasetMembershipRows(tenant: string, membership: TenantDat
     ...membership.team.map(function _mapTeam(subject)
     {
       return { tenant, scope: "Team" as const, subject };
+    }),
+    ...membership.department.map(function _mapDepartment(subject)
+    {
+      return { tenant, scope: "Department" as const, subject };
     }),
     ...membership.project.map(function _mapProject(subject)
     {
@@ -864,7 +870,7 @@ function _BuildTenantDatasetMembershipRows(tenant: string, membership: TenantDat
  * @param memberships - SQL projection rows for a tenant.
  */
 function _BuildTenantDatasetMembershipResponse(memberships: Array<{
-  scope: "Org" | "Team" | "Project" | "Personal";
+  scope: "Org" | "Team" | "Department" | "Project" | "Personal";
   subject: string;
 }>): TenantDatasetsResponse
 {
@@ -879,6 +885,10 @@ function _BuildTenantDatasetMembershipResponse(memberships: Array<{
     else if (membership.scope === "Team")
     {
       response.team.push(membership.subject);
+    }
+    else if (membership.scope === "Department")
+    {
+      response.department.push(membership.subject);
     }
     else if (membership.scope === "Project")
     {
@@ -921,6 +931,10 @@ async function _ApplyTenantDatasetMembershipToCognee(
         ...membership.team.map(function _mapTeam(subject)
         {
           return { scope: "team", subject };
+        }),
+        ...membership.department.map(function _mapDepartment(subject)
+        {
+          return { scope: "department", subject };
         }),
         ...membership.project.map(function _mapProject(subject)
         {

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -2397,6 +2397,7 @@ export interface components {
         DatasetMembership: {
             org: string[];
             team: string[];
+            department: string[];
             project: string[];
             personal: string[];
         };

--- a/libs/contracts/src/grant.types.ts
+++ b/libs/contracts/src/grant.types.ts
@@ -20,6 +20,7 @@ export enum GrantScope
 {
   Org = "org",
   Department = "department",
+  Team = "team",
   Project = "project",
   Personal = "personal",
 }


### PR DESCRIPTION
**S4c foundation.** S4c derives Cognee dataset memberships from the group/grant expansion, which needs the grant/group scope vocabulary and the Cognee dataset-scope vocabulary aligned 1:1. They diverged on the middle tier — grants used `department`, datasets used `team`. Per the decision, give **each the level it lacked**:

- `GrantScope` (contracts + grant-compiler) gains `team`
- `DatasetScope` (domain) gains `department`
- **migration 0029**: `ALTER TYPE grant_scope ADD VALUE 'team'`; widen the `tenant_dataset_memberships` CHECK to allow `department` (that scope is a **TEXT+CHECK column, not a PG enum** — unlike `grant_scope`).
- Threaded `department` through the dataset-membership pipeline: `TenantDatasetMembership` type, default/validate/build-rows/build-response, the **Cognee permission sync**, and the OpenAPI `DatasetMembership` schema; updated the groups + mcp-servers route scope maps for the new `team`.

Additive only — no existing rows change. **479 control-plane + 186 operator tests; cp+cli+contracts build clean.**

> Note: built on branch `s4c1-scope-vocab-sync` (the name `s4c-cognee-derivation` was already taken on origin by a concurrent S4d-refactor branch).

## Next (S4c.2)
The actual derivation — compute a tenant's dataset memberships from the groups its principal-set {tenant, subject} is in, **replace** the manual path, **auto-sync to Cognee** (+ the `_ApplyTenantDatasetMembershipToCognee` transaction-pattern fix). Blocked on one semantic decision: which subjects populate each derived scope (the group's members, or just the tenant).