### PR TITLE
docs: fix stale clusterTenantManagement.enabled key -> fleetManager.clusterTenantApi.enabled

### DIFF
--- a/website/operators/fleet-silo-model.md
+++ b/website/operators/fleet-silo-model.md
@@ -123,7 +123,7 @@ fleetManager:
     serviceAccountKeyKey: service-account-key
 ```
 
-When `existingSecret` is set and `clusterTenantManagement.enabled` is true, the chart renders a namespaced `Role` + `RoleBinding` granting the fleet-manager's ServiceAccount `patch` on that single named Secret — the minimum RBAC surface for in-place key rotation. Source: [`apps/fleet-platform/templates/fleet-manager-zitadel-rotation-rbac.yaml`](https://github.com/italanta/opencrane/blob/main/apps/fleet-platform/templates/fleet-manager-zitadel-rotation-rbac.yaml).
+When `existingSecret` is set and `fleetManager.clusterTenantApi.enabled` is true, the chart renders a namespaced `Role` + `RoleBinding` granting the fleet-manager's ServiceAccount `patch` on that single named Secret — the minimum RBAC surface for in-place key rotation. Source: [`apps/fleet-platform/templates/fleet-manager-zitadel-rotation-rbac.yaml`](https://github.com/italanta/opencrane/blob/main/apps/fleet-platform/templates/fleet-manager-zitadel-rotation-rbac.yaml).
 
 ### Per-silo OIDC (clustertenant-manager)
 
@@ -150,11 +150,12 @@ Per-org subdomain login is **not active** until the fleet provisions that organi
 
 ### Self-service gate
 
-The ClusterTenant management API, Zitadel-admin routes, and platform-DNS RBAC on the fleet-manager are all gated by `clusterTenantManagement.enabled` (the flag `apps/fleet-platform/deploy.sh` sets to `true`; `apps/clustertenant-platform/deploy.sh` sets it to `false`):
+The ClusterTenant management API, Zitadel-admin routes, and platform-DNS RBAC on the fleet-manager are all gated by `fleetManager.clusterTenantApi.enabled` (the flag `apps/fleet-platform/deploy.sh` sets to `true`; `apps/clustertenant-platform/deploy.sh` sets it to `false`):
 
 ```yaml
-clusterTenantManagement:
-  enabled: true   # true on the fleet/multi-tenant install; false on each silo
+fleetManager:
+  clusterTenantApi:
+    enabled: true   # true on the fleet/multi-tenant install; false on each silo
 billing:
   enabled: true   # true on the fleet install; false on each silo
 ```
@@ -167,7 +168,7 @@ The Helm chart sets these on the fleet-manager pod; you do not set them directly
 
 | Variable | Set when | Description |
 |---|---|---|
-| `OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED` | `clusterTenantManagement.enabled` | Mounts the ClusterTenant lifecycle, Zitadel-admin, and platform-DNS routes |
+| `OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED` | `fleetManager.clusterTenantApi.enabled` | Mounts the ClusterTenant lifecycle, Zitadel-admin, and platform-DNS routes |
 | `OPENCRANE_BILLING_ENABLED` | `billing.enabled` | Mounts the billing-accounts routes |
 | `ZITADEL_MGMT_API_URL` | `fleetManager.zitadel.mgmtApiUrl` | Zitadel Management API base URL |
 | `ZITADEL_MGMT_SA_KEY` | from `fleetManager.zitadel.existingSecret` | SA key JSON (JWT bearer) at pod start |

--- a/website/operators/runbook.md
+++ b/website/operators/runbook.md
@@ -94,7 +94,7 @@ Set these via Helm values — the deploy scripts wire them automatically. The va
 | Variable | Required | Helm key | Description |
 |----------|----------|----------|-------------|
 | `DATABASE_URL` | Yes | `fleetManager.database.existingSecret` | Fleet registry PostgreSQL connection string |
-| `OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED` | Yes | `clusterTenantManagement.enabled` | Gates the ClusterTenant lifecycle and Zitadel-admin routes |
+| `OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED` | Yes | `fleetManager.clusterTenantApi.enabled` | Gates the ClusterTenant lifecycle and Zitadel-admin routes |
 | `ZITADEL_MGMT_API_URL` | When CT management on | `fleetManager.zitadel.mgmtApiUrl` | Zitadel Management API URL |
 | `ZITADEL_MGMT_SA_KEY` | When CT management on | `fleetManager.zitadel.existingSecret` | Zitadel SA key JSON |
 

--- a/website/operators/silo-deployment.md
+++ b/website/operators/silo-deployment.md
@@ -37,7 +37,7 @@ The silo model eliminates both problems in the same move: each ClusterTenant get
 │  ┌─────────────┐                                              │
 │  │  Zitadel    │  (trusted OIDC IdP for both planes)          │
 │  └─────────────┘                                              │
-│  clusterTenantManagement.enabled: true                        │
+│  fleetManager.clusterTenantApi.enabled: true                  │
 │  billing.enabled: true                                        │
 │  Cluster-wide infra: ingress-nginx, external-dns,             │
 │    CloudNativePG operator, cert-manager                       │
@@ -61,7 +61,7 @@ The silo model eliminates both problems in the same move: each ClusterTenant get
 │  │   this NS only)   │               ┌─────────────────┐    │
 │  └───────────────────┘               │ Cognee          │    │
 │                                      └─────────────────┘    │
-│  clusterTenantManagement.enabled: false                       │
+│  fleetManager.clusterTenantApi.enabled: false                 │
 │  billing.enabled: false                                       │
 │  Reuses cluster-wide infra installed by the fleet release     │
 └───────────────────────────────────────────────────────────────┘
@@ -72,7 +72,7 @@ The silo model eliminates both problems in the same move: each ClusterTenant get
 | Primary manager | `fleet-manager` | `clustertenant-manager` |
 | Helm image key | `fleetManager.image` | `clustertenantManager.image` |
 | Namespace | `opencrane-system` | `opencrane-<cluster-tenant>` |
-| ClusterTenant lifecycle + billing | Yes (`clusterTenantManagement.enabled: true`) | No |
+| ClusterTenant lifecycle + billing | Yes (`fleetManager.clusterTenantApi.enabled: true`) | No |
 | Zitadel IAM admin + SA key | Yes (`fleetManager.zitadel.*`) | No |
 | Per-org user login (OIDC) | Fleet OIDC (`fleetManager.oidc.*`) | Silo OIDC (`clustertenantManager.oidc.*`) |
 | Fleet registry DB | Yes (`fleetManager.database.*`) | No |
@@ -121,7 +121,7 @@ Repeat this command for each ClusterTenant. Each invocation:
 - installs into the silo namespace (`opencrane-<cluster-tenant>` by default);
 - passes `--no-ingress-nginx --no-external-dns --no-db-operator` so the cluster-wide singletons are not re-installed;
 - applies a dedicated CNPG `Cluster` CR in the silo namespace — one Postgres per silo, reconciled by the cluster-wide CNPG operator;
-- sets `clusterTenantManagement.enabled=false` and `billing.enabled=false`.
+- sets `fleetManager.clusterTenantApi.enabled=false` and `billing.enabled=false`.
 
 ::: info One Postgres per silo
 Each silo gets its own CNPG `Cluster` in its own namespace. The silo's clustertenant-manager connects to its own database — there is no shared database and no cross-tenant query path. The cluster-wide CloudNativePG operator (installed by the fleet release) watches all namespaces and reconciles every silo's `Cluster` CR.
@@ -149,7 +149,7 @@ The operator in each silo is namespace-scoped (`requireWatchNamespace`). It owns
 
 Both the fleet-manager and clustertenant-manager deployments are always rendered by the chart. What differs is which features each exposes:
 
-- **Fleet-manager** renders its ClusterTenant lifecycle, billing, Zitadel-admin, and platform-DNS routes only when `clusterTenantManagement.enabled=true`. The fleet-manager's cluster-scoped RBAC and the Zitadel rotation `Role`/`RoleBinding` are gated on the same flag.
+- **Fleet-manager** renders its ClusterTenant lifecycle, billing, Zitadel-admin, and platform-DNS routes only when `fleetManager.clusterTenantApi.enabled=true`. The fleet-manager's cluster-scoped RBAC and the Zitadel rotation `Role`/`RoleBinding` are gated on the same flag.
 - **Clustertenant-manager** renders the tenant-facing surface (tenants, policies, groups, budgets, model routing, sessions) and holds ClusterTenant/OrgMembership as local read-models projected from the fleet.
 
 Source: [`apps/fleet-platform/templates/fleet-manager-deployment.yaml`](https://github.com/italanta/opencrane/blob/main/apps/fleet-platform/templates/fleet-manager-deployment.yaml) and [`apps/clustertenant-platform/templates/clustertenant-manager-deployment.yaml`](https://github.com/italanta/opencrane/blob/main/apps/clustertenant-platform/templates/clustertenant-manager-deployment.yaml).
@@ -176,7 +176,7 @@ All clustertenant-manager configuration is supplied via Helm values in `clustert
 
 | Variable | Description |
 |---|---|
-| `OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED` | Mounts the ClusterTenant lifecycle, Zitadel-admin, and platform-DNS routes. Set from `clusterTenantManagement.enabled`. |
+| `OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED` | Mounts the ClusterTenant lifecycle, Zitadel-admin, and platform-DNS routes. Set from `fleetManager.clusterTenantApi.enabled`. |
 | `OPENCRANE_BILLING_ENABLED` | Mounts the billing-accounts routes. Set from `billing.enabled`. |
 | `ZITADEL_MGMT_API_URL` | Zitadel instance base URL for the Management API. Set from `fleetManager.zitadel.mgmtApiUrl`. |
 | `ZITADEL_MGMT_SA_KEY` | Service-account key JSON for Zitadel (JWT bearer). Set from `fleetManager.zitadel.existingSecret`. |


### PR DESCRIPTION
## What

The operator docs referenced a Helm values key `clusterTenantManagement.enabled` that **does not exist in any chart**. The real gate for the fleet ClusterTenant-management surface (`OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED`) is `fleetManager.clusterTenantApi.enabled`.

Verified against:
- `apps/fleet-platform/templates/fleet-manager-deployment.yaml:68-69` (renders the env var from `.Values.fleetManager.clusterTenantApi.enabled`)
- `apps/fleet-platform/values.yaml:139` (`fleetManager.clusterTenantApi`)
- `apps/fleet-platform/deploy.sh` / `apps/clustertenant-platform/deploy.sh` (both `--set fleetManager.clusterTenantApi.enabled`)

## Changes

- **fleet-silo-model.md** — rotation-RBAC gate prose, self-service gate prose, the ```yaml``` block (now nested `fleetManager: → clusterTenantApi: → enabled:`), env-var table
- **runbook.md** — Helm-key table cell
- **silo-deployment.md** — both ASCII fleet/silo box diagrams (re-padded to keep the 69-char borders aligned), concern table, two prose bullets, env-var table

`grep clusterTenantManagement` now returns nothing across `apps/` and `website/`. `billing.enabled` references left intact (real fleet-chart key). VitePress build passes with no dead-link errors.

## Context

Noticed while doing #217 (removing the dead `clusterTenant.seed` + billing block from the opencrane-silo chart); that PR deliberately left this doc drift alone to stay scoped.