### PR TITLE
🐛 tenant: roll the openclaw pod on config change (fixes stale keyless agent)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { defaultConfig, gcpConfig, gcpAdapter, onPremAdapter, _makeAccessPolicy, _makeTenant } from "../fixtures.js";
-import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildClusterTenantScheduling, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc } from "../../tenants/deploy/index.js";
+import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildClusterTenantScheduling, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc, _ConfigChecksum } from "../../tenants/deploy/index.js";
 
 describe("TenantResourceBuilder", () =>
 {
@@ -554,5 +554,34 @@ describe("ClusterTenant isolation builders (CT.5)", () =>
 
     expect(podSpec?.nodeSelector).toBeUndefined();
     expect(podSpec?.tolerations).toBeUndefined();
+  });
+});
+
+describe("config checksum → pod roll", () =>
+{
+  const _annotations = (config: string | undefined) =>
+    _BuildDeployment(defaultConfig, onPremAdapter.buildStateVolume("jente"), _makeTenant("jente"), "default", undefined, config)
+      .spec?.template?.metadata?.annotations;
+
+  it("computes a deterministic, config-sensitive digest", () =>
+  {
+    const cmA = _BuildConfigMap(defaultConfig, _makeTenant("jente"), "default");
+    const cmAAgain = _BuildConfigMap(defaultConfig, _makeTenant("jente"), "default");
+    const cmB = _BuildConfigMap(defaultConfig, _makeTenant("other"), "default");
+
+    // Stable across identical renders (no spurious rolls), and changes with the config.
+    expect(_ConfigChecksum(cmA)).toBe(_ConfigChecksum(cmAAgain));
+    expect(_ConfigChecksum(cmA)).not.toBe(_ConfigChecksum(cmB));
+    expect(_ConfigChecksum(cmA)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("stamps the checksum on the pod template so a config change rolls the pod", () =>
+  {
+    expect(_annotations("abc123")).toEqual({ "opencrane.io/config-checksum": "abc123" });
+  });
+
+  it("omits the annotation when no checksum is supplied (suspend path unchanged)", () =>
+  {
+    expect(_annotations(undefined)).toBeUndefined();
   });
 });

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -243,6 +244,28 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
       "USER.md.seed": _ReadWorkspaceTemplate("USER.md.seed"),
     },
   };
+}
+
+/**
+ * Deterministic SHA-256 over a ConfigMap's `data` block, for the pod-template
+ * `opencrane.io/config-checksum` annotation (see `_BuildDeployment`).
+ *
+ * WHY: OpenClaw reads `openclaw.json` only at process START. A mounted ConfigMap
+ * update (e.g. a newly-registered BYOK default model landing in the `models`
+ * block) refreshes the file on disk but does NOT restart the running process, so
+ * a pod that booted before its models existed stays on the keyless
+ * `gateway-injected` fallback forever. Stamping this digest on the pod template
+ * makes any config change alter the template → the Recreate strategy rolls the
+ * pod → OpenClaw re-reads the config and picks up the LiteLLM default model.
+ *
+ * Keys are sorted so the digest is stable across reconciles (no spurious rolls);
+ * the values are the already-deterministic rendered config strings.
+ */
+export function _ConfigChecksum(configMap: k8s.V1ConfigMap): string
+{
+  const data = configMap.data ?? {};
+  const canonical = JSON.stringify(data, Object.keys(data).sort());
+  return createHash("sha256").update(canonical).digest("hex");
 }
 
 /**

--- a/apps/clustertenant-operator/src/tenants/deploy/3-deployment.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/3-deployment.ts
@@ -24,9 +24,15 @@ import { _BuildClusterTenantScheduling } from "./cluster-tenant-scheduling.js";
  * @param compute - Optional ClusterTenant compute placement; when `dedicated`
  *   with a node pool, the pod is pinned to that pool. Omitted/shared leaves the
  *   pod unconstrained, keeping ref-less openclaws byte-for-byte unchanged.
+ * @param configChecksum - Optional SHA of the tenant ConfigMap (`_ConfigChecksum`).
+ *   When set it is stamped as the pod-template `opencrane.io/config-checksum`
+ *   annotation so a config change (e.g. a newly-registered BYOK default model)
+ *   rolls the pod — a mounted ConfigMap update alone does not restart OpenClaw,
+ *   which reads `openclaw.json` only at startup. Omitted ⇒ no annotation, so the
+ *   suspend path and existing tests render byte-for-byte unchanged.
  */
 export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolume: TenantStateVolume, tenant: Tenant,
-                                 namespace: string, compute?: ClusterTenantComputeView): k8s.V1Deployment
+                                 namespace: string, compute?: ClusterTenantComputeView, configChecksum?: string): k8s.V1Deployment
 {
   const name = tenant.metadata!.name!;
   const image = tenant.spec.openclawImage ?? config.tenantDefaultImage;
@@ -169,6 +175,9 @@ export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolu
             "opencrane.io/tenant": name,
             ...(tenant.spec.team ? { "opencrane.io/team": tenant.spec.team } : {}),
           },
+          // Roll the pod when the tenant config changes (OpenClaw reads openclaw.json
+          // only at startup). Omitted when no checksum is supplied (suspend path).
+          ...(configChecksum ? { annotations: { "opencrane.io/config-checksum": configChecksum } } : {}),
         },
         spec: {
           // 4. Pod defaults — enforce the baseline runtime hardening profile

--- a/apps/clustertenant-operator/src/tenants/deploy/index.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/index.ts
@@ -1,5 +1,5 @@
 export { _BuildServiceAccount } from "./1-service-account.js";
-export { _BuildConfigMap } from "./2-config-map.js";
+export { _BuildConfigMap, _ConfigChecksum } from "./2-config-map.js";
 export { _BuildStatePvc } from "./3-state-pvc.js";
 export { _BuildDeployment } from "./3-deployment.js";
 export { _BuildService } from "./4-service.js";

--- a/apps/clustertenant-operator/src/tenants/operator.ts
+++ b/apps/clustertenant-operator/src/tenants/operator.ts
@@ -10,7 +10,7 @@ import { TenantPolicyResolutionState, TenantStatusPhase } from "./models/tenant-
 import { __IsK8sForbidden, __K8sApplyResource } from "@opencrane/infra-api";
 import { _RunWatchLoop, K8sWatchEventType } from "@opencrane/infra-api";
 import { OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "@opencrane/infra-api";
-import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildService, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc } from "./deploy/index.js";
+import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildService, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc, _ConfigChecksum } from "./deploy/index.js";
 import { TenantCleanup } from "./destroy/tenant-cleanup.js";
 import { LinkerdIdentityClient } from "./internal/linkerd-identity.client.js";
 
@@ -335,8 +335,16 @@ export class TenantOperator
       }
 
       // 5. ConfigMap — serialises the base OpenClaw JSON config merged with any
-      //    spec.configOverrides the tenant author provided.
-      await __K8sApplyResource(this.coreApi, _BuildConfigMap(this.config, effectiveTenant, namespace, policyResolution.effectivePolicy, modelSet, ingressDomain), this.log);
+      //    spec.configOverrides the tenant author provided. Capture it so its
+      //    checksum can roll the pod when the config changes (step 7).
+      const configMap = _BuildConfigMap(this.config, effectiveTenant, namespace, policyResolution.effectivePolicy, modelSet, ingressDomain);
+      await __K8sApplyResource(this.coreApi, configMap, this.log);
+      // Checksum of the rendered config — stamped on the pod template so a config
+      // change (e.g. a newly-registered BYOK default model landing in openclaw.json)
+      // rolls the pod. Without this, a mounted ConfigMap update never restarts the
+      // running OpenClaw process, which reads openclaw.json only at startup — so a
+      // pod that booted before its models existed stays on the keyless fallback.
+      const configChecksum = _ConfigChecksum(configMap);
 
       // 6. State volume — adapter decides CSI mount (cloud) vs PVC (on-prem).
       //    Create the PVC only when the adapter requests it (on-prem path).
@@ -348,7 +356,7 @@ export class TenantOperator
 
       // 7. Deployment — single-replica pod running the tenant's OpenClaw gateway.
       //    Mounts the ConfigMap, encryption key, state volume, and projected identity tokens.
-      await __K8sApplyResource(this.appsApi, _BuildDeployment(this.config, stateVolume, effectiveTenant, namespace, compute), this.log);
+      await __K8sApplyResource(this.appsApi, _BuildDeployment(this.config, stateVolume, effectiveTenant, namespace, compute, configChecksum), this.log);
 
       // 8. Service — ClusterIP that makes the gateway reachable inside the cluster
       //    on the configured gateway port.


### PR DESCRIPTION
## Symptom

The org-admin chat renders an assistant reply of:

> ⚠️ Agent failed before reply: No API key found for provider "openai" … | missing-provider-auth

with `model: "gateway-injected"`, `provider: "openclaw"`. The agent is falling back to OpenClaw's built-in **keyless** openai provider instead of routing through LiteLLM — the exact failure the BYOK/`replace`-mode work was meant to eliminate.

## Root cause

OpenClaw reads `openclaw.json` **only at process start**, and updating a mounted ConfigMap does **not** restart the running process. The tenant Deployment had **no config-checksum annotation**, so regenerating the ConfigMap on reconcile never rolled the pod.

So a pod that booted *before* its models were registered keeps a stale `openclaw.json`. Under `models.mode: replace` with an empty allowlist that means **zero usable models**, and the gateway injects a keyless `openai` fallback → the error above. The BYOK provisioning path is deliberately "no-restart" (LiteLLM picks up the key/models live), but the agent's `openclaw.json` `models` block genuinely needs the pod to restart to take effect.

## Fix

Stamp a deterministic SHA-256 of the tenant ConfigMap `data` onto the pod-template `opencrane.io/config-checksum` annotation (new `_ConfigChecksum`), threaded through the reconcile path into `_BuildDeployment`. When the config changes (e.g. a newly-registered BYOK default model lands in the `litellm-proxy` block) the template changes → the `Recreate` strategy rolls the pod → OpenClaw re-reads `openclaw.json` and routes through LiteLLM.

- Keys are sorted so the digest is **stable across reconciles** (no spurious rolls).
- The annotation is **omitted** when no checksum is supplied, so the suspend path (`replicas=0`) and existing renders stay byte-for-byte unchanged.

## Validation

- `tsc --noEmit` clean; **608 operator tests pass** (+3: deterministic + config-sensitive digest, annotation stamped/omitted).

## Immediate remediation for an already-stuck silo

This fix rolls the pod automatically on the *next* config change. To unstick a pod that's already on the keyless fallback, force a reconcile so the ConfigMap regenerates with the BYOK models, then restart the pod:

```
kubectl -n opencrane-<org> rollout restart deploy/openclaw-<org>-default
# or force a tenant reconcile (bumps generation → regenerates ConfigMap):
kubectl patch tenant <org>-default -n opencrane-<org> --subresource=status --type=merge -p '{"status":{"observedGeneration":0}}'
```

## Related / follow-up

- The BYOK route (`/providers/byok`) is a **no-restart** path by design. Full auto-propagation to the agent also wants that path to trigger a tenant reconcile so the ConfigMap regenerates (this PR ensures the pod then rolls). Filed as follow-up.
- Companion frontend fix (WeOwnAI): the `chat` event payload shape was mis-parsed so replies were dropped in the UI — separate PR.