### PR TITLE
chore(opencrane-infra): remove vestigial billing + clusterTenant.seed

### DIFF
--- a/apps/opencrane-infra/deploy.sh
+++ b/apps/opencrane-infra/deploy.sh
@@ -104,7 +104,6 @@ PROFILE_SET=(
   # Two fleet-managers would contend over the ClusterTenant CRs + IAM.
   --set "fleetManager.enabled=false"
   --set "fleetManager.clusterTenantApi.enabled=false"
-  --set "billing.enabled=false"
   --set "multiInstance.enabled=false"
   # NOTE: same-origin org hosting is now the chart's only mode (the legacy `*.<domain>` wildcard
   # gateway-ingress was removed) — no --set needed here to select it.

--- a/apps/opencrane-infra/values.yaml
+++ b/apps/opencrane-infra/values.yaml
@@ -1239,37 +1239,14 @@ observability:
 #    (the default), `dedicatedCluster` stays unavailable and the opencrane-ui API
 #    rejects it with 422 TIER_UNAVAILABLE (fail-closed). The control plane refuses a
 #    non-`https://` URL so the bearer token is never sent in plaintext.
-# -- Tenancy profile toggles (Chunk 4). Default ON = the MULTI-tenant profile: callers
-#    self-serve a billing account then create their own organisations (ClusterTenants).
-#    The SINGLE-tenant profile sets BOTH to false and seeds ONE org instead (see
-#    `clusterTenant.seed` below) — there is no self-service billing or org management on a
-#    single-tenant box. Wired to the opencrane-ui as OPENCRANE_BILLING_ENABLED /
-#    OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED; when false the matching self-service router
-#    is not mounted. `multiInstance` is a separate, lower-level switch and stays OFF here.
-# NOTE: the fleet ClusterTenant-management surface gate moved UP into `fleetManager.clusterTenantApi`
-# (it is a fleet-manager sub-feature) so it is unmistakably distinct from the `clustertenantManager`
-# COMPONENT key. See the `fleetManager:` block above.
-billing:
-  # -- Expose the self-service billing-accounts API (the gate for org creation).
-  #    Single-tenant: false (no billing relationship on a single-tenant install).
-  enabled: true
-
+# NOTE: the tenancy-profile gates — self-service billing (`OPENCRANE_BILLING_ENABLED`) and the
+# fleet ClusterTenant-management surface (`OPENCRANE_CLUSTER_TENANT_MANAGER_ENABLED`) — together
+# with the single-tenant org SEED (`OPENCRANE_SEED_CLUSTER_TENANT_*`) are fleet-manager concerns
+# and live in the fleet chart (`apps/fleet-platform`: `billing.enabled` + `clusterTenant.seed`).
+# A silo never runs the fleet-manager (`fleetManager.enabled=false`), so none of them are wired
+# here. The silo's own single-tenant seed is `clustertenantManager.standaloneSeed` (see above);
+# the only `clusterTenant` key the silo consumes is the `provisionerWebhook` below.
 clusterTenant:
-  # -- Single-tenant SEED (Chunk 4). When `name` is set the opencrane-ui seeds ONE org
-  #    DIRECTLY at boot — the ClusterTenant CR + its `owner` OrgMembership — bypassing the
-  #    billing-gated POST. The #50 reconciler then provisions it. Idempotent and
-  #    fail-soft; a re-run converges. Leave `name` empty (the default, multi-tenant
-  #    profile) to seed nothing. Wired as OPENCRANE_SEED_CLUSTER_TENANT_*.
-  seed:
-    # -- Stable org name (the ClusterTenant id + CR name). Empty → no seed.
-    name: ""
-    # -- Human-readable org display name; defaults to `name` when empty.
-    displayName: ""
-    # -- Owner email, recorded as the org's single `owner` membership subject (the
-    #    OIDC-sub-else-email fallback, since the owner has not logged in at install).
-    ownerEmail: ""
-    # -- Isolation tier for the seeded org: shared | dedicatedNodes | dedicatedCluster.
-    tier: shared
   provisionerWebhook:
     # -- HTTPS base URL of the external provisioner (must start with https://).
     url: ""


### PR DESCRIPTION
Small follow-up salvaged from closed #233 (its #217 fold), rebased clean on current main.

Removes the vestigial top-level `billing:` block and the `clusterTenant.seed:` sub-block from the `opencrane-infra` chart (values + `deploy.sh`). These are fleet-manager concerns and live in the fleet chart (WeOwnAI); a silo never runs the fleet-manager. Confirmed no template logic or operator code reads them. Keeps `clusterTenant.provisionerWebhook`; the silo's own single-tenant seed is the separate `clustertenantManager.standaloneSeed` (#151).

`helm template` on `apps/opencrane-infra` renders clean in both default and standalone modes.

Note: the other half of #233 (the `opencrane-api`→`opencrane` docs naming sweep) is deferred — it overlaps files that #236 just corrected on main and needs careful conflict resolution, so it's not bundled into this small PR.