### PR TITLE
fix(cognee): persist Cognee data on a PVC + self-heal per-tenant identity

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/cognee-silo-tenant.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cognee-silo-tenant.test.ts
@@ -122,9 +122,18 @@ describe("CogneeSiloTenant", () =>
     expect(_field(final, "tenantId")).toBe("tenant-123");
   });
 
-  it("is fully idempotent when a tenantId was already resolved (no fetch calls at all)", async () =>
+  it("skips re-provisioning when the resolved owner/tenant is still live (liveness-checked, not just Secret-gated)", async () =>
   {
-    const fetchMock = vi.fn();
+    // tenantId cached AND the owner still logs in AND tenants/me still returns it → converged:
+    // only the liveness probe (login + tenants/me) fires, no register / no tenant create.
+    const seen: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      seen.push(url);
+      if (url.endsWith("/auth/login")) { return new Response(JSON.stringify({ access_token: "jwt-owner" }), { status: 200 }); }
+      if (url.endsWith("/api/v1/permissions/tenants/me")) { return new Response(JSON.stringify([{ id: "tenant-already-resolved" }]), { status: 200 }); }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
     vi.stubGlobal("fetch", fetchMock);
     const { coreApi, objectApi, store } = _makeApis();
     store.set("default/cognee-silo-owner", {
@@ -138,7 +147,44 @@ describe("CogneeSiloTenant", () =>
 
     await new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(seen).toEqual(["http://cognee:8000/api/v1/auth/login", "http://cognee:8000/api/v1/permissions/tenants/me"]);
+    expect(_field(store.get("default/cognee-silo-owner")!, "tenantId")).toBe("tenant-already-resolved");
+  });
+
+  it("re-provisions when the resolved owner/tenant is no longer live (Cognee identity-store reset)", async () =>
+  {
+    // tenantId cached but the owner login 401s (its Cognee user was wiped) → re-register the owner,
+    // re-create the tenant (tenants/me now empty), and rewrite the Secret with the NEW id.
+    let ownerRegistered = false;
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/auth/register")) { ownerRegistered = true; return new Response("{}", { status: 201 }); }
+      if (url.endsWith("/auth/login"))
+      {
+        // 401 until the owner is (re)registered, 200 after — models the wiped-then-restored user.
+        return ownerRegistered
+          ? new Response(JSON.stringify({ access_token: "jwt-owner" }), { status: 200 })
+          : new Response("Unauthorized", { status: 401 });
+      }
+      if (url.endsWith("/api/v1/permissions/tenants/me")) { return new Response(JSON.stringify([]), { status: 200 }); }
+      if (url.includes("/api/v1/permissions/tenants?tenant_name=")) { return new Response(JSON.stringify({ tenant_id: "tenant-REPROVISIONED" }), { status: 200 }); }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeApis();
+    store.set("default/cognee-silo-owner", {
+      metadata: { name: COGNEE_SILO_OWNER_SECRET_NAME, namespace: "default" },
+      data: {
+        username: Buffer.from("silo-owner@opencrane.internal").toString("base64"),
+        password: Buffer.from("existing-pass").toString("base64"),
+        tenantId: Buffer.from("tenant-STALE").toString("base64"),
+      },
+    } as unknown as k8s.V1Secret);
+
+    await new CogneeSiloTenant(_enabledConfig, coreApi, objectApi, _log).ensureSiloTenant("acme", "default");
+
+    expect(ownerRegistered).toBe(true);
+    expect(_field(store.get("default/cognee-silo-owner")!, "tenantId")).toBe("tenant-REPROVISIONED");
   });
 
   it("resumes phase 2 with the SAME persisted password after a simulated crash (tenantId empty but credential exists)", async () =>

--- a/apps/clustertenant-operator/src/__tests__/tenants/cognee-tenant-identity.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cognee-tenant-identity.test.ts
@@ -97,17 +97,49 @@ describe("CogneeTenantIdentity", () =>
     expect(coreApi.readNamespacedSecret as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 
-  it("no-ops when the tenant's cognee-credentials Secret already exists (never rotated)", async () =>
+  it("skips re-registration when the existing login still authenticates (verifies liveness, not mere Secret existence)", async () =>
   {
-    const fetchMock = vi.fn();
+    // Secret present AND a login attempt succeeds → converged, no re-register / no Secret write.
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      if (url.endsWith("/api/v1/auth/login")) { return new Response(JSON.stringify({ access_token: "jwt" }), { status: 200 }); }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
     vi.stubGlobal("fetch", fetchMock);
     const objectApi = _makeObjectApi();
 
     const identity = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi({ credentialsExist: true }), objectApi, _log);
     await identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "default");
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    // Exactly one fetch — the liveness login — and NO register call, NO Secret write.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("http://cognee:8000/api/v1/auth/login");
     expect(objectApi.create as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+  });
+
+  it("re-registers when the existing login no longer authenticates (Cognee identity-store wipe)", async () =>
+  {
+    // Secret present but the login 401s (its Cognee user was wiped) → re-register + rewrite Secret
+    // with tenantId reset to "" so the join step re-runs.
+    const seen: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      seen.push(url);
+      if (url.endsWith("/api/v1/auth/login")) { return new Response("Unauthorized", { status: 401 }); }
+      if (url.endsWith("/api/v1/auth/register")) { return new Response("{}", { status: 201 }); }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const objectApi = _makeObjectApi();
+
+    const identity = new CogneeTenantIdentity(_enabledConfig, _makeCoreApi({ credentialsExist: true }), objectApi, _log);
+    await identity.ensureTenantCogneeIdentity(_makeTenant("acme"), "default");
+
+    expect(seen).toContain("http://cognee:8000/api/v1/auth/login");
+    expect(seen).toContain("http://cognee:8000/api/v1/auth/register");
+    expect(objectApi.create as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
+    const rewritten = (objectApi.create as ReturnType<typeof vi.fn>).mock.calls[0][0] as k8s.V1Secret;
+    expect(Buffer.from(rewritten.data!["tenantId"], "base64").toString("utf8")).toBe("");
   });
 
   it("registers the tenant's owner email and writes a Secret readable by _CredentialsSecretName", async () =>
@@ -348,16 +380,42 @@ describe("CogneeTenantIdentity.ensureTenantJoinedToSiloTenant", () =>
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("no-ops when this tenant is already joined (tenantId already set)", async () =>
+  it("no-ops when already joined to the CURRENT silo tenant (cached id matches the owner's)", async () =>
   {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     const { coreApi, objectApi, store } = _makeStatefulApis();
-    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "pw", tenantId: "already-joined" });
+    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "pw", tenantId: "tenant-1" });
+    _seedOwner(store, "default", { username: "owner@x", password: "owner-pw", tenantId: "tenant-1" });
 
     await new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "default");
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("re-joins when the cached tenant id no longer matches the current silo tenant (silo re-provisioned)", async () =>
+  {
+    // The silo owner's Cognee Tenant was re-created with a NEW id (CogneeSiloTenant self-heal after
+    // an identity-store reset); the cached membership is stale → the login must re-join + re-select.
+    const seen: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(async (url: string) =>
+    {
+      seen.push(url);
+      if (url.endsWith("/auth/login")) { return new Response(JSON.stringify({ access_token: "jwt" }), { status: 200 }); }
+      if (url.endsWith("/api/v1/users/get-user-id")) { return new Response(JSON.stringify({ user_id: "u1" }), { status: 200 }); }
+      if (url.includes("/tenants?tenant_id=tenant-NEW")) { return new Response("{}", { status: 200 }); }
+      if (url.endsWith("/api/v1/permissions/tenants/select")) { return new Response("{}", { status: 200 }); }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { coreApi, objectApi, store } = _makeStatefulApis();
+    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "tenant-pw", tenantId: "tenant-OLD" });
+    _seedOwner(store, "default", { username: "owner@x", password: "owner-pw", tenantId: "tenant-NEW" });
+
+    await new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).ensureTenantJoinedToSiloTenant(_makeTenant("acme"), "default");
+
+    expect(seen.some(u => u.includes("/tenants?tenant_id=tenant-NEW"))).toBe(true);
+    expect(_field(store.get("default/" + _CredentialsSecretName("acme"))!, "tenantId")).toBe("tenant-NEW");
   });
 
   it("no-ops (retried later) when the silo owner's Cognee Tenant isn't resolved yet", async () =>

--- a/apps/clustertenant-operator/src/tenants/internal/cognee-silo-tenant.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-silo-tenant.ts
@@ -122,11 +122,21 @@ export class CogneeSiloTenant
       await this._writeState(namespace, state);
       this.log.info({ clusterTenantName, namespace }, "created cognee silo owner credentials");
     }
-
-    if (state.tenantId)
+    else if (state.tenantId)
     {
-      this.log.debug({ clusterTenantName, namespace }, "cognee silo tenant already resolved");
-      return;
+      // Already resolved once — but verify it is STILL live in Cognee before trusting the cached
+      // tenantId. Cognee's identity store is persisted now (PVC), but a Cognee provisioned before
+      // persistence landed, a rebuilt instance, or a manual reset leaves an empty user table, and
+      // gating on "the Secret has a tenantId" alone would then never re-provision (the wipe-blind
+      // bug this replaces). If the owner still logs in and its tenant still resolves we are
+      // converged; otherwise fall through to re-provision. Re-provisioning mints a NEW tenantId,
+      // which the per-tenant join step detects (its cached id no longer matches) and re-joins.
+      if (await this._siloTenantIsLive(state, clusterTenantName))
+      {
+        this.log.debug({ clusterTenantName, namespace }, "cognee silo tenant already resolved and live");
+        return;
+      }
+      this.log.warn({ clusterTenantName, namespace }, "cognee silo owner/tenant not live (identity store reset?); re-provisioning");
     }
 
     // Phase 2 — register (tolerating "already registered"), then find-or-create the silo's
@@ -138,6 +148,35 @@ export class CogneeSiloTenant
 
     await this._writeState(namespace, { ...state, tenantId });
     this.log.info({ clusterTenantName, namespace, tenantId }, "resolved cognee silo tenant");
+  }
+
+  /**
+   * Best-effort liveness probe of an already-resolved silo owner + Cognee Tenant: can the owner
+   * still log in, and does `tenants/me` still return the cached tenant id? Returns false (⇒
+   * re-provision) on a failed login, a non-OK lookup, or a tenant that no longer resolves. A
+   * transient/unexpected error also returns false rather than throwing, so a wipe is never
+   * silently treated as converged — re-provisioning is itself idempotent, so a false negative on a
+   * blip just re-runs harmless register/find-or-create work.
+   */
+  private async _siloTenantIsLive(state: CogneeSiloOwnerState, clusterTenantName: string): Promise<boolean>
+  {
+    try
+    {
+      const token = await this._loginOwner(state.username, state.password, clusterTenantName);
+      const response = await fetch(`${this.config.cogneeEndpoint}/api/v1/permissions/tenants/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!response.ok)
+      {
+        return false;
+      }
+      const mine = await response.json() as Array<{ id?: string }>;
+      return mine.some(function _match(t) { return t.id === state.tenantId; });
+    }
+    catch
+    {
+      return false;
+    }
   }
 
   /** Register the owner account. A 400 (already registered) is treated as success. */

--- a/apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts
@@ -84,38 +84,39 @@ export class CogneeTenantIdentity
     const name = tenant.metadata!.name!;
     const secretName = _CredentialsSecretName(name);
 
-    // 1. Idempotency check — a tenant's Cognee login, once minted, is never rotated.
-    try
+    // Email is the SAME identity the gateway's trusted-proxy allowlist already pins the pod to
+    // (`_BuildConfigMap`'s `ownerEmail`) — "the user login" the tenant's owner authenticates with.
+    // `subject` (an opaque OIDC `sub`) is deliberately NOT used: Cognee validates `email` as a real
+    // email address and would reject a non-email subject string.
+    const email = tenant.spec.email.trim().toLowerCase();
+
+    // 1. Idempotency + self-heal. The login is minted once and never rotated (the password is
+    //    derived deterministically), but "the Secret exists" is NOT proof the login still WORKS: a
+    //    Cognee identity-store reset (a restart before persistence landed, a rebuilt instance) wipes
+    //    the user while the Secret lingers, orphaning it (→ 401 on every memory write). So when the
+    //    Secret is present, verify the login actually authenticates; skip only if it does. A failed
+    //    login (or missing Secret) falls through to (re-)register — the deterministic password makes
+    //    re-registration converge on the identical credential.
+    const existing = await this._readCredentialsSecret(namespace, name);
+    if (existing !== undefined && await this._loginSucceeds(existing.username, existing.password))
     {
-      await this.coreApi.readNamespacedSecret({ name: secretName, namespace });
-      this.log.debug({ name, secretName }, "cognee tenant identity already exists");
+      this.log.debug({ name, secretName }, "cognee tenant identity already exists and authenticates");
       return;
     }
-    catch
-    {
-      // Secret does not exist — continue to registration.
-    }
 
-    // 2. Derive the login. Email is the SAME identity the gateway's trusted-proxy
-    //    allowlist already pins the pod to (`_BuildConfigMap`'s `ownerEmail`) — "the user
-    //    login" the tenant's owner actually authenticates with. `subject` (an opaque OIDC
-    //    `sub`) is deliberately NOT used here: Cognee validates `email` as a real email
-    //    address and would reject a non-email subject string.
-    const email = tenant.spec.email.trim().toLowerCase();
+    // 2. Register with Cognee. A 400 almost always means the email is already registered — since the
+    //    password is derived deterministically, retrying with the identical password converges
+    //    either way, so both outcomes proceed to step 3.
     const password = await this._deriveTenantPassword(name, namespace, email);
-
-    // 3. Register with Cognee. A 400 almost always means the email is already registered
-    //    (e.g. a prior reconcile crashed before step 4 wrote the Secret) — since the
-    //    password is derived deterministically, retrying with the identical password
-    //    converges correctly either way, so both outcomes proceed to step 4.
     await this._registerCogneeUser(email, password, name);
 
-    // 4. Persist the login as a per-tenant Secret. `_BuildDeployment` mounts `username`/
-    //    `password` as COGNEE_USERNAME/COGNEE_PASSWORD env vars (secretKeyRef); the plugin
-    //    reads those directly since `2-config-map.ts` renders no username/password/apiKey.
-    //    `tenantId` starts empty — populated once `ensureTenantJoinedToSiloTenant` succeeds.
+    // 3. Persist the login. `_BuildDeployment` mounts `username`/`password` as COGNEE_USERNAME/
+    //    COGNEE_PASSWORD env vars (secretKeyRef); the plugin reads those directly since
+    //    `2-config-map.ts` renders no username/password/apiKey. `tenantId` is reset to empty: if we
+    //    reached this path the Cognee user (and thus its tenant membership) was absent, so the join
+    //    step must re-run — `ensureTenantJoinedToSiloTenant` keys off this.
     await this._writeCredentialsSecret(namespace, name, { username: email, password, tenantId: "" });
-    this.log.info({ name, secretName, email }, "created cognee tenant identity");
+    this.log.info({ name, secretName, email }, existing !== undefined ? "re-provisioned cognee tenant identity (login no longer authenticated)" : "created cognee tenant identity");
   }
 
   /**
@@ -148,16 +149,21 @@ export class CogneeTenantIdentity
       return;
     }
 
-    if (credentials.tenantId)
-    {
-      this.log.debug({ name }, "cognee tenant identity already joined to the silo tenant");
-      return;
-    }
-
     const owner = await _ReadSiloOwnerState(this.coreApi, namespace);
     if (owner === undefined || !owner.tenantId)
     {
       this.log.debug({ name }, "cognee silo owner/tenant not resolved yet; will retry joining on a later reconcile");
+      return;
+    }
+
+    // Gate on membership of the CURRENT silo tenant, not merely "some tenantId is cached". A silo
+    // re-provision (CogneeSiloTenant self-heal after an identity-store reset) mints a NEW owner
+    // tenantId, and a wiped login has its cached tenantId reset to "" by ensureTenantCogneeIdentity
+    // — both cases make the cached id differ from the owner's current one, so the (re)join below
+    // runs. When they already match, the login is joined to the live silo tenant: converged.
+    if (credentials.tenantId === owner.tenantId)
+    {
+      this.log.debug({ name }, "cognee tenant identity already joined to the current silo tenant");
       return;
     }
 
@@ -243,6 +249,25 @@ export class CogneeTenantIdentity
     }
 
     return payload.access_token;
+  }
+
+  /**
+   * Best-effort liveness gate: does this Cognee login authenticate right now? Returns false on a
+   * 401 or any error (⇒ the caller re-registers) rather than throwing. Distinct from
+   * {@link _loginCognee}, which throws — this is used only to decide whether a cached credential is
+   * still valid, so a transient blip conservatively re-runs the (idempotent) register path.
+   */
+  private async _loginSucceeds(email: string, password: string): Promise<boolean>
+  {
+    try
+    {
+      await this._loginCognee(email, password, "liveness check");
+      return true;
+    }
+    catch
+    {
+      return false;
+    }
   }
 
   /** Resolve a Cognee user's UUID from their email, authenticated as the silo owner. */

--- a/apps/clustertenant-platform/templates/cognee-deployment.yaml
+++ b/apps/clustertenant-platform/templates/cognee-deployment.yaml
@@ -46,6 +46,14 @@ metadata:
     app.kubernetes.io/component: cognee
 spec:
   replicas: 1
+  {{- if .Values.clustertenantManager.cognee.persistence.enabled }}
+  # The data PVC is ReadWriteOnce — only one pod may mount it at a time. Recreate
+  # avoids a new pod deadlocking on the disk the old pod still holds (mirrors the
+  # tenant pod's own state-volume strategy). Cognee is a per-silo singleton, so the
+  # brief downtime on a roll is acceptable.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "opencrane.selectorLabels" . | nindent 6 }}
@@ -78,6 +86,17 @@ spec:
               value: "0.0.0.0"
             - name: PORT
               value: {{ .Values.clustertenantManager.cognee.service.port | quote }}
+            {{- if .Values.clustertenantManager.cognee.persistence.enabled }}
+            # Point Cognee's data + system roots at the mounted PVC so its relational/identity
+            # DB, graph store, and vector store survive pod restarts. Cognee's BaseConfig is
+            # pydantic-settings, so these env vars override the defaults (which live on the
+            # pod's ephemeral filesystem and are WIPED on every restart — taking the operator-
+            # registered per-tenant logins with them). Cache + logs stay ephemeral by design.
+            - name: DATA_ROOT_DIRECTORY
+              value: /cognee-data/data_storage
+            - name: SYSTEM_ROOT_DIRECTORY
+              value: /cognee-data/cognee_system
+            {{- end }}
             {{- if .Values.litellm.enabled }}
             # Embedding + LLM (graph-extraction) provider, routed through this release's
             # LiteLLM proxy via a DEDICATED key the operator mints at boot (Secret name here
@@ -116,6 +135,42 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.clustertenantManager.cognee.resources | nindent 12 }}
+          {{- if .Values.clustertenantManager.cognee.persistence.enabled }}
+          volumeMounts:
+            - name: cognee-data
+              mountPath: /cognee-data
+          {{- end }}
+      {{- if .Values.clustertenantManager.cognee.persistence.enabled }}
+      volumes:
+        - name: cognee-data
+          persistentVolumeClaim:
+            claimName: {{ include "opencrane.fullname" . }}-cognee-data
+      {{- end }}
+{{- if .Values.clustertenantManager.cognee.persistence.enabled }}
+---
+# Persistent store for Cognee's identity/relational DB + graph + vector data. Without it
+# Cognee runs entirely on the pod's ephemeral filesystem, so every restart wipes the memory
+# graph AND the per-tenant Cognee logins the operator registers (orphaning their cached
+# Secrets → `qa store failed: 401 Unauthorized`). ReadWriteOnce, single-replica (Recreate).
+# The GKE default StorageClass (pd.csi, allowVolumeExpansion) resizes online — grow by
+# bumping `persistence.size` and re-deploying (grow-only; it never shrinks).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "opencrane.fullname" . }}-cognee-data
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: cognee
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.clustertenantManager.cognee.persistence.storageClassName }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.clustertenantManager.cognee.persistence.size | quote }}
+{{- end }}
 {{- if .Values.networkPolicy.enabled }}
 ---
 # Defence-in-depth ingress policy for the bundled Cognee. Only the control-plane

--- a/apps/clustertenant-platform/values.yaml
+++ b/apps/clustertenant-platform/values.yaml
@@ -316,6 +316,20 @@ clustertenantManager:
       pullPolicy: IfNotPresent
     service:
       port: 8000
+    # -- Persist Cognee's identity/relational DB + graph + vector stores on a PVC so they
+    #    survive pod restarts. WITHOUT this, all of Cognee's state lives on the pod's
+    #    ephemeral filesystem and is WIPED on every restart — resetting org memory AND
+    #    orphaning the per-tenant Cognee logins the operator registers (their cached Secrets
+    #    then 401). Only consumed when `install` is true.
+    persistence:
+      enabled: true
+      # -- Size of the Cognee data volume. Grow-only: the GKE default StorageClass (pd.csi,
+      #    allowVolumeExpansion) resizes online, so bump this + re-deploy to grow (never shrinks).
+      #    Sized modestly for a dev silo; raise for a real corpus.
+      size: 10Gi
+      # -- StorageClass for the volume. Empty ⇒ the cluster default (on GKE: standard-rwo, a
+      #    PD-backed, expandable ReadWriteOnce class). Set explicitly for on-prem / other clouds.
+      storageClassName: ""
     resources:
       requests:
         cpu: 100m


### PR DESCRIPTION
## Summary

Live verification of #184 (which fixed the embedding 400s — confirmed working) surfaced a **deeper blocker**: Cognee has **no persistent storage**. Its identity/relational DB, graph store, and vector store all live on the pod's ephemeral filesystem (`cognee-deployment.yaml` had no volumes at all). So every pod restart wipes them — and the restart required to apply #184 wiped the per-tenant Cognee login registered by #182, leaving elewa with `qa store failed: 401 Unauthorized`. Even aside from that, org-memory data could never survive a restart.

### Chart — persistent volume for Cognee
- New `clustertenantManager.cognee.persistence` values (`enabled` / `size` / `storageClassName`).
- `cognee-deployment.yaml` mounts a ReadWriteOnce PVC at `/cognee-data` and points Cognee's `DATA_ROOT_DIRECTORY` + `SYSTEM_ROOT_DIRECTORY` there — verified those are pydantic-settings env overrides against Cognee's `BaseConfig`, so the databases + graph + vector stores persist. `Recreate` strategy (RWO, single replica, mirrors the tenant pod). The disk is **online-expandable (grow-only)** on the GKE default `pd.csi` StorageClass — bump `size` and re-deploy to grow.

### Operator — self-heal instead of trusting a cached Secret
The identity chain gated on "does the k8s Secret exist," which is wipe-blind — it never noticed Cognee's user table had been reset. Now it verifies against Cognee:
- `ensureTenantCogneeIdentity`: verify the cached login actually authenticates; on a failed login, re-register (deterministic password) and reset the credentials' `tenantId` so the join step re-runs.
- `ensureTenantJoinedToSiloTenant`: gate on membership of the **current** silo tenant (cached id == owner's id), not merely "some tenantId cached" — a re-provisioned silo tenant triggers a re-join.
- `CogneeSiloTenant.ensureSiloTenant`: liveness-probe the resolved owner+tenant (owner login + `tenants/me` still returns the id); re-provision and rewrite the Secret with the new id when it was wiped.

Together: the PVC stops future wipes, and the self-heal recovers the one-time transition (elewa's currently-orphaned login) and any future data loss.

## Test plan
- [x] Full `clustertenant-operator` suite: 94 files / 737 tests green (rewritten "already-provisioned" tests to assert liveness-checked behaviour + new self-heal tests: login-wipe re-register, silo-tenant re-join, owner liveness re-provision)
- [x] `tsc --noEmit` clean; full monorepo `pnpm build` clean
- [x] `helm template` renders the PVC + mount + root-dir env with `persistence.enabled` (default), and cleanly omits all three when disabled
- [ ] After merge: redeploy elewa; confirm the Cognee PVC binds, the pod comes up with `DATA_ROOT_DIRECTORY`/`SYSTEM_ROOT_DIRECTORY` set, the operator re-registers elewa's login (401 clears), and a real turn produces a successful embed + recall that **survives a Cognee pod restart**

## Related
- #184 embedding fix (verified live; this unblocks the layer beneath it)
- #182 / #183 per-tenant Cognee identity + silo tenant (the logins this persists + self-heals)