### PR TITLE
🏗️ Phase D: add durable ArtifactStore CAS mechanics

### DIFF
--- a/libs/backend/artifacts/filesystem/main/project.json
+++ b/libs/backend/artifacts/filesystem/main/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend-artifacts-filesystem",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/artifacts/filesystem/main/src",
+  "tags": ["type:lib", "layer:backend", "scope:artifacts"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/artifacts/filesystem/main" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/artifacts/filesystem/main" } }
+  }
+}

--- a/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.test.ts
+++ b/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.test.ts
@@ -1,0 +1,109 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { __FilesystemArtifactStore } from "./filesystem-artifact-store.js";
+
+/** Builds an authorized upload lease that remains valid through the test. */
+function _lease(id: string): { readonly leaseId: string; readonly siloId: string; readonly artifactId: string; readonly action: "artifact.write"; readonly expiresAtEpochSeconds: number }
+{
+	return { leaseId: id, siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60 };
+}
+
+/** Exposes byte chunks as an asynchronous upload stream. */
+async function* _bytes(...chunks: string[]): AsyncIterable<Uint8Array>
+{
+	for (const chunk of chunks)
+	{
+		yield Buffer.from(chunk, "utf8");
+	}
+}
+
+/** Collects a strict ArtifactStore read stream for assertion. */
+async function _collect(stream: AsyncIterable<Uint8Array>): Promise<Buffer>
+{
+	const chunks: Uint8Array[] = [];
+	for await (const chunk of stream)
+	{
+		chunks.push(chunk);
+	}
+	return Buffer.concat(chunks);
+}
+
+describe("filesystem ArtifactStore", function _suite()
+{
+	it("promotes concurrent identical staged uploads into one immutable CAS object", async function _concurrentPromotion()
+	{
+		const rootPath = await mkdtemp(join(tmpdir(), "opencrane-artifact-store-"));
+		try
+		{
+			const store = new __FilesystemArtifactStore({ rootPath });
+			const [first, second] = await Promise.all([
+				store.stage({ lease: _lease("lease-1"), bytes: _bytes("open", "crane"), expectedContentAddress: null, expectedByteLength: null, mediaType: "text/plain" }),
+				store.stage({ lease: _lease("lease-2"), bytes: _bytes("opencrane"), expectedContentAddress: null, expectedByteLength: null, mediaType: "text/plain" }),
+			]);
+			const promotions = await Promise.all([store.promote(first), store.promote(second)]);
+			expect(promotions.map(promotion => promotion.created).sort()).toEqual([false, true]);
+			expect(promotions[0]?.contentAddress).toBe(promotions[1]?.contentAddress);
+			const stream = await store.read(promotions[0]?.contentAddress ?? "");
+			expect(stream === null ? null : (await _collect(stream)).toString("utf8")).toBe("opencrane");
+		}
+		finally
+		{
+			await rm(rootPath, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects mismatched expected metadata and never leaves a canonical file", async function _mismatchedMetadata()
+	{
+		const rootPath = await mkdtemp(join(tmpdir(), "opencrane-artifact-store-"));
+		try
+		{
+			const store = new __FilesystemArtifactStore({ rootPath });
+			await expect(store.stage({ lease: _lease("lease-1"), bytes: _bytes("artifact"), expectedContentAddress: `sha256:${"a".repeat(64)}`, expectedByteLength: 8, mediaType: "text/plain" })).rejects.toThrow(/do not match/);
+			expect(await readFile(join(rootPath, "sha256", "aa", "a".repeat(64))).catch(function _missing(): null { return null; })).toBeNull();
+		}
+		finally
+		{
+			await rm(rootPath, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a same-sized canonical pathname whose bytes no longer match its address", async function _tamperedCanonicalFile()
+	{
+		const rootPath = await mkdtemp(join(tmpdir(), "opencrane-artifact-store-"));
+		try
+		{
+			const store = new __FilesystemArtifactStore({ rootPath });
+			const first = await store.stage({ lease: _lease("lease-1"), bytes: _bytes("opencrane"), expectedContentAddress: null, expectedByteLength: null, mediaType: "text/plain" });
+			const promotion = await store.promote(first);
+			await writeFile(join(rootPath, "sha256", promotion.contentAddress.slice("sha256:".length, "sha256:".length + 2), promotion.contentAddress.slice("sha256:".length)), "corrupted");
+			const second = await store.stage({ lease: _lease("lease-2"), bytes: _bytes("opencrane"), expectedContentAddress: null, expectedByteLength: null, mediaType: "text/plain" });
+			await expect(store.promote(second)).rejects.toThrow(/does not match its content address/);
+		}
+		finally
+		{
+			await rm(rootPath, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects traversal-shaped reads and performs an idempotent physical purge", async function _safePurge()
+	{
+		const rootPath = await mkdtemp(join(tmpdir(), "opencrane-artifact-store-"));
+		try
+		{
+			const store = new __FilesystemArtifactStore({ rootPath });
+			const staged = await store.stage({ lease: _lease("lease-1"), bytes: _bytes("artifact"), expectedContentAddress: null, expectedByteLength: null, mediaType: "text/plain" });
+			const promotion = await store.promote(staged);
+			await expect(store.read("../../etc/passwd")).rejects.toThrow(/invalid ArtifactStore content address/);
+			expect(await store.purge(promotion.contentAddress)).toEqual({ purged: true });
+			expect(await store.purge(promotion.contentAddress)).toEqual({ purged: false });
+		}
+		finally
+		{
+			await rm(rootPath, { recursive: true, force: true });
+		}
+	});
+});

--- a/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
+++ b/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
@@ -1,0 +1,243 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { link, lstat, mkdir, open, stat, unlink } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { join } from "node:path";
+
+import { __ValidateStageArtifactCommand, __ValidateStagedArtifact } from "@opencrane/backend/artifacts/store";
+import type { ArtifactByteStream, ArtifactStore, ArtifactStorePromotion, ArtifactStorePurgeResult, StageArtifactCommand, StagedArtifact } from "@opencrane/backend/artifacts/store";
+import { ___IsSha256ContentAddress } from "@opencrane/models/artifacts";
+import type { FilesystemArtifactStoreOptions } from "./filesystem-artifact-store.types.js";
+
+/** POSIX-backed ArtifactStore adapter with private staging and atomic content-addressed promotion. */
+export class __FilesystemArtifactStore implements ArtifactStore
+{
+	/** Mounted volume root owned only by the artifact-service process. */
+	private readonly rootPath: string;
+
+	/** Creates an adapter rooted at one app-owned mounted volume. */
+	constructor(options: FilesystemArtifactStoreOptions)
+	{
+		if (!options.rootPath.startsWith("/"))
+		{
+			throw new Error("ArtifactStore rootPath must be absolute");
+		}
+		this.rootPath = options.rootPath;
+	}
+
+	/** Stages untrusted bytes while computing their only accepted canonical address. */
+	async stage(command: StageArtifactCommand): Promise<StagedArtifact>
+	{
+		if (!__ValidateStageArtifactCommand(command, Math.floor(Date.now() / 1_000)))
+		{
+			throw new Error("invalid or expired ArtifactStore stage command");
+		}
+
+		// 1. Create only private, deterministic staging directories under the mounted artifact volume.
+		await mkdir(this._stagingDirectory(), { recursive: true });
+		const stagingHandle = createHash("sha256").update(command.lease.leaseId, "utf8").digest("hex");
+		const stagingPath = this._stagingPath(stagingHandle);
+		const file = await open(stagingPath, "wx", 0o600);
+		const hash = createHash("sha256");
+		let byteLength = 0;
+
+		try
+		{
+			// 2. Hash and fsync every supplied chunk before accepting any promotion metadata.
+			for await (const chunk of command.bytes)
+			{
+				const bytes = Buffer.from(chunk);
+				byteLength += bytes.byteLength;
+				hash.update(bytes);
+				await this._writeAll(file, bytes);
+			}
+			await file.sync();
+		}
+		catch (error)
+		{
+			await file.close();
+			await unlink(stagingPath).catch(function _ignoreMissingStagingFile() {});
+			throw error;
+		}
+		await file.close();
+
+		// 3. Reject a caller-supplied digest or length that does not match the durable bytes.
+		const contentAddress = `sha256:${hash.digest("hex")}`;
+		if ((command.expectedContentAddress !== null && command.expectedContentAddress !== contentAddress)
+			|| (command.expectedByteLength !== null && command.expectedByteLength !== byteLength))
+		{
+			await unlink(stagingPath).catch(function _ignoreMissingStagingFile() {});
+			throw new Error("ArtifactStore staged bytes do not match the authorized digest or byte length");
+		}
+
+		return { leaseId: command.lease.leaseId, stagingHandle, contentAddress, byteLength, mediaType: command.mediaType };
+	}
+
+	/** Atomically publishes staged bytes to `sha256/ab/<digest>` without overwriting a peer upload. */
+	async promote(staged: StagedArtifact): Promise<ArtifactStorePromotion>
+	{
+		if (!__ValidateStagedArtifact(staged))
+		{
+			throw new Error("invalid ArtifactStore staging handle");
+		}
+
+		const sourcePath = this._stagingPath(staged.stagingHandle);
+		const targetPath = this._contentPath(staged.contentAddress);
+		await mkdir(this._contentDirectory(staged.contentAddress), { recursive: true });
+		let created = false;
+		try
+		{
+			// 1. Hard-linking creates the final address only when no concurrent writer already owns it.
+			await link(sourcePath, targetPath);
+			await this._syncDirectory(this._contentDirectory(staged.contentAddress));
+			created = true;
+		}
+		catch (error)
+		{
+			if (!(error instanceof Error) || !("code" in error) || error.code !== "EEXIST")
+			{
+				throw error;
+			}
+
+			// 2. Never trust a same-size pathname: it must still be a regular file at the exact digest.
+			const existing = await lstat(targetPath);
+			if (!existing.isFile() || existing.size !== staged.byteLength || await this._hashFile(targetPath) !== staged.contentAddress)
+			{
+				throw new Error("ArtifactStore canonical object does not match its content address");
+			}
+		}
+
+		// 3. Remove only the private staging link after the canonical link is durable or confirmed present.
+		await unlink(sourcePath);
+		return { leaseId: staged.leaseId, contentAddress: staged.contentAddress, byteLength: staged.byteLength, mediaType: staged.mediaType, created };
+	}
+
+	/** Opens immutable bytes only by a strict canonical address, never a caller-provided path. */
+	async read(contentAddress: string): Promise<ArtifactByteStream | null>
+	{
+		if (!___IsSha256ContentAddress(contentAddress))
+		{
+			throw new Error("invalid ArtifactStore content address");
+		}
+		try
+		{
+			await stat(this._contentPath(contentAddress));
+			return createReadStream(this._contentPath(contentAddress));
+		}
+		catch (error)
+		{
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+			throw error;
+		}
+	}
+
+	/** Physically purges one address after the catalog authority has completed its reference-safe gate. */
+	async purge(contentAddress: string): Promise<ArtifactStorePurgeResult>
+	{
+		if (!___IsSha256ContentAddress(contentAddress))
+		{
+			throw new Error("invalid ArtifactStore content address");
+		}
+		try
+		{
+			await unlink(this._contentPath(contentAddress));
+			return { purged: true };
+		}
+		catch (error)
+		{
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return { purged: false };
+			throw error;
+		}
+	}
+
+	/** Returns the private mounted directory for incomplete upload bytes. */
+	private _stagingDirectory(): string
+	{
+		return join(this.rootPath, "staging");
+	}
+
+	/** Write a complete chunk even when the operating system accepts only a partial buffer. */
+	private async _writeAll(file: FileHandle, bytes: Buffer): Promise<void>
+	{
+		let offset = 0;
+		while (offset < bytes.byteLength)
+		{
+			const result = await file.write(bytes, offset, bytes.byteLength - offset);
+			if (result.bytesWritten < 1)
+			{
+				throw new Error("ArtifactStore staging write made no progress");
+			}
+			offset += result.bytesWritten;
+		}
+	}
+
+	/** Hash an existing regular file before accepting concurrent CAS promotion idempotently. */
+	private async _hashFile(path: string): Promise<string>
+	{
+		const file = await open(path, "r");
+		const hash = createHash("sha256");
+		const buffer = Buffer.allocUnsafe(64 * 1024);
+		try
+		{
+			while (true)
+			{
+				const result = await file.read(buffer, 0, buffer.byteLength, null);
+				if (result.bytesRead === 0) break;
+				hash.update(buffer.subarray(0, result.bytesRead));
+			}
+		}
+		finally
+		{
+			await file.close();
+		}
+		return `sha256:${hash.digest("hex")}`;
+	}
+
+	/** Persist a newly linked canonical directory entry before an acknowledged promotion. */
+	private async _syncDirectory(directory: string): Promise<void>
+	{
+		const handle = await open(directory, "r");
+		try
+		{
+			await handle.sync();
+		}
+		finally
+		{
+			await handle.close();
+		}
+	}
+
+	/** Converts a deterministic internal staging handle into a path below the private staging root. */
+	private _stagingPath(stagingHandle: string): string
+	{
+		if (!/^[a-f0-9]{64}$/u.test(stagingHandle))
+		{
+			throw new Error("invalid ArtifactStore staging handle");
+		}
+		return join(this._stagingDirectory(), stagingHandle);
+	}
+
+	/** Returns the sharded directory for a strict SHA-256 content address. */
+	private _contentDirectory(contentAddress: string): string
+	{
+		const digest = this._digest(contentAddress);
+		return join(this.rootPath, "sha256", digest.slice(0, 2));
+	}
+
+	/** Returns the only permitted canonical path for a strict SHA-256 content address. */
+	private _contentPath(contentAddress: string): string
+	{
+		const digest = this._digest(contentAddress);
+		return join(this._contentDirectory(contentAddress), digest);
+	}
+
+	/** Strips the validated address prefix without accepting arbitrary filesystem path input. */
+	private _digest(contentAddress: string): string
+	{
+		if (!___IsSha256ContentAddress(contentAddress))
+		{
+			throw new Error("invalid ArtifactStore content address");
+		}
+		return contentAddress.slice("sha256:".length);
+	}
+}

--- a/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.types.ts
+++ b/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.types.ts
@@ -1,0 +1,6 @@
+/** Filesystem root used exclusively for the ArtifactStore CAS and staging paths. */
+export interface FilesystemArtifactStoreOptions
+{
+  /** Absolute mounted volume root owned by the artifact-service process. */
+  readonly rootPath: string;
+}

--- a/libs/backend/artifacts/filesystem/main/src/index.ts
+++ b/libs/backend/artifacts/filesystem/main/src/index.ts
@@ -1,0 +1,2 @@
+export { __FilesystemArtifactStore } from "./filesystem-artifact-store.js";
+export type { FilesystemArtifactStoreOptions } from "./filesystem-artifact-store.types.js";

--- a/libs/backend/artifacts/filesystem/main/tsconfig.json
+++ b/libs/backend/artifacts/filesystem/main/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/backend/artifacts/filesystem/main/vitest.config.ts
+++ b/libs/backend/artifacts/filesystem/main/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../vitest.cache.js";
+
+/** Vitest configuration for the POSIX ArtifactStore adapter. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../tsconfig.vitest.json"] })], test: { environment: "node" } });

--- a/libs/backend/artifacts/store/main/project.json
+++ b/libs/backend/artifacts/store/main/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend-artifacts-store",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/artifacts/store/main/src",
+  "tags": ["type:lib", "layer:backend", "scope:artifacts"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/artifacts/store/main" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/artifacts/store/main" } }
+  }
+}

--- a/libs/backend/artifacts/store/main/src/artifact-store.test.ts
+++ b/libs/backend/artifacts/store/main/src/artifact-store.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { __ValidateArtifactStorePromotion, __ValidateStageArtifactCommand, __ValidateStagedArtifact, __ValidateVerifiedArtifactWriteLease } from "./artifact-store.js";
+
+/** Builds one valid durable write lease. */
+function _lease(): { readonly leaseId: string; readonly siloId: string; readonly artifactId: string; readonly action: "artifact.write"; readonly expiresAtEpochSeconds: number }
+{
+	return { leaseId: "lease-1", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: 1_750_000_100 };
+}
+
+describe("ArtifactStore contracts", function _suite()
+{
+	it("rejects expired or non-artifact write leases before staging", function _leaseValidation()
+	{
+		expect(__ValidateVerifiedArtifactWriteLease(_lease(), 1_750_000_000)).toBe(true);
+		expect(__ValidateVerifiedArtifactWriteLease({ ..._lease(), action: "artifact.read" as "artifact.write" }, 1_750_000_000)).toBe(false);
+		expect(__ValidateVerifiedArtifactWriteLease({ ..._lease(), expiresAtEpochSeconds: 1_749_999_999 }, 1_750_000_000)).toBe(false);
+	});
+
+	it("accepts only bounded stage metadata with canonical optional digest", function _stageValidation()
+	{
+		const command = { lease: _lease(), bytes: (async function* _bytes(): AsyncIterable<Uint8Array> { yield Buffer.from("artifact"); })(), expectedContentAddress: `sha256:${"a".repeat(64)}`, expectedByteLength: 8, mediaType: "text/plain" };
+		expect(__ValidateStageArtifactCommand(command, 1_750_000_000)).toBe(true);
+		expect(__ValidateStageArtifactCommand({ ...command, expectedContentAddress: "digest" }, 1_750_000_000)).toBe(false);
+		expect(__ValidateStageArtifactCommand({ ...command, expectedByteLength: -1 }, 1_750_000_000)).toBe(false);
+	});
+
+	it("keeps staging and promotion values content-addressed", function _promotionValidation()
+	{
+		const staged = { leaseId: "lease-1", stagingHandle: "staging-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 8, mediaType: "text/plain" };
+		expect(__ValidateStagedArtifact(staged)).toBe(true);
+		expect(__ValidateArtifactStorePromotion({ ...staged, created: true })).toBe(true);
+		expect(__ValidateStagedArtifact({ ...staged, contentAddress: "relative/path" })).toBe(false);
+	});
+});

--- a/libs/backend/artifacts/store/main/src/artifact-store.ts
+++ b/libs/backend/artifacts/store/main/src/artifact-store.ts
@@ -1,0 +1,49 @@
+import { ___IsSha256ContentAddress } from "@opencrane/models/artifacts";
+
+import type { ArtifactStorePromotion, StageArtifactCommand, StagedArtifact, VerifiedArtifactWriteLease } from "./artifact-store.types.js";
+
+/** Validates an OpenCrane-issued lease before an adapter creates temporary bytes. */
+export function __ValidateVerifiedArtifactWriteLease(lease: VerifiedArtifactWriteLease, nowEpochSeconds: number): boolean
+{
+	return lease.leaseId.trim().length > 0
+		&& lease.siloId.trim().length > 0
+		&& lease.artifactId.trim().length > 0
+		&& lease.action === "artifact.write"
+		&& Number.isSafeInteger(lease.expiresAtEpochSeconds)
+		&& lease.expiresAtEpochSeconds >= nowEpochSeconds;
+}
+
+/** Validates stage coordinates before untrusted bytes are accepted by an ArtifactStore adapter. */
+export function __ValidateStageArtifactCommand(command: StageArtifactCommand, nowEpochSeconds: number): boolean
+{
+	const expectedAddressIsValid = command.expectedContentAddress === null || ___IsSha256ContentAddress(command.expectedContentAddress);
+	const expectedLengthIsValid = command.expectedByteLength === null || (Number.isSafeInteger(command.expectedByteLength) && command.expectedByteLength >= 0);
+	return __ValidateVerifiedArtifactWriteLease(command.lease, nowEpochSeconds)
+		&& expectedAddressIsValid
+		&& expectedLengthIsValid
+		&& command.mediaType.trim().length > 0
+		&& command.mediaType.includes("/");
+}
+
+/** Validates a staged handle before immutable promotion. */
+export function __ValidateStagedArtifact(staged: StagedArtifact): boolean
+{
+	return staged.leaseId.trim().length > 0
+		&& staged.stagingHandle.trim().length > 0
+		&& ___IsSha256ContentAddress(staged.contentAddress)
+		&& Number.isSafeInteger(staged.byteLength)
+		&& staged.byteLength >= 0
+		&& staged.mediaType.trim().length > 0
+		&& staged.mediaType.includes("/");
+}
+
+/** Validates metadata returned by an idempotent canonical promotion. */
+export function __ValidateArtifactStorePromotion(promotion: ArtifactStorePromotion): boolean
+{
+	return promotion.leaseId.trim().length > 0
+		&& ___IsSha256ContentAddress(promotion.contentAddress)
+		&& Number.isSafeInteger(promotion.byteLength)
+		&& promotion.byteLength >= 0
+		&& promotion.mediaType.trim().length > 0
+		&& promotion.mediaType.includes("/");
+}

--- a/libs/backend/artifacts/store/main/src/artifact-store.types.ts
+++ b/libs/backend/artifacts/store/main/src/artifact-store.types.ts
@@ -1,0 +1,82 @@
+/** A byte stream supplied for one authorized artifact upload. */
+export type ArtifactByteStream = AsyncIterable<Uint8Array>;
+
+/** Immutable authorization coordinates already verified by the OpenCrane catalog before byte staging. */
+export interface VerifiedArtifactWriteLease
+{
+	/** Durable OpenCrane-issued lease identifier. */
+	readonly leaseId: string;
+	/** Silo in which the catalog remains authoritative. */
+	readonly siloId: string;
+	/** Exact logical artifact that may receive the promoted bytes. */
+	readonly artifactId: string;
+	/** Exact capability action that authorized the bytes. */
+	readonly action: "artifact.write";
+	/** Epoch-second expiry after which staging must be rejected. */
+	readonly expiresAtEpochSeconds: number;
+}
+
+/** Request to stage one bounded byte stream behind a previously authorized lease. */
+export interface StageArtifactCommand
+{
+	/** Already-verified lease supplied by the OpenCrane catalog. The storage adapter never authenticates it. */
+	readonly lease: VerifiedArtifactWriteLease;
+	/** Untrusted bytes to hash and durably stage. */
+	readonly bytes: ArtifactByteStream;
+	/** Expected content address when the caller already knows it, otherwise null. */
+	readonly expectedContentAddress: string | null;
+	/** Expected byte length when the caller already knows it, otherwise null. */
+	readonly expectedByteLength: number | null;
+	/** Claimed media type retained with the promotion receipt. */
+	readonly mediaType: string;
+}
+
+/** Private staged content that has been hashed but is not yet canonical. */
+export interface StagedArtifact
+{
+	/** Lease that owns this temporary staged file. */
+	readonly leaseId: string;
+	/** Opaque adapter-local staging handle. */
+	readonly stagingHandle: string;
+	/** Computed lowercase SHA-256 content address. */
+	readonly contentAddress: string;
+	/** Exact staged byte count. */
+	readonly byteLength: number;
+	/** Media type retained from the validated stage command. */
+	readonly mediaType: string;
+}
+
+/** Canonical immutable bytes created by an idempotent promotion. */
+export interface ArtifactStorePromotion
+{
+	/** Lease whose staged bytes were promoted. */
+	readonly leaseId: string;
+	/** Canonical lowercase SHA-256 content address. */
+	readonly contentAddress: string;
+	/** Exact immutable byte count. */
+	readonly byteLength: number;
+	/** Media type recorded for later catalog finalization. */
+	readonly mediaType: string;
+	/** Whether this call first created the canonical object. */
+	readonly created: boolean;
+}
+
+/** Result of an idempotent, reference-authorized physical purge. */
+export interface ArtifactStorePurgeResult
+{
+	/** Whether canonical bytes were removed by this call. */
+	readonly purged: boolean;
+}
+
+/** Storage-neutral byte authority. OpenCrane owns leases, receipts, catalog state, and authorization. */
+export interface ArtifactStore
+{
+	/** Hashes and durably stages bytes without publishing a catalog reference. */
+	stage(command: StageArtifactCommand): Promise<StagedArtifact>;
+	/** Atomically promotes staged bytes to their immutable content address. */
+	promote(staged: StagedArtifact): Promise<ArtifactStorePromotion>;
+	/** Reads canonical bytes by an already-authorized immutable content address. */
+	read(contentAddress: string): Promise<ArtifactByteStream | null>;
+	/** Removes bytes only after the OpenCrane authority proved no active lease or reference remains. */
+	purge(contentAddress: string): Promise<ArtifactStorePurgeResult>;
+}

--- a/libs/backend/artifacts/store/main/src/index.ts
+++ b/libs/backend/artifacts/store/main/src/index.ts
@@ -1,0 +1,2 @@
+export { __ValidateArtifactStorePromotion, __ValidateStageArtifactCommand, __ValidateStagedArtifact, __ValidateVerifiedArtifactWriteLease } from "./artifact-store.js";
+export type { ArtifactByteStream, ArtifactStore, ArtifactStorePromotion, ArtifactStorePurgeResult, StageArtifactCommand, StagedArtifact, VerifiedArtifactWriteLease } from "./artifact-store.types.js";

--- a/libs/backend/artifacts/store/main/tsconfig.json
+++ b/libs/backend/artifacts/store/main/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/backend/artifacts/store/main/vitest.config.ts
+++ b/libs/backend/artifacts/store/main/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../vitest.cache.js";
+
+/** Vitest configuration for storage-neutral ArtifactStore contracts. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../tsconfig.vitest.json"] })], test: { environment: "node" } });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,12 @@
       "@opencrane/backend/server/artifacts": [
         "./libs/backend/server/artifacts/main/src/index.ts"
       ],
+      "@opencrane/backend/artifacts/store": [
+        "./libs/backend/artifacts/store/main/src/index.ts"
+      ],
+      "@opencrane/backend/artifacts/filesystem": [
+        "./libs/backend/artifacts/filesystem/main/src/index.ts"
+      ],
       "@opencrane/backend/server/api-spec": [
         "./libs/backend/server/api-spec/main/src/index.ts"
       ],


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — artifact storage.** Agents produce files (documents, images, results). This PR builds the vault those files live in: content-addressed and atomic, so nothing can end up half-written, overwritten, or smuggled outside its folder.

**What it adds**
- The storage engine: files are staged first, then promoted in one atomic step
- Deduplication by content hash
- Protection against path tricks and partial writes

<details>
<summary>Technical details (original description)</summary>

## Summary

- add storage-neutral ArtifactStore contracts that accept only an already-verified lease
- add a POSIX content-addressed adapter with private staging, fsync-backed promotion, and strict hash/path validation
- cover concurrent promotions, metadata mismatches, safe reads/purge, and tampered same-size canonical bytes

## Deliberate scope

This is the mechanics foundation only: it deploys no byte service and adds no catalog authority. The immediately dependent branch will add the proof-bound OpenCrane lease, signed service receipt, atomic catalog finalization, and app-owned deployment.

## Validation

- ArtifactStore and filesystem Nx lint targets
- ArtifactStore and filesystem Vitest targets (7 tests)
- repository diff check

## Review

- architecture gate approved this narrow non-deployable scope
- reaper gate PASS for `b4acee4..509480d`

</details>
