### PR TITLE
fix(cognee): heal silo owner on a loop + roll tenant pod on identity change

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/tenants/cognee-tenant-identity.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/cognee-tenant-identity.test.ts
@@ -516,3 +516,29 @@ describe("CogneeTenantIdentity.ensureTenantJoinedToSiloTenant", () =>
       .rejects.toThrow(/Cognee get-user-id failed/);
   });
 });
+
+describe("CogneeTenantIdentity.currentJoinedTenantId", () =>
+{
+  beforeEach(() => { vi.restoreAllMocks(); });
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it("returns the cached joined tenant id (the pod roll-stamp) when present", async () =>
+  {
+    const { coreApi, objectApi, store } = _makeStatefulApis();
+    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "pw", tenantId: "tenant-live-7" });
+
+    const id = await new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log).currentJoinedTenantId("acme", "default");
+    expect(id).toBe("tenant-live-7");
+  });
+
+  it("returns empty string when not joined yet (tenantId empty) or no credentials Secret", async () =>
+  {
+    const { coreApi, objectApi, store } = _makeStatefulApis();
+    _seedCredentials(store, "default", "acme", { username: "acme@example.com", password: "pw" }); // tenantId defaults to ""
+
+    const identity = new CogneeTenantIdentity(_enabledConfig, coreApi, objectApi, _log);
+    expect(await identity.currentJoinedTenantId("acme", "default")).toBe("");
+    // No credentials Secret at all → also empty (never throws).
+    expect(await identity.currentJoinedTenantId("nonexistent", "default")).toBe("");
+  });
+});

--- a/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/tenants/tenant-resource-builder.test.ts
@@ -741,4 +741,28 @@ describe("config checksum → pod roll", () =>
   {
     expect(_annotations(undefined)).toBeUndefined();
   });
+
+  it("stamps the Cognee identity so an identity heal rolls the pod, alongside the config checksum", () =>
+  {
+    const anns = _BuildDeployment(defaultConfig, onPremAdapter.buildStateVolume("jente"), _makeTenant("jente"), "default", undefined, "cfg1", "tenant-uuid-1")
+      .spec?.template?.metadata?.annotations;
+    expect(anns).toEqual({ "opencrane.io/config-checksum": "cfg1", "opencrane.io/cognee-identity": "tenant-uuid-1" });
+  });
+
+  it("rolls on a Cognee identity change even when the config checksum is unchanged", () =>
+  {
+    const build = (stamp: string) => _BuildDeployment(defaultConfig, onPremAdapter.buildStateVolume("jente"), _makeTenant("jente"), "default", undefined, "cfg1", stamp)
+      .spec?.template?.metadata?.annotations?.["opencrane.io/cognee-identity"];
+    // Same config checksum, different Cognee tenant id (silo re-provisioned) ⇒ annotation differs ⇒ roll.
+    expect(build("old-tenant")).toBe("old-tenant");
+    expect(build("new-tenant")).toBe("new-tenant");
+  });
+
+  it("omits the Cognee-identity annotation when the stamp is empty (Cognee-less / not joined)", () =>
+  {
+    const anns = _BuildDeployment(defaultConfig, onPremAdapter.buildStateVolume("jente"), _makeTenant("jente"), "default", undefined, "cfg1", "")
+      .spec?.template?.metadata?.annotations;
+    expect(anns).toEqual({ "opencrane.io/config-checksum": "cfg1" });
+    expect(anns).not.toHaveProperty("opencrane.io/cognee-identity");
+  });
 });

--- a/apps/clustertenant-operator/src/index.ts
+++ b/apps/clustertenant-operator/src/index.ts
@@ -217,6 +217,9 @@ void (async function _startMembershipRepairer()
 /** Idle-checker handle, set during controller bootstrap for shutdown access. */
 let _idleCheckerRef: IdleChecker | null = null;
 
+/** Periodic Cognee silo-tenant heal timer, cleared on shutdown. */
+let _cogneeSiloHealTimerRef: ReturnType<typeof setInterval> | null = null;
+
 /** In-process gateway proxy server handle, for graceful shutdown. */
 let _gatewayProxyRef: GatewayProxyServer | null = null;
 
@@ -326,6 +329,39 @@ async function _startInSiloControllers(): Promise<void>
       }
     })();
 
+    // Periodic Cognee silo-tenant heal. The boot attempt above is one-shot, but the silo owner +
+    // Cognee Tenant live in Cognee's OWN database (unlike the LiteLLM key, a durable k8s Secret) —
+    // a Cognee restart onto a fresh/empty store (notably the FIRST mount of its new persistent
+    // volume) wipes them, and the single boot attempt misses that window whenever Cognee isn't
+    // ready at exactly that moment (it usually restarts alongside this pod on a deploy). Without a
+    // live owner, EVERY per-tenant `ensureTenantJoinedToSiloTenant` fails at owner-login and the
+    // tenant stays 401 forever. Re-running on a slow cadence closes that gap: `ensureSiloTenant`
+    // is idempotent + liveness-checked (a cheap no-op once the owner authenticates) and
+    // re-provisions when it was wiped. Slow interval — this is a silo singleton that changes rarely.
+    if (config.cogneeEndpoint)
+    {
+      const cogneeSiloHealer = new CogneeSiloTenant(config, coreApi, k8s.KubernetesObjectApi.makeApiClient(kc), log);
+      _cogneeSiloHealTimerRef = setInterval(function _healCogneeSiloTenant()
+      {
+        void (async function _run()
+        {
+          try
+          {
+            const ctName = await _ResolveOwnClusterTenantName(customApi, config.watchNamespace, log);
+            if (!ctName)
+            {
+              return;
+            }
+            await cogneeSiloHealer.ensureSiloTenant(ctName, config.watchNamespace);
+          }
+          catch (err)
+          {
+            log.warn({ err }, "cognee silo-tenant heal tick failed; will retry next interval");
+          }
+        })();
+      }, 60_000);
+    }
+
     const tenantOperator = _CreateTenantOperator(kc, config, log);
     const policyOperator = new PolicyOperator(kc, config, log);
 
@@ -423,6 +459,10 @@ async function _shutdown(signal: string): Promise<void>
   // Stop the projection-repair loops + in-silo controllers so no sweep races the disconnect below.
   tenantProjectionRepairer.stop();
   _membershipRepairerRef?.stop();
+  if (_cogneeSiloHealTimerRef)
+  {
+    clearInterval(_cogneeSiloHealTimerRef);
+  }
   _idleCheckerRef?.stop();
   await _gatewayProxyRef?.stop();
 

--- a/apps/clustertenant-operator/src/tenants/deploy/3-deployment.ts
+++ b/apps/clustertenant-operator/src/tenants/deploy/3-deployment.ts
@@ -31,9 +31,15 @@ import { _CredentialsSecretName } from "../internal/cognee-tenant-identity.js";
  *   rolls the pod — a mounted ConfigMap update alone does not restart OpenClaw,
  *   which reads `openclaw.json` only at startup. Omitted ⇒ no annotation, so the
  *   suspend path and existing tests render byte-for-byte unchanged.
+ * @param cogneeIdentityStamp - Optional current Cognee silo-tenant id this pod's login is joined
+ *   to (`CogneeTenantIdentity.currentJoinedTenantId`). Stamped as `opencrane.io/cognee-identity`
+ *   so a server-side Cognee identity heal (silo re-provisioned → new tenant id, or a wiped login
+ *   re-registered + re-joined) rolls the pod: it reads its Cognee credentials once at start and
+ *   does NOT re-login on a 401, so it otherwise never picks up the healed identity. Omitted/empty ⇒
+ *   no annotation (Cognee-less deploys + suspend path unchanged).
  */
 export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolume: TenantStateVolume, tenant: Tenant,
-                                 namespace: string, compute?: ClusterTenantComputeView, configChecksum?: string): k8s.V1Deployment
+                                 namespace: string, compute?: ClusterTenantComputeView, configChecksum?: string, cogneeIdentityStamp?: string): k8s.V1Deployment
 {
   const name = tenant.metadata!.name!;
   const image = tenant.spec.openclawImage ?? config.tenantDefaultImage;
@@ -203,9 +209,17 @@ export function _BuildDeployment(config: OpenClawTenantOperatorConfig, stateVolu
             "opencrane.io/tenant": name,
             ...(tenant.spec.team ? { "opencrane.io/team": tenant.spec.team } : {}),
           },
-          // Roll the pod when the tenant config changes (OpenClaw reads openclaw.json
-          // only at startup). Omitted when no checksum is supplied (suspend path).
-          ...(configChecksum ? { annotations: { "opencrane.io/config-checksum": configChecksum } } : {}),
+          // Roll the pod when the tenant config changes (OpenClaw reads openclaw.json only at
+          // startup), or when its Cognee identity is (re)provisioned (the pod caches its Cognee
+          // session at start and never re-logins on a 401). Both omitted on the suspend path.
+          ...((configChecksum || cogneeIdentityStamp)
+            ? {
+                annotations: {
+                  ...(configChecksum ? { "opencrane.io/config-checksum": configChecksum } : {}),
+                  ...(cogneeIdentityStamp ? { "opencrane.io/cognee-identity": cogneeIdentityStamp } : {}),
+                },
+              }
+            : {}),
         },
         spec: {
           // 4. Pod defaults — enforce the baseline runtime hardening profile

--- a/apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts
+++ b/apps/clustertenant-operator/src/tenants/internal/cognee-tenant-identity.ts
@@ -179,6 +179,21 @@ export class CogneeTenantIdentity
   }
 
   /**
+   * The Cognee silo-tenant id this tenant's login is currently joined to (from its credentials
+   * Secret), or `""` when not provisioned/joined yet. The reconcile loop folds this into the tenant
+   * pod's roll-checksum: the pod caches its Cognee session at start and does NOT re-login on a 401,
+   * so a server-side identity heal (silo re-provisioned → new tenant id, or a wiped login
+   * re-registered → id reset then re-joined) is invisible to a long-running pod until it rolls.
+   * Stamping the id makes a successful (re)join change the pod template → a Recreate roll → the
+   * plugin logs in fresh against the healed Cognee.
+   */
+  async currentJoinedTenantId(tenantName: string, namespace: string): Promise<string>
+  {
+    const credentials = await this._readCredentialsSecret(namespace, tenantName);
+    return credentials?.tenantId ?? "";
+  }
+
+  /**
    * Register `email`/`password` as a Cognee user. Idempotent: a 400 response (Cognee's
    * signal for "email already registered", verified against the shipped `test_backend_auth.py`:
    * `assert register_response.status_code in (201, 400)`) is treated as success since the

--- a/apps/clustertenant-operator/src/tenants/operator.ts
+++ b/apps/clustertenant-operator/src/tenants/operator.ts
@@ -390,6 +390,24 @@ export class TenantOperator
         this.log.warn({ err, name }, "cognee silo-tenant join failed; continuing reconcile");
       }
 
+      // 5c. Capture the tenant's current Cognee silo-tenant id (best-effort) so step 8 can stamp it
+      //     on the pod template. A server-side Cognee identity heal (silo re-provisioned, or a wiped
+      //     login re-registered + re-joined above) changes this id; the running pod caches its
+      //     Cognee session and never re-logins on a 401, so without this stamp it stays 401 until
+      //     something else happens to roll it. Empty string when Cognee is off / not joined yet.
+      let cogneeIdentityStamp = "";
+      if (this.config.cogneeEndpoint)
+      {
+        try
+        {
+          cogneeIdentityStamp = await this.cogneeTenantIdentity.currentJoinedTenantId(name, namespace);
+        }
+        catch (err)
+        {
+          this.log.warn({ err, name }, "reading cognee identity stamp failed; pod roll on identity change skipped this cycle");
+        }
+      }
+
       // 6. ConfigMap — serialises the base OpenClaw JSON config merged with any
       //    spec.configOverrides the tenant author provided. Capture it so its
       //    checksum can roll the pod when the config changes (step 7).
@@ -443,7 +461,7 @@ export class TenantOperator
 
       // 8. Deployment — single-replica pod running the tenant's OpenClaw gateway.
       //    Mounts the ConfigMap, encryption key, state volume, and projected identity tokens.
-      await __K8sApplyResource(this.appsApi, _BuildDeployment(this.config, stateVolume, effectiveTenant, namespace, compute, configChecksum), this.log);
+      await __K8sApplyResource(this.appsApi, _BuildDeployment(this.config, stateVolume, effectiveTenant, namespace, compute, configChecksum, cogneeIdentityStamp), this.log);
 
       // 9. Service — ClusterIP that makes the gateway reachable inside the cluster
       //    on the configured gateway port.


### PR DESCRIPTION
## Summary

Persistence (#187/#189) is working — Cognee data now survives restarts, verified live. But elewa's memory still returns `401 Unauthorized` on writes, and the live deploy pinpointed exactly why. Two gaps:

1. **Silo-owner self-heal was one-shot.** `CogneeSiloTenant.ensureSiloTenant` (the owner account + shared Cognee Tenant every per-tenant login joins) ran *once*, fire-and-forget, at operator boot. On a deploy the operator and Cognee restart together; if Cognee isn't ready at that instant, the owner is never re-registered against the now-persistent-but-freshly-empty Cognee, and every `ensureTenantJoinedToSiloTenant` then fails at owner-login (`400 LOGIN_BAD_CREDENTIALS`) in a tight loop. Unlike the LiteLLM key (a durable k8s Secret), the owner lives in Cognee's own DB, so the first mount of its new PVC wipes it.
   → **Fix:** run `ensureSiloTenant` on a slow **periodic loop** (`index.ts`, 60s, cleared on shutdown) in addition to the boot attempt. It's idempotent + liveness-checked (cheap no-op once the owner authenticates) and re-provisions when wiped, so the owner heals within ~a minute of any reset — no manager restart needed.

2. **The running tenant pod never picks up the healed identity.** It reads its Cognee credentials once at start, the plugin doesn't re-login on a 401, and its only roll trigger (`opencrane.io/config-checksum`) hashes the ConfigMap, which excludes the Cognee credentials Secret.
   → **Fix:** stamp the tenant pod template with its current joined Cognee tenant id (`opencrane.io/cognee-identity`, via new `CogneeTenantIdentity.currentJoinedTenantId`, threaded through `_BuildDeployment`). A server-side identity heal changes the id → the pod Recreate-rolls → the plugin logs in fresh against the healed Cognee.

Together these close the customer-visible 401 automatically after any Cognee identity reset (the one-time PVC transition, or a future wipe).

## Test plan
- [x] Full `clustertenant-operator` suite: 94 files / 742 tests green (new tests: `opencrane.io/cognee-identity` annotation present/absent + rolls on id change; `currentJoinedTenantId` returns id / "" / never throws)
- [x] `tsc --noEmit` clean; full monorepo `pnpm build` clean
- [ ] After merge: redeploy elewa — the periodic loop registers the owner into the persistent Cognee, the per-tenant join succeeds, the tenant pod rolls on the new `cognee-identity` stamp, and the `qa store` 401 clears (a real turn produces a successful embed + recall that survives a Cognee restart)

## Follow-ups (not in this PR)
- No `podAnnotations` lever on the clustertenant-manager Deployment (the periodic loop removes the need to restart it, so this is pure operability) — separate.
- #174 unthrottled reconcile loop still recurring.

Related: #187/#189 (persistence — this makes it actually clear the 401), #182/#183 (the identity + silo-tenant model being healed).