### PR TITLE
🔐 Persist controller workload authority

### DIFF
--- a/libs/backend/server/runs/main/src/controller-authority.router.test.ts
+++ b/libs/backend/server/runs/main/src/controller-authority.router.test.ts
@@ -17,7 +17,7 @@ function _authApi(username = "system:serviceaccount:opencrane-system:agent-contr
 function _repository(): ControllerAuthorityRepository
 {
 	return {
-		claimDesiredJob: vi.fn().mockResolvedValue({ runId: "run-1", attempt: 1, agentServiceId: "service-1", agentRevisionId: "revision-1", siloId: "silo-1", subjectId: "user-1", namespace: "runtime", serviceAccountName: "agent-runtime", image: "ghcr.io/opencrane/runtime@sha256:abc", expiresAtEpochMs: 2_000 }),
+		claimDesiredJob: vi.fn().mockResolvedValue({ runId: "run-1", attempt: 1, agentServiceId: "service-1", agentRevisionId: "revision-1", siloId: "silo-1", subjectId: "user-1", namespace: "runtime", serviceAccountName: "agent-runtime", image: "ghcr.io/opencrane/runtime@sha256:abc" }),
 		recordJob: vi.fn().mockResolvedValue({ bootstrapReady: false }),
 		recordPod: vi.fn().mockResolvedValue(undefined),
 		rejectDesiredJob: vi.fn().mockResolvedValue(undefined),

--- a/libs/backend/server/runs/main/src/controller-authority.ts
+++ b/libs/backend/server/runs/main/src/controller-authority.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolves one server-owned runtime profile for a durable AgentService workload-profile key.
+ *
+ * Images are accepted only as immutable OCI digests. The controller never chooses these
+ * coordinates, and a missing or malformed profile simply prevents assignment.
+ *
+ * @param workloadProfile - Persisted AgentService profile key.
+ * @param profiles - Product configuration indexed by the accepted profile key.
+ * @returns Validated runtime coordinates, or null when no safe profile is configured.
+ */
+export function __ResolveControllerRuntimeProfile(workloadProfile: string, profiles: ReadonlyMap<string, { readonly namespace: string; readonly serviceAccountName: string; readonly image: string; readonly assignmentTtlMs: number }>): { readonly namespace: string; readonly serviceAccountName: string; readonly image: string; readonly assignmentTtlMs: number } | null
+{
+	const profile = profiles.get(workloadProfile);
+	if (profile === undefined) return null;
+	if (!_dnsLabel(profile.namespace) || !_dnsLabel(profile.serviceAccountName)) return null;
+	if (!/^.+@sha256:[a-f0-9]{64}$/u.test(profile.image)) return null;
+	if (!Number.isSafeInteger(profile.assignmentTtlMs) || profile.assignmentTtlMs < 60_000 || profile.assignmentTtlMs > 300_000) return null;
+	return profile;
+}
+
+/** Returns whether a Kubernetes namespace or ServiceAccount name is a conservative DNS label. */
+function _dnsLabel(value: string): boolean
+{
+	return /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/u.test(value) && value.length <= 63;
+}

--- a/libs/backend/server/runs/main/src/controller-authority.types.ts
+++ b/libs/backend/server/runs/main/src/controller-authority.types.ts
@@ -19,8 +19,6 @@ export interface ControllerDesiredJob
 	readonly serviceAccountName: string;
 	/** Exact immutable runtime image. */
 	readonly image: string;
-	/** Epoch-millisecond expiry for the assignment/bootstrap authority. */
-	readonly expiresAtEpochMs: number;
 }
 
 /** Immutable Kubernetes Job acknowledgement supplied by the authenticated controller. */

--- a/libs/backend/server/runs/main/src/index.ts
+++ b/libs/backend/server/runs/main/src/index.ts
@@ -2,4 +2,6 @@ export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-au
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
 export { __CreateControllerAuthorityRouter } from "./controller-authority.router.js";
+export { __ResolveControllerRuntimeProfile } from "./controller-authority.js";
+export { PrismaControllerAuthorityRepository } from "./prisma-controller-authority.js";
 export type { ControllerAuthorityIdentityPolicy, ControllerAuthorityRepository, ControllerAuthorityRouterDependencies, ControllerDesiredJob, ControllerJobObservation, ControllerPodObservation, VerifiedControllerIdentity } from "./controller-authority.types.js";

--- a/libs/backend/server/runs/main/src/prisma-controller-authority.test.ts
+++ b/libs/backend/server/runs/main/src/prisma-controller-authority.test.ts
@@ -1,0 +1,131 @@
+import { AgentRevisionState, AgentRunState, AgentServiceState, RunOutboxEventKind } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaControllerAuthorityRepository } from "./prisma-controller-authority.js";
+
+/** Creates the fixed server-owned runtime policy used by controller persistence tests. */
+function _profiles(): ReadonlyMap<string, { readonly namespace: string; readonly serviceAccountName: string; readonly image: string; readonly assignmentTtlMs: number }>
+{
+	return new Map([["personal-default", { namespace: "agent-runtimes", serviceAccountName: "agent-runtime", image: `registry.example/runtime@sha256:${"a".repeat(64)}`, assignmentTtlMs: 120_000 }]]);
+}
+
+/** Builds the smallest durable event row accepted by the controller authority. */
+function _event(claimedAt: Date | null = new Date(990_000))
+{
+	return { id: "event-1", runId: "run-1", attempt: 1, kind: RunOutboxEventKind.RunAttemptRequested, payload: { runId: "run-1", attempt: 1 }, availableAt: new Date(0), claimedAt, publishedAt: null, failedAt: null, deliveryCount: 0 };
+}
+
+/** Builds one current queued run for an acknowledged controller Job. */
+function _run(state: AgentRunState = AgentRunState.Queued)
+{
+	return { id: "run-1", attempt: 1, state, siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", executionSubjectId: "user-1" };
+}
+
+/** Builds active service authority for the current run revision. */
+function _service()
+{
+	return { id: "service-1", siloId: "silo-1", state: AgentServiceState.Active, activeRevisionId: "revision-1", workloadProfile: "personal-default" };
+}
+
+/** Executes a controller transaction against a lightweight Prisma facade. */
+function _repository(transaction: Record<string, unknown>): PrismaControllerAuthorityRepository
+{
+	const prisma = { $transaction: async function _transaction<T>(operation: (client: never) => Promise<T>): Promise<T> { return operation(transaction as never); } } as never;
+	return new PrismaControllerAuthorityRepository(prisma, _profiles());
+}
+
+describe("Prisma controller authority adapter", function _suite()
+{
+	it("claims a durable event and derives desired coordinates solely from canonical rows", async function _claim()
+	{
+		const transaction = {
+			outboxEvent: {
+				findFirst: vi.fn().mockResolvedValue(_event(null)),
+				findUnique: vi.fn().mockResolvedValue(_event(null)),
+				update: vi.fn().mockResolvedValue({}),
+			},
+			$queryRaw: vi.fn().mockResolvedValue([{ id: "event-1" }]),
+			agentRun: { findUnique: vi.fn().mockResolvedValue(_run(AgentRunState.Accepted)), update: vi.fn().mockResolvedValue({}) },
+			agentService: { findUnique: vi.fn().mockResolvedValue(_service()) },
+			agentRevision: { findUnique: vi.fn().mockResolvedValue({ id: "revision-1", state: AgentRevisionState.Published }) },
+		};
+		const desired = await _repository(transaction).claimDesiredJob(1_000_000);
+
+		expect(desired).toEqual(expect.objectContaining({ runId: "run-1", attempt: 1, subjectId: "user-1", namespace: "agent-runtimes", serviceAccountName: "agent-runtime" }));
+		expect(transaction.agentRun.update).toHaveBeenCalledWith({ where: { id: "run-1" }, data: { state: AgentRunState.Queued } });
+		expect(transaction.outboxEvent.update).toHaveBeenCalledWith(expect.objectContaining({ data: { claimedAt: new Date(1_000_000), deliveryCount: { increment: 1 } } }));
+	});
+
+	it("writes assignment and opaque bootstrap before assigning the run, but never unsuspends a Job", async function _acknowledge()
+	{
+		const assignmentCreate = vi.fn().mockResolvedValue({});
+		const bootstrapCreate = vi.fn().mockResolvedValue({});
+		const runUpdate = vi.fn().mockResolvedValue({});
+		const eventUpdate = vi.fn().mockResolvedValue({});
+		const transaction = {
+			$queryRaw: vi.fn().mockResolvedValue([]),
+			outboxEvent: { findMany: vi.fn().mockResolvedValue([_event()]), update: eventUpdate },
+			agentRun: { findUnique: vi.fn().mockResolvedValue(_run()), update: runUpdate },
+			agentService: { findUnique: vi.fn().mockResolvedValue(_service()) },
+			agentRevision: { findUnique: vi.fn().mockResolvedValue({ id: "revision-1", state: AgentRevisionState.Published }) },
+			workloadAssignment: { findUnique: vi.fn().mockResolvedValue(null), create: assignmentCreate },
+			workloadBootstrap: { create: bootstrapCreate },
+		};
+		const result = await _repository(transaction).recordJob({ runId: "run-1", attempt: 1, workloadName: "agent-run-run-1-a2d003afd28962f6-a1", workloadUid: "job-uid-1" }, 1_000_000);
+
+		expect(result).toEqual({ bootstrapReady: false });
+		expect(assignmentCreate).toHaveBeenCalledBefore(bootstrapCreate);
+		expect(bootstrapCreate).toHaveBeenCalledBefore(runUpdate);
+		expect(runUpdate).toHaveBeenCalledBefore(eventUpdate);
+		expect(assignmentCreate).toHaveBeenCalledWith({ data: expect.objectContaining({ workloadUid: "job-uid-1", audience: "opencrane" }) });
+		expect(bootstrapCreate).toHaveBeenCalledWith({ data: expect.objectContaining({ claimDigest: expect.stringMatching(/^sha256:/u) }) });
+	});
+
+	it("refuses a Pod acknowledgement that does not belong to the current assigned Job", async function _pod()
+	{
+		const transaction = {
+			$queryRaw: vi.fn().mockResolvedValue([]),
+			workloadAssignment: { findUnique: vi.fn().mockResolvedValue({ workloadKind: "Job", workloadUid: "job-uid-other", podUid: null }) },
+			agentRun: { findUnique: vi.fn().mockResolvedValue(_run(AgentRunState.Assigned)) },
+		};
+
+		await expect(_repository(transaction).recordPod({ runId: "run-1", attempt: 1, workloadName: "agent-run-run-1-a2d003afd28962f6-a1", workloadUid: "job-uid-1", podUid: "pod-uid-1" }, 1_000_000)).rejects.toThrow("pod does not belong");
+	});
+
+	it("rejects an acknowledgement whose name is not the server-derived Job name", async function _name()
+	{
+		const transaction = { $queryRaw: vi.fn() };
+
+		await expect(_repository(transaction).recordJob({ runId: "run-1", attempt: 1, workloadName: "attacker-job", workloadUid: "job-uid-1" }, 1_000_000)).rejects.toThrow("unexpected deterministic Job name");
+	});
+
+	it("fails a queued run with its exhausted controller-delivery event", async function _exhausted()
+	{
+		const exhausted = { ..._event(new Date(900_000)), deliveryCount: 5 };
+		const eventUpdate = vi.fn().mockResolvedValue({});
+		const runUpdate = vi.fn().mockResolvedValue({});
+		const transaction = {
+			outboxEvent: { findFirst: vi.fn().mockResolvedValue(exhausted), findUnique: vi.fn().mockResolvedValue(exhausted), update: eventUpdate },
+			$queryRaw: vi.fn().mockResolvedValue([]),
+			agentRun: { findUnique: vi.fn().mockResolvedValue(_run()), update: runUpdate },
+		};
+
+		await expect(_repository(transaction).claimDesiredJob(1_000_000)).resolves.toBeNull();
+		expect(runUpdate).toHaveBeenCalledWith({ where: { id: "run-1" }, data: { state: AgentRunState.Failed, finishedAt: new Date(1_000_000), terminalReason: "RuntimeFailure" } });
+		expect(eventUpdate).toHaveBeenCalledWith({ where: { id: "event-1" }, data: { failedAt: new Date(1_000_000), failureCode: "controller_delivery_exhausted" } });
+	});
+
+	it("rejects a stale acknowledgement lease before creating an assignment", async function _expiredLease()
+	{
+		const transaction = {
+			$queryRaw: vi.fn().mockResolvedValue([]),
+			outboxEvent: { findMany: vi.fn().mockResolvedValue([_event(new Date(900_000))]) },
+			agentRun: { findUnique: vi.fn().mockResolvedValue(_run()) },
+			agentService: { findUnique: vi.fn().mockResolvedValue(_service()) },
+			agentRevision: { findUnique: vi.fn().mockResolvedValue({ id: "revision-1", state: AgentRevisionState.Published }) },
+			workloadAssignment: { findUnique: vi.fn().mockResolvedValue(null) },
+		};
+
+		await expect(_repository(transaction).recordJob({ runId: "run-1", attempt: 1, workloadName: "agent-run-run-1-a2d003afd28962f6-a1", workloadUid: "job-uid-1" }, 1_000_000)).rejects.toThrow("lease expired");
+	});
+});

--- a/libs/backend/server/runs/main/src/prisma-controller-authority.ts
+++ b/libs/backend/server/runs/main/src/prisma-controller-authority.ts
@@ -1,0 +1,265 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { AgentRevisionState, AgentRunState, AgentServiceState, Prisma, RunOutboxEventKind, WorkloadAssignmentState, WorkloadKind, type PrismaClient } from "@prisma/client";
+
+import { __ResolveControllerRuntimeProfile } from "./controller-authority.js";
+import type { ControllerAuthorityRepository, ControllerDesiredJob, ControllerJobObservation, ControllerPodObservation } from "./controller-authority.types.js";
+
+/** Maximum number of controller deliveries attempted for one durable run-attempt event. */
+const _MAX_CLAIM_DELIVERIES = 5;
+
+/** Lease period after which an unacknowledged desired job can be reclaimed safely. */
+const _CLAIM_LEASE_MS = 30_000;
+
+/** Audience used by runtime Pods when exchanging their projected workload token. */
+const _RUNTIME_AUDIENCE = "opencrane";
+
+/** Prisma-backed controller authority that derives all desired workload state from canonical rows. */
+export class PrismaControllerAuthorityRepository implements ControllerAuthorityRepository
+{
+	/** OpenCrane product-authority database client. */
+	private readonly prisma: PrismaClient;
+
+	/** Server-owned runtime coordinates indexed by immutable AgentService profile key. */
+	private readonly runtimeProfiles: ReadonlyMap<string, { readonly namespace: string; readonly serviceAccountName: string; readonly image: string; readonly assignmentTtlMs: number }>;
+
+	/** Creates the controller persistence adapter over canonical database and deployment policy. */
+	constructor(prisma: PrismaClient, runtimeProfiles: ReadonlyMap<string, { readonly namespace: string; readonly serviceAccountName: string; readonly image: string; readonly assignmentTtlMs: number }>)
+	{
+		this.prisma = prisma;
+		this.runtimeProfiles = runtimeProfiles;
+	}
+
+	/** Claims at most one reclaimable durable run-attempt request and derives its desired Job. */
+	async claimDesiredJob(nowEpochMs: number): Promise<ControllerDesiredJob | null>
+	{
+		const now = new Date(nowEpochMs);
+		const leaseExpiry = new Date(nowEpochMs - _CLAIM_LEASE_MS);
+		return this.prisma.$transaction(async (transaction: Prisma.TransactionClient) =>
+		{
+			// 1. Read a candidate without locking it; all durable locks below use service, run, then event.
+			const candidate = await transaction.outboxEvent.findFirst({
+				where: { kind: RunOutboxEventKind.RunAttemptRequested, publishedAt: null, failedAt: null, availableAt: { lte: now }, OR: [{ deliveryCount: { gte: _MAX_CLAIM_DELIVERIES }, claimedAt: null }, { deliveryCount: { gte: _MAX_CLAIM_DELIVERIES }, claimedAt: { lt: leaseExpiry } }, { deliveryCount: { lt: _MAX_CLAIM_DELIVERIES }, claimedAt: null }, { deliveryCount: { lt: _MAX_CLAIM_DELIVERIES }, claimedAt: { lt: leaseExpiry } }] },
+				orderBy: [{ availableAt: "asc" }, { createdAt: "asc" }, { id: "asc" }],
+			});
+			if (candidate === null) return null;
+
+			// 2. Lock canonical service and run before the selected outbox event to avoid lock inversions.
+			const initialRun = await transaction.agentRun.findUnique({ where: { id: candidate.runId } });
+			if (initialRun === null)
+			{
+				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "run_outbox_events" WHERE "id" = ${candidate.id} FOR UPDATE`);
+				const event = await transaction.outboxEvent.findUnique({ where: { id: candidate.id } });
+				if (event !== null && event.publishedAt === null && event.failedAt === null) await _failOutboxEvent(transaction, event.id, now, "stale_or_invalid_run_attempt");
+				return null;
+			}
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${initialRun.agentServiceId} FOR UPDATE`);
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${candidate.runId} FOR UPDATE`);
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "run_outbox_events" WHERE "id" = ${candidate.id} FOR UPDATE`);
+			const event = await transaction.outboxEvent.findUnique({ where: { id: candidate.id } });
+			const run = await transaction.agentRun.findUnique({ where: { id: candidate.runId } });
+			if (event === null || event.publishedAt !== null || event.failedAt !== null || event.availableAt > now) return null;
+			if (event.deliveryCount >= _MAX_CLAIM_DELIVERIES)
+			{
+				if (event.claimedAt === null || event.claimedAt >= leaseExpiry) return null;
+				if (run !== null && run.attempt === event.attempt && (run.state === AgentRunState.Accepted || run.state === AgentRunState.Queued))
+				{
+					await transaction.agentRun.update({ where: { id: run.id }, data: { state: AgentRunState.Failed, finishedAt: now, terminalReason: "RuntimeFailure" } });
+				}
+				await _failOutboxEvent(transaction, event.id, now, "controller_delivery_exhausted");
+				return null;
+			}
+			if (event.claimedAt !== null && event.claimedAt >= leaseExpiry) return null;
+			await transaction.outboxEvent.update({ where: { id: event.id }, data: { claimedAt: now, deliveryCount: { increment: 1 } } });
+
+			// 3. Derive desired state only after the current canonical rows are locked and revalidated.
+			if (run === null || run.agentServiceId !== initialRun.agentServiceId || !_requestedPayloadMatches(event.payload, event.runId, event.attempt) || run.attempt !== event.attempt || (run.state !== AgentRunState.Accepted && run.state !== AgentRunState.Queued))
+			{
+				await _failOutboxEvent(transaction, event.id, now, "stale_or_invalid_run_attempt");
+				return null;
+			}
+			const service = await transaction.agentService.findUnique({ where: { id: run.agentServiceId } });
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_revisions" WHERE "agent_service_id" = ${run.agentServiceId} AND "id" = ${run.agentRevisionId} FOR UPDATE`);
+			const revision = await transaction.agentRevision.findUnique({ where: { agentServiceId_id: { agentServiceId: run.agentServiceId, id: run.agentRevisionId } } });
+			const profile = service === null ? null : __ResolveControllerRuntimeProfile(service.workloadProfile, this.runtimeProfiles);
+			if (service === null || revision === null || service.siloId !== run.siloId || service.state !== AgentServiceState.Active || service.activeRevisionId !== run.agentRevisionId || revision.state !== AgentRevisionState.Published || profile === null)
+			{
+				await _failOutboxEvent(transaction, event.id, now, "runtime_authority_unavailable");
+				return null;
+			}
+
+			// 4. Persist Queued before returning so a later acknowledgement can atomically create the assignment.
+			if (run.state === AgentRunState.Accepted)
+			{
+				await transaction.agentRun.update({ where: { id: run.id }, data: { state: AgentRunState.Queued } });
+			}
+			return {
+				runId: run.id,
+				attempt: run.attempt,
+				agentServiceId: run.agentServiceId,
+				agentRevisionId: run.agentRevisionId,
+				siloId: run.siloId,
+				subjectId: run.executionSubjectId,
+				namespace: profile.namespace,
+				serviceAccountName: profile.serviceAccountName,
+				image: profile.image,
+			};
+		});
+	}
+
+	/** Records a controller Job acknowledgement without accepting any controller-selected authority fields. */
+	async recordJob(observation: ControllerJobObservation, nowEpochMs: number): Promise<{ readonly bootstrapReady: boolean }>
+	{
+		const coordinates = _jobCoordinates(observation);
+		if (coordinates.workloadName !== _kubernetesJobName(coordinates.runId, coordinates.attempt)) throw new Error("unexpected deterministic Job name");
+		const now = new Date(nowEpochMs);
+		return this.prisma.$transaction(async (transaction: Prisma.TransactionClient) =>
+		{
+			// 1. Match the shared service-then-run lock order before the event lock.
+			const initialRun = await transaction.agentRun.findUnique({ where: { id: coordinates.runId } });
+			if (initialRun === null) throw new Error("run attempt is not awaiting assignment");
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${initialRun.agentServiceId} FOR UPDATE`);
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${coordinates.runId} FOR UPDATE`);
+			const run = await transaction.agentRun.findUnique({ where: { id: coordinates.runId } });
+			if (run === null || run.agentServiceId !== initialRun.agentServiceId || run.attempt !== coordinates.attempt || (run.state !== AgentRunState.Queued && run.state !== AgentRunState.Assigned))
+			{
+				throw new Error("run attempt is not awaiting assignment");
+			}
+
+			// 2. Reconfirm the service profile before storing the proof-bound workload identity.
+			const service = await transaction.agentService.findUnique({ where: { id: run.agentServiceId } });
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_revisions" WHERE "agent_service_id" = ${run.agentServiceId} AND "id" = ${run.agentRevisionId} FOR UPDATE`);
+			const revision = await transaction.agentRevision.findUnique({ where: { agentServiceId_id: { agentServiceId: run.agentServiceId, id: run.agentRevisionId } } });
+			const profile = service === null ? null : __ResolveControllerRuntimeProfile(service.workloadProfile, this.runtimeProfiles);
+			if (service === null || revision === null || service.siloId !== run.siloId || service.state !== AgentServiceState.Active || service.activeRevisionId !== run.agentRevisionId || revision.state !== AgentRevisionState.Published || profile === null)
+			{
+				throw new Error("runtime authority is unavailable");
+			}
+			const existing = await transaction.workloadAssignment.findUnique({ where: { runId_attempt: { runId: run.id, attempt: run.attempt } } });
+			if (existing !== null)
+			{
+				if (existing.workloadKind !== WorkloadKind.Job || existing.workloadUid !== coordinates.workloadUid) throw new Error("conflicting workload acknowledgement");
+				return { bootstrapReady: false };
+			}
+			if (run.state !== AgentRunState.Queued) throw new Error("assigned run has no workload assignment");
+			const event = await _lockAttemptEvent(transaction, coordinates.runId, coordinates.attempt);
+			if (event === null) throw new Error("run attempt is not awaiting assignment");
+			if (event.claimedAt === null || event.claimedAt.getTime() < nowEpochMs - _CLAIM_LEASE_MS) throw new Error("controller acknowledgement lease expired");
+
+			// 3. Insert assignment and opaque bootstrap before marking the outbox delivered or changing run lifecycle.
+			const expiresAt = new Date(nowEpochMs + profile.assignmentTtlMs);
+			await transaction.workloadAssignment.create({
+				data: { runId: run.id, attempt: run.attempt, agentServiceId: run.agentServiceId, agentRevisionId: run.agentRevisionId, siloId: run.siloId, subjectId: run.executionSubjectId, audience: _RUNTIME_AUDIENCE, serviceAccountName: profile.serviceAccountName, namespace: profile.namespace, workloadKind: WorkloadKind.Job, workloadUid: coordinates.workloadUid, expiresAt },
+			});
+			await transaction.workloadBootstrap.create({
+				data: { runId: run.id, attempt: run.attempt, agentServiceId: run.agentServiceId, agentRevisionId: run.agentRevisionId, siloId: run.siloId, subjectId: run.executionSubjectId, audience: _RUNTIME_AUDIENCE, serviceAccountName: profile.serviceAccountName, namespace: profile.namespace, workloadKind: WorkloadKind.Job, workloadUid: coordinates.workloadUid, claimDigest: _opaqueBootstrapDigest(), expiresAt },
+			});
+			await transaction.agentRun.update({ where: { id: run.id }, data: { state: AgentRunState.Assigned } });
+			await transaction.outboxEvent.update({ where: { id: event.id }, data: { publishedAt: now } });
+
+			// 4. Keep the Job suspended: no bootstrap delivery mechanism exists in this slice yet.
+			return { bootstrapReady: false };
+		});
+	}
+
+	/** Records the first Pod UID for an exact previously assigned Job. */
+	async recordPod(observation: ControllerPodObservation, nowEpochMs: number): Promise<void>
+	{
+		const coordinates = _podCoordinates(observation);
+		if (coordinates.workloadName !== _kubernetesJobName(coordinates.runId, coordinates.attempt)) throw new Error("unexpected deterministic Job name");
+		return this.prisma.$transaction(async (transaction: Prisma.TransactionClient) =>
+		{
+			// 1. Lock the run before the assignment, matching runtime bootstrap consumption.
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${coordinates.runId} FOR UPDATE`);
+			await transaction.$queryRaw(Prisma.sql`SELECT "run_id" FROM "workload_assignments" WHERE "run_id" = ${coordinates.runId} AND "attempt" = ${coordinates.attempt} FOR UPDATE`);
+			const assignment = await transaction.workloadAssignment.findUnique({ where: { runId_attempt: { runId: coordinates.runId, attempt: coordinates.attempt } } });
+			const run = await transaction.agentRun.findUnique({ where: { id: coordinates.runId } });
+			if (assignment === null || run === null || run.attempt !== coordinates.attempt || (run.state !== AgentRunState.Assigned && run.state !== AgentRunState.Running) || assignment.workloadKind !== WorkloadKind.Job || assignment.workloadUid !== coordinates.workloadUid)
+			{
+				throw new Error("pod does not belong to the current workload assignment");
+			}
+
+			// 2. Preserve the first immutable Pod UID; repeats are idempotent and competing Pods fail closed.
+			if (assignment.podUid === null)
+			{
+				await transaction.workloadAssignment.update({ where: { runId_attempt: { runId: coordinates.runId, attempt: coordinates.attempt } }, data: { podUid: coordinates.podUid, state: WorkloadAssignmentState.Registered, registeredAt: new Date(nowEpochMs) } });
+				return;
+			}
+			if (assignment.podUid !== coordinates.podUid) throw new Error("conflicting pod acknowledgement");
+		});
+	}
+
+	/** Marks one undeliverable desired Job failed and fails its current queued run attempt transactionally. */
+	async rejectDesiredJob(runId: string, attempt: number, reason: string, nowEpochMs: number): Promise<void>
+	{
+		const now = new Date(nowEpochMs);
+		return this.prisma.$transaction(async (transaction: Prisma.TransactionClient) =>
+		{
+			// 1. Lock the run before the event so rejection cannot invert a claim or acknowledgement.
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${runId} FOR UPDATE`);
+			const run = await transaction.agentRun.findUnique({ where: { id: runId } });
+			const event = await _lockAttemptEvent(transaction, runId, attempt);
+			if (event === null || run === null || run.attempt !== attempt || run.state !== AgentRunState.Queued) throw new Error("run attempt cannot be rejected");
+
+			// 2. Fail both durable records together so the bad event cannot block later work or look pending.
+			await transaction.agentRun.update({ where: { id: run.id }, data: { state: AgentRunState.Failed, finishedAt: now, terminalReason: "RuntimeFailure" } });
+			await _failOutboxEvent(transaction, event.id, now, _failureCode(reason));
+		});
+	}
+}
+
+/** Locks the one unpublished attempt-request event for a run attempt. */
+async function _lockAttemptEvent(transaction: Prisma.TransactionClient, runId: string, attempt: number): Promise<{ readonly id: string; readonly claimedAt: Date | null } | null>
+{
+	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "run_outbox_events" WHERE "run_id" = ${runId} AND "attempt" = ${attempt} AND "kind" = CAST(${"run.attempt_requested"} AS "RunOutboxEventKind") AND "published_at" IS NULL AND "failed_at" IS NULL FOR UPDATE`);
+	const events = await transaction.outboxEvent.findMany({ where: { runId, attempt, kind: RunOutboxEventKind.RunAttemptRequested, publishedAt: null, failedAt: null }, select: { id: true, claimedAt: true }, take: 2 });
+	return events.length === 1 ? events[0] ?? null : null;
+}
+
+/** Marks a locked outbox record terminally failed without discarding its audit trail. */
+async function _failOutboxEvent(transaction: Prisma.TransactionClient, eventId: string, failedAt: Date, failureCode: string): Promise<void>
+{
+	await transaction.outboxEvent.update({ where: { id: eventId }, data: { failedAt, failureCode } });
+}
+
+/** Returns true only when an outbox payload repeats the row's exact durable attempt coordinates. */
+function _requestedPayloadMatches(payload: Prisma.JsonValue, runId: string, attempt: number): boolean
+{
+	if (typeof payload !== "object" || payload === null || Array.isArray(payload)) return false;
+	const value = payload as Record<string, unknown>;
+	return value.runId === runId && value.attempt === attempt;
+}
+
+/** Narrows the evolving public acknowledgement contract to its non-authoritative coordinates. */
+function _jobCoordinates(observation: ControllerJobObservation): { readonly runId: string; readonly attempt: number; readonly workloadName: string; readonly workloadUid: string }
+{
+	return observation;
+}
+
+/** Narrows the evolving public Pod acknowledgement contract to its non-authoritative coordinates. */
+function _podCoordinates(observation: ControllerPodObservation): { readonly runId: string; readonly attempt: number; readonly workloadName: string; readonly workloadUid: string; readonly podUid: string }
+{
+	return observation;
+}
+
+/** Builds the exact deterministic Job name accepted from the controller acknowledgement protocol. */
+function _kubernetesJobName(runId: string, attempt: number): string
+{
+	const prefix = "agent-run-";
+	const digest = createHash("sha256").update(`${runId}:${attempt}`).digest("hex").slice(0, 16);
+	const suffix = `-${digest}-a${attempt}`;
+	return `${prefix}${runId.slice(0, 63 - prefix.length - suffix.length)}${suffix}`;
+}
+
+/** Produces a server-only opaque bootstrap digest; the secret material is never returned to the controller. */
+function _opaqueBootstrapDigest(): string
+{
+	return `sha256:${createHash("sha256").update(randomUUID()).digest("hex")}`;
+}
+
+/** Converts an untrusted controller reason into a bounded durable diagnostic code. */
+function _failureCode(reason: string): string
+{
+	const normalized = reason.trim().replace(/[^a-z0-9_.-]/giu, "_");
+	return normalized.slice(0, 120) || "controller_rejected_desired_job";
+}


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — durable controller decisions.** Records every controller decision — claiming work, registering a Job, registering a Pod — in the database, so crashes and restarts can never lose work or run it twice.

**What it adds**
- Claim / acknowledge / reject persistence with expiring leases
- First-writer-wins Pod registration (competing Pods are rejected)

<details>
<summary>Technical details (original description)</summary>

## Summary

- derive every controller desired Job from canonical run, service, revision, and server-owned runtime-profile authority
- add bounded, durable outbox delivery leases with failure of exhausted queued attempts
- validate only deterministic Job names plus Kubernetes-observed UIDs from the controller
- persist assignment and opaque bootstrap before an assigned state, while keeping `bootstrapReady: false` until a real pod-only delivery mechanism exists
- enforce service → run → outbox and run → assignment lock order, including stale-lease acknowledgement rejection

## Validation

- `npx nx run backend-server-runs:lint --skip-nx-cache`
- `npx nx run backend-server-runs:test --skip-nx-cache` (20 tests)
- `scripts/agent-style-check.sh`
- `git diff --check`

## Review

- independent adversarial review found lock-order, exhausted-event lifecycle, and stale-lease issues; all are addressed with regression coverage
- a follow-up verification is in progress
- no controller/runtime deployment is introduced here, so no workload can start from this authority yet

</details>
