### PR TITLE
fix(infra-auth): snapshot auth env at factory time to clear boundaries lint

### DIFF
--- a/apps/clustertenant-operator/src/__tests__/index.test.ts
+++ b/apps/clustertenant-operator/src/__tests__/index.test.ts
@@ -4,6 +4,7 @@ import type { Express } from "express";
 import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import request from "supertest";
 
+import { ___AuthMiddleware } from "@opencrane/infra/auth";
 import { _CheckDbHealth, _RateLimit } from "@opencrane/infra/http";
 
 /**
@@ -25,16 +26,14 @@ function _buildHealthApp(dbHealthy: boolean): Express
 }
 
 /**
- * Build a minimal Express app with auth middleware loaded after env setup.
+ * Build a minimal Express app with the auth middleware constructed after env setup —
+ * the factory snapshots OPENCRANE_API_TOKEN when called, so each test gets a fresh read.
  * No Prisma client is passed so DB-token validation is skipped; these tests
  * only exercise the env-var token and dev-mode bypass paths.
  * @returns An Express app wired for auth testing
  */
-async function _buildAuthApp(): Promise<Express>
+function _buildAuthApp(): Express
 {
-  vi.resetModules();
-
-  const { ___AuthMiddleware } = await import("@opencrane/infra/auth");
   const app = express();
   app.use(express.json());
   // Mirror production middleware order: the per-IP limiter is mounted before auth + routes.
@@ -94,14 +93,12 @@ describe("Control Plane", () =>
       {
         delete process.env.OPENCRANE_API_TOKEN;
       }
-
-      vi.resetModules();
     });
 
     it("rejects requests without Authorization header when token is configured", async () =>
     {
       process.env.OPENCRANE_API_TOKEN = "test-secret";
-      const app = await _buildAuthApp();
+      const app = _buildAuthApp();
 
       const res = await request(app).get("/api/test");
       expect(res.status).toBe(401);
@@ -111,7 +108,7 @@ describe("Control Plane", () =>
     it("rejects requests with wrong token", async () =>
     {
       process.env.OPENCRANE_API_TOKEN = "test-secret";
-      const app = await _buildAuthApp();
+      const app = _buildAuthApp();
 
       const res = await request(app)
         .get("/api/test")
@@ -124,7 +121,7 @@ describe("Control Plane", () =>
     it("allows requests with correct token", async () =>
     {
       process.env.OPENCRANE_API_TOKEN = "test-secret";
-      const app = await _buildAuthApp();
+      const app = _buildAuthApp();
 
       const res = await request(app)
         .get("/api/test")
@@ -136,7 +133,7 @@ describe("Control Plane", () =>
     it("allows all requests when no token is configured (dev mode)", async () =>
     {
       delete process.env.OPENCRANE_API_TOKEN;
-      const app = await _buildAuthApp();
+      const app = _buildAuthApp();
 
       const res = await request(app).get("/api/test");
       expect(res.status).toBe(200);
@@ -145,7 +142,7 @@ describe("Control Plane", () =>
     it("healthz bypasses auth even with token configured", async () =>
     {
       process.env.OPENCRANE_API_TOKEN = "test-secret";
-      const app = await _buildAuthApp();
+      const app = _buildAuthApp();
 
       const res = await request(app).get("/healthz");
       expect(res.status).toBe(200);

--- a/libs/infra/auth/src/auth-middleware.ts
+++ b/libs/infra/auth/src/auth-middleware.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import type { NextFunction, Request, RequestHandler, Response } from "express";
 
 import { ___LoadOidcAuthConfig } from "./oidc-config.js";
+import type { OidcAuthConfig } from "./oidc-config.types.js";
 
 /**
  * Minimal `AccessToken` read surface for per-user DB token validation. A manager that
@@ -18,14 +19,6 @@ export interface AccessTokenReader
 }
 
 /**
- * Module-level env-var snapshot read once at startup.
- * Tests that need a different value must call `vi.resetModules()` before
- * re-importing this module so the variable is re-evaluated.
- */
-const _envToken = process.env.OPENCRANE_API_TOKEN?.trim() ?? "";
-const _oidcConfig = ___LoadOidcAuthConfig();
-
-/**
  * Express authentication middleware shared by both managers.
  *
  * Authentication is resolved in priority order:
@@ -35,33 +28,44 @@ const _oidcConfig = ___LoadOidcAuthConfig();
  *   4. DB access token      — per-user token created via `oc auth login` (when a reader is given).
  *   5. Dev-mode bypass     — when neither OIDC nor OPENCRANE_API_TOKEN is configured.
  *
+ * The env-var token and OIDC config are snapshotted when the factory is called —
+ * once at startup in production; per-test in tests, so setting the env before
+ * calling the factory is enough (no module re-import needed).
+ *
  * @param reader - Optional access-token reader. When provided, bearer tokens are also
  *                 validated against the `access_tokens` table (step 4). Omit when the
  *                 manager issues no DB tokens.
  */
 export function ___AuthMiddleware(reader?: AccessTokenReader): RequestHandler
 {
+  const envToken = process.env.OPENCRANE_API_TOKEN?.trim() ?? "";
+  const oidcConfig = ___LoadOidcAuthConfig();
+
   return function _authHandler(req, res, next)
   {
     // Delegate to an async helper so we can await the DB lookup while still
     // presenting the synchronous `RequestHandler` signature Express expects.
-    _resolveAuth(req, res, next, reader).catch(next);
+    _resolveAuth(req, res, next, reader, envToken, oidcConfig).catch(next);
   };
 }
 
 /**
  * Resolve authentication for a single request.
  *
- * @param req    - Incoming Express request.
- * @param res    - Express response (used only to send 401/403).
- * @param next   - Express next function (called with no args on success).
- * @param reader - Optional access-token reader for per-user DB token lookup.
+ * @param req        - Incoming Express request.
+ * @param res        - Express response (used only to send 401/403).
+ * @param next       - Express next function (called with no args on success).
+ * @param reader     - Optional access-token reader for per-user DB token lookup.
+ * @param envToken   - The OPENCRANE_API_TOKEN snapshot taken at factory time.
+ * @param oidcConfig - The OIDC config snapshot taken at factory time.
  */
 async function _resolveAuth(
   req: Request,
   res: Response,
   next: NextFunction,
   reader: AccessTokenReader | undefined,
+  envToken: string,
+  oidcConfig: OidcAuthConfig,
 ): Promise<void>
 {
   // 1. Public paths bypass all auth checks — /healthz and the auth router
@@ -73,7 +77,7 @@ async function _resolveAuth(
   }
 
   // 2. Accept an established OIDC browser session (human operator flow).
-  if (_oidcConfig.enabled && req.session?.authUser)
+  if (oidcConfig.enabled && req.session?.authUser)
   {
     next();
     return;
@@ -84,7 +88,7 @@ async function _resolveAuth(
   const providedToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
 
   // 4. Accept the static env-var token (CI / service-account automation).
-  if (_envToken && providedToken === _envToken)
+  if (envToken && providedToken === envToken)
   {
     next();
     return;
@@ -119,7 +123,7 @@ async function _resolveAuth(
 
   // 6. Dev-mode bypass — allow unauthenticated access when OIDC is disabled
   //    and no env-var token is set.
-  if (!_envToken && !_oidcConfig.enabled)
+  if (!envToken && !oidcConfig.enabled)
   {
     next();
     return;

--- a/libs/infra/auth/src/auth-mode.ts
+++ b/libs/infra/auth/src/auth-mode.ts
@@ -3,7 +3,7 @@ import { ___LoadOidcAuthConfig } from "./oidc-config.js";
 /**
  * True when the manager runs with NO real auth configured — neither OIDC nor an
  * `OPENCRANE_API_TOKEN`. This is the dev-mode bypass, mirroring the condition in
- * `___AuthMiddleware` (`!_envToken && !_oidcConfig.enabled`).
+ * `___AuthMiddleware` (`!envToken && !oidcConfig.enabled`).
  *
  * Scope guards and read-time scope filters use this to decide their fallthrough posture for a
  * request with no established session: **fail OPEN under dev mode** (so a fresh local install or


### PR DESCRIPTION
## Problem

`npm run lint:boundaries` reported 7 errors, all of the form:

> Static imports of lazy-loaded libraries are forbidden. Library 'infra-auth' is lazy-loaded in these files: apps/clustertenant-operator/src/__tests__/index.test.ts

Root cause: `___AuthMiddleware` snapshotted `OPENCRANE_API_TOKEN` and the OIDC config at **module load time**, so `index.test.ts` had to `vi.resetModules()` + dynamically `import("@opencrane/infra/auth")` to test different env values. That single dynamic import marked infra-auth as lazy-loaded in the nx project graph, making every static import of it an error.

## Fix

Move the env snapshot into the `___AuthMiddleware()` **factory**. Production semantics are unchanged — both operators call the factory exactly once at boot, so it's still a startup snapshot. Tests now set env and call the factory via an ordinary static import; the `resetModules`/dynamic-import dance is deleted. (Precedent: `_IsDevAuthMode` in the same lib already reads env live for the same reason.)

## Verification

- `npm run lint:boundaries` — clean (0 errors; previously 7)
- `nx run clustertenant-operator:test` — 43 files / 411 tests pass, incl. the reworked `index.test.ts`
- `nx run infra-auth:lint` (tsc) + `infra-auth:test` — clean
- Pre-existing, unrelated typecheck failures confirmed identical with the change stashed: `libs/observability/src/telemetry.ts` OTLPTraceExporter type error (OTEL bump) and fleet-operator's un-generated Prisma client.