### PR TITLE
docs(tenant): make Cognee the native-only memory path

### DIFF
--- a/apps/clustertenant-operator/src/core/contract/tools-markdown.ts
+++ b/apps/clustertenant-operator/src/core/contract/tools-markdown.ts
@@ -66,6 +66,12 @@ const _ORG_MEMORY_SECTION = [
   "Durable, generalizable notes you write into `MEMORY.md` / `memory/*.md` are auto-indexed into " +
     "Cognee and routed to the right scope; keep personal style, this user's preferences, and transient " +
     "task state in MEMORY.md as usual.",
+  "Those three interfaces — auto-recall, the cognee_memories tool, and writing `MEMORY.md` / " +
+    "`memory/*.md` — are the ONLY way you touch Cognee. Writing those files IS a real, durable Cognee " +
+    "write (the plugin indexes them), not a fake local substitute, so never dismiss a file write as " +
+    "\"not really Cognee\" and hunt for a raw API. Do NOT call Cognee's HTTP API (COGNEE_ENDPOINT, " +
+    "/api/v1/...), do NOT run `openclaw cognee ...` CLI subcommands, and do NOT write a bespoke client " +
+    "— those bypass the plugin's scope, ACL, and provenance guarantees.",
   "If memory is momentarily unavailable (e.g. just after startup), the turn proceeds without it and " +
     "recovers on its own — never invent an error, an index status, or a remediation command; report " +
     "what you actually see.",

--- a/apps/clustertenant-operator/src/tenants/deploy/workspace/AGENTS.md
+++ b/apps/clustertenant-operator/src/tenants/deploy/workspace/AGENTS.md
@@ -49,7 +49,17 @@ is scope-partitioned and permission-filtered by the platform: you only ever see 
 is granted. Prefer it over your personal `MEMORY.md` for company documents, prior decisions, and
 project facts. To PERSIST a generalizable learning, just write it into `MEMORY.md` / `memory/*.md` —
 the plugin auto-indexes those files into Cognee and routes them to the right scope
-(company / user / agent); there is no separate "remember" tool to call. Cognee is a settled platform
+(company / user / agent); there is no separate "remember" tool to call.
+
+**Those three interfaces are the *only* way you touch Cognee: the auto-recall block and the
+`cognee_memories` tool to read, and writing `MEMORY.md` / `memory/*.md` to persist.** Writing those
+files IS a real, durable Cognee write — the plugin indexes them for you; it is not a fake or
+local-only substitute, so never treat a file write as "not really Cognee" and go looking for a
+"real" one. Do NOT reach Cognee any other way: do not call its HTTP API (`COGNEE_ENDPOINT`,
+`/api/v1/...`), do not run `openclaw cognee ...` CLI subcommands, and do not write a bespoke client
+script. Those bypass the plugin's scope-partitioning, ACL, and provenance guarantees, so the
+platform treats them as out of bounds. If you ever feel you need a raw API to store memory, you are
+mistaken — write the file. Cognee is a settled platform
 dependency, not an option — if it is ever missing at startup the runtime logs a warning and org
 memory is unavailable until an operator fixes it. If org memory is momentarily unavailable (just
 after startup, or a slow recall), the turn proceeds without it and recovers on its own. Never

--- a/apps/clustertenant-operator/src/tenants/deploy/workspace/TOOLS.md
+++ b/apps/clustertenant-operator/src/tenants/deploy/workspace/TOOLS.md
@@ -33,6 +33,13 @@ Durable, generalizable notes you write into `MEMORY.md` / `memory/*.md` are auto
 and routed to the right scope (company / user / agent) — you don't call a separate "remember" tool.
 Keep personal style, this user's preferences, and transient task state in `MEMORY.md` as usual.
 
+Those three interfaces — the auto-recall block, the `cognee_memories` tool, and writing
+`MEMORY.md` / `memory/*.md` — are the **only** way you touch Cognee. Writing those files IS a real,
+durable Cognee write (the plugin indexes them), not a fake local substitute, so never dismiss a file
+write as "not really Cognee" and hunt for a raw API. Do NOT call Cognee's HTTP API
+(`COGNEE_ENDPOINT`, `/api/v1/...`), do NOT run `openclaw cognee ...` CLI subcommands, and do NOT
+write a bespoke client — those bypass the plugin's scope, ACL, and provenance guarantees.
+
 If org memory is momentarily unavailable (e.g. just after startup, or a slow recall), the turn
 proceeds without it and recovers on its own. Never invent an error message, an index status, or a
 `memory`/index CLI command — report exactly what you see.


### PR DESCRIPTION
## Why

A deployed tenant clone stumbled on its first memory use (session transcript). It:
1. created fake `memory/*.md` files it described as "not really Cognee", then
2. reached Cognee's raw `/api/v1/remember/entry` HTTP endpoint directly.

Both bypass the native plugin path. The platform-owned workspace docs already describe the plugin (auto-recall + `cognee_memories` + auto-indexed `MEMORY.md`) but never (a) closed the interface — nothing forbade the raw HTTP API or `openclaw cognee` CLI — or (b) countered the "markdown writes are fake" misconception that sent the clone hunting for a "real" API.

## What

Harden the three surfaces that reach every future clone:
- `workspace/AGENTS.md` (static L0)
- `workspace/TOOLS.md` (static L0)
- `core/contract/tools-markdown.ts` `_ORG_MEMORY_SECTION` (poll-regenerated doc that shadows TOOLS.md)

Each now states the **closed set** of native interfaces — auto-recall + `cognee_memories` to read, writing `MEMORY.md`/`memory/*.md` to persist — affirms that a file write **is** a real durable Cognee write (not a local substitute), and forbids every other route: Cognee's HTTP API, `openclaw cognee ...` CLI subcommands, bespoke clients.

## Test

`tools-markdown.test.ts` 4/4 pass. Docs-only + regenerated-section change; no runtime behaviour change.