### PR TITLE
✨ S5 (first slice): Linkerd identity substrate — gated, off by default

### DIFF
--- a/apps/operator/src/__tests__/fixtures.ts
+++ b/apps/operator/src/__tests__/fixtures.ts
@@ -49,6 +49,7 @@ export const defaultConfig: OpenClawTenantOperatorConfig = {
   obotDeploymentName: "opencrane-mcp-gateway",
   skillRegistryDeploymentName: "opencrane-skill-registry",
   projectedTokenTtlSeconds: 600,
+  linkerdMeshEnabled: false,
 };
 
 /**

--- a/apps/operator/src/__tests__/runtime-planes/drift-repairer.test.ts
+++ b/apps/operator/src/__tests__/runtime-planes/drift-repairer.test.ts
@@ -47,6 +47,7 @@ function _buildConfig(overrides: Partial<OpenClawTenantOperatorConfig> = {}): Op
     obotDeploymentName: "opencrane-mcp-gateway",
     skillRegistryDeploymentName: "opencrane-skill-registry",
     projectedTokenTtlSeconds: 600,
+    linkerdMeshEnabled: false,
     ...overrides,
   };
 }

--- a/apps/operator/src/__tests__/tenants/linkerd-identity.client.test.ts
+++ b/apps/operator/src/__tests__/tenants/linkerd-identity.client.test.ts
@@ -1,0 +1,71 @@
+import type * as k8s from "@kubernetes/client-node";
+import type { Logger } from "pino";
+import { describe, expect, it, vi } from "vitest";
+
+import { _BuildSiloLinkerdIdentityPolicy } from "../../tenants/deploy/silo-linkerd-identity.js";
+import { LinkerdIdentityClient } from "../../tenants/internal/linkerd-identity.client.js";
+import { defaultConfig } from "../fixtures.js";
+
+/** A 404 the API server returns when a Linkerd policy CRD type is NOT served (Linkerd absent). */
+const _CRD_ABSENT = Object.assign(new Error("the server could not find the requested resource"), { code: 404, body: { message: "the server could not find the requested resource" } });
+/** A 404 the API server returns when the TARGET NAMESPACE is missing (CRDs present). */
+const _NAMESPACE_MISSING = Object.assign(new Error("namespaces \"opencrane-acme\" not found"), { code: 404, body: { reason: "NotFound", message: "namespaces \"opencrane-acme\" not found", details: { kind: "namespaces", name: "opencrane-acme" } } });
+/** A 409 error matching the client's conflict shape. */
+const _CONFLICT = Object.assign(new Error("already exists"), { code: 409 });
+
+/** No-op logger so the fail-closed warn path is exercised without console noise. */
+const _LOG = { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() } as unknown as Logger;
+
+/** A representative bundle for the silo `opencrane-acme`. */
+const _BUNDLE = _BuildSiloLinkerdIdentityPolicy("opencrane-acme", "acme", { ...defaultConfig, operatorNamespace: "opencrane-system" });
+
+describe("LinkerdIdentityClient — silo identity policy apply (fail-closed on absent Linkerd)", function _suite()
+{
+  it("creates all three policy objects as namespaced custom objects (Server, MeshTLS, AuthzPolicy)", async function _create()
+  {
+    const createNamespacedCustomObject = vi.fn().mockResolvedValue({});
+    const customApi = { createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    const result = await new LinkerdIdentityClient(customApi, _LOG).applySiloIdentityPolicy("opencrane-acme", _BUNDLE);
+
+    expect(result).toEqual({ applied: true });
+    expect(createNamespacedCustomObject).toHaveBeenCalledTimes(3);
+    const plurals = createNamespacedCustomObject.mock.calls.map(c => c[0].plural);
+    expect(plurals).toEqual(["servers", "meshtlsauthentications", "authorizationpolicies"]);
+  });
+
+  it("gates applied:false when a Linkerd policy CRD is absent (unserved-type 404) — never throws", async function _crdAbsent()
+  {
+    const createNamespacedCustomObject = vi.fn().mockRejectedValue(_CRD_ABSENT);
+    const customApi = { createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    const result = await new LinkerdIdentityClient(customApi, _LOG).applySiloIdentityPolicy("opencrane-acme", _BUNDLE);
+
+    // First object's absent CRD short-circuits the whole bundle (no partial apply).
+    expect(result.applied).toBe(false);
+    expect(createNamespacedCustomObject).toHaveBeenCalledOnce();
+  });
+
+  it("RE-THROWS a namespace-missing 404 rather than misattributing it as Linkerd-absent", async function _namespaceMissing()
+  {
+    const createNamespacedCustomObject = vi.fn().mockRejectedValue(_NAMESPACE_MISSING);
+    const customApi = { createNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    await expect(new LinkerdIdentityClient(customApi, _LOG).applySiloIdentityPolicy("opencrane-acme", _BUNDLE)).rejects.toThrow(/not found/);
+  });
+
+  it("replaces on 409 carrying the live resourceVersion (idempotent re-apply)", async function _conflict()
+  {
+    const createNamespacedCustomObject = vi.fn().mockRejectedValue(_CONFLICT);
+    const getNamespacedCustomObject = vi.fn().mockResolvedValue({ metadata: { resourceVersion: "42" } });
+    const replaceNamespacedCustomObject = vi.fn().mockResolvedValue({});
+    const customApi = { createNamespacedCustomObject, getNamespacedCustomObject, replaceNamespacedCustomObject } as unknown as k8s.CustomObjectsApi;
+
+    const result = await new LinkerdIdentityClient(customApi, _LOG).applySiloIdentityPolicy("opencrane-acme", _BUNDLE);
+
+    expect(result).toEqual({ applied: true });
+    expect(replaceNamespacedCustomObject).toHaveBeenCalledTimes(3);
+    const body = replaceNamespacedCustomObject.mock.calls[0][0].body as { metadata: { resourceVersion?: string } };
+    expect(body.metadata.resourceVersion).toBe("42");
+  });
+});

--- a/apps/operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { defaultConfig, gcpConfig, gcpAdapter, onPremAdapter, _makeAccessPolicy, _makeTenant } from "../fixtures.js";
-import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildClusterTenantScheduling, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildStatePvc } from "../../tenants/deploy/index.js";
+import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildClusterTenantScheduling, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc } from "../../tenants/deploy/index.js";
 
 describe("TenantResourceBuilder", () =>
 {
@@ -338,6 +338,61 @@ describe("Silo baseline NetworkPolicy (S2 / Phase 1 — default-deny silo edge)"
   });
 });
 
+describe("Silo Linkerd identity policy (S5 / ADR 0001 — meshed default-deny silo edge)", () =>
+{
+  const config = { ...defaultConfig, operatorNamespace: "opencrane-system", gatewayPort: 18789 };
+  const bundle = _BuildSiloLinkerdIdentityPolicy("opencrane-acme", "acme", config);
+
+  it("emits a deny-by-default Server over every pod (empty podSelector, v1beta1)", () =>
+  {
+    const { server } = bundle;
+    expect(server.apiVersion).toBe("policy.linkerd.io/v1beta1");
+    expect(server.kind).toBe("Server");
+    expect(server.metadata.namespace).toBe("opencrane-acme");
+    expect(server.metadata.labels["opencrane.io/cluster-tenant"]).toBe("acme");
+    // Empty selector → every pod in the silo namespace; deny → default-deny baseline.
+    expect(server.spec.podSelector).toEqual({});
+    expect(server.spec.accessPolicy).toBe("deny");
+    expect(server.spec.port).toBe(18789);
+  });
+
+  it("admits ingress identities only from the same silo and the operator namespace", () =>
+  {
+    const { meshTlsAuthentication } = bundle;
+    expect(meshTlsAuthentication.apiVersion).toBe("policy.linkerd.io/v1alpha1");
+    expect(meshTlsAuthentication.kind).toBe("MeshTLSAuthentication");
+    expect(meshTlsAuthentication.spec.identities).toContain(
+      "*.opencrane-acme.serviceaccount.identity.linkerd.cluster.local",
+    );
+    expect(meshTlsAuthentication.spec.identities).toContain(
+      "*.opencrane-system.serviceaccount.identity.linkerd.cluster.local",
+    );
+  });
+
+  it("binds the Server to the authentication via an AuthorizationPolicy (v1alpha1)", () =>
+  {
+    const { authorizationPolicy, server, meshTlsAuthentication } = bundle;
+    expect(authorizationPolicy.apiVersion).toBe("policy.linkerd.io/v1alpha1");
+    expect(authorizationPolicy.kind).toBe("AuthorizationPolicy");
+    // targetRef points at the deny-by-default Server.
+    expect(authorizationPolicy.spec.targetRef).toEqual({ group: "policy.linkerd.io", kind: "Server", name: server.metadata.name });
+    // requiredAuthenticationRefs points at the allow-list MeshTLSAuthentication.
+    expect(authorizationPolicy.spec.requiredAuthenticationRefs).toContainEqual({
+      group: "policy.linkerd.io", kind: "MeshTLSAuthentication", name: meshTlsAuthentication.metadata.name,
+    });
+  });
+
+  it("creates NO cross-silo identity path (no foreign silo identity is ever listed)", () =>
+  {
+    const serialized = JSON.stringify(bundle);
+    // The only identity domains referenced are the silo's own and the operator plane —
+    // never another ClusterTenant silo (e.g. opencrane-bcorp).
+    expect(serialized).not.toContain("opencrane-bcorp");
+    const nsDomains = [...serialized.matchAll(/\*\.([^.]+)\.serviceaccount\.identity/g)].map(m => m[1]);
+    expect(new Set(nsDomains)).toEqual(new Set(["opencrane-acme", "opencrane-system"]));
+  });
+});
+
 describe("ClusterTenant isolation builders (CT.5)", () =>
 {
   it("builds a Namespace labelled for PSA restricted enforce/warn/audit", () =>
@@ -350,6 +405,16 @@ describe("ClusterTenant isolation builders (CT.5)", () =>
     expect(labels["pod-security.kubernetes.io/warn"]).toBe("restricted");
     expect(labels["pod-security.kubernetes.io/audit"]).toBe("restricted");
     expect(labels["opencrane.io/cluster-tenant"]).toBe("acme");
+  });
+
+  it("omits the Linkerd inject annotation by default and stamps it when gated on (S5)", () =>
+  {
+    // Default (gate off) — no mesh injection annotation.
+    const off = _BuildClusterTenantNamespace("ct-acme", "acme");
+    expect(off.metadata?.annotations?.["linkerd.io/inject"]).toBeUndefined();
+    // Gate on — namespace opts its pods into the mesh.
+    const on = _BuildClusterTenantNamespace("ct-acme", "acme", true);
+    expect(on.metadata?.annotations?.["linkerd.io/inject"]).toBe("enabled");
   });
 
   it("builds a ResourceQuota from every present quota dimension", () =>

--- a/apps/operator/src/config.ts
+++ b/apps/operator/src/config.ts
@@ -162,6 +162,17 @@ export interface OpenClawTenantOperatorConfig
 
   /** Projected ServiceAccount token TTL in seconds for ingress-plane audiences. */
   projectedTokenTtlSeconds: number;
+
+  /**
+   * Linkerd identity substrate gate (S5 / ADR 0001), default OFF. When true the silo
+   * reconcile additionally annotates the silo namespace for Linkerd mesh injection and
+   * emits a per-silo deny-by-default `Server` + `MeshTLSAuthentication` +
+   * `AuthorizationPolicy` (the meshed mTLS-identity analogue of the S2 baseline
+   * NetworkPolicy). Fail-closed default: a cluster without Linkerd installed is wholly
+   * unaffected because the objects are applied ONLY when the operator is told the mesh
+   * exists, and the apply itself fails closed (skips) if the Linkerd CRDs are absent.
+   */
+  linkerdMeshEnabled: boolean;
 }
 
 /**
@@ -238,6 +249,7 @@ export function _LoadOperatorConfig(): OpenClawTenantOperatorConfig
     obotDeploymentName: _readEnvValue<string>("OBOT_DEPLOYMENT_NAME", "string", false, "opencrane-mcp-gateway"),
     skillRegistryDeploymentName: _readEnvValue<string>("SKILL_REGISTRY_DEPLOYMENT_NAME", "string", false, "opencrane-skill-registry"),
     projectedTokenTtlSeconds: _readEnvValue<number>("PROJECTED_TOKEN_TTL_SECONDS", "number", false, 600),
+    linkerdMeshEnabled: _readEnvValue<boolean>("LINKERD_MESH_ENABLED", "boolean", false, false),
   };
 
   // 4. Fail closed in multi-instance mode: refuse to watch the whole cluster when

--- a/apps/operator/src/tenants/deploy/6-cluster-tenant-namespace.ts
+++ b/apps/operator/src/tenants/deploy/6-cluster-tenant-namespace.ts
@@ -1,5 +1,7 @@
 import type * as k8s from "@kubernetes/client-node";
 
+import { LINKERD_INJECT_ANNOTATION, LINKERD_INJECT_ENABLED } from "./silo-linkerd-identity.js";
+
 /**
  * Build the per-ClusterTenant Namespace, labelled for Pod Security Admission
  * (PSA) `restricted` enforcement.
@@ -16,16 +18,25 @@ import type * as k8s from "@kubernetes/client-node";
  *
  * @param namespace - The bound namespace name resolved from the ClusterTenant.
  * @param clusterTenantName - Parent ClusterTenant name, recorded as a label for traceability.
+ * @param linkerdInject - When true, annotate the namespace for Linkerd mesh injection so
+ *   workloads get the sidecar/identity (S5; default off — gated by `linkerdMeshEnabled`).
  * @returns A Namespace object carrying the standard PSA enforce/warn/audit labels.
  * @see https://kubernetes.io/docs/concepts/security/pod-security-admission/ - PSA reference
  */
-export function _BuildClusterTenantNamespace(namespace: string, clusterTenantName: string): k8s.V1Namespace
+export function _BuildClusterTenantNamespace(
+  namespace: string,
+  clusterTenantName: string,
+  linkerdInject: boolean = false,
+): k8s.V1Namespace
 {
   return {
     apiVersion: "v1",
     kind: "Namespace",
     metadata: {
       name: namespace,
+      // Linkerd mesh injection (S5) — only stamped when the gate is on, so a cluster
+      // without Linkerd is unaffected (an unrecognised annotation is otherwise inert).
+      ...(linkerdInject ? { annotations: { [LINKERD_INJECT_ANNOTATION]: LINKERD_INJECT_ENABLED } } : {}),
       labels: {
         "app.kubernetes.io/part-of": "opencrane",
         "app.kubernetes.io/managed-by": "opencrane-operator",

--- a/apps/operator/src/tenants/deploy/index.ts
+++ b/apps/operator/src/tenants/deploy/index.ts
@@ -5,6 +5,7 @@ export { _BuildDeployment } from "./3-deployment.js";
 export { _BuildService } from "./4-service.js";
 export { _BuildGatewayNetworkPolicy } from "./network-policy.js";
 export { _BuildSiloBaselineNetworkPolicy } from "./silo-baseline-network-policy.js";
+export { _BuildSiloLinkerdIdentityPolicy } from "./silo-linkerd-identity.js";
 export { _BuildClusterTenantNamespace } from "./6-cluster-tenant-namespace.js";
 export { _BuildClusterTenantResourceQuota, _BuildClusterTenantLimitRange } from "./7-resource-quota.js";
 export { _BuildClusterTenantScheduling } from "./cluster-tenant-scheduling.js";

--- a/apps/operator/src/tenants/deploy/silo-linkerd-identity.ts
+++ b/apps/operator/src/tenants/deploy/silo-linkerd-identity.ts
@@ -1,0 +1,135 @@
+import type { OpenClawTenantOperatorConfig } from "../../config.js";
+
+import type {
+  LinkerdAuthorizationPolicy,
+  LinkerdMeshTlsAuthentication,
+  LinkerdServer,
+  SiloLinkerdIdentityPolicy,
+} from "./silo-linkerd-identity.types.js";
+
+/**
+ * Trust domain suffix of a Linkerd mesh ServiceAccount identity. A meshed pod's mTLS
+ * identity is `<serviceaccount>.<namespace>.serviceaccount.identity.linkerd.cluster.local`;
+ * `*.<namespace>.<this suffix>` therefore matches every ServiceAccount in a namespace.
+ */
+const _LINKERD_IDENTITY_SUFFIX = "serviceaccount.identity.linkerd.cluster.local";
+
+/** The namespace-injection annotation that opts a namespace's pods into the Linkerd mesh. */
+export const LINKERD_INJECT_ANNOTATION = "linkerd.io/inject";
+
+/** The annotation value enabling automatic sidecar/identity injection. */
+export const LINKERD_INJECT_ENABLED = "enabled";
+
+/**
+ * Wildcard mesh-identity string matching every ServiceAccount in a namespace.
+ *
+ * @param namespace - The namespace whose meshed identities should be matched.
+ * @returns A `*.<namespace>.serviceaccount.identity.linkerd.cluster.local` identity.
+ */
+function _meshIdentityForNamespace(namespace: string): string
+{
+  return `*.${namespace}.${_LINKERD_IDENTITY_SUFFIX}`;
+}
+
+/**
+ * Build the per-silo Linkerd identity policy bundle — the meshed (mTLS-identity) analogue
+ * of the S2 default-deny baseline NetworkPolicy (S5 — Linkerd identity substrate, ADR 0001).
+ *
+ * ADR 0001 layers Linkerd ADDITIVELY on top of the Dataplane-V2/Cilium L3/4 floor: the S2
+ * `_BuildSiloBaselineNetworkPolicy` closes the silo edge at L3/4, and this closes it again at
+ * the identity layer, so a silo is isolated both by namespace network reachability AND by
+ * cryptographic workload identity. The bundle mirrors the S2 posture exactly:
+ *
+ * - **Server** (`policy.linkerd.io/v1beta1`): empty `podSelector` selects EVERY pod in the
+ *   silo namespace and `accessPolicy: deny` flips them to default-deny — the identity-layer
+ *   equivalent of the S2 NetworkPolicy's empty `podSelector` + `Ingress`/`Egress` default-deny.
+ * - **MeshTLSAuthentication** (`policy.linkerd.io/v1alpha1`): the allow-list of mesh identities,
+ *   set to the silo's OWN ServiceAccount identity domain (intra-silo) and the operator/
+ *   control-plane namespace's (the only cross-silo principal) — exactly the S2 ingress
+ *   allow-list (`{ podSelector: {} }` + the operator-namespace selector). No OTHER silo's
+ *   identity is ever listed, so no cross-silo path is created at the identity layer either.
+ * - **AuthorizationPolicy** (`policy.linkerd.io/v1alpha1`): binds the deny-by-default Server to
+ *   that authentication, re-opening only intra-silo + operator-namespace meshed traffic.
+ *
+ * Emitted as untyped custom objects by the caller (the operator has no generated client model
+ * for Linkerd CRDs); this builder is pure so it is covered by the same kind of unit test as
+ * `_BuildSiloBaselineNetworkPolicy`. Gated OFF by default at the call site
+ * ({@link OpenClawTenantOperatorConfig.linkerdMeshEnabled}) so a cluster without Linkerd installed
+ * is wholly unaffected — the objects are only applied when the operator is told the mesh exists.
+ *
+ * @param namespace - The silo (ClusterTenant) namespace the objects are created in.
+ * @param clusterTenantName - Parent ClusterTenant name, recorded in names + labels.
+ * @param config - Operator config; supplies the control-plane/operator namespace.
+ * @returns The Server + MeshTLSAuthentication + AuthorizationPolicy bundle for the silo.
+ */
+export function _BuildSiloLinkerdIdentityPolicy(
+  namespace: string,
+  clusterTenantName: string,
+  config: OpenClawTenantOperatorConfig,
+): SiloLinkerdIdentityPolicy
+{
+  // 1. Resolve the shared-plane namespace — the operator/control-plane is the only
+  //    cross-silo principal, so it is the one foreign identity domain the silo admits
+  //    (matching the operator-namespace selector in the S2 baseline ingress rule).
+  const platformNamespace = config.operatorNamespace;
+
+  // 2. Deterministic, namespace-scoped object names so re-applies converge (idempotent)
+  //    and never collide with another silo's bundle.
+  const serverName = `opencrane-${clusterTenantName}-silo-identity`;
+  const authName = `opencrane-${clusterTenantName}-silo-identity`;
+  const authzName = `opencrane-${clusterTenantName}-silo-identity`;
+
+  // 3. Provenance/ownership labels mirroring the S2 baseline NetworkPolicy so both
+  //    isolation layers are discoverable under the same `silo-isolation` component.
+  const labels = {
+    "app.kubernetes.io/part-of": "opencrane",
+    "app.kubernetes.io/managed-by": "opencrane-operator",
+    "app.kubernetes.io/component": "silo-isolation",
+    "opencrane.io/cluster-tenant": clusterTenantName,
+  };
+
+  // 4. The deny-by-default Server over every pod in the silo namespace.
+  const server: LinkerdServer = {
+    apiVersion: "policy.linkerd.io/v1beta1",
+    kind: "Server",
+    metadata: { name: serverName, namespace, labels },
+    spec: {
+      // Empty selector → every pod in the silo namespace (default-deny baseline).
+      podSelector: {},
+      // The OpenClaw gateway listens here; the meshed proxy governs this inbound port.
+      port: config.gatewayPort,
+      accessPolicy: "deny",
+    },
+  };
+
+  // 5. The mesh-identity allow-list: intra-silo + the operator/control-plane plane only.
+  const meshTlsAuthentication: LinkerdMeshTlsAuthentication = {
+    apiVersion: "policy.linkerd.io/v1alpha1",
+    kind: "MeshTLSAuthentication",
+    metadata: { name: authName, namespace, labels },
+    spec: {
+      identities: [
+        // Intra-silo: every ServiceAccount in this same namespace.
+        _meshIdentityForNamespace(namespace),
+        // The control-plane/operator super-admin plane (the only cross-silo principal).
+        _meshIdentityForNamespace(platformNamespace),
+      ],
+    },
+  };
+
+  // 6. Bind the deny-by-default Server to the allow-list — the single rule that re-opens
+  //    intra-silo + operator-namespace meshed traffic at the identity layer.
+  const authorizationPolicy: LinkerdAuthorizationPolicy = {
+    apiVersion: "policy.linkerd.io/v1alpha1",
+    kind: "AuthorizationPolicy",
+    metadata: { name: authzName, namespace, labels },
+    spec: {
+      targetRef: { group: "policy.linkerd.io", kind: "Server", name: serverName },
+      requiredAuthenticationRefs: [
+        { group: "policy.linkerd.io", kind: "MeshTLSAuthentication", name: authName },
+      ],
+    },
+  };
+
+  return { server, meshTlsAuthentication, authorizationPolicy };
+}

--- a/apps/operator/src/tenants/deploy/silo-linkerd-identity.types.ts
+++ b/apps/operator/src/tenants/deploy/silo-linkerd-identity.types.ts
@@ -1,0 +1,127 @@
+/**
+ * Type shapes for the per-silo Linkerd identity-layer policy objects emitted by
+ * {@link _BuildSiloLinkerdIdentityPolicy} (S5 — the Linkerd identity substrate).
+ *
+ * These mirror the `policy.linkerd.io` CRDs at the field level. The operator applies
+ * them as untyped custom objects via the Kubernetes `CustomObjectsApi` (the same path
+ * the DNSEndpoint/cert-manager clients use), so they are modelled as plain typed
+ * records rather than generated `@kubernetes/client-node` models — there are none for
+ * Linkerd's CRDs. Keeping the shapes typed (not `Record<string, unknown>`) gives the
+ * builder and its unit test a checked contract for the exact apiVersions/kinds.
+ */
+
+/** A `metadata` block carried by every emitted Linkerd policy object. */
+export interface LinkerdObjectMeta
+{
+  /** Object name (deterministic, derived from the ClusterTenant name). */
+  name: string;
+  /** The silo namespace the object is created in. */
+  namespace: string;
+  /** Provenance + ownership labels mirroring the S2 baseline NetworkPolicy. */
+  labels: Record<string, string>;
+}
+
+/**
+ * Linkerd `Server` (`policy.linkerd.io/v1beta1`) — selects a set of meshed pods/ports
+ * and, with `accessPolicy: deny`, flips them to default-deny so only an
+ * {@link LinkerdAuthorizationPolicy} can admit traffic. The baseline selects EVERY pod
+ * in the silo namespace (empty `podSelector`), the identity-layer analogue of the S2
+ * NetworkPolicy's empty `podSelector` default-deny.
+ */
+export interface LinkerdServer
+{
+  /** Pinned policy CRD apiVersion. */
+  apiVersion: "policy.linkerd.io/v1beta1";
+  /** CRD kind. */
+  kind: "Server";
+  /** Object metadata. */
+  metadata: LinkerdObjectMeta;
+  /** Server spec. */
+  spec: {
+    /** Empty selector → every pod in the silo namespace (default-deny baseline). */
+    podSelector: Record<string, never>;
+    /** Port this Server governs; the meshed proxy admits all inbound ports by name. */
+    port: string | number;
+    /** Default disposition for traffic not matched by an AuthorizationPolicy. */
+    accessPolicy: "deny";
+  };
+}
+
+/**
+ * Linkerd `MeshTLSAuthentication` (`policy.linkerd.io/v1alpha1`) — names the mesh mTLS
+ * identities allowed to reach a {@link LinkerdServer}. The baseline names the silo's
+ * own ServiceAccount identity domain and the operator/control-plane namespace's, so the
+ * only meshed callers admitted are intra-silo + the super-admin plane (mirroring the S2
+ * ingress allow-list); no other silo's identity is ever listed (no cross-silo path).
+ */
+export interface LinkerdMeshTlsAuthentication
+{
+  /** Pinned policy CRD apiVersion. */
+  apiVersion: "policy.linkerd.io/v1alpha1";
+  /** CRD kind. */
+  kind: "MeshTLSAuthentication";
+  /** Object metadata. */
+  metadata: LinkerdObjectMeta;
+  /** Authentication spec. */
+  spec: {
+    /**
+     * Allowed mesh-identity strings. Each is a SPIFFE-style identity of the form
+     * `*.<namespace>.serviceaccount.identity.linkerd.cluster.local` — the wildcard
+     * matches every ServiceAccount in that namespace.
+     */
+    identities: string[];
+  };
+}
+
+/**
+ * Linkerd `AuthorizationPolicy` (`policy.linkerd.io/v1alpha1`) — binds a target
+ * ({@link LinkerdServer}) to the authentication(s) that may reach it. With the baseline
+ * Server denying by default, this is the single rule that re-opens intra-silo +
+ * operator-namespace traffic at the identity layer.
+ */
+export interface LinkerdAuthorizationPolicy
+{
+  /** Pinned policy CRD apiVersion. */
+  apiVersion: "policy.linkerd.io/v1alpha1";
+  /** CRD kind. */
+  kind: "AuthorizationPolicy";
+  /** Object metadata. */
+  metadata: LinkerdObjectMeta;
+  /** Authorization spec. */
+  spec: {
+    /** The protected target — the baseline {@link LinkerdServer} in this namespace. */
+    targetRef: {
+      /** Target API group (`policy.linkerd.io`). */
+      group: "policy.linkerd.io";
+      /** Target kind. */
+      kind: "Server";
+      /** Target Server name. */
+      name: string;
+    };
+    /** Authentications that must match for traffic to be admitted. */
+    requiredAuthenticationRefs: Array<{
+      /** Authentication API group. */
+      group: "policy.linkerd.io";
+      /** Authentication kind. */
+      kind: "MeshTLSAuthentication";
+      /** Authentication object name. */
+      name: string;
+    }>;
+  };
+}
+
+/**
+ * The full per-silo Linkerd identity policy bundle: a default-deny {@link LinkerdServer},
+ * the {@link LinkerdMeshTlsAuthentication} allow-list, and the
+ * {@link LinkerdAuthorizationPolicy} binding them. Emitted together so the silo's
+ * identity edge is closed and re-opened atomically (mirrors the single S2 NetworkPolicy).
+ */
+export interface SiloLinkerdIdentityPolicy
+{
+  /** Default-deny Server over every pod in the silo namespace. */
+  server: LinkerdServer;
+  /** Allowed mesh-identity allow-list (intra-silo + operator namespace). */
+  meshTlsAuthentication: LinkerdMeshTlsAuthentication;
+  /** Binds the Server to the authentication allow-list. */
+  authorizationPolicy: LinkerdAuthorizationPolicy;
+}

--- a/apps/operator/src/tenants/internal/linkerd-identity.client.ts
+++ b/apps/operator/src/tenants/internal/linkerd-identity.client.ts
@@ -1,0 +1,151 @@
+import type * as k8s from "@kubernetes/client-node";
+import type { Logger } from "pino";
+
+import { _IsConflict, _IsCrdAbsent } from "../../cluster-tenants/internal/k8s-api-errors.js";
+import type { SiloLinkerdIdentityPolicy } from "../deploy/silo-linkerd-identity.types.js";
+
+/** Linkerd policy API group for the Server/AuthorizationPolicy/MeshTLSAuthentication CRDs. */
+const _LINKERD_POLICY_GROUP = "policy.linkerd.io";
+/** Stable apiVersion for the `Server` CRD. */
+const _SERVER_VERSION = "v1beta1";
+/** Plural for the namespaced `Server` custom resource. */
+const _SERVER_PLURAL = "servers";
+/** apiVersion shared by `AuthorizationPolicy` + `MeshTLSAuthentication`. */
+const _ALPHA_VERSION = "v1alpha1";
+/** Plural for the namespaced `MeshTLSAuthentication` custom resource. */
+const _MESHTLS_PLURAL = "meshtlsauthentications";
+/** Plural for the namespaced `AuthorizationPolicy` custom resource. */
+const _AUTHZ_PLURAL = "authorizationpolicies";
+
+/**
+ * One member of the per-silo Linkerd identity bundle, paired with the discovery
+ * coordinates needed to apply it as an untyped custom object.
+ */
+interface LinkerdObjectToApply
+{
+  /** CRD apiVersion segment (e.g. `v1beta1`). */
+  version: string;
+  /** CRD plural (e.g. `servers`). */
+  plural: string;
+  /** The custom-object manifest to apply. */
+  manifest: Record<string, unknown>;
+}
+
+/**
+ * Applies the per-silo Linkerd identity policy bundle (S5 — Server +
+ * MeshTLSAuthentication + AuthorizationPolicy) over the operator's custom-objects API.
+ *
+ * The operator has no generated `@kubernetes/client-node` model for the `policy.linkerd.io`
+ * CRDs, so the bundle is applied as untyped custom objects — the same path the
+ * `DnsEndpointClient`/`CertManagerClient` use for their CRs. It carries the identical
+ * create-then-replace-on-409 + fail-closed-on-absent-CRD posture: when Linkerd is NOT
+ * installed (the policy CRDs are not served) apply does NOT crash the silo reconcile — it
+ * logs a structured skip and returns `applied: false`, so enabling the gate on a cluster
+ * that lacks Linkerd is a safe no-op rather than a wedged reconcile.
+ */
+export class LinkerdIdentityClient
+{
+  /** Kubernetes custom-objects client (Linkerd policy CRDs). */
+  private readonly customApi: k8s.CustomObjectsApi;
+
+  /** Scoped logger for apply/skip lifecycle messages. */
+  private readonly log: Logger;
+
+  /**
+   * @param customApi - Kubernetes custom-objects client.
+   * @param log - Logger used for apply/skip lifecycle messages.
+   */
+  public constructor(customApi: k8s.CustomObjectsApi, log: Logger)
+  {
+    this.customApi = customApi;
+    this.log = log;
+  }
+
+  /**
+   * Apply the full identity bundle into the silo namespace, idempotently.
+   *
+   * @param namespace - The silo namespace the objects are created in.
+   * @param bundle - The Server + MeshTLSAuthentication + AuthorizationPolicy bundle.
+   * @returns Whether the bundle was applied (`false` when Linkerd's CRDs are absent).
+   */
+  public async applySiloIdentityPolicy(
+    namespace: string,
+    bundle: SiloLinkerdIdentityPolicy,
+  ): Promise<{ applied: boolean }>
+  {
+    // 1. Order Server first so the deny-by-default posture exists before the
+    //    authentication + binding that re-open it; MeshTLSAuthentication before the
+    //    AuthorizationPolicy that references it.
+    const objects: LinkerdObjectToApply[] = [
+      { version: _SERVER_VERSION, plural: _SERVER_PLURAL, manifest: bundle.server as unknown as Record<string, unknown> },
+      { version: _ALPHA_VERSION, plural: _MESHTLS_PLURAL, manifest: bundle.meshTlsAuthentication as unknown as Record<string, unknown> },
+      { version: _ALPHA_VERSION, plural: _AUTHZ_PLURAL, manifest: bundle.authorizationPolicy as unknown as Record<string, unknown> },
+    ];
+
+    // 2. Apply each member; an absent Linkerd CRD short-circuits the WHOLE bundle to a
+    //    fail-closed not-applied result (no partial bundle is left behind).
+    for (const obj of objects)
+    {
+      const result = await this._applyOne(namespace, obj);
+      if (!result.applied)
+      {
+        return result;
+      }
+    }
+
+    return { applied: true };
+  }
+
+  /**
+   * Apply a single Linkerd custom object with create-then-replace-on-409 semantics and a
+   * fail-closed-on-absent-CRD short-circuit.
+   *
+   * @param namespace - The silo namespace the object is created in.
+   * @param obj - The object coordinates + manifest to apply.
+   * @returns Whether this object was applied (`false` only when its CRD is absent).
+   */
+  private async _applyOne(namespace: string, obj: LinkerdObjectToApply): Promise<{ applied: boolean }>
+  {
+    const { version, plural, manifest } = obj;
+    const name = ((manifest.metadata as Record<string, unknown>)?.name) as string;
+
+    try
+    {
+      // 1. Create first — the common path on a fresh silo.
+      await this.customApi.createNamespacedCustomObject({
+        group: _LINKERD_POLICY_GROUP, version, namespace, plural, body: manifest,
+      });
+      return { applied: true };
+    }
+    catch (err)
+    {
+      // 2. No Linkerd → the policy CRD is not served. Fail closed, never crash: log a
+      //    structured skip so an operator who flipped the gate on a Linkerd-less cluster
+      //    sees exactly why nothing was applied.
+      if (_IsCrdAbsent(err, _LINKERD_POLICY_GROUP, plural))
+      {
+        this.log.warn(
+          { namespace, plural, name },
+          "Linkerd mesh enabled but policy CRD is absent (Linkerd not installed); skipping silo identity policy",
+        );
+        return { applied: false };
+      }
+
+      // 3. 409 Conflict → already exists; fetch the live resourceVersion and replace
+      //    in-place so a re-apply converges (idempotent).
+      if (_IsConflict(err))
+      {
+        const existing = await this.customApi.getNamespacedCustomObject({ group: _LINKERD_POLICY_GROUP, version, namespace, plural, name });
+        const resourceVersion = (existing as { metadata?: { resourceVersion?: string } }).metadata?.resourceVersion;
+        const body = { ...manifest, metadata: { ...(manifest.metadata as Record<string, unknown>), resourceVersion } };
+        await this.customApi.replaceNamespacedCustomObject({ group: _LINKERD_POLICY_GROUP, version, namespace, plural, name, body });
+        return { applied: true };
+      }
+
+      // 4. Any other failure (incl. an unrelated 404, e.g. a missing namespace — which
+      //    `_IsCrdAbsent` deliberately does NOT classify as a CRD absence) is a real error.
+      //    Re-throw so the reconcile surfaces it rather than masking it.
+      throw err;
+    }
+  }
+}

--- a/apps/operator/src/tenants/operator.ts
+++ b/apps/operator/src/tenants/operator.ts
@@ -10,8 +10,9 @@ import { TenantPolicyResolutionState, TenantStatusPhase } from "./models/tenant-
 import { __K8sApplyResource } from "../infra/k8s.js";
 import { _RunWatchLoop, K8sWatchEventType } from "../shared/watch-runner.js";
 import { OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "../shared/crd-constants.js";
-import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildService, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildStatePvc } from "./deploy/index.js";
+import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildService, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc } from "./deploy/index.js";
 import { TenantCleanup } from "./destroy/tenant-cleanup.js";
+import { LinkerdIdentityClient } from "./internal/linkerd-identity.client.js";
 
 import { TenantEncryptionKeys } from "./internal/tenant-encryption-keys.js";
 import { TenantLiteLlmKeys } from "./internal/tenant-litellm-keys.js";
@@ -409,14 +410,33 @@ export class TenantOperator
     const clusterTenantName = clusterTenant.metadata?.name ?? namespace;
 
     // 1. Namespace — ensure the fenced namespace exists and carries the PSA
-    //    restricted enforce/warn/audit labels before any workload lands in it.
-    await __K8sApplyResource(this.coreApi, _BuildClusterTenantNamespace(namespace, clusterTenantName), this.log);
+    //    restricted enforce/warn/audit labels before any workload lands in it. When the
+    //    Linkerd gate is on (S5) it is also annotated for mesh injection so workloads
+    //    pick up the sidecar/identity; the annotation is inert on a Linkerd-less cluster.
+    await __K8sApplyResource(this.coreApi, _BuildClusterTenantNamespace(namespace, clusterTenantName, this.config.linkerdMeshEnabled), this.log);
 
     // 1b. Silo baseline NetworkPolicy — flip the namespace to default-deny (S2 /
     //     Phase 1) right after it exists and before any workload lands, so the silo
     //     edge is closed from the start: only intra-silo + the control-plane plane,
     //     DNS, and external HTTPS are allowed; no silo→silo path is ever created.
     await __K8sApplyResource(this.networkingApi, _BuildSiloBaselineNetworkPolicy(namespace, clusterTenantName, this.config), this.log);
+
+    // 1c. Linkerd identity layer (S5 / ADR 0001) — gated OFF by default. When on, lay
+    //     the meshed mTLS-identity analogue of the S2 baseline ON TOP of the L3/4 floor:
+    //     a deny-by-default Server + a MeshTLSAuthentication allow-list (intra-silo + the
+    //     operator plane only) + the AuthorizationPolicy binding them. Applied as untyped
+    //     CRs; the client fails closed (logs + skips) if Linkerd's CRDs are absent, so
+    //     enabling the gate on a Linkerd-less cluster is a safe no-op, not a wedged reconcile.
+    if (this.config.linkerdMeshEnabled)
+    {
+      const linkerdClient = new LinkerdIdentityClient(this.customApi, this.log);
+      const bundle = _BuildSiloLinkerdIdentityPolicy(namespace, clusterTenantName, this.config);
+      const { applied } = await linkerdClient.applySiloIdentityPolicy(namespace, bundle);
+      if (!applied)
+      {
+        this.log.warn({ namespace, clusterTenant: clusterTenantName }, "Linkerd identity policy skipped (CRDs absent); silo isolated at L3/4 only");
+      }
+    }
 
     // 2. ResourceQuota — cap the customer's aggregate CPU/memory/pods/storage/GPU
     //    so a single customer cannot starve the cluster. Only stamped when the

--- a/platform/helm/templates/_helpers.tpl
+++ b/platform/helm/templates/_helpers.tpl
@@ -94,6 +94,15 @@ All resources here are namespaced, so the same rule list is valid in a Role.
 - apiGroups: ["cilium.io"]
   resources: ["ciliumnetworkpolicies"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- if .Values.operator.linkerdMeshEnabled }}
+# Linkerd identity-layer policy CRs the silo reconcile applies per silo namespace (S5):
+# a deny-by-default Server + MeshTLSAuthentication allow-list + the AuthorizationPolicy
+# binding them. Granted only when the Linkerd mesh gate is on; without it the operator
+# never builds or applies these objects, and an absent Linkerd CRD makes the apply skip.
+- apiGroups: ["policy.linkerd.io"]
+  resources: ["servers", "meshtlsauthentications", "authorizationpolicies"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+{{- end }}
 {{- if .Values.certManager.enabled }}
 # Per-org wildcard TLS Certificates the ClusterTenant reconciler applies into each
 # org's bound namespace (fixed-wildcard topology). Granted only when cert-manager is

--- a/platform/helm/templates/operator-deployment.yaml
+++ b/platform/helm/templates/operator-deployment.yaml
@@ -121,6 +121,13 @@ spec:
               value: {{ .Values.operator.idleTimeoutMinutes | quote }}
             - name: IDLE_CHECK_INTERVAL_SECONDS
               value: {{ .Values.operator.idleCheckIntervalSeconds | quote }}
+            # -- Linkerd identity substrate gate (S5 / ADR 0001), default off. When true the
+            #    silo reconcile annotates the silo namespace for mesh injection and emits the
+            #    per-silo deny-by-default Server + MeshTLSAuthentication + AuthorizationPolicy
+            #    (the meshed analogue of the S2 baseline NetworkPolicy). Fails closed if the
+            #    Linkerd policy CRDs are absent, so it is a safe no-op without Linkerd.
+            - name: LINKERD_MESH_ENABLED
+              value: {{ .Values.operator.linkerdMeshEnabled | quote }}
             # -- Runtime-plane endpoints injected into tenant Deployments. Resolved via
             #    sharedPlatform scope (B5): instance mode → release-prefixed in-cluster
             #    Service; shared mode → the externally-provided endpoint.

--- a/platform/helm/values.yaml
+++ b/platform/helm/values.yaml
@@ -117,6 +117,14 @@ operator:
   idleTimeoutMinutes: 30
   # -- How often (seconds) the idle-checker scans for inactive tenants
   idleCheckIntervalSeconds: 60
+  # -- Linkerd identity substrate (S5 / ADR 0001). DEFAULT OFF. When true the silo
+  #    reconcile annotates each silo namespace for Linkerd mesh injection and emits a
+  #    per-silo deny-by-default Server + MeshTLSAuthentication + AuthorizationPolicy
+  #    (the meshed mTLS-identity analogue of the S2 default-deny NetworkPolicy), layered
+  #    ADDITIVELY on top of the Cilium/Dataplane-V2 L3/4 floor. Requires Linkerd installed
+  #    in the cluster; if its policy CRDs are absent the operator fails closed (skips the
+  #    objects) so flipping this on without Linkerd is a safe no-op.
+  linkerdMeshEnabled: false
 
 # -- Control plane settings
 controlPlane:


### PR DESCRIPTION
First bounded slice of S5 (ADR 0001 = Linkerd). **Gated behind `LINKERD_MESH_ENABLED` (default OFF, fail-closed)** so a cluster without Linkerd is wholly unaffected. When on, the silo reconcile annotates the silo namespace `linkerd.io/inject` and emits a per-silo **deny-by-default `Server` + `MeshTLSAuthentication` + `AuthorizationPolicy`** — the meshed mTLS-identity analogue of the S2 NetworkPolicy baseline (allow intra-silo + operator ns, deny cross-silo). Applied via a fail-closed CR client (absent Linkerd CRD → logged skip; silo stays L3/4-isolated). + Helm value/env + scoped RBAC. **195 operator tests; build + helm lint clean.** Built by an agent in parallel with 3 other lanes.