### PR TITLE
fix(cognee): RWO-safe rollout via RollingUpdate maxSurge:0 (not Recreate)

### DIFF
--- a/apps/clustertenant-platform/templates/cognee-deployment.yaml
+++ b/apps/clustertenant-platform/templates/cognee-deployment.yaml
@@ -47,21 +47,24 @@ metadata:
 spec:
   replicas: 1
   {{- if .Values.clustertenantManager.cognee.persistence.enabled }}
-  # The data PVC is ReadWriteOnce — only one pod may mount it at a time. Recreate
-  # avoids a new pod deadlocking on the disk the old pod still holds (mirrors the
-  # tenant pod's own state-volume strategy). Cognee is a per-silo singleton, so the
-  # brief downtime on a roll is acceptable.
+  # The data PVC is ReadWriteOnce — two pods can't mount it at once, so a rollout that
+  # surged a second pod would deadlock (the new pod stuck Pending on the volume the old
+  # pod still holds). `maxSurge: 0` tears the OLD pod down BEFORE creating the new one, so
+  # the volume is free when the new pod mounts — RWO-safe, like Recreate would be.
   #
-  # `rollingUpdate: null` is load-bearing on an UPGRADE of an already-live Deployment:
-  # a pre-existing pod defaulted to `RollingUpdate` carries an API-set
-  # `strategy.rollingUpdate{maxSurge,maxUnavailable}` block, and a patch that sets only
-  # `type: Recreate` leaves that block in place → the API server rejects the object
-  # ("rollingUpdate may not be specified when type is 'Recreate'"). Rendering an explicit
-  # null deletes the stale field in the merge. (A fresh install has nothing to clear, so
-  # null is a harmless no-op there.)
+  # We deliberately do NOT use `type: Recreate`: switching an ALREADY-LIVE Deployment from
+  # RollingUpdate→Recreate is rejected by the API server because the pre-existing object
+  # carries an API-defaulted `strategy.rollingUpdate` block that can't coexist with
+  # type:Recreate, and a Helm template `rollingUpdate: null` does NOT reliably clear a
+  # field Helm never previously owned (the 3-way merge drops the null — verified live, the
+  # #187/#188 failures). Keeping `type: RollingUpdate` and only tuning the params is a
+  # plain in-place field update that upgrades cleanly on the live object AND on a fresh
+  # install, with no strategy-type transition to migrate.
   strategy:
-    type: Recreate
-    rollingUpdate: null
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary

Third and final fix for the Cognee-persistence rollout. #187 introduced `type: Recreate` (needed because the new Cognee data PVC is ReadWriteOnce); #188 tried to make it upgrade cleanly with `rollingUpdate: null`. Both `helm upgrade`s **failed identically on the live elewa release** (rev 32 and rev 33) with:

```
Deployment.apps "opencrane-cognee" is invalid: spec.strategy.rollingUpdate:
Forbidden: may not be specified when strategy `type` is 'Recreate'
```

Root cause (verified live by the deploy agent): switching an **already-live** Deployment from RollingUpdate→Recreate is rejected because the pre-existing object carries an API-server-defaulted `strategy.rollingUpdate` block, and a Helm template `rollingUpdate: null` does **not** reliably clear a field Helm never previously owned — its 3-way merge drops the null. `helm template`/CI can't catch this (they render fresh manifests, never diff a live object). Cognee therefore never got onto the PVC, blocking the persistence fix on every already-installed silo. This is a **live-cluster-only** hazard — a fresh install is born as Recreate and never hits it.

## Fix

Don't change `strategy.type` at all. Keep `type: RollingUpdate` and set `maxSurge: 0, maxUnavailable: 1`:
- **RWO-safe** (the reason Recreate was chosen): `maxSurge: 0` tears the old pod down *before* creating the new one, so the single ReadWriteOnce volume is never double-mounted and the rollout can't deadlock.
- **Upgrades cleanly on the live object**: no strategy-type transition, just an in-place tuning of two allowed fields — no forbidden-field rejection, no hooks, no orphan-delete surgery. Fresh and live clusters converge identically.

## Test plan
- [x] `helm template` renders `strategy: {type: RollingUpdate, rollingUpdate: {maxSurge: 0, maxUnavailable: 1}}` with `persistence.enabled` (default) and omits the strategy block when disabled
- [ ] After merge: redeploy elewa — `helm upgrade` now applies, the Cognee PVC binds, the pod rolls onto `/cognee-data`, the operator self-heal re-registers elewa's login, and memory survives a Cognee restart (the #187 checks blocked twice so far)

## Follow-ups (from the blocked runs, not in this PR)
- The already-running tenant pod does **not** self-recover on `401` after its Cognee login is re-registered (the plugin doesn't transparently re-login) — it needs a one-time roll once Cognee is persistent + healed. Will confirm on the clean redeploy and, if it persists, roll the tenant pod when the silo's Cognee identity is (re)provisioned.
- Deploy-script friction (2nd occurrence): no sanctioned scripted-recovery lever for a live object that drifted on a field Helm never owned — worth a `k8s-deploy.sh` passthrough.
- #174 unthrottled reconcile loop still recurring (now also spamming Cognee logins).

Related: #187 (persistence + self-heal), #188 (the `rollingUpdate: null` attempt this supersedes).