### PR TITLE
🔒️ Superadmin Zitadel SA-key rotation (validate-then-swap)

### DIFF
--- a/apps/cli/src/commands/admin.ts
+++ b/apps/cli/src/commands/admin.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from "fs";
+
+import type { Command } from "commander";
+
+import type { CliConfig } from "../config.js";
+import { _MakeClient } from "../config.js";
+import { _PrintApiError, _PrintSuccess } from "../format.js";
+
+/**
+ * Register all `oc admin *` sub-commands on the given parent Command.
+ *
+ * This group is gated platform-operator — the control-plane enforces the IAM
+ * check; the CLI just surfaces the outcome.
+ *
+ * @param parent    - The root commander program.
+ * @param getConfig - Lazily resolves the CLI config (base URL + auth) per invocation.
+ */
+export function _RegisterAdmin(parent: Command, getConfig: () => CliConfig): void
+{
+  const admin = parent
+    .command("admin")
+    .description("Superadmin operations (platform-operator gated)");
+
+  _registerZitadel(admin, getConfig);
+}
+
+/**
+ * Register all `oc admin zitadel *` sub-commands on the given parent Command.
+ *
+ * @param parent    - The `admin` commander sub-command.
+ * @param getConfig - Lazily resolves the CLI config (base URL + auth) per invocation.
+ */
+function _registerZitadel(parent: Command, getConfig: () => CliConfig): void
+{
+  const zitadel = parent
+    .command("zitadel")
+    .description("Zitadel platform-admin operations (service-account key management)");
+
+  zitadel
+    .command("rotate-key")
+    .description(
+      "Validate and rotate the platform Zitadel service-account key. "
+      + "The candidate key is validated (jwt-bearer exchange + instance IAM_OWNER probe) before it goes live. "
+      + "On validation failure the old key stays active and the command exits non-zero.",
+    )
+    .option("--key-file <path>", "Path to the Zitadel SA key JSON file (preferred — keeps key material off the shell history)")
+    .option("--key <json>", "Zitadel SA key as a raw JSON string (use --key-file in production)")
+    .action(async function _rotateKey(opts: { keyFile?: string; key?: string })
+    {
+      // 1. Resolve the candidate key JSON from --key-file, --key, or stdin.
+      //    Never echo key material; it travels in the request body only.
+      let serviceAccountKey: string;
+
+      if (opts.keyFile)
+      {
+        // Read from file — the safest path: nothing appears in shell history or process args.
+        serviceAccountKey = readFileSync(opts.keyFile, "utf8").trim();
+      }
+      else if (opts.key)
+      {
+        // Inline JSON provided via --key.
+        serviceAccountKey = opts.key;
+      }
+      else
+      {
+        // Fall back to stdin so operators can pipe the key file.
+        serviceAccountKey = await _readStdin();
+      }
+
+      // 2. Validate that we actually received something before hitting the wire.
+      if (!serviceAccountKey)
+      {
+        console.error("error: admin zitadel rotate-key — provide a key via --key-file <path>, --key <json>, or stdin.");
+        process.exit(1);
+      }
+
+      // 3. POST the candidate key to the control-plane rotate endpoint.
+      const client = _MakeClient(getConfig());
+      const { data, error, response } = await client.POST("/admin/zitadel/sa-key:rotate", {
+        body: { serviceAccountKey },
+      });
+
+      // 4. Transport / HTTP error (network failure, 400, 403, 409, etc.).
+      if (error)
+      {
+        _PrintApiError("admin zitadel rotate-key", error);
+      }
+
+      // 5. Validation failure (422) — key was not accepted, old key is still live.
+      //    Surface the validation flags so the operator can see exactly why it failed.
+      if (response.status === 422 || (data && !data.rotated))
+      {
+        const v = data?.validation;
+        console.error("error: admin zitadel rotate-key — candidate key failed validation; no change was made.");
+        if (v)
+        {
+          console.error(`  tokenExchangeOk  : ${String(v.tokenExchangeOk)}`);
+          console.error(`  instanceScopeOk  : ${String(v.instanceScopeOk)}`);
+          if (v.detail) { console.error(`  detail           : ${v.detail}`); }
+        }
+        process.exit(1);
+      }
+
+      // 6. Success — the new key is live. Print the key-id pair (never the material itself).
+      _PrintSuccess(`Zitadel SA key rotated successfully.`);
+      console.log(`  newKeyId      : ${data?.keyId ?? "(unknown)"}`);
+      console.log(`  previousKeyId : ${data?.previousKeyId ?? "(none)"}`);
+    });
+}
+
+/**
+ * Consume all of stdin and return the contents as a trimmed string.
+ * Used when neither --key-file nor --key is supplied.
+ */
+async function _readStdin(): Promise<string>
+{
+  // 1. Collect incoming chunks into a buffer list to avoid string concatenation overhead.
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin)
+  {
+    chunks.push(Buffer.from(chunk as Buffer));
+  }
+
+  // 2. Join all chunks and decode as UTF-8.
+  return Buffer.concat(chunks).toString("utf8").trim();
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -27,6 +27,7 @@ import { Command } from "commander";
 import { ___ShutdownTelemetry } from "@opencrane/observability";
 
 import { type CliConfig, _ResolveConfig } from "./config.js";
+import { _RegisterAdmin } from "./commands/admin.js";
 import { _RegisterAudit } from "./commands/audit.js";
 import { _RegisterAuth } from "./commands/auth.js";
 import { _RegisterAwareness } from "./commands/awareness.js";
@@ -75,6 +76,7 @@ function _getConfig(): CliConfig
 }
 
 // Register all command groups against the root program.
+_RegisterAdmin(program, _getConfig);
 _RegisterTenants(program, _getConfig);
 _RegisterClusterTenants(program, _getConfig);
 _RegisterPolicies(program, _getConfig);

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -2107,6 +2107,77 @@
             "description": "Minimum polling interval in seconds (5)."
           }
         }
+      },
+      "ZitadelCandidateKeyValidation": {
+        "type": "object",
+        "required": [
+          "tokenExchangeOk",
+          "instanceScopeOk",
+          "keyId",
+          "detail"
+        ],
+        "properties": {
+          "tokenExchangeOk": {
+            "type": "boolean",
+            "description": "Whether the candidate key's jwt-bearer token exchange succeeded."
+          },
+          "instanceScopeOk": {
+            "type": "boolean",
+            "description": "Whether the candidate key passed the non-destructive instance IAM_OWNER probe."
+          },
+          "keyId": {
+            "type": "string",
+            "nullable": true,
+            "description": "The candidate key's keyId, or null when the key was malformed."
+          },
+          "detail": {
+            "type": "string",
+            "description": "Human-readable validation detail (never contains key material)."
+          }
+        }
+      },
+      "ZitadelKeyRotateRequest": {
+        "type": "object",
+        "required": [
+          "serviceAccountKey"
+        ],
+        "properties": {
+          "serviceAccountKey": {
+            "description": "The candidate Zitadel service-account key — a JSON string (the downloaded key file) or the equivalent JSON object.",
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object"
+              }
+            ]
+          }
+        }
+      },
+      "ZitadelKeyRotateResult": {
+        "type": "object",
+        "required": [
+          "rotated",
+          "validation"
+        ],
+        "properties": {
+          "rotated": {
+            "type": "boolean",
+            "description": "True only when the live key was replaced (both validation flags passed and the Secret persisted)."
+          },
+          "keyId": {
+            "type": "string",
+            "description": "The newly-active key's keyId (present only when rotated)."
+          },
+          "previousKeyId": {
+            "type": "string",
+            "description": "The keyId that was active before the swap (present only when rotated)."
+          },
+          "validation": {
+            "$ref": "#/components/schemas/ZitadelCandidateKeyValidation"
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -2123,6 +2194,78 @@
     }
   ],
   "paths": {
+    "/admin/zitadel/sa-key:rotate": {
+      "post": {
+        "operationId": "rotateZitadelSaKey",
+        "summary": "Rotate the platform Zitadel service-account key (validate-then-swap; superadmin only)",
+        "description": "Validates the candidate key against the live instance (jwt-bearer exchange + a non-destructive instance IAM_OWNER probe) and swaps the live key ONLY when both pass; on any validation failure the old key stays active (422). Platform-operator gated.",
+        "tags": [
+          "Admin"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ZitadelKeyRotateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The candidate was validated, persisted, and made live.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZitadelKeyRotateResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request body did not include a usable `serviceAccountKey`.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not a platform operator.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Key-Secret persistence is not configured (ZITADEL_MGMT_SECRET_NAME unset); rotation refused.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "The candidate key failed validation (token exchange or instance IAM_OWNER scope); no change was made.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/platform/dns": {
       "get": {
         "operationId": "getPlatformDns",

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants-org-admin-gate.test.ts
@@ -14,6 +14,9 @@ const _fakeZitadel: ZitadelManagementClient = {
   async provisionOrg(input) { return { orgId: "z", projectId: "p", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
   async setAppRedirectUris() { /* no-op */ },
   async teardownOrg() { /* no-op */ },
+  async validateCandidateKey() { return { tokenExchangeOk: true, instanceScopeOk: true, keyId: "k", detail: "ok" }; },
+  currentKeyId() { return "k"; },
+  reloadKey() { /* no-op */ },
 };
 
 /**

--- a/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenants.test.ts
@@ -17,6 +17,9 @@ function _fakeZitadel(): ZitadelManagementClient
     async provisionOrg(input) { return { orgId: "zorg-test", projectId: "zproj-test", appId: "zapp-test", clientId: "zclient-test", redirectUri: input.redirectUri }; },
     async setAppRedirectUris() { /* no-op */ },
     async teardownOrg() { /* no-op */ },
+    async validateCandidateKey() { return { tokenExchangeOk: true, instanceScopeOk: true, keyId: "k", detail: "ok" }; },
+    currentKeyId() { return "k"; },
+    reloadKey() { /* no-op */ },
   };
 }
 
@@ -374,6 +377,9 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
       },
       async setAppRedirectUris(input) { redirectCalls.push(input); },
       async teardownOrg() { /* no-op */ },
+    async validateCandidateKey() { return { tokenExchangeOk: true, instanceScopeOk: true, keyId: "k", detail: "ok" }; },
+    currentKeyId() { return "k"; },
+    reloadKey() { /* no-op */ },
     };
     return { client, calls, redirectCalls };
   }
@@ -405,6 +411,9 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
       async provisionOrg() { throw new Error("zitadel rejected: org name taken"); },
       async setAppRedirectUris() { /* no-op */ },
       async teardownOrg() { /* no-op */ },
+    async validateCandidateKey() { return { tokenExchangeOk: true, instanceScopeOk: true, keyId: "k", detail: "ok" }; },
+    currentKeyId() { return "k"; },
+    reloadKey() { /* no-op */ },
     };
     const app = _buildApp(_mockPrisma(store), _mockRegistry(false), null, { sub: "owner-1", email: "owner@acme.test" }, throwing);
 
@@ -425,6 +434,9 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
       async provisionOrg(input) { return { orgId: "z", projectId: "p", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
       async setAppRedirectUris() { /* no-op */ },
       async teardownOrg() { teardownCalled = true; throw new Error("zitadel unreachable"); },
+      async validateCandidateKey() { return { tokenExchangeOk: true, instanceScopeOk: true, keyId: "k", detail: "ok" }; },
+      currentKeyId() { return "k"; },
+      reloadKey() { /* no-op */ },
     };
     // No session → dev-auth bypass for the org-manager gate (matches the CRUD test), so the
     // delete handler runs and we exercise the transactional teardown directly.
@@ -475,6 +487,9 @@ describe("clusterTenantsRouter — Zitadel org provisioning (S3 / Phase 2a)", fu
       async provisionOrg(input) { return { orgId: "z", projectId: "p", appId: "a", clientId: "c", redirectUri: input.redirectUri }; },
       async setAppRedirectUris() { syncCalled = true; throw new Error("zitadel unreachable"); },
       async teardownOrg() { /* no-op */ },
+    async validateCandidateKey() { return { tokenExchangeOk: true, instanceScopeOk: true, keyId: "k", detail: "ok" }; },
+    currentKeyId() { return "k"; },
+    reloadKey() { /* no-op */ },
     };
     const app = _buildApp(_mockPrisma(store), _mockRegistry(false), null, undefined, throwingSync);
 

--- a/apps/control-plane/src/__tests__/routes/zitadel-key-rotate.test.ts
+++ b/apps/control-plane/src/__tests__/routes/zitadel-key-rotate.test.ts
@@ -1,0 +1,209 @@
+import express from "express";
+import type { Express } from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _log } from "../../log.js";
+import { zitadelKeyRouter } from "../../routes/admin/zitadel-key.js";
+import type { ZitadelKeySecretStore } from "../../infra/zitadel/key-secret-store.js";
+import type { ZitadelCandidateKeyValidation, ZitadelManagementClient } from "../../infra/zitadel/zitadel-client.types.js";
+
+/**
+ * Security-critical matrix for the platform Zitadel SA-key rotation (the master IdP
+ * credential). The whole point is the SAFE-ROTATION invariant: the live key is swapped ONLY
+ * when the candidate validates (token exchange + instance IAM_OWNER) AND persists; otherwise
+ * the old key stays active and neither the Secret nor the in-memory key changes.
+ */
+
+/** A spyable Zitadel client double; `validation` controls the candidate-validation result. */
+function _fakeClient(validation: ZitadelCandidateKeyValidation): {
+  client: ZitadelManagementClient;
+  reloadKey: ReturnType<typeof vi.fn>;
+  validateCandidateKey: ReturnType<typeof vi.fn>;
+}
+{
+  const reloadKey = vi.fn();
+  const validateCandidateKey = vi.fn(async function _v() { return validation; });
+  const client = {
+    async provisionOrg() { throw new Error("unused"); },
+    async setAppRedirectUris() { /* unused */ },
+    async teardownOrg() { /* unused */ },
+    validateCandidateKey,
+    currentKeyId() { return "old-key-id"; },
+    reloadKey,
+  } as unknown as ZitadelManagementClient;
+  return { client, reloadKey, validateCandidateKey };
+}
+
+/** A spyable secret-store double. */
+function _fakeStore(opts: { configured?: boolean; persistThrows?: boolean } = {}): { store: ZitadelKeySecretStore; persistKey: ReturnType<typeof vi.fn> }
+{
+  const persistKey = vi.fn(async function _p() { if (opts.persistThrows) { throw new Error("secret patch failed"); } });
+  const store: ZitadelKeySecretStore = {
+    isConfigured() { return opts.configured ?? true; },
+    persistKey,
+  };
+  return { store, persistKey };
+}
+
+/** A passing validation result (both flags true). */
+const _OK: ZitadelCandidateKeyValidation = { tokenExchangeOk: true, instanceScopeOk: true, keyId: "new-key-id", detail: "ok" };
+
+/** Session user shape (subset of the OIDC session user). */
+interface User { sub: string; isPlatformOperator: boolean }
+
+/** Mount the router, optionally seeding a session user. */
+function _buildApp(client: ZitadelManagementClient, store: ZitadelKeySecretStore, user?: User): Express
+{
+  const app = express();
+  app.use(express.json());
+  if (user)
+  {
+    app.use(function _seedSession(req, _res, next) { (req as unknown as { session: { authUser: User } }).session = { authUser: user }; next(); });
+  }
+  app.use("/api/v1/admin/zitadel", zitadelKeyRouter(client, store));
+  return app;
+}
+
+describe("zitadelKeyRouter — POST /sa-key:rotate (safe-rotation gate)", function _suite()
+{
+  // Force REAL-auth mode so the platform-operator gate fail-closes for non-operators.
+  const _AUTH_ENV = ["OPENCRANE_API_TOKEN", "OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET", "OIDC_REDIRECT_URI", "OIDC_SESSION_SECRET"] as const;
+  const _saved: Record<string, string | undefined> = {};
+
+  beforeEach(function _enableAuth()
+  {
+    for (const key of _AUTH_ENV) { _saved[key] = process.env[key]; delete process.env[key]; }
+    process.env.OPENCRANE_API_TOKEN = "ci-token";
+  });
+
+  afterEach(function _restoreEnv()
+  {
+    for (const key of _AUTH_ENV) { if (_saved[key] === undefined) { delete process.env[key]; } else { process.env[key] = _saved[key]; } }
+  });
+
+  it("rotates only when both validation flags pass: persists FIRST, then reloads the live key", async function _rotates()
+  {
+    const { client, reloadKey, validateCandidateKey } = _fakeClient(_OK);
+    const { store, persistKey } = _fakeStore({ configured: true });
+    const res = await request(_buildApp(client, store, { sub: "op", isPlatformOperator: true }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: "{\"keyId\":\"new-key-id\"}" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ rotated: true, keyId: "new-key-id", previousKeyId: "old-key-id" });
+    expect(validateCandidateKey).toHaveBeenCalledOnce();
+    // Persist-first: the Secret write happened before the in-memory swap.
+    expect(persistKey).toHaveBeenCalledOnce();
+    expect(reloadKey).toHaveBeenCalledOnce();
+    expect(persistKey.mock.invocationCallOrder[0]).toBeLessThan(reloadKey.mock.invocationCallOrder[0]);
+  });
+
+  it("returns 422 and makes NO change when the instance-scope probe fails", async function _scopeFail()
+  {
+    const { client, reloadKey } = _fakeClient({ tokenExchangeOk: true, instanceScopeOk: false, keyId: "new-key-id", detail: "scope" });
+    const { store, persistKey } = _fakeStore({ configured: true });
+    const res = await request(_buildApp(client, store, { sub: "op", isPlatformOperator: true }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: "{}" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.rotated).toBe(false);
+    // The old key stays active: neither persisted nor reloaded.
+    expect(persistKey).not.toHaveBeenCalled();
+    expect(reloadKey).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 and makes NO change when the token exchange fails", async function _tokenFail()
+  {
+    const { client, reloadKey } = _fakeClient({ tokenExchangeOk: false, instanceScopeOk: false, keyId: null, detail: "token" });
+    const { store, persistKey } = _fakeStore({ configured: true });
+    const res = await request(_buildApp(client, store, { sub: "op", isPlatformOperator: true }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: "{}" });
+
+    expect(res.status).toBe(422);
+    expect(persistKey).not.toHaveBeenCalled();
+    expect(reloadKey).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reload the live key when persistence fails AFTER a passing validation (500, old key stays)", async function _persistFails()
+  {
+    const { client, reloadKey } = _fakeClient(_OK);
+    const { store } = _fakeStore({ configured: true, persistThrows: true });
+    const res = await request(_buildApp(client, store, { sub: "op", isPlatformOperator: true }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: "{}" });
+
+    expect(res.status).toBe(500);
+    expect(res.body.code).toBe("KEY_PERSIST_FAILED");
+    // Persist-first guarantee: a failed persist must NEVER reach the in-memory swap.
+    expect(reloadKey).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 (and never validates) when key-Secret persistence is not configured", async function _notConfigured()
+  {
+    const { client, validateCandidateKey, reloadKey } = _fakeClient(_OK);
+    const { store, persistKey } = _fakeStore({ configured: false });
+    const res = await request(_buildApp(client, store, { sub: "op", isPlatformOperator: true }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: "{}" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("SECRET_PERSISTENCE_NOT_CONFIGURED");
+    expect(validateCandidateKey).not.toHaveBeenCalled();
+    expect(persistKey).not.toHaveBeenCalled();
+    expect(reloadKey).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for a non-operator (platform-operator gate, fail-closed)", async function _nonOperator()
+  {
+    const { client, validateCandidateKey } = _fakeClient(_OK);
+    const { store } = _fakeStore({ configured: true });
+    const res = await request(_buildApp(client, store, { sub: "user-1", isPlatformOperator: false }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: "{}" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("FORBIDDEN_NOT_PLATFORM_OPERATOR");
+    // The gate fires before any work — the candidate is never validated.
+    expect(validateCandidateKey).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for an anonymous caller under real-auth mode (fail-closed)", async function _anon()
+  {
+    const { client } = _fakeClient(_OK);
+    const { store } = _fakeStore({ configured: true });
+    const res = await request(_buildApp(client, store)).post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: "{}" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("never logs the candidate key material on either the rotate or the reject path", async function _noSecretLog()
+  {
+    const secret = "{\"keyId\":\"new-key-id\",\"key\":\"-----BEGIN RSA PRIVATE KEY-----SUPER-SECRET-PEM-----END RSA PRIVATE KEY-----\",\"userId\":\"u1\"}";
+    const seen: unknown[] = [];
+    const infoSpy = vi.spyOn(_log, "info").mockImplementation(((obj: unknown) => { seen.push(obj); return _log; }) as never);
+    const warnSpy = vi.spyOn(_log, "warn").mockImplementation(((obj: unknown) => { seen.push(obj); return _log; }) as never);
+
+    // Rotate (success) path.
+    const ok = _fakeClient(_OK);
+    await request(_buildApp(ok.client, _fakeStore({ configured: true }).store, { sub: "op", isPlatformOperator: true }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: secret });
+    // Reject (422) path.
+    const bad = _fakeClient({ tokenExchangeOk: false, instanceScopeOk: false, keyId: null, detail: "token" });
+    await request(_buildApp(bad.client, _fakeStore({ configured: true }).store, { sub: "op", isPlatformOperator: true }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: secret });
+
+    const serialised = JSON.stringify(seen);
+    expect(serialised).not.toContain("SUPER-SECRET-PEM");
+    expect(serialised).not.toContain("BEGIN RSA PRIVATE KEY");
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("returns 400 when the request omits a usable serviceAccountKey", async function _badBody()
+  {
+    const { client } = _fakeClient(_OK);
+    const { store } = _fakeStore({ configured: true });
+    const res = await request(_buildApp(client, store, { sub: "op", isPlatformOperator: true }))
+      .post("/api/v1/admin/zitadel/sa-key:rotate").send({ serviceAccountKey: "   " });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("INVALID_REQUEST");
+  });
+});

--- a/apps/control-plane/src/__tests__/zitadel/zitadel-client.test.ts
+++ b/apps/control-plane/src/__tests__/zitadel/zitadel-client.test.ts
@@ -135,6 +135,105 @@ describe("_HttpZitadelManagementClient — live provisioning lifecycle (injected
   });
 });
 
+describe("_HttpZitadelManagementClient.validateCandidateKey — safe-rotation gate (injected fetch)", function _validateSuite()
+{
+  /** A candidate-validation fetch fake: token exchange + the instance IAM_OWNER probe. */
+  function _validatorFetch(opts: { tokenStatus?: number; tokenBody?: unknown; probeStatus?: number } = {}): { fetchImpl: typeof fetch; calls: string[] }
+  {
+    const calls: string[] = [];
+    const fetchImpl = (async function _f(url: string, init: { method?: string }) {
+      const path = url.replace(/^https:\/\/[^/]+/, "");
+      calls.push(`${init?.method ?? "GET"} ${path}`);
+      if (path === "/oauth/v2/token")
+      {
+        const status = opts.tokenStatus ?? 200;
+        const body = opts.tokenBody ?? { access_token: "cand-tok", expires_in: 3600 };
+        return { ok: status < 400, status, json: async () => body, text: async () => JSON.stringify(body) };
+      }
+      if (path === "/admin/v1/instances/me")
+      {
+        const status = opts.probeStatus ?? 200;
+        return { ok: status < 400, status, json: async () => ({}), text: async () => "{}" };
+      }
+      return { ok: true, status: 200, json: async () => ({}), text: async () => "{}" };
+    }) as unknown as typeof fetch;
+    return { fetchImpl, calls };
+  }
+
+  it("returns both flags true when the token exchange AND the instance IAM_OWNER probe succeed", async function _bothOk()
+  {
+    const { fetchImpl, calls } = _validatorFetch({});
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: _saKeyJson(), baseDomain: "d" }, fetchImpl);
+
+    const result = await client.validateCandidateKey(_saKeyJson());
+
+    expect(result.tokenExchangeOk).toBe(true);
+    expect(result.instanceScopeOk).toBe(true);
+    expect(result.keyId).toBe("k1");
+    // The probe is the read-only Admin API instance read (org-managers can't call it).
+    expect(calls).toContain("GET /admin/v1/instances/me");
+  });
+
+  it("returns tokenExchangeOk=false (and skips the probe) when the token exchange fails", async function _tokenFail()
+  {
+    const { fetchImpl, calls } = _validatorFetch({ tokenStatus: 401 });
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: _saKeyJson(), baseDomain: "d" }, fetchImpl);
+
+    const result = await client.validateCandidateKey(_saKeyJson());
+
+    expect(result.tokenExchangeOk).toBe(false);
+    expect(result.instanceScopeOk).toBe(false);
+    // A failed token exchange must short-circuit — the IAM_OWNER probe is never attempted.
+    expect(calls).not.toContain("GET /admin/v1/instances/me");
+  });
+
+  it("returns instanceScopeOk=false when the key authenticates but lacks instance IAM_OWNER (403)", async function _scopeFail()
+  {
+    const { fetchImpl } = _validatorFetch({ probeStatus: 403 });
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: _saKeyJson(), baseDomain: "d" }, fetchImpl);
+
+    const result = await client.validateCandidateKey(_saKeyJson());
+
+    expect(result.tokenExchangeOk).toBe(true);
+    expect(result.instanceScopeOk).toBe(false);
+  });
+
+  it("flags a malformed candidate key (no throw) and never touches the network", async function _malformed()
+  {
+    const { fetchImpl, calls } = _validatorFetch({});
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: _saKeyJson(), baseDomain: "d" }, fetchImpl);
+
+    const result = await client.validateCandidateKey("{}");
+
+    expect(result).toEqual({ tokenExchangeOk: false, instanceScopeOk: false, keyId: null, detail: expect.stringContaining("malformed") });
+    expect(calls).toHaveLength(0);
+  });
+
+  it("does NOT mutate the live key/token cache while validating a candidate", async function _noMutation()
+  {
+    const { fetchImpl } = _validatorFetch({});
+    const liveKey = _saKeyJson();
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: liveKey, baseDomain: "d" }, fetchImpl);
+
+    const before = client.currentKeyId();
+    await client.validateCandidateKey(_saKeyJson()); // a DIFFERENT key (fresh keypair, same keyId "k1")
+    expect(client.currentKeyId()).toBe(before);
+  });
+
+  it("reloadKey swaps the live key id and rejects a malformed key", async function _reload()
+  {
+    const { fetchImpl } = _validatorFetch({});
+    const client = new _HttpZitadelManagementClient({ apiUrl: "https://z.example.com", serviceAccountKey: _saKeyJson(), baseDomain: "d" }, fetchImpl);
+
+    const { privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const pem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+    client.reloadKey(JSON.stringify({ type: "serviceaccount", keyId: "k2", key: pem, userId: "u2" }));
+    expect(client.currentKeyId()).toBe("k2");
+
+    expect(() => client.reloadKey("{}")).toThrow(/service-account key/);
+  });
+});
+
 describe("_DeriveOrgRedirectUri", function _deriveSuite()
 {
   it("derives the per-org callback URI from the org name + base domain", function _derives()

--- a/apps/control-plane/src/infra/middleware/require-platform-operator.ts
+++ b/apps/control-plane/src/infra/middleware/require-platform-operator.ts
@@ -1,0 +1,62 @@
+import type { RequestHandler } from "express";
+
+import { _IsDevAuthMode } from "../auth/auth-mode.js";
+
+/**
+ * Authorization guard restricting a route to the PLATFORM OPERATOR — the fleet-wide
+ * superadmin (env-seeded via `OPENCRANE_PLATFORM_OPERATOR_GROUPS` / seed email; see
+ * `_ResolveIdentityClaims`). This is the strongest gate in the control-plane and is the
+ * only acceptable gate for the master IdP-credential rotation route: a per-org owner/admin
+ * must NEVER be able to rotate the platform's Zitadel service-account key.
+ *
+ * IAM-first: the decision is derived purely from the caller's IdP-verified session
+ * (`session.authUser.isPlatformOperator`), never from request input.
+ *
+ * Posture, mirroring `_RequireOrgAdmin` / `_IsDevAuthMode`:
+ *   1. No established session — FAIL OPEN under dev mode (no OIDC and no
+ *      `OPENCRANE_API_TOKEN`, so a fresh local install / the OPEN dev backend isn't
+ *      locked out); FAIL CLOSED otherwise (403) — a real deployment must never let an
+ *      unauthenticated or token-only caller reach a superadmin action.
+ *   2. Session present — allow iff `isPlatformOperator`; else 403.
+ *
+ * TODO (S5): `isPlatformOperator` is the non-presumptuous, config-driven stopgap until
+ * OpenCrane has a role model. This MUST tighten to a first-class super-admin role once that
+ * model lands — operating the fleet and holding the master IdP credential are distinct grants.
+ *
+ * @returns Express middleware that continues for platform operators and rejects others (403).
+ */
+export function _RequirePlatformOperator(): RequestHandler
+{
+  /** Express handler: allow the verified platform operator (or dev-mode bypass), else 403. */
+  return function _platformOperatorHandler(req, res, next)
+  {
+    const authUser = req.session?.authUser;
+
+    // 1. No session — honour the auth posture: dev-mode opens the bypass, real auth denies.
+    if (!authUser)
+    {
+      if (_IsDevAuthMode())
+      {
+        next();
+        return;
+      }
+      _deny(res);
+      return;
+    }
+
+    // 2. Established session — allow only the platform operator (the fleet superadmin).
+    if (authUser.isPlatformOperator === true)
+    {
+      next();
+      return;
+    }
+
+    _deny(res);
+  };
+}
+
+/** Emit the canonical 403 envelope; never leak which specific check failed. */
+function _deny(res: Parameters<RequestHandler>[1]): void
+{
+  res.status(403).json({ error: "Platform operator role required.", code: "FORBIDDEN_NOT_PLATFORM_OPERATOR" });
+}

--- a/apps/control-plane/src/infra/zitadel/key-secret-store.ts
+++ b/apps/control-plane/src/infra/zitadel/key-secret-store.ts
@@ -1,0 +1,107 @@
+import * as k8s from "@kubernetes/client-node";
+
+import { _log } from "../../log.js";
+
+/**
+ * Persistence seam for the platform's Zitadel service-account key, backed by the Kubernetes
+ * Secret the control-plane pod mounts into `ZITADEL_MGMT_SA_KEY`. Key rotation MUST persist
+ * the validated candidate here BEFORE the in-memory swap, so a pod restart keeps the new key
+ * (an in-memory-only swap would silently revert to the old key on the next restart).
+ *
+ * Config is read from env so a misconfigured deploy fails loud, not silently in-memory-only:
+ *   - `ZITADEL_MGMT_SECRET_NAME`  — the Secret carrying the SA key (REQUIRED to enable rotation).
+ *   - `ZITADEL_MGMT_SECRET_KEY`   — the data key within the Secret (default `service-account-key`).
+ *   - `NAMESPACE`                 — the namespace the Secret lives in (default `default`).
+ */
+export interface ZitadelKeySecretStore
+{
+  /**
+   * Whether key persistence is configured (the Secret name env is set). When false the rotate
+   * route must refuse (the orchestrator returns 409/501) rather than swap in-memory only.
+   */
+  isConfigured(): boolean;
+
+  /**
+   * Patch the validated candidate key JSON into the backing Secret (JSON-merge patch,
+   * base64-encoded value). Throws on any API failure so the caller leaves the live key
+   * untouched (persist-first: a failed persist means no in-memory swap).
+   *
+   * @param serviceAccountKeyJson - The validated candidate SA key JSON to persist.
+   */
+  persistKey(serviceAccountKeyJson: string): Promise<void>;
+}
+
+/** Read-only view of the resolved Secret coordinates (null name ⇒ not configured). */
+interface _SecretCoordinates
+{
+  /** The Secret name, or null when `ZITADEL_MGMT_SECRET_NAME` is unset. */
+  name: string | null;
+  /** The data key within the Secret holding the SA key JSON. */
+  dataKey: string;
+  /** The namespace the Secret lives in. */
+  namespace: string;
+}
+
+/** Resolve the Secret coordinates from the environment (live read). */
+function _ReadSecretCoordinates(): _SecretCoordinates
+{
+  const name = process.env.ZITADEL_MGMT_SECRET_NAME?.trim() || null;
+  const dataKey = process.env.ZITADEL_MGMT_SECRET_KEY?.trim() || "service-account-key";
+  const namespace = process.env.NAMESPACE?.trim() || "default";
+  return { name, dataKey, namespace };
+}
+
+/** Live, k8s-backed implementation of {@link ZitadelKeySecretStore}. */
+export class _K8sZitadelKeySecretStore implements ZitadelKeySecretStore
+{
+  /** Injectable CoreV1Api (the live client in prod; a fake in tests). */
+  private readonly coreApi: k8s.CoreV1Api;
+  /** Resolved Secret coordinates (snapshotted at construction). */
+  private readonly coords: _SecretCoordinates;
+
+  /**
+   * @param coreApi - Kubernetes Core V1 API client used to patch the Secret.
+   * @param coords  - Optional pre-resolved coordinates (defaults to an env read); tests inject.
+   */
+  public constructor(coreApi: k8s.CoreV1Api, coords: _SecretCoordinates = _ReadSecretCoordinates())
+  {
+    this.coreApi = coreApi;
+    this.coords = coords;
+  }
+
+  public isConfigured(): boolean
+  {
+    return this.coords.name !== null;
+  }
+
+  public async persistKey(serviceAccountKeyJson: string): Promise<void>
+  {
+    // 1. Refuse loud when unconfigured — the caller must have checked isConfigured(); this is
+    //    the defence-in-depth guard so a misconfigured deploy can never persist nowhere.
+    if (this.coords.name === null)
+    {
+      throw new Error("ZITADEL_MGMT_SECRET_NAME is not set; cannot persist the rotated key");
+    }
+
+    // 2. JSON-merge-patch the single data key (base64-encoded). A merge patch leaves every
+    //    other key in the Secret intact, so a Secret carrying more than the SA key is safe.
+    const body = { data: { [this.coords.dataKey]: Buffer.from(serviceAccountKeyJson, "utf8").toString("base64") } };
+    await this.coreApi.patchNamespacedSecret(
+      { name: this.coords.name, namespace: this.coords.namespace, body },
+      k8s.setHeaderOptions("Content-Type", k8s.PatchStrategy.MergePatch),
+    );
+    _log.info({ secretName: this.coords.name, namespace: this.coords.namespace, dataKey: this.coords.dataKey }, "zitadel key rotation: persisted rotated key to backing Secret");
+  }
+}
+
+/**
+ * Build the live k8s-backed key-secret store. Always returns a store; whether persistence is
+ * actually configured is exposed via `isConfigured()` so the rotate route can fail loud
+ * (409/501) on a misconfigured deploy rather than swap in-memory only.
+ *
+ * @param coreApi - Kubernetes Core V1 API client used to patch the Secret.
+ */
+export function _BuildZitadelKeySecretStore(coreApi: k8s.CoreV1Api): ZitadelKeySecretStore
+{
+  return new _K8sZitadelKeySecretStore(coreApi);
+}

--- a/apps/control-plane/src/infra/zitadel/zitadel-client.ts
+++ b/apps/control-plane/src/infra/zitadel/zitadel-client.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 
 import { _log } from "../../log.js";
-import type { ZitadelProvisionOrgInput, ZitadelProvisionOrgResult, ZitadelSetRedirectUrisInput, ZitadelClientConfig, ZitadelManagementClient } from "./zitadel-client.types.js";
+import type { ZitadelCandidateKeyValidation, ZitadelProvisionOrgInput, ZitadelProvisionOrgResult, ZitadelSetRedirectUrisInput, ZitadelClientConfig, ZitadelManagementClient } from "./zitadel-client.types.js";
 
 export type { ZitadelClientConfig };
 
@@ -11,6 +11,47 @@ interface _ServiceAccountKey
   keyId: string;
   key: string;
   userId: string;
+}
+
+/**
+ * Parse + validate a Zitadel SA key JSON into the fields the jwt-bearer signer needs.
+ * Throws on a malformed key (missing keyId/key/userId) — the single guard shared by the
+ * constructor and `reloadKey` so the malformed-key rule cannot drift between them.
+ *
+ * @param serviceAccountKeyJson - The raw SA key JSON string.
+ */
+function _ParseServiceAccountKey(serviceAccountKeyJson: string): _ServiceAccountKey
+{
+  const parsed = JSON.parse(serviceAccountKeyJson) as Partial<_ServiceAccountKey>;
+  if (!parsed.keyId || !parsed.key || !parsed.userId)
+  {
+    throw new Error("Zitadel service-account key is invalid (missing keyId/key/userId)");
+  }
+  return { keyId: parsed.keyId, key: parsed.key, userId: parsed.userId };
+}
+
+/** URL-safe base64 of a string or buffer (JWT segments / signatures). */
+function _b64urlSegment(input: string | Buffer): string
+{
+  return Buffer.from(input).toString("base64url");
+}
+
+/**
+ * Build + RS256-sign a service-account jwt-bearer assertion for the given key + audience.
+ * Pure (no `this`) so it serves both the live client and the throwaway candidate signer in
+ * `validateCandidateKey` — the candidate path must NEVER touch the live key/token cache.
+ *
+ * @param saKey  - The parsed SA key to sign with.
+ * @param apiUrl - The Zitadel instance base URL (the assertion audience).
+ */
+function _SignServiceAccountAssertion(saKey: _ServiceAccountKey, apiUrl: string): string
+{
+  const nowSec = Math.floor(Date.now() / 1000);
+  const header = _b64urlSegment(JSON.stringify({ alg: "RS256", kid: saKey.keyId }));
+  const claims = _b64urlSegment(JSON.stringify({ iss: saKey.userId, sub: saKey.userId, aud: apiUrl, iat: nowSec, exp: nowSec + 300 }));
+  const signingInput = `${header}.${claims}`;
+  const signature = _b64urlSegment(crypto.sign("RSA-SHA256", Buffer.from(signingInput), saKey.key));
+  return `${signingInput}.${signature}`;
 }
 
 /** Scope that requests an access token audience-bound to the Zitadel management API. */
@@ -46,8 +87,11 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
 {
   /** Trailing-slash-trimmed Zitadel instance base URL. */
   private readonly apiUrl: string;
-  /** Parsed service-account key used to sign the jwt-bearer assertion. */
-  private readonly saKey: _ServiceAccountKey;
+  /**
+   * Parsed service-account key used to sign the jwt-bearer assertion. Mutable: an atomic
+   * in-memory swap via {@link reloadKey} replaces it on key rotation (the only writer).
+   */
+  private saKey: _ServiceAccountKey;
   /** Injectable HTTP transport (global `fetch` in prod; a fake in tests). */
   private readonly fetchImpl: typeof fetch;
   /** Cached management access token + its refresh deadline (epoch ms). */
@@ -61,12 +105,96 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
   {
     this.apiUrl = config.apiUrl.replace(/\/+$/, "");
     this.fetchImpl = fetchImpl;
-    const parsed = JSON.parse(config.serviceAccountKey) as Partial<_ServiceAccountKey>;
-    if (!parsed.keyId || !parsed.key || !parsed.userId)
+    this.saKey = _ParseServiceAccountKey(config.serviceAccountKey);
+  }
+
+  public async validateCandidateKey(serviceAccountKeyJson: string): Promise<ZitadelCandidateKeyValidation>
+  {
+    // 1. Parse the candidate into a THROWAWAY signer. A malformed key is an expected
+    //    validation failure (not a transport error), so report it as a flagged result —
+    //    never mutate the live key/token cache and never throw here.
+    let candidate: _ServiceAccountKey;
+    try
     {
-      throw new Error("ZITADEL_MGMT_SA_KEY is not a valid Zitadel service-account key (missing keyId/key/userId)");
+      candidate = _ParseServiceAccountKey(serviceAccountKeyJson);
     }
-    this.saKey = { keyId: parsed.keyId, key: parsed.key, userId: parsed.userId };
+    catch (err)
+    {
+      _log.warn({ err }, "zitadel key rotation: candidate key is malformed (rejected, no change)");
+      return { tokenExchangeOk: false, instanceScopeOk: false, keyId: null, detail: "candidate key is malformed (missing keyId/key/userId)" };
+    }
+
+    // 2. Exchange the candidate for an access token via the jwt-bearer profile, using a
+    //    fresh assertion signed with the CANDIDATE key. A non-OK exchange means the key is
+    //    not trusted by the instance — a flagged failure, not an exception.
+    let candidateToken: string;
+    try
+    {
+      const assertion = _SignServiceAccountAssertion(candidate, this.apiUrl);
+      const res = await this.fetchImpl(`${this.apiUrl}/oauth/v2/token`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer", assertion, scope: _MGMT_SCOPE }),
+      });
+      if (!res.ok)
+      {
+        _log.warn({ keyId: candidate.keyId, status: res.status }, "zitadel key rotation: candidate token exchange failed (rejected, no change)");
+        return { tokenExchangeOk: false, instanceScopeOk: false, keyId: candidate.keyId, detail: `token exchange failed (${res.status})` };
+      }
+      const json = await res.json() as { access_token?: string };
+      if (!json.access_token)
+      {
+        _log.warn({ keyId: candidate.keyId }, "zitadel key rotation: candidate token exchange returned no access_token (rejected, no change)");
+        return { tokenExchangeOk: false, instanceScopeOk: false, keyId: candidate.keyId, detail: "token exchange returned no access_token" };
+      }
+      candidateToken = json.access_token;
+    }
+    catch (err)
+    {
+      // Unexpected transport error (network/DNS) — surface it; the route maps this to a 5xx.
+      _log.error({ keyId: candidate.keyId, err }, "zitadel key rotation: transport error during candidate token exchange");
+      throw err;
+    }
+
+    // 3. Non-destructive instance-`IAM_OWNER` probe: GET /admin/v1/instances/me. The Admin
+    //    API is instance-scoped and an org-level manager cannot call it, so a 200 here proves
+    //    the candidate holds the instance IAM_OWNER the platform's provisioning path depends
+    //    on; a 401/403 proves it authenticated but lacks the scope (flagged, not thrown).
+    try
+    {
+      const probe = await this.fetchImpl(`${this.apiUrl}/admin/v1/instances/me`, {
+        method: "GET",
+        headers: { authorization: `Bearer ${candidateToken}` },
+      });
+      if (!probe.ok)
+      {
+        _log.warn({ keyId: candidate.keyId, status: probe.status }, "zitadel key rotation: candidate lacks instance IAM_OWNER scope (rejected, no change)");
+        return { tokenExchangeOk: true, instanceScopeOk: false, keyId: candidate.keyId, detail: `instance IAM_OWNER probe failed (${probe.status})` };
+      }
+      _log.info({ keyId: candidate.keyId }, "zitadel key rotation: candidate validated (token exchange + instance IAM_OWNER probe OK)");
+      return { tokenExchangeOk: true, instanceScopeOk: true, keyId: candidate.keyId, detail: "candidate key validated: token exchange + instance IAM_OWNER probe succeeded" };
+    }
+    catch (err)
+    {
+      _log.error({ keyId: candidate.keyId, err }, "zitadel key rotation: transport error during instance IAM_OWNER probe");
+      throw err;
+    }
+  }
+
+  public currentKeyId(): string
+  {
+    return this.saKey.keyId;
+  }
+
+  public reloadKey(serviceAccountKeyJson: string): void
+  {
+    // Atomic in-memory swap: re-parse (malformed → throw, no partial state) then drop the
+    // cached token so the next call re-authenticates with the new key. Single assignment, so
+    // an in-flight call either sees the old key+token fully or the new key with a fresh token.
+    const next = _ParseServiceAccountKey(serviceAccountKeyJson);
+    this.saKey = next;
+    this._cachedToken = null;
+    _log.info({ keyId: next.keyId }, "zitadel key rotation: live service-account key swapped + token cache cleared");
   }
 
   public async provisionOrg(input: ZitadelProvisionOrgInput): Promise<ZitadelProvisionOrgResult>
@@ -233,12 +361,7 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
   /** Build + RS256-sign the service-account assertion JWT (iss/sub = SA userId, aud = instance). */
   private _signServiceAccountJwt(): string
   {
-    const nowSec = Math.floor(Date.now() / 1000);
-    const header = _b64url(JSON.stringify({ alg: "RS256", kid: this.saKey.keyId }));
-    const claims = _b64url(JSON.stringify({ iss: this.saKey.userId, sub: this.saKey.userId, aud: this.apiUrl, iat: nowSec, exp: nowSec + 300 }));
-    const signingInput = `${header}.${claims}`;
-    const signature = _b64url(crypto.sign("RSA-SHA256", Buffer.from(signingInput), this.saKey.key));
-    return `${signingInput}.${signature}`;
+    return _SignServiceAccountAssertion(this.saKey, this.apiUrl);
   }
 }
 
@@ -281,10 +404,4 @@ export function _DeriveOrgRedirectUri(orgName: string, baseDomain: string): stri
 export function _DeriveVanityRedirectUri(vanityDomain: string): string
 {
   return `https://${vanityDomain}/api/v1/auth/callback`;
-}
-
-/** URL-safe base64 of a string or buffer (JWT segments / signatures). */
-function _b64url(input: string | Buffer): string
-{
-  return Buffer.from(input).toString("base64url");
 }

--- a/apps/control-plane/src/infra/zitadel/zitadel-client.types.ts
+++ b/apps/control-plane/src/infra/zitadel/zitadel-client.types.ts
@@ -51,6 +51,28 @@ export interface ZitadelSetRedirectUrisInput
   redirectUris: string[];
 }
 
+/**
+ * Granular result of validating a CANDIDATE service-account key — the security gate
+ * the key-rotation feature requires before swapping the platform's master IdP credential.
+ *
+ * Both flags must be true for the candidate to be accepted: `tokenExchangeOk` proves the
+ * key can authenticate (jwt-bearer exchange succeeds), and `instanceScopeOk` proves the key
+ * holds the instance-level `IAM_OWNER` scope the platform depends on (org create/delete) —
+ * a key that authenticates but only holds an org-level role would silently break
+ * provisioning, so the scope probe is non-negotiable.
+ */
+export interface ZitadelCandidateKeyValidation
+{
+  /** Whether the jwt-bearer token exchange succeeded with the candidate key. */
+  tokenExchangeOk: boolean;
+  /** Whether the candidate key passed the non-destructive instance-`IAM_OWNER` probe. */
+  instanceScopeOk: boolean;
+  /** The candidate key's `keyId` when the key parsed, else null (malformed/unparseable). */
+  keyId: string | null;
+  /** Human-readable detail for logging/response (never contains key material). */
+  detail: string;
+}
+
 /** The Zitadel identifiers persisted onto the ClusterTenant row after provisioning. */
 export interface ZitadelProvisionOrgResult
 {
@@ -89,4 +111,31 @@ export interface ZitadelManagementClient
 
   /** Tear down a previously-provisioned org (tolerates an already-absent org). */
   teardownOrg(orgId: string): Promise<void>;
+
+  /**
+   * Validate a CANDIDATE service-account key WITHOUT touching the live client's key or
+   * token cache. Builds a throwaway signer from the candidate, performs a jwt-bearer token
+   * exchange, then a NON-DESTRUCTIVE instance-`IAM_OWNER` probe (`GET /admin/v1/instances/me`,
+   * which an org-level manager cannot call). Returns granular flags; it NEVER throws for an
+   * expected validation failure (bad key, wrong scope) — only for unexpected transport errors.
+   *
+   * The driver of key rotation: the live key is swapped (via {@link reloadKey}) ONLY after
+   * this returns `tokenExchangeOk && instanceScopeOk`.
+   *
+   * @param serviceAccountKeyJson - The candidate SA key JSON to validate.
+   */
+  validateCandidateKey(serviceAccountKeyJson: string): Promise<ZitadelCandidateKeyValidation>;
+
+  /** The `keyId` of the live service-account key — captured for the rotation audit trail. */
+  currentKeyId(): string;
+
+  /**
+   * Atomically swap the live client's service-account key to the given candidate and clear
+   * the cached access token, so every subsequent call authenticates with the new key. Called
+   * ONLY after the candidate has been validated AND persisted to the backing Secret, so a
+   * process restart keeps the new key. Throws only on a malformed key (missing keyId/key/userId).
+   *
+   * @param serviceAccountKeyJson - The validated candidate SA key JSON to make live.
+   */
+  reloadKey(serviceAccountKeyJson: string): void;
 }

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -855,6 +855,36 @@ export const spec = {
       ThirdPartySource: ThirdPartySourceSchema,
       TokenUsage: TokenUsageSchema,
       DeviceGrant: DeviceGrantSchema,
+      ZitadelCandidateKeyValidation: {
+        type: "object",
+        required: ["tokenExchangeOk", "instanceScopeOk", "keyId", "detail"],
+        properties: {
+          tokenExchangeOk: { type: "boolean", description: "Whether the candidate key's jwt-bearer token exchange succeeded." },
+          instanceScopeOk: { type: "boolean", description: "Whether the candidate key passed the non-destructive instance IAM_OWNER probe." },
+          keyId: { type: "string", nullable: true, description: "The candidate key's keyId, or null when the key was malformed." },
+          detail: { type: "string", description: "Human-readable validation detail (never contains key material)." },
+        },
+      },
+      ZitadelKeyRotateRequest: {
+        type: "object",
+        required: ["serviceAccountKey"],
+        properties: {
+          serviceAccountKey: {
+            description: "The candidate Zitadel service-account key — a JSON string (the downloaded key file) or the equivalent JSON object.",
+            oneOf: [{ type: "string" }, { type: "object" }],
+          },
+        },
+      },
+      ZitadelKeyRotateResult: {
+        type: "object",
+        required: ["rotated", "validation"],
+        properties: {
+          rotated: { type: "boolean", description: "True only when the live key was replaced (both validation flags passed and the Secret persisted)." },
+          keyId: { type: "string", description: "The newly-active key's keyId (present only when rotated)." },
+          previousKeyId: { type: "string", description: "The keyId that was active before the swap (present only when rotated)." },
+          validation: { $ref: "#/components/schemas/ZitadelCandidateKeyValidation" },
+        },
+      },
     },
     securitySchemes: {
       bearerAuth: {
@@ -866,6 +896,30 @@ export const spec = {
   },
   security: [{ bearerAuth: [] }],
   paths: {
+
+    // ------------------------------------------------------------------
+    // Admin — Zitadel SA key rotation (superadmin / platform-operator only)
+    // ------------------------------------------------------------------
+
+    "/admin/zitadel/sa-key:rotate": {
+      post: {
+        operationId: "rotateZitadelSaKey",
+        summary: "Rotate the platform Zitadel service-account key (validate-then-swap; superadmin only)",
+        description: "Validates the candidate key against the live instance (jwt-bearer exchange + a non-destructive instance IAM_OWNER probe) and swaps the live key ONLY when both pass; on any validation failure the old key stays active (422). Platform-operator gated.",
+        tags: ["Admin"],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { $ref: "#/components/schemas/ZitadelKeyRotateRequest" } } },
+        },
+        responses: {
+          200: ok("The candidate was validated, persisted, and made live.", { $ref: "#/components/schemas/ZitadelKeyRotateResult" }),
+          400: badRequest("The request body did not include a usable `serviceAccountKey`."),
+          403: forbidden("Caller is not a platform operator."),
+          409: conflict("Key-Secret persistence is not configured (ZITADEL_MGMT_SECRET_NAME unset); rotation refused."),
+          422: unprocessable("The candidate key failed validation (token exchange or instance IAM_OWNER scope); no change was made."),
+        },
+      },
+    },
 
     // ------------------------------------------------------------------
     // Platform DNS / TLS issuance (CONN.8a)

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -44,6 +44,8 @@ import { platformDnsRouter } from "./routes/platform-dns.js";
 import { clusterTenantsRouter } from "./routes/cluster-tenants.js";
 import { _BuildClusterTenantProvisionerRegistry } from "./core/cluster-tenants/registry.js";
 import { _BuildZitadelManagementClient } from "./infra/zitadel/zitadel-client.js";
+import { _BuildZitadelKeySecretStore } from "./infra/zitadel/key-secret-store.js";
+import { zitadelKeyRouter } from "./routes/admin/zitadel-key.js";
 import { _CheckDbHealth } from "./infra/db/healtcheck-db.js";
 
 /**
@@ -155,6 +157,10 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
     // so a single-cluster install (manager off) never requires it; fail-loud if unset.
     const zitadelClient = _BuildZitadelManagementClient();
     app.use("/api/v1/cluster-tenants", clusterTenantsRouter(prisma, clusterTenantRegistry, customApi, zitadelClient));
+    // Superadmin-gated rotation of the platform's Zitadel SA key (the master IdP credential).
+    // Mounted here, on the manager-enabled path, because that is the ONLY place the live
+    // Zitadel client exists; the key Secret is patched via the same CoreV1Api the app uses.
+    app.use("/api/v1/admin/zitadel", zitadelKeyRouter(zitadelClient, _BuildZitadelKeySecretStore(coreApi)));
   }
   app.use("/api/v1/awareness/rollout", awarenessRolloutRouter(prisma));
   app.use("/api/v1/awareness/participation", awarenessParticipationRouter(prisma));

--- a/apps/control-plane/src/routes/admin/zitadel-key.ts
+++ b/apps/control-plane/src/routes/admin/zitadel-key.ts
@@ -1,0 +1,120 @@
+import { Router } from "express";
+
+import { _RequirePlatformOperator } from "../../infra/middleware/require-platform-operator.js";
+import type { ZitadelKeySecretStore } from "../../infra/zitadel/key-secret-store.js";
+import type { ZitadelManagementClient } from "../../infra/zitadel/zitadel-client.types.js";
+import { _log } from "../../log.js";
+
+/**
+ * Normalise the request body's candidate key into a JSON string. The route accepts either a
+ * JSON STRING (the downloaded SA key file content) or an already-parsed OBJECT (a client that
+ * posted the parsed key), and re-serialises an object so the downstream signer always gets a
+ * string. Returns null when the field is absent or an empty/blank string (a 400 input error).
+ *
+ * @param raw - The `serviceAccountKey` field from the request body.
+ */
+function _NormaliseCandidateKey(raw: unknown): string | null
+{
+  if (typeof raw === "string")
+  {
+    return raw.trim() === "" ? null : raw;
+  }
+  if (raw && typeof raw === "object")
+  {
+    return JSON.stringify(raw);
+  }
+  return null;
+}
+
+/**
+ * Superadmin-gated router for rotating the platform's Zitadel service-account key — the master
+ * IdP credential. The whole point of this route is the SAFE-ROTATION invariant: the live key is
+ * swapped ONLY AFTER the candidate is proven (a) able to authenticate and (b) holding the
+ * instance-level `IAM_OWNER` scope the platform depends on. If validation fails the route
+ * returns 422 with NO change and the old key stays active.
+ *
+ * Mounted at `/api/v1/admin/zitadel`, behind {@link _RequirePlatformOperator}. Only the
+ * multi-tenant (cluster-tenant manager) path constructs the Zitadel client, so this router is
+ * mounted only there (see `routes.ts`).
+ *
+ * @param client      - The LIVE Zitadel management client; validated candidates are swapped into it.
+ * @param secretStore - Persistence for the SA key Secret; persist-first so a restart keeps the new key.
+ * @returns Configured Express router.
+ */
+export function zitadelKeyRouter(client: ZitadelManagementClient, secretStore: ZitadelKeySecretStore): Router
+{
+  const router = Router();
+
+  router.use(_RequirePlatformOperator());
+
+  /**
+   * Rotate the platform Zitadel SA key. Body: `{ serviceAccountKey: string | object }`.
+   * Flow: validate → (persist → reload) on success, 422 (no change) on validation failure.
+   */
+  router.post("/sa-key:rotate", async function _rotateSaKey(req, res)
+  {
+    // 1. Normalise + validate the input shape (a missing/blank candidate is a 400, not a 422 —
+    //    422 is reserved for a well-formed candidate that FAILED the live validation gate).
+    const candidate = _NormaliseCandidateKey((req.body as { serviceAccountKey?: unknown } | undefined)?.serviceAccountKey);
+    if (candidate === null)
+    {
+      res.status(400).json({ error: "Request body must include a non-empty `serviceAccountKey` (JSON string or object).", code: "INVALID_REQUEST" });
+      return;
+    }
+
+    // 2. Refuse loud when persistence is not configured — an in-memory-only swap would silently
+    //    revert to the old key on the next pod restart, so a misconfigured deploy must fail here
+    //    rather than appear to rotate. Checked BEFORE validation so we never validate-then-strand.
+    if (!secretStore.isConfigured())
+    {
+      _log.warn({}, "zitadel key rotation: refused — key-Secret persistence not configured (ZITADEL_MGMT_SECRET_NAME unset)");
+      res.status(409).json({ error: "Key-Secret persistence is not configured; cannot rotate the Zitadel service-account key safely.", code: "SECRET_PERSISTENCE_NOT_CONFIGURED" });
+      return;
+    }
+
+    // 3. Validate the candidate against the live instance: jwt-bearer exchange + a
+    //    non-destructive instance-`IAM_OWNER` probe. A transport error here is a 5xx (thrown).
+    let validation;
+    try
+    {
+      validation = await client.validateCandidateKey(candidate);
+    }
+    catch (err)
+    {
+      _log.error({ err }, "zitadel key rotation: transport error validating candidate key (no change)");
+      res.status(502).json({ error: "Failed to reach Zitadel to validate the candidate key; no change was made.", code: "ZITADEL_UNREACHABLE" });
+      return;
+    }
+
+    // 4. SAFE-ROTATION gate: accept ONLY when BOTH the token exchange and the instance scope
+    //    probe pass. Anything less leaves the live key untouched and returns 422.
+    if (!validation.tokenExchangeOk || !validation.instanceScopeOk)
+    {
+      _log.warn({ keyId: validation.keyId, tokenExchangeOk: validation.tokenExchangeOk, instanceScopeOk: validation.instanceScopeOk }, "zitadel key rotation: candidate REJECTED — validation failed (live key unchanged)");
+      res.status(422).json({ rotated: false, validation });
+      return;
+    }
+
+    // 5. Capture the outgoing keyId for the audit trail before the swap, then PERSIST FIRST:
+    //    if the Secret write fails we must NOT swap in-memory (else memory and Secret diverge,
+    //    and a restart reverts the live key). A persist failure is a 5xx — old key stays active.
+    const previousKeyId = client.currentKeyId();
+    try
+    {
+      await secretStore.persistKey(candidate);
+    }
+    catch (err)
+    {
+      _log.error({ keyId: validation.keyId, err }, "zitadel key rotation: candidate validated but persisting to the Secret FAILED (live key unchanged)");
+      res.status(500).json({ error: "The candidate key was valid but could not be persisted; no change was made.", code: "KEY_PERSIST_FAILED" });
+      return;
+    }
+
+    // 6. Persisted — now make the validated key live (atomic in-memory swap + token-cache clear).
+    client.reloadKey(candidate);
+    _log.info({ keyId: validation.keyId, previousKeyId }, "zitadel key rotation: ROTATED — live service-account key replaced after validation + persistence");
+    res.status(200).json({ rotated: true, keyId: validation.keyId, previousKeyId, validation });
+  });
+
+  return router;
+}

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -4,6 +4,26 @@
  */
 
 export interface paths {
+    "/admin/zitadel/sa-key:rotate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rotate the platform Zitadel service-account key (validate-then-swap; superadmin only)
+         * @description Validates the candidate key against the live instance (jwt-bearer exchange + a non-destructive instance IAM_OWNER probe) and swaps the live key ONLY when both pass; on any validation failure the old key stays active (422). Platform-operator gated.
+         */
+        post: operations["rotateZitadelSaKey"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/platform/dns": {
         parameters: {
             query?: never;
@@ -2452,6 +2472,29 @@ export interface components {
             /** @description Minimum polling interval in seconds (5). */
             interval: number;
         };
+        ZitadelCandidateKeyValidation: {
+            /** @description Whether the candidate key's jwt-bearer token exchange succeeded. */
+            tokenExchangeOk: boolean;
+            /** @description Whether the candidate key passed the non-destructive instance IAM_OWNER probe. */
+            instanceScopeOk: boolean;
+            /** @description The candidate key's keyId, or null when the key was malformed. */
+            keyId: string | null;
+            /** @description Human-readable validation detail (never contains key material). */
+            detail: string;
+        };
+        ZitadelKeyRotateRequest: {
+            /** @description The candidate Zitadel service-account key — a JSON string (the downloaded key file) or the equivalent JSON object. */
+            serviceAccountKey: string | Record<string, never>;
+        };
+        ZitadelKeyRotateResult: {
+            /** @description True only when the live key was replaced (both validation flags passed and the Secret persisted). */
+            rotated: boolean;
+            /** @description The newly-active key's keyId (present only when rotated). */
+            keyId?: string;
+            /** @description The keyId that was active before the swap (present only when rotated). */
+            previousKeyId?: string;
+            validation: components["schemas"]["ZitadelCandidateKeyValidation"];
+        };
     };
     responses: never;
     parameters: never;
@@ -2461,6 +2504,66 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    rotateZitadelSaKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ZitadelKeyRotateRequest"];
+            };
+        };
+        responses: {
+            /** @description The candidate was validated, persisted, and made live. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ZitadelKeyRotateResult"];
+                };
+            };
+            /** @description The request body did not include a usable `serviceAccountKey`. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is not a platform operator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Key-Secret persistence is not configured (ZITADEL_MGMT_SECRET_NAME unset); rotation refused. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The candidate key failed validation (token exchange or instance IAM_OWNER scope); no change was made. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getPlatformDns: {
         parameters: {
             query?: {

--- a/platform/helm/templates/control-plane-deployment.yaml
+++ b/platform/helm/templates/control-plane-deployment.yaml
@@ -184,6 +184,14 @@ spec:
                 secretKeyRef:
                   name: {{ .existingSecret }}
                   key: {{ .serviceAccountKeyKey | default "service-account-key" }}
+            # -- Key-rotation support: the superadmin rotate endpoint needs to know
+            #    which Secret to patch and which data key carries the SA-key JSON, so
+            #    it can write the newly issued key back in-place without config drift.
+            #    Paired with the Role/RoleBinding in control-plane-zitadel-rotation-rbac.yaml.
+            - name: ZITADEL_MGMT_SECRET_NAME
+              value: {{ .existingSecret | quote }}
+            - name: ZITADEL_MGMT_SECRET_KEY
+              value: {{ .serviceAccountKeyKey | default "service-account-key" | quote }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/platform/helm/templates/control-plane-zitadel-rotation-rbac.yaml
+++ b/platform/helm/templates/control-plane-zitadel-rotation-rbac.yaml
@@ -1,9 +1,10 @@
 {{- /*
   Superadmin Zitadel SA-key rotation RBAC (S4 key-rotation feature).
 
-  When the control-plane needs to rotate its own Zitadel service-account key
-  in-place (via the superadmin API), it must be able to `get` the current key
-  from the Secret and `patch` it with the newly issued one.
+  When the control-plane rotates its own Zitadel service-account key in-place
+  (via the superadmin API), it `patch`es the Secret with the newly issued key
+  after validating it. (The current key is read from env at boot, not from the
+  k8s API, so no `get` is needed — least privilege.)
 
   Rendered ONLY when:
     - clusterTenantManager.enabled is true  (the feature lives in the multi-tenant path)
@@ -23,12 +24,13 @@ metadata:
   labels:
     {{- include "opencrane.labels" . | nindent 4 }}
 rules:
-  # Superadmin key-rotation: the control-plane reads the current SA-key JSON and
-  # patches it with the newly issued key after a successful Zitadel rotation call.
+  # Superadmin key-rotation: the control-plane PATCHES the SA-key Secret with the
+  # newly issued key after validating it (the in-use key is read from env at boot,
+  # not via the k8s API, so `get` is intentionally NOT granted — least privilege).
   # Locked to the single named Secret that carries the SA key — never all secrets.
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "patch"]
+    verbs: ["patch"]
     resourceNames:
       - {{ .Values.controlPlane.zitadel.existingSecret | quote }}
 ---

--- a/platform/helm/templates/control-plane-zitadel-rotation-rbac.yaml
+++ b/platform/helm/templates/control-plane-zitadel-rotation-rbac.yaml
@@ -1,0 +1,50 @@
+{{- /*
+  Superadmin Zitadel SA-key rotation RBAC (S4 key-rotation feature).
+
+  When the control-plane needs to rotate its own Zitadel service-account key
+  in-place (via the superadmin API), it must be able to `get` the current key
+  from the Secret and `patch` it with the newly issued one.
+
+  Rendered ONLY when:
+    - clusterTenantManager.enabled is true  (the feature lives in the multi-tenant path)
+    - controlPlane.zitadel.existingSecret is set  (there is a Secret to rotate)
+
+  The Role is scoped to a single named Secret via `resourceNames`, so the
+  control-plane SA cannot read or write any other Secret in the release namespace.
+  This is a namespaced Role + RoleBinding (NOT ClusterRole/ClusterRoleBinding).
+*/}}
+{{- if and .Values.clusterTenantManager.enabled .Values.controlPlane.zitadel.existingSecret }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "opencrane.fullname" . }}-control-plane-zitadel-rotation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+rules:
+  # Superadmin key-rotation: the control-plane reads the current SA-key JSON and
+  # patches it with the newly issued key after a successful Zitadel rotation call.
+  # Locked to the single named Secret that carries the SA key — never all secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "patch"]
+    resourceNames:
+      - {{ .Values.controlPlane.zitadel.existingSecret | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "opencrane.fullname" . }}-control-plane-zitadel-rotation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "opencrane.fullname" . }}-control-plane-zitadel-rotation
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "opencrane.fullname" . }}-control-plane
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -232,8 +232,16 @@ controlPlane:
   # -- Zitadel Management API (S3 / Phase 2a). When mgmtApiUrl is set, the control-plane
   #    provisions a per-org Zitadel Organization + OIDC app on ClusterTenant create.
   #    Empty (default) → org provisioning is a no-op (orgs created without a Zitadel org).
-  #    NOTE: the live management client ships in a follow-up S3 slice; setting these today
-  #    is wired through but still no-ops (logged), so it is safe to leave configured.
+  #    The live management client is active and provisions per-org Zitadel orgs when a
+  #    ClusterTenant is created (shipped in S3; no longer a no-op).
+  #
+  #    Key rotation: when existingSecret is set AND clusterTenantManager.enabled is true,
+  #    the chart renders a namespaced Role + RoleBinding
+  #    (control-plane-zitadel-rotation-rbac.yaml) granting the control-plane ServiceAccount
+  #    `get` and `patch` on that single named Secret. This lets the superadmin key-rotation
+  #    API overwrite the SA-key JSON in-place after issuing a new key via Zitadel, without
+  #    requiring broad secrets access. The Secret name and data key are also surfaced to
+  #    the pod as ZITADEL_MGMT_SECRET_NAME / ZITADEL_MGMT_SECRET_KEY.
   zitadel:
     # -- Zitadel instance base URL (e.g. https://weownai-oidc-8dwlat.eu1.zitadel.cloud).
     #    REQUIRED when clusterTenantManager.enabled (the control-plane hard-commits to
@@ -242,6 +250,7 @@ controlPlane:
     # -- Existing K8s Secret carrying the service-account key JSON (jwt-bearer auth). The
     #    service account MUST hold instance-level IAM_OWNER (per-org create/delete is an
     #    instance privilege). Key name configurable below.
+    #    When set, also enables the key-rotation Role/RoleBinding (see note above).
     existingSecret: ""
     serviceAccountKeyKey: service-account-key
 


### PR DESCRIPTION
Superadmin-gated rotation of the platform's master Zitadel service-account key. **The live key rotates ONLY after the candidate is confirmed (a) working and (b) holding instance `IAM_OWNER`** — otherwise 422, no change, the old key stays active.

## Flow — `POST /api/v1/admin/zitadel/sa-key:rotate` (platform-operator gated)
1. `validateCandidateKey` — a **throwaway signer** (never touches the live key/token cache) does a jwt-bearer token exchange, then a non-destructive instance-IAM_OWNER probe (`GET /admin/v1/instances/me` — Admin API is instance-scoped; an org-manager 403s). Token vs scope flagged separately.
2. **Only if both pass** → persist the new key to the `existingSecret` (k8s patch) **first**, then atomic in-memory `reloadKey` (so a restart keeps the new key). Persist unconfigured → 409 fail-loud (never silent in-memory-only); persist fails → 500, no reload.
3. Any validation failure → 422 `{ rotated:false, validation }`, zero change. Old Zitadel key stays valid until the superadmin revokes it.

## Surface
- **API + tests:** `validateCandidateKey`/`reloadKey`/`currentKeyId` on the client; `_RequirePlatformOperator` (fail-closed; tightens to a real super-admin role in S5); `key-secret-store` (injectable CoreV1Api); OpenAPI `rotateZitadelSaKey` + contracts. **494 control-plane tests** incl. rotate-only-when-both-flags-pass, no-secret-patch/reload on failure, never-logs-key-material, 403 gates.
- **Helm:** tightly-scoped **Role/RoleBinding** (`patch` on the *one* named Secret via `resourceNames`, namespaced) bound to the CP ServiceAccount, rendered only when manager-enabled + `existingSecret` set; +secret-name/key env; fixed the stale 'no-op' values comment.
- **CLI:** `oc admin zitadel rotate-key` (`--key-file` | `--key` | stdin); surfaces the validation detail on rejection; never echoes key material.

## Built by 4 agents (sized to task)
heavy (core TS) + light (Helm RBAC) in parallel → light (CLI) → review. Security review: **no Critical/High**; the one Medium (RBAC granted an unused `get`) folded in — dropped to **patch-only** (least privilege).

This is the prod key-rotation answer (replacing manual secret-roll + restart). Base = strong-siloes.