### PR TITLE
docs: drift fixes + least-technical top-level pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ OpenCrane is a **control plane for organizational AI**. It sits on top of agent 
 **Your organization stays in control:**
 - **Personal assistants at scale**: Deploy a private AI assistant for every employee in minutes—each one isolated, secure, and acting on behalf of that employee.
 - **One dedicated silo per organisation**: Every customer org runs its own isolated stack—dedicated operator, control plane, LLM proxy, MCP gateway, knowledge base, skill registry, and database—provisioned and managed by a central fleet. There is no shared singleton that mixes org data.
-- **Vendor independence and BYOK**: Choose your LLM provider—Claude, GPT, open-source models—without lock-in. Each org sets its own provider keys (Bring Your Own Key); keys are stored as Kubernetes Secrets and routed only through the org's LiteLLM proxy, never written to the database.
-- **Model routing and cost control**: Pin a model per skill or let the platform choose, enforce a per-tenant allowlist, and run an eval-driven, human-gated optimisation loop that surfaces "switch this skill's model to save N% at equal quality"—all through the API and `oc` CLI.
+- **Vendor independence and BYOK**: Choose your LLM provider—Claude, GPT, open-source models—without lock-in. Each org sets its own provider keys (Bring Your Own Key) through the platform API (with CLI coverage for day-to-day operations); keys are stored as Kubernetes Secrets and routed only through the org's LiteLLM proxy, never written to the database.
+- **Model routing and cost control**: Pin a model per skill or let the platform choose. The platform sets per-employee budgets and model allowlists, which the org's LiteLLM proxy enforces at request time; the control plane meters spend and warns as budgets approach. An eval-driven, human-gated optimisation loop surfaces "switch this skill's model to save N% at equal quality".
 - **Self-hosted, data-sovereign**: Deploy OpenCrane on your infrastructure. Your organizational data—documents, conversations, collected information—stays on your network, never sent to external vendors. Shared skills are stored and versioned in your repository.
 - **Security and governance**: Identity-keyed network isolation (Cilium + SPIFFE) gives every workload a cryptographic identity; each silo is default-deny. One fleet release manages identity, access control, skill deployment, cost tracking, audit, and RBAC-filtered access to organizational knowledge across all silos.
-- **Organizational intelligence**: Company-wide information gathering agents harvest knowledge from your platforms (Slack, Teams, email, tickets) and make it available to assistants through retrieval plugins, with automatic role-based filtering.
+- **Organizational intelligence**: Company-wide information gathering agents harvest knowledge from your platforms—starting with Slack, with further sources connecting through the MCP gateway as they land—and make it available to assistants through retrieval plugins, with automatic role-based filtering.
 - **Scale from day one**: From 10 employees to 10,000—the same Kubernetes-native architecture scales seamlessly.
 
 ## How It Works
@@ -61,12 +61,12 @@ Each employee gets their own **private AI assistant**—an isolated OpenClaw ins
 - **Accesses organizational knowledge directly**: Queries Cognee from the OpenClaw/Clawdbot runtime during the agentic loop, with policy-compatible dataset scope selection and citations.
 
 OpenCrane also runs **company-wide information gathering agents** (dedicated tenant deployments with elevated permissions) that:
-- Continuously harvest organizational knowledge from Slack, Teams, email, ticketing systems, and other company platforms
+- Continuously harvest organizational knowledge, starting with Slack, with further sources (Teams, email, ticketing systems) connecting through the MCP gateway as they land
 - Index this knowledge into a centralized Org Knowledge Index
 - Make it available to all tenant assistants via retrieval plugins (role-based access)
 
 OpenCrane orchestrates all of this by:
-- **Infrastructure Management**: Deploying and managing assistants for each employee. Supporting local or remote LLM models. Enforcing token budgets and cost limits per employee.
+- **Infrastructure Management**: Deploying and managing assistants for each employee. Supporting local or remote LLM models. Setting token budgets and cost limits per employee, enforced by the org's LLM proxy and metered by the control plane.
 - **Permissions Control Plane**: Managing dataset memberships and permissions in Cognee (for org/team/project/personal scopes) without sitting in the retrieval request path.
 - **Uniform Awareness Runtime**: Enforcing a common awareness contract across tenant runtimes (query rewrite rules, scope selection, citations, fallback, freshness behavior).
 - **Organizational Knowledge**: Company-wide agents harvest and index org data; direct tenant retrieval runtimes make it accessible based on role and dataset scope.
@@ -147,7 +147,7 @@ Legend:   [live] live today      [partial] partial / gated      [desired] desire
 | Platform library | `libs/k8s-platform/` | Helm library chart (shared named templates), shared deploy engine (`k8s-deploy.sh`, `configure-oidc.sh`) + cluster provisioning (`provision.sh`, behind `--provision`), Terraform, migrations, tests, and `deploy-single-tenant.sh` |
 | CLI | `apps/cli/` | `oc` binary — full administrative surface over the control-plane API |
 | Contracts | `libs/contracts/` | Generated TypeScript client + DTOs from `openapi.json`; consumed by CLI and external surfaces |
-| Docker | `docker/` | Container images for tenant pods, fleet operator, and silo operator |
+| Docker | `apps/*/deploy/Dockerfile` | Per-app Dockerfiles (fleet operator, silo operator, tenant runtime, skill registry), built and published by `.github/workflows/docker.yml` |
 | Skills | `skills/shared/` | Org/team shared skill library |
 | Docs site | `website/` | VitePress documentation site published to GitHub Pages |
 
@@ -246,29 +246,19 @@ The operator provisions everything the tenant needs — storage, identity, an en
 
 ### CLI Quick Reference
 
+Every administrative capability is reachable through `oc`, the platform CLI:
+
 ```bash
-# Point the CLI at your control plane
 export OPENCRANE_URL=https://opencrane.ai
 export OPENCRANE_TOKEN=<your-access-token>
 
-oc tenants list                         # list all tenants
-oc tenants get jente                    # inspect a tenant
-oc tenants suspend jente                # scale to zero
-oc tenants resume jente                 # bring back
-
-oc policies list                        # list access policies
-oc mcp list                             # list MCP servers
-oc skills list                          # list skill catalog
-oc budget spend jente                   # current spend for a tenant
-
-oc audit list --tenant jente --limit 50 # query the audit log
-oc metrics server                       # server utilisation snapshot
-oc auth me                              # current auth identity
-
-oc tenants list --output json | jq '.[].name'   # machine-readable output
+oc tenants list              # list all employee assistants
+oc tenants suspend jente     # scale one to zero
+oc budget spend jente        # current spend for a tenant
+oc audit list --tenant jente # query the audit log
 ```
 
-See the [CLI reference](https://opencrane.ai/reference/cli) for the full command reference and the [API reference](https://opencrane.ai/reference/api) for the HTTP API.
+See the [CLI reference](https://opencrane.ai/reference/cli) for the full command list and the [API reference](https://opencrane.ai/reference/api) for the HTTP API.
 
 ### Version Pinning
 

--- a/website/guide/audit.md
+++ b/website/guide/audit.md
@@ -8,17 +8,9 @@ changed a policy, shared a skill, connected a tool, or adjusted a budget. It doe
 
 ## Look it up
 
-```bash
-oc audit list                          # most recent activity
-oc audit list --tenant alice           # everything about one assistant
-oc audit list --tenant alice --limit 50
-```
-
-Add `--output json` to feed it into other tools:
-
-```bash
-oc audit list --output json | jq '.[] | {time, actor, action}'
-```
+Look up the most recent activity across your company, or everything about one
+assistant, and feed the results into another tool if you like. Manage this from the
+command line — see [CLI reference → `oc audit`](/reference/cli#oc-audit).
 
 The log is kept accurate even if part of the system is briefly unavailable, so it's a
 reliable record for reviews and compliance.

--- a/website/guide/budgets.md
+++ b/website/guide/budgets.md
@@ -7,65 +7,52 @@ company-wide — so there are no surprises and no runaway bills.
 
 ## Set a budget when you create an assistant
 
-```bash
-oc tenants create --name alice --display-name "Alice" --email alice@example.com \
-  --budget 50        # monthly cap, in USD
-```
+You can give an assistant a monthly spend cap the moment you create it — see
+[Create your first employee assistant](/guide/first-tenant).
 
 ## Adjust budgets later
 
-```bash
-oc budget set-global 5000        # company-wide monthly ceiling
-oc budget global                 # show the global ceiling
-
-oc budget set-account alice 75   # cap for one person
-oc budget accounts               # all per-person caps
-
-oc budget spend alice            # what Alice has spent this month
-```
+You can also set a company-wide ceiling, cap or change one person's budget, and
+check what anyone has spent this month, at any time. Manage this from the command
+line — see [CLI reference → `oc budget`](/reference/cli#oc-budget).
 
 When someone hits their cap, their assistant pauses AI calls until the budget resets
 or you raise it — it never silently overspends.
 
 ## Choose your AI provider
 
-You're not tied to one vendor. Add the model providers your company uses, and switch
-freely:
+You're not tied to one vendor. OpenCrane supports two distinct ways to connect a
+model provider, and it's worth knowing which one you're using:
 
-```bash
-oc providers list
-oc providers set claude <api-key>
-oc providers set openai <api-key>
-oc providers delete claude
-```
+::: info Provider keys vs. BYOK — two distinct paths
+**Provider keys** (below) are the everyday way to add a vendor key from the CLI.
+**BYOK** (bring your own key) is a separate, org-admin-only path that provisions one
+raw upstream key for the whole silo directly into the model-routing layer. They are
+not the same mechanism — see [Bring your own provider key](#bring-your-own-provider-key-byok)
+below for when to reach for BYOK instead.
+:::
 
-Use Claude, GPT, or open-source models without changing anything about your
-assistants or skills. Budget and provider changes are recorded in the
-[audit log](/guide/audit).
+### Provider keys
 
-## Bring your own provider key (BYOK)
+Add the model providers your company uses, and switch freely between them. Use
+Claude, GPT, or open-source models without changing anything about your assistants
+or skills. Budget and provider changes are recorded in the [audit log](/guide/audit).
 
-An org-admin can set one raw upstream provider key per provider for the whole silo.
-The key is written into a Kubernetes Secret and registered with LiteLLM — assistants
-never receive it directly. Instead, each assistant gets a per-tenant LiteLLM virtual
-key that carries its own spend budget and model allow-list. The raw key is never
-returned by any read endpoint.
+Manage this from the command line — see [CLI reference → `oc providers`](/reference/cli#oc-providers).
 
-::: tip How BYOK keys seed the model catalogue
+### Bring your own provider key (BYOK)
+
+BYOK is a separate path for an org-admin to set one raw upstream provider key per
+provider for the **whole silo**, rather than per-assistant. The key is written into a
+Kubernetes Secret and registered with LiteLLM — assistants never receive it directly.
+Instead, each assistant gets a per-tenant LiteLLM virtual key that carries its own
+spend budget and model allow-list. The raw key is never returned by any read endpoint.
+
 When you set a BYOK key for a provider, LiteLLM automatically makes that provider's
 models available to route assistant calls through. You can then use
 [`oc model`](/reference/cli#oc-model) to register specific model definitions backed
 by that provider credential.
-:::
 
-BYOK is an org-admin action. There is no `oc` sub-command for it — use the API
-directly or the platform admin UI:
-
-```
-PUT  /api/v1/providers/byok/:provider   Set or refresh the raw provider key
-GET  /api/v1/providers/byok             List configured BYOK providers (presence + timestamps, no key material)
-DELETE /api/v1/providers/byok/:provider Remove a provider key
-```
-
-Supported provider values are defined in the `ByokProvider` contract enum (e.g.
-`openai`, `anthropic`). The mutation requires an IdP-verified org-admin identity.
+BYOK is API-only today — there is no `oc` sub-command for it yet. See
+[CLI reference → BYOK](/reference/cli#oc-providers) for the API routes and
+authorisation requirements.

--- a/website/guide/dns.md
+++ b/website/guide/dns.md
@@ -46,18 +46,11 @@ oc platform dns set \
   --token-file ./cloudflare-token.txt
 ```
 
-- `--provider` — your DNS host (`cloudflare`, `route53`, `digitalocean`, …)
-- `--zone` — the domain being secured
-- `--email` — where Let's Encrypt sends renewal notices
-- `--token-file` — a file holding an API token scoped to edit that zone
-
-Check it anytime:
-
-```bash
-oc platform dns show
-```
-
-Certificates renew automatically from here on.
+Point `--provider` at your DNS host, `--zone` at the domain being secured, `--email`
+at where Let's Encrypt should send renewal notices, and `--token-file` at a file
+holding an API token scoped to edit that zone. Certificates renew automatically from
+here on; check the configuration anytime with `oc platform dns show`. Full flag
+reference: [CLI reference → `oc platform dns`](/reference/cli#oc-platform-dns).
 
 ::: tip Just testing locally?
 On a laptop install you can skip all of this — local mode doesn't need real DNS or

--- a/website/guide/first-tenant.md
+++ b/website/guide/first-tenant.md
@@ -18,28 +18,15 @@ oc tenants create \
 That's it — Alice's assistant is now live. She can [sign in and use](/guide/connect) it
 at your organisation's address (e.g. `https://acme.<your-domain>`).
 
-You can set a few things up front:
-
-```bash
-oc tenants create \
-  --name alice \
-  --display-name "Alice Smith" \
-  --email alice@example.com \
-  --team engineering \      # the team she belongs to
-  --budget 50               # monthly spend cap, in USD
-```
-
-The `--team` label is how you group people — see [Organize your company](/guide/organize).
+You can also set a few things up front — which team she belongs to (see
+[Organize your company](/guide/organize)) and a monthly spend cap (see
+[Manage cost](/guide/budgets)).
 
 ## Manage assistants
 
-```bash
-oc tenants list             # everyone's assistants
-oc tenants get alice        # details for one
-oc tenants suspend alice    # pause it (frees resources)
-oc tenants resume alice     # bring it back
-oc tenants delete alice     # remove it
-```
+Once created, you can list everyone's assistants, look up one person's details, pause
+an assistant to free resources, bring it back, or remove it altogether. Manage this
+from the command line — see [CLI reference → `oc tenants`](/reference/cli#oc-tenants).
 
 ## What's next
 

--- a/website/guide/knowledge.md
+++ b/website/guide/knowledge.md
@@ -21,25 +21,14 @@ with citations**, instead of guessing.
 So every assistant behaves the same way when it looks things up — same rules for
 which sources to use, when to cite, and how fresh information must be — OpenCrane
 applies a shared set of rules across the fleet. You roll changes out gradually (to a
-few assistants first, then everyone) and can undo in one step:
-
-```bash
-oc awareness rollout show
-oc awareness rollout set <version> --waves engineering,sales
-oc awareness rollout promote
-oc awareness rollout rollback
-```
+few assistants first, then everyone) and can undo in one step. Manage this from the
+command line — see [CLI reference → `oc awareness`](/reference/cli#oc-awareness).
 
 ## Keep contexts from bleeding together
 
 To stop one project's context from leaking into an unrelated chat, you can pin a
-conversation to a scope:
-
-```bash
-oc sessions scope set <session> --principal alice --scope project:acme
-oc sessions scope show <session>
-oc sessions scope clear <session>
-```
+conversation to a scope. Manage this from the command line — see
+[CLI reference → `oc sessions`](/reference/cli#oc-sessions).
 
 ## Going deeper
 

--- a/website/guide/model-routing.md
+++ b/website/guide/model-routing.md
@@ -22,21 +22,11 @@ Nothing changes silently. The platform *proposes*; a human *approves*.
 
 Each skill can be **pinned** to a model you choose, or set to **auto** so OpenCrane picks the
 default for that scope. Pin when you want predictability; use auto when you'd rather manage
-the choice in one place.
+the choice in one place. When a skill is on auto, the choice comes from a default you set
+once — for the whole company, or per customer.
 
-```bash
-oc skill-posture set <skill-key> --pinned-model my-fast-model   # always use this model
-oc skill-posture set <skill-key> --auto                         # let the platform choose
-oc skill-posture list
-```
-
-When a skill is on **auto**, the choice comes from a default you set once — for the whole
-company, or per customer:
-
-```bash
-oc model-default set --model my-fast-model            # company-wide default
-oc model-default set --cluster-tenant <id> --model …  # default for one customer
-```
+Manage this from the command line — see [CLI reference → `oc skill-posture`](/reference/cli#oc-skill-posture)
+and [`oc model`](/reference/cli#oc-model).
 
 ## Keep each customer to their allowed models
 
@@ -57,97 +47,26 @@ This is the part that protects quality. Instead of guessing whether a cheaper mo
 3. **Nothing changes.** A good result becomes a *suggestion* waiting for your approval — live
    traffic is never touched during a measurement.
 
-```bash
-# 1. Record example tasks for a skill
-oc routing eval-case add --skill-name summarise --skill-scope org \
-  --input '{"messages":[{"role":"user","content":"Summarise: …"}]}' \
-  --expected "A two-sentence summary covering …" \
-  --quality-bar 0.8
-
-# 2. Try a cheaper model against them
-oc routing measurement run --skill-name summarise --candidate-model my-cheap-model
-
-# 3. See the result
-oc routing measurement list --skill-name summarise
-```
+Manage this from the command line — see [CLI reference → `oc routing`](/reference/cli#oc-routing).
 
 ## Approve or reject — you decide
 
 A measurement that shows real savings turns into a ranked suggestion. You review it and
-choose; nothing is ever applied on its own.
-
-```bash
-oc routing recommendation list      # ranked "save up to N%" suggestions
-oc routing proposal approve <id>    # switch the skill to the cheaper model
-oc routing proposal reject <id>     # leave everything exactly as-is
-```
-
-Approving switches the skill and records the decision in the [audit log](/guide/audit);
-rejecting changes nothing.
+choose; nothing is ever applied on its own. Approving switches the skill and records the
+decision in the [audit log](/guide/audit); rejecting changes nothing.
 
 ## See cost & quality at a glance
 
-```bash
-oc routing metrics
-```
+`oc routing metrics` shows the fleet's cost and quality trend at a glance — see the
+[CLI reference](/reference/cli#oc-routing). Operators see the whole fleet; everyone else
+sees only their own usage. Credentials stay on the server — the browser never holds them.
 
-Operators see the whole fleet; everyone else sees only their own usage. Credentials stay on
-the server — the browser never holds them.
+## Going deeper
 
----
-
-## How it works (the details)
-
-You don't need this to use routing day to day — it's here when you want to understand
-exactly what the platform does.
-
-### Registering models
-
-A model is routable once it's in the registry. Each entry maps a public slug to an upstream
-model and the provider credential behind it. Models and credentials are scoped **Global** or
-**per-ClusterTenant**, and a credential only ever stores a Kubernetes Secret *reference* — a
-raw API key is never written to the database.
-
-```bash
-oc model add --name my-cheap-model --upstream openai/gpt-4o-mini --credential <id>
-oc model list / show <id> / update <id> / remove <id>
-```
-
-### How the effective model is resolved
-
-At call time the control plane walks this precedence and writes the winner into the tenant's
-effective contract — **no pod restart**:
-
-```
-explicit request override
-  → skill-pinned model
-    → skill auto-config
-      → ClusterTenant default
-        → Global default
-```
-
-### How the allowlist is enforced
-
-Each tenant's LiteLLM virtual key carries a `models[]` allowlist, populated from the registry
-at key-mint time and kept in sync by the operator's reconcile loop. A call to a model outside
-the allowlist is rejected at the gateway.
-
-### How measurement estimates savings
-
-A run replays every eval case through both the **baseline** and the **candidate**, grades each
-output with an independent **judge** model, reads the real per-call USD cost from LiteLLM, and
-estimates the saving with a bootstrap **95% confidence interval**. A proposal is emitted *only*
-when that interval excludes zero.
-
-The measurement seams are **live** — they require a deployed LiteLLM, provider keys, and a
-`ROUTING_JUDGE_MODEL`. With any unset, a run is a safe no-op. Full operator recipe:
+How model resolution, allowlists, and savings measurement work under the hood is covered in
+the [API overview → Model routing](/reference/api-overview#model-routing). The full operator
+recipe for turning on measurement lives at
 [`docs/operators/routing-measurement.md`](https://github.com/italanta/opencrane/blob/main/docs/operators/routing-measurement.md).
-
-::: warning Trust the judge, but verify it
-Keep the judge model independent of the candidate's family — a model graded by a sibling of
-itself scores too highly. LLM-as-judge grading also carries position and verbosity bias, so
-calibrate against a small human-graded slice before trusting the absolute savings figure.
-:::
 
 ## See also
 

--- a/website/guide/organize.md
+++ b/website/guide/organize.md
@@ -37,15 +37,10 @@ The same four scopes appear everywhere you share or restrict something:
 
 ## Grouping people
 
-When you create an assistant you can tag the person's team:
-
-```bash
-oc tenants create --name alice --display-name "Alice" --email alice@example.com \
-  --team engineering
-```
-
-That team label is what you then reference when you share skills with "engineering"
-or give a department access to a tool — so everyone in that group is covered at once.
+When you create an assistant, you can tag the person's team — see
+[Create your first employee assistant](/guide/first-tenant). That team label is what
+you then reference when you share skills with "engineering" or give a department
+access to a tool — so everyone in that group is covered at once.
 
 ## A simple way to start
 

--- a/website/guide/permissions.md
+++ b/website/guide/permissions.md
@@ -21,21 +21,10 @@ team. Widen or revoke at any time, and changes take effect almost immediately.
 
 An **access policy** draws a boundary around what an assistant may reach on the
 network — which external sites it can call, and which connected tools are off-limits.
-It's your safety net.
+It's your safety net, and its safest starting point is "block everything except what's
+explicitly listed."
 
-```bash
-oc policies list
-oc policies create --body '{
-  "name": "default-egress",
-  "domains": { "allow": ["*.example.com", "api.openai.com"], "defaultDeny": true },
-  "mcpServers": { "deny": ["risky-tool"] }
-}'
-oc policies get <name>
-oc policies delete <name>
-```
-
-`defaultDeny: true` means "block everything except what's listed" — the safest
-starting point.
+Manage this from the command line — see [CLI reference → `oc policies`](/reference/cli#oc-policies).
 
 ## Putting it together
 

--- a/website/guide/skills.md
+++ b/website/guide/skills.md
@@ -9,25 +9,13 @@ once, then share it with whoever should have it.
 Skills live in your own catalog. OpenCrane keeps each one **versioned** and
 **security-scanned**, and only delivers it to assistants you've allowed.
 
-## See the catalog
+## See the catalog and add a skill
 
-```bash
-oc skills list
-oc skills get <id>
-```
-
-## Add a skill
-
-```bash
-oc skills create \
-  --name sales-follow-up \
-  --version 1.0.0 \
-  --digest sha256:… \
-  --scope personal
-```
-
+Browse what's already there, or add a new one by name, version, and starting scope.
 A skill is added in **draft** and must pass a **security scan** before it can go live —
 so an unsafe skill never reaches an assistant.
+
+Manage this from the command line — see [CLI reference → `oc skills`](/reference/cli#oc-skills).
 
 ## Share it more widely (promotion)
 

--- a/website/guide/tools.md
+++ b/website/guide/tools.md
@@ -10,31 +10,18 @@ see "an MCP server," read it as "one connected tool."
 
 ## Connect a tool
 
-Register the tool once, by name and address:
-
-```bash
-oc mcp create --name slack --endpoint https://slack-mcp.internal
-oc mcp list
-oc mcp get <id>
-```
+Register the tool once, by name and address. Manage this from the command line —
+see [CLI reference → `oc mcp`](/reference/cli#oc-mcp).
 
 ## Give it credentials (safely)
 
 A tool usually needs to authenticate to the system it talks to. OpenCrane stores and
 brokers those credentials **for** the assistant — they're never handed to the
-assistant or the browser:
+assistant or the browser. Two modes are available:
 
-```bash
-# Per-user sign-in (each person authorizes with their own account):
-oc mcp cred add <id> --display-name "Slack (per user)" --mode obo
-
-# Or a single shared credential:
-oc mcp cred add <id> --display-name "Shared key" --mode static --secret-ref my-secret
-```
-
-- **`obo`** ("on behalf of") — each person connects with their own account, so the
+- **Per-user sign-in** — each person authorises with their own account, so the
   assistant acts as *them*.
-- **`static`** — one shared credential for everyone.
+- **Shared credential** — one credential used on behalf of everyone.
 
 ## Decide who can use it
 

--- a/website/integrators/skill-registry.md
+++ b/website/integrators/skill-registry.md
@@ -94,7 +94,12 @@ runtime contract governs whether the skill mechanism is active at all — see
 - ✅ Catalog CRUD, scan (Grype/Trivy) + promote gate, entitlement grants, audit.
 - ✅ Skill Registry delivery app: TokenReview + proxy, scan/entitlement gates,
   existence-hiding, per-read delivery.
-- 🔶 OCI/ORAS (Zot) digest-pinned bundle storage is the longer-term design; today
-  bundle `content` is served from the control-plane DB through the registry, not an OCI
-  registry. The `digest` field already pins identity, so the storage backend can change
-  without altering the delivery contract.
+- 🔶 OCI/ORAS (Zot) digest-pinned bundle storage: **built, gated; cutover in
+  progress.** The store, dual-write on publish, digest-verified delivery, and a
+  backfill tool for existing bundles all exist behind
+  `skillRegistry.ociStore.enabled` (default `false` — see
+  [skill-oci-store.yaml](https://github.com/italanta/opencrane/blob/main/apps/clustertenant-platform/templates/skill-oci-store.yaml)),
+  so today bundle `content` is still served from the control-plane DB through the
+  registry. The `digest` field already pins identity, so flipping the flag changes
+  only the storage backend, not the delivery contract. Tracked in
+  [issue #133](https://github.com/italanta/opencrane/issues/133).

--- a/website/reference/api-overview.md
+++ b/website/reference/api-overview.md
@@ -195,6 +195,40 @@ Shadow-savings measurement pipeline: eval cases, measurements, proposals, recomm
 | `GET` | `/model-routing/defaults` | Get default model routing settings |
 | `PUT` | `/model-routing/defaults` | Update default model routing settings |
 
+:::: details How the effective model is resolved
+At call time the control plane walks this precedence and writes the winner into the
+tenant's effective contract — no pod restart:
+
+```
+explicit request override
+  → skill-pinned model
+    → skill auto-config
+      → ClusterTenant default
+        → Global default
+```
+
+Each tenant's LiteLLM virtual key carries a `models[]` allowlist, populated from the
+registry at key-mint time and kept in sync by the operator's reconcile loop. A call to
+a model outside the allowlist is rejected at the gateway.
+
+**How measurement estimates savings.** A run replays every eval case through both the
+baseline and the candidate model, grades each output with an independent judge model,
+reads the real per-call USD cost from LiteLLM, and estimates the saving with a
+bootstrap 95% confidence interval. A proposal is emitted only when that interval
+excludes zero.
+
+The measurement seams are **live** — they require a deployed LiteLLM, provider keys,
+and a `ROUTING_JUDGE_MODEL`. With any unset, a run is a safe no-op. Full operator
+recipe: [`docs/operators/routing-measurement.md`](https://github.com/italanta/opencrane/blob/main/docs/operators/routing-measurement.md).
+
+::: warning Trust the judge, but verify it
+Keep the judge model independent of the candidate's family — a model graded by a
+sibling of itself scores too highly. LLM-as-judge grading also carries position and
+verbosity bias, so calibrate against a small human-graded slice before trusting the
+absolute savings figure.
+:::
+::::
+
 ### Sharing
 
 Inter-user entitlement sharing (MCP servers, skill bundles) and direct resource sharing (files, chats, datasets).

--- a/website/reference/cli.md
+++ b/website/reference/cli.md
@@ -123,13 +123,23 @@ These commands manage resources in a silo's clustertenant-manager. Set `OPENCRAN
 
 ### `oc tenants`
 
-Manage tenant lifecycle.
+Manage tenant lifecycle — a tenant is one person's employee assistant.
 
 ```
 oc tenants list                         List all tenants
+  --cluster-tenant <name>               Only list tenants attached to this parent ClusterTenant (customer)
+
 oc tenants get <name>                   Get a tenant by name
-oc tenants create                       Create a tenant (reads JSON from stdin)
-oc tenants update <name>                Update a tenant (reads JSON from stdin)
+oc tenants create                       Create a new tenant
+  --name <name>                         Tenant name (must be a valid DNS label)
+  --display-name <displayName>          Human-readable display name
+  --email <email>                       Contact email for the tenant
+  --team <team>                         Team name
+  --cluster-tenant <name>               Parent ClusterTenant (customer) to attach this tenant to
+  --budget <usd>                        Monthly budget ceiling in USD
+  --policy-ref <policyRef>              AccessPolicy name to attach
+
+oc tenants update <name>                Update a tenant (same flags as create, all optional)
 oc tenants delete <name>                Delete a tenant
 oc tenants suspend <name>               Suspend a tenant pod
 oc tenants resume <name>                Resume a suspended tenant
@@ -142,14 +152,31 @@ oc tenants contract <name>              Print the compiled effective runtime con
 
 ### `oc policies`
 
-Manage AccessPolicy resources.
+Manage AccessPolicy resources — network/tool egress guardrails.
 
 ```
 oc policies list                        List all access policies
 oc policies get <name>                  Get a policy by name
-oc policies create                      Create a policy (reads JSON from stdin)
-oc policies update <name>               Update a policy (reads JSON from stdin)
+oc policies create                      Create a policy
+  --body <json>                         JSON payload for the policy spec
+
+oc policies update <name>               Update a policy
+  --body <json>                         JSON payload for the policy spec update
+
 oc policies delete <name>               Delete a policy
+oc policies drift                       Report drift between policy CRDs and PostgreSQL projections
+oc policies repair                      Repair drifted policy projections (dry-run unless --apply)
+```
+
+Example payload — `defaultDeny: true` means "block everything except what's listed",
+the safest starting point:
+
+```bash
+oc policies create --body '{
+  "name": "default-egress",
+  "domains": { "allow": ["*.example.com", "api.openai.com"], "defaultDeny": true },
+  "mcpServers": { "deny": ["risky-tool"] }
+}'
 ```
 
 ---
@@ -161,10 +188,30 @@ Manage MCP server registrations.
 ```
 oc mcp list                             List MCP servers
 oc mcp get <id>                         Get an MCP server
-oc mcp create                           Register an MCP server (reads JSON from stdin)
-oc mcp update <id>                      Update an MCP server (reads JSON from stdin)
-oc mcp delete <id>                      Delete an MCP server
+oc mcp create                           Register an MCP server
+  --name <name>                         Display name
+  --endpoint <endpoint>                 Server endpoint URL
+  --transport <transport>               Transport: streamable-http|sse|websocket (default: streamable-http)
+  --body <json>                         Full JSON payload (overrides individual flags)
+
+oc mcp update <id>                      Update an MCP server (pass --body JSON or individual flags)
+oc mcp delete <id>                      Delete an MCP server and its linked grants
 ```
+
+Brokered downstream credentials — how the server authenticates to the system it talks to:
+
+```
+oc mcp cred list <serverId>             List the brokered credentials of an MCP server
+oc mcp cred add <serverId>              Add a brokered credential
+  --display-name <name>                 Operator-facing credential label
+  --mode <mode>                         Brokering mode: static|obo (default: static)
+  --secret-ref <ref>                    Secret reference (required for --mode static, omit for obo)
+
+oc mcp cred rm <serverId> <credentialId>   Remove a brokered credential from an MCP server
+```
+
+`static` uses one shared credential for everyone; `obo` ("on behalf of") has each
+person authorise with their own account, so the assistant acts as *them*.
 
 ---
 
@@ -232,7 +279,8 @@ oc tokens delete <id>                   Revoke an access token
 
 ### `oc providers`
 
-Manage provider API keys (e.g. OpenAI, Anthropic).
+Manage provider API keys (e.g. OpenAI, Anthropic). Backed by `/api/v1/providers/keys`,
+a database-backed credential store (`ProviderApiKey`).
 
 ```
 oc providers list                       List configured provider keys (status only — key is never returned)
@@ -240,9 +288,20 @@ oc providers set <provider> <key>       Set a provider key by name and value
 oc providers delete <provider>          Remove a provider key
 ```
 
-::: info BYOK (raw upstream keys)
-Setting a raw upstream provider key for the whole silo is an org-admin API action — use
-`PUT /api/v1/providers/byok/:provider`. See [Manage cost](/guide/budgets#bring-your-own-provider-key-byok) for details.
+::: info BYOK is a separate, API-only path
+BYOK (bring your own key) provisions one **raw upstream key per provider for the whole
+silo**, written into a Kubernetes Secret and registered with LiteLLM — a different
+mechanism from `oc providers` above, and not (yet) wrapped by an `oc` sub-command:
+
+```
+PUT    /api/v1/providers/byok/:provider   Set or refresh the raw provider key
+GET    /api/v1/providers/byok             List configured BYOK providers (presence + timestamps, no key material)
+DELETE /api/v1/providers/byok/:provider   Remove a provider key
+```
+
+Supported provider values are defined in the `ByokProvider` contract enum (e.g.
+`openai`, `anthropic`). The mutation requires an IdP-verified org-admin identity.
+See [Manage cost](/guide/budgets#bring-your-own-provider-key-byok) for when to use it.
 :::
 
 ---
@@ -416,6 +475,22 @@ oc awareness rollout resolve <tenant>   Resolve the contract version a tenant ru
 
 oc awareness participation              Fleet participation health
   --severity <severity>                 Filter: critical|warning
+```
+
+---
+
+### `oc sessions`
+
+Bind, inspect, or clear a chat session's awareness scope, so one project's context
+can't spill into an unrelated chat.
+
+```
+oc sessions scope set <sessionKey>      Bind a session's scope (control plane intersects it with the principal's entitlements)
+  --principal <principal>               Tenant/user that owns the session
+  --scope <level:payloadId...>          Scope selector(s), repeatable: org|department|project|personal:<payloadId>
+
+oc sessions scope show <sessionKey>     Inspect a session's current scope binding
+oc sessions scope clear <sessionKey>    Clear a session's scope binding
 ```
 
 ---


### PR DESCRIPTION
## What

Docs-only. Two jobs from the 2026-07-06 docs review:

**Drift fixes (verified against code):**
- README: `docker/` component row → per-app `deploy/Dockerfile`s (`.github/workflows/docker.yml`); harvesting claim scoped to Slack with the MCP-harness plan (#129); budget/allowlist sentences name the LiteLLM enforcement seam; BYOK CLI claim softened (API-only today, #131); CLI quick-reference trimmed to four illustrative commands + the reference link.
- `guide/budgets.md` + `reference/cli.md`: provider keys (`oc providers`, DB-backed) vs BYOK (`/api/v1/providers/byok/:provider`, Secret-backed, org-admin, API-only) split into clearly distinct paths.
- `integrators/skill-registry.md`: Zot marker corrected to built-and-gated, cutover in progress (#133).

**Least-technical top-level (house decision 2026-07-06):** ten `guide/` pages trimmed to plain-prose what/why; their CLI blocks and API mechanics merged into `reference/cli.md` (which gained `oc mcp cred` and `oc sessions` sections that previously existed only as guide prose) and `reference/api-overview.md` (model-routing details block). Nothing dropped — only relocated; two pre-existing "(reads JSON from stdin)" mislabels in cli.md fixed where the merge touched them.

## Validation

- Site build green with `ignoreDeadLinks: false`; edited pages render.
- New CLI doc blocks spot-verified against `apps/cli/src/commands/{sessions,mcp-servers}.ts`.
- Known follow-up (left for #131): the same stdin-mislabel pattern on `oc cluster-tenant`/`oc mcp`/`oc skills`/`oc budget`/`oc tokens` blocks.