### PR TITLE
🔁 Restart Cognee after minting its LiteLLM key (fixes the boot-order race)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/cognee-litellm-key.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cognee-litellm-key.test.ts
@@ -48,6 +48,17 @@ function _makeObjectApi(): k8s.KubernetesObjectApi
   } as unknown as k8s.KubernetesObjectApi;
 }
 
+/** Stub AppsV1Api: lists a single cognee Deployment (or none) and records restart patches. */
+function _makeAppsApi(deploymentNames: string[] = ["opencrane-elewa-opencrane-cognee"]): k8s.AppsV1Api
+{
+  return {
+    listNamespacedDeployment: vi.fn().mockResolvedValue({
+      items: deploymentNames.map(function _toDeployment(name) { return { metadata: { name } }; }),
+    }),
+    patchNamespacedDeployment: vi.fn().mockResolvedValue({}),
+  } as unknown as k8s.AppsV1Api;
+}
+
 /** Parse the JSON body of a recorded fetch call. */
 function _bodyOf(call: unknown[]): Record<string, unknown>
 {
@@ -74,7 +85,7 @@ describe("CogneeLiteLlmKey", () =>
     );
     vi.stubGlobal("fetch", fetchMock);
 
-    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), _makeObjectApi(), _log);
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), _makeObjectApi(), _makeAppsApi(), _log);
     await keys.ensureCogneeLiteLlmKeySecret("acme", "default");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -99,7 +110,7 @@ describe("CogneeLiteLlmKey", () =>
     vi.stubGlobal("fetch", fetchMock);
 
     const objectApi = _makeObjectApi();
-    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), objectApi, _log);
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), objectApi, _makeAppsApi(), _log);
     await keys.ensureCogneeLiteLlmKeySecret("acme", "opencrane-elewa");
 
     expect(objectApi.create as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
@@ -115,12 +126,17 @@ describe("CogneeLiteLlmKey", () =>
     vi.stubGlobal("fetch", fetchMock);
 
     const objectApi = _makeObjectApi();
-    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi("sk-cognee-existing"), objectApi, _log);
+    const appsApi = _makeAppsApi();
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi("sk-cognee-existing"), objectApi, appsApi, _log);
     await keys.ensureCogneeLiteLlmKeySecret("acme", "default");
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toBe("http://litellm:4000/key/update");
+
+    // The existing-secret (reconcile-params) path must NOT restart Cognee — the key value
+    // didn't rotate, so any pod already running still has the credential it started with.
+    expect(appsApi.patchNamespacedDeployment as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
 
     const body = _bodyOf(fetchMock.mock.calls[0]);
     expect(body["key"]).toBe("sk-cognee-existing");
@@ -137,14 +153,14 @@ describe("CogneeLiteLlmKey", () =>
     const fetchMock = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
     vi.stubGlobal("fetch", fetchMock);
 
-    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi("sk-cognee-existing"), _makeObjectApi(), _log);
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi("sk-cognee-existing"), _makeObjectApi(), _makeAppsApi(), _log);
     await expect(keys.ensureCogneeLiteLlmKeySecret("acme", "default")).resolves.toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("throws when LITELLM_MASTER_KEY is missing while enabled", async () =>
   {
-    const keys = new CogneeLiteLlmKey({ ..._enabledConfig, liteLlmMasterKey: "" }, _makeCoreApi(), _makeObjectApi(), _log);
+    const keys = new CogneeLiteLlmKey({ ..._enabledConfig, liteLlmMasterKey: "" }, _makeCoreApi(), _makeObjectApi(), _makeAppsApi(), _log);
     await expect(keys.ensureCogneeLiteLlmKeySecret("acme", "default")).rejects.toThrow(/LITELLM_MASTER_KEY is required/);
   });
 
@@ -153,9 +169,60 @@ describe("CogneeLiteLlmKey", () =>
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    const keys = new CogneeLiteLlmKey(defaultConfig, _makeCoreApi(), _makeObjectApi(), _log);
+    const keys = new CogneeLiteLlmKey(defaultConfig, _makeCoreApi(), _makeObjectApi(), _makeAppsApi(), _log);
     await keys.ensureCogneeLiteLlmKeySecret("acme", "default");
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("restarts the cognee Deployment (found by label) on the CREATE path, closing the boot-order race", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ key: "sk-cognee-new" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const appsApi = _makeAppsApi(["opencrane-elewa-opencrane-cognee"]);
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), _makeObjectApi(), appsApi, _log);
+    await keys.ensureCogneeLiteLlmKeySecret("acme", "opencrane-elewa");
+
+    expect(appsApi.listNamespacedDeployment as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      expect.objectContaining({ namespace: "opencrane-elewa", labelSelector: "app.kubernetes.io/component=cognee" }),
+    );
+    expect(appsApi.patchNamespacedDeployment as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    const [patchArgs] = (appsApi.patchNamespacedDeployment as ReturnType<typeof vi.fn>).mock.calls[0] as [{ name: string; namespace: string; body: unknown }];
+    expect(patchArgs.name).toBe("opencrane-elewa-opencrane-cognee");
+    expect(patchArgs.namespace).toBe("opencrane-elewa");
+  });
+
+  it("does not crash the set when no cognee Deployment is found to restart", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ key: "sk-cognee-new" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const appsApi = _makeAppsApi([]);
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), _makeObjectApi(), appsApi, _log);
+    await expect(keys.ensureCogneeLiteLlmKeySecret("acme", "default")).resolves.toBeUndefined();
+    expect(appsApi.patchNamespacedDeployment as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("does not crash the set when the restart patch fails (best-effort, non-fatal); the Secret is already durably written regardless", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ key: "sk-cognee-new" }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const appsApi = {
+      listNamespacedDeployment: vi.fn().mockResolvedValue({ items: [{ metadata: { name: "opencrane-elewa-opencrane-cognee" } }] }),
+      patchNamespacedDeployment: vi.fn().mockRejectedValue(new Error("RBAC denied")),
+    } as unknown as k8s.AppsV1Api;
+    const objectApi = _makeObjectApi();
+    const keys = new CogneeLiteLlmKey(_enabledConfig, _makeCoreApi(), objectApi, appsApi, _log);
+
+    await expect(keys.ensureCogneeLiteLlmKeySecret("acme", "default")).resolves.toBeUndefined();
+    expect(objectApi.create as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/clustertenant-operator/src/index.ts
+++ b/apps/clustertenant-operator/src/index.ts
@@ -299,9 +299,10 @@ async function _startInSiloControllers(): Promise<void>
         return;
       }
       const objectApi = k8s.KubernetesObjectApi.makeApiClient(kc);
+      const cogneeAppsApi = kc.makeApiClient(k8s.AppsV1Api);
       try
       {
-        await new CogneeLiteLlmKey(config, coreApi, objectApi, log).ensureCogneeLiteLlmKeySecret(clusterTenantName, config.watchNamespace);
+        await new CogneeLiteLlmKey(config, coreApi, objectApi, cogneeAppsApi, log).ensureCogneeLiteLlmKeySecret(clusterTenantName, config.watchNamespace);
       }
       catch (err)
       {

--- a/apps/clustertenant-operator/src/tenants/internal/cognee-litellm-key.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-litellm-key.ts
@@ -34,18 +34,21 @@ export class CogneeLiteLlmKey
   private config: OpenClawTenantOperatorConfig;
   private coreApi: k8s.CoreV1Api;
   private objectApi: k8s.KubernetesObjectApi;
+  private appsApi: k8s.AppsV1Api;
   private log: Logger;
 
   constructor(
     config: OpenClawTenantOperatorConfig,
     coreApi: k8s.CoreV1Api,
     objectApi: k8s.KubernetesObjectApi,
+    appsApi: k8s.AppsV1Api,
     log: Logger,
   )
   {
     this.config = config;
     this.coreApi = coreApi;
     this.objectApi = objectApi;
+    this.appsApi = appsApi;
     this.log = log;
   }
 
@@ -107,6 +110,15 @@ export class CogneeLiteLlmKey
 
     await __K8sApplyResource(this.objectApi, secret, this.log);
     this.log.info({ clusterTenantName, budget }, "created cognee litellm virtual key secret");
+
+    // Close the boot-order race: Cognee's Deployment is Helm-templated and starts as part of
+    // the SAME `helm upgrade` that rolls this manager pod, with no ordering guarantee that this
+    // Secret exists first. `secretKeyRef` env vars resolve empty (not an error, since the chart
+    // marks them `optional: true`) when the Secret is missing at pod start, and — being env vars,
+    // not a mounted volume — never pick up the Secret's value without a restart. Only needed on
+    // the CREATE path: an update-existing-secret reconcile doesn't rotate the key value, so any
+    // pod already running still has the credential it started with.
+    await this._restartCogneeDeployment(namespace, clusterTenantName);
   }
 
   /**
@@ -197,6 +209,67 @@ export class CogneeLiteLlmKey
     catch
     {
       return undefined;
+    }
+  }
+
+  /**
+   * Trigger a rollout restart of this silo's Cognee Deployment so it picks up the just-minted
+   * key Secret — mirrors what `kubectl rollout restart` does under the hood (a pod-template
+   * annotation patch), since a Secret consumed via `secretKeyRef` env vars never refreshes on
+   * its own. Discovered by label (`app.kubernetes.io/component: cognee`, matching
+   * `cognee-deployment.yaml`'s own labels) rather than by name — the operator cannot compute
+   * the chart's release-prefixed Deployment name, and there is exactly one Cognee Deployment
+   * per namespace (documented invariant), so label discovery is safe and chart-agnostic.
+   *
+   * Best-effort and non-fatal: the Secret is already durably written regardless of whether this
+   * succeeds — a failure here (RBAC, no Cognee installed yet, API hiccup) just means Cognee picks
+   * up the credential on its NEXT restart (a future deploy, pod eviction, etc.) instead of now.
+   */
+  private async _restartCogneeDeployment(namespace: string, clusterTenantName: string): Promise<void>
+  {
+    try
+    {
+      const list = await this.appsApi.listNamespacedDeployment({
+        namespace,
+        labelSelector: "app.kubernetes.io/component=cognee",
+      });
+      const deployments = list.items ?? [];
+      if (deployments.length === 0)
+      {
+        this.log.debug({ clusterTenantName, namespace }, "no cognee deployment found to restart (not installed in this release?)");
+        return;
+      }
+
+      for (const deployment of deployments)
+      {
+        const name = deployment.metadata?.name;
+        if (!name)
+        {
+          continue;
+        }
+
+        await this.appsApi.patchNamespacedDeployment(
+          {
+            name,
+            namespace,
+            body: {
+              spec: {
+                template: {
+                  metadata: {
+                    annotations: { "opencrane.io/restarted-at": new Date().toISOString() },
+                  },
+                },
+              },
+            },
+          },
+          k8s.setHeaderOptions("Content-Type", k8s.PatchStrategy.StrategicMergePatch),
+        );
+        this.log.info({ clusterTenantName, namespace, deployment: name }, "restarted cognee deployment to pick up its new litellm key");
+      }
+    }
+    catch (err)
+    {
+      this.log.warn({ clusterTenantName, namespace, err }, "cognee deployment restart failed; it will pick up the new key on its next natural restart instead");
     }
   }
 }


### PR DESCRIPTION
## Why

Redeploying #175 to elewa proved the embedding-model fix itself works — confirmed via boot log (`"litellm model registered"`) and LiteLLM's own `/model/info` (`mode: "embedding"`). But the real end-to-end test still failed, exposing the **next** link in the chain:

Cognee's pod started **14 seconds before** the operator's boot-time reconcile created the `cognee-litellm-key` Secret. `LLM_API_KEY`/`EMBEDDING_API_KEY` (`secretKeyRef`, `optional: true`) resolved **empty**, and — being env vars, not a mounted volume — never pick up the Secret's value without a restart.

Cognee's own logs confirmed exactly this: `Missing credentials ... EMBEDDING_ENDPOINT='http://opencrane-litellm:4000'` — the endpoint and model are now *correct* (unlike #172/#173's `EMBEDDING_ENDPOINT='None'`), it's purely a missing credential from the race.

This is **structural, not a one-off timing fluke**: Cognee's Deployment is Helm-templated and starts as part of the same `helm upgrade` that rolls the manager pod, with no ordering guarantee the Secret exists first. It will recur identically on every deploy until fixed.

## Fix

On the **CREATE path only** (a brand-new key — the existing-secret/budget-reconcile path never rotates the key value, so an already-running pod still has what it started with), trigger a rollout restart of the Cognee Deployment: the same mechanism `kubectl rollout restart` uses under the hood (a pod-template annotation patch via `AppsV1Api.patchNamespacedDeployment`, `Content-Type: strategic-merge-patch`, mirroring this codebase's own `k8s.setHeaderOptions` pattern from `tenant-suspension.ts`).

Discovered by **label** (`app.kubernetes.io/component=cognee`), not by name — the operator has no way to compute the chart's release-prefixed Deployment name (the same reason the key Secret itself already uses a fixed, non-prefixed name). RBAC already grants full CRUD on `apps/deployments` to the `clustertenant-manager` ServiceAccount, so no chart/RBAC change is needed.

Best-effort and non-fatal throughout: a restart failure just means Cognee picks up the credential on its next natural restart instead of immediately — the Secret is durably written either way.

## Verification

- 3 new tests: restart triggered on create with a Deployment present; no-op when none found; best-effort/non-fatal on patch failure. Also verified the existing "existing-secret path" test now asserts NO restart fires there.
- Operator suite: **702 pass**. `tsc --noEmit` clean. Full monorepo build green.

## After merge → redeploy → verify

Redeploy elewa. This time the Cognee pod that starts should either (a) start after the Secret already exists (if the manager pod happens to boot first), or (b) get an automatic restart once the operator mints the key. Check the Cognee pod's env for non-empty `LLM_API_KEY`/`EMBEDDING_API_KEY`, then trigger a real turn and look for a successful embed (not `Missing credentials`). This really should be the point the whole chain finally closes.