### PR TITLE
sec: provision a real, per-openclaw-tenant Cognee login (never a shared default)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts
@@ -120,6 +120,7 @@ function _makeOperator(core: RecordingClient, apps: RecordingClient, networking:
   const statusWriter = { async patchStatus(_t: unknown, _ns: unknown, status: Record<string, unknown>): Promise<void> { statusSink?.push(status); } } as never;
   const encryptionKeys = { async ensureEncryptionKeySecret(): Promise<void> {} } as never;
   const liteLlmKeys = { async ensureLiteLlmKeySecret(): Promise<void> {} } as never;
+  const cogneeTenantIdentity = { async ensureTenantCogneeIdentity(): Promise<void> {} } as never;
   const cleanup = { async cleanupTenant(): Promise<void> {} } as never;
 
   return new TenantOperator(
@@ -135,6 +136,7 @@ function _makeOperator(core: RecordingClient, apps: RecordingClient, networking:
     statusWriter,
     encryptionKeys,
     liteLlmKeys,
+    cogneeTenantIdentity,
   );
 }
 

--- a/apps/clustertenant-operator/src/__tests__/tenants/cognee-tenant-identity.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cognee-tenant-identity.test.ts
@@ -1,0 +1,246 @@
+import { Buffer } from "node:buffer";
+
+import * as k8s from "@kubernetes/client-node";
+import pino from "pino";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { defaultConfig, _makeTenant } from "../fixtures.js";
+import { CogneeTenantIdentity, _CredentialsSecretName } from "../../tenants/internal/cognee-tenant-identity.js";
+import type { OpenClawTenantOperatorConfig } from "../../config.js";
+
+const _log = pino({ level: "silent" });
+
+/** Config with Cognee wired, the baseline for these tests. */
+const _enabledConfig: OpenClawTenantOperatorConfig = {
+  ...defaultConfig,
+  cogneeEndpoint: "http://cognee:8000",
+};
+
+/** A stable 32-byte encryption key (base64), matching TenantEncryptionKeys's Secret shape. */
+const _ENCRYPTION_KEY_BASE64 = Buffer.from("b".repeat(32)).toString("base64");
+
+/**
+ * Stub CoreV1Api distinguishing the two Secrets this class reads: the tenant's own
+ * cognee-credentials Secret (idempotency check) and its encryption-key Secret (password
+ * derivation input).
+ */
+function _makeCoreApi(opts: { credentialsExist?: boolean; encryptionKeyBase64?: string | null } = {}): k8s.CoreV1Api
+{
+  const { credentialsExist = false, encryptionKeyBase64 = _ENCRYPTION_KEY_BASE64 } = opts;
+  return {
+    readNamespacedSecret: vi.fn().mockImplementation(function _read({ name }: { name: string }): Promise<k8s.V1Secret>
+    {
+      if (name.endsWith("-cognee-credentials"))
+      {
+        if (!credentialsExist)
+        {
+          return Promise.reject(new Error("404 not found"));
+        }
+
+        return Promise.resolve({
+          data: {
+            username: Buffer.from("acme@example.com").toString("base64"),
+            password: Buffer.from("already-set-password").toString("base64"),
+          },
+        } as unknown as k8s.V1Secret);
+      }
+
+      if (name.endsWith("-encryption-key"))
+      {
+        if (encryptionKeyBase64 === null)
+        {
+          // Secret exists but carries no "key" field (distinct from a missing Secret,
+          // which would reject instead — see the "Secret missing" test below).
+          return Promise.resolve({ data: {} } as unknown as k8s.V1Secret);
+        }
+
+        return Promise.resolve({ data: { key: encryptionKeyBase64 } } as unknown as k8s.V1Secret);
+      }
+
+      return Promise.reject(new Error(`unexpected secret name: ${name}`));
+    }),
+  } as unknown as k8s.CoreV1Api;
+}
+
+/** Stub KubernetesObjectApi recording server-side applies without a cluster. */
+function _makeObjectApi(): k8s.KubernetesObjectApi
+{
+  return {
+    read: vi.fn().mockRejectedValue(new Error("not found")),
+    patch: vi.fn().mockResolvedValue({ body: {} }),
+    create: vi.fn().mockResolvedValue({ body: {} }),
+  } as unknown as k8s.KubernetesObjectApi;
+}
+
+describe("CogneeTenantIdentity", () =>
+{
+  beforeEach(() =>
+  {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() =>
+  {
+    vi.unstubAllGlobals();
+  });
+
+  it("is a no-op when Cognee is not configured for this silo", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const coreApi = _makeCoreApi();
+
+    const identity = new CogneeTenantIdentity(defaultConfig, coreApi, _makeObjectApi(), _log);
+    await identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(coreApi.readNamespacedSecret as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the tenant's cognee-credentials Secret already exists (never rotated)", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const objectApi = _makeObjectApi();
+
+    const identity = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi({ credentialsExist: true }), objectApi, _log);
+    await identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(objectApi.create as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("registers the tenant's owner email and writes a Secret readable by _CredentialsSecretName", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const objectApi = _makeObjectApi();
+
+    const identity = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi(), objectApi, _log);
+    await identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "opencrane-elewa");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://cognee:8000/api/v1/auth/register");
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body["email"]).toBe("acme@example.com");
+    expect(typeof body["password"]).toBe("string");
+    expect((body["password"] as string).length).toBeGreaterThan(0);
+    // Only email/password — Cognee's register endpoint schema is not assumed to accept
+    // client-supplied is_active/is_superuser/is_verified fields.
+    expect(Object.keys(body).sort()).toEqual(["email", "password"]);
+
+    expect(objectApi.create as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    const created = (objectApi.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as k8s.V1Secret;
+    expect(created.metadata?.name).toBe(_CredentialsSecretName("acme"));
+    expect(created.metadata?.namespace).toBe("opencrane-elewa");
+    expect(Buffer.from(created.data!["username"], "base64").toString("utf8")).toBe("acme@example.com");
+    expect(Buffer.from(created.data!["password"], "base64").toString("utf8")).toBe(body["password"]);
+  });
+
+  it("derives the SAME password on repeated calls given the same tenant encryption key (crash-safe retry)", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const identity1 = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi(), _makeObjectApi(), _log);
+    await identity1.ensureTenantCogneeIdentity(_makeTenant("acme"), "default");
+    const password1 = (JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>)["password"];
+
+    fetchMock.mockClear();
+    const identity2 = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi(), _makeObjectApi(), _log);
+    await identity2.ensureTenantCogneeIdentity(_makeTenant("acme"), "default");
+    const password2 = (JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>)["password"];
+
+    expect(password1).toBe(password2);
+  });
+
+  it("derives a DIFFERENT password for a different tenant (distinct encryption keys)", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const otherKeyBase64 = Buffer.from("c".repeat(32)).toString("base64");
+    const identity1 = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi(), _makeObjectApi(), _log);
+    await identity1.ensureTenantCogneeIdentity(_makeTenant("acme"), "default");
+    const password1 = (JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>)["password"];
+
+    fetchMock.mockClear();
+    const identity2 = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi({ encryptionKeyBase64: otherKeyBase64 }), _makeObjectApi(), _log);
+    await identity2.ensureTenantCogneeIdentity(_makeTenant("bcorp"), "default");
+    const password2 = (JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>)["password"];
+
+    expect(password1).not.toBe(password2);
+  });
+
+  it("treats a 400 register response as already-registered and still writes the Secret", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("REGISTER_USER_ALREADY_EXISTS", { status: 400 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const objectApi = _makeObjectApi();
+
+    const identity = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi(), objectApi, _log);
+    await expect(identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "default")).resolves.toBeUndefined();
+
+    expect(objectApi.create as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when registration fails with an unexpected status (not 2xx/400)", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const objectApi = _makeObjectApi();
+
+    const identity = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi(), objectApi, _log);
+    await expect(identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "default")).rejects.toThrow(/Cognee user registration failed/);
+
+    expect(objectApi.create as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("throws a clear error when the tenant's encryption key Secret has no key field", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const identity = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi({ encryptionKeyBase64: null }), _makeObjectApi(), _log);
+    await expect(identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "default")).rejects.toThrow(/encryption-key/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates the raw error when the tenant's encryption key Secret does not exist at all", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const coreApi = {
+      readNamespacedSecret: vi.fn().mockImplementation(function _read({ name }: { name: string }): Promise<k8s.V1Secret>
+      {
+        if (name.endsWith("-cognee-credentials"))
+        {
+          return Promise.reject(new Error("404 not found"));
+        }
+
+        // encryption-key Secret genuinely missing (e.g. reconciled out of order).
+        return Promise.reject(new Error("secrets \"openclaw-acme-encryption-key\" not found"));
+      }),
+    } as unknown as k8s.CoreV1Api;
+
+    const identity = new CogneeTenantIdentity(_enabledConfig, coreApi, _makeObjectApi(), _log);
+    await expect(identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "default")).rejects.toThrow(/encryption-key.*not found/);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("lowercases/trims the owner email before registering", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const tenant = _makeTenant("acme", { email: "  Acme.Owner@Example.com  " });
+    const identity = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi(), _makeObjectApi(), _log);
+    await identity.ensureTenantCogneeIdentity(tenant, "default");
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string) as Record<string, unknown>;
+    expect(body["email"]).toBe("acme.owner@example.com");
+  });
+});

--- a/apps/clustertenant-operator/src/__tests__/tenants/model-gate.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/model-gate.test.ts
@@ -151,13 +151,14 @@ function _buildHarness(options: { existingConfigMap?: k8s.V1ConfigMap | null })
 
   const encryptionKeys = { ensureEncryptionKeySecret: vi.fn(async () => {}) } as unknown as import("../../tenants/internal/tenant-encryption-keys.js").TenantEncryptionKeys;
   const liteLlmKeys = { ensureLiteLlmKeySecret: vi.fn(async () => {}) } as unknown as import("../../tenants/internal/tenant-litellm-keys.js").TenantLiteLlmKeys;
+  const cogneeTenantIdentity = { ensureTenantCogneeIdentity: vi.fn(async () => {}) } as unknown as import("../../tenants/internal/cognee-tenant-identity.js").CogneeTenantIdentity;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const stub = {} as any;
   const config = { ...defaultConfig, liteLlmEnabled: true };
   const op = new TenantOperator(
     stub, customApi, coreApi, appsApi, networkingApi, _log, config,
-    onPremAdapter, stub, statusWriter, encryptionKeys, liteLlmKeys,
+    onPremAdapter, stub, statusWriter, encryptionKeys, liteLlmKeys, cogneeTenantIdentity,
   );
 
   return { op, coreApi, appsApi, statusPatches, applied };

--- a/apps/clustertenant-operator/src/__tests__/tenants/operator.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/operator.test.ts
@@ -102,7 +102,7 @@ describe("TenantOperator reconcile guard + coalescing", () =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const stub = {} as any;
     const op = new TenantOperator(stub, stub, stub, stub, stub, pino({ level: "silent" }),
-      defaultConfig, stub, stub, statusWriter, stub, stub);
+      defaultConfig, stub, stub, statusWriter, stub, stub, stub);
     return { op, patch };
   }
 
@@ -195,7 +195,7 @@ describe("TenantOperator suspend self-loop guard", () =>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const appsApi = driveBody ? ({ createNamespacedDeployment: async () => ({}) } as any) : stub;
     const op = new TenantOperator(stub, stub, stub, appsApi, stub, pino({ level: "silent" }),
-      defaultConfig, hosting, stub, statusWriter, stub, stub);
+      defaultConfig, hosting, stub, statusWriter, stub, stub, stub);
     return { op, patch };
   }
 

--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -323,6 +323,28 @@ describe("TenantResourceBuilder", () =>
     expect(wiredEnv.OPENCRANE_MEMORY_BACKEND).toBe("cognee");
   });
 
+  it("wires COGNEE_USERNAME/COGNEE_PASSWORD from the tenant's own cognee-credentials Secret (never a shared default)", () =>
+  {
+    const cogneeConfig = { ...defaultConfig, cogneeEndpoint: "http://cognee:8000" };
+    const tenant = _makeTenant("cognee-identity");
+    const stateVolume = onPremAdapter.buildStateVolume("cognee-identity");
+
+    // Unset ⇒ no Cognee login env leaks into the pod.
+    const bare = _BuildDeployment(defaultConfig, stateVolume, tenant, "default");
+    const bareEnvNames = (bare.spec?.template?.spec?.containers?.[0]?.env ?? []).map((e) => e.name);
+    expect(bareEnvNames).not.toContain("COGNEE_USERNAME");
+    expect(bareEnvNames).not.toContain("COGNEE_PASSWORD");
+
+    // Configured ⇒ both env vars are populated from the PER-TENANT credentials Secret
+    // (openclaw-<name>-cognee-credentials), not any shared/silo-wide Secret.
+    const wired = _BuildDeployment(cogneeConfig, stateVolume, tenant, "default");
+    const wiredEnv = wired.spec?.template?.spec?.containers?.[0]?.env ?? [];
+    const username = wiredEnv.find((e) => e.name === "COGNEE_USERNAME");
+    const password = wiredEnv.find((e) => e.name === "COGNEE_PASSWORD");
+    expect(username?.valueFrom?.secretKeyRef).toEqual({ name: "openclaw-cognee-identity-cognee-credentials", key: "username", optional: true });
+    expect(password?.valueFrom?.secretKeyRef).toEqual({ name: "openclaw-cognee-identity-cognee-credentials", key: "password", optional: true });
+  });
+
   it("builds Deployment with PVC volume on-prem", () =>
   {
     const tenant = _makeTenant("local");

--- a/apps/clustertenant-operator/src/tenants/deploy/3-deployment.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/3-deployment.ts
@@ -6,6 +6,7 @@ import type { Tenant } from "../models/tenant.interface.js";
 import type { ClusterTenantComputeView } from "@opencrane/infra-api";
 import { _BuildTenantLabels } from "./tenant-labels.js";
 import { _BuildClusterTenantScheduling } from "./cluster-tenant-scheduling.js";
+import { _CredentialsSecretName } from "../internal/cognee-tenant-identity.js";
 
 /**
  * Build the tenant Deployment that runs a single OpenClaw gateway pod.
@@ -80,6 +81,18 @@ export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolu
       ? [
           { name: "OPENCRANE_MEMORY_BACKEND", value: "cognee" },
           { name: "COGNEE_ENDPOINT", value: config.cogneeEndpoint },
+          // Real, per-tenant Cognee login (see CogneeTenantIdentity) — NOT the plugin's
+          // hardcoded default_user fallback. The plugin's config.js reads these env vars
+          // directly when its rendered config carries no username/password (2-config-map.ts
+          // deliberately omits them — a real password never belongs in a ConfigMap).
+          {
+            name: "COGNEE_USERNAME",
+            valueFrom: { secretKeyRef: { name: _CredentialsSecretName(name), key: "username", optional: true } },
+          },
+          {
+            name: "COGNEE_PASSWORD",
+            valueFrom: { secretKeyRef: { name: _CredentialsSecretName(name), key: "password", optional: true } },
+          },
         ]
       : []),
     ...(tenant.spec.team ? [{ name: "OPENCRANE_TEAM", value: tenant.spec.team }] : []),

--- a/apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts
@@ -1,0 +1,191 @@
+import { Buffer } from "node:buffer";
+import { createHmac } from "node:crypto";
+
+import * as k8s from "@kubernetes/client-node";
+import type { Logger } from "pino";
+
+import type { OpenClawTenantOperatorConfig } from "../../config.js";
+import { __K8sApplyResource } from "@opencrane/infra-api";
+import { _BuildTenantLabels } from "../deploy/tenant-labels.js";
+import type { Tenant } from "../models/tenant.interface.js";
+
+/**
+ * Provisions a REAL, per-openclaw-tenant Cognee user account — the tenant's pod
+ * authenticates to Cognee AS THE TENANT'S OWNER, never as a shared/default identity.
+ *
+ * Why this exists: Cognee's `ENABLE_BACKEND_ACCESS_CONTROL` defaults on, so every request
+ * needs a real user session. Left unconfigured, the official `@cognee/cognee-openclaw`
+ * plugin (verified against the shipped package's `client.js`: `login()`) falls back to
+ * Cognee's hardcoded default account (`default_user@example.com` / `default_password`) —
+ * every tenant in the silo would then share ONE Cognee identity, which both defeats
+ * Cognee's own per-user dataset access control (the actual enforcement the plugin's
+ * multi-scope config in `_BuildConfigMap` relies on) and means a single well-known
+ * credential exposes every tenant's memory (worse given the unpatched
+ * topoteretes/cognee#3084 self-registration bug — see PR #178's egress mitigation).
+ *
+ * This registers the tenant's OWNER EMAIL — the SAME identity the gateway's trusted-proxy
+ * `allowUsers` allowlist already pins the pod to (`_BuildConfigMap`'s `ownerEmail`), i.e.
+ * the actual login the tenant's user authenticates with — as a real Cognee account with a
+ * per-tenant password. `2-config-map.ts` deliberately renders NO `apiKey`/`username`/
+ * `password` into the plugin's config (never put a real password into a ConfigMap); the
+ * plugin falls back to reading `COGNEE_USERNAME`/`COGNEE_PASSWORD` from the pod's own
+ * environment instead (verified in the shipped plugin's `config.js`), which
+ * `_BuildDeployment` populates via `secretKeyRef` from the Secret this class writes. From
+ * there the plugin manages its own JWT login/re-login (verified in `client.js`: it lazily
+ * logs in on first request and transparently re-authenticates on a 401) — the operator
+ * never has to track a token lifecycle.
+ *
+ * The password is NOT freshly `randomBytes`-generated on every reconcile — it is derived
+ * deterministically (HMAC-SHA256) from the tenant's own encryption key (already minted by
+ * `TenantEncryptionKeys` one reconcile step earlier). This makes registration crash-safe:
+ * if the operator dies between the register call and writing this Secret, the next
+ * reconcile derives the IDENTICAL password and retries — Cognee's register endpoint
+ * returns 400 for a duplicate email, treated here as success, so the retry converges on
+ * the correct credential instead of leaving an unrecoverable password mismatch.
+ */
+export class CogneeTenantIdentity
+{
+  private config: OpenClawTenantOperatorConfig;
+  private coreApi: k8s.CoreV1Api;
+  private objectApi: k8s.KubernetesObjectApi;
+  private log: Logger;
+
+  constructor(
+    config: OpenClawTenantOperatorConfig,
+    coreApi: k8s.CoreV1Api,
+    objectApi: k8s.KubernetesObjectApi,
+    log: Logger,
+  )
+  {
+    this.config = config;
+    this.coreApi = coreApi;
+    this.objectApi = objectApi;
+    this.log = log;
+  }
+
+  /**
+   * Ensure the tenant has a real, dedicated Cognee login. No-ops when Cognee is not
+   * configured for this silo, or when the tenant's credentials Secret already exists —
+   * the login is minted once and never rotated (mirrors `TenantEncryptionKeys`).
+   *
+   * @param tenant - The Tenant CR being reconciled. Requires its encryption key Secret
+   *        (`openclaw-<name>-encryption-key`) to already exist — call after
+   *        `TenantEncryptionKeys.ensureEncryptionKeySecret` in the same reconcile pass.
+   * @param namespace - Namespace the credentials Secret is written to.
+   */
+  async ensureTenantCogneeIdentity(tenant: Tenant, namespace: string): Promise<void>
+  {
+    if (!this.config.cogneeEndpoint)
+    {
+      return;
+    }
+
+    const name = tenant.metadata!.name!;
+    const secretName = _CredentialsSecretName(name);
+
+    // 1. Idempotency check — a tenant's Cognee login, once minted, is never rotated.
+    try
+    {
+      await this.coreApi.readNamespacedSecret({ name: secretName, namespace });
+      this.log.debug({ name, secretName }, "cognee tenant identity already exists");
+      return;
+    }
+    catch
+    {
+      // Secret does not exist — continue to registration.
+    }
+
+    // 2. Derive the login. Email is the SAME identity the gateway's trusted-proxy
+    //    allowlist already pins the pod to (`_BuildConfigMap`'s `ownerEmail`) — "the user
+    //    login" the tenant's owner actually authenticates with. `subject` (an opaque OIDC
+    //    `sub`) is deliberately NOT used here: Cognee validates `email` as a real email
+    //    address and would reject a non-email subject string.
+    const email = tenant.spec.email.trim().toLowerCase();
+    const password = await this._deriveTenantPassword(name, namespace, email);
+
+    // 3. Register with Cognee. A 400 almost always means the email is already registered
+    //    (e.g. a prior reconcile crashed before step 4 wrote the Secret) — since the
+    //    password is derived deterministically, retrying with the identical password
+    //    converges correctly either way, so both outcomes proceed to step 4.
+    await this._registerCogneeUser(email, password, name);
+
+    // 4. Persist the login as a per-tenant Secret. `_BuildDeployment` mounts `username`/
+    //    `password` as COGNEE_USERNAME/COGNEE_PASSWORD env vars (secretKeyRef); the plugin
+    //    reads those directly since `2-config-map.ts` renders no username/password/apiKey.
+    const secret: k8s.V1Secret = {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: secretName,
+        namespace,
+        labels: _BuildTenantLabels(name),
+      },
+      type: "Opaque",
+      data: {
+        username: Buffer.from(email).toString("base64"),
+        password: Buffer.from(password).toString("base64"),
+      },
+    };
+
+    await __K8sApplyResource(this.objectApi, secret, this.log);
+    this.log.info({ name, secretName, email }, "created cognee tenant identity");
+  }
+
+  /**
+   * Register `email`/`password` as a Cognee user. Idempotent: a 400 response (Cognee's
+   * signal for "email already registered", verified against the shipped `test_backend_auth.py`:
+   * `assert register_response.status_code in (201, 400)`) is treated as success since the
+   * password is derived deterministically and will match whatever was registered previously.
+   */
+  private async _registerCogneeUser(email: string, password: string, tenantName: string): Promise<void>
+  {
+    const response = await fetch(`${this.config.cogneeEndpoint}/api/v1/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (response.ok)
+    {
+      return;
+    }
+
+    if (response.status === 400)
+    {
+      const body = await response.text();
+      this.log.info({ tenantName, email, body }, "cognee user already registered; adopting existing account");
+      return;
+    }
+
+    const body = await response.text();
+    throw new Error(`Cognee user registration failed for ${tenantName} (${response.status}): ${body}`);
+  }
+
+  /**
+   * Derive a stable per-tenant Cognee password from the tenant's own encryption key
+   * (already minted by `TenantEncryptionKeys` earlier in the same reconcile pass), so a
+   * retry after a partial failure (see class doc comment) always reproduces the same value.
+   */
+  private async _deriveTenantPassword(tenantName: string, namespace: string, email: string): Promise<string>
+  {
+    const encryptionKeySecretName = `openclaw-${tenantName}-encryption-key`;
+    const encryptionKeySecret = await this.coreApi.readNamespacedSecret({ name: encryptionKeySecretName, namespace });
+    const encoded = encryptionKeySecret.data?.["key"];
+    if (!encoded)
+    {
+      throw new Error(`${encryptionKeySecretName} Secret has no "key" field — cannot derive a stable cognee password`);
+    }
+
+    const keyBytes = Buffer.from(encoded, "base64");
+    return createHmac("sha256", keyBytes).update(`cognee-tenant-identity-v1:${email}`).digest("base64url");
+  }
+}
+
+/**
+ * The per-tenant Secret name carrying this tenant's Cognee login (`username`/`password`
+ * fields), consumed by `_BuildDeployment` (COGNEE_USERNAME/COGNEE_PASSWORD env vars).
+ */
+export function _CredentialsSecretName(tenantName: string): string
+{
+  return `openclaw-${tenantName}-cognee-credentials`;
+}

--- a/apps/clustertenant-operator/src/tenants/operator.ts
+++ b/apps/clustertenant-operator/src/tenants/operator.ts
@@ -18,6 +18,7 @@ import { LinkerdIdentityClient } from "./internal/linkerd-identity.client.js";
 
 import { TenantEncryptionKeys } from "./internal/tenant-encryption-keys.js";
 import { TenantLiteLlmKeys } from "./internal/tenant-litellm-keys.js";
+import { CogneeTenantIdentity } from "./internal/cognee-tenant-identity.js";
 import { _ResolveTenantPolicy } from "./internal/policy-resolution.js";
 import { _FetchTenantModels } from "./internal/tenant-models.js";
 import { _ResolveClusterTenant } from "./internal/cluster-tenant-resolution.js";
@@ -71,6 +72,9 @@ export class TenantOperator
   /** Helper for LiteLLM virtual key provisioning and Secret creation. */
   private liteLlmKeys: TenantLiteLlmKeys;
 
+  /** Helper for provisioning a real, per-tenant Cognee login (never a shared default). */
+  private cogneeTenantIdentity: CogneeTenantIdentity;
+
   /**
    * Per-tenant reconcile coalescing. The watch runner dispatches handlers fire-and-forget,
    * so a watch reconnect replays every Tenant as `ADDED` at once, and a persistently failing
@@ -111,7 +115,8 @@ export class TenantOperator
               cleanup: TenantCleanup,
               statusWriter: TenantStatusWriter,
               encryptionKeys: TenantEncryptionKeys,
-              liteLlmKeys: TenantLiteLlmKeys)
+              liteLlmKeys: TenantLiteLlmKeys,
+              cogneeTenantIdentity: CogneeTenantIdentity)
   {
     this.watch = watch;
     this.customApi = customApi;
@@ -125,6 +130,7 @@ export class TenantOperator
     this.statusWriter = statusWriter;
     this.encryptionKeys = encryptionKeys;
     this.liteLlmKeys = liteLlmKeys;
+    this.cogneeTenantIdentity = cogneeTenantIdentity;
     this.configChecksum = _OperatorConfigChecksum(config);
   }
 
@@ -355,7 +361,22 @@ export class TenantOperator
         this.log.warn({ err, name }, "litellm key provisioning failed; continuing reconcile");
       }
 
-      // 5. ConfigMap — serialises the base OpenClaw JSON config merged with any
+      // 5. Cognee tenant identity — registers a REAL Cognee user account for this tenant
+      //    (the same owner email the gateway's trusted-proxy allowlist already pins the pod
+      //    to), so the pod authenticates to Cognee as ITSELF rather than the plugin's
+      //    hardcoded default_user fallback. Best-effort so a Cognee outage does not block
+      //    tenant startup (memory is a dependency, not a hard requirement). Skipped when
+      //    Cognee is not configured for this silo.
+      try
+      {
+        await this.cogneeTenantIdentity.ensureTenantCogneeIdentity(effectiveTenant, namespace);
+      }
+      catch (err)
+      {
+        this.log.warn({ err, name }, "cognee tenant identity provisioning failed; continuing reconcile");
+      }
+
+      // 6. ConfigMap — serialises the base OpenClaw JSON config merged with any
       //    spec.configOverrides the tenant author provided. Capture it so its
       //    checksum can roll the pod when the config changes (step 7).
       //
@@ -398,7 +419,7 @@ export class TenantOperator
         configChecksum = _ConfigChecksum(configMap);
       }
 
-      // 6. State volume — adapter decides CSI mount (cloud) vs PVC (on-prem).
+      // 7. State volume — adapter decides CSI mount (cloud) vs PVC (on-prem).
       //    Create the PVC only when the adapter requests it (on-prem path).
       const stateVolume = this.hosting.buildStateVolume(name);
       if (stateVolume.requiresPvc)
@@ -406,15 +427,15 @@ export class TenantOperator
         await __K8sApplyResource(this.coreApi, _BuildStatePvc(name, namespace, this.config.tenantStorageClassName), this.log);
       }
 
-      // 7. Deployment — single-replica pod running the tenant's OpenClaw gateway.
+      // 8. Deployment — single-replica pod running the tenant's OpenClaw gateway.
       //    Mounts the ConfigMap, encryption key, state volume, and projected identity tokens.
       await __K8sApplyResource(this.appsApi, _BuildDeployment(this.config, stateVolume, effectiveTenant, namespace, compute, configChecksum), this.log);
 
-      // 8. Service — ClusterIP that makes the gateway reachable inside the cluster
+      // 9. Service — ClusterIP that makes the gateway reachable inside the cluster
       //    on the configured gateway port.
       await __K8sApplyResource(this.coreApi, _BuildService(this.config, effectiveTenant, namespace), this.log);
 
-      // 9. NetworkPolicy — lock the gateway port to the identity-routing proxy (now folded
+      // 10. NetworkPolicy — lock the gateway port to the identity-routing proxy (now folded
       //    into the operator) so the trusted-proxy auth (CONN.4) can't be abused by other
       //    in-cluster pods. No per-user Ingress is minted: every user reaches their pod
       //    through the org's single host `<org>.<base>`, reverse-proxied by the operator to
@@ -422,7 +443,7 @@ export class TenantOperator
       //    cert and gets an explicit external-dns record (see the org-domain provisioner).
       await __K8sApplyResource(this.networkingApi, _BuildGatewayNetworkPolicy(this.config, effectiveTenant, namespace), this.log);
 
-      // 10. Status — write the observed state back to the Tenant CR so that kubectl, the
+      // 11. Status — write the observed state back to the Tenant CR so that kubectl, the
       //    control-plane API, and the UI all see the current phase. When the model gate
       //    skipped the ConfigMap refresh the pod is still serving on its last-applied
       //    (good) config, so the phase is Degraded (not Error) with the reason recorded;
@@ -682,6 +703,7 @@ export function _CreateTenantOperator(kc: k8s.KubeConfig, config: OpenClawTenant
   const statusWriter = new TenantStatusWriter(customApi, log);
   const encryptionKeys = new TenantEncryptionKeys(coreApi, objectApi, log);
   const liteLlmKeys = new TenantLiteLlmKeys(config, coreApi, objectApi, log);
+  const cogneeTenantIdentity = new CogneeTenantIdentity(config, coreApi, objectApi, log);
 
-  return new TenantOperator(watch, customApi, coreApi, appsApi, networkingApi, log, config, hosting, cleanup, statusWriter, encryptionKeys, liteLlmKeys);
+  return new TenantOperator(watch, customApi, coreApi, appsApi, networkingApi, log, config, hosting, cleanup, statusWriter, encryptionKeys, liteLlmKeys, cogneeTenantIdentity);
 }


### PR DESCRIPTION
## Summary

- Fixes the root cause behind Cognee's 401 "Unauthorized" errors and closes a real tenant-isolation gap: with `ENABLE_BACKEND_ACCESS_CONTROL` on (Cognee's default), the official `@cognee/cognee-openclaw` plugin was never given any credential, so it silently fell back to Cognee's hardcoded `default_user@example.com`/`default_password` account — verified against the shipped plugin's `client.js`/`config.js`. Every openclaw tenant in a silo was authenticating as the SAME Cognee identity.
- That defeats Cognee's own per-user dataset access control (the actual enforcement the plugin's multi-scope `company`/`user`/`agent` dataset config in `2-config-map.ts` relies on), and means one well-known credential exposes every tenant's memory — worse given the unpatched `topoteretes/cognee#3084` self-registration bug that PR #178 already mitigated at the network layer.
- New `CogneeTenantIdentity` (`apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts`), wired into the per-tenant reconcile in `operator.ts` (new step 5): on first reconcile it registers the tenant's **owner email** — the same identity the gateway's trusted-proxy `allowUsers` allowlist already pins the pod to — as a real Cognee user via `POST /api/v1/auth/register`, and writes a per-tenant Secret (`openclaw-<name>-cognee-credentials`).
- `_BuildDeployment` (`3-deployment.ts`) mounts that Secret as `COGNEE_USERNAME`/`COGNEE_PASSWORD` env vars. The plugin reads those directly — `2-config-map.ts` deliberately renders no `apiKey`/`username`/`password` into the ConfigMap (a real password never belongs there) — and manages its own JWT login/re-login from there (verified in the plugin's `client.js`: lazy login on first request, transparent re-auth on a 401). No operator-side token lifecycle is needed.
- The password is derived deterministically (HMAC-SHA256 keyed by the tenant's own encryption key, already minted one reconcile step earlier) rather than freshly random on every attempt, so a crash between the register call and the Secret write is safe to retry: the same password re-derives, Cognee's 400 "already registered" is treated as success, and the retry converges instead of leaving an unrecoverable credential mismatch.

## Test plan

- [x] New `cognee-tenant-identity.test.ts` — 10 tests (no-op when unconfigured/already-provisioned, register + Secret write, deterministic password across retries, distinct passwords per tenant, 400-already-registered treated as success, hard failure on other statuses, missing/malformed encryption-key Secret)
- [x] Updated `3-deployment.ts` Deployment tests — `COGNEE_USERNAME`/`COGNEE_PASSWORD` wired from the per-tenant Secret only when Cognee is configured
- [x] Updated `operator.ts`/`model-gate.test.ts`/`cluster-tenant-isolation.test.ts` call sites for the new constructor dependency
- [x] Full `clustertenant-operator` suite: 93 files / 716 tests green
- [x] `tsc --noEmit` clean
- [x] Full monorepo `pnpm build` clean
- [ ] After merge: redeploy elewa and verify a real turn produces a successful Cognee embed/recall with no auth errors (the final end-to-end check for the whole org-memory chain)