### PR TITLE
✨ model-routing: stable "Auto" model option (cheapest-capable, native LiteLLM)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/model-routing/provision-byok-key.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/model-routing/provision-byok-key.test.ts
@@ -66,12 +66,15 @@ describe("_ProvisionByokKey / _DeprovisionByokKey", function _suite()
     expect(result.litellmRegistered).toBe(false);
     expect(Buffer.from(secrets.get(_byokSecretName("openai"))!.data!.apiKey, "base64").toString("utf8")).toBe("sk-test-123");
     expect(Array.from(creds.values())[0]).toMatchObject({ scope: "Global", clusterTenant: null, provider: "openai" });
-    // All of the provider's model classes are seeded, ALL bound to the one credential.
+    // All of the provider's model classes are seeded PLUS the stable "auto" model, ALL bound to the one credential.
     const seeded = Array.from(models.values());
-    expect(seeded).toHaveLength(3);
-    expect(seeded.map(function slug(m) { return m.publicModelName; }).sort()).toEqual(["openai/gpt-5.4", "openai/gpt-5.4-nano", "openai/gpt-5.5"]);
+    expect(seeded).toHaveLength(4);
+    expect(seeded.map(function slug(m) { return m.publicModelName; }).sort()).toEqual(["auto", "openai/gpt-5.4", "openai/gpt-5.4-nano", "openai/gpt-5.5"]);
     expect(seeded.every(function bound(m) { return m.providerCredentialId === result.row.id; })).toBe(true);
-    // The flagship (default class) claims the silo default; the other tiers do not.
+    // "auto" is backed by the cheapest (fast) class model and is NOT the default (it's a selectable option).
+    const auto = seeded.find(function a(m) { return m.publicModelName === "auto"; });
+    expect(auto).toMatchObject({ upstreamModel: "openai/gpt-5.4-nano", isDefault: false });
+    // The flagship (default class) claims the silo default; the other tiers + auto do not.
     const flagship = seeded.find(function f(m) { return m.publicModelName === "openai/gpt-5.5"; });
     expect(flagship).toMatchObject({ isDefault: true });
     expect(seeded.filter(function d(m) { return m.isDefault; })).toHaveLength(1);

--- a/apps/clustertenant-operator/src/__tests__/routes/provider-byok.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/routes/provider-byok.test.ts
@@ -174,11 +174,13 @@ describe("providerByokRouter", function _suite()
     const app = _buildApp(store, new Map(), { isOrgAdmin: true }, models);
     await request(app).put("/api/v1/providers/byok/openai").send({ apiKey: "sk-live-123" });
 
-    // All of OpenAI's model classes are seeded (one credential, many models); flagship is default.
+    // All of OpenAI's model classes are seeded PLUS the stable "auto" model; flagship is default.
     const seeded = Array.from(models.values());
-    expect(seeded).toHaveLength(3);
+    expect(seeded).toHaveLength(4);
     const flagship = seeded.find(function f(m) { return m.publicModelName === "openai/gpt-5.5"; });
     expect(flagship).toMatchObject({ scope: "Global", clusterTenant: null, isDefault: true });
+    // "auto" is backed by the cheapest (fast) model and is a selectable option, not the default.
+    expect(seeded.find(function a(m) { return m.publicModelName === "auto"; })).toMatchObject({ upstreamModel: "openai/gpt-5.4-nano", isDefault: false });
     expect(seeded.filter(function d(m) { return m.isDefault; })).toHaveLength(1);
     // Every class is bound to the one upserted credential row.
     const cred = Array.from(store.values())[0];
@@ -193,12 +195,15 @@ describe("providerByokRouter", function _suite()
     await request(app).put("/api/v1/providers/byok/openai").send({ apiKey: "k1" });
     await request(app).put("/api/v1/providers/byok/anthropic").send({ apiKey: "k2" });
 
-    // Both providers' full catalogs are registered (3 + 3), but only OpenAI's flagship is default.
+    // Both providers' full catalogs are registered (3 + 3) plus a single shared "auto" (first
+    // provider wins), but only OpenAI's flagship is default.
     const byName = new Map(Array.from(models.values()).map(function _n(m) { return [m.publicModelName, m]; }));
     expect(byName.get("openai/gpt-5.5")).toMatchObject({ isDefault: true });
     expect(byName.get("anthropic/claude-opus-4-8")).toMatchObject({ isDefault: false });
+    // "auto" is registered once (by the first provider, OpenAI) and backed by its cheapest model.
+    expect(byName.get("auto")).toMatchObject({ upstreamModel: "openai/gpt-5.4-nano", isDefault: false });
     expect(Array.from(models.values()).filter(function d(m) { return m.isDefault; })).toHaveLength(1);
-    expect(models.size).toBe(6);
+    expect(models.size).toBe(7);
   });
 
   it("never echoes the raw key back in the response body", async function _noEcho()

--- a/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
@@ -20,6 +20,13 @@ import type { ByokProviderCatalog } from "./byok-default-models.js";
  * default model bound to it. A key is Global-scoped (silo-wide), never per openclaw tenant.
  */
 
+/**
+ * Public model name of the stable "auto" selection. Backed by the cheapest catalogued model
+ * today (LiteLLM has no capability-aware routing); the AIR router can re-point it later without
+ * callers/skills re-selecting. See `_ensureProviderModels` step 3.
+ */
+const _AUTO_MODEL_NAME = "auto";
+
 /** Outcome of {@link _ProvisionByokKey}. */
 export interface ProvisionByokKeyResult
 {
@@ -280,6 +287,33 @@ async function _ensureProviderModels(prisma: PrismaClient, catalog: ByokProvider
     if (!hasDefault)
     {
       await prisma.modelDefinition.update({ where: { id: defaultModelId }, data: { isDefault: true } });
+    }
+  }
+
+  // 3. Register the "auto" model — a STABLE selection id, so a caller/skill can pick "auto" once
+  //    and its backing model can improve later without re-selecting. Backed today by the provider's
+  //    CHEAPEST (`fast`-class) model: LiteLLM has no capability-aware routing (it is static/reactive
+  //    — cost/latency/shuffle only), so native "auto" deterministically resolves to the cheapest
+  //    deployment. The intelligent cost/quality router (RouteLLM + measurement, AIR track) can later
+  //    re-point this same "auto" id without any caller change. Registered ONCE (first provider wins).
+  const cheapest = catalog.models.find((m) => m.className === "fast") ?? catalog.models[catalog.models.length - 1];
+  if (cheapest)
+  {
+    const existingAuto = await prisma.modelDefinition.findFirst({ where: { scope: "Global", clusterTenant: null, publicModelName: _AUTO_MODEL_NAME } });
+    if (!existingAuto)
+    {
+      const litellmModelId = await _RegisterLiteLlmModel({
+        publicModelName: _AUTO_MODEL_NAME,
+        upstreamModel: cheapest.slug,
+        scope: ModelRoutingScope.Global,
+        clusterTenant: null,
+        apiBase: null,
+        apiKeyEnvRef: null,
+        litellmCredentialName,
+      });
+      await prisma.modelDefinition.create({
+        data: { scope: "Global", clusterTenant: null, publicModelName: _AUTO_MODEL_NAME, litellmModelId, upstreamModel: cheapest.slug, apiBase: null, isDefault: false, providerCredentialId },
+      });
     }
   }
 }

--- a/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
@@ -296,6 +296,7 @@ async function _ensureProviderModels(prisma: PrismaClient, catalog: ByokProvider
   //    — cost/latency/shuffle only), so native "auto" deterministically resolves to the cheapest
   //    deployment. The intelligent cost/quality router (RouteLLM + measurement, AIR track) can later
   //    re-point this same "auto" id without any caller change. Registered ONCE (first provider wins).
+  //    @todo - Do smart via RouteLLM & LangFuse
   const cheapest = catalog.models.find((m) => m.className === "fast") ?? catalog.models[catalog.models.length - 1];
   if (cheapest)
   {


### PR DESCRIPTION
## What

Adds an **"Auto" model** to every BYOK-provisioned silo — the option you asked for. It's a **stable selection id** (`auto`) backed **today** by the provider's cheapest (`fast`-class) model.

## Why this shape (the honest native limit)

Verified against our own research (`litellm-router-autonomous-improvement-research.md`) + LiteLLM v1.81.0: LiteLLM's router is **static/reactive** (`simple-shuffle` / `latency-based` / `cost-based` / `usage-based`) — it does **not** do capability-aware "pick the best model for this task" (that's proprietary: NotDiamond / OpenRouter auto / GPT-5). So native "auto" can only mean **cheapest** (or fastest). The intelligent quality/cost router is the **AIR track** (RouteLLM + Langfuse measurement + nightly loop) — deferred.

The win is the **stable id**: a caller/skill (or the org default) selects `auto` once, and when the AIR router lands it **re-points the same `auto` id** with zero caller change.

## Implementation

- `_ensureProviderModels` (BYOK provisioning) now registers, **once** (first configured provider wins, like the default-claim):
  - a LiteLLM deployment `model_name: "auto"` → the fast-class slug on the same credential;
  - a Global `ModelDefinition("auto")`.
- It flows through `/api/internal/tenant-models` into the openclaw config like any other model — **selectable, not forced as the default**.
- No contract/OpenAPI change — `auto` is just a name in the model set.

## Validation

**609 operator tests pass** — provisioning + route tests assert `auto` is present, backed by the fast-class model (`openai/gpt-5.4-nano`), registered once across providers, and is **not** the default.

## Follow-ups (not in this PR)

- **weownai UI**: label/select "Auto" in the Model Keys screen (it already appears in the model set from the API; needs a friendly label + "set as default" affordance).
- **Existing keys**: `auto` registers on the next BYOK key set — after deploy I'll re-provision elewa's key (or set via UI) so `auto` appears.
- **Upgrade path**: AIR cost/quality router re-points `auto` (tracked in the AIR track).