### PR TITLE
📝 docs: ClusterTenant members + Linkerd identity substrate

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -107,6 +107,8 @@ export default defineConfig({
           { text: 'Hosting & deployment', link: '/operators/hosting' },
           { text: 'DNS configuration', link: '/operators/dns-config' },
           { text: 'Networking & isolation', link: '/operators/networking' },
+          { text: 'Linkerd identity substrate', link: '/operators/linkerd-identity' },
+          { text: 'ClusterTenant members', link: '/operators/cluster-tenant-members' },
           { text: 'Identity & connection auth', link: '/security/identity' },
           { text: 'Connection security', link: '/security/connection-security' },
           { text: 'Zitadel key rotation', link: '/security/zitadel-key-rotation' },

--- a/website/integrators/silo-iam.md
+++ b/website/integrators/silo-iam.md
@@ -7,7 +7,8 @@ designed retrieval scope precedence.
 > See also: [Authentication](/security/identity) (OIDC flow, session model, credential types),
 > [Retrieval & memory (Cognee)](/integrators/retrieval-memory) (write-through ingest and the dataset model),
 > [Control who can access what](/guide/permissions) (admin guide to grants and policies),
-> [MCP gateway (Obot)](/integrators/mcp-gateway) (how entitlements reach the agent tool surface).
+> [MCP gateway (Obot)](/integrators/mcp-gateway) (how entitlements reach the agent tool surface),
+> [ClusterTenant members](/operators/cluster-tenant-members) (who may administer the org — the OrgMembership registry the org-manager gate reads).
 
 ---
 

--- a/website/operators/cluster-tenant-members.md
+++ b/website/operators/cluster-tenant-members.md
@@ -1,0 +1,184 @@
+# ClusterTenant member management
+
+Managing who can administer a ClusterTenant (organisation) — the roles, the API + CLI surface, and the guardrail that prevents an org from losing all its owners.
+
+> See also:
+> [Silo IAM: inheritance & sharing](/integrators/silo-iam) — how org membership feeds grant compilation and dataset-scope derivation for the agents inside a silo.
+> [Networking & isolation](/operators/networking) — the per-silo default-deny baseline that this org model sits on top of.
+> [Zitadel key rotation](/security/zitadel-key-rotation) — the IdP-side complement: Zitadel service-account keys versus the local membership registry described here.
+
+---
+
+## What the membership registry is
+
+Each ClusterTenant owns a set of **OrgMembership** rows in the control-plane database. These rows record which OIDC subjects (users) can manage the org and at what role. The org-manager gate — the middleware that guards every ClusterTenant write and the members API itself — reads this registry to decide whether to admit or reject a request.
+
+::: info Local registry, not Zitadel grants
+`OrgMembership` rows are **control-plane-local**: they live in the platform's own database and are not Zitadel role grants. Adding a member here does not automatically create a Zitadel grant, and removing one does not touch the IdP. The registry's purpose is to control who may call the management API for a given org; it is not the full RBAC model for what users _inside_ the org can access (that is handled by the grant/policy system described in [Silo IAM](/integrators/silo-iam)).
+:::
+
+The three membership roles are:
+
+| Role | What it can do |
+|------|----------------|
+| `Owner` | Full management of the org — members, config, deletion. At least one `Owner` must always exist. |
+| `Admin` | Same management rights as Owner via the API; cannot be used to demote/remove the last Owner. |
+| `Member` | Read — currently reserved; the org-manager gate admits `Owner` and `Admin` only. |
+
+---
+
+## The last-owner guardrail
+
+An org must always retain at least one `Owner`. The API enforces this in two places:
+
+- **Removing an `Owner`** via `DELETE /members/:subject` when they are the sole Owner → HTTP 409, code `LAST_OWNER`.
+- **Demoting an `Owner`** to `Admin` or `Member` via `POST /members` when they are the sole Owner → HTTP 409, code `LAST_OWNER`.
+
+Both operations are rejected before the database write. The error message is explicit: `"Cannot remove/demote the last Owner of an organisation."` Promoting a second user to `Owner` first unblocks either operation.
+
+::: warning Transferring ownership
+Always add the new owner before removing the old one. Attempting to remove or demote the sole owner will be rejected with 409, and the org will remain intact.
+:::
+
+---
+
+## API reference
+
+All member endpoints sit under the org path and are gated by the org-manager middleware: a platform operator or an `Owner`/`Admin` of the named org may call them. The caller's identity is taken from the OIDC session — there is no request parameter for it.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/cluster-tenants/:name/members` | List all members (subject + role), ordered by `createdAt` ascending. |
+| `POST` | `/api/v1/cluster-tenants/:name/members` | Add a new member or update an existing member's role (upsert on subject). |
+| `DELETE` | `/api/v1/cluster-tenants/:name/members/:subject` | Remove a member from the org. |
+
+### Request body for POST
+
+```json
+{
+  "subject": "<oidc-sub>",
+  "role": "Owner | Admin | Member"
+}
+```
+
+`subject` must be a non-blank OIDC `sub` string — the same value stored on the `Tenant` row when a user's assistant was created. `role` must be exactly `Owner`, `Admin`, or `Member`; anything else returns HTTP 400.
+
+### Response shapes
+
+`GET` returns an array:
+
+```json
+[
+  { "subject": "auth0|abc123", "role": "Owner" },
+  { "subject": "auth0|def456", "role": "Admin" }
+]
+```
+
+`POST` returns the upserted row:
+
+```json
+{ "subject": "auth0|def456", "role": "Admin" }
+```
+
+`DELETE` returns a confirmation envelope:
+
+```json
+{ "subject": "auth0|def456", "status": "removed" }
+```
+
+### Error codes
+
+| HTTP | Code | Meaning |
+|------|------|---------|
+| 400 | `VALIDATION_ERROR` | Missing or invalid `subject` or `role`. |
+| 401 | `UNAUTHORIZED` | No authenticated session. |
+| 403 | `FORBIDDEN_ORG_SCOPE` | Caller is neither a platform operator nor an Owner/Admin of this org. |
+| 404 | `CLUSTER_TENANT_NOT_FOUND` | No ClusterTenant with that name exists. |
+| 404 | `MEMBERSHIP_NOT_FOUND` | `DELETE` target subject is not a member of the org. |
+| 409 | `LAST_OWNER` | The operation would leave the org with zero Owners. |
+
+Source: [`apps/control-plane/src/routes/cluster-tenant-members.ts`](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/routes/cluster-tenant-members.ts)
+
+---
+
+## CLI reference
+
+The `oc cluster-tenant members` sub-group mirrors the API exactly. Output defaults to table mode; pass `--output json` for machine-readable results.
+
+### List members
+
+```bash
+oc cluster-tenant members list <org-name>
+oc cluster-tenant members list <org-name> --output json
+```
+
+Prints the `subject` and `role` columns for every member of the named org.
+
+### Add or update a member
+
+```bash
+# Add a new owner
+oc cluster-tenant members add <org-name> \
+  --subject auth0|abc123 \
+  --role Owner
+
+# Promote an existing member to admin
+oc cluster-tenant members add <org-name> \
+  --subject auth0|def456 \
+  --role Admin
+```
+
+`add` is an upsert: if the subject already has a row, only the role is changed. The last-owner guardrail applies — demoting the sole Owner returns a 409.
+
+### Remove a member
+
+```bash
+oc cluster-tenant members remove <org-name> <subject>
+```
+
+Prints a confirmation on success. The sole Owner cannot be removed (409).
+
+Source: [`apps/cli/src/commands/cluster-tenants.ts`](https://github.com/italanta/opencrane/blob/main/apps/cli/src/commands/cluster-tenants.ts)
+
+---
+
+## How the gate uses the registry
+
+The `_RequireOrgManager` middleware is applied to every route mounted under `/api/v1/cluster-tenants/:name/members`, as well as to ClusterTenant write routes (PUT, DELETE on `/:name`). Its decision tree is:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  _RequireOrgManager                                 │
+│                                                     │
+│  1. No session?                                     │
+│     dev-mode bypass → pass                          │
+│     real auth → 401                                 │
+│                                                     │
+│  2. isPlatformOperator? → pass (manages any org)    │
+│                                                     │
+│  3. No :name in path (collection route)? → 403      │
+│     (a per-org member cannot read the whole fleet)  │
+│                                                     │
+│  4. OrgMembership lookup for (orgName, subject):    │
+│     role = Owner or Admin → pass                    │
+│     else → 403                                      │
+└─────────────────────────────────────────────────────┘
+```
+
+The gate never leaks which specific check failed — every rejection returns the same `FORBIDDEN_ORG_SCOPE` code. A platform operator (identified by the `isPlatformOperator` session flag) bypasses the membership check and can manage every org.
+
+Source: [`apps/control-plane/src/infra/middleware/cluster-tenant-org-admin.ts`](https://github.com/italanta/opencrane/blob/main/apps/control-plane/src/infra/middleware/cluster-tenant-org-admin.ts)
+
+---
+
+## Operational notes
+
+**Finding a user's OIDC subject.** The `subject` field is the OIDC `sub` claim from the user's identity provider (Zitadel in the default setup). It is stored on the user's `Tenant` row when an assistant is created. You can retrieve it with:
+
+```bash
+oc tenants show <tenant-name> --output json | jq '.subject'
+```
+
+**Bootstrapping the first owner.** When a ClusterTenant is first created, it has no OrgMembership rows. A platform operator must add the first `Owner` via the API or CLI before an org admin can manage the org through their own session.
+
+**Membership is not IdP group membership.** A user may be a member of a Zitadel group without appearing in `OrgMembership`, and vice versa. The org-manager gate reads only `OrgMembership`. The grant/policy system that governs what the user's _agent_ can access reads the Zitadel group projection — both systems are independent.

--- a/website/operators/linkerd-identity.md
+++ b/website/operators/linkerd-identity.md
@@ -1,0 +1,133 @@
+# Linkerd identity substrate (S5)
+
+How OpenCrane's operator layers cryptographic workload identity on top of the L3/4 NetworkPolicy floor — the Linkerd mTLS-identity analogue of the silo isolation baseline. **This feature is gated off by default** (`LINKERD_MESH_ENABLED=false`) and has no effect on clusters without Linkerd installed.
+
+> See also:
+> [Networking & isolation](/operators/networking) — the S2 L3/4 NetworkPolicy baseline this layer sits on top of; read that page first for the overall silo model.
+> [Hosting & deployment](/operators/hosting) — operator configuration, env vars, and the Helm chart.
+> [ADR 0001 — ClusterTenant-as-virtual-network strict isolation](https://github.com/italanta/opencrane/blob/main/docs/adr/0001-cluster-tenant-virtual-network-isolation.md) — the architecture decision record that defines the substrate choice and the layering contract.
+
+---
+
+## Why a second isolation layer
+
+The S2 NetworkPolicy baseline (described in [Networking & isolation](/operators/networking)) closes the silo edge at **L3/L4**: it selects pods by namespace label, restricts ports, and drops everything not on the explicit allow-list. That floor is robust and CNI-enforced, but it cannot express **who** a workload is — only where it lives in the network.
+
+Linkerd adds a second, additive layer keyed on **cryptographic workload identity** (mTLS, SPIFFE/X.509 SVIDs bound to Kubernetes ServiceAccounts). The silo posture at this layer is identical to the L3/4 posture: default-deny, with exactly two identities admitted — workloads in the same silo namespace and the operator/control-plane super-admin namespace.
+
+The two layers are **independent defences**. Neither replaces the other:
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Silo isolation (ClusterTenant namespace)                        │
+│                                                                  │
+│  L3/4 floor (S2 — always active, CNI-enforced)                  │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │  NetworkPolicy: default-deny + allow intra-silo            │  │
+│  │  + allow operator namespace + DNS + external HTTPS         │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                          ↕  additive                             │
+│  Identity layer (S5 — gated, Linkerd required)                   │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │  Server: default-deny all pods in silo namespace           │  │
+│  │  MeshTLSAuthentication: allow intra-silo identity          │  │
+│  │                       + allow operator namespace identity  │  │
+│  │  AuthorizationPolicy: bind Server to authentication        │  │
+│  └────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+A connection between two silos is blocked at **both layers**: L3/4 drops the packet (wrong namespace, not in the allow-list) and the Linkerd policy also rejects it (the source identity is not in the `MeshTLSAuthentication`). A L3/4-only bypass would still hit the identity gate; a compromised Linkerd mesh would still hit the NetworkPolicy gate.
+
+::: tip The floor never goes away
+Enabling `LINKERD_MESH_ENABLED` does not remove or relax the S2 NetworkPolicy baseline. The Linkerd objects are applied *in addition*. On a cluster without Linkerd, the L3/4 floor is the only active layer and remains in full effect.
+:::
+
+---
+
+## What the operator emits per silo
+
+When `LINKERD_MESH_ENABLED=true`, the operator performs two actions for every ClusterTenant silo namespace it provisions or reconciles:
+
+**1. Namespace annotation.** The silo namespace receives the annotation `linkerd.io/inject: enabled`. This causes the Linkerd control plane to inject a sidecar proxy into every pod that lands in the namespace, giving each workload a Linkerd mTLS identity tied to its Kubernetes ServiceAccount. The annotation is written idempotently — re-applying the namespace with the same annotation is a no-op.
+
+**2. Identity policy bundle.** Three Linkerd custom resources are applied in order:
+
+| Resource | API version | Name | Purpose |
+|----------|-------------|------|---------|
+| `Server` | `policy.linkerd.io/v1beta1` | `opencrane-<org>-silo-identity` | Selects every pod in the namespace (empty `podSelector`) and sets `accessPolicy: deny` — the default-deny stance at the identity layer. |
+| `MeshTLSAuthentication` | `policy.linkerd.io/v1alpha1` | `opencrane-<org>-silo-identity` | Declares the allow-list: `*.<namespace>.serviceaccount.identity.linkerd.cluster.local` (intra-silo) and `*.<operator-namespace>.serviceaccount.identity.linkerd.cluster.local` (the super-admin plane). |
+| `AuthorizationPolicy` | `policy.linkerd.io/v1alpha1` | `opencrane-<org>-silo-identity` | Binds the deny-by-default `Server` to the `MeshTLSAuthentication`, re-opening only the allowed identities. |
+
+The three objects share the same deterministic name, so re-applies converge idempotently and one silo's bundle never collides with another's. All carry the labels `app.kubernetes.io/component=silo-isolation` and `opencrane.io/cluster-tenant=<org>`, matching the S2 NetworkPolicy labels so both isolation layers are discoverable together.
+
+Source: [`apps/operator/src/tenants/deploy/silo-linkerd-identity.ts`](https://github.com/italanta/opencrane/blob/main/apps/operator/src/tenants/deploy/silo-linkerd-identity.ts)
+
+---
+
+## Fail-closed behaviour
+
+The operator does not crash or stall the silo reconcile when Linkerd is not installed.
+
+The `LinkerdIdentityClient` applies each object using the `CustomObjectsApi`. If the Linkerd policy CRDs are not served by the API server (i.e., Linkerd is not installed), the API server returns a 404 with a `NotFound` response for the resource group `policy.linkerd.io`. The client detects this as a CRD-absent condition and:
+
+1. Logs a structured `warn` message: `"Linkerd mesh enabled but policy CRD is absent (Linkerd not installed); skipping silo identity policy"`.
+2. Returns `applied: false` — the whole bundle is skipped atomically (no partial bundle is left in the namespace).
+3. The operator logs a second `warn`: `"Linkerd identity policy skipped (CRDs absent); silo isolated at L3/4 only"`.
+4. The silo reconcile continues normally; the rest of the namespace resources are applied as usual.
+
+This means **setting `LINKERD_MESH_ENABLED=true` on a cluster without Linkerd is a safe no-op**, not a wedged reconcile. The cost is two warn-level log lines per silo provisioning cycle.
+
+Existing objects are applied with create-then-replace-on-conflict semantics: if the resource already exists (409 Conflict), the operator fetches the live `resourceVersion` and replaces in-place, so a re-applied silo converges rather than erroring.
+
+---
+
+## Enabling the substrate
+
+Set the environment variable on the operator deployment:
+
+```
+LINKERD_MESH_ENABLED=true
+```
+
+The operator picks this up at startup via `_readEnvValue<boolean>("LINKERD_MESH_ENABLED", "boolean", false, false)` in [`apps/operator/src/config.ts`](https://github.com/italanta/opencrane/blob/main/apps/operator/src/config.ts). The default is `false`.
+
+**Prerequisites before enabling:**
+
+1. Linkerd is installed on the cluster and its control plane is healthy (`linkerd check`).
+2. The Linkerd policy CRDs (`servers.policy.linkerd.io`, `meshtlsauthentications.policy.linkerd.io`, `authorizationpolicies.policy.linkerd.io`) are registered with the API server.
+3. The operator's ServiceAccount has permission to create and replace custom resources in the `policy.linkerd.io` group in silo namespaces (the same RBAC that permits applying `DNSEndpoint` CRs applies here).
+
+Once the flag is on, every **new** silo namespace provisioned will receive the annotation and policy bundle. **Existing** silo namespaces are updated on the next reconcile cycle — the operator re-applies all namespace resources on every `ADDED`/`MODIFIED` Tenant watch event, so existing silos converge without manual intervention.
+
+::: info Disable: flag off, manual cleanup
+Setting `LINKERD_MESH_ENABLED=false` stops the operator from emitting new Linkerd objects. It does not delete objects already applied to existing namespaces. To remove the identity layer from a live silo, delete the three named custom resources manually and remove the `linkerd.io/inject` annotation from the namespace. The S2 NetworkPolicy baseline remains active throughout.
+:::
+
+---
+
+## The identity domain
+
+Linkerd derives each workload's mTLS identity from its Kubernetes ServiceAccount using the trust domain:
+
+```
+<serviceaccount>.<namespace>.serviceaccount.identity.linkerd.cluster.local
+```
+
+The `MeshTLSAuthentication` uses a wildcard to match **every ServiceAccount in a namespace**:
+
+```
+*.<namespace>.serviceaccount.identity.linkerd.cluster.local
+```
+
+This means any pod in the silo namespace can talk to any other pod in the same namespace (intra-silo), regardless of which specific ServiceAccount it runs as — mirroring the S2 NetworkPolicy rule that admits all pods in the same namespace by `podSelector: {}`.
+
+The only foreign identity domain admitted is the operator/control-plane namespace's wildcard. No other silo's domain is ever listed, so the mTLS identity layer enforces the same cross-silo denial as the L3/4 floor.
+
+---
+
+## Current status
+
+🔶 Gated, default OFF. The implementation is complete and the operator applies the objects correctly when the gate is on, but the feature is off by default pending broader mesh rollout. The S2 L3/4 NetworkPolicy baseline is the active isolation floor on all current deployments.
+
+See the [networking & isolation](/operators/networking) page for the known gaps in the current enforcement status, including the note on identity-aware L7 enforcement.

--- a/website/operators/networking.md
+++ b/website/operators/networking.md
@@ -184,9 +184,9 @@ This **replaces the retired `opencrane-tenant-default` policy**, which sat in th
 This baseline is an **L3/L4** floor — a namespace-scoped, port-keyed allow-list. It only takes effect on a `NetworkPolicy`-enforcing CNI: GKE Dataplane V2 (and Autopilot) enforce it inherently; Calico/Cilium do elsewhere. On a CNI that does not enforce `NetworkPolicy`, the floor is inert.
 :::
 
-### Identity-aware L7 isolation is coming (Linkerd)
+### Linkerd identity substrate (S5, gated off by default)
 
-The baseline above is keyed on namespaces and ports, not on **workload identity**, and it cannot express L7 (per-route) authorization. The next layer of the silo model adds a [Linkerd](https://linkerd.io) service mesh on top of this floor: the operator will annotate each silo namespace `linkerd.io/inject: enabled` (giving every silo workload an mTLS identity bound to its service account) and emit a Linkerd `Server` + `AuthorizationPolicy` per silo expressing the same default-deny + allow-super-admin posture at the request layer. The rollout is **additive** — the `NetworkPolicy` floor stays in place as defence-in-depth, and a silo gains identity/L7 isolation as it is meshed, never going below the floor described here. See [ADR 0001 — ClusterTenant-as-virtual-network strict isolation](https://github.com/italanta/opencrane/blob/main/docs/adr/0001-cluster-tenant-virtual-network-isolation.md) for the substrate decision and why Linkerd (portable, no cloud lock-in) was chosen.
+The baseline above is keyed on namespaces and ports, not on **workload identity**, and it cannot express L7 (per-route) authorisation. The Linkerd identity substrate adds a second, additive isolation layer on top of this floor: when `LINKERD_MESH_ENABLED=true`, the operator annotates each silo namespace `linkerd.io/inject: enabled` (giving every silo workload an mTLS identity bound to its ServiceAccount) and emits a Linkerd `Server` + `MeshTLSAuthentication` + `AuthorizationPolicy` per silo expressing the same default-deny + allow-intra-silo + allow-super-admin posture at the identity layer. The rollout is **additive** — the `NetworkPolicy` floor stays in place as defence-in-depth; enabling the Linkerd layer never relaxes it. The feature is off by default and fails closed if the Linkerd CRDs are absent. See [Linkerd identity substrate](/operators/linkerd-identity) for the full mechanism, the env var, and the fail-closed behaviour. See [ADR 0001 — ClusterTenant-as-virtual-network strict isolation](https://github.com/italanta/opencrane/blob/main/docs/adr/0001-cluster-tenant-virtual-network-isolation.md) for the substrate decision and why Linkerd (portable, no cloud lock-in) was chosen.
 
 For fine-grained egress FQDN filtering (e.g. allowing only `api.openai.com`), an operator can additionally bind an `AccessPolicy` with `egressRules`, or apply a `CiliumNetworkPolicy` with `spec.domains.allow` on a Cilium-enabled cluster.
 
@@ -200,14 +200,16 @@ The following gaps are honest assessments verified against the live codebase. Th
 
 **Plane ingress rules use tenant podSelectors without a namespaceSelector.** The rules admitting tenant pods to the control plane and plane services select by `app.kubernetes.io/component=tenant` without scoping to the correct namespace. In a multi-instance cluster, a tenant pod from a different instance's namespace could match. This is a multi-instance hygiene gap; the fix is to also add a `namespaceSelector` that constrains to the instance's own org namespaces.
 
-**Identity-aware L7 enforcement is not yet live.** Until the Linkerd layer lands, cross-silo isolation rests on the L3/L4 baseline alone — robust against routing position but not yet expressing per-workload identity or per-route authorization. The super-admin namespace is trusted as a whole at L3/L4; L7 will narrow that to the super-admin *identity*.
+**Identity-aware L7 enforcement is gated off by default.** Until `LINKERD_MESH_ENABLED=true` is set and Linkerd is installed, cross-silo isolation rests on the L3/L4 baseline alone — robust against routing position but not yet expressing per-workload identity or per-route authorisation. The super-admin namespace is trusted as a whole at L3/L4; the Linkerd layer narrows that to the super-admin *identity*. See [Linkerd identity substrate](/operators/linkerd-identity) for how to enable it.
 
 ---
 
 ## See also
 
+- [Linkerd identity substrate](/operators/linkerd-identity) — the S5 mTLS-identity layer that sits additively on top of this L3/4 baseline; includes the env var, fail-closed behaviour, and what the operator emits per silo
+- [ClusterTenant members](/operators/cluster-tenant-members) — managing who can administrate an org (Owner/Admin/Member roles) and the last-owner guardrail
 - [Identity & connection auth](/security/identity) — credential types, OIDC session, projected-identity tokens, and the identity-routing proxy flow
 - [Connection security](/security/connection-security) — the full CONN.9/CONN.10 threat model, the trusted-proxy auth decision record, and the transport hardening posture
 - [DNS configuration](/operators/dns-config) — external-dns setup, cert-manager issuers, and the zone-write identity model
 - [Hosting & deployment](/operators/hosting) — ingress class, TLS cert modes, cloud hosting adapters
-- [ADR 0001 — ClusterTenant-as-virtual-network strict isolation](https://github.com/italanta/opencrane/blob/main/docs/adr/0001-cluster-tenant-virtual-network-isolation.md) — the substrate decision behind the per-silo baseline and the coming Linkerd L7 layer
+- [ADR 0001 — ClusterTenant-as-virtual-network strict isolation](https://github.com/italanta/opencrane/blob/main/docs/adr/0001-cluster-tenant-virtual-network-isolation.md) — the substrate decision behind the per-silo baseline and the Linkerd identity layer


### PR DESCRIPTION
Operator docs for the newly-merged `oc cluster-tenant members` (OrgMembership roles + last-Owner guardrail + API/CLI) and the gated Linkerd identity substrate (S5 first slice — additive over the S2 NetworkPolicy floor, fail-closed). Updated networking.md (L7 now implemented/gated) + cross-links; nav wired; VitePress build validated.