### PR TITLE
✨ default agent reasoning to visible so it persists in chat.history

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -129,3 +129,40 @@ describe("configOverrides cannot clobber the platform gateway (C1)", function _c
     expect(trustedProxy.allowUsers).toEqual(["contract@example.com"]);
   });
 });
+
+/**
+ * Reasoning visibility — `agents.defaults.reasoningDefault`/`thinkingDefault` make
+ * the model's thinking stream live AND persist into `chat.history` (rendered as a
+ * collapsible "Thinking" card in the org-admin SPA). They are DEFAULTS a tenant
+ * can override, not platform-pinned like the gateway block.
+ */
+describe("reasoning visibility defaults", function _reasoningSuite()
+{
+  function _render(overrides?: Record<string, unknown>): Record<string, unknown>
+  {
+    const tenant = _makeTenant("contract", overrides ? { configOverrides: overrides } : undefined);
+    return JSON.parse(_BuildConfigMap(defaultConfig, tenant, "default").data?.["openclaw.json"] ?? "{}") as Record<string, unknown>;
+  }
+
+  function _defaults(config: Record<string, unknown>): Record<string, unknown>
+  {
+    return (config["agents"] as Record<string, unknown>)["defaults"] as Record<string, unknown>;
+  }
+
+  it("enables reasoning by default so it lands in history", function _default()
+  {
+    const defaults = _defaults(_render());
+    expect(defaults["reasoningDefault"]).toBe("stream");
+    expect(defaults["thinkingDefault"]).toBe("medium");
+    expect(_OpenclawConfigSchema.safeParse(_render()).success).toBe(true);
+  });
+
+  it("lets a tenant override reasoning off to save tokens", function _override()
+  {
+    const config = _render({ agents: { defaults: { reasoningDefault: "off" } } });
+    const defaults = _defaults(config);
+    expect(defaults["reasoningDefault"]).toBe("off"); // tenant wins over the platform default
+    expect(defaults["workspace"]).toBe("/data/openclaw/workspace"); // platform-pinned keys still applied
+    expect(_OpenclawConfigSchema.safeParse(config).success).toBe(true);
+  });
+});

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -17,6 +17,28 @@ const _WORKSPACE_TEMPLATES_DIR = join(dirname(fileURLToPath(import.meta.url)), "
 const _WORKSPACE_PATH = "/data/openclaw/workspace";
 
 /**
+ * Default agent reasoning posture — makes the model's thinking a first-class part
+ * of the transcript so it streams live AND is returned by `chat.history` (the
+ * org-admin SPA renders reasoning as a collapsible "Thinking" card).
+ *
+ * Verified against openclaw@2026.6.9 `AgentDefaultsConfig` (both keys are valid;
+ * the operator's `agents.defaults` block is `.passthrough`, and OpenClaw accepts
+ * them):
+ *  - `reasoningDefault: "stream"` — deliver reasoning as it happens (as reasoning
+ *    content parts on the assistant turn), so it persists into history rather than
+ *    being dropped by the visible-history projection.
+ *  - `thinkingDefault: "medium"` — a middle thinking level so reasoning-capable
+ *    models actually produce a trace (with `"off"` there is nothing to show).
+ *
+ * These are DEFAULTS, not platform-pinned: they are spread BEFORE the tenant's
+ * merged `agents.defaults`, so a tenant can dial either down via
+ * `spec.configOverrides.agents.defaults` (e.g. `reasoningDefault: "off"` to save
+ * tokens/latency). NOTE: enabling reasoning has a real token-cost/latency cost.
+ */
+const _REASONING_DEFAULT = "stream";
+const _THINKING_DEFAULT = "medium";
+
+/**
  * The OpenClaw provider id the LiteLLM proxy is registered under (in `models.providers`).
  *
  * This id is ALSO the mandatory prefix on any model reference that must route through the proxy
@@ -243,6 +265,11 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
     agents: {
       ...(existingAgents ?? {}),
       defaults: {
+        // Reasoning-visibility DEFAULTS (overridable) — spread first so a tenant's
+        // `configOverrides.agents.defaults` wins. Makes the model's thinking stream
+        // live and persist into `chat.history` (see _REASONING_DEFAULT).
+        reasoningDefault: _REASONING_DEFAULT,
+        thinkingDefault: _THINKING_DEFAULT,
         ...existingDefaults,
         workspace: _WORKSPACE_PATH,
         skipBootstrap: true,

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -153,6 +153,10 @@ const _agentsDefaultsSchema = z
     skipBootstrap: z.boolean(),
     /** Effective default model id (OpenClaw reads the default from here, not models.default). */
     model: z.string().optional(),
+    /** Reasoning visibility default (openclaw AgentDefaultsConfig); "stream" persists the trace into history. */
+    reasoningDefault: z.enum(["off", "on", "stream"]).optional(),
+    /** Default thinking level (openclaw AgentDefaultsConfig) so reasoning-capable models produce a trace. */
+    thinkingDefault: z.enum(["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"]).optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Why
The org-admin SPA already renders assistant reasoning as a collapsible **"Thinking"** card whenever a message carries reasoning content parts (weownai side). But the tenant's `chat.history` returned none: openclaw's visible-history projection drops raw reasoning unless the agent is configured to surface it. So thinking traces showed live (sometimes) but never in history.

This is the pod-side half of "we want thinking traces in history."

## What
Two **overridable** defaults on the rendered tenant `openclaw.json` at `agents.defaults` (verified against `openclaw@2026.6.9` `AgentDefaultsConfig`):

| key | value | effect |
|-----|-------|--------|
| `reasoningDefault` | `"stream"` | deliver reasoning as reasoning content parts on the assistant turn → streams live **and** persists into `chat.history` |
| `thinkingDefault` | `"medium"` | a middle thinking level so reasoning-capable models actually produce a trace (`"off"` = nothing to show) |

They're spread **before** the tenant's merged `agents.defaults`, so a tenant can override via `spec.configOverrides.agents.defaults` (e.g. `reasoningDefault: "off"` to save tokens) — unlike the platform-pinned `gateway` block. Both keys are vendored into `openclaw-config.schema.ts` (the block is `.passthrough`, so no strict-schema boot crash).

## Validation
- `pnpm --filter @opencrane/clustertenant-operator test` — **611 passing**, incl. two new `openclaw-config-contract` cases: default render enables reasoning + validates against the vendored schema; a tenant `reasoningDefault:"off"` override wins while platform-pinned keys still apply.
- `tsc` build clean.

## Deferred / to verify on deploy
- **Behavioural, needs a live check on elewa-be.** `"stream"` is the best bet for reasoning persisting into `chat.history` as renderable parts, but the exact retention is decided by openclaw's history projection at runtime. After deploy, confirm `chat.history` returns reasoning parts for an assistant turn; if not, switch to `reasoningDefault: "on"` (reasoning delivered as a persisted "Thinking." message).
- **Cost/latency.** Enabling reasoning fleet-wide has a real token/latency cost; it's an overridable default precisely so tenants can opt out.
- **Rollout.** Needs the clustertenant-operator image built + deployed, and the operator only re-renders converged tenants when generation changes — force with `kubectl patch tenant … --subresource=status -p '{"status":{"observedGeneration":0}}'`.