### PR TITLE
🩹 tenant runtime: actually upgrade OpenClaw (F2) + curl (F5) + keep org-memory warm (idle-TTL)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -54,6 +54,18 @@ describe("openclaw.json render contract — zod schema (task_d611ab4d)", functio
     expect(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error?.issues, null, 2)).toBe(true);
   });
 
+  it("disables MCP idle eviction (sessionIdleTtlMs=0) so org-memory never idle-respawns", function _idleTtl()
+  {
+    // openclaw evicts an idle bundled MCP runtime after mcp.sessionIdleTtlMs (default 10min) and
+    // re-spawns on next use, racing its own connect -> -32000. 0 keeps the org-memory stdio server
+    // warm for the pod's life. Rendered only when Cognee is wired (the org-memory branch).
+    const cogneeConfig = { ...defaultConfig, cogneeEndpoint: "http://cognee:8000" };
+    const config = JSON.parse(_BuildConfigMap(cogneeConfig, _makeTenant("contract"), "default").data?.["openclaw.json"] ?? "{}") as Record<string, unknown>;
+    const mcp = config["mcp"] as Record<string, unknown>;
+    expect(mcp["sessionIdleTtlMs"]).toBe(0);
+    expect((mcp["servers"] as Record<string, unknown>)["org-memory"]).toBeTruthy();
+  });
+
   it("never leaks the internal trustNothing flag into the gateway block", function _noTrustNothing()
   {
     // The exact f6afafd regression: trustNothing is operator-internal, not an

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -350,6 +350,14 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
     const existingServers = (existingMcp["servers"] as Record<string, unknown> | undefined) ?? {};
     merged["mcp"] = {
       ...existingMcp,
+      // Keep the org-memory stdio runtime warm for the pod's whole life. OpenClaw evicts an idle
+      // bundled MCP runtime after `mcp.sessionIdleTtlMs` (default 10 min) and RE-SPAWNS it on next
+      // use — and OpenClaw does not retry a failed stdio spawn, so that periodic re-spawn races its
+      // connect and surfaces as `MCP error -32000: Connection closed` roughly every ~10-30 min.
+      // `0` disables idle eviction (verified in openclaw@2026.6.11: `idleTtlMs <= 0` skips the sweep),
+      // so the server spawns once at startup and stays up. Set AFTER the tenant spread so a
+      // `configOverrides.mcp` can't re-enable eviction and break org-memory. Requires openclaw ≥ 2026.6.11.
+      sessionIdleTtlMs: 0,
       servers: {
         ...existingServers,
         [_ORG_MEMORY_SERVER_NAME]: {

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -222,6 +222,11 @@ const _mcpSchema = z
   .object({
     /** Server id → server config map. */
     servers: z.record(z.string(), _mcpServerSchema),
+    /**
+     * MCP runtime idle TTL in ms (openclaw ≥ 2026.6.11 `mcp.sessionIdleTtlMs`). `0` disables idle
+     * eviction so stdio servers (org-memory) stay warm and are never re-spawned mid-session.
+     */
+    sessionIdleTtlMs: z.number().int().min(0).optional(),
   })
   .passthrough();
 

--- a/apps/tenant/deploy/Dockerfile
+++ b/apps/tenant/deploy/Dockerfile
@@ -38,6 +38,13 @@ RUN mkdir -p /opt/org-memory-mcp/dist \
 # Runtime stage — Node runtime + entrypoint + the baked org-memory MCP server.
 FROM node:22-bookworm-slim
 
+# curl is required by entrypoint.sh's 30s effective-contract re-pull loop. bookworm-slim ships
+# without it, which silently turned that loop into a fleet-wide no-op (the pod never refreshed
+# its runtime contract / openclaw.json after boot). Kept minimal: no recommends, apt lists purged.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends curl \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /opt/org-memory-mcp /opt/org-memory-mcp
 
 COPY apps/tenant/deploy/entrypoint.sh /entrypoint.sh

--- a/apps/tenant/deploy/entrypoint.sh
+++ b/apps/tenant/deploy/entrypoint.sh
@@ -468,14 +468,27 @@ function _main()
   # Ensure temporary writable paths exist when the root filesystem is read-only.
   mkdir -p /tmp/opencrane-home /tmp/npm-cache
 
-  # Install or verify OpenClaw runtime on persistent storage
+  # Install or UPGRADE the OpenClaw runtime on persistent storage. The runtime lives on the
+  # pod's PVC and survives restarts, so a pinned-version bump only takes effect if we compare
+  # the INSTALLED version to $OPENCLAW_VERSION and reinstall on mismatch — an existence-only
+  # check (the previous behaviour) left already-provisioned tenants stuck on their first-boot
+  # version forever, silently ignoring every subsequent pin bump.
   OPENCLAW_BIN="$RUNTIME_DIR/node_modules/.bin/openclaw"
-  if [ ! -x "$OPENCLAW_BIN" ]; then
-    echo "[opencrane] Installing OpenClaw@${OPENCLAW_VERSION} to persistent storage..."
+  OPENCLAW_PKG="$RUNTIME_DIR/node_modules/openclaw/package.json"
+  installed_version=""
+  if [ -x "$OPENCLAW_BIN" ] && [ -f "$OPENCLAW_PKG" ]; then
+    installed_version="$(node -p "require('$OPENCLAW_PKG').version" 2>/dev/null || echo "")"
+  fi
+  if [ "$installed_version" != "$OPENCLAW_VERSION" ]; then
+    if [ -n "$installed_version" ]; then
+      echo "[opencrane] OpenClaw ${installed_version} installed but ${OPENCLAW_VERSION} is pinned — upgrading..."
+    else
+      echo "[opencrane] Installing OpenClaw@${OPENCLAW_VERSION} to persistent storage..."
+    fi
     npm install --prefix "$RUNTIME_DIR" "openclaw@${OPENCLAW_VERSION}" --omit=dev
-    echo "[opencrane] OpenClaw installed successfully"
+    echo "[opencrane] OpenClaw@${OPENCLAW_VERSION} installed successfully"
   else
-    echo "[opencrane] OpenClaw runtime found at $OPENCLAW_BIN"
+    echo "[opencrane] OpenClaw@${installed_version} runtime found at $OPENCLAW_BIN (matches pin)"
   fi
 
   # Add runtime bin to PATH


### PR DESCRIPTION
## Why

The org-memory `-32000 Connection closed` loop **survived #163–#166** — verified still firing on live elewa (`08:13:09`, ~18 min after a fresh pod start). A dev deploy of the merged pin exposed why: two runtime bugs meant the fix never reached the running binary, and the actual re-spawn trigger was elsewhere.

## Fixes

**F2 — entrypoint never upgraded OpenClaw.** The runtime lives on the pod PVC; the install was existence-gated (`[ ! -x openclaw ]`), so an already-provisioned tenant kept its first-boot version forever. elewa's env said `OPENCLAW_VERSION=2026.6.11` but the binary was still `2026.6.9` — so the `gateway.reload` key from #165 was inert. Now: read the installed `openclaw/package.json` version and reinstall on mismatch. **Every future pin bump now actually lands, on existing and new tenants.**

**F5 — the contract-refresh loop was a fleet-wide no-op.** `entrypoint.sh` re-pulls the effective contract every 30s with `curl`, which `node:22-bookworm-slim` doesn't ship — so pods never refreshed their contract/`openclaw.json` after boot (since 2026-06-21). Add `curl`. Consequence worth noting: the reload-based mitigation in #164/#165 was targeting a loop that wasn't firing.

**Real trigger — MCP idle eviction (the actual `-32000` cause).** OpenClaw evicts an idle bundled MCP runtime after `mcp.sessionIdleTtlMs` (**default 10 min**) and re-spawns on next use; with no upstream stdio spawn-retry, that periodic re-spawn races connect → `-32000`, on the exact ~10–30 min cadence observed. Render **`mcp.sessionIdleTtlMs: 0`** (verified in `openclaw@2026.6.11`: `idleTtlMs <= 0` skips the idle sweep) so org-memory spawns once at startup and stays warm. Force-set after the tenant merge so `configOverrides.mcp` can't re-enable eviction; vendored into the strict zod mirror.

## Permanent + new clusters

All three land via the **tenant image** (entrypoint + Dockerfile) and the **operator render** (idle-TTL), so they apply to existing-after-redeploy *and* newly-provisioned clusters automatically. `defaultOpenclawVersion` is already `2026.6.11` in the chart (#166), so fresh clusters install it and F2 keeps them current.

## Verification

- Operator suite **687 pass** (incl. new `sessionIdleTtlMs=0` contract test); `tsc --noEmit` clean; `entrypoint.sh` `bash -n` clean.
- Tenant image `curl` + Dockerfile build validated by CI's tenant-image build.

## After merge → deploy → verify

Roll elewa onto the new sha and confirm: installed `openclaw@2026.6.11`, `mcp.sessionIdleTtlMs: 0` in the config, and **no `-32000` for >15 min** (past the old idle-eviction window) on the fresh pod.

## Deferred (per decision)
- `elewa-be`/`northwind` orphaned-Certificate recovery (dropped for now).
- `--tenant-tag` dead-wiring (F3) + elewa operator reconcile loop / missing LiteLLM `Team=elewa` (F4) — separate follow-ups.
- Upstream OpenClaw feature request: supervised stdio spawn-retry (the true root cause).