### PR TITLE
✨ gateway: route the OpenClaw WS at /gateway under same-origin hosting

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
@@ -3,7 +3,7 @@ import type { Duplex } from "node:stream";
 import pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 
-import { _HandleUpgrade } from "../../gateway-proxy/proxy.js";
+import { _HandleUpgrade, _StripGatewayPrefix } from "../../gateway-proxy/proxy.js";
 import type { UpgradeDeps, WsProxy, GatewayProxyRuntime } from "../../gateway-proxy/proxy.js";
 import type { ResolveOutcome } from "../../gateway-proxy/auth-client.js";
 import { FixedWindowRateLimiter } from "../../gateway-proxy/rate-limit.js";
@@ -123,5 +123,36 @@ describe("_HandleUpgrade (in-operator gateway proxy)", () =>
     await _HandleUpgrade(limited.deps, _req({ origin: "https://acme.opencrane.ai", cookie: "x" }), b, Buffer.alloc(0));
     expect(limited.proxy.targets).toHaveLength(1);
     expect(b.written[0]).toMatch(/^HTTP\/1\.1 429/);
+  });
+
+  it("strips the /gateway routing prefix before forwarding so the pod sees the path it expects", async () =>
+  {
+    const resolve = vi.fn().mockResolvedValue(okTarget);
+    const { deps } = _deps(resolve);
+    // The org host routes the WS at /gateway (the SPA owns /); the pod gateway listens at /.
+    const req = { headers: { origin: "https://acme.opencrane.ai", host: "acme.opencrane.ai", cookie: "x" }, url: "/gateway", socket: { remoteAddress: "10.0.0.1" } } as unknown as IncomingMessage;
+
+    await _HandleUpgrade(deps, req, _fakeSocket(), Buffer.alloc(0));
+
+    expect(req.url).toBe("/");
+  });
+});
+
+describe("_StripGatewayPrefix", () =>
+{
+  it("strips a leading /gateway segment, preserving the remainder and query", () =>
+  {
+    expect(_StripGatewayPrefix("/gateway")).toBe("/");
+    expect(_StripGatewayPrefix("/gateway/")).toBe("/");
+    expect(_StripGatewayPrefix("/gateway/socket")).toBe("/socket");
+    expect(_StripGatewayPrefix("/gateway?token=x")).toBe("/?token=x");
+  });
+
+  it("leaves a non-prefixed path untouched (backward-compatible with a bare / client)", () =>
+  {
+    expect(_StripGatewayPrefix("/")).toBe("/");
+    expect(_StripGatewayPrefix("/api")).toBe("/api");
+    expect(_StripGatewayPrefix("/gateways")).toBe("/gateways"); // not the /gateway segment
+    expect(_StripGatewayPrefix(undefined)).toBe("/");
   });
 });

--- a/apps/clustertenant-operator/src/__tests__/infra/openclaw-pairing.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/infra/openclaw-pairing.test.ts
@@ -10,10 +10,12 @@ describe("_ResolveOpenClawPairing", function _suite()
 		expect(pairing).toEqual({ gatewayUrl: "wss://pod/gateway" });
 	});
 
-	it("derives the gateway URL from ingressHost when none is stored", function _derived()
+	it("derives the gateway URL from ingressHost when none is stored, routed at /gateway", function _derived()
 	{
+		// Same-origin hosting: the SPA owns `/` and the control plane `/api`, so the WS is
+		// exposed at `/gateway` (the proxy strips the prefix before forwarding to the pod).
 		const pairing = _ResolveOpenClawPairing(null, "pod.example.com");
-		expect(pairing).toEqual({ gatewayUrl: "wss://pod.example.com" });
+		expect(pairing).toEqual({ gatewayUrl: "wss://pod.example.com/gateway" });
 	});
 
 	it("returns null when there is no URL and no ingress host", function _notReady()
@@ -24,14 +26,14 @@ describe("_ResolveOpenClawPairing", function _suite()
 
 	it("ignores a malformed configOverrides shape", function _malformed()
 	{
-		expect(_ResolveOpenClawPairing("not-an-object", "pod.example.com")?.gatewayUrl).toBe("wss://pod.example.com");
+		expect(_ResolveOpenClawPairing("not-an-object", "pod.example.com")?.gatewayUrl).toBe("wss://pod.example.com/gateway");
 		expect(_ResolveOpenClawPairing({ openclaw: 42 }, null)).toBeNull();
 	});
 
 	it("rejects a non-wss stored gateway URL, falling back to wss ingress", function _rejectsWs()
 	{
 		const pairing = _ResolveOpenClawPairing({ openclaw: { gatewayUrl: "ws://pod/gateway" } }, "pod.example.com");
-		expect(pairing).toEqual({ gatewayUrl: "wss://pod.example.com" });
+		expect(pairing).toEqual({ gatewayUrl: "wss://pod.example.com/gateway" });
 	});
 
 	it("returns null when the stored URL is non-wss and there is no ingress host", function _rejectsWsNoFallback()

--- a/apps/clustertenant-operator/src/__tests__/routes/auth-pod-token.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/routes/auth-pod-token.test.ts
@@ -63,7 +63,7 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 		});
 	});
 
-	it("derives the gateway URL from ingressHost when no pairing is stored", async function _derived()
+	it("derives the gateway URL from ingressHost when no pairing is stored, routed at /gateway", async function _derived()
 	{
 		const prisma = _buildPrisma([{ name: "alex.oc", ingressHost: "alex.oc.example.com", configOverrides: null }]);
 		const app = _buildApp({ authUser: { sub: "u1", email: "alex@acme.com" } }, prisma);
@@ -71,7 +71,8 @@ describe("POST /auth/pod-token (OpenClaw connection broker)", function _suite()
 		const res = await request(app).post("/auth/pod-token");
 
 		expect(res.status).toBe(200);
-		expect(res.body.gatewayUrl).toBe("wss://alex.oc.example.com");
+		// Same-origin hosting: the SPA owns `/`, so the WS is exposed at `/gateway`.
+		expect(res.body.gatewayUrl).toBe("wss://alex.oc.example.com/gateway");
 	});
 
 	it("returns 401 without a session", async function _noSession()

--- a/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
+++ b/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
@@ -46,6 +46,42 @@ export interface UpgradeDeps
 const _RESOLVE_TIMEOUT_MS = 5_000;
 
 /**
+ * External path prefix the gateway WebSocket is exposed under on the org host.
+ *
+ * Same-origin hosting (DOMAIN.T4) puts the org-admin SPA at `/` and the control plane
+ * at `/api`, so the gateway WS cannot also own `/` — it is routed at `/gateway`. The
+ * OpenClaw pod's gateway listens at `/`, so the proxy strips this prefix before
+ * forwarding (see {@link _StripGatewayPrefix}). No ingress `rewrite-target` is needed,
+ * and a legacy client connecting at `/` still works (the prefix is only stripped when
+ * present), so the change is backward-compatible.
+ */
+const _GATEWAY_PATH_PREFIX = "/gateway";
+
+/**
+ * Strip a leading `/gateway` segment from the upgrade request path so the upstream
+ * OpenClaw pod (whose gateway listens at `/`) sees the path it expects, regardless of
+ * the external routing prefix. Only strips when the prefix is actually present, so a
+ * bare `/` upgrade is forwarded unchanged.
+ *
+ * @param url - The raw upgrade request URL (path + optional query).
+ * @returns The path with any leading `/gateway` segment removed.
+ */
+export function _StripGatewayPrefix(url: string | undefined): string
+{
+  const u = typeof url === "string" && url.length > 0 ? url : "/";
+  if (u === _GATEWAY_PATH_PREFIX)
+  {
+    return "/";
+  }
+  if (u.startsWith(`${_GATEWAY_PATH_PREFIX}/`) || u.startsWith(`${_GATEWAY_PATH_PREFIX}?`))
+  {
+    const rest = u.slice(_GATEWAY_PATH_PREFIX.length);
+    return rest.startsWith("/") ? rest : `/${rest}`;
+  }
+  return u;
+}
+
+/**
  * Authorise and route a single gateway WebSocket upgrade — the proxy's only job, now
  * folded into the operator process.
  *
@@ -117,6 +153,10 @@ export async function _HandleUpgrade(deps: UpgradeDeps, req: IncomingMessage, so
 
   // 4. Strip any client-supplied identity header, inject the verified one, forward.
   delete req.headers[config.userHeader.toLowerCase()];
+  // The gateway WS is exposed at `/gateway` on the org host (the SPA owns `/`); the pod
+  // gateway listens at `/`, so drop the prefix before forwarding. Backward-compatible: a
+  // bare `/` upgrade is left untouched.
+  req.url = _StripGatewayPrefix(req.url);
   const target = `ws://${podService.name}.${podService.namespace}.${config.clusterDomain}:${config.gatewayPort}`;
   reqLog.info({ email: user.email, tenant: tenant.name, target }, "gateway upgrade authorised; proxying");
   proxy.ws(req, socket, head, { target, headers: { [config.userHeader]: user.email } }, function _onProxyError(err: Error)

--- a/apps/clustertenant-operator/src/infra/auth/openclaw-pairing.ts
+++ b/apps/clustertenant-operator/src/infra/auth/openclaw-pairing.ts
@@ -1,5 +1,12 @@
 import type { OpenClawPairing } from "./openclaw-pairing.types.js";
 
+/**
+ * Path the gateway WebSocket is exposed under on the org host. The SPA owns `/` and the
+ * control plane `/api`, so the WS is routed at `/gateway`; the proxy strips it before
+ * forwarding to the pod (gateway-proxy/proxy.ts). Keep in sync with that prefix.
+ */
+const OPENCLAW_GATEWAY_WS_PATH = "/gateway";
+
 /** Shape we read out of `Tenant.configOverrides.openclaw`. */
 interface _StoredPairing
 {
@@ -24,11 +31,17 @@ export function _ResolveOpenClawPairing(configOverrides: unknown, ingressHost: s
   // Only ever hand the browser an encrypted `wss://` endpoint. A stored `ws://`
   // (or any non-wss) URL is rejected and we fall back to the `wss://<ingressHost>`
   // form — never downgrade the transport, even if the column is misconfigured.
+  //
+  // The host-derived URL targets `/gateway`: under same-origin hosting the org host
+  // serves the SPA at `/` and the control plane at `/api`, so the gateway WS is routed
+  // at `/gateway` (the proxy strips the prefix before forwarding — see
+  // gateway-proxy/proxy.ts `_StripGatewayPrefix`). A stored URL is used verbatim so an
+  // operator can pin an explicit endpoint (including its own path).
   const storedUrl = typeof stored?.gatewayUrl === "string" ? stored.gatewayUrl : "";
   const gatewayUrl = storedUrl.startsWith("wss://")
     ? storedUrl
     : ingressHost
-      ? `wss://${ingressHost}`
+      ? `wss://${ingressHost}${OPENCLAW_GATEWAY_WS_PATH}`
       : null;
 
   if (!gatewayUrl)

--- a/apps/clustertenant-platform/templates/gateway-ingress.yaml
+++ b/apps/clustertenant-platform/templates/gateway-ingress.yaml
@@ -3,10 +3,13 @@
 Single-per-org-host topology (DOMAIN.T4). Every org is served at its own host under the
 platform wildcard `*.<ingress.domain>` (e.g. `acme.weownai.eu`). One wildcard Ingress covers
 them all and path-routes the SAME origin:
-  - `/api/*`  → the control plane (so the OIDC session cookie is host-scoped to the org host)
-  - `/`       → the operator's in-process gateway proxy (the gateway WebSocket upgrade)
-There are NO per-user subdomains and NO per-user Ingresses; the proxy routes each socket to the
-right pod by session identity (see /auth/gateway-resolve). The org host gets an EXPLICIT
+  - `/api/*`     → the control plane (so the OIDC session cookie is host-scoped to the org host)
+  - `/gateway/*` → the operator's in-process gateway proxy (the gateway WebSocket upgrade)
+  - `/`          → free for the org-admin SPA served same-origin by the frontend layer
+The gateway WS is routed at `/gateway`, NOT `/`, so the same-origin SPA can own `/`. The proxy
+strips the prefix before forwarding (the pod gateway listens at `/`), so no rewrite-target is
+needed. There are NO per-user subdomains and NO per-user Ingresses; the proxy routes each socket
+to the right pod by session identity (see /auth/gateway-resolve). The org host gets an EXPLICIT
 external-dns record (org-domain provisioner) and rides the platform `*.<domain>` TLS cert.
 See website/security/connection-security.md.
 */ -}}
@@ -43,8 +46,10 @@ spec:
                 name: {{ include "opencrane.fullname" . }}-clustertenant-manager
                 port:
                   number: {{ .Values.clustertenantManager.service.port }}
-          # Everything else (the gateway WebSocket upgrade) → the operator's proxy Service.
-          - path: /
+          # The gateway WebSocket upgrade → the operator's proxy Service. Routed at
+          # `/gateway` (not `/`) so the same-origin SPA can own `/`; the proxy strips the
+          # prefix before forwarding to the pod (which listens at `/`).
+          - path: /gateway
             pathType: Prefix
             backend:
               service:


### PR DESCRIPTION
## What landed

The org-admin SPA is served same-origin at `/` on the org host (`<org>.dev.opencrane.ai`), with the control plane at `/api`. That left the OpenClaw gateway WebSocket — which connected to bare `wss://<org-host>/` — landing on the SPA's static server, which can't upgrade, so the socket **closed immediately**. (Surfaced once `/auth/pod-token` started returning 200; see #100 / the POD_NOT_READY fix.)

This routes the gateway WS at **`/gateway`** so all three can coexist on one origin: `/`→SPA, `/api`→control plane, `/gateway`→gateway proxy.

- **`/auth/pod-token`** now returns `gatewayUrl = wss://<ingressHost>/gateway` (a stored `configOverrides.openclaw.gatewayUrl` is still used verbatim).
- **The in-operator proxy strips a leading `/gateway`** before forwarding, so the OpenClaw pod (gateway listens at `/`) is unchanged and **no ingress `rewrite-target` is needed**. A legacy bare-`/` client still works — the prefix is only stripped when present, so the change is backward-compatible.
- **The chart's org gateway-ingress** routes `/gateway` (not `/`) to the proxy Service, leaving `/` free for the same-origin SPA.

## Validation

`@opencrane/clustertenant-operator`: **588 tests pass**, typecheck clean. New tests cover `_StripGatewayPrefix` (incl. query + non-prefixed passthrough), the proxy forwarding `/` after strip, and pairing/pod-token deriving `wss://<host>/gateway`. `helm template` renders the gateway-ingress with `/api`→API and `/gateway`→proxy.
