### PR TITLE
🔧 deploy: helm upgrade --force-conflicts so SSA reclaims chart-owned fields (fixes #146)

### DIFF
--- a/libs/k8s-platform/k8s-deploy.sh
+++ b/libs/k8s-platform/k8s-deploy.sh
@@ -861,7 +861,17 @@ log "Installing the OpenCrane Helm release '$RELEASE'…"
 # STORE_MODEL_IN_DB on, so models/keys are stored and seeded at runtime via the admin API. The
 # Prisma query-engine crash on the Chainguard/wolfi base is fixed by the non_root image variant
 # (pre-baked engine binaries), set in the chart — see values.yaml litellm.image.
+# --force-conflicts: Helm 4 applies server-side, so any out-of-band actor that has
+# claimed field ownership of a chart-rendered field (e.g. a `kubectl patch`/`kubectl set
+# image` leaving a `kubectl-*` manager, or a now-removed operator drift-repairer whose
+# stale `node-fetch` ownership persists on the live object — see the warning above and
+# issue #146) makes `helm upgrade` fail with a field-ownership conflict. This engine's
+# contract is that Helm is the SOLE owner of chart-rendered fields, so on conflict Helm
+# should always reclaim them. Idempotent: a no-op when there is no conflicting manager,
+# and it only forces fields the chart actually applies (foreign managers of OTHER fields
+# are untouched). Without it a single stray imperative patch wedges every future upgrade.
 helm_args=(upgrade --install "$RELEASE" "$CHART_DIR" --namespace "$NAMESPACE" --create-namespace
+  --force-conflicts
   --set "clustertenantManager.database.existingSecret=$DB_SECRET"
   --set "fleetManager.database.existingSecret=$DB_SECRET"
   --set "litellm.existingDatabaseSecret=opencrane-litellm-db"


### PR DESCRIPTION
Fixes #146.

## Problem
Helm 4 (`v4.1.4` on the deploy hosts) applies **server-side by default**. Any out-of-band actor that has claimed field ownership of a chart-rendered field then wedges every subsequent `helm upgrade` with an SSA field-ownership conflict.

This bites existing dev silos on the **transitional** upgrade to the post-#143 operator: they still run the old runtime-plane drift-repairer, whose `node-fetch` field-manager owns `opencrane-skill-registry`'s `CONTROL_PLANE_URL` env. So the very upgrade that would *remove* the drift-repairer fails first on the conflict the drift-repairer created — `opencrane-elewa`'s release is stuck `STATUS: failed` at rev 14, no upgrade can land (verified by the deploy agent, 2026-07-05).

## Fix
Add `--force-conflicts` to the engine's `helm upgrade` (`libs/k8s-platform/k8s-deploy.sh`).

This engine's contract — already stated in the `--image-tag` warning near the top of the file — is that **Helm is the sole owner of chart-rendered fields**; an imperative patch that steals ownership is a bug. So on conflict, Helm should always reclaim its fields.

- **Idempotent**: a no-op when no foreign manager conflicts.
- **Scoped**: `--force-conflicts` only forces fields the chart actually applies; foreign managers of *other* fields are untouched.
- **General**: fixes the whole class of "one stray `kubectl patch` / `kubectl set image` wedges all future upgrades", not just the drift-repairer case.

## Validation
- `bash -n libs/k8s-platform/k8s-deploy.sh` — clean.
- `helm upgrade --help` on `v4.1.4` confirms `--force-conflicts` ("if set server-side apply will force changes against conflicts").
- No shell test suite exists for the deploy engine; change is a single additive flag on the existing `helm_args`.

## Next
Unblocks deploying Control UI Phase 0 (#145, merged) to the existing dev silos (elewa). After this lands, `apps/clustertenant-platform/deploy.sh --cluster-tenant elewa` can complete instead of failing on the stale `node-fetch` ownership.
