### PR TITLE
fix(deploy): tag-float guard, --helm-arg passthrough, preflight/header docs

### DIFF
--- a/apps/fleet-platform/deploy.sh
+++ b/apps/fleet-platform/deploy.sh
@@ -17,13 +17,21 @@
 #   apps/fleet-platform/deploy.sh \
 #       --base-domain dev.opencrane.ai \
 #       [--ingress-ip 34.1.2.3] [--dns-managed-zone my-zone] \
+#       [--platform-operator-seed-email admin@org] \
 #       [ANY k8s-deploy.sh flag, e.g. --cert-manager --acme-email … --dns01-provider clouddns]
 #
 # --base-domain is required (the platform wildcard base every org is served under).
+# --platform-operator-seed-email is required for every deploy (a fail-closed gate, not
+# a stored value; set it via --platform-operator-seed-email or the OPENCRANE_PLATFORM_OPERATOR_SEED_EMAIL
+# env var). Without it the fleet grants operator to nobody and the control-plane UI is inaccessible.
 # --ingress-ip / --dns-managed-zone wire the operator's per-org DNS side effect. When
 # --ingress-ip is OMITTED the core auto-derives it from the ingress-nginx LoadBalancer
 # (--auto-ingress-ip); on-prem with no LB it stays unset and the operator skips the DNS
 # write (per-org Certificate still applied). Add --verify for an advisory post-deploy check.
+#
+# Environment:
+#   OPENCRANE_SKIP_PREFLIGHT=1  Skip the mandatory multi-CT preflight check (not recommended;
+#                               preflight validates cross-tenant isolation will work).
 #
 # Prereqs: kubectl (pointed at the target cluster) and helm.
 # =============================================================================

--- a/libs/k8s-platform/k8s-deploy.sh
+++ b/libs/k8s-platform/k8s-deploy.sh
@@ -27,7 +27,7 @@
 #                            [--cert-manager] [--acme-email EMAIL]
 #                            [--dns01-provider clouddns] [--dns01-credentials FILE]
 #                            [--dns01-project PROJECT_ID] [--dns-writer-gsa EMAIL]
-#                            [--values FILE] [--set k=v ...]
+#                            [--values FILE] [--set k=v ...] [--helm-arg ARG ...]
 #                            [--reuse-values | --reset-values]
 #
 # Value preservation: on an UPGRADE (release already exists) this engine defaults to Helm's
@@ -35,6 +35,18 @@
 # restates fewer values (a component-tag bump preserves the rest). Pass --reuse-values to
 # inherit the last release verbatim without refreshing chart defaults, or --reset-values to
 # intentionally drop prior overrides and start from chart defaults + this run's flags.
+#
+# Image-tag float guard: after a prior release's --reset-then-reuse-values upgrade, component
+# images may be pinned to a specific tag (e.g. sha-5036a0a). If this invocation does not restate
+# those tags (no --control-plane-tag/--operator-tag/--tenant-tag) and does not explicitly float
+# (OPENCRANE_ALLOW_TAG_FLOAT=1), the script detects the prior pin, warns loudly, and
+# automatically re-pins from the last release so pinned tags float silently (a live gotcha from
+# 2026-07-12 deploy). Pass OPENCRANE_ALLOW_TAG_FLOAT=1 to intentionally float tags to chart-default.
+#
+# Raw Helm-arg passthrough: --helm-arg ARG (or OPENCRANE_HELM_EXTRA_ARGS='ARG1 ARG2 …')
+# appends verbatim arguments to the final helm upgrade invocation. Useful for sanctioned
+# one-time fixes like --take-ownership (e.g. when a Certificate loses ownership across versions).
+# Repeatable: --helm-arg --take-ownership --helm-arg --force-fields-order.
 #
 # TLS / cert-manager (Step 2.5) has THREE modes:
 #   off (default)  — no cert-manager install; the chart renders no issuer/cert.
@@ -127,6 +139,8 @@ VALUES_FILE=""
 REUSE_VALUES=""      # explicit "--reuse-values": inherit last release's values verbatim; add only overrides
 RESET_VALUES=""      # explicit "--reset-values": DROP prior values, start from chart defaults + this run's --set
 EXTRA_SET=()
+EXTRA_HELM_ARGS=()   # raw --helm-arg passthrough args (e.g. --take-ownership for Certificate ownership recovery)
+ALLOW_TAG_FLOAT="${OPENCRANE_ALLOW_TAG_FLOAT:-0}"  # allow component images to float to chart-default
 
 # OIDC + per-cluster operator bootstrap. All default empty (OIDC stays disabled and the
 # seed grants operator to nobody — fail-closed). The seed also accepts an env var so a
@@ -273,6 +287,7 @@ while [[ $# -gt 0 ]]; do
     --reuse-values)  REUSE_VALUES="1"; shift ;;
     --reset-values)  RESET_VALUES="1"; shift ;;
     --set)           EXTRA_SET+=(--set "$2"); shift 2 ;;
+    --helm-arg)      EXTRA_HELM_ARGS+=("$2"); shift 2 ;;
     -h|--help)       grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *)               err "Unknown flag: $1"; exit 1 ;;
   esac
@@ -912,6 +927,59 @@ helm_args=(upgrade --install "$RELEASE" "$CHART_DIR" --namespace "$NAMESPACE" --
   --set "litellm.existingDatabaseSecret=opencrane-litellm-db"
   --set "litellm.existingSecret=opencrane-litellm"
   --set "litellm.storeModelInDb=true")
+
+# Pinned-tag float guard: detect if the prior release pinned component images to a specific
+# tag. If this invocation does not restate them (no --control-plane-tag/--operator-tag/--tenant-tag),
+# re-pin from the prior release so they don't silently float to chart-default (a 2026-07-12 live gotcha).
+# Escape: OPENCRANE_ALLOW_TAG_FLOAT=1 to intentionally float tags.
+_enforce_tag_pins() {
+  # Only check on an existing release (upgrade path). Fresh installs have no prior values.
+  if ! helm status "$RELEASE" -n "$NAMESPACE" >/dev/null 2>&1; then
+    return 0
+  fi
+  # Allow explicit float escape.
+  if [[ "$ALLOW_TAG_FLOAT" == "1" ]]; then
+    return 0
+  fi
+  # Check what tags are pinned in the PRIOR release, and what THIS run explicitly sets.
+  local prior_cp prior_op prior_tn prior_vals
+  prior_vals="$(helm get values "$RELEASE" -n "$NAMESPACE" -o json 2>/dev/null || echo '{}')"
+
+  # Extract tags using jq if available, otherwise fall back to grep.
+  if command -v jq >/dev/null 2>&1; then
+    prior_cp="$(echo "$prior_vals" | jq -r '.clustertenantManager.image.tag // empty')"
+    prior_op="$(echo "$prior_vals" | jq -r '.fleetManager.image.tag // empty')"
+    prior_tn="$(echo "$prior_vals" | jq -r '.tenant.image.tag // empty')"
+  else
+    # Grep fallback for when jq is not available (simple pattern, may miss nested structures).
+    prior_cp="$(echo "$prior_vals" | grep -o '"clustertenantManager":[^}]*"tag":"[^"]*' | grep -o '"tag":"[^"]*' | head -1 | cut -d'"' -f4 || true)"
+    prior_op="$(echo "$prior_vals" | grep -o '"fleetManager":[^}]*"tag":"[^"]*' | grep -o '"tag":"[^"]*' | head -1 | cut -d'"' -f4 || true)"
+    prior_tn="$(echo "$prior_vals" | grep -o '"tenant":[^}]*"tag":"[^"]*' | grep -o '"tag":"[^"]*' | head -1 | cut -d'"' -f4 || true)"
+  fi
+
+  local need_warn=0
+  # If prior release had a tag and this run doesn't set one, re-pin it.
+  if [[ -n "$prior_cp" && -z "$CONTROL_PLANE_TAG" ]]; then
+    warn "Prior release had clustertenantManager.image.tag='$prior_cp' — re-pinning (to avoid silent float to chart-default). Pass OPENCRANE_ALLOW_TAG_FLOAT=1 to float intentionally."
+    CONTROL_PLANE_TAG="$prior_cp"
+    need_warn=1
+  fi
+  if [[ -n "$prior_op" && -z "$OPERATOR_TAG" ]]; then
+    warn "Prior release had fleetManager.image.tag='$prior_op' — re-pinning (to avoid silent float to chart-default). Pass OPENCRANE_ALLOW_TAG_FLOAT=1 to float intentionally."
+    OPERATOR_TAG="$prior_op"
+    need_warn=1
+  fi
+  if [[ -n "$prior_tn" && -z "$TENANT_TAG" ]]; then
+    warn "Prior release had tenant.image.tag='$prior_tn' — re-pinning (to avoid silent float to chart-default). Pass OPENCRANE_ALLOW_TAG_FLOAT=1 to float intentionally."
+    TENANT_TAG="$prior_tn"
+    need_warn=1
+  fi
+  if [[ "$need_warn" == "1" ]]; then
+    warn "Image-tag re-pin: tags were auto-restored from the prior release. Run evidence: $(date -u +%Y-%m-%dT%H:%M:%SZ) $(hostname)"
+  fi
+}
+_enforce_tag_pins
+
 # Per-component tags override the unified --image-tag so a single component can be
 # rolled through Helm (which keeps Helm the sole owner of the image field). Each
 # falls back to IMAGE_TAG when its flag is unset, preserving the all-same default.
@@ -980,6 +1048,8 @@ _DB_CKSUM="$(printf '%s' "$DB_PASSWORD" | sha256sum | cut -c1-8)"
 helm_args+=(--set "litellm.podAnnotations.db-checksum=$_DB_CKSUM")
 helm_args+=(--set "mcpGateway.podAnnotations.db-checksum=$_DB_CKSUM")
 helm_args+=("${EXTRA_SET[@]}")
+# Raw helm-arg passthrough for sanctioned one-time fixes (e.g. --take-ownership).
+[[ ${#EXTRA_HELM_ARGS[@]} -gt 0 ]] && helm_args+=("${EXTRA_HELM_ARGS[@]}")
 # Value-preservation mode. Helm's DEFAULT on upgrade drops any value a prior release set
 # via --set/-f that this invocation does not restate, silently reverting it to the chart
 # default — a footgun that broke a live silo once (a pure `--control-plane-tag` bump reverted

--- a/libs/k8s-platform/k8s-deploy.sh
+++ b/libs/k8s-platform/k8s-deploy.sh
@@ -140,6 +140,11 @@ REUSE_VALUES=""      # explicit "--reuse-values": inherit last release's values 
 RESET_VALUES=""      # explicit "--reset-values": DROP prior values, start from chart defaults + this run's --set
 EXTRA_SET=()
 EXTRA_HELM_ARGS=()   # raw --helm-arg passthrough args (e.g. --take-ownership for Certificate ownership recovery)
+# OPENCRANE_HELM_EXTRA_ARGS: whitespace-separated raw helm args (env-var form of --helm-arg).
+if [[ -n "${OPENCRANE_HELM_EXTRA_ARGS:-}" ]]; then
+  read -ra _env_helm_args <<< "$OPENCRANE_HELM_EXTRA_ARGS"
+  EXTRA_HELM_ARGS+=("${_env_helm_args[@]}")
+fi
 ALLOW_TAG_FLOAT="${OPENCRANE_ALLOW_TAG_FLOAT:-0}"  # allow component images to float to chart-default
 
 # OIDC + per-cluster operator bootstrap. All default empty (OIDC stays disabled and the
@@ -986,9 +991,11 @@ _enforce_tag_pins
 CP_TAG="${CONTROL_PLANE_TAG:-$IMAGE_TAG}"
 OP_TAG="${OPERATOR_TAG:-$IMAGE_TAG}"
 TN_TAG="${TENANT_TAG:-$IMAGE_TAG}"
-[[ -n "$CP_TAG" ]] && helm_args+=(--set "clustertenantManager.image.tag=$CP_TAG")
-[[ -n "$OP_TAG" ]] && helm_args+=(--set "fleetManager.image.tag=$OP_TAG")
-[[ -n "$TN_TAG" ]] && helm_args+=(--set "tenant.image.tag=$TN_TAG")
+# --set-string: a tag like "1.2.3" or a numeric-looking sha must never be YAML-coerced
+# (same guideline as the OIDC string values below; see the deploy ledger).
+[[ -n "$CP_TAG" ]] && helm_args+=(--set-string "clustertenantManager.image.tag=$CP_TAG")
+[[ -n "$OP_TAG" ]] && helm_args+=(--set-string "fleetManager.image.tag=$OP_TAG")
+[[ -n "$TN_TAG" ]] && helm_args+=(--set-string "tenant.image.tag=$TN_TAG")
 # --base-domain drives ingress.domain; controlPlaneHost defaults to platform.<domain>
 # in the chart, and the cert-manager wildcard SANs (*.<domain>, <domain>,
 # controlPlaneHost) are derived from it. Setting it explicitly here keeps a single


### PR DESCRIPTION
## Summary

Three hardening fixes for the deploy scripts, found during the 2026-07-12 dev deploy run. None have been re-deployed yet — the next run will validate that these guards work.

## Item 1: Pinned-tag float guard

**Run evidence:**
After dropping `--reuse-values` in favour of the default `--reset-then-reuse-values`, component image tags silently reverted from the prior release's pinned value (e.g. `sha-5036a0a`) to the chart-default `latest`.

Confirmed via `helm get values` before/after a 2026-07-12 upgrade:
- Before: `fleetManager.image.tag: sha-5036a0a`, `clustertenantManager.image.tag: sha-5036a0a`
- After (no re-pin): `fleetManager.image.tag: latest`, `clustertenantManager.image.tag: latest`

**Fix:**
- Before the helm upgrade, detect if the prior release pinned component images.
- If the current invocation does not restate those tags (no `--control-plane-tag`, `--operator-tag`, `--tenant-tag`), warn loudly and re-pin from the stored values.
- Escape flag: `OPENCRANE_ALLOW_TAG_FLOAT=1` to intentionally float tags.
- Pattern follows existing `--auto-ingress-ip` derivation style (detect, derive, don't demand).

## Item 2: Raw helm-arg passthrough

**Need:**
Sanctioned one-time recoveries like `--take-ownership` are blocked because the script rejects unknown flags. Certificate ownership issues (e.g. elewa-be/northwind, blocked since 2026-07-02) are a known blocker.

**Fix:**
- New `--helm-arg <arg>` repeatable flag appends verbatim arguments to the final helm upgrade invocation.
- Also accepts `OPENCRANE_HELM_EXTRA_ARGS` env for script automation.
- Example: `--helm-arg --take-ownership --helm-arg --force-fields-order`
- Documented in the header with the Certificate recovery example.

## Item 3: Header docs

**Fleet-platform/deploy.sh updates:**
- Document `OPENCRANE_SKIP_PREFLIGHT=1` (exists in code, was undocumented — needed on dev cluster every run).
- Note that `--platform-operator-seed-email` must be restated on every invocation (fail-closed gate, not a stored value). It defaults empty; without it the fleet grants operator to nobody and the control-plane UI is inaccessible.

## Validation

✓ All three scripts pass `bash -n` syntax check
✓ `--helm-arg` flag parsing handles repeated args correctly (tested via array append logic)
✓ Help output (`--help`) shows new documentation
✓ Image-tag detection uses `jq` (primary) with `grep` fallback (robust across environments)

## Next steps

Not yet re-deployed. The next dev deploy run will validate:
1. Image tags are auto-restored from the prior release when not explicitly set.
2. `--helm-arg --take-ownership` successfully passes through to helm (unblocking Certificate recovery).
3. Help docs display correctly on `--help`.