### PR TITLE
sec: join per-tenant Cognee logins to a shared silo Cognee Tenant

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cluster-tenant-isolation.test.ts
@@ -120,7 +120,10 @@ function _makeOperator(core: RecordingClient, apps: RecordingClient, networking:
   const statusWriter = { async patchStatus(_t: unknown, _ns: unknown, status: Record<string, unknown>): Promise<void> { statusSink?.push(status); } } as never;
   const encryptionKeys = { async ensureEncryptionKeySecret(): Promise<void> {} } as never;
   const liteLlmKeys = { async ensureLiteLlmKeySecret(): Promise<void> {} } as never;
-  const cogneeTenantIdentity = { async ensureTenantCogneeIdentity(): Promise<void> {} } as never;
+  const cogneeTenantIdentity = {
+    async ensureTenantCogneeIdentity(): Promise<void> {},
+    async ensureTenantJoinedToSiloTenant(): Promise<void> {},
+  } as never;
   const cleanup = { async cleanupTenant(): Promise<void> {} } as never;
 
   return new TenantOperator(

--- a/apps/clustertenant-operator/src/__tests__/tenants/cognee-silo-tenant.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cognee-silo-tenant.test.ts
@@ -1,0 +1,269 @@
+import { Buffer } from "node:buffer";
+
+import * as k8s from "@kubernetes/client-node";
+import pino from "pino";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import { defaultConfig } from "../fixtures.js";
+import { CogneeSiloTenant, COGNEE_SILO_OWNER_SECRET_NAME } from "../../tenants/internal/cognee-silo-tenant.js";
+import type { OpenClawTenantOperatorConfig } from "../../config.js";
+
+const _log = pino({ level: "silent" });
+
+const _enabledConfig: OpenClawTenantOperatorConfig = {
+  ...defaultConfig,
+  cogneeEndpoint: "http://cognee:8000",
+};
+
+/**
+ * A tiny in-memory Secret store shared by a coreApi/objectApi pair, so a test can observe
+ * the two-phase write (durable password persisted BEFORE the register/login/create calls)
+ * exactly as the real cluster would: a write via objectApi.create is visible to a
+ * subsequent coreApi.readNamespacedSecret in the SAME test.
+ */
+function _makeApis(): { coreApi: k8s.CoreV1Api; objectApi: k8s.KubernetesObjectApi; store: Map<string, k8s.V1Secret> }
+{
+  const store = new Map<string, k8s.V1Secret>();
+
+  const coreApi = {
+    readNamespacedSecret: vi.fn().mockImplementation(function _read({ name, namespace }: { name: string; namespace: string }): Promise<k8s.V1Secret>
+    {
+      const secret = store.get(`${namespace}/${name}`);
+      return secret ? Promise.resolve(secret) : Promise.reject(new Error("404 not found"));
+    }),
+  } as unknown as k8s.CoreV1Api;
+
+  const objectApi = {
+    read: vi.fn().mockImplementation(function _read(resource: k8s.KubernetesObject): Promise<{ body: k8s.V1Secret }>
+    {
+      const secret = store.get(`${resource.metadata!.namespace}/${resource.metadata!.name}`);
+      return secret ? Promise.resolve({ body: secret }) : Promise.reject(new Error("not found"));
+    }),
+    create: vi.fn().mockImplementation(function _create(resource: k8s.V1Secret): Promise<{ body: k8s.V1Secret }>
+    {
+      store.set(`${resource.metadata!.namespace}/${resource.metadata!.name}`, resource);
+      return Promise.resolve({ body: resource });
+    }),
+    patch: vi.fn().mockImplementation(function _patch(resource: k8s.V1Secret): Promise<{ body: k8s.V1Secret }>
+    {
+      store.set(`${resource.metadata!.namespace}/${resource.metadata!.name}`, resource);
+      return Promise.resolve({ body: resource });
+    }),
+  } as unknown as k8s.KubernetesObjectApi;
+
+  return { coreApi, objectApi, store };
+}
+
+/** Decode a stored Secret's field back to a plain string. */
+function _field(secret: k8s.V1Secret, key: string): string
+{
+  return Buffer.from(secret.data![key]!, "base64").toString("utf8");
+}
+
+describe("CogneeSiloTenant", () =>
+{
+  beforeEach(() =>
+  {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() =>
+  {
+    vi.unstubAllGlobals();
+  });
+
+  it("is a no-op when Cognee is not configured for this silo", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi } = _makeApis();
+
+    await new CogneeSiloTenant(defaultConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("persists the owner credential BEFORE any external call (durable phase 1), then registers/logs in/creates the tenant", async () =>
+  {
+    let secretAtRegisterTime: k8s.V1Secret | undefined;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/auth/register"))
+      {
+        // The credential must already be durably persisted by the time we register.
+        secretAtRegisterTime = store.get("opencrane-elewa/cognee-silo-owner");
+        return new Response("{}", { status: 201 });
+      }
+      if (url.endsWith("/auth/login"))
+      {
+        return new Response(JSON.stringify({ access_token: "jwt-owner" }), { status: 200 });
+      }
+      if (url.endsWith("/api/v1/permissions/tenants/me"))
+      {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (url.includes("/api/v1/permissions/tenants?tenant_name="))
+      {
+        return new Response(JSON.stringify({ tenant_id: "tenant-123" }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeApis();
+
+    await new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("elewa", "opencrane-elewa");
+
+    expect(secretAtRegisterTime).toBeDefined();
+    expect(_field(secretAtRegisterTime!, "username")).toBe("silo-owner@opencrane.internal");
+    expect(_field(secretAtRegisterTime!, "password").length).toBeGreaterThan(0);
+    expect(_field(secretAtRegisterTime!, "tenantId")).toBe("");
+
+    const final = store.get("opencrane-elewa/cognee-silo-owner")!;
+    expect(_field(final, "tenantId")).toBe("tenant-123");
+  });
+
+  it("is fully idempotent when a tenantId was already resolved (no fetch calls at all)", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeApis();
+    store.set("default/cognee-silo-owner", {
+      metadata: { name: COGNEE_SILO_OWNER_SECRET_NAME, namespace: "default" },
+      data: {
+        username: Buffer.from("silo-owner@opencrane.internal").toString("base64"),
+        password: Buffer.from("existing-pass").toString("base64"),
+        tenantId: Buffer.from("tenant-already-resolved").toString("base64"),
+      },
+    } as unknown as k8s.V1Secret);
+
+    await new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("resumes phase 2 with the SAME persisted password after a simulated crash (tenantId empty but credential exists)", async () =>
+  {
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) =>
+    {
+      if (url.endsWith("/auth/register"))
+      {
+        const body = JSON.parse(init!.body as string) as Record<string, string>;
+        expect(body.password).toBe("already-persisted-password");
+        return new Response("{}", { status: 201 });
+      }
+      if (url.endsWith("/auth/login"))
+      {
+        return new Response(JSON.stringify({ access_token: "jwt-owner" }), { status: 200 });
+      }
+      if (url.endsWith("/api/v1/permissions/tenants/me"))
+      {
+        return new Response(JSON.stringify([]), { status: 200 });
+      }
+      if (url.includes("/api/v1/permissions/tenants?tenant_name="))
+      {
+        return new Response(JSON.stringify({ tenant_id: "tenant-456" }), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeApis();
+    store.set("default/cognee-silo-owner", {
+      metadata: { name: COGNEE_SILO_OWNER_SECRET_NAME, namespace: "default" },
+      data: {
+        username: Buffer.from("silo-owner@opencrane.internal").toString("base64"),
+        password: Buffer.from("already-persisted-password").toString("base64"),
+        tenantId: Buffer.from("").toString("base64"),
+      },
+    } as unknown as k8s.V1Secret);
+
+    await new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default");
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(_field(store.get("default/cognee-silo-owner")!, "tenantId")).toBe("tenant-456");
+  });
+
+  it("reuses an existing Cognee Tenant found via tenants/me instead of creating a new one", async () =>
+  {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/auth/register")) return new Response("{}", { status: 201 });
+      if (url.endsWith("/auth/login")) return new Response(JSON.stringify({ access_token: "jwt-owner" }), { status: 200 });
+      if (url.endsWith("/api/v1/permissions/tenants/me"))
+      {
+        return new Response(JSON.stringify([{ id: "existing-tenant-id", name: "acme" }]), { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url} (should not create — tenants/me already returned one)`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeApis();
+
+    await new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default");
+
+    expect(_field(store.get("default/cognee-silo-owner")!, "tenantId")).toBe("existing-tenant-id");
+  });
+
+  it("treats a 400 on register as already-registered and proceeds", async () =>
+  {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/auth/register")) return new Response("already exists", { status: 400 });
+      if (url.endsWith("/auth/login")) return new Response(JSON.stringify({ access_token: "jwt-owner" }), { status: 200 });
+      if (url.endsWith("/api/v1/permissions/tenants/me")) return new Response(JSON.stringify([{ id: "t1", name: "acme" }]), { status: 200 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeApis();
+
+    await expect(new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default")).resolves.toBeUndefined();
+    expect(_field(store.get("default/cognee-silo-owner")!, "tenantId")).toBe("t1");
+  });
+
+  it("retries tenants/me once after a 409 on create (lost a race) instead of failing", async () =>
+  {
+    let mineCallCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/auth/register")) return new Response("{}", { status: 201 });
+      if (url.endsWith("/auth/login")) return new Response(JSON.stringify({ access_token: "jwt-owner" }), { status: 200 });
+      if (url.endsWith("/api/v1/permissions/tenants/me"))
+      {
+        mineCallCount += 1;
+        // First check: empty (about to create). Second check (after the 409): resolved.
+        return new Response(JSON.stringify(mineCallCount === 1 ? [] : [{ id: "t-race", name: "acme" }]), { status: 200 });
+      }
+      if (url.includes("/api/v1/permissions/tenants?tenant_name=")) return new Response("conflict", { status: 409 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeApis();
+
+    await new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default");
+
+    expect(mineCallCount).toBe(2);
+    expect(_field(store.get("default/cognee-silo-owner")!, "tenantId")).toBe("t-race");
+  });
+
+  it("throws when registration fails with an unexpected status", async () =>
+  {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi } = _makeApis();
+
+    await expect(new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default"))
+      .rejects.toThrow(/Cognee silo-owner registration failed/);
+  });
+
+  it("throws when login fails", async () =>
+  {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/auth/register")) return new Response("{}", { status: 201 });
+      return new Response("bad credentials", { status: 400 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi } = _makeApis();
+
+    await expect(new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default"))
+      .rejects.toThrow(/Cognee silo-owner login failed/);
+  });
+});

--- a/apps/clustertenant-operator/src/__tests__/tenants/cognee-tenant-identity.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cognee-tenant-identity.test.ts
@@ -244,3 +244,217 @@ describe("CogneeTenantIdentity", () =>
     expect(body["email"]).toBe("acme.owner@example.com");
   });
 });
+
+/** Decode a stored Secret's field back to a plain string. */
+function _field(secret: k8s.V1Secret, key: string): string
+{
+  return Buffer.from(secret.data![key]!, "base64").toString("utf8");
+}
+
+/**
+ * A tiny in-memory Secret store shared by a coreApi/objectApi pair, mirroring
+ * cognee-silo-tenant.test.ts's helper — needed here because `ensureTenantJoinedToSiloTenant`
+ * reads BOTH this tenant's credentials Secret and the silo owner's Secret, and a test needs
+ * to observe the write that lands afterward.
+ */
+function _makeStatefulApis(): { coreApi: k8s.CoreV1Api; objectApi: k8s.KubernetesObjectApi; store: Map<string, k8s.V1Secret> }
+{
+  const store = new Map<string, k8s.V1Secret>();
+
+  const coreApi = {
+    readNamespacedSecret: vi.fn().mockImplementation(function _read({ name, namespace }: { name: string; namespace: string }): Promise<k8s.V1Secret>
+    {
+      const secret = store.get(`${namespace}/${name}`);
+      return secret ? Promise.resolve(secret) : Promise.reject(new Error("404 not found"));
+    }),
+  } as unknown as k8s.CoreV1Api;
+
+  const objectApi = {
+    read: vi.fn().mockImplementation(function _read(resource: k8s.KubernetesObject): Promise<{ body: k8s.V1Secret }>
+    {
+      const secret = store.get(`${resource.metadata!.namespace}/${resource.metadata!.name}`);
+      return secret ? Promise.resolve({ body: secret }) : Promise.reject(new Error("not found"));
+    }),
+    create: vi.fn().mockImplementation(function _create(resource: k8s.V1Secret): Promise<{ body: k8s.V1Secret }>
+    {
+      store.set(`${resource.metadata!.namespace}/${resource.metadata!.name}`, resource);
+      return Promise.resolve({ body: resource });
+    }),
+    patch: vi.fn().mockImplementation(function _patch(resource: k8s.V1Secret): Promise<{ body: k8s.V1Secret }>
+    {
+      store.set(`${resource.metadata!.namespace}/${resource.metadata!.name}`, resource);
+      return Promise.resolve({ body: resource });
+    }),
+  } as unknown as k8s.KubernetesObjectApi;
+
+  return { coreApi, objectApi, store };
+}
+
+function _seedCredentials(store: Map<string, k8s.V1Secret>, namespace: string, tenantName: string, opts: { username: string; password: string; tenantId?: string }): void
+{
+  store.set(`${namespace}/${_CredentialsSecretName(tenantName)}`, {
+    metadata: { name: _CredentialsSecretName(tenantName), namespace },
+    data: {
+      username: Buffer.from(opts.username).toString("base64"),
+      password: Buffer.from(opts.password).toString("base64"),
+      tenantId: Buffer.from(opts.tenantId ?? "").toString("base64"),
+    },
+  } as unknown as k8s.V1Secret);
+}
+
+function _seedOwner(store: Map<string, k8s.V1Secret>, namespace: string, opts: { username: string; password: string; tenantId?: string }): void
+{
+  store.set(`${namespace}/cognee-silo-owner`, {
+    metadata: { name: "cognee-silo-owner", namespace },
+    data: {
+      username: Buffer.from(opts.username).toString("base64"),
+      password: Buffer.from(opts.password).toString("base64"),
+      tenantId: Buffer.from(opts.tenantId ?? "").toString("base64"),
+    },
+  } as unknown as k8s.V1Secret);
+}
+
+describe("CogneeTenantIdentity.ensureTenantJoinedToSiloTenant", () =>
+{
+  beforeEach(() =>
+  {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() =>
+  {
+    vi.unstubAllGlobals();
+  });
+
+  it("is a no-op when Cognee is not configured", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi } = _makeStatefulApis();
+
+    await new CogneeTenantIdentity(defaultConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when this tenant has no Cognee credentials yet", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi } = _makeStatefulApis();
+
+    await new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when this tenant is already joined (tenantId already set)", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeStatefulApis();
+    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "pw", tenantId: "already-joined" });
+
+    await new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops (retried later) when the silo owner's Cognee Tenant isn't resolved yet", async () =>
+  {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeStatefulApis();
+    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "pw" });
+    // Owner Secret doesn't exist at all — CogneeSiloTenant hasn't run yet.
+
+    await new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "default");
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("logs in as owner, resolves the user id, joins the tenant, then selects it as the user's active tenant", async () =>
+  {
+    const calls: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string, init?: RequestInit) =>
+    {
+      calls.push(url);
+      if (url.endsWith("/auth/login"))
+      {
+        const body = new URLSearchParams(init!.body as string);
+        const token = body.get("username") === "silo-owner@opencrane.internal" ? "jwt-owner" : "jwt-user";
+        return new Response(JSON.stringify({ access_token: token }), { status: 200 });
+      }
+      if (url.endsWith("/api/v1/users/get-user-id"))
+      {
+        expect(init!.headers).toMatchObject({ Authorization: "Bearer jwt-owner" });
+        return new Response(JSON.stringify({ user_id: "user-uuid-acme" }), { status: 200 });
+      }
+      if (url.includes("/api/v1/permissions/users/user-uuid-acme/tenants"))
+      {
+        expect(url).toContain("tenant_id=tenant-silo-1");
+        expect(init!.headers).toMatchObject({ Authorization: "Bearer jwt-owner" });
+        return new Response("{}", { status: 200 });
+      }
+      if (url.endsWith("/api/v1/permissions/tenants/select"))
+      {
+        expect(init!.headers).toMatchObject({ Authorization: "Bearer jwt-user" });
+        expect(JSON.parse(init!.body as string)).toEqual({ tenant_id: "tenant-silo-1" });
+        return new Response("{}", { status: 200 });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeStatefulApis();
+    _seedCredentials(store, "opencrane-elewa", "acme", { username: "acme@example.com", password: "tenant-pw" });
+    _seedOwner(store, "opencrane-elewa", { username: "silo-owner@opencrane.internal", password: "owner-pw", tenantId: "tenant-silo-1" });
+
+    await new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "opencrane-elewa");
+
+    expect(calls).toEqual([
+      "http://cognee:8000/api/v1/auth/login",
+      "http://cognee:8000/api/v1/users/get-user-id",
+      "http://cognee:8000/api/v1/permissions/users/user-uuid-acme/tenants?tenant_id=tenant-silo-1",
+      "http://cognee:8000/api/v1/auth/login",
+      "http://cognee:8000/api/v1/permissions/tenants/select",
+    ]);
+    expect(_field(store.get("opencrane-elewa/" + _CredentialsSecretName("acme"))!, "tenantId")).toBe("tenant-silo-1");
+  });
+
+  it("tolerates a 409 (already a member) when adding the user to the tenant", async () =>
+  {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/auth/login")) return new Response(JSON.stringify({ access_token: "jwt" }), { status: 200 });
+      if (url.endsWith("/api/v1/users/get-user-id")) return new Response(JSON.stringify({ user_id: "user-uuid" }), { status: 200 });
+      if (url.includes("/tenants?tenant_id=")) return new Response("already a member", { status: 409 });
+      if (url.endsWith("/api/v1/permissions/tenants/select")) return new Response("{}", { status: 200 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeStatefulApis();
+    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "tenant-pw" });
+    _seedOwner(store, "default", { username: "owner@x", password: "owner-pw", tenantId: "tenant-1" });
+
+    await expect(new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "default"))
+      .resolves.toBeUndefined();
+    expect(_field(store.get("default/" + _CredentialsSecretName("acme"))!, "tenantId")).toBe("tenant-1");
+  });
+
+  it("throws when the user-id lookup fails", async () =>
+  {
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/auth/login")) return new Response(JSON.stringify({ access_token: "jwt" }), { status: 200 });
+      if (url.endsWith("/api/v1/users/get-user-id")) return new Response("not found", { status: 404 });
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeStatefulApis();
+    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "tenant-pw" });
+    _seedOwner(store, "default", { username: "owner@x", password: "owner-pw", tenantId: "tenant-1" });
+
+    await expect(new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "default"))
+      .rejects.toThrow(/Cognee get-user-id failed/);
+  });
+});

--- a/apps/clustertenant-operator/src/__tests__/tenants/model-gate.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/model-gate.test.ts
@@ -151,7 +151,10 @@ function _buildHarness(options: { existingConfigMap?: k8s.V1ConfigMap | null })
 
   const encryptionKeys = { ensureEncryptionKeySecret: vi.fn(async () => {}) } as unknown as import("../../tenants/internal/tenant-encryption-keys.js").TenantEncryptionKeys;
   const liteLlmKeys = { ensureLiteLlmKeySecret: vi.fn(async () => {}) } as unknown as import("../../tenants/internal/tenant-litellm-keys.js").TenantLiteLlmKeys;
-  const cogneeTenantIdentity = { ensureTenantCogneeIdentity: vi.fn(async () => {}) } as unknown as import("../../tenants/internal/cognee-tenant-identity.js").CogneeTenantIdentity;
+  const cogneeTenantIdentity = {
+    ensureTenantCogneeIdentity: vi.fn(async () => {}),
+    ensureTenantJoinedToSiloTenant: vi.fn(async () => {}),
+  } as unknown as import("../../tenants/internal/cognee-tenant-identity.js").CogneeTenantIdentity;
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const stub = {} as any;

--- a/apps/clustertenant-operator/src/index.ts
+++ b/apps/clustertenant-operator/src/index.ts
@@ -26,6 +26,7 @@ import { TenantProjectionRepairer } from "./infra/tenant-projection-repairer.js"
 import { MembershipProjectionRepairer, _BuildHttpFleetMembershipReader, _BuildHttpFleetMembershipWriter } from "./infra/membership-projection-repairer.js";
 import { _ResolveOwnClusterTenantName } from "./core/cluster-tenants/resolve-own-cluster-tenant.js";
 import { CogneeLiteLlmKey } from "./tenants/internal/cognee-litellm-key.js";
+import { CogneeSiloTenant } from "./tenants/internal/cognee-silo-tenant.js";
 
 // In-silo controllers (Stage 5). The silo runs every in-silo reconcile loop over its OWN
 // namespace, so a silo stands on its own; the fleet-manager watches only the cluster-scoped
@@ -307,6 +308,21 @@ async function _startInSiloControllers(): Promise<void>
       catch (err)
       {
         log.warn({ err, clusterTenantName }, "cognee litellm key provisioning failed; cognee will run without embedding/LLM credentials until this is retried");
+      }
+
+      // Ensure this silo has ONE Cognee owner account + Cognee Tenant — the grouping every
+      // per-openclaw-tenant Cognee login (CogneeTenantIdentity) joins so the plugin's
+      // companyDataset scope is actually shared silo-wide instead of a private dataset per
+      // tenant (see CogneeSiloTenant's doc comment). Independent try/catch: this has no
+      // dependency on the LiteLLM key above other than running after it in this same IIFE;
+      // a failure here must not affect that key already having been provisioned.
+      try
+      {
+        await new CogneeSiloTenant(config, coreApi, objectApi, log).ensureSiloTenant(clusterTenantName, config.watchNamespace);
+      }
+      catch (err)
+      {
+        log.warn({ err, clusterTenantName }, "cognee silo tenant provisioning failed; per-tenant logins will join it once this is retried");
       }
     })();
 

--- a/apps/clustertenant-operator/src/tenants/internal/cognee-silo-tenant.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-silo-tenant.ts
@@ -1,0 +1,262 @@
+import { Buffer } from "node:buffer";
+import { randomBytes } from "node:crypto";
+
+import * as k8s from "@kubernetes/client-node";
+import type { Logger } from "pino";
+
+import type { OpenClawTenantOperatorConfig } from "../../config.js";
+import { __K8sApplyResource } from "@opencrane/infra-api";
+
+/**
+ * Fixed Secret name carrying the silo's Cognee OWNER login (`username`/`password`) and the
+ * Cognee Tenant it owns (`tenantId`). Fixed, not release-prefixed, for the same reason as
+ * {@link import("./cognee-litellm-key.js").COGNEE_LITELLM_KEY_SECRET_NAME}: there is exactly
+ * one Cognee instance per silo/namespace, so exactly one owner.
+ */
+export const COGNEE_SILO_OWNER_SECRET_NAME = "cognee-silo-owner";
+
+/** Fixed email for the silo's Cognee owner account (each silo's Cognee is a wholly separate server/user-db). */
+const _OWNER_EMAIL = "silo-owner@opencrane.internal";
+
+/** Decoded shape persisted in the {@link COGNEE_SILO_OWNER_SECRET_NAME} Secret. */
+export interface CogneeSiloOwnerState
+{
+  username: string;
+  password: string;
+  /** Empty until the Cognee Tenant has been created/resolved (see {@link CogneeSiloTenant.ensureSiloTenant}). */
+  tenantId: string;
+}
+
+/**
+ * Read the silo owner's Cognee login + resolved Tenant id, or `undefined` when the Secret
+ * doesn't exist yet. Shared with `CogneeTenantIdentity.ensureTenantJoinedToSiloTenant`, which
+ * needs the owner's credentials to add each per-tenant login to the silo's Cognee Tenant.
+ */
+export async function _ReadSiloOwnerState(coreApi: k8s.CoreV1Api, namespace: string): Promise<CogneeSiloOwnerState | undefined>
+{
+  try
+  {
+    const secret = await coreApi.readNamespacedSecret({ name: COGNEE_SILO_OWNER_SECRET_NAME, namespace });
+    const data = secret.data ?? {};
+    const username = data["username"] ? Buffer.from(data["username"], "base64").toString("utf8") : "";
+    const password = data["password"] ? Buffer.from(data["password"], "base64").toString("utf8") : "";
+    const tenantId = data["tenantId"] ? Buffer.from(data["tenantId"], "base64").toString("utf8") : "";
+    if (!username || !password)
+    {
+      throw new Error(`${COGNEE_SILO_OWNER_SECRET_NAME} Secret is missing username/password`);
+    }
+
+    return { username, password, tenantId };
+  }
+  catch
+  {
+    return undefined;
+  }
+}
+
+/**
+ * Provisions ONE Cognee "owner" account + ONE Cognee Tenant per silo — the grouping every
+ * per-openclaw-tenant Cognee login (see `CogneeTenantIdentity`) joins so the plugin's
+ * `companyDataset` scope is actually SHARED across every openclaw tenant in the silo,
+ * rather than silently becoming a separate private dataset per tenant.
+ *
+ * Why this exists: Cognee's own dataset-access resolution
+ * (`get_all_user_permission_datasets` in the shipped server) unions a user's OWN ACLs with
+ * their Cognee-TENANT's ACLs, then filters to `dataset.tenant_id == user.tenant_id` — a
+ * freshly `register`-ed user (see `CogneeTenantIdentity`) has `tenant_id = NULL`, so without
+ * this, EVERY openclaw tenant's "company" dataset would be a distinct, non-overlapping
+ * dataset instead of the shared one the multi-scope plugin config advertises.
+ *
+ * Boot-time, one-shot per silo (mirrors `CogneeLiteLlmKey`): there is exactly one Cognee per
+ * silo and this rarely changes, unlike per-tenant identities which provision on every
+ * Tenant-CR reconcile.
+ *
+ * Crash-safe by construction: the credential is durably written to the Secret BEFORE the
+ * first external Cognee call (register), so a crash between minting the password and
+ * registering it can never leave an unrecoverable mismatch — a retry re-reads the SAME
+ * already-persisted password. `tenantId` is left empty until the Cognee Tenant is
+ * created/resolved; its presence is the idempotency marker for the whole method.
+ */
+export class CogneeSiloTenant
+{
+  private config: OpenClawTenantOperatorConfig;
+  private coreApi: k8s.CoreV1Api;
+  private objectApi: k8s.KubernetesObjectApi;
+  private log: Logger;
+
+  constructor(
+    config: OpenClawTenantOperatorConfig,
+    coreApi: k8s.CoreV1Api,
+    objectApi: k8s.KubernetesObjectApi,
+    log: Logger,
+  )
+  {
+    this.config = config;
+    this.coreApi = coreApi;
+    this.objectApi = objectApi;
+    this.log = log;
+  }
+
+  /**
+   * Ensure this silo has a Cognee owner account + Cognee Tenant. No-ops when Cognee is not
+   * configured, or when a prior run already resolved a `tenantId`.
+   *
+   * @param clusterTenantName - This silo's own ClusterTenant name, used as the Cognee Tenant's
+   *        display name only (`GET /permissions/tenants/me` is what actually re-identifies it
+   *        on retry, not the name).
+   * @param namespace - The silo's own namespace.
+   */
+  async ensureSiloTenant(clusterTenantName: string, namespace: string): Promise<void>
+  {
+    if (!this.config.cogneeEndpoint)
+    {
+      return;
+    }
+
+    let state = await _ReadSiloOwnerState(this.coreApi, namespace);
+    if (state === undefined)
+    {
+      // Phase 1 — mint + durably persist the credential BEFORE any external call, so a crash
+      // before phase 2 completes is always safe to retry with the IDENTICAL password.
+      state = { username: _OWNER_EMAIL, password: randomBytes(32).toString("base64url"), tenantId: "" };
+      await this._writeState(namespace, state);
+      this.log.info({ clusterTenantName, namespace }, "created cognee silo owner credentials");
+    }
+
+    if (state.tenantId)
+    {
+      this.log.debug({ clusterTenantName, namespace }, "cognee silo tenant already resolved");
+      return;
+    }
+
+    // Phase 2 — register (tolerating "already registered"), then find-or-create the silo's
+    // Cognee Tenant. Both sub-steps are themselves idempotent, so this whole phase is safe
+    // to retry from scratch on any failure.
+    await this._registerOwner(state.username, state.password, clusterTenantName);
+    const token = await this._loginOwner(state.username, state.password, clusterTenantName);
+    const tenantId = await this._findOrCreateTenant(token, clusterTenantName);
+
+    await this._writeState(namespace, { ...state, tenantId });
+    this.log.info({ clusterTenantName, namespace, tenantId }, "resolved cognee silo tenant");
+  }
+
+  /** Register the owner account. A 400 (already registered) is treated as success. */
+  private async _registerOwner(email: string, password: string, clusterTenantName: string): Promise<void>
+  {
+    const response = await fetch(`${this.config.cogneeEndpoint}/api/v1/auth/register`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+
+    if (response.ok || response.status === 400)
+    {
+      return;
+    }
+
+    const body = await response.text();
+    throw new Error(`Cognee silo-owner registration failed for ${clusterTenantName} (${response.status}): ${body}`);
+  }
+
+  /** Log in as the owner and return a bearer JWT. */
+  private async _loginOwner(email: string, password: string, clusterTenantName: string): Promise<string>
+  {
+    const response = await fetch(`${this.config.cogneeEndpoint}/api/v1/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ username: email, password }),
+    });
+
+    if (!response.ok)
+    {
+      const body = await response.text();
+      throw new Error(`Cognee silo-owner login failed for ${clusterTenantName} (${response.status}): ${body}`);
+    }
+
+    const payload = await response.json() as { access_token?: string };
+    if (!payload.access_token)
+    {
+      throw new Error(`Cognee silo-owner login for ${clusterTenantName} returned no access_token`);
+    }
+
+    return payload.access_token;
+  }
+
+  /**
+   * Return the owner's existing Cognee Tenant if one is already resolvable
+   * (`GET /permissions/tenants/me`), otherwise create one. Checking first makes this
+   * safe to retry after a crash between creating the Tenant and persisting its id.
+   *
+   * @param retriesLeft - Guards the single re-check after a 409 race (see below) against
+   *        looping forever if Cognee's own state is genuinely inconsistent.
+   */
+  private async _findOrCreateTenant(token: string, clusterTenantName: string, retriesLeft = 1): Promise<string>
+  {
+    const mineResponse = await fetch(`${this.config.cogneeEndpoint}/api/v1/permissions/tenants/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!mineResponse.ok)
+    {
+      const body = await mineResponse.text();
+      throw new Error(`Cognee tenants/me lookup failed for ${clusterTenantName} (${mineResponse.status}): ${body}`);
+    }
+
+    const mine = await mineResponse.json() as Array<{ id: string; name: string }>;
+    if (mine.length > 0)
+    {
+      return mine[0]!.id;
+    }
+
+    const createResponse = await fetch(
+      `${this.config.cogneeEndpoint}/api/v1/permissions/tenants?tenant_name=${encodeURIComponent(clusterTenantName)}`,
+      { method: "POST", headers: { Authorization: `Bearer ${token}` } },
+    );
+
+    if (createResponse.status === 409 && retriesLeft > 0)
+    {
+      // Lost a race against a concurrent create (or `tenants/me` was stale) — re-fetch rather
+      // than fail; the tenant now exists either way.
+      return this._findOrCreateTenant(token, clusterTenantName, retriesLeft - 1);
+    }
+
+    if (!createResponse.ok)
+    {
+      const body = await createResponse.text();
+      throw new Error(`Cognee tenant creation failed for ${clusterTenantName} (${createResponse.status}): ${body}`);
+    }
+
+    const created = await createResponse.json() as { tenant_id?: string };
+    if (!created.tenant_id)
+    {
+      throw new Error(`Cognee tenant creation for ${clusterTenantName} returned no tenant_id`);
+    }
+
+    return created.tenant_id;
+  }
+
+  private async _writeState(namespace: string, state: CogneeSiloOwnerState): Promise<void>
+  {
+    const secret: k8s.V1Secret = {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: COGNEE_SILO_OWNER_SECRET_NAME,
+        namespace,
+        labels: {
+          "app.kubernetes.io/part-of": "opencrane",
+          "app.kubernetes.io/component": "cognee",
+          "app.kubernetes.io/managed-by": "opencrane-clustertenant-manager",
+        },
+      },
+      type: "Opaque",
+      data: {
+        username: Buffer.from(state.username).toString("base64"),
+        password: Buffer.from(state.password).toString("base64"),
+        tenantId: Buffer.from(state.tenantId).toString("base64"),
+      },
+    };
+
+    await __K8sApplyResource(this.objectApi, secret, this.log);
+  }
+}

--- a/apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts
@@ -8,6 +8,7 @@ import type { OpenClawTenantOperatorConfig } from "../../config.js";
 import { __K8sApplyResource } from "@opencrane/infra-api";
 import { _BuildTenantLabels } from "../deploy/tenant-labels.js";
 import type { Tenant } from "../models/tenant.interface.js";
+import { _ReadSiloOwnerState } from "./cognee-silo-tenant.js";
 
 /**
  * Provisions a REAL, per-openclaw-tenant Cognee user account — the tenant's pod
@@ -112,23 +113,63 @@ export class CogneeTenantIdentity
     // 4. Persist the login as a per-tenant Secret. `_BuildDeployment` mounts `username`/
     //    `password` as COGNEE_USERNAME/COGNEE_PASSWORD env vars (secretKeyRef); the plugin
     //    reads those directly since `2-config-map.ts` renders no username/password/apiKey.
-    const secret: k8s.V1Secret = {
-      apiVersion: "v1",
-      kind: "Secret",
-      metadata: {
-        name: secretName,
-        namespace,
-        labels: _BuildTenantLabels(name),
-      },
-      type: "Opaque",
-      data: {
-        username: Buffer.from(email).toString("base64"),
-        password: Buffer.from(password).toString("base64"),
-      },
-    };
-
-    await __K8sApplyResource(this.objectApi, secret, this.log);
+    //    `tenantId` starts empty — populated once `ensureTenantJoinedToSiloTenant` succeeds.
+    await this._writeCredentialsSecret(namespace, name, { username: email, password, tenantId: "" });
     this.log.info({ name, secretName, email }, "created cognee tenant identity");
+  }
+
+  /**
+   * Join this tenant's Cognee login to the silo's shared Cognee Tenant (see
+   * `CogneeSiloTenant`), and make it that login's ACTIVE tenant. Without this, the tenant's
+   * login has `tenant_id = NULL` and the plugin's `companyDataset` scope silently becomes a
+   * private, non-shared dataset instead of the org-wide shared one — see the class doc
+   * comment for the full Cognee-side mechanics.
+   *
+   * No-ops when: Cognee is not configured; this tenant has no credentials yet (call after
+   * `ensureTenantCogneeIdentity` in the same reconcile pass); membership was already
+   * resolved by a prior reconcile; or the silo's owner/Tenant isn't provisioned yet (best
+   * effort — retried automatically on a later reconcile once `CogneeSiloTenant` catches up).
+   *
+   * @param tenant - The Tenant CR being reconciled.
+   * @param namespace - Namespace both this tenant's and the silo owner's Secrets live in.
+   */
+  async ensureTenantJoinedToSiloTenant(tenant: Tenant, namespace: string): Promise<void>
+  {
+    if (!this.config.cogneeEndpoint)
+    {
+      return;
+    }
+
+    const name = tenant.metadata!.name!;
+    const credentials = await this._readCredentialsSecret(namespace, name);
+    if (credentials === undefined)
+    {
+      this.log.debug({ name }, "cognee tenant identity not provisioned yet; skipping silo-tenant join");
+      return;
+    }
+
+    if (credentials.tenantId)
+    {
+      this.log.debug({ name }, "cognee tenant identity already joined to the silo tenant");
+      return;
+    }
+
+    const owner = await _ReadSiloOwnerState(this.coreApi, namespace);
+    if (owner === undefined || !owner.tenantId)
+    {
+      this.log.debug({ name }, "cognee silo owner/tenant not resolved yet; will retry joining on a later reconcile");
+      return;
+    }
+
+    const ownerToken = await this._loginCognee(owner.username, owner.password, `${name} (as silo owner)`);
+    const userId = await this._getUserIdByEmail(ownerToken, credentials.username, name);
+    await this._addUserToTenant(ownerToken, userId, owner.tenantId, name);
+
+    const userToken = await this._loginCognee(credentials.username, credentials.password, name);
+    await this._selectTenant(userToken, owner.tenantId, name);
+
+    await this._writeCredentialsSecret(namespace, name, { ...credentials, tenantId: owner.tenantId });
+    this.log.info({ name, tenantId: owner.tenantId }, "joined cognee tenant identity to the silo tenant");
   }
 
   /**
@@ -179,6 +220,151 @@ export class CogneeTenantIdentity
     const keyBytes = Buffer.from(encoded, "base64");
     return createHmac("sha256", keyBytes).update(`cognee-tenant-identity-v1:${email}`).digest("base64url");
   }
+
+  /** Log in to Cognee and return a bearer JWT. */
+  private async _loginCognee(email: string, password: string, context: string): Promise<string>
+  {
+    const response = await fetch(`${this.config.cogneeEndpoint}/api/v1/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ username: email, password }),
+    });
+
+    if (!response.ok)
+    {
+      const body = await response.text();
+      throw new Error(`Cognee login failed for ${context} (${response.status}): ${body}`);
+    }
+
+    const payload = await response.json() as { access_token?: string };
+    if (!payload.access_token)
+    {
+      throw new Error(`Cognee login for ${context} returned no access_token`);
+    }
+
+    return payload.access_token;
+  }
+
+  /** Resolve a Cognee user's UUID from their email, authenticated as the silo owner. */
+  private async _getUserIdByEmail(ownerToken: string, email: string, tenantName: string): Promise<string>
+  {
+    const response = await fetch(`${this.config.cogneeEndpoint}/api/v1/users/get-user-id`, {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${ownerToken}` },
+      body: JSON.stringify({ email }),
+    });
+
+    if (!response.ok)
+    {
+      const body = await response.text();
+      throw new Error(`Cognee get-user-id failed for ${tenantName} (${response.status}): ${body}`);
+    }
+
+    const payload = await response.json() as { user_id?: string };
+    if (!payload.user_id)
+    {
+      throw new Error(`Cognee get-user-id for ${tenantName} returned no user_id`);
+    }
+
+    return payload.user_id;
+  }
+
+  /**
+   * Add `userId` to the silo's Cognee Tenant, authenticated as the silo owner (the tenant
+   * owner). A 409 (Cognee's `EntityAlreadyExistsError` for "User is already part of group")
+   * is treated as success — this call is safe to repeat across reconciles.
+   */
+  private async _addUserToTenant(ownerToken: string, userId: string, tenantId: string, tenantName: string): Promise<void>
+  {
+    const response = await fetch(
+      `${this.config.cogneeEndpoint}/api/v1/permissions/users/${userId}/tenants?tenant_id=${tenantId}`,
+      { method: "POST", headers: { Authorization: `Bearer ${ownerToken}` } },
+    );
+
+    if (response.ok || response.status === 409)
+    {
+      return;
+    }
+
+    const body = await response.text();
+    throw new Error(`Cognee add-user-to-tenant failed for ${tenantName} (${response.status}): ${body}`);
+  }
+
+  /**
+   * Make `tenantId` the CALLER's active Cognee tenant (authenticated as the tenant's own
+   * login, not the owner — `select_tenant` only ever operates on the authenticated caller).
+   * This is what actually makes `user.tenant_id` match the silo tenant's datasets — plain
+   * membership (`_addUserToTenant`) alone is not enough, per Cognee's own
+   * `get_all_user_permission_datasets` dataset filter.
+   */
+  private async _selectTenant(userToken: string, tenantId: string, tenantName: string): Promise<void>
+  {
+    const response = await fetch(`${this.config.cogneeEndpoint}/api/v1/permissions/tenants/select`, {
+      method: "POST",
+      headers: { "content-type": "application/json", Authorization: `Bearer ${userToken}` },
+      body: JSON.stringify({ tenant_id: tenantId }),
+    });
+
+    if (!response.ok)
+    {
+      const body = await response.text();
+      throw new Error(`Cognee select-tenant failed for ${tenantName} (${response.status}): ${body}`);
+    }
+  }
+
+  /** Read this tenant's Cognee login + silo-tenant-membership state, or `undefined` if absent. */
+  private async _readCredentialsSecret(namespace: string, tenantName: string): Promise<_CogneeCredentials | undefined>
+  {
+    try
+    {
+      const secret = await this.coreApi.readNamespacedSecret({ name: _CredentialsSecretName(tenantName), namespace });
+      const data = secret.data ?? {};
+      const username = data["username"] ? Buffer.from(data["username"], "base64").toString("utf8") : "";
+      const password = data["password"] ? Buffer.from(data["password"], "base64").toString("utf8") : "";
+      const tenantId = data["tenantId"] ? Buffer.from(data["tenantId"], "base64").toString("utf8") : "";
+      if (!username || !password)
+      {
+        return undefined;
+      }
+
+      return { username, password, tenantId };
+    }
+    catch
+    {
+      return undefined;
+    }
+  }
+
+  /** Write this tenant's Cognee login + silo-tenant-membership state (create-or-replace). */
+  private async _writeCredentialsSecret(namespace: string, tenantName: string, credentials: _CogneeCredentials): Promise<void>
+  {
+    const secret: k8s.V1Secret = {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: _CredentialsSecretName(tenantName),
+        namespace,
+        labels: _BuildTenantLabels(tenantName),
+      },
+      type: "Opaque",
+      data: {
+        username: Buffer.from(credentials.username).toString("base64"),
+        password: Buffer.from(credentials.password).toString("base64"),
+        tenantId: Buffer.from(credentials.tenantId).toString("base64"),
+      },
+    };
+
+    await __K8sApplyResource(this.objectApi, secret, this.log);
+  }
+}
+
+/** Decoded shape persisted in a tenant's `_CredentialsSecretName` Secret. */
+interface _CogneeCredentials
+{
+  username: string;
+  password: string;
+  /** Empty until `ensureTenantJoinedToSiloTenant` resolves the silo's shared Cognee Tenant. */
+  tenantId: string;
 }
 
 /**

--- a/apps/clustertenant-operator/src/tenants/operator.ts
+++ b/apps/clustertenant-operator/src/tenants/operator.ts
@@ -376,6 +376,20 @@ export class TenantOperator
         this.log.warn({ err, name }, "cognee tenant identity provisioning failed; continuing reconcile");
       }
 
+      // 5b. Join that login to the silo's shared Cognee Tenant (see CogneeSiloTenant), so the
+      //     plugin's companyDataset scope is actually shared across every openclaw tenant in
+      //     this silo instead of becoming a private dataset per tenant. Independent try/catch:
+      //     a failure here must not block step 5's login from having already been created, and
+      //     is itself retried on the next reconcile regardless of this one's outcome.
+      try
+      {
+        await this.cogneeTenantIdentity.ensureTenantJoinedToSiloTenant(effectiveTenant, namespace);
+      }
+      catch (err)
+      {
+        this.log.warn({ err, name }, "cognee silo-tenant join failed; continuing reconcile");
+      }
+
       // 6. ConfigMap — serialises the base OpenClaw JSON config merged with any
       //    spec.configOverrides the tenant author provided. Capture it so its
       //    checksum can roll the pod when the config changes (step 7).


### PR DESCRIPTION
## Summary

Direct follow-up to #182. PR #182 gave each openclaw tenant a real Cognee login (fixing the shared-`default_user` problem), but left a gap: a freshly `register`-ed Cognee user has `tenant_id = NULL`. I traced Cognee's own dataset-access resolution (`get_all_user_permission_datasets` in the shipped server):

```python
# datasets a user can see = their own ACLs ∪ their Cognee-Tenant's ACLs ∪ their roles' ACLs,
# filtered to only datasets whose tenant_id matches the user's CURRENT active tenant_id
filtered_datasets = [d for d in unique.values() if d.tenant_id == user.tenant_id]
```

Without joining a shared Cognee Tenant, the plugin's `companyDataset` scope — meant to be shared org-wide across every openclaw tenant in a silo — would silently become a private, non-overlapping dataset per tenant instead of the shared context the multi-scope config advertises.

- **`CogneeSiloTenant`** (new, `cognee-silo-tenant.ts`): boot-time, one-shot per silo (mirrors `CogneeLiteLlmKey`, wired into the same `index.ts` IIFE). Provisions ONE Cognee owner account + ONE Cognee Tenant per silo. Crash-safe by construction: the owner credential is durably written to its Secret **before** any external Cognee call (register/login/create), so a crash mid-sequence always retries with the identical password; `GET /permissions/tenants/me` is checked before create, so a retry after a crash between creating the Tenant and persisting its id converges on the existing one instead of duplicating.
- **`CogneeTenantIdentity.ensureTenantJoinedToSiloTenant`** (new method, extends #182's class): called right after `ensureTenantCogneeIdentity` in the per-tenant reconcile (its own try/catch — independent of the login step). Looks up the new user's Cognee UUID (`POST /users/get-user-id`), adds them to the silo's Cognee Tenant as the owner (`POST /permissions/users/{id}/tenants`, tolerating a 409 "already a member"), then logs in **as the new user themselves** to call `POST /permissions/tenants/select` — per Cognee's own `add_user_to_tenant`/`select_tenant` source, membership alone does not set `user.tenant_id`; only the user's own `select_tenant` call does.
- This is a network-layer-adjacent, auth-adjacent change but does not touch the egress isolation from #178 — the silo owner + all per-tenant users are still confined to Cognee's own internal API, no new external calls introduced.

## Test plan

- [x] New `cognee-silo-tenant.test.ts` — 9 tests (no-op unconfigured, two-phase crash-safety — credential durably persisted before any external call and a simulated crash-then-retry reuses it, idempotent when already resolved, reuse-vs-create via `tenants/me`, 400-already-registered tolerated, 409-create-race retried once, hard failures on register/login)
- [x] New tests in `cognee-tenant-identity.test.ts` for `ensureTenantJoinedToSiloTenant` — 7 tests (no-op unconfigured/no-credentials/already-joined/owner-not-ready, full happy-path call sequence assertion, 409-already-member tolerated, hard failure on user-id lookup)
- [x] Full `clustertenant-operator` suite: 94 files / 732 tests green (one unrelated `ECONNRESET` flake in `model-registry.test.ts`, confirmed transient on rerun in isolation)
- [x] `tsc --noEmit` clean
- [x] Full monorepo `pnpm build` clean
- [ ] After merge: redeploy elewa and verify end-to-end — a real turn produces a successful Cognee embed/recall with no auth errors, AND a second openclaw tenant in the same silo can see the shared `company`-scope memory the first tenant wrote (the actual proof this fix works, not just that the API calls succeed)