### PR TITLE
🔐 Add strict internal controller authority API

### DIFF
--- a/libs/backend/server/runs/main/src/controller-authority.router.test.ts
+++ b/libs/backend/server/runs/main/src/controller-authority.router.test.ts
@@ -1,0 +1,83 @@
+import type * as k8s from "@kubernetes/client-node";
+import express from "express";
+import type { Express } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { __CreateControllerAuthorityRouter } from "./controller-authority.router.js";
+import type { ControllerAuthorityRepository } from "./controller-authority.types.js";
+
+/** Creates the only controller identity accepted by the internal authority. */
+function _authApi(username = "system:serviceaccount:opencrane-system:agent-controller", audience = "agent-controller"): k8s.AuthenticationV1Api
+{
+	return { createTokenReview: vi.fn().mockResolvedValue({ status: { authenticated: true, audiences: [audience], user: { username } } }) } as unknown as k8s.AuthenticationV1Api;
+}
+
+/** Builds a compact server-side controller authority fake. */
+function _repository(): ControllerAuthorityRepository
+{
+	return {
+		claimDesiredJob: vi.fn().mockResolvedValue({ runId: "run-1", attempt: 1, agentServiceId: "service-1", agentRevisionId: "revision-1", siloId: "silo-1", subjectId: "user-1", namespace: "runtime", serviceAccountName: "agent-runtime", image: "ghcr.io/opencrane/runtime@sha256:abc", expiresAtEpochMs: 2_000 }),
+		recordJob: vi.fn().mockResolvedValue({ bootstrapReady: false }),
+		recordPod: vi.fn().mockResolvedValue(undefined),
+		rejectDesiredJob: vi.fn().mockResolvedValue(undefined),
+	};
+}
+
+/** Creates the otherwise separate internal listener for adapter tests. */
+function _app(repository: ControllerAuthorityRepository, authApi: k8s.AuthenticationV1Api): Express
+{
+	const app = express();
+	app.use(express.json());
+	app.use("/api/internal/agent-controller", __CreateControllerAuthorityRouter({ repository, authApi, identity: { audience: "agent-controller", namespace: "opencrane-system", serviceAccountName: "agent-controller" }, nowEpochMs: function _now() { return 1_000; } }));
+	return app;
+}
+
+describe("controller authority internal router", function _suite()
+{
+	it("accepts only the exact audience and service account before returning desired work", async function _desired()
+	{
+		const repository = _repository();
+		const authApi = _authApi();
+		const response = await request(_app(repository, authApi)).get("/api/internal/agent-controller/desired").set("Authorization", "Bearer controller-token");
+
+		expect(response.status).toBe(200);
+		expect(response.body.desired).toMatchObject({ runId: "run-1", attempt: 1 });
+		expect(repository.claimDesiredJob).toHaveBeenCalledWith(1_000);
+		expect(authApi.createTokenReview).toHaveBeenCalledWith(expect.objectContaining({ body: expect.objectContaining({ spec: expect.objectContaining({ audiences: ["agent-controller"], token: "controller-token" }) }) }));
+	});
+
+	it("rejects a valid token with another service-account identity or audience", async function _identity()
+	{
+		const wrongIdentity = await request(_app(_repository(), _authApi("system:serviceaccount:opencrane-system:other"))).get("/api/internal/agent-controller/desired").set("Authorization", "Bearer t");
+		const wrongAudience = await request(_app(_repository(), _authApi(undefined, "opencrane"))).get("/api/internal/agent-controller/desired").set("Authorization", "Bearer t");
+
+		expect(wrongIdentity.status).toBe(401);
+		expect(wrongAudience.status).toBe(401);
+	});
+
+	it("acknowledges only compact durable coordinates and observed Kubernetes UIDs", async function _acknowledges()
+	{
+		const repository = _repository();
+		const app = _app(repository, _authApi());
+		const job = await request(app).post("/api/internal/agent-controller/workloads/job").set("Authorization", "Bearer t").send({ runId: "run-1", attempt: 1, workloadName: "agent-run-run-1", workloadUid: "job-uid", desired: { image: "attacker/image:latest" } });
+		const pod = await request(app).post("/api/internal/agent-controller/workloads/pod").set("Authorization", "Bearer t").send({ runId: "run-1", attempt: 1, workloadName: "agent-run-run-1", workloadUid: "job-uid", podUid: "pod-uid" });
+
+		expect(job.status).toBe(200);
+		expect(pod.status).toBe(204);
+		expect(repository.recordJob).toHaveBeenCalledWith({ runId: "run-1", attempt: 1, workloadName: "agent-run-run-1", workloadUid: "job-uid" }, 1_000);
+		expect(repository.recordPod).toHaveBeenCalledWith({ runId: "run-1", attempt: 1, workloadName: "agent-run-run-1", workloadUid: "job-uid", podUid: "pod-uid" }, 1_000);
+	});
+
+	it("does not invoke authority methods for missing tokens or malformed acknowledgement data", async function _rejectsUntrusted()
+	{
+		const repository = _repository();
+		const app = _app(repository, _authApi());
+		const missingToken = await request(app).post("/api/internal/agent-controller/workloads/job").send({ runId: "run-1", attempt: 1, workloadName: "job", workloadUid: "uid" });
+		const malformed = await request(app).post("/api/internal/agent-controller/workloads/job").set("Authorization", "Bearer t").send({ runId: "run-1", attempt: 0, workloadName: "job", workloadUid: "uid" });
+
+		expect(missingToken.status).toBe(401);
+		expect(malformed.status).toBe(400);
+		expect(repository.recordJob).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/runs/main/src/controller-authority.router.ts
+++ b/libs/backend/server/runs/main/src/controller-authority.router.ts
@@ -1,0 +1,152 @@
+import { Router, type Request, type Response } from "express";
+import * as k8s from "@kubernetes/client-node";
+
+import type { ControllerAuthorityRouterDependencies, ControllerJobObservation, ControllerPodObservation } from "./controller-authority.types.js";
+
+/**
+ * Creates the controller-only internal authority router.
+ *
+ * This router is mounted only on OpenCrane's separate INTERNAL listener. It deliberately bypasses
+ * browser session middleware but validates the controller's projected ServiceAccount token through
+ * TokenReview before every authority operation.
+ *
+ * @see apps/opencrane/helm/templates/_networkpolicy.tpl
+ * @see apps/agent-controller/helm/templates/_resources.tpl
+ */
+export function __CreateControllerAuthorityRouter(dependencies: ControllerAuthorityRouterDependencies): Router
+{
+	const router = Router();
+	router.get("/desired", async function _desired(request: Request, response: Response)
+	{
+		if (!await _authenticate(request, response, dependencies)) return;
+		try
+		{
+			const desired = await dependencies.repository.claimDesiredJob(dependencies.nowEpochMs());
+			response.status(200).json({ desired });
+		}
+		catch
+		{
+			_problem(response, 503, "authority_unavailable");
+		}
+	});
+
+	router.post("/workloads/job", async function _recordJob(request: Request, response: Response)
+	{
+		if (!await _authenticate(request, response, dependencies)) return;
+		const observation = _jobObservation(request.body);
+		if (observation === null)
+		{
+			_problem(response, 400, "invalid_observation");
+			return;
+		}
+		try
+		{
+			response.status(200).json(await dependencies.repository.recordJob(observation, dependencies.nowEpochMs()));
+		}
+		catch
+		{
+			_problem(response, 409, "workload_rejected");
+		}
+	});
+
+	router.post("/workloads/pod", async function _recordPod(request: Request, response: Response)
+	{
+		if (!await _authenticate(request, response, dependencies)) return;
+		const observation = _podObservation(request.body);
+		if (observation === null)
+		{
+			_problem(response, 400, "invalid_observation");
+			return;
+		}
+		try
+		{
+			await dependencies.repository.recordPod(observation, dependencies.nowEpochMs());
+			response.status(204).end();
+		}
+		catch
+		{
+			_problem(response, 409, "pod_rejected");
+		}
+	});
+	return router;
+}
+
+/** Verify one exact projected controller token through the Kubernetes authority. */
+async function _authenticate(request: Request, response: Response, dependencies: ControllerAuthorityRouterDependencies): Promise<boolean>
+{
+	const token = _bearer(request.header("authorization"));
+	if (token === null)
+	{
+		_problem(response, 401, "controller_auth_required");
+		return false;
+	}
+	try
+	{
+		const review = new k8s.V1TokenReview();
+		review.spec = new k8s.V1TokenReviewSpec();
+		review.spec.token = token;
+		review.spec.audiences = [dependencies.identity.audience];
+		const result = await dependencies.authApi.createTokenReview({ body: review });
+		const status = result.status;
+		const expectedUsername = `system:serviceaccount:${dependencies.identity.namespace}:${dependencies.identity.serviceAccountName}`;
+		if (!status?.authenticated || !status.audiences?.includes(dependencies.identity.audience) || status.user?.username !== expectedUsername)
+		{
+			_problem(response, 401, "controller_denied");
+			return false;
+		}
+		return true;
+	}
+	catch
+	{
+		_problem(response, 503, "identity_unavailable");
+		return false;
+	}
+}
+
+/** Parse one exact compact bearer value. */
+function _bearer(value: string | undefined): string | null
+{
+	const match = /^Bearer ([^\s,]+)$/u.exec(value ?? "");
+	return match?.[1] ?? null;
+}
+
+/** Parse an acknowledgement with only immutable server-selected run coordinates. */
+function _jobObservation(value: unknown): ControllerJobObservation | null
+{
+	if (!_record(value)
+		|| typeof value.runId !== "string"
+		|| !Number.isSafeInteger(value.attempt)
+		|| typeof value.workloadName !== "string"
+		|| typeof value.workloadUid !== "string"
+		|| !_identifier(value.runId)
+		|| (value.attempt as number) < 1
+		|| !_identifier(value.workloadName)
+		|| !_identifier(value.workloadUid)) return null;
+	return { runId: value.runId, attempt: value.attempt as number, workloadName: value.workloadName, workloadUid: value.workloadUid };
+}
+
+/** Parse a controller Pod observation with a first immutable Pod UID. */
+function _podObservation(value: unknown): ControllerPodObservation | null
+{
+	const job = _jobObservation(value);
+	if (job === null || !_record(value) || typeof value.podUid !== "string" || !_identifier(value.podUid)) return null;
+	return { ...job, podUid: value.podUid };
+}
+
+/** Narrow untrusted JSON to a non-array record. */
+function _record(value: unknown): value is Record<string, unknown>
+{
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Require bounded non-whitespace identifiers while the persistence authority applies exact policy. */
+function _identifier(value: string): boolean
+{
+	return value.trim().length > 0 && value.length <= 512;
+}
+
+/** Write a non-sensitive private-route problem. */
+function _problem(response: Response, status: number, error: string): void
+{
+	response.status(status).json({ error });
+}

--- a/libs/backend/server/runs/main/src/controller-authority.types.ts
+++ b/libs/backend/server/runs/main/src/controller-authority.types.ts
@@ -23,11 +23,13 @@ export interface ControllerDesiredJob
 	readonly expiresAtEpochMs: number;
 }
 
-/** Immutable Kubernetes Job observation supplied by the authenticated controller. */
+/** Immutable Kubernetes Job acknowledgement supplied by the authenticated controller. */
 export interface ControllerJobObservation
 {
-	/** Server-issued desired Job coordinates. */
-	readonly desired: ControllerDesiredJob;
+	/** Durable run identifier selected by the server. */
+	readonly runId: string;
+	/** Current durable run attempt selected by the server. */
+	readonly attempt: number;
 	/** Deterministic Kubernetes Job name. */
 	readonly workloadName: string;
 	/** Kubernetes-assigned immutable Job UID. */
@@ -48,6 +50,30 @@ export interface VerifiedControllerIdentity
 	readonly namespace: string;
 	/** TokenReview-confirmed service-account name. */
 	readonly serviceAccountName: string;
+}
+
+/** Fixed identity policy for the sole controller workload. */
+export interface ControllerAuthorityIdentityPolicy
+{
+	/** TokenReview audience required from the controller's projected token. */
+	readonly audience: "agent-controller";
+	/** Exact namespace containing the controller KSA. */
+	readonly namespace: string;
+	/** Exact controller service-account name. */
+	readonly serviceAccountName: string;
+}
+
+/** Dependencies for the private controller authority HTTP adapter. */
+export interface ControllerAuthorityRouterDependencies
+{
+	/** Durable OpenCrane run/outbox authority. */
+	readonly repository: ControllerAuthorityRepository;
+	/** Kubernetes TokenReview client owned only by the OpenCrane server. */
+	readonly authApi: import("@kubernetes/client-node").AuthenticationV1Api;
+	/** Exact projected controller identity policy. */
+	readonly identity: ControllerAuthorityIdentityPolicy;
+	/** Trusted wall-clock source. */
+	readonly nowEpochMs: () => number;
 }
 
 /** Persistence boundary for controller desired state and immutable acknowledgements. */

--- a/libs/backend/server/runs/main/src/index.ts
+++ b/libs/backend/server/runs/main/src/index.ts
@@ -1,4 +1,5 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
-export type { ControllerAuthorityRepository, ControllerDesiredJob, ControllerJobObservation, ControllerPodObservation, VerifiedControllerIdentity } from "./controller-authority.types.js";
+export { __CreateControllerAuthorityRouter } from "./controller-authority.router.js";
+export type { ControllerAuthorityIdentityPolicy, ControllerAuthorityRepository, ControllerAuthorityRouterDependencies, ControllerDesiredJob, ControllerJobObservation, ControllerPodObservation, VerifiedControllerIdentity } from "./controller-authority.types.js";


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — the controller's private line.** The controller talks to the platform over a strict internal API: every request must prove exactly who it is (verified live against Kubernetes), and anything unproven or malformed is refused before it touches data.

**What it adds**
- The internal authority API with caller-identity verification
- Strict input validation that rejects bad requests up front

<details>
<summary>Technical details (original description)</summary>

## Summary

- add a controller-only OpenCrane internal HTTP adapter guarded by Kubernetes TokenReview
- require the dedicated `agent-controller` audience and exact controller ServiceAccount subject for every operation
- return server-issued desired work but accept acknowledgements containing only run/attempt and observed Kubernetes UIDs
- reject malformed, unauthenticated, wrong-audience, and wrong-ServiceAccount input before it reaches persistence

## Scope

This is deliberately the transport boundary only. The next stacked slice supplies the canonical run/outbox persistence and mounts it in the OpenCrane internal listener; no controller workload is deployed yet.

## Validation

- `npx nx run backend-server-runs:lint`
- `npx nx run backend-server-runs:test` (14 tests)
- `scripts/agent-style-check.sh`
- `git diff --check`

## Review

- independent authentication and acknowledgement-authority review: no findings
- local Claude Code review attempted; CLI is still not logged in (`/login` required)

</details>
