### PR TITLE
✨ silo: serve + secure the Control UI for chat embedding (Phase 0)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
@@ -84,6 +84,21 @@ describe("_HandleUpgrade (in-operator gateway proxy)", () =>
     expect(resolve).toHaveBeenCalledWith("http://cp:3000", "sid=x", "acme.opencrane.ai", expect.any(AbortSignal));
   });
 
+  it("caps the session to chat-only scopes and strips a client-supplied scopes header", async () =>
+  {
+    const resolve = vi.fn().mockResolvedValue(okTarget);
+    const { deps, proxy } = _deps(resolve);
+    // A client tries to self-declare admin scopes on the upgrade.
+    const req = _req({ origin: "https://acme.opencrane.ai", host: "acme.opencrane.ai", cookie: "sid=x", "x-openclaw-scopes": "operator.admin" });
+
+    await _HandleUpgrade(deps, req, _fakeSocket(), Buffer.alloc(0));
+
+    // The proxy injects the chat-only cap (operator.read/write, no admin)…
+    expect(proxy.headers[0]?.["x-openclaw-scopes"]).toBe("operator.read operator.write");
+    // …and the client's self-declared header never reaches the pod.
+    expect(req.headers["x-openclaw-scopes"]).toBeUndefined();
+  });
+
   it("forwards x-forwarded-host (first value) over the Host header when both are present", async () =>
   {
     const resolve = vi.fn().mockResolvedValue(okTarget);

--- a/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
@@ -1,10 +1,10 @@
-import type { IncomingMessage } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 import pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 
-import { _HandleUpgrade, _StripGatewayPrefix } from "../../gateway-proxy/proxy.js";
-import type { UpgradeDeps, WsProxy, GatewayProxyRuntime } from "../../gateway-proxy/proxy.js";
+import { _HandleControlUiRequest, _HandleUpgrade, _IsControlUiRequest, _StripGatewayPrefix } from "../../gateway-proxy/proxy.js";
+import type { ControlUiDeps, UpgradeDeps, WebProxy, WsProxy, GatewayProxyRuntime } from "../../gateway-proxy/proxy.js";
 import type { ResolveOutcome } from "../../gateway-proxy/auth-client.js";
 import { FixedWindowRateLimiter } from "../../gateway-proxy/rate-limit.js";
 
@@ -169,5 +169,87 @@ describe("_StripGatewayPrefix", () =>
     expect(_StripGatewayPrefix("/api")).toBe("/api");
     expect(_StripGatewayPrefix("/gateways")).toBe("/gateways"); // not the /gateway segment
     expect(_StripGatewayPrefix(undefined)).toBe("/");
+  });
+});
+
+describe("_IsControlUiRequest", () =>
+{
+  it("matches the /control-ui segment and its descendants/query", () =>
+  {
+    expect(_IsControlUiRequest("/control-ui")).toBe(true);
+    expect(_IsControlUiRequest("/control-ui/")).toBe(true);
+    expect(_IsControlUiRequest("/control-ui/assets/index-a1.js")).toBe(true);
+    expect(_IsControlUiRequest("/control-ui?x=1")).toBe(true);
+  });
+
+  it("does not match a sibling path, the WS route, or health probes", () =>
+  {
+    expect(_IsControlUiRequest("/control-uix")).toBe(false);
+    expect(_IsControlUiRequest("/gateway")).toBe(false);
+    expect(_IsControlUiRequest("/api")).toBe(false);
+    expect(_IsControlUiRequest("/healthz")).toBe(false);
+    expect(_IsControlUiRequest(undefined)).toBe(false);
+  });
+});
+
+/** A fake HTTP proxy recording forward targets + injected options. */
+function _fakeWebProxy(): WebProxy & { targets: string[]; options: Array<{ target: string; headers?: Record<string, string> }> }
+{
+  const targets: string[] = [];
+  const options: Array<{ target: string; headers?: Record<string, string> }> = [];
+  return {
+    targets,
+    options,
+    web(_req, _res, opts) { targets.push(opts.target); options.push(opts as { target: string; headers?: Record<string, string> }); }
+  };
+}
+
+/** A fake ServerResponse recording status + headersSent. */
+function _fakeRes(): ServerResponse & { status: number | null; headersSent: boolean; ended: boolean }
+{
+  const res = {
+    status: null as number | null,
+    headersSent: false,
+    ended: false,
+    writeHead(status: number) { (res as { status: number | null }).status = status; (res as { headersSent: boolean }).headersSent = true; return res; },
+    end() { (res as { ended: boolean }).ended = true; return res; }
+  };
+  return res as unknown as ServerResponse & { status: number | null; headersSent: boolean; ended: boolean };
+}
+
+describe("_HandleControlUiRequest (Control UI static bundle)", () =>
+{
+  function _controlUiDeps(resolve: ControlUiDeps["resolve"]): { deps: ControlUiDeps; proxy: ReturnType<typeof _fakeWebProxy> }
+  {
+    const proxy = _fakeWebProxy();
+    return { deps: { config: baseConfig, proxy, log, resolve }, proxy };
+  }
+
+  function _httpReq(url: string, headers: Record<string, string | undefined> = {}): IncomingMessage
+  {
+    return { headers: { host: "acme.opencrane.ai", cookie: "sid=x", ...headers }, url, socket: { remoteAddress: "10.0.0.1" } } as unknown as IncomingMessage;
+  }
+
+  it("proxies to the caller's pod gateway over HTTP with NO identity/scope injection", async () =>
+  {
+    const resolve = vi.fn().mockResolvedValue(okTarget);
+    const { deps, proxy } = _controlUiDeps(resolve);
+
+    await _HandleControlUiRequest(deps, _httpReq("/control-ui/assets/index-a1.js"), _fakeRes());
+
+    expect(proxy.targets).toEqual(["http://openclaw-alice.opencrane-acme.svc.cluster.local:18789"]);
+    // Static bundle: no X-Forwarded-User / x-openclaw-scopes on the forward.
+    expect(proxy.options[0]?.headers).toBeUndefined();
+  });
+
+  it("refuses with the control plane's status when resolution fails", async () =>
+  {
+    const { deps, proxy } = _controlUiDeps(vi.fn().mockResolvedValue({ ok: false, status: 403, reason: "no tenant" } as ResolveOutcome));
+    const res = _fakeRes();
+
+    await _HandleControlUiRequest(deps, _httpReq("/control-ui/"), res);
+
+    expect(res.status).toBe(403);
+    expect(proxy.targets).toEqual([]);
   });
 });

--- a/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -36,6 +36,17 @@ describe("openclaw.json render contract — zod schema (task_d611ab4d)", functio
     expect(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error.issues, null, 2)).toBe(true);
   });
 
+  it("serves + configures the Control UI for embedding (enabled, basePath, chatMessageMaxWidth)", function _controlUi()
+  {
+    const config = _renderConfig();
+    const controlUi = ((config["gateway"] as Record<string, unknown>)["controlUi"]) as Record<string, unknown>;
+    expect(controlUi["enabled"]).toBe(true);
+    expect(controlUi["basePath"]).toBe("/control-ui");
+    expect(typeof controlUi["chatMessageMaxWidth"]).toBe("string");
+    expect(controlUi["dangerouslyDisableDeviceAuth"]).toBe(true); // device-less trusted-proxy preserved
+    expect(_OpenclawConfigSchema.safeParse(config).success).toBe(true);
+  });
+
   it("validates the LiteLLM-enabled config (models block) against the schema", function _modelsOk()
   {
     // Exercise the optional `models` branch so the provider/mode shape is covered.

--- a/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
+++ b/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Duplex } from "node:stream";
 
 import type { Logger } from "pino";
@@ -31,6 +31,15 @@ export interface WsProxy
   ws(req: IncomingMessage, socket: Duplex, head: Buffer, options: { target: string; headers?: Record<string, string> }, callback: (err: Error) => void): void;
 }
 
+/** Minimal HTTP reverse-proxy surface for serving the Control UI (satisfied by `http-proxy`). */
+export interface WebProxy
+{
+  web(req: IncomingMessage, res: ServerResponse, options: { target: string }, callback: (err: Error) => void): void;
+}
+
+/** Delegated-auth resolver signature; defaults to the live control-plane call. */
+type ResolveFn = (controlPlaneUrl: string, cookie: string | undefined, host: string | undefined, signal: AbortSignal) => Promise<ResolveOutcome>;
+
 /** Dependencies for {@link _HandleUpgrade}; injectable so the handler is unit-testable. */
 export interface UpgradeDeps
 {
@@ -39,7 +48,17 @@ export interface UpgradeDeps
   limiter: FixedWindowRateLimiter;
   log: Logger;
   /** Delegated-auth resolver; defaults to the live control-plane call. */
-  resolve?: (controlPlaneUrl: string, cookie: string | undefined, host: string | undefined, signal: AbortSignal) => Promise<ResolveOutcome>;
+  resolve?: ResolveFn;
+}
+
+/** Dependencies for {@link _HandleControlUiRequest}; injectable so the handler is unit-testable. */
+export interface ControlUiDeps
+{
+  config: GatewayProxyRuntime;
+  proxy: WebProxy;
+  log: Logger;
+  /** Delegated-auth resolver; defaults to the live control-plane call. */
+  resolve?: ResolveFn;
 }
 
 /** Bound on the delegated-auth call so a slow control plane can't pin a socket open. */
@@ -182,6 +201,90 @@ export async function _HandleUpgrade(deps: UpgradeDeps, req: IncomingMessage, so
     if (!socket.destroyed)
     {
       socket.destroy();
+    }
+  });
+}
+
+/** External path prefix the Control UI static bundle is served under on the org host. */
+const _CONTROL_UI_PATH_PREFIX = "/control-ui";
+
+/**
+ * Whether an HTTP request targets the Control UI static bundle (`/control-ui/…`).
+ *
+ * Exact prefix match on the `/control-ui` segment so a sibling path (`/control-uix`)
+ * is not captured; the gateway serves the bundle under this same base path, so the
+ * URL is forwarded unchanged (no prefix strip, unlike the `/gateway` WS route).
+ *
+ * @param url - The raw request URL (path + optional query).
+ * @returns True when the request should be served by {@link _HandleControlUiRequest}.
+ */
+export function _IsControlUiRequest(url: string | undefined): boolean
+{
+  const u = url ?? "";
+  return u === _CONTROL_UI_PATH_PREFIX || u.startsWith(`${_CONTROL_UI_PATH_PREFIX}/`) || u.startsWith(`${_CONTROL_UI_PATH_PREFIX}?`);
+}
+
+/**
+ * Serve OpenClaw's Control UI static bundle by reverse-proxying `/control-ui/…` to the
+ * caller's own pod gateway (which serves the bundle under the same base path).
+ *
+ * Unlike the WS upgrade this injects NO identity/scope headers: the bundle is static
+ * and the gateway serves it without auth (auth happens on the WS the loaded app opens
+ * at `/gateway`). We still resolve the caller→pod via the control plane, so a request
+ * is only ever forwarded to that user's silo pod; and the whole org host already sits
+ * behind the ingress OIDC gate, so an unauthenticated request never reaches here.
+ *
+ * The path is forwarded unchanged (the gateway's `controlUi.basePath` is `/control-ui`).
+ * NOTE: the caller→pod resolution runs per request; the Control UI's service worker +
+ * browser cache mean this is essentially a first-load cost. A cookie→pod cache is a
+ * cheap future optimisation if that proves hot.
+ *
+ * @param deps - Injected config, HTTP proxy, logger, and (optionally) resolver.
+ * @param req  - The HTTP request.
+ * @param res  - The HTTP response.
+ */
+export async function _HandleControlUiRequest(deps: ControlUiDeps, req: IncomingMessage, res: ServerResponse): Promise<void>
+{
+  const { config, proxy, log } = deps;
+  const resolve = deps.resolve ?? _ResolveTarget;
+  const reqLog = log.child({ component: "gateway-proxy", url: req.url });
+
+  const forwardedHost = typeof req.headers["x-forwarded-host"] === "string" ? req.headers["x-forwarded-host"].split(",")[0].trim() : undefined;
+  const host = forwardedHost ?? (typeof req.headers.host === "string" ? req.headers.host : undefined);
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), _RESOLVE_TIMEOUT_MS);
+  let outcome: ResolveOutcome;
+  try
+  {
+    outcome = await resolve(config.controlPlaneUrl, req.headers.cookie, host, ac.signal);
+  }
+  finally
+  {
+    clearTimeout(timer);
+  }
+
+  if (!outcome.ok)
+  {
+    reqLog.warn({ status: outcome.status, reason: outcome.reason }, "control-ui request refused by control plane");
+    res.writeHead(outcome.status, { "content-type": "text/plain" });
+    res.end(_REASONS[outcome.status] ?? "Bad Gateway");
+    return;
+  }
+
+  const { podService } = outcome.target;
+  const target = `http://${podService.name}.${podService.namespace}.${config.clusterDomain}:${config.gatewayPort}`;
+  reqLog.info({ tenant: outcome.target.tenant.name, target }, "control-ui request authorised; proxying");
+  proxy.web(req, res, { target }, function _onProxyError(err: Error)
+  {
+    reqLog.error({ err, target }, "control-ui proxy transport error");
+    if (!res.headersSent)
+    {
+      res.writeHead(502, { "content-type": "text/plain" });
+      res.end("Bad Gateway");
+    }
+    else if (!res.writableEnded)
+    {
+      res.end();
     }
   });
 }

--- a/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
+++ b/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
@@ -57,6 +57,21 @@ const _RESOLVE_TIMEOUT_MS = 5_000;
  */
 const _GATEWAY_PATH_PREFIX = "/gateway";
 
+/** Header the gateway reads to CAP a Control-UI session's scopes (intersection, not a grant). */
+const _SCOPES_HEADER = "x-openclaw-scopes";
+
+/**
+ * Scopes the proxy caps every gateway WS session to (chat-only).
+ *
+ * OpenClaw intersects the session's requested scopes with `x-openclaw-scopes` when the
+ * proxy sends it (see docs/gateway/trusted-proxy-auth). Capping to `operator.read` +
+ * `operator.write` grants exactly what chat needs (read history + send) while denying
+ * `operator.admin` — so the Control UI's config/nodes/admin surfaces are refused at the
+ * gateway, not merely hidden. The proxy is the trust boundary, so a client cannot widen
+ * this by self-declaring the header (we strip any inbound copy before injecting ours).
+ */
+const _CHAT_SCOPES = "operator.read operator.write";
+
 /**
  * Strip a leading `/gateway` segment from the upgrade request path so the upstream
  * OpenClaw pod (whose gateway listens at `/`) sees the path it expects, regardless of
@@ -151,15 +166,17 @@ export async function _HandleUpgrade(deps: UpgradeDeps, req: IncomingMessage, so
     return;
   }
 
-  // 4. Strip any client-supplied identity header, inject the verified one, forward.
+  // 4. Strip any client-supplied identity/scope headers, inject the verified identity
+  //    and the chat-only scope cap, forward.
   delete req.headers[config.userHeader.toLowerCase()];
+  delete req.headers[_SCOPES_HEADER];
   // The gateway WS is exposed at `/gateway` on the org host (the SPA owns `/`); the pod
   // gateway listens at `/`, so drop the prefix before forwarding. Backward-compatible: a
   // bare `/` upgrade is left untouched.
   req.url = _StripGatewayPrefix(req.url);
   const target = `ws://${podService.name}.${podService.namespace}.${config.clusterDomain}:${config.gatewayPort}`;
   reqLog.info({ email: user.email, tenant: tenant.name, target }, "gateway upgrade authorised; proxying");
-  proxy.ws(req, socket, head, { target, headers: { [config.userHeader]: user.email } }, function _onProxyError(err: Error)
+  proxy.ws(req, socket, head, { target, headers: { [config.userHeader]: user.email, [_SCOPES_HEADER]: _CHAT_SCOPES } }, function _onProxyError(err: Error)
   {
     reqLog.error({ err, target }, "gateway proxy transport error");
     if (!socket.destroyed)

--- a/apps/clustertenant-operator/src/gateway-proxy/server.ts
+++ b/apps/clustertenant-operator/src/gateway-proxy/server.ts
@@ -5,8 +5,8 @@ import type { Duplex } from "node:stream";
 import httpProxy from "http-proxy";
 import type { Logger } from "pino";
 
-import { _HandleUpgrade } from "./proxy.js";
-import type { GatewayProxyRuntime, WsProxy } from "./proxy.js";
+import { _HandleControlUiRequest, _HandleUpgrade, _IsControlUiRequest } from "./proxy.js";
+import type { ControlUiDeps, GatewayProxyRuntime, WebProxy, WsProxy } from "./proxy.js";
 import { FixedWindowRateLimiter } from "./rate-limit.js";
 
 /** Everything the in-operator proxy server needs, derived from the operator config. */
@@ -59,6 +59,7 @@ export class GatewayProxyServer
 
     const limiter = new FixedWindowRateLimiter(this.config.rateLimitPerMinute);
     const deps = { config: this.config, proxy: proxy as unknown as WsProxy, limiter, log: this.log };
+    const controlUiDeps: ControlUiDeps = { config: this.config, proxy: proxy as unknown as WebProxy, log: this.log };
 
     const server = createServer((req: IncomingMessage, res: ServerResponse) =>
     {
@@ -66,6 +67,21 @@ export class GatewayProxyServer
       {
         res.writeHead(200, { "content-type": "text/plain" });
         res.end("ok");
+        return;
+      }
+      // Serve the Control UI static bundle (so the org SPA can embed it) by proxying
+      // to the caller's pod gateway; static assets, so no identity/scope injection.
+      if (_IsControlUiRequest(req.url))
+      {
+        void _HandleControlUiRequest(controlUiDeps, req, res).catch((err: unknown) =>
+        {
+          this.log.error({ err }, "unhandled error in control-ui request handler");
+          if (!res.headersSent)
+          {
+            res.writeHead(502, { "content-type": "text/plain" });
+            res.end("Bad Gateway");
+          }
+        });
         return;
       }
       res.writeHead(404, { "content-type": "text/plain" });

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -18,6 +18,21 @@ const _WORKSPACE_TEMPLATES_DIR = join(dirname(fileURLToPath(import.meta.url)), "
 const _WORKSPACE_PATH = "/data/openclaw/workspace";
 
 /**
+ * Base path the gateway serves its built-in Control UI (Vite+Lit SPA) under, so the
+ * org-admin SPA can EMBED it as the chat surface instead of maintaining a bespoke
+ * renderer. The SPA owns `/` and the gateway WS is proxied at `/gateway`, so the
+ * Control UI mounts under its own prefix; the org ingress routes this path to the
+ * gateway (via the gateway-proxy) in the embedding phase.
+ */
+const _CONTROL_UI_BASE_PATH = "/control-ui";
+
+/**
+ * Reading-measure cap for grouped Control UI chat messages (openclaw default is
+ * `min(900px, 68%)`). Pinned to a comfortable, legible width for the embed.
+ */
+const _CONTROL_UI_CHAT_MAX_WIDTH = "min(820px, 100%)";
+
+/**
  * Default agent reasoning posture — makes the model's thinking a first-class part
  * of the transcript so it streams live AND is returned by `chat.history` (the
  * org-admin SPA renders reasoning as a collapsible "Thinking" card).
@@ -150,6 +165,12 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
       //    not yet — tracked separately. The owner-pin (auth.allowUsers) is defence-in-depth, not a
       //    substitute (a caller that asserts the owner email is trusted under trusted-proxy).
       controlUi: {
+        // Serve the gateway's built-in Control UI so the org-admin SPA can embed it as
+        // the chat surface (see _CONTROL_UI_BASE_PATH). Chat-only is enforced at the
+        // gateway-proxy, which caps the WS session to operator.read/write.
+        enabled: true,
+        basePath: _CONTROL_UI_BASE_PATH,
+        chatMessageMaxWidth: _CONTROL_UI_CHAT_MAX_WIDTH,
         dangerouslyDisableDeviceAuth: true,
         ...(servingHost ? { allowedOrigins: [`https://${servingHost}`] } : {}),
       },

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -71,6 +71,12 @@ const _authSchema = z
  */
 const _controlUiSchema = z
   .object({
+    /** Serve the gateway's built-in Control UI (so the org SPA can embed it for chat). */
+    enabled: z.boolean().optional(),
+    /** Base path the Control UI is served under (e.g. `/control-ui`). */
+    basePath: z.string().optional(),
+    /** Reading-measure cap for grouped chat messages (e.g. `min(820px, 100%)`). */
+    chatMessageMaxWidth: z.string().optional(),
     /** Browser Origins allowed to open a Control-UI WS (e.g. `https://<org>.<base>`). */
     allowedOrigins: z.array(z.string()).optional(),
     /** Trust the proxy as the auth authority instead of per-browser device identity. */

--- a/apps/clustertenant-platform/templates/clustertenant-manager-ingress.yaml
+++ b/apps/clustertenant-platform/templates/clustertenant-manager-ingress.yaml
@@ -50,6 +50,16 @@ spec:
                 name: {{ include "opencrane.fullname" . }}-gateway-proxy
                 port:
                   number: {{ .Values.gatewayProxy.port }}
+          # OpenClaw's Control UI static bundle, so the org SPA can embed it as the chat
+          # surface. The gateway-proxy reverse-proxies /control-ui to the caller's pod
+          # gateway (which serves the bundle under this base path); the WS stays on /gateway.
+          - path: /control-ui
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "opencrane.fullname" . }}-gateway-proxy
+                port:
+                  number: {{ .Values.gatewayProxy.port }}
           {{- end }}
           - path: /
             pathType: Prefix


### PR DESCRIPTION
**Phase 0** of the plan to embed OpenClaw's built-in Control UI as the chat surface (weownai `plan/control-ui-embed`, [PR #36](https://github.com/italanta/WeOwnAI/pull/36)) — so we stop maintaining a bespoke Markdown/MDX renderer.

Investigation already cleared both blockers; this lands the enabling backend change in three parts: **serve** the bundle, **route** it through the proxy/ingress, and **cap** its scopes to chat-only.

### 1. Serve the Control UI (config)
`2-config-map.ts` sets `gateway.controlUi` on the rendered `openclaw.json`:
- `enabled: true`, `basePath: /control-ui`, `chatMessageMaxWidth: min(820px, 100%)`
- keeps the existing `dangerouslyDisableDeviceAuth: true` (device-less trusted-proxy) + host `allowedOrigins`

Keys verified against `openclaw@2026.6.9` `GatewayControlUiConfig` and added to the vendored `_controlUiSchema` (which is `.strict()`, so they had to be declared).

### 2. Route the bundle same-origin (new)
The gateway serves the Control UI **from each org's pod**, so the SPA has to reach it same-origin without an iframe:
- `proxy.ts`: `_IsControlUiRequest` (exact `/control-ui` segment match) + `_HandleControlUiRequest` — resolves caller→pod via the control plane, then reverse-proxies the HTTP request to that pod's gateway. These are **static assets**, so there is **no** `x-forwarded-user`/`x-openclaw-scopes` injection on this path (identity + scope cap live on the WS upgrade). Per-request resolve is a first-load cost only (service-worker + browser cache thereafter); a cookie→pod cache is a noted future optimisation.
- `server.ts`: routes `_IsControlUiRequest` → `_HandleControlUiRequest` before the 404, with a 502 fallback.
- `clustertenant-manager-ingress.yaml`: adds a `/control-ui` Prefix path → `gateway-proxy` (alongside the existing `/gateway` WS path, under `sameOrigin`).

### 3. Enforce chat-only (server-side)
`gateway-proxy` injects **`x-openclaw-scopes: operator.read operator.write`** on every gateway WS upgrade (after stripping any client-supplied copy). OpenClaw intersects the session's requested scopes with this header, so the session is **capped to chat** — the Control UI's config/nodes/admin surfaces are refused at the gateway, not merely hidden. Combined with landing the embed on the `/chat` route, chat-only is both scope-enforced and route-scoped.

**OIDC passthrough** needs no change — it's the existing trusted-proxy `x-forwarded-user` path our chat already uses (no device pairing).

## Validation
- `pnpm --filter @opencrane/clustertenant-operator test` — **620 passing** (new: config-contract `controlUi` assertions; proxy scope-cap + client-header-strip; `_IsControlUiRequest` predicate + `_HandleControlUiRequest` forward/refusal). `tsc` + build clean.

## Deferred / open items
- **Types-in-impl**: the new `WebProxy`/`ControlUiDeps` interfaces are co-located inline in `proxy.ts`, matching the seam's 4 pre-existing inline types (`GatewayProxyRuntime`, `WsProxy`, `UpgradeDeps`, `GatewayProxyServerConfig`). A full extraction to a `proxy.types.ts` is out of scope for this PR.
- **cookie→pod resolve cache** for `/control-ui` static requests (first-load only today).
- Phase 3 runtime validation is gated on a working silo + the backend deploy.

## Next
Phase 1 (weownai, [PR #37](https://github.com/italanta/WeOwnAI/pull/37)): mount the Control UI `<openclaw-app>` web component in the org-admin shell behind a feature flag + apply a WeOwnAI tweakcn theme. Phase 2: retire the custom renderer. Phase 3: validate on a working silo.
