### PR TITLE
🐛 Correct the openclaw.json meta fix — PR #170 targeted the wrong hasConfigMeta

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -5,6 +5,22 @@ import { _BuildConfigMap } from "../../tenants/deploy/index.js";
 import { _OpenclawConfigSchema } from "../../tenants/deploy/openclaw-config.schema.js";
 
 /**
+ * Mirrors `hasConfigMeta$1` EXACTLY as verified in the installed openclaw@2026.6.11 binary
+ * (`dist/io-9CAVAPVZ.js:1121-1123`, re-confirmed inside a live pod after PR #170's `meta: {}`
+ * was silently reverted in production) — a presence-only `meta` object does NOT satisfy it; a
+ * string `lastTouchedVersion`/`lastTouchedAt` is required. Encoding the real predicate here
+ * (not `toEqual({})`) is the point: PR #170's tests passed while the fix didn't actually work.
+ * Module scope — shared by every describe block in this file.
+ */
+function _satisfiesOpenClawConfigMetaGuard(config: Record<string, unknown>): boolean
+{
+  const meta = config["meta"];
+  if (typeof meta !== "object" || meta === null) return false;
+  const m = meta as Record<string, unknown>;
+  return typeof m["lastTouchedVersion"] === "string" || typeof m["lastTouchedAt"] === "string";
+}
+
+/**
  * Schema contract test for the rendered `openclaw.json` (task_d611ab4d, S1).
  *
  * OpenClaw's config schema is **strict** — an unknown key crashes the pod on boot
@@ -81,16 +97,17 @@ describe("openclaw.json render contract — zod schema (task_d611ab4d)", functio
     expect((config["gateway"] as Record<string, unknown>)["reload"]).toBeUndefined();
   });
 
-  it("renders a `meta` stub so OpenClaw's config-integrity guard doesn't revert our config", function _metaStub()
+  it("renders a `meta` stub that satisfies OpenClaw's config-integrity guard", function _metaStub()
   {
-    // Verified against openclaw@2026.6.11 (dist/io-*.js): hasConfigMeta() is a presence-only check
-    // (isRecord(value.meta)); a config observed WITHOUT it, after one WITH it was last-known-good,
-    // is flagged "missing-meta-vs-last-good" and silently reverted to the gateway's own .bak — which
-    // is exactly how a prior deploy's plugins/gateway/mcp changes failed to reach the running pod
-    // (the entrypoint's `openclaw plugins install` writes a meta-stamped config just before our
-    // `cp -f` overwrote it with one that lacked `meta`). An empty object satisfies the guard.
+    // Verified against openclaw@2026.6.11 (dist/io-*.js `hasConfigMeta$1`, re-confirmed inside a
+    // live pod): a config observed without a string lastTouchedVersion/lastTouchedAt, after one
+    // WITH it was last-known-good, is flagged "missing-meta-vs-last-good" and silently reverted
+    // to the gateway's own .bak — exactly how a deploy's plugins/gateway/mcp changes failed to
+    // reach the running pod (entrypoint's `openclaw plugins install` writes a meta-stamped config
+    // just before our `cp -f` overwrote it). Assert the REAL predicate, not just key presence —
+    // a bare `meta: {}` (PR #170) passes `isRecord` but not this, and still gets reverted.
     const config = _renderConfig();
-    expect(config["meta"]).toEqual({});
+    expect(_satisfiesOpenClawConfigMetaGuard(config)).toBe(true);
   });
 
   it("never leaks the internal trustNothing flag into the gateway block", function _noTrustNothing()
@@ -164,16 +181,17 @@ describe("configOverrides cannot clobber the platform gateway (C1)", function _c
     // 4. The result still validates against the strict OpenClaw schema.
     expect(_OpenclawConfigSchema.safeParse(config).success).toBe(true);
     // 5. `meta` survives too — a tenant can't drop it and reopen the config-integrity clobber.
-    expect(config["meta"]).toEqual({});
+    expect(_satisfiesOpenClawConfigMetaGuard(config)).toBe(true);
   });
 
   it("ignores a tenant override of the platform-owned meta stub", function _metaOverride()
   {
-    // A tenant tries to drop/replace `meta` (e.g. via a stale/hand-authored override). The
-    // re-pin must restore the empty stub regardless — dropping it would reopen the
-    // config-integrity clobber this field exists to prevent.
-    const config = _render({ meta: { lastTouchedVersion: "not-a-real-stamp" } });
-    expect(config["meta"]).toEqual({});
+    // A tenant tries to override `meta` with a value that would NOT satisfy OpenClaw's guard
+    // (a bare object, no string sub-field — exactly PR #170's mistake). The re-pin must restore
+    // the platform's own conforming value regardless of what the tenant supplied.
+    const config = _render({ meta: { lastTouchedVersion: 12345 } });
+    expect(_satisfiesOpenClawConfigMetaGuard(config)).toBe(true);
+    expect((config["meta"] as Record<string, unknown>)["lastTouchedVersion"]).toBe("opencrane-operator");
   });
 
   it("still applies a non-gateway override", function _nonGatewayOverride()

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -281,22 +281,30 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
   //     reference) keeps `merged` free of aliasing into the local baseConfig object.
   tenantMerged["gateway"] = { ...(baseConfig["gateway"] as Record<string, unknown>) };
 
-  // 3c. Platform-owned `meta` stub — a bare `{}` record at the config root. This is NOT
-  //     tenant-facing config; it exists solely to satisfy OpenClaw@2026.6.11's own config-
-  //     integrity guard, verified against the installed package (`dist/io-*.js`,
-  //     `hasConfigMeta` = `isRecord(value.meta)`; `resolveConfigObserveSuspiciousReasons`
-  //     flags `missing-meta-vs-last-good` whenever a config the gateway reads lacks `meta`
-  //     but the last-known-good snapshot had it). Without this, the entrypoint's `openclaw
-  //     plugins install` step writes a small config update WITH a `meta` stamp (OpenClaw's
-  //     own writer auto-stamps it), which becomes the gateway's "last known good" baseline;
-  //     the entrypoint then `cp -f`s our full rendered config over it, which (pre-fix) had
-  //     no `meta` key — so on next read the gateway flags it as suspicious, discards it, and
-  //     silently RESTORES THE STALE PRE-DEPLOY CONFIG from its own `.bak`, which is exactly
-  //     how a prior deploy's `plugins`/`gateway.reload`/`mcp` changes failed to take effect.
-  //     Re-pinned after the tenant merge (like `gateway`) so a tenant override can never
-  //     drop it and reintroduce the bug. An empty object is sufficient — the guard only
-  //     checks presence, not shape.
-  tenantMerged["meta"] = {};
+  // 3c. Platform-owned `meta` stub at the config root. This is NOT tenant-facing config; it
+  //     exists solely to satisfy OpenClaw@2026.6.11's own config-integrity guard.
+  //
+  //     CORRECTED (see PR #171 — a first attempt at this, PR #170, rendered a bare `meta: {}`
+  //     and was verified LIVE to still fail): the bundled openclaw.json has TWO same-named but
+  //     DIFFERENT `hasConfigMeta` helpers (an esbuild artifact of two bundled modules). The one
+  //     that actually gates the gateway-startup/config-observe path is `hasConfigMeta$1`
+  //     (`dist/io-*.js`): `isRecord(value.meta) && (typeof value.meta.lastTouchedVersion ===
+  //     "string" || typeof value.meta.lastTouchedAt === "string")` — NOT presence-only. A bare
+  //     `{}` satisfies `isRecord` but neither string clause, so `hasConfigMeta$1` still returns
+  //     false and `resolveConfigObserveSuspiciousReasons` still flags `missing-meta-vs-last-good`
+  //     against the meta-stamped write `openclaw plugins install` leaves as "last known good" —
+  //     confirmed by re-deploying PR #170 to elewa: a fresh `.clobbered.*` file appeared holding
+  //     our correctly-rendered (but still-non-conforming) config, and the gateway reverted to
+  //     `.bak` and rebooted with the stale pre-#168 plugin set. Re-verified this time against
+  //     BOTH the downloaded openclaw@2026.6.11 tarball AND the literal installed binary inside
+  //     the live pod (`/data/openclaw/runtime/node_modules/openclaw/dist/io-9CAVAPVZ.js`) before
+  //     writing this fix — not inferred from a commit message.
+  //
+  //     `lastTouchedVersion` is a static, deterministic string (not a live timestamp) so the
+  //     rendered ConfigMap never churns between reconciles — a moving `lastTouchedAt` would
+  //     force a spurious redeploy/reload on every poll cycle. Re-pinned after the tenant merge
+  //     (like `gateway`) so a tenant override can never drop it and reintroduce the bug.
+  tenantMerged["meta"] = { lastTouchedVersion: "opencrane-operator" };
 
   // 4. Platform-owned agent workspace settings — applied after the tenant merge so
   //    they cannot be overridden by spec.configOverrides.  The workspace path must

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -240,11 +240,17 @@ export const _OpenclawConfigSchema = z
     /** Optional MCP block (only when a tenant declares its own `mcp.servers`). */
     mcp: _mcpSchema.optional(),
     /**
-     * Platform-owned `meta` stub (always `{}`) — satisfies OpenClaw@2026.6.11's config-integrity
-     * guard (`hasConfigMeta` = presence-only check), which otherwise flags our externally-written
-     * config as suspicious on the next read and silently reverts to the gateway's last-known-good
-     * `.bak` snapshot. `.passthrough()` since OpenClaw's own writes may add sub-fields here.
+     * Platform-owned `meta` stub — satisfies OpenClaw@2026.6.11's config-integrity guard
+     * (`hasConfigMeta$1` in `dist/io-*.js`, verified against the installed binary: requires
+     * `lastTouchedVersion` OR `lastTouchedAt` to be a STRING, not just `isRecord(meta)` — see
+     * 2-config-map.ts for the PR #170→#171 correction history), which otherwise flags our
+     * externally-written config as suspicious on the next read and silently reverts to the
+     * gateway's last-known-good `.bak` snapshot. `.passthrough()` since OpenClaw's own writes
+     * may add sub-fields here.
      */
-    meta: z.object({}).passthrough().optional(),
+    meta: z
+      .object({ lastTouchedVersion: z.string().optional(), lastTouchedAt: z.string().optional() })
+      .passthrough()
+      .optional(),
   })
   .passthrough();


### PR DESCRIPTION
## PR #170 didn't actually fix the bug — confirmed by redeploying it

Deployed #170's `meta: {}` fix to elewa (sha-7d22b18). The bug recurred **identically** to the original #168 incident: a fresh `.clobbered.*` file appeared holding our correctly-merged config (`meta: {}`, full `plugins` block, no `mcp`/`gateway.reload`), and the gateway reverted to `.bak`, booting with the stale pre-#168 `memory-core` plugin set. Confirmed via the pod's own `logs/config-audit.jsonl` and gateway startup log.

## Why #170 was wrong

The bundled `openclaw.json`'s runtime ships **two different functions both named `hasConfigMeta`** — an esbuild artifact of two bundled modules, one gets a `$1` suffix. I read the presence-only one (`hasConfigMeta`, no suffix) and wrongly generalized it to the guard that actually gates the gateway-startup/config-observe path.

This time I verified against **both** the downloaded `openclaw@2026.6.11` tarball **and** the literal installed binary inside the live pod (`/data/openclaw/runtime/node_modules/openclaw/dist/io-9CAVAPVZ.js`) before writing the fix — they agree:

```js
function hasConfigMeta$1(value) {
  return isRecord$1(value) && isRecord$1(value.meta) &&
    (typeof value.meta.lastTouchedVersion === "string" || typeof value.meta.lastTouchedAt === "string");
}
```

A bare `{}` satisfies `isRecord` but neither string clause — so it still returns `false`, and the config still gets flagged `missing-meta-vs-last-good` and reverted.

## Fix

Render `meta: { lastTouchedVersion: "opencrane-operator" }` — a static, deterministic string (not a live timestamp, so the ConfigMap doesn't churn on every reconcile). Re-pinned after the tenant merge (unchanged from #170).

**Also rewrote the 3 meta-related tests** to assert the actual verified predicate (a helper mirroring `hasConfigMeta$1` exactly) instead of `toEqual({})` — #170's tests passed while the fix didn't work in production, which is precisely the gap this closes. One test is now adversarial: a tenant override with a non-string `lastTouchedVersion` must be replaced by the platform's conforming value.

## Verification

- Operator suite: **688 pass**. `tsc --noEmit` clean.

## After merge → redeploy → verify (same rigor as before — trust nothing short of live evidence)

Redeploy elewa, then check the **live on-disk `openclaw.json`** for `meta.lastTouchedVersion == "opencrane-operator"` + the full `plugins` block, confirm **no fresh `.clobbered.*` file** appears, confirm `logs/config-audit.jsonl` shows no `restoredFromBackup`/`suspicious` entries after this boot, and quote the gateway's own startup log line — it must list `cognee-openclaw`, not `memory-core`.