### PR TITLE
🐛 tenant: openclaw model config shape (id/name objects + agents.defaults.model) — unbricks the agent

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -66,9 +66,15 @@ describe("TenantResourceBuilder", () =>
     // Non-empty modelSet → replace, default surfaced, allowlist restricted to the set.
     const withModels = JSON.parse(_BuildConfigMap(liteLlmConfig, tenant, "default", undefined, { models: ["openai/gpt-4o", "anthropic/claude-sonnet-4-5"], defaultModel: "openai/gpt-4o" }).data?.["openclaw.json"] ?? "{}");
     expect(withModels.models.mode).toBe("replace");
-    expect(withModels.models.default).toBe("openai/gpt-4o");
+    // The default lives at agents.defaults.model — OpenClaw's models block has no `default` key.
+    expect(withModels.models.default).toBeUndefined();
+    expect(withModels.agents.defaults.model).toBe("openai/gpt-4o");
     expect(Object.keys(withModels.models.providers)).toEqual(["litellm-proxy"]);
-    expect(withModels.models.providers["litellm-proxy"].models).toEqual(["openai/gpt-4o", "anthropic/claude-sonnet-4-5"]);
+    // OpenClaw@2026.6.9 requires each model to be an { id, name } object, not a bare string.
+    expect(withModels.models.providers["litellm-proxy"].models).toEqual([
+      { id: "openai/gpt-4o", name: "openai/gpt-4o" },
+      { id: "anthropic/claude-sonnet-4-5", name: "anthropic/claude-sonnet-4-5" },
+    ]);
 
     // Empty/null modelSet → still replace (no built-in fallback); empty allowlist, no default.
     // This bricked-pod window is what cluster onboarding's ≥1-model requirement prevents.
@@ -143,8 +149,13 @@ describe("TenantResourceBuilder", () =>
     const configMap = _BuildConfigMap(litellmConfig, tenant, "default", undefined, { models: ["gpt-4o", "claude-opus-4-8"], defaultModel: "gpt-4o" });
     const payload = JSON.parse(configMap.data?.["openclaw.json"] ?? "{}");
 
-    expect(payload.models.providers["litellm-proxy"].models).toEqual(["gpt-4o", "claude-opus-4-8"]);
-    expect(payload.models.default).toBe("gpt-4o");
+    expect(payload.models.providers["litellm-proxy"].models).toEqual([
+      { id: "gpt-4o", name: "gpt-4o" },
+      { id: "claude-opus-4-8", name: "claude-opus-4-8" },
+    ]);
+    // Default is at agents.defaults.model (OpenClaw's models block has no `default`).
+    expect(payload.models.default).toBeUndefined();
+    expect(payload.agents.defaults.model).toBe("gpt-4o");
   });
 
   it("keeps litellm-proxy models[] empty when the model set is empty or null", () =>

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -132,13 +132,21 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
               // is provisioned (see fleet-operator ClusterTenant readiness). The BYOK key flow also
               // auto-seeds a default model, so a key-configured silo always satisfies this.
               mode: "replace",
-              ...(defaultModel ? { default: defaultModel } : {}),
+              // NOTE: the default model is NOT set here. OpenClaw's `models` block is strict
+              // and has no `default` key (only `mode` + `providers`) — a `models.default`
+              // fails startup with "models: Invalid input". The effective default lives at
+              // `agents.defaults.model` (set in step 4 below).
               providers: {
                 "litellm-proxy": {
                   baseUrl: config.liteLlmEndpoint,
                   apiKey: "${LITELLM_API_KEY}",
                   api: "openai-completions",
-                  models: allowedModels,
+                  // OpenClaw's config schema (verified against openclaw@2026.6.9
+                  // plugin-sdk/config-schema) requires each provider model to be an OBJECT
+                  // with `id` + `name` (both required) — NOT a bare string. Rendering strings
+                  // makes the gateway fail startup with "models.providers.*.models.N: Invalid
+                  // input". We use the LiteLLM public model name for both id and name.
+                  models: allowedModels.map((model) => ({ id: model, name: model })),
                 },
               },
             },
@@ -214,6 +222,11 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
         ...existingDefaults,
         workspace: _WORKSPACE_PATH,
         skipBootstrap: true,
+        // Effective default model (from the tenant's model set). OpenClaw reads the default
+        // from `agents.defaults.model`, NOT `models.default`. Applied platform-side so it
+        // can't be dropped by a tenant `configOverrides.agents` override. Omitted when no
+        // default resolves (then OpenClaw falls back to its own model selection).
+        ...(defaultModel ? { model: defaultModel } : {}),
       },
     },
   };

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -111,21 +111,29 @@ const _modelProviderSchema = z
     apiKey: z.string().optional(),
     /** Wire protocol the provider speaks (e.g. `openai-completions`). */
     api: z.string().optional(),
-    /** Allowed model ids; `[]` keeps the proxy default. */
-    models: z.array(z.string()).optional(),
+    /**
+     * Allowed models. OpenClaw@2026.6.9 requires each entry to be an OBJECT with
+     * `id` + `name` (both required) — a bare string array fails gateway startup
+     * ("models.providers.*.models.N: Invalid input"). `[]` keeps the proxy default.
+     * `passthrough` tolerates the extra optional per-model fields OpenClaw accepts
+     * (api/baseUrl/cost/contextWindow/…) without pinning them here.
+     */
+    models: z
+      .array(z.object({ id: z.string(), name: z.string() }).passthrough())
+      .optional(),
   })
   .strict();
 
 /**
- * Models block emitted only when LiteLLM is enabled. `mode` ∈ {merge,replace}
- * (PINNED from docs); `default` is the optional default model id.
+ * Models block emitted only when LiteLLM is enabled. `mode` ∈ {merge,replace}.
+ * NOTE: OpenClaw's `models` block is strict and has NO `default` key — the effective
+ * default model lives at `agents.defaults.model` (see `_agentsDefaultsSchema`). Emitting
+ * `models.default` fails gateway startup with "models: Invalid input".
  */
 const _modelsSchema = z
   .object({
     /** How the provider map merges with built-in providers. */
     mode: z.enum(["merge", "replace"]),
-    /** Default model id, surfaced when the control-plane returned one. */
-    default: z.string().optional(),
     /** Provider id → provider config map. */
     providers: z.record(z.string(), _modelProviderSchema),
   })
@@ -143,6 +151,8 @@ const _agentsDefaultsSchema = z
     workspace: z.string(),
     /** Skip the interactive bootstrap ritual in the headless pod. */
     skipBootstrap: z.boolean(),
+    /** Effective default model id (OpenClaw reads the default from here, not models.default). */
+    model: z.string().optional(),
   })
   .passthrough();
 

--- a/apps/clustertenant-platform/templates/gateway-ingress.yaml
+++ b/apps/clustertenant-platform/templates/gateway-ingress.yaml
@@ -1,5 +1,12 @@
-{{- if and .Values.ingress.enabled .Values.gatewayProxy.enabled -}}
+{{- if and .Values.ingress.enabled .Values.gatewayProxy.enabled (not .Values.ingress.sameOrigin.enabled) -}}
 {{- /*
+SUPERSEDED by `ingress.sameOrigin` (clustertenant-manager-ingress.yaml): this wildcard
+`*.<domain>` Ingress path-routes ALL orgs' /api + /gateway to THIS silo — correct only for a
+single-org install. In a multi-silo cluster it both mis-routes cross-org traffic and collides
+(nginx rejects a second silo claiming the same `*.<domain>`+`/api`). When sameOrigin is enabled
+the per-org host (`<org>.<domain>`) Ingress owns /api + /gateway + /, so this wildcard is gated
+OFF. Kept only for the legacy single-org-wildcard path (sameOrigin disabled).
+
 Single-per-org-host topology (DOMAIN.T4). Every org is served at its own host under the
 platform wildcard `*.<ingress.domain>` (e.g. `acme.weownai.eu`). One wildcard Ingress covers
 them all and path-routes the SAME origin:


### PR DESCRIPTION
## The last layer under #112–#115

With #112–#115 deployed, the model set finally reaches the openclaw config — which exposed that the operator writes it in a shape **openclaw@2026.6.9 rejects**, so the gateway never starts:

```
Gateway failed to start: Invalid config at /data/openclaw/openclaw.json.
models.providers.litellm-proxy.models.0: Invalid input   ← bare string
models: Invalid input                                     ← models.default (unknown key)
```

Verified against openclaw's real schema (`plugin-sdk/config-schema.d.ts`):
- provider `models[]` element must be an **object with required `id` + `name`**, not a string;
- the `models` block is **strict with no `default` key** — the default belongs at **`agents.defaults.model`**.

## Fix

- `2-config-map.ts`: render `models: allowedModels.map(m => ({ id: m, name: m }))`; move the default from `models.default` → `agents.defaults.model` (platform-pinned).
- `openclaw-config.schema.ts`: self-schema updated (object models; drop `models.default`; add `agents.defaults.model`).
- Plus a chart fix (2nd commit): gate the superseded wildcard `gateway-ingress` off when `ingress.sameOrigin.enabled` (it collided across silos — hit live upgrading elewa).

## Validated LIVE on elewa

Patched the running configmap to this exact shape + restarted the pod — the gateway went from CrashLoopBackOff to:
```
[gateway] openai/gpt-5.5 model configured, enabled automatically
[gateway] agent model: openai/gpt-5.5 (thinking=medium, fast=off)
[gateway] ready
```
The agent now routes through LiteLLM. `tsc` clean; **609 operator tests pass**; `helm lint` clean.

## Deploy note

This needs the operator image rebuilt (CI on merge) + the silos redeployed to the new sha — the live elewa configmap patch is a temporary manual proof that reverts on the next reconcile. After merge I'll redeploy elewa/elewa-be/northwind to the fixed image.