### PR TITLE
🔐 Controller authority groundwork: immutable run attempt fencing

### DIFF
--- a/apps/opencrane/prisma/migrations/0047_run_execution_subject/migration.sql
+++ b/apps/opencrane/prisma/migrations/0047_run_execution_subject/migration.sql
@@ -1,0 +1,6 @@
+-- Every queued/runtime attempt needs one immutable non-null authorization subject.
+-- This is a clean target-state schema: no legacy data is migrated or inferred.
+ALTER TABLE "agent_runs" ADD COLUMN "execution_subject_id" TEXT NOT NULL;
+
+ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_execution_subject_check"
+  CHECK (btrim("execution_subject_id") <> '');

--- a/apps/opencrane/prisma/migrations/0048_run_bootstrap_attempt_guards/migration.sql
+++ b/apps/opencrane/prisma/migrations/0048_run_bootstrap_attempt_guards/migration.sql
@@ -1,0 +1,36 @@
+-- A target run's execution subject is immutable after admission.
+CREATE FUNCTION "enforce_agent_run_execution_subject_immutable"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF NEW."execution_subject_id" IS DISTINCT FROM OLD."execution_subject_id" THEN
+        RAISE EXCEPTION 'AgentRun execution subject is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "agent_runs_execution_subject_immutable"
+    BEFORE UPDATE OF "execution_subject_id" ON "agent_runs"
+    FOR EACH ROW EXECUTE FUNCTION "enforce_agent_run_execution_subject_immutable"();
+
+-- A stale bootstrap may never transition a later run attempt to Running.
+CREATE FUNCTION "enforce_bootstrap_current_run_attempt"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    current_attempt INTEGER;
+    current_state "AgentRunState";
+BEGIN
+    IF OLD."consumed_at" IS NULL AND NEW."consumed_at" IS NOT NULL THEN
+        SELECT "attempt", "state" INTO current_attempt, current_state
+        FROM "agent_runs"
+        WHERE "id" = NEW."run_id"
+        FOR UPDATE;
+        IF current_attempt IS DISTINCT FROM NEW."attempt" OR current_state IS DISTINCT FROM 'assigned'::"AgentRunState" THEN
+            RAISE EXCEPTION 'WorkloadBootstrap must consume only the current Assigned run attempt';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "workload_bootstraps_current_run_attempt"
+    BEFORE UPDATE OF "consumed_at" ON "workload_bootstraps"
+    FOR EACH ROW EXECUTE FUNCTION "enforce_bootstrap_current_run_attempt"();

--- a/apps/opencrane/prisma/schema/runs.prisma
+++ b/apps/opencrane/prisma/schema/runs.prisma
@@ -51,6 +51,7 @@ model AgentRun {
   threadId                String?                  @map("thread_id")
   trigger                 AgentRunTrigger
   delegatedUserId         String?                  @map("delegated_user_id")
+  executionSubjectId      String                   @map("execution_subject_id")
   requestIdempotencyKey   String                   @map("request_idempotency_key")
   rootRunId               String                   @map("root_run_id")
   parentRunId             String?                  @map("parent_run_id")

--- a/libs/backend/server/authorization/main/src/prisma-runtime-authority.test.ts
+++ b/libs/backend/server/authorization/main/src/prisma-runtime-authority.test.ts
@@ -67,8 +67,9 @@ describe("Prisma runtime authority adapter", function _suite()
 		const proofCreate = vi.fn().mockResolvedValue({ id: "proof-1" });
 		const transaction = {
 			$queryRaw: vi.fn().mockResolvedValue([]),
-			workloadBootstrap: { findUnique: vi.fn().mockResolvedValue({ id: "bootstrap-1", consumedAt: null }), update: bootstrapUpdate },
+			workloadBootstrap: { findUnique: vi.fn().mockResolvedValue({ id: "bootstrap-1", runId: "run-1", attempt: 1, workloadUid: "job-1", agentServiceId: "service-1", agentRevisionId: "revision-1", consumedAt: null }), update: bootstrapUpdate },
 			runProofKey: { create: proofCreate },
+			agentRun: { findUnique: vi.fn().mockResolvedValue({ attempt: 1, state: "Assigned" }), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
 		};
 		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
 		const repository = new PrismaRuntimeAuthorityRepository(prisma);
@@ -79,6 +80,22 @@ describe("Prisma runtime authority adapter", function _suite()
 		expect(transaction.$queryRaw).toHaveBeenCalledTimes(3);
 		expect(bootstrapUpdate).toHaveBeenCalledOnce();
 		expect(proofCreate).toHaveBeenCalledWith({ data: expect.objectContaining({ publicKeyJwk: { kty: "EC", crv: "P-256", x: "x", y: "y" }, keyThumbprint: "k".repeat(43) }) });
+		expect(transaction.agentRun.updateMany).toHaveBeenCalledWith({ where: { id: "run-1", attempt: 1, state: "Assigned" }, data: expect.objectContaining({ state: "Running", startedAt: expect.any(Date) }) });
+	});
+
+	it("refuses a bootstrap when the current run moved to a later attempt", async function _rejectsStaleAttempt()
+	{
+		const transaction = {
+			$queryRaw: vi.fn().mockResolvedValue([]),
+			workloadBootstrap: { findUnique: vi.fn().mockResolvedValue({ id: "bootstrap-1", runId: "run-1", attempt: 1, workloadUid: "job-1", agentServiceId: "service-1", agentRevisionId: "revision-1", consumedAt: null }), update: vi.fn() },
+			runProofKey: { create: vi.fn() },
+			agentRun: { findUnique: vi.fn().mockResolvedValue({ attempt: 2, state: "Assigned" }), updateMany: vi.fn() },
+		};
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+
+		await expect(new PrismaRuntimeAuthorityRepository(prisma).consumeAndBindProofKeyAtomically(_bootstrap())).resolves.toEqual({ status: "conflict" });
+		expect(transaction.workloadBootstrap.update).not.toHaveBeenCalled();
+		expect(transaction.runProofKey.create).not.toHaveBeenCalled();
 	});
 
 	it("reserves receipt and appends audit before external action execution", async function _reserve()

--- a/libs/backend/server/authorization/main/src/prisma-runtime-authority.ts
+++ b/libs/backend/server/authorization/main/src/prisma-runtime-authority.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 
-import { ActionExecutionState, ActionReplayMode as PrismaActionReplayMode, Prisma, WorkloadKind, type PrismaClient } from "@prisma/client";
+import { ActionExecutionState, ActionReplayMode as PrismaActionReplayMode, AgentRunState, Prisma, WorkloadKind, type PrismaClient } from "@prisma/client";
 
 import type { JsonValue } from "@opencrane/util";
 
@@ -53,6 +53,15 @@ export class PrismaRuntimeAuthorityRepository implements RuntimeBootstrapReposit
 				const bootstrap = await transaction.workloadBootstrap.findUnique({ where: { id: claim.bootstrapId } });
 				if (bootstrap === null) return { status: "conflict" } as const;
 				if (bootstrap.consumedAt !== null) return { status: "already_consumed" } as const;
+				if (bootstrap.runId !== claim.runId || bootstrap.attempt !== claim.attempt || bootstrap.workloadUid !== claim.workloadUid || bootstrap.agentServiceId !== claim.agentServiceId || bootstrap.agentRevisionId !== claim.agentRevisionId)
+				{
+					return { status: "conflict" } as const;
+				}
+				const run = await transaction.agentRun.findUnique({ where: { id: claim.runId }, select: { attempt: true, state: true } });
+				if (run === null || run.attempt !== claim.attempt || run.state !== AgentRunState.Assigned)
+				{
+					return { status: "conflict" } as const;
+				}
 
 				// 2. Consume exact bootstrap coordinates; database triggers revalidate live assignment authority.
 				const receiptId = randomUUID();
@@ -76,6 +85,16 @@ export class PrismaRuntimeAuthorityRepository implements RuntimeBootstrapReposit
 						expiresAt: new Date(claim.expiresAtEpochMs),
 					},
 				});
+
+				// 4. Only a registered Pod that consumed its exact bootstrap may begin the durable run.
+				const transition = await transaction.agentRun.updateMany({
+					where: { id: claim.runId, attempt: claim.attempt, state: AgentRunState.Assigned },
+					data: { state: AgentRunState.Running, startedAt: new Date() },
+				});
+				if (transition.count !== 1)
+				{
+					throw new Error("run attempt changed while consuming bootstrap");
+				}
 				return { status: "consumed", receiptId } as const;
 			});
 		}

--- a/libs/backend/server/runs/main/src/controller-authority.types.ts
+++ b/libs/backend/server/runs/main/src/controller-authority.types.ts
@@ -1,0 +1,64 @@
+/** Server-issued immutable desired Job descriptor for the database-blind controller. */
+export interface ControllerDesiredJob
+{
+	/** Logical run identifier. */
+	readonly runId: string;
+	/** Current durable run attempt. */
+	readonly attempt: number;
+	/** Immutable AgentService identifier. */
+	readonly agentServiceId: string;
+	/** Immutable AgentRevision identifier. */
+	readonly agentRevisionId: string;
+	/** Silo authority identifier. */
+	readonly siloId: string;
+	/** Server-derived authorization subject. */
+	readonly subjectId: string;
+	/** Exact runtime namespace. */
+	readonly namespace: string;
+	/** Exact zero-RBAC runtime KSA. */
+	readonly serviceAccountName: string;
+	/** Exact immutable runtime image. */
+	readonly image: string;
+	/** Epoch-millisecond expiry for the assignment/bootstrap authority. */
+	readonly expiresAtEpochMs: number;
+}
+
+/** Immutable Kubernetes Job observation supplied by the authenticated controller. */
+export interface ControllerJobObservation
+{
+	/** Server-issued desired Job coordinates. */
+	readonly desired: ControllerDesiredJob;
+	/** Deterministic Kubernetes Job name. */
+	readonly workloadName: string;
+	/** Kubernetes-assigned immutable Job UID. */
+	readonly workloadUid: string;
+}
+
+/** Immutable Pod observation supplied by the authenticated controller. */
+export interface ControllerPodObservation extends ControllerJobObservation
+{
+	/** First immutable runtime Pod UID observed for the Job. */
+	readonly podUid: string;
+}
+
+/** Exact controller identity extracted from a successful Kubernetes TokenReview. */
+export interface VerifiedControllerIdentity
+{
+	/** TokenReview-confirmed service-account namespace. */
+	readonly namespace: string;
+	/** TokenReview-confirmed service-account name. */
+	readonly serviceAccountName: string;
+}
+
+/** Persistence boundary for controller desired state and immutable acknowledgements. */
+export interface ControllerAuthorityRepository
+{
+	/** Claim at most one reclaimable desired Job without publishing its outbox event. */
+	claimDesiredJob(nowEpochMs: number): Promise<ControllerDesiredJob | null>;
+	/** Persist the exact Job UID and bootstrap authority before returning readiness. */
+	recordJob(observation: ControllerJobObservation, nowEpochMs: number): Promise<{ readonly bootstrapReady: boolean }>;
+	/** Persist only the first exact Pod UID for the previously acknowledged Job. */
+	recordPod(observation: ControllerPodObservation, nowEpochMs: number): Promise<void>;
+	/** Fail one invalid desired record durably so it cannot starve later controller work. */
+	rejectDesiredJob(runId: string, attempt: number, reason: string, nowEpochMs: number): Promise<void>;
+}

--- a/libs/backend/server/runs/main/src/index.ts
+++ b/libs/backend/server/runs/main/src/index.ts
@@ -1,3 +1,4 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
+export type { ControllerAuthorityRepository, ControllerDesiredJob, ControllerJobObservation, ControllerPodObservation, VerifiedControllerIdentity } from "./controller-authority.types.js";

--- a/libs/backend/server/runs/main/src/prisma-run-authority.test.ts
+++ b/libs/backend/server/runs/main/src/prisma-run-authority.test.ts
@@ -14,6 +14,7 @@ function _runRow()
 		threadId: null,
 		trigger: "Interactive",
 		delegatedUserId: "user-1",
+		executionSubjectId: "user-1",
 		requestIdempotencyKey: "request-1",
 		rootRunId: "run-1",
 		parentRunId: null,

--- a/libs/backend/server/runs/main/src/prisma-run-authority.ts
+++ b/libs/backend/server/runs/main/src/prisma-run-authority.ts
@@ -61,7 +61,7 @@ function _serviceState(value: string | null): AgentServiceState | null
 }
 
 /** Maps one Prisma run row to the dependency-light target contract. */
-function _mapRun(row: { id: string; siloId: string; agentServiceId: string; agentRevisionId: string; threadId: string | null; trigger: string; delegatedUserId: string | null; requestIdempotencyKey: string; rootRunId: string; parentRunId: string | null; attempt: number; state: string; effectiveContractDigest: string; inputSnapshotDigest: string; acceptedAt: Date; startedAt: Date | null; finishedAt: Date | null; terminalReason: string | null }): AgentRun
+function _mapRun(row: { id: string; siloId: string; agentServiceId: string; agentRevisionId: string; threadId: string | null; trigger: string; delegatedUserId: string | null; executionSubjectId: string; requestIdempotencyKey: string; rootRunId: string; parentRunId: string | null; attempt: number; state: string; effectiveContractDigest: string; inputSnapshotDigest: string; acceptedAt: Date; startedAt: Date | null; finishedAt: Date | null; terminalReason: string | null }): AgentRun
 {
 	return {
 		id: row.id,
@@ -71,6 +71,7 @@ function _mapRun(row: { id: string; siloId: string; agentServiceId: string; agen
 		threadId: row.threadId,
 		trigger: _runTrigger(row.trigger),
 		delegatedUserId: row.delegatedUserId,
+		executionSubjectId: row.executionSubjectId,
 		requestIdempotencyKey: row.requestIdempotencyKey,
 		lineage: { rootRunId: row.rootRunId, parentRunId: row.parentRunId },
 		attempt: row.attempt,

--- a/libs/backend/server/runs/main/src/run-authority.test.ts
+++ b/libs/backend/server/runs/main/src/run-authority.test.ts
@@ -15,6 +15,7 @@ function _run(): AgentRun
 		threadId: "thread-1",
 		trigger: "interactive",
 		delegatedUserId: "user-1",
+		executionSubjectId: "user-1",
 		requestIdempotencyKey: "request-1",
 		lineage: { rootRunId: "run-1", parentRunId: null },
 		attempt: 1,

--- a/libs/contracts/src/__tests__/target-contracts.test.ts
+++ b/libs/contracts/src/__tests__/target-contracts.test.ts
@@ -72,6 +72,7 @@ describe("canonical model exports", function ()
       threadId: "thread-1",
       trigger: "interactive",
       delegatedUserId: "user-1",
+      executionSubjectId: "user-1",
       requestIdempotencyKey: "request-1",
       lineage: { rootRunId: "run-1", parentRunId: null },
       attempt: 1,

--- a/libs/models/agents/main/src/agent-run.types.ts
+++ b/libs/models/agents/main/src/agent-run.types.ts
@@ -35,6 +35,8 @@ export interface AgentRun
 	readonly trigger: AgentRunTrigger;
 	/** Delegated interactive user, or null when the service acts as itself. */
 	readonly delegatedUserId: UserId | null;
+	/** Immutable non-null subject whose authorization admitted this attempt. */
+	readonly executionSubjectId: UserId;
 	/** Idempotency key for the request that created the run. */
 	readonly requestIdempotencyKey: string;
 	/** Root and parent lineage for delegated or child work. */


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — run integrity groundwork.** Ensures a run attempt, once started, cannot be tampered with or hijacked: the identity a run executes as is fixed forever at creation, and stale or replayed attempts are rejected at the database itself.

**What it adds**
- Database-level immutability and fencing guarantees, with tests

<details>
<summary>Technical details (original description)</summary>

## Summary

- bind each AgentRun to an immutable execution subject
- persist the subject through the run authority mapping
- fence runtime bootstrap consumption to the current assigned run attempt at both the transaction and database-trigger layers
- reject stale bootstrap consumption after a retry advances the attempt

## Scope

This groundwork does not deploy a controller or claim a bootstrap delivery path. The next stacked PR adds the authenticated controller authority API and durable desired-work persistence.

## Validation

- `npm run db:generate -w @opencrane/server`
- `DATABASE_URL=... npx prisma validate --schema prisma/schema`
- `npx nx run backend-server-runs:lint/test`
- `npx nx run backend-server-authorization:lint/test`
- `scripts/agent-style-check.sh`
- `git diff --check`

## Review

- independent architecture and adversarial correctness review passed after stale-attempt and immutable-subject fixes
- live Postgres migration execution remains a CI check because this workstation has no local database daemon

</details>
