### PR TITLE
🔐 Compose fail-closed controller authority server route

### DIFF
--- a/apps/opencrane/helm/templates/_rbac.tpl
+++ b/apps/opencrane/helm/templates/_rbac.tpl
@@ -40,6 +40,37 @@ subjects:
 {{- end }}
 ---
 {{- /*
+  TokenReview is a Kubernetes cluster-scoped authentication API, so this narrow server-owned
+  permission cannot live in a namespace Role. Internal runtime and controller routes validate
+  projected ServiceAccount tokens here; neither caller receives this permission.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "opencrane.fullname" . }}-opencrane-server-tokenreview-{{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "opencrane.fullname" . }}-opencrane-server-tokenreview-{{ .Release.Namespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "opencrane.fullname" . }}-opencrane-server-tokenreview-{{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "opencrane.fullname" . }}-opencrane-server
+    namespace: {{ .Release.Namespace }}
+---
+{{- /*
   Stage 4: the silo READS the cluster-scoped ClusterTenant CR to resolve a host's per-org
   login client (per-org-client.ts: get by name, list by vanityDomain). ClusterTenant is
   cluster-scoped, so a get/list/watch grant cannot live in the namespaced Role above — it

--- a/apps/opencrane/src/__tests__/controller-authority.config.test.ts
+++ b/apps/opencrane/src/__tests__/controller-authority.config.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { _LoadControllerAuthorityConfig } from "../app/controller-authority.config.js";
+
+/** Creates a complete closed controller/runtime environment fixture. */
+function _environment(): NodeJS.ProcessEnv
+{
+	return {
+		AGENT_CONTROLLER_NAMESPACE: "opencrane-system",
+		AGENT_CONTROLLER_SERVICE_ACCOUNT: "agent-controller",
+		AGENT_RUNTIME_PROFILE: "personal-default",
+		AGENT_RUNTIME_NAMESPACE: "agent-runtimes",
+		AGENT_RUNTIME_SERVICE_ACCOUNT: "agent-runtime",
+		AGENT_RUNTIME_IMAGE: `registry.example/runtime@sha256:${"a".repeat(64)}`,
+		AGENT_RUNTIME_ASSIGNMENT_TTL_SECONDS: "120",
+	};
+}
+
+describe("controller authority server configuration", function _suite()
+{
+	it("loads one closed controller identity and immutable runtime profile", function _loads()
+	{
+		const config = _LoadControllerAuthorityConfig(_environment());
+
+		expect(config).toMatchObject({ identity: { audience: "agent-controller", namespace: "opencrane-system", serviceAccountName: "agent-controller" } });
+		expect(config?.runtimeProfiles.get("personal-default")).toEqual(expect.objectContaining({ namespace: "agent-runtimes", assignmentTtlMs: 120_000 }));
+	});
+
+	it("fails closed when deployment configuration is incomplete or widens runtime image selection", function _failsClosed()
+	{
+		const missingIdentity = _environment();
+		delete missingIdentity.AGENT_CONTROLLER_SERVICE_ACCOUNT;
+		const mutableImage = { ..._environment(), AGENT_RUNTIME_IMAGE: "registry.example/runtime:latest" };
+
+		expect(_LoadControllerAuthorityConfig(missingIdentity)).toBeNull();
+		expect(_LoadControllerAuthorityConfig(mutableImage)).toBeNull();
+	});
+});

--- a/apps/opencrane/src/app/controller-authority.config.ts
+++ b/apps/opencrane/src/app/controller-authority.config.ts
@@ -1,0 +1,27 @@
+import type { ControllerAuthorityConfig } from "./controller-authority.config.types.js";
+
+/** Loads the closed controller authority configuration, or disables the route when incomplete. */
+export function _LoadControllerAuthorityConfig(environment: NodeJS.ProcessEnv = process.env): ControllerAuthorityConfig | null
+{
+	const controllerNamespace = environment["AGENT_CONTROLLER_NAMESPACE"]?.trim() ?? "";
+	const controllerServiceAccountName = environment["AGENT_CONTROLLER_SERVICE_ACCOUNT"]?.trim() ?? "";
+	const profileName = environment["AGENT_RUNTIME_PROFILE"]?.trim() ?? "";
+	const runtimeNamespace = environment["AGENT_RUNTIME_NAMESPACE"]?.trim() ?? "";
+	const runtimeServiceAccountName = environment["AGENT_RUNTIME_SERVICE_ACCOUNT"]?.trim() ?? "";
+	const runtimeImage = environment["AGENT_RUNTIME_IMAGE"]?.trim() ?? "";
+	const assignmentTtlSeconds = Number(environment["AGENT_RUNTIME_ASSIGNMENT_TTL_SECONDS"]?.trim());
+	if (!_dnsLabel(controllerNamespace) || !_dnsLabel(controllerServiceAccountName) || !_dnsLabel(profileName) || !_dnsLabel(runtimeNamespace) || !_dnsLabel(runtimeServiceAccountName) || !/^.+@sha256:[a-f0-9]{64}$/u.test(runtimeImage) || !Number.isSafeInteger(assignmentTtlSeconds) || assignmentTtlSeconds < 60 || assignmentTtlSeconds > 300)
+	{
+		return null;
+	}
+	return {
+		identity: { audience: "agent-controller", namespace: controllerNamespace, serviceAccountName: controllerServiceAccountName },
+		runtimeProfiles: new Map([[profileName, { namespace: runtimeNamespace, serviceAccountName: runtimeServiceAccountName, image: runtimeImage, assignmentTtlMs: assignmentTtlSeconds * 1000 }]]),
+	};
+}
+
+/** Returns whether a constrained configuration name is Kubernetes DNS-label safe. */
+function _dnsLabel(value: string): boolean
+{
+	return /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/u.test(value) && value.length <= 63;
+}

--- a/apps/opencrane/src/app/controller-authority.config.types.ts
+++ b/apps/opencrane/src/app/controller-authority.config.types.ts
@@ -1,0 +1,10 @@
+import type { ControllerAuthorityIdentityPolicy } from "@opencrane/backend/server/runs";
+
+/** Closed server-side configuration required to expose controller authority routes. */
+export interface ControllerAuthorityConfig
+{
+	/** Exact projected-token identity accepted from the controller. */
+	readonly identity: ControllerAuthorityIdentityPolicy;
+	/** Runtime profiles selected only from persisted AgentService workload-profile keys. */
+	readonly runtimeProfiles: ReadonlyMap<string, { readonly namespace: string; readonly serviceAccountName: string; readonly image: string; readonly assignmentTtlMs: number }>;
+}

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -19,6 +19,9 @@ import { thirdPartySourcesRouter } from "@opencrane/backend/server/retrieval";
 import { _BuildDocMergeReconciler, companyDocsRouter } from "@opencrane/backend/server/company-docs";
 import { _CheckDbHealth, _OpenapiRouter } from "@opencrane/server/_infra/http";
 import { spec } from "@opencrane/backend/server/api-spec";
+import { __CreateControllerAuthorityRouter, PrismaControllerAuthorityRepository } from "@opencrane/backend/server/runs";
+
+import type { ControllerAuthorityConfig } from "./controller-authority.config.types.js";
 
 /**
  * Registers all API routes on the given Express application instance.
@@ -43,7 +46,7 @@ import { spec } from "@opencrane/backend/server/api-spec";
  *     projected pod token, which the browser-session middleware cannot satisfy.
  * @see apps/opencrane/helm/templates/_networkpolicy.tpl — the runtime-plane policies.
  */
-export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, authApi: k8s.AuthenticationV1Api): void
+export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, authApi: k8s.AuthenticationV1Api, controllerAuthority: ControllerAuthorityConfig | null = null): void
 {
   // NetworkPolicy-only (no auth/TokenReview): the operator fetches a tenant's
   // allowed model set + effective default at reconcile. Best-effort — never 404/500.
@@ -51,6 +54,12 @@ export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, auth
   // Note: /api/internal/contract enforces per-tenant identity via TokenReview — not NetworkPolicy-only.
   app.use("/api/internal/contract", _RegisterInternalTenantContract(prisma, authApi));
   app.use("/api/internal/awareness/participation", _RegisterInternalParticipation(prisma, authApi));
+  // Controller authority is internal-only and performs its own exact TokenReview. It is disabled
+  // until the chart provides one closed controller identity and one immutable runtime profile.
+  if (controllerAuthority !== null)
+  {
+    app.use("/api/internal/agent-controller", __CreateControllerAuthorityRouter({ repository: new PrismaControllerAuthorityRepository(prisma, controllerAuthority.runtimeProfiles), authApi, identity: controllerAuthority.identity, nowEpochMs: Date.now }));
+  }
 }
 
 /**

--- a/apps/opencrane/src/index.ts
+++ b/apps/opencrane/src/index.ts
@@ -29,6 +29,7 @@ import { _SetTenantSuspended } from "@opencrane/backend/server/tenants";
 // namespace, so a silo stands on its own; the fleet-manager watches only the cluster-scoped
 // ClusterTenant CR and nothing inside a silo.
 import { _LoadOperatorConfig } from "./app/config.js";
+import { _LoadControllerAuthorityConfig } from "./app/controller-authority.config.js";
 import { _BuildHostingAdapter } from "./hosting/index.js";
 
 // Route any stray console.* call (first-party or third-party) through the
@@ -116,7 +117,7 @@ export function createInternalApp(prisma: PrismaClient, authApi: k8s.Authenticat
   app.use(express.json());
   app.use(___RequestContext());
   app.use(pinoHttp({ logger: log, genReqId: function _genReqId() { return ___GetContext()?.requestId ?? randomUUID(); } }));
-  _RegisterInternalRoutes(app, prisma, authApi);
+  _RegisterInternalRoutes(app, prisma, authApi, _LoadControllerAuthorityConfig());
   app.use(_ErrorHandler(log));
   return app;
 }


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — switching the private line on.** Mounts the controller's internal API into the platform server — but only when its full identity and runtime-profile configuration is present. If anything is missing, the API simply does not exist. (Replaces #275, which was based on an outdated branch.)

**What it adds**
- Fail-closed route mounting on the internal listener only
- The narrow permission the server needs to verify caller identities

<details>
<summary>Technical details (original description)</summary>

Restacked server-composition slice on the runtime-profile binding fix (#276). Adds closed config, internal route mounting, and server-only TokenReview RBAC.

Validation: server lint + focused config test; runs lint; style + diff checks.

</details>
