### PR TITLE
🏗️ Phase D: add fail-closed agent controller foundation

### DIFF
--- a/libs/backend/agent-controller/main/project.json
+++ b/libs/backend/agent-controller/main/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend-agent-controller",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/agent-controller/main/src",
+  "tags": ["type:lib", "layer:backend", "scope:agents"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/agent-controller/main" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/agent-controller/main" } }
+  }
+}

--- a/libs/backend/agent-controller/main/src/agent-controller.test.ts
+++ b/libs/backend/agent-controller/main/src/agent-controller.test.ts
@@ -43,11 +43,11 @@ describe("agent workload controller", function _describeController()
 		expect(fixture.calls).toEqual(["get", "create", "job:job-uid", "unsuspend:job-uid", "pod", "pod:pod-uid"]);
 	});
 
-	it("is idempotent when the exact suspended Job already exists", async function _doesNotCreateAgain()
+	it("recovers a matching running Job only after authority re-confirms bootstrap readiness", async function _doesNotCreateAgain()
 	{
-		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: _BuildJobProjection(_Desired()).labels, uid: "job-uid", suspended: true });
+		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: _BuildJobProjection(_Desired()).labels, uid: "job-uid", suspended: false });
 		await __ReconcileAgentJob(fixture.dependencies);
-		expect(fixture.calls).toEqual(["get", "job:job-uid", "unsuspend:job-uid", "pod", "pod:pod-uid"]);
+		expect(fixture.calls).toEqual(["get", "job:job-uid", "pod", "pod:pod-uid"]);
 	});
 
 	it("rejects a desired Job that widens the approved image boundary", async function _rejectsImage()
@@ -69,7 +69,7 @@ describe("agent workload controller", function _describeController()
 	{
 		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: _BuildJobProjection(_Desired()).labels, uid: "job-uid", suspended: false }, false);
 		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "rejected", reason: "unsafe_existing_job", runId: "run-123", attempt: 1 });
-		expect(fixture.calls).toEqual(["get", "delete:job-uid", "reject:unsafe_existing_job"]);
+		expect(fixture.calls).toEqual(["get", "job:job-uid", "delete:job-uid", "reject:unsafe_existing_job"]);
 	});
 
 	it("deletes a creation result that violates the initial suspended invariant", async function _rejectsUnexpectedCreation()

--- a/libs/backend/agent-controller/main/src/agent-controller.test.ts
+++ b/libs/backend/agent-controller/main/src/agent-controller.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { __ReconcileAgentJob, _BuildJobProjection } from "./agent-controller.js";
+import type { AgentControllerDependencies, AgentJobProjection, DesiredAgentJob, ObservedAgentJob } from "./agent-controller.types.js";
+
+/** Construct one target-shaped desired Job for controller tests. */
+function _Desired(): DesiredAgentJob
+{
+	return { runId: "run-123", attempt: 1, agentServiceId: "service-123", agentRevisionId: "revision-123", siloId: "silo-123", subjectId: "user-123", namespace: "opencrane-runtime", serviceAccountName: "agent-runtime", image: "ghcr.io/opencrane/agent-runtime@sha256:abc" };
+}
+
+/** Construct isolated fake dependencies while recording the security-relevant call order. */
+function _Dependencies(desired: DesiredAgentJob | null, observed: ObservedAgentJob | null = null, bootstrapReady = true): { readonly dependencies: AgentControllerDependencies; readonly calls: string[] }
+{
+	const calls: string[] = [];
+	return {
+		calls,
+		dependencies: {
+			policy: { runtimeNamespace: "opencrane-runtime", runtimeServiceAccountName: "agent-runtime", runtimeImage: "ghcr.io/opencrane/agent-runtime@sha256:abc" },
+			desiredJobs: { async readNext() { return desired; } },
+			jobs: {
+				async get() { calls.push("get"); return observed; },
+				async createSuspended(projection: AgentJobProjection) { calls.push("create"); return { name: projection.name, labels: projection.labels, uid: "job-uid", suspended: true }; },
+				async unsuspend(_: AgentJobProjection, uid: string) { calls.push(`unsuspend:${uid}`); },
+				async firstPodUid() { calls.push("pod"); return "pod-uid"; },
+			},
+			status: {
+				async rejectDesired(_: DesiredAgentJob, reason: "invalid_desired_job") { calls.push(`reject:${reason}`); },
+				async recordJob(_: DesiredAgentJob, __: AgentJobProjection, uid: string) { calls.push(`job:${uid}`); return { bootstrapReady }; },
+				async recordPod(_: DesiredAgentJob, __: AgentJobProjection, ___: string, uid: string) { calls.push(`pod:${uid}`); },
+			},
+		},
+	};
+}
+
+describe("agent workload controller", function _describeController()
+{
+	it("creates suspended, records its UID, then unsuspends and records the first Pod", async function _createsInOrder()
+	{
+		const fixture = _Dependencies(_Desired());
+		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "reconciled", runId: "run-123", attempt: 1, workloadUid: "job-uid", podUid: "pod-uid" });
+		expect(fixture.calls).toEqual(["get", "create", "job:job-uid", "unsuspend:job-uid", "pod", "pod:pod-uid"]);
+	});
+
+	it("is idempotent when the exact Job already exists", async function _doesNotCreateAgain()
+	{
+		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: _BuildJobProjection(_Desired()).labels, uid: "job-uid", suspended: false });
+		await __ReconcileAgentJob(fixture.dependencies);
+		expect(fixture.calls).toEqual(["get", "job:job-uid", "pod", "pod:pod-uid"]);
+	});
+
+	it("rejects a desired Job that widens the approved image boundary", async function _rejectsImage()
+	{
+		const desired = { ..._Desired(), image: "ghcr.io/untrusted/image:latest" };
+		const fixture = _Dependencies(desired);
+		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "rejected", reason: "invalid_desired_job", runId: "run-123", attempt: 1 });
+		expect(fixture.calls).toEqual(["reject:invalid_desired_job"]);
+	});
+
+	it("keeps a Job suspended until the authority confirms UID-bound bootstrap delivery", async function _keepsPrepared()
+	{
+		const fixture = _Dependencies(_Desired(), null, false);
+		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "prepared", runId: "run-123", attempt: 1, workloadUid: "job-uid" });
+		expect(fixture.calls).toEqual(["get", "create", "job:job-uid"]);
+	});
+
+	it("rejects an already-running Job when the authority cannot prove its bootstrap delivery", async function _rejectsUnsafeExistingJob()
+	{
+		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: _BuildJobProjection(_Desired()).labels, uid: "job-uid", suspended: false }, false);
+		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "rejected", reason: "unsafe_existing_job", runId: "run-123", attempt: 1 });
+		expect(fixture.calls).toEqual(["get", "job:job-uid"]);
+	});
+
+	it("keeps the Kubernetes projection deterministic and retry-distinct", function _buildsProjection()
+	{
+		expect(_BuildJobProjection(_Desired())).toMatchObject({ name: expect.stringMatching(/^agent-run-run-123-[a-f0-9]{16}-a1$/), suspend: true, backoffLimit: 0, serviceAccountName: "agent-runtime" });
+		expect(_BuildJobProjection({ ..._Desired(), attempt: 2 }).name).not.toBe(_BuildJobProjection(_Desired()).name);
+	});
+
+	it("bounds deterministic Job names and rejects IDs unsafe for Kubernetes labels", async function _boundsKubernetesFields()
+	{
+		const longRunId = "r".repeat(63);
+		expect(_BuildJobProjection({ ..._Desired(), runId: longRunId, attempt: 9_999_999_999 }).name).toHaveLength(63);
+		const fixture = _Dependencies({ ..._Desired(), agentRevisionId: "revision/unsafe" });
+		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "rejected", reason: "invalid_desired_job", runId: "run-123", attempt: 1 });
+	});
+
+	it("does not collide long run names that share an initial Kubernetes-safe prefix", function _avoidsLongNameCollision()
+	{
+		const common = "r".repeat(50);
+		expect(_BuildJobProjection({ ..._Desired(), runId: `${common}aaaaaaaaaaaaa` }).name).not.toBe(_BuildJobProjection({ ..._Desired(), runId: `${common}bbbbbbbbbbbbb` }).name);
+	});
+
+	it("refuses a same-name Job whose immutable run labels do not match the desired projection", async function _refusesMismatchedJob()
+	{
+		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: { "opencrane.io/run-id": "other-run" }, uid: "other-job", suspended: true });
+		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "rejected", reason: "mismatched_existing_job", runId: "run-123", attempt: 1 });
+		expect(fixture.calls).toEqual(["get"]);
+	});
+});

--- a/libs/backend/agent-controller/main/src/agent-controller.test.ts
+++ b/libs/backend/agent-controller/main/src/agent-controller.test.ts
@@ -10,7 +10,7 @@ function _Desired(): DesiredAgentJob
 }
 
 /** Construct isolated fake dependencies while recording the security-relevant call order. */
-function _Dependencies(desired: DesiredAgentJob | null, observed: ObservedAgentJob | null = null, bootstrapReady = true): { readonly dependencies: AgentControllerDependencies; readonly calls: string[] }
+function _Dependencies(desired: DesiredAgentJob | null, observed: ObservedAgentJob | null = null, bootstrapReady = true, createdSuspended = true): { readonly dependencies: AgentControllerDependencies; readonly calls: string[] }
 {
 	const calls: string[] = [];
 	return {
@@ -20,12 +20,13 @@ function _Dependencies(desired: DesiredAgentJob | null, observed: ObservedAgentJ
 			desiredJobs: { async readNext() { return desired; } },
 			jobs: {
 				async get() { calls.push("get"); return observed; },
-				async createSuspended(projection: AgentJobProjection) { calls.push("create"); return { name: projection.name, labels: projection.labels, uid: "job-uid", suspended: true }; },
+				async createSuspended(projection: AgentJobProjection) { calls.push("create"); return { name: projection.name, labels: projection.labels, uid: "job-uid", suspended: createdSuspended }; },
+				async delete(_: AgentJobProjection, uid: string) { calls.push(`delete:${uid}`); },
 				async unsuspend(_: AgentJobProjection, uid: string) { calls.push(`unsuspend:${uid}`); },
 				async firstPodUid() { calls.push("pod"); return "pod-uid"; },
 			},
 			status: {
-				async rejectDesired(_: DesiredAgentJob, reason: "invalid_desired_job") { calls.push(`reject:${reason}`); },
+				async rejectDesired(_: DesiredAgentJob, reason: "invalid_desired_job" | "unsafe_existing_job") { calls.push(`reject:${reason}`); },
 				async recordJob(_: DesiredAgentJob, __: AgentJobProjection, uid: string) { calls.push(`job:${uid}`); return { bootstrapReady }; },
 				async recordPod(_: DesiredAgentJob, __: AgentJobProjection, ___: string, uid: string) { calls.push(`pod:${uid}`); },
 			},
@@ -42,11 +43,11 @@ describe("agent workload controller", function _describeController()
 		expect(fixture.calls).toEqual(["get", "create", "job:job-uid", "unsuspend:job-uid", "pod", "pod:pod-uid"]);
 	});
 
-	it("is idempotent when the exact Job already exists", async function _doesNotCreateAgain()
+	it("is idempotent when the exact suspended Job already exists", async function _doesNotCreateAgain()
 	{
-		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: _BuildJobProjection(_Desired()).labels, uid: "job-uid", suspended: false });
+		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: _BuildJobProjection(_Desired()).labels, uid: "job-uid", suspended: true });
 		await __ReconcileAgentJob(fixture.dependencies);
-		expect(fixture.calls).toEqual(["get", "job:job-uid", "pod", "pod:pod-uid"]);
+		expect(fixture.calls).toEqual(["get", "job:job-uid", "unsuspend:job-uid", "pod", "pod:pod-uid"]);
 	});
 
 	it("rejects a desired Job that widens the approved image boundary", async function _rejectsImage()
@@ -64,11 +65,18 @@ describe("agent workload controller", function _describeController()
 		expect(fixture.calls).toEqual(["get", "create", "job:job-uid"]);
 	});
 
-	it("rejects an already-running Job when the authority cannot prove its bootstrap delivery", async function _rejectsUnsafeExistingJob()
+	it("deletes and rejects an already-running Job before it can run without bootstrap acknowledgement", async function _rejectsUnsafeExistingJob()
 	{
 		const fixture = _Dependencies(_Desired(), { name: _BuildJobProjection(_Desired()).name, labels: _BuildJobProjection(_Desired()).labels, uid: "job-uid", suspended: false }, false);
 		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "rejected", reason: "unsafe_existing_job", runId: "run-123", attempt: 1 });
-		expect(fixture.calls).toEqual(["get", "job:job-uid"]);
+		expect(fixture.calls).toEqual(["get", "delete:job-uid", "reject:unsafe_existing_job"]);
+	});
+
+	it("deletes a creation result that violates the initial suspended invariant", async function _rejectsUnexpectedCreation()
+	{
+		const fixture = _Dependencies(_Desired(), null, true, false);
+		await expect(__ReconcileAgentJob(fixture.dependencies)).resolves.toEqual({ outcome: "rejected", reason: "unsafe_existing_job", runId: "run-123", attempt: 1 });
+		expect(fixture.calls).toEqual(["get", "create", "delete:job-uid", "reject:unsafe_existing_job"]);
 	});
 
 	it("keeps the Kubernetes projection deterministic and retry-distinct", function _buildsProjection()

--- a/libs/backend/agent-controller/main/src/agent-controller.ts
+++ b/libs/backend/agent-controller/main/src/agent-controller.ts
@@ -24,21 +24,21 @@ export async function __ReconcileAgentJob(dependencies: AgentControllerDependenc
 	{
 		return { outcome: "rejected", reason: "mismatched_existing_job", runId: desired.runId, attempt: desired.attempt };
 	}
+	if (!observed.suspended)
+	{
+		// 3. A Job active before acknowledgement could have executed without a UID-bound bootstrap.
+		await dependencies.jobs.delete(projection, observed.uid);
+		await dependencies.status.rejectDesired(desired, "unsafe_existing_job");
+		return { outcome: "rejected", reason: "unsafe_existing_job", runId: desired.runId, attempt: desired.attempt };
+	}
 	const start = await dependencies.status.recordJob(desired, projection, observed.uid);
 	if (!start.bootstrapReady)
 	{
-		if (!observed.suspended)
-		{
-			return { outcome: "rejected", reason: "unsafe_existing_job", runId: desired.runId, attempt: desired.attempt };
-		}
 		return { outcome: "prepared", runId: desired.runId, attempt: desired.attempt, workloadUid: observed.uid };
 	}
 
-	// 3. Permit execution only after OpenCrane proves UID-bound bootstrap delivery, then report Pod identity.
-	if (observed.suspended)
-	{
-		await dependencies.jobs.unsuspend(projection, observed.uid);
-	}
+	// 4. Permit execution only after OpenCrane proves UID-bound bootstrap delivery, then report Pod identity.
+	await dependencies.jobs.unsuspend(projection, observed.uid);
 	const podUid = await dependencies.jobs.firstPodUid(projection, observed.uid);
 	if (podUid !== null)
 	{

--- a/libs/backend/agent-controller/main/src/agent-controller.ts
+++ b/libs/backend/agent-controller/main/src/agent-controller.ts
@@ -19,14 +19,15 @@ export async function __ReconcileAgentJob(dependencies: AgentControllerDependenc
 
 	// 2. Create only an inert projection and durably acknowledge its immutable Kubernetes UID.
 	const projection = _BuildJobProjection(desired);
-	const observed = await dependencies.jobs.get(projection) ?? await dependencies.jobs.createSuspended(projection);
+	const existing = await dependencies.jobs.get(projection);
+	const observed = existing ?? await dependencies.jobs.createSuspended(projection);
 	if (!_MatchesProjection(observed, projection))
 	{
 		return { outcome: "rejected", reason: "mismatched_existing_job", runId: desired.runId, attempt: desired.attempt };
 	}
-	if (!observed.suspended)
+	if (existing === null && !observed.suspended)
 	{
-		// 3. A Job active before acknowledgement could have executed without a UID-bound bootstrap.
+		// 3. A new Job active before acknowledgement could have executed without a UID-bound bootstrap.
 		await dependencies.jobs.delete(projection, observed.uid);
 		await dependencies.status.rejectDesired(desired, "unsafe_existing_job");
 		return { outcome: "rejected", reason: "unsafe_existing_job", runId: desired.runId, attempt: desired.attempt };
@@ -34,11 +35,20 @@ export async function __ReconcileAgentJob(dependencies: AgentControllerDependenc
 	const start = await dependencies.status.recordJob(desired, projection, observed.uid);
 	if (!start.bootstrapReady)
 	{
+		if (!observed.suspended)
+		{
+			await dependencies.jobs.delete(projection, observed.uid);
+			await dependencies.status.rejectDesired(desired, "unsafe_existing_job");
+			return { outcome: "rejected", reason: "unsafe_existing_job", runId: desired.runId, attempt: desired.attempt };
+		}
 		return { outcome: "prepared", runId: desired.runId, attempt: desired.attempt, workloadUid: observed.uid };
 	}
 
 	// 4. Permit execution only after OpenCrane proves UID-bound bootstrap delivery, then report Pod identity.
-	await dependencies.jobs.unsuspend(projection, observed.uid);
+	if (observed.suspended)
+	{
+		await dependencies.jobs.unsuspend(projection, observed.uid);
+	}
 	const podUid = await dependencies.jobs.firstPodUid(projection, observed.uid);
 	if (podUid !== null)
 	{

--- a/libs/backend/agent-controller/main/src/agent-controller.ts
+++ b/libs/backend/agent-controller/main/src/agent-controller.ts
@@ -1,0 +1,102 @@
+import { createHash } from "node:crypto";
+
+import type { AgentControllerDependencies, AgentControllerReconcileResult, AgentJobProjection, DesiredAgentJob, ObservedAgentJob } from "./agent-controller.types.js";
+
+/** Reconcile one authority-selected run into one tightly bounded Kubernetes Job. */
+export async function __ReconcileAgentJob(dependencies: AgentControllerDependencies): Promise<AgentControllerReconcileResult>
+{
+	// 1. Load one desired state record from the OpenCrane authority, never from controller storage.
+	const desired = await dependencies.desiredJobs.readNext();
+	if (desired === null)
+	{
+		return { outcome: "idle" };
+	}
+	if (!_IsAllowedDesiredJob(desired, dependencies.policy))
+	{
+		await dependencies.status.rejectDesired(desired, "invalid_desired_job");
+		return { outcome: "rejected", reason: "invalid_desired_job", runId: desired.runId, attempt: desired.attempt };
+	}
+
+	// 2. Create only an inert projection and durably acknowledge its immutable Kubernetes UID.
+	const projection = _BuildJobProjection(desired);
+	const observed = await dependencies.jobs.get(projection) ?? await dependencies.jobs.createSuspended(projection);
+	if (!_MatchesProjection(observed, projection))
+	{
+		return { outcome: "rejected", reason: "mismatched_existing_job", runId: desired.runId, attempt: desired.attempt };
+	}
+	const start = await dependencies.status.recordJob(desired, projection, observed.uid);
+	if (!start.bootstrapReady)
+	{
+		if (!observed.suspended)
+		{
+			return { outcome: "rejected", reason: "unsafe_existing_job", runId: desired.runId, attempt: desired.attempt };
+		}
+		return { outcome: "prepared", runId: desired.runId, attempt: desired.attempt, workloadUid: observed.uid };
+	}
+
+	// 3. Permit execution only after OpenCrane proves UID-bound bootstrap delivery, then report Pod identity.
+	if (observed.suspended)
+	{
+		await dependencies.jobs.unsuspend(projection, observed.uid);
+	}
+	const podUid = await dependencies.jobs.firstPodUid(projection, observed.uid);
+	if (podUid !== null)
+	{
+		await dependencies.status.recordPod(desired, projection, observed.uid, podUid);
+	}
+	return { outcome: "reconciled", runId: desired.runId, attempt: desired.attempt, workloadUid: observed.uid, podUid };
+}
+
+/** Build a deterministic projection that carries no untrusted Kubernetes fields. */
+export function _BuildJobProjection(desired: DesiredAgentJob): AgentJobProjection
+{
+	return {
+		name: _KubernetesJobName(desired.runId, desired.attempt),
+		namespace: desired.namespace,
+		labels: {
+			"app.kubernetes.io/component": "agent-runtime",
+			"opencrane.io/run-id": desired.runId,
+			"opencrane.io/run-attempt": String(desired.attempt),
+			"opencrane.io/agent-service-id": desired.agentServiceId,
+			"opencrane.io/agent-revision-id": desired.agentRevisionId,
+			"opencrane.io/silo-id": desired.siloId,
+		},
+		serviceAccountName: desired.serviceAccountName,
+		image: desired.image,
+		suspend: true,
+		backoffLimit: 0,
+	};
+}
+
+/** Reject a desired record that tries to widen the controller's immutable boundary. */
+function _IsAllowedDesiredJob(desired: DesiredAgentJob, policy: AgentControllerDependencies["policy"]): boolean
+{
+	return /^[a-z0-9][a-z0-9-]{0,62}$/.test(desired.runId)
+		&& Number.isSafeInteger(desired.attempt) && desired.attempt > 0
+		&& _IsKubernetesLabelValue(desired.agentServiceId) && _IsKubernetesLabelValue(desired.agentRevisionId) && _IsKubernetesLabelValue(desired.siloId)
+		&& desired.namespace === policy.runtimeNamespace
+		&& desired.serviceAccountName === policy.runtimeServiceAccountName
+		&& desired.image === policy.runtimeImage;
+}
+
+/** Convert a durable identifier to the Kubernetes DNS-label segment used in the deterministic name. */
+function _KubernetesJobName(runId: string, attempt: number): string
+{
+	const prefix = "agent-run-";
+	const digest = createHash("sha256").update(`${runId}:${attempt}`).digest("hex").slice(0, 16);
+	const suffix = `-${digest}-a${attempt}`;
+	return `${prefix}${runId.slice(0, 63 - prefix.length - suffix.length)}${suffix}`;
+}
+
+/** Return whether an authority identifier can be emitted unchanged as a Kubernetes label value. */
+function _IsKubernetesLabelValue(value: string): boolean
+{
+	return /^[a-z0-9]([a-z0-9._-]*[a-z0-9])?$/.test(value) && value.length <= 63;
+}
+
+/** Verify a named existing Job still belongs to the exact desired run projection. */
+function _MatchesProjection(observed: ObservedAgentJob, projection: AgentJobProjection): boolean
+{
+	return observed.name === projection.name
+		&& Object.entries(projection.labels).every(function _matchingLabel([key, value]) { return observed.labels[key] === value; });
+}

--- a/libs/backend/agent-controller/main/src/agent-controller.types.ts
+++ b/libs/backend/agent-controller/main/src/agent-controller.types.ts
@@ -1,0 +1,123 @@
+/** Exact durable run coordinates selected by the OpenCrane authority. */
+export interface DesiredAgentJob
+{
+	/** Logical run identifier. */
+	readonly runId: string;
+	/** Positive durable attempt number. */
+	readonly attempt: number;
+	/** Immutable AgentService identifier. */
+	readonly agentServiceId: string;
+	/** Immutable AgentRevision identifier. */
+	readonly agentRevisionId: string;
+	/** Silo whose authority selected the run. */
+	readonly siloId: string;
+	/** Subject that authorized the run. */
+	readonly subjectId: string;
+	/** Exact runtime namespace selected by OpenCrane. */
+	readonly namespace: string;
+	/** Exact runtime service account selected by OpenCrane. */
+	readonly serviceAccountName: string;
+	/** Immutable OCI image reference selected by OpenCrane. */
+	readonly image: string;
+}
+
+/** Minimal immutable projection of one bounded Kubernetes Job. */
+export interface AgentJobProjection
+{
+	/** Deterministic Kubernetes Job name. */
+	readonly name: string;
+	/** Namespace in which the Job is allowed to exist. */
+	readonly namespace: string;
+	/** Labels that bind the Job to one exact durable attempt. */
+	readonly labels: Readonly<Record<string, string>>;
+	/** Runtime service account with no Kubernetes RBAC. */
+	readonly serviceAccountName: string;
+	/** Exact controller-approved runtime image. */
+	readonly image: string;
+	/** Whether the Job must remain suspended. */
+	readonly suspend: boolean;
+	/** No retry is delegated to Kubernetes under the same durable attempt. */
+	readonly backoffLimit: 0;
+}
+
+/** Immutable identity returned by Kubernetes after Job creation. */
+export interface ObservedAgentJob
+{
+	/** Deterministic Job name. */
+	readonly name: string;
+	/** Immutable labels observed on the Kubernetes Job. */
+	readonly labels: Readonly<Record<string, string>>;
+	/** Kubernetes-assigned immutable Job UID. */
+	readonly uid: string;
+	/** Whether the current Job is suspended. */
+	readonly suspended: boolean;
+}
+
+/** Controller configuration that pins every Kubernetes projection boundary. */
+export interface AgentControllerPolicy
+{
+	/** Only namespace the controller can project into. */
+	readonly runtimeNamespace: string;
+	/** Only workload KSA the controller may assign. */
+	readonly runtimeServiceAccountName: string;
+	/** Only runtime image the controller may project. */
+	readonly runtimeImage: string;
+}
+
+/** OpenCrane-owned source of already-authorized desired state. */
+export interface DesiredAgentJobSource
+{
+	/** Return at most one desired Job, or null when the authority has no work. */
+	readNext(): Promise<DesiredAgentJob | null>;
+}
+
+/** Kubernetes-only port owned by the controller app adapter. */
+export interface AgentJobMutator
+{
+	/** Load a Job by deterministic identity without modifying it. */
+	get(projection: AgentJobProjection): Promise<ObservedAgentJob | null>;
+	/** Create a suspended Job and return its immutable identity. */
+	createSuspended(projection: AgentJobProjection): Promise<ObservedAgentJob>;
+	/** Unsuspend only the exact Job whose identity was durably acknowledged. */
+	unsuspend(projection: AgentJobProjection, workloadUid: string): Promise<void>;
+	/** Return the first observed runtime Pod UID for the exact Job, if any. */
+	firstPodUid(projection: AgentJobProjection, workloadUid: string): Promise<string | null>;
+}
+
+/** OpenCrane-owned acknowledgement sink; this is never a controller database. */
+export interface AgentJobStatusReporter
+{
+	/** Durably reject an invalid desired record so it cannot starve later work. */
+	rejectDesired(desired: DesiredAgentJob, reason: "invalid_desired_job"): Promise<void>;
+	/** Durably bind the immutable Job UID before it can start. */
+	recordJob(desired: DesiredAgentJob, projection: AgentJobProjection, workloadUid: string): Promise<AgentJobStartDecision>;
+	/** Durably bind the first runtime Pod UID after Kubernetes creates it. */
+	recordPod(desired: DesiredAgentJob, projection: AgentJobProjection, workloadUid: string, podUid: string): Promise<void>;
+}
+
+/** Server-authoritative decision on whether bootstrap delivery makes a suspended Job safe to start. */
+export interface AgentJobStartDecision
+{
+	/** Only true after the future runtime authority proves UID-bound bootstrap delivery is ready. */
+	readonly bootstrapReady: boolean;
+}
+
+/** Dependencies for one bounded, idempotent controller reconciliation. */
+export interface AgentControllerDependencies
+{
+	/** Pinned projection policy. */
+	readonly policy: AgentControllerPolicy;
+	/** OpenCrane desired-state authority. */
+	readonly desiredJobs: DesiredAgentJobSource;
+	/** Kubernetes mutation/read adapter. */
+	readonly jobs: AgentJobMutator;
+	/** OpenCrane acknowledgement authority. */
+	readonly status: AgentJobStatusReporter;
+}
+
+/** Observable result of reconciling at most one desired Job. */
+export type AgentControllerReconcileResult =
+	| { readonly outcome: "idle" }
+	| { readonly outcome: "prepared"; readonly runId: string; readonly attempt: number; readonly workloadUid: string }
+	| { readonly outcome: "reconciled"; readonly runId: string; readonly attempt: number; readonly workloadUid: string; readonly podUid: string | null }
+	| { readonly outcome: "rejected"; readonly reason: "invalid_desired_job" | "mismatched_existing_job" | "unsafe_existing_job"; readonly runId: string; readonly attempt: number };

--- a/libs/backend/agent-controller/main/src/agent-controller.types.ts
+++ b/libs/backend/agent-controller/main/src/agent-controller.types.ts
@@ -78,6 +78,8 @@ export interface AgentJobMutator
 	get(projection: AgentJobProjection): Promise<ObservedAgentJob | null>;
 	/** Create a suspended Job and return its immutable identity. */
 	createSuspended(projection: AgentJobProjection): Promise<ObservedAgentJob>;
+	/** Delete an unexpectedly active Job by its exact immutable UID. */
+	delete(projection: AgentJobProjection, workloadUid: string): Promise<void>;
 	/** Unsuspend only the exact Job whose identity was durably acknowledged. */
 	unsuspend(projection: AgentJobProjection, workloadUid: string): Promise<void>;
 	/** Return the first observed runtime Pod UID for the exact Job, if any. */
@@ -88,7 +90,7 @@ export interface AgentJobMutator
 export interface AgentJobStatusReporter
 {
 	/** Durably reject an invalid desired record so it cannot starve later work. */
-	rejectDesired(desired: DesiredAgentJob, reason: "invalid_desired_job"): Promise<void>;
+	rejectDesired(desired: DesiredAgentJob, reason: "invalid_desired_job" | "unsafe_existing_job"): Promise<void>;
 	/** Durably bind the immutable Job UID before it can start. */
 	recordJob(desired: DesiredAgentJob, projection: AgentJobProjection, workloadUid: string): Promise<AgentJobStartDecision>;
 	/** Durably bind the first runtime Pod UID after Kubernetes creates it. */

--- a/libs/backend/agent-controller/main/src/index.ts
+++ b/libs/backend/agent-controller/main/src/index.ts
@@ -1,0 +1,3 @@
+/** Target agent workload controller domain boundary. */
+export { __ReconcileAgentJob, _BuildJobProjection } from "./agent-controller.js";
+export type { AgentControllerDependencies, AgentControllerPolicy, AgentControllerReconcileResult, AgentJobMutator, AgentJobProjection, AgentJobStartDecision, AgentJobStatusReporter, DesiredAgentJob, DesiredAgentJobSource, ObservedAgentJob } from "./agent-controller.types.js";

--- a/libs/backend/agent-controller/main/tsconfig.json
+++ b/libs/backend/agent-controller/main/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": { "noEmit": true },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/libs/backend/agent-controller/main/vitest.config.ts
+++ b/libs/backend/agent-controller/main/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../vitest.cache.js";
+
+/** Vitest configuration for the target agent workload controller domain. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../tsconfig.vitest.json"] })], test: { globals: true, environment: "node", include: ["src/**/*.test.ts"] } });


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — the agent controller's brain.** The controller is the only component allowed to start agent work in the cluster. This PR adds its decision core: it turns "this run should execute" into a suspended, powerless Kubernetes Job — and refuses to act on anything it cannot verify with the platform first.

**What it adds**
- The reconciliation logic and its contracts (deliberately fail-closed)
- Deployment of the controller itself comes later in this stack (#278)

<details>
<summary>Technical details (original description)</summary>

## Summary

- add a reusable, app-independent controller domain boundary for authority-selected one-attempt Jobs
- pin every desired projection to exact namespace, runtime KSA, image, run labels, and a collision-resistant deterministic name
- require suspended creation, durable bootstrap readiness before unsuspension, and exact Job/Pod UID acknowledgement
- fail closed by rejecting invalid desired work and deleting unacknowledged/unsafe active Jobs, while preserving authority-confirmed running Jobs after a restart

## Validation

- `npx nx run backend-agent-controller:lint`
- `npx nx run backend-agent-controller:test` (10 tests)
- `scripts/agent-style-check.sh`
- `bash scripts/phase-a-forbidden-references.sh`
- `git diff --check`

## Review

- architecture post-diff gate: PASS
- independent security/IAM review: PASS
- adversarial correctness review: PASS after collision, starvation, unsafe-creation, and restart-recovery fixes

## Follow-up

This intentionally ships no deployed controller. The next stacked slice must add the authenticated OpenCrane authority, distinct Kubernetes/OpenCrane projected token audiences, readiness gating, and the runtime network policy together before an app/chart exists.

</details>
