### PR TITLE
🚑 unblock CI (cli tenant subject) + complete openclaw 2026.6.11 pin (values.yaml)

### DIFF
--- a/apps/cli/src/commands/tenants.ts
+++ b/apps/cli/src/commands/tenants.ts
@@ -44,6 +44,7 @@ export function _RegisterTenants(parent: Command, getConfig: () => CliConfig): v
     .requiredOption("--name <name>", "Tenant name (must be a valid DNS label)")
     .requiredOption("--display-name <displayName>", "Human-readable display name")
     .requiredOption("--email <email>", "Contact email for the tenant")
+    .requiredOption("--subject <sub>", "IdP-verified subject (OIDC `sub`) to bind this workspace to; the contract compiler inherits this principal's rights")
     .option("--team <team>", "Team name")
     .option("--cluster-tenant <name>", "Parent ClusterTenant (customer) to attach this tenant to")
     .option("--budget <usd>", "Monthly budget ceiling in USD")
@@ -53,6 +54,7 @@ export function _RegisterTenants(parent: Command, getConfig: () => CliConfig): v
       name: string;
       displayName: string;
       email: string;
+      subject: string;
       team?: string;
       clusterTenant?: string;
       budget?: string;
@@ -66,6 +68,7 @@ export function _RegisterTenants(parent: Command, getConfig: () => CliConfig): v
           name: opts.name,
           displayName: opts.displayName,
           email: opts.email,
+          subject: opts.subject,
           ...(opts.team ? { team: opts.team } : {}),
           ...(opts.clusterTenant ? { clusterTenantRef: opts.clusterTenant } : {}),
           ...(opts.budget ? { monthlyBudgetUsd: Number(opts.budget) } : {}),

--- a/apps/clustertenant-platform/values.yaml
+++ b/apps/clustertenant-platform/values.yaml
@@ -543,7 +543,7 @@ tenant:
   # -- OpenClaw npm package version installed into each tenant pod. Pinned (not `latest`)
   # so the gateway can't silently roll across breaking changes; bump deliberately. A
   # Tenant CR's `spec.openclawVersion` overrides this per-tenant.
-  defaultOpenclawVersion: "2026.6.9"
+  defaultOpenclawVersion: "2026.6.11"
 
 # -- Hosting provider: onprem (default), gcp, azure, aws.
 # Override with values/gcp.yaml etc. for cloud installs.

--- a/apps/fleet-platform/values.yaml
+++ b/apps/fleet-platform/values.yaml
@@ -527,7 +527,7 @@ tenant:
   # -- OpenClaw npm package version installed into each tenant pod. Pinned (not `latest`)
   # so the gateway can't silently roll across breaking changes; bump deliberately. A
   # Tenant CR's `spec.openclawVersion` overrides this per-tenant.
-  defaultOpenclawVersion: "2026.6.9"
+  defaultOpenclawVersion: "2026.6.11"
 
 # -- Hosting provider: onprem (default), gcp, azure, aws.
 # Override with values/gcp.yaml etc. for cloud installs.


### PR DESCRIPTION
Discovered while deploying #165 to dev: **main has no deployable image and the pin bump was incomplete.** Two blockers, both fixed here.

## 1. CI has been red on `main` (blocks all image publishing)

`docker.yml`'s `build-and-push` is gated on the `test` job, which fails at `pnpm build`:

```
apps/cli/src/commands/tenants.ts(65,9): error TS2322: Property 'subject' is missing …
```

`POST /tenants` now **requires `subject`** — the IdP-verified OIDC `sub` the workspace binds to (the contract compiler inherits that principal's rights) — added by the member-onboarding work (#159/#161). The CLI's `tenants create` was never updated. **Fix:** add a required `--subject` option and pass it in the body.

This is pre-existing (reproduces at `e4d9cf0`, before #165's diff) and is the *only* thing gating publishing — no image exists for any commit since last-green `80e400a`, so #165 currently cannot be deployed through any sanctioned path.

## 2. The openclaw 2026.6.11 pin was incomplete

#165 bumped only the code-level **fallbacks** (operator `config.ts` default, tenant `entrypoint.sh` default). But the chart template sets `DEFAULT_OPENCLAW_VERSION` from `tenant.defaultOpenclawVersion` in **values.yaml** — the real source of truth — still `"2026.6.9"`. **Fix:** bump it to `"2026.6.11"` in both `apps/clustertenant-platform/values.yaml` and `apps/fleet-platform/values.yaml`, so the pin (and the `gateway.reload:hot` render, which requires ≥2026.6.11) actually lands on tenant pods.

## Verification (mirrors the CI `test` job locally)

- `pnpm build` — green (was failing at cli).
- Generated-spec drift gate — clean (`git diff` on the openapi.json/generated clients shows nothing regenerated).
- `fleet-operator` 197 · `clustertenant-operator` 686 · `skill-registry` 6 · `cli` 4 — all pass.

## After merge

CI publishes an image for the merged sha → re-run the dev deploy of `clustertenant-platform` to roll all three tenants onto openclaw 2026.6.11 + `gateway.reload:hot` (and wire Cognee for the stale `elewa-be`/`northwind`).

Note: `elewa`'s pod is actively looping the `-32000 Connection closed` bug this fixes (~every 30 min), so unblocking this is time-sensitive.