### PR TITLE
fix(fleet-chart): nil-safe multiCt access — --reuse-values upgrade panic

### DIFF
--- a/apps/clustertenant-platform/templates/clustertenant-manager-deployment.yaml
+++ b/apps/clustertenant-platform/templates/clustertenant-manager-deployment.yaml
@@ -260,7 +260,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: REQUIRE_WATCH_NAMESPACE
-              value: {{ .Values.multiInstance.requireWatchNamespace | quote }}
+              value: {{ (.Values.multiInstance).requireWatchNamespace | quote }}
             - name: TENANT_DEFAULT_IMAGE
               value: "{{ .Values.tenant.defaultImage.repository }}:{{ .Values.tenant.defaultImage.tag }}"
             - name: DEFAULT_OPENCLAW_VERSION

--- a/apps/clustertenant-platform/templates/networkpolicy-multi-instance.yaml
+++ b/apps/clustertenant-platform/templates/networkpolicy-multi-instance.yaml
@@ -1,7 +1,7 @@
-{{- if and .Values.multiCt.enabled (not .Values.multiInstance.enabled) }}
+{{- if and (.Values.multiCt).enabled (not (.Values.multiInstance).enabled) }}
 {{- fail "multiCt.enabled=true requires multiInstance.enabled=true: the cross-instance default-deny is mandatory for a multi-ClusterTenant install and derives its namespace allow-list from multiInstance.instanceNamespaces. Set multiInstance.enabled=true (and instanceNamespaces), or drop the --multi-ct profile for a single-tenant box." }}
 {{- end }}
-{{- if and .Values.networkPolicy.enabled (or .Values.multiInstance.enabled .Values.multiCt.enabled) }}
+{{- if and (.Values.networkPolicy).enabled (or (.Values.multiInstance).enabled (.Values.multiCt).enabled) }}
 {{- /*
   Cross-instance default-deny NetworkPolicy (brief B6, MI.6).
 

--- a/apps/fleet-platform/templates/networkpolicy-main-network-baseline.yaml
+++ b/apps/fleet-platform/templates/networkpolicy-main-network-baseline.yaml
@@ -39,10 +39,10 @@
   independently and provide the per-component ingress allow-list. This template
   adds the missing egress and the catch-all default-deny on top of them.
 */}}
-{{- if and .Values.multiCt.enabled (not .Values.networkPolicy.mainNetworkDefaultDeny.enabled) }}
+{{- if and (.Values.multiCt).enabled (not (.Values.networkPolicy).mainNetworkDefaultDeny.enabled) }}
 {{- fail "multiCt.enabled=true requires networkPolicy.mainNetworkDefaultDeny.enabled=true: the platform-namespace default-deny is mandatory for a multi-ClusterTenant install. Set networkPolicy.mainNetworkDefaultDeny.enabled=true, or drop the --multi-ct profile for a single-tenant box." }}
 {{- end }}
-{{- if or .Values.networkPolicy.mainNetworkDefaultDeny.enabled .Values.multiCt.enabled }}
+{{- if or (.Values.networkPolicy).mainNetworkDefaultDeny.enabled (.Values.multiCt).enabled }}
 ---
 # ──────────────────────────────────────────────────────────────────────────────
 # 1. DEFAULT-DENY: drop all ingress+egress for every pod in the platform

--- a/libs/k8s-platform/values/opencrane-dev.yaml
+++ b/libs/k8s-platform/values/opencrane-dev.yaml
@@ -3,17 +3,17 @@
 # Cluster: gke_weownai-proto_europe-west1-b_opencrane-dev  (project weownai-proto)
 # Base domain: dev.opencrane.ai
 #
-# Usage (via the multi-tenant profile). --reuse-values inherits every value already
-# on the live release (GCP SA, cert-manager, external-dns, OIDC, …); this overlay only
-# overrides the three knobs that were left at their (off) defaults and disabled the
-# per-org hosting path entirely (see below). k8s-deploy.sh takes a single --values file,
-# so reuse-values (not a second -f) is how the prior config is preserved.
+# Usage (via the multi-tenant profile). The deploy script uses --reset-then-reuse-values:
+# it merges chart defaults (new keys like multiCt) with the prior release values, so the
+# overlay only needs to override non-default keys. Since reset re-applies chart defaults
+# for all keys the invocation doesn't supply, per-component image tags (--control-plane-tag,
+# --operator-tag, etc.) must be restated explicitly with --tag flags (they are not carried
+# from --values files).
 #
 #   apps/fleet-platform/deploy.sh \
 #     --base-domain dev.opencrane.ai \
 #     --ingress-ip 34.22.213.142 \
 #     --operator-tag <new-operator-image-tag> \
-#     --reuse-values \
 #     --values libs/k8s-platform/values/opencrane-dev.yaml
 
 global:


### PR DESCRIPTION
## Error Evidence (from 2026-07-12 dev deploy run)

```
Error: UPGRADE FAILED: opencrane-fleet/templates/networkpolicy-main-network-baseline.yaml:42:18 executing ... at <.Values.multiCt.enabled>: nil pointer evaluating interface {}.enabled
```

## Root Cause

`multiCt.enabled: false` was added to the chart defaults after the fleet's last release (rev 8, 2026-06-29). Helm's `--reuse-values` does NOT re-merge new chart defaults into the prior release's stored values, so the entire `multiCt` map is nil at render time. Bare nested access like `.Values.multiCt.enabled` panics.

The dev values preset header explicitly recommended `--reuse-values`, so following the documented usage failed.

## Fix

Made all bare nested `.Values.multiCt.*` and `.Values.multiInstance.*` accesses nil-safe using the parenthesised idiom: `(.Values.multiCt).enabled` instead of `.Values.multiCt.enabled`.

This is nil-safe in Helm templates — accessing `.enabled` on a nil map returns false/nil gracefully.

**Files fixed:**
- `apps/fleet-platform/templates/networkpolicy-main-network-baseline.yaml`: Lines 42, 45
- `apps/clustertenant-platform/templates/networkpolicy-multi-instance.yaml`: Lines 1, 4
- `apps/clustertenant-platform/templates/clustertenant-manager-deployment.yaml`: Line 263

**Documentation update:**
- `libs/k8s-platform/values/opencrane-dev.yaml` header: stopped recommending `--reuse-values`, clarified that the deploy script uses `--reset-then-reuse-values` (which re-applies chart defaults) and that per-component image tags must be restated explicitly via `--tag` flags.

## Validation

All tests pass:
```bash
# (a) default values
helm template apps/fleet-platform ✓

# (b) opencrane-dev.yaml overlay
helm template apps/fleet-platform --values libs/k8s-platform/values/opencrane-dev.yaml ✓

# (c) nil-case simulation (regression proof)
helm template apps/fleet-platform --set-json 'multiCt=null' ✓
helm template apps/clustertenant-platform --set-json 'multiCt=null' --set-json 'multiInstance=null' ✓

# Chart lint
helm lint apps/fleet-platform ✓
helm lint apps/clustertenant-platform ✓
```

---

**Note:** Found by the 2026-07-12 dev deploy run (ledger entry on feat/nx-domain-libs); fix not yet re-deployed — next deploy run proves it.