### PR TITLE
🧠 byok: register Cognee's embedding model + fix chart model placeholders

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/model-routing/provision-byok-key-embedding.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/model-routing/provision-byok-key-embedding.test.ts
@@ -1,0 +1,177 @@
+import { Buffer } from "node:buffer";
+
+import * as k8s from "@kubernetes/client-node";
+import type { Logger } from "pino";
+import type { PrismaClient } from "@prisma/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _ProvisionByokKey } from "../../core/model-routing/provision-byok-key.js";
+
+/**
+ * Covers `_ensureProviderEmbeddingModel` (the embedding-registration step added alongside the
+ * Cognee LiteLLM wiring) — exercised through the public `_ProvisionByokKey` entry point, the same
+ * way `provision-byok-key.test.ts` covers the chat-model seeding step. Unlike that suite, THIS one
+ * sets `LITELLM_ENDPOINT`/`LITELLM_MASTER_KEY` so the live registration path actually runs and the
+ * embedding-specific request shape + idempotency check can be asserted.
+ */
+
+type Row = Record<string, unknown>;
+
+const _log = { info() { /* noop */ }, warn() { /* noop */ }, debug() { /* noop */ } } as unknown as Logger;
+
+function _mockPrisma(): PrismaClient
+{
+  const creds = new Map<string, Row>();
+  const models = new Map<string, Row>();
+  let credSeq = 0;
+  let modelSeq = 0;
+  return {
+    providerCredential: {
+      findFirst: async function _f(args: { where: { provider?: string } }) { return Array.from(creds.values()).find(function _m(r) { return r.provider === args.where.provider; }) ?? null; },
+      create: async function _c(args: { data: Row }) { const id = `cred-${++credSeq}`; const row = { id, ...args.data }; creds.set(id, row); return row; },
+      update: async function _u(args: { where: { id: string }; data: Row }) { const row = { ...(creds.get(args.where.id) as Row), ...args.data }; creds.set(args.where.id, row); return row; },
+    },
+    modelDefinition: {
+      findFirst: async function _mf(args: { where: Record<string, unknown> }) { return Array.from(models.values()).find(function _m(r) { return (args.where.publicModelName === undefined || r.publicModelName === args.where.publicModelName) && (args.where.isDefault === undefined || r.isDefault === args.where.isDefault); }) ?? null; },
+      create: async function _mc(args: { data: Row }) { const id = `model-${++modelSeq}`; const row = { id, isDefault: false, providerCredentialId: null, ...args.data }; models.set(id, row); return row; },
+      update: async function _mu(args: { where: { id: string }; data: Row }) { const row = { ...(models.get(args.where.id) as Row), ...args.data }; models.set(args.where.id, row); return row; },
+    },
+  } as unknown as PrismaClient;
+}
+
+function _mockCoreApi(): k8s.CoreV1Api
+{
+  const secrets = new Map<string, k8s.V1Secret>();
+  const notFound = () => Object.assign(new Error("not found"), { code: 404 });
+  return {
+    readNamespacedSecret: async function _r(a: { name: string }) { const s = secrets.get(a.name); if (!s) { throw notFound(); } return s; },
+    createNamespacedSecret: async function _c(a: { body: k8s.V1Secret }) { secrets.set(a.body.metadata!.name!, a.body); return a.body; },
+    replaceNamespacedSecret: async function _rp(a: { name: string; body: k8s.V1Secret }) { secrets.set(a.name, a.body); return a.body; },
+  } as unknown as k8s.CoreV1Api;
+}
+
+/** Route every fetch call by URL/method so `/credentials` and `/model/new` always succeed generically. */
+function _routedFetch(modelInfoData: Array<{ model_name: string }>): ReturnType<typeof vi.fn>
+{
+  return vi.fn().mockImplementation(async function _fetch(url: string, init?: RequestInit)
+  {
+    if (url.includes("/model/info"))
+    {
+      return new Response(JSON.stringify({ data: modelInfoData }), { status: 200 });
+    }
+    if (url.includes("/credentials"))
+    {
+      return new Response(JSON.stringify({}), { status: 200 });
+    }
+    if (url.includes("/model/new"))
+    {
+      return new Response(JSON.stringify({ model_id: `id-${Math.random()}` }), { status: 200 });
+    }
+    void init;
+    return new Response("not found", { status: 404 });
+  });
+}
+
+/** Parse the JSON body of a recorded fetch call. */
+function _bodyOf(call: unknown[]): Record<string, unknown>
+{
+  const init = call[1] as RequestInit;
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+}
+
+describe("_ProvisionByokKey — embedding model registration", function _suite()
+{
+  const _saved: Record<string, string | undefined> = {};
+
+  beforeEach(function _setEnv()
+  {
+    _saved.LITELLM_ENDPOINT = process.env.LITELLM_ENDPOINT;
+    _saved.LITELLM_MASTER_KEY = process.env.LITELLM_MASTER_KEY;
+    process.env.LITELLM_ENDPOINT = "http://litellm:4000";
+    process.env.LITELLM_MASTER_KEY = "sk-master";
+  });
+
+  afterEach(function _restoreEnv()
+  {
+    for (const k of ["LITELLM_ENDPOINT", "LITELLM_MASTER_KEY"])
+    {
+      if (_saved[k] === undefined) { delete process.env[k]; } else { process.env[k] = _saved[k]; }
+    }
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("registers openai's embedding model with mode:'embedding', explicitly tagged", async function _registers()
+  {
+    const fetchMock = _routedFetch([]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await _ProvisionByokKey({ prisma: _mockPrisma(), coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "openai", apiKey: "sk-test", log: _log });
+
+    const registerCalls = fetchMock.mock.calls.filter(function _isNewModel(c) { return (c[0] as string).includes("/model/new"); });
+    const embeddingCall = registerCalls.find(function _isEmbedding(c) { return _bodyOf(c)["model_name"] === "openai/text-embedding-3-large"; });
+    expect(embeddingCall).toBeDefined();
+    const body = _bodyOf(embeddingCall!);
+    expect(body["model_info"]).toEqual({ mode: "embedding" });
+    expect((body["litellm_params"] as Record<string, unknown>)["model"]).toBe("openai/text-embedding-3-large");
+  });
+
+  it("does NOT create a ModelDefinition row for the embedding model (never tenant-selectable)", async function _noRow()
+  {
+    vi.stubGlobal("fetch", _routedFetch([]));
+
+    const prisma = _mockPrisma();
+    await _ProvisionByokKey({ prisma, coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "openai", apiKey: "sk-test", log: _log });
+
+    // The chat-model seeding path (provision-byok-key.test.ts) already asserts the 3 catalog
+    // classes + "auto" get ModelDefinition rows; this asserts the embedding slug gets NONE —
+    // it must never surface as a tenant-selectable chat model (see ByokProviderCatalog.embeddingModel).
+    const embeddingRow = await prisma.modelDefinition.findFirst({ where: { publicModelName: "openai/text-embedding-3-large" } } as never);
+    expect(embeddingRow).toBeNull();
+  });
+
+  it("skips re-registration when /model/info already lists the embedding model (idempotent)", async function _idempotent()
+  {
+    const fetchMock = _routedFetch([{ model_name: "openai/text-embedding-3-large" }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await _ProvisionByokKey({ prisma: _mockPrisma(), coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "openai", apiKey: "sk-test", log: _log });
+
+    const registerCalls = fetchMock.mock.calls.filter(function _isNewModel(c) { return (c[0] as string).includes("/model/new"); });
+    const embeddingCall = registerCalls.find(function _isEmbedding(c) { return _bodyOf(c)["model_name"] === "openai/text-embedding-3-large"; });
+    expect(embeddingCall).toBeUndefined();
+  });
+
+  it("does not register any embedding model for a provider with none catalogued (anthropic)", async function _noneCatalogued()
+  {
+    const fetchMock = _routedFetch([]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await _ProvisionByokKey({ prisma: _mockPrisma(), coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "anthropic", apiKey: "sk-test", log: _log });
+
+    const infoCalls = fetchMock.mock.calls.filter(function _isInfo(c) { return (c[0] as string).includes("/model/info"); });
+    expect(infoCalls).toHaveLength(0);
+  });
+
+  it("does not crash the set when embedding registration fails (best-effort, non-fatal)", async function _resilient()
+  {
+    const fetchMock = vi.fn().mockImplementation(async function _fetch(url: string)
+    {
+      if (url.includes("/model/new") && url === "http://litellm:4000/model/new")
+      {
+        // Fail every /model/new call, including the embedding one.
+        return new Response("boom", { status: 500 });
+      }
+      if (url.includes("/model/info"))
+      {
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({}), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      _ProvisionByokKey({ prisma: _mockPrisma(), coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "openai", apiKey: "sk-test", log: _log }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/apps/clustertenant-operator/src/core/model-routing/byok-default-models.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/byok-default-models.ts
@@ -38,6 +38,17 @@ export interface ByokProviderCatalog
   defaultClass: ByokModelClassName;
   /** Model classes for this provider (≥1); ALL share the provider's single credential/key. */
   models: readonly ByokModelClass[];
+  /**
+   * Optional embedding model, registered directly with LiteLLM (see
+   * `provision-byok-key.ts` `_ensureProviderEmbeddingModel`) — deliberately NOT a `models[]`
+   * entry: every `models[]` class becomes a Global `ModelDefinition` row, and
+   * `tenant-models.ts` exposes ALL Global rows unconditionally as tenant-selectable CHAT
+   * models. An embedding deployment must never appear there, so it bypasses `ModelDefinition`
+   * entirely — internal callers needing it (Cognee, via its own dedicated LiteLLM key; see
+   * `cognee-litellm-key.ts`) reference the slug directly. Absent ⇒ no embedding model for
+   * this provider yet (set only where needed, not required for every provider).
+   */
+  embeddingModel?: { slug: string };
 }
 
 /** BYOK provider key → its model catalog. Absent providers set a key but seed no model. */
@@ -50,6 +61,9 @@ export const _BYOK_PROVIDER_CATALOG: Readonly<Record<string, ByokProviderCatalog
       { className: "balanced", slug: "openai/gpt-5.4" },
       { className: "fast", slug: "openai/gpt-5.4-nano" },
     ],
+    // Cognee's embedding pipeline (its own dedicated LiteLLM key — cognee-litellm-key.ts) needs
+    // this; it is NOT a tenant-selectable chat model (see ByokProviderCatalog.embeddingModel).
+    embeddingModel: { slug: "openai/text-embedding-3-large" },
   },
   anthropic: {
     litellmProvider: "anthropic",

--- a/apps/clustertenant-operator/src/core/model-routing/litellm-model-registration.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/litellm-model-registration.ts
@@ -79,6 +79,9 @@ async function _registerLive(endpoint: string, masterKey: string, input: LiteLlm
       body: JSON.stringify({
         model_name: input.publicModelName,
         litellm_params: litellmParams,
+        // Explicit mode (e.g. "embedding") rather than relying on LiteLLM's own model-name
+        // inference — omitted (LiteLLM defaults to chat) for the ordinary catalog models.
+        ...(input.mode ? { model_info: { mode: input.mode } } : {}),
       }),
     });
 

--- a/apps/clustertenant-operator/src/core/model-routing/litellm-model-registration.types.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/litellm-model-registration.types.ts
@@ -24,4 +24,11 @@ export interface LiteLlmModelRegistration
    * LiteLLM's encrypted credential store with no pod restart, instead of the `os.environ` baseline.
    */
   litellmCredentialName?: string | null;
+  /**
+   * Optional explicit LiteLLM `model_info.mode`. Omitted for ordinary chat/completion models (the
+   * default across this catalog) — set to `"embedding"` for an embedding deployment so LiteLLM's
+   * `/embeddings` route resolves it correctly rather than relying on LiteLLM's own internal
+   * model-name inference.
+   */
+  mode?: "chat" | "embedding";
 }

--- a/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
@@ -96,6 +96,17 @@ export async function _ProvisionByokKey(opts: {
     log.warn({ provider, err }, "byok model seed failed; key is set but its models were not seeded");
   }
 
+  // 5. Best-effort: register the provider's embedding model (if catalogued) directly with LiteLLM —
+  //    deliberately OUTSIDE step 4's ModelDefinition path (see ByokProviderCatalog.embeddingModel).
+  try
+  {
+    await _ensureProviderEmbeddingModel(catalog, litellmCredentialName, log);
+  }
+  catch (err)
+  {
+    log.warn({ provider, err }, "byok embedding model registration failed; key is set but no embedding model was registered");
+  }
+
   return { litellmRegistered, row };
 }
 
@@ -317,4 +328,75 @@ async function _ensureProviderModels(prisma: PrismaClient, catalog: ByokProvider
       });
     }
   }
+}
+
+/**
+ * Best-effort, idempotent registration of a provider's embedding model directly with LiteLLM —
+ * deliberately WITHOUT a `ModelDefinition` row (see `ByokProviderCatalog.embeddingModel`'s doc:
+ * every Global `ModelDefinition` is exposed to EVERY tenant as a selectable chat model, so an
+ * embedding deployment must never become one). No-op when the provider has no catalogued
+ * embedding model, or when LiteLLM is unconfigured (dev/tests — mirrors `_RegisterLiteLlmModel`'s
+ * own guard).
+ *
+ * Idempotency is checked directly against LiteLLM (`GET /model/info`) rather than a local
+ * bookkeeping row, since intentionally skipping `ModelDefinition` here means there is no row to
+ * check against; a read failure falls through to attempting registration anyway (LiteLLM's own
+ * `/model/new` on an existing `model_name` is itself safe to repeat).
+ *
+ * @param catalog               - The provider's catalog, or undefined (provider not catalogued).
+ * @param litellmCredentialName - The LiteLLM credential name (null ⇒ Secret-only baseline).
+ * @param log                   - Scoped logger for the registration outcome.
+ */
+async function _ensureProviderEmbeddingModel(catalog: ByokProviderCatalog | undefined, litellmCredentialName: string | null, log: Logger): Promise<void>
+{
+  if (!catalog?.embeddingModel)
+  {
+    return;
+  }
+
+  const endpoint = process.env.LITELLM_ENDPOINT?.trim() ?? "";
+  const masterKey = process.env.LITELLM_MASTER_KEY?.trim() ?? "";
+  if (!endpoint || !masterKey)
+  {
+    return;
+  }
+
+  const slug = catalog.embeddingModel.slug;
+
+  // 1. Skip re-registration when LiteLLM already has this model_name — best-effort: any failure
+  //    here (network, non-2xx, bad JSON) just falls through to attempting registration anyway.
+  try
+  {
+    const infoResponse = await fetch(`${endpoint}/model/info`, {
+      headers: { Authorization: `Bearer ${masterKey}` },
+    });
+    if (infoResponse.ok)
+    {
+      const info = await infoResponse.json() as { data?: Array<{ model_name?: string }> };
+      if ((info.data ?? []).some(function _match(m) { return m.model_name === slug; }))
+      {
+        log.debug({ slug }, "provider embedding model already registered with litellm");
+        return;
+      }
+    }
+  }
+  catch
+  {
+    // Fall through — an unreachable /model/info must not block attempting registration.
+  }
+
+  // 2. Register GLOBALLY, explicitly tagged `mode: "embedding"` so LiteLLM's `/embeddings` route
+  //    resolves it correctly. scope/clusterTenant are only used to build a discarded placeholder
+  //    id when LiteLLM is unreachable — no ModelDefinition row is created for this deployment.
+  await _RegisterLiteLlmModel({
+    publicModelName: slug,
+    upstreamModel: slug,
+    scope: ModelRoutingScope.Global,
+    clusterTenant: null,
+    apiBase: null,
+    apiKeyEnvRef: null,
+    litellmCredentialName,
+    mode: "embedding",
+  });
+  log.info({ slug }, "provider embedding model registered with litellm");
 }

--- a/apps/clustertenant-platform/values.yaml
+++ b/apps/clustertenant-platform/values.yaml
@@ -330,22 +330,27 @@ clustertenantManager:
     #    it Cognee has no embedding/LLM credentials and every memory-capture attempt aborts
     #    after ~60s of failed embedding calls (the pre-fix symptom).
     #
-    #    IMPORTANT — the model names below are PLACEHOLDERS. Verify they are actually
-    #    registered/routable on this cluster's live LiteLLM proxy before relying on them in
-    #    production (e.g. `curl $LITELLM_ENDPOINT/v1/models`); override per-deploy with
-    #    `--set clustertenantManager.cognee.llm.model=...` /
-    #    `--set clustertenantManager.cognee.embedding.model=...` if they differ.
+    #    Verified against the live opencrane-dev LiteLLM proxy (`/model/info`) — the two
+    #    original placeholders here did NOT exist (neither `openai/gpt-4o-mini` nor any
+    #    embedding model was registered). Fixed as follows:
     llm:
       # -- "openai" matches Cognee's own default AND this platform's litellm-proxy
       #    convention (api: openai-completions) for an OpenAI-compatible upstream.
       provider: "openai"
-      model: "openai/gpt-4o-mini"
+      # -- "auto" is this platform's own stable model-selection alias (byok-default-models.ts),
+      #    seeded by the BYOK bootstrap alongside every provider's chat models — it currently
+      #    resolves to openai/gpt-5.4-nano on opencrane-dev, but re-points automatically if the
+      #    catalog's cheapest tier changes, so this stays correct without a values.yaml edit.
+      model: "auto"
     embedding:
       # -- "custom" (NOT "openai") — verified against Cognee's own docs: the "custom"
       #    provider passes EMBEDDING_ENDPOINT straight through to LiteLLM as `api_base`
       #    with no automatic /v1 append or /embeddings strip, which the "openai" provider
       #    does and which breaks routing through a proxy base URL.
       provider: "custom"
+      # -- Registered directly with LiteLLM by the BYOK bootstrap flow (see
+      #    ByokProviderCatalog.embeddingModel / _ensureProviderEmbeddingModel) — NOT a
+      #    tenant-selectable ModelDefinition, so this exact slug must match that registration.
       model: "openai/text-embedding-3-large"
       dimensions: 3072
   # -- OIDC human-login session config for the control-plane. Zitadel is the single


### PR DESCRIPTION
## Why

Before deploying #173 (Cognee LiteLLM wiring), I checked the live LiteLLM proxy on opencrane-dev rather than guess. Neither placeholder model existed: no embedding model was registered **at all**, and the chat placeholder (`openai/gpt-4o-mini`) doesn't exist either — the real registered tier is `openai/gpt-5.x`.

Per your direction: extend the BYOK bootstrap flow so it registers a default embedding model too, rather than a one-off manual fix.

## Investigation before implementing

Checked whether I could just add an embedding entry to the existing chat-model seeding loop (`_ensureProviderModels`) — traced it through `tenant-models.ts` and confirmed that's **wrong**: every Global `ModelDefinition` row is exposed unconditionally to every tenant as a selectable chat model (no type/capability filter exists anywhere in the schema). Registering the embedding model there would let a tenant pick `openai/text-embedding-3-large` as their chat model and break.

The codebase's own established pattern for "an internal caller needs a model, tenants shouldn't pick it" is exactly what #173 already built for Cognee's own LiteLLM key — a credential with no tenant-model-set binding at all. This follows the same principle for the model registration itself.

## What this does

- **`ByokProviderCatalog.embeddingModel?: {slug}`** (`byok-default-models.ts`) — optional, populated only for `openai` (`openai/text-embedding-3-large`, a real OpenAI model the org's already-approved `byok-openai` credential can serve).
- **New `_ensureProviderEmbeddingModel`** (`provision-byok-key.ts`), called alongside (not instead of) the existing chat-model seed: registers directly with LiteLLM via `_RegisterLiteLlmModel`, explicitly tagged `model_info.mode:"embedding"` (new optional field, rather than relying on LiteLLM's model-name inference) — and deliberately creates **no** `ModelDefinition` row, so it can never surface in a tenant's model list. Idempotency checked directly against LiteLLM's `/model/info` (no local bookkeeping row exists by design); a read failure falls through to attempting registration anyway. Best-effort, non-fatal.
- **Chart fix**: `LLM_MODEL` placeholder → `"auto"` (this platform's own stable model-selection alias, already seeded for every provider — resolves to `openai/gpt-5.4-nano` today, re-points automatically if the catalog's cheapest tier changes). `EMBEDDING_MODEL` was already correct and now matches exactly what gets registered.

## Verification

- 5 new tests: `mode:"embedding"` sent explicitly; no `ModelDefinition` row created; idempotent against `/model/info`; no-op for a provider with no catalogued embedding model (e.g. anthropic); best-effort on registration failure.
- Full operator suite: **699 pass**. `tsc --noEmit` clean. `helm lint`/`helm template` clean (LLM_MODEL renders `"auto"`). Full monorepo build green.

## After merge → redeploy → verify

Redeploy elewa. The operator's boot-time BYOK bootstrap should register the embedding model with LiteLLM (log line: `"litellm model registered"`, `publicModelName: openai/text-embedding-3-large`). Then trigger a real turn again and look for a **successful** embedding call in Cognee's logs (not `EmbeddingException`/`AbortError`). Only then re-run the original "check if you can access cognee" end-to-end test.