### PR TITLE
✨ S3d: idempotent Zitadel reconcile/backfill

### DIFF
--- a/apps/cli/src/commands/cluster-tenants.ts
+++ b/apps/cli/src/commands/cluster-tenants.ts
@@ -188,6 +188,20 @@ export function _RegisterClusterTenants(parent: Command, getConfig: () => CliCon
       _PrintSuccess(`Cluster tenant "${name}" deleted`);
     });
 
+  clusterTenant
+    .command("reconcile-zitadel [name]")
+    .description("Reconcile/backfill incomplete Zitadel orgs (superadmin) — re-provisions every cluster tenant whose Zitadel ids are missing/partial, or just [name] when given")
+    .option("-o, --output <format>", "Output format: table|json", "json")
+    .action(async function _reconcileZitadel(name: string | undefined, opts: { output: OutputFormat })
+    {
+      // Scope the run to a single org when a name is given, else reconcile the whole fleet.
+      // The API is superadmin-gated and idempotent; it always returns the run summary.
+      const client = _MakeClient(getConfig());
+      const { data, error } = await client.POST("/admin/zitadel/reconcile", { body: name ? { name } : {} });
+      if (error) _PrintApiError("cluster-tenant reconcile-zitadel", error);
+      _Print(data, opts.output);
+    });
+
   // --- members sub-group: the org's LOCAL membership registry (the rows the
   //     org-admin gate reads — OrgMembership, NOT Zitadel grants). ----------
   const members = clusterTenant

--- a/apps/control-plane/openapi.json
+++ b/apps/control-plane/openapi.json
@@ -2258,6 +2258,75 @@
             "$ref": "#/components/schemas/ZitadelCandidateKeyValidation"
           }
         }
+      },
+      "ZitadelReconcileRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "When set, reconcile ONLY this ClusterTenant; when absent, scan the whole fleet."
+          }
+        }
+      },
+      "ZitadelReconcileSummary": {
+        "type": "object",
+        "required": [
+          "reconciled",
+          "skipped",
+          "failed"
+        ],
+        "properties": {
+          "reconciled": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Names of ClusterTenants whose Zitadel ids were (re-)provisioned and persisted."
+          },
+          "skipped": {
+            "type": "array",
+            "description": "ClusterTenants left untouched, with the reason.",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "reason"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "reason": {
+                  "type": "string",
+                  "enum": [
+                    "already-provisioned",
+                    "no-owner"
+                  ]
+                }
+              }
+            }
+          },
+          "failed": {
+            "type": "array",
+            "description": "ClusterTenants whose reconcile threw (a per-CT failure never aborts the run).",
+            "items": {
+              "type": "object",
+              "required": [
+                "name",
+                "error"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "error": {
+                  "type": "string",
+                  "description": "Human-readable error detail (never key material)."
+                }
+              }
+            }
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -2335,6 +2404,58 @@
           },
           "422": {
             "description": "The candidate key failed validation (token exchange or instance IAM_OWNER scope); no change was made.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/admin/zitadel/reconcile": {
+      "post": {
+        "operationId": "reconcileZitadelOrgs",
+        "summary": "Reconcile/backfill incomplete Zitadel orgs across the fleet (idempotent; superadmin only)",
+        "description": "For every ClusterTenant whose Zitadel ids are incomplete (missing orgId, clientId, appId, or projectId), re-runs provisionOrg (master subject = the org's Owner membership) and persists the ids transactionally. Idempotent: a fully-provisioned org is skipped (no Zitadel call); an org with no Owner is skipped (no-owner); a per-org provision failure is collected (failed) and never aborts the run. Optionally pass { name } to reconcile a single org. Platform-operator gated.",
+        "tags": [
+          "Admin"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ZitadelReconcileRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The reconcile run completed; summary of reconciled / skipped / failed orgs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZitadelReconcileSummary"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not a platform operator.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The named cluster tenant does not exist (single-org reconcile).",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/control-plane/src/__tests__/routes/zitadel-reconcile.test.ts
+++ b/apps/control-plane/src/__tests__/routes/zitadel-reconcile.test.ts
@@ -1,0 +1,220 @@
+import express from "express";
+import type { Express } from "express";
+import { type PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { zitadelReconcileRouter } from "../../routes/admin/zitadel-reconcile.js";
+import type { ZitadelManagementClient } from "../../infra/zitadel/zitadel-client.types.js";
+
+/**
+ * Matrix for the idempotent Zitadel reconcile/backfill (S3d). The invariants under test:
+ *   - an incomplete CT (null ids) is re-provisioned and its ids persisted (transactionally);
+ *   - a fully-provisioned CT is skipped with NO Zitadel call (idempotency);
+ *   - a CT with no Owner membership is skipped:no-owner;
+ *   - a provisionOrg throw for one CT is collected as `failed` while others still reconcile;
+ *   - the route is platform-operator gated (403 for a non-operator).
+ */
+
+/** An in-memory cluster_tenants row. */
+type Row = Record<string, unknown>;
+
+/** A spyable Zitadel client double; `provisionThrowsFor` forces a per-org failure by name. */
+function _fakeZitadel(opts: { provisionThrowsFor?: Set<string> } = {}): {
+  client: ZitadelManagementClient;
+  provisionOrg: ReturnType<typeof vi.fn>;
+}
+{
+  const provisionOrg = vi.fn(async function _provision(input: { orgName: string; redirectUri: string })
+  {
+    if (opts.provisionThrowsFor?.has(input.orgName)) { throw new Error(`zitadel boom for ${input.orgName}`); }
+    return { orgId: `zorg-${input.orgName}`, projectId: `zproj-${input.orgName}`, appId: `zapp-${input.orgName}`, clientId: `zclient-${input.orgName}`, redirectUri: input.redirectUri };
+  });
+  const client = {
+    provisionOrg,
+    async setAppRedirectUris() { /* unused */ },
+    async teardownOrg() { /* unused */ },
+    async validateCandidateKey() { return { tokenExchangeOk: true, instanceScopeOk: true, keyId: "k", detail: "ok" }; },
+    currentKeyId() { return "k"; },
+    reloadKey() { /* unused */ },
+  } as unknown as ZitadelManagementClient;
+  return { client, provisionOrg };
+}
+
+/**
+ * Build a Prisma stub over in-memory maps. `owners` maps a CT name → the Owner subject (absent
+ * → no Owner membership). The `update` mutates the backing row so the persisted ids are visible.
+ */
+function _mockPrisma(store: Map<string, Row>, owners: Map<string, string>): { prisma: PrismaClient; update: ReturnType<typeof vi.fn>; tx: ReturnType<typeof vi.fn> }
+{
+  const update = vi.fn(async function _update(args: { where: { name: string }; data: Row })
+  {
+    const row = { ...(store.get(args.where.name) as Row), ...args.data };
+    store.set(args.where.name, row);
+    return row;
+  });
+  const tx = vi.fn(async function _tx(fn: (t: PrismaClient) => Promise<unknown>) { return fn(prisma); });
+  const prisma = {
+    clusterTenant: {
+      findMany: vi.fn(async function _findMany() { return Array.from(store.values()); }),
+      findUnique: vi.fn(async function _findUnique(args: { where: { name: string } }) { return store.get(args.where.name) ?? null; }),
+      update,
+    },
+    orgMembership: {
+      findFirst: vi.fn(async function _findFirst(args: { where: { clusterTenant: string; role: string } })
+      {
+        const subject = owners.get(args.where.clusterTenant);
+        return subject ? { clusterTenant: args.where.clusterTenant, subject, role: "Owner" } : null;
+      }),
+    },
+    $transaction: tx,
+  } as unknown as PrismaClient;
+  return { prisma, update, tx };
+}
+
+/** A complete (already-provisioned) CT row. */
+function _complete(name: string): Row
+{
+  return { name, displayName: name, vanityDomain: null, zitadelOrgId: "o", zitadelClientId: "c", zitadelAppId: "a", zitadelProjectId: "p", zitadelRedirectUri: "r", createdAt: new Date() };
+}
+
+/** An incomplete CT row (all Zitadel ids null). */
+function _incomplete(name: string, vanityDomain: string | null = null): Row
+{
+  return { name, displayName: name, vanityDomain, zitadelOrgId: null, zitadelClientId: null, zitadelAppId: null, zitadelProjectId: null, zitadelRedirectUri: null, createdAt: new Date() };
+}
+
+/** Session user shape (subset of the OIDC session user). */
+interface User { sub: string; isPlatformOperator: boolean }
+
+/** Mount the router, optionally seeding a session user. */
+function _buildApp(prisma: PrismaClient, client: ZitadelManagementClient, user?: User): Express
+{
+  const app = express();
+  app.use(express.json());
+  if (user)
+  {
+    app.use(function _seedSession(req, _res, next) { (req as unknown as { session: { authUser: User } }).session = { authUser: user }; next(); });
+  }
+  app.use("/api/v1/admin/zitadel", zitadelReconcileRouter(prisma, client));
+  return app;
+}
+
+/** The platform-operator session used by the happy-path tests. */
+const _OP: User = { sub: "op", isPlatformOperator: true };
+
+describe("zitadelReconcileRouter — POST /reconcile (idempotent backfill)", function _suite()
+{
+  // Force REAL-auth mode so the platform-operator gate fail-closes for non-operators.
+  const _AUTH_ENV = ["OPENCRANE_API_TOKEN", "OIDC_ISSUER_URL", "OIDC_CLIENT_ID", "OIDC_CLIENT_SECRET", "OIDC_REDIRECT_URI", "OIDC_SESSION_SECRET"] as const;
+  const _saved: Record<string, string | undefined> = {};
+
+  beforeEach(function _enableAuth()
+  {
+    for (const key of _AUTH_ENV) { _saved[key] = process.env[key]; delete process.env[key]; }
+    process.env.OPENCRANE_API_TOKEN = "ci-token";
+    process.env.PLATFORM_BASE_DOMAIN = "example.com";
+  });
+
+  afterEach(function _restoreEnv()
+  {
+    for (const key of _AUTH_ENV) { if (_saved[key] === undefined) { delete process.env[key]; } else { process.env[key] = _saved[key]; } }
+    delete process.env.PLATFORM_BASE_DOMAIN;
+  });
+
+  it("re-provisions an incomplete CT and persists the ids inside the transaction", async function _reconciles()
+  {
+    const store = new Map<string, Row>([["acme", _incomplete("acme")]]);
+    const { prisma, update, tx } = _mockPrisma(store, new Map([["acme", "subj-owner"]]));
+    const { client, provisionOrg } = _fakeZitadel();
+
+    const res = await request(_buildApp(prisma, client, _OP)).post("/api/v1/admin/zitadel/reconcile").send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ reconciled: ["acme"], skipped: [], failed: [] });
+    // provisionOrg ran with the Owner as the master subject + the derived redirect URI.
+    expect(provisionOrg).toHaveBeenCalledOnce();
+    expect(provisionOrg.mock.calls[0][0]).toMatchObject({ orgName: "acme", masterSubject: "subj-owner" });
+    // The persist ran inside a $transaction and stamped the returned ids.
+    expect(tx).toHaveBeenCalledOnce();
+    expect(update).toHaveBeenCalledOnce();
+    expect(store.get("acme")).toMatchObject({ zitadelOrgId: "zorg-acme", zitadelClientId: "zclient-acme", zitadelAppId: "zapp-acme", zitadelProjectId: "zproj-acme" });
+  });
+
+  it("skips a fully-provisioned CT with NO Zitadel call (idempotency)", async function _idempotent()
+  {
+    const store = new Map<string, Row>([["acme", _complete("acme")]]);
+    const { prisma } = _mockPrisma(store, new Map([["acme", "subj-owner"]]));
+    const { client, provisionOrg } = _fakeZitadel();
+
+    const res = await request(_buildApp(prisma, client, _OP)).post("/api/v1/admin/zitadel/reconcile").send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ reconciled: [], skipped: [{ name: "acme", reason: "already-provisioned" }], failed: [] });
+    expect(provisionOrg).not.toHaveBeenCalled();
+  });
+
+  it("skips an incomplete CT with no Owner membership as skipped:no-owner (no call)", async function _noOwner()
+  {
+    const store = new Map<string, Row>([["acme", _incomplete("acme")]]);
+    const { prisma } = _mockPrisma(store, new Map()); // no Owner registered
+    const { client, provisionOrg } = _fakeZitadel();
+
+    const res = await request(_buildApp(prisma, client, _OP)).post("/api/v1/admin/zitadel/reconcile").send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ reconciled: [], skipped: [{ name: "acme", reason: "no-owner" }], failed: [] });
+    expect(provisionOrg).not.toHaveBeenCalled();
+  });
+
+  it("collects a per-CT provision failure as `failed` and still reconciles the others", async function _failureIsolation()
+  {
+    const store = new Map<string, Row>([
+      ["bad", _incomplete("bad")],
+      ["good", _incomplete("good")],
+    ]);
+    const { prisma } = _mockPrisma(store, new Map([["bad", "s1"], ["good", "s2"]]));
+    const { client, provisionOrg } = _fakeZitadel({ provisionThrowsFor: new Set(["bad"]) });
+
+    const res = await request(_buildApp(prisma, client, _OP)).post("/api/v1/admin/zitadel/reconcile").send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body.reconciled).toEqual(["good"]);
+    expect(res.body.failed).toHaveLength(1);
+    expect(res.body.failed[0]).toMatchObject({ name: "bad" });
+    expect(res.body.failed[0].error).toContain("zitadel boom");
+    // Both orgs were attempted — the failure did not abort the run.
+    expect(provisionOrg).toHaveBeenCalledTimes(2);
+    expect(store.get("good")).toMatchObject({ zitadelOrgId: "zorg-good" });
+  });
+
+  it("reconciles a single CT when a { name } body is given (404 when absent)", async function _singleScope()
+  {
+    const store = new Map<string, Row>([["acme", _incomplete("acme")], ["other", _incomplete("other")]]);
+    const { prisma } = _mockPrisma(store, new Map([["acme", "s1"], ["other", "s2"]]));
+    const { client, provisionOrg } = _fakeZitadel();
+
+    const ok = await request(_buildApp(prisma, client, _OP)).post("/api/v1/admin/zitadel/reconcile").send({ name: "acme" });
+    expect(ok.status).toBe(200);
+    expect(ok.body.reconciled).toEqual(["acme"]);
+    expect(provisionOrg).toHaveBeenCalledOnce(); // only the named org
+
+    const missing = await request(_buildApp(prisma, client, _OP)).post("/api/v1/admin/zitadel/reconcile").send({ name: "ghost" });
+    expect(missing.status).toBe(404);
+    expect(missing.body.code).toBe("CLUSTER_TENANT_NOT_FOUND");
+  });
+
+  it("returns 403 for a non-operator (platform-operator gate, fail-closed)", async function _nonOperator()
+  {
+    const store = new Map<string, Row>([["acme", _incomplete("acme")]]);
+    const { prisma } = _mockPrisma(store, new Map([["acme", "s1"]]));
+    const { client, provisionOrg } = _fakeZitadel();
+
+    const res = await request(_buildApp(prisma, client, { sub: "user-1", isPlatformOperator: false }))
+      .post("/api/v1/admin/zitadel/reconcile").send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("FORBIDDEN_NOT_PLATFORM_OPERATOR");
+    expect(provisionOrg).not.toHaveBeenCalled();
+  });
+});

--- a/apps/control-plane/src/openapi/spec.ts
+++ b/apps/control-plane/src/openapi/spec.ts
@@ -918,6 +918,43 @@ export const spec = {
           validation: { $ref: "#/components/schemas/ZitadelCandidateKeyValidation" },
         },
       },
+      ZitadelReconcileRequest: {
+        type: "object",
+        properties: {
+          name: { type: "string", description: "When set, reconcile ONLY this ClusterTenant; when absent, scan the whole fleet." },
+        },
+      },
+      ZitadelReconcileSummary: {
+        type: "object",
+        required: ["reconciled", "skipped", "failed"],
+        properties: {
+          reconciled: { type: "array", items: { type: "string" }, description: "Names of ClusterTenants whose Zitadel ids were (re-)provisioned and persisted." },
+          skipped: {
+            type: "array",
+            description: "ClusterTenants left untouched, with the reason.",
+            items: {
+              type: "object",
+              required: ["name", "reason"],
+              properties: {
+                name: { type: "string" },
+                reason: { type: "string", enum: ["already-provisioned", "no-owner"] },
+              },
+            },
+          },
+          failed: {
+            type: "array",
+            description: "ClusterTenants whose reconcile threw (a per-CT failure never aborts the run).",
+            items: {
+              type: "object",
+              required: ["name", "error"],
+              properties: {
+                name: { type: "string" },
+                error: { type: "string", description: "Human-readable error detail (never key material)." },
+              },
+            },
+          },
+        },
+      },
     },
     securitySchemes: {
       bearerAuth: {
@@ -950,6 +987,24 @@ export const spec = {
           403: forbidden("Caller is not a platform operator."),
           409: conflict("Key-Secret persistence is not configured (ZITADEL_MGMT_SECRET_NAME unset); rotation refused."),
           422: unprocessable("The candidate key failed validation (token exchange or instance IAM_OWNER scope); no change was made."),
+        },
+      },
+    },
+
+    "/admin/zitadel/reconcile": {
+      post: {
+        operationId: "reconcileZitadelOrgs",
+        summary: "Reconcile/backfill incomplete Zitadel orgs across the fleet (idempotent; superadmin only)",
+        description: "For every ClusterTenant whose Zitadel ids are incomplete (missing orgId, clientId, appId, or projectId), re-runs provisionOrg (master subject = the org's Owner membership) and persists the ids transactionally. Idempotent: a fully-provisioned org is skipped (no Zitadel call); an org with no Owner is skipped (no-owner); a per-org provision failure is collected (failed) and never aborts the run. Optionally pass { name } to reconcile a single org. Platform-operator gated.",
+        tags: ["Admin"],
+        requestBody: {
+          required: false,
+          content: { "application/json": { schema: { $ref: "#/components/schemas/ZitadelReconcileRequest" } } },
+        },
+        responses: {
+          200: ok("The reconcile run completed; summary of reconciled / skipped / failed orgs.", { $ref: "#/components/schemas/ZitadelReconcileSummary" }),
+          403: forbidden("Caller is not a platform operator."),
+          404: notFound("The named cluster tenant does not exist (single-org reconcile)."),
         },
       },
     },

--- a/apps/control-plane/src/routes.ts
+++ b/apps/control-plane/src/routes.ts
@@ -48,6 +48,7 @@ import { _BuildClusterTenantProvisionerRegistry } from "./core/cluster-tenants/r
 import { _BuildZitadelManagementClient } from "./infra/zitadel/zitadel-client.js";
 import { _BuildZitadelKeySecretStore } from "./infra/zitadel/key-secret-store.js";
 import { zitadelKeyRouter } from "./routes/admin/zitadel-key.js";
+import { zitadelReconcileRouter } from "./routes/admin/zitadel-reconcile.js";
 import { _CheckDbHealth } from "./infra/db/healtcheck-db.js";
 
 /**
@@ -167,6 +168,10 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
     // Mounted here, on the manager-enabled path, because that is the ONLY place the live
     // Zitadel client exists; the key Secret is patched via the same CoreV1Api the app uses.
     app.use("/api/v1/admin/zitadel", zitadelKeyRouter(zitadelClient, _BuildZitadelKeySecretStore(coreApi)));
+    // Idempotent reconcile/backfill (S3d): re-provision ClusterTenants whose Zitadel org is
+    // missing/partial (created before Zitadel was configured, or a half-failed provision) and
+    // heal the drift. Superadmin-gated; sibling of the SA-key router on the same live client.
+    app.use("/api/v1/admin/zitadel", zitadelReconcileRouter(prisma, zitadelClient));
   }
   app.use("/api/v1/awareness/rollout", awarenessRolloutRouter(prisma));
   app.use("/api/v1/awareness/participation", awarenessParticipationRouter(prisma));

--- a/apps/control-plane/src/routes/admin/zitadel-reconcile.ts
+++ b/apps/control-plane/src/routes/admin/zitadel-reconcile.ts
@@ -1,0 +1,160 @@
+import { Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { _RequirePlatformOperator } from "../../infra/middleware/require-platform-operator.js";
+import { _DeriveOrgRedirectUri, _DeriveVanityRedirectUri } from "../../infra/zitadel/zitadel-client.js";
+import type { ZitadelManagementClient } from "../../infra/zitadel/zitadel-client.types.js";
+import { _log } from "../../log.js";
+import type { ZitadelReconcileRequest, ZitadelReconcileSummary } from "./zitadel-reconcile.types.js";
+
+/** A `cluster_tenants` row as returned by Prisma `findMany`/`findUnique`. */
+type ClusterTenantRow = NonNullable<Awaited<ReturnType<PrismaClient["clusterTenant"]["findUnique"]>>>;
+
+/**
+ * Whether a ClusterTenant row has a COMPLETE Zitadel provisioning — all four ids present.
+ * A row missing any of orgId / clientId / appId / projectId is a reconcile candidate (it was
+ * created before Zitadel was configured, or a provision half-failed). The reconcile is
+ * idempotent off this predicate: a complete row makes no Zitadel call.
+ *
+ * @param row - The ClusterTenant row to inspect.
+ * @returns True when every Zitadel id column is populated.
+ */
+function _IsZitadelComplete(row: ClusterTenantRow): boolean
+{
+  return Boolean(row.zitadelOrgId && row.zitadelClientId && row.zitadelAppId && row.zitadelProjectId);
+}
+
+/**
+ * Re-provision a single ClusterTenant's Zitadel org and persist the ids in ONE transaction
+ * (the external Zitadel call is the LAST fallible step, per the standing rule: a Prisma write
+ * plus an external call go in one `$transaction` with the external call last, so a Zitadel
+ * failure rolls the persist back and the DB never drifts).
+ *
+ * The org's master subject is the CT's `Owner` membership. When no Owner membership exists the
+ * caller has already decided to skip the CT, so this helper assumes a non-empty `masterSubject`.
+ *
+ * @param prisma        - Prisma client (the persist runs inside its `$transaction`).
+ * @param zitadelClient - The live Zitadel management client.
+ * @param row           - The ClusterTenant row being reconciled.
+ * @param masterSubject - The Owner subject granted `admin` on the (re-)provisioned org.
+ * @param baseDomain    - Platform base domain used to derive the canonical redirect URI.
+ */
+async function _ReconcileOne(prisma: PrismaClient, zitadelClient: ZitadelManagementClient,
+                             row: ClusterTenantRow, masterSubject: string, baseDomain: string): Promise<void>
+{
+  await prisma.$transaction(async function _persistAfterProvision(tx)
+  {
+    // The Zitadel call is the LAST fallible step: derive the redirect URIs as the create
+    // handler does (canonical apex + the vanity callback when the org carries a vanity
+    // domain) and re-provision. `provisionOrg` self-compensates on a mid-flight failure.
+    const zitadel = await zitadelClient.provisionOrg({
+      orgName: row.name,
+      displayName: row.displayName,
+      redirectUri: _DeriveOrgRedirectUri(row.name, baseDomain),
+      ...(row.vanityDomain ? { vanityRedirectUri: _DeriveVanityRedirectUri(row.vanityDomain) } : {}),
+      masterSubject,
+    });
+    await tx.clusterTenant.update({
+      where: { name: row.name },
+      data: { zitadelOrgId: zitadel.orgId, zitadelProjectId: zitadel.projectId, zitadelAppId: zitadel.appId, zitadelClientId: zitadel.clientId, zitadelRedirectUri: zitadel.redirectUri },
+    });
+  });
+}
+
+/**
+ * Superadmin-gated router for the idempotent Zitadel reconcile/backfill (S3d).
+ *
+ * For every ClusterTenant whose Zitadel ids are incomplete (missing orgId OR clientId OR appId
+ * OR projectId), it re-runs `provisionOrg` (master subject = the CT's `Owner` membership) and
+ * persists the ids transactionally (external call LAST). It is **idempotent**: a fully-provisioned
+ * CT is skipped with no Zitadel call, and re-running it on an already-healed fleet is a no-op.
+ *
+ * Failure isolation: a per-CT failure (no Owner → `skipped: no-owner`; a `provisionOrg`/persist
+ * throw → `failed`) NEVER aborts the run — each outcome is collected and the scan continues, and
+ * the route always returns 200 with the full summary. Every skip/fail is structured-logged.
+ *
+ * Mounted at `/api/v1/admin/zitadel` (sibling of the SA-key router), behind
+ * {@link _RequirePlatformOperator}. Only the multi-tenant path constructs the Zitadel client,
+ * so it is mounted only there (see `routes.ts`).
+ *
+ * @param prisma        - Prisma client used to read the fleet + persist the reconciled ids.
+ * @param zitadelClient - The live Zitadel management client used to (re-)provision orgs.
+ * @returns Configured Express router.
+ */
+export function zitadelReconcileRouter(prisma: PrismaClient, zitadelClient: ZitadelManagementClient): Router
+{
+  const router = Router();
+
+  router.use(_RequirePlatformOperator());
+
+  /**
+   * Reconcile incomplete Zitadel orgs across the fleet (or a single CT when `{ name }` is given).
+   * Always 200 with a `{ reconciled, skipped, failed }` summary; per-CT failures are collected.
+   */
+  router.post("/reconcile", async function _reconcile(req, res)
+  {
+    const body = (req.body ?? {}) as ZitadelReconcileRequest;
+    const baseDomain = process.env.PLATFORM_BASE_DOMAIN?.trim() ?? "";
+
+    // 1. Resolve the scope: a single named CT (404 when absent) or the whole fleet.
+    let rows: ClusterTenantRow[];
+    if (typeof body.name === "string" && body.name.trim())
+    {
+      const row = await prisma.clusterTenant.findUnique({ where: { name: body.name.trim() } });
+      if (!row)
+      {
+        res.status(404).json({ error: "Cluster tenant not found", code: "CLUSTER_TENANT_NOT_FOUND" });
+        return;
+      }
+      rows = [row];
+    }
+    else
+    {
+      rows = await prisma.clusterTenant.findMany({ orderBy: { createdAt: "asc" } });
+    }
+
+    const summary: ZitadelReconcileSummary = { reconciled: [], skipped: [], failed: [] };
+
+    // 2. Walk every candidate. Each CT lands in exactly one bucket; a per-CT failure is
+    //    collected and the loop continues so one bad org never strands the rest.
+    for (const row of rows)
+    {
+      // 2a. Idempotency: a fully-provisioned CT makes no Zitadel call.
+      if (_IsZitadelComplete(row))
+      {
+        summary.skipped.push({ name: row.name, reason: "already-provisioned" });
+        continue;
+      }
+
+      // 2b. The master subject is the CT's Owner membership; with no Owner there is no
+      //     identity to grant `admin`, so skip (reported) rather than guess.
+      const owner = await prisma.orgMembership.findFirst({ where: { clusterTenant: row.name, role: "Owner" } });
+      if (!owner)
+      {
+        _log.warn({ orgName: row.name }, "zitadel reconcile: skipped — no Owner membership to use as the org master subject");
+        summary.skipped.push({ name: row.name, reason: "no-owner" });
+        continue;
+      }
+
+      // 2c. (Re-)provision + persist transactionally (external LAST). A throw here is this
+      //     CT's failure alone — collect it and move on.
+      try
+      {
+        await _ReconcileOne(prisma, zitadelClient, row, owner.subject, baseDomain);
+        _log.info({ orgName: row.name }, "zitadel reconcile: re-provisioned org and persisted ids");
+        summary.reconciled.push(row.name);
+      }
+      catch (err)
+      {
+        const message = err instanceof Error ? err.message : String(err);
+        _log.error({ err, orgName: row.name }, "zitadel reconcile: provision/persist FAILED for this org (continuing with the rest)");
+        summary.failed.push({ name: row.name, error: message });
+      }
+    }
+
+    _log.info({ reconciled: summary.reconciled.length, skipped: summary.skipped.length, failed: summary.failed.length }, "zitadel reconcile: run complete");
+    res.status(200).json(summary);
+  });
+
+  return router;
+}

--- a/apps/control-plane/src/routes/admin/zitadel-reconcile.types.ts
+++ b/apps/control-plane/src/routes/admin/zitadel-reconcile.types.ts
@@ -1,0 +1,52 @@
+/**
+ * Types for the idempotent Zitadel reconcile/backfill (S3d).
+ *
+ * A ClusterTenant can carry a missing or partial Zitadel org — `zitadelOrgId`,
+ * `zitadelClientId`, `zitadelAppId`, or `zitadelProjectId` null — when it was created
+ * before Zitadel was configured, or when a provision half-failed. The reconcile route
+ * re-runs `provisionOrg` for the gaps and heals the drift. These shapes describe its
+ * request body and its per-CT outcome summary.
+ */
+
+/** Optional request body for the reconcile route: scope the run to a single ClusterTenant. */
+export interface ZitadelReconcileRequest
+{
+  /** When set, reconcile ONLY this ClusterTenant (by name); when absent, scan the whole fleet. */
+  name?: string;
+}
+
+/** A single skipped ClusterTenant and the reason it was not reconciled. */
+export interface ZitadelReconcileSkip
+{
+  /** The ClusterTenant name. */
+  name: string;
+  /** Why it was skipped (`already-provisioned` or `no-owner`). */
+  reason: ZitadelReconcileSkipReason;
+}
+
+/** The reasons a ClusterTenant is skipped during reconcile. */
+export type ZitadelReconcileSkipReason = "already-provisioned" | "no-owner";
+
+/** A single ClusterTenant whose reconcile FAILED, with the error detail. */
+export interface ZitadelReconcileFailure
+{
+  /** The ClusterTenant name. */
+  name: string;
+  /** Human-readable error detail (never key material). */
+  error: string;
+}
+
+/**
+ * Summary of a reconcile run. Each ClusterTenant lands in exactly one bucket:
+ * `reconciled` (provisionOrg ran + ids persisted), `skipped` (already complete, or no
+ * Owner membership), or `failed` (provisionOrg or the persist threw — collected, not fatal).
+ */
+export interface ZitadelReconcileSummary
+{
+  /** Names of ClusterTenants whose Zitadel ids were (re-)provisioned and persisted. */
+  reconciled: string[];
+  /** ClusterTenants left untouched, with the reason. */
+  skipped: ZitadelReconcileSkip[];
+  /** ClusterTenants whose reconcile threw (a per-CT failure never aborts the run). */
+  failed: ZitadelReconcileFailure[];
+}

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -24,6 +24,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/admin/zitadel/reconcile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reconcile/backfill incomplete Zitadel orgs across the fleet (idempotent; superadmin only)
+         * @description For every ClusterTenant whose Zitadel ids are incomplete (missing orgId, clientId, appId, or projectId), re-runs provisionOrg (master subject = the org's Owner membership) and persists the ids transactionally. Idempotent: a fully-provisioned org is skipped (no Zitadel call); an org with no Owner is skipped (no-owner); a per-org provision failure is collected (failed) and never aborts the run. Optionally pass { name } to reconcile a single org. Platform-operator gated.
+         */
+        post: operations["reconcileZitadelOrgs"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/platform/dns": {
         parameters: {
             query?: never;
@@ -2604,6 +2624,26 @@ export interface components {
             previousKeyId?: string;
             validation: components["schemas"]["ZitadelCandidateKeyValidation"];
         };
+        ZitadelReconcileRequest: {
+            /** @description When set, reconcile ONLY this ClusterTenant; when absent, scan the whole fleet. */
+            name?: string;
+        };
+        ZitadelReconcileSummary: {
+            /** @description Names of ClusterTenants whose Zitadel ids were (re-)provisioned and persisted. */
+            reconciled: string[];
+            /** @description ClusterTenants left untouched, with the reason. */
+            skipped: {
+                name: string;
+                /** @enum {string} */
+                reason: "already-provisioned" | "no-owner";
+            }[];
+            /** @description ClusterTenants whose reconcile threw (a per-CT failure never aborts the run). */
+            failed: {
+                name: string;
+                /** @description Human-readable error detail (never key material). */
+                error: string;
+            }[];
+        };
     };
     responses: never;
     parameters: never;
@@ -2664,6 +2704,48 @@ export interface operations {
             };
             /** @description The candidate key failed validation (token exchange or instance IAM_OWNER scope); no change was made. */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    reconcileZitadelOrgs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["ZitadelReconcileRequest"];
+            };
+        };
+        responses: {
+            /** @description The reconcile run completed; summary of reconciled / skipped / failed orgs. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ZitadelReconcileSummary"];
+                };
+            };
+            /** @description Caller is not a platform operator. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The named cluster tenant does not exist (single-org reconcile). */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
Heals the orphan/partial Zitadel-org drift class (we hit it manually during consolidation). `POST /api/v1/admin/zitadel/reconcile` (platform-operator gated) re-provisions ClusterTenants whose Zitadel ids are missing/partial — masterSubject from the Owner membership, redirect/vanity derived as the create handler does, persisted in one `prisma.$transaction` (external call LAST). **Idempotent:** fully-provisioned → skipped (no call); no-Owner → `skipped:no-owner`; a per-CT failure is collected (`{reconciled, skipped, failed}` summary) and never aborts the run. `oc cluster-tenant reconcile-zitadel [name]`. **529 cp tests (+6); tsc + cli build clean.**