### PR TITLE
fix(cognee): auto-embedding track + openai_compatible engine (fixes live embedding 400s)

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/model-routing/provision-byok-key-embedding.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/model-routing/provision-byok-key-embedding.test.ts
@@ -5,7 +5,7 @@ import type { Logger } from "pino";
 import type { PrismaClient } from "@prisma/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { _ProvisionByokKey } from "../../core/model-routing/provision-byok-key.js";
+import { _ProvisionByokKey, _AUTO_EMBEDDING_MODEL_NAME } from "../../core/model-routing/provision-byok-key.js";
 
 /**
  * Covers `_ensureProviderEmbeddingModel` (the embedding-registration step added alongside the
@@ -116,7 +116,24 @@ describe("_ProvisionByokKey — embedding model registration", function _suite()
     expect((body["litellm_params"] as Record<string, unknown>)["model"]).toBe("openai/text-embedding-3-large");
   });
 
-  it("does NOT create a ModelDefinition row for the embedding model (never tenant-selectable)", async function _noRow()
+  it("registers the stable auto-embedding alias pointing at the provider's real embedding upstream", async function _alias()
+  {
+    const fetchMock = _routedFetch([]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await _ProvisionByokKey({ prisma: _mockPrisma(), coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "openai", apiKey: "sk-test", log: _log });
+
+    const registerCalls = fetchMock.mock.calls.filter(function _isNewModel(c) { return (c[0] as string).includes("/model/new"); });
+    const aliasCall = registerCalls.find(function _isAlias(c) { return _bodyOf(c)["model_name"] === _AUTO_EMBEDDING_MODEL_NAME; });
+    expect(aliasCall).toBeDefined();
+    const body = _bodyOf(aliasCall!);
+    expect(body["model_info"]).toEqual({ mode: "embedding" });
+    // The alias resolves to the provider's REAL embedding upstream (not to itself), so the proxy
+    // routes it to OpenAI on the BYOK credential — exactly how the chat `auto` alias works.
+    expect((body["litellm_params"] as Record<string, unknown>)["model"]).toBe("openai/text-embedding-3-large");
+  });
+
+  it("does NOT create a ModelDefinition row for the embedding model OR the alias (never tenant-selectable)", async function _noRow()
   {
     vi.stubGlobal("fetch", _routedFetch([]));
 
@@ -124,13 +141,30 @@ describe("_ProvisionByokKey — embedding model registration", function _suite()
     await _ProvisionByokKey({ prisma, coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "openai", apiKey: "sk-test", log: _log });
 
     // The chat-model seeding path (provision-byok-key.test.ts) already asserts the 3 catalog
-    // classes + "auto" get ModelDefinition rows; this asserts the embedding slug gets NONE —
-    // it must never surface as a tenant-selectable chat model (see ByokProviderCatalog.embeddingModel).
+    // classes + "auto" get ModelDefinition rows; this asserts BOTH embedding deployments (the real
+    // slug AND the auto-embedding alias) get NONE — neither may surface as a tenant-selectable chat
+    // model (see ByokProviderCatalog.embeddingModel).
     const embeddingRow = await prisma.modelDefinition.findFirst({ where: { publicModelName: "openai/text-embedding-3-large" } } as never);
     expect(embeddingRow).toBeNull();
+    const aliasRow = await prisma.modelDefinition.findFirst({ where: { publicModelName: _AUTO_EMBEDDING_MODEL_NAME } } as never);
+    expect(aliasRow).toBeNull();
   });
 
-  it("skips re-registration when /model/info already lists the embedding model (idempotent)", async function _idempotent()
+  it("skips re-registration of BOTH the embedding model and the alias when /model/info lists them (idempotent)", async function _idempotent()
+  {
+    const fetchMock = _routedFetch([{ model_name: "openai/text-embedding-3-large" }, { model_name: _AUTO_EMBEDDING_MODEL_NAME }]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await _ProvisionByokKey({ prisma: _mockPrisma(), coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "openai", apiKey: "sk-test", log: _log });
+
+    const registerCalls = fetchMock.mock.calls.filter(function _isNewModel(c) { return (c[0] as string).includes("/model/new"); });
+    const embeddingNames = registerCalls
+      .map(function _n(c) { return _bodyOf(c)["model_name"]; })
+      .filter(function _e(n) { return n === "openai/text-embedding-3-large" || n === _AUTO_EMBEDDING_MODEL_NAME; });
+    expect(embeddingNames).toHaveLength(0);
+  });
+
+  it("still registers the alias when only the real embedding slug is already present (independent idempotency)", async function _aliasOnlyMissing()
   {
     const fetchMock = _routedFetch([{ model_name: "openai/text-embedding-3-large" }]);
     vi.stubGlobal("fetch", fetchMock);
@@ -138,8 +172,9 @@ describe("_ProvisionByokKey — embedding model registration", function _suite()
     await _ProvisionByokKey({ prisma: _mockPrisma(), coreApi: _mockCoreApi(), operatorNamespace: "default", provider: "openai", apiKey: "sk-test", log: _log });
 
     const registerCalls = fetchMock.mock.calls.filter(function _isNewModel(c) { return (c[0] as string).includes("/model/new"); });
-    const embeddingCall = registerCalls.find(function _isEmbedding(c) { return _bodyOf(c)["model_name"] === "openai/text-embedding-3-large"; });
-    expect(embeddingCall).toBeUndefined();
+    // Real slug already present ⇒ skipped; alias absent ⇒ registered.
+    expect(registerCalls.find(function _s(c) { return _bodyOf(c)["model_name"] === "openai/text-embedding-3-large"; })).toBeUndefined();
+    expect(registerCalls.find(function _a(c) { return _bodyOf(c)["model_name"] === _AUTO_EMBEDDING_MODEL_NAME; })).toBeDefined();
   });
 
   it("does not register any embedding model for a provider with none catalogued (anthropic)", async function _noneCatalogued()

--- a/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
+++ b/apps/clustertenant-operator/src/core/model-routing/provision-byok-key.ts
@@ -27,6 +27,19 @@ import type { ByokProviderCatalog } from "./byok-default-models.js";
  */
 const _AUTO_MODEL_NAME = "auto";
 
+/**
+ * Public model name of the stable EMBEDDING selection — the embedding-side mirror of
+ * {@link _AUTO_MODEL_NAME}. Backed by the configured provider's catalogued embedding model
+ * (see `_ensureProviderEmbeddingModel`); an internal consumer (Cognee) references this stable
+ * alias instead of a provider-specific slug, so the operator can re-point the backing embedding
+ * model without a consumer/values edit.
+ *
+ * MUST equal `apps/clustertenant-platform/values.yaml`'s
+ * `clustertenantManager.cognee.embedding.model` (the two agree by convention — the chart cannot
+ * import this constant), exactly like the `cognee-litellm-key` Secret-name agreement.
+ */
+export const _AUTO_EMBEDDING_MODEL_NAME = "auto-embedding";
+
 /** Outcome of {@link _ProvisionByokKey}. */
 export interface ProvisionByokKeyResult
 {
@@ -363,40 +376,70 @@ async function _ensureProviderEmbeddingModel(catalog: ByokProviderCatalog | unde
 
   const slug = catalog.embeddingModel.slug;
 
-  // 1. Skip re-registration when LiteLLM already has this model_name — best-effort: any failure
-  //    here (network, non-2xx, bad JSON) just falls through to attempting registration anyway.
+  // Register TWO embedding deployments, both GLOBAL, both explicitly `mode: "embedding"` so
+  // LiteLLM's `/embeddings` route resolves them, and both WITHOUT a ModelDefinition row (see
+  // ByokProviderCatalog.embeddingModel — an embedding deployment must never surface as a
+  // tenant-selectable chat model):
+  //   1. the provider's real embedding model under its own slug; and
+  //   2. the stable `auto-embedding` alias (_AUTO_EMBEDDING_MODEL_NAME) pointing at that same
+  //      upstream — the embedding-side mirror of the chat `auto` selection. Cognee references
+  //      the alias, so its backing model can be re-pointed here without a Cognee/values edit.
+  // First-wins across providers: the alias resolves to whichever provider's embedding model is
+  // registered first, and the /model/info check below skips it thereafter — two different-provider
+  // embedding models must never both answer to `auto-embedding` (incompatible vector spaces).
+  const deployments = [
+    { publicModelName: slug, upstreamModel: slug },
+    { publicModelName: _AUTO_EMBEDDING_MODEL_NAME, upstreamModel: slug },
+  ];
+
+  // Best-effort idempotency: read the already-registered model names ONCE. Any failure here
+  // (network, non-2xx, bad JSON) yields an empty set, so registration is simply attempted —
+  // LiteLLM's own `/model/new` on an existing `model_name` is itself safe to repeat.
+  const registered = await _litellmRegisteredModelNames(endpoint, masterKey);
+
+  for (const deployment of deployments)
+  {
+    if (registered.has(deployment.publicModelName))
+    {
+      log.debug({ publicModelName: deployment.publicModelName }, "embedding model already registered with litellm");
+      continue;
+    }
+
+    await _RegisterLiteLlmModel({
+      publicModelName: deployment.publicModelName,
+      upstreamModel: deployment.upstreamModel,
+      scope: ModelRoutingScope.Global,
+      clusterTenant: null,
+      apiBase: null,
+      apiKeyEnvRef: null,
+      litellmCredentialName,
+      mode: "embedding",
+    });
+    log.info({ publicModelName: deployment.publicModelName, upstreamModel: deployment.upstreamModel }, "embedding model registered with litellm");
+  }
+}
+
+/**
+ * Best-effort read of the set of `model_name`s LiteLLM already has registered (`GET /model/info`).
+ * Returns an empty set on any failure (unconfigured, unreachable, non-2xx, bad JSON) so callers
+ * fall through to attempting registration rather than being blocked by a transient read.
+ */
+async function _litellmRegisteredModelNames(endpoint: string, masterKey: string): Promise<Set<string>>
+{
   try
   {
-    const infoResponse = await fetch(`${endpoint}/model/info`, {
+    const response = await fetch(`${endpoint}/model/info`, {
       headers: { Authorization: `Bearer ${masterKey}` },
     });
-    if (infoResponse.ok)
+    if (!response.ok)
     {
-      const info = await infoResponse.json() as { data?: Array<{ model_name?: string }> };
-      if ((info.data ?? []).some(function _match(m) { return m.model_name === slug; }))
-      {
-        log.debug({ slug }, "provider embedding model already registered with litellm");
-        return;
-      }
+      return new Set();
     }
+    const info = await response.json() as { data?: Array<{ model_name?: string }> };
+    return new Set((info.data ?? []).map(function _name(m) { return m.model_name ?? ""; }).filter(Boolean));
   }
   catch
   {
-    // Fall through — an unreachable /model/info must not block attempting registration.
+    return new Set();
   }
-
-  // 2. Register GLOBALLY, explicitly tagged `mode: "embedding"` so LiteLLM's `/embeddings` route
-  //    resolves it correctly. scope/clusterTenant are only used to build a discarded placeholder
-  //    id when LiteLLM is unreachable — no ModelDefinition row is created for this deployment.
-  await _RegisterLiteLlmModel({
-    publicModelName: slug,
-    upstreamModel: slug,
-    scope: ModelRoutingScope.Global,
-    clusterTenant: null,
-    apiBase: null,
-    apiKeyEnvRef: null,
-    litellmCredentialName,
-    mode: "embedding",
-  });
-  log.info({ slug }, "provider embedding model registered with litellm");
 }

--- a/apps/clustertenant-platform/values.yaml
+++ b/apps/clustertenant-platform/values.yaml
@@ -343,15 +343,23 @@ clustertenantManager:
       #    catalog's cheapest tier changes, so this stays correct without a values.yaml edit.
       model: "auto"
     embedding:
-      # -- "custom" (NOT "openai") — verified against Cognee's own docs: the "custom"
-      #    provider passes EMBEDDING_ENDPOINT straight through to LiteLLM as `api_base`
-      #    with no automatic /v1 append or /embeddings strip, which the "openai" provider
-      #    does and which breaks routing through a proxy base URL.
-      provider: "custom"
-      # -- Registered directly with LiteLLM by the BYOK bootstrap flow (see
-      #    ByokProviderCatalog.embeddingModel / _ensureProviderEmbeddingModel) — NOT a
-      #    tenant-selectable ModelDefinition, so this exact slug must match that registration.
-      model: "openai/text-embedding-3-large"
+      # -- "openai_compatible" (NOT "custom") — verified against Cognee's shipped source
+      #    (cognee/infrastructure/databases/vector/embeddings/get_embedding_engine.py). Cognee
+      #    picks an embedding engine by this string: "custom" falls through to its
+      #    LiteLLMEmbeddingEngine, which runs the model name through the litellm CLIENT's provider
+      #    inference and STRIPS a provider prefix (so "openai/text-embedding-3-large" was sent to
+      #    our proxy as the bare "text-embedding-3-large" → 400 unregistered, the pre-fix symptom).
+      #    "openai_compatible" selects OpenAICompatibleEmbeddingEngine, which calls the proxy with
+      #    the OpenAI SDK and sends the model name VERBATIM (and normalises the endpoint to
+      #    `.../v1` → `.../v1/embeddings`, which our LiteLLM proxy serves).
+      provider: "openai_compatible"
+      # -- "auto-embedding" is this platform's stable embedding-selection alias, the embedding-side
+      #    mirror of the chat "auto" above. Registered by the BYOK bootstrap flow
+      #    (_AUTO_EMBEDDING_MODEL_NAME in provision-byok-key.ts / _ensureProviderEmbeddingModel),
+      #    pointing at the configured provider's real embedding model — NOT a tenant-selectable
+      #    ModelDefinition. This exact string MUST match that constant; re-pointing the backing
+      #    embedding model needs no edit here.
+      model: "auto-embedding"
       dimensions: 3072
     # -- Extra pod-template annotations, same convention as `litellm.podAnnotations` /
     #    `mcpGateway.podAnnotations`. Also a sanctioned, script-driven rollout trigger: Cognee's


### PR DESCRIPTION
## Summary

Follow-up to the Cognee identity work (#182/#183). Those closed the 401 auth errors — which exposed a **pre-existing embedding-wiring bug** underneath. On the live elewa silo, Cognee's embedding calls were failing in a retry loop (`litellm.BadRequestError ... Invalid model name passed in model=text-embedding-3-large`), so every memory write aborted (`qa store failed`).

**Root cause** (confirmed against Cognee's shipped source, `get_embedding_engine.py`): `EMBEDDING_PROVIDER` selects the embedding engine.
- `custom` (what we set) → `LiteLLMEmbeddingEngine`, which runs the model name through the litellm **client's** provider inference and **strips the `openai/` prefix** → sends bare `text-embedding-3-large` to our proxy, which only knows it as `openai/text-embedding-3-large` → 400. Verified live: prefixed succeeds, bare 400s.
- `openai_compatible` → `OpenAICompatibleEmbeddingEngine`, which calls the proxy via the OpenAI SDK and sends the model name **verbatim** (and normalises the endpoint `…:4000` → `…:4000/v1` → `/v1/embeddings`, which our LiteLLM proxy serves).

This also answers "why not just use the `auto` model?" — `auto` is a chat/completion alias (routes to a text-gen model); embeddings need a model registered on the `/embeddings` route. So this builds the **embedding-side equivalent**.

## Changes

- **`auto-embedding` selection alias** — the embedding-side mirror of the chat `auto` alias. `_ensureProviderEmbeddingModel` now registers both the provider's real embedding model **and** `auto-embedding` pointing at that same upstream. Both `mode: "embedding"`, neither a `ModelDefinition` row (must never be a tenant-selectable chat model). First-wins across providers via the `/model/info` check, so two providers' embedding models can never collide on one alias (incompatible vector spaces). New exported `_AUTO_EMBEDDING_MODEL_NAME`.
- **Cognee wiring** (`values.yaml`): `EMBEDDING_PROVIDER` `custom` → `openai_compatible`, `EMBEDDING_MODEL` `openai/text-embedding-3-large` → `auto-embedding`. Comments rewritten to reflect the real Cognee engine behaviour (the old comment's diagnosis was incomplete — it fixed an endpoint concern but missed the model-name strip).

Net: Cognee references one stable, provider-agnostic embedding name forever; the operator re-points the backing model with no Cognee/values edit — exactly how `auto` works for chat.

## Test plan

- [x] `provision-byok-key-embedding.test.ts` extended: alias registered with `mode:"embedding"` pointing at the real upstream; no `ModelDefinition` row for either; full idempotency (both present → no re-register); independent idempotency (real slug present, alias still registered)
- [x] Full `clustertenant-operator` suite: 94 files / 734 tests green
- [x] `tsc --noEmit` clean; full monorepo `pnpm build` clean
- [ ] After merge: redeploy elewa and confirm the embedding retry loop is gone (no more `Invalid model name` / `qa store failed`), and a real turn produces a successful Cognee embed + recall — the final end-to-end proof