### PR TITLE
chore(silo-chart): remove vestigial clusterTenant.seed + billing block

### DIFF
--- a/apps/clustertenant-platform/deploy.sh
+++ b/apps/clustertenant-platform/deploy.sh
@@ -89,10 +89,11 @@ if [[ -n "${OIDC_ISSUER_URL:-}" ]]; then
   [[ -n "${OIDC_REDIRECT_URI:-}" ]] || export OIDC_REDIRECT_URI="https://${CLUSTER_TENANT}.${BASE_DOMAIN}/api/v1/auth/callback"
 fi
 
-# SILO value profile: a per-ClusterTenant install in its own namespace — self-service manager +
-# billing OFF, multi-instance OFF. The cluster-wide infra is installed once by the admin/registry
-# release, so skip re-installing the ingress controller, external-dns and the CNPG operator (the
-# silo's own per-namespace CNPG Cluster CR is still applied and reconciled by the cluster-wide operator).
+# SILO value profile: a per-ClusterTenant install in its own namespace — the fleet-manager and its
+# self-service surfaces (ClusterTenant management + billing) are OFF, multi-instance OFF. The
+# cluster-wide infra is installed once by the admin/registry release, so skip re-installing the
+# ingress controller, external-dns and the CNPG operator (the silo's own per-namespace CNPG Cluster
+# CR is still applied and reconciled by the cluster-wide operator).
 PROFILE_SET=(
   --namespace "$NAMESPACE"
   --no-ingress-nginx
@@ -102,7 +103,6 @@ PROFILE_SET=(
   # (apps/fleet-platform/deploy.sh). Two fleet-managers would contend over the ClusterTenant CRs + IAM.
   --set "fleetManager.enabled=false"
   --set "fleetManager.clusterTenantApi.enabled=false"
-  --set "billing.enabled=false"
   --set "multiInstance.enabled=false"
   # NOTE: same-origin org hosting is now the chart's only mode (the legacy `*.<domain>` wildcard
   # gateway-ingress was removed) — no --set needed here to select it.

--- a/apps/clustertenant-platform/values.yaml
+++ b/apps/clustertenant-platform/values.yaml
@@ -135,7 +135,8 @@ fleetManager:
   #    fleet-manager as OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED; when false the ClusterTenant
   #    management + Zitadel-admin + platform-DNS routers are not mounted and the fleet's
   #    cluster-scoped management/issuer RBAC is not rendered. Single-tenant: false (the one org
-  #    is seeded directly at boot — see `clusterTenant.seed`).
+  #    is seeded directly at boot by the fleet-manager — see `clusterTenant.seed` in the fleet
+  #    chart, `apps/fleet-platform`).
   clusterTenantApi:
     enabled: true
   image:
@@ -1106,37 +1107,13 @@ observability:
 #    (the default), `dedicatedCluster` stays unavailable and the control-plane API
 #    rejects it with 422 TIER_UNAVAILABLE (fail-closed). The control plane refuses a
 #    non-`https://` URL so the bearer token is never sent in plaintext.
-# -- Tenancy profile toggles (Chunk 4). Default ON = the MULTI-tenant profile: callers
-#    self-serve a billing account then create their own organisations (ClusterTenants).
-#    The SINGLE-tenant profile sets BOTH to false and seeds ONE org instead (see
-#    `clusterTenant.seed` below) — there is no self-service billing or org management on a
-#    single-tenant box. Wired to the control-plane as OPENCRANE_BILLING_ENABLED /
-#    OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED; when false the matching self-service router
-#    is not mounted. `multiInstance` is a separate, lower-level switch and stays OFF here.
-# NOTE: the fleet ClusterTenant-management surface gate moved UP into `fleetManager.clusterTenantApi`
-# (it is a fleet-manager sub-feature) so it is unmistakably distinct from the `clustertenantManager`
-# COMPONENT key. See the `fleetManager:` block above.
-billing:
-  # -- Expose the self-service billing-accounts API (the gate for org creation).
-  #    Single-tenant: false (no billing relationship on a single-tenant install).
-  enabled: true
-
+# NOTE: the tenancy-profile gates — self-service billing (`OPENCRANE_BILLING_ENABLED`) and the
+# fleet ClusterTenant-management surface (`OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED`) — together
+# with the single-tenant org SEED (`OPENCRANE_SEED_CLUSTER_TENANT_*`) are fleet-manager concerns
+# and live in the fleet chart (`apps/fleet-platform`: `billing.enabled` + `clusterTenant.seed`).
+# A silo never runs the fleet-manager (`fleetManager.enabled=false`), so none of them are wired
+# here — the only `clusterTenant` key the silo consumes is the `provisionerWebhook` below.
 clusterTenant:
-  # -- Single-tenant SEED (Chunk 4). When `name` is set the control-plane seeds ONE org
-  #    DIRECTLY at boot — the ClusterTenant CR + its `owner` OrgMembership — bypassing the
-  #    billing-gated POST. The #50 reconciler then provisions it. Idempotent and
-  #    fail-soft; a re-run converges. Leave `name` empty (the default, multi-tenant
-  #    profile) to seed nothing. Wired as OPENCRANE_SEED_CLUSTER_TENANT_*.
-  seed:
-    # -- Stable org name (the ClusterTenant id + CR name). Empty → no seed.
-    name: ""
-    # -- Human-readable org display name; defaults to `name` when empty.
-    displayName: ""
-    # -- Owner email, recorded as the org's single `owner` membership subject (the
-    #    OIDC-sub-else-email fallback, since the owner has not logged in at install).
-    ownerEmail: ""
-    # -- Isolation tier for the seeded org: shared | dedicatedNodes | dedicatedCluster.
-    tier: shared
   provisionerWebhook:
     # -- HTTPS base URL of the external provisioner (must start with https://).
     url: ""

--- a/website/operators/silo-deployment.md
+++ b/website/operators/silo-deployment.md
@@ -61,8 +61,7 @@ The silo model eliminates both problems in the same move: each ClusterTenant get
 │  │   this NS only)   │               ┌─────────────────┐    │
 │  └───────────────────┘               │ Cognee          │    │
 │                                      └─────────────────┘    │
-│  clusterTenantManagement.enabled: false                       │
-│  billing.enabled: false                                       │
+│  fleetManager.enabled: false                                      │
 │  Reuses cluster-wide infra installed by the fleet release     │
 └───────────────────────────────────────────────────────────────┘
 ```
@@ -121,7 +120,7 @@ Repeat this command for each ClusterTenant. Each invocation:
 - installs into the silo namespace (`opencrane-<cluster-tenant>` by default);
 - passes `--no-ingress-nginx --no-external-dns --no-db-operator` so the cluster-wide singletons are not re-installed;
 - applies a dedicated CNPG `Cluster` CR in the silo namespace — one Postgres per silo, reconciled by the cluster-wide CNPG operator;
-- sets `clusterTenantManagement.enabled=false` and `billing.enabled=false`.
+- disables the fleet-manager and its self-service surfaces (`fleetManager.enabled=false`, `fleetManager.clusterTenantApi.enabled=false`) — a silo runs no ClusterTenant-management or billing API.
 
 ::: info One Postgres per silo
 Each silo gets its own CNPG `Cluster` in its own namespace. The silo's clustertenant-manager connects to its own database — there is no shared database and no cross-tenant query path. The cluster-wide CloudNativePG operator (installed by the fleet release) watches all namespaces and reconciles every silo's `Cluster` CR.


### PR DESCRIPTION
## What

The `clusterTenant.seed` and `billing` blocks in the **opencrane-silo** chart (`apps/clustertenant-platform`) are dead — nothing in `clustertenant-operator` or the silo templates reads `OPENCRANE_SEED_CLUSTER_TENANT_*` or `.Values.billing`. Both are fleet-manager concerns whose live wiring lives in the fleet chart (`apps/fleet-platform` → `fleet-manager-deployment.yaml`). They're leftovers from before the fleet/silo chart split (#150), and sitting next to the actually-wired keys they invited conflation (e.g. a reader could wire the dead `seed` block by mistake).

## Changes

- **`values.yaml`** — drop the `billing:` block and `clusterTenant.seed`; keep `clusterTenant.provisionerWebhook` (still consumed by `clustertenant-manager-deployment.yaml`). Replace the tenancy-profile comment header with a NOTE pointing at the fleet chart; fix the `fleetManager.clusterTenantApi` cross-reference to `clusterTenant.seed`.
- **`deploy.sh`** — drop the no-op `--set billing.enabled=false` (the value no longer exists in this chart and the silo already sets `fleetManager.enabled=false`); update the profile comment.
- **`website/operators/silo-deployment.md`** — correct the *silo-profile* references (now `fleetManager.enabled=false`, not the dead `billing.enabled=false`). Fleet-chart `billing.enabled` references (real) left intact.

## Verification

- `helm lint apps/clustertenant-platform` → 0 charts failed
- `helm template` renders clean; `clusterTenant.provisionerWebhook` still wires `CLUSTER_TENANT_PROVISIONER_WEBHOOK_*` when set; no `OPENCRANE_SEED_CLUSTER_TENANT_*` / `OPENCRANE_BILLING_ENABLED` env leaks (only the explanatory comment remains).

## Notes

The fleet chart (`apps/fleet-platform`) is untouched — its `billing.enabled` and `clusterTenant.seed` are real and wired.