### PR TITLE
fix(cognee): clear rollingUpdate when switching Cognee to Recreate strategy

### DIFF
--- a/apps/clustertenant-platform/templates/cognee-deployment.yaml
+++ b/apps/clustertenant-platform/templates/cognee-deployment.yaml
@@ -51,8 +51,17 @@ spec:
   # avoids a new pod deadlocking on the disk the old pod still holds (mirrors the
   # tenant pod's own state-volume strategy). Cognee is a per-silo singleton, so the
   # brief downtime on a roll is acceptable.
+  #
+  # `rollingUpdate: null` is load-bearing on an UPGRADE of an already-live Deployment:
+  # a pre-existing pod defaulted to `RollingUpdate` carries an API-set
+  # `strategy.rollingUpdate{maxSurge,maxUnavailable}` block, and a patch that sets only
+  # `type: Recreate` leaves that block in place → the API server rejects the object
+  # ("rollingUpdate may not be specified when type is 'Recreate'"). Rendering an explicit
+  # null deletes the stale field in the merge. (A fresh install has nothing to clear, so
+  # null is a harmless no-op there.)
   strategy:
     type: Recreate
+    rollingUpdate: null
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary

Hotfix for #187. That PR added `strategy: {type: Recreate}` to the Cognee Deployment but didn't clear `rollingUpdate`. On an **upgrade of an already-live Deployment** (every existing silo — elewa/elewa-be/northwind), the running pod defaulted to `RollingUpdate` and carries an API-set `strategy.rollingUpdate{maxSurge,maxUnavailable}` block. A Helm patch that sets only `type: Recreate` leaves that block in place, so the API server rejects the object:

```
Deployment.apps "opencrane-cognee" is invalid: spec.strategy.rollingUpdate:
Forbidden: may not be specified when strategy `type` is 'Recreate'
```

…which aborts the entire `helm upgrade` before Cognee ever gets its PVC. Caught only by a live `helm upgrade` against elewa — `helm template`/CI render fresh manifests and never diff against a live object, so it shipped green.

## Fix

Render an explicit `rollingUpdate: null` under the Recreate strategy so the merge patch deletes the stale field on the live object. Harmless no-op on a fresh install (nothing to clear).

## Test plan
- [x] `helm template` renders `strategy: {type: Recreate, rollingUpdate: null}` with `persistence.enabled` (default) and omits the strategy block entirely when disabled
- [ ] After merge: redeploy elewa — the `helm upgrade` now applies, the Cognee PVC binds, the pod rolls onto `/cognee-data` with `DATA_ROOT_DIRECTORY`/`SYSTEM_ROOT_DIRECTORY`, the operator self-heal re-registers elewa's login, and memory survives a Cognee restart (the #187 checks that were blocked)

## Note / follow-up
The blocked run also surfaced that an **already-running tenant pod** kept logging a `401` a full cycle after the operator's self-heal re-registered its login (its `COGNEE_USERNAME`/`COGNEE_PASSWORD` are `secretKeyRef`-resolved once at pod start). Whether that persists once Cognee is genuinely on the PVC + healed is unclear (the password is deterministic, so the cached env should still authenticate) — will confirm on the clean redeploy and, if it does persist, follow up by rolling the tenant pod when its Cognee-credentials Secret changes. Not fixing speculatively here.

Related: #187 (persistence + self-heal, this unblocks it), #174 (unthrottled reconcile loop, recurred).