### PR TITLE
🐛 control-plane: mount /api/internal routes before session auth (unbricks BYOK model delivery)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/index.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/index.test.ts
@@ -151,5 +151,37 @@ describe("Control Plane", () =>
       expect(res.status).toBe(200);
       expect(res.body.status).toBe("ok");
     });
+
+    it("mounts internal routes BEFORE the auth gate, so tokenless calls reach them", async () =>
+    {
+      // Regression: `/api/internal/*` was registered AFTER ___AuthMiddleware, so the
+      // operator's tokenless reconcile fetch of tenant-models 401'd → empty model set →
+      // replace-mode pods bricked. `_RegisterInternalRoutes` must run first. We assert the
+      // ORDERING invariant directly with a stand-in "deny-all" gate (deterministic — no
+      // dependency on the auth lib's env/module-init timing): anything mounted AFTER the
+      // internal routes cannot see requests the internal routes already handled.
+      const { _RegisterInternalRoutes } = await import("../routes.js");
+
+      const prisma = {
+        tenant: { findUnique: vi.fn().mockResolvedValue(null) },
+        modelDefinition: { findMany: vi.fn().mockResolvedValue([]) },
+        modelRoutingDefault: { findFirst: vi.fn().mockResolvedValue(null) },
+      } as unknown as PrismaClient;
+
+      const app = express();
+      app.use(express.json());
+      // Production order: internal routes first …
+      _RegisterInternalRoutes(app, prisma, {} as never);
+      // … then the auth gate (stand-in for ___AuthMiddleware) that blocks everything reaching it.
+      app.use(function _denyAll(req, res) { res.status(401).json({ error: "blocked by auth gate" }); });
+      app.get("/api/test", function _test(req, res) { res.json({ ok: true }); });
+
+      // A route mounted after the gate is unreachable → 401 …
+      expect((await request(app).get("/api/test")).status).toBe(401);
+      // … but the NetworkPolicy-only internal models route is handled before the gate.
+      const internal = await request(app).get("/api/internal/tenant-models/some-tenant");
+      expect(internal.status).toBe(200);
+      expect(internal.body).toEqual({ models: [], defaultModel: null });
+    });
   });
 });

--- a/apps/clustertenant-operator/src/index.ts
+++ b/apps/clustertenant-operator/src/index.ts
@@ -21,7 +21,7 @@ import { ___CreateOidcAuthService } from "./infra/auth/oidc.service.js";
 import { ___CreatePrismaClient } from "./infra/db/db.js";
 import { _TransportSecurity } from "./infra/middleware/transport-security.middleware.js";
 import { _log as log } from "./log.js";
-import { _RegisterRoutes } from "./routes.js";
+import { _RegisterInternalRoutes, _RegisterRoutes } from "./routes.js";
 import { TenantProjectionRepairer } from "./infra/tenant-projection-repairer.js";
 
 // In-silo controllers (Stage 5). The silo runs every in-silo reconcile loop over its OWN
@@ -78,6 +78,13 @@ export function createApp(prisma: PrismaClient, customApi: k8s.CustomObjectsApi,
   // inherently public — the device-flow activate handler enforces its own
   // session check internally.
   app.use("/api/v1/auth", ___AuthRouter(authService, prisma, coreApi, _BuildGatewayAdmin()));
+
+  // Internal routes (`/api/internal/*`) MUST be mounted BEFORE the session auth
+  // middleware: the NetworkPolicy-only routes take no token (the operator fetches
+  // `tenant-models` on its reconcile hot path with no credential) and the pod-identity
+  // routes run their own TokenReview — neither can pass browser-session auth, so gating
+  // them behind it 401s the operator's own fetch and every pod poll.
+  _RegisterInternalRoutes(app, prisma, authApi);
 
   // Pass prisma so DB-issued access tokens (from `oc auth login` and
   // POST /access-tokens) are validated in addition to the env-var token.

--- a/apps/clustertenant-operator/src/routes.ts
+++ b/apps/clustertenant-operator/src/routes.ts
@@ -73,20 +73,21 @@ function _BuildOciBundleStore(): OciBundleStore | null
  * @param authApi   - Kubernetes Authentication API for tenant contract TokenReview validation.
  * @returns The Express application instance with registered routes.
  */
-export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k8s.CustomObjectsApi, coreApi: k8s.CoreV1Api, authApi: k8s.AuthenticationV1Api): Express
+/**
+ * Mount the internal (`/api/internal/*`) routers. These MUST be registered BEFORE the
+ * session `___AuthMiddleware` (see index.ts) — mounting them after it 401s every caller:
+ *   - NetworkPolicy-only routes (`bundles`, `tenant-models`) take NO token; access is
+ *     enforced at the network layer. The operator fetches `tenant-models` on its own
+ *     reconcile hot path with no credential, so behind session auth it 401s → the model
+ *     set is always null → replace-mode pods brick with an empty allowlist.
+ *   - pod-identity routes (`contract`, `participation`) run their OWN TokenReview over a
+ *     projected pod token, which the browser-session middleware cannot satisfy.
+ * @see apps/clustertenant-platform/templates/networkpolicy-planes.yaml — the runtime-plane policies.
+ */
+export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, authApi: k8s.AuthenticationV1Api): void
 {
-  // Internal routes — mounted before ___AuthMiddleware and not behind any token check.
-  // Access is enforced by Kubernetes NetworkPolicy: only the Obot, skill-registry, and
-  // tenant pods can reach the control-plane service on the cluster network.
-  // @see apps/clustertenant-platform/templates/networkpolicy-planes.yaml — runtime-plane policies.
-  // @see apps/clustertenant-platform/templates/obot-mcp-gateway-deployment.yaml — OBOT_SERVER_PROVIDER_REGISTRIES wiring.
   // Optional OCI store for skill-bundle content (P4D.2); null → DB-only delivery.
   const ociBundleStore = _BuildOciBundleStore();
-
-  // Gateway admin for the connection kill-switch (CONN.5); no-op until a
-  // control-plane operator device is paired (CONN.4 — needs live infra).
-  const gatewayAdmin = _BuildGatewayAdmin();
-
   app.use("/api/internal/bundles", _RegisterInternalBundles(prisma, ociBundleStore));
   // NetworkPolicy-only (no auth/TokenReview): the operator fetches a tenant's
   // allowed model set + effective default at reconcile. Best-effort — never 404/500.
@@ -94,6 +95,20 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   // Note: /api/internal/contract enforces per-tenant identity via TokenReview — not NetworkPolicy-only.
   app.use("/api/internal/contract", _RegisterInternalTenantContract(prisma, authApi));
   app.use("/api/internal/awareness/participation", _RegisterInternalParticipation(prisma, authApi));
+}
+
+export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k8s.CustomObjectsApi, coreApi: k8s.CoreV1Api, authApi: k8s.AuthenticationV1Api): Express
+{
+  // NOTE: the internal (`/api/internal/*`) routers are mounted separately by
+  // `_RegisterInternalRoutes`, which index.ts calls BEFORE `___AuthMiddleware` so the
+  // operator's tokenless reconcile fetch + the pod-identity TokenReview routes are not
+  // gated by the browser-session auth. Do NOT re-mount them here.
+  // Optional OCI store for skill-bundle content (P4D.2); null → DB-only delivery.
+  const ociBundleStore = _BuildOciBundleStore();
+
+  // Gateway admin for the connection kill-switch (CONN.5); no-op until a
+  // control-plane operator device is paired (CONN.4 — needs live infra).
+  const gatewayAdmin = _BuildGatewayAdmin();
 
   app.use("/api/v1/metrics", metricsRouter(customApi, prisma));
   app.use("/api/v1/audit", auditRouter(prisma));


### PR DESCRIPTION
## The real root cause behind the stuck agent

Diagnosed live: the operator's reconcile fetches `GET /api/internal/tenant-models/<tenant>` **with no credential** and gets **401**:

```
GET /api/internal/tenant-models/elewa-default → 401
"tenant-models fetch returned non-200; falling back to unrestricted models"
```

`_FetchTenantModels` then returns `null` → the tenant ConfigMap renders `models: []`. Under `models.mode: replace` that's **zero usable models**, so the openclaw pod either CrashLoopBackOffs (replace) or falls back to a keyless built-in `openai` model (older merge configs) → *"No API key found for provider openai"*. Verified on the live cluster: `elewa` pod in CrashLoopBackOff (201 restarts) with `models: []`, and the internal fetch 401ing in the manager logs.

## Why it 401s

`index.ts` registers `app.use(___AuthMiddleware(prisma))` **before** `_RegisterRoutes(...)`, and the internal routers were mounted *inside* `_RegisterRoutes`. So the browser-session auth ran for every `/api/internal/*` request — even the NetworkPolicy-only ones that are supposed to take no token. The route's own comment ("mounted before `___AuthMiddleware`") was simply false in the wiring.

## Fix

Extract `_RegisterInternalRoutes` and call it in `index.ts` **before** `___AuthMiddleware`, restoring the documented intent. This unblocks:
- the NetworkPolicy-only routes (`bundles`, `tenant-models`) — no token, network-enforced;
- the pod-identity routes (`contract`, `participation`) — which run their own TokenReview and likewise can't pass the browser-session gate.

## Validation

- New test asserts the ordering invariant deterministically (internal route reachable before a stand-in deny-all gate; a route after the gate 401s).
- `tsc --noEmit` clean; **606 operator tests pass**.

## Deploy ordering (this is the key one)

This is **upstream** of the config-checksum fix ([#113](https://github.com/italanta/opencrane/pull/113)). To fully unstick a silo, deploy the operator with **both**:
1. **This PR** — so the model set is actually fetched (non-empty).
2. **[#113](https://github.com/italanta/opencrane/pull/113)** — so the ConfigMap change rolls the openclaw pod.

Then force a reconcile (`kubectl patch tenant <org>-default --subresource=status --type=merge -p '{"status":{"observedGeneration":0}}'`). The per-tenant LiteLLM key secret and the registered BYOK models are already present on `elewa`, so once these two land the agent routes through LiteLLM.