### PR TITLE
✨ silo: device-less Control-UI operator scopes over trusted-proxy + fix gateway netpol selector

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -80,17 +80,22 @@ describe("TenantResourceBuilder", () =>
     const payload = JSON.parse(configMap.data?.["openclaw.json"] ?? "{}");
 
     expect(payload.gateway.controlUi.allowedOrigins).toEqual(["https://acme.dev.opencrane.ai"]);
+    // Device-less trusted-proxy model: device auth disabled so the proxy-injected identity's
+    // scopes stand (otherwise the gateway strips them). Safe only behind the gateway NetworkPolicy.
+    expect(payload.gateway.controlUi.dangerouslyDisableDeviceAuth).toBe(true);
     // Survives the step-3b gateway re-pin (controlUi is part of the platform-owned block).
     expect(payload.gateway.auth.trustedProxy.allowUsers).toEqual(["acme-user@example.com"]);
   });
 
-  it("omits the Control-UI origin allowlist when no serving host is given (ref-less default)", () =>
+  it("disables Control-UI device auth even with no serving host, but omits the origin allowlist", () =>
   {
     const tenant = _makeTenant("plain");
     const configMap = _BuildConfigMap(defaultConfig, tenant, "default");
     const payload = JSON.parse(configMap.data?.["openclaw.json"] ?? "{}");
 
-    expect(payload.gateway).not.toHaveProperty("controlUi");
+    // Device-less model applies regardless of host; the origin allowlist is host-derived.
+    expect(payload.gateway.controlUi.dangerouslyDisableDeviceAuth).toBe(true);
+    expect(payload.gateway.controlUi).not.toHaveProperty("allowedOrigins");
   });
 
   it("renders an unambiguous trust-nothing gateway config when no proxy is configured (OC-2 / CONN.4)", () =>
@@ -305,11 +310,13 @@ describe("TenantResourceBuilder", () =>
     const netpol = _BuildGatewayNetworkPolicy(config, tenant, "default");
 
     expect(netpol.spec?.policyTypes).toEqual(["Ingress"]);
-    // Only the operator pods (which now host the identity-routing proxy) in the operator's
-    // namespace may reach the gateway port — no per-user Ingress, no other pod, can connect.
+    // Only the clustertenant-manager pod (which hosts the identity-routing proxy) in the
+    // operator's namespace may reach the gateway port — no per-user Ingress, no other pod, can
+    // connect and assert an arbitrary X-Forwarded-User. The selector MUST match the proxy pod's
+    // real label (`clustertenant-manager`); "operator" matched nothing → fail-open/closed bug.
     const rule = netpol.spec?.ingress?.[0];
     expect(rule?._from?.[0]?.namespaceSelector?.matchLabels?.["kubernetes.io/metadata.name"]).toBe("opencrane");
-    expect(rule?._from?.[0]?.podSelector?.matchLabels?.["app.kubernetes.io/component"]).toBe("operator");
+    expect(rule?._from?.[0]?.podSelector?.matchLabels?.["app.kubernetes.io/component"]).toBe("clustertenant-manager");
     expect(rule?.ports?.[0]?.port).toBe(config.gatewayPort);
   });
 });

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -68,12 +68,24 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
       mode: "local",
       port: config.gatewayPort,
       bind: "lan",
-      // With bind:lan the gateway enforces a Control-UI Origin allowlist (since
-      // v2026.2.26): a WS whose Origin isn't allowlisted is refused with
-      // CONTROL_UI_ORIGIN_NOT_ALLOWED. The org-admin SPA reaches the gateway through the
-      // org host, so allow its `https://<host>` origin. Omitted host ⇒ leave the gateway's
-      // own localhost seeding (ref-less / pre-same-origin default).
-      ...(servingHost ? { controlUi: { allowedOrigins: [`https://${servingHost}`] } } : {}),
+      // Control-UI (org-admin SPA) policy:
+      //  - allowedOrigins: with bind:lan the gateway enforces a Control-UI Origin allowlist
+      //    (since v2026.2.26) and refuses an unlisted Origin with CONTROL_UI_ORIGIN_NOT_ALLOWED.
+      //    The SPA reaches the gateway through the org host, so allow its https origin (when known).
+      //  - dangerouslyDisableDeviceAuth: this platform is device-less by design — identity is the
+      //    OIDC session the operator proxy verifies and injects as X-Forwarded-User (CONN.4), not a
+      //    per-browser device key. Without this flag the gateway connects a trusted-proxy Control-UI
+      //    but STRIPS its operator scopes (shouldClearUnboundScopesForMissingDeviceIdentity), so
+      //    chat RPCs fail "missing scope". Disabling device auth lets the proxy be the authority and
+      //    the connect's scopes stand. SAFE ONLY IF the gateway port is reachable solely through the
+      //    proxy — enforced by the openclaw-<name>-gateway NetworkPolicy. NOTE: that requires the
+      //    cluster to actually ENFORCE NetworkPolicy (Dataplane V2 / Calico); the dev cluster does
+      //    not yet — tracked separately. The owner-pin (auth.allowUsers) is defence-in-depth, not a
+      //    substitute (a caller that asserts the owner email is trusted under trusted-proxy).
+      controlUi: {
+        dangerouslyDisableDeviceAuth: true,
+        ...(servingHost ? { allowedOrigins: [`https://${servingHost}`] } : {}),
+      },
       // OC-2 / CONN.4 — the gateway delegates auth to the control-plane: the pod
       // ingress validates the OIDC session and injects the user header, and the
       // gateway trusts it only from the configured proxy source. No shared token

--- a/apps/clustertenant-operator/src/tenants/deploy/network-policy.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/network-policy.ts
@@ -59,11 +59,14 @@ export function _BuildGatewayNetworkPolicy(
           //
           // The rule itself: the in-operator identity-routing proxy is the sole client of
           // the gateway port now (per-user Ingresses are retired), so admit only the
-          // operator pods in the operator's namespace — no other pod can connect and assert
-          // an arbitrary X-Forwarded-User.
+          // proxy pod in the operator's namespace — no other pod can connect and assert
+          // an arbitrary X-Forwarded-User. The proxy is folded into the clustertenant-manager
+          // pod, which carries `app.kubernetes.io/component: clustertenant-manager` (NOT
+          // "operator" — that selector matched no pod, so the rule admitted nothing and, on a
+          // cluster that actually enforces NetworkPolicy, would fail closed and block the proxy).
           _from: [{
             namespaceSelector: { matchLabels: { [_NAMESPACE_NAME_LABEL]: config.operatorNamespace } },
-            podSelector: { matchLabels: { "app.kubernetes.io/component": "operator" } },
+            podSelector: { matchLabels: { "app.kubernetes.io/component": "clustertenant-manager" } },
           }],
           ports: [{ protocol: "TCP", port: config.gatewayPort }],
         },

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -64,6 +64,21 @@ const _authSchema = z
   .strict();
 
 /**
+ * Control-UI (browser operator surface) block. With `bind:lan` the gateway enforces a
+ * browser Origin allowlist, and a device-less trusted-proxy session keeps its operator
+ * scopes only when device auth is explicitly disabled (the platform is device-less by
+ * design — see `_BuildConfigMap`). Both keys are optional; `allowedOrigins` is host-derived.
+ */
+const _controlUiSchema = z
+  .object({
+    /** Browser Origins allowed to open a Control-UI WS (e.g. `https://<org>.<base>`). */
+    allowedOrigins: z.array(z.string()).optional(),
+    /** Trust the proxy as the auth authority instead of per-browser device identity. */
+    dangerouslyDisableDeviceAuth: z.boolean().optional(),
+  })
+  .strict();
+
+/**
  * PLATFORM-OWNED gateway block. `.strict()` is the load-bearing guarantee: an
  * unknown key here is the exact class of bug that crashed live tenant pods on boot.
  */
@@ -75,6 +90,8 @@ const _gatewaySchema = z
     port: z.number().int().positive(),
     /** Network bind scope. */
     bind: _bindMode,
+    /** Browser operator-UI policy (origin allowlist + device-auth posture). */
+    controlUi: _controlUiSchema.optional(),
     /** Reverse-proxy source IPs/CIDRs trusted for trusted-proxy auth. */
     trustedProxies: z.array(z.string()),
     /** Delegated-auth configuration. */


### PR DESCRIPTION
## What landed

The final blocker for the org-admin chat handshake: `connect` succeeded (health events flowed) but the gateway **stripped the session's operator scopes**, so `chat.history` failed `missing scope: operator.read`. For a device-less trusted-proxy Control-UI the gateway connects but clears scopes (`shouldClearUnboundScopesForMissingDeviceIdentity`, `authMethod=trusted-proxy`) unless device auth is explicitly disabled.

This platform is device-less by design — identity is the OIDC session the operator proxy verifies and injects as `X-Forwarded-User` (CONN.4), not a per-browser device key.

- `_BuildConfigMap` emits **`gateway.controlUi.dangerouslyDisableDeviceAuth: true`** (alongside `allowedOrigins`) so the proxy is the auth authority and the connect's operator scopes stand.
- Added `controlUi` to the strict `_OpenclawConfigSchema` (the render-contract test rejects unknown gateway keys — same class of bug that crashes pods on boot).
- **Fixed `_BuildGatewayNetworkPolicy`**: the gateway-port allow-rule targeted `component: operator`, but the proxy runs in the `clustertenant-manager` pod — that selector matched **no pod**, so on an enforcing cluster it would fail closed and block the proxy. Now targets the real label.

## ⚠️ Security dependency — #105

`dangerouslyDisableDeviceAuth` is safe **only** because the gateway port is meant to be reachable solely via the proxy (the `openclaw-<name>-gateway` NetworkPolicy). **The dev cluster does not enforce NetworkPolicy** (no Dataplane V2 / Calico), so that lockdown isn't real yet — filed as #105 (enable enforcement the k8s-native way). This is enabled now to unblock dev chat on a non-adversarial cluster; do not treat the trusted-proxy gateway as hardened in prod until #105 is done.

## Validation

590 tests pass; typecheck clean. Tests assert `dangerouslyDisableDeviceAuth` is set (with and without a serving host), the origin allowlist is host-derived, and the netpol admits `component: clustertenant-manager`.

## Deploy note

Roll the silo to this image + force a reconcile so the ConfigMap regenerates. Heads-up: the tenant auto-suspends when idle — unsuspend (`spec.suspended=false`) if the pod is gone.