### PR TITLE
🐛 openclaw.json: render meta:{} to stop OpenClaw's config-integrity revert

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -81,6 +81,18 @@ describe("openclaw.json render contract — zod schema (task_d611ab4d)", functio
     expect((config["gateway"] as Record<string, unknown>)["reload"]).toBeUndefined();
   });
 
+  it("renders a `meta` stub so OpenClaw's config-integrity guard doesn't revert our config", function _metaStub()
+  {
+    // Verified against openclaw@2026.6.11 (dist/io-*.js): hasConfigMeta() is a presence-only check
+    // (isRecord(value.meta)); a config observed WITHOUT it, after one WITH it was last-known-good,
+    // is flagged "missing-meta-vs-last-good" and silently reverted to the gateway's own .bak — which
+    // is exactly how a prior deploy's plugins/gateway/mcp changes failed to reach the running pod
+    // (the entrypoint's `openclaw plugins install` writes a meta-stamped config just before our
+    // `cp -f` overwrote it with one that lacked `meta`). An empty object satisfies the guard.
+    const config = _renderConfig();
+    expect(config["meta"]).toEqual({});
+  });
+
   it("never leaks the internal trustNothing flag into the gateway block", function _noTrustNothing()
   {
     // The exact f6afafd regression: trustNothing is operator-internal, not an
@@ -151,6 +163,17 @@ describe("configOverrides cannot clobber the platform gateway (C1)", function _c
     expect(gateway["trustedProxies"]).toEqual(["10.0.0.0/8"]);
     // 4. The result still validates against the strict OpenClaw schema.
     expect(_OpenclawConfigSchema.safeParse(config).success).toBe(true);
+    // 5. `meta` survives too — a tenant can't drop it and reopen the config-integrity clobber.
+    expect(config["meta"]).toEqual({});
+  });
+
+  it("ignores a tenant override of the platform-owned meta stub", function _metaOverride()
+  {
+    // A tenant tries to drop/replace `meta` (e.g. via a stale/hand-authored override). The
+    // re-pin must restore the empty stub regardless — dropping it would reopen the
+    // config-integrity clobber this field exists to prevent.
+    const config = _render({ meta: { lastTouchedVersion: "not-a-real-stamp" } });
+    expect(config["meta"]).toEqual({});
   });
 
   it("still applies a non-gateway override", function _nonGatewayOverride()

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -281,6 +281,23 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
   //     reference) keeps `merged` free of aliasing into the local baseConfig object.
   tenantMerged["gateway"] = { ...(baseConfig["gateway"] as Record<string, unknown>) };
 
+  // 3c. Platform-owned `meta` stub — a bare `{}` record at the config root. This is NOT
+  //     tenant-facing config; it exists solely to satisfy OpenClaw@2026.6.11's own config-
+  //     integrity guard, verified against the installed package (`dist/io-*.js`,
+  //     `hasConfigMeta` = `isRecord(value.meta)`; `resolveConfigObserveSuspiciousReasons`
+  //     flags `missing-meta-vs-last-good` whenever a config the gateway reads lacks `meta`
+  //     but the last-known-good snapshot had it). Without this, the entrypoint's `openclaw
+  //     plugins install` step writes a small config update WITH a `meta` stamp (OpenClaw's
+  //     own writer auto-stamps it), which becomes the gateway's "last known good" baseline;
+  //     the entrypoint then `cp -f`s our full rendered config over it, which (pre-fix) had
+  //     no `meta` key — so on next read the gateway flags it as suspicious, discards it, and
+  //     silently RESTORES THE STALE PRE-DEPLOY CONFIG from its own `.bak`, which is exactly
+  //     how a prior deploy's `plugins`/`gateway.reload`/`mcp` changes failed to take effect.
+  //     Re-pinned after the tenant merge (like `gateway`) so a tenant override can never
+  //     drop it and reintroduce the bug. An empty object is sufficient — the guard only
+  //     checks presence, not shape.
+  tenantMerged["meta"] = {};
+
   // 4. Platform-owned agent workspace settings — applied after the tenant merge so
   //    they cannot be overridden by spec.configOverrides.  The workspace path must
   //    be pinned to the persistent volume; skipBootstrap prevents the interactive

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -239,5 +239,12 @@ export const _OpenclawConfigSchema = z
     plugins: _pluginsSchema.optional(),
     /** Optional MCP block (only when a tenant declares its own `mcp.servers`). */
     mcp: _mcpSchema.optional(),
+    /**
+     * Platform-owned `meta` stub (always `{}`) — satisfies OpenClaw@2026.6.11's config-integrity
+     * guard (`hasConfigMeta` = presence-only check), which otherwise flags our externally-written
+     * config as suspicious on the next read and silently reverts to the gateway's last-known-good
+     * `.bak` snapshot. `.passthrough()` since OpenClaw's own writes may add sub-fields here.
+     */
+    meta: z.object({}).passthrough().optional(),
   })
   .passthrough();


### PR DESCRIPTION
## Why

Deploying #168 (Cognee plugin swap) to elewa **rolled cleanly but the new config never reached the running gateway** — verified live: the gateway booted with the old plugin set (`memory-core` present, `cognee-openclaw` absent), and the on-disk `openclaw.json` still had `mcp.servers.org-memory` + `gateway.reload` (both removed in #168) with **no `plugins` key at all**.

## Root cause (verified against the installed openclaw@2026.6.11 package, not guessed)

`dist/io-*.js`: `hasConfigMeta()` is a presence-only check — `isRecord(value.meta)`. `resolveConfigObserveSuspiciousReasons()` flags a config read as `missing-meta-vs-last-good` whenever the gateway's **last-known-good** snapshot had `meta` but the current on-disk file doesn't, and reverts to `.bak`.

Sequence on the pod:
1. `entrypoint.sh`'s `openclaw plugins install --force` step writes a config update. OpenClaw's own writer auto-stamps `meta` on it → this becomes the gateway's last-known-good baseline.
2. `entrypoint.sh`'s subsequent `cp -f` overwrites the file with our fully-rendered `openclaw.json` — a raw filesystem write, no `meta` key.
3. On the next read (gateway startup), OpenClaw sees `hasMeta: false` vs. a last-known-good that had `hasMeta: true` → flags it suspicious → **silently reverts to `.bak`** (the stale pre-deploy config).

Confirmed directly on the pod: `logs/config-audit.jsonl` shows exactly this `config.write` → `config.observe` sequence with `restoredFromBackup: true`, and `openclaw.json.clobbered.<timestamp>` — the file that got discarded — matches our correct operator-rendered config byte-for-byte.

## Fix

Render a platform-owned `meta: {}` stub into `openclaw.json` (`2-config-map.ts`), re-pinned after the tenant merge (same pattern as `gateway`) so a tenant override can never drop it and reopen the clobber. An empty object satisfies the guard — it's presence-only, no specific shape required. Vendored into `openclaw-config.schema.ts`.

This is independent of entrypoint step ordering — since *every* write from now on carries `meta`, the guard's `hasMeta: true → false` transition (the only thing that triggers a revert) can no longer happen, regardless of which write lands last.

## Verification

- Operator suite: **688 pass** (3 new — `meta` renders as `{}`, survives a malicious `gateway` override, survives a direct `meta` override).
- `tsc --noEmit` clean.

## After merge → redeploy → verify

Re-run the elewa deploy on the new sha and confirm: the live `openclaw.json` on the PVC now has `meta: {}` + the full `plugins` block, the gateway's own startup log lists `cognee-openclaw` (not `memory-core`), and `openclaw.json.clobbered.*`/`.bak` don't reappear after this boot. Then re-run the original "check if you can access cognee" test end-to-end.