### PR TITLE
fix(operator): route the default model through litellm-proxy (fixes "No API key found for provider openai")

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -68,7 +68,9 @@ describe("TenantResourceBuilder", () =>
     expect(withModels.models.mode).toBe("replace");
     // The default lives at agents.defaults.model — OpenClaw's models block has no `default` key.
     expect(withModels.models.default).toBeUndefined();
-    expect(withModels.agents.defaults.model).toBe("openai/gpt-4o");
+    // Prefixed with the provider id so OpenClaw routes the reference through litellm-proxy rather
+    // than parsing `openai/` as the built-in openai provider (→ "No API key found for provider openai").
+    expect(withModels.agents.defaults.model).toBe("litellm-proxy/openai/gpt-4o");
     expect(Object.keys(withModels.models.providers)).toEqual(["litellm-proxy"]);
     // OpenClaw@2026.6.9 requires each model to be an { id, name } object, not a bare string.
     expect(withModels.models.providers["litellm-proxy"].models).toEqual([
@@ -153,9 +155,10 @@ describe("TenantResourceBuilder", () =>
       { id: "gpt-4o", name: "gpt-4o" },
       { id: "claude-opus-4-8", name: "claude-opus-4-8" },
     ]);
-    // Default is at agents.defaults.model (OpenClaw's models block has no `default`).
+    // Default is at agents.defaults.model (OpenClaw's models block has no `default`), prefixed
+    // with the provider id so the reference routes through litellm-proxy (not the built-in provider).
     expect(payload.models.default).toBeUndefined();
-    expect(payload.agents.defaults.model).toBe("gpt-4o");
+    expect(payload.agents.defaults.model).toBe("litellm-proxy/gpt-4o");
   });
 
   it("keeps litellm-proxy models[] empty when the model set is empty or null", () =>

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -17,6 +17,30 @@ const _WORKSPACE_TEMPLATES_DIR = join(dirname(fileURLToPath(import.meta.url)), "
 const _WORKSPACE_PATH = "/data/openclaw/workspace";
 
 /**
+ * The OpenClaw provider id the LiteLLM proxy is registered under (in `models.providers`).
+ *
+ * This id is ALSO the mandatory prefix on any model reference that must route through the proxy
+ * (see `_toModelRef`). OpenClaw resolves a model reference by splitting on the FIRST `/`: the head
+ * is the provider, the tail is the model. So a bare LiteLLM public name like `openai/gpt-5.5`
+ * resolves to OpenClaw's BUILT-IN `openai` provider — which then demands a real OpenAI key in the
+ * per-agent auth store and fails the first turn with `No API key found for provider "openai"`,
+ * NEVER touching our `litellm-proxy` provider. Prefixing the reference (`litellm-proxy/openai/gpt-5.5`)
+ * pins provider resolution to this proxy; OpenClaw strips the head and sends the tail (`openai/gpt-5.5`,
+ * the LiteLLM public model name) upstream. The provider's own `models[].id` catalog stays BARE (the
+ * name is relative to the provider), so only the *reference* — `agents.defaults.model` — is prefixed.
+ */
+const _LITELLM_PROVIDER_ID = "litellm-proxy";
+
+/**
+ * Turn a LiteLLM public model name into an OpenClaw model REFERENCE that routes through the proxy.
+ * See {@link _LITELLM_PROVIDER_ID} for why the provider prefix is mandatory.
+ */
+function _toModelRef(publicModelName: string): string
+{
+  return `${_LITELLM_PROVIDER_ID}/${publicModelName}`;
+}
+
+/**
  * Build the tenant ConfigMap that carries both OpenClaw runtime configuration
  * and the OpenCrane managed-runtime contract.
  *
@@ -137,7 +161,7 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
               // fails startup with "models: Invalid input". The effective default lives at
               // `agents.defaults.model` (set in step 4 below).
               providers: {
-                "litellm-proxy": {
+                [_LITELLM_PROVIDER_ID]: {
                   baseUrl: config.liteLlmEndpoint,
                   apiKey: "${LITELLM_API_KEY}",
                   api: "openai-completions",
@@ -226,7 +250,12 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
         // from `agents.defaults.model`, NOT `models.default`. Applied platform-side so it
         // can't be dropped by a tenant `configOverrides.agents` override. Omitted when no
         // default resolves (then OpenClaw falls back to its own model selection).
-        ...(defaultModel ? { model: defaultModel } : {}),
+        //
+        // MUST be prefixed with the litellm-proxy provider id (`_toModelRef`): OpenClaw resolves
+        // the provider from the reference's leading segment, so a bare `openai/gpt-5.5` would bind
+        // to the built-in `openai` provider (→ "No API key found for provider openai") instead of
+        // routing through the proxy. The prefix pins it to `litellm-proxy`; the tail is sent upstream.
+        ...(defaultModel ? { model: _toModelRef(defaultModel) } : {}),
       },
     },
   };


### PR DESCRIPTION
## What landed

The agent booted with a model configured but failed the **first turn** at runtime:

```
⚠️ Agent failed before reply: No API key found for provider "openai".
  Auth store: /data/openclaw/agents/main/agent/openclaw-agent.sqlite … | missing-provider-auth
```

Root cause is model-reference resolution in OpenClaw, not a missing key. OpenClaw parses a model reference by splitting on the **first `/`** (`parseModelRef` → provider = head, model = tail). The operator rendered `agents.defaults.model` as the **bare** LiteLLM public name:

```jsonc
"agents": { "defaults": { "model": "openai/gpt-5.5" } }   // ← head "openai" = built-in provider
```

So OpenClaw bound the call to its **built-in `openai` provider**, which looks for a real OpenAI key in the per-agent SQLite auth store — and threw `missing-provider-auth`. It never routed through the `litellm-proxy` provider that actually holds the virtual key (`apiKey: ${LITELLM_API_KEY}`), even though `models.mode: replace` makes that the only configured provider. The declared `models[].id` catalog does **not** drive resolution — only the reference prefix does.

**Fix:** prefix the default-model *reference* with the provider id via a new `_toModelRef()` helper:

```jsonc
"agents": { "defaults": { "model": "litellm-proxy/openai/gpt-5.5" } }
```

OpenClaw now pins provider resolution to `litellm-proxy`, strips the head, and sends the tail (`openai/gpt-5.5`, the LiteLLM public name) upstream — where LiteLLM authenticates with the BYOK virtual key. The provider's own `models[].id` catalog stays **bare** (the id is relative to the provider); only the reference is prefixed.

## Validation

Traced against the shipped `openclaw@2026.6.9` package to confirm the exact behaviour before changing anything:

- `parseModelRef` / `normalizeModelRef` — provider is the segment before the first `/`; `stripSelfProviderModelPrefix` leaves `openai/gpt-5.5` intact when the provider is `litellm-proxy`.
- `resolveUsableCustomProviderApiKey` → `resolveProviderConfig(cfg, "litellm-proxy")` reads `apiKey: ${LITELLM_API_KEY}`; `coerceSecretRef` matches the `${VAR}` env-template form → `{source:"env", id:"LITELLM_API_KEY"}`.
- Live pod check: `LITELLM_API_KEY` is wired via `secretKeyRef` and the secret carries a real virtual key.

Tests: `tenant-resource-builder` + `openclaw-config-contract` — **47/47 pass** (expectations updated to the prefixed reference).

## Deferred

- Tenant-supplied `configOverrides.agents.defaults.model` is passed through verbatim (not auto-prefixed). It's an advanced escape hatch and not on the live BYOK path; documenting rather than normalising it here.

## Commits

- `bc19a67` fix(operator): prefix the agent default model with the litellm-proxy provider id
