### PR TITLE
🐛✨ gateway-proxy: fix zero-scope Control UI sessions + enable same-origin iframe embed

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
@@ -93,8 +93,10 @@ describe("_HandleUpgrade (in-operator gateway proxy)", () =>
 
     await _HandleUpgrade(deps, req, _fakeSocket(), Buffer.alloc(0));
 
-    // The proxy injects the chat-only cap (operator.read/write, no admin)…
-    expect(proxy.headers[0]?.["x-openclaw-scopes"]).toBe("operator.read operator.write");
+    // The proxy injects the chat-only cap (operator.read/write, no admin), COMMA-separated
+    // because openclaw parses this header with split(",") — a space-separated value reads
+    // as one unknown scope and the session ends up with NO scopes.
+    expect(proxy.headers[0]?.["x-openclaw-scopes"]).toBe("operator.read,operator.write");
     // …and the client's self-declared header never reaches the pod.
     expect(req.headers["x-openclaw-scopes"]).toBeUndefined();
   });

--- a/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/gateway-proxy/proxy.test.ts
@@ -3,7 +3,7 @@ import type { Duplex } from "node:stream";
 import pino from "pino";
 import { describe, expect, it, vi } from "vitest";
 
-import { _HandleControlUiRequest, _HandleUpgrade, _IsControlUiRequest, _StripGatewayPrefix } from "../../gateway-proxy/proxy.js";
+import { _HandleControlUiRequest, _HandleUpgrade, _IsControlUiRequest, _RelaxControlUiFrameHeaders, _StripGatewayPrefix } from "../../gateway-proxy/proxy.js";
 import type { ControlUiDeps, UpgradeDeps, WebProxy, WsProxy, GatewayProxyRuntime } from "../../gateway-proxy/proxy.js";
 import type { ResolveOutcome } from "../../gateway-proxy/auth-client.js";
 import { FixedWindowRateLimiter } from "../../gateway-proxy/rate-limit.js";
@@ -171,6 +171,32 @@ describe("_StripGatewayPrefix", () =>
     expect(_StripGatewayPrefix("/api")).toBe("/api");
     expect(_StripGatewayPrefix("/gateways")).toBe("/gateways"); // not the /gateway segment
     expect(_StripGatewayPrefix(undefined)).toBe("/");
+  });
+});
+
+describe("_RelaxControlUiFrameHeaders", () =>
+{
+  it("drops X-Frame-Options and rewrites frame-ancestors 'none' to 'self' (same-origin iframe embed)", () =>
+  {
+    const headers: Record<string, unknown> = {
+      "x-frame-options": "DENY",
+      "content-security-policy": "default-src 'self'; frame-ancestors 'none'; img-src 'self' data: blob:",
+      "x-content-type-options": "nosniff"
+    };
+
+    _RelaxControlUiFrameHeaders(headers);
+
+    expect(headers["x-frame-options"]).toBeUndefined();
+    expect(headers["content-security-policy"]).toBe("default-src 'self'; frame-ancestors 'self'; img-src 'self' data: blob:");
+    // Unrelated security headers are untouched.
+    expect(headers["x-content-type-options"]).toBe("nosniff");
+  });
+
+  it("is a no-op on responses without frame headers (static assets)", () =>
+  {
+    const headers: Record<string, unknown> = { "content-type": "application/javascript" };
+    _RelaxControlUiFrameHeaders(headers);
+    expect(headers).toEqual({ "content-type": "application/javascript" });
   });
 });
 

--- a/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
+++ b/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
@@ -88,8 +88,13 @@ const _SCOPES_HEADER = "x-openclaw-scopes";
  * `operator.admin` — so the Control UI's config/nodes/admin surfaces are refused at the
  * gateway, not merely hidden. The proxy is the trust boundary, so a client cannot widen
  * this by self-declaring the header (we strip any inbound copy before injecting ours).
+ *
+ * COMMA-separated: openclaw's `resolveTrustedProxyControlUiScopes` parses this header
+ * with `split(",")` (verified against openclaw@2026.6.9 dist). A space-separated value
+ * reads as ONE unknown scope, the intersection goes empty, and the session gets NO
+ * scopes ("this connection is missing operator.read").
  */
-const _CHAT_SCOPES = "operator.read operator.write";
+const _CHAT_SCOPES = "operator.read,operator.write";
 
 /**
  * Strip a leading `/gateway` segment from the upgrade request path so the upstream

--- a/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
+++ b/apps/clustertenant-operator/src/gateway-proxy/proxy.ts
@@ -230,6 +230,30 @@ export function _IsControlUiRequest(url: string | undefined): boolean
 }
 
 /**
+ * Relax the gateway's frame-blocking headers on Control UI responses so the org-admin
+ * SPA can embed the chat surface in a SAME-ORIGIN iframe.
+ *
+ * OpenClaw serves the Control UI with `X-Frame-Options: DENY` and a CSP containing
+ * `frame-ancestors 'none'` (verified against openclaw@2026.6.9), which blocks ALL
+ * framing — including our own same-origin embed. The proxy rewrites these to the
+ * same-origin equivalents: drop `X-Frame-Options` (superseded by CSP frame-ancestors
+ * in every modern browser) and rewrite `frame-ancestors 'none'` → `'self'`, so ONLY
+ * the org host itself may frame it — clickjacking protection is preserved, third-party
+ * framing stays refused. Every other CSP directive is left untouched.
+ *
+ * @param headers - The upstream response headers, mutated in place.
+ */
+export function _RelaxControlUiFrameHeaders(headers: Record<string, unknown>): void
+{
+  delete headers["x-frame-options"];
+  const csp = headers["content-security-policy"];
+  if (typeof csp === "string")
+  {
+    headers["content-security-policy"] = csp.replace(/frame-ancestors 'none'/g, "frame-ancestors 'self'");
+  }
+}
+
+/**
  * Serve OpenClaw's Control UI static bundle by reverse-proxying `/control-ui/…` to the
  * caller's own pod gateway (which serves the bundle under the same base path).
  *

--- a/apps/clustertenant-operator/src/gateway-proxy/server.ts
+++ b/apps/clustertenant-operator/src/gateway-proxy/server.ts
@@ -5,7 +5,7 @@ import type { Duplex } from "node:stream";
 import httpProxy from "http-proxy";
 import type { Logger } from "pino";
 
-import { _HandleControlUiRequest, _HandleUpgrade, _IsControlUiRequest } from "./proxy.js";
+import { _HandleControlUiRequest, _HandleUpgrade, _IsControlUiRequest, _RelaxControlUiFrameHeaders } from "./proxy.js";
 import type { ControlUiDeps, GatewayProxyRuntime, WebProxy, WsProxy } from "./proxy.js";
 import { FixedWindowRateLimiter } from "./rate-limit.js";
 
@@ -55,6 +55,14 @@ export class GatewayProxyServer
 
     const proxy = httpProxy.createProxyServer({ ws: true });
     proxy.on("error", (err) => this.log.error({ err }, "http-proxy emitted an error"));
+    // Control UI responses: relax the gateway's frame-blocking headers (XFO DENY +
+    // frame-ancestors 'none') to same-origin so the org SPA can iframe the chat surface.
+    // Mutating proxyRes.headers here is the http-proxy seam — they are copied to the
+    // client response after this event fires. Scoped to /control-ui requests only.
+    proxy.on("proxyRes", (proxyRes, req) =>
+    {
+      if (_IsControlUiRequest(req.url)) _RelaxControlUiFrameHeaders(proxyRes.headers as Record<string, unknown>);
+    });
     this.proxy = proxy;
 
     const limiter = new FixedWindowRateLimiter(this.config.rateLimitPerMinute);


### PR DESCRIPTION
Two fixes found while validating the Control UI embed on elewa (follow-up to #145), both verified against the `openclaw@2026.6.9` dist:

### 1. Comma-separate the `x-openclaw-scopes` cap (bug)
openclaw's `resolveTrustedProxyControlUiScopes` parses the header with `split(",")`. Our space-separated `operator.read operator.write` read as **one unknown scope**, the intersection went empty, and every Control-UI session connected with **no scopes** — the live embed showed *'This connection is missing operator.read…'*. One-line fix.

### 2. Relax Control UI frame headers to same-origin (enables the iframe embed)
openclaw serves the Control UI with `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'`, blocking ALL framing — including our own same-origin embed. The embed investigation concluded the web-component mount is unworkable (`<openclaw-app>` is the FULL SPA: it pushState-rewrites the address bar, fighting Angular's router — refresh landed users on the standalone Control UI — and its global light-DOM CSS clashes with the host app). The proper shape is a **same-origin iframe** of `/control-ui/chat?session=…` with injected chat-only CSS.

The proxy now rewrites frame headers on `/control-ui` responses only: drop XFO, rewrite `frame-ancestors 'none'` → `'self'`. Only the org host itself may frame the chat surface — clickjacking protection preserved, third-party framing still refused. All other CSP directives untouched.

## Validation
`pnpm --filter @opencrane/clustertenant-operator test` — **622 passing** (new: comma-format assertion + `_RelaxControlUiFrameHeaders` rewrite/no-op tests). Build clean.

## Deploy note
elewa runs the space-separated header today (sha-2acc1b3), so its embed is scope-dead until this lands. After merge, deploy with `--reuse-values` (rev 16 baseline) — #148 (values preservation default) is still open.