### PR TITLE
Onboarding flow sign up

### DIFF
--- a/apps/fleet-operator/openapi.json
+++ b/apps/fleet-operator/openapi.json
@@ -2477,6 +2477,14 @@
               "type": "string"
             },
             "description": "Path to redirect back to after a successful login."
+          },
+          {
+            "name": "prompt",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "OIDC prompt value. Pass \"create\" to show the Zitadel registration form instead of login."
           }
         ],
         "responses": {

--- a/apps/fleet-operator/src/__tests__/zitadel/zitadel-client.test.ts
+++ b/apps/fleet-operator/src/__tests__/zitadel/zitadel-client.test.ts
@@ -55,6 +55,7 @@ describe("_HttpZitadelManagementClient — live provisioning lifecycle (injected
       "/management/v1/projects/proj-9/roles/_bulk",
       "/management/v1/projects/proj-9/apps/oidc",
       "/management/v1/users/u-master/grants",
+      "/management/v1/orgs/me/members",
     ]);
     // Every in-org call carries the new org's context header.
     expect(calls.filter(c => c.path.startsWith("/management")).every(c => c.orgId === "org-9")).toBe(true);

--- a/apps/fleet-operator/src/infra/auth/auth.router.ts
+++ b/apps/fleet-operator/src/infra/auth/auth.router.ts
@@ -42,7 +42,8 @@ export function ___FleetAuthRouter(authService: FleetOidcAuthService): Router
       }
 
       const returnTo = typeof req.query.returnTo === "string" ? req.query.returnTo : "/";
-      const loginUrl = await authService.buildLoginUrl(req, returnTo);
+      const prompt = typeof req.query.prompt === "string" ? req.query.prompt : undefined;
+      const loginUrl = await authService.buildLoginUrl(req, returnTo, { prompt });
       res.redirect(302, loginUrl);
     }
     catch (err)

--- a/apps/fleet-operator/src/infra/zitadel/zitadel-client.ts
+++ b/apps/fleet-operator/src/infra/zitadel/zitadel-client.ts
@@ -259,6 +259,13 @@ export class _HttpZitadelManagementClient implements ZitadelManagementClient
         roleKeys: ["admin"],
       }, orgId);
 
+      // Grant the master ORG_OWNER rights so they can invite team members
+      // from within their new Zitadel organization.
+      await this._call("POST", "/management/v1/orgs/me/members", {
+        userId: input.masterSubject,
+        roles: ["ORG_OWNER"],
+      }, orgId);
+
       _log.info({ orgId, projectId, appId: app.appId, orgName: input.orgName, redirectUriCount: redirectUris.length }, "provisioned Zitadel org for ClusterTenant");
       return { orgId, projectId, appId: app.appId, clientId: app.clientId, redirectUri: input.redirectUri };
     }

--- a/apps/fleet-operator/src/openapi/spec.ts
+++ b/apps/fleet-operator/src/openapi/spec.ts
@@ -1037,6 +1037,7 @@ export const spec = {
         security: [],
         parameters: [
           { name: "returnTo", in: "query", schema: { type: "string" }, description: "Path to redirect back to after a successful login." },
+          { name: "prompt", in: "query", schema: { type: "string" }, description: "OIDC prompt value. Pass \"create\" to show the Zitadel registration form instead of login." },
         ],
         responses: {
           302: { description: "Redirect to identity provider." },

--- a/libs/contracts/src/generated/fleet-api.ts
+++ b/libs/contracts/src/generated/fleet-api.ts
@@ -1241,6 +1241,8 @@ export interface operations {
             query?: {
                 /** @description Path to redirect back to after a successful login. */
                 returnTo?: string;
+                /** @description OIDC prompt value. Pass "create" to show the Zitadel registration form instead of login. */
+                prompt?: string;
             };
             header?: never;
             path?: never;

--- a/libs/infra-auth/src/oidc-service.ts
+++ b/libs/infra-auth/src/oidc-service.ts
@@ -226,7 +226,7 @@ export abstract class OidcAuthServiceBase
   }
 
   /** Build the provider redirect URL and persist PKCE state in the local session. */
-  async buildLoginUrl(req: Request, returnTo: string): Promise<string>
+  async buildLoginUrl(req: Request, returnTo: string, options?: { prompt?: string }): Promise<string>
   {
     // 1. Resolve which OIDC client + scope to authorize against (base = masters client).
     const login = await this.resolveLoginClient(req);
@@ -256,6 +256,7 @@ export abstract class OidcAuthServiceBase
       code_challenge_method: "S256",
       state,
       nonce,
+      ...(options?.prompt ? { prompt: options.prompt } : {}),
     });
 
     return loginUrl.href;


### PR DESCRIPTION
#122 

# Changes:
- OIDC Prompt Parameter Support: Added support for passing an OIDC `prompt` query parameter to the `GET /auth/login` route in the fleet-operator (and the underlying `OidcAuthServiceBase`). This allows the frontend to trigger specific IdP flows, such as `prompt=create` to render Zitadel's hosted registration form for the new self-serve onboarding funnel.
- Zitadel ORG_OWNER Provisioning Grant: Updated the `ZitadelManagementClient.provisionOrg` method to explicitly grant the `ORG_OWNER` role to the master user inside their newly created tenant organization. This ensures the tenant admin has the correct permissions to natively invite team members via the Zitadel Console.
- OpenAPI Specification Update: Documented the new optional `prompt` query parameter on the `/auth/login` route in the fleet-manager OpenAPI spec.

# Files Changed:
- `apps/fleet-operator/src/infra/auth/auth.router.ts`
- `libs/infra-auth/src/oidc-service.ts`
- `apps/fleet-operator/src/infra/zitadel/zitadel-client.ts`
- `apps/fleet-operator/src/__tests__/zitadel/zitadel-client.test.ts`
- `apps/fleet-operator/src/openapi/spec.ts`
- `apps/fleet-operator/openapi.json`

# Testing:
Executed `pnpm --filter @opencrane/infra-auth build` and `pnpm --filter @opencrane/fleet-operator build`, verifying that the typescript compilation succeeds and the OpenAPI specification is successfully generated.
