### PR TITLE
🔧 fix k3d local harness fleet API and rollout names

### DIFF
--- a/libs/k8s-platform/tests/k3d-local.sh
+++ b/libs/k8s-platform/tests/k3d-local.sh
@@ -243,6 +243,8 @@ helm_args=(
   --set
   "fleetManager.database.existingSecret=$DB_SECRET_NAME"
   --set
+  "fleetManager.clusterTenantApi.enabled=false"
+  --set
   "litellm.existingDatabaseSecret=opencrane-litellm-db"
 )
 
@@ -290,10 +292,10 @@ helm "${silo_args[@]}"
 
 # 7. Wait for the platform workloads that depend on the database.
 _wait_for_rollout "deployment/opencrane-fleet-manager"
-_wait_for_rollout "deployment/opencrane-clustertenant-manager"
+_wait_for_rollout "deployment/opencrane-silo-clustertenant-manager"
 
-if kubectl get deployment/opencrane-litellm -n "$NAMESPACE" >/dev/null 2>&1; then
-  _wait_for_rollout "deployment/opencrane-litellm"
+if kubectl get deployment/opencrane-silo-litellm -n "$NAMESPACE" >/dev/null 2>&1; then
+  _wait_for_rollout "deployment/opencrane-silo-litellm"
 fi
 
 echo "[local] PASS: local full-stack install succeeded"


### PR DESCRIPTION
## Summary

This PR fixes two issues in the local k3d deployment harness that were causing local setup failures:

- disables the fleet ClusterTenant API in the local k3d path so `opencrane-fleet-manager` does not require Zitadel admin credentials
- updates the rollout wait targets to the current release-prefixed deployment names after the chart split

## Root cause

`opencrane-fleet-manager` was failing in local k3d because the local test script was accidentally enabling the multi-tenant fleet management API. That API expects Zitadel admin credentials, but the local setup does not provide Zitadel, so the pod started and then exited immediately.

The script was still waiting for outdated deployment names, which caused the deployment flow to fail even when the correct silo services were starting.

## Files changed

- `libs/k8s-platform/tests/k3d-local.sh`
  - set `fleetManager.clusterTenantApi.enabled=false` for the local k3d flow
  - update rollout waits to:
    - `opencrane-silo-clustertenant-manager`
    - `opencrane-silo-litellm`