### PR TITLE
🔁 org-memory: retry stdio startup + transient search, signal agent to retry

### DIFF
--- a/apps/clustertenant-operator/src/core/contract/tools-markdown.ts
+++ b/apps/clustertenant-operator/src/core/contract/tools-markdown.ts
@@ -64,6 +64,9 @@ const _ORG_MEMORY_SECTION = [
     "`title`, `scope`, optional `subject`/`sensitivityTags`). Use for durable org/domain facts " +
     "other agents would want — NOT personal style, this user's preferences, or transient task " +
     "state (those stay in MEMORY.md). Remembered facts are attributed to you.",
+  "- If memory_search returns a \"temporarily unavailable\" error, or is momentarily missing just " +
+    "after startup, wait a few seconds and retry — it is a transient hiccup. Never invent an error, " +
+    "an index status, or a remediation command; report what the tool actually returns.",
 ].join("\n");
 
 /** Options controlling optional sections of the generated `TOOLS.md`. */

--- a/apps/clustertenant-operator/src/tenants/deploy/workspace/AGENTS.md
+++ b/apps/clustertenant-operator/src/tenants/deploy/workspace/AGENTS.md
@@ -50,7 +50,10 @@ facts. To PERSIST a generalizable learning back to org memory, use the **`memory
 (`org`/`team`/`department`/`project`/`personal`) — it is stored attributed to you and becomes
 retrievable by other agents. Cognee is a settled platform dependency, not an option — if it is ever
 missing at startup the runtime logs a warning and these tools are unavailable until an operator
-fixes it.
+fixes it. If `memory_search` returns a "temporarily unavailable" error, or is momentarily absent
+from your tools just after startup, that is a transient startup/backend hiccup: wait a few seconds
+and try again. Never fabricate an error, an index status, or a remediation command — report what
+the tool actually returns, and if org memory stays unavailable after a retry, tell the user plainly.
 
 ## Workspace Ownership
 

--- a/apps/clustertenant-operator/src/tenants/deploy/workspace/TOOLS.md
+++ b/apps/clustertenant-operator/src/tenants/deploy/workspace/TOOLS.md
@@ -34,8 +34,15 @@ To persist a generalizable learning back to org memory, use **`memory_remember`*
 decisions other agents would want — NOT for your personal style, this user's preferences, or
 transient task state (those stay in `MEMORY.md`). Remembered facts are attributed to you.
 
+If `memory_search` returns a "temporarily unavailable" error, or is briefly missing from your
+tools just after startup, treat it as a transient hiccup: wait a few seconds and call it again.
+Never invent an error message, an index status, or a `memory`/index CLI command — the tool
+reports exactly what happened, and there is no memory-index command to run.
+
 If the runtime starts up without Cognee wired, that is a **misconfiguration**, not a fallback:
-the pod logs a startup warning and org memory is unavailable until an operator fixes it.
+the pod logs a startup warning and org memory is unavailable until an operator fixes it. If org
+memory stays unavailable after you retry, say so plainly to the user and note that an operator
+should check the pod.
 
 ## LiteLLM Proxy
 

--- a/apps/org-memory-mcp/src/__tests__/server.test.ts
+++ b/apps/org-memory-mcp/src/__tests__/server.test.ts
@@ -31,10 +31,11 @@ const _citableRow: CogneeSearchHit = {
 /** An uncitable hit (no title/uri) — the SDK must drop it. */
 const _uncitableRow: CogneeSearchHit = { content: "orphan fact", metadata: {} };
 
-/** Wire a Client to a freshly-built org-memory server over an in-memory transport pair. */
+/** Wire a Client to a freshly-built org-memory server over an in-memory transport pair.
+ * Injects a zero-delay `sleep` so the search-retry loop runs instantly under test. */
 async function _connectClient(client: AwarenessClient, writer?: MemoryWriter): Promise<Client>
 {
-  const server = _BuildOrgMemoryServer({ client, writer });
+  const server = _BuildOrgMemoryServer({ client, writer, sleep: async function _noWait() {} });
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
   const mcpClient = new Client({ name: "test", version: "0.0.0" });
@@ -121,17 +122,41 @@ describe("org-memory MCP surface", function _mcpSuite()
     expect(res.isError).toBeFalsy();
   });
 
-  it("surfaces a backend failure as a tool error, not a crash", async function _errors()
+  it("surfaces a persistent backend failure as a temporary-unavailable retry signal, not a crash", async function _errors()
   {
+    let calls = 0;
     const failing = new AwarenessClient({
       cogneeEndpoint: "http://cognee:8000",
-      search: async function _boom() { throw new Error("cognee unreachable"); },
+      search: async function _boom() { calls += 1; throw new Error("cognee unreachable"); },
     });
     const mcpClient = await _connectClient(failing);
     const res = await mcpClient.callTool({ name: "memory_search", arguments: { query: "x" } });
     expect(res.isError).toBe(true);
     const text = (res.content as Array<{ type: string; text?: string }>).map((c) => c.text ?? "").join("\n");
-    expect(text).toContain("Org-memory search failed: cognee unreachable");
+    // The agent must be told this is transient and to retry — NOT be handed a bare failure it might
+    // dress up into an invented index error.
+    expect(text).toContain("Org-memory search is temporarily unavailable (cognee unreachable)");
+    expect(text).toContain("wait a few seconds and call memory_search again");
+    expect(text).toContain("Do NOT invent");
+    // It retried in-process before giving up (defends against a single cold-start flake).
+    expect(calls).toBe(3);
+  });
+
+  it("retries a transient failure in-process and returns results once it clears", async function _retryRecovers()
+  {
+    let calls = 0;
+    const flaky = new AwarenessClient({
+      cogneeEndpoint: "http://cognee:8000",
+      // Fail the first two attempts, then succeed on the third with a citable hit.
+      search: async function _flaky() { calls += 1; if (calls < 3) { throw new Error("cold start"); } return [_citableRow]; },
+    });
+    const mcpClient = await _connectClient(flaky);
+    const res = await mcpClient.callTool({ name: "memory_search", arguments: { query: "launch date" } });
+    expect(res.isError).toBeFalsy();
+    const text = (res.content as Array<{ type: string; text?: string }>).map((c) => c.text ?? "").join("\n");
+    expect(text).toContain("15 September");
+    expect(text).toContain("Source: Q3 Launch Plan");
+    expect(calls).toBe(3);
   });
 });
 

--- a/apps/org-memory-mcp/src/index.ts
+++ b/apps/org-memory-mcp/src/index.ts
@@ -4,6 +4,13 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { _BuildAwarenessClientFromEnv, _BuildMemoryWriterFromEnv } from "./memory-tools.js";
 import { _BuildOrgMemoryServer, ORG_MEMORY_SERVER_NAME } from "./server.js";
 
+/** Attempts to establish the stdio transport before giving up, and the base linear backoff. */
+const _STARTUP_MAX_ATTEMPTS = 5;
+const _STARTUP_BACKOFF_MS = 500;
+
+/** Wall-clock sleep between connect attempts. */
+const _sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Stdio entrypoint for the org-memory MCP server.
  *
@@ -11,16 +18,40 @@ import { _BuildOrgMemoryServer, ORG_MEMORY_SERVER_NAME } from "./server.js";
  * `command`/`args` entry the operator renders into `openclaw.json`) and speaks MCP
  * to it over stdio. Because stdio IS the JSON-RPC channel, all diagnostics MUST go
  * to stderr — a stray stdout write would corrupt the protocol stream.
+ *
+ * The connect is retried with backoff: the runtime's stdio spawn can transiently fail
+ * the handshake under cold-start pressure (observed as OpenClaw logging
+ * `MCP error -32000: Connection closed`), so a single flake should self-heal rather than
+ * leave the tenant with no `memory_search` tool for the life of the pod. A fresh transport
+ * is used per attempt because a failed one may have half-bound the process streams.
+ * (A parent that has already torn down the pipe can only be recovered by OpenClaw
+ * re-spawning us — that retry is upstream; this loop covers connect-time failures.)
  */
 async function _main(): Promise<void>
 {
   const client = _BuildAwarenessClientFromEnv(process.env);
   const writer = _BuildMemoryWriterFromEnv(process.env);
   const server = _BuildOrgMemoryServer({ client, writer });
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
   const tools = writer ? "memory_search + memory_remember" : "memory_search (read-only)";
-  process.stderr.write(`[${ORG_MEMORY_SERVER_NAME}] connected over stdio; ${tools}; Cognee ${process.env.COGNEE_ENDPOINT}\n`);
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= _STARTUP_MAX_ATTEMPTS; attempt += 1)
+  {
+    try
+    {
+      await server.connect(new StdioServerTransport());
+      process.stderr.write(`[${ORG_MEMORY_SERVER_NAME}] connected over stdio (attempt ${attempt}); ${tools}; Cognee ${process.env.COGNEE_ENDPOINT}\n`);
+      return;
+    }
+    catch (error)
+    {
+      lastError = error;
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`[${ORG_MEMORY_SERVER_NAME}] connect attempt ${attempt}/${_STARTUP_MAX_ATTEMPTS} failed: ${message}\n`);
+      if (attempt < _STARTUP_MAX_ATTEMPTS) { await _sleep(_STARTUP_BACKOFF_MS * attempt); }
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 _main().catch(function _fatal(error: unknown)

--- a/apps/org-memory-mcp/src/server.ts
+++ b/apps/org-memory-mcp/src/server.ts
@@ -18,6 +18,46 @@ const _SERVER_VERSION = "0.1.0";
 const _MAX_LIMIT = 50;
 
 /**
+ * How many times a transient `memory_search` is attempted in-process before it gives up
+ * and hands the agent a retry signal, and the base (linear) backoff between attempts.
+ *
+ * Retrieval is safe to retry: `AwarenessClient.query` is a read, so a duplicated attempt
+ * has no side effect. Writes (`memory_remember`) are deliberately NOT retried here — a
+ * partially-applied Cognee `/v1/add` must never be silently duplicated.
+ */
+const _SEARCH_MAX_ATTEMPTS = 3;
+const _SEARCH_BACKOFF_MS = 400;
+
+/** Real wall-clock sleep; injectable so tests exercise the retry loop with zero delay. */
+const _defaultSleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `op`, retrying on ANY thrown error up to `attempts` times with linear backoff.
+ * Returns the first success; rethrows the last error once attempts are exhausted so the
+ * caller can turn it into an agent-facing signal.
+ *
+ * @param op    - The idempotent async operation to attempt.
+ * @param opts  - Attempt count, base backoff, and the sleep function to wait between tries.
+ */
+async function _withRetry<T>(op: () => Promise<T>, opts: { attempts: number; backoffMs: number; sleep: (ms: number) => Promise<void> }): Promise<T>
+{
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= opts.attempts; attempt += 1)
+  {
+    try
+    {
+      return await op();
+    }
+    catch (error)
+    {
+      lastError = error;
+      if (attempt < opts.attempts) { await opts.sleep(opts.backoffMs * attempt); }
+    }
+  }
+  throw lastError;
+}
+
+/**
  * Build the org-memory MCP server: a LOCAL, in-pod tool OpenClaw spawns over stdio
  * to retrieve org context per turn. It is deliberately NOT routed through the Obot
  * MCP gateway — org-memory retrieval is a first-class platform capability that talks
@@ -30,12 +70,14 @@ const _MAX_LIMIT = 50;
  * learning up into the shared graph (omit the writer — or disable it via env — to run
  * read-only). Both deps are injected so the server is unit-testable with no live backend.
  *
- * @param deps - The awareness client (read) and optional memory writer (remember).
+ * @param deps - The awareness client (read), optional memory writer (remember), and an
+ *   optional `sleep` override so tests can drive the search-retry loop without real waits.
  * @returns A configured (not yet connected) MCP server; the caller attaches a transport.
  */
-export function _BuildOrgMemoryServer(deps: { client: AwarenessClient; writer?: MemoryWriter | null }): McpServer
+export function _BuildOrgMemoryServer(deps: { client: AwarenessClient; writer?: MemoryWriter | null; sleep?: (ms: number) => Promise<void> }): McpServer
 {
   const { client, writer } = deps;
+  const sleep = deps.sleep ?? _defaultSleep;
   const server = new McpServer({ name: ORG_MEMORY_SERVER_NAME, version: _SERVER_VERSION });
 
   server.registerTool(
@@ -65,15 +107,29 @@ export function _BuildOrgMemoryServer(deps: { client: AwarenessClient; writer?: 
     {
       try
       {
-        const result = await client.query({ query, ...(datasets ? { datasets } : {}), ...(limit ? { limit } : {}) });
+        // Retry transient blips in-process first — a cold Cognee or a spawn-time hiccup
+        // usually clears within a couple of attempts, so the agent gets results rather
+        // than a spurious "unavailable" on the first flake.
+        const result = await _withRetry(
+          () => client.query({ query, ...(datasets ? { datasets } : {}), ...(limit ? { limit } : {}) }),
+          { attempts: _SEARCH_MAX_ATTEMPTS, backoffMs: _SEARCH_BACKOFF_MS, sleep },
+        );
         return { content: [{ type: "text" as const, text: _FormatAwarenessResult(result) }] };
       }
       catch (error)
       {
-        // Surface the failure to the agent as a tool error rather than throwing, so the
-        // turn continues with a clear "memory unavailable" signal instead of crashing.
+        // In-process retries are exhausted. Hand the agent an EXPLICIT, honest retry signal
+        // so it waits and calls memory_search again rather than inventing an error, an index
+        // status, or a remediation command it cannot actually run (a real observed failure mode).
         const message = error instanceof Error ? error.message : String(error);
-        return { content: [{ type: "text" as const, text: `Org-memory search failed: ${message}` }], isError: true };
+        return {
+          content: [{ type: "text" as const, text:
+            `Org-memory search is temporarily unavailable (${message}). This is usually a brief ` +
+            `startup or backend hiccup — wait a few seconds and call memory_search again. Do NOT invent ` +
+            `an error, an index status, or a remediation command; if it keeps failing after you retry, ` +
+            `tell the user org memory is temporarily unavailable and an operator should check the pod.` }],
+          isError: true,
+        };
       }
     },
   );


### PR DESCRIPTION
## What & why

Live diagnosis of the `elewa` tenant (helm rev 18) found that OpenClaw **intermittently fails to spawn** the org-memory stdio MCP server — its `[bundle-mcp]` logs `MCP error -32000: Connection closed` (4× over ~1h). When that happens the `memory_search` tool isn't registered, and the tenant agent — instead of reporting "the tool is unavailable" — **confabulated** a detailed fake error (`index metadata is missing`, `embedding provider/model/settings` mismatch) and two fake remediation commands (`openclaw memory status --index`, `openclaw memory index --force`). None of those strings or commands exist anywhere in the codebase.

Re-executing the exact same binary with the exact same pod env **inside the live pod connected first try**, so this is a transient spawn/handshake race, not an env, config, or Cognee-reachability fault. `COGNEE_ENDPOINT` / `OPENCRANE_MEMORY_BACKEND` are correctly wired and Cognee is healthy.

## Changes (in-repo hardening)

- **`index.ts`** — retry the MCP stdio `connect` with linear backoff (5×, fresh transport per attempt) so a cold-start flake self-heals instead of leaving the pod with no `memory_search` for its whole lifetime.
- **`server.ts`** — `memory_search` retries transient query failures in-process (3×), then returns an **explicit retry signal** (`isError`): *"temporarily unavailable — wait a few seconds and call memory_search again; do NOT invent an error, an index status, or a remediation command."* Writes (`memory_remember`) are intentionally **not** retried (non-idempotent Cognee `/v1/add`).
- **`AGENTS.md` / `TOOLS.md` / `tools-markdown.ts`** — the same guidance for the **tool-absent** case (the static L0 template *and* the poll-regenerated contract doc, so neither shadows the other), so the agent retries and reports honestly instead of confabulating.

## Scope / residual

A parent-side pipe close can only be recovered by **OpenClaw re-spawning** the child — that retry is upstream and cannot be a chart/`openclaw.json` change (an unrecognized key crashes the pod). This PR covers connect-time and query-time transients + the confabulation; the upstream spawn-retry is tracked separately.

## Tests

- `@opencrane/org-memory-mcp`: 20/20 (new: retry-recovers-after-transient-failures; updated: failure now asserts the retry signal + that it retried 3×).
- `@opencrane/clustertenant-operator`: 685/685.
- Both typecheck clean (`tsc --noEmit`).