### PR TITLE
chore: delete stale root tsconfig.json solution file

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,0 @@
-{
-  "files": [],
-  "references": [
-    { "path": "operator" },
-    { "path": "control-plane" }
-  ]
-}


### PR DESCRIPTION
## Problem

The root `tsconfig.json` is a TS "solution" file from the initial commit:

```json
{ "files": [], "references": [{ "path": "operator" }, { "path": "control-plane" }] }
```

Both referenced paths don't exist at repo root — the real apps are `apps/clustertenant-operator` and (as of #152) `apps/control-plane`. Nothing in the repo reads the file: Nx's `sharedGlobals` hashes `tsconfig.base.json`, every project's typecheck runs `tsc -p tsconfig.json` against its own local tsconfig, and no script or CI workflow references it.

It's not just dead weight: `vite-tsconfig-paths`/tsconfck (used by the frontend vitest configs coming in #152) walks up to it as the nearest tsconfig for repo-root files and throws `ENOENT` on the dangling references.

## Fix

Delete the file. Fixing the references instead would require making the app tsconfigs `composite` for a solution build nobody runs — deletion is the honest fix.

## Verification

- `git log --follow` shows the file untouched since the initial commit
- repo-wide grep: no config, script, or workflow references the root `tsconfig.json` (only `tsconfig.base.json` and per-project tsconfigs)
- `nx run-many -t build`: 6 projects green after deletion