### PR TITLE
✨ silo: allowlist the org Control-UI origin for the gateway WS handshake

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -71,6 +71,28 @@ describe("TenantResourceBuilder", () =>
     expect(payload.gateway.auth.trustedProxy.allowUsers).toEqual(["mike.owner@example.com"]);
   });
 
+  it("allowlists the org Control-UI origin when a serving host is given (CONTROL_UI_ORIGIN_NOT_ALLOWED)", () =>
+  {
+    // With bind:lan the gateway refuses a Control-UI WS whose Origin isn't allowlisted.
+    // The org-admin SPA connects through the org host, so its https origin must be allowed.
+    const tenant = _makeTenant("acme-user");
+    const configMap = _BuildConfigMap(defaultConfig, tenant, "default", undefined, undefined, "acme.dev.opencrane.ai");
+    const payload = JSON.parse(configMap.data?.["openclaw.json"] ?? "{}");
+
+    expect(payload.gateway.controlUi.allowedOrigins).toEqual(["https://acme.dev.opencrane.ai"]);
+    // Survives the step-3b gateway re-pin (controlUi is part of the platform-owned block).
+    expect(payload.gateway.auth.trustedProxy.allowUsers).toEqual(["acme-user@example.com"]);
+  });
+
+  it("omits the Control-UI origin allowlist when no serving host is given (ref-less default)", () =>
+  {
+    const tenant = _makeTenant("plain");
+    const configMap = _BuildConfigMap(defaultConfig, tenant, "default");
+    const payload = JSON.parse(configMap.data?.["openclaw.json"] ?? "{}");
+
+    expect(payload.gateway).not.toHaveProperty("controlUi");
+  });
+
   it("renders an unambiguous trust-nothing gateway config when no proxy is configured (OC-2 / CONN.4)", () =>
   {
     // An operator with no GATEWAY_TRUSTED_PROXIES resolves to trust-nothing. We rely

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -38,8 +38,14 @@ const _WORKSPACE_PATH = "/data/openclaw/workspace";
  *        `litellm-proxy` provider is restricted to those models and the default
  *        model is surfaced; when empty/null the provider keeps `models: []`
  *        (unchanged today's behaviour — OpenClaw treats `[]` as the proxy default).
+ * @param servingHost - The host the org's Control UI is served at (`<org>.<base>` or
+ *        vanity), used to allowlist the browser Origin in `gateway.controlUi.allowedOrigins`.
+ *        With `bind: lan` the gateway rejects a Control-UI WS whose Origin is not allowlisted
+ *        (`CONTROL_UI_ORIGIN_NOT_ALLOWED`); the SPA reaches the gateway via this host, so its
+ *        `https://<host>` origin must be allowed. Omitted ⇒ no origin is added (the gateway's
+ *        own localhost seeding applies — the pre-same-origin behaviour).
  */
-export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Tenant, namespace: string, effectivePolicy?: AccessPolicy, modelSet?: TenantModelSet | null): k8s.V1ConfigMap
+export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Tenant, namespace: string, effectivePolicy?: AccessPolicy, modelSet?: TenantModelSet | null, servingHost?: string): k8s.V1ConfigMap
 {
   const name = tenant.metadata!.name!;
 
@@ -62,6 +68,12 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
       mode: "local",
       port: config.gatewayPort,
       bind: "lan",
+      // With bind:lan the gateway enforces a Control-UI Origin allowlist (since
+      // v2026.2.26): a WS whose Origin isn't allowlisted is refused with
+      // CONTROL_UI_ORIGIN_NOT_ALLOWED. The org-admin SPA reaches the gateway through the
+      // org host, so allow its `https://<host>` origin. Omitted host ⇒ leave the gateway's
+      // own localhost seeding (ref-less / pre-same-origin default).
+      ...(servingHost ? { controlUi: { allowedOrigins: [`https://${servingHost}`] } } : {}),
       // OC-2 / CONN.4 — the gateway delegates auth to the control-plane: the pod
       // ingress validates the OIDC session and injects the user header, and the
       // gateway trusts it only from the configured proxy source. No shared token

--- a/apps/clustertenant-operator/src/tenants/operator.ts
+++ b/apps/clustertenant-operator/src/tenants/operator.ts
@@ -336,7 +336,7 @@ export class TenantOperator
 
       // 5. ConfigMap — serialises the base OpenClaw JSON config merged with any
       //    spec.configOverrides the tenant author provided.
-      await __K8sApplyResource(this.coreApi, _BuildConfigMap(this.config, effectiveTenant, namespace, policyResolution.effectivePolicy, modelSet), this.log);
+      await __K8sApplyResource(this.coreApi, _BuildConfigMap(this.config, effectiveTenant, namespace, policyResolution.effectivePolicy, modelSet, ingressDomain), this.log);
 
       // 6. State volume — adapter decides CSI mount (cloud) vs PVC (on-prem).
       //    Create the PVC only when the adapter requests it (on-prem path).


### PR DESCRIPTION
## What landed

After the WS routing (#103) and client connect-params fixes, the OpenClaw gateway still rejected the handshake with `INVALID_REQUEST` / `CONTROL_UI_ORIGIN_NOT_ALLOWED`: with `gateway.bind: lan` the gateway enforces a Control-UI **Origin allowlist** (since v2026.2.26) and seeds it to **localhost only**. The operator set `bind: lan` but never the matching `controlUi.allowedOrigins`, so the org-admin SPA — which reaches the gateway through the org host — was refused at `connect`.

This emits `gateway.controlUi.allowedOrigins: ["https://<servingHost>"]` from the org's serving host (the same host used for `status.ingressHost`). It's folded into the platform-owned `gateway` block so it survives the step-3b re-pin and can't be clobbered by `configOverrides`; omitted when no serving host is known (ref-less default keeps the gateway's localhost seeding).

## Validation

`@opencrane/clustertenant-operator`: **590 tests pass**, typecheck clean. New tests assert the origin is allowlisted when a serving host is given and absent without one, and that it survives the gateway re-pin alongside the owner allowlist.

## Deploy note

Needs the silo rolled to this image **and a forced reconcile** (`kubectl patch tenant <name> --subresource=status -p '{"status":{"observedGeneration":0}}'`) so the openclaw ConfigMap regenerates with the origin and the pod restarts. This is the last blocker for the org-admin chat WS handshake (`ok:true`).