### PR TITLE
feat(memory): make OpenClaw use Cognee as its org-memory engine

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/contract/tools-markdown.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/contract/tools-markdown.test.ts
@@ -39,6 +39,7 @@ describe("_RenderToolsMarkdown", function _suite()
 		const withMemory = _RenderToolsMarkdown([], [], { orgMemory: true });
 		expect(withMemory).toContain("## Org memory (Cognee)");
 		expect(withMemory).toContain("**memory_search**");
+		expect(withMemory).toContain("**memory_remember**");
 		expect(withMemory.endsWith("\n")).toBe(true);
 	});
 

--- a/apps/clustertenant-operator/src/__tests__/contract/tools-markdown.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/contract/tools-markdown.test.ts
@@ -30,6 +30,18 @@ describe("_RenderToolsMarkdown", function _suite()
 		expect(md).toContain("No skills are currently entitled.");
 	});
 
+	it("omits the org-memory section by default and includes it when Cognee is wired", function _orgMemory()
+	{
+		const without = _RenderToolsMarkdown([], []);
+		expect(without).not.toContain("Org memory (Cognee)");
+		expect(without).not.toContain("memory_search");
+
+		const withMemory = _RenderToolsMarkdown([], [], { orgMemory: true });
+		expect(withMemory).toContain("## Org memory (Cognee)");
+		expect(withMemory).toContain("**memory_search**");
+		expect(withMemory.endsWith("\n")).toBe(true);
+	});
+
 	it("is deterministic and ends with a trailing newline", function _deterministic()
 	{
 		const a = _RenderToolsMarkdown([{ id: "1", name: "B", description: "x" }, { id: "2", name: "A", description: "y" }], []);

--- a/apps/clustertenant-operator/src/__tests__/fixtures.ts
+++ b/apps/clustertenant-operator/src/__tests__/fixtures.ts
@@ -45,6 +45,7 @@ export const defaultConfig: OpenClawTenantOperatorConfig = {
   liteLlmDefaultRpmLimit: 0,
   mcpGatewayUrl: "http://opencrane-mcp-gateway.default.svc:8080",
   skillRegistryUrl: "http://opencrane-skill-registry.default.svc:5000",
+  cogneeEndpoint: "",
   internalPort: 8081,
   controlPlaneInternalUrl: "http://localhost:8081",
   controlPlaneInternalServiceUrl: "http://opencrane-clustertenant-manager.default.svc:8081",

--- a/apps/clustertenant-operator/src/__tests__/runtime-planes/drift-repairer.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/runtime-planes/drift-repairer.test.ts
@@ -43,6 +43,7 @@ function _buildConfig(overrides: Partial<OpenClawTenantOperatorConfig> = {}): Op
     liteLlmDefaultRpmLimit: 0,
     mcpGatewayUrl: "http://obot:8080",
     skillRegistryUrl: "http://skill-registry:5000",
+    cogneeEndpoint: "",
     internalPort: 8081,
     controlPlaneInternalUrl: "http://localhost:8081",
     controlPlaneInternalServiceUrl: "http://control-plane:8081",

--- a/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -45,6 +45,15 @@ describe("openclaw.json render contract — zod schema (task_d611ab4d)", functio
     expect(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error?.issues, null, 2)).toBe(true);
   });
 
+  it("validates the Cognee-wired config (mcp.servers block) against the schema", function _mcpOk()
+  {
+    // Exercise the optional `mcp` branch so the local org-memory stdio server shape is covered.
+    const cogneeConfig = { ...defaultConfig, cogneeEndpoint: "http://cognee:8000" };
+    const configMap = _BuildConfigMap(cogneeConfig, _makeTenant("contract"), "default");
+    const parsed = _OpenclawConfigSchema.safeParse(JSON.parse(configMap.data?.["openclaw.json"] ?? "{}"));
+    expect(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error?.issues, null, 2)).toBe(true);
+  });
+
   it("never leaks the internal trustNothing flag into the gateway block", function _noTrustNothing()
   {
     // The exact f6afafd regression: trustNothing is operator-internal, not an

--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -220,6 +220,11 @@ describe("TenantResourceBuilder", () =>
     expect(data["TOOLS.md"]).toContain("OPENCRANE_MCP_GATEWAY_URL");
     expect(data["TOOLS.md"]).toContain("OPENCRANE_SKILL_REGISTRY_URL");
 
+    // Both platform docs must make the agent AWARE of the Cognee org-memory layer.
+    expect(data["AGENTS.md"]).toContain("OPENCRANE_MEMORY_BACKEND");
+    expect(data["AGENTS.md"]).toContain("Cognee");
+    expect(data["TOOLS.md"]).toContain("Org Memory (Cognee)");
+
     // L2 seed files must have non-empty content.
     expect(data["SOUL.md.seed"]!.length).toBeGreaterThan(0);
     expect(data["IDENTITY.md.seed"]!.length).toBeGreaterThan(0);
@@ -241,6 +246,75 @@ describe("TenantResourceBuilder", () =>
     expect(runtimeContract.policy.mcpServers).toBeUndefined();
     expect(runtimeContract.mcp.servers).toEqual([]);
     expect(runtimeContract.skills.entitled).toEqual([]);
+  });
+
+  it("advertises workspace-only org memory when Cognee is not configured", () =>
+  {
+    const tenant = _makeTenant("no-cognee");
+    const configMap = _BuildConfigMap(defaultConfig, tenant, "default");
+    const runtimeContract = JSON.parse(configMap.data?.["opencrane-managed-runtime.json"] ?? "{}");
+
+    // Cognee-less deployment: the contract must declare the workspace fallback and carry no endpoint.
+    expect(runtimeContract.memory).toEqual({ backend: "workspace" });
+  });
+
+  it("advertises the Cognee org-memory backend when configured", () =>
+  {
+    const cogneeConfig = { ...defaultConfig, cogneeEndpoint: "http://cognee:8000" };
+    const tenant = _makeTenant("with-cognee");
+    const configMap = _BuildConfigMap(cogneeConfig, tenant, "default");
+    const runtimeContract = JSON.parse(configMap.data?.["opencrane-managed-runtime.json"] ?? "{}");
+
+    expect(runtimeContract.memory.backend).toBe("cognee");
+    expect(runtimeContract.memory.endpoint).toBe("http://cognee:8000");
+    // Stamped so the pod's awareness client can reason about contract skew.
+    expect(typeof runtimeContract.memory.contractVersion).toBe("string");
+  });
+
+  it("registers the local org-memory MCP server only when Cognee is configured", () =>
+  {
+    const tenant = _makeTenant("mcp-mem");
+
+    // Unset ⇒ no mcp block leaks into openclaw.json (byte-for-byte unchanged path).
+    const bare = JSON.parse(_BuildConfigMap(defaultConfig, tenant, "default").data?.["openclaw.json"] ?? "{}");
+    expect(bare.mcp).toBeUndefined();
+
+    // Configured ⇒ OpenClaw is told to spawn the local org-memory server over stdio.
+    const cogneeConfig = { ...defaultConfig, cogneeEndpoint: "http://cognee:8000" };
+    const wired = JSON.parse(_BuildConfigMap(cogneeConfig, tenant, "default").data?.["openclaw.json"] ?? "{}");
+    expect(wired.mcp.servers["org-memory"]).toEqual({ command: "node", args: ["/opt/org-memory-mcp/dist/index.js"] });
+  });
+
+  it("preserves a tenant's own mcp.servers while forcing org-memory in", () =>
+  {
+    const cogneeConfig = { ...defaultConfig, cogneeEndpoint: "http://cognee:8000" };
+    const tenant = _makeTenant("mcp-merge", {
+      configOverrides: { mcp: { servers: { custom: { command: "true", args: [] } } } },
+    });
+    const cfg = JSON.parse(_BuildConfigMap(cogneeConfig, tenant, "default").data?.["openclaw.json"] ?? "{}");
+
+    // Tenant server survives, and the platform org-memory server is merged in on top.
+    expect(cfg.mcp.servers.custom).toEqual({ command: "true", args: [] });
+    expect(cfg.mcp.servers["org-memory"].args).toEqual(["/opt/org-memory-mcp/dist/index.js"]);
+  });
+
+  it("injects the Cognee org-memory env only when configured", () =>
+  {
+    const cogneeConfig = { ...defaultConfig, cogneeEndpoint: "http://cognee:8000" };
+    const tenant = _makeTenant("cognee-env");
+    const stateVolume = onPremAdapter.buildStateVolume("cognee-env");
+
+    // Unset ⇒ no Cognee env leaks into the pod (byte-for-byte unchanged path).
+    const bare = _BuildDeployment(defaultConfig, stateVolume, tenant, "default");
+    const bareEnv = Object.fromEntries((bare.spec?.template?.spec?.containers?.[0]?.env ?? []).map((e) => [e.name ?? "", e.value ?? ""]));
+    expect(bareEnv.COGNEE_ENDPOINT).toBeUndefined();
+    expect(bareEnv.OPENCRANE_MEMORY_BACKEND).toBeUndefined();
+
+    // Configured ⇒ both the endpoint and the explicit backend signal are injected.
+    const wired = _BuildDeployment(cogneeConfig, stateVolume, tenant, "default");
+    const wiredEnv = Object.fromEntries((wired.spec?.template?.spec?.containers?.[0]?.env ?? []).map((e) => [e.name ?? "", e.value ?? ""]));
+    expect(wiredEnv.COGNEE_ENDPOINT).toBe("http://cognee:8000");
+    expect(wiredEnv.OPENCRANE_MEMORY_BACKEND).toBe("cognee");
   });
 
   it("builds Deployment with PVC volume on-prem", () =>

--- a/apps/clustertenant-operator/src/config.ts
+++ b/apps/clustertenant-operator/src/config.ts
@@ -152,6 +152,16 @@ export interface OpenClawTenantOperatorConfig
   skillRegistryUrl: string;
 
   /**
+   * In-cluster per-tenant Cognee base URL (e.g. `http://cognee:8000`), injected into tenant
+   * pods as `COGNEE_ENDPOINT` so the OpenClaw runtime's `@opencrane/awareness` org-memory client
+   * can retrieve org context directly (no control-plane mediation in the hot path — see
+   * `libs/awareness`). Empty string ⇒ Cognee is not wired into the pod and the runtime falls back
+   * to workspace-file memory only; this mirrors the control-plane's "skip when unset" grant-sync
+   * behaviour so a Cognee-less deployment stays byte-for-byte unchanged.
+   */
+  cogneeEndpoint: string;
+
+  /**
    * The operator's OWN in-pod internal API base — the second (internal) listener. Used by the
    * operator's reconcile fetches (tenant-models). Defaults to `http://localhost:<internalPort>`;
    * the internal routes are NOT on the public listener, so this must target the internal port.
@@ -265,6 +275,7 @@ export function _LoadOperatorConfig(): OpenClawTenantOperatorConfig
     defaultTenantPolicyRef: _readEnvValue<string>("DEFAULT_TENANT_POLICY_REF", "string", false, ""),
     mcpGatewayUrl: _readEnvValue<string>("MCP_GATEWAY_URL", "string", false, `http://opencrane-mcp-gateway.${ownNamespace}.svc:8080`),
     skillRegistryUrl: _readEnvValue<string>("SKILL_REGISTRY_URL", "string", false, `http://opencrane-skill-registry.${ownNamespace}.svc:5000`),
+    cogneeEndpoint: _readEnvValue<string>("COGNEE_ENDPOINT", "string", false, ""),
     internalPort: _readEnvValue<number>("INTERNAL_PORT", "number", false, 8081),
     controlPlaneInternalUrl: _readEnvValue<string>("CLUSTERTENANT_MANAGER_INTERNAL_URL", "string", false, "http://localhost:8081"),
     controlPlaneInternalServiceUrl: _readEnvValue<string>("CLUSTERTENANT_MANAGER_INTERNAL_SERVICE_URL", "string", false, `http://opencrane-clustertenant-manager.${ownNamespace}.svc:8081`),

--- a/apps/clustertenant-operator/src/core/contract/tools-markdown.ts
+++ b/apps/clustertenant-operator/src/core/contract/tools-markdown.ts
@@ -60,6 +60,10 @@ const _ORG_MEMORY_SECTION = [
     "directly (not via the Obot gateway), so it is always available. Results are scope-aware, " +
     "permission-filtered, and every one carries a citation. Prefer it over personal MEMORY.md " +
     "for org-wide facts.",
+  "- **memory_remember** — persist a generalizable learning back to org memory (`content`, " +
+    "`title`, `scope`, optional `subject`/`sensitivityTags`). Use for durable org/domain facts " +
+    "other agents would want — NOT personal style, this user's preferences, or transient task " +
+    "state (those stay in MEMORY.md). Remembered facts are attributed to you.",
 ].join("\n");
 
 /** Options controlling optional sections of the generated `TOOLS.md`. */

--- a/apps/clustertenant-operator/src/core/contract/tools-markdown.ts
+++ b/apps/clustertenant-operator/src/core/contract/tools-markdown.ts
@@ -47,15 +47,39 @@ function _renderSection(title: string, entries: ToolEntry[], emptyNote: string):
 }
 
 /**
+ * The org-memory section, emitted when Cognee is wired for the fleet. Describes the
+ * always-available local `memory_search` tool so the contract-derived TOOLS.md keeps
+ * the agent aware of its org memory — otherwise the poll loop's regenerated doc would
+ * silently drop the section the static L0 template carries.
+ */
+const _ORG_MEMORY_SECTION = [
+  "## Org memory (Cognee)",
+  "",
+  "- **memory_search** — retrieve organisational memory (company documents, prior decisions, " +
+    "project facts) from the Cognee knowledge graph. A local, in-pod tool that queries Cognee " +
+    "directly (not via the Obot gateway), so it is always available. Results are scope-aware, " +
+    "permission-filtered, and every one carries a citation. Prefer it over personal MEMORY.md " +
+    "for org-wide facts.",
+].join("\n");
+
+/** Options controlling optional sections of the generated `TOOLS.md`. */
+export interface RenderToolsOptions
+{
+  /** Emit the org-memory (`memory_search`) section — set when Cognee is wired for the fleet. */
+  orgMemory?: boolean;
+}
+
+/**
  * Render the tenant's `TOOLS.md` workspace doc from its entitled MCP servers and
  * skills. Pure and deterministic: identical inputs always produce identical output
  * so the in-pod content diff only fires on a real entitlement change.
  *
  * @param servers - Entitled MCP servers (allow-decided by the grant compiler).
  * @param skills  - Entitled skill bundles (allow-decided by the grant compiler).
+ * @param options - Optional sections (e.g. org memory when Cognee is wired).
  * @returns The full `TOOLS.md` markdown document.
  */
-export function _RenderToolsMarkdown(servers: ToolEntry[], skills: ToolEntry[]): string
+export function _RenderToolsMarkdown(servers: ToolEntry[], skills: ToolEntry[], options: RenderToolsOptions = {}): string
 {
   // 1. MCP servers the agent may reach through the Obot gateway (allow-decided).
   const mcpSection = _renderSection("MCP servers", servers, "No MCP servers are currently entitled.");
@@ -63,6 +87,9 @@ export function _RenderToolsMarkdown(servers: ToolEntry[], skills: ToolEntry[]):
   // 2. Skills mounted into the agent workspace.
   const skillsSection = _renderSection("Skills", skills, "No skills are currently entitled.");
 
-  // 3. Assemble with a trailing newline so POSIX tools (and git) treat it as a text file.
-  return `${_PREAMBLE}\n\n${mcpSection}\n\n${skillsSection}\n`;
+  // 3. Org memory (local memory_search tool) — only when Cognee is wired for the fleet.
+  const orgMemorySection = options.orgMemory ? `\n\n${_ORG_MEMORY_SECTION}` : "";
+
+  // 4. Assemble with a trailing newline so POSIX tools (and git) treat it as a text file.
+  return `${_PREAMBLE}\n\n${mcpSection}\n\n${skillsSection}${orgMemorySection}\n`;
 }

--- a/apps/clustertenant-operator/src/routes/internal/tenant-contract.ts
+++ b/apps/clustertenant-operator/src/routes/internal/tenant-contract.ts
@@ -181,7 +181,9 @@ export function _RegisterInternalTenantContract(prisma: PrismaClient, authApi: k
       // 7. Render the contract-derived TOOLS.md (L1 workspace doc). The entrypoint
       //    poll loop writes this over the workspace file and SIGHUPs OpenClaw, so a
       //    grant/deny reflects in the agent's tool list within one poll interval.
-      const toolsMarkdown = _RenderToolsMarkdown(mcpServers, skillBundles);
+      //    The org-memory section is included when Cognee is wired for the fleet, so the
+      //    regenerated doc keeps the agent aware of its always-available `memory_search` tool.
+      const toolsMarkdown = _RenderToolsMarkdown(mcpServers, skillBundles, { orgMemory: Boolean(process.env.COGNEE_ENDPOINT?.trim()) });
 
       // 7b. Resolve approved L2 personalisation docs (P4C.5). Unlike TOOLS.md
       //     (platform-owned, re-applied every poll), these are tenant-editable, so

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -8,6 +8,7 @@ import type { OpenClawTenantOperatorConfig } from "../../config.js";
 import type { AccessPolicy } from "../../policies/types.js";
 import type { Tenant } from "../models/tenant.interface.js";
 import type { TenantModelSet } from "@opencrane/contracts";
+import { AWARENESS_CONTRACT_VERSION } from "@opencrane/awareness";
 import { _BuildTenantLabels } from "./tenant-labels.js";
 
 /** Directory containing the workspace template files shipped with the operator. */
@@ -30,6 +31,21 @@ const _WORKSPACE_PATH = "/data/openclaw/workspace";
  * name is relative to the provider), so only the *reference* — `agents.defaults.model` — is prefixed.
  */
 const _LITELLM_PROVIDER_ID = "litellm-proxy";
+
+/**
+ * The `mcp.servers` key OpenClaw registers the org-memory tool under. Mirrors
+ * `ORG_MEMORY_SERVER_NAME` in `@opencrane/org-memory-mcp` (duplicated as a plain
+ * string rather than imported, to avoid pulling the MCP SDK into the operator).
+ */
+const _ORG_MEMORY_SERVER_NAME = "org-memory";
+
+/**
+ * Absolute path to the org-memory MCP server baked into the tenant image
+ * (see `apps/tenant/deploy/Dockerfile`). OpenClaw spawns it over stdio and the
+ * process inherits the pod env — including `COGNEE_ENDPOINT` — so no per-server
+ * env block is needed.
+ */
+const _ORG_MEMORY_MCP_ENTRYPOINT = "/opt/org-memory-mcp/dist/index.js";
 
 /**
  * Turn a LiteLLM public model name into an OpenClaw model REFERENCE that routes through the proxy.
@@ -207,6 +223,26 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
       // Actual entitled skill index is fetched from effective-contract at runtime.
       entitled: [],
     },
+    // Org-memory backend advertised to the runtime. Cognee IS the platform memory engine — a
+    // settled dependency, not an option. When it is wired (COGNEE_ENDPOINT injected into the pod —
+    // see 3-deployment.ts), the OpenClaw runtime's `@opencrane/awareness` client retrieves org
+    // context DIRECTLY from its per-tenant Cognee knowledge graph — a first-class in-pod capability,
+    // NOT an MCP server, so it is deliberately outside the Obot-gateway "no direct MCP" boundary
+    // (retrieval has no control-plane mediation in the hot path by design). A `backend: "workspace"`
+    // value is NOT a supported mode — it marks a MISCONFIGURED pod (no Cognee wired), which the pod
+    // entrypoint surfaces as a startup warning; org memory is unavailable until an operator fixes it.
+    memory: config.cogneeEndpoint
+      ? {
+          backend: "cognee",
+          // Per-tenant Cognee base URL the awareness client retrieves from (also injected as
+          // the COGNEE_ENDPOINT env var). Datasets are scope-derived (`org`, `team/<subject>`, …)
+          // and access is enforced by the awareness grants the control-plane syncs to Cognee.
+          endpoint: config.cogneeEndpoint,
+          contractVersion: AWARENESS_CONTRACT_VERSION,
+        }
+      : {
+          backend: "workspace",
+        },
     capabilities: {
       liteLlmProxy: config.liteLlmEnabled,
       hostingProvider: config.hostingProvider,
@@ -259,6 +295,29 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
       },
     },
   };
+
+  // 5. Platform-owned org-memory tool — applied after the tenant merge so it cannot be
+  //    dropped by a `spec.configOverrides.mcp` override. When Cognee is wired, register the
+  //    LOCAL org-memory MCP server OpenClaw spawns over stdio (the binary is baked into the
+  //    tenant image at `_ORG_MEMORY_MCP_ENTRYPOINT`). This is a first-class in-pod capability,
+  //    NOT an Obot-gateway server — it talks directly to the per-tenant Cognee, so it lives in
+  //    `mcp.servers` here rather than in the effective-contract grant set. Any tenant-declared
+  //    mcp.servers are preserved; the org-memory entry is merged in on top so it is always present.
+  if (config.cogneeEndpoint)
+  {
+    const existingMcp = (merged["mcp"] as Record<string, unknown> | undefined) ?? {};
+    const existingServers = (existingMcp["servers"] as Record<string, unknown> | undefined) ?? {};
+    merged["mcp"] = {
+      ...existingMcp,
+      servers: {
+        ...existingServers,
+        [_ORG_MEMORY_SERVER_NAME]: {
+          command: "node",
+          args: [_ORG_MEMORY_MCP_ENTRYPOINT],
+        },
+      },
+    };
+  }
 
   return {
     apiVersion: "v1",

--- a/apps/clustertenant-operator/src/tenants/deploy/3-deployment.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/3-deployment.ts
@@ -70,6 +70,18 @@ export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolu
     { name: "TMPDIR", value: "/tmp" },
     { name: "NPM_CONFIG_CACHE", value: "/tmp/npm-cache" },
     ...(config.liteLlmEnabled ? [{ name: "LITELLM_ENDPOINT", value: config.liteLlmEndpoint }] : []),
+    // Org-memory backend. When Cognee is wired at the cluster level, the pod's `@opencrane/awareness`
+    // client retrieves org context DIRECTLY from its per-tenant Cognee (no control-plane mediation in
+    // the hot path — see libs/awareness). `OPENCRANE_MEMORY_BACKEND=cognee` is the explicit signal the
+    // runtime/workspace docs key off; both are injected only when configured so a Cognee-less
+    // deployment renders byte-for-byte unchanged and the runtime cleanly falls back to workspace-file
+    // memory (the docs treat an unset backend as `workspace`).
+    ...(config.cogneeEndpoint
+      ? [
+          { name: "OPENCRANE_MEMORY_BACKEND", value: "cognee" },
+          { name: "COGNEE_ENDPOINT", value: config.cogneeEndpoint },
+        ]
+      : []),
     ...(tenant.spec.team ? [{ name: "OPENCRANE_TEAM", value: tenant.spec.team }] : []),
     ...(tenant.spec.policyRef ? [{ name: "OPENCRANE_POLICY_REF", value: tenant.spec.policyRef }] : []),
     // Gateway auth is trusted-proxy (OC-2 / CONN.4), configured in openclaw.json

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -168,6 +168,38 @@ const _agentsSchema = z
   .passthrough();
 
 /**
+ * A single `mcp.servers` entry. INFERRED shape (docs: configuration-reference): a LOCAL
+ * server uses `command` + `args` (stdio transport); a REMOTE server uses `url` + `transport`
+ * ("streamable-http"/"sse"). Common optional fields (headers, toolFilter, timeouts) are tolerated
+ * via `.passthrough()` rather than pinned. The operator only emits the local `command`/`args` form
+ * (the org-memory server OpenClaw spawns over stdio — see 2-config-map.ts).
+ */
+const _mcpServerSchema = z
+  .object({
+    /** Executable to spawn for a local stdio server (e.g. `node`). */
+    command: z.string().optional(),
+    /** Arguments for the spawned local server. */
+    args: z.array(z.string()).optional(),
+    /** Endpoint URL for a remote server. */
+    url: z.string().optional(),
+    /** Remote transport kind. */
+    transport: z.enum(["streamable-http", "sse"]).optional(),
+  })
+  .passthrough();
+
+/**
+ * MCP block. Optional (present only when the operator wires a local server such as org-memory).
+ * `.passthrough()` at the block level tolerates any sibling MCP keys OpenClaw accepts; the server
+ * map is `id → entry`.
+ */
+const _mcpSchema = z
+  .object({
+    /** Server id → server config map. */
+    servers: z.record(z.string(), _mcpServerSchema),
+  })
+  .passthrough();
+
+/**
  * Top-level `openclaw.json` schema for the operator-emitted config. `.passthrough()`
  * at the root tolerates tenant `configOverrides` adding non-platform top-level keys
  * (which is supported), while the nested `gateway` block stays `.strict()` — exactly
@@ -181,5 +213,7 @@ export const _OpenclawConfigSchema = z
     models: _modelsSchema.optional(),
     /** Agents block carrying the platform-pinned defaults. */
     agents: _agentsSchema,
+    /** Optional MCP block (present only when a local server such as org-memory is wired). */
+    mcp: _mcpSchema.optional(),
   })
   .passthrough();

--- a/apps/clustertenant-operator/src/tenants/deploy/workspace/AGENTS.md
+++ b/apps/clustertenant-operator/src/tenants/deploy/workspace/AGENTS.md
@@ -24,11 +24,18 @@ You are running inside **OpenCrane**, a managed multi-tenant AI-agent platform.
 You have **two distinct memory layers** — use the right one:
 
 - **Personal memory** — the workspace files `MEMORY.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`.
-  Your own curated, durable notes, persona, and learned patterns. Private to you, edited by
-  writing the files. This is the right place for *your* preferences, decisions, and working style.
+  Your persona, your notes on *this* user, your working style, and transient task state. Private
+  to you, edited by writing the files. What belongs here is anything *about you, this user, or how
+  you work* that has **no external source of truth**. What does NOT belong: org/company facts,
+  bulk data, secrets (use `/data/secrets`), or anything another agent would need.
 - **Org memory** — a **Cognee-backed knowledge graph** shared across the organisation, holding
   harvested company documents, prior decisions, and project facts. This is the authoritative
   source for org-wide context — do NOT reconstruct it from personal notes.
+
+**Which layer?** Ask: is this fact *about the org* (another agent would want it / it has a
+system-of-record)? → org memory. Is it *about me, this user, or how I work* (private, no external
+source)? → personal memory. A **generalizable learning** (e.g. "the deploy needs `helm dep build`")
+is org memory — promote it up with `memory_remember`, don't strand it in `MEMORY.md`.
 
 Your org memory **is** Cognee: `OPENCRANE_MEMORY_BACKEND` is `cognee` and its endpoint is in
 `COGNEE_ENDPOINT` (see also `memory` in your runtime contract). You reach it through the
@@ -38,8 +45,12 @@ exempt from the "do not connect to MCP servers directly" rule above, which gover
 gateway-entitled servers). Retrieval is scope-aware and permission-filtered by the platform: you
 only ever see datasets your tenant is granted, and every returned fact carries a citation. Prefer
 `memory_search` over your personal `MEMORY.md` for company documents, prior decisions, and project
-facts. Cognee is a settled platform dependency, not an option — if it is ever missing at startup
-the runtime logs a warning and `memory_search` is unavailable until an operator fixes it.
+facts. To PERSIST a generalizable learning back to org memory, use the **`memory_remember`** tool
+(same local server): give it the fact, a short title, and the narrowest fitting scope
+(`org`/`team`/`department`/`project`/`personal`) — it is stored attributed to you and becomes
+retrievable by other agents. Cognee is a settled platform dependency, not an option — if it is ever
+missing at startup the runtime logs a warning and these tools are unavailable until an operator
+fixes it.
 
 ## Workspace Ownership
 

--- a/apps/clustertenant-operator/src/tenants/deploy/workspace/AGENTS.md
+++ b/apps/clustertenant-operator/src/tenants/deploy/workspace/AGENTS.md
@@ -19,6 +19,28 @@ You are running inside **OpenCrane**, a managed multi-tenant AI-agent platform.
 - **State**: Your persistent workspace lives at `/data/openclaw`. It survives pod restarts.
 - **Secrets**: Personal API keys live in `/data/secrets` (ephemeral — re-enter after restart).
 
+## Memory
+
+You have **two distinct memory layers** — use the right one:
+
+- **Personal memory** — the workspace files `MEMORY.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`.
+  Your own curated, durable notes, persona, and learned patterns. Private to you, edited by
+  writing the files. This is the right place for *your* preferences, decisions, and working style.
+- **Org memory** — a **Cognee-backed knowledge graph** shared across the organisation, holding
+  harvested company documents, prior decisions, and project facts. This is the authoritative
+  source for org-wide context — do NOT reconstruct it from personal notes.
+
+Your org memory **is** Cognee: `OPENCRANE_MEMORY_BACKEND` is `cognee` and its endpoint is in
+`COGNEE_ENDPOINT` (see also `memory` in your runtime contract). You reach it through the
+**`memory_search`** tool — a platform-provided, in-pod memory server that queries Cognee
+**directly**. It is a local capability and does NOT route through the Obot MCP gateway (so it is
+exempt from the "do not connect to MCP servers directly" rule above, which governs the
+gateway-entitled servers). Retrieval is scope-aware and permission-filtered by the platform: you
+only ever see datasets your tenant is granted, and every returned fact carries a citation. Prefer
+`memory_search` over your personal `MEMORY.md` for company documents, prior decisions, and project
+facts. Cognee is a settled platform dependency, not an option — if it is ever missing at startup
+the runtime logs a warning and `memory_search` is unavailable until an operator fixes it.
+
 ## Workspace Ownership
 
 | File | Owned by | Editable? |

--- a/apps/clustertenant-operator/src/tenants/deploy/workspace/TOOLS.md
+++ b/apps/clustertenant-operator/src/tenants/deploy/workspace/TOOLS.md
@@ -29,6 +29,11 @@ personal `MEMORY.md` for company documents, prior decisions, and project facts.
 `memory_search` takes a natural-language `query` (plus optional `datasets` scopes and `limit`) and
 returns cited results.
 
+To persist a generalizable learning back to org memory, use **`memory_remember`** (`content`,
+`title`, `scope`, optional `subject`/`sensitivityTags`). Use it for durable org/domain facts and
+decisions other agents would want — NOT for your personal style, this user's preferences, or
+transient task state (those stay in `MEMORY.md`). Remembered facts are attributed to you.
+
 If the runtime starts up without Cognee wired, that is a **misconfiguration**, not a fallback:
 the pod logs a startup warning and org memory is unavailable until an operator fixes it.
 

--- a/apps/clustertenant-operator/src/tenants/deploy/workspace/TOOLS.md
+++ b/apps/clustertenant-operator/src/tenants/deploy/workspace/TOOLS.md
@@ -16,7 +16,26 @@ Skills are fetched from `OPENCRANE_SKILL_REGISTRY_URL`.
 
 Your entitled skills are listed in your runtime contract (`skills.entitled`).
 
-## LiteLLM Proxy (if enabled)
+## Org Memory (Cognee)
 
-When `LITELLM_ENDPOINT` is set, model requests route through the LiteLLM proxy.
-Configure your preferred model via `LITELLM_ENDPOINT`.
+Your organisation's shared long-term memory **is** a Cognee knowledge graph at `COGNEE_ENDPOINT`
+(`OPENCRANE_MEMORY_BACKEND` is `cognee`; see also `memory` in your runtime contract). You query it
+with the **`memory_search`** tool — a platform-provided, in-pod memory server that talks to Cognee
+**directly**. It is a local tool and does NOT route through the Obot MCP gateway, so it is always
+available regardless of your gateway entitlements. Retrieval is scope-aware and permission-filtered
+by the platform, and every returned fact carries a citation. Prefer `memory_search` over your
+personal `MEMORY.md` for company documents, prior decisions, and project facts.
+
+`memory_search` takes a natural-language `query` (plus optional `datasets` scopes and `limit`) and
+returns cited results.
+
+If the runtime starts up without Cognee wired, that is a **misconfiguration**, not a fallback:
+the pod logs a startup warning and org memory is unavailable until an operator fixes it.
+
+## LiteLLM Proxy
+
+All model requests route through the LiteLLM proxy at `LITELLM_ENDPOINT` — this is the only path to
+a model (the proxy meters usage and applies the BYOK upstream key). Select your model as normal;
+the platform pins the effective default. If the runtime starts up without `LITELLM_ENDPOINT`, that
+is a **misconfiguration**, not a fallback: the pod logs a startup warning and model calls fail
+until an operator fixes it.

--- a/apps/org-memory-mcp/package.json
+++ b/apps/org-memory-mcp/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@opencrane/org-memory-mcp",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-or-later",
+  "type": "module",
+  "bin": {
+    "org-memory-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@opencrane/awareness": "workspace:*",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.1.0"
+  }
+}

--- a/apps/org-memory-mcp/src/__tests__/server.test.ts
+++ b/apps/org-memory-mcp/src/__tests__/server.test.ts
@@ -5,8 +5,10 @@ import { AwarenessClient } from "@opencrane/awareness";
 import type { CogneeSearchHit, CogneeSearchTransport } from "@opencrane/awareness";
 
 import { _FormatAwarenessResult } from "../format.js";
-import { _BuildAwarenessClientFromEnv } from "../memory-tools.js";
+import { _BuildAwarenessClientFromEnv, _BuildMemoryWriterFromEnv } from "../memory-tools.js";
 import { _BuildOrgMemoryServer } from "../server.js";
+import { MemoryWriter, _ResolveDatasetName } from "../memory-write.js";
+import type { CogneeAddPayload } from "../memory-write.js";
 
 /** Build a fake Cognee transport returning fixed rows, so tests need no live backend. */
 function _fakeTransport(rows: CogneeSearchHit[]): CogneeSearchTransport
@@ -30,14 +32,33 @@ const _citableRow: CogneeSearchHit = {
 const _uncitableRow: CogneeSearchHit = { content: "orphan fact", metadata: {} };
 
 /** Wire a Client to a freshly-built org-memory server over an in-memory transport pair. */
-async function _connectClient(client: AwarenessClient): Promise<Client>
+async function _connectClient(client: AwarenessClient, writer?: MemoryWriter): Promise<Client>
 {
-  const server = _BuildOrgMemoryServer(client);
+  const server = _BuildOrgMemoryServer({ client, writer });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
   const mcpClient = new Client({ name: "test", version: "0.0.0" });
   await mcpClient.connect(clientTransport);
   return mcpClient;
+}
+
+/** A read client that returns nothing — sufficient when the test only exercises writes. */
+function _emptyReadClient(): AwarenessClient
+{
+  return new AwarenessClient({ cogneeEndpoint: "http://cognee:8000", search: _fakeTransport([]) });
+}
+
+/** A MemoryWriter over a capturing add transport, plus the array it records payloads into. */
+function _capturingWriter(owner = "acme"): { writer: MemoryWriter; captured: CogneeAddPayload[] }
+{
+  const captured: CogneeAddPayload[] = [];
+  const writer = new MemoryWriter({
+    endpoint: "http://cognee:8000",
+    owner,
+    add: async function _add(_endpoint, payload) { captured.push(payload); },
+    now: () => new Date("2026-07-03T00:00:00.000Z"),
+  });
+  return { writer, captured };
 }
 
 describe("_BuildAwarenessClientFromEnv", function _envSuite()
@@ -111,5 +132,105 @@ describe("org-memory MCP surface", function _mcpSuite()
     expect(res.isError).toBe(true);
     const text = (res.content as Array<{ type: string; text?: string }>).map((c) => c.text ?? "").join("\n");
     expect(text).toContain("Org-memory search failed: cognee unreachable");
+  });
+});
+
+describe("_ResolveDatasetName", function _datasetSuite()
+{
+  it("maps org to the bare 'org' dataset", function _org()
+  {
+    expect(_ResolveDatasetName("org", undefined, "acme")).toBe("org");
+  });
+
+  it("composes scope/subject for team/department/project", function _scoped()
+  {
+    expect(_ResolveDatasetName("team", "platform", "acme")).toBe("team/platform");
+    expect(_ResolveDatasetName("project", "opencrane", "acme")).toBe("project/opencrane");
+  });
+
+  it("requires a subject for team/department/project", function _requiresSubject()
+  {
+    expect(() => _ResolveDatasetName("team", undefined, "acme")).toThrow(/team scope requires a subject/);
+  });
+
+  it("defaults personal scope to the owner", function _personal()
+  {
+    expect(_ResolveDatasetName("personal", undefined, "acme")).toBe("personal/acme");
+    expect(_ResolveDatasetName("personal", "alice", "acme")).toBe("personal/alice");
+  });
+});
+
+describe("_BuildMemoryWriterFromEnv", function _writerEnvSuite()
+{
+  it("returns a writer by default when Cognee is set", function _default()
+  {
+    expect(_BuildMemoryWriterFromEnv({ COGNEE_ENDPOINT: "http://cognee:8000" })).toBeInstanceOf(MemoryWriter);
+  });
+
+  it("returns null when writes are disabled by the kill-switch", function _disabled()
+  {
+    expect(_BuildMemoryWriterFromEnv({ COGNEE_ENDPOINT: "http://cognee:8000", ORG_MEMORY_WRITE_ENABLED: "false" })).toBeNull();
+  });
+
+  it("throws when COGNEE_ENDPOINT is missing (and writes enabled)", function _missing()
+  {
+    expect(() => _BuildMemoryWriterFromEnv({})).toThrow(/COGNEE_ENDPOINT is required/);
+  });
+});
+
+describe("org-memory write surface", function _writeSuite()
+{
+  it("stamps provenance + freshness when remembering a fact", async function _provenance()
+  {
+    const { writer, captured } = _capturingWriter("acme");
+    await writer.remember({ content: "Deploy uses helm dep build", title: "Deploy note", scope: "team", subject: "platform", sensitivityTags: ["internal"] });
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].dataset_name).toBe("team/platform");
+    expect(captured[0].data).toBe("Deploy uses helm dep build");
+    expect(captured[0].metadata).toMatchObject({
+      source: "agent-remember",
+      acl_origin: "agent",
+      owner: "acme",
+      title: "Deploy note",
+      scope: "team",
+      subject: "platform",
+      sensitivity_tags: ["internal"],
+      source_updated_at: "2026-07-03T00:00:00.000Z",
+      freshness_recorded_at: "2026-07-03T00:00:00.000Z",
+    });
+  });
+
+  it("does NOT register memory_remember when no writer is supplied (read-only pod)", async function _readOnly()
+  {
+    const mcpClient = await _connectClient(_emptyReadClient());
+    const names = (await mcpClient.listTools()).tools.map((t) => t.name);
+    expect(names).toContain("memory_search");
+    expect(names).not.toContain("memory_remember");
+  });
+
+  it("persists a fact through a memory_remember MCP call", async function _remembers()
+  {
+    const { writer, captured } = _capturingWriter("acme");
+    const mcpClient = await _connectClient(_emptyReadClient(), writer);
+
+    const names = (await mcpClient.listTools()).tools.map((t) => t.name);
+    expect(names).toContain("memory_remember");
+
+    const res = await mcpClient.callTool({ name: "memory_remember", arguments: { content: "fact", title: "T", scope: "org" } });
+    const text = (res.content as Array<{ type: string; text?: string }>).map((c) => c.text ?? "").join("\n");
+    expect(res.isError).toBeFalsy();
+    expect(text).toContain("Remembered to org memory (dataset: org)");
+    expect(captured[0].dataset_name).toBe("org");
+  });
+
+  it("returns a tool error (not a crash) when a scoped remember omits its subject", async function _missingSubject()
+  {
+    const { writer } = _capturingWriter("acme");
+    const mcpClient = await _connectClient(_emptyReadClient(), writer);
+    const res = await mcpClient.callTool({ name: "memory_remember", arguments: { content: "fact", title: "T", scope: "team" } });
+    expect(res.isError).toBe(true);
+    const text = (res.content as Array<{ type: string; text?: string }>).map((c) => c.text ?? "").join("\n");
+    expect(text).toContain("team scope requires a subject");
   });
 });

--- a/apps/org-memory-mcp/src/__tests__/server.test.ts
+++ b/apps/org-memory-mcp/src/__tests__/server.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { AwarenessClient } from "@opencrane/awareness";
+import type { CogneeSearchHit, CogneeSearchTransport } from "@opencrane/awareness";
+
+import { _FormatAwarenessResult } from "../format.js";
+import { _BuildAwarenessClientFromEnv } from "../memory-tools.js";
+import { _BuildOrgMemoryServer } from "../server.js";
+
+/** Build a fake Cognee transport returning fixed rows, so tests need no live backend. */
+function _fakeTransport(rows: CogneeSearchHit[]): CogneeSearchTransport
+{
+  return async function _search() { return rows; };
+}
+
+/** A citable hit (complete metadata → survives the SDK citation invariant). */
+const _citableRow: CogneeSearchHit = {
+  content: "The Q3 launch date is 15 September.",
+  score: 0.9,
+  datasets: ["team/platform"],
+  metadata: {
+    title: "Q3 Launch Plan",
+    uri: "https://sharepoint/q3-plan",
+    source_updated_at: "2026-06-01T00:00:00.000Z",
+  },
+};
+
+/** An uncitable hit (no title/uri) — the SDK must drop it. */
+const _uncitableRow: CogneeSearchHit = { content: "orphan fact", metadata: {} };
+
+/** Wire a Client to a freshly-built org-memory server over an in-memory transport pair. */
+async function _connectClient(client: AwarenessClient): Promise<Client>
+{
+  const server = _BuildOrgMemoryServer(client);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const mcpClient = new Client({ name: "test", version: "0.0.0" });
+  await mcpClient.connect(clientTransport);
+  return mcpClient;
+}
+
+describe("_BuildAwarenessClientFromEnv", function _envSuite()
+{
+  it("throws when COGNEE_ENDPOINT is missing", function _missing()
+  {
+    expect(() => _BuildAwarenessClientFromEnv({})).toThrow(/COGNEE_ENDPOINT is required/);
+  });
+
+  it("builds a client when COGNEE_ENDPOINT is set", function _present()
+  {
+    expect(() => _BuildAwarenessClientFromEnv({ COGNEE_ENDPOINT: "http://cognee:8000" })).not.toThrow();
+  });
+});
+
+describe("_FormatAwarenessResult", function _formatSuite()
+{
+  it("renders each hit with its citation", async function _cited()
+  {
+    const aware = new AwarenessClient({ cogneeEndpoint: "http://cognee:8000", search: _fakeTransport([_citableRow]) });
+    const text = _FormatAwarenessResult(await aware.query({ query: "launch date" }));
+    expect(text).toContain("The Q3 launch date is 15 September.");
+    expect(text).toContain("Source: Q3 Launch Plan — https://sharepoint/q3-plan");
+    expect(text).toContain("team/platform");
+  });
+
+  it("discloses withheld uncitable hits instead of silently dropping them", async function _dropped()
+  {
+    const aware = new AwarenessClient({ cogneeEndpoint: "http://cognee:8000", search: _fakeTransport([_citableRow, _uncitableRow]) });
+    const text = _FormatAwarenessResult(await aware.query({ query: "launch date" }));
+    expect(text).toContain("1 uncitable result withheld");
+  });
+
+  it("reports no results without inventing content", async function _empty()
+  {
+    const aware = new AwarenessClient({ cogneeEndpoint: "http://cognee:8000", search: _fakeTransport([]) });
+    const text = _FormatAwarenessResult(await aware.query({ query: "nothing here" }));
+    expect(text).toContain("No org-memory results");
+  });
+});
+
+describe("org-memory MCP surface", function _mcpSuite()
+{
+  it("exposes a memory_search tool over MCP", async function _lists()
+  {
+    const aware = new AwarenessClient({ cogneeEndpoint: "http://cognee:8000", search: _fakeTransport([_citableRow]) });
+    const mcpClient = await _connectClient(aware);
+    const { tools } = await mcpClient.listTools();
+    expect(tools.map((t) => t.name)).toContain("memory_search");
+  });
+
+  it("returns cited org context through a memory_search call", async function _calls()
+  {
+    const aware = new AwarenessClient({ cogneeEndpoint: "http://cognee:8000", search: _fakeTransport([_citableRow]) });
+    const mcpClient = await _connectClient(aware);
+    const res = await mcpClient.callTool({ name: "memory_search", arguments: { query: "launch date" } });
+    const text = (res.content as Array<{ type: string; text?: string }>).map((c) => c.text ?? "").join("\n");
+    expect(text).toContain("15 September");
+    expect(text).toContain("Source: Q3 Launch Plan");
+    expect(res.isError).toBeFalsy();
+  });
+
+  it("surfaces a backend failure as a tool error, not a crash", async function _errors()
+  {
+    const failing = new AwarenessClient({
+      cogneeEndpoint: "http://cognee:8000",
+      search: async function _boom() { throw new Error("cognee unreachable"); },
+    });
+    const mcpClient = await _connectClient(failing);
+    const res = await mcpClient.callTool({ name: "memory_search", arguments: { query: "x" } });
+    expect(res.isError).toBe(true);
+    const text = (res.content as Array<{ type: string; text?: string }>).map((c) => c.text ?? "").join("\n");
+    expect(text).toContain("Org-memory search failed: cognee unreachable");
+  });
+});

--- a/apps/org-memory-mcp/src/format.ts
+++ b/apps/org-memory-mcp/src/format.ts
@@ -1,0 +1,44 @@
+import type { AwarenessResult } from "@opencrane/awareness";
+
+/**
+ * Render an {@link AwarenessResult} as the plain-text block returned to the agent
+ * through the `memory_search` MCP tool.
+ *
+ * Every hit is printed with its enforced citation (title + URI + freshness) so the
+ * agent can attribute any org fact it uses — the citation invariant is the whole
+ * point of routing retrieval through `@opencrane/awareness` rather than letting the
+ * runtime hit Cognee raw. Uncitable hits never reach here (the SDK drops them); we
+ * surface the dropped COUNT so the agent knows retrieval was lossy rather than empty.
+ *
+ * @param result - The awareness result to format.
+ * @returns A human/agent-readable, citation-carrying text block.
+ */
+export function _FormatAwarenessResult(result: AwarenessResult): string
+{
+  const lines: string[] = [];
+
+  if (result.hits.length === 0)
+  {
+    lines.push(`No org-memory results for: "${result.query}".`);
+  }
+  else
+  {
+    lines.push(`Org-memory results for: "${result.query}"`);
+    lines.push("");
+    result.hits.forEach(function _renderHit(hit, index)
+    {
+      const scope = hit.datasets.length > 0 ? ` [${hit.datasets.join(", ")}]` : "";
+      lines.push(`${index + 1}. ${hit.content}`);
+      lines.push(`   Source: ${hit.citation.title} — ${hit.citation.uri} (updated ${hit.citation.freshnessTimestamp})${scope}`);
+    });
+  }
+
+  // Always disclose withheld uncitable hits so "empty" is never confused with "lossy".
+  if (result.droppedUncitable > 0)
+  {
+    lines.push("");
+    lines.push(`(${result.droppedUncitable} uncitable result${result.droppedUncitable === 1 ? "" : "s"} withheld — no verifiable source.)`);
+  }
+
+  return lines.join("\n");
+}

--- a/apps/org-memory-mcp/src/index.ts
+++ b/apps/org-memory-mcp/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 
-import { _BuildAwarenessClientFromEnv } from "./memory-tools.js";
+import { _BuildAwarenessClientFromEnv, _BuildMemoryWriterFromEnv } from "./memory-tools.js";
 import { _BuildOrgMemoryServer, ORG_MEMORY_SERVER_NAME } from "./server.js";
 
 /**
@@ -15,10 +15,12 @@ import { _BuildOrgMemoryServer, ORG_MEMORY_SERVER_NAME } from "./server.js";
 async function _main(): Promise<void>
 {
   const client = _BuildAwarenessClientFromEnv(process.env);
-  const server = _BuildOrgMemoryServer(client);
+  const writer = _BuildMemoryWriterFromEnv(process.env);
+  const server = _BuildOrgMemoryServer({ client, writer });
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  process.stderr.write(`[${ORG_MEMORY_SERVER_NAME}] connected over stdio; retrieving from ${process.env.COGNEE_ENDPOINT}\n`);
+  const tools = writer ? "memory_search + memory_remember" : "memory_search (read-only)";
+  process.stderr.write(`[${ORG_MEMORY_SERVER_NAME}] connected over stdio; ${tools}; Cognee ${process.env.COGNEE_ENDPOINT}\n`);
 }
 
 _main().catch(function _fatal(error: unknown)

--- a/apps/org-memory-mcp/src/index.ts
+++ b/apps/org-memory-mcp/src/index.ts
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { _BuildAwarenessClientFromEnv } from "./memory-tools.js";
+import { _BuildOrgMemoryServer, ORG_MEMORY_SERVER_NAME } from "./server.js";
+
+/**
+ * Stdio entrypoint for the org-memory MCP server.
+ *
+ * OpenClaw spawns this process per tenant pod (via the `mcp.servers.org-memory`
+ * `command`/`args` entry the operator renders into `openclaw.json`) and speaks MCP
+ * to it over stdio. Because stdio IS the JSON-RPC channel, all diagnostics MUST go
+ * to stderr — a stray stdout write would corrupt the protocol stream.
+ */
+async function _main(): Promise<void>
+{
+  const client = _BuildAwarenessClientFromEnv(process.env);
+  const server = _BuildOrgMemoryServer(client);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write(`[${ORG_MEMORY_SERVER_NAME}] connected over stdio; retrieving from ${process.env.COGNEE_ENDPOINT}\n`);
+}
+
+_main().catch(function _fatal(error: unknown)
+{
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`[${ORG_MEMORY_SERVER_NAME}] fatal: ${message}\n`);
+  process.exit(1);
+});

--- a/apps/org-memory-mcp/src/memory-tools.ts
+++ b/apps/org-memory-mcp/src/memory-tools.ts
@@ -1,11 +1,21 @@
 import { AwarenessClient } from "@opencrane/awareness";
 
+import { MemoryWriter } from "./memory-write.js";
+
 /**
  * The subset of process env the org-memory MCP server reads at startup.
  * Modelled as an index map (not a named-optional interface) so `process.env`
  * assigns cleanly without TypeScript's weak-type check tripping.
  */
 export type OrgMemoryEnv = Record<string, string | undefined>;
+
+/** Parse a boolean-ish env value; unset/blank ⇒ the supplied default. */
+function _envFlag(value: string | undefined, fallback: boolean): boolean
+{
+  const v = value?.trim().toLowerCase();
+  if (v === undefined || v === "") { return fallback; }
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
 
 /**
  * Build the {@link AwarenessClient} the MCP server retrieves through, from pod env.
@@ -31,4 +41,36 @@ export function _BuildAwarenessClientFromEnv(env: OrgMemoryEnv): AwarenessClient
   const defaultLimit = Number.isInteger(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
 
   return new AwarenessClient({ cogneeEndpoint: endpoint, ...(defaultLimit ? { defaultLimit } : {}) });
+}
+
+/**
+ * Build the {@link MemoryWriter} the `memory_remember` tool persists through, from pod env.
+ *
+ * Returns `null` when the write path is disabled (`ORG_MEMORY_WRITE_ENABLED=false`) — a fleet
+ * kill-switch so operators can turn off agent writes to the shared graph without redeploying the
+ * tool. When enabled (the default), the writer stamps this pod's tenant identity
+ * (`OPENCLAW_TENANT_NAME`) as the fact owner so remembered facts are attributable.
+ *
+ * @param env - The environment to read.
+ * @returns A configured MemoryWriter, or null when writes are disabled.
+ * @throws When COGNEE_ENDPOINT is unset/blank.
+ */
+export function _BuildMemoryWriterFromEnv(env: OrgMemoryEnv): MemoryWriter | null
+{
+  if (!_envFlag(env.ORG_MEMORY_WRITE_ENABLED, true))
+  {
+    return null;
+  }
+
+  const endpoint = env.COGNEE_ENDPOINT?.trim();
+  if (!endpoint)
+  {
+    throw new Error("COGNEE_ENDPOINT is required for the org-memory MCP server");
+  }
+
+  // Owner identity for provenance; falls back to "unknown-tenant" so a mis-provisioned pod still
+  // writes attributable-ish data rather than crashing (the write itself is far more useful than
+  // failing the turn over a missing label).
+  const owner = env.OPENCLAW_TENANT_NAME?.trim() || "unknown-tenant";
+  return new MemoryWriter({ endpoint, owner });
 }

--- a/apps/org-memory-mcp/src/memory-tools.ts
+++ b/apps/org-memory-mcp/src/memory-tools.ts
@@ -1,0 +1,34 @@
+import { AwarenessClient } from "@opencrane/awareness";
+
+/**
+ * The subset of process env the org-memory MCP server reads at startup.
+ * Modelled as an index map (not a named-optional interface) so `process.env`
+ * assigns cleanly without TypeScript's weak-type check tripping.
+ */
+export type OrgMemoryEnv = Record<string, string | undefined>;
+
+/**
+ * Build the {@link AwarenessClient} the MCP server retrieves through, from pod env.
+ *
+ * COGNEE_ENDPOINT is mandatory: the server exists only to serve Cognee-backed org
+ * memory, so a missing endpoint is a hard error (fail loud at startup) — never a
+ * silent no-op that would leave the agent believing it queried org memory when it
+ * did not. This mirrors the control-plane's "COGNEE_ENDPOINT is required" contract.
+ *
+ * @param env - The environment to read (defaults to `process.env` at the call site).
+ * @returns A configured AwarenessClient that retrieves directly from the per-tenant Cognee.
+ * @throws When COGNEE_ENDPOINT is unset/blank.
+ */
+export function _BuildAwarenessClientFromEnv(env: OrgMemoryEnv): AwarenessClient
+{
+  const endpoint = env.COGNEE_ENDPOINT?.trim();
+  if (!endpoint)
+  {
+    throw new Error("COGNEE_ENDPOINT is required for the org-memory MCP server");
+  }
+
+  const parsedLimit = env.ORG_MEMORY_DEFAULT_LIMIT ? Number.parseInt(env.ORG_MEMORY_DEFAULT_LIMIT, 10) : NaN;
+  const defaultLimit = Number.isInteger(parsedLimit) && parsedLimit > 0 ? parsedLimit : undefined;
+
+  return new AwarenessClient({ cogneeEndpoint: endpoint, ...(defaultLimit ? { defaultLimit } : {}) });
+}

--- a/apps/org-memory-mcp/src/memory-write.ts
+++ b/apps/org-memory-mcp/src/memory-write.ts
@@ -1,0 +1,177 @@
+/**
+ * Write path for org memory — the agent "remember" behaviour that promotes a
+ * generalizable learning UP into the shared Cognee knowledge graph, so OTHER agents
+ * can later retrieve it. This is the explicit high-value persistence the retrieval
+ * deep-dive calls for (baseline harvest ingest is the harvesting-agent's job).
+ *
+ * Kept in-pod and direct-to-Cognee for symmetry with the read path (AwarenessClient).
+ * Dataset WRITE authorization is enforced server-side by Cognee's backend access
+ * control (`backendAccessControl: true`); this client stamps provenance so a
+ * remembered fact is attributable and later citable on the read side.
+ */
+
+/** Cognee dataset scope. Mirrors the operator's `DatasetScope` (schema.prisma). */
+export type DatasetScope = "org" | "team" | "department" | "project" | "personal";
+
+/** Scopes that address a specific subject and therefore REQUIRE one. */
+const _SUBJECT_REQUIRED: ReadonlySet<DatasetScope> = new Set<DatasetScope>(["team", "department", "project"]);
+
+/** The `/v1/add` request body Cognee accepts (mirrors harvesting-agent's ingest). */
+export interface CogneeAddPayload
+{
+  /** The content to persist. */
+  data: string;
+  /** Target dataset name (scope-derived — the relevance partition). */
+  dataset_name: string;
+  /** Provenance + policy metadata; drives later citation + ACL placement. */
+  metadata: Record<string, unknown>;
+}
+
+/**
+ * Pluggable Cognee ingest transport (default: `fetch` POST to `/v1/add`).
+ * Injectable so the writer is unit-testable without a live backend.
+ */
+export type CogneeAddTransport = (endpoint: string, payload: CogneeAddPayload, signal?: AbortSignal) => Promise<void>;
+
+/** Parameters for a single `memory_remember` call. */
+export interface MemoryWriteParams
+{
+  /** The fact/learning to persist. */
+  content: string;
+  /** A short title so the stored fact is citable when retrieved later. */
+  title: string;
+  /** Which shared scope this belongs to. */
+  scope: DatasetScope;
+  /** Subject for scoped datasets (e.g. team name); required for team/department/project. */
+  subject?: string;
+  /** Optional sensitivity tags carried into Cognee metadata. */
+  sensitivityTags?: string[];
+}
+
+/** Result of a successful remember: the dataset the fact landed in. */
+export interface MemoryWriteResult
+{
+  /** The resolved Cognee dataset name the fact was written to. */
+  dataset: string;
+}
+
+/**
+ * Resolve the Cognee dataset name for a scope+subject, aligned with the
+ * harvesting-agent's `_ResolveDatasetName` (`<scope>/<subject>`, or bare `org`).
+ *
+ * @param scope   - The dataset scope.
+ * @param subject - The subject (team/department/project id, or personal owner).
+ * @param owner   - Fallback subject for `personal` scope (the tenant/agent identity).
+ * @returns The dataset name string.
+ * @throws When a subject-requiring scope is missing its subject.
+ */
+export function _ResolveDatasetName(scope: DatasetScope, subject: string | undefined, owner: string): string
+{
+  if (scope === "org")
+  {
+    return "org";
+  }
+
+  if (scope === "personal")
+  {
+    // Personal scope defaults to the pod owner when no explicit subject is given.
+    const who = subject?.trim() || owner.trim();
+    if (!who)
+    {
+      throw new Error("personal scope requires a subject or a known owner identity");
+    }
+    return `personal/${who}`;
+  }
+
+  const trimmed = subject?.trim();
+  if (_SUBJECT_REQUIRED.has(scope) && !trimmed)
+  {
+    throw new Error(`${scope} scope requires a subject (e.g. the ${scope} name)`);
+  }
+  return `${scope}/${trimmed}`;
+}
+
+/**
+ * The org-memory writer: turns a `memory_remember` request into a provenance-stamped
+ * Cognee ingest. Provenance marks the fact as agent-authored and owned by this tenant,
+ * and stamps freshness so the read side can build a citation for it later.
+ */
+export class MemoryWriter
+{
+  /** Cognee base URL (no trailing slash). */
+  private readonly endpoint: string;
+
+  /** Tenant/agent identity recorded as the fact's owner + personal-scope subject. */
+  private readonly owner: string;
+
+  /** The ingest transport (default `fetch` → `/v1/add`). */
+  private readonly add: CogneeAddTransport;
+
+  /** Clock, injectable for deterministic tests. */
+  private readonly now: () => Date;
+
+  /**
+   * @param options - Endpoint, owner identity, optional transport + clock overrides.
+   */
+  constructor(options: { endpoint: string; owner: string; add?: CogneeAddTransport; now?: () => Date })
+  {
+    this.endpoint = options.endpoint.replace(/\/+$/, "");
+    this.owner = options.owner;
+    this.add = options.add ?? _DefaultCogneeAdd;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  /**
+   * Persist a generalizable fact to the resolved shared dataset.
+   *
+   * @param params - The remember request.
+   * @param signal - Optional abort signal.
+   * @returns The dataset the fact was written to.
+   */
+  async remember(params: MemoryWriteParams, signal?: AbortSignal): Promise<MemoryWriteResult>
+  {
+    const dataset = _ResolveDatasetName(params.scope, params.subject, this.owner);
+    const timestamp = this.now().toISOString();
+
+    const metadata: Record<string, unknown> = {
+      // Provenance: mark this as an agent-authored memory owned by the tenant, so the
+      // graph can distinguish it from harvested source documents and attribute it.
+      source: "agent-remember",
+      acl_origin: "agent",
+      owner: this.owner,
+      title: params.title,
+      scope: params.scope,
+      // Freshness so the read side (AwarenessClient) can build a complete citation.
+      source_updated_at: timestamp,
+      freshness_recorded_at: timestamp,
+    };
+    if (params.subject) { metadata.subject = params.subject; }
+    if (params.sensitivityTags && params.sensitivityTags.length > 0) { metadata.sensitivity_tags = params.sensitivityTags; }
+
+    await this.add(this.endpoint, { data: params.content, dataset_name: dataset, metadata }, signal);
+    return { dataset };
+  }
+}
+
+/**
+ * Default Cognee ingest transport: a `fetch` POST to `<endpoint>/v1/add`.
+ *
+ * @param endpoint - Cognee base URL (no trailing slash).
+ * @param payload  - The ingest body.
+ * @param signal   - Optional abort signal.
+ * @throws When Cognee responds non-2xx.
+ */
+const _DefaultCogneeAdd: CogneeAddTransport = async function _add(endpoint, payload, signal)
+{
+  const res = await fetch(`${endpoint}/v1/add`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+    signal,
+  });
+
+  if (!res.ok)
+  {
+    throw new Error(`Cognee ingest failed: ${res.status} ${res.statusText}`);
+  }
+};

--- a/apps/org-memory-mcp/src/server.ts
+++ b/apps/org-memory-mcp/src/server.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { AwarenessClient } from "@opencrane/awareness";
 
 import { _FormatAwarenessResult } from "./format.js";
+import type { MemoryWriter } from "./memory-write.js";
 
 /**
  * The MCP server name OpenClaw registers this local memory tool under. Kept in one
@@ -22,16 +23,19 @@ const _MAX_LIMIT = 50;
  * MCP gateway — org-memory retrieval is a first-class platform capability that talks
  * directly to the per-tenant Cognee (no control-plane mediation in the hot path).
  *
- * The single `memory_search` tool wraps {@link AwarenessClient}, so every result the
- * agent sees inherits the SDK's guarantees: enforced citations, dropped-uncitable
- * accounting, and contract-version stamping. The client is injected so the server is
- * unit-testable against a fake Cognee transport with no live backend.
+ * The `memory_search` tool wraps {@link AwarenessClient}, so every result the agent
+ * sees inherits the SDK's guarantees: enforced citations, dropped-uncitable accounting,
+ * and contract-version stamping. When a {@link MemoryWriter} is supplied, a
+ * `memory_remember` tool is also registered so the agent can PROMOTE a generalizable
+ * learning up into the shared graph (omit the writer — or disable it via env — to run
+ * read-only). Both deps are injected so the server is unit-testable with no live backend.
  *
- * @param client - The awareness client the tool retrieves through.
+ * @param deps - The awareness client (read) and optional memory writer (remember).
  * @returns A configured (not yet connected) MCP server; the caller attaches a transport.
  */
-export function _BuildOrgMemoryServer(client: AwarenessClient): McpServer
+export function _BuildOrgMemoryServer(deps: { client: AwarenessClient; writer?: MemoryWriter | null }): McpServer
 {
+  const { client, writer } = deps;
   const server = new McpServer({ name: ORG_MEMORY_SERVER_NAME, version: _SERVER_VERSION });
 
   server.registerTool(
@@ -73,6 +77,49 @@ export function _BuildOrgMemoryServer(client: AwarenessClient): McpServer
       }
     },
   );
+
+  // Write path — registered only when a writer is provided (env kill-switch off ⇒ read-only pod).
+  if (writer)
+  {
+    server.registerTool(
+      "memory_remember",
+      {
+        title: "Remember to organisational memory",
+        description:
+          "Persist a GENERALIZABLE, reusable fact to shared org memory (Cognee) so OTHER agents can " +
+          "retrieve it later. Use for durable org/domain knowledge and decisions. Do NOT use it for " +
+          "your personal style, this user's preferences, or transient task state — those belong in your " +
+          "personal MEMORY.md. Give a clear title and the correct scope; the fact is attributed to you.",
+        inputSchema: {
+          content: z.string().min(1).describe("The fact/learning to persist, self-contained enough to be useful out of context."),
+          title: z.string().min(1).describe("A short title so the fact is citable when later retrieved."),
+          scope: z
+            .enum(["org", "team", "department", "project", "personal"])
+            .describe("Which shared scope this belongs to. Use the narrowest scope that fits."),
+          subject: z
+            .string()
+            .optional()
+            .describe("Subject for scoped datasets (e.g. the team/department/project name). Required for team, department, and project."),
+          sensitivityTags: z.array(z.string()).optional().describe("Optional sensitivity tags to carry into org memory."),
+        },
+      },
+      async function _handleMemoryRemember({ content, title, scope, subject, sensitivityTags })
+      {
+        try
+        {
+          const { dataset } = await writer.remember({ content, title, scope, ...(subject ? { subject } : {}), ...(sensitivityTags ? { sensitivityTags } : {}) });
+          return { content: [{ type: "text" as const, text: `Remembered to org memory (dataset: ${dataset}).` }] };
+        }
+        catch (error)
+        {
+          // Validation errors (e.g. missing subject) and backend/ACL rejections both land here as a
+          // tool error, so the agent gets an actionable message instead of the turn crashing.
+          const message = error instanceof Error ? error.message : String(error);
+          return { content: [{ type: "text" as const, text: `Org-memory remember failed: ${message}` }], isError: true };
+        }
+      },
+    );
+  }
 
   return server;
 }

--- a/apps/org-memory-mcp/src/server.ts
+++ b/apps/org-memory-mcp/src/server.ts
@@ -1,0 +1,78 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { AwarenessClient } from "@opencrane/awareness";
+
+import { _FormatAwarenessResult } from "./format.js";
+
+/**
+ * The MCP server name OpenClaw registers this local memory tool under. Kept in one
+ * place so the operator's `openclaw.json` `mcp.servers` key and this server agree.
+ */
+export const ORG_MEMORY_SERVER_NAME = "org-memory";
+
+/** Server version reported in the MCP handshake (independent of the npm package version). */
+const _SERVER_VERSION = "0.1.0";
+
+/** Hard cap on requested hits, defence-in-depth against a runaway `limit`. */
+const _MAX_LIMIT = 50;
+
+/**
+ * Build the org-memory MCP server: a LOCAL, in-pod tool OpenClaw spawns over stdio
+ * to retrieve org context per turn. It is deliberately NOT routed through the Obot
+ * MCP gateway — org-memory retrieval is a first-class platform capability that talks
+ * directly to the per-tenant Cognee (no control-plane mediation in the hot path).
+ *
+ * The single `memory_search` tool wraps {@link AwarenessClient}, so every result the
+ * agent sees inherits the SDK's guarantees: enforced citations, dropped-uncitable
+ * accounting, and contract-version stamping. The client is injected so the server is
+ * unit-testable against a fake Cognee transport with no live backend.
+ *
+ * @param client - The awareness client the tool retrieves through.
+ * @returns A configured (not yet connected) MCP server; the caller attaches a transport.
+ */
+export function _BuildOrgMemoryServer(client: AwarenessClient): McpServer
+{
+  const server = new McpServer({ name: ORG_MEMORY_SERVER_NAME, version: _SERVER_VERSION });
+
+  server.registerTool(
+    "memory_search",
+    {
+      title: "Search organisational memory",
+      description:
+        "Retrieve organisational memory — company documents, prior decisions, and project facts — " +
+        "from the Cognee knowledge graph. Results are scope-aware, permission-filtered, and every " +
+        "one carries a citation. Prefer this over your personal MEMORY.md for org-wide facts.",
+      inputSchema: {
+        query: z.string().min(1).describe("Natural-language question or keywords to look up in org memory."),
+        datasets: z
+          .array(z.string())
+          .optional()
+          .describe("Optional Cognee dataset scopes to restrict to (e.g. 'org', 'team/platform'). Omit to search everything this tenant is entitled to."),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(_MAX_LIMIT)
+          .optional()
+          .describe("Maximum number of results to return."),
+      },
+    },
+    async function _handleMemorySearch({ query, datasets, limit })
+    {
+      try
+      {
+        const result = await client.query({ query, ...(datasets ? { datasets } : {}), ...(limit ? { limit } : {}) });
+        return { content: [{ type: "text" as const, text: _FormatAwarenessResult(result) }] };
+      }
+      catch (error)
+      {
+        // Surface the failure to the agent as a tool error rather than throwing, so the
+        // turn continues with a clear "memory unavailable" signal instead of crashing.
+        const message = error instanceof Error ? error.message : String(error);
+        return { content: [{ type: "text" as const, text: `Org-memory search failed: ${message}` }], isError: true };
+      }
+    },
+  );
+
+  return server;
+}

--- a/apps/org-memory-mcp/tsconfig.json
+++ b/apps/org-memory-mcp/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/tenant/deploy/Dockerfile
+++ b/apps/tenant/deploy/Dockerfile
@@ -1,7 +1,36 @@
+# NOTE: build context is the REPO ROOT (e.g. `docker build -f apps/tenant/deploy/Dockerfile .`),
+# not the app dir — required so the pnpm workspace + @opencrane/* deps resolve.
+#
+# The runtime image stays slim: OpenClaw itself is NOT baked in — it is installed into the
+# per-tenant GCS bucket on first boot (see entrypoint.sh). What we DO bake in is the
+# platform-owned org-memory MCP server, which OpenClaw spawns over stdio to retrieve org
+# context from the per-tenant Cognee (see 2-config-map.ts `mcp.servers.org-memory`).
+
+# Build stage — compile and bundle the org-memory MCP server into a self-contained dir.
+FROM node:22-bookworm-slim AS build
+
+RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
+
+WORKDIR /app
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY tsconfig.base.json ./
+COPY libs/awareness/package.json libs/awareness/tsconfig.json libs/awareness/
+COPY apps/org-memory-mcp/package.json apps/org-memory-mcp/tsconfig.json apps/org-memory-mcp/
+RUN pnpm install --frozen-lockfile --filter @opencrane/awareness --filter @opencrane/org-memory-mcp
+
+COPY libs/awareness/src libs/awareness/src
+COPY apps/org-memory-mcp/src apps/org-memory-mcp/src
+RUN pnpm --filter @opencrane/awareness build \
+ && pnpm --filter @opencrane/org-memory-mcp build
+
+# Produce a self-contained deployable dir (real node_modules, no workspace symlinks).
+# `--legacy` is required from pnpm v10 to deploy non-injected workspace packages.
+RUN pnpm --filter @opencrane/org-memory-mcp deploy --prod --legacy /opt/org-memory-mcp
+
+# Runtime stage — Node runtime + entrypoint + the baked org-memory MCP server.
 FROM node:22-bookworm-slim
 
-# Slim image — Node runtime only, no OpenClaw baked in.
-# OpenClaw is installed into the per-tenant GCS bucket on first boot.
+COPY --from=build /opt/org-memory-mcp /opt/org-memory-mcp
 
 COPY apps/tenant/deploy/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/apps/tenant/deploy/entrypoint.sh
+++ b/apps/tenant/deploy/entrypoint.sh
@@ -33,6 +33,13 @@ OPENCRANE_TENANT_MCP_DENY="${OPENCRANE_TENANT_MCP_DENY:-}"
 # skill-registry, authenticating with the audience-bound projected SA token.
 OPENCRANE_SKILL_REGISTRY_URL="${OPENCRANE_SKILL_REGISTRY_URL:-}"
 OPENCRANE_SKILL_REGISTRY_TOKEN_PATH="${OPENCRANE_SKILL_REGISTRY_TOKEN_PATH:-/var/run/opencrane/tokens/skill-registry.token}"
+# Mandatory platform backends (decided, not optional). Org memory is Cognee; model routing is the
+# LiteLLM proxy. The workspace docs state these as facts, so a pod that boots without them is
+# MISCONFIGURED — the preflight below surfaces that loudly instead of letting the runtime silently
+# degrade to workspace-only memory or a keyless model fallback.
+OPENCRANE_MEMORY_BACKEND="${OPENCRANE_MEMORY_BACKEND:-}"
+COGNEE_ENDPOINT="${COGNEE_ENDPOINT:-}"
+LITELLM_ENDPOINT="${LITELLM_ENDPOINT:-}"
 
 function _csv_contains()
 {
@@ -378,8 +385,28 @@ function _contract_poll_loop()
   done
 }
 
+# Warn loudly when a mandatory platform backend is missing. These are settled platform
+# decisions (org memory = Cognee, model routing = LiteLLM), so their absence is a
+# misconfiguration, not a supported mode. Warn rather than hard-exit so a partially-provisioned
+# pod can still boot for diagnosis, but make the gap impossible to miss in the logs.
+function _preflight_platform_deps()
+{
+  if [ "$OPENCRANE_MEMORY_BACKEND" != "cognee" ] || [ -z "$COGNEE_ENDPOINT" ]; then
+    echo "[opencrane] WARNING: org memory is not wired — expected OPENCRANE_MEMORY_BACKEND=cognee and COGNEE_ENDPOINT set (got backend='${OPENCRANE_MEMORY_BACKEND:-unset}', endpoint='${COGNEE_ENDPOINT:-unset}'). Cognee is the platform memory engine; the agent will have no org memory until this is fixed." >&2
+  else
+    echo "[opencrane] Org memory backend: Cognee at ${COGNEE_ENDPOINT}" >&2
+  fi
+
+  if [ -z "$LITELLM_ENDPOINT" ]; then
+    echo "[opencrane] WARNING: model routing is not wired — LITELLM_ENDPOINT is unset. LiteLLM is the platform model proxy; model calls will fail until this is fixed." >&2
+  else
+    echo "[opencrane] Model routing: LiteLLM proxy at ${LITELLM_ENDPOINT}" >&2
+  fi
+}
+
 function _main()
 {
+  _preflight_platform_deps
   _load_mcp_policy
 
   # Ensure GCS-backed directory structure

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,31 @@ importers:
         specifier: ^3.1.0
         version: 3.2.4(@types/node@22.15.31)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)
 
+  apps/org-memory-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      '@opencrane/awareness':
+        specifier: workspace:*
+        version: link:../../libs/awareness
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.15.31
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.8.2
+      vitest:
+        specifier: ^3.1.0
+        version: 3.2.4(@types/node@22.15.31)(jiti@2.6.1)(sass@1.97.1)(tsx@4.21.0)
+
   apps/skill-registry:
     dependencies:
       '@kubernetes/client-node':
@@ -346,7 +371,7 @@ importers:
         version: 1.9.1
       '@opentelemetry/auto-instrumentations-node':
         specifier: ^0.56.0
-        version: 0.56.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+        version: 0.56.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: ^0.57.0
         version: 0.57.2(@opentelemetry/api@1.9.1)
@@ -839,6 +864,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@iconify-json/simple-icons@1.2.86':
     resolution: {integrity: sha512-t3jck5qPQuK1qy+bRn9eCoDQhIB7XSazKz1Fjp8hcan3XOAsTI5Mq/s3F0ekOKSvMQqkVORYK6ns6o6T9f5EMA==}
 
@@ -878,6 +909,16 @@ packages:
 
   '@kubernetes/client-node@1.4.0':
     resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
@@ -1974,8 +2015,19 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   algoliasearch@5.54.0:
     resolution: {integrity: sha512-APAX4ajIOgsmYoUlGe++oNZkSTBgmXYM4maHC0OxC+Yo7xkaKQElV0ATZYCZA7jzrSJX1OBiqEs7mk+ZxXgYqA==}
@@ -2255,6 +2307,14 @@ packages:
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2422,12 +2482,26 @@ packages:
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -2469,6 +2543,9 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
@@ -2621,6 +2698,10 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
@@ -2687,6 +2768,10 @@ packages:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -2720,6 +2805,9 @@ packages:
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
@@ -2768,6 +2856,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -2961,6 +3052,10 @@ packages:
   oauth4webapi@3.8.5:
     resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-hash@2.2.0:
     resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
     engines: {node: '>= 6'}
@@ -3028,6 +3123,10 @@ packages:
     resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
     engines: {node: '>=14.0.0'}
 
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -3080,6 +3179,10 @@ packages:
   pino@9.14.0:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
@@ -3296,6 +3399,14 @@ packages:
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   shiki@2.5.0:
     resolution: {integrity: sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==}
@@ -3739,6 +3850,11 @@ packages:
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3796,6 +3912,11 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4175,6 +4296,10 @@ snapshots:
       protobufjs: 7.6.4
       yargs: 17.7.3
 
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
+
   '@iconify-json/simple-icons@1.2.86':
     dependencies:
       '@iconify/types': 2.0.0
@@ -4254,6 +4379,28 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@noble/hashes@1.8.0': {}
 
   '@nodable/entities@2.1.1':
@@ -4265,7 +4412,7 @@ snapshots:
 
   '@opentelemetry/api@1.9.1': {}
 
-  '@opentelemetry/auto-instrumentations-node@0.56.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)':
+  '@opentelemetry/auto-instrumentations-node@0.56.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/instrumentation': 0.57.2(@opentelemetry/api@1.9.1)
@@ -4312,7 +4459,7 @@ snapshots:
       '@opentelemetry/resource-detector-aws': 1.12.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resource-detector-azure': 0.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resource-detector-container': 0.6.1(@opentelemetry/api@1.9.1)
-      '@opentelemetry/resource-detector-gcp': 0.33.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)
+      '@opentelemetry/resource-detector-gcp': 0.33.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-node': 0.57.2(@opentelemetry/api@1.9.1)
     transitivePeerDependencies:
@@ -4849,7 +4996,7 @@ snapshots:
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.41.1
 
-  '@opentelemetry/resource-detector-gcp@0.33.1(@opentelemetry/api@1.9.1)(encoding@0.1.13)':
+  '@opentelemetry/resource-detector-gcp@0.33.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
@@ -5593,12 +5740,23 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   algoliasearch@5.54.0:
     dependencies:
@@ -5866,6 +6024,17 @@ snapshots:
 
   core-util-is@1.0.2: {}
 
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
   csstype@3.2.3: {}
 
   dashdash@1.14.1:
@@ -6057,11 +6226,22 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
 
   express-rate-limit@7.5.1(express@5.2.1):
     dependencies:
       express: 5.2.1
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
 
   express-session@1.19.0:
     dependencies:
@@ -6162,6 +6342,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-uri@3.1.3: {}
 
   fast-xml-builder@1.2.0:
     dependencies:
@@ -6373,6 +6555,8 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hono@4.12.27: {}
+
   hookable@5.5.3: {}
 
   hpagent@1.2.0: {}
@@ -6457,6 +6641,8 @@ snapshots:
 
   ip-address@10.1.0: {}
 
+  ip-address@10.2.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-core-module@2.16.2:
@@ -6480,6 +6666,8 @@ snapshots:
   is-typedarray@1.0.0: {}
 
   is-what@5.5.0: {}
+
+  isexe@2.0.0: {}
 
   isomorphic-ws@5.0.0(ws@8.19.0):
     dependencies:
@@ -6515,6 +6703,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -6678,6 +6868,8 @@ snapshots:
 
   oauth4webapi@3.8.5: {}
 
+  object-assign@4.1.1: {}
+
   object-hash@2.2.0:
     optional: true
 
@@ -6751,6 +6943,8 @@ snapshots:
   path-expression-matcher@1.5.0:
     optional: true
 
+  path-key@3.1.1: {}
+
   path-parse@1.0.7: {}
 
   path-to-regexp@0.1.13: {}
@@ -6807,6 +7001,8 @@ snapshots:
       safe-stable-stringify: 2.5.0
       sonic-boom: 4.2.1
       thread-stream: 3.1.0
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@2.3.0:
     dependencies:
@@ -7123,6 +7319,12 @@ snapshots:
       - supports-color
 
   setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
 
   shiki@2.5.0:
     dependencies:
@@ -7727,6 +7929,10 @@ snapshots:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -7770,6 +7976,10 @@ snapshots:
 
   yocto-queue@0.1.0:
     optional: true
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
   - apps/fleet-operator
   - apps/clustertenant-operator
   - apps/harvesting-agent
+  - apps/org-memory-mcp
   - apps/cli
   - apps/skill-registry
   - website


### PR DESCRIPTION
## Why

A live OpenClaw instance reported it had *no idea Cognee was installed* — because it didn't. The tenant pod never received `COGNEE_ENDPOINT`, `@opencrane/awareness` was never instantiated anywhere outside tests, and the workspace docs only mentioned the personal `MEMORY.md`. This wires org memory end-to-end so the agent both **knows about** and can **use** the Cognee knowledge graph on every turn.

## What

**Awareness + reachability**
- `config.cogneeEndpoint` reads `COGNEE_ENDPOINT` (empty ⇒ no-op); injected into the tenant pod as `COGNEE_ENDPOINT` + `OPENCRANE_MEMORY_BACKEND=cognee`.
- Runtime contract gains a `memory` block (`backend`/`endpoint`/`contractVersion`). A `workspace` backend now marks a **misconfigured** pod, not a supported fallback.
- `AGENTS.md`/`TOOLS.md` state Cognee as the settled memory engine (no "when/if" hedging); the entrypoint preflight **warns loudly** when Cognee or LiteLLM are missing.

**Per-turn retrieval hook (Option 1: local stdio MCP, SDK-backed)**
- New app `@opencrane/org-memory-mcp`: a **local stdio MCP server** exposing a `memory_search` tool backed by `AwarenessClient` — preserving the citation invariant, contract-version stamping, and dropped-uncitable accounting (the guarantees a native-retrieval shortcut would have discarded).
- Baked into the tenant image at `/opt/org-memory-mcp` via a multi-stage Dockerfile (`pnpm deploy --prod --legacy`).
- Operator renders `mcp.servers.org-memory` into `openclaw.json` **post-merge** (a tenant can't drop it), guarded by `cogneeEndpoint`. It's local/stdio, **not** via the Obot gateway; `AGENTS.md` exempts it from the "no direct MCP" rule.
- Contract-derived `TOOLS.md` (`_RenderToolsMarkdown`) also carries the org-memory section, so the poll-loop-regenerated doc doesn't shadow the static one.

## Testing
- 8 `org-memory-mcp` tests incl. a **real MCP round-trip** (`listTools`+`callTool` over the SDK in-memory transport) and the error path.
- **616/616** operator tests (mcp.servers rendering, tenant-override merge, schema contract, memory contract, env injection, TOOLS.md section).
- `--frozen-lockfile`, `bash -n`, `tsc` all clean. **No Helm change** — the manager already sets `COGNEE_ENDPOINT`.

## Caveats (verify after deploy)
- OpenClaw's stdio-MCP support and env-forwarding to spawned servers were confirmed against its **published config docs**, not the live 2026.6.9 binary (not vendored). First real integration test is a deploy — both are contained fixes if the handshake/env don't behave.