### PR TITLE
✨ deploy: --dev-resources profile to right-size silo planes for a small dev cluster

### DIFF
--- a/apps/clustertenant-operator/openapi.json
+++ b/apps/clustertenant-operator/openapi.json
@@ -896,6 +896,54 @@
           }
         }
       },
+      "ByokProviderKeyStatus": {
+        "type": "object",
+        "required": [
+          "provider",
+          "configured",
+          "litellmRegistered"
+        ],
+        "properties": {
+          "provider": {
+            "type": "string",
+            "enum": [
+              "openai",
+              "anthropic",
+              "gemini",
+              "mistral",
+              "deepseek",
+              "glm"
+            ],
+            "description": "The provider this status describes."
+          },
+          "configured": {
+            "type": "boolean",
+            "description": "Whether a key is currently set for this provider in this silo."
+          },
+          "litellmRegistered": {
+            "type": "boolean",
+            "description": "Whether LiteLLM's /credentials dynamic path accepted the key (false ⇒ Secret-only)."
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "When the key was last set; null when not configured."
+          }
+        }
+      },
+      "ProviderKeySetRequest": {
+        "type": "object",
+        "required": [
+          "apiKey"
+        ],
+        "properties": {
+          "apiKey": {
+            "type": "string",
+            "description": "The raw upstream provider API key. Accepted only over HTTPS; written to a k8s Secret + LiteLLM and never returned by any read."
+          }
+        }
+      },
       "ProviderCredential": {
         "type": "object",
         "required": [
@@ -5927,6 +5975,129 @@
           },
           "404": {
             "description": "Provider key not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/providers/byok": {
+      "get": {
+        "operationId": "listByokProviderKeys",
+        "summary": "List BYOK provider key status for every supported provider (never the key value)",
+        "tags": [
+          "Provider Keys"
+        ],
+        "responses": {
+          "200": {
+            "description": "BYOK provider key status list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ByokProviderKeyStatus"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/providers/byok/{provider}": {
+      "put": {
+        "operationId": "setByokProviderKey",
+        "summary": "Set or refresh a provider's raw key (writes a k8s Secret + LiteLLM credential)",
+        "tags": [
+          "Provider Keys"
+        ],
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "openai",
+                "anthropic",
+                "gemini",
+                "mistral",
+                "deepseek",
+                "glm"
+              ]
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderKeySetRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Key set; returns the provider's status.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ByokProviderKeyStatus"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Unsupported provider (code UNSUPPORTED_PROVIDER) or missing apiKey (code VALIDATION_ERROR).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteByokProviderKey",
+        "summary": "Remove a provider's key (deletes the Secret, LiteLLM credential, and record)",
+        "tags": [
+          "Provider Keys"
+        ],
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "openai",
+                "anthropic",
+                "gemini",
+                "mistral",
+                "deepseek",
+                "glm"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Key removed (idempotent — 204 even when no key was set)."
+          },
+          "400": {
+            "description": "Unsupported provider (code UNSUPPORTED_PROVIDER).",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/clustertenant-operator/src/__tests__/cluster-tenants/default-tenant-onboarding-gate.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/cluster-tenants/default-tenant-onboarding-gate.test.ts
@@ -1,0 +1,53 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { _EnsureOwnerDefaultTenant } from "../../core/cluster-tenants/default-tenant.js";
+
+/**
+ * Onboarding precondition (LiteLLM `replace` mode): a silo with zero registered models would
+ * provision a pod with an empty allowlist and no usable models, so the default-workspace seed is
+ * refused until at least one model exists at the org's scope. These tests pin both branches.
+ */
+
+/** Minimal Prisma stub for the no-cluster (customApi=null) seed path; `count` drives the gate. */
+function _mockPrisma(modelCount: number, onCreate: () => void): PrismaClient
+{
+  return {
+    tenant: {
+      findUnique: async function _findUnique() { return null; },
+      create: async function _create(args: { data: Record<string, unknown> }) { onCreate(); return args.data; },
+    },
+    modelDefinition: {
+      count: async function _count() { return modelCount; },
+    },
+    auditEntry: {
+      create: async function _create() { return {}; },
+    },
+  } as unknown as PrismaClient;
+}
+
+describe("_EnsureOwnerDefaultTenant — onboarding ≥1-model gate", function _suite()
+{
+  it("skips the default-tenant seed when no models are registered", async function _gated()
+  {
+    const createSpy = vi.fn();
+    const res = await _EnsureOwnerDefaultTenant({
+      customApi: null, prisma: _mockPrisma(0, createSpy), namespace: "ns", orgName: "acme", orgDisplayName: "Acme", ownerEmail: "owner@acme.com",
+    });
+
+    expect(res.created).toBe(false);
+    expect(res.skippedReason).toMatch(/no models registered/i);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("seeds the default tenant once at least one model exists", async function _proceeds()
+  {
+    const createSpy = vi.fn();
+    const res = await _EnsureOwnerDefaultTenant({
+      customApi: null, prisma: _mockPrisma(1, createSpy), namespace: "ns", orgName: "acme", orgDisplayName: "Acme", ownerEmail: "owner@acme.com",
+    });
+
+    expect(res.created).toBe(true);
+    expect(createSpy).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/clustertenant-operator/src/__tests__/model-routing/provision-byok-key.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/model-routing/provision-byok-key.test.ts
@@ -1,0 +1,85 @@
+import { Buffer } from "node:buffer";
+
+import * as k8s from "@kubernetes/client-node";
+import type { Logger } from "pino";
+import type { PrismaClient } from "@prisma/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { _DeprovisionByokKey, _ProvisionByokKey, _byokSecretName } from "../../core/model-routing/provision-byok-key.js";
+
+/**
+ * The shared provisioning core behind both the BYOK route and the boot-time bootstrap. These pin
+ * its contract directly (the bootstrap calls it without the HTTP layer): a set writes the Secret,
+ * records the Global credential, and seeds a default model; a deprovision removes all three.
+ */
+
+type Row = Record<string, unknown>;
+
+const _NS = "opencrane-acme";
+const _log = { info() { /* noop */ }, warn() { /* noop */ } } as unknown as Logger;
+
+function _mockPrisma(creds: Map<string, Row>, models: Map<string, Row>): PrismaClient
+{
+  let credSeq = 0;
+  let modelSeq = 0;
+  return {
+    providerCredential: {
+      findFirst: async function _f(args: { where: { provider?: string } }) { return Array.from(creds.values()).find(function _m(r) { return r.provider === args.where.provider; }) ?? null; },
+      create: async function _c(args: { data: Row }) { const id = `cred-${++credSeq}`; const row = { id, updatedAt: new Date("2026-06-30T00:00:00.000Z"), ...args.data }; creds.set(id, row); return row; },
+      update: async function _u(args: { where: { id: string }; data: Row }) { const row = { ...(creds.get(args.where.id) as Row), ...args.data }; creds.set(args.where.id, row); return row; },
+      deleteMany: async function _d(args: { where: { provider: string } }) { let count = 0; for (const [id, r] of creds) { if (r.provider === args.where.provider) { creds.delete(id); count++; } } return { count }; },
+    },
+    modelDefinition: {
+      findFirst: async function _mf(args: { where: Record<string, unknown> }) { return Array.from(models.values()).find(function _m(r) { return (args.where.publicModelName === undefined || r.publicModelName === args.where.publicModelName) && (args.where.isDefault === undefined || r.isDefault === args.where.isDefault); }) ?? null; },
+      create: async function _mc(args: { data: Row }) { const id = `model-${++modelSeq}`; const row = { id, isDefault: false, providerCredentialId: null, ...args.data }; models.set(id, row); return row; },
+      update: async function _mu(args: { where: { id: string }; data: Row }) { const row = { ...(models.get(args.where.id) as Row), ...args.data }; models.set(args.where.id, row); return row; },
+    },
+  } as unknown as PrismaClient;
+}
+
+function _mockCoreApi(secrets: Map<string, k8s.V1Secret>): k8s.CoreV1Api
+{
+  const notFound = () => Object.assign(new Error("not found"), { code: 404 });
+  return {
+    readNamespacedSecret: async function _r(a: { name: string }) { const s = secrets.get(a.name); if (!s) { throw notFound(); } return s; },
+    createNamespacedSecret: async function _c(a: { body: k8s.V1Secret }) { secrets.set(a.body.metadata!.name!, a.body); return a.body; },
+    replaceNamespacedSecret: async function _rp(a: { name: string; body: k8s.V1Secret }) { secrets.set(a.name, a.body); return a.body; },
+    deleteNamespacedSecret: async function _d(a: { name: string }) { if (!secrets.has(a.name)) { throw notFound(); } secrets.delete(a.name); return {}; },
+  } as unknown as k8s.CoreV1Api;
+}
+
+describe("_ProvisionByokKey / _DeprovisionByokKey", function _suite()
+{
+  const _saved: Record<string, string | undefined> = {};
+  beforeAll(function _clearEnv() { for (const k of ["LITELLM_ENDPOINT", "LITELLM_MASTER_KEY"]) { _saved[k] = process.env[k]; delete process.env[k]; } });
+  afterAll(function _restoreEnv() { for (const k of ["LITELLM_ENDPOINT", "LITELLM_MASTER_KEY"]) { if (_saved[k] !== undefined) { process.env[k] = _saved[k]; } } });
+
+  it("provisions: writes the Secret, records the credential, seeds a default model", async function _provision()
+  {
+    const creds = new Map<string, Row>();
+    const models = new Map<string, Row>();
+    const secrets = new Map<string, k8s.V1Secret>();
+
+    const result = await _ProvisionByokKey({ prisma: _mockPrisma(creds, models), coreApi: _mockCoreApi(secrets), operatorNamespace: _NS, provider: "openai", apiKey: "sk-test-123", log: _log });
+
+    // LiteLLM unconfigured in the test → Secret-only.
+    expect(result.litellmRegistered).toBe(false);
+    expect(Buffer.from(secrets.get(_byokSecretName("openai"))!.data!.apiKey, "base64").toString("utf8")).toBe("sk-test-123");
+    expect(Array.from(creds.values())[0]).toMatchObject({ scope: "Global", clusterTenant: null, provider: "openai" });
+    const seeded = Array.from(models.values());
+    expect(seeded).toHaveLength(1);
+    expect(seeded[0]).toMatchObject({ publicModelName: "openai/gpt-4o", isDefault: true });
+    expect(seeded[0].providerCredentialId).toBe(result.row.id);
+  });
+
+  it("deprovisions: removes the Secret and the credential row", async function _deprovision()
+  {
+    const creds = new Map<string, Row>([["cred-1", { id: "cred-1", scope: "Global", clusterTenant: null, provider: "openai" }]]);
+    const secrets = new Map<string, k8s.V1Secret>([[_byokSecretName("openai"), { metadata: { name: _byokSecretName("openai"), namespace: _NS } }]]);
+
+    await _DeprovisionByokKey({ prisma: _mockPrisma(creds, new Map()), coreApi: _mockCoreApi(secrets), operatorNamespace: _NS, provider: "openai" });
+
+    expect(secrets.has(_byokSecretName("openai"))).toBe(false);
+    expect(creds.size).toBe(0);
+  });
+});

--- a/apps/clustertenant-operator/src/__tests__/routes/provider-byok.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/routes/provider-byok.test.ts
@@ -1,0 +1,280 @@
+import { Buffer } from "node:buffer";
+
+import express from "express";
+import type { Express } from "express";
+import * as k8s from "@kubernetes/client-node";
+import type { PrismaClient } from "@prisma/client";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { providerByokRouter } from "../../routes/provider-byok.js";
+
+/** In-memory provider_credentials store backing the mock Prisma client. */
+type Row = Record<string, unknown>;
+
+/** The operator namespace the router writes Secrets into, in tests. */
+const _NS = "opencrane-acme";
+
+/**
+ * Build a Prisma stub over an in-memory map keyed by credential id, covering the calls the BYOK
+ * router makes: findMany (with a provider `in` filter), findFirst, create, update, deleteMany.
+ */
+function _mockPrisma(store: Map<string, Row>, models: Map<string, Row> = new Map()): PrismaClient
+{
+  let seq = 0;
+  let modelSeq = 0;
+  const match = (r: Row, where?: { scope?: string; clusterTenant?: string | null; provider?: string }): boolean =>
+    !where || ((where.scope === undefined || r.scope === where.scope)
+      && (where.clusterTenant === undefined || r.clusterTenant === where.clusterTenant)
+      && (where.provider === undefined || r.provider === where.provider));
+  const matchModel = (r: Row, where?: { scope?: string; clusterTenant?: string | null; publicModelName?: string; isDefault?: boolean }): boolean =>
+    !where || ((where.scope === undefined || r.scope === where.scope)
+      && (where.clusterTenant === undefined || r.clusterTenant === where.clusterTenant)
+      && (where.publicModelName === undefined || r.publicModelName === where.publicModelName)
+      && (where.isDefault === undefined || r.isDefault === where.isDefault));
+  return {
+    modelDefinition: {
+      findFirst: async function _mFindFirst(args: { where: Record<string, unknown> })
+      {
+        return Array.from(models.values()).find(function _m(r) { return matchModel(r, args.where); }) ?? null;
+      },
+      create: async function _mCreate(args: { data: Row })
+      {
+        const id = `model-${++modelSeq}`;
+        const row = { id, isDefault: false, providerCredentialId: null, apiBase: null, ...args.data };
+        models.set(id, row);
+        return row;
+      },
+      update: async function _mUpdate(args: { where: { id: string }; data: Row })
+      {
+        const row = { ...(models.get(args.where.id) as Row), ...args.data };
+        models.set(args.where.id, row);
+        return row;
+      },
+    },
+    providerCredential: {
+      findMany: async function _findMany(args?: { where?: { provider?: { in?: string[] } } })
+      {
+        const inList = args?.where?.provider?.in;
+        return Array.from(store.values()).filter(function _byIn(r) { return !inList || inList.includes(r.provider as string); });
+      },
+      findFirst: async function _findFirst(args: { where: { scope: string; clusterTenant: string | null; provider: string } })
+      {
+        return Array.from(store.values()).find(function _m(r) { return match(r, args.where); }) ?? null;
+      },
+      create: async function _create(args: { data: Row })
+      {
+        const id = `cred-${++seq}`;
+        const now = new Date("2026-06-30T00:00:00.000Z");
+        const row = { id, createdAt: now, updatedAt: now, ...args.data };
+        store.set(id, row);
+        return row;
+      },
+      update: async function _update(args: { where: { id: string }; data: Row })
+      {
+        const row = { ...(store.get(args.where.id) as Row), ...args.data, updatedAt: new Date("2026-06-30T12:00:00.000Z") };
+        store.set(args.where.id, row);
+        return row;
+      },
+      deleteMany: async function _deleteMany(args: { where: { provider: string } })
+      {
+        let count = 0;
+        for (const [id, r] of store)
+        {
+          if (match(r, args.where)) { store.delete(id); count++; }
+        }
+        return { count };
+      },
+    },
+  } as unknown as PrismaClient;
+}
+
+/** A k8s 404 error shaped like the client's NotFound, used to drive the create path. */
+function _notFound(): Error & { code: number }
+{
+  return Object.assign(new Error("not found"), { code: 404 });
+}
+
+/** Build a CoreV1Api stub backed by an in-memory Secret store keyed by name. */
+function _mockCoreApi(secrets: Map<string, k8s.V1Secret>): k8s.CoreV1Api
+{
+  return {
+    readNamespacedSecret: async function _read(args: { name: string })
+    {
+      const s = secrets.get(args.name);
+      if (!s) { throw _notFound(); }
+      return s;
+    },
+    createNamespacedSecret: async function _create(args: { body: k8s.V1Secret })
+    {
+      secrets.set(args.body.metadata!.name!, args.body);
+      return args.body;
+    },
+    replaceNamespacedSecret: async function _replace(args: { name: string; body: k8s.V1Secret })
+    {
+      secrets.set(args.name, args.body);
+      return args.body;
+    },
+    deleteNamespacedSecret: async function _delete(args: { name: string })
+    {
+      if (!secrets.has(args.name)) { throw _notFound(); }
+      secrets.delete(args.name);
+      return {};
+    },
+  } as unknown as k8s.CoreV1Api;
+}
+
+/**
+ * Mount only the BYOK router over the supplied stores, seeding an org-admin session by default so
+ * the `_RequireOrgAdmin`-gated mutations pass. Pass `{ isOrgAdmin: false }` to exercise the 403 path.
+ */
+function _buildApp(store: Map<string, Row>, secrets: Map<string, k8s.V1Secret>, user: { isOrgAdmin: boolean } = { isOrgAdmin: true }, models: Map<string, Row> = new Map()): Express
+{
+  const app = express();
+  app.use(express.json());
+  app.use(function _seedSession(req, _res, next) { (req as unknown as { session: { authUser: { isOrgAdmin: boolean } } }).session = { authUser: user }; next(); });
+  app.use("/api/v1/providers/byok", providerByokRouter(_mockPrisma(store, models), _mockCoreApi(secrets), _NS));
+  return app;
+}
+
+describe("providerByokRouter", function _suite()
+{
+  // LiteLLM is unconfigured in tests, so the /credentials push is a no-op and keys stay Secret-only.
+  const _saved: Record<string, string | undefined> = {};
+  beforeAll(function _clearLitellmEnv()
+  {
+    for (const k of ["LITELLM_ENDPOINT", "LITELLM_MASTER_KEY"]) { _saved[k] = process.env[k]; delete process.env[k]; }
+  });
+  afterAll(function _restoreLitellmEnv()
+  {
+    for (const k of ["LITELLM_ENDPOINT", "LITELLM_MASTER_KEY"]) { if (_saved[k] !== undefined) { process.env[k] = _saved[k]; } }
+  });
+
+  it("sets a provider key: writes the Secret (base64), records the credential, Secret-only without LiteLLM", async function _set()
+  {
+    const store = new Map<string, Row>();
+    const secrets = new Map<string, k8s.V1Secret>();
+    const res = await request(_buildApp(store, secrets)).put("/api/v1/providers/byok/openai").send({ apiKey: "sk-live-123" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ provider: "openai", configured: true, litellmRegistered: false });
+
+    const secret = secrets.get("byok-provider-key-openai");
+    expect(secret?.metadata?.namespace).toBe(_NS);
+    expect(Buffer.from(secret!.data!.apiKey, "base64").toString("utf8")).toBe("sk-live-123");
+
+    const row = Array.from(store.values())[0];
+    expect(row).toMatchObject({ scope: "Global", clusterTenant: null, provider: "openai", secretRef: "byok-provider-key-openai", litellmCredentialName: null });
+  });
+
+  it("seeds a default model bound to the credential so the agent can route through LiteLLM", async function _seedsDefault()
+  {
+    const store = new Map<string, Row>();
+    const models = new Map<string, Row>();
+    const app = _buildApp(store, new Map(), { isOrgAdmin: true }, models);
+    await request(app).put("/api/v1/providers/byok/openai").send({ apiKey: "sk-live-123" });
+
+    const seeded = Array.from(models.values());
+    expect(seeded).toHaveLength(1);
+    expect(seeded[0]).toMatchObject({ scope: "Global", clusterTenant: null, publicModelName: "openai/gpt-4o", isDefault: true });
+    // Bound to the upserted credential row so LiteLLM resolves the BYOK key for it.
+    const cred = Array.from(store.values())[0];
+    expect(seeded[0].providerCredentialId).toBe(cred.id);
+  });
+
+  it("first provider configured wins the silo default; the second is added but not default", async function _firstWins()
+  {
+    const store = new Map<string, Row>();
+    const models = new Map<string, Row>();
+    const app = _buildApp(store, new Map(), { isOrgAdmin: true }, models);
+    await request(app).put("/api/v1/providers/byok/openai").send({ apiKey: "k1" });
+    await request(app).put("/api/v1/providers/byok/anthropic").send({ apiKey: "k2" });
+
+    const byName = new Map(Array.from(models.values()).map(function _n(m) { return [m.publicModelName, m]; }));
+    expect(byName.get("openai/gpt-4o")).toMatchObject({ isDefault: true });
+    expect(byName.get("anthropic/claude-sonnet-4-5")).toMatchObject({ isDefault: false });
+  });
+
+  it("never echoes the raw key back in the response body", async function _noEcho()
+  {
+    const res = await request(_buildApp(new Map(), new Map())).put("/api/v1/providers/byok/anthropic").send({ apiKey: "sk-secret-xyz" });
+
+    expect(JSON.stringify(res.body)).not.toContain("sk-secret-xyz");
+  });
+
+  it("refreshes an existing key in place (update, not duplicate row)", async function _refresh()
+  {
+    const store = new Map<string, Row>();
+    const secrets = new Map<string, k8s.V1Secret>();
+    const app = _buildApp(store, secrets);
+    await request(app).put("/api/v1/providers/byok/gemini").send({ apiKey: "key-1" });
+    const res = await request(app).put("/api/v1/providers/byok/gemini").send({ apiKey: "key-2" });
+
+    expect(res.status).toBe(200);
+    expect(Array.from(store.values()).filter(function _g(r) { return r.provider === "gemini"; })).toHaveLength(1);
+    expect(Buffer.from(secrets.get("byok-provider-key-gemini")!.data!.apiKey, "base64").toString("utf8")).toBe("key-2");
+  });
+
+  it("denies a non-org-admin caller with 403 (mutations are org-admin only)", async function _denyNonAdmin()
+  {
+    const store = new Map<string, Row>();
+    const secrets = new Map<string, k8s.V1Secret>();
+    const app = _buildApp(store, secrets, { isOrgAdmin: false });
+    const res = await request(app).put("/api/v1/providers/byok/openai").send({ apiKey: "sk-live-123" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("FORBIDDEN_NOT_ORG_ADMIN");
+    expect(secrets.size).toBe(0);
+    expect(store.size).toBe(0);
+  });
+
+  it("rejects an unsupported provider with 400", async function _badProvider()
+  {
+    const res = await request(_buildApp(new Map(), new Map())).put("/api/v1/providers/byok/cohere").send({ apiKey: "x" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("UNSUPPORTED_PROVIDER");
+  });
+
+  it("rejects a missing apiKey with 400", async function _missingKey()
+  {
+    const res = await request(_buildApp(new Map(), new Map())).put("/api/v1/providers/byok/openai").send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("lists status across all supported providers, never the key", async function _list()
+  {
+    const store = new Map<string, Row>([
+      ["cred-1", { id: "cred-1", scope: "Global", clusterTenant: null, provider: "openai", secretRef: "byok-provider-key-openai", litellmCredentialName: "byok-openai", updatedAt: new Date("2026-06-30T00:00:00.000Z") }],
+    ]);
+    const res = await request(_buildApp(store, new Map())).get("/api/v1/providers/byok");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(6);
+    const openai = res.body.find(function _o(s: { provider: string }) { return s.provider === "openai"; });
+    expect(openai).toMatchObject({ configured: true, litellmRegistered: true });
+    const mistral = res.body.find(function _m(s: { provider: string }) { return s.provider === "mistral"; });
+    expect(mistral).toMatchObject({ configured: false, litellmRegistered: false, updatedAt: null });
+    expect(JSON.stringify(res.body)).not.toContain("apiKey");
+  });
+
+  it("removes a key: deletes the Secret and the record, idempotent 204", async function _delete()
+  {
+    const store = new Map<string, Row>([
+      ["cred-1", { id: "cred-1", scope: "Global", clusterTenant: null, provider: "deepseek", secretRef: "byok-provider-key-deepseek", litellmCredentialName: null, updatedAt: new Date() }],
+    ]);
+    const secrets = new Map<string, k8s.V1Secret>([["byok-provider-key-deepseek", { metadata: { name: "byok-provider-key-deepseek", namespace: _NS } }]]);
+    const app = _buildApp(store, secrets);
+
+    const res = await request(app).delete("/api/v1/providers/byok/deepseek");
+    expect(res.status).toBe(204);
+    expect(secrets.has("byok-provider-key-deepseek")).toBe(false);
+    expect(Array.from(store.values())).toHaveLength(0);
+
+    // Idempotent: deleting again still returns 204.
+    const again = await request(app).delete("/api/v1/providers/byok/deepseek");
+    expect(again.status).toBe(204);
+  });
+});

--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -58,6 +58,26 @@ describe("TenantResourceBuilder", () =>
     expect(runtimeContract.skills.registry).toBe(defaultConfig.skillRegistryUrl);
   });
 
+  it("emits litellm-proxy in replace mode (LiteLLM is the only provider — no bare-provider bypass)", () =>
+  {
+    const liteLlmConfig = { ...defaultConfig, liteLlmEnabled: true };
+    const tenant = _makeTenant("ll");
+
+    // Non-empty modelSet → replace, default surfaced, allowlist restricted to the set.
+    const withModels = JSON.parse(_BuildConfigMap(liteLlmConfig, tenant, "default", undefined, { models: ["openai/gpt-4o", "anthropic/claude-sonnet-4-5"], defaultModel: "openai/gpt-4o" }).data?.["openclaw.json"] ?? "{}");
+    expect(withModels.models.mode).toBe("replace");
+    expect(withModels.models.default).toBe("openai/gpt-4o");
+    expect(Object.keys(withModels.models.providers)).toEqual(["litellm-proxy"]);
+    expect(withModels.models.providers["litellm-proxy"].models).toEqual(["openai/gpt-4o", "anthropic/claude-sonnet-4-5"]);
+
+    // Empty/null modelSet → still replace (no built-in fallback); empty allowlist, no default.
+    // This bricked-pod window is what cluster onboarding's ≥1-model requirement prevents.
+    const noModels = JSON.parse(_BuildConfigMap(liteLlmConfig, tenant, "default", undefined, null).data?.["openclaw.json"] ?? "{}");
+    expect(noModels.models.mode).toBe("replace");
+    expect(noModels.models.default).toBeUndefined();
+    expect(noModels.models.providers["litellm-proxy"].models).toEqual([]);
+  });
+
   it("normalises the gateway owner allowlist (trim + lowercase) to match gateway-verify", () =>
   {
     // gateway-verify injects email.trim().toLowerCase(); a mixed-case / padded owner

--- a/apps/clustertenant-operator/src/core/cluster-tenants/default-tenant.ts
+++ b/apps/clustertenant-operator/src/core/cluster-tenants/default-tenant.ts
@@ -59,6 +59,20 @@ export async function _EnsureOwnerDefaultTenant(opts: {
     return { tenantName, created: false };
   }
 
+  // 1b. Onboarding precondition — at least one model must be registered. Tenant pods run LiteLLM
+  //     in `replace` mode (the proxy is the ONLY provider — see 2-config-map.ts `models.mode`), so a
+  //     silo with no models would provision a pod with an empty allowlist and zero usable models.
+  //     Refuse to seed the org's first workspace until a model exists at its scope (Global, or its
+  //     own ClusterTenant). Self-heals: registering a model — or setting a provider key, which
+  //     auto-seeds one — then refreshing the org re-runs this seed.
+  const modelCount = await prisma.modelDefinition.count({
+    where: { OR: [{ scope: "Global" }, { scope: "ClusterTenant", clusterTenant: orgName }] },
+  });
+  if (modelCount === 0)
+  {
+    return { tenantName, created: false, skippedReason: "no models registered for this org — register a model or set a provider key before its workspace can start (LiteLLM replace mode requires ≥1 model)" };
+  }
+
   // 2. Resolve the owner email: the caller's value wins; otherwise recover it from an
   //    already-seeded CRD (the path we are repairing). The CRD read also tells us whether
   //    to skip the create-CRD step below.

--- a/apps/clustertenant-operator/src/core/model-routing/byok-default-models.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/byok-default-models.ts
@@ -1,0 +1,21 @@
+/**
+ * Starter default model per BYOK provider — the model auto-seeded (best-effort) when a provider's
+ * key is first set, so the silo has a working routable model + default without a separate
+ * model-registry call. The first provider configured becomes the silo's default model.
+ *
+ * These are sensible flagship defaults expressed as LiteLLM `provider/model` slugs; they are the
+ * single place to tune which model a freshly-set key lights up. Adjust per the models the silo's
+ * LiteLLM actually serves — an unknown slug simply fails to route until corrected, it does not
+ * affect the key itself (the key is persisted independently of this seed).
+ *
+ * A provider absent from this map sets its key but seeds no model (the admin registers one via the
+ * model-registry instead).
+ */
+export const _BYOK_DEFAULT_MODELS: Readonly<Record<string, string>> = {
+  openai: "openai/gpt-4o",
+  anthropic: "anthropic/claude-sonnet-4-5",
+  gemini: "gemini/gemini-2.5-pro",
+  mistral: "mistral/mistral-large-latest",
+  deepseek: "deepseek/deepseek-chat",
+  glm: "openai/glm-4.6",
+};

--- a/apps/clustertenant-operator/src/core/model-routing/litellm-credential-registration.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/litellm-credential-registration.ts
@@ -1,0 +1,148 @@
+import { ___DoWithTrace } from "@opencrane/observability";
+
+import { _log } from "../../log.js";
+import type { LiteLlmCredentialUpsert } from "./litellm-credential-registration.types.js";
+
+/**
+ * Per-request timeout for the LiteLLM `/credentials` calls. Bounds the boot-time bootstrap (which
+ * awaits these) so a hung or unreachable LiteLLM cannot wedge silo controller startup — on timeout
+ * the fetch aborts, the catch returns `false`, and the key stays Secret-only until the next attempt.
+ */
+const _LITELLM_HTTP_TIMEOUT_MS = 10_000;
+
+/**
+ * Best-effort upsert of a provider credential into LiteLLM via its `/credentials` API — the
+ * BYOK "dynamic no-restart path" the contract describes (see ProviderCredential.litellmCredentialName).
+ *
+ * Guarded by `LITELLM_ENDPOINT` + `LITELLM_MASTER_KEY`: when either is unset (dev / tests) this is
+ * a no-op returning `false`, so the BYOK set path stays functional without a live LiteLLM — the
+ * raw key still persists to its k8s Secret and the ProviderCredential row, and the credential can
+ * be reconciled later. The call is non-fatal and isolated: a LiteLLM error also returns `false`
+ * rather than failing the request, mirroring the resilient posture of `_RegisterLiteLlmModel`.
+ *
+ * Upsert is implemented as delete-then-create so a refreshed key always replaces the stored value
+ * regardless of whether the LiteLLM build exposes a credential update verb.
+ *
+ * @param input - The credential name, provider, and raw key to store in LiteLLM.
+ * @returns `true` when LiteLLM accepted the credential; `false` when unconfigured or on any error.
+ */
+export async function _UpsertLiteLlmCredential(input: LiteLlmCredentialUpsert): Promise<boolean>
+{
+  const endpoint = process.env.LITELLM_ENDPOINT?.trim() ?? "";
+  const masterKey = process.env.LITELLM_MASTER_KEY?.trim() ?? "";
+  if (!endpoint || !masterKey)
+  {
+    _log.debug({ credentialName: input.credentialName, provider: input.provider, configured: false }, "litellm credential upsert skipped (unconfigured)");
+    return false;
+  }
+
+  return ___DoWithTrace(
+    "litellm.credential.upsert",
+    { credentialName: input.credentialName, provider: input.provider },
+    function _upsert(): Promise<boolean> { return _upsertLive(endpoint, masterKey, input); },
+  );
+}
+
+/**
+ * Best-effort delete of a LiteLLM credential by name (used on BYOK key removal). Mirrors the
+ * resilient posture above: unconfigured or any non-OK / error is swallowed and returns `false`,
+ * never failing the caller's delete of the Secret + DB row.
+ *
+ * @param credentialName - The LiteLLM credential name to remove.
+ * @returns `true` when LiteLLM acknowledged the delete; `false` when unconfigured or on any error.
+ */
+export async function _DeleteLiteLlmCredential(credentialName: string): Promise<boolean>
+{
+  const endpoint = process.env.LITELLM_ENDPOINT?.trim() ?? "";
+  const masterKey = process.env.LITELLM_MASTER_KEY?.trim() ?? "";
+  if (!endpoint || !masterKey)
+  {
+    return false;
+  }
+
+  return ___DoWithTrace(
+    "litellm.credential.delete",
+    { credentialName },
+    function _delete(): Promise<boolean> { return _deleteLive(endpoint, masterKey, credentialName); },
+  );
+}
+
+/**
+ * Perform the live delete-then-create against LiteLLM. The delete clears any prior value so a
+ * refreshed key replaces it; the create stores the new value. Either step failing is logged as a
+ * warning and yields `false` — the request still succeeds with the key persisted to its Secret.
+ *
+ * @param endpoint  - LiteLLM base URL.
+ * @param masterKey - LiteLLM bearer credential.
+ * @param input     - The credential to upsert.
+ */
+async function _upsertLive(endpoint: string, masterKey: string, input: LiteLlmCredentialUpsert): Promise<boolean>
+{
+  try
+  {
+    // 1. Clear any existing value first so a refresh is a true replace (idempotent — 404 is fine).
+    await _deleteLive(endpoint, masterKey, input.credentialName);
+
+    // 2. Create the credential carrying the raw key inline. LiteLLM encrypts it at rest with
+    //    LITELLM_SALT_KEY; the key is never echoed back and never written to OpenClaw's config.
+    const response = await fetch(`${endpoint}/credentials`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${masterKey}`,
+      },
+      body: JSON.stringify({
+        credential_name: input.credentialName,
+        credential_info: { custom_llm_provider: input.provider },
+        credential_values: { api_key: input.apiKey },
+      }),
+      signal: AbortSignal.timeout(_LITELLM_HTTP_TIMEOUT_MS),
+    });
+
+    if (!response.ok)
+    {
+      _log.warn({ credentialName: input.credentialName, provider: input.provider, status: response.status }, "litellm credential upsert failed; key persisted to Secret only");
+      return false;
+    }
+
+    _log.info({ credentialName: input.credentialName, provider: input.provider }, "litellm credential upserted");
+    return true;
+  }
+  catch (err)
+  {
+    _log.warn({ credentialName: input.credentialName, provider: input.provider, err }, "litellm credential upsert errored; key persisted to Secret only");
+    return false;
+  }
+}
+
+/**
+ * Perform the live `DELETE /credentials/<name>` call, treating a 404 as success (already gone).
+ *
+ * @param endpoint       - LiteLLM base URL.
+ * @param masterKey      - LiteLLM bearer credential.
+ * @param credentialName - The credential name to remove.
+ */
+async function _deleteLive(endpoint: string, masterKey: string, credentialName: string): Promise<boolean>
+{
+  try
+  {
+    const response = await fetch(`${endpoint}/credentials/${encodeURIComponent(credentialName)}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${masterKey}` },
+      signal: AbortSignal.timeout(_LITELLM_HTTP_TIMEOUT_MS),
+    });
+
+    if (!response.ok && response.status !== 404)
+    {
+      _log.warn({ credentialName, status: response.status }, "litellm credential delete failed");
+      return false;
+    }
+
+    return true;
+  }
+  catch (err)
+  {
+    _log.warn({ credentialName, err }, "litellm credential delete errored");
+    return false;
+  }
+}

--- a/apps/clustertenant-operator/src/core/model-routing/litellm-credential-registration.types.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/litellm-credential-registration.types.ts
@@ -1,0 +1,17 @@
+/**
+ * Inputs for a best-effort LiteLLM `/credentials` upsert — the BYOK "dynamic no-restart path".
+ *
+ * Unlike {@link LiteLlmModelRegistration} (which references a key via `os.environ/<ref>` — the
+ * env baseline), a credential carries the RAW provider key inline. LiteLLM persists it in its
+ * own DB-backed store encrypted with `LITELLM_SALT_KEY`, so a model that references the credential
+ * by name picks up the key with no pod restart and the key never lands in OpenClaw's config.
+ */
+export interface LiteLlmCredentialUpsert
+{
+  /** The credential name models reference via `litellm_params.litellm_credential_name`. */
+  credentialName: string;
+  /** The LiteLLM provider this key authenticates, e.g. `openai`, `anthropic`, `gemini`. */
+  provider: string;
+  /** The raw upstream provider API key. Never logged, never returned to a caller. */
+  apiKey: string;
+}

--- a/apps/clustertenant-operator/src/core/model-routing/litellm-model-registration.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/litellm-model-registration.ts
@@ -52,14 +52,20 @@ async function _registerLive(endpoint: string, masterKey: string, input: LiteLlm
 {
   try
   {
-    // 2. Register the deployment GLOBALLY. `api_key` is an `os.environ/<KEY>` reference so the
-    //    raw key never transits OpenCrane — LiteLLM reads it from its own synced environment.
+    // 2. Register the deployment GLOBALLY. Prefer the BYOK dynamic path: when a credential name is
+    //    bound, reference it via `litellm_credential_name` so LiteLLM resolves the key from its
+    //    encrypted store. Otherwise fall back to the env baseline — `api_key` as an `os.environ/<KEY>`
+    //    reference so the raw key never transits OpenCrane (LiteLLM reads it from its own environment).
     const litellmParams: Record<string, unknown> = { model: input.upstreamModel };
     if (input.apiBase)
     {
       litellmParams.api_base = input.apiBase;
     }
-    if (input.apiKeyEnvRef)
+    if (input.litellmCredentialName)
+    {
+      litellmParams.litellm_credential_name = input.litellmCredentialName;
+    }
+    else if (input.apiKeyEnvRef)
     {
       litellmParams.api_key = `os.environ/${input.apiKeyEnvRef}`;
     }

--- a/apps/clustertenant-operator/src/core/model-routing/litellm-model-registration.types.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/litellm-model-registration.types.ts
@@ -18,4 +18,10 @@ export interface LiteLlmModelRegistration
   apiBase?: string | null;
   /** Optional environment variable name LiteLLM reads the provider key from (`os.environ/<ref>`). */
   apiKeyEnvRef?: string | null;
+  /**
+   * Optional LiteLLM `/credentials` name (the BYOK dynamic path). When set it takes precedence over
+   * `apiKeyEnvRef`: the deployment binds `litellm_credential_name` so the key is resolved from
+   * LiteLLM's encrypted credential store with no pod restart, instead of the `os.environ` baseline.
+   */
+  litellmCredentialName?: string | null;
 }

--- a/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
@@ -1,0 +1,261 @@
+import { Buffer } from "node:buffer";
+
+import * as k8s from "@kubernetes/client-node";
+import type { Logger } from "pino";
+import { ModelRoutingScope } from "@opencrane/contracts";
+import type { PrismaClient, ProviderCredential as PrismaProviderCredential } from "@prisma/client";
+
+import { _DeleteLiteLlmCredential, _UpsertLiteLlmCredential } from "./litellm-credential-registration.js";
+import { _RegisterLiteLlmModel } from "./litellm-model-registration.js";
+import { _BYOK_DEFAULT_MODELS } from "./byok-default-models.js";
+
+/**
+ * Reusable core for setting/removing a silo's BYOK provider key — the work behind both the HTTP
+ * route (`providerByokRouter`) and the boot-time bootstrap. Writing it here (not in `routes/`) keeps
+ * the provisioning logic out of the HTTP layer so the operator boot path can call it directly.
+ *
+ * A set: write the raw key to a k8s Secret (durable source of truth) → push to LiteLLM's
+ * `/credentials` dynamic path (best-effort) → upsert the Global ProviderCredential row → seed a
+ * default model bound to it. A key is Global-scoped (silo-wide), never per openclaw tenant.
+ */
+
+/** Outcome of {@link _ProvisionByokKey}. */
+export interface ProvisionByokKeyResult
+{
+  /** True when LiteLLM's `/credentials` accepted the key (false ⇒ Secret-only / env baseline). */
+  litellmRegistered: boolean;
+  /** The upserted Global ProviderCredential row. */
+  row: PrismaProviderCredential;
+}
+
+/** Name of the k8s Secret carrying a provider's raw BYOK key, in the operator's own namespace. */
+export function _byokSecretName(provider: string): string
+{
+  return `byok-provider-key-${provider}`;
+}
+
+/** Name of the LiteLLM `/credentials` entry for a provider's BYOK key. */
+export function _byokCredentialName(provider: string): string
+{
+  return `byok-${provider}`;
+}
+
+/**
+ * Provision (set or refresh) a silo's raw BYOK key for a provider: persist the Secret, register the
+ * LiteLLM credential, record the ProviderCredential row, and seed a default model bound to it.
+ *
+ * @param opts.prisma            - Prisma client for the credential + model rows.
+ * @param opts.coreApi           - Kubernetes Core V1 API for the Secret write.
+ * @param opts.operatorNamespace - The operator's own namespace (where the silo's keys live).
+ * @param opts.provider          - The provider the key is for (e.g. `openai`).
+ * @param opts.apiKey            - The raw upstream key (never logged or echoed).
+ * @param opts.log               - Scoped logger for the best-effort model-seed warning.
+ * @returns Whether LiteLLM accepted the key, and the upserted credential row.
+ */
+export async function _ProvisionByokKey(opts: {
+  prisma: PrismaClient;
+  coreApi: k8s.CoreV1Api;
+  operatorNamespace: string;
+  provider: string;
+  apiKey: string;
+  log: Logger;
+}): Promise<ProvisionByokKeyResult>
+{
+  const { prisma, coreApi, operatorNamespace, provider, apiKey, log } = opts;
+
+  // 1. Persist the raw key to its k8s Secret first — the durable source of truth.
+  await _applyProviderKeySecret(coreApi, operatorNamespace, provider, apiKey);
+
+  // 2. Best-effort push to LiteLLM's /credentials dynamic path; Secret-only when unconfigured/down.
+  const credentialName = _byokCredentialName(provider);
+  const litellmRegistered = await _UpsertLiteLlmCredential({ credentialName, provider, apiKey });
+
+  // 3. Record the credential reference (litellmCredentialName set only when LiteLLM accepted it).
+  const secretRef = _byokSecretName(provider);
+  const litellmCredentialName = litellmRegistered ? credentialName : null;
+  const row = await _upsertCredentialRow(prisma, provider, secretRef, litellmCredentialName);
+
+  // 4. Best-effort: light up a default model so the key is usable end-to-end. Never fail the set.
+  try
+  {
+    await _ensureProviderDefaultModel(prisma, provider, row.id, litellmCredentialName);
+  }
+  catch (err)
+  {
+    log.warn({ provider, err }, "byok default-model seed failed; key is set but no default model was seeded");
+  }
+
+  return { litellmRegistered, row };
+}
+
+/**
+ * Remove a silo's BYOK key for a provider: delete the Secret, the LiteLLM credential, and the row.
+ *
+ * @param opts.prisma            - Prisma client.
+ * @param opts.coreApi           - Kubernetes Core V1 API.
+ * @param opts.operatorNamespace - The operator's own namespace.
+ * @param opts.provider          - The provider whose key to remove.
+ */
+export async function _DeprovisionByokKey(opts: {
+  prisma: PrismaClient;
+  coreApi: k8s.CoreV1Api;
+  operatorNamespace: string;
+  provider: string;
+}): Promise<void>
+{
+  await _deleteProviderKeySecret(opts.coreApi, opts.operatorNamespace, opts.provider);
+  await _DeleteLiteLlmCredential(_byokCredentialName(opts.provider));
+  await opts.prisma.providerCredential.deleteMany({ where: { scope: "Global", clusterTenant: null, provider: opts.provider } });
+}
+
+/**
+ * Write (create-or-replace) the provider's raw key into a k8s Secret in the operator's namespace.
+ * Reads first to carry `resourceVersion` on replace (PUT requires it); a 404 read falls through to
+ * a create. The Secret is the durable source of truth — it survives a LiteLLM DB reset.
+ */
+async function _applyProviderKeySecret(coreApi: k8s.CoreV1Api, namespace: string, provider: string, apiKey: string): Promise<void>
+{
+  const name = _byokSecretName(provider);
+  const body: k8s.V1Secret = {
+    apiVersion: "v1",
+    kind: "Secret",
+    metadata: {
+      name,
+      namespace,
+      labels: {
+        "app.kubernetes.io/managed-by": "clustertenant-operator",
+        "opencrane.io/byok-provider": provider,
+      },
+    },
+    type: "Opaque",
+    data: { apiKey: Buffer.from(apiKey).toString("base64") },
+  };
+
+  try
+  {
+    const existing = await coreApi.readNamespacedSecret({ name, namespace });
+    body.metadata!.resourceVersion = existing.metadata?.resourceVersion;
+    await coreApi.replaceNamespacedSecret({ name, namespace, body });
+  }
+  catch (err)
+  {
+    if (_k8sStatus(err) !== 404)
+    {
+      throw err;
+    }
+    await coreApi.createNamespacedSecret({ namespace, body });
+  }
+}
+
+/** Best-effort delete of the provider's key Secret, treating 404 (already gone) as success. */
+async function _deleteProviderKeySecret(coreApi: k8s.CoreV1Api, namespace: string, provider: string): Promise<void>
+{
+  try
+  {
+    await coreApi.deleteNamespacedSecret({ name: _byokSecretName(provider), namespace });
+  }
+  catch (err)
+  {
+    if (_k8sStatus(err) !== 404)
+    {
+      throw err;
+    }
+  }
+}
+
+/** Extract a Kubernetes API status code from the common client error shapes. */
+function _k8sStatus(err: unknown): number | undefined
+{
+  if (typeof err !== "object" || err === null)
+  {
+    return undefined;
+  }
+  const e = err as { statusCode?: unknown; code?: unknown; body?: { code?: unknown } };
+  if (typeof e.statusCode === "number") { return e.statusCode; }
+  if (typeof e.code === "number") { return e.code; }
+  if (e.body && typeof e.body.code === "number") { return e.body.code; }
+  return undefined;
+}
+
+/**
+ * Upsert the Global-scoped {@link PrismaProviderCredential} row for a provider. findFirst →
+ * update | create (not Prisma `upsert`) because the compound unique `[scope, clusterTenant, provider]`
+ * carries a null `clusterTenant`. A concurrent create trips P2002 on the second writer; that is
+ * caught and converged into an update so two simultaneous sets never 500.
+ */
+async function _upsertCredentialRow(prisma: PrismaClient, provider: string, secretRef: string, litellmCredentialName: string | null): Promise<PrismaProviderCredential>
+{
+  const where = { scope: "Global" as const, clusterTenant: null, provider };
+  const existing = await prisma.providerCredential.findFirst({ where });
+  if (existing)
+  {
+    return prisma.providerCredential.update({ where: { id: existing.id }, data: { secretRef, litellmCredentialName } });
+  }
+  try
+  {
+    return await prisma.providerCredential.create({ data: { ...where, secretRef, litellmCredentialName } });
+  }
+  catch (err)
+  {
+    // A concurrent create won the race — converge by updating the row it inserted.
+    if ((err as { code?: unknown }).code !== "P2002")
+    {
+      throw err;
+    }
+    const raced = await prisma.providerCredential.findFirst({ where });
+    if (!raced)
+    {
+      throw err;
+    }
+    return prisma.providerCredential.update({ where: { id: raced.id }, data: { secretRef, litellmCredentialName } });
+  }
+}
+
+/**
+ * Best-effort: ensure the silo has a routable default model for a provider whose key was just set,
+ * so the pod's `main` agent resolves to a `litellm-proxy` model. Registered Global-scoped and bound
+ * to the BYOK credential, then surfaced by the tenant-models endpoint into the pod config.
+ *
+ * Non-destructive: an existing Global row for the slug is reused (re-bound rather than duplicated),
+ * and the silo default is claimed only when no Global model is default yet — first provider wins.
+ */
+async function _ensureProviderDefaultModel(prisma: PrismaClient, provider: string, providerCredentialId: string, litellmCredentialName: string | null): Promise<void>
+{
+  const slug = _BYOK_DEFAULT_MODELS[provider];
+  if (!slug)
+  {
+    return;
+  }
+
+  // 1. Find or register the Global model deployment for this slug, bound to the BYOK credential.
+  let model = await prisma.modelDefinition.findFirst({ where: { scope: "Global", clusterTenant: null, publicModelName: slug } });
+  if (model)
+  {
+    if (model.providerCredentialId !== providerCredentialId)
+    {
+      model = await prisma.modelDefinition.update({ where: { id: model.id }, data: { providerCredentialId } });
+    }
+  }
+  else
+  {
+    const litellmModelId = await _RegisterLiteLlmModel({
+      publicModelName: slug,
+      upstreamModel: slug,
+      scope: ModelRoutingScope.Global,
+      clusterTenant: null,
+      apiBase: null,
+      apiKeyEnvRef: null,
+      litellmCredentialName,
+    });
+    model = await prisma.modelDefinition.create({
+      data: { scope: "Global", clusterTenant: null, publicModelName: slug, litellmModelId, upstreamModel: slug, apiBase: null, isDefault: false, providerCredentialId },
+    });
+  }
+
+  // 2. Claim the silo default only when nothing is default yet — first provider configured wins.
+  const hasDefault = await prisma.modelDefinition.findFirst({ where: { scope: "Global", clusterTenant: null, isDefault: true } });
+  if (!hasDefault)
+  {
+    await prisma.modelDefinition.update({ where: { id: model.id }, data: { isDefault: true } });
+  }
+}

--- a/apps/clustertenant-operator/src/index.ts
+++ b/apps/clustertenant-operator/src/index.ts
@@ -28,6 +28,8 @@ import { TenantProjectionRepairer } from "./infra/tenant-projection-repairer.js"
 // namespace, so a silo stands on its own; the fleet-manager watches only the cluster-scoped
 // ClusterTenant CR and nothing inside a silo.
 import { _LoadOperatorConfig } from "./config.js";
+import type { OpenClawTenantOperatorConfig } from "./config.js";
+import { _ProvisionByokKey } from "./core/model-routing/provision-byok-key.js";
 import { _CreateTenantOperator, IdleChecker } from "./tenants/index.js";
 import { PolicyOperator } from "./policies/operator.js";
 import { RuntimePlaneDriftRepairer } from "./runtime-planes/drift-repairer.js";
@@ -158,12 +160,49 @@ let _gatewayProxyRef: GatewayProxyServer | null = null;
  * management API + health endpoint stay up so the misconfiguration is diagnosable rather than
  * crash-looping.
  */
+/**
+ * Optional boot-time bootstrap of this silo's OpenAI BYOK key, gated on the
+ * `OPENCRANE_BOOTSTRAP_OPENAI_KEY` env var (injected from a deploy Secret — never hardcoded). When
+ * set, provisions it as the silo's Global OpenAI key via the same path as the BYOK route: writes the
+ * encrypted Secret, registers the LiteLLM credential, and seeds a default model. Idempotent (upsert)
+ * so re-running on every boot is safe, and best-effort so a hiccup never blocks controller startup.
+ *
+ * Intended for short-lived testing: populate the deploy Secret to light a silo up, then delete it to
+ * stop re-applying (the live key is removed via the BYOK delete endpoint / Model Keys UI, not by
+ * clearing the env). The raw key is never logged.
+ *
+ * @param config - Operator config; supplies the operator's own namespace for the Secret write.
+ */
+async function _BootstrapProviderKeyIfConfigured(config: OpenClawTenantOperatorConfig): Promise<void>
+{
+  const apiKey = process.env.OPENCRANE_BOOTSTRAP_OPENAI_KEY?.trim();
+  if (!apiKey)
+  {
+    return;
+  }
+
+  try
+  {
+    const result = await _ProvisionByokKey({ prisma, coreApi, operatorNamespace: config.operatorNamespace, provider: "openai", apiKey, log });
+    log.info({ provider: "openai", litellmRegistered: result.litellmRegistered }, "bootstrap provider key provisioned for silo");
+  }
+  catch (err)
+  {
+    log.warn({ err }, "bootstrap provider key provisioning failed; continuing boot");
+  }
+}
+
 async function _startInSiloControllers(): Promise<void>
 {
   try
   {
     const config = _LoadOperatorConfig();
     log.info({ watchNamespace: config.watchNamespace }, "starting in-silo controllers");
+
+    // Optional test bootstrap — provision this silo's OpenAI BYOK key from an injected env var
+    // (sourced from a deploy Secret), BEFORE the default-tenant seed so the model it seeds satisfies
+    // the seed's ≥1-model onboarding gate and the silo comes up usable. Awaited for that ordering.
+    await _BootstrapProviderKeyIfConfigured(config);
 
     // Seed this silo's own `<org>-default` workspace Tenant from its ClusterTenant CR owner.
     // Use config.watchNamespace (the namespace the operators below reconcile in) so the seed

--- a/apps/clustertenant-operator/src/openapi/spec.ts
+++ b/apps/clustertenant-operator/src/openapi/spec.ts
@@ -426,6 +426,25 @@ const ProviderKeySchema = {
   },
 };
 
+const ByokProviderKeyStatusSchema = {
+  type: "object" as const,
+  required: ["provider", "configured", "litellmRegistered"],
+  properties: {
+    provider: { type: "string", enum: ["openai", "anthropic", "gemini", "mistral", "deepseek", "glm"], description: "The provider this status describes." },
+    configured: { type: "boolean", description: "Whether a key is currently set for this provider in this silo." },
+    litellmRegistered: { type: "boolean", description: "Whether LiteLLM's /credentials dynamic path accepted the key (false ⇒ Secret-only)." },
+    updatedAt: { type: "string", format: "date-time", nullable: true, description: "When the key was last set; null when not configured." },
+  },
+};
+
+const ProviderKeySetRequestSchema = {
+  type: "object" as const,
+  required: ["apiKey"],
+  properties: {
+    apiKey: { type: "string", description: "The raw upstream provider API key. Accepted only over HTTPS; written to a k8s Secret + LiteLLM and never returned by any read." },
+  },
+};
+
 const ProviderCredentialSchema = {
   type: "object" as const,
   required: ["id", "scope", "provider", "secretRef"],
@@ -815,6 +834,8 @@ export const spec = {
       AuditEntry: AuditEntrySchema,
       AccessToken: AccessTokenSchema,
       ProviderKey: ProviderKeySchema,
+      ByokProviderKeyStatus: ByokProviderKeyStatusSchema,
+      ProviderKeySetRequest: ProviderKeySetRequestSchema,
       ProviderCredential: ProviderCredentialSchema,
       ProviderCredentialWrite: ProviderCredentialWriteSchema,
       ModelDefinition: ModelDefinitionSchema,
@@ -2177,6 +2198,49 @@ export const spec = {
         responses: {
           204: { description: "Key deleted." },
           404: notFound("Provider key not found."),
+        },
+      },
+    },
+
+    // ------------------------------------------------------------------
+    // BYOK provider keys — set/refresh a RAW upstream key over HTTPS for this
+    // silo. The key is written to a k8s Secret + LiteLLM's /credentials dynamic
+    // path; reads return presence + timestamps only, never the key value.
+    // ------------------------------------------------------------------
+    "/providers/byok": {
+      get: {
+        operationId: "listByokProviderKeys",
+        summary: "List BYOK provider key status for every supported provider (never the key value)",
+        tags: ["Provider Keys"],
+        responses: {
+          200: ok("BYOK provider key status list.", { type: "array", items: { $ref: "#/components/schemas/ByokProviderKeyStatus" } }),
+        },
+      },
+    },
+
+    "/providers/byok/{provider}": {
+      put: {
+        operationId: "setByokProviderKey",
+        summary: "Set or refresh a provider's raw key (writes a k8s Secret + LiteLLM credential)",
+        tags: ["Provider Keys"],
+        parameters: [{ name: "provider", in: "path", required: true, schema: { type: "string", enum: ["openai", "anthropic", "gemini", "mistral", "deepseek", "glm"] } }],
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { $ref: "#/components/schemas/ProviderKeySetRequest" } } },
+        },
+        responses: {
+          200: ok("Key set; returns the provider's status.", { $ref: "#/components/schemas/ByokProviderKeyStatus" }),
+          400: badRequest("Unsupported provider (code UNSUPPORTED_PROVIDER) or missing apiKey (code VALIDATION_ERROR)."),
+        },
+      },
+      delete: {
+        operationId: "deleteByokProviderKey",
+        summary: "Remove a provider's key (deletes the Secret, LiteLLM credential, and record)",
+        tags: ["Provider Keys"],
+        parameters: [{ name: "provider", in: "path", required: true, schema: { type: "string", enum: ["openai", "anthropic", "gemini", "mistral", "deepseek", "glm"] } }],
+        responses: {
+          204: { description: "Key removed (idempotent — 204 even when no key was set)." },
+          400: badRequest("Unsupported provider (code UNSUPPORTED_PROVIDER)."),
         },
       },
     },

--- a/apps/clustertenant-operator/src/routes.ts
+++ b/apps/clustertenant-operator/src/routes.ts
@@ -17,6 +17,7 @@ import { policiesRouter } from "./routes/policies.js";
 import { prometheusMetricsRouter } from "./routes/prometheus-metrics.js";
 import { providerKeysRouter } from "./routes/provider-keys.js";
 import { providerCredentialsRouter } from "./routes/provider-credentials.js";
+import { providerByokRouter } from "./routes/provider-byok.js";
 import { modelRegistryRouter } from "./routes/model-registry.js";
 import { modelRoutingDefaultsRouter } from "./routes/model-routing-defaults.js";
 import { modelRoutingRecommendationsRouter } from "./routes/model-routing-recommendations.js";
@@ -126,6 +127,9 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/access-tokens", accessTokensRouter(prisma));
   app.use("/api/v1/providers/keys", providerKeysRouter(prisma));
   app.use("/api/v1/providers/credentials", providerCredentialsRouter(prisma));
+  // BYOK raw-key path — writes the silo's provider key Secret in the operator's own namespace
+  // (POD_NAMESPACE, downward-API populated; "default" fallback mirrors config._readOwnNamespace).
+  app.use("/api/v1/providers/byok", providerByokRouter(prisma, coreApi, process.env.POD_NAMESPACE?.trim() || "default"));
   app.use("/api/v1/models", modelRegistryRouter(prisma));
   app.use("/api/v1/openapi.json", _OpenapiRouter(spec));
   app.get("/healthz", _CheckDbHealth(prisma));

--- a/apps/clustertenant-operator/src/routes/model-registry.ts
+++ b/apps/clustertenant-operator/src/routes/model-registry.ts
@@ -80,13 +80,15 @@ function _validateWrite(body: Record<string, unknown>): { error: string; code: s
  * @param prisma - Prisma client used to look up the credential.
  * @param providerCredentialId - The requested credential id, or undefined/null when none.
  * @param modelClusterTenant - The owning ClusterTenant of the model (null for Global scope).
- * @returns `{ secretRef }` (null when no credential requested), or a `{ error, code }` envelope.
+ * @returns `{ secretRef, litellmCredentialName }` (both null when no credential requested), or a
+ *          `{ error, code }` envelope. `litellmCredentialName` is non-null for a BYOK credential on
+ *          the dynamic path and selects `litellm_credential_name` over the `os.environ` baseline.
  */
-async function _resolveCredential(prisma: PrismaClient, providerCredentialId: string | null | undefined, modelClusterTenant: string | null): Promise<{ secretRef: string | null } | { error: string; code: string }>
+async function _resolveCredential(prisma: PrismaClient, providerCredentialId: string | null | undefined, modelClusterTenant: string | null): Promise<{ secretRef: string | null; litellmCredentialName: string | null } | { error: string; code: string }>
 {
   if (!providerCredentialId)
   {
-    return { secretRef: null };
+    return { secretRef: null, litellmCredentialName: null };
   }
   const credential = await prisma.providerCredential.findUnique({ where: { id: providerCredentialId } });
   if (!credential)
@@ -98,7 +100,7 @@ async function _resolveCredential(prisma: PrismaClient, providerCredentialId: st
   {
     return { error: "providerCredentialId is owned by a different ClusterTenant.", code: "CREDENTIAL_SCOPE_MISMATCH" };
   }
-  return { secretRef: credential.secretRef };
+  return { secretRef: credential.secretRef, litellmCredentialName: credential.litellmCredentialName };
 }
 
 /**
@@ -187,6 +189,7 @@ export function modelRegistryRouter(prisma: PrismaClient): Router
     const apiKeyEnvRef = credentialResult.secretRef;
 
     // 3. Best-effort LiteLLM registration; returns a deterministic placeholder when unconfigured.
+    //    A BYOK credential name (when present) selects the dynamic path over the env baseline.
     const litellmModelId = await _RegisterLiteLlmModel({
       publicModelName: write.publicModelName.trim(),
       upstreamModel: write.upstreamModel.trim(),
@@ -194,6 +197,7 @@ export function modelRegistryRouter(prisma: PrismaClient): Router
       clusterTenant: scope === ModelRoutingScope.ClusterTenant ? write.clusterTenant!.trim() : null,
       apiBase: write.apiBase?.trim() || null,
       apiKeyEnvRef,
+      litellmCredentialName: credentialResult.litellmCredentialName,
     });
 
     // 4. Persist the row with the resolved deployment id.

--- a/apps/clustertenant-operator/src/routes/provider-byok.ts
+++ b/apps/clustertenant-operator/src/routes/provider-byok.ts
@@ -1,0 +1,101 @@
+import { Router } from "express";
+import * as k8s from "@kubernetes/client-node";
+import { ByokProvider } from "@opencrane/contracts";
+import type { ProviderKeyStatus } from "@opencrane/contracts";
+import { _RequireOrgAdmin } from "@opencrane/infra-auth";
+import type { PrismaClient, ProviderCredential as PrismaProviderCredential } from "@prisma/client";
+
+import { _log } from "../log.js";
+import { _DeprovisionByokKey, _ProvisionByokKey } from "../core/model-routing/provision-byok-key.js";
+
+/** The providers a raw BYOK key may be set for; mirrors the {@link ByokProvider} contract union. */
+const _BYOK_PROVIDERS = Object.values(ByokProvider) as readonly string[];
+
+/**
+ * Project a persisted {@link PrismaProviderCredential} row (or its absence) into the read-side
+ * status DTO. `litellmRegistered` reflects whether the row carries a `litellmCredentialName` — set
+ * only when LiteLLM accepted the key on the dynamic path; a Secret-only key reports `false`. Never
+ * carries key material.
+ *
+ * @param provider - The provider this status describes.
+ * @param row      - The persisted credential row, or undefined when no key is set.
+ */
+function _toStatus(provider: string, row: PrismaProviderCredential | undefined): ProviderKeyStatus
+{
+  return {
+    provider: provider as ByokProvider,
+    configured: Boolean(row),
+    litellmRegistered: Boolean(row?.litellmCredentialName),
+    updatedAt: row ? row.updatedAt.toISOString() : null,
+  };
+}
+
+/**
+ * Router for BYOK provider keys — set/refresh/remove a RAW upstream provider key for this silo.
+ *
+ * Unlike {@link providerCredentialsRouter} (reference-only, raw keys rejected), this is the BYOK
+ * "dynamic no-restart path". The provisioning work (Secret write + LiteLLM `/credentials` + the
+ * Global ProviderCredential row + default-model seed) lives in {@link _ProvisionByokKey} so the
+ * boot-time bootstrap can reuse it; this router is the HTTP wrapper (validation + status DTO).
+ * Reads return presence + timestamps only — the key is never echoed back.
+ *
+ * Authz: the silo-wide key spends real money and backs every model call, so mutations are gated by
+ * `_RequireOrgAdmin` — only an IdP-verified org admin may set or remove it. Reads stay open.
+ *
+ * @param prisma            - Prisma client used for the credential record.
+ * @param coreApi           - Kubernetes Core V1 API client for Secret writes.
+ * @param operatorNamespace - The operator's own namespace; where the key Secret is written.
+ * @returns Configured Express router.
+ */
+export function providerByokRouter(prisma: PrismaClient, coreApi: k8s.CoreV1Api, operatorNamespace: string): Router
+{
+  const router = Router();
+
+  /** List BYOK key status for every supported provider (presence + timestamps, no key material). */
+  router.get("/", async function _listProviderKeys(_req, res)
+  {
+    const rows = await prisma.providerCredential.findMany({
+      where: { scope: "Global", clusterTenant: null, provider: { in: [..._BYOK_PROVIDERS] } },
+    });
+    const byProvider = new Map(rows.map(function _byProvider(row) { return [row.provider, row]; }));
+    res.json(_BYOK_PROVIDERS.map(function _status(provider) { return _toStatus(provider, byProvider.get(provider)); }));
+  });
+
+  /** Set or refresh a provider's raw key (delegates the provisioning to {@link _ProvisionByokKey}). */
+  router.put("/:provider", _RequireOrgAdmin(), async function _setProviderKey(req, res)
+  {
+    const provider = String(req.params.provider ?? "").trim().toLowerCase();
+    if (!_BYOK_PROVIDERS.includes(provider))
+    {
+      res.status(400).json({ error: `Unsupported provider '${provider}'. Supported: ${_BYOK_PROVIDERS.join(", ")}.`, code: "UNSUPPORTED_PROVIDER" });
+      return;
+    }
+    const apiKey = String((req.body ?? {}).apiKey ?? "").trim();
+    if (!apiKey)
+    {
+      res.status(400).json({ error: "apiKey is required.", code: "VALIDATION_ERROR" });
+      return;
+    }
+
+    const { litellmRegistered, row } = await _ProvisionByokKey({ prisma, coreApi, operatorNamespace, provider, apiKey, log: _log });
+    _log.info({ provider, litellmRegistered }, "byok provider key set");
+    res.json(_toStatus(provider, row));
+  });
+
+  /** Remove a provider's key (delegates to {@link _DeprovisionByokKey}). */
+  router.delete("/:provider", _RequireOrgAdmin(), async function _deleteProviderKey(req, res)
+  {
+    const provider = String(req.params.provider ?? "").trim().toLowerCase();
+    if (!_BYOK_PROVIDERS.includes(provider))
+    {
+      res.status(400).json({ error: `Unsupported provider '${provider}'. Supported: ${_BYOK_PROVIDERS.join(", ")}.`, code: "UNSUPPORTED_PROVIDER" });
+      return;
+    }
+
+    await _DeprovisionByokKey({ prisma, coreApi, operatorNamespace, provider });
+    _log.info({ provider }, "byok provider key removed");
+    res.status(204).send();
+  });
+
+  return router;
+}

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -34,10 +34,13 @@ const _WORKSPACE_PATH = "/data/openclaw/workspace";
  * @param namespace - Namespace the ConfigMap is written to.
  * @param effectivePolicy - The resolved AccessPolicy, when one applies.
  * @param modelSet - The tenant's allowed model set fetched best-effort from the
- *        control-plane, or `null`. When non-empty (and LiteLLM is enabled) the
- *        `litellm-proxy` provider is restricted to those models and the default
- *        model is surfaced; when empty/null the provider keeps `models: []`
- *        (unchanged today's behaviour — OpenClaw treats `[]` as the proxy default).
+ *        control-plane, or `null`. When LiteLLM is enabled the `litellm-proxy` provider runs in
+ *        `replace` mode (it is the ONLY provider), restricted to these models with the default
+ *        surfaced. An empty/null result yields `models: []` — and because there are no built-in
+ *        providers to fall back to, the pod then has zero usable models. Cluster onboarding makes
+ *        that impossible by requiring ≥1 registered model before a silo is provisioned; a transient
+ *        control-plane outage at reconcile is the only window it can occur, and it self-heals on the
+ *        next successful fetch.
  * @param servingHost - The host the org's Control UI is served at (`<org>.<base>` or
  *        vanity), used to allowlist the browser Origin in `gateway.controlUi.allowedOrigins`.
  *        With `bind: lan` the gateway rejects a Control-UI WS whose Origin is not allowlisted
@@ -49,10 +52,11 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
 {
   const name = tenant.metadata!.name!;
 
-  // 0. Allowed models — restrict the litellm-proxy provider to the tenant's
-  //    registered set when the control-plane returned a non-empty list. An empty
-  //    or null result falls back to `[]` (unchanged), so a control-plane outage
-  //    never narrows or breaks the tenant's model access.
+  // 0. Allowed models — the litellm-proxy provider (the ONLY provider under `replace` mode below)
+  //    is restricted to the tenant's registered set. An empty or null result yields `[]`; with no
+  //    built-ins to fall back to that means no usable models, which onboarding prevents by requiring
+  //    ≥1 registered model before provisioning (the empty case is only reachable on a transient
+  //    control-plane outage at reconcile, and self-heals on the next fetch).
   const allowedModels = modelSet && modelSet.models.length > 0 ? [...modelSet.models] : [];
   const defaultModel = modelSet?.defaultModel ?? null;
 
@@ -119,7 +123,14 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
     ...(config.liteLlmEnabled
       ? {
             models: {
-              mode: "merge",
+              // `replace` (not `merge`): the litellm-proxy provider REPLACES OpenClaw's built-in
+              // providers, so EVERY model call must go through LiteLLM — no bare-provider bypass of
+              // the virtual key / budget metering / BYOK upstream key. This makes a non-empty model
+              // allowlist a hard requirement (an empty list ⇒ the pod has zero usable models), which
+              // cluster onboarding enforces by requiring at least one registered model before a silo
+              // is provisioned (see fleet-operator ClusterTenant readiness). The BYOK key flow also
+              // auto-seeds a default model, so a key-configured silo always satisfies this.
+              mode: "replace",
               ...(defaultModel ? { default: defaultModel } : {}),
               providers: {
                 "litellm-proxy": {

--- a/apps/clustertenant-platform/templates/clustertenant-manager-deployment.yaml
+++ b/apps/clustertenant-platform/templates/clustertenant-manager-deployment.yaml
@@ -179,6 +179,20 @@ spec:
                   {{- end }}
                   key: {{ .Values.litellm.secretKey }}
             {{- end }}
+            {{- /* Optional, short-lived TEST bootstrap: when bootstrap.providerKey.existingSecret is
+                   set, the operator self-provisions this silo's OpenAI BYOK key on boot (writes the
+                   encrypted Secret + LiteLLM credential + seeds a default model). OFF by default;
+                   the raw key lives only in the named Secret, never in this chart. Delete the Secret
+                   (or clear existingSecret) to stop re-applying. Not for production — one shared key
+                   per silo, no per-tenant spend isolation. */ -}}
+            {{- if .Values.bootstrap.providerKey.existingSecret }}
+            - name: OPENCRANE_BOOTSTRAP_OPENAI_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.bootstrap.providerKey.existingSecret }}
+                  key: {{ .Values.bootstrap.providerKey.secretKey }}
+                  optional: true
+            {{- end }}
             {{- include "opencrane.clustertenantManagerDatabaseEnv" . | nindent 12 }}
             {{- if .Values.clusterTenant.provisionerWebhook.url }}
             - name: CLUSTER_TENANT_PROVISIONER_WEBHOOK_URL

--- a/apps/clustertenant-platform/values-dev.yaml
+++ b/apps/clustertenant-platform/values-dev.yaml
@@ -1,0 +1,57 @@
+# =============================================================================
+# Dev resource profile — apply with `clustertenant-platform/deploy.sh --dev-resources`.
+#
+# Tunes the per-silo platform planes for a small, CPU-reservation-constrained dev cluster.
+# Principle (NOT for prod — size to real load there):
+#   - CPU is compressible (throttle, not crash), and dev load is near-idle, so CPU REQUESTS
+#     are cut hard to relieve the scheduling squeeze; CPU limits stay generous for burst.
+#   - Memory is NOT compressible (under-request → OOM/eviction), so memory REQUESTS are raised
+#     to observed usage + headroom (litellm/cognee/clustertenant-manager were running ABOVE
+#     their requests — first to be evicted under node pressure).
+# Frees ~0.3 vCPU of requests per silo (~0.9 vCPU across three) vs the default profile.
+# =============================================================================
+
+clustertenantManager:
+  resources:
+    requests:
+      cpu: 50m       # was 100m; observed ~2m, but it's operator+proxy+API — keep headroom
+      memory: 256Mi  # was 128Mi; observed ~135Mi (was OVER its request)
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  # cognee plane (opencrane-cognee) is configured under clustertenantManager.cognee
+  cognee:
+    resources:
+      requests:
+        cpu: 25m       # was 100m; observed ~3m
+        memory: 384Mi  # was 256Mi; observed ~303Mi (was OVER its request)
+      limits:
+        cpu: "1"
+        memory: 1Gi
+
+litellm:
+  resources:
+    requests:
+      cpu: 25m       # was 100m; observed ~6m
+      memory: 768Mi  # was 256Mi; observed ~584Mi (was WAY over its request — OOM risk)
+    limits:
+      cpu: "1"
+      memory: 1280Mi
+
+mcpGateway:
+  resources:
+    requests:
+      cpu: 75m       # was 250m (the biggest over-reservation); observed ~34m
+      memory: 256Mi  # observed ~116Mi — keep as-is for headroom
+    limits:
+      cpu: "1"
+      memory: 512Mi
+
+skillRegistry:
+  resources:
+    requests:
+      cpu: 25m       # was 100m; observed ~1m
+      memory: 128Mi  # observed ~71Mi — fine
+    limits:
+      cpu: 500m
+      memory: 256Mi

--- a/apps/clustertenant-platform/values-dev.yaml
+++ b/apps/clustertenant-platform/values-dev.yaml
@@ -11,6 +11,15 @@
 # Frees ~0.3 vCPU of requests per silo (~0.9 vCPU across three) vs the default profile.
 # =============================================================================
 
+# Disable idle auto-suspend in dev. Suspend scales the OpenClaw agent pod to zero after
+# IDLE_TIMEOUT_MINUTES (default 30); on this small, packed cluster resume is slow (autoscale +
+# image pull), so a tester who steps away returns to a dead gateway socket. 0 disables the
+# IdleChecker entirely (idle-checker.ts: "idle auto-suspend disabled"). PROD keeps auto-suspend —
+# the correct prod answer is wake-on-access (pod-token unsuspends + the SPA provisioning loader),
+# tracked in docs/optimalisation-plan.md (D5); until that ships, dev simply stays warm.
+fleetManager:
+  idleTimeoutMinutes: 0
+
 clustertenantManager:
   resources:
     requests:

--- a/apps/clustertenant-platform/values.yaml
+++ b/apps/clustertenant-platform/values.yaml
@@ -327,6 +327,20 @@ clustertenantManager:
   # `clustertenantManager.oidc.issuerUrl`; it makes no Zitadel management API calls.
 
 # -- LiteLLM integration settings
+# -- Short-lived TEST bootstrap of a silo's provider key. When providerKey.existingSecret names a
+#    Secret, the operator provisions its OpenAI key as this silo's BYOK key on boot (encrypted
+#    Secret + LiteLLM credential + seeded default model), so a freshly-deployed silo is usable
+#    without a manual key-set. OFF by default. NOT for production: it injects ONE shared key for all
+#    tenants in the silo (no per-tenant spend isolation). Create the Secret out-of-band, e.g.
+#    `kubectl -n <silo-ns> create secret generic opencrane-bootstrap-provider-key --from-literal=openaiApiKey=sk-...`
+#    then set providerKey.existingSecret to its name; delete the Secret to stop re-applying.
+bootstrap:
+  providerKey:
+    # -- Name of an existing Secret holding the OpenAI key; empty disables the bootstrap.
+    existingSecret: ""
+    # -- Key within that Secret carrying the raw OpenAI API key.
+    secretKey: openaiApiKey
+
 litellm:
   # -- Cost routing is enabled by default as part of platform setup.
   enabled: true

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -871,6 +871,41 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/providers/byok": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List BYOK provider key status for every supported provider (never the key value) */
+        get: operations["listByokProviderKeys"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/providers/byok/{provider}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Set or refresh a provider's raw key (writes a k8s Secret + LiteLLM credential) */
+        put: operations["setByokProviderKey"];
+        post?: never;
+        /** Remove a provider's key (deletes the Secret, LiteLLM credential, and record) */
+        delete: operations["deleteByokProviderKey"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/providers/credentials": {
         parameters: {
             query?: never;
@@ -1872,6 +1907,26 @@ export interface components {
             configured?: boolean;
             /** Format: date-time */
             updatedAt?: string;
+        };
+        ByokProviderKeyStatus: {
+            /**
+             * @description The provider this status describes.
+             * @enum {string}
+             */
+            provider: "openai" | "anthropic" | "gemini" | "mistral" | "deepseek" | "glm";
+            /** @description Whether a key is currently set for this provider in this silo. */
+            configured: boolean;
+            /** @description Whether LiteLLM's /credentials dynamic path accepted the key (false ⇒ Secret-only). */
+            litellmRegistered: boolean;
+            /**
+             * Format: date-time
+             * @description When the key was last set; null when not configured.
+             */
+            updatedAt?: string | null;
+        };
+        ProviderKeySetRequest: {
+            /** @description The raw upstream provider API key. Accepted only over HTTPS; written to a k8s Secret + LiteLLM and never returned by any read. */
+            apiKey: string;
         };
         ProviderCredential: {
             /** @description Stable identifier. */
@@ -4963,6 +5018,90 @@ export interface operations {
             };
             /** @description Provider key not found. */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listByokProviderKeys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description BYOK provider key status list. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ByokProviderKeyStatus"][];
+                };
+            };
+        };
+    };
+    setByokProviderKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "openai" | "anthropic" | "gemini" | "mistral" | "deepseek" | "glm";
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ProviderKeySetRequest"];
+            };
+        };
+        responses: {
+            /** @description Key set; returns the provider's status. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ByokProviderKeyStatus"];
+                };
+            };
+            /** @description Unsupported provider (code UNSUPPORTED_PROVIDER) or missing apiKey (code VALIDATION_ERROR). */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    deleteByokProviderKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                provider: "openai" | "anthropic" | "gemini" | "mistral" | "deepseek" | "glm";
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Key removed (idempotent — 204 even when no key was set). */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unsupported provider (code UNSUPPORTED_PROVIDER). */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -32,6 +32,7 @@ export {
 } from "./mcp-operator.types.js";
 export {
   AutoRoutingObjective,
+  ByokProvider,
   ModelRoutingScope,
   RoutingProposalStatus,
   SkillModelMode,
@@ -42,6 +43,8 @@ export {
   type ModelRoutingDefaultWrite,
   type ProviderCredential,
   type ProviderCredentialWrite,
+  type ProviderKeySetRequest,
+  type ProviderKeyStatus,
   type RoutingEvalCase,
   type RoutingEvalCaseWrite,
   type RoutingMeasurement,

--- a/libs/contracts/src/model-routing.types.ts
+++ b/libs/contracts/src/model-routing.types.ts
@@ -80,6 +80,47 @@ export interface ModelDefinition
   updatedAt: string;
 }
 
+/**
+ * Providers a BYOK upstream key may be set for. Unlike {@link ProviderCredential} (a reference to
+ * an externally-synced Secret), a BYOK key is set with its RAW value over HTTPS, persisted to a
+ * k8s Secret, and registered with LiteLLM's `/credentials` dynamic path. Add providers here as the
+ * runtime gains routing support for them.
+ */
+export const ByokProvider = {
+  OpenAI: "openai",
+  Anthropic: "anthropic",
+  Gemini: "gemini",
+  Mistral: "mistral",
+  Deepseek: "deepseek",
+  Glm: "glm",
+} as const;
+
+/** Union of the {@link ByokProvider} values. */
+export type ByokProvider = (typeof ByokProvider)[keyof typeof ByokProvider];
+
+/**
+ * Set/refresh body for a BYOK provider key. Carries the RAW upstream key — accepted only over
+ * HTTPS, written straight to a k8s Secret and LiteLLM, and NEVER echoed back by any read endpoint.
+ */
+export interface ProviderKeySetRequest
+{
+  /** The raw upstream provider API key (e.g. `sk-...`). */
+  apiKey: string;
+}
+
+/** Read-side status of a BYOK provider key. Carries no key material — presence and timestamps only. */
+export interface ProviderKeyStatus
+{
+  /** The provider this status describes. */
+  provider: ByokProvider;
+  /** Whether a key is currently set for this provider in this silo. */
+  configured: boolean;
+  /** Whether the key was accepted by LiteLLM's `/credentials` dynamic path (false ⇒ Secret-only). */
+  litellmRegistered: boolean;
+  /** When the key was last set (ISO-8601); null when not configured. */
+  updatedAt: string | null;
+}
+
 /** Create/update body for a {@link ModelDefinition}. */
 export interface ModelDefinitionWrite
 {

--- a/libs/k8s-platform/k8s-deploy.sh
+++ b/libs/k8s-platform/k8s-deploy.sh
@@ -117,6 +117,7 @@ TENANT_TAG=""           # empty → falls back to IMAGE_TAG
 BASE_DOMAIN="${OPENCRANE_BASE_DOMAIN:-}"
 STORAGE_CLASS=""        # empty → cluster default StorageClass
 VALUES_FILE=""
+DEV_RESOURCES=""     # "--dev-resources": overlay the chart's values-dev.yaml (small dev footprint)
 REUSE_VALUES=""      # "--reuse-values" mode: inherit current helm values; add only overrides
 EXTRA_SET=()
 
@@ -253,6 +254,7 @@ while [[ $# -gt 0 ]]; do
     --dns01-credentials) DNS01_CREDENTIALS="$2"; shift 2 ;;
     --dns01-project)     DNS01_PROJECT="$2"; shift 2 ;;
     --values)        VALUES_FILE="$2"; shift 2 ;;
+    --dev-resources) DEV_RESOURCES="1"; shift ;;
     --reuse-values)  REUSE_VALUES="1"; shift ;;
     --set)           EXTRA_SET+=(--set "$2"); shift 2 ;;
     -h|--help)       grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
@@ -921,6 +923,19 @@ if [[ -n "$PLATFORM_OPERATOR_GROUPS" ]]; then
   helm_args+=(--set-string "clustertenantManager.oidc.platformOperatorGroups=$PLATFORM_OPERATOR_GROUPS")
 fi
 [[ -n "$VALUES_FILE" ]] && helm_args+=(--values "$VALUES_FILE")
+# --dev-resources: overlay the chart's values-dev.yaml (small CPU requests / right-sized memory
+# for a reservation-constrained dev cluster). Placed AFTER --values and BEFORE --set so an
+# explicit --values can still seed it and a --set can still override an individual field. Only
+# applies when the chart actually ships the overlay (the fleet chart may not), else fail fast so
+# a typo'd profile never silently deploys prod-sized requests onto a dev cluster.
+if [[ -n "$DEV_RESOURCES" ]]; then
+  if [[ -f "$CHART_DIR/values-dev.yaml" ]]; then
+    warn "applying the DEV resource profile (values-dev.yaml) — small requests, NOT for production"
+    helm_args+=(--values "$CHART_DIR/values-dev.yaml")
+  else
+    err "--dev-resources given but $CHART_DIR/values-dev.yaml does not exist for this chart."; exit 1
+  fi
+fi
 # cert-manager flags resolved in Step 2.5 (empty in mode=off). Placed before --set
 # overrides so an operator can still override individual issuer fields on the CLI.
 [ ${#CERT_MANAGER_HELM_FLAGS[@]} -gt 0 ] && helm_args+=("${CERT_MANAGER_HELM_FLAGS[@]}")


### PR DESCRIPTION
## Why

The dev cluster (6× `e2-medium`) is **CPU-reservation-starved**: requests total ~86% of allocatable while *actual* usage is ~12%. That's why the OpenClaw pod couldn't reschedule after an idle-suspend without a cluster autoscale. Two compounding causes — per-silo planes over-request CPU ~8× (mcp-gateway 250m req / 34m actual; others 100m / 1–6m), and several **under-request memory** (litellm 256Mi req / **584Mi** actual, cognee 256/303, clustertenant-manager 128/135 → running above their reservation, first to be evicted under node pressure).

## What

A `--dev-resources` flag on `k8s-deploy.sh` that overlays the new `apps/clustertenant-platform/values-dev.yaml`:
- **CPU requests cut hard** (compressible; dev is near-idle), generous limits kept for burst.
- **Memory requests raised to observed usage + headroom** (not compressible).

| Plane | CPU req | Mem req |
|---|---|---|
| mcp-gateway | 250m → **75m** | 256Mi |
| clustertenant-manager | 100m → **50m** | 128Mi → **256Mi** |
| cognee | 100m → **25m** | 256Mi → **384Mi** |
| litellm | 100m → **25m** | 256Mi → **768Mi** |
| skill-registry | 100m → **25m** | 128Mi |

Frees **~450m CPU/silo (~1.35 vCPU across three)**. `helm template -f values-dev.yaml` confirms the requests shift to 25m/50m/75m.

Gated behind the flag and **fails fast** if the chart ships no overlay, so prod never silently gets dev-sized requests. `clustertenant-platform/deploy.sh` forwards the flag via its existing passthrough.

## Not in scope
- **Prod sizing** — size to real load; this is dev-only.
- **openclaw pod** resources are set in `_BuildDeployment` (operator code), not the chart — it currently requests none, so it's not part of the reservation squeeze.
- **Node consolidation** (fewer/bigger nodes) removes the per-node kube-system overhead — the other half of the squeeze; complementary.