### PR TITLE
🔑 cognee: wire dedicated LiteLLM embedding/LLM key (separately trackable spend)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/fixtures.ts
+++ b/apps/clustertenant-operator/src/__tests__/fixtures.ts
@@ -44,6 +44,7 @@ export const defaultConfig: OpenClawTenantOperatorConfig = {
   liteLlmBudgetDuration: "30d",
   liteLlmDefaultTpmLimit: 0,
   liteLlmDefaultRpmLimit: 0,
+  cogneeLiteLlmMonthlyBudgetUsd: 10,
   mcpGatewayUrl: "http://opencrane-mcp-gateway.default.svc:8080",
   skillRegistryUrl: "http://opencrane-skill-registry.default.svc:5000",
   cogneeEndpoint: "",

--- a/apps/clustertenant-operator/src/__tests__/tenants/cognee-litellm-key.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cognee-litellm-key.test.ts
@@ -1,0 +1,161 @@
+import { Buffer } from "node:buffer";
+
+import * as k8s from "@kubernetes/client-node";
+import pino from "pino";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { defaultConfig } from "../fixtures.js";
+import { CogneeLiteLlmKey, COGNEE_LITELLM_KEY_SECRET_NAME } from "../../tenants/internal/cognee-litellm-key.js";
+import type { OpenClawTenantOperatorConfig } from "../../config.js";
+
+const _log = pino({ level: "silent" });
+
+/** Config with LiteLLM enabled + a master key, the baseline for these tests. */
+const _enabledConfig: OpenClawTenantOperatorConfig = {
+  ...defaultConfig,
+  liteLlmEnabled: true,
+  liteLlmEndpoint: "http://litellm:4000",
+  liteLlmMasterKey: "sk-master",
+  liteLlmBudgetDuration: "30d",
+  cogneeLiteLlmMonthlyBudgetUsd: 15,
+};
+
+/** Stub CoreV1Api: throws (Secret missing → create path) or returns the given key (update path). */
+function _makeCoreApi(existingKeyValue?: string): k8s.CoreV1Api
+{
+  return {
+    readNamespacedSecret: vi.fn().mockImplementation(function _read(): Promise<k8s.V1Secret>
+    {
+      if (existingKeyValue === undefined)
+      {
+        return Promise.reject(new Error("404 not found"));
+      }
+
+      return Promise.resolve({
+        data: { apiKey: Buffer.from(existingKeyValue).toString("base64") },
+      } as unknown as k8s.V1Secret);
+    }),
+  } as unknown as k8s.CoreV1Api;
+}
+
+/** Stub KubernetesObjectApi recording server-side applies without a cluster. */
+function _makeObjectApi(): k8s.KubernetesObjectApi
+{
+  return {
+    read: vi.fn().mockRejectedValue(new Error("not found")),
+    patch: vi.fn().mockResolvedValue({ body: {} }),
+    create: vi.fn().mockResolvedValue({ body: {} }),
+  } as unknown as k8s.KubernetesObjectApi;
+}
+
+/** Parse the JSON body of a recorded fetch call. */
+function _bodyOf(call: unknown[]): Record<string, unknown>
+{
+  const init = call[1] as RequestInit;
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+}
+
+describe("CogneeLiteLlmKey", () =>
+{
+  beforeEach(() =>
+  {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() =>
+  {
+    vi.unstubAllGlobals();
+  });
+
+  it("generate mints a key with its own alias/budget and NEVER sends team_id", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ key: "sk-cognee-new" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), _makeObjectApi(), _log);
+    await keys.ensureCogneeLiteLlmKeySecret("acme", "default");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("http://litellm:4000/key/generate");
+
+    const body = _bodyOf(fetchMock.mock.calls[0]);
+    expect(body["key_alias"]).toBe("opencrane-cognee-acme");
+    expect(body["metadata"]).toEqual({ clusterTenant: "acme", component: "cognee" });
+    expect(body["max_budget"]).toBe(15);
+    expect(body["budget_duration"]).toBe("30d");
+    // The whole point of a dedicated key: no team_id, ever — LiteLLM's Team object is not
+    // provisioned anywhere in this codebase, and attaching team_id 404s (the elewa bug).
+    expect(body).not.toHaveProperty("team_id");
+  });
+
+  it("writes the minted key to the fixed COGNEE_LITELLM_KEY_SECRET_NAME (chart-agreed literal)", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ key: "sk-cognee-new" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const objectApi = _makeObjectApi();
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), objectApi, _log);
+    await keys.ensureCogneeLiteLlmKeySecret("acme", "opencrane-elewa");
+
+    expect(objectApi.create as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    const created = (objectApi.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as k8s.V1Secret;
+    expect(created.metadata?.name).toBe(COGNEE_LITELLM_KEY_SECRET_NAME);
+    expect(created.metadata?.namespace).toBe("opencrane-elewa");
+    expect(Buffer.from(created.data!["apiKey"], "base64").toString("utf8")).toBe("sk-cognee-new");
+  });
+
+  it("existing-secret path calls /key/update with the existing key value (no rotation, no generate)", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const objectApi = _makeObjectApi();
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi("sk-cognee-existing"), objectApi, _log);
+    await keys.ensureCogneeLiteLlmKeySecret("acme", "default");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("http://litellm:4000/key/update");
+
+    const body = _bodyOf(fetchMock.mock.calls[0]);
+    expect(body["key"]).toBe("sk-cognee-existing");
+    expect(body["max_budget"]).toBe(15);
+    expect(body).not.toHaveProperty("team_id");
+
+    // No new Secret written → key value is not rotated.
+    expect(objectApi.patch as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(objectApi.create as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("does not crash reconcile when /key/update fails (best-effort, non-fatal)", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi("sk-cognee-existing"), _makeObjectApi(), _log);
+    await expect(keys.ensureCogneeLiteLlmKeySecret("acme", "default")).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when LITELLM_MASTER_KEY is missing while enabled", async () =>
+  {
+    const keys = new CogneeLiteLlmKey({ ..._enabledConfig, liteLlmMasterKey: "" }, _makeCoreApi(), _makeObjectApi(), _log);
+    await expect(keys.ensureCogneeLiteLlmKeySecret("acme", "default")).rejects.toThrow(/LITELLM_MASTER_KEY is required/);
+  });
+
+  it("is a no-op when LiteLLM integration is disabled", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const keys = new CogneeLiteLlmKey(defaultConfig, _makeCoreApi(), _makeObjectApi(), _log);
+    await keys.ensureCogneeLiteLlmKeySecret("acme", "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/clustertenant-operator/src/config.ts
+++ b/apps/clustertenant-operator/src/config.ts
@@ -152,6 +152,15 @@ export interface OpenClawTenantOperatorConfig
    */
   liteLlmDefaultRpmLimit: number;
 
+  /**
+   * Monthly budget (USD) for this silo's dedicated Cognee LiteLLM key (embedding +
+   * graph-extraction LLM calls). Deliberately a SEPARATE key/budget from tenant chat
+   * spend — Cognee's spend must be trackable as its own identity, not folded into a
+   * tenant's cap. No `team_id` is ever attached (LiteLLM's Team object is not
+   * provisioned anywhere in this codebase yet; see tenant-litellm-keys.ts).
+   */
+  cogneeLiteLlmMonthlyBudgetUsd: number;
+
   /** Optional default AccessPolicy name used when no explicit or selector match is found. */
   defaultTenantPolicyRef?: string;
 
@@ -289,6 +298,7 @@ export function _LoadOperatorConfig(): OpenClawTenantOperatorConfig
     liteLlmBudgetDuration: _readEnvValue<string>("LITELLM_BUDGET_DURATION", "string", false, "30d"),
     liteLlmDefaultTpmLimit: _readEnvValue<number>("LITELLM_DEFAULT_TPM_LIMIT", "number", false, 0),
     liteLlmDefaultRpmLimit: _readEnvValue<number>("LITELLM_DEFAULT_RPM_LIMIT", "number", false, 0),
+    cogneeLiteLlmMonthlyBudgetUsd: _readEnvValue<number>("COGNEE_LITELLM_MONTHLY_BUDGET_USD", "number", false, 10),
     defaultTenantPolicyRef: _readEnvValue<string>("DEFAULT_TENANT_POLICY_REF", "string", false, ""),
     mcpGatewayUrl: _readEnvValue<string>("MCP_GATEWAY_URL", "string", false, `http://opencrane-mcp-gateway.${ownNamespace}.svc:8080`),
     skillRegistryUrl: _readEnvValue<string>("SKILL_REGISTRY_URL", "string", false, `http://opencrane-skill-registry.${ownNamespace}.svc:5000`),

--- a/apps/clustertenant-operator/src/index.ts
+++ b/apps/clustertenant-operator/src/index.ts
@@ -25,6 +25,7 @@ import { _RegisterInternalRoutes, _RegisterRoutes } from "./routes.js";
 import { TenantProjectionRepairer } from "./infra/tenant-projection-repairer.js";
 import { MembershipProjectionRepairer, _BuildHttpFleetMembershipReader, _BuildHttpFleetMembershipWriter } from "./infra/membership-projection-repairer.js";
 import { _ResolveOwnClusterTenantName } from "./core/cluster-tenants/resolve-own-cluster-tenant.js";
+import { CogneeLiteLlmKey } from "./tenants/internal/cognee-litellm-key.js";
 
 // In-silo controllers (Stage 5). The silo runs every in-silo reconcile loop over its OWN
 // namespace, so a silo stands on its own; the fleet-manager watches only the cluster-scoped
@@ -282,6 +283,31 @@ async function _startInSiloControllers(): Promise<void>
     // lands where the TenantOperator will pick it up — not the projection-repair namespace,
     // which is derived independently and could diverge under manual env overrides.
     void _SeedOwnDefaultTenant(customApi, prisma, config.watchNamespace, log);
+
+    // Ensure this silo's Cognee has its own dedicated LiteLLM virtual key — a SEPARATE
+    // identity/budget from tenant chat spend (Cognee's embedding + graph-extraction calls
+    // must be trackable on their own, not folded into a tenant's cap). One-shot at boot:
+    // there is exactly one Cognee per silo and its params rarely change, unlike per-tenant
+    // keys which reconcile every tenant-CR poll. Best-effort — a LiteLLM outage at boot
+    // must not block the tenant/policy operators from starting.
+    void (async function _ensureCogneeLiteLlmKey()
+    {
+      const clusterTenantName = await _ResolveOwnClusterTenantName(customApi, config.watchNamespace, log);
+      if (!clusterTenantName)
+      {
+        log.info({ namespace: config.watchNamespace }, "no ClusterTenant bound to this namespace yet; cognee litellm key provisioning idle");
+        return;
+      }
+      const objectApi = k8s.KubernetesObjectApi.makeApiClient(kc);
+      try
+      {
+        await new CogneeLiteLlmKey(config, coreApi, objectApi, log).ensureCogneeLiteLlmKeySecret(clusterTenantName, config.watchNamespace);
+      }
+      catch (err)
+      {
+        log.warn({ err, clusterTenantName }, "cognee litellm key provisioning failed; cognee will run without embedding/LLM credentials until this is retried");
+      }
+    })();
 
     const tenantOperator = _CreateTenantOperator(kc, config, log);
     const policyOperator = new PolicyOperator(kc, config, log);

--- a/apps/clustertenant-operator/src/tenants/internal/cognee-litellm-key.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-litellm-key.ts
@@ -1,0 +1,202 @@
+import { Buffer } from "node:buffer";
+
+import * as k8s from "@kubernetes/client-node";
+import type { Logger } from "pino";
+
+import type { OpenClawTenantOperatorConfig } from "../../config.js";
+import { __K8sApplyResource } from "@opencrane/infra-api";
+
+/**
+ * The Secret name the Cognee Deployment's Helm template expects this key under. Fixed
+ * (not release-prefixed) because it is a per-silo/per-namespace singleton — exactly one
+ * Cognee Deployment exists per release/namespace — and the operator (which mints this
+ * key at runtime) has no way to compute the chart's `opencrane.fullname` release prefix.
+ * `apps/clustertenant-platform/templates/cognee-deployment.yaml` MUST reference this
+ * exact literal name.
+ */
+export const COGNEE_LITELLM_KEY_SECRET_NAME = "cognee-litellm-key";
+
+/**
+ * Handles LiteLLM virtual key provisioning for the silo's own Cognee instance.
+ *
+ * Mirrors {@link import("./tenant-litellm-keys.js").TenantLiteLlmKeys} (same generate/
+ * update/Secret shape) but is scoped to the SILO's ClusterTenant, not an openclaw Tenant:
+ * there is exactly one Cognee per silo, so exactly one key, minted once at operator boot
+ * and reconciled thereafter. Deliberately NEVER sends `team_id` — LiteLLM's Team object
+ * is not provisioned anywhere in this codebase (see the elewa reconcile-loop 404s this
+ * causes for tenant keys that DO set `team_id`), so Cognee's key stays unscoped-but-own,
+ * which still gives it fully independent, separately trackable spend via its own
+ * `key_alias`/budget — the actual requirement (Cognee spend must not fold into tenant
+ * chat spend) does not need a Team object to be satisfied.
+ */
+export class CogneeLiteLlmKey
+{
+  private config: OpenClawTenantOperatorConfig;
+  private coreApi: k8s.CoreV1Api;
+  private objectApi: k8s.KubernetesObjectApi;
+  private log: Logger;
+
+  constructor(
+    config: OpenClawTenantOperatorConfig,
+    coreApi: k8s.CoreV1Api,
+    objectApi: k8s.KubernetesObjectApi,
+    log: Logger,
+  )
+  {
+    this.config = config;
+    this.coreApi = coreApi;
+    this.objectApi = objectApi;
+    this.log = log;
+  }
+
+  /**
+   * Ensure this silo's Cognee has a dedicated LiteLLM virtual key Secret, minting or
+   * updating it as needed. No-ops when LiteLLM integration is disabled.
+   *
+   * @param clusterTenantName - This silo's own ClusterTenant name (from
+   *        `_ResolveOwnClusterTenantName`), used only for the key's alias/metadata —
+   *        never sent as `team_id`.
+   * @param namespace - The silo's own namespace (where Cognee's Deployment lives).
+   */
+  async ensureCogneeLiteLlmKeySecret(clusterTenantName: string, namespace: string): Promise<void>
+  {
+    if (!this.config.liteLlmEnabled)
+    {
+      return;
+    }
+
+    if (!this.config.liteLlmMasterKey)
+    {
+      throw new Error("LITELLM_MASTER_KEY is required when LITELLM_ENABLED=true");
+    }
+
+    const budget = this.config.cogneeLiteLlmMonthlyBudgetUsd;
+    const existingKey = await this._readExistingKeyValue(namespace);
+    if (existingKey !== undefined)
+    {
+      await this._updateLiteLlmVirtualKey(existingKey, clusterTenantName, budget);
+      this.log.debug({ clusterTenantName, budget }, "reconciled existing cognee litellm virtual key params");
+      return;
+    }
+
+    const issuedAt = new Date().toISOString();
+    const keyAlias = `opencrane-cognee-${clusterTenantName}`;
+    const apiKey = await this._generateLiteLlmVirtualKey(clusterTenantName, budget);
+    const secret: k8s.V1Secret = {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: COGNEE_LITELLM_KEY_SECRET_NAME,
+        namespace,
+        labels: {
+          "app.kubernetes.io/part-of": "opencrane",
+          "app.kubernetes.io/component": "cognee",
+          "app.kubernetes.io/managed-by": "opencrane-clustertenant-manager",
+        },
+        annotations: {
+          "opencrane.io/litellm-key-alias": keyAlias,
+          "opencrane.io/litellm-issued-at": issuedAt,
+          "opencrane.io/litellm-monthly-budget-usd": String(budget),
+        },
+      },
+      type: "Opaque",
+      data: {
+        apiKey: Buffer.from(apiKey).toString("base64"),
+      },
+    };
+
+    await __K8sApplyResource(this.objectApi, secret, this.log);
+    this.log.info({ clusterTenantName, budget }, "created cognee litellm virtual key secret");
+  }
+
+  /**
+   * Request a new LiteLLM virtual key scoped to this silo's Cognee instance.
+   */
+  private async _generateLiteLlmVirtualKey(clusterTenantName: string, monthlyBudgetUsd: number): Promise<string>
+  {
+    const response = await fetch(`${this.config.liteLlmEndpoint}/key/generate`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${this.config.liteLlmMasterKey}`,
+      },
+      body: JSON.stringify({
+        key_alias: `opencrane-cognee-${clusterTenantName}`,
+        metadata: { clusterTenant: clusterTenantName, component: "cognee" },
+        max_budget: monthlyBudgetUsd,
+        budget_duration: this.config.liteLlmBudgetDuration,
+      }),
+    });
+
+    if (!response.ok)
+    {
+      const body = await response.text();
+      throw new Error(`LiteLLM key generation failed for cognee (${response.status}): ${body}`);
+    }
+
+    const payload = await response.json() as { key?: string; api_key?: string; generated_key?: string };
+    const key = payload.key ?? payload.api_key ?? payload.generated_key;
+    if (!key)
+    {
+      throw new Error("LiteLLM key generation response did not include a key");
+    }
+
+    return key;
+  }
+
+  /**
+   * Re-apply the desired budget to the existing Cognee key via `/key/update`. Best-effort
+   * and non-fatal — mirrors the tenant-key posture (a LiteLLM blip must not crash the
+   * silo's reconcile loop).
+   */
+  private async _updateLiteLlmVirtualKey(keyValue: string, clusterTenantName: string, monthlyBudgetUsd: number): Promise<void>
+  {
+    try
+    {
+      const response = await fetch(`${this.config.liteLlmEndpoint}/key/update`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          Authorization: `Bearer ${this.config.liteLlmMasterKey}`,
+        },
+        body: JSON.stringify({
+          key: keyValue,
+          max_budget: monthlyBudgetUsd,
+          budget_duration: this.config.liteLlmBudgetDuration,
+        }),
+      });
+
+      if (!response.ok)
+      {
+        const body = await response.text();
+        this.log.warn({ clusterTenantName, status: response.status, body }, "cognee litellm key update failed; existing key params left as-is");
+      }
+    }
+    catch (err)
+    {
+      this.log.warn({ clusterTenantName, err }, "cognee litellm key update threw; existing key params left as-is");
+    }
+  }
+
+  /**
+   * Read the current key value from the existing Secret, or `undefined` when absent.
+   */
+  private async _readExistingKeyValue(namespace: string): Promise<string | undefined>
+  {
+    try
+    {
+      const secret = await this.coreApi.readNamespacedSecret({ name: COGNEE_LITELLM_KEY_SECRET_NAME, namespace });
+      const encoded = secret.data?.["apiKey"];
+      if (!encoded)
+      {
+        return undefined;
+      }
+
+      return Buffer.from(encoded, "base64").toString("utf8");
+    }
+    catch
+    {
+      return undefined;
+    }
+  }
+}

--- a/apps/clustertenant-platform/templates/cognee-deployment.yaml
+++ b/apps/clustertenant-platform/templates/cognee-deployment.yaml
@@ -68,6 +68,42 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: {{ .Values.clustertenantManager.cognee.service.port | quote }}
+            {{- if .Values.litellm.enabled }}
+            # Embedding + LLM (graph-extraction) provider, routed through this release's
+            # LiteLLM proxy via a DEDICATED key the operator mints at boot (Secret name here
+            # MUST match cognee-litellm-key.ts's COGNEE_LITELLM_KEY_SECRET_NAME literal —
+            # the operator has no way to compute this chart's release-prefixed fullname).
+            # `optional: true`: on first install the Secret doesn't exist yet until the
+            # operator's boot-time reconcile creates it, so Cognee must start without it
+            # rather than crash-loop; embedding/LLM calls fail until the key appears and this
+            # pod is restarted (same bootstrap posture already accepted for tenant LiteLLM keys).
+            - name: LLM_PROVIDER
+              value: {{ .Values.clustertenantManager.cognee.llm.provider | quote }}
+            - name: LLM_MODEL
+              value: {{ .Values.clustertenantManager.cognee.llm.model | quote }}
+            - name: LLM_ENDPOINT
+              value: {{ include "opencrane.litellmEndpoint" . | quote }}
+            - name: LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cognee-litellm-key
+                  key: apiKey
+                  optional: true
+            - name: EMBEDDING_PROVIDER
+              value: {{ .Values.clustertenantManager.cognee.embedding.provider | quote }}
+            - name: EMBEDDING_MODEL
+              value: {{ .Values.clustertenantManager.cognee.embedding.model | quote }}
+            - name: EMBEDDING_DIMENSIONS
+              value: {{ .Values.clustertenantManager.cognee.embedding.dimensions | quote }}
+            - name: EMBEDDING_ENDPOINT
+              value: {{ include "opencrane.litellmEndpoint" . | quote }}
+            - name: EMBEDDING_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cognee-litellm-key
+                  key: apiKey
+                  optional: true
+            {{- end }}
           resources:
             {{- toYaml .Values.clustertenantManager.cognee.resources | nindent 12 }}
 {{- if .Values.networkPolicy.enabled }}

--- a/apps/clustertenant-platform/values.yaml
+++ b/apps/clustertenant-platform/values.yaml
@@ -323,6 +323,31 @@ clustertenantManager:
       limits:
         cpu: "1"
         memory: 1Gi
+    # -- Cognee's own embedding + LLM (graph-extraction) provider, routed through this
+    #    release's LiteLLM proxy via a DEDICATED virtual key the operator mints at boot
+    #    (see cognee-litellm-key.ts) — Cognee's spend is tracked as its own identity, never
+    #    folded into a tenant's budget. Only rendered when `litellm.enabled` is true; without
+    #    it Cognee has no embedding/LLM credentials and every memory-capture attempt aborts
+    #    after ~60s of failed embedding calls (the pre-fix symptom).
+    #
+    #    IMPORTANT — the model names below are PLACEHOLDERS. Verify they are actually
+    #    registered/routable on this cluster's live LiteLLM proxy before relying on them in
+    #    production (e.g. `curl $LITELLM_ENDPOINT/v1/models`); override per-deploy with
+    #    `--set clustertenantManager.cognee.llm.model=...` /
+    #    `--set clustertenantManager.cognee.embedding.model=...` if they differ.
+    llm:
+      # -- "openai" matches Cognee's own default AND this platform's litellm-proxy
+      #    convention (api: openai-completions) for an OpenAI-compatible upstream.
+      provider: "openai"
+      model: "openai/gpt-4o-mini"
+    embedding:
+      # -- "custom" (NOT "openai") — verified against Cognee's own docs: the "custom"
+      #    provider passes EMBEDDING_ENDPOINT straight through to LiteLLM as `api_base`
+      #    with no automatic /v1 append or /embeddings strip, which the "openai" provider
+      #    does and which breaks routing through a proxy base URL.
+      provider: "custom"
+      model: "openai/text-embedding-3-large"
+      dimensions: 3072
   # -- OIDC human-login session config for the control-plane. Zitadel is the single
   #    trusted issuer (Mode-2 broker, no upstream Entra), but nothing here is
   #    Zitadel-specific — any spec-compliant issuer works. OIDC is OFF unless


### PR DESCRIPTION
## Why

Redeploying #172 (hooks-access fix) confirmed the memory plugin now genuinely attempts to write to Cognee — real progress. But every attempt aborted after ~60s. Root cause: Cognee's Deployment has **never** had an embedding/LLM provider wired (`cognee-deployment.yaml` only ever set `HOST`/`PORT`), so every embedding call fails with `EMBEDDING_ENDPOINT='None'` + missing credentials, LiteLLM retries with backoff, and the plugin's own HTTP client eventually times out.

## Design decision

Per direction: route Cognee through the existing in-cluster LiteLLM proxy, but its spend must be **trackable as its own identity** — not folded into any tenant's budget.

Before building this, I checked the existing tenant-key provisioning pattern (`tenant-litellm-keys.ts`) and found a **separate, real, already-live bug**: LiteLLM's `Team` object is referenced (`team_id` sent on `/key/generate`/`/key/update`) but **never actually created anywhere in this codebase** — that's the exact cause of the elewa reconcile-loop hammering `/key/update` every ~1s with 404s, already in the deploy ledger. I deliberately did **not** build Cognee's key on that broken path.

## What this does

- **New `CogneeLiteLlmKey`** (`apps/clustertenant-operator/src/tenants/internal/cognee-litellm-key.ts`): mirrors `TenantLiteLlmKeys`' generate/update/Secret shape, scoped per-silo (one Cognee per silo, minted once at operator boot), and **never sends `team_id`**. A dedicated `key_alias` + its own `max_budget` already gives fully independent, separately-trackable spend — the actual requirement — without needing the not-yet-built Team system.
- Wired into `index.ts`'s boot sequence, alongside the existing `_ResolveOwnClusterTenantName`-based membership repairer start.
- **Chart**: `cognee-deployment.yaml` renders `LLM_PROVIDER`/`MODEL`/`ENDPOINT`/`API_KEY` + `EMBEDDING_PROVIDER`/`MODEL`/`ENDPOINT`/`API_KEY`/`DIMENSIONS` (gated on `litellm.enabled`), reusing the same `opencrane.litellmEndpoint` helper `clustertenant-manager` already uses. `API_KEY` is `secretKeyRef optional:true` against a **fixed** Secret name (`cognee-litellm-key` — not release-prefixed, since the operator can't compute the chart's Helm fullname) that the operator's boot-time reconcile creates.
- Env var names verified against Cognee's own `.env.template` + docs (not guessed): `EMBEDDING_PROVIDER="custom"` specifically — Cognee's docs confirm `"custom"` passes `EMBEDDING_ENDPOINT` straight through as `api_base` with no `/v1`-append or `/embeddings`-strip mangling, which `"openai"` does and which would break routing through a proxy base URL.
- New config field `cogneeLiteLlmMonthlyBudgetUsd` (env `COGNEE_LITELLM_MONTHLY_BUDGET_USD`, default `10`).

## ⚠️ Known gap — flagging honestly, not hiding it

The **model names in `values.yaml` are placeholders** (`openai/gpt-4o-mini`, `openai/text-embedding-3-large`). I could not confirm they're actually registered/routable on this cluster's live LiteLLM proxy without checking it directly, and I also could not find authoritative confirmation of the correct `LLM_PROVIDER` value for a custom-endpoint LLM call (unlike the embedding case, where Cognee's docs were explicit). **Before relying on this in production, verify against `$LITELLM_ENDPOINT/v1/models` and override via `--set clustertenantManager.cognee.llm.model=...` / `.embedding.model=...` if needed** — same deploy-time-override pattern already used for `tenant.defaultImage.tag`.

## Verification

- `helm lint` clean; `helm template` confirms the env block renders correctly and is fully omitted when `litellm.enabled=false`.
- No egress `NetworkPolicy` blocks Cognee from reaching the in-cluster LiteLLM Service (checked — only Ingress-type policies exist in this chart).
- Operator suite: **694 pass** (6 new for `CogneeLiteLlmKey`, including a regression guard that `team_id` is never sent). `tsc --noEmit` clean. Full monorepo build green.

## After merge → redeploy → verify

1. Check the live LiteLLM proxy's registered models; adjust the `--set` overrides if the placeholders don't match.
2. Redeploy elewa; confirm the operator minted the `cognee-litellm-key` Secret and the Cognee pod picked up the env (may need a Cognee pod restart on first install, same bootstrap-race already accepted for tenant LiteLLM keys).
3. Trigger a real turn again — this time look for a successful embedding call in Cognee's own logs instead of the `EmbeddingException`/`AbortError` pair.
4. Only then re-run the original "check if you can access cognee" end-to-end test.