### PR TITLE
fix(operator): fail-safe tenant reconcile — keep a good config on empty/failed model fetch (#144)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/model-gate.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/model-gate.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import pino from "pino";
+import type * as k8s from "@kubernetes/client-node";
+
+import { defaultConfig, onPremAdapter, _makeTenant } from "../fixtures.js";
+import { _ResolveTenantModelGate } from "../../tenants/deploy/model-gate.js";
+import { _BuildConfigMap, _ConfigChecksum } from "../../tenants/deploy/index.js";
+import { TenantOperator } from "../../tenants/operator.js";
+import { TenantStatusWriter } from "../../tenants/internal/tenant-status-writer.js";
+import { TenantDegradedReason, TenantStatusPhase } from "../../tenants/models/tenant-status.interface.js";
+import type { TenantStatus } from "../../tenants/models/tenant-status.interface.js";
+import type { TenantModelSet } from "@opencrane/contracts";
+
+const _log = pino({ level: "silent" });
+
+/**
+ * Fail-safe reconcile — issue #144.
+ *
+ * A reconcile whose `tenant-models` read is empty or failing must NOT re-render the
+ * openclaw ConfigMap from that read (which would emit `models: []` + no default and
+ * drop openclaw to the keyless built-in provider → `missing-provider-auth`). It keeps
+ * the last-applied ConfigMap and marks the Tenant Degraded. A valid read renders as
+ * before, and a first-ever provision is allowed to render even without models.
+ */
+describe("_ResolveTenantModelGate (issue #144)", function _gateSuite()
+{
+  it("renders when LiteLLM is disabled regardless of the fetch outcome", function _liteLlmOff()
+  {
+    // No `models` block is emitted when LiteLLM is off, so there is no model-less
+    // failure mode to guard — always safe to render.
+    for (const status of ["ok", "empty", "error"] as const)
+    {
+      expect(_ResolveTenantModelGate(status, false, true)).toEqual({ action: "render" });
+      expect(_ResolveTenantModelGate(status, false, false)).toEqual({ action: "render" });
+    }
+  });
+
+  it("renders on a valid (ok) model set", function _ok()
+  {
+    expect(_ResolveTenantModelGate("ok", true, true)).toEqual({ action: "render" });
+    expect(_ResolveTenantModelGate("ok", true, false)).toEqual({ action: "render" });
+  });
+
+  it("renders on empty/error when there is NO existing ConfigMap (first provision)", function _firstProvision()
+  {
+    // Nothing good exists to protect and skipping would deadlock provisioning; the
+    // model-less config self-heals on the next successful fetch.
+    expect(_ResolveTenantModelGate("empty", true, false)).toEqual({ action: "render" });
+    expect(_ResolveTenantModelGate("error", true, false)).toEqual({ action: "render" });
+  });
+
+  it("skips (Degraded/ModelSetEmpty) on an empty fetch over an existing ConfigMap", function _skipEmpty()
+  {
+    const decision = _ResolveTenantModelGate("empty", true, true);
+    expect(decision.action).toBe("skip-degraded");
+    if (decision.action !== "skip-degraded") throw new Error("unreachable");
+    expect(decision.reason).toBe(TenantDegradedReason.ModelSetEmpty);
+  });
+
+  it("skips (Degraded/ModelFetchFailed) on a failed fetch over an existing ConfigMap", function _skipError()
+  {
+    const decision = _ResolveTenantModelGate("error", true, true);
+    expect(decision.action).toBe("skip-degraded");
+    if (decision.action !== "skip-degraded") throw new Error("unreachable");
+    expect(decision.reason).toBe(TenantDegradedReason.ModelFetchFailed);
+  });
+});
+
+describe("_BuildConfigMap never emits a bare (unprefixed) model (issue #144)", function _renderSuite()
+{
+  function _openclaw(modelSet: TenantModelSet | null): Record<string, unknown>
+  {
+    const liteLlmConfig = { ...defaultConfig, liteLlmEnabled: true };
+    const configMap = _BuildConfigMap(liteLlmConfig, _makeTenant("acme"), "default", undefined, modelSet);
+    return JSON.parse(configMap.data?.["openclaw.json"] ?? "{}") as Record<string, unknown>;
+  }
+
+  function _defaultModel(config: Record<string, unknown>): unknown
+  {
+    const agents = config["agents"] as Record<string, unknown>;
+    return (agents["defaults"] as Record<string, unknown>)["model"];
+  }
+
+  it("prefixes a resolved default with litellm-proxy, never the bare built-in", function _prefixed()
+  {
+    const config = _openclaw({ models: ["openai/gpt-5.5"], defaultModel: "openai/gpt-5.5" });
+    expect(_defaultModel(config)).toBe("litellm-proxy/openai/gpt-5.5");
+    // The bare reference (which would bind openclaw's built-in openai provider) must
+    // never appear as the effective default.
+    expect(_defaultModel(config)).not.toBe("openai/gpt-5.5");
+  });
+
+  it("leaves agents.defaults.model UNSET when no default resolves", function _unset()
+  {
+    // With an empty/absent model set the render omits the default rather than emitting a
+    // bare one — openclaw is left with no default instead of the keyless built-in.
+    const emptySet = _openclaw({ models: [], defaultModel: null });
+    expect(_defaultModel(emptySet)).toBeUndefined();
+    expect(_openclaw(null)["agents"]).toBeDefined();
+    expect(_defaultModel(_openclaw(null))).toBeUndefined();
+  });
+});
+
+/**
+ * Minimal K8s client harness for driving `reconcileTenant` end-to-end. The typed
+ * clients expose only the create/replace/read methods `__K8sApplyResource` reaches for
+ * (it has no generic `.create`, so it falls through to the `createNamespaced*` switch).
+ * Records every applied resource by kind so a test can assert what the reconcile wrote.
+ */
+function _buildHarness(options: { existingConfigMap?: k8s.V1ConfigMap | null })
+{
+  const applied: Record<string, k8s.KubernetesObject[]> = {};
+  function _record(resource: k8s.KubernetesObject): k8s.KubernetesObject
+  {
+    const kind = resource.kind ?? "unknown";
+    (applied[kind] ??= []).push(resource);
+    return resource;
+  }
+
+  const notFound = Object.assign(new Error("not found"), { statusCode: 404 });
+
+  const coreApi = {
+    createNamespacedServiceAccount: vi.fn(async (a: { body: k8s.KubernetesObject }) => _record(a.body)),
+    createNamespacedConfigMap: vi.fn(async (a: { body: k8s.KubernetesObject }) => _record(a.body)),
+    createNamespacedService: vi.fn(async (a: { body: k8s.KubernetesObject }) => _record(a.body)),
+    createNamespacedPersistentVolumeClaim: vi.fn(async (a: { body: k8s.KubernetesObject }) => _record(a.body)),
+    readNamespacedPersistentVolumeClaim: vi.fn(async () => { throw notFound; }),
+    readNamespacedConfigMap: vi.fn(async () => {
+      if (options.existingConfigMap) return options.existingConfigMap;
+      throw notFound;
+    }),
+  } as unknown as k8s.CoreV1Api;
+
+  const appsApi = {
+    createNamespacedDeployment: vi.fn(async (a: { body: k8s.KubernetesObject }) => _record(a.body)),
+  } as unknown as k8s.AppsV1Api;
+
+  const networkingApi = {
+    createNamespacedNetworkPolicy: vi.fn(async (a: { body: k8s.KubernetesObject }) => _record(a.body)),
+  } as unknown as k8s.NetworkingV1Api;
+
+  const customApi = {
+    listNamespacedCustomObject: vi.fn(async () => ({ items: [] })),
+    patchNamespacedCustomObjectStatus: vi.fn(async () => ({})),
+  } as unknown as k8s.CustomObjectsApi;
+
+  const statusPatches: Partial<TenantStatus>[] = [];
+  const statusWriter = {
+    patchStatus: vi.fn(async (_t: unknown, _ns: unknown, status: Partial<TenantStatus>) => { statusPatches.push(status); }),
+  } as unknown as TenantStatusWriter;
+
+  const encryptionKeys = { ensureEncryptionKeySecret: vi.fn(async () => {}) } as unknown as import("../../tenants/internal/tenant-encryption-keys.js").TenantEncryptionKeys;
+  const liteLlmKeys = { ensureLiteLlmKeySecret: vi.fn(async () => {}) } as unknown as import("../../tenants/internal/tenant-litellm-keys.js").TenantLiteLlmKeys;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const stub = {} as any;
+  const config = { ...defaultConfig, liteLlmEnabled: true };
+  const op = new TenantOperator(
+    stub, customApi, coreApi, appsApi, networkingApi, _log, config,
+    onPremAdapter, stub, statusWriter, encryptionKeys, liteLlmKeys,
+  );
+
+  return { op, coreApi, appsApi, statusPatches, applied };
+}
+
+/** Build a good, LiteLLM-enabled ConfigMap to stand in as the "last-applied" one. */
+function _goodConfigMap(): k8s.V1ConfigMap
+{
+  const config = { ...defaultConfig, liteLlmEnabled: true };
+  const modelSet: TenantModelSet = { models: ["openai/gpt-5.5"], defaultModel: "openai/gpt-5.5" };
+  return _BuildConfigMap(config, _makeTenant("acme"), "default", undefined, modelSet, "acme.opencrane.local");
+}
+
+describe("reconcileTenant fail-safe on empty/failed tenant-models (issue #144)", function _reconcileSuite()
+{
+  afterEach(function _restore() { vi.unstubAllGlobals(); });
+
+  function _stubFetch(body: unknown, status = 200): void
+  {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify(body), { status })));
+  }
+
+  it("leaves the existing ConfigMap unchanged and marks Degraded on an empty fetch", async function _empty()
+  {
+    _stubFetch({ models: [], defaultModel: null });
+    const good = _goodConfigMap();
+    const { op, coreApi, appsApi, statusPatches } = _buildHarness({ existingConfigMap: good });
+
+    await op.reconcileTenant(_makeTenant("acme", { phase: TenantStatusPhase.Running }));
+
+    // The ConfigMap was NOT re-applied — the good one stays.
+    expect(coreApi.createNamespacedConfigMap).not.toHaveBeenCalled();
+    // The deployment is pinned to the EXISTING config's checksum, not a fresh model-less one.
+    const deployment = (appsApi.createNamespacedDeployment as ReturnType<typeof vi.fn>).mock.calls[0][0].body as k8s.V1Deployment;
+    const checksum = deployment.spec?.template.metadata?.annotations?.["opencrane.io/config-checksum"];
+    expect(checksum).toBe(_ConfigChecksum(good));
+    // Status is Degraded with the empty-set reason (not Error — the pod keeps serving).
+    const last = statusPatches.at(-1)!;
+    expect(last.phase).toBe(TenantStatusPhase.Degraded);
+    expect(last.degradedReason).toBe(TenantDegradedReason.ModelSetEmpty);
+    // observedGeneration is NOT stamped while degraded, so the next reconcile retries.
+    expect(last.observedGeneration).toBeUndefined();
+  });
+
+  it("leaves the existing ConfigMap unchanged and marks Degraded on a failed fetch", async function _error()
+  {
+    _stubFetch("boom", 500);
+    const good = _goodConfigMap();
+    const { op, coreApi, statusPatches } = _buildHarness({ existingConfigMap: good });
+
+    await op.reconcileTenant(_makeTenant("acme", { phase: TenantStatusPhase.Running }));
+
+    expect(coreApi.createNamespacedConfigMap).not.toHaveBeenCalled();
+    const last = statusPatches.at(-1)!;
+    expect(last.phase).toBe(TenantStatusPhase.Degraded);
+    expect(last.degradedReason).toBe(TenantDegradedReason.ModelFetchFailed);
+  });
+
+  it("renders normally and marks Running on a valid model set (regression)", async function _valid()
+  {
+    _stubFetch({ models: ["openai/gpt-5.5"], defaultModel: "openai/gpt-5.5" });
+    const { op, coreApi, statusPatches, applied } = _buildHarness({ existingConfigMap: _goodConfigMap() });
+
+    await op.reconcileTenant(_makeTenant("acme", { phase: TenantStatusPhase.Running }));
+
+    // The ConfigMap WAS re-rendered and applied, carrying the prefixed default model.
+    expect(coreApi.createNamespacedConfigMap).toHaveBeenCalledTimes(1);
+    const openclaw = JSON.parse((applied["ConfigMap"][0] as k8s.V1ConfigMap).data?.["openclaw.json"] ?? "{}");
+    expect(openclaw.agents.defaults.model).toBe("litellm-proxy/openai/gpt-5.5");
+    const last = statusPatches.at(-1)!;
+    expect(last.phase).toBe(TenantStatusPhase.Running);
+    expect(last.degradedReason).toBeUndefined();
+  });
+
+  it("forcing observedGeneration:0 on a healthy tenant never downgrades the working model", async function _forcedReconcile()
+  {
+    // The elewa-be regression: a forced reconcile (observedGeneration reset) races an
+    // empty/failed tenant-models read. The gate must keep the good config and NOT emit
+    // a model-less one, so the working default survives the forced re-render.
+    _stubFetch({ models: [], defaultModel: null });
+    const good = _goodConfigMap();
+    const { op, coreApi } = _buildHarness({ existingConfigMap: good });
+    const tenant = _makeTenant("acme", { phase: TenantStatusPhase.Running });
+    tenant.metadata!.generation = 5;
+    tenant.status!.observedGeneration = 0; // forced re-reconcile
+
+    await op.reconcileTenant(tenant);
+
+    // No re-render: the good config (with its litellm-proxy default) is untouched.
+    expect(coreApi.createNamespacedConfigMap).not.toHaveBeenCalled();
+    const openclaw = JSON.parse(good.data?.["openclaw.json"] ?? "{}");
+    expect(openclaw.agents.defaults.model).toBe("litellm-proxy/openai/gpt-5.5");
+  });
+});

--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-models.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-models.test.ts
@@ -18,7 +18,7 @@ describe("_FetchTenantModels", () =>
     vi.unstubAllGlobals();
   });
 
-  it("returns the parsed model set on a 200 response", async () =>
+  it("reports ok with the parsed model set on a non-empty 200 response", async () =>
   {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ models: ["gpt-4o", "claude-opus-4-8"], defaultModel: "gpt-4o" }), { status: 200 }),
@@ -27,44 +27,61 @@ describe("_FetchTenantModels", () =>
 
     const result = await _FetchTenantModels(_controlPlaneUrl, "acme-user", _log);
 
-    expect(result).toEqual({ models: ["gpt-4o", "claude-opus-4-8"], defaultModel: "gpt-4o" });
+    expect(result).toEqual({ status: "ok", modelSet: { models: ["gpt-4o", "claude-opus-4-8"], defaultModel: "gpt-4o" } });
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toBe(`${_controlPlaneUrl}/api/internal/tenant-models/acme-user`);
   });
 
-  it("returns null (non-fatal) on a network error", async () =>
+  it("reports error (non-fatal) on a network error", async () =>
   {
     const fetchMock = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await _FetchTenantModels(_controlPlaneUrl, "acme-user", _log);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ status: "error", modelSet: null });
   });
 
-  it("returns null on a non-200 response", async () =>
+  it("reports error on a non-200 response", async () =>
   {
     const fetchMock = vi.fn().mockResolvedValue(new Response("not found", { status: 404 }));
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await _FetchTenantModels(_controlPlaneUrl, "ghost", _log);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ status: "error", modelSet: null });
   });
 
-  it("returns null without calling fetch when the control-plane URL is empty", async () =>
+  it("reports empty (NOT error) on a well-formed 200 with no models", async () =>
+  {
+    // The onboarding-incomplete case: the endpoint is healthy but the tenant has no
+    // registered models. This must be distinguishable from a fetch failure so the gate
+    // can log/condition it differently while still refusing to clobber a good config.
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ models: [], defaultModel: null }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await _FetchTenantModels(_controlPlaneUrl, "fresh-org", _log);
+
+    expect(result).toEqual({ status: "empty", modelSet: { models: [], defaultModel: null } });
+  });
+
+  it("reports error without calling fetch when the control-plane URL is empty", async () =>
   {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
     const result = await _FetchTenantModels("", "acme-user", _log);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ status: "error", modelSet: null });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("normalises a malformed body to an empty model set rather than throwing", async () =>
+  it("reports error on a malformed body rather than throwing", async () =>
   {
+    // A body whose `models` is not an array means the real model set is unknown — treat
+    // as error, not empty, so a good config is never clobbered on a garbled response.
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ models: "oops", defaultModel: 7 }), { status: 200 }),
     );
@@ -72,6 +89,6 @@ describe("_FetchTenantModels", () =>
 
     const result = await _FetchTenantModels(_controlPlaneUrl, "acme-user", _log);
 
-    expect(result).toEqual({ models: [], defaultModel: null });
+    expect(result).toEqual({ status: "error", modelSet: null });
   });
 });

--- a/apps/clustertenant-operator/src/tenants/deploy/index.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/index.ts
@@ -1,5 +1,7 @@
 export { _BuildServiceAccount } from "./1-service-account.js";
 export { _BuildConfigMap, _ConfigChecksum } from "./2-config-map.js";
+export { _ResolveTenantModelGate } from "./model-gate.js";
+export type { TenantModelGateDecision } from "./model-gate.types.js";
 export { _BuildStatePvc } from "./3-state-pvc.js";
 export { _BuildDeployment } from "./3-deployment.js";
 export { _BuildService } from "./4-service.js";

--- a/apps/clustertenant-operator/src/tenants/deploy/model-gate.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/model-gate.ts
@@ -1,0 +1,62 @@
+import type { TenantModelFetchStatus } from "../internal/tenant-models.types.js";
+import { TenantDegradedReason } from "../models/tenant-status.interface.js";
+import type { TenantModelGateDecision } from "./model-gate.types.js";
+
+/**
+ * Decide whether it is SAFE to re-render the tenant's openclaw ConfigMap from the
+ * just-fetched model set — the fail-safe at the heart of issue #144.
+ *
+ * The render is fail-UNSAFE by itself: when LiteLLM is enabled the litellm-proxy provider
+ * runs in `replace` mode, so an empty/unknown model set renders `models: []` with no
+ * `agents.defaults.model`, and openclaw then falls back to the bare built-in `openai`
+ * provider and fails every turn with `missing-provider-auth`. A transient empty/failed
+ * `tenant-models` read at reconcile would therefore overwrite a previously-good config.
+ *
+ * This gate refuses that overwrite:
+ *  - LiteLLM disabled ⇒ there is no `models` block to render badly, so always `render`.
+ *  - Fetch `ok` (non-empty) ⇒ `render` — the normal path.
+ *  - Fetch `empty`/`error` with NO existing ConfigMap ⇒ `render`. This is a first-ever
+ *    provision (onboarding-incomplete); there is nothing good to protect and skipping
+ *    would wedge provisioning forever. The rendered config is model-less but that state
+ *    self-heals on the next successful fetch (onboarding requires ≥1 model before use).
+ *  - Fetch `empty`/`error` WITH an existing ConfigMap ⇒ `skip-degraded`. A working config
+ *    is already applied; keep it, do not clobber, and surface the reason on the CR.
+ *
+ * @param fetchStatus - Outcome of the `tenant-models` fetch (`ok` | `empty` | `error`).
+ * @param liteLlmEnabled - Whether the operator renders the `replace`-mode LiteLLM provider.
+ * @param hasExistingConfigMap - Whether a prior openclaw ConfigMap is already applied.
+ */
+export function _ResolveTenantModelGate(
+  fetchStatus: TenantModelFetchStatus,
+  liteLlmEnabled: boolean,
+  hasExistingConfigMap: boolean,
+): TenantModelGateDecision
+{
+  // Without the replace-mode LiteLLM provider there is no model-less failure mode to
+  // guard: the config carries no `models` block, so a re-render is always safe.
+  if (!liteLlmEnabled || fetchStatus === "ok")
+  {
+    return { action: "render" };
+  }
+
+  // First-ever provision — nothing good exists to protect, and skipping would deadlock
+  // the tenant. Render the (temporarily model-less) config; it self-heals on next fetch.
+  if (!hasExistingConfigMap)
+  {
+    return { action: "render" };
+  }
+
+  // A good ConfigMap is already applied and the fresh read is empty/unknown: keep the
+  // last-applied config and mark the tenant Degraded rather than clobbering it.
+  return fetchStatus === "empty"
+    ? {
+        action: "skip-degraded",
+        reason: TenantDegradedReason.ModelSetEmpty,
+        message: "tenant-models returned an empty set; kept the last-applied openclaw config (tenant has no registered models — complete onboarding to restore model refresh)",
+      }
+    : {
+        action: "skip-degraded",
+        reason: TenantDegradedReason.ModelFetchFailed,
+        message: "tenant-models fetch failed; kept the last-applied openclaw config to avoid rendering a model-less config",
+      };
+}

--- a/apps/clustertenant-operator/src/tenants/deploy/model-gate.types.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/model-gate.types.ts
@@ -1,0 +1,12 @@
+import type { TenantDegradedReason } from "../models/tenant-status.interface.js";
+
+/**
+ * The two ways a reconcile can treat the tenant ConfigMap once the model set is known.
+ *
+ *  - `render`        — safe to (re-)render and apply the ConfigMap from live state.
+ *  - `skip-degraded` — the model set is empty/unknown AND a good ConfigMap already
+ *                      exists; keep the last-applied one and mark the tenant Degraded.
+ */
+export type TenantModelGateDecision =
+  | { action: "render" }
+  | { action: "skip-degraded"; reason: TenantDegradedReason; message: string };

--- a/apps/clustertenant-operator/src/tenants/internal/tenant-models.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/tenant-models.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "pino";
 
-import type { TenantModelSet } from "@opencrane/contracts";
+import type { TenantModelFetch } from "./tenant-models.types.js";
 
 /** Maximum time (ms) to wait on the control-plane before giving up and falling back. */
 const _FETCH_TIMEOUT_MS = 2000;
@@ -8,29 +8,30 @@ const _FETCH_TIMEOUT_MS = 2000;
 /**
  * Fetch the tenant's allowed model set from the control-plane internal API.
  *
- * This introduces a deliberate, best-effort operator → control-plane dependency:
- * it MUST never break tenant reconcile. Any failure — missing URL, network error,
- * timeout, non-200, or malformed body — resolves to `null` (logged at warn) so the
- * caller falls back to today's unrestricted behaviour. Mirrors the resilience
- * posture of the LiteLLM key helper, where backend issues degrade rather than crash.
+ * This is a deliberate, best-effort operator → control-plane dependency: it MUST never
+ * break tenant reconcile. Every failure — missing URL, network error, timeout, non-200,
+ * or malformed body — resolves to `{ status: "error" }` (logged at warn); a genuine
+ * no-models tenant resolves to `{ status: "empty" }` (logged at info). Neither throws.
+ * The caller decides what to do with each (see `_ResolveTenantModelGate`).
  *
  * @param controlPlaneUrl - In-cluster control-plane base URL (no trailing slash needed).
  * @param tenant - Tenant CR name to resolve the model set for.
- * @param log - Scoped logger for the (non-fatal) warning on failure.
- * @returns The resolved {@link TenantModelSet}, or `null` on any error / missing URL.
+ * @param log - Scoped logger for the (non-fatal) diagnostics.
+ * @returns A {@link TenantModelFetch} whose `status` distinguishes ok / empty / error.
  */
-export async function _FetchTenantModels(controlPlaneUrl: string, tenant: string, log: Logger): Promise<TenantModelSet | null>
+export async function _FetchTenantModels(controlPlaneUrl: string, tenant: string, log: Logger): Promise<TenantModelFetch>
 {
-  // 1. Missing config — without a control-plane URL there is nothing to call, so
-  //    fall back silently-ish (debug) rather than warning on every reconcile.
+  // 1. Missing config — without a control-plane URL there is nothing to call. This is a
+  //    known-degraded posture (the reconcile cannot learn the model set), so treat it as
+  //    `error` — "unknown", not "genuinely empty" — but log at debug to avoid per-reconcile noise.
   if (!controlPlaneUrl || controlPlaneUrl.trim().length === 0)
   {
-    log.debug({ tenant }, "control-plane URL unset; skipping tenant-models fetch");
-    return null;
+    log.debug({ tenant }, "control-plane URL unset; cannot resolve tenant-models");
+    return { status: "error", modelSet: null };
   }
 
   // 2. Bounded request — abort after a short timeout so a hung control-plane never
-  //    stalls the reconcile loop; the fallback path is always acceptable.
+  //    stalls the reconcile loop.
   const controller = new AbortController();
   const timer = setTimeout(function _abort(): void { controller.abort(); }, _FETCH_TIMEOUT_MS);
 
@@ -40,27 +41,39 @@ export async function _FetchTenantModels(controlPlaneUrl: string, tenant: string
     const response = await fetch(url, { signal: controller.signal });
 
     // 3. Non-200 — the endpoint is reachable but did not return a model set (404 for
-    //    unknown tenant, 5xx, etc.); treat as a fallback signal, not a failure.
+    //    unknown tenant, 5xx, etc.); the real model set is unknown, so this is `error`.
     if (!response.ok)
     {
-      log.warn({ tenant, status: response.status }, "tenant-models fetch returned non-200; falling back to unrestricted models");
-      return null;
+      log.warn({ tenant, status: response.status }, "tenant-models fetch returned non-200; model set unknown");
+      return { status: "error", modelSet: null };
     }
 
-    // 4. Parse + normalise — defend against a malformed body by coercing to the
-    //    expected shape; anything unexpected falls back rather than throwing upstream.
+    // 4. Parse — a body whose `models` is not even an array is malformed, so the real
+    //    model set is unknown → `error` (not the onboarding-incomplete `empty`).
     const payload = await response.json() as { models?: unknown; defaultModel?: unknown };
-    const models = Array.isArray(payload.models)
-      ? payload.models.filter(function _isString(value: unknown): value is string { return typeof value === "string"; })
-      : [];
+    if (!Array.isArray(payload.models))
+    {
+      log.warn({ tenant }, "tenant-models returned a malformed body; model set unknown");
+      return { status: "error", modelSet: null };
+    }
+    const models = payload.models.filter(function _isString(value: unknown): value is string { return typeof value === "string"; });
     const defaultModel = typeof payload.defaultModel === "string" ? payload.defaultModel : null;
 
-    return { models, defaultModel };
+    // 5. Empty result — a well-formed 200 that lists no models. The tenant genuinely has
+    //    none (onboarding-incomplete), which is NOT a fetch failure but still must not
+    //    clobber a previously-good config.
+    if (models.length === 0)
+    {
+      log.info({ tenant }, "tenant-models returned an empty set; tenant has no registered models");
+      return { status: "empty", modelSet: { models, defaultModel } };
+    }
+
+    return { status: "ok", modelSet: { models, defaultModel } };
   }
   catch (err)
   {
-    log.warn({ tenant, err }, "tenant-models fetch failed; falling back to unrestricted models");
-    return null;
+    log.warn({ tenant, err }, "tenant-models fetch failed; model set unknown");
+    return { status: "error", modelSet: null };
   }
   finally
   {

--- a/apps/clustertenant-operator/src/tenants/internal/tenant-models.types.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/tenant-models.types.ts
@@ -1,0 +1,26 @@
+import type { TenantModelSet } from "@opencrane/contracts";
+
+/**
+ * Outcome of a `tenant-models` fetch, kept distinct from the model set itself so the
+ * caller can tell three cases apart — a distinction the config-map gate needs to
+ * decide whether it is SAFE to re-render (see `_ResolveTenantModelGate`):
+ *
+ *  - `ok`    — the endpoint returned a non-empty model set. Safe to render.
+ *  - `empty` — the endpoint returned 200 with `[]`: the tenant genuinely has NO
+ *              registered models (onboarding-incomplete). Not an error, but rendering
+ *              a LiteLLM config from it would emit `models: []` + no default.
+ *  - `error` — transport failure, timeout, non-200, or a malformed body. The upstream
+ *              read is untrustworthy; the tenant's real model set is UNKNOWN.
+ *
+ * `empty` and `error` are surfaced separately (logged/conditioned differently) but the
+ * gate treats BOTH as "do not clobber a working config".
+ */
+export type TenantModelFetchStatus = "ok" | "empty" | "error";
+
+/** Discriminated result of `_FetchTenantModels`. */
+export interface TenantModelFetch
+{
+  status: TenantModelFetchStatus;
+  /** The parsed model set; `null` on `error` and on a missing control-plane URL. */
+  modelSet: TenantModelSet | null;
+}

--- a/apps/clustertenant-operator/src/tenants/models/tenant-status.interface.ts
+++ b/apps/clustertenant-operator/src/tenants/models/tenant-status.interface.ts
@@ -13,8 +13,33 @@ export enum TenantStatusPhase
   /** Tenant workload is intentionally scaled down to zero replicas. */
   Suspended = "Suspended",
 
+  /**
+   * The tenant is running on a previously-applied config, but the latest reconcile
+   * could not safely refresh it. Set when the `tenant-models` fetch returned empty or
+   * failed and the operator DELIBERATELY skipped the ConfigMap re-render to avoid
+   * clobbering a working config with a model-less one (see `_ResolveTenantModelGate`).
+   * The workload keeps serving; `degradedReason` records why the refresh was skipped.
+   */
+  Degraded = "Degraded",
+
   /** Reconciliation failed and operator recorded the latest error message. */
   Error = "Error",
+}
+
+/** Why a reconcile marked the tenant {@link TenantStatusPhase.Degraded}. */
+export enum TenantDegradedReason
+{
+  /**
+   * The control-plane returned a well-formed empty model set (the tenant has no
+   * registered models — onboarding is incomplete). The last-applied ConfigMap was kept.
+   */
+  ModelSetEmpty = "ModelSetEmpty",
+
+  /**
+   * The `tenant-models` fetch failed (transport error, timeout, non-200, or malformed
+   * body), so the real model set is unknown. The last-applied ConfigMap was kept.
+   */
+  ModelFetchFailed = "ModelFetchFailed",
 }
 
 /** Resolution state for how tenant policy assignment was computed. */
@@ -65,6 +90,13 @@ export interface TenantStatus
 
   /** Resolution state of tenant policy assignment. */
   policyResolutionState?: TenantPolicyResolutionState;
+
+  /**
+   * Why the tenant is {@link TenantStatusPhase.Degraded}, when it is. Cleared (set to
+   * `undefined`) on any reconcile that resolves back to a healthy phase so a recovered
+   * tenant does not carry a stale reason.
+   */
+  degradedReason?: TenantDegradedReason;
 
   /** ISO-8601 timestamp of the last successful reconciliation. */
   lastReconciled?: string;

--- a/apps/clustertenant-operator/src/tenants/operator.ts
+++ b/apps/clustertenant-operator/src/tenants/operator.ts
@@ -6,11 +6,12 @@ import { _BuildHostingAdapter, type HostingAdapter } from "../hosting/index.js";
 
 import type { Tenant } from "./models/tenant.interface.js";
 import { TenantPolicyResolutionState, TenantStatusPhase } from "./models/tenant-status.interface.js";
+import type { TenantDegradedReason } from "./models/tenant-status.interface.js";
 
-import { __IsK8sForbidden, __K8sApplyResource } from "@opencrane/infra-api";
+import { __IsK8sForbidden, __K8sApplyResource, _IsK8sNotFound } from "@opencrane/infra-api";
 import { _RunWatchLoop, K8sWatchEventType } from "@opencrane/infra-api";
 import { OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "@opencrane/infra-api";
-import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildService, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc, _ConfigChecksum } from "./deploy/index.js";
+import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildService, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc, _ConfigChecksum, _ResolveTenantModelGate } from "./deploy/index.js";
 import { TenantCleanup } from "./destroy/tenant-cleanup.js";
 import { LinkerdIdentityClient } from "./internal/linkerd-identity.client.js";
 
@@ -306,9 +307,11 @@ export class TenantOperator
 
       // 0c. Allowed model set — best-effort fetch of the tenant's registered models
       //     from the control-plane internal API. This is a deliberate, non-fatal
-      //     operator → control-plane dependency: a null result (outage, 404, timeout)
-      //     falls back to today's unrestricted behaviour and never blocks reconcile.
-      const modelSet = await _FetchTenantModels(this.config.controlPlaneInternalUrl, name, this.log);
+      //     operator → control-plane dependency: it never throws. The fetch reports
+      //     ok / empty / error so step 5 can refuse to clobber a good config with a
+      //     model-less one on a transient empty/failed read (issue #144).
+      const modelFetch = await _FetchTenantModels(this.config.controlPlaneInternalUrl, name, this.log);
+      const modelSet = modelFetch.modelSet;
 
       // 1. ServiceAccount — identity annotations come from the adapter; empty on-prem,
       //    Workload Identity annotation on GKE, IRSA on EKS, etc.
@@ -337,14 +340,45 @@ export class TenantOperator
       // 5. ConfigMap — serialises the base OpenClaw JSON config merged with any
       //    spec.configOverrides the tenant author provided. Capture it so its
       //    checksum can roll the pod when the config changes (step 7).
-      const configMap = _BuildConfigMap(this.config, effectiveTenant, namespace, policyResolution.effectivePolicy, modelSet, ingressDomain);
-      await __K8sApplyResource(this.coreApi, configMap, this.log);
-      // Checksum of the rendered config — stamped on the pod template so a config
-      // change (e.g. a newly-registered BYOK default model landing in openclaw.json)
-      // rolls the pod. Without this, a mounted ConfigMap update never restarts the
-      // running OpenClaw process, which reads openclaw.json only at startup — so a
-      // pod that booted before its models existed stays on the keyless fallback.
-      const configChecksum = _ConfigChecksum(configMap);
+      //
+      //    FAIL-SAFE (issue #144): when LiteLLM is enabled the config's model set comes
+      //    from the live `tenant-models` read; an empty/failed read would render a
+      //    model-less config and openclaw would fall back to the keyless built-in
+      //    provider (missing-provider-auth). The gate refuses to re-render over an
+      //    already-applied config in that case — it keeps the last-applied ConfigMap and
+      //    marks the tenant Degraded — while a first-ever provision still renders.
+      //
+      //    The existing ConfigMap is only read when it could change the decision (LiteLLM
+      //    on AND the fetch was not clean-ok); on the happy path the gate is `render`
+      //    regardless, so the extra API read is skipped.
+      const needsExistingConfigMap = this.config.liteLlmEnabled && modelFetch.status !== "ok";
+      const existingConfigMap = needsExistingConfigMap ? await this.readExistingConfigMap(name, namespace) : null;
+      const modelGate = _ResolveTenantModelGate(modelFetch.status, this.config.liteLlmEnabled, existingConfigMap !== null);
+
+      let configChecksum: string;
+      let degradedReason: TenantDegradedReason | undefined;
+      let degradedMessage: string | undefined;
+      if (modelGate.action === "skip-degraded")
+      {
+        // Keep the last-applied ConfigMap untouched and pin the pod template to ITS
+        // checksum so the deployment does not roll onto a config we deliberately did not
+        // write. The condition is surfaced on the CR in step 10.
+        this.log.warn({ name, reason: modelGate.reason }, modelGate.message);
+        degradedReason = modelGate.reason;
+        degradedMessage = modelGate.message;
+        configChecksum = _ConfigChecksum(existingConfigMap!);
+      }
+      else
+      {
+        const configMap = _BuildConfigMap(this.config, effectiveTenant, namespace, policyResolution.effectivePolicy, modelSet, ingressDomain);
+        await __K8sApplyResource(this.coreApi, configMap, this.log);
+        // Checksum of the rendered config — stamped on the pod template so a config
+        // change (e.g. a newly-registered BYOK default model landing in openclaw.json)
+        // rolls the pod. Without this, a mounted ConfigMap update never restarts the
+        // running OpenClaw process, which reads openclaw.json only at startup — so a
+        // pod that booted before its models existed stays on the keyless fallback.
+        configChecksum = _ConfigChecksum(configMap);
+      }
 
       // 6. State volume — adapter decides CSI mount (cloud) vs PVC (on-prem).
       //    Create the PVC only when the adapter requests it (on-prem path).
@@ -370,10 +404,17 @@ export class TenantOperator
       //    cert and gets an explicit external-dns record (see the org-domain provisioner).
       await __K8sApplyResource(this.networkingApi, _BuildGatewayNetworkPolicy(this.config, effectiveTenant, namespace), this.log);
 
-      // 10. Status — write the observed Running state back to the Tenant CR so that
-      //    kubectl, the control-plane API, and the UI all see the current phase.
+      // 10. Status — write the observed state back to the Tenant CR so that kubectl, the
+      //    control-plane API, and the UI all see the current phase. When the model gate
+      //    skipped the ConfigMap refresh the pod is still serving on its last-applied
+      //    (good) config, so the phase is Degraded (not Error) with the reason recorded;
+      //    otherwise Running with any stale reason cleared. observedGeneration is NOT
+      //    stamped when degraded so the next reconcile retries the model fetch rather than
+      //    being short-circuited by the generation guard — the requeue that self-heals it.
       await this.statusWriter.patchStatus(tenant, crNamespace, {
-        phase: TenantStatusPhase.Running,
+        phase: degradedReason ? TenantStatusPhase.Degraded : TenantStatusPhase.Running,
+        message: degradedMessage,
+        degradedReason,
         podName: `openclaw-${name}`,
         // Served at the ORG host (`<org>.<base>` or vanity) via the proxy — no per-user subdomain.
         ingressHost: ingressDomain,
@@ -383,8 +424,8 @@ export class TenantOperator
         lastReconciled: new Date().toISOString(),
         // Record the generation we converged so the guard at the top of reconcileTenant
         // skips the next watch replay of this unchanged Tenant. A spec edit bumps generation
-        // and re-arms a full reconcile.
-        observedGeneration: tenant.metadata?.generation,
+        // and re-arms a full reconcile. Left UNSET while degraded so the fetch is retried.
+        observedGeneration: degradedReason ? undefined : tenant.metadata?.generation,
       });
     }
     catch (err)
@@ -395,6 +436,35 @@ export class TenantOperator
         message: err instanceof Error ? err.message : String(err),
         lastReconciled: new Date().toISOString(),
       });
+      throw err;
+    }
+  }
+
+  /**
+   * Read the tenant's currently-applied openclaw ConfigMap, if any.
+   *
+   * Used by the model gate (issue #144) to tell a first-ever provision (nothing to
+   * protect — render the temporarily model-less config) apart from a re-reconcile over
+   * an already-good config (keep it, mark Degraded). A confirmed 404 means "no ConfigMap
+   * yet" → `null`. Any OTHER read error is inconclusive: we must NOT assume absence, or a
+   * transient API blip could let an empty/failed model fetch clobber a working config, so
+   * it is re-thrown to fail the reconcile into a retry rather than resolved to `null`.
+   *
+   * @param name - Tenant CR name (the ConfigMap is `openclaw-<name>-config`).
+   * @param namespace - Namespace the tenant's child resources live in.
+   */
+  private async readExistingConfigMap(name: string, namespace: string): Promise<k8s.V1ConfigMap | null>
+  {
+    try
+    {
+      return await this.coreApi.readNamespacedConfigMap({ name: `openclaw-${name}-config`, namespace });
+    }
+    catch (err)
+    {
+      if (_IsK8sNotFound(err))
+      {
+        return null;
+      }
       throw err;
     }
   }


### PR DESCRIPTION
## What landed

Makes the clustertenant-operator's tenant reconcile **fail-safe** so a transient or empty upstream read can no longer overwrite a known-good openclaw config. Fixes #144 (the elewa-be chat-break: a forced reconcile re-rendered from an empty `tenant-models` response, dropped `agents.defaults.model`, and every turn failed with `missing-provider-auth`).

**Approach — skip-update** (keep the last-applied ConfigMap) rather than carry-forward, matching the operator's existing idempotent-apply pattern and reusing the exact bytes already serving:

- `_FetchTenantModels` now returns a discriminated `{ status: "ok" | "empty" | "error", modelSet }` — `empty` (200 `[]`, onboarding-incomplete) is distinguished from `error` (transport / non-200 / malformed), logged differently, both treated as "don't clobber".
- New pure `_ResolveTenantModelGate(fetchStatus, liteLlmEnabled, hasExistingConfigMap)` → `render` | `skip-degraded`. Skips **only** when LiteLLM is on, the fetch is empty/error, **and** a ConfigMap already exists. First-ever provision still renders (self-heals on the next fetch); LiteLLM-off always renders.
- New `Degraded` Tenant phase + `TenantDegradedReason` (`ModelSetEmpty` / `ModelFetchFailed`) + `degradedReason` status field. On skip the operator keeps the ConfigMap, pins the pod template to the existing config's checksum, patches `Degraded` (not `Error` — the pod keeps serving), and leaves `observedGeneration` unset so the next reconcile retries.
- `_BuildConfigMap` was already safe (only emits `litellm-proxy/`-prefixed refs, omits the default when none resolves) — locked in with a regression test rather than changed.

## Validation

- New `__tests__/tenants/model-gate.test.ts` + updated `tenant-models.test.ts`: full gate matrix; never-emit-a-bare-model render contract; end-to-end `reconcileTenant` — empty/error leaves the ConfigMap unchanged + marks `Degraded` with the right reason, a valid set renders `Running` with the prefixed default, and forcing `observedGeneration:0` never downgrades a working model.
- All 626 operator tests pass (`vitest run`); `tsc --noEmit` clean; style-check reports zero new violations.

## Open items

- The `readExistingConfigMap` inconclusive-read path re-throws (fails into a retry) rather than assuming absence — deliberate, to avoid clobbering on a transient API blip. If noisy in production it could be softened to `skip-degraded`.

Phase A of the cross-repo execution plan (stabilise the live cluster before launch verification).

Commit: `db6e9f7`
