### PR TITLE
🔌 cognee-openclaw: grant hooks.allowPromptInjection + allowConversationAccess

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/openclaw-config-contract.test.ts
@@ -80,9 +80,13 @@ describe("openclaw.json render contract — zod schema (task_d611ab4d)", functio
     const plugins = config["plugins"] as Record<string, unknown>;
     expect(plugins["allow"]).toEqual(["cognee-openclaw"]);
     expect((plugins["slots"] as Record<string, unknown>)["memory"]).toBe("cognee-openclaw");
-    const entries = plugins["entries"] as Record<string, { enabled?: boolean; config?: Record<string, unknown> }>;
+    const entries = plugins["entries"] as Record<string, { enabled?: boolean; hooks?: Record<string, unknown>; config?: Record<string, unknown> }>;
     expect(entries["memory-core"].enabled).toBe(false);
     expect(entries["cognee-openclaw"].enabled).toBe(true);
+    // Hook permissions — without these OpenClaw blocks the plugin's typed hooks at gateway startup
+    // (verified live: "non-bundled plugins must set plugins.entries.cognee-openclaw.hooks.<key>=true")
+    // and auto-recall/session-capture silently do nothing despite the plugin showing "enabled".
+    expect(entries["cognee-openclaw"].hooks).toEqual({ allowPromptInjection: true, allowConversationAccess: true });
     const cfg = entries["cognee-openclaw"].config as Record<string, unknown>;
     expect(cfg["baseUrl"]).toBe("http://cognee:8000");
     expect(cfg["companyDataset"]).toBe("company");

--- a/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/2-config-map.ts
@@ -367,6 +367,17 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
         "memory-core": { enabled: false },
         [_COGNEE_PLUGIN_ID]: {
           enabled: true,
+          // Grant the plugin its required hook permissions — verified live: without these, OpenClaw
+          // blocks the plugin's typed hooks at gateway startup with "non-bundled plugins must set
+          // plugins.entries.cognee-openclaw.hooks.<key>=true", and the plugin silently does nothing.
+          // allowPromptInjection gates `before_prompt_build` (auto-recall — the whole point of this
+          // plugin); allowConversationAccess gates `llm_output`/`agent_end` (session capture into
+          // Cognee). Both are independent, currently-valid keys (verified in the installed
+          // openclaw@2026.6.11 binary's config-normalization path) — the plugin's own README claims
+          // allowConversationAccess was renamed/rejected pre-2026.4.2, but the live gateway explicitly
+          // requested it by this exact name, so both are granted rather than trusting either source
+          // alone.
+          hooks: { allowPromptInjection: true, allowConversationAccess: true },
           config: {
             mode: "local",
             baseUrl: config.cogneeEndpoint,

--- a/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/openclaw-config.schema.ts
@@ -216,8 +216,23 @@ const _pluginsSchema = z
     allow: z.array(z.string()).optional(),
     /** Capability slot → owning plugin id (e.g. `{ memory: "cognee-openclaw" }`). */
     slots: z.record(z.string(), z.string()).optional(),
-    /** Plugin id → `{ enabled, config }` entry. */
-    entries: z.record(z.string(), z.object({ enabled: z.boolean().optional() }).passthrough()).optional(),
+    /**
+     * Plugin id → `{ enabled, hooks, config }` entry. `hooks` grants a non-bundled plugin's typed
+     * hooks (verified: `allowPromptInjection` gates `before_prompt_build`, `allowConversationAccess`
+     * gates `llm_output`/`agent_end` — openclaw@2026.6.11 `config-normalization-shared`); without it
+     * OpenClaw blocks the hook at gateway startup and the plugin silently does nothing.
+     */
+    entries: z
+      .record(
+        z.string(),
+        z
+          .object({
+            enabled: z.boolean().optional(),
+            hooks: z.object({ allowPromptInjection: z.boolean().optional(), allowConversationAccess: z.boolean().optional() }).passthrough().optional(),
+          })
+          .passthrough(),
+      )
+      .optional(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Why

Redeploying #171 (the config-integrity fix) to elewa confirmed the memory plugin now loads and owns the memory slot — a real PASS. But the gateway's own startup log surfaced a secondary gap: the plugin's typed hooks are blocked.

\`\`\`
[gateway] [plugins] typed hook "llm_output" blocked because non-bundled plugins must set
plugins.entries.cognee-openclaw.hooks.allowConversationAccess=true
\`\`\`

Without this, the plugin sits "enabled" but is functionally inert: no recall, no capture.

## What's needed (verified against the installed openclaw@2026.6.11 binary)

- `hooks.allowPromptInjection` gates `before_prompt_build` — **auto-recall**, the entire reason this plugin was adopted (issue #130).
- `hooks.allowConversationAccess` gates `llm_output`/`agent_end` — session capture into Cognee.

The plugin's own README claims `allowConversationAccess` was renamed to `allowPromptInjection` before OpenClaw 2026.4.2 and is now silently rejected. But the *live* gateway explicitly asked for it by this exact name, and reading `config-normalization-shared` in the installed binary confirms **both** keys are read and preserved independently — no aliasing. Rather than trust either source alone, this grants both.

## Fix

Render `plugins.entries.cognee-openclaw.hooks = { allowPromptInjection: true, allowConversationAccess: true }` in `2-config-map.ts`; vendored into the schema.

## Verification

Operator suite **688 pass** (extended the existing plugin-config contract test); `tsc --noEmit` clean.

## After merge → redeploy → verify

Redeploy elewa; confirm the `typed hook ... blocked` warnings are gone from the gateway startup log, then finally re-run the original "check if you can access cognee" test end-to-end — this should be the point where it actually works.