### PR TITLE
sec: split external-HTTPS egress out of silo baseline, exclude Cognee

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { defaultConfig, gcpConfig, gcpAdapter, onPremAdapter, _makeAccessPolicy, _makeTenant } from "../fixtures.js";
-import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildClusterTenantScheduling, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc, _ConfigChecksum } from "../../tenants/deploy/index.js";
+import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildClusterTenantScheduling, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloExternalEgressNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc, _ConfigChecksum } from "../../tenants/deploy/index.js";
 
 describe("TenantResourceBuilder", () =>
 {
@@ -470,17 +470,18 @@ describe("Silo baseline NetworkPolicy (S2 / Phase 1 — default-deny silo edge)"
     expect(rule?._from).toContainEqual({ namespaceSelector: { matchLabels: { "kubernetes.io/metadata.name": "opencrane-system" } } });
   });
 
-  it("allows egress to DNS, the platform namespace, intra-silo, and external HTTPS only", () =>
+  it("allows egress to DNS and the platform namespace/intra-silo — NOT external HTTPS (split out)", () =>
   {
     const egress = netpol.spec?.egress ?? [];
     // DNS on 53/UDP+TCP to kube-system.
     const dns = egress.find(e => e.to?.some(t => t.namespaceSelector?.matchLabels?.["kubernetes.io/metadata.name"] === "kube-system"));
     expect(dns?.ports).toEqual([{ protocol: "UDP", port: 53 }, { protocol: "TCP", port: 53 }]);
-    // External HTTPS on 443 (no `to` ⇒ any destination) for LLM/MCP/Git.
-    expect(egress).toContainEqual({ ports: [{ protocol: "TCP", port: 443 }] });
     // Platform-plane reachability.
     const platform = egress.find(e => e.to?.some(t => t.namespaceSelector?.matchLabels?.["kubernetes.io/metadata.name"] === "opencrane-system"));
     expect(platform).toBeDefined();
+    // External HTTPS (443, no `to`) is NOT here — it moved to _BuildSiloExternalEgressNetworkPolicy
+    // so the bundled Cognee pod can be excluded from it (topoteretes/cognee#3084).
+    expect(egress).not.toContainEqual({ ports: [{ protocol: "TCP", port: 443 }] });
   });
 
   it("creates NO silo→silo path (no rule names another silo namespace)", () =>
@@ -491,6 +492,31 @@ describe("Silo baseline NetworkPolicy (S2 / Phase 1 — default-deny silo edge)"
     expect(serialized).not.toContain("opencrane-bcorp");
     const nsNames = [...serialized.matchAll(/"kubernetes\.io\/metadata\.name":"([^"]+)"/g)].map(m => m[1]);
     expect(new Set(nsNames)).toEqual(new Set(["opencrane-system", "kube-system"]));
+  });
+});
+
+describe("Silo external-egress NetworkPolicy (Cognee excluded — topoteretes/cognee#3084)", () =>
+{
+  const netpol = _BuildSiloExternalEgressNetworkPolicy("opencrane-acme", "acme");
+
+  it("targets the silo namespace and records the ClusterTenant label", () =>
+  {
+    expect(netpol.metadata?.namespace).toBe("opencrane-acme");
+    expect(netpol.metadata?.labels?.["opencrane.io/cluster-tenant"]).toBe("acme");
+    expect(netpol.spec?.policyTypes).toEqual(["Egress"]);
+  });
+
+  it("excludes the Cognee pod via a NotIn podSelector (not an empty selector)", () =>
+  {
+    expect(netpol.spec?.podSelector).not.toEqual({});
+    const expr = netpol.spec?.podSelector?.matchExpressions?.[0];
+    expect(expr).toEqual({ key: "app.kubernetes.io/component", operator: "NotIn", values: ["cognee"] });
+  });
+
+  it("allows unrestricted-destination HTTPS on 443 for every non-Cognee pod", () =>
+  {
+    const egress = netpol.spec?.egress ?? [];
+    expect(egress).toContainEqual({ ports: [{ protocol: "TCP", port: 443 }] });
   });
 });
 

--- a/apps/clustertenant-operator/src/tenants/deploy/index.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/index.ts
@@ -6,7 +6,7 @@ export { _BuildStatePvc } from "./3-state-pvc.js";
 export { _BuildDeployment } from "./3-deployment.js";
 export { _BuildService } from "./4-service.js";
 export { _BuildGatewayNetworkPolicy } from "./network-policy.js";
-export { _BuildSiloBaselineNetworkPolicy } from "./silo-baseline-network-policy.js";
+export { _BuildSiloBaselineNetworkPolicy, _BuildSiloExternalEgressNetworkPolicy } from "./silo-baseline-network-policy.js";
 export { _BuildSiloLinkerdIdentityPolicy } from "./silo-linkerd-identity.js";
 export { _BuildClusterTenantNamespace } from "@opencrane/infra-api";
 export { _BuildClusterTenantResourceQuota, _BuildClusterTenantLimitRange } from "./7-resource-quota.js";

--- a/apps/clustertenant-operator/src/tenants/deploy/silo-baseline-network-policy.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/silo-baseline-network-policy.ts
@@ -8,6 +8,9 @@ const _NAMESPACE_NAME_LABEL = "kubernetes.io/metadata.name";
 /** The cluster DNS namespace whose kube-dns/CoreDNS every pod must be able to reach. */
 const _DNS_NAMESPACE = "kube-system";
 
+/** Component label the bundled Cognee pod carries (`cognee-deployment.yaml`). */
+const _COGNEE_COMPONENT_LABEL = "cognee";
+
 /**
  * Build the per-silo baseline NetworkPolicy — the default-deny edge of a
  * ClusterTenant namespace (S2 / silo Phase 1, task_08734d58 + task_d6404452).
@@ -21,15 +24,27 @@ const _DNS_NAMESPACE = "kube-system";
  * - **Ingress** from the same silo namespace (intra-silo) and from the
  *   control-plane/operator namespace (the super-admin plane is the only principal
  *   allowed to reach in — it brokers the gateway connection).
- * - **Egress** to cluster DNS, to the same silo namespace, to the control-plane
+ * - **Egress** to cluster DNS, and to the same silo namespace + the control-plane
  *   namespace (the shared planes — control-plane, Obot/MCP, skill-registry, LiteLLM,
- *   Cognee — live there in the shared tier), and to external HTTPS (LLM/MCP/Git).
+ *   Cognee — live there in the shared tier).
+ *
+ * External HTTPS (LLM/MCP/Git) is deliberately NOT in this policy — see
+ * {@link _BuildSiloExternalEgressNetworkPolicy}, a separate policy so Cognee can be
+ * excluded from it (an unpatched Cognee vuln — topoteretes/cognee#3084 — lets ANY
+ * authenticated Cognee user overwrite the process-wide LLM/embedding endpoint with no
+ * admin check; unrestricted external egress would let that be pointed at an
+ * attacker-controlled host to exfiltrate every tenant's data flowing through this
+ * silo's shared Cognee instance). NetworkPolicy is purely additive — a workload
+ * covered by this baseline's intra-silo/DNS rules can still be excluded from a
+ * DIFFERENT policy's broader grant, but the reverse (one policy narrowing what
+ * another already allows) is not expressible in one resource, hence the split.
  *
  * This replaces the old single `opencrane-tenant-default` policy that sat in the
  * install namespace and (mis)selected tenant pods cluster-wide; the operator now
- * emits one correctly-scoped policy per silo namespace it provisions. The companion
- * {@link _BuildGatewayNetworkPolicy} narrows the gateway PORT to the operator on top
- * of this baseline (NetworkPolicy rules are additive, so the two compose).
+ * emits one correctly-scoped policy per silo namespace it provisions. The companions
+ * {@link _BuildGatewayNetworkPolicy} and {@link _BuildSiloExternalEgressNetworkPolicy}
+ * narrow/extend on top of this baseline (NetworkPolicy rules are additive, so all
+ * three compose).
  *
  * NOTE: this is an L3/L4 namespace-scoped floor — the identity-based (SPIFFE/Cilium)
  * enforcement of the silo model lands later (S5). It only takes effect on a
@@ -91,13 +106,68 @@ export function _BuildSiloBaselineNetworkPolicy(
           ],
         },
         // Intra-silo + the shared platform planes (control-plane, Obot, skills, LiteLLM, Cognee).
+        // Unrestricted by port — this is namespace/platform-scoped only (not an exfiltration
+        // path to an external attacker), and Cognee legitimately needs it to reach LiteLLM in
+        // the same namespace. External HTTPS is deliberately NOT here — see
+        // _BuildSiloExternalEgressNetworkPolicy.
         {
           to: [
             { podSelector: {} },
             { namespaceSelector: { matchLabels: { [_NAMESPACE_NAME_LABEL]: platformNamespace } } },
           ],
         },
-        // External HTTPS — the agent legitimately calls out to LLM/MCP/Git endpoints.
+      ],
+    },
+  };
+}
+
+/**
+ * Build the silo's external-HTTPS egress allowance — split OUT of
+ * {@link _BuildSiloBaselineNetworkPolicy} so Cognee can be excluded from it.
+ *
+ * The baseline's own egress rules (DNS + intra-silo/platform) are safe to leave
+ * unrestricted-by-destination because they never leave the cluster. "External HTTPS
+ * to anywhere" is different: it is exactly the egress an unpatched Cognee
+ * vulnerability (topoteretes/cognee#3084) would need to exploit. That bug lets ANY
+ * authenticated Cognee user overwrite the process-wide LLM/embedding endpoint
+ * (`POST /api/v1/settings` has no admin/superuser check) — if Cognee could reach an
+ * attacker-controlled host on 443, every tenant's prompts/entities/graph data flowing
+ * through this silo's shared Cognee instance would be exfiltrated the moment anyone
+ * points that endpoint off-cluster. The rest of the silo (the openclaw agent itself)
+ * legitimately calls out to LLM/MCP/Git providers over HTTPS, so it keeps this grant —
+ * only Cognee's pod is carved out via the `NotIn` match below.
+ *
+ * @param namespace - The silo (ClusterTenant) namespace the policy is created in.
+ * @param clusterTenantName - Parent ClusterTenant name, recorded as a label.
+ * @returns The external-HTTPS egress policy, excluding the bundled Cognee pod.
+ */
+export function _BuildSiloExternalEgressNetworkPolicy(
+  namespace: string,
+  clusterTenantName: string,
+): k8s.V1NetworkPolicy
+{
+  return {
+    apiVersion: "networking.k8s.io/v1",
+    kind: "NetworkPolicy",
+    metadata: {
+      name: `opencrane-${clusterTenantName}-external-egress`,
+      namespace,
+      labels: {
+        "app.kubernetes.io/part-of": "opencrane",
+        "app.kubernetes.io/managed-by": "opencrane-fleet-manager",
+        "app.kubernetes.io/component": "silo-isolation",
+        "opencrane.io/cluster-tenant": clusterTenantName,
+      },
+    },
+    spec: {
+      // Every pod in the namespace EXCEPT Cognee (see the doc comment above for why).
+      podSelector: {
+        matchExpressions: [
+          { key: "app.kubernetes.io/component", operator: "NotIn", values: [_COGNEE_COMPONENT_LABEL] },
+        ],
+      },
+      policyTypes: ["Egress"],
+      egress: [
         {
           ports: [{ protocol: "TCP", port: 443 }],
         },

--- a/apps/clustertenant-operator/src/tenants/operator.ts
+++ b/apps/clustertenant-operator/src/tenants/operator.ts
@@ -12,7 +12,7 @@ import type { TenantDegradedReason } from "./models/tenant-status.interface.js";
 import { __K8sApplyResource, _IsK8sNotFound } from "@opencrane/infra-api";
 import { _RunWatchLoop, K8sWatchEventType } from "@opencrane/infra-api";
 import { OPENCRANE_API_GROUP, OPENCRANE_API_VERSION, TENANT_CRD_PLURAL } from "@opencrane/infra-api";
-import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildService, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc, _ConfigChecksum, _ResolveTenantModelGate } from "./deploy/index.js";
+import { _BuildClusterTenantLimitRange, _BuildClusterTenantNamespace, _BuildClusterTenantResourceQuota, _BuildConfigMap, _BuildDeployment, _BuildGatewayNetworkPolicy, _BuildService, _BuildServiceAccount, _BuildSiloBaselineNetworkPolicy, _BuildSiloExternalEgressNetworkPolicy, _BuildSiloLinkerdIdentityPolicy, _BuildStatePvc, _ConfigChecksum, _ResolveTenantModelGate } from "./deploy/index.js";
 import { TenantCleanup } from "./destroy/tenant-cleanup.js";
 import { LinkerdIdentityClient } from "./internal/linkerd-identity.client.js";
 
@@ -532,9 +532,17 @@ export class TenantOperator
 
     // 1b. Silo baseline NetworkPolicy — flip the namespace to default-deny (S2 /
     //     Phase 1) right after it exists and before any workload lands, so the silo
-    //     edge is closed from the start: only intra-silo + the control-plane plane,
-    //     DNS, and external HTTPS are allowed; no silo→silo path is ever created.
+    //     edge is closed from the start: only intra-silo + the control-plane plane
+    //     and DNS are allowed; no silo→silo path is ever created.
     await __K8sApplyResource(this.networkingApi, _BuildSiloBaselineNetworkPolicy(namespace, clusterTenantName, this.config), this.log);
+
+    // 1b-2. External-HTTPS egress — a SEPARATE policy from the baseline above (see its
+    //       doc comment) so the bundled Cognee pod can be excluded from it. An
+    //       unpatched Cognee vuln (topoteretes/cognee#3084) lets any authenticated
+    //       Cognee user redirect its process-wide LLM endpoint with no admin check;
+    //       without this exclusion Cognee could exfiltrate the silo's data to an
+    //       attacker-controlled host the moment that's exploited.
+    await __K8sApplyResource(this.networkingApi, _BuildSiloExternalEgressNetworkPolicy(namespace, clusterTenantName), this.log);
 
     // 1c. Linkerd identity layer (S5 / ADR 0001) — gated OFF by default. When on, lay
     //     the meshed mTLS-identity analogue of the S2 baseline ON TOP of the L3/4 floor:


### PR DESCRIPTION
## Summary

- Mitigates an unpatched Cognee vulnerability (topoteretes/cognee#3084): `POST /api/v1/settings` has no admin/superuser check, so ANY authenticated Cognee user can overwrite the process-wide LLM/embedding endpoint. Combined with the silo baseline's previously-unrestricted external-HTTPS egress, an exploited pod could exfiltrate the silo's data to an attacker-controlled host.
- `_BuildSiloBaselineNetworkPolicy` (`apps/clustertenant-operator/src/tenants/deploy/silo-baseline-network-policy.ts`) granted every pod in the namespace — DNS, intra-silo/platform, **and unrestricted external HTTPS on 443** — since NetworkPolicy is purely additive, a Cognee-only restrictive policy alone would have been silently overridden by this existing broad grant.
- Split external HTTPS out into a new `_BuildSiloExternalEgressNetworkPolicy`, whose `podSelector` excludes `app.kubernetes.io/component: cognee` via a `NotIn` match expression. The baseline keeps DNS + intra-silo/platform egress unrestricted-by-destination (never leaves the cluster, and Cognee still needs it to reach LiteLLM in-namespace).
- `operator.ts` now applies both policies during silo reconcile (new step "1b-2", right after the existing baseline apply).
- This is a network-layer mitigation only — it does not touch Cognee's own auth model. Per-tenant Cognee logins (keyed to each openclaw tenant's IdP identity) are tracked as separate, deliberately deferred follow-up work.

## Test plan

- [x] `apps/clustertenant-operator` unit tests: full suite green — 92 files / 705 tests (incl. new `describe("Silo external-egress NetworkPolicy (Cognee excluded — topoteretes/cognee#3084)")` block and the updated baseline assertion that 443 is no longer present there)
- [x] `tsc --noEmit` clean
- [x] full monorepo `pnpm build` clean
- [ ] After merge: redeploy elewa and verify (read-only) that the Cognee pod cannot reach an external host on 443 while other silo pods still can