### PR TITLE
docs(design): fleet↔silo contract spec + open-core licensing ADR (#150)

### DIFF
--- a/docs/adr/0004-open-core-fleet-silo-licence-split.md
+++ b/docs/adr/0004-open-core-fleet-silo-licence-split.md
@@ -1,0 +1,123 @@
+# ADR 0004 — Open-core licence split at the fleet ↔ silo boundary
+
+- **Status:** Accepted
+- **Date:** 2026-07-07
+- **Task:** `#150` (Phase 3 pull-forward — the fleet/silo repo split preparation)
+- **Supersedes / superseded by:** none — establishes the licensing posture for the Phase 3 repo split.
+- **Related:** [`docs/design/fleet-silo-contract.md`](../design/fleet-silo-contract.md) (the one contract that
+  survives the split) · [ADR 0002 — per-ClusterTenant silo architecture](0002-per-clustertenant-silo-architecture.md)
+  (the fleet vs. silo boundary this licence line follows) · [`libs/contracts/README.md`](../../libs/contracts/README.md)
+  (the pre-existing MIT relicensing of the SDK).
+
+## Context
+
+OpenCrane is being restructured (Phase 3) so that `opencrane-2` becomes a **standalone ClusterTenant
+template** — deployable alone (self-hosted, single-tenant) or fleet-managed by an external fleet manager that
+lives in a separate repo, `weownai`. The fleet manager (`apps/fleet-operator`'s HTTP/provisioning routes plus
+the `apps/fleet-platform` Helm chart) moves OUT to `weownai`; the per-silo control plane
+(`apps/clustertenant-operator`) and the rest of `opencrane-2` stay behind, joined to the fleet only by the
+cross-repo contract specified in the fleet↔silo contract design.
+
+Today the whole platform is **AGPL-3.0-or-later** (root `LICENSE`; `apps/fleet-operator` and
+`apps/clustertenant-operator` both declare `"license": "AGPL-3.0-or-later"`), with **one deliberate
+exception already in place**: `libs/contracts` is **MIT** so external — including proprietary — consumers can
+generate a typed client from the published OpenAPI spec without inheriting AGPL obligations
+(`libs/contracts/README.md`).
+
+The owner has decided the platform's commercial model: **open core.** A self-hostable AGPL template
+(the silo) plus a **proprietary hosted fleet manager** (the value-add: multi-tenant provisioning, Zitadel org
+provisioning, billing, platform DNS, the dedicated-cluster provisioner). This requires settling *which
+components are proprietary, which stay AGPL, and when the relicense happens* — before the Phase 3 move, so the
+split lands the code on the correct side of the licence line rather than relicensing after the fact.
+
+Two constraints shape the decision:
+
+1. **The AGPL boundary must be a process/network boundary, not a code link.** AGPL's network-use clause makes
+   an in-process link between AGPL and proprietary code untenable; the split is only clean if the two planes
+   talk exclusively through the versioned contract (CR schema, OpenAPI, the MIT SDK).
+2. **The template must stay genuinely self-hostable.** A user who takes only `opencrane-2` must get a working
+   single-tenant OpenCrane under AGPL, with no proprietary component required to run it.
+
+## Decision
+
+### The licence line follows the fleet ↔ silo contract boundary
+
+Components are relicensed by which side of the [fleet↔silo contract](../design/fleet-silo-contract.md) they
+sit on:
+
+| Component | Repo after Phase 3 | Licence | Rationale |
+|---|---|---|---|
+| Fleet manager — `apps/fleet-operator` provisioning/HTTP routes (cluster-tenants, billing, platform DNS, Zitadel admin) | `weownai` | **Proprietary** | The hosted multi-tenant value-add; the commercial product. |
+| `apps/fleet-platform` Helm chart | `weownai` | **Proprietary** | Deploys the proprietary fleet manager. |
+| Dedicated-cluster provisioner (behind the webhook seam) | `weownai` | **Proprietary** | The enterprise dedicated-tier backend (ADR 0001/0002's arm's-length seam). |
+| `apps/clustertenant-operator` (the silo control plane) | `opencrane-2` | **AGPL-3.0-or-later** | The self-hostable template. |
+| Silo planes, operator, per-org identity/tenant/model/skill surfaces | `opencrane-2` | **AGPL-3.0-or-later** | The template. |
+| Control-plane frontend (arriving from weownai) | `opencrane-2` | **AGPL-3.0-or-later** | Ships with the template as its UI. |
+| `libs/contracts` (shared DTOs + generated clients + CR types) | `opencrane-2` | **MIT** (unchanged) | The contract must be linkable from BOTH the AGPL silo and the proprietary fleet without imposing AGPL on the latter. |
+| The CR schema + published OpenAPI + CRD YAML | `opencrane-2` (emitted) | Contract artifacts | The interface itself is the licence boundary. |
+
+The single test for "which side": **does this component implement the hosted fleet's value-add (multi-tenant
+provisioning / billing / IdP org provisioning / dedicated-cluster backend)?** If yes → proprietary, moves to
+`weownai`. If it is part of what a self-hoster runs to get a working OpenCrane → AGPL, stays in `opencrane-2`.
+
+### The AGPL boundary IS the fleet ↔ silo contract
+
+The contract (CR `spec`/`status`, the OpenAPI provisioning API, the `spec.zitadel` OIDC delegation payload,
+the dedicated-cluster webhook) is deliberately the licence boundary. The AGPL silo and the proprietary fleet
+manager share **no code** — only the MIT `@opencrane/contracts` types and the wire artifacts. This is why the
+delegation payload is carried on the CR (public OIDC ids only) rather than by an in-process call: it keeps the
+proprietary IdP authority entirely on the fleet side of an arm's-length boundary.
+
+### The relicense happens AHEAD of the Phase 3 move, not now
+
+The relicensing of `fleet-operator` + `fleet-platform` to proprietary happens **as part of preparing the
+Phase 3 move** — before the code physically moves to `weownai`, so it moves already correctly licensed. It
+does **not** happen in this pull-forward change (#150): #150 writes down the decision and the contract; it
+flips no licence headers and moves no code. The AGPL template and the MIT `libs/contracts` posture are
+unchanged today.
+
+## Alternatives considered
+
+- **Keep everything AGPL (no proprietary split).** Rejected. It forecloses the hosted commercial model the
+  owner has chosen: a competitor could run the fleet manager as a service under AGPL without contributing the
+  hosted value-add back in any way that protects the business. Open core (AGPL template + proprietary fleet)
+  is the deliberate model.
+- **Dual-track licensing (AGPL + a paid commercial licence for the SAME fleet code).** Rejected as the
+  primary model — it needs a CLA with copyright assignment from every contributor to relicense their
+  contributions, which is heavier governance than the split warrants and muddies the "what's open" story. The
+  cleaner line is a *physical* split: the open template and the proprietary fleet are different codebases in
+  different repos, not the same code under two licences. (A commercial licence for the proprietary fleet
+  remains possible on top of the split — it is orthogonal.)
+- **Make the whole platform permissively licensed (MIT/Apache).** Rejected. AGPL's network-use protection is
+  the point for the self-hostable template — it keeps hosted forks of the *template* honest — while the
+  proprietary fleet manager carries the commercial terms. A permissive template would give away the network
+  protection with no offsetting benefit.
+- **Relicense after the move rather than before.** Rejected. Moving AGPL-headered code into a proprietary repo
+  and relicensing it there is error-prone (mixed headers, unclear provenance) and creates a window of
+  ambiguous licensing. Relicensing while the code is still owner-controlled and in one tree is cleaner.
+
+## Consequences
+
+- **Contributor / CLA implications.** New contributions to code destined to become proprietary
+  (`fleet-operator`, `fleet-platform`) must be covered by a contributor agreement that permits the
+  proprietary relicense — put this in place **before** accepting outside contributions to those paths, or keep
+  them owner-authored until the move. Contributions to the AGPL silo and the MIT `libs/contracts` follow their
+  existing inbound=outbound terms. Until the CLA exists, treat the fleet paths as owner-authored.
+- **The contract is now a licence-load-bearing artifact.** Because the AGPL boundary is the contract, any
+  change that would force AGPL and proprietary code to link in-process is a licence regression, not just a
+  design one. The contract must stay expressible as CR + wire + MIT types (this is why `spec.zitadel` carries
+  only public ids — see the contract design's new-work list).
+- **Third-party-notice hygiene.** The split creates two dependency-licence surfaces. The AGPL template's
+  third-party notices stay in `opencrane-2`; the proprietary fleet's move with it to `weownai`. Any dependency
+  currently shared but only *used* by fleet code must be attributed on the correct side after the move — audit
+  the dependency graph as part of the physical split so no proprietary build ships AGPL/GPL transitive deps it
+  cannot comply with, and no AGPL build claims notices for fleet-only deps.
+- **`libs/contracts` MIT posture is reaffirmed, not new.** The one pre-existing exception (MIT SDK) is exactly
+  the mechanism this ADR generalises; no change to it is needed, and its rationale (external proprietary
+  consumers) now formally includes the fleet manager itself.
+- **Self-hostability is preserved by construction.** Because the delegation payload degrades to a no-op
+  (a silo with no fleet stamping `spec.zitadel` uses its masters client), the AGPL template runs standalone
+  with zero proprietary components — satisfying the "genuinely self-hostable" constraint and unblocking #151.
+- **Open questions deliberately left to the owner.** The *terms* of the proprietary licence and of the
+  contributor agreement are commercial decisions not settled here; this ADR settles only the **split itself**
+  (which components, which side, when) — that part is decided.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@ is not itself published.
 | [0001](0001-cluster-tenant-virtual-network-isolation.md) | ClusterTenant-as-virtual-network strict isolation (substrate) | Superseded by 0003 |
 | [0002](0002-per-clustertenant-silo-architecture.md) | Per-ClusterTenant silo architecture (dedicated operator, planes, API/DB per tenant) | Accepted |
 | [0003](0003-cilium-spiffe-identity-substrate.md) | Cilium + SPIFFE identity substrate (identity-keyed L3/L4/L7 + SVID mTLS) | Accepted |
+| [0004](0004-open-core-fleet-silo-licence-split.md) | Open-core licence split at the fleet ↔ silo boundary (AGPL template + proprietary fleet) | Accepted |
 
 ## Writing a new ADR
 

--- a/docs/design/fleet-silo-contract.md
+++ b/docs/design/fleet-silo-contract.md
@@ -1,0 +1,297 @@
+# Fleet ↔ silo contract specification
+
+Status: **design — the one contract that survives the fleet/silo repo split (Phase 3, #150 pull-forward).**
+This document specifies the single cross-repo interface between the **fleet manager** (moving OUT to the
+`weownai` repo, relicensed proprietary) and the **ClusterTenant silo** (staying in `opencrane-2`, AGPL).
+It moves no code and flips no licence headers — it records the decisions so the later move (#151) can happen
+mechanically. The licensing rationale is [ADR 0004](../adr/0004-open-core-fleet-silo-licence-split.md).
+
+## Why this contract exists
+
+`opencrane-2` is becoming a standalone **ClusterTenant template**: deployable alone (single-tenant, self-hosted,
+AGPL) *or* fleet-managed by an external, proprietary fleet manager. Everything the two planes share must be
+expressible through a small, versioned, network/CR-level boundary — never a code link. Today the two are one
+NX repo; after Phase 3 the fleet manager (`apps/fleet-operator` routes + `apps/fleet-platform` Helm chart) lives
+in `weownai` and talks to the silo only through what this document specifies.
+
+The boundary has **four surfaces** plus a **versioning discipline**:
+
+| Surface | Direction | Medium | Today's owner |
+|---|---|---|---|
+| 1. `ClusterTenant` CR | fleet → silo (desired) · silo → fleet (observed) | Kubernetes cluster-scoped CRD | fleet writes `spec`, operator writes `status` |
+| 2. Provisioning API | external fleet manager → fleet-manager HTTP | OpenAPI 3.1 (`/api/v1/cluster-tenants`) | `apps/fleet-operator/src/routes/cluster-tenants.ts` |
+| 3. OIDC delegation payload | fleet → silo | `ClusterTenant.spec.zitadel` on the CR | `cr-bridge.ts` writes; `per-org-client.ts` reads |
+| 4. Dedicated-cluster provisioner webhook | fleet → external provisioner | HTTPS webhook | `external-webhook.config.ts` (seam only) |
+| 5. Versioned artifacts | opencrane-2 emits, weownai pins | `openapi.json` + `@opencrane/contracts` + CRD YAML | released per tag |
+
+> See also: [ADR 0002 — per-ClusterTenant silo architecture](../adr/0002-per-clustertenant-silo-architecture.md)
+> · [silo read-model projection](silo-readmodel-projection-design.md) (the origin of surface 3, Option A)
+> · [`docs/agents/apps/fleet-operator.md`](../agents/apps/fleet-operator.md).
+
+---
+
+## Surface 1 — the `ClusterTenant` CR
+
+The `ClusterTenant` custom resource is the durable, declarative boundary between the two planes. The fleet is
+the system of record for **desired state** (`spec`); the silo operator is the system of record for **observed
+state** (`status`). Neither writes the other's half — the CR bridge writes only `spec`
+(`apps/fleet-operator/src/core/cluster-tenants/cr-bridge.ts`), the operator writes only `status`
+(`apps/fleet-operator/src/cluster-tenants/internal/cluster-tenant-status-writer.ts`).
+
+### Identity and scope
+
+- **Group/version/kind:** `opencrane.io/v1alpha1`, `kind: ClusterTenant`, plural `clustertenants`, short name `ct`.
+- **Scope:** `Cluster` (one CR per customer org; the org name is the CR name).
+- **CRD source:** `apps/fleet-platform/crds/opencrane.io_clustertenants.yaml`.
+- **Shared TypeScript type:** `ClusterTenant` in `libs/contracts/src/cluster-tenant.types.ts`.
+
+### Spec (fleet-owned desired state)
+
+Current CRD fields (`spec`), each grounded in the CRD YAML and the `ClusterTenant` contract type:
+
+| Field | Type | Required | Meaning |
+|---|---|---|---|
+| `displayName` | string (minLength 1) | yes | Human-readable customer name. |
+| `vanityDomain` | string (DNS domain, ≤253) | no | Customer-vanity host CNAMEd onto the derived apex `<name>.<base>`. An **overlay**, not the org identity. |
+| `isolationTier` | enum `shared \| dedicatedNodes \| dedicatedCluster` | yes (default `shared`) | Isolation strength. `dedicatedCluster` requires a registered external provisioner (surface 4). |
+| `compute` | `{ mode: shared \| dedicated, nodePool? }` | no (default `shared`) | Bin-pack on shared nodes vs. pin to a dedicated pool. `nodePool` required when `mode=dedicated`. |
+| `resources.quota` | `{ cpu?, memory?, pods?, storage?, gpu? }` | no | Aggregate ceiling enforced as `ResourceQuota`/`LimitRange` over the org namespace. |
+| `owner` | `{ subject, email? }` | yes at create (control-plane-enforced, not CRD-enforced) | The org root owner's OIDC `sub` (+ IdP-verified email). The **only channel** for owner identity — the operator has no DB access and attributes the auto-seeded default `Tenant` from this field. |
+
+**Contract gap — `spec.zitadel` (see surface 3).** The shared TypeScript type
+(`ClusterTenantZitadel` in `libs/contracts/src/cluster-tenant.types.ts`), the fleet writer
+(`_BuildSpecPatch` in `cr-bridge.ts`), and the silo reader (`_ResolvePerOrgClient` in
+`apps/clustertenant-operator/src/infra/auth/per-org-client.ts`) **all already reference
+`spec.zitadel.{clientId, orgId, redirectUri}`** — but the CRD YAML
+(`opencrane.io_clustertenants.yaml`) does **not declare it**. On an API server pruning unknown fields
+(the default under structural schemas), the block is silently dropped on write, so the silo reads nothing
+and per-org login falls through to the masters client. **This is new work for #150/#151** (see the
+new-work list at the end). Everything below assumes the CRD is amended to declare `spec.zitadel`.
+
+### Status (silo-operator-owned observed state)
+
+| Field | Type | Meaning |
+|---|---|---|
+| `phase` | enum `pending \| provisioning \| ready \| failed` | Lifecycle phase the operator drove the CR to. |
+| `message` | string | Human-readable detail (set on failure/transition). |
+| `boundNamespace` | string | Namespace bound to the org once provisioned (`opencrane-<name>`). |
+| `provisioner` | string | Identifier of the provisioner that owns the boundary. |
+| `lastReconciled` | date-time | Last successful reconcile timestamp. |
+| `observedGeneration` | int64 | `metadata.generation` the operator last drove to ready; the reconcile-skip guard compares this against `metadata.generation`. Must be declared in the schema or the API server prunes it, defeating the guard. |
+
+`ClusterTenantStatus` / `ClusterTenantObservedStatus` in `libs/contracts/src/cluster-tenant.types.ts` are the
+typed mirror; the fleet read path (`_ReadClusterTenantObservedStatus` → `_ObservedStatusToContract`) maps the
+raw CR status into the API response, because the DB `phase` column is desired-only and never receives the
+operator's write-back.
+
+### Lifecycle
+
+**Create.** `POST /api/v1/cluster-tenants` (surface 2) validates the request, persists the org + single
+owner membership + Zitadel provisioning in one DB transaction, then projects the persisted desired state onto
+a new CR via `_ApplyClusterTenantCr` with `spec.owner` mandatory (`cr-bridge.ts` `_CreateCr`; on 409 falls
+back to a spec merge-patch). The operator's `ClusterTenantOperator` reconcile loop
+(`apps/fleet-operator/src/cluster-tenants/operator.ts`) picks up the CR and drives
+`pending → provisioning → ready`: resolve the isolation boundary, fence the `opencrane-<name>` namespace
+(PSA `baseline`, `ResourceQuota`, `LimitRange`, dedicated-node scheduling), provision the per-org domain
+(wildcard `Certificate` + external-dns `DNSEndpoint`, runtime-gated), then stamp `status`.
+
+**Update.** `PUT /api/v1/cluster-tenants/:name` collects only desired-state fields (never `phase`/
+`boundNamespace`/`message`/`provisioner`), persists them, and re-projects the spec via `_ApplyClusterTenantCr`
+(no owner → spec merge-patch only). When `vanityDomain` actually changes on a provisioned org, the row update
+and the Zitadel redirect-URI allowlist sync happen in one transaction (IdP call last) so the two never drift.
+The operator re-converges to the changed spec idempotently; the reconcile-skip guard (`observedGeneration`)
+prevents a no-op re-provision on watch replays.
+
+**Teardown (align with #138).** `DELETE /api/v1/cluster-tenants/:name` deletes the DB row and tears down the
+Zitadel org in one transaction (Zitadel last, 404-tolerant, so a missing IdP org still commits), then deletes
+the CR via `_DeleteClusterTenantCr` **outside** the transaction (a Prisma tx cannot roll back a k8s mutation).
+A CR-delete failure is logged, not 500'd — the row (source of truth) is already gone, so a retry would 404 and
+never re-attempt, leaving an orphaned CR for operator cleanup. On CR delete the operator's `deprovision`
+handler (`operator.ts`, DOMAIN.T2) deletes the per-org wildcard `Certificate` + `DNSEndpoint` so external-dns
+reaps the DNS records; namespace GC is the backstop for everything else in the namespace.
+
+**#138 direction to honour in the split** (from `plan.md` #138 — *ClusterTenant teardown*): teardown should
+become **finalizer-driven** so the silo can complete its own deprovision (drain planes, honour the #126
+dataset-retention policy) *before* the CR and namespace are reclaimed, rather than relying on best-effort
+CR-delete + namespace GC racing the operator. Under the split, the finalizer is the clean handshake: the
+fleet requests deletion, the silo operator runs teardown and removes its finalizer, and only then does the CR
+disappear. The data-retention policy (datasets retained per #126) is a **silo-side** decision, so it must be
+expressible without the fleet knowing silo internals — a teardown-policy field on the CR spec, or a silo
+finalizer that consults its own policy, keeps the retention decision on the AGPL side of the boundary.
+
+---
+
+## Surface 2 — the provisioning API
+
+The external fleet manager (in `weownai`) drives org lifecycle by calling the fleet-manager HTTP API. After
+the split this is the **only synchronous call path** from the hosted control plane into the platform; it is
+served today from `apps/fleet-operator/src/routes/cluster-tenants.ts`, mounted at `/api/v1/cluster-tenants`,
+and specified in `apps/fleet-operator/src/openapi/spec.ts` → `apps/fleet-operator/openapi.json`.
+
+| Method + path | Purpose | Auth guard | Notable codes |
+|---|---|---|---|
+| `GET /api/v1/cluster-tenants` | List all orgs (fleet/super-admin view). | `requireOrgManager` | — |
+| `GET /api/v1/cluster-tenants/:name` | Get one org; overlays the operator's observed `status` from the CR. | `requireOrgManager` | `404 CLUSTER_TENANT_NOT_FOUND` |
+| `GET /api/v1/cluster-tenants/:name/status` | Observed status only (drives the onboarding poll). | `requireOrgManager` | `404` |
+| `POST /api/v1/cluster-tenants/:name/refresh` | Re-read + mirror observed status. | `requireOrgManager` | `404` |
+| `POST /api/v1/cluster-tenants` | Create org (persist + Zitadel + owner membership + CR). | `_RequireBillingAccountForOrgCreate` (billing gate — a user becomes admin BY creating) | `400 VALIDATION_ERROR`, `409 CONFLICT`, `422 TIER_UNAVAILABLE` |
+| `PUT /api/v1/cluster-tenants/:name` | Update desired state; re-gate tier; sync vanity redirect URIs. | `requireOrgManager` | `400`, `404`, `422 TIER_UNAVAILABLE` |
+| `DELETE /api/v1/cluster-tenants/:name` | Teardown (row + Zitadel + CR). | `requireOrgManager` | `404` |
+
+Adjacent fleet-owned surfaces that stay on the fleet side of the boundary (documented here so the split knows
+what moves with the API, not what the silo depends on): `cluster-tenants/:name/members` (org membership),
+`billing-accounts` (seat ordering), `platform/dns` (DNS-01 issuer + wildcard cert creds), and
+`admin/zitadel-*` (per-org OIDC client provisioning + SA-key rotation). All of these are **fleet-manager
+internals** — the silo never calls them. Their existence matters to the split only because they move to
+`weownai` together with the routes above.
+
+**Tier gating.** `POST`/`PUT` call `registry.isTierAvailable(tier)`
+(`ClusterTenantProvisionerRegistry` in `libs/contracts`, built by
+`_BuildClusterTenantProvisionerRegistry` in `apps/fleet-operator/src/core/cluster-tenants/registry.ts`) and
+reject an unserviceable tier with `422 TIER_UNAVAILABLE` (`ClusterTenantTierUnavailableCode`) rather than
+stranding the org in `pending`. The built-in `shared` provisioner always advertises `shared` +
+`dedicatedNodes`; `dedicatedCluster` is advertised only when the external webhook (surface 4) is configured.
+
+---
+
+## Surface 3 — the OIDC delegation payload (the key decoupling)
+
+This is the surface that unblocks the standalone silo (#151): **a silo must log its users in without any
+direct Zitadel/IdP access.** Today the fleet manager is the sole IdP authority — on `POST /cluster-tenants`
+it calls `zitadelClient.provisionOrg(...)` (`apps/fleet-operator/src/infra/zitadel/`) to create the org's
+dedicated Zitadel Organization + `opencrane` project + roles + OIDC app, grant the owner `admin`, and persist
+the resulting identifiers. The silo has no Zitadel credentials and must not gain any (that authority stays
+proprietary, on the fleet side of the AGPL boundary — see ADR 0004).
+
+### What fleet must expose
+
+The delegation payload is the minimal set of **public** OIDC identifiers a silo needs to build a per-org login
+against the org's isolated user pool. `provisionOrg` already returns them (`ZitadelProvisionOrgResult` in
+`apps/fleet-operator/src/infra/zitadel/zitadel-client.types.ts`):
+
+| Field | Source | Silo use |
+|---|---|---|
+| `clientId` | provisioned OIDC app's `client_id` | The per-org public credential login authorizes with. |
+| `orgId` | provisioned Zitadel Organization id | Restricts login to that org's user pool via the `urn:zitadel:iam:org:id:{orgId}` scope (`_OrgScope` in `per-org-client.ts`). |
+| `redirectUri` | registered callback (`<org>.<base>/api/v1/auth/callback`) | The org's canonical callback; vanity callbacks are additional allowlist entries. |
+
+These are **public OIDC identifiers, not secrets** — a `client_id`, an org id, and a redirect URI. Carrying
+them on a cluster-scoped CR is safe (the confidential SA key never leaves the fleet). The silo's OIDC
+discovery URL, JWKS, token endpoint, etc. are the shared IdP metadata (one Zitadel instance base URL); the
+silo resolves those from its own OIDC config — the per-org payload is only the org-scoping delta.
+
+### The transport: CR `spec.zitadel` (design decision — Option A)
+
+The delegation payload is delivered on the `ClusterTenant` CR `spec.zitadel` block, **not** via a fleet→silo
+API call. This is Option A from the [silo read-model projection design](silo-readmodel-projection-design.md):
+the fleet writes the ids onto the CR after `provisionOrg` (`_BuildSpecPatch` in `cr-bridge.ts`), and the silo
+reads them straight off the CR at login (`_ResolvePerOrgClient` in
+`apps/clustertenant-operator/src/infra/auth/per-org-client.ts`). Chosen over the alternatives because it:
+
+- keeps the **CR as the single source of truth** (consistent with the desired-state pattern);
+- removes the silo's `ClusterTenant` read-model table rather than adding a sync path;
+- puts **no plane on the login hot path** (a fleet outage cannot block silo logins — the CR is already in etcd);
+- needs **no new auth between the planes** and is unit-testable against a mocked `customApi`;
+- exposes only public ids on a cluster-scoped object.
+
+Silo login resolution, already implemented: resolve the CR for the request host (canonical first DNS label,
+else exact `spec.vanityDomain` match across the cluster-scoped list), fail-closed to the masters client when
+the host matches no CR or the org is not fully provisioned (`clientId`/`orgId` absent), else return
+`{ clusterTenant, clientId, orgId, redirectUri }` and authorize against that org's pool.
+
+### Standalone-silo (#151) implication
+
+When a silo runs **without** a fleet manager, nothing writes `spec.zitadel` and the silo falls through to its
+masters client — which is the correct single-tenant behaviour (one OIDC client, no per-org pools). The
+contract therefore degrades cleanly: the delegation payload is **optional desired state**, present only when a
+fleet manager provisioned the org. #151's standalone path is "the CR has no `zitadel` block, and that's fine";
+the fleet-managed path is "the fleet stamps it." No code branch beyond the existing fail-closed fallthrough is
+required once the CRD declares the field.
+
+---
+
+## Surface 4 — the dedicated-cluster provisioner webhook
+
+For the `dedicatedCluster` tier (own kube-apiserver per silo — vcluster/Kamaji), provisioning is
+**out-of-process** and arm's-length by design (ADR 0001/0002 call this the AGPL/WeOwnAI enterprise seam). The
+fleet↔external-provisioner boundary is an HTTPS webhook, configured entirely from the environment
+(`_ReadExternalWebhookConfig` in `apps/fleet-operator/src/core/cluster-tenants/external-webhook.config.ts`):
+
+- `CLUSTER_TENANT_PROVISIONER_WEBHOOK_URL` — HTTPS endpoint (non-HTTPS fails loud at config load, so the
+  bearer token is never sent in plaintext);
+- `CLUSTER_TENANT_PROVISIONER_WEBHOOK_TOKEN` — bearer token (a compatibility shim; IAM-first is preferred);
+- `CLUSTER_TENANT_PROVISIONER_WEBHOOK_ID` — the stable id the backend advertises in the registry (default `external`).
+
+The generic request/result shapes are already in the contract
+(`ClusterTenantProvisionRequest` / `ClusterTenantProvisionResult` in `libs/contracts/src/cluster-tenant.types.ts`):
+the request carries only `{ name, isolationTier, compute, quota }` (no vendor-specific fields), and the result
+returns `{ phase, message?, boundNamespace?, kubeconfigSecretRef? }` — the kubeconfig is handed back **only as
+a Kubernetes Secret reference**, never as inline credential material.
+
+**Current state to reconcile in the split.** The registry today is a pure *tier-availability gate* — the
+webhook config only decides whether `dedicatedCluster` is *advertised*; the control plane no longer POSTs to
+the backend itself (`registry.ts` / `registry.infra.ts` comments: "the operator owns provisioning, see
+DOMAIN.T1/T2"). So `ClusterTenantProvisionRequest`/`Result` are the **published shape** for whoever does POST
+to the webhook, but the live POST caller (operator vs. external orchestrator) is not yet wired. For the split
+this means: the webhook shapes stay in the AGPL `@opencrane/contracts` (they are public), the *proprietary
+dedicated-cluster provisioner* lives in `weownai` behind this webhook, and the seam between them is exactly
+`{ url, token, id }` + the request/result DTOs. New work: decide and wire the POST caller (below).
+
+---
+
+## Surface 5 — versioning: how the contract is published and pinned
+
+The split hinges on `opencrane-2` **emitting** versioned contract artifacts that `weownai` **pins** — never a
+source dependency across the repo boundary. This mirrors the pattern already in place (see
+[`libs/contracts/README.md`](../../libs/contracts/README.md) and MEMORY: *OpenCrane split contract* — weownai
+pins two specs/clients).
+
+**Three artifacts, one release tag.** Each tagged `opencrane-2` release emits:
+
+1. **`apps/fleet-operator/openapi.json`** — the fleet-manager HTTP API (surface 2), authored in
+   `src/openapi/spec.ts` and regenerated by `pnpm --filter @opencrane/fleet-operator emit-openapi`. A CI drift
+   gate fails if `openapi.json` is stale, so the committed spec always matches the routes. weownai pins a
+   released `openapi.json` and runs `openapi-typescript` against it to generate its own client — a clean
+   process/network boundary with no AGPL linkage (the fleet-manager routes are the proprietary side, so
+   weownai *owns* this API after the move; the pin pattern is what any external consumer uses today).
+2. **`@opencrane/contracts`** (`libs/contracts`, version `0.1.0`) — the shared DTOs + typed client, **MIT**-
+   licensed (not AGPL) precisely so proprietary consumers can link the types without inheriting AGPL. It
+   carries `ClusterTenant*`, `ClusterTenantZitadel`, the provisioner registry/request/result types, and the
+   generated `api.ts` + `fleet-api.ts` clients. This is the shape both planes agree on.
+3. **`apps/fleet-platform/crds/opencrane.io_clustertenants.yaml`** — the CRD schema (surface 1). This is the
+   authoritative wire schema for the CR; the silo (and any external fleet manager) must apply/pin the CRD
+   version that declares the fields it depends on — in particular `spec.zitadel` (new work).
+
+**Versioning discipline for the split.** The CR is `v1alpha1` today. The contract-bearing changes this
+document introduces (`spec.zitadel`, teardown finalizer, webhook POST wiring) should land while both planes
+are still in one repo (the #150 "pull-forward"), so the *first* cross-repo release already carries them.
+After the split, any breaking change to surfaces 1–4 must bump the artifact version (CRD served version,
+`@opencrane/contracts` semver, OpenAPI `info.version`) and weownai re-pins deliberately — the two repos never
+share a working tree, only tagged artifacts.
+
+---
+
+## New work the split requires (the #151 enabler list)
+
+Everything below is code the current tree does **not** yet expose but the contract needs. This is the concrete
+hand-off list; none of it is done by this design doc.
+
+1. **Declare `spec.zitadel` on the CRD.** `opencrane.io_clustertenants.yaml` must add
+   `spec.zitadel: { clientId, orgId, redirectUri }` (all strings, optional). The TypeScript type, the fleet
+   writer, and the silo reader already use it; without the CRD field a structural-schema API server prunes it
+   on write and per-org login silently degrades to the masters client. **This is the single highest-priority
+   gap** — it is what makes surface 3 (OIDC delegation) actually work end-to-end.
+2. **Finalizer-driven teardown (#138).** Move CR teardown from best-effort CR-delete + namespace-GC race to a
+   silo-operator finalizer, so the silo drains its planes and honours the #126 dataset-retention policy before
+   the namespace is reclaimed. Decide where the retention policy lives (a CR `spec` field vs. a silo-internal
+   policy) — it must stay a silo-side decision on the AGPL boundary.
+3. **Wire the dedicated-cluster webhook POST caller.** The registry is a tier-availability gate only; the
+   `ClusterTenantProvisionRequest`/`Result` DTOs are published but nothing currently POSTs them. Decide the
+   caller (operator vs. external orchestrator) and wire it against the `{ url, token, id }` seam, so
+   `dedicatedCluster` actually provisions through the proprietary backend after the split.
+4. **Confirm the artifact emit for the split.** `openapi.json` is emitted + drift-gated today; add the CRD
+   YAML and (if not already) a released `@opencrane/contracts` build to the tagged-release asset set so
+   weownai can pin all three from one tag.
+5. **Prove standalone-silo login (#151).** Verify the fail-closed masters-client path is the intended
+   single-tenant behaviour when no fleet manager stamps `spec.zitadel`, and document it as the standalone
+   contract (no-op delegation is a first-class mode, not a degraded one).


### PR DESCRIPTION
## What landed

The **design deliverables** for #150 — the one contract that survives the Phase 3 fleet/silo repo split, plus the open-core licensing decision. Design + docs only: no code moved, no license headers flipped (that happens ahead of the actual Phase 3 move, not here).

- `docs/design/fleet-silo-contract.md` — the fleet↔silo contract across five surfaces, every field grounded in real code:
  1. **`ClusterTenant` CR** (`opencrane.io/v1alpha1`, cluster-scoped) — actual `spec`/`status` fields; fleet writes spec, operator writes status; full create/update/teardown lifecycle (teardown aligned to #138).
  2. **Provisioning API** — the seven `/api/v1/cluster-tenants` routes with auth guards + status codes.
  3. **OIDC delegation payload** — `spec.zitadel.{clientId,orgId,redirectUri}`, the key decoupling that lets a silo log users in without direct Zitadel access; includes the standalone degrade-to-masters-client path for #151.
  4. **Dedicated-cluster webhook** — the external-provisioner seam + generic request/result DTOs.
  5. **Versioning** — three artifacts pinned per release tag, mirroring the existing spec-pin pattern.
- `docs/adr/0004-open-core-fleet-silo-licence-split.md` (indexed in `docs/adr/README.md`) — fleet-operator routes + fleet-platform chart + dedicated-cluster provisioner → **proprietary** in weownai; clustertenant-operator + template + incoming control-plane frontend → **AGPL-3.0**; `libs/contracts` stays **MIT**. Relicense happens ahead of the move; AGPL boundary = the contract itself. Alternatives (keep-all-AGPL, dual-track, all-permissive, relicense-after-move) recorded and rejected; only the commercial-licence *terms* left open.

## New-work surfaced for #151 (the real standalone-silo gap list)

1. ~~CRD `spec.zitadel` undeclared → pruned on write~~ — **fixed in the CRD-schema PR** (was the highest-priority blocker).
2. Finalizer-driven teardown (#138) — today best-effort CR-delete racing namespace GC; needs a silo finalizer honouring #126 retention.
3. Dedicated-cluster webhook POST caller unwired — DTOs published, nothing POSTs them yet.
4. Confirm the release-asset emit adds the CRD YAML + a `@opencrane/contracts` build alongside the drift-gated `openapi.json`.
5. Prove/document the no-fleet masters-client login path as a first-class standalone mode.

## Note

`apps/fleet-operator` currently holds **both** the fleet HTTP routes and the ClusterTenant reconcile loop (`src/cluster-tenants/operator.ts`) — the doc treats the loop as silo-side per the post-split topology, but the physical code is still co-located. The #151/#38 split will need to separate them.

Phase E pull-forward (design-only, safe to land during the launch push).

Commit: `ad5ef25`
