### PR TITLE
✨ S3c: ClusterTenant member API + oc cluster-tenant members

### DIFF
--- a/apps/cli/src/commands/cluster-tenants.ts
+++ b/apps/cli/src/commands/cluster-tenants.ts
@@ -3,10 +3,13 @@ import type { Command } from "commander";
 import type { CliConfig } from "../config.js";
 import { _MakeClient } from "../config.js";
 import { _Print, _PrintApiError, _PrintSuccess, type OutputFormat } from "../format.js";
-import type { ClusterTenantCreateOptions, ClusterTenantQuotaBody, ClusterTenantQuotaOptions, ClusterTenantUpdateOptions } from "./cluster-tenants.types.js";
+import type { ClusterTenantCreateOptions, ClusterTenantMemberAddOptions, ClusterTenantQuotaBody, ClusterTenantQuotaOptions, ClusterTenantUpdateOptions } from "./cluster-tenants.types.js";
 
 /** Columns shown for `oc cluster-tenant list` in table mode. */
 const _LIST_COLUMNS = ["name", "displayName", "isolationTier", "compute", "resources", "status"];
+
+/** Columns shown for `oc cluster-tenant members list` in table mode. */
+const _MEMBER_LIST_COLUMNS = ["subject", "role"];
 
 /**
  * Build the resource-quota body block from the raw quota flags.
@@ -183,5 +186,53 @@ export function _RegisterClusterTenants(parent: Command, getConfig: () => CliCon
       const { error } = await client.DELETE("/cluster-tenants/{name}", { params: { path: { name } } });
       if (error) _PrintApiError("cluster-tenant delete", error);
       _PrintSuccess(`Cluster tenant "${name}" deleted`);
+    });
+
+  // --- members sub-group: the org's LOCAL membership registry (the rows the
+  //     org-admin gate reads — OrgMembership, NOT Zitadel grants). ----------
+  const members = clusterTenant
+    .command("members")
+    .description("Manage an organisation's members (list, add/update, remove) — the local membership registry");
+
+  members
+    .command("list <name>")
+    .description("List an organisation's members (subject + role)")
+    .option("-o, --output <format>", "Output format: table|json", "table")
+    .action(async function _membersList(name: string, opts: { output: OutputFormat })
+    {
+      const client = _MakeClient(getConfig());
+      const { data, error } = await client.GET("/cluster-tenants/{name}/members", { params: { path: { name } } });
+      if (error) _PrintApiError("cluster-tenant members list", error);
+      _Print(data, opts.output, _MEMBER_LIST_COLUMNS);
+    });
+
+  members
+    .command("add <name>")
+    .description("Add or update an organisation member (upsert on subject)")
+    .requiredOption("--subject <subject>", "IdP-verified subject (OIDC sub) of the member")
+    .requiredOption("--role <role>", "Role to grant: Owner|Admin|Member")
+    .option("-o, --output <format>", "Output format: table|json", "table")
+    .action(async function _membersAdd(name: string, opts: ClusterTenantMemberAddOptions)
+    {
+      // The role string is passed straight through so the API stays the single
+      // validator (it rejects anything outside Owner|Admin|Member with a 400).
+      const client = _MakeClient(getConfig());
+      const { data, error } = await client.POST("/cluster-tenants/{name}/members", {
+        params: { path: { name } },
+        body: { subject: opts.subject, role: opts.role as "Owner" | "Admin" | "Member" },
+      });
+      if (error) _PrintApiError("cluster-tenant members add", error);
+      _Print(data, opts.output);
+    });
+
+  members
+    .command("remove <name> <subject>")
+    .description("Remove an organisation member (rejected for the last Owner)")
+    .action(async function _membersRemove(name: string, subject: string)
+    {
+      const client = _MakeClient(getConfig());
+      const { error } = await client.DELETE("/cluster-tenants/{name}/members/{subject}", { params: { path: { name, subject } } });
+      if (error) _PrintApiError("cluster-tenant members remove", error);
+      _PrintSuccess(`Member "${subject}" removed from "${name}"`);
     });
 }

--- a/apps/cli/src/commands/cluster-tenants.types.ts
+++ b/apps/cli/src/commands/cluster-tenants.types.ts
@@ -56,6 +56,17 @@ export interface ClusterTenantUpdateOptions extends ClusterTenantQuotaOptions
   output: OutputFormat;
 }
 
+/** Flag values accepted by `oc cluster-tenant members add`. */
+export interface ClusterTenantMemberAddOptions
+{
+  /** IdP-verified subject (OIDC `sub`) of the member to add/update. */
+  subject: string;
+  /** Role to grant within the org: Owner | Admin | Member. */
+  role: string;
+  /** Output format: table | json. */
+  output: OutputFormat;
+}
+
 /** Resource-quota body block built from the quota flags. */
 export interface ClusterTenantQuotaBody
 {

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -607,6 +607,52 @@
           }
         }
       },
+      "OrgMember": {
+        "type": "object",
+        "required": [
+          "subject",
+          "role"
+        ],
+        "description": "A single organisation membership row — the LOCAL membership registry the org-admin gate reads (an OrgMembership, NOT a Zitadel grant).",
+        "properties": {
+          "subject": {
+            "type": "string",
+            "description": "IdP-verified subject (OIDC `sub`) holding the membership."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "Owner",
+              "Admin",
+              "Member"
+            ],
+            "description": "Role held within the organisation."
+          }
+        }
+      },
+      "OrgMemberWrite": {
+        "type": "object",
+        "required": [
+          "subject",
+          "role"
+        ],
+        "description": "Add or update an organisation member (upsert on the unique [org, subject]).",
+        "properties": {
+          "subject": {
+            "type": "string",
+            "description": "IdP-verified subject (OIDC `sub`) of the member to add/update."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "Owner",
+              "Admin",
+              "Member"
+            ],
+            "description": "Role to grant within the organisation."
+          }
+        }
+      },
       "BillingAccount": {
         "type": "object",
         "required": [
@@ -4047,6 +4093,249 @@
           },
           "404": {
             "description": "Cluster tenant not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cluster-tenants/{name}/members": {
+      "get": {
+        "operationId": "listClusterTenantMembers",
+        "summary": "List an organisation's members (operator OR owner/admin of that org)",
+        "description": "Lists the org's membership rows (subject + role) — the LOCAL membership registry the org-admin gate reads (OrgMembership rows, NOT Zitadel grants).",
+        "tags": [
+          "Cluster Tenants"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organisation membership list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/OrgMember"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is neither a platform operator nor an owner/admin of this org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Cluster tenant not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "addClusterTenantMember",
+        "summary": "Add or update an organisation member (operator OR owner/admin of that org)",
+        "description": "Upserts a membership on the unique [org, subject]: adds a new member or changes an existing member's role. Last-Owner guardrail: demoting the org's sole Owner to a lesser role is rejected (409 LAST_OWNER).",
+        "tags": [
+          "Cluster Tenants"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrgMemberWrite"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Member added or updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrgMember"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request body failed validation (subject required; role must be Owner|Admin|Member).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is neither a platform operator nor an owner/admin of this org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Cluster tenant not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The change would demote the organisation's last Owner (code LAST_OWNER).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cluster-tenants/{name}/members/{subject}": {
+      "delete": {
+        "operationId": "removeClusterTenantMember",
+        "summary": "Remove an organisation member (operator OR owner/admin of that org)",
+        "description": "Removes a membership row. Last-Owner guardrail: removing the org's sole Owner is rejected (409 LAST_OWNER).",
+        "tags": [
+          "Cluster Tenants"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subject",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Member removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "subject": {
+                      "type": "string"
+                    },
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated session (real-auth deployments).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is neither a platform operator nor an owner/admin of this org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Cluster tenant or membership not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Removing this member would remove the organisation's last Owner (code LAST_OWNER).",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/control-plane/src/__tests__/routes/cluster-tenant-members.test.ts
+++ b/apps/control-plane/src/__tests__/routes/cluster-tenant-members.test.ts
@@ -1,0 +1,271 @@
+import express from "express";
+import type { Express } from "express";
+import type { PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { clusterTenantMembersRouter } from "../../routes/cluster-tenant-members.js";
+
+/**
+ * Route tests for the org MEMBER management API (S3c):
+ *   - list / add (upsert) / remove the local OrgMembership rows,
+ *   - the last-Owner guardrail (409 on demoting/removing the sole Owner),
+ *   - 404 when the org (or membership) is missing,
+ *   - the org-manager gate (403 for a non-member; allow operator + owner/admin).
+ */
+
+type Row = Record<string, unknown>;
+
+/** A membership fixture row. */
+interface Membership { clusterTenant: string; subject: string; role: "Owner" | "Admin" | "Member" }
+
+/** Seed shape for the in-memory fixtures. */
+interface Seed
+{
+  orgs?: string[];
+  memberships?: Membership[];
+}
+
+/**
+ * Build a Prisma stub backed by in-memory arrays for the membership tables.
+ * Implements only the surface the members router touches: clusterTenant.findUnique,
+ * and orgMembership.{findMany,findUnique,count,upsert,delete}.
+ */
+function _mockPrisma(seed: Seed = {}): { prisma: PrismaClient; memberships: Membership[] }
+{
+  const orgs = new Set(seed.orgs ?? []);
+  const memberships: Membership[] = (seed.memberships ?? []).map(m => ({ ...m }));
+
+  const _find = (clusterTenant: string, subject: string): Membership | undefined =>
+    memberships.find(m => m.clusterTenant === clusterTenant && m.subject === subject);
+
+  const prisma = {
+    clusterTenant: {
+      findUnique: vi.fn(async function _findUnique(args: { where: { name: string } }) { return orgs.has(args.where.name) ? { name: args.where.name } : null; }),
+    },
+    orgMembership: {
+      findMany: vi.fn(async function _findMany(args: { where: { clusterTenant: string } })
+      {
+        return memberships.filter(m => m.clusterTenant === args.where.clusterTenant).map(m => ({ subject: m.subject, role: m.role }));
+      }),
+      findUnique: vi.fn(async function _findUnique(args: { where: { clusterTenant_subject: { clusterTenant: string; subject: string } } })
+      {
+        const { clusterTenant, subject } = args.where.clusterTenant_subject;
+        const m = _find(clusterTenant, subject);
+        return m ? { role: m.role } : null;
+      }),
+      count: vi.fn(async function _count(args: { where: { clusterTenant: string; role: string } })
+      {
+        return memberships.filter(m => m.clusterTenant === args.where.clusterTenant && m.role === args.where.role).length;
+      }),
+      upsert: vi.fn(async function _upsert(args: { where: { clusterTenant_subject: { clusterTenant: string; subject: string } }; create: Membership; update: { role: Membership["role"] } })
+      {
+        const { clusterTenant, subject } = args.where.clusterTenant_subject;
+        const existing = _find(clusterTenant, subject);
+        if (existing) { existing.role = args.update.role; return { subject, role: existing.role }; }
+        memberships.push({ ...args.create }); return { subject, role: args.create.role };
+      }),
+      delete: vi.fn(async function _delete(args: { where: { clusterTenant_subject: { clusterTenant: string; subject: string } } })
+      {
+        const { clusterTenant, subject } = args.where.clusterTenant_subject;
+        const idx = memberships.findIndex(m => m.clusterTenant === clusterTenant && m.subject === subject);
+        if (idx >= 0) memberships.splice(idx, 1);
+        return {};
+      }),
+    },
+  } as unknown as PrismaClient;
+
+  return { prisma, memberships };
+}
+
+/** Session user shape (subset of the OIDC session user). */
+interface User { sub: string; isPlatformOperator: boolean }
+
+/** Mount the members router under the org `:name`, optionally seeding a session user. */
+function _buildApp(prisma: PrismaClient, user?: User): Express
+{
+  const app = express();
+  app.use(express.json());
+  if (user)
+  {
+    app.use(function _seedSession(req, _res, next) { (req as unknown as { session: { authUser: User } }).session = { authUser: user }; next(); });
+  }
+  app.use("/api/v1/cluster-tenants/:name/members", clusterTenantMembersRouter(prisma));
+  return app;
+}
+
+describe("clusterTenantMembersRouter — org member management (S3c)", function _suite()
+{
+  const _AUTH_ENV = ["OPENCRANE_API_TOKEN", "OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET", "OIDC_REDIRECT_URI", "OIDC_SESSION_SECRET"] as const;
+  const _saved: Record<string, string | undefined> = {};
+
+  /** Force REAL-auth mode so the org-manager gate exercises its fail-closed posture. */
+  beforeEach(function _enableAuth()
+  {
+    for (const key of _AUTH_ENV) { _saved[key] = process.env[key]; delete process.env[key]; }
+    process.env.OPENCRANE_API_TOKEN = "ci-token";
+  });
+
+  afterEach(function _restoreEnv()
+  {
+    for (const key of _AUTH_ENV) { if (_saved[key] === undefined) { delete process.env[key]; } else { process.env[key] = _saved[key]; } }
+  });
+
+  const _owner: User = { sub: "owner-1", isPlatformOperator: false };
+
+  // --- list ----------------------------------------------------------------
+
+  it("lists the org's members (subject + role) for an owner", async function _list()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [
+      { clusterTenant: "acme", subject: "owner-1", role: "Owner" },
+      { clusterTenant: "acme", subject: "user-2", role: "Member" },
+    ] });
+    const res = await request(_buildApp(prisma, _owner)).get("/api/v1/cluster-tenants/acme/members");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body).toContainEqual({ subject: "user-2", role: "Member" });
+  });
+
+  it("returns 404 listing members of a missing org", async function _listMissing()
+  {
+    const { prisma } = _mockPrisma({ orgs: [] });
+    const res = await request(_buildApp(prisma, { sub: "op", isPlatformOperator: true })).get("/api/v1/cluster-tenants/ghost/members");
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("CLUSTER_TENANT_NOT_FOUND");
+  });
+
+  // --- add / upsert --------------------------------------------------------
+
+  it("adds a new member (upsert) and returns it", async function _add()
+  {
+    const { prisma, memberships } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "owner-1", role: "Owner" }] });
+    const res = await request(_buildApp(prisma, _owner)).post("/api/v1/cluster-tenants/acme/members").send({ subject: "user-2", role: "Admin" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ subject: "user-2", role: "Admin" });
+    expect(memberships).toContainEqual({ clusterTenant: "acme", subject: "user-2", role: "Admin" });
+  });
+
+  it("updates an existing member's role on upsert", async function _upsert()
+  {
+    const { prisma, memberships } = _mockPrisma({ orgs: ["acme"], memberships: [
+      { clusterTenant: "acme", subject: "owner-1", role: "Owner" },
+      { clusterTenant: "acme", subject: "user-2", role: "Member" },
+    ] });
+    const res = await request(_buildApp(prisma, _owner)).post("/api/v1/cluster-tenants/acme/members").send({ subject: "user-2", role: "Admin" });
+
+    expect(res.status).toBe(200);
+    expect(memberships.find(m => m.subject === "user-2")?.role).toBe("Admin");
+  });
+
+  it("rejects an add with an invalid role (400)", async function _addBadRole()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "owner-1", role: "Owner" }] });
+    const res = await request(_buildApp(prisma, _owner)).post("/api/v1/cluster-tenants/acme/members").send({ subject: "user-2", role: "Superuser" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("returns 404 adding a member to a missing org", async function _addMissingOrg()
+  {
+    const { prisma } = _mockPrisma({ orgs: [] });
+    const res = await request(_buildApp(prisma, { sub: "op", isPlatformOperator: true })).post("/api/v1/cluster-tenants/ghost/members").send({ subject: "x", role: "Member" });
+
+    expect(res.status).toBe(404);
+  });
+
+  // --- last-Owner guardrail ------------------------------------------------
+
+  it("rejects demoting the org's last Owner with 409 LAST_OWNER", async function _demoteLastOwner()
+  {
+    const { prisma, memberships } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "owner-1", role: "Owner" }] });
+    const res = await request(_buildApp(prisma, _owner)).post("/api/v1/cluster-tenants/acme/members").send({ subject: "owner-1", role: "Admin" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("LAST_OWNER");
+    // The Owner row must be untouched.
+    expect(memberships.find(m => m.subject === "owner-1")?.role).toBe("Owner");
+  });
+
+  it("allows demoting an Owner when another Owner remains", async function _demoteWithSpareOwner()
+  {
+    const { prisma, memberships } = _mockPrisma({ orgs: ["acme"], memberships: [
+      { clusterTenant: "acme", subject: "owner-1", role: "Owner" },
+      { clusterTenant: "acme", subject: "owner-2", role: "Owner" },
+    ] });
+    const res = await request(_buildApp(prisma, _owner)).post("/api/v1/cluster-tenants/acme/members").send({ subject: "owner-1", role: "Admin" });
+
+    expect(res.status).toBe(200);
+    expect(memberships.find(m => m.subject === "owner-1")?.role).toBe("Admin");
+  });
+
+  it("rejects removing the org's last Owner with 409 LAST_OWNER", async function _removeLastOwner()
+  {
+    const { prisma, memberships } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "owner-1", role: "Owner" }] });
+    const res = await request(_buildApp(prisma, _owner)).delete("/api/v1/cluster-tenants/acme/members/owner-1");
+
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("LAST_OWNER");
+    expect(memberships).toHaveLength(1);
+  });
+
+  // --- remove --------------------------------------------------------------
+
+  it("removes a non-Owner member", async function _remove()
+  {
+    const { prisma, memberships } = _mockPrisma({ orgs: ["acme"], memberships: [
+      { clusterTenant: "acme", subject: "owner-1", role: "Owner" },
+      { clusterTenant: "acme", subject: "user-2", role: "Member" },
+    ] });
+    const res = await request(_buildApp(prisma, _owner)).delete("/api/v1/cluster-tenants/acme/members/user-2");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ subject: "user-2", status: "removed" });
+    expect(memberships.find(m => m.subject === "user-2")).toBeUndefined();
+  });
+
+  it("returns 404 removing a member who is not in the org", async function _removeMissingMember()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "owner-1", role: "Owner" }] });
+    const res = await request(_buildApp(prisma, _owner)).delete("/api/v1/cluster-tenants/acme/members/ghost");
+
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("MEMBERSHIP_NOT_FOUND");
+  });
+
+  // --- org-manager gate ----------------------------------------------------
+
+  it("denies a non-member listing/managing someone else's org members (403)", async function _nonMember()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "owner-1", role: "Owner" }] });
+    const app = _buildApp(prisma, { sub: "stranger", isPlatformOperator: false });
+
+    const list = await request(app).get("/api/v1/cluster-tenants/acme/members");
+    expect(list.status).toBe(403);
+    expect(list.body.code).toBe("FORBIDDEN_ORG_SCOPE");
+
+    const add = await request(app).post("/api/v1/cluster-tenants/acme/members").send({ subject: "x", role: "Member" });
+    expect(add.status).toBe(403);
+  });
+
+  it("denies a plain Member managing the org's members (403)", async function _plainMember()
+  {
+    const { prisma } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "user-3", role: "Member" }] });
+    const res = await request(_buildApp(prisma, { sub: "user-3", isPlatformOperator: false })).post("/api/v1/cluster-tenants/acme/members").send({ subject: "x", role: "Member" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("lets a platform operator manage any org's members", async function _operator()
+  {
+    const { prisma, memberships } = _mockPrisma({ orgs: ["acme"], memberships: [{ clusterTenant: "acme", subject: "owner-1", role: "Owner" }] });
+    const res = await request(_buildApp(prisma, { sub: "op", isPlatformOperator: true })).post("/api/v1/cluster-tenants/acme/members").send({ subject: "user-9", role: "Member" });
+
+    expect(res.status).toBe(200);
+    expect(memberships).toContainEqual({ clusterTenant: "acme", subject: "user-9", role: "Member" });
+  });
+});

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -366,6 +366,26 @@ const ClusterTenantUpdateSchema = {
   },
 };
 
+const OrgMemberSchema = {
+  type: "object" as const,
+  required: ["subject", "role"],
+  description: "A single organisation membership row — the LOCAL membership registry the org-admin gate reads (an OrgMembership, NOT a Zitadel grant).",
+  properties: {
+    subject: { type: "string", description: "IdP-verified subject (OIDC `sub`) holding the membership." },
+    role: { type: "string", enum: ["Owner", "Admin", "Member"], description: "Role held within the organisation." },
+  },
+};
+
+const OrgMemberWriteSchema = {
+  type: "object" as const,
+  required: ["subject", "role"],
+  description: "Add or update an organisation member (upsert on the unique [org, subject]).",
+  properties: {
+    subject: { type: "string", description: "IdP-verified subject (OIDC `sub`) of the member to add/update." },
+    role: { type: "string", enum: ["Owner", "Admin", "Member"], description: "Role to grant within the organisation." },
+  },
+};
+
 const GroupSchema = {
   type: "object" as const,
   properties: {
@@ -782,6 +802,8 @@ export const spec = {
       ClusterTenantWrite: ClusterTenantWriteSchema,
       ClusterTenantUpdate: ClusterTenantUpdateSchema,
       ClusterTenantResourceQuota: ClusterTenantResourceQuotaSchema,
+      OrgMember: OrgMemberSchema,
+      OrgMemberWrite: OrgMemberWriteSchema,
       BillingAccount: BillingAccountSchema,
       BillingAccountWrite: BillingAccountWriteSchema,
       Group: GroupSchema,
@@ -1532,6 +1554,61 @@ export const spec = {
           401: unauthorized("No authenticated session (real-auth deployments)."),
           403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
           404: notFound("Cluster tenant not found."),
+        },
+      },
+    },
+
+    "/cluster-tenants/{name}/members": {
+      get: {
+        operationId: "listClusterTenantMembers",
+        summary: "List an organisation's members (operator OR owner/admin of that org)",
+        description: "Lists the org's membership rows (subject + role) — the LOCAL membership registry the org-admin gate reads (OrgMembership rows, NOT Zitadel grants).",
+        tags: ["Cluster Tenants"],
+        parameters: [{ name: "name", in: "path", required: true, schema: { type: "string" } }],
+        responses: {
+          200: ok("Organisation membership list.", { type: "array", items: { $ref: "#/components/schemas/OrgMember" } }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
+          404: notFound("Cluster tenant not found."),
+        },
+      },
+      post: {
+        operationId: "addClusterTenantMember",
+        summary: "Add or update an organisation member (operator OR owner/admin of that org)",
+        description: "Upserts a membership on the unique [org, subject]: adds a new member or changes an existing member's role. Last-Owner guardrail: demoting the org's sole Owner to a lesser role is rejected (409 LAST_OWNER).",
+        tags: ["Cluster Tenants"],
+        parameters: [{ name: "name", in: "path", required: true, schema: { type: "string" } }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { $ref: "#/components/schemas/OrgMemberWrite" } } },
+        },
+        responses: {
+          200: ok("Member added or updated.", { $ref: "#/components/schemas/OrgMember" }),
+          400: badRequest("Request body failed validation (subject required; role must be Owner|Admin|Member)."),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
+          404: notFound("Cluster tenant not found."),
+          409: conflict("The change would demote the organisation's last Owner (code LAST_OWNER)."),
+        },
+      },
+    },
+
+    "/cluster-tenants/{name}/members/{subject}": {
+      delete: {
+        operationId: "removeClusterTenantMember",
+        summary: "Remove an organisation member (operator OR owner/admin of that org)",
+        description: "Removes a membership row. Last-Owner guardrail: removing the org's sole Owner is rejected (409 LAST_OWNER).",
+        tags: ["Cluster Tenants"],
+        parameters: [
+          { name: "name", in: "path", required: true, schema: { type: "string" } },
+          { name: "subject", in: "path", required: true, schema: { type: "string" } },
+        ],
+        responses: {
+          200: ok("Member removed.", { type: "object", properties: { subject: { type: "string" }, status: { type: "string" } } }),
+          401: unauthorized("No authenticated session (real-auth deployments)."),
+          403: forbidden("Caller is neither a platform operator nor an owner/admin of this org."),
+          404: notFound("Cluster tenant or membership not found."),
+          409: conflict("Removing this member would remove the organisation's last Owner (code LAST_OWNER)."),
         },
       },
     },

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -42,6 +42,7 @@ import { awarenessParticipationRouter } from "./routes/awareness-participation.j
 import { sessionsRouter } from "./routes/sessions.js";
 import { platformDnsRouter } from "./routes/platform-dns.js";
 import { clusterTenantsRouter } from "./routes/cluster-tenants.js";
+import { clusterTenantMembersRouter } from "./routes/cluster-tenant-members.js";
 import { _BuildClusterTenantProvisionerRegistry } from "./core/cluster-tenants/registry.js";
 import { _BuildZitadelManagementClient } from "./infra/zitadel/zitadel-client.js";
 import { _CheckDbHealth } from "./infra/db/healtcheck-db.js";
@@ -155,6 +156,9 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
     // so a single-cluster install (manager off) never requires it; fail-loud if unset.
     const zitadelClient = _BuildZitadelManagementClient();
     app.use("/api/v1/cluster-tenants", clusterTenantsRouter(prisma, clusterTenantRegistry, customApi, zitadelClient));
+    // Org membership registry (the LOCAL rows the org-admin gate reads), mounted under
+    // the parent org's `:name`. `mergeParams` carries `:name` into the child router.
+    app.use("/api/v1/cluster-tenants/:name/members", clusterTenantMembersRouter(prisma));
   }
   app.use("/api/v1/awareness/rollout", awarenessRolloutRouter(prisma));
   app.use("/api/v1/awareness/participation", awarenessParticipationRouter(prisma));

--- a/apps/control-plane/src/routes/cluster-tenant-members.ts
+++ b/apps/control-plane/src/routes/cluster-tenant-members.ts
@@ -1,0 +1,202 @@
+import { Router } from "express";
+import type { Request } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { _RequireOrgManager } from "../infra/middleware/cluster-tenant-org-admin.js";
+import { _log } from "../log.js";
+
+/** The org roles a membership may hold (mirrors the Prisma `OrgRole` enum). */
+const _ORG_ROLES = ["Owner", "Admin", "Member"] as const;
+
+/** A single valid org role. */
+type OrgRoleValue = (typeof _ORG_ROLES)[number];
+
+/** Request body for adding/updating a member. */
+interface MemberWriteBody
+{
+  /** IdP-verified subject (OIDC `sub`) of the member to add/update. */
+  subject?: unknown;
+  /** Role to grant within the org (Owner | Admin | Member). */
+  role?: unknown;
+}
+
+/** Whether a value is one of the three valid org roles. */
+function _isOrgRole(value: unknown): value is OrgRoleValue
+{
+  return typeof value === "string" && (_ORG_ROLES as readonly string[]).includes(value);
+}
+
+/**
+ * Whether the named org exists, used to return 404 before touching memberships.
+ *
+ * @param prisma - Prisma client for the lookup.
+ * @param name   - ClusterTenant (org) name from the path.
+ * @returns True when a ClusterTenant row with that name exists.
+ */
+async function _orgExists(prisma: PrismaClient, name: string): Promise<boolean>
+{
+  const row = await prisma.clusterTenant.findUnique({ where: { name }, select: { name: true } });
+  return row !== null;
+}
+
+/**
+ * Count the org's current `Owner` memberships — the guardrail input for the
+ * last-Owner invariant (an org must always retain at least one Owner).
+ *
+ * @param prisma - Prisma client for the count.
+ * @param orgName - ClusterTenant (org) name.
+ * @returns The number of `Owner` memberships in the org.
+ */
+async function _ownerCount(prisma: PrismaClient, orgName: string): Promise<number>
+{
+  return prisma.orgMembership.count({ where: { clusterTenant: orgName, role: "Owner" } });
+}
+
+/**
+ * Member-management router for an organisation (ClusterTenant): the LOCAL
+ * membership registry the org-admin gate reads. Members here are
+ * `OrgMembership` rows — NOT Zitadel grants — so this slice is DB-only and
+ * makes no IdP call.
+ *
+ * Mounted under `/api/v1/cluster-tenants/:name/members` and gated wholesale by
+ * {@link _RequireOrgManager}: only a platform operator or an owner/admin of the
+ * named org may read or mutate its membership.
+ *
+ * Last-Owner guardrail: an org must always retain ≥1 `Owner`. Both the role
+ * change (POST demoting the sole Owner) and the removal (DELETE of the sole
+ * Owner) are rejected with HTTP 409 so an org can never be orphaned.
+ *
+ * @param prisma - Prisma client used for the membership reads/writes.
+ * @returns Configured Express router (mount under the org's `:name`).
+ */
+export function clusterTenantMembersRouter(prisma: PrismaClient): Router
+{
+  // `mergeParams` so the parent's `:name` (org) is visible on this child router,
+  // both for the handlers and for the org-manager gate (which reads `req.params.name`).
+  const router = Router({ mergeParams: true });
+
+  const requireOrgManager = _RequireOrgManager(prisma);
+
+  /** List the org's memberships (subject + role). */
+  router.get("/", requireOrgManager, async function _listMembers(req: Request<{ name: string }>, res)
+  {
+    const orgName = req.params.name;
+    if (!(await _orgExists(prisma, orgName)))
+    {
+      res.status(404).json({ error: "Cluster tenant not found", code: "CLUSTER_TENANT_NOT_FOUND" });
+      return;
+    }
+    const rows = await prisma.orgMembership.findMany({
+      where: { clusterTenant: orgName },
+      orderBy: { createdAt: "asc" },
+      select: { subject: true, role: true },
+    });
+    res.json(rows);
+  });
+
+  /**
+   * Add or update a member (upsert on the unique [clusterTenant, subject]).
+   *
+   * Last-Owner guardrail: demoting the org's sole `Owner` to a lesser role is
+   * rejected with 409 so the org always retains at least one Owner.
+   */
+  router.post("/", requireOrgManager, async function _upsertMember(req: Request<{ name: string }>, res)
+  {
+    const orgName = req.params.name;
+    const body = (req.body ?? {}) as MemberWriteBody;
+
+    // 1. Validate the body: a non-blank subject and a role in {Owner,Admin,Member}.
+    const subject = typeof body.subject === "string" ? body.subject.trim() : "";
+    if (!subject)
+    {
+      res.status(400).json({ error: "subject is required.", code: "VALIDATION_ERROR" });
+      return;
+    }
+    if (!_isOrgRole(body.role))
+    {
+      res.status(400).json({ error: "role must be 'Owner', 'Admin', or 'Member'.", code: "VALIDATION_ERROR" });
+      return;
+    }
+    const role = body.role;
+
+    // 2. 404 when the org doesn't exist (never create a membership for a phantom org).
+    if (!(await _orgExists(prisma, orgName)))
+    {
+      res.status(404).json({ error: "Cluster tenant not found", code: "CLUSTER_TENANT_NOT_FOUND" });
+      return;
+    }
+
+    // 3. Last-Owner guardrail: if this write would demote the org's sole Owner to a
+    //    lesser role, reject — an org must always retain ≥1 Owner. Only relevant when
+    //    the existing row is an Owner and the new role is not Owner.
+    if (role !== "Owner")
+    {
+      const existing = await prisma.orgMembership.findUnique({
+        where: { clusterTenant_subject: { clusterTenant: orgName, subject } },
+        select: { role: true },
+      });
+      if (existing?.role === "Owner" && (await _ownerCount(prisma, orgName)) <= 1)
+      {
+        _log.warn({ orgName, subject }, "denied org-membership change: would demote the last Owner of the org");
+        res.status(409).json({ error: "Cannot demote the last Owner of an organisation.", code: "LAST_OWNER" });
+        return;
+      }
+    }
+
+    // 4. Upsert on the unique [clusterTenant, subject]: add a new member or change
+    //    an existing member's role.
+    const member = await prisma.orgMembership.upsert({
+      where: { clusterTenant_subject: { clusterTenant: orgName, subject } },
+      create: { clusterTenant: orgName, subject, role },
+      update: { role },
+      select: { subject: true, role: true },
+    });
+    res.json(member);
+  });
+
+  /**
+   * Remove a member from the org.
+   *
+   * Last-Owner guardrail: removing the org's sole `Owner` is rejected with 409.
+   */
+  router.delete("/:subject", requireOrgManager, async function _removeMember(req: Request<{ name: string; subject: string }>, res)
+  {
+    const orgName = req.params.name;
+    const subject = req.params.subject;
+
+    // 1. 404 when the org doesn't exist.
+    if (!(await _orgExists(prisma, orgName)))
+    {
+      res.status(404).json({ error: "Cluster tenant not found", code: "CLUSTER_TENANT_NOT_FOUND" });
+      return;
+    }
+
+    // 2. 404 when the member isn't in the org (nothing to remove).
+    const existing = await prisma.orgMembership.findUnique({
+      where: { clusterTenant_subject: { clusterTenant: orgName, subject } },
+      select: { role: true },
+    });
+    if (!existing)
+    {
+      res.status(404).json({ error: "Membership not found", code: "MEMBERSHIP_NOT_FOUND" });
+      return;
+    }
+
+    // 3. Last-Owner guardrail: refuse to remove the org's sole Owner — an org must
+    //    always retain ≥1 Owner.
+    if (existing.role === "Owner" && (await _ownerCount(prisma, orgName)) <= 1)
+    {
+      _log.warn({ orgName, subject }, "denied org-membership removal: would remove the last Owner of the org");
+      res.status(409).json({ error: "Cannot remove the last Owner of an organisation.", code: "LAST_OWNER" });
+      return;
+    }
+
+    // 4. Delete the membership row.
+    await prisma.orgMembership.delete({
+      where: { clusterTenant_subject: { clusterTenant: orgName, subject } },
+    });
+    res.json({ subject, status: "removed" });
+  });
+
+  return router;
+}

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -418,6 +418,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/cluster-tenants/{name}/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List an organisation's members (operator OR owner/admin of that org)
+         * @description Lists the org's membership rows (subject + role) — the LOCAL membership registry the org-admin gate reads (OrgMembership rows, NOT Zitadel grants).
+         */
+        get: operations["listClusterTenantMembers"];
+        put?: never;
+        /**
+         * Add or update an organisation member (operator OR owner/admin of that org)
+         * @description Upserts a membership on the unique [org, subject]: adds a new member or changes an existing member's role. Last-Owner guardrail: demoting the org's sole Owner to a lesser role is rejected (409 LAST_OWNER).
+         */
+        post: operations["addClusterTenantMember"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/cluster-tenants/{name}/members/{subject}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Remove an organisation member (operator OR owner/admin of that org)
+         * @description Removes a membership row. Last-Owner guardrail: removing the org's sole Owner is rejected (409 LAST_OWNER).
+         */
+        delete: operations["removeClusterTenantMember"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/billing-accounts": {
         parameters: {
             query?: never;
@@ -1868,6 +1912,26 @@ export interface components {
             storage?: string;
             /** @description Total GPUs the customer may request. */
             gpu?: number;
+        };
+        /** @description A single organisation membership row — the LOCAL membership registry the org-admin gate reads (an OrgMembership, NOT a Zitadel grant). */
+        OrgMember: {
+            /** @description IdP-verified subject (OIDC `sub`) holding the membership. */
+            subject: string;
+            /**
+             * @description Role held within the organisation.
+             * @enum {string}
+             */
+            role: "Owner" | "Admin" | "Member";
+        };
+        /** @description Add or update an organisation member (upsert on the unique [org, subject]). */
+        OrgMemberWrite: {
+            /** @description IdP-verified subject (OIDC `sub`) of the member to add/update. */
+            subject: string;
+            /**
+             * @description Role to grant within the organisation.
+             * @enum {string}
+             */
+            role: "Owner" | "Admin" | "Member";
         };
         BillingAccount: {
             /** @description Surrogate identifier. */
@@ -3771,6 +3835,188 @@ export interface operations {
             };
             /** @description Cluster tenant not found. */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listClusterTenantMembers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Organisation membership list. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgMember"][];
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is neither a platform operator nor an owner/admin of this org. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Cluster tenant not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    addClusterTenantMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OrgMemberWrite"];
+            };
+        };
+        responses: {
+            /** @description Member added or updated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OrgMember"];
+                };
+            };
+            /** @description Request body failed validation (subject required; role must be Owner|Admin|Member). */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is neither a platform operator nor an owner/admin of this org. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Cluster tenant not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The change would demote the organisation's last Owner (code LAST_OWNER). */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    removeClusterTenantMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                name: string;
+                subject: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Member removed. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        subject?: string;
+                        status?: string;
+                    };
+                };
+            };
+            /** @description No authenticated session (real-auth deployments). */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Caller is neither a platform operator nor an owner/admin of this org. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Cluster tenant or membership not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Removing this member would remove the organisation's last Owner (code LAST_OWNER). */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
S3 follow-up slice. `GET/POST/DELETE /api/v1/cluster-tenants/:name/members` (org-manager gated) over the `OrgMembership` registry the org-admin gate reads — list, upsert `{subject,role}`, remove. DB-only (no Zitadel call this slice). **Last-Owner guardrail:** demoting/removing the sole Owner → 409 `LAST_OWNER`. OpenAPI `OrgMember` + contracts regen; `oc cluster-tenant members list|add|remove`. **493 control-plane tests (+14); tsc + cli build clean.**