### PR TITLE
fix(crd): declare ClusterTenant spec.zitadel so per-org OIDC delegation isn't pruned

### DIFF
--- a/apps/fleet-operator/src/__tests__/cluster-tenants/crd-schema.test.ts
+++ b/apps/fleet-operator/src/__tests__/cluster-tenants/crd-schema.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import * as k8s from "@kubernetes/client-node";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Guards the ClusterTenant CRD's structural schema against field pruning. A Kubernetes
+ * structural schema (no spec-level `x-kubernetes-preserve-unknown-fields`) PRUNES any field
+ * the schema does not declare on write, silently. Both the fleet CR bridge (writes
+ * `spec.zitadel`) and the silo login resolver (reads `spec.zitadel`) depend on the per-org
+ * Zitadel OIDC ids surviving on the CR; if the schema drops `zitadel`, per-org login degrades
+ * to the shared masters client with no error. This asserts the field is declared so that
+ * regression cannot recur.
+ */
+const _CRD_PATH = fileURLToPath(new URL("../../../../fleet-platform/crds/opencrane.io_clustertenants.yaml", import.meta.url));
+
+interface _CrdSchemaProps
+{
+  type?: string;
+  properties?: Record<string, _CrdSchemaProps>;
+  "x-kubernetes-preserve-unknown-fields"?: boolean;
+}
+
+function _loadClusterTenantSpecSchema(): _CrdSchemaProps
+{
+  const crd = k8s.loadYaml(readFileSync(_CRD_PATH, "utf8")) as {
+    spec: { versions: Array<{ schema: { openAPIV3Schema: _CrdSchemaProps } }> };
+  };
+  const root = crd.spec.versions[0].schema.openAPIV3Schema;
+  const spec = root.properties?.spec;
+  if (!spec) throw new Error("ClusterTenant CRD has no spec schema");
+  return spec;
+}
+
+describe("ClusterTenant CRD structural schema", function _suite()
+{
+  it("declares spec.zitadel with the OIDC ids the CR bridge writes and the silo login reads", function ()
+  {
+    const spec = _loadClusterTenantSpecSchema();
+
+    // A structural schema (no spec-level preserve-unknown) prunes undeclared fields, so the
+    // whole zitadel block must be declared or the API server drops it on the bridge's write.
+    expect(spec["x-kubernetes-preserve-unknown-fields"]).toBeUndefined();
+
+    const zitadel = spec.properties?.zitadel;
+    expect(zitadel, "spec.zitadel must be declared or the API server prunes per-org OIDC ids").toBeDefined();
+    expect(zitadel?.type).toBe("object");
+
+    for (const field of ["clientId", "orgId", "redirectUri"])
+    {
+      expect(zitadel?.properties?.[field]?.type, `spec.zitadel.${field} must be a declared string`).toBe("string");
+    }
+  });
+});

--- a/apps/fleet-platform/crds/opencrane.io_clustertenants.yaml
+++ b/apps/fleet-platform/crds/opencrane.io_clustertenants.yaml
@@ -84,6 +84,28 @@ spec:
                           type: integer
                           minimum: 0
                           description: Total GPUs the customer may request.
+                zitadel:
+                  type: object
+                  description: >-
+                    Public per-org Zitadel OIDC identifiers, projected onto the CR by the fleet
+                    manager after the org is provisioned so the silo resolves per-org login
+                    straight from the CR (the single source of truth). These are PUBLIC OIDC
+                    ids (client_id, org id, redirect URI), NOT secrets, so carrying them on a
+                    cluster-scoped CR is safe. Absent until the org is provisioned in Zitadel.
+                    MUST be present in the schema or the API server prunes it from spec writes,
+                    silently degrading per-org login to the shared masters client.
+                  properties:
+                    clientId:
+                      type: string
+                      description: The org's OIDC client_id login authorizes with (the per-org public credential).
+                    orgId:
+                      type: string
+                      description: >-
+                        The org's Zitadel Organization id, added as the
+                        urn:zitadel:iam:org:id:{orgId} login scope to restrict login to the org's user pool.
+                    redirectUri:
+                      type: string
+                      description: The redirect URI registered on the org's OIDC app, when known.
                 owner:
                   type: object
                   required: [subject]


### PR DESCRIPTION
## What landed

Declares `spec.zitadel` in the `ClusterTenant` CRD so per-org OIDC delegation stops being silently broken.

**The bug:** the CRD schema is structural (`type: object` + explicit `properties`, no `x-kubernetes-preserve-unknown-fields` at the spec level), but `spec.zitadel` was **absent** from it. The Kubernetes API server therefore **pruned** the field on write — even though the type (`libs/contracts/src/cluster-tenant.types.ts`), the fleet writer (`cr-bridge.ts` `_BuildSpecPatch`), and the silo login reader (`clustertenant-operator .../auth/per-org-client.ts` `_ResolvePerOrgClient`) all use `clientId` / `orgId` / `redirectUri`. Result: per-org login fell through to the shared masters OIDC client instead of the org-scoped one.

Surfaced by the #150 contract-design pass; this is the highest-priority concrete gap it found and it's a live correctness bug, not just future work.

## What changed

- Added the `spec.zitadel` object (`clientId` / `orgId` / `redirectUri` string properties, matching sibling-field descriptions/style) to `apps/fleet-platform/crds/opencrane.io_clustertenants.yaml`, between `resources` and `owner`.
- CRD is **hand-maintained** (no controller-gen / codegen), so the schema edit is the source of truth and won't be regenerated away.

## Validation

- New `apps/fleet-operator/src/__tests__/cluster-tenants/crd-schema.test.ts` parses the CRD and asserts `spec.zitadel` is declared with the three string sub-fields — **verified red without the fix, green with it**.
- Full schema audit: `spec.zitadel` was the **only** drifted field; all other spec/status fields are declared. No further pruning risk.
- fleet-operator suite (144 tests) + silo reader tests (14) pass; `tsc` clean.

Unblocks the OIDC-delegation decoupling that the standalone-silo work (#151) depends on.

Commit: `47c602a`
