### PR TITLE
📝 docs: silo IAM + Zitadel key-rotation runbook

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
           { text: 'Networking & isolation', link: '/operators/networking' },
           { text: 'Identity & connection auth', link: '/security/identity' },
           { text: 'Connection security', link: '/security/connection-security' },
+          { text: 'Zitadel key rotation', link: '/security/zitadel-key-rotation' },
           { text: 'Runbook', link: '/operators/runbook' },
           { text: 'Telemetry & logging', link: '/operators/telemetry-logging' },
           { text: 'Awareness SLOs', link: '/operators/awareness-slos' },
@@ -122,6 +123,7 @@ export default defineConfig({
           { text: 'MCP gateway (Obot)', link: '/integrators/mcp-gateway' },
           { text: 'Skill registry & delivery', link: '/integrators/skill-registry' },
           { text: 'Retrieval & memory (Cognee)', link: '/integrators/retrieval-memory' },
+          { text: 'Silo IAM: inheritance & sharing', link: '/integrators/silo-iam' },
         ],
       },
       {

--- a/website/integrators/retrieval-memory.md
+++ b/website/integrators/retrieval-memory.md
@@ -16,6 +16,9 @@ The memory layer provides:
 > for the workspace layering). *This* document is about the **Cognee retrieval plane**,
 > a different thing entirely: org knowledge, not the agent's own scratch notes.
 
+> See also: [Silo IAM: inheritance & sharing](/integrators/silo-iam) (how IAM groups drive Cognee dataset
+> memberships, resource share-groups, and the designed retrieval scope precedence cascade).
+
 ## Current state (2026-06)
 
 The core path is **cut over and live**; some controls remain deferred:

--- a/website/integrators/silo-iam.md
+++ b/website/integrators/silo-iam.md
@@ -1,0 +1,327 @@
+# Silo IAM: inheritance, sharing, and dataset scopes
+
+How OpenCrane's IAM layer connects the user identity to the runtime agent —
+covering grant inheritance, inter-user sharing, Cognee dataset derivation, and the
+designed retrieval scope precedence.
+
+> See also: [Authentication](/security/identity) (OIDC flow, session model, credential types),
+> [Retrieval & memory (Cognee)](/integrators/retrieval-memory) (write-through ingest and the dataset model),
+> [Control who can access what](/guide/permissions) (admin guide to grants and policies),
+> [MCP gateway (Obot)](/integrators/mcp-gateway) (how entitlements reach the agent tool surface).
+
+---
+
+## The principal set
+
+An openclaw UserTenant is a 1:1 personal agent for one ClusterTenant user. Before
+S4, a Tenant's effective entitlements were compiled over only the Tenant's own name —
+the human user's group memberships played no part. After S4 that changes: the runtime
+contract is compiled over the **principal set** `{tenant-name, subject}`.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Contract compile  (S4a)                                │
+│                                                         │
+│  principalIds = [ tenantName, tenant.subject ]          │
+│                      │              │                   │
+│                      ▼              ▼                   │
+│          direct grants on       grants on the           │
+│          the Tenant row         user's IdP subject      │
+│                      │              │                   │
+│                      └──────┬───────┘                   │
+│                             ▼                           │
+│             group grants where ANY principal            │
+│             is a group member                           │
+│                             │                           │
+│                             ▼                           │
+│         precedence pass: highest priority wins          │
+│         Deny beats Allow at equal priority              │
+│         newest createdAt breaks a full tie              │
+└─────────────────────────────────────────────────────────┘
+```
+
+`tenant.subject` is the OIDC `sub` stored on the `Tenant` row at creation time (bound
+via `Tenant.subject` — migration 0025). Tenants created before S4a that have no bound
+subject compile over the tenant name only (the legacy path, unchanged).
+
+The key consequence: **a user-level Deny always overrides a tenant-level Allow**, no
+matter which principal carried either grant. Deny-over-Allow precedence is unchanged
+and deterministic — it operates across the full merged candidate list.
+
+Source:
+[`grant-compiler.ts`](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/core/grants/grant-compiler.ts)
+— `compileForPrincipals(principalIds, payloadType, prisma)`.
+
+[`tenant-contract.ts`](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/routes/internal/tenant-contract.ts)
+— the contract poll route that assembles the principal set and calls `compileForPrincipals`.
+
+::: info Precedence rules
+Three-level tie-break, evaluated in order:
+
+1. Higher `priority` value wins.
+2. At equal priority, `Deny` beats `Allow`.
+3. At equal priority and same access, the newer `createdAt` wins.
+
+This is global across all principals in the set — there is no "tenant grant beats
+user grant" or vice versa. A single Deny anywhere in the set (at the winning priority)
+suppresses the entitlement.
+:::
+
+---
+
+## Inter-user sharing (S4d)
+
+A user who holds an entitlement to a tool (MCP server) or skill bundle can share that
+entitlement with another user or group. This is an explicit, identity-bound action:
+the share is written as an `Allow` grant on the recipient, and the recipient's Tenant
+picks it up on its next contract poll.
+
+### How it works
+
+```
+┌────────────────────────────────────────────────┐
+│  POST /api/v1/shares  (S4d)                    │
+│                                                │
+│  1. Resolve caller from OIDC session           │
+│  2. Validate payloadType + recipientType       │
+│  3. Confirm the payload exists (MCP/skill)     │
+│  4. Confirm the group exists (group recipient) │
+│  5. LEAST-PRIVILEGE GATE:                      │
+│     compile(caller, payloadType) → Allow?      │
+│     No → 403 (no escalation)                  │
+│  6. Write Allow Grant (sharedBy = caller)      │
+│     recipient picks up on next contract poll   │
+└────────────────────────────────────────────────┘
+```
+
+The sharer is stamped on every row (`Grant.sharedBy`). List and revoke only retrieve
+grants where `sharedBy` equals the caller — a sharer holds no power over grants
+created by others or by the platform admin path.
+
+### CLI
+
+```bash
+# Share an MCP server you hold with a specific user
+oc share grant --type mcp-server --id <server-id> --with-user <oidc-subject>
+
+# Share a skill bundle with a group, scoped to a department
+oc share grant --type skill-bundle --id <bundle-id> --with-group <group-id> --scope department
+
+# List the shares you have created
+oc share list
+
+# Revoke a share you created
+oc share revoke <share-id>
+```
+
+### API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/shares` | Create a share (least-privilege gated) |
+| `GET` | `/api/v1/shares` | List your shares |
+| `DELETE` | `/api/v1/shares/{id}` | Revoke a share you created |
+
+Request body for `POST`:
+
+```json
+{
+  "payloadType": "mcp-server",
+  "payloadId": "<server-id>",
+  "recipientType": "user",
+  "recipientId": "<oidc-subject>",
+  "scope": "personal",
+  "note": "optional annotation"
+}
+```
+
+`payloadType` must be `mcp-server` or `skill-bundle`. `recipientType` must be `user`
+or `group`. `scope` must be one of `org`, `department`, `project`, or `personal`
+(defaults to `personal`).
+
+::: warning Least-privilege is enforced server-side
+The gate compiles the caller's own grants at request time and requires an `Allow` on
+the exact payload. A `Deny` or absent grant returns `403`. You cannot share an
+entitlement you do not currently hold, and sharing never escalates privilege.
+:::
+
+Source:
+[`routes/shares.ts`](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/routes/shares.ts)
+— the full share router with the least-privilege gate at step 5.
+
+---
+
+## Dataset-scope derivation (S4c)
+
+Cognee dataset memberships — which knowledge scopes a tenant's agent can retrieve
+from — are derived automatically from IAM group expansion rather than being set
+manually.
+
+### The unified model
+
+Every dataset tier IS a scope-typed `Group`. The five tiers map directly to the five
+`GrantScope` values:
+
+| Tier | `Group.scope` | Dataset key | Notes |
+|------|--------------|-------------|-------|
+| Org | `Org` | `"default"` | Singleton; every tenant is a member |
+| Department | `Department` | `department` | S4c.1 — aligned with grant scope vocabulary |
+| Team | `Team` | `team` | |
+| Project | `Project` | `project` | |
+| Personal | `Personal` | `personal` | Populated by resource share-groups |
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  _DeriveTenantDatasetMembership (S4c)                    │
+│                                                          │
+│  principals = { tenantName, subject }                    │
+│                                                          │
+│  for each Group in the group mirror:                     │
+│    if any(principal ∈ group.members):                    │
+│      add group.members → membership[group.scope tier]    │
+│                                                          │
+│  org tier → always ["default"]  (org singleton)         │
+│  each tier → dedupe + sort (stable diff)                 │
+│                                                          │
+│  → { org, department, team, project, personal }          │
+└──────────────────────────────────────────────────────────┘
+```
+
+The derivation reads only the local `Group` table — it never calls Cognee or any
+external service. The result is compared (diffed) against the persisted projection. If
+they differ, the control plane replaces the projection and pushes the new membership
+to Cognee. If they are identical, no write occurs. This **diff-gate** prevents
+redundant Cognee traffic on every contract poll.
+
+Source:
+[`core/grants/derive-dataset-membership.ts`](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/core/grants/derive-dataset-membership.ts).
+
+### Resource share-groups (direct file and chat sharing)
+
+Sharing a file or chat directly creates a **Personal-scoped resource group** — a
+`Group` with `scope=Personal` and a deterministic name `resource:<type>:<id>`. The
+group's members are the sharer and the recipient. Because Personal-scoped groups
+populate the `personal` dataset tier via the derivation above, the recipient's agent
+gains Cognee access to the shared item through the normal group-expansion path.
+
+```bash
+# Share a file with a colleague (POST /api/v1/resource-shares)
+oc share resource --type file --id <file-id> --with <oidc-subject>
+
+# Share a chat transcript
+oc share resource --type chat --id <chat-id> --with <oidc-subject>
+
+# List resource shares you are a member of
+oc share resource list
+
+# Revoke a recipient from a resource share
+oc share resource revoke <group-id> --subject <oidc-subject>
+```
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/api/v1/resource-shares` | Create or add to a resource share-group |
+| `GET` | `/api/v1/resource-shares` | List resource share-groups you are in |
+| `DELETE` | `/api/v1/resource-shares/{groupId}/recipients/{subject}` | Remove a recipient |
+
+The least-privilege rule applies here too: only a current member of the resource
+group may add further recipients. A user who does not hold the resource cannot share it.
+
+Source:
+[`routes/resource-shares.ts`](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/routes/resource-shares.ts).
+
+### Cognee sync mechanics
+
+The contract poll loop (pod-side `entrypoint.sh`, calling `GET
+/api/v1/internal/tenants/:name/contract`) triggers the derivation and Cognee sync:
+
+1. Derive the membership from the group mirror.
+2. Load the persisted projection from `TenantDatasetMembership`.
+3. If they differ, replace the projection rows (in a single transaction) and push
+   the new membership to Cognee via `PUT /v1/permissions/tenants/:name/awareness-grants`.
+4. If they are identical, skip both writes.
+
+The Cognee push is best-effort and timeout-bounded (default 5 s,
+`COGNEE_PERMISSIONS_TIMEOUT_MS`). A Cognee failure is logged and captured — it does
+not block the contract response or the DB write. The DB projection is the source of
+truth; Cognee converges on the next successful push.
+
+::: tip Isolation stays on the ACL, not the datasets param
+The Cognee permissions ACL (`/v1/permissions/…`) is the isolation boundary — not the
+`datasets=` query parameter. Passing arbitrary dataset names in the retrieval request
+does not bypass the ACL. The dataset/node-set layer is a relevance partition, not a
+security gate.
+:::
+
+---
+
+## Retrieval scope precedence (designed — not yet implemented)
+
+::: warning This section describes a designed but not yet built behaviour
+The `DATASET_SCOPE_RETRIEVAL_PRECEDENCE` constant and the derivation of memberships
+that feed it (S4c) are shipped. The retrieval cascade that acts on them is not yet
+built (tracked as S4e). The section below describes the intended design.
+:::
+
+Once S4e is built, retrieval will use the following scope precedence, from most
+relevant to least relevant:
+
+```
+Personal  →  Project  →  Team  →  Department  →  Org
+(highest relevance)                          (lowest relevance)
+```
+
+Cognee has no native per-scope weighting and no exposed similarity score for the
+graph-completion search family. Scope precedence is therefore **control-plane
+orchestration over Cognee**, not a Cognee setting.
+
+### Pattern A — cascade (start here)
+
+Query the most-specific scope first. If fewer than `top_k` results are returned,
+widen to the next scope to fill the remainder. Continue widening until either `top_k`
+is satisfied or all scopes are exhausted.
+
+```
+query → Personal datasets    → ≥ top_k? → return
+              ↓ not enough
+        Project datasets     → ≥ top_k? → return
+              ↓ not enough
+        Team datasets        → ≥ top_k? → return
+              ↓ not enough
+        Department datasets  → ≥ top_k? → return
+              ↓ not enough
+        Org dataset ("default")          → return
+```
+
+Broad-scope results strictly trail narrower-scope results. No similarity score is
+required. The precedence is encoded by construction.
+
+### Pattern B — parallel + weighted re-rank (planned upgrade)
+
+Fetch candidates from all scopes in parallel using `only_context=true` (CHUNKS mode).
+Tag each result by its source scope, then re-rank by `similarity × scope_weight` and
+synthesise. This interleaves broad context by relevance rather than trailing it, at
+the cost of requiring a score surface.
+
+Scope weights (indicative):
+
+| Scope | Weight |
+|-------|--------|
+| Personal | 1.0 |
+| Project | 0.8 |
+| Team | 0.6 |
+| Department | 0.4 |
+| Org | 0.2 |
+
+### Ingestion tagging
+
+The harvesting-agent `_PushDocumentToCognee` will also pass
+`node_set=[scope, "<scope>:<subject>"]` so scope is a first-class, filterable graph
+tag. This makes scope a retrieval dimension in its own right, independent of dataset
+placement.
+
+### Isolation reminder
+
+The isolation guarantee rests on the Cognee permissions ACL (the grants synced via
+`/v1/permissions/…`), not the `datasets=` parameter. Dataset and node-set are
+relevance/partition dimensions; the ACL is the security gate.

--- a/website/security/identity.md
+++ b/website/security/identity.md
@@ -274,3 +274,5 @@ Authentication establishes *who*; authorization is split across the two planes:
 
 - [Networking & isolation](/operators/networking) — the two-plane model, NetworkPolicy enforcement, the three-layer gateway seam, and known egress gaps
 - [Connection security](/security/connection-security) — CONN.9/CONN.10 threat model and transport hardening posture
+- [Zitadel key rotation](/security/zitadel-key-rotation) — how to rotate the platform SA key that the control plane uses to manage ClusterTenant Zitadel Orgs
+- [Silo IAM: inheritance & sharing](/integrators/silo-iam) — how the Zitadel-bound subject flows into grant compilation and dataset derivation

--- a/website/security/zitadel-key-rotation.md
+++ b/website/security/zitadel-key-rotation.md
@@ -1,0 +1,206 @@
+# Zitadel service-account key rotation
+
+How to rotate the platform's Zitadel service-account key — the master IdP credential
+that the control plane uses to provision and manage ClusterTenant organisations — using
+the safe validate-then-swap procedure.
+
+> See also: [Authentication](/security/identity) (how the Zitadel SA key fits into the OIDC model),
+> [Runbook](/operators/runbook) (general operational procedures),
+> [Networking & isolation](/operators/networking) (the platform network model).
+
+---
+
+## What this key is and why it matters
+
+The control plane authenticates to the Zitadel Management API as a **service account**
+using a key-pair JSON file (the Zitadel "SA key"). This credential is used to:
+
+- Create and tear down per-organisation Zitadel Orgs on ClusterTenant provisioning.
+- Grant the ClusterTenant owner admin rights inside their Zitadel Org.
+- Set and update OIDC application redirect URIs (e.g. when a vanity domain is added).
+
+The SA key must hold the Zitadel **instance-level `IAM_OWNER` role** — an
+instance-scoped privilege that allows org create and delete operations. Losing or
+leaking this credential is a platform-level incident.
+
+::: warning Multi-tenant path only
+The SA key and its rotation apply only when the control plane is running the
+cluster-tenant manager (i.e. `ZITADEL_MGMT_API_URL`, `ZITADEL_MGMT_SA_KEY`, and
+`PLATFORM_BASE_DOMAIN` are all set). Single-cluster installs are unaffected.
+:::
+
+---
+
+## The safe-rotation invariant
+
+The rotation procedure enforces a **validate-then-swap** invariant: the live key is
+replaced only after the candidate key passes both of the following checks:
+
+1. **Token exchange succeeds** — the candidate can authenticate to the Zitadel token
+   endpoint via the JWT-bearer SA grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`).
+2. **Instance-scope probe passes** — the resulting access token holds the
+   `IAM_OWNER` scope the platform depends on (verified by a non-destructive probe
+   against the Zitadel instance API).
+
+If either check fails, the API returns `422`, the old key stays active, and no change
+is made. The CLI exits non-zero and prints which check failed so the operator can
+diagnose before retrying.
+
+Persistence is also required before the in-memory swap. The control plane writes the
+validated key to the `ZITADEL_MGMT_SECRET_NAME` Kubernetes Secret first. If the
+Secret write fails, the live key is not swapped — a restart would otherwise revert to
+the old (potentially revoked) key, so the control plane refuses to proceed. A
+misconfigured persistence path (the env var unset) is rejected with `409` before
+validation even starts.
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  POST /api/v1/admin/zitadel/sa-key:rotate                │
+│                                                          │
+│  1. Normalise the candidate key JSON                     │
+│  2. Check Secret persistence is configured  ─── 409 ────┤
+│  3. Validate the candidate against the live              │
+│     Zitadel instance:                                    │
+│       a. jwt-bearer token exchange          ─── 422 ────┤
+│       b. IAM_OWNER scope probe              ─── 422 ────┤
+│  4. Persist the validated key to the Secret ─── 500 ────┤
+│  5. Swap the in-memory client + clear token              │
+│     cache (atomic)                                       │
+│  6. Return { rotated: true, keyId, previousKeyId }       │
+└──────────────────────────────────────────────────────────┘
+```
+
+Source:
+[`routes/admin/zitadel-key.ts`](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/routes/admin/zitadel-key.ts).
+
+---
+
+## Rotation runbook
+
+Follow these steps when rotating the Zitadel SA key in production. Do not skip the
+validation step or revoke the old key before confirming the rotation succeeded.
+
+### Step 1 — mint a new key in Zitadel
+
+In the Zitadel console, navigate to the service account that the control plane uses
+(the one whose `userId` matches the current key's `userId` field):
+
+1. Open the service account's **Keys** tab.
+2. Click **Add key** and choose **JSON** as the key type.
+3. Download the generated JSON file and store it securely (e.g. a secrets manager).
+   The file has the shape `{ "keyId": "…", "key": "-----BEGIN RSA PRIVATE KEY…", "userId": "…" }`.
+
+Do **not** revoke the old key yet. Both keys are valid at this point.
+
+### Step 2 — rotate via the API or CLI
+
+::: tip Prefer --key-file
+Pass the key JSON via `--key-file` so the key material stays off your shell history
+and process arguments. Inline `--key` is available for scripting but should be
+avoided in production.
+:::
+
+```bash
+# Using the CLI (recommended)
+oc admin zitadel rotate-key --key-file /path/to/new-key.json
+
+# Using the API directly
+curl -X POST \
+  -H "Authorization: Bearer $OPENCRANE_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  https://control.example.com/api/v1/admin/zitadel/sa-key:rotate \
+  --data-raw "{ \"serviceAccountKey\": $(cat /path/to/new-key.json | jq -c .) }"
+```
+
+On success the CLI prints:
+
+```
+✓ Zitadel SA key rotated successfully.
+  newKeyId      : <new-key-id>
+  previousKeyId : <old-key-id>
+```
+
+On validation failure it prints which check failed and exits non-zero — the old key
+remains active. Diagnose the failure before retrying.
+
+### Step 3 — verify the new key is working
+
+After a successful rotation, confirm that the control plane can still provision
+ClusterTenant organisations by creating a test ClusterTenant (or re-provisioning an
+existing one with a forced reconcile). Check the control-plane logs:
+
+```bash
+kubectl logs -n opencrane deployment/control-plane --tail 50 | grep zitadel
+```
+
+A healthy log line looks like:
+
+```
+{"level":30,"msg":"provisioned Zitadel org for ClusterTenant","orgId":"…","orgName":"…"}
+```
+
+### Step 4 — revoke the old key in Zitadel
+
+Only after confirming the rotation succeeded, return to the Zitadel console and delete
+the old key from the service account's **Keys** tab using the `previousKeyId` printed
+in step 2.
+
+---
+
+## Access control
+
+The rotation endpoint is gated behind the **platform-operator** role check
+(`_RequirePlatformOperator` middleware). Only a caller whose OIDC session grants
+`isPlatformOperator` (via the `OPENCRANE_PLATFORM_OPERATOR_GROUPS` env or the seed
+email) can invoke it. An authenticated but non-operator caller receives `403`.
+
+The Kubernetes RBAC for the rotation path is `patch`-only on the single named Secret
+(`ZITADEL_MGMT_SECRET_NAME`). The control-plane service account does not hold `get`
+on the Secret — it reads the initial key at boot from `ZITADEL_MGMT_SA_KEY` env (set
+from the Secret via the Helm template) and patches the Secret only during rotation.
+
+---
+
+## Environment variables
+
+| Variable | Required | Purpose |
+|----------|----------|---------|
+| `ZITADEL_MGMT_API_URL` | Yes | Zitadel instance base URL (e.g. `https://your-instance.zitadel.cloud`) |
+| `ZITADEL_MGMT_SA_KEY` | Yes | Service-account key JSON (set from the Secret at pod start) |
+| `ZITADEL_MGMT_SECRET_NAME` | Yes (rotation) | Name of the Kubernetes Secret to patch during rotation |
+| `PLATFORM_BASE_DOMAIN` | Yes | Base domain used to derive per-org redirect URIs |
+
+`ZITADEL_MGMT_SECRET_NAME` must be set for the rotation endpoint to accept requests.
+If it is unset the endpoint returns `409` immediately — an in-memory-only swap would
+revert to the old key on the next pod restart, so the control plane refuses it.
+
+---
+
+## Incident response
+
+### Rotation returns 422 (validation failed)
+
+The candidate key failed the token exchange or the `IAM_OWNER` scope probe. The old
+key is untouched. Check:
+
+- The key JSON is complete and valid (has `keyId`, `key`, `userId`).
+- The service account in Zitadel still exists and the key has not expired.
+- The service account holds the **instance-level** `IAM_OWNER` role (not org-level).
+- `ZITADEL_MGMT_API_URL` is reachable from the control-plane pod.
+
+### Rotation returns 409 (persistence not configured)
+
+`ZITADEL_MGMT_SECRET_NAME` is not set on the control-plane deployment. Set the env var
+(via the Helm value `controlPlane.zitadel.secretName`) and redeploy before retrying.
+
+### Key was revoked before rotation completed
+
+If the old key was revoked and the rotation failed (or was not started), the control
+plane loses the ability to manage Zitadel. Restore access by:
+
+1. Creating a new SA key in Zitadel for the service account.
+2. Updating the `ZITADEL_MGMT_SA_KEY` env (the Kubernetes Secret) directly with the
+   new key JSON.
+3. Restarting the control-plane pod so it reads the new key from env on boot.
+4. Then running `oc admin zitadel rotate-key` normally to register the key in
+   persistence, ready for the next rotation.


### PR DESCRIPTION
VitePress docs for the shipped silo/identity work: `integrators/silo-iam` (S4a inheritance, S4d `oc share`, S4c dataset-scope derivation + resource sharing, and the S4e retrieval-precedence design clearly marked not-yet-built) + `security/zitadel-key-rotation` runbook (validate-then-swap; mint→rotate→revoke). Nav + sidebar wired, reciprocal See-also cross-links, VitePress build validated.