### PR TITLE
📝 fleet: document the live /auth/* endpoints in the OpenAPI spec

### DIFF
--- a/apps/fleet-operator/openapi.json
+++ b/apps/fleet-operator/openapi.json
@@ -2343,6 +2343,234 @@
     }
   ],
   "paths": {
+    "/auth/me": {
+      "get": {
+        "operationId": "getAuthStatus",
+        "summary": "Return current auth mode and authenticated user identity (if any)",
+        "description": "No authentication required. Returns 200 with the current session or an anonymous identity when no session is established. The fleet plane is cluster-wide, so (unlike the silo control plane) the user carries no per-silo `clusterTenant`.",
+        "tags": [
+          "Auth"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Auth status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "mode",
+                    "authenticated"
+                  ],
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "development",
+                        "oidc",
+                        "token"
+                      ],
+                      "description": "Active authentication mode for this instance."
+                    },
+                    "authenticated": {
+                      "type": "boolean"
+                    },
+                    "user": {
+                      "type": "object",
+                      "nullable": true,
+                      "required": [
+                        "sub",
+                        "issuer",
+                        "groups",
+                        "isPlatformOperator",
+                        "isOrgAdmin"
+                      ],
+                      "properties": {
+                        "sub": {
+                          "type": "string"
+                        },
+                        "issuer": {
+                          "type": "string",
+                          "description": "Identity provider that authenticated the user."
+                        },
+                        "groups": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "The caller's group memberships from the OIDC groups claim (empty when none)."
+                        },
+                        "isPlatformOperator": {
+                          "type": "boolean",
+                          "description": "True iff the caller's groups intersect OPENCRANE_PLATFORM_OPERATOR_GROUPS. Empty/unset config ⇒ false (fail-closed). Introspection only — the API stays the enforcement point and the frontend uses this only to hide UI."
+                        },
+                        "isOrgAdmin": {
+                          "type": "boolean",
+                          "description": "True iff the caller is an organisation admin (groups intersect OPENCRANE_ORG_ADMIN_GROUPS, or the caller is a platform operator). Empty/unset config ⇒ false (fail-closed). Introspection only — the API stays the enforcement point."
+                        },
+                        "ownedOrgs": {
+                          "type": "array",
+                          "description": "Organisations the caller owns or administers, derived fresh from their OrgMembership rows (owner/admin only; members excluded). Empty when the caller administers no org. Introspection only — never taken from request input.",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "clusterTenant",
+                              "role"
+                            ],
+                            "properties": {
+                              "clusterTenant": {
+                                "type": "string",
+                                "description": "The organisation (ClusterTenant) key."
+                              },
+                              "role": {
+                                "type": "string",
+                                "enum": [
+                                  "owner",
+                                  "admin"
+                                ],
+                                "description": "The administering role the caller holds in this org."
+                              }
+                            }
+                          }
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "emailVerified": {
+                          "type": "boolean"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "picture": {
+                          "type": "string"
+                        },
+                        "authenticatedAt": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/login": {
+      "get": {
+        "operationId": "startOidcLogin",
+        "summary": "Redirect the browser to the configured OIDC identity provider to start login",
+        "description": "Browser redirect — not intended for programmatic use. Returns 503 when OIDC is not configured.",
+        "tags": [
+          "Auth"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "returnTo",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Path to redirect back to after a successful login."
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to identity provider."
+          },
+          "503": {
+            "description": "OIDC not configured.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/callback": {
+      "get": {
+        "operationId": "completeOidcLogin",
+        "summary": "OIDC authorization callback — validates the response and establishes a session",
+        "description": "Called by the identity provider after a successful login. Redirects back to the SPA.",
+        "tags": [
+          "Auth"
+        ],
+        "security": [],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect back into the application."
+          },
+          "503": {
+            "description": "OIDC not configured.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/auth/logout": {
+      "post": {
+        "operationId": "logout",
+        "summary": "Destroy the current session and return the IdP RP-initiated logout URL",
+        "description": "Invalidates the server-side session. When OIDC is enabled and the identity provider advertises an `end_session_endpoint`, returns the URL the browser should navigate to so the upstream IdP session is also terminated (OIDC RP-Initiated Logout). The local session is always destroyed; `endSessionUrl` is null when no upstream logout is possible (OIDC disabled, IdP exposes no end-session endpoint, or the session captured no id_token). Non-browser callers may ignore the URL.",
+        "tags": [
+          "Auth"
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Session destroyed; optional IdP logout URL returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "endSessionUrl"
+                  ],
+                  "properties": {
+                    "endSessionUrl": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Absolute URL the browser should navigate to in order to terminate the upstream IdP session. Null when no upstream logout is configured or possible."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/admin/zitadel/sa-key:rotate": {
       "post": {
         "operationId": "rotateZitadelSaKey",

--- a/apps/fleet-operator/src/openapi/spec.ts
+++ b/apps/fleet-operator/src/openapi/spec.ts
@@ -969,6 +969,124 @@ export const spec = {
   paths: {
 
     // ------------------------------------------------------------------
+    // Auth — platform-operator OIDC session (browser login flow only;
+    // no per-user pod brokering / device grant — those are silo-plane).
+    // ------------------------------------------------------------------
+
+    "/auth/me": {
+      get: {
+        operationId: "getAuthStatus",
+        summary: "Return current auth mode and authenticated user identity (if any)",
+        description: "No authentication required. Returns 200 with the current session or an anonymous identity when no session is established. The fleet plane is cluster-wide, so (unlike the silo control plane) the user carries no per-silo `clusterTenant`.",
+        tags: ["Auth"],
+        security: [],
+        responses: {
+          200: ok("Auth status.", {
+            type: "object",
+            required: ["mode", "authenticated"],
+            properties: {
+              mode: { type: "string", enum: ["development", "oidc", "token"], description: "Active authentication mode for this instance." },
+              authenticated: { type: "boolean" },
+              user: {
+                type: "object",
+                nullable: true,
+                required: ["sub", "issuer", "groups", "isPlatformOperator", "isOrgAdmin"],
+                properties: {
+                  sub: { type: "string" },
+                  issuer: { type: "string", description: "Identity provider that authenticated the user." },
+                  groups: { type: "array", items: { type: "string" }, description: "The caller's group memberships from the OIDC groups claim (empty when none)." },
+                  isPlatformOperator: {
+                    type: "boolean",
+                    description: "True iff the caller's groups intersect OPENCRANE_PLATFORM_OPERATOR_GROUPS. Empty/unset config ⇒ false (fail-closed). Introspection only — the API stays the enforcement point and the frontend uses this only to hide UI.",
+                  },
+                  isOrgAdmin: {
+                    type: "boolean",
+                    description: "True iff the caller is an organisation admin (groups intersect OPENCRANE_ORG_ADMIN_GROUPS, or the caller is a platform operator). Empty/unset config ⇒ false (fail-closed). Introspection only — the API stays the enforcement point.",
+                  },
+                  ownedOrgs: {
+                    type: "array",
+                    description: "Organisations the caller owns or administers, derived fresh from their OrgMembership rows (owner/admin only; members excluded). Empty when the caller administers no org. Introspection only — never taken from request input.",
+                    items: {
+                      type: "object",
+                      required: ["clusterTenant", "role"],
+                      properties: {
+                        clusterTenant: { type: "string", description: "The organisation (ClusterTenant) key." },
+                        role: { type: "string", enum: ["owner", "admin"], description: "The administering role the caller holds in this org." },
+                      },
+                    },
+                  },
+                  email: { type: "string" },
+                  emailVerified: { type: "boolean" },
+                  name: { type: "string" },
+                  picture: { type: "string" },
+                  authenticatedAt: { type: "string", format: "date-time" },
+                },
+              },
+            },
+          }),
+        },
+      },
+    },
+
+    "/auth/login": {
+      get: {
+        operationId: "startOidcLogin",
+        summary: "Redirect the browser to the configured OIDC identity provider to start login",
+        description: "Browser redirect — not intended for programmatic use. Returns 503 when OIDC is not configured.",
+        tags: ["Auth"],
+        security: [],
+        parameters: [
+          { name: "returnTo", in: "query", schema: { type: "string" }, description: "Path to redirect back to after a successful login." },
+        ],
+        responses: {
+          302: { description: "Redirect to identity provider." },
+          503: { description: "OIDC not configured.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+        },
+      },
+    },
+
+    "/auth/callback": {
+      get: {
+        operationId: "completeOidcLogin",
+        summary: "OIDC authorization callback — validates the response and establishes a session",
+        description: "Called by the identity provider after a successful login. Redirects back to the SPA.",
+        tags: ["Auth"],
+        security: [],
+        parameters: [
+          { name: "code", in: "query", schema: { type: "string" } },
+          { name: "state", in: "query", schema: { type: "string" } },
+        ],
+        responses: {
+          302: { description: "Redirect back into the application." },
+          503: { description: "OIDC not configured.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+        },
+      },
+    },
+
+    "/auth/logout": {
+      post: {
+        operationId: "logout",
+        summary: "Destroy the current session and return the IdP RP-initiated logout URL",
+        description: "Invalidates the server-side session. When OIDC is enabled and the identity provider advertises an `end_session_endpoint`, returns the URL the browser should navigate to so the upstream IdP session is also terminated (OIDC RP-Initiated Logout). The local session is always destroyed; `endSessionUrl` is null when no upstream logout is possible (OIDC disabled, IdP exposes no end-session endpoint, or the session captured no id_token). Non-browser callers may ignore the URL.",
+        tags: ["Auth"],
+        security: [],
+        responses: {
+          200: ok("Session destroyed; optional IdP logout URL returned.", {
+            type: "object",
+            required: ["endSessionUrl"],
+            properties: {
+              endSessionUrl: {
+                type: "string",
+                nullable: true,
+                description: "Absolute URL the browser should navigate to in order to terminate the upstream IdP session. Null when no upstream logout is configured or possible.",
+              },
+            },
+          }),
+        },
+      },
+    },
+
+    // ------------------------------------------------------------------
     // Admin — Zitadel SA key rotation (superadmin / platform-operator only)
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
**Documents the fleet-manager's already-live OIDC session endpoints in its OpenAPI contract.** `___FleetAuthRouter` serves `/auth/me`, `/auth/login`, `/auth/callback`, and `/auth/logout`, but `apps/fleet-operator/openapi.json` omitted them — so any typed client generated from the fleet contract had no auth surface (notably the WeOwnAI fleet client, which must self-authenticate against the fleet plane rather than borrow the silo control plane's session).

## What landed
- Added the four `/auth/*` path definitions to `apps/fleet-operator/src/openapi/spec.ts` and regenerated `openapi.json`.
- `/auth/me` mirrors the control-plane response shape **minus** the per-silo `clusterTenant` — the fleet plane is cluster-wide and `FleetOidcAuthService` adds no `enrichStatusUser`, so the schema reflects exactly what `getStatus` returns (`mode`, `authenticated`, `user{ sub, issuer, groups, isPlatformOperator, isOrgAdmin, ownedOrgs, email, … }`).
- No handler/behaviour change — documentation only; the endpoints were already wired in `apps/fleet-operator/src/index.ts`.

## Validation
- `pnpm --filter @opencrane/fleet-operator emit-openapi` regenerates cleanly (spec.ts compiles via tsx); the openapi.json drift gate is satisfied (regenerated in the same commit).
- `jq` confirms the four `/auth/*` paths are present and `/auth/me.user` carries no `clusterTenant`.
