### PR TITLE
✨ S4c.2: derive Cognee dataset scopes from group expansion + resource-group sharing

### DIFF
--- a/apps/cli/src/commands/share.ts
+++ b/apps/cli/src/commands/share.ts
@@ -58,6 +58,46 @@ export function _RegisterShare(parent: Command, getConfig: () => CliConfig): voi
     });
 
   share
+    .command("resource")
+    .description("Share a file/chat with a user (creates/extends the resource's share group)")
+    .requiredOption("--type <type>", "Resource kind: file|chat|dataset")
+    .requiredOption("--id <resourceId>", "Id of the file/chat/dataset to share")
+    .requiredOption("--with-user <subject>", "Recipient user's IdP subject")
+    .action(async function _shareResource(opts: { type: "file" | "chat" | "dataset"; id: string; withUser: string })
+    {
+      const client = _MakeClient(getConfig());
+      const { data, error } = await client.POST("/resource-shares", {
+        body: { resourceType: opts.type, resourceId: opts.id, recipientSubject: opts.withUser },
+      });
+      if (error) _PrintApiError("share resource", error);
+      _PrintSuccess(`Shared ${opts.type} '${opts.id}' with '${opts.withUser}'.`);
+      console.log(JSON.stringify(data, null, 2));
+    });
+
+  share
+    .command("resources")
+    .description("List the file/chat resource shares you are a member of")
+    .option("-o, --output <format>", "Output format: table|json", "table")
+    .action(async function _listResources(opts: { output: OutputFormat })
+    {
+      const client = _MakeClient(getConfig());
+      const { data, error } = await client.GET("/resource-shares");
+      if (error) _PrintApiError("share resources", error);
+      _Print(data, opts.output, ["groupId", "resourceType", "resourceId", "members"]);
+    });
+
+  share
+    .command("unshare-resource <groupId> <subject>")
+    .description("Revoke a recipient from a resource share")
+    .action(async function _unshareResource(groupId: string, subject: string)
+    {
+      const client = _MakeClient(getConfig());
+      const { error } = await client.DELETE("/resource-shares/{groupId}/recipients/{subject}", { params: { path: { groupId, subject } } });
+      if (error) _PrintApiError("share unshare-resource", error);
+      _PrintSuccess(`Revoked '${subject}' from resource share '${groupId}'.`);
+    });
+
+  share
     .command("list")
     .description("List the shares you have created")
     .option("-o, --output <format>", "Output format: table|json", "table")

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -743,6 +743,40 @@
           "createdAt"
         ]
       },
+      "ResourceShare": {
+        "type": "object",
+        "description": "A direct share of a file/chat (S4c): the resource-scoped Personal group whose members can access it.",
+        "properties": {
+          "groupId": {
+            "type": "string",
+            "description": "Id of the resource-scoped share group."
+          },
+          "resourceType": {
+            "type": "string",
+            "enum": [
+              "file",
+              "chat",
+              "dataset"
+            ]
+          },
+          "resourceId": {
+            "type": "string"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "IdP subjects the resource is shared with (incl. the owner)."
+          }
+        },
+        "required": [
+          "groupId",
+          "resourceType",
+          "resourceId",
+          "members"
+        ]
+      },
       "SkillBundle": {
         "type": "object",
         "properties": {
@@ -5281,6 +5315,190 @@
           },
           "403": {
             "description": "Caller is not an organisation admin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resource-shares": {
+      "get": {
+        "operationId": "listResourceShares",
+        "summary": "List the file/chat resource shares the caller is a member of",
+        "tags": [
+          "Shares"
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource shares the caller is in.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResourceShare"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "shareResource",
+        "summary": "Share a file/chat with a user (creates/extends the resource's share group)",
+        "tags": [
+          "Shares"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "resourceType",
+                  "resourceId",
+                  "recipientSubject"
+                ],
+                "properties": {
+                  "resourceType": {
+                    "type": "string",
+                    "enum": [
+                      "file",
+                      "chat",
+                      "dataset"
+                    ]
+                  },
+                  "resourceId": {
+                    "type": "string"
+                  },
+                  "recipientSubject": {
+                    "type": "string",
+                    "description": "IdP subject of the user to share with."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Recipient added (or already present).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceShare"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Resource share created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceShare"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid resource share request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "You can only share a resource you have access to.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resource-shares/{groupId}/recipients/{subject}": {
+      "delete": {
+        "operationId": "revokeResourceShare",
+        "summary": "Revoke a recipient from a resource share",
+        "tags": [
+          "Shares"
+        ],
+        "parameters": [
+          {
+            "name": "groupId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recipient revoked.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceShare"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource share not found, or caller is not a member.",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/control-plane/src/__tests__/grants/derive-dataset-membership.test.ts
+++ b/apps/control-plane/src/__tests__/grants/derive-dataset-membership.test.ts
@@ -1,0 +1,70 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { _DeriveTenantDatasetMembership } from "../../core/grants/derive-dataset-membership.js";
+
+/** A group row in the shape the derivation selects. */
+interface _GroupRow
+{
+  scope: string;
+  members: unknown;
+}
+
+/** Build a Prisma stub whose group.findMany returns the given groups. */
+function _prisma(groups: _GroupRow[]): PrismaClient
+{
+  return { group: { findMany: vi.fn(async function _findMany() { return groups; }) } } as unknown as PrismaClient;
+}
+
+describe("_DeriveTenantDatasetMembership — dataset scopes from group membership (S4c)", function _suite()
+{
+  it("populates each tier from the members of the groups the principal set is in", async function _derives()
+  {
+    const groups: _GroupRow[] = [
+      { scope: "Team", members: ["alice", "bob"] },           // tenant's user is alice → team = members
+      { scope: "Department", members: ["alice", "carol"] },   // matches via alice
+      { scope: "Project", members: ["dave"] },                // no principal → excluded
+      { scope: "Personal", members: ["alice", "erin"] },      // a resource share-group → personal
+    ];
+
+    const membership = await _DeriveTenantDatasetMembership(_prisma(groups), "acme-tenant", "alice");
+
+    // Org is always the singleton; group members never enumerate it.
+    expect(membership.org).toEqual(["default"]);
+    // Matched groups contribute their members (deduped + sorted); the unmatched project group does not.
+    expect(membership.team).toEqual(["alice", "bob"]);
+    expect(membership.department).toEqual(["alice", "carol"]);
+    expect(membership.project).toEqual([]);
+    // Personal is NOT self-only — it is the members of the resource share-groups the tenant is in.
+    expect(membership.personal).toEqual(["alice", "erin"]);
+  });
+
+  it("matches a group via the tenant NAME too, not only the subject", async function _matchesTenantName()
+  {
+    const groups: _GroupRow[] = [{ scope: "Team", members: ["acme-tenant"] }];
+    const membership = await _DeriveTenantDatasetMembership(_prisma(groups), "acme-tenant", "alice");
+    expect(membership.team).toEqual(["acme-tenant"]);
+  });
+
+  it("unions + dedupes members across multiple groups of the same scope", async function _unions()
+  {
+    const groups: _GroupRow[] = [
+      { scope: "Team", members: ["alice", "bob"] },
+      { scope: "Team", members: ["alice", "zoe"] },
+    ];
+    const membership = await _DeriveTenantDatasetMembership(_prisma(groups), "acme-tenant", "alice");
+    expect(membership.team).toEqual(["alice", "bob", "zoe"]);
+  });
+
+  it("an unbound tenant (no subject) still matches groups by tenant name; otherwise empty", async function _unbound()
+  {
+    const groups: _GroupRow[] = [
+      { scope: "Team", members: ["alice"] },        // no tenant-name, no subject → excluded
+      { scope: "Project", members: ["acme-tenant"] }, // tenant-name → included
+    ];
+    const membership = await _DeriveTenantDatasetMembership(_prisma(groups), "acme-tenant", null);
+    expect(membership.team).toEqual([]);
+    expect(membership.project).toEqual(["acme-tenant"]);
+    expect(membership.org).toEqual(["default"]);
+  });
+});

--- a/apps/control-plane/src/__tests__/grants/derive-dataset-membership.test.ts
+++ b/apps/control-plane/src/__tests__/grants/derive-dataset-membership.test.ts
@@ -56,6 +56,23 @@ describe("_DeriveTenantDatasetMembership — dataset scopes from group membershi
     expect(membership.team).toEqual(["alice", "bob", "zoe"]);
   });
 
+  it("populates every tier at once, including Department, across a multi-scope membership", async function _multiScope()
+  {
+    const groups: _GroupRow[] = [
+      { scope: "Department", members: ["alice", "dee"] },
+      { scope: "Team", members: ["alice", "tom"] },
+      { scope: "Project", members: ["alice", "pat"] },
+      { scope: "Personal", members: ["alice", "perry"] },
+      { scope: "Org", members: ["alice"] }, // org never enumerates members → stays the singleton
+    ];
+    const membership = await _DeriveTenantDatasetMembership(_prisma(groups), "acme-tenant", "alice");
+    expect(membership.org).toEqual(["default"]);
+    expect(membership.department).toEqual(["alice", "dee"]);
+    expect(membership.team).toEqual(["alice", "tom"]);
+    expect(membership.project).toEqual(["alice", "pat"]);
+    expect(membership.personal).toEqual(["alice", "perry"]);
+  });
+
   it("an unbound tenant (no subject) still matches groups by tenant name; otherwise empty", async function _unbound()
   {
     const groups: _GroupRow[] = [

--- a/apps/control-plane/src/__tests__/grants/derived-dataset-sync.test.ts
+++ b/apps/control-plane/src/__tests__/grants/derived-dataset-sync.test.ts
@@ -1,0 +1,89 @@
+import type { PrismaClient } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _SyncDerivedDatasetMembership } from "../../routes/tenants.js";
+
+/** Capture of the membership rows written by a sync. */
+let _written: Array<{ scope: string; subject: string }> | null = null;
+/** Whether the Cognee permission endpoint was called. */
+let _cogneeCalled = false;
+
+/**
+ * Build a Prisma stub: `group.findMany` drives the derivation, `tenantDatasetMembership.findMany`
+ * is the persisted projection to diff against, and `$transaction` runs the callback inline while
+ * recording the createMany payload + that deleteMany ran.
+ */
+function _prisma(groups: Array<{ scope: string; members: string[] }>, persisted: Array<{ scope: string; subject: string }>): PrismaClient
+{
+  const tdm = {
+    findMany: vi.fn(async () => persisted),
+    deleteMany: vi.fn(async () => ({ count: persisted.length })),
+    createMany: vi.fn(async (a: { data: Array<{ scope: string; subject: string }> }) => { _written = a.data; return { count: a.data.length }; }),
+  };
+  const prisma = {
+    group: { findMany: vi.fn(async () => groups) },
+    tenantDatasetMembership: tdm,
+    $transaction: vi.fn(async (fn: (tx: PrismaClient) => Promise<unknown>) => fn(prisma)),
+  } as unknown as PrismaClient;
+  return prisma;
+}
+
+describe("_SyncDerivedDatasetMembership — diff-gated derive→replace→Cognee (S4c.2)", function _suite()
+{
+  beforeEach(function _reset()
+  {
+    _written = null;
+    _cogneeCalled = false;
+    process.env.COGNEE_ENDPOINT = "https://cognee.test";
+    vi.stubGlobal("fetch", vi.fn(async () => { _cogneeCalled = true; return { ok: true, status: 200 }; }));
+  });
+  afterEach(function _restore() { vi.unstubAllGlobals(); delete process.env.COGNEE_ENDPOINT; });
+
+  it("is a no-op when the derived membership equals the persisted projection", async function _noop()
+  {
+    // Group puts alice in a Team with [alice,bob]; the persisted projection already matches.
+    const prisma = _prisma(
+      [{ scope: "Team", members: ["alice", "bob"] }],
+      // Prisma returns the enum MEMBER NAME (PascalCase) for scope, not the @map'd DB value.
+      [{ scope: "Org", subject: "default" }, { scope: "Team", subject: "alice" }, { scope: "Team", subject: "bob" }],
+    );
+
+    const result = await _SyncDerivedDatasetMembership(prisma, "acme", "alice");
+
+    expect(result.changed).toBe(false);
+    expect(_written).toBeNull();        // no row replacement
+    expect(_cogneeCalled).toBe(false);  // no Cognee write on a no-op
+  });
+
+  it("replaces rows AND syncs Cognee when the derivation changed", async function _changed()
+  {
+    // Derivation yields a team membership the persisted projection lacks → must write + sync.
+    const prisma = _prisma(
+      [{ scope: "Team", members: ["alice", "bob"] }],
+      [{ scope: "Org", subject: "default" }],
+    );
+
+    const result = await _SyncDerivedDatasetMembership(prisma, "acme", "alice");
+
+    expect(result.changed).toBe(true);
+    expect(_cogneeCalled).toBe(true);
+    // The replacement rows carry the derived team members (+ the org singleton).
+    expect(_written).toEqual(expect.arrayContaining([
+      { tenant: "acme", scope: "Org", subject: "default" },
+      { tenant: "acme", scope: "Team", subject: "alice" },
+      { tenant: "acme", scope: "Team", subject: "bob" },
+    ]));
+  });
+
+  it("updates the projection but skips Cognee when COGNEE_ENDPOINT is unset", async function _noCognee()
+  {
+    delete process.env.COGNEE_ENDPOINT;
+    const prisma = _prisma([{ scope: "Team", members: ["alice"] }], [{ scope: "Org", subject: "default" }]);
+
+    const result = await _SyncDerivedDatasetMembership(prisma, "acme", "alice");
+
+    expect(result.changed).toBe(true);
+    expect(_written).not.toBeNull();    // rows still replaced
+    expect(_cogneeCalled).toBe(false);  // Cognee not deployed → no external write
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/resource-shares.test.ts
+++ b/apps/control-plane/src/__tests__/routes/resource-shares.test.ts
@@ -1,0 +1,104 @@
+import express from "express";
+import type { Express, Request, Response, NextFunction } from "express";
+import type { PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { resourceSharesRouter } from "../../routes/resource-shares.js";
+
+/** Capture of the last group.create / group.update payload. */
+let _lastWrite: Record<string, unknown> | null = null;
+
+/** Build a Prisma stub around the group mirror for resource-share tests. */
+function _prisma(opts: { byName?: Record<string, { id: string; name: string; members: string[] }>; byId?: Record<string, { id: string; name: string; members: string[] }>; all?: Array<{ id: string; name: string; members: string[] }> } = {}): PrismaClient
+{
+  return {
+    group: {
+      findUnique: vi.fn(async (a: { where: { name?: string; id?: string } }) => (a.where.name ? opts.byName?.[a.where.name] : opts.byId?.[a.where.id ?? ""]) ?? null),
+      findMany: vi.fn(async () => opts.all ?? []),
+      create: vi.fn(async (a: { data: Record<string, unknown> }) => { _lastWrite = a.data; return { id: "grp-new", name: a.data.name, members: a.data.members }; }),
+      update: vi.fn(async (a: { where: { name?: string; id?: string }; data: Record<string, unknown> }) => { _lastWrite = a.data; return { id: "grp-x", name: "resource:file:f1", members: a.data.members }; }),
+    },
+  } as unknown as PrismaClient;
+}
+
+/** Build a test app mounting the resource-shares router with an injected caller session. */
+function _app(prisma: PrismaClient, caller?: string): Express
+{
+  const app = express();
+  app.use(express.json());
+  app.use(function _session(req: Request, _res: Response, next: NextFunction)
+  {
+    (req as unknown as { session?: unknown }).session = caller ? { authUser: { sub: caller } } : {};
+    next();
+  });
+  app.use("/api/v1/resource-shares", resourceSharesRouter(prisma));
+  return app;
+}
+
+describe("resourceSharesRouter — direct file/chat sharing → resource group (S4c)", function _suite()
+{
+  it("401s an unauthenticated caller", async function _unauth()
+  {
+    const res = await request(_app(_prisma())).post("/api/v1/resource-shares").send({ resourceType: "file", resourceId: "f1", recipientSubject: "bob" });
+    expect(res.status).toBe(401);
+  });
+
+  it("400s an invalid body", async function _bad()
+  {
+    const res = await request(_app(_prisma(), "alice")).post("/api/v1/resource-shares").send({ resourceType: "nope", resourceId: "", recipientSubject: "" });
+    expect(res.status).toBe(400);
+  });
+
+  it("creates the resource group with the sharer + recipient on first share (201)", async function _create()
+  {
+    _lastWrite = null;
+    const res = await request(_app(_prisma(), "alice")).post("/api/v1/resource-shares").send({ resourceType: "file", resourceId: "f1", recipientSubject: "bob" });
+    expect(res.status).toBe(201);
+    // Personal-scoped group named for the resource, members = sharer + recipient.
+    expect(_lastWrite).toMatchObject({ name: "resource:file:f1", scope: "Personal" });
+    expect(_lastWrite?.members).toEqual(["alice", "bob"]);
+    expect(res.body.members).toEqual(["alice", "bob"]);
+  });
+
+  it("adds the recipient to an existing group when the caller is a member (200)", async function _addMember()
+  {
+    _lastWrite = null;
+    const prisma = _prisma({ byName: { "resource:file:f1": { id: "g1", name: "resource:file:f1", members: ["alice"] } } });
+    const res = await request(_app(prisma, "alice")).post("/api/v1/resource-shares").send({ resourceType: "file", resourceId: "f1", recipientSubject: "bob" });
+    expect(res.status).toBe(200);
+    expect(_lastWrite?.members).toEqual(["alice", "bob"]);
+  });
+
+  it("403s when a non-member tries to share an existing resource (least-privilege)", async function _gate()
+  {
+    const prisma = _prisma({ byName: { "resource:file:f1": { id: "g1", name: "resource:file:f1", members: ["alice"] } } });
+    // carol is not a member → cannot share alice's resource.
+    const res = await request(_app(prisma, "carol")).post("/api/v1/resource-shares").send({ resourceType: "file", resourceId: "f1", recipientSubject: "bob" });
+    expect(res.status).toBe(403);
+  });
+
+  it("lists only the resource shares the caller is a member of", async function _list()
+  {
+    const prisma = _prisma({ all: [
+      { id: "g1", name: "resource:file:f1", members: ["alice", "bob"] },
+      { id: "g2", name: "resource:chat:c9", members: ["carol"] },
+    ] });
+    const res = await request(_app(prisma, "alice")).get("/api/v1/resource-shares");
+    expect(res.status).toBe(200);
+    expect(res.body.map((s: { resourceId: string }) => s.resourceId)).toEqual(["f1"]);
+  });
+
+  it("revokes a recipient only from a group the caller is in; otherwise 404", async function _revoke()
+  {
+    const prisma = _prisma({ byId: { g1: { id: "g1", name: "resource:file:f1", members: ["alice", "bob"] }, g2: { id: "g2", name: "resource:file:f2", members: ["carol"] } } });
+
+    const notMine = await request(_app(prisma, "alice")).delete("/api/v1/resource-shares/g2/recipients/carol");
+    expect(notMine.status).toBe(404);
+
+    _lastWrite = null;
+    const mine = await request(_app(prisma, "alice")).delete("/api/v1/resource-shares/g1/recipients/bob");
+    expect(mine.status).toBe(200);
+    expect(_lastWrite?.members).toEqual(["alice"]);
+  });
+});

--- a/apps/control-plane/src/__tests__/routes/resource-shares.test.ts
+++ b/apps/control-plane/src/__tests__/routes/resource-shares.test.ts
@@ -57,7 +57,7 @@ describe("resourceSharesRouter — direct file/chat sharing → resource group (
     expect(res.status).toBe(201);
     // Personal-scoped group named for the resource, members = sharer + recipient.
     expect(_lastWrite).toMatchObject({ name: "resource:file:f1", scope: "Personal" });
-    expect(_lastWrite?.members).toEqual(["alice", "bob"]);
+    expect((_lastWrite as Record<string, unknown> | null)?.members).toEqual(["alice", "bob"]);
     expect(res.body.members).toEqual(["alice", "bob"]);
   });
 
@@ -67,7 +67,7 @@ describe("resourceSharesRouter — direct file/chat sharing → resource group (
     const prisma = _prisma({ byName: { "resource:file:f1": { id: "g1", name: "resource:file:f1", members: ["alice"] } } });
     const res = await request(_app(prisma, "alice")).post("/api/v1/resource-shares").send({ resourceType: "file", resourceId: "f1", recipientSubject: "bob" });
     expect(res.status).toBe(200);
-    expect(_lastWrite?.members).toEqual(["alice", "bob"]);
+    expect((_lastWrite as Record<string, unknown> | null)?.members).toEqual(["alice", "bob"]);
   });
 
   it("403s when a non-member tries to share an existing resource (least-privilege)", async function _gate()
@@ -99,6 +99,6 @@ describe("resourceSharesRouter — direct file/chat sharing → resource group (
     _lastWrite = null;
     const mine = await request(_app(prisma, "alice")).delete("/api/v1/resource-shares/g1/recipients/bob");
     expect(mine.status).toBe(200);
-    expect(_lastWrite?.members).toEqual(["alice"]);
+    expect((_lastWrite as Record<string, unknown> | null)?.members).toEqual(["alice"]);
   });
 });

--- a/apps/control-plane/src/core/grants/derive-dataset-membership.ts
+++ b/apps/control-plane/src/core/grants/derive-dataset-membership.ts
@@ -17,8 +17,13 @@ const _DATASET_KEY_BY_GROUP_SCOPE: Record<string, keyof TenantDatasetMembership 
   Personal: "personal",
 };
 
-/** The non-org dataset tiers that are enumerated from group membership (deduped + sorted). */
-const _ENUMERATED_KEYS = ["team", "department", "project", "personal"] as const;
+/**
+ * The non-org dataset tiers enumerated from group membership. Listed in retrieval relevance
+ * order (most → least relevant; see DATASET_SCOPE_RETRIEVAL_PRECEDENCE) for readability, but
+ * the order here is cosmetic — it only drives the per-tier normalisation loop below. Org is
+ * excluded (it is the `["default"]` singleton, never enumerated from members).
+ */
+const _ENUMERATED_KEYS = ["personal", "project", "team", "department"] as const;
 
 /**
  * Derive a tenant's Cognee dataset memberships from the IAM groups its principal set belongs to
@@ -68,8 +73,11 @@ export async function _DeriveTenantDatasetMembership(prisma: PrismaClient, tenan
     membership[key].push(...members);
   }
 
-  // 4. Normalise each enumerated tier (dedupe + stable order) so the result diffs cleanly against
-  //    the persisted membership and against Cognee.
+  // 4. Canonicalise the SUBJECTS within each tier — dedupe + alphabetical sort — purely so the
+  //    derived membership diffs cleanly (byte-identical arrays) against the persisted projection
+  //    and Cognee, keeping the diff-gate stable. This sorts subjects inside a tier; it is NOT a
+  //    relevance ordering of the scope tiers (that is DATASET_SCOPE_RETRIEVAL_PRECEDENCE, consumed
+  //    by the retrieval chain, not here).
   for (const key of _ENUMERATED_KEYS)
   {
     membership[key] = Array.from(new Set(membership[key])).sort();

--- a/apps/control-plane/src/core/grants/derive-dataset-membership.ts
+++ b/apps/control-plane/src/core/grants/derive-dataset-membership.ts
@@ -1,0 +1,78 @@
+import type { PrismaClient } from "@prisma/client";
+
+import type { TenantDatasetMembership } from "../../routes/internal/tenant-datasets.types.js";
+
+/**
+ * Dataset-membership key for each group scope. The vocabularies are 1:1 since S4c.1, so the
+ * map is the identity except for `Org`: the org dataset is the `["default"]` singleton (every
+ * member of the org shares it), so it is never enumerated from a group's member list. A
+ * `Personal`-scoped group is a resource-scoped share-group (created around a shared file/chat),
+ * so its members populate the recipient's `personal` dataset — Personal is NOT self-only.
+ */
+const _DATASET_KEY_BY_GROUP_SCOPE: Record<string, keyof TenantDatasetMembership | null> = {
+  Org: null,
+  Department: "department",
+  Team: "team",
+  Project: "project",
+  Personal: "personal",
+};
+
+/** The non-org dataset tiers that are enumerated from group membership (deduped + sorted). */
+const _ENUMERATED_KEYS = ["team", "department", "project", "personal"] as const;
+
+/**
+ * Derive a tenant's Cognee dataset memberships from the IAM groups its principal set belongs to
+ * (S4c). In the unified model every dataset tier IS a scope-typed `Group`; a tenant's membership
+ * at a scope is the union of the members of every group (of that scope) that contains the
+ * tenant's `{tenant-name, subject}`. The org tier is the `["default"]` singleton (not enumerated);
+ * every other tier — including Personal, which is populated by per-resource share-groups — is the
+ * union of the matching groups' members. This is the source of truth that replaces the manual
+ * dataset path and is synced to Cognee.
+ *
+ * Pure read over the `Group` table — no Cognee or external call — so it is safe to run on every
+ * contract compile and diff against the persisted membership before writing.
+ *
+ * @param prisma - Prisma client used to read the group mirror.
+ * @param tenantName - The openclaw Tenant whose memberships are derived.
+ * @param subject - The tenant's bound IdP subject, or null for a legacy/unbound tenant.
+ * @returns The derived dataset membership ({org,team,department,project,personal}).
+ */
+export async function _DeriveTenantDatasetMembership(prisma: PrismaClient, tenantName: string, subject: string | null): Promise<TenantDatasetMembership>
+{
+  // 1. The principal set is the tenant name plus its bound subject (the same set the contract
+  //    compiler inherits over). A group matches when it contains ANY principal.
+  const principals = new Set<string>([tenantName]);
+  if (subject)
+  {
+    principals.add(subject);
+  }
+
+  // 2. Read the group mirror and seed the membership with the org singleton.
+  const groups = await prisma.group.findMany({ select: { scope: true, members: true } });
+  const membership: TenantDatasetMembership = { org: ["default"], team: [], department: [], project: [], personal: [] };
+
+  // 3. For every group the principal set is in, add the group's members to that group's scope tier
+  //    (org is the singleton and is never enumerated from members).
+  for (const group of groups)
+  {
+    const members = Array.isArray(group.members) ? group.members.filter(function _isString(m): m is string { return typeof m === "string"; }) : [];
+    if (!members.some(function _contains(m) { return principals.has(m); }))
+    {
+      continue;
+    }
+    const key = _DATASET_KEY_BY_GROUP_SCOPE[group.scope as string];
+    if (!key)
+    {
+      continue;
+    }
+    membership[key].push(...members);
+  }
+
+  // 4. Normalise each enumerated tier (dedupe + stable order) so the result diffs cleanly against
+  //    the persisted membership and against Cognee.
+  for (const key of _ENUMERATED_KEYS)
+  {
+    membership[key] = Array.from(new Set(membership[key])).sort();
+  }
+  return membership;
+}

--- a/apps/control-plane/src/domain/retrieval/retrieval.types.ts
+++ b/apps/control-plane/src/domain/retrieval/retrieval.types.ts
@@ -13,6 +13,23 @@ export enum DatasetScope
   Personal = "personal",
 }
 
+/**
+ * Canonical retrieval relevance order, MOST → LEAST relevant. The agent's retrieval chain
+ * consults datasets in this order — the caller's own self/session (Personal) is the most
+ * specific and relevant context, widening outward through Project → Team → Department to the
+ * broad Org corpus (still pullable, just lower-priority context). This is a RELEVANCE ranking
+ * of the scope tiers; it is unrelated to how subjects are sorted within a single tier (that
+ * sort is only for deterministic dedup/diffing). The single source of truth for scope ordering
+ * so the derivation, the contract, and the scope-aware retrieval plugin never disagree.
+ */
+export const DATASET_SCOPE_RETRIEVAL_PRECEDENCE: readonly DatasetScope[] = [
+  DatasetScope.Personal,
+  DatasetScope.Project,
+  DatasetScope.Team,
+  DatasetScope.Department,
+  DatasetScope.Org,
+];
+
 /** Request body for a retrieval query. */
 export interface RetrievalQueryRequest
 {

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -801,6 +801,17 @@ export const spec = {
         },
         required: ["id", "payloadType", "payloadId", "recipientType", "recipientId", "scope", "createdAt"],
       },
+      ResourceShare: {
+        type: "object",
+        description: "A direct share of a file/chat (S4c): the resource-scoped Personal group whose members can access it.",
+        properties: {
+          groupId: { type: "string", description: "Id of the resource-scoped share group." },
+          resourceType: { type: "string", enum: ["file", "chat", "dataset"] },
+          resourceId: { type: "string" },
+          members: { type: "array", items: { type: "string" }, description: "IdP subjects the resource is shared with (incl. the owner)." },
+        },
+        required: ["groupId", "resourceType", "resourceId", "members"],
+      },
       SkillBundle: SkillBundleSchema,
       AuditEntry: AuditEntrySchema,
       AccessToken: AccessTokenSchema,
@@ -1914,6 +1925,59 @@ export const spec = {
     // ------------------------------------------------------------------
     // Groups
     // ------------------------------------------------------------------
+
+    "/resource-shares": {
+      get: {
+        operationId: "listResourceShares",
+        summary: "List the file/chat resource shares the caller is a member of",
+        tags: ["Shares"],
+        responses: {
+          200: ok("Resource shares the caller is in.", { type: "array", items: { $ref: "#/components/schemas/ResourceShare" } }),
+          401: unauthorized("Authentication required."),
+        },
+      },
+      post: {
+        operationId: "shareResource",
+        summary: "Share a file/chat with a user (creates/extends the resource's share group)",
+        tags: ["Shares"],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: {
+            type: "object",
+            required: ["resourceType", "resourceId", "recipientSubject"],
+            properties: {
+              resourceType: { type: "string", enum: ["file", "chat", "dataset"] },
+              resourceId: { type: "string" },
+              recipientSubject: { type: "string", description: "IdP subject of the user to share with." },
+            },
+          } } },
+        },
+        responses: {
+          201: created("Resource share created.", { $ref: "#/components/schemas/ResourceShare" }),
+          200: ok("Recipient added (or already present).", { $ref: "#/components/schemas/ResourceShare" }),
+          400: badRequest("Invalid resource share request."),
+          401: unauthorized("Authentication required."),
+          403: forbidden("You can only share a resource you have access to."),
+        },
+      },
+    },
+
+    "/resource-shares/{groupId}/recipients/{subject}": {
+      delete: {
+        operationId: "revokeResourceShare",
+        summary: "Revoke a recipient from a resource share",
+        tags: ["Shares"],
+        parameters: [
+          { name: "groupId", in: "path", required: true, schema: { type: "string" } },
+          { name: "subject", in: "path", required: true, schema: { type: "string" } },
+        ],
+        responses: {
+          200: ok("Recipient revoked.", { $ref: "#/components/schemas/ResourceShare" }),
+          401: unauthorized("Authentication required."),
+          404: notFound("Resource share not found, or caller is not a member."),
+        },
+      },
+    },
 
     "/shares": {
       get: {

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -27,6 +27,7 @@ import { routingEvalCasesRouter } from "./routes/routing-eval-cases.js";
 import { routingMeasurementsRouter } from "./routes/routing-measurements.js";
 import { routingProposalsRouter } from "./routes/routing-proposals.js";
 import { _BuildShadowSeams } from "./core/model-routing/shadow-seams.js";
+import { resourceSharesRouter } from "./routes/resource-shares.js";
 import { sharesRouter } from "./routes/shares.js";
 import { skillCatalogRouter } from "./routes/skill-catalog.js";
 import { skillModelPostureRouter } from "./routes/skill-model-posture.js";
@@ -130,6 +131,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));
   app.use("/api/v1/shares", sharesRouter(prisma));
+  app.use("/api/v1/resource-shares", resourceSharesRouter(prisma));
   app.use("/api/v1/skills/catalog", skillCatalogRouter(prisma, ociBundleStore));
   app.use("/api/v1/skills/posture", skillModelPostureRouter(prisma));
   app.use("/api/v1/model-routing/defaults", modelRoutingDefaultsRouter(prisma));

--- a/apps/control-plane/src/routes/internal/tenant-contract.ts
+++ b/apps/control-plane/src/routes/internal/tenant-contract.ts
@@ -8,6 +8,8 @@ import { _RenderToolsMarkdown } from "../../core/contract/tools-markdown.js";
 import { _LoadAwarenessRollout } from "../../core/awareness/rollout-store.js";
 import { _ResolveAwarenessVersion } from "../../core/awareness/rollout.js";
 import { _ResolveContractSkillModels } from "../../core/model-routing/resolve-contract-skill-models.js";
+import { _SyncDerivedDatasetMembership } from "../tenants.js";
+import { _log } from "../../log.js";
 
 /** Expected audience on the projected token the tenant pod uses to call this endpoint. */
 const _EXPECTED_AUDIENCE = "control-plane";
@@ -129,6 +131,14 @@ export function _RegisterInternalTenantContract(prisma: PrismaClient, authApi: k
         res.status(404).json({ error: "Not found", code: "NOT_FOUND" });
         return;
       }
+
+      // 4b. Re-derive this tenant's Cognee dataset memberships from its group expansion and sync
+      //     them when they changed (S4c). Fire-and-forget + diff-gated: it must not delay or fail
+      //     the contract response (the pod polls frequently and the contract does not depend on
+      //     the dataset sync), and an unchanged derivation writes nothing. Errors are logged, not
+      //     propagated. `_SyncDerivedDatasetMembership` is internally transactional (Cognee last).
+      void _SyncDerivedDatasetMembership(prisma, name, tenant.subject ?? null)
+        .catch(function _syncFailed(err) { _log.warn({ err, tenant: name }, "derived dataset membership sync failed on contract poll; will retry next poll"); });
 
       // 5. Compile MCP server and skill grants over the tenant's principal SET (S4 inheritance):
       //    the openclaw Tenant inherits the rights of its 1:1 ClusterTenant user, so we compile

--- a/apps/control-plane/src/routes/resource-shares.ts
+++ b/apps/control-plane/src/routes/resource-shares.ts
@@ -1,0 +1,163 @@
+import { Router } from "express";
+import type { Request } from "express";
+import { GrantScope, type PrismaClient } from "@prisma/client";
+
+import { _log } from "../log.js";
+
+/** Resource kinds a user can directly share (a file or a chat/conversation). */
+const _RESOURCE_TYPES = ["file", "chat", "dataset"] as const;
+type _ResourceTypeStr = typeof _RESOURCE_TYPES[number];
+
+/** Request body for sharing a resource with another user. */
+interface _ResourceShareBody
+{
+  resourceType?: string;
+  resourceId?: string;
+  recipientSubject?: string;
+}
+
+/** The caller's IdP subject (OIDC sub, else verified email), or null when unauthenticated. */
+function _CallerSubject(req: Request): string | null
+{
+  const authUser = req.session?.authUser;
+  const sub = typeof authUser?.sub === "string" ? authUser.sub.trim() : "";
+  const email = typeof authUser?.email === "string" ? authUser.email.trim().toLowerCase() : "";
+  return sub || email || null;
+}
+
+/** Deterministic, unique group name for a shared resource — one share-group per resource. */
+function _ResourceGroupName(resourceType: _ResourceTypeStr, resourceId: string): string
+{
+  return `resource:${resourceType}:${resourceId}`;
+}
+
+/** Read a group's `members` JSON as a string list (the canonical stored shape). */
+function _MemberList(members: unknown): string[]
+{
+  return Array.isArray(members) ? members.filter(function _isString(m): m is string { return typeof m === "string"; }) : [];
+}
+
+/** Shape a resource share-group into the API representation. */
+function _ToResourceShare(row: { id: string; name: string; members: unknown })
+{
+  // Group name is `resource:<type>:<id>` — split back into the resource coordinates.
+  const [, resourceType = "", ...idParts] = row.name.split(":");
+  return { groupId: row.id, resourceType, resourceId: idParts.join(":"), members: _MemberList(row.members) };
+}
+
+/**
+ * Inter-user RESOURCE sharing (S4c) — distinct from `/shares` (which shares tool/skill
+ * entitlements). In the unified model a direct share of a file/chat materialises a
+ * **resource-scoped, Personal-tier Group** whose members are everyone the resource is shared
+ * with; the recipient's openclaw Tenant then inherits read access through the derived dataset
+ * membership → Cognee (S4c.2). The sharer must already be a member of the resource's group
+ * (its owner on first share) to add others — no sharing a resource you don't hold.
+ *
+ * @param prisma - Prisma client for the group mirror.
+ * @returns Configured Express router.
+ */
+export function resourceSharesRouter(prisma: PrismaClient): Router
+{
+  const router = Router();
+
+  /** Share a resource with a user — create the resource group (first share) or add the recipient. */
+  router.post("/", async function _shareResource(req: Request, res)
+  {
+    const caller = _CallerSubject(req);
+    if (!caller)
+    {
+      res.status(401).json({ error: "Authentication required to share.", code: "UNAUTHORIZED" });
+      return;
+    }
+
+    const body = (req.body ?? {}) as _ResourceShareBody;
+    const resourceType = body.resourceType as _ResourceTypeStr;
+    const resourceId = typeof body.resourceId === "string" ? body.resourceId.trim() : "";
+    const recipient = typeof body.recipientSubject === "string" ? body.recipientSubject.trim() : "";
+    if (!_RESOURCE_TYPES.includes(resourceType) || !resourceId || !recipient)
+    {
+      res.status(400).json({ error: "resourceType (file|chat|dataset), resourceId, and recipientSubject are required.", code: "VALIDATION_ERROR" });
+      return;
+    }
+
+    const groupName = _ResourceGroupName(resourceType, resourceId);
+    const existing = await prisma.group.findUnique({ where: { name: groupName }, select: { id: true, name: true, members: true } });
+
+    // First share → the caller creates the resource group and is its founding member (owner).
+    if (!existing)
+    {
+      const created = await prisma.group.create({
+        data: {
+          name: groupName,
+          scope: GrantScope.Personal,
+          description: `Direct share of ${resourceType} ${resourceId}`,
+          members: Array.from(new Set([caller, recipient])),
+        },
+        select: { id: true, name: true, members: true },
+      });
+      _log.info({ caller, resourceType, resourceId, recipient, groupId: created.id }, "resource share-group created");
+      res.status(201).json(_ToResourceShare(created));
+      return;
+    }
+
+    // Subsequent share → least-privilege: only a current member may add others (you cannot share
+    // a resource you do not have access to). Then add the recipient if not already present.
+    const members = _MemberList(existing.members);
+    if (!members.includes(caller))
+    {
+      _log.warn({ caller, resourceType, resourceId }, "resource share denied: caller is not a member of the resource group (least-privilege gate)");
+      res.status(403).json({ error: "You can only share a resource you have access to.", code: "FORBIDDEN" });
+      return;
+    }
+    if (members.includes(recipient))
+    {
+      res.status(200).json(_ToResourceShare(existing));
+      return;
+    }
+    const updated = await prisma.group.update({
+      where: { name: groupName },
+      data: { members: [...members, recipient] },
+      select: { id: true, name: true, members: true },
+    });
+    _log.info({ caller, resourceType, resourceId, recipient, groupId: updated.id }, "recipient added to resource share-group");
+    res.status(200).json(_ToResourceShare(updated));
+  });
+
+  /** List the resource share-groups the caller is a member of. */
+  router.get("/", async function _listResourceShares(req: Request, res)
+  {
+    const caller = _CallerSubject(req);
+    if (!caller)
+    {
+      res.status(401).json({ error: "Authentication required.", code: "UNAUTHORIZED" });
+      return;
+    }
+    // Resource groups are the Personal-scoped groups named `resource:*`; filter to the caller's.
+    const groups = await prisma.group.findMany({ where: { scope: GrantScope.Personal, name: { startsWith: "resource:" } }, select: { id: true, name: true, members: true } });
+    res.json(groups.filter(function _mine(g) { return _MemberList(g.members).includes(caller); }).map(_ToResourceShare));
+  });
+
+  /** Revoke a recipient from a resource share — only a current member may unshare. */
+  router.delete("/:groupId/recipients/:subject", async function _unshareResource(req: Request<{ groupId: string; subject: string }>, res)
+  {
+    const caller = _CallerSubject(req);
+    if (!caller)
+    {
+      res.status(401).json({ error: "Authentication required.", code: "UNAUTHORIZED" });
+      return;
+    }
+    const group = await prisma.group.findUnique({ where: { id: req.params.groupId }, select: { id: true, name: true, members: true } });
+    // Not a resource group, or one the caller is not in, is not theirs to modify — fail closed.
+    if (!group || !group.name.startsWith("resource:") || !_MemberList(group.members).includes(caller))
+    {
+      res.status(404).json({ error: "Resource share not found.", code: "NOT_FOUND" });
+      return;
+    }
+    const remaining = _MemberList(group.members).filter(function _notTarget(m) { return m !== req.params.subject; });
+    const updated = await prisma.group.update({ where: { id: req.params.groupId }, data: { members: remaining }, select: { id: true, name: true, members: true } });
+    _log.info({ caller, groupId: req.params.groupId, removed: req.params.subject }, "recipient revoked from resource share-group");
+    res.json(_ToResourceShare(updated));
+  });
+
+  return router;
+}

--- a/apps/control-plane/src/routes/tenants.ts
+++ b/apps/control-plane/src/routes/tenants.ts
@@ -956,14 +956,19 @@ async function _ApplyTenantDatasetMembershipToCognee(
   }
 }
 
-/** Whether two memberships hold the same subjects per tier (order-independent → set compare). */
+/**
+ * Whether two memberships hold the same subjects per tier. Compares as SETS (order- AND
+ * duplicate-independent): the derived side is deduped, but the persisted projection is built
+ * in row order and could carry an accidental duplicate, so comparing distinct sets keeps the
+ * diff-gate from firing a spurious Cognee sync on a semantically-unchanged membership.
+ */
 function _DatasetMembershipEqual(a: TenantDatasetsResponse, b: TenantDatasetsResponse): boolean
 {
   return (["org", "team", "department", "project", "personal"] as const).every(function _sameTier(key)
   {
-    if (a[key].length !== b[key].length) return false;
-    const set = new Set(a[key]);
-    return b[key].every(function _has(subject) { return set.has(subject); });
+    const setA = new Set(a[key]);
+    const setB = new Set(b[key]);
+    return setA.size === setB.size && Array.from(setA).every(function _has(subject) { return setB.has(subject); });
   });
 }
 

--- a/apps/control-plane/src/routes/tenants.ts
+++ b/apps/control-plane/src/routes/tenants.ts
@@ -6,6 +6,7 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 
 import { compile, compileForPrincipals } from "../core/grants/grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "../core/grants/grant-compiler.types.js";
+import { _DeriveTenantDatasetMembership } from "../core/grants/derive-dataset-membership.js";
 import { _CutTenant } from "../core/connections/cut-tenant.js";
 import type { OpenClawGatewayAdmin } from "../core/connections/gateway-admin.types.js";
 import { _IsK8sNotFound } from "../shared/k8s-errors.js";
@@ -953,6 +954,59 @@ async function _ApplyTenantDatasetMembershipToCognee(
   {
     throw new Error(`Cognee permission sync failed with status ${response.status}`);
   }
+}
+
+/** Whether two memberships hold the same subjects per tier (order-independent → set compare). */
+function _DatasetMembershipEqual(a: TenantDatasetsResponse, b: TenantDatasetsResponse): boolean
+{
+  return (["org", "team", "department", "project", "personal"] as const).every(function _sameTier(key)
+  {
+    if (a[key].length !== b[key].length) return false;
+    const set = new Set(a[key]);
+    return b[key].every(function _has(subject) { return set.has(subject); });
+  });
+}
+
+/**
+ * Derive a tenant's dataset memberships from its group expansion (S4c) and, when they differ
+ * from the persisted projection, REPLACE the rows and re-sync Cognee — both in one transaction
+ * with the Cognee call LAST, so the DB and Cognee never drift (a Cognee rejection rolls the
+ * row replacement back). Diff-gated: an unchanged derivation is a no-op with no Cognee write,
+ * so this is safe to call on every contract poll. Cognee sync is skipped when COGNEE_ENDPOINT
+ * is unset (Cognee not deployed) — the DB projection is still updated so other readers converge.
+ *
+ * @param prisma - Prisma client.
+ * @param tenant - The tenant whose memberships are derived.
+ * @param subject - The tenant's bound IdP subject, or null when unbound.
+ * @returns Whether the membership changed (and was written).
+ */
+export async function _SyncDerivedDatasetMembership(prisma: PrismaClient, tenant: string, subject: string | null): Promise<{ changed: boolean }>
+{
+  // 1. Derive the target membership and diff it against the persisted projection.
+  const derived = await _DeriveTenantDatasetMembership(prisma, tenant, subject);
+  const persisted = _BuildTenantDatasetMembershipResponse(
+    await prisma.tenantDatasetMembership.findMany({ where: { tenant }, select: { scope: true, subject: true } }),
+  );
+  if (_DatasetMembershipEqual(derived, persisted))
+  {
+    return { changed: false };
+  }
+
+  // 2. Replace the projection rows; when Cognee is deployed, push the new membership as the LAST
+  //    fallible step in the transaction so a Cognee failure rolls the row replacement back. When
+  //    Cognee is absent, only the projection is updated (no external step to wrap).
+  const rows = _BuildTenantDatasetMembershipRows(tenant, derived);
+  const cogneeConfigured = Boolean(process.env.COGNEE_ENDPOINT?.trim());
+  await prisma.$transaction(async function _replaceDerived(tx)
+  {
+    await tx.tenantDatasetMembership.deleteMany({ where: { tenant } });
+    await tx.tenantDatasetMembership.createMany({ data: rows, skipDuplicates: true });
+    if (cogneeConfigured)
+    {
+      await _ApplyTenantDatasetMembershipToCognee(tenant, derived, undefined);
+    }
+  });
+  return { changed: true };
 }
 
 /**

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -738,6 +738,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/resource-shares": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the file/chat resource shares the caller is a member of */
+        get: operations["listResourceShares"];
+        put?: never;
+        /** Share a file/chat with a user (creates/extends the resource's share group) */
+        post: operations["shareResource"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/resource-shares/{groupId}/recipients/{subject}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Revoke a recipient from a resource share */
+        delete: operations["revokeResourceShare"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/shares": {
         parameters: {
             query?: never;
@@ -1919,6 +1954,16 @@ export interface components {
             sharedBy?: string;
             /** Format: date-time */
             createdAt: string;
+        };
+        /** @description A direct share of a file/chat (S4c): the resource-scoped Personal group whose members can access it. */
+        ResourceShare: {
+            /** @description Id of the resource-scoped share group. */
+            groupId: string;
+            /** @enum {string} */
+            resourceType: "file" | "chat" | "dataset";
+            resourceId: string;
+            /** @description IdP subjects the resource is shared with (incl. the owner). */
+            members: string[];
         };
         SkillBundle: {
             id?: string;
@@ -4680,6 +4725,142 @@ export interface operations {
             };
             /** @description Caller is not an organisation admin. */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listResourceShares: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resource shares the caller is in. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceShare"][];
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    shareResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    resourceType: "file" | "chat" | "dataset";
+                    resourceId: string;
+                    /** @description IdP subject of the user to share with. */
+                    recipientSubject: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Recipient added (or already present). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceShare"];
+                };
+            };
+            /** @description Resource share created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceShare"];
+                };
+            };
+            /** @description Invalid resource share request. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description You can only share a resource you have access to. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    revokeResourceShare: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                groupId: string;
+                subject: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Recipient revoked. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceShare"];
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Resource share not found, or caller is not a member. */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
**Completes S4c** (stacked on #81 / `s4c1-scope-vocab-sync` — retarget to strong-siloes once #81 merges). Implements the unified model you described: **every dataset tier IS a scope-typed IAM Group**, and a **direct file/chat share materialises a resource-scoped Personal group** whose members get read access via the derived dataset → Cognee.

### Three pieces
1. **Derivation** (`core/grants/derive-dataset-membership.ts`) — a tenant's dataset membership at each scope = the union of members of the IAM groups (of that scope) its principal-set `{tenant, subject}` is in. Org = `default` singleton (never enumerated); Personal is populated by per-resource share-groups (not self-only). Pure read, safe to run per-compile.
2. **Diff-gated sync** (`_SyncDerivedDatasetMembership` in tenants.ts, wired fire-and-forget into the internal contract poll) — recompute → diff (set-based, dup-safe) → only when changed, **REPLACE** the projection rows + re-sync Cognee in one `$transaction` (Cognee LAST → DB↔Cognee never drift). Skips Cognee when `COGNEE_ENDPOINT` unset; never delays/fails the pod's contract response; writes nothing when unchanged.
3. **Resource-group sharing** (`/resource-shares` + `oc share resource|resources|unshare-resource`) — a direct share creates/extends a Personal-tier Group around the file/chat; least-privilege: only a current member may add/remove others (founding sharer owns). Distinct from `/shares` (tool/skill grants).

### Validation
494 control-plane tests (derive ×5, sync ×3, resource-shares ×7, + existing); cp/cli/contracts build clean. Fresh-context **security review**: no Critical/High security regressions — derivation can't over-grant, transaction rollback correct, resource-share least-privilege confirmed. Review follow-ups folded in (dup-safe diff; Department derive test).

> Note: built on `s4c2-cognee-derive` (the `s4c-cognee-derivation` name is held on origin by a concurrent S4d-refactor branch).