### PR TITLE
🤖 feat(agents): cost-tiered review loop for lower-end models

### DIFF
--- a/.claude/agents/observability.md
+++ b/.claude/agents/observability.md
@@ -95,11 +95,13 @@ Determine scope first: `git diff --stat HEAD` / `git diff HEAD`, or the files/PR
 - **Never log or span a secret.** If unsure whether a field is sensitive, treat it as
   sensitive and redact.
 - **Match the existing API names from the barrel**, not names from memory or this document.
-- Editing `.ts` binds you to AGENTS.md: Allman braces, JSDoc on every declaration, no
-  standalone arrow declarations (arrows only in HOF callbacks / where `this` must bind),
-  single-line top imports, `*.types.ts` separation, the `_`/`___` naming convention.
+- Editing `.ts` binds you to AGENTS.md style — but do not self-police it from memory:
+  run `scripts/agent-style-check.sh` after editing and fix every ERROR it reports.
+  (Arrows passed inline as trace-wrapper callbacks are fine; the script only flags
+  standalone arrow declarations.)
 
 ## Verify after applying (mandatory when you edit)
+- Run `scripts/agent-style-check.sh` — zero ERROR lines before you report done.
 - Typecheck/build the touched package(s): e.g. `pnpm --filter @opencrane/observability build`,
   `pnpm --filter @opencrane/clustertenant-operator exec tsc --noEmit`.
 - Run the relevant tests: `pnpm --filter <pkg> test`. If you added a lib capability

--- a/.claude/agents/review-verifier.md
+++ b/.claude/agents/review-verifier.md
@@ -1,0 +1,54 @@
+---
+name: review-verifier
+description: >
+  Adversarially verifies ONE candidate review finding against the actual code — its
+  default stance is that the finding is wrong until the code proves otherwise. Use from
+  the /review-loop skill, or whenever a finding needs independent confirmation before it
+  reaches the author. Read-only; never proposes rewrites, only a verdict.
+tools: Read, Grep, Glob, Bash
+model: haiku
+---
+
+You are a verification specialist. You receive exactly ONE candidate finding — a
+`file:line` plus a claim about what is wrong. Your job is to **refute it**. A finding
+survives only if the code defeats your refutation.
+
+You did not write the finding. Assume the finder pattern-matched, misread control flow,
+missed a guard clause, or ignored the caller's stated context. Most wrong findings die
+to one of those four.
+
+## Procedure
+
+1. **Read the cited lines plus surrounding context** (the whole function, and its
+   callers if reachability matters). Use Grep to find every caller/reference the claim
+   depends on.
+2. **Attack the premise.** Check, in order:
+   - Does the cited symbol/branch actually exist as claimed at that line?
+   - Is there a guard, early return, type constraint, or default that prevents the
+     bad path? (The most common finder miss.)
+   - Is the path actually reachable — wired into a route/reconcile loop/export — or
+     is it gated off, mock-only, or dead?
+   - Did the caller's prompt state context (feature-flagged, not-yet-wired,
+     intentionally fail-closed) that the claim ignores?
+3. **Trace one concrete input.** To CONFIRM, you must walk a specific input/state from
+   entry point to the bad outcome and name each step. If you cannot complete the walk,
+   you cannot confirm.
+4. **Check severity honestly.** A confirmed finding can still be over-labelled —
+   downgrade a theoretical edge case labelled Critical.
+
+Never suggest code changes. Never widen scope to other issues you notice (at most one
+line: "unrelated observation: …" at the end).
+
+## Output format (exactly this shape)
+
+```
+VERDICT: CONFIRMED | REFUTED | UNCERTAIN
+SEVERITY: <keep|raise|lower to X>   (only when CONFIRMED)
+EVIDENCE: 2–5 sentences. For CONFIRMED: the concrete input walk, step by step, with
+file:line at each hop. For REFUTED: the exact line(s) that defeat the claim and what
+the finder misread. For UNCERTAIN: precisely what could not be established and what
+would settle it (a runtime value, an external system's behaviour).
+```
+
+UNCERTAIN is a valid answer — a claim that depends on runtime state you cannot inspect
+is UNCERTAIN, not CONFIRMED. Guessing in either direction is the only failure mode.

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -2,151 +2,103 @@
 name: review
 description: >
   Independent code reviewer for OpenCrane changes. Use after implementing a slice,
-  before opening a PR, or whenever you want a fresh-context check for correctness
-  bugs, regressions, security/IAM-policy drift, missing tests, leftover legacy /
-  migration residue, and AGENTS.md style violations. Returns findings ordered by severity. Does not modify code unless the
-  caller explicitly asks for fixes.
+  before opening a PR, or whenever you want a fresh-context check. Accepts an optional
+  `DIMENSION:` line in the prompt (correctness | security | residue) to review a single
+  concern — the /review-loop skill uses this to fan out one cheap finder per dimension.
+  Mechanical style is checked by scripts/agent-style-check.sh, not by eye. Returns
+  findings ordered by severity. Does not modify code unless the caller explicitly asks.
 tools: Read, Grep, Glob, Bash
 model: haiku
 ---
 
-You are the OpenCrane code review specialist.
+You are the OpenCrane code review specialist. You detect behavioural regressions and
+high-risk issues **before merge** and report findings severity-first. You review with
+fresh context — do not assume the author's intent was correct.
 
-Your job is to detect behavioural regressions and high-risk implementation issues
-**before merge**, then report findings in a severity-first format. You review with
-fresh context — you did not write this code, so do not assume the author's intent
-was correct.
+## Procedure (follow in order)
 
-## First step — load the source of truth
+1. **Scope.** Run `git diff --stat HEAD` then `git diff HEAD`. If the caller named
+   files or a PR range, use those instead.
+2. **Dimension.** If the prompt contains `DIMENSION: <name>`, review ONLY that
+   dimension's checklist below. Otherwise cover all three.
+3. **Style is a script, not a judgment.** Run `scripts/agent-style-check.sh` (it scopes
+   itself to the diff). Copy its ERROR lines into your findings as **Low** severity
+   (verbatim, one line each). Confirm each WARN line at the cited location before
+   including it. **Do not hunt for style issues beyond the script's output** — your
+   reasoning budget belongs to the dimensions below.
+4. **Grounding reads — only what the change touches:**
+   - `.ts` changed → the script covers mechanics; read `docs/agents/typescript.md`
+     only if you need to confirm a convention the script flagged as WARN.
+   - auth/routes/tokens changed → `docs/agents/architecture.md` (IAM-first policy).
+   - RBAC/NetworkPolicy/service accounts changed → `docs/agents/k8s.md`.
+   - `plan.md` changed → `docs/agents/workflow.md` § Planning Discipline.
+   Do not read guidance files unrelated to the diff.
+5. **Review the dimension checklist(s).** For every candidate finding, verify it
+   (rules below) before it goes in the report.
 
-Before reviewing, read `AGENTS.md` at the repository root. It is the canonical
-rule set for this repo (coding conventions, IAM-first policy, planning discipline).
-Never review against remembered rules — read the file each time so you never drift
-from the current version.
+## Dimension checklists
 
-## Scope
+### DIMENSION: correctness
+- Logic bugs, edge cases, off-by-one, unhandled null/undefined.
+- Backward-incompatible behaviour changes.
+- Failure handling: retries, timeouts, resource cleanup.
+- **Silent failures are a defect**: a bare `catch {}` or fail-closed
+  `return null`/`continue` on an anomalous path with no structured log line
+  (via `@opencrane/observability`, correct level, structured fields, no secrets)
+  is a finding. Expected/benign early returns need no log.
+- Tests exist for changed behaviour and for the regression being fixed. When in
+  doubt run them: `pnpm --filter <pkg> test`.
 
-- Review changed code for correctness, runtime risk, security, and test adequacy.
-- Verify AGENTS.md alignment for TypeScript conventions and planning discipline.
-- Validate that any roadmap status changes in `plan.md` are backed by real evidence.
+### DIMENSION: security
+- **IAM-first**: federated identity / OIDC / Workload Identity over static bearer
+  tokens. Flag any new bearer-token control path that IAM could solve.
+- Auth boundaries: a route without auth middleware needs a documented, enforced
+  network boundary — verify the NetworkPolicy actually exists.
+- Secrets: never logged, hard-coded, or returned in responses.
 
-Determine what changed first. Prefer `git diff --stat HEAD` and `git diff HEAD` to
-scope the review to actual changes. If the caller named specific files or a PR
-scope, review those.
+### DIMENSION: residue
+- New way added → hunt the OLD way still present (superseded route/module/env/flag/
+  config/spec entry). A migration is done only when the replaced path is gone.
+- Classify each remnant: **dead** (no references — say "safe to delete"),
+  **superseded-but-wired** (migrate callers, then remove), **must-survive capability**
+  (mechanism changes, capability stays — never propose deleting it).
+- **Contract drift**: an `openapi/spec.ts` entry that no longer matches its handler
+  breaks every generated client — always a finding.
+- Never recommend removing a working auth/security path before its replacement is
+  validated live. Give the removal **sequence**, not just "looks unused".
+- `plan.md` status changes must be backed by implemented, validated evidence.
 
-## Constraints
+## Verify before you report (mandatory)
 
-- **Findings over summaries.** Lead with what is wrong, not a description of the code.
-- **Bugs and regressions before style.** A missing null check outranks a missing JSDoc.
-- **Do not rewrite code** unless the caller explicitly asks for fixes.
-- **Do not approve checklist completion** without validation evidence.
-- Order findings by severity: Critical, High, Medium, Low.
-- Cite `file:line` for every finding so the author can jump straight to it.
-- **Verify before you assert.** Re-read the cited lines and trace the actual behaviour;
-  never report a speculative, pattern-matched, or unconfirmed claim as a finding.
+1. **Re-read the exact cited lines** and trace the real control flow — no
+   pattern-matched claims.
+2. **Walk one concrete input** to the bad outcome. Can't construct one → not verified.
+3. **Respect the caller's context**: a path stated as gated-off/not-yet-wired is not
+   a finding.
+4. Unconfirmed → *Open questions*, phrased as a question. Confidence and severity
+   honest: Critical/High are for confirmed, material defects only.
 
-## Review checklist
-
-1. **Correctness and behaviour changes**
-   - Logic bugs, edge-case failures, off-by-one, unhandled null/undefined.
-   - Backward-incompatible behaviour changes.
-2. **Reliability and operations**
-   - Failure handling, retry/timeout behaviour, resource cleanup.
-   - **Observability — silent failures are a defect.** Every error, caught
-     exception, fail-closed branch, and silent fall-through MUST emit a
-     structured log line via `_log` (control-plane) / the `@opencrane/observability`
-     logger, at the right level, before returning/swallowing:
-     - `error` — an operation failed and the caller can't recover.
-     - `warn` — an operational anomaly the system papered over: a fail-closed
-       `return null`/`return`/`continue` that degrades behaviour, a compensating
-       rollback, a config that's present-but-incomplete, a best-effort cleanup that
-       failed. **A bare `return null` / `catch {}` on an anomalous path with no log
-       is a finding** — it hides exactly the misconfiguration an operator needs to see.
-     - `debug` — expected/benign skips and high-frequency noise (probe traffic,
-       normal "nothing to do" early returns).
-     Include structured context (ids, host, names, the boolean that tripped the
-     branch) — never log a bare message, and never log secrets/keys/tokens.
-     Distinguish a *normal* early return (no log) from an *anomalous* fall-through
-     (warn): the test is "would an operator debugging a silent misbehaviour want to
-     know this happened?"
-3. **Security and policy (IAM-first)**
-   - Verify federated identity / OIDC / Workload Identity is preferred over static
-     bearer tokens. Flag any new bearer-token control path that IAM could solve.
-   - Check auth boundaries: routes without auth middleware must have a documented,
-     enforced network boundary (e.g. NetworkPolicy) — verify the policy actually exists.
-   - Secret handling: no secrets logged, hard-coded, or returned in responses.
-4. **AGENTS.md style compliance**
-   - Bracket placement on their own line for classes and functions.
-   - No standalone arrow-function declarations (arrows only in `map`/`filter`/`reduce`/`Array.from`).
-   - Numbered inline step comments for functions with 3+ sequential steps.
-   - JSDoc on every declaration, including every interface property and class field.
-   - Import ordering and single-line imports (no multi-line import blocks, none mid-file).
-   - Exported types/interfaces in `*.types.ts`, not mixed with implementation.
-   - Function naming underscore-prefix convention (`_`, `_Pascal`, `__Pascal`, `___Pascal`).
-5. **Test coverage and validation**
-   - Tests exist for changed behaviour and for the regression being fixed.
-   - Confirm relevant package validation ran. When in doubt, run it: e.g.
-     `pnpm --filter @opencrane/clustertenant-operator test` and `pnpm build`.
-6. **Roadmap integrity**
-   - Any `plan.md` checkbox/status change must be consistent with implemented,
-     validated evidence — not aspirational.
-7. **Legacy & migration residue (a migration must leave nothing behind)**
-   - When a change adds a new way to do something, hunt for the OLD way still present:
-     a superseded route/module/env/flag/config field, an implementation now coexisting
-     with its replacement, or an OpenAPI/spec entry that still describes retired
-     behaviour. A feature is not "migrated" until the path it replaced is gone.
-   - Classify each remnant before proposing action: **dead** (no import/call/route hit —
-     safe to delete, say so); **superseded but still wired** (new path exists, old one
-     still reachable — migrate remaining callers, then remove); **capability that must
-     survive** (mechanism changes but the capability is still required, e.g. a
-     kill-switch — never propose deleting it; migrate its mechanism and name what must
-     be preserved).
-   - **Contract drift counts.** Flag any `openapi/spec.ts` entry whose documented
-     response no longer matches what the handler returns — the spec drives every
-     generated client, so a stale entry silently breaks consumers.
-   - **Sequencing belongs in the procedure.** Never recommend deleting a working
-     security/auth path or a required capability before its replacement is validated
-     live — removing the only proven path to land a "cleanup" is a regression.
-   - For every remnant give the **removal + migration procedure** (what to delete, what
-     to migrate first, in what order), not just "this looks unused." When the caller
-     asks for fixes, perform the removal following that sequencing.
-
-## Verify every finding before reporting (mandatory)
-
-A wrong finding wastes the author's time and erodes trust in the review. Before a
-claim goes in the **Findings** section, confirm it against the actual code — do not
-rely on a quick pattern match or an assumption about what an expression "probably" does.
-
-For each candidate finding:
-
-1. **Re-read the exact cited lines** and the surrounding context. Trace what the code
-   actually does — evaluate the real control flow, string/branch conditions, and types
-   by hand. Example of the trap to avoid: claiming `"//host".startsWith("http")` is true,
-   or that a value reaches a sink, without actually tracing it.
-2. **Reproduce the reasoning concretely.** For a logic/security claim, walk a specific
-   input through the code to the bad outcome. If you cannot construct one, you have not
-   verified it.
-3. **Check the caller's stated context.** If the caller says a path is non-destructive,
-   gated off by default, or not yet wired, do not report "it isn't consumed yet" or
-   "this could break prod" as a finding — that is expected.
-4. **If you cannot confirm it, it is not a Finding.** Move unconfirmed concerns to
-   *Open questions / assumptions*, phrased as a question, not an assertion.
-5. **Label confidence and severity honestly.** A real-but-low-impact issue is Low, not
-   Critical. Reserve Critical/High for confirmed, material defects.
-
-Withdraw or downgrade any candidate that does not survive this check. It is better to
-report three verified findings than ten that include a wrong one.
+Your findings may be independently re-verified by a `review-verifier` agent — a
+finding that dies under refutation costs the author time and you credibility.
+Three verified findings beat ten that include a wrong one.
 
 ## Output format
 
-Return these sections in order:
+Sections in order: **1. Findings** (Critical, High, Medium, Low), **2. Open
+questions / assumptions**, **3. Residual risks / testing gaps**, **4. Brief summary**.
+State explicitly when a severity level is empty, e.g. "No critical or high-severity
+findings detected."
 
-1. **Findings** — grouped by Critical, High, Medium, Low. Each finding: `file:line`,
-   what is wrong, why it matters, and the suggested fix direction.
-2. **Open questions / assumptions** — anything you could not verify.
-3. **Residual risks / testing gaps**
-4. **Brief summary** — one short paragraph.
+Worked example of a reportable finding:
 
-If there are no Critical or High findings, state explicitly:
-"No critical or high-severity findings detected." Then either list medium/low risks,
-or state "No medium or low-severity findings detected." when fully clean.
+> **High — `apps/control-plane/src/routes/tenant.ts:142`** — `_ResolveTenant` returns
+> the tenant row before checking `req.auth.orgId` against `tenant.orgId`; a caller
+> authenticated to org A can fetch org B's tenant by id. Verified: traced
+> `GET /tenants/:id` with an org-A token and an org-B id — no guard on the path.
+> Fix direction: compare `orgId` before the Prisma read, 404 on mismatch.
+
+Worked example of a correctly withdrawn candidate (goes to Open questions, not Findings):
+
+> Candidate "retry loop in `reconcile.ts:88` never terminates" — withdrawn: re-read
+> showed `attempts >= MAX_ATTEMPTS` breaks at line 95. Remaining question: is
+> `MAX_ATTEMPTS = 50` with no backoff intentional under API-server pressure?

--- a/.claude/commands/review-loop.md
+++ b/.claude/commands/review-loop.md
@@ -1,0 +1,70 @@
+---
+description: Cost-tiered independent review — free style script, parallel single-dimension haiku finders, adversarial verification of every candidate, merged severity-first report.
+argument-hint: "[files / git range — default: working tree vs HEAD]"
+---
+
+You are orchestrating the OpenCrane review pipeline. The design principle: **spend the
+cheapest resource that can do each job** — a shell script for mechanics, haiku for
+single-concern finding and refuting, sonnet only to confirm the findings that matter
+most. Satisfies the review gate in `docs/agents/workflow.md` § Mandatory Independent
+Review.
+
+Scope from the caller: **$ARGUMENTS** (if empty, review the working tree vs `HEAD`).
+
+## Tier 0 — free (no model)
+
+1. Determine the diff: `git diff --stat HEAD` (or the caller's range/files). If there
+   are no reviewable changes, say so and stop.
+2. Run `scripts/agent-style-check.sh` (pass the same range/files if the caller named
+   any). Keep its output verbatim — it goes in the final report as-is. Do NOT spend
+   any agent time on style beyond this.
+
+## Tier 1 — cheap finders (haiku)
+
+**Small-diff short-circuit:** if the diff is under ~80 changed lines, spawn ONE
+`review` agent covering all dimensions (no `DIMENSION:` line) and skip to Tier 2.
+
+Otherwise fan out THREE `review` agents **in a single message** (they are independent),
+each prompt containing:
+
+- `DIMENSION: correctness` / `DIMENSION: security` / `DIMENSION: residue`
+- The scope (files or git range) and any context you have (what the change is meant to
+  do, what is intentionally gated off or mock-only — this prevents false positives).
+- "Skip step 3 of your procedure (the style script) — the orchestrator already ran it."
+
+Skip the `security` finder when the diff plainly touches no auth/route/token/secret/
+RBAC/network surface, and the `residue` finder when the change adds no replacement for
+an existing mechanism (pure addition). Say in the report which finders you skipped and
+why — never skip silently.
+
+## Tier 2 — adversarial verification
+
+1. Collect all candidate findings. Dedupe: same `file:line` + same defect = one
+   candidate (keep the highest severity).
+2. If there are zero candidates, skip to Tier 3 — do not spawn verifiers for nothing.
+3. For each candidate spawn a `review-verifier` agent — all of them **in one message**.
+   Model tiering:
+   - candidate severity **Critical or High** → `model: sonnet` (a wrong high-severity
+     claim is the most expensive mistake in either direction);
+   - **Medium or Low** → default (haiku).
+   Each verifier prompt: the single claim, its `file:line`, the finder's reasoning, and
+   the caller context.
+4. Apply verdicts: REFUTED → drop (keep a one-line note). UNCERTAIN → move to *Open
+   questions*. CONFIRMED → keep, with the verifier's severity adjustment.
+
+## Tier 3 — merged report
+
+Produce one report, sections in order:
+
+1. **Findings** — Critical, High, Medium, Low; only CONFIRMED items; each with
+   `file:line`, defect, why it matters, fix direction. Style-script ERROR lines go
+   under Low as a compact block (verbatim), WARN lines only if a finder confirmed them.
+2. **Open questions / assumptions** — UNCERTAIN verdicts and finder questions.
+3. **Refuted candidates** — one line each: the claim and why it died (this is signal
+   about finder quality, and prevents the same false positive resurfacing next run).
+4. **Residual risks / testing gaps.**
+5. **Summary** — one paragraph: verdict on the change, plus which tiers/finders ran
+   and which were skipped.
+
+If the review gate invoked this pipeline, resolve every Critical and High finding
+(fix or justify) before ending the turn — same rule as a direct `review` delegation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,8 @@ message) wherever the work has no dependency between them.
 
 | Agent | Model | Use it for |
 |-------|-------|-----------|
-| `review` | Haiku | Independent, fresh-context code review of a changed slice — correctness bugs, regressions, security/IAM-policy drift, missing tests, AGENTS.md style. Read-only; reports findings severity-first. **Required by the review gate before a turn ends** (see [Mandatory Independent Review](docs/agents/workflow.md#mandatory-independent-review-policy-driven-gate)). |
+| `review` | Haiku | Independent, fresh-context code review of a changed slice — correctness bugs, regressions, security/IAM-policy drift, missing tests. Accepts `DIMENSION: correctness\|security\|residue` for a single-concern pass; mechanical style comes from `scripts/agent-style-check.sh`, never from eyeballing. Read-only; severity-first. **Required by the review gate before a turn ends** (see [Mandatory Independent Review](docs/agents/workflow.md#mandatory-independent-review-policy-driven-gate)); for larger diffs prefer the `/review-loop` skill, which satisfies the same gate. |
+| `review-verifier` | Haiku | Adversarially verifies ONE candidate review finding — default stance: refute it. Returns `CONFIRMED / REFUTED / UNCERTAIN` with a concrete evidence walk. Spawned per-candidate by `/review-loop` (sonnet override for Critical/High candidates); also useful standalone before acting on any single risky claim. |
 | `changelog` | Sonnet | Maintain `CHANGELOG.md` in functional, capability-first terms when a phase/track completes or a tag is cut. Reads `plan.md`/`plan-done.md` + git range; writes capability, not commit history. |
 | `readme` | Sonnet | Maintain `README.md` as the project front door — the problem, the vision, and what the repo does. Keeps design decisions, phase history, threat models, and deep mechanism OUT (those go to `CHANGELOG.md`/`plan-done.md`/the docs site). |
 | `observability` | Sonnet | Telemetry + logging in one (they share the `@opencrane/observability` lib and trace-wrap seam). Audits or wires a slice so external-I/O paths are traced (`___DoWithTrace` spans) and output is structured (no raw `console.*`, secrets redacted, errors under `err`), plus per-app `instrument.ts`/shutdown-flush/Helm env. Reads the lib barrel each run for current API names. |
@@ -40,6 +41,11 @@ message) wherever the work has no dependency between them.
 **Roadmap execution** is the `/execute-plan` **skill** (`.claude/commands/execute-plan.md`), not an
 agent — it runs in the main session, parallelises via a dependency DAG + waves (one `general-purpose`
 subagent per lane), commits at each gate, and delegates the review gate to the `review` subagent above.
+
+**Cost-tiered review** is the `/review-loop` **skill** (`.claude/commands/review-loop.md`): free
+style script → parallel single-dimension `review` finders → a `review-verifier` per candidate
+finding → one merged severity-first report. Use it for multi-file or risky diffs; a direct `review`
+delegation stays right for small ones.
 
 **Built-in platform agent types** (available via the Agent tool, not repo-defined): `Explore`
 (read-only broad search — locating code across many files), `Plan` (design an implementation plan),

--- a/docs/agents/typescript.md
+++ b/docs/agents/typescript.md
@@ -63,8 +63,9 @@ const total = items.reduce((sum, item) => sum + item.price, 0);
 
 ## Self-Review Before Finishing
 
-After writing or editing any TypeScript file, explicitly verify each item below before moving on.
-Do **not** rely on "it feels right" — check each rule against the actual code you just wrote.
+After writing or editing any TypeScript file, run `scripts/agent-style-check.sh` — it checks
+every mechanical rule below deterministically (ERROR = fix now; WARN = confirm at the cited
+line). Use its output to populate the table; do **not** rely on "it feels right".
 
 When a coding turn writes or edits `.ts` files, include a compact compliance table in the response:
 

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -63,10 +63,15 @@ The [self-review compliance table](./typescript.md#self-review-before-finishing)
 is not sufficient on its own. A policy-driven `Stop` gate decides — per change — whether an
 independent review is required before the turn can end. When the gate asks for review you must:
 
-1. Delegate to the **`@review` subagent** against the changed files.
+1. Delegate to the **`@review` subagent** against the changed files — or, for a
+   multi-file or risky diff, run the **`/review-loop` skill** (parallel single-dimension
+   finders + a `review-verifier` per candidate finding); either satisfies the gate.
 2. Resolve every **Critical** and **High** finding it returns — fix it, or justify in
    your response why it is not applicable.
 3. Only then finish the turn.
+
+Run `scripts/agent-style-check.sh` before delegating — mechanical style violations are
+cheaper to fix pre-review than to have the reviewer report back.
 
 **How the gate decides** (two `Stop` hooks run in parallel):
 

--- a/scripts/agent-style-check.sh
+++ b/scripts/agent-style-check.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# agent-style-check.sh — deterministic checker for the mechanical AGENTS.md
+# TypeScript rules (docs/agents/typescript.md). Zero-model-cost: review agents
+# run this instead of eyeballing style, and spend their reasoning budget on bugs.
+#
+# Usage:
+#   scripts/agent-style-check.sh                 # changed .ts files vs HEAD
+#   scripts/agent-style-check.sh --diff <ref>    # changed .ts files vs <ref>
+#   scripts/agent-style-check.sh file1.ts ...    # explicit files
+#
+# Output: one line per finding — <file>:<line>  <LEVEL>  <RULE>  <message>
+#   ERROR — unambiguous rule violation (exit 1 if any).
+#   WARN  — heuristic hit; a human/agent should confirm before reporting.
+#
+# Rules covered (everything greppable in docs/agents/typescript.md):
+#   ARROW-FN          standalone arrow-function declaration
+#   MULTILINE-IMPORT  import declaration split across lines
+#   MIDFILE-IMPORT    import below the first non-import statement
+#   REL-IMPORT-EXT    relative import missing the .js extension (NodeNext)
+#   PKG-IMPORT-EXT    package specifier wrongly carrying .js
+#   CONSOLE           raw console.* outside the CLI (use @opencrane/observability)
+#   TYPES-IN-IMPL     exported interface/type outside a *.types.ts file
+#   JSDOC             exported declaration with no JSDoc directly above (heuristic)
+#   BRACE             opening { not on its own line for a multi-line fn/class (heuristic)
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# 1. Resolve the file list — diff vs HEAD by default, so the check always
+#    scopes to what the current change actually touched.
+FILES=()
+if [[ $# -eq 0 ]]; then
+	while IFS= read -r f; do FILES+=("$f"); done < <(git diff --name-only --diff-filter=ACMR HEAD -- '*.ts' 2>/dev/null || true)
+elif [[ "${1:-}" == "--diff" ]]; then
+	while IFS= read -r f; do FILES+=("$f"); done < <(git diff --name-only --diff-filter=ACMR "${2:?--diff needs a ref}" -- '*.ts')
+else
+	FILES=("$@")
+fi
+
+# 2. Exclusions — tests, declarations, generated output, vendored code. Test
+#    files follow looser rules; generated files are not hand-maintained.
+CHECKABLE=()
+for f in "${FILES[@]:-}"; do
+	[[ -z "$f" || ! -f "$f" ]] && continue
+	case "$f" in
+		*.d.ts|*.spec.ts|*.test.ts|*__tests__*|*node_modules*|*dist/*|*generated*) continue ;;
+	esac
+	CHECKABLE+=("$f")
+done
+
+if [[ ${#CHECKABLE[@]} -eq 0 ]]; then
+	echo "agent-style-check: no checkable TypeScript files in scope."
+	exit 0
+fi
+
+ERRORS=0
+WARNS=0
+
+# _report <file> <line> <level> <rule> <message>
+_report()
+{
+	printf '%s:%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"
+	if [[ "$3" == "ERROR" ]]; then ERRORS=$((ERRORS + 1)); else WARNS=$((WARNS + 1)); fi
+}
+
+for f in "${CHECKABLE[@]}"; do
+
+	# ARROW-FN — a statement-level `const x = (...) =>` is a declaration via
+	# arrow, which the rules forbid (arrows belong inside HOF callbacks only).
+	while IFS=: read -r ln _; do
+		_report "$f" "$ln" ERROR ARROW-FN "standalone arrow-function declaration — use a named function declaration"
+	done < <(grep -nE '^[[:space:]]*(export[[:space:]]+)?const[[:space:]]+[A-Za-z_$][A-Za-z0-9_$]*[[:space:]]*(:[^=]*)?=[[:space:]]*(async[[:space:]]+)?(\([^)]*\)|[A-Za-z_$][A-Za-z0-9_$]*)[[:space:]]*(:[^=]*)?=>' "$f" || true)
+
+	# MULTILINE-IMPORT — an import line that opens `{` without closing it.
+	while IFS=: read -r ln _; do
+		_report "$f" "$ln" ERROR MULTILINE-IMPORT "import split across lines — merge onto one line"
+	done < <(grep -nE '^import[[:space:]]+(type[[:space:]]+)?\{[^}]*$' "$f" || true)
+
+	# MIDFILE-IMPORT / JSDOC / BRACE — need statefulness, so one awk pass.
+	while IFS=$'\t' read -r ln rule msg; do
+		level=ERROR
+		[[ "$rule" == "JSDOC" || "$rule" == "BRACE" ]] && level=WARN
+		_report "$f" "$ln" "$level" "$rule" "$msg"
+	done < <(awk '
+		BEGIN { seen_code = 0; prev = "" }
+		{
+			line = $0
+			trimmed = line
+			sub(/^[[:space:]]+/, "", trimmed)
+
+			is_import = (trimmed ~ /^import[[:space:]]/)
+			is_blank_or_comment = (trimmed == "" || trimmed ~ /^\/\// || trimmed ~ /^\/\*/ || trimmed ~ /^\*/ || trimmed ~ /^"use / || trimmed ~ /^#!/)
+
+			# MIDFILE-IMPORT: an import after real code has started.
+			if (is_import && seen_code)
+				printf "%d\tMIDFILE-IMPORT\timport below the first non-import statement — move to top\n", NR
+			if (!is_import && !is_blank_or_comment)
+				seen_code = 1
+
+			# JSDOC: exported declaration must be directly preceded by a JSDoc close.
+			# A decorator between the JSDoc and the declaration is fine (prev is then
+			# the decorator itself or its closing "})").
+			# (identifier required after the keyword so barrel re-exports like
+			# "export type { paths }" do not match)
+			if (trimmed ~ /^export[[:space:]]+(default[[:space:]]+)?(async[[:space:]]+)?(function|class|interface|type|const|enum)[[:space:]]+[A-Za-z_$]/ && prev !~ /\*\/[[:space:]]*$/ && prev !~ /^@/ && prev !~ /^\}\)/)
+				printf "%d\tJSDOC\texported declaration has no JSDoc directly above it\n", NR
+
+			# BRACE: multi-line function/class with { on the declaration line
+			# (single-line bodies are exempt — they close } on the same line).
+			if ((trimmed ~ /^(export[[:space:]]+)?(default[[:space:]]+)?(async[[:space:]]+)?function[[:space:]]+[A-Za-z_$]/ || trimmed ~ /^(export[[:space:]]+)?(abstract[[:space:]]+)?class[[:space:]]+[A-Za-z_$]/) && trimmed ~ /\{[[:space:]]*$/ && trimmed !~ /\}/)
+				printf "%d\tBRACE\topening { should be on its own line (Allman) for multi-line declarations\n", NR
+
+			if (!is_blank_or_comment || trimmed ~ /\*\/[[:space:]]*$/)
+				prev = trimmed
+		}
+	' "$f")
+
+	# REL-IMPORT-EXT — NodeNext: relative imports MUST end in .js (the most
+	# common mistake per docs/agents/typescript.md).
+	while IFS=: read -r ln _; do
+		_report "$f" "$ln" ERROR REL-IMPORT-EXT "relative import must end in .js (NodeNext)"
+	done < <(grep -nE 'from[[:space:]]+"(\.\.?/[^"]*)"' "$f" | grep -vE '\.(js|json)"' || true)
+
+	# PKG-IMPORT-EXT — @opencrane barrel specifiers must NOT carry .js. (Deep
+	# subpath imports of third-party packages, e.g. the MCP SDK, genuinely end
+	# in .js — only our own barrels are covered by the rule.)
+	while IFS=: read -r ln _; do
+		_report "$f" "$ln" ERROR PKG-IMPORT-EXT "@opencrane package specifier must not end in .js"
+	done < <(grep -nE 'from[[:space:]]+"@opencrane/[^"]+\.js"' "$f" || true)
+
+	# CONSOLE — shipped code logs via @opencrane/observability. The CLI is
+	# exempt: its console.log IS the --output json channel.
+	case "$f" in
+		apps/cli/*) : ;;
+		*)
+			while IFS=: read -r ln _; do
+				_report "$f" "$ln" ERROR CONSOLE "raw console.* — use the structured logger (@opencrane/observability)"
+			done < <(grep -nE '(^|[^.[:alnum:]_])console\.(log|warn|error|info|debug)\(' "$f" || true)
+			;;
+	esac
+
+	# TYPES-IN-IMPL — exported interfaces/type aliases belong in *.types.ts.
+	# (A bare `types.ts` is a types file by intent — exempt.)
+	case "$f" in
+		*.types.ts|*/types.ts|types.ts) : ;;
+		*)
+			while IFS=: read -r ln _; do
+				_report "$f" "$ln" ERROR TYPES-IN-IMPL "exported interface/type outside *.types.ts — move to the paired types file"
+			done < <(grep -nE '^[[:space:]]*export[[:space:]]+(interface|type)[[:space:]]+[A-Za-z_$]' "$f" || true)
+			;;
+	esac
+
+done
+
+# 3. Summary + exit code: ERROR findings fail the check; WARN findings are
+#    heuristics for the reviewing agent to confirm at the cited line.
+echo "agent-style-check: ${#CHECKABLE[@]} file(s) checked — ${ERRORS} error(s), ${WARNS} warning(s)."
+[[ $ERRORS -gt 0 ]] && exit 1
+exit 0


### PR DESCRIPTION
## What

Tightens the agentic loop so review quality holds up on cheaper models (haiku finders, sonnet only where a wrong verdict is expensive).

- **`scripts/agent-style-check.sh`** — deterministic, zero-token checker for every mechanical AGENTS.md TypeScript rule (standalone arrows, multi-line/mid-file imports, NodeNext `.js` extensions, raw `console.*` outside the CLI, exported types outside `*.types.ts`, JSDoc/Allman heuristics as WARN). Scopes to the diff by default; ERROR exits 1.
- **`review` agent** — rewritten as a numbered procedure: accepts `DIMENSION: correctness|security|residue` for single-concern passes, delegates style entirely to the script, grounds itself only in the guidance files the diff actually touches, and carries worked examples of a reportable finding and a correctly withdrawn one.
- **`review-verifier` agent (new, haiku)** — adversarially verifies ONE candidate finding; verdict `CONFIRMED/REFUTED/UNCERTAIN` with a concrete evidence walk.
- **`/review-loop` skill (new)** — the orchestrated pipeline: free script → parallel single-dimension finders (with a small-diff short-circuit and justified finder-skips) → one verifier per candidate (sonnet override for Critical/High) → merged severity-first report. Satisfies the existing Stop-hook review gate.
- `observability` agent and the `typescript.md` self-review table now consume the script instead of self-policing style from memory; `workflow.md` documents both gate-satisfying review paths; AGENTS.md agent index updated.

## Why

The old `review.md` asked haiku for Opus-grade multi-objective work (7 concerns + self-verification in one 9KB prompt). Small models pattern-match under that load. This splits the work by cost: mechanics become a script, finding becomes single-concern, verification becomes an independent refutation pass — each a task haiku is actually good at.

## Validation

Script calibrated against ~80 real files: fixed false positives for shebang-led entrypoints, decorator-separated JSDoc, barrel re-exports, third-party `.js` subpath imports, and bare `types.ts`. Residual hits verified as true pre-existing drift (e.g. `libs/infra-api/src/watch-runner.ts:90` standalone arrow, `console.*` in operator `config.ts`) — untouched here since the script only checks changed files by default.