### PR TITLE
docs(agents): teach deploy+review agents the live-upgrade & stateful-service traps

### DIFF
--- a/.claude/agents/deploy.md
+++ b/.claude/agents/deploy.md
@@ -56,6 +56,16 @@ the next deploy cannot reproduce, which defeats your purpose.
 4. `helm dep build` (NOT `dep update`) for the profile chart — dependencies resolve
    from `Chart.lock` so every run is reproducible.
 5. Run the script's own `--preflight` when available.
+6. **In-place upgrade ≠ fresh render.** If this deploy carries a chart change to an
+   immutable or API-defaulted field — a Deployment/StatefulSet `strategy` or
+   `selector`, a PVC spec, a Service `clusterIP`/`type`, or a resource's
+   Helm-ownership metadata — diff the RENDERED manifest against the LIVE object first
+   (`helm get manifest` / `kubectl get <res> -o yaml`). The API server rejects some
+   in-place transitions even when `helm template` and CI are green: e.g.
+   RollingUpdate↔Recreate leaves a forbidden `strategy.rollingUpdate` block unless the
+   template nulls it, and a resource created out-of-band has no Helm ownership so the
+   upgrade errors "cannot be imported into the current release". Flag the hazard as a
+   `chart` finding BEFORE applying — it has cost this fleet multiple failed revisions.
 
 ## Running the deploy
 

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -48,6 +48,24 @@ fresh context — do not assume the author's intent was correct.
   is a finding. Expected/benign early returns need no log.
 - Tests exist for changed behaviour and for the regression being fixed. When in
   doubt run them: `pnpm --filter <pkg> test`.
+- **Operational correctness** (these cost real live-deploy iterations when missed —
+  flag them at PR time):
+  - *Persistence.* A workload that stores state it must not lose (database, vector/graph
+    index, identity/user table) with only ephemeral pod storage loses everything on
+    restart. A stateful container needs a volume — flag a Deployment/pod writing durable
+    state with no PVC/mount.
+  - *In-place upgrade safety.* A chart change to an immutable/API-defaulted field
+    (Deployment `strategy`/`selector`, PVC spec, Service `clusterIP`) must transition
+    cleanly on an ALREADY-LIVE object, not just render — e.g. RollingUpdate→Recreate must
+    `rollingUpdate: null` or the live upgrade is rejected. Prefer a change that avoids the
+    transition (tune `maxSurge:0` instead of switching to Recreate) over one that needs it.
+  - *Reconcile, not one-shot.* Provisioning a dependency at boot fire-and-forget (a single
+    attempt that only logs a warning on failure) silently never converges if the
+    dependency wasn't ready at that instant — it needs retry/periodic reconciliation.
+  - *Config/credential propagation.* A pod consuming a Secret/ConfigMap via env or
+    `secretKeyRef` reads it once at start and does not hot-reload; if that value's meaning
+    can change at runtime, there must be a pod-roll trigger (a checksum/identity annotation
+    on the pod template).
 
 ### DIMENSION: security
 - **IAM-first**: federated identity / OIDC / Workload Identity over static bearer

--- a/docs/agents/deploy-ledger.md
+++ b/docs/agents/deploy-ledger.md
@@ -25,7 +25,9 @@ Friction items seen across runs; bump the count, and when it hits 2, file the fi
 
 | Friction item | Seen | Status |
 |---|---|---|
-| _(none yet)_ | | |
+| No raw-helm-flag passthrough in `k8s-deploy.sh` (blocks sanctioned `--take-ownership` / one-time field-clear recoveries) | 2 (07-09, 07-11) | **graduated** — needs a `--helm-arg` passthrough fix PR |
+| `--preflight` NS-delegation check false-positives on `dev.opencrane.ai` every run (A-record in parent zone, not a delegated subzone) | 3+ (07-10..07-12) | **graduated** — scope the check to only fire when ACME/DNS-01 issuance is requested |
+| `--set` numeric-string coercion breaks string values (annotations) — needs `--set-string`/`--values` | 2 (07-10, 07-11) | fixed-forward in usage; consider a script guard |
 
 ## Standing lessons (read these first)
 
@@ -36,6 +38,21 @@ Friction items seen across runs; bump the count, and when it hits 2, file the fi
 - Known dev-cluster history (see auto-memory / plan.md): migrate-on-deploy
   initContainer, tenant-pod `trustNothing` config crash, `trustedProxies: []`
   fail-closed — check whether a "new" failure is one of these before diagnosing fresh.
+- **In-place upgrade ≠ fresh render.** A chart change to an immutable/API-defaulted
+  field (Deployment `strategy`/`selector`, PVC spec, Service `clusterIP`) or a resource's
+  Helm-ownership metadata can be rejected by `helm upgrade` on an already-live object even
+  when `helm template`/CI are green. Diff `helm get manifest` / the live object before
+  applying. Two burns: RollingUpdate→Recreate needing `rollingUpdate: null` then
+  ultimately `maxSurge:0` (PRs #187→#188→#189, 3 revisions); Certificate created
+  out-of-band failing "cannot be imported into the current release" (2026-07-09).
+- `--set` coerces a numeric-looking string to a number (e.g. a `restartedAt` epoch
+  annotation → `expected string, got 1783…`). Use `--set-string` or a `--values` file
+  with a quoted value for annotation/string values.
+- A service that stores state (Cognee: identity DB + graph + vector) needs a PVC, or it
+  wipes on every restart — and any operator-registered state inside it (per-tenant logins)
+  is orphaned with it. Boot-time provisioning of such state must reconcile on a loop, not
+  one-shot; and a tenant pod that reads its credentials via `secretKeyRef` needs a
+  pod-template stamp to roll when that state is re-provisioned (PR #187→#190).
 
 ## Runs
 
@@ -99,3 +116,48 @@ Friction items seen across runs; bump the count, and when it hits 2, file the fi
 - lesson: a successful `helm upgrade` + "successfully rolled out" is NOT proof the
   intended runtime change took effect inside the tenant pod — verify the actual
   installed package version on the PVC, not just the pod's env vars/ConfigMap.
+
+## 2026-07-10 · dev · clustertenant-platform (silo: elewa) · e974df3 → 014250f → 1418d70 · LIVE
+- context: Cognee org-memory fix chain (issues behind PRs #178/#182/#183/#184). Multiple
+  same-day silo redeploys as each layer landed.
+- findings: infra: opencrane-dev has NO NetworkPolicy-enforcing CNI (standard GKE, no
+  Dataplane V2, `networkPolicy: null`, no calico/cilium DaemonSet) — every silo/Cognee
+  NetworkPolicy is declared-but-INERT, incl. the #178 Cognee egress exclusion. Filed #180.
+- findings: codebase: Cognee had no LLM/embedding creds, then no registered embedding
+  model, then a shared-`default_user` login — fixed across #182/#183/#184 (per-tenant
+  Cognee logins keyed to the IdP email + a shared silo Cognee tenant + an `auto-embedding`
+  alias). Verified live: `/v1/embeddings` model=auto-embedding → 200, no more
+  `Invalid model name` / `EmbeddingException`.
+- lesson: LiteLLM `/model/new` is not idempotent by name — guard with a `/model/info`
+  check (the embedding path does; chat guards via the ModelDefinition row). Registry
+  stayed duplicate-free across many redeploys.
+
+## 2026-07-11 · dev · clustertenant-platform (silo: elewa) · 8905cdc / 53a64f9 · FAILED ×2
+- findings: chart: Cognee had NO persistent storage — identity DB + graph + vector on the
+  pod's ephemeral fs, wiped every restart (the #184 restart orphaned the per-tenant login →
+  `qa store failed: 401`). Fixed by a PVC (#187). BUT #187/#188 used `type: Recreate`, which
+  the API server rejected on the already-live Deployment (`spec.strategy.rollingUpdate:
+  Forbidden`) — `helm upgrade` aborted at rev 32 AND rev 33, so Cognee never got the PVC. A
+  template `rollingUpdate: null` (#188) did not clear the field via Helm's 3-way merge.
+- lesson: see standing lesson "in-place upgrade ≠ fresh render". Superseded by #189's
+  `RollingUpdate maxSurge:0` (RWO-safe, no strategy-type transition).
+
+## 2026-07-12 · dev · clustertenant-platform (silo: elewa) · 584bd3c → 830f42e · LIVE
+- findings: chart: #189 (`RollingUpdate maxSurge:0`) applies cleanly on the live Deployment;
+  Cognee PVC Bound, and data VERIFIED to survive a forced restart (same PVC re-attached,
+  db mtimes pre-date the restart; transient Multi-Attach self-resolves in ~15s — the
+  RWO-safe handoff working as designed).
+- findings: codebase: the silo-owner self-heal (`ensureSiloTenant`) was one-shot at operator
+  boot with no retry — it missed the Cognee readiness window on a deploy, so the persistent
+  Cognee stayed owner-less and every per-tenant join looped on owner-login 400s. And the
+  running tenant pod (secretKeyRef creds, no re-login on 401) never picked up a healed
+  identity. Both fixed in #190: periodic 60s silo heal + an `opencrane.io/cognee-identity`
+  pod-template stamp that rolls the tenant pod when its Cognee tenant id changes. Verified
+  live: owner re-provisioned within 14s of boot, tenant pod rolled, no 401 in the post-roll
+  window, embedding 200.
+- friction: `--preflight` NS-delegation check false-positives on dev.opencrane.ai (A-record
+  in the parent zone, not a delegated subzone) on every run — candidate to scope the check
+  to only fire when ACME/DNS-01 issuance is actually requested.
+- lesson: org-memory is only "working" when the tenant pod can invoke it — a green rollout +
+  healed server-side identity is necessary but not sufficient; confirm from the tenant pod's
+  own logs (fresh login, no 401) after it rolls.


### PR DESCRIPTION
## Summary

The Cognee org-memory fix took ~6 deploy iterations because several problems render green from `helm template`/`pnpm build`/CI but only fail against **live** cluster state. This encodes those classes into the agents so they're caught up front — tight checks, no backwards-compat cruft.

- **deploy agent** (`.claude/agents/deploy.md`): new pre-deploy step — when a deploy carries a chart change to an immutable/API-defaulted field (Deployment `strategy`/`selector`, PVC spec, Service `clusterIP`) or Helm-ownership metadata, diff the rendered manifest against the **live object** first. The API server rejects some in-place transitions even when the render is green (RollingUpdate↔Recreate's forbidden `rollingUpdate` block — 3 failed revisions; out-of-band Certificate ownership — 2026-07-09).
- **review agent** (`.claude/agents/review.md`, correctness dimension): four operational-correctness heuristics to flag at PR time — stateful workload without persistence, in-place-upgrade field transitions, one-shot vs reconcile provisioning, and `secretKeyRef`/env consumers that need a pod-roll trigger when the value's meaning changes.
- **deploy-ledger** (`docs/agents/deploy-ledger.md`): standing lessons for the above + the 2026-07-10→12 run history; graduated two recurring friction items (no `--helm-arg` passthrough; `--preflight` NS-delegation false positive) in the simplification counters per the ledger's own 2-occurrence rule.

Also saved the meta-lesson to persistent agent memory (outside the repo) so future sessions apply it by default.

## Test plan
- [x] Docs/agent-definition only — no code paths changed. Reviewed for concision (each addition is a few lines, no bloat).