### PR TITLE
⬆️ openclaw 2026.6.11 + gateway.reload:hot — end restart-driven MCP re-spawn

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/fixtures.ts
+++ b/apps/clustertenant-operator/src/__tests__/fixtures.ts
@@ -15,7 +15,7 @@ export const defaultConfig: OpenClawTenantOperatorConfig = {
   watchNamespace: "default",
   requireWatchNamespace: false,
   tenantDefaultImage: "ghcr.io/opencrane/tenant:latest",
-  defaultOpenclawVersion: "2026.6.9",
+  defaultOpenclawVersion: "2026.6.11",
   ingressDomain: "opencrane.local",
   ingressIp: "",
   certManagerIssuerName: "opencrane-issuer",

--- a/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -79,6 +79,19 @@ describe("openclaw.json render contract — zod schema (task_d611ab4d)", functio
     const trustedProxy = auth["trustedProxy"] as { allowUsers: string[] };
     expect(trustedProxy.allowUsers).toEqual(["contract@example.com"]);
   });
+
+  it("pins gateway.reload to hot so a config rewrite never restart-respawns MCP servers", function _reloadHot()
+  {
+    // openclaw@2026.6.11 `gateway.reload`: `hot` keeps every apply in-process, so the entrypoint's
+    // openclaw.json rewrites never escalate to a full gateway restart (which would re-spawn the
+    // stdio org-memory server and re-open the -32000 spawn race). debounceMs > OpenClaw's 300
+    // default coalesces burst rewrites into one apply.
+    const gateway = _renderConfig()["gateway"] as Record<string, unknown>;
+    const reload = gateway["reload"] as { mode: string; debounceMs: number };
+    expect(reload.mode).toBe("hot");
+    expect(reload.debounceMs).toBeGreaterThan(300);
+    expect(_OpenclawConfigSchema.safeParse(_renderConfig()).success).toBe(true);
+  });
 });
 
 /**

--- a/apps/clustertenant-operator/src/__tests__/tenants/operator.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/operator.test.ts
@@ -86,7 +86,7 @@ describe("TenantOperator", () =>
   {
     const tenant = _makeTenant("default-version");
     const version = tenant.spec.openclawVersion ?? defaultConfig.defaultOpenclawVersion;
-    expect(version).toBe("2026.6.9");
+    expect(version).toBe("2026.6.11");
     expect(version).not.toBe("latest");
   });
 });

--- a/apps/clustertenant-operator/src/config.ts
+++ b/apps/clustertenant-operator/src/config.ts
@@ -253,7 +253,7 @@ export function _LoadOperatorConfig(): OpenClawTenantOperatorConfig
     watchNamespace: _readEnvValue<string>("WATCH_NAMESPACE", "string"),
     requireWatchNamespace: _readEnvValue<boolean>("REQUIRE_WATCH_NAMESPACE", "boolean", false, false),
     tenantDefaultImage: _readEnvValue<string>("TENANT_DEFAULT_IMAGE", "string"),
-    defaultOpenclawVersion: _readEnvValue<string>("DEFAULT_OPENCLAW_VERSION", "string", false, "2026.6.9"),
+    defaultOpenclawVersion: _readEnvValue<string>("DEFAULT_OPENCLAW_VERSION", "string", false, "2026.6.11"),
     ingressDomain: _readEnvValue<string>("INGRESS_DOMAIN", "string"),
     ingressIp: _readEnvValue<string>("INGRESS_IP", "string", false, ""),
     certManagerIssuerName: _readEnvValue<string>("CERT_MANAGER_ISSUER_NAME", "string", false, "opencrane-issuer"),

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -182,6 +182,20 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
           allowUsers: [ownerEmail],
         },
       },
+      // Config-reload policy (openclaw@2026.6.11 `gateway.reload`, the pinned default). The pod
+      // entrypoint rewrites openclaw.json to hot-apply contract/skills/docs changes without a pod
+      // restart (guarded by a reload-only-when-relevant fingerprint — PR #164). OpenClaw's default
+      // `hybrid` mode promotes a "critical" change to a FULL gateway restart, which tears down and
+      // re-spawns every stdio MCP server (incl. the org-memory server) and re-opens the
+      // `-32000 Connection closed` spawn race that OpenClaw itself does NOT retry (verified: its
+      // `connectWithTimeout` is called once, no backoff). `hot` keeps every apply in-process so a
+      // rewrite never triggers that restart-driven re-spawn; `debounceMs` (up from the 300 default)
+      // coalesces burst rewrites into a single apply. Requires openclaw ≥ 2026.6.11 — the gateway
+      // schema is strict, so this key must never be emitted for an older pin.
+      reload: {
+        mode: "hot",
+        debounceMs: 1000,
+      },
     },
     ...(config.liteLlmEnabled
       ? {

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
  * validate the rendered config in the contract test (task_d611ab4d).
  *
  * PINNED OpenClaw version: 2026.6.x (operator `config.ts` `defaultOpenclawVersion`
- * = "2026.6.9"). OpenClaw is shipped as a container image, not an npm dependency,
+ * = "2026.6.11"). OpenClaw is shipped as a container image, not an npm dependency,
  * so its canonical schema is not importable; this file VENDORS a strict best-effort
  * mirror of the documented config schema for the subset of keys the operator emits.
  *
@@ -79,6 +79,26 @@ const _controlUiSchema = z
   .strict();
 
 /**
+ * Config-reload policy (`gateway.reload`), from openclaw@2026.6.11. VERIFIED against the
+ * installed package's `resolveGatewayReloadSettings` (not the docs): `mode` ∈
+ * {off,restart,hot,hybrid} (default `hybrid`), `debounceMs`/`deferralTimeoutMs` optional
+ * non-negative ints. The operator pins `mode:"hot"` so a runtime config rewrite never
+ * escalates to a full gateway restart (which tears down and re-spawns every stdio MCP
+ * server). `.strict()` — an unknown key here would crash the gateway on boot, and this
+ * whole block only exists from 2026.6.11 (the pinned default; older pins must not emit it).
+ */
+const _reloadSchema = z
+  .object({
+    /** How config changes apply: never / always-restart / always-hot / hybrid. */
+    mode: z.enum(["off", "restart", "hot", "hybrid"]),
+    /** Debounce window (ms) coalescing burst rewrites into one apply. */
+    debounceMs: z.number().int().min(0).optional(),
+    /** Deferral window (ms) before a deferred apply runs. */
+    deferralTimeoutMs: z.number().int().min(0).optional(),
+  })
+  .strict();
+
+/**
  * PLATFORM-OWNED gateway block. `.strict()` is the load-bearing guarantee: an
  * unknown key here is the exact class of bug that crashed live tenant pods on boot.
  */
@@ -96,6 +116,8 @@ const _gatewaySchema = z
     trustedProxies: z.array(z.string()),
     /** Delegated-auth configuration. */
     auth: _authSchema,
+    /** Config-reload policy (openclaw ≥ 2026.6.11): pinned `hot` to avoid restart-driven MCP re-spawn. */
+    reload: _reloadSchema.optional(),
   })
   .strict();
 

--- a/apps/tenant/deploy/entrypoint.sh
+++ b/apps/tenant/deploy/entrypoint.sh
@@ -15,7 +15,7 @@ SKILLS_DIR="$STATE_DIR/agents/main/skills"
 # Pinned default (not `latest`) so a pod whose operator didn't inject OPENCLAW_VERSION
 # still installs a known-good OpenClaw; the operator normally sets this from
 # tenant.defaultOpenclawVersion (or a Tenant CR's spec.openclawVersion).
-OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.6.9}"
+OPENCLAW_VERSION="${OPENCLAW_VERSION:-2026.6.11}"
 # Control-plane re-pull configuration (injected by operator into every tenant Deployment).
 OPENCRANE_CONTROL_PLANE_URL="${OPENCRANE_CONTROL_PLANE_URL:-}"
 OPENCRANE_CONTRACT_TOKEN_PATH="${OPENCRANE_CONTRACT_TOKEN_PATH:-/var/run/opencrane/tokens/control-plane.token}"


### PR DESCRIPTION
## Why

Follow-up to #163 (in-server retry) and #164 (bundle + reload-fingerprint gate) on the intermittent org-memory `MCP error -32000: Connection closed` spawn race.

Root cause recap: `-32000` is the MCP SDK rejecting the in-flight `initialize` handshake when the stdio child exits or the transport is torn down mid-spawn. One trigger we control is **reload-driven teardown** — OpenClaw's default `hybrid` reload mode promotes a "critical" config change to a **full gateway restart**, which tears down and re-spawns *every* stdio MCP server (incl. org-memory). Verified upstream gap: OpenClaw's `connectWithTimeout` is called **once, with no retry/backoff**, so a single spawn flake loses the tool for the session.

## What

1. **Bump the pinned OpenClaw default `2026.6.9 → 2026.6.11`** — `entrypoint.sh` default, operator `defaultOpenclawVersion`, and the fixtures/tests that assert it.
2. **Render `gateway.reload = { mode: "hot", debounceMs: 1000 }`** into the platform-owned gateway block. `hot` keeps every config apply in-process (never restarts), so the entrypoint's `openclaw.json` rewrites can never trigger the restart-driven re-spawn. `debounceMs` (up from OpenClaw's `300` default) coalesces burst rewrites. The gateway block is re-pinned after the tenant merge, so a tenant `configOverrides.gateway` can't drop `reload`.
3. **Vendor `gateway.reload`** into the strict `openclaw-config` zod mirror (`mode ∈ off|restart|hot|hybrid`, `debounceMs`/`deferralTimeoutMs` int≥0).

## Verification method (not docs — the installed package)

`npm pack openclaw@2026.6.11` + grep the shipped bundle, cross-checked against the live elewa pod's `node_modules/openclaw`:
- `gateway.reload` is real: `resolveGatewayReloadSettings` → `{ mode ∈ off|restart|hot|hybrid (default hybrid), debounceMs (default 300), deferralTimeoutMs }`. (It did **not** exist in 2026.6.9 — the earlier refutation was version-accurate.)
- Every key the operator already emits (trusted-proxy/controlUi/reasoningDefault/models providers/…) still exists in 2026.6.11 — the strict schema would crash the pod on a dropped key, so this was checked before bumping.

## Safety: version coupling

The strict gateway schema crashes on an unknown key, so `gateway.reload` must never reach a pre-2026.6.11 pod. It's coupled to the pin bump: a deploy that changes `OPENCLAW_VERSION` rolls the pod, which reinstalls 2026.6.11 before the new `openclaw.json` is read. (Overriding `OPENCLAW_VERSION` to an older pin while this renders would crash — documented in the code comment.)

## Not fixed here (tracked follow-ups)

- **Upstream:** OpenClaw has no stdio spawn retry/backoff — worth a feature request. #163's in-server retry remains the only retry in the path.
- **k8s:** a pod CPU-request bump to reduce spawn-time contention (the remaining environmental trigger).

## Tests

- Operator suite: **686 pass** (incl. a new `gateway.reload:hot` contract test that parses the rendered config and re-validates against the strict schema).
- `tsc --noEmit` clean; `entrypoint.sh` `bash -n` clean.