### PR TITLE
🔧 cognee: script-driven pod-restart lever + fix invisible reconcile log

### DIFF
--- a/apps/clustertenant-operator/src/tenants/internal/cognee-litellm-key.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-litellm-key.ts
@@ -78,7 +78,12 @@ export class CogneeLiteLlmKey
     if (existingKey !== undefined)
     {
       await this._updateLiteLlmVirtualKey(existingKey, clusterTenantName, budget);
-      this.log.debug({ clusterTenantName, budget }, "reconciled existing cognee litellm virtual key params");
+      // .info (not .debug): the deployed fleet runs LOG_LEVEL=info, so a .debug line here was
+      // PERMANENTLY invisible in production — the only way to tell this path fired (vs. the
+      // create+restart path) was inferring it from the ABSENCE of the create-path's own .info
+      // line. This is exactly the log a human/agent needs when diagnosing the boot-order race
+      // this class of Secret can hit (see `_restartCogneeDeployment`'s doc comment).
+      this.log.info({ clusterTenantName, budget }, "reconciled existing cognee litellm virtual key params (no restart — key value unchanged)");
       return;
     }
 

--- a/apps/clustertenant-platform/templates/cognee-deployment.yaml
+++ b/apps/clustertenant-platform/templates/cognee-deployment.yaml
@@ -55,6 +55,16 @@ spec:
       labels:
         {{- include "opencrane.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: cognee
+      # Same convention as litellm/mcpGateway's own `podAnnotations` (values.yaml). Also doubles as
+      # a sanctioned, script-driven way to force a rollout — e.g.
+      # `--set clustertenantManager.cognee.podAnnotations.restartedAt=<value>` — when Cognee needs
+      # to pick up a credential change (its LiteLLM key Secret is minted by the operator at
+      # runtime, not Helm-templated, so `helm upgrade` has no checksum of it to trigger a natural
+      # roll on its own).
+      {{- with .Values.clustertenantManager.cognee.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
         - name: cognee

--- a/apps/clustertenant-platform/values.yaml
+++ b/apps/clustertenant-platform/values.yaml
@@ -353,6 +353,14 @@ clustertenantManager:
       #    tenant-selectable ModelDefinition, so this exact slug must match that registration.
       model: "openai/text-embedding-3-large"
       dimensions: 3072
+    # -- Extra pod-template annotations, same convention as `litellm.podAnnotations` /
+    #    `mcpGateway.podAnnotations`. Also a sanctioned, script-driven rollout trigger: Cognee's
+    #    LiteLLM key Secret is minted by the operator at runtime (not Helm-templated), so a plain
+    #    `helm upgrade` has no checksum of it to roll Cognee automatically when the key changes.
+    #    Bump this (e.g. `--set clustertenantManager.cognee.podAnnotations.restartedAt=<value>`)
+    #    to force Cognee to pick up a credential it missed at boot, without touching kubectl/helm
+    #    directly.
+    podAnnotations: {}
   # -- OIDC human-login session config for the control-plane. Zitadel is the single
   #    trusted issuer (Mode-2 broker, no upstream Entra), but nothing here is
   #    Zitadel-specific — any spec-compliant issuer works. OIDC is OFF unless


### PR DESCRIPTION
## Why

Redeploying #176 to elewa confirmed the restart-trigger logic itself is correct — but exposed a first-time-bootstrap gap. elewa's `cognee-litellm-key` Secret was already minted by the earlier #175 deploy, **before** #176 shipped. So this run took the "existing secret, reconcile params" branch — which correctly does **not** restart Cognee (the key value didn't rotate) — but that leaves an already-raced Cognee pod stuck with no credentials indefinitely, since nothing else in a normal `helm upgrade` touches its pod template.

Unsticking it without a bare `kubectl delete secret` (outside the sanctioned deploy-script boundary I've held to this whole session) needed a script-driven way to force a legitimate pod-template change.

## What this does

- **`clustertenantManager.cognee.podAnnotations`** (values.yaml, default `{}`) → rendered into the Cognee pod template's `metadata.annotations`. Mirrors the **existing** `litellm.podAnnotations` / `mcpGateway.podAnnotations` convention already in this same chart — same `{{- with ... }}` pattern, nothing new invented.
- Bumping it via `--set clustertenantManager.cognee.podAnnotations.restartedAt=<value>` through `apps/clustertenant-platform/deploy.sh` forces Kubernetes' own rolling restart — entirely through the sanctioned script, no raw kubectl/helm. Reusable any time Cognee needs to pick up a credential change: its LiteLLM key Secret is minted by the operator at runtime (not Helm-templated), so a plain `helm upgrade` has no checksum of it to roll Cognee automatically.
- **Also fixed a diagnostic gap** the same investigation surfaced: the "reconciled existing key" log line was `.debug`, but the deployed fleet runs `LOG_LEVEL=info` — so this branch was **permanently invisible** in production. Telling it apart from the create+restart path required inferring from the *absence* of the other path's log line plus manual pod/Secret timestamp cross-referencing. Bumped to `.info` with an explicit "(no restart — key value unchanged)" suffix.

## Verification

- `helm lint` clean; `helm template` confirms `podAnnotations` is absent by default and renders correctly under `--set`.
- Operator suite: **702 pass**. `tsc --noEmit` clean. Full monorepo build green.

## After merge → use it to unstick elewa → verify

Redeploy elewa with `--set clustertenantManager.cognee.podAnnotations.restartedAt=$(date +%s)` (or any changing value) added to the standard deploy command — this forces Cognee's pod to restart and pick up the already-correct, already-minted key. Confirm `LLM_API_KEY`/`EMBEDDING_API_KEY` are now populated, then trigger a real turn and check for a successful embed. This should finally close the whole org-memory chain.