### PR TITLE
✨ Integration authority foundation

### DIFF
--- a/apps/opencrane/prisma/migrations/0049_integrations_authority/migration.sql
+++ b/apps/opencrane/prisma/migrations/0049_integrations_authority/migration.sql
@@ -1,0 +1,162 @@
+-- Fresh integration authority. Target AgentRevision assignments replace their isolated MCP seam;
+-- no MCP catalogue, credential, OAuth, token, or assignment row is copied or bridged.
+
+DROP TABLE "agent_revision_mcp_assignments";
+
+CREATE TYPE "IntegrationState" AS ENUM ('active', 'retired');
+CREATE TYPE "IntegrationCustodyState" AS ENUM ('ready', 'revoked', 'expired');
+
+CREATE FUNCTION "has_nonempty_distinct_tool_ids"(TEXT[]) RETURNS BOOLEAN LANGUAGE sql IMMUTABLE AS $$
+  SELECT COALESCE(
+    cardinality($1) > 0 AND NOT EXISTS (
+      SELECT 1
+      FROM unnest($1) AS tool("value")
+      GROUP BY tool."value"
+      HAVING tool."value" IS NULL OR btrim(tool."value") = '' OR count(*) > 1
+    ),
+    FALSE
+  );
+$$;
+
+CREATE TABLE "integrations" (
+  "id" TEXT NOT NULL,
+  "silo_id" TEXT NOT NULL,
+  "obot_catalog_entry_id" TEXT NOT NULL,
+  "display_name" TEXT NOT NULL,
+  "state" "IntegrationState" NOT NULL DEFAULT 'active',
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "integrations_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "integrations_identity_nonempty" CHECK (
+    btrim("silo_id") <> '' AND btrim("obot_catalog_entry_id") <> '' AND btrim("display_name") <> ''
+  )
+);
+
+CREATE UNIQUE INDEX "integrations_id_silo_id_key" ON "integrations"("id", "silo_id");
+CREATE UNIQUE INDEX "integrations_silo_id_obot_catalog_entry_id_key" ON "integrations"("silo_id", "obot_catalog_entry_id");
+CREATE INDEX "integrations_silo_id_state_idx" ON "integrations"("silo_id", "state");
+
+CREATE TABLE "integration_custody_references" (
+  "id" TEXT NOT NULL,
+  "integration_id" TEXT NOT NULL,
+  "silo_id" TEXT NOT NULL,
+  "obot_custody_reference" TEXT NOT NULL,
+  "state" "IntegrationCustodyState" NOT NULL DEFAULT 'ready',
+  "expires_at" TIMESTAMP(3) NOT NULL,
+  "revoked_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "integration_custody_references_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "integration_custody_references_identity_nonempty" CHECK (
+    btrim("integration_id") <> '' AND btrim("silo_id") <> '' AND btrim("obot_custody_reference") <> ''
+  ),
+  CONSTRAINT "integration_custody_references_revocation_evidence" CHECK (
+    ("state" = 'revoked' AND "revoked_at" IS NOT NULL) OR ("state" <> 'revoked' AND "revoked_at" IS NULL)
+  ),
+  CONSTRAINT "integration_custody_references_integration_fkey" FOREIGN KEY ("integration_id", "silo_id")
+    REFERENCES "integrations"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "integration_custody_references_id_integration_id_silo_id_key"
+  ON "integration_custody_references"("id", "integration_id", "silo_id");
+CREATE UNIQUE INDEX "integration_custody_references_obot_custody_reference_key"
+  ON "integration_custody_references"("obot_custody_reference");
+CREATE INDEX "integration_custody_references_integration_id_state_expires_at_idx"
+  ON "integration_custody_references"("integration_id", "state", "expires_at");
+CREATE UNIQUE INDEX "integration_custody_references_one_ready_per_integration"
+  ON "integration_custody_references"("integration_id") WHERE "state" = 'ready' AND "revoked_at" IS NULL;
+
+CREATE TABLE "agent_revision_integration_assignments" (
+  "agent_revision_id" TEXT NOT NULL,
+  "integration_id" TEXT NOT NULL,
+  "silo_id" TEXT NOT NULL,
+  "custody_reference_id" TEXT NOT NULL,
+  "allowed_tools" TEXT[] NOT NULL,
+
+  CONSTRAINT "agent_revision_integration_assignments_pkey" PRIMARY KEY ("agent_revision_id", "integration_id"),
+  CONSTRAINT "agent_revision_integration_assignments_allowed_tools_check" CHECK ("has_nonempty_distinct_tool_ids"("allowed_tools")),
+  CONSTRAINT "agent_revision_integration_assignments_revision_fkey" FOREIGN KEY ("agent_revision_id")
+    REFERENCES "agent_revisions"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "agent_revision_integration_assignments_integration_fkey" FOREIGN KEY ("integration_id", "silo_id")
+    REFERENCES "integrations"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "agent_revision_integration_assignments_custody_fkey" FOREIGN KEY ("custody_reference_id", "integration_id", "silo_id")
+    REFERENCES "integration_custody_references"("id", "integration_id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "agent_revision_integration_assignments_integration_id_silo_id_idx"
+  ON "agent_revision_integration_assignments"("integration_id", "silo_id");
+
+CREATE FUNCTION "enforce_integration_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW."state" <> 'active' THEN RAISE EXCEPTION 'a new Integration must begin Active'; END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'Integration rows cannot be deleted'; END IF;
+  IF OLD."state" = 'retired' THEN RAISE EXCEPTION 'a Retired Integration is closed'; END IF;
+  IF NEW."id" IS DISTINCT FROM OLD."id" OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id"
+    OR NEW."obot_catalog_entry_id" IS DISTINCT FROM OLD."obot_catalog_entry_id" OR NEW."created_at" IS DISTINCT FROM OLD."created_at" THEN
+    RAISE EXCEPTION 'Integration identity is immutable';
+  END IF;
+  IF NEW."state" NOT IN ('active', 'retired') THEN RAISE EXCEPTION 'invalid Integration lifecycle transition'; END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "integrations_closed_lifecycle"
+  BEFORE INSERT OR UPDATE OR DELETE ON "integrations"
+  FOR EACH ROW EXECUTE FUNCTION "enforce_integration_lifecycle"();
+
+CREATE FUNCTION "enforce_integration_custody_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW."state" = 'ready' AND NEW."expires_at" <= NEW."created_at" THEN
+      RAISE EXCEPTION 'a Ready custody reference must expire after creation';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'Integration custody references cannot be deleted'; END IF;
+  IF NEW."id" IS DISTINCT FROM OLD."id" OR NEW."integration_id" IS DISTINCT FROM OLD."integration_id"
+    OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id" OR NEW."obot_custody_reference" IS DISTINCT FROM OLD."obot_custody_reference"
+    OR NEW."expires_at" IS DISTINCT FROM OLD."expires_at" OR NEW."created_at" IS DISTINCT FROM OLD."created_at" THEN
+    RAISE EXCEPTION 'Integration custody identity is immutable';
+  END IF;
+  IF OLD."state" <> 'ready' OR NEW."state" NOT IN ('ready', 'revoked', 'expired') THEN
+    RAISE EXCEPTION 'invalid Integration custody lifecycle transition';
+  END IF;
+  IF NEW."state" = 'expired' AND NEW."expires_at" > clock_timestamp() THEN
+    RAISE EXCEPTION 'a custody reference expires only after its expiry instant';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "integration_custody_references_closed_lifecycle"
+  BEFORE INSERT OR UPDATE OR DELETE ON "integration_custody_references"
+  FOR EACH ROW EXECUTE FUNCTION "enforce_integration_custody_lifecycle"();
+
+CREATE FUNCTION "enforce_agent_revision_integration_assignment_authority"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE agent_silo_id TEXT; integration_state "IntegrationState"; custody_state "IntegrationCustodyState"; custody_expiry TIMESTAMP(3); custody_revoked_at TIMESTAMP(3);
+BEGIN
+  SELECT service."silo_id" INTO agent_silo_id
+    FROM "agent_revisions" revision JOIN "agent_services" service ON service."id" = revision."agent_service_id"
+    WHERE revision."id" = NEW."agent_revision_id" FOR UPDATE OF revision, service;
+  SELECT integration."state" INTO integration_state FROM "integrations" integration
+    WHERE integration."id" = NEW."integration_id" AND integration."silo_id" = NEW."silo_id" FOR UPDATE;
+  SELECT custody."state", custody."expires_at", custody."revoked_at"
+    INTO custody_state, custody_expiry, custody_revoked_at FROM "integration_custody_references" custody
+    WHERE custody."id" = NEW."custody_reference_id" AND custody."integration_id" = NEW."integration_id" AND custody."silo_id" = NEW."silo_id" FOR UPDATE;
+  IF agent_silo_id IS DISTINCT FROM NEW."silo_id" OR integration_state IS DISTINCT FROM 'active'::"IntegrationState" THEN
+    RAISE EXCEPTION 'AgentRevision may assign only an Active Integration from the same silo';
+  END IF;
+  IF custody_state IS DISTINCT FROM 'ready'::"IntegrationCustodyState" OR custody_revoked_at IS NOT NULL OR custody_expiry <= clock_timestamp() THEN
+    RAISE EXCEPTION 'AgentRevision may assign only a ready unexpired Integration custody reference';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "agent_revision_integration_assignments_authority"
+  BEFORE INSERT OR UPDATE ON "agent_revision_integration_assignments"
+  FOR EACH ROW EXECUTE FUNCTION "enforce_agent_revision_integration_assignment_authority"();
+CREATE TRIGGER "agent_revision_integration_assignments_immutable"
+  BEFORE INSERT OR UPDATE OR DELETE ON "agent_revision_integration_assignments"
+  FOR EACH ROW EXECUTE FUNCTION "enforce_agent_revision_assignment_immutability"();

--- a/apps/opencrane/prisma/schema/agent-services.prisma
+++ b/apps/opencrane/prisma/schema/agent-services.prisma
@@ -67,7 +67,7 @@ model AgentRevision {
   agentService        AgentService                   @relation("AgentServiceRevisions", fields: [agentServiceId], references: [id], onDelete: Restrict)
   activeFor           AgentService[]                 @relation("ActiveAgentRevision")
   skillAssignments    AgentRevisionSkillAssignment[]
-  mcpAssignments      AgentRevisionMcpAssignment[]
+  integrationAssignments AgentRevisionIntegrationAssignment[]
   runs                AgentRun[]
 
   @@unique([agentServiceId, revision])
@@ -88,12 +88,18 @@ model AgentRevisionSkillAssignment {
   @@map("agent_revision_skill_assignments")
 }
 
-model AgentRevisionMcpAssignment {
-  agentRevisionId String        @map("agent_revision_id")
-  mcpServerId     String        @map("mcp_server_id")
-  allowedTools    String[]      @map("allowed_tools")
-  agentRevision   AgentRevision @relation(fields: [agentRevisionId], references: [id], onDelete: Restrict)
+/// Immutable tool allow-list for one integration on one draft AgentRevision.
+model AgentRevisionIntegrationAssignment {
+  agentRevisionId      String                       @map("agent_revision_id")
+  integrationId        String                       @map("integration_id")
+  siloId               String                       @map("silo_id")
+  custodyReferenceId   String                       @map("custody_reference_id")
+  allowedTools         String[]                     @map("allowed_tools")
+  agentRevision        AgentRevision                @relation(fields: [agentRevisionId], references: [id], onDelete: Restrict)
+  integration          Integration                  @relation(fields: [integrationId, siloId], references: [id, siloId], onDelete: Restrict)
+  custodyReference     IntegrationCustodyReference  @relation(fields: [custodyReferenceId, integrationId, siloId], references: [id, integrationId, siloId], onDelete: Restrict)
 
-  @@id([agentRevisionId, mcpServerId])
-  @@map("agent_revision_mcp_assignments")
+  @@id([agentRevisionId, integrationId])
+  @@index([integrationId, siloId])
+  @@map("agent_revision_integration_assignments")
 }

--- a/apps/opencrane/prisma/schema/integrations.prisma
+++ b/apps/opencrane/prisma/schema/integrations.prisma
@@ -1,0 +1,49 @@
+/// Lifecycle of a silo-scoped integration catalogue entry.
+enum IntegrationState {
+  Active  @map("active")
+  Retired @map("retired")
+}
+
+/// Lifecycle of one opaque Obot custody reference.
+enum IntegrationCustodyState {
+  Ready   @map("ready")
+  Revoked @map("revoked")
+  Expired @map("expired")
+}
+
+/// Silo-scoped catalogue record for one integration whose credentials remain with Obot.
+model Integration {
+  id                  String                              @id @default(cuid())
+  siloId              String                              @map("silo_id")
+  obotCatalogEntryId  String                              @map("obot_catalog_entry_id")
+  displayName         String                              @map("display_name")
+  state               IntegrationState                    @default(Active)
+  createdAt           DateTime                            @default(now()) @map("created_at")
+  updatedAt           DateTime                            @updatedAt @map("updated_at")
+  custodyReferences   IntegrationCustodyReference[]
+  assignments         AgentRevisionIntegrationAssignment[]
+
+  @@unique([id, siloId])
+  @@unique([siloId, obotCatalogEntryId])
+  @@index([siloId, state])
+  @@map("integrations")
+}
+
+/// Opaque Obot-issued custody handle. This database never stores the underlying credential.
+model IntegrationCustodyReference {
+  id                    String                  @id @default(cuid())
+  integrationId         String                  @map("integration_id")
+  siloId                String                  @map("silo_id")
+  obotCustodyReference  String                  @map("obot_custody_reference")
+  state                 IntegrationCustodyState @default(Ready)
+  expiresAt             DateTime                @map("expires_at")
+  revokedAt             DateTime?               @map("revoked_at")
+  createdAt             DateTime                @default(now()) @map("created_at")
+  integration           Integration             @relation(fields: [integrationId, siloId], references: [id, siloId], onDelete: Restrict)
+  assignments           AgentRevisionIntegrationAssignment[]
+
+  @@unique([id, integrationId, siloId])
+  @@unique([obotCustodyReference])
+  @@index([integrationId, state, expiresAt])
+  @@map("integration_custody_references")
+}

--- a/libs/backend/README.md
+++ b/libs/backend/README.md
@@ -33,7 +33,8 @@ flattening unrelated responsibilities together.
 - Tenant and runtime lifecycle: tenants, connections, effective contracts, and projection repair.
 - Models and economics: providers, model routing, spend, and budgets.
 - Knowledge and memory: awareness, retrieval sources, and company documents.
-- Tools and integrations: skills and MCP servers.
+- Tools and integrations: skills and silo-scoped integrations; the legacy MCP catalogue remains
+  isolated until a target browser/runtime integration path replaces it.
 - Operations and API composition: audit, metrics, and the generated API specification.
 
 These are current code ownership boundaries, not promises that legacy Tenant, AccessPolicy,

--- a/libs/backend/server/agent-services/main/src/agent-publication.test.ts
+++ b/libs/backend/server/agent-services/main/src/agent-publication.test.ts
@@ -34,7 +34,7 @@ function _revision(): AgentRevision
 		personaRevisionId: "persona-1",
 		modelPolicyId: "model-policy-1",
 		skills: [],
-		mcpAssignments: [],
+		integrationAssignments: [],
 		budget: { maxTurns: 10, maxTokens: 10000, maxDurationMs: 60000 },
 		authoredBy: "user-1",
 		createdAt: "2026-07-18T00:00:00.000Z",

--- a/libs/backend/server/agent-services/main/src/prisma-agent-publication.test.ts
+++ b/libs/backend/server/agent-services/main/src/prisma-agent-publication.test.ts
@@ -39,7 +39,7 @@ function _revisionRow()
 		createdAt: new Date("2026-07-18T00:00:00.000Z"),
 		publishedAt: null,
 		skillAssignments: [],
-		mcpAssignments: [],
+		integrationAssignments: [],
 	};
 }
 

--- a/libs/backend/server/agent-services/main/src/prisma-agent-publication.ts
+++ b/libs/backend/server/agent-services/main/src/prisma-agent-publication.ts
@@ -73,7 +73,7 @@ function _mapService(row: { id: string; siloId: string; kind: string; name: stri
 }
 
 /** Maps one locked Prisma revision row and its immutable assignments to the target contract. */
-function _mapRevision(row: { id: string; agentServiceId: string; revision: number; state: string; digest: string; promptPolicyVersion: string; personaRevisionId: string | null; modelPolicyId: string; budget: Prisma.JsonValue; authoredBy: string; createdAt: Date; publishedAt: Date | null; skillAssignments: Array<{ skillId: string; skillRevisionId: string }>; mcpAssignments: Array<{ mcpServerId: string; allowedTools: string[] }> }): AgentRevision
+function _mapRevision(row: { id: string; agentServiceId: string; revision: number; state: string; digest: string; promptPolicyVersion: string; personaRevisionId: string | null; modelPolicyId: string; budget: Prisma.JsonValue; authoredBy: string; createdAt: Date; publishedAt: Date | null; skillAssignments: Array<{ skillId: string; skillRevisionId: string }>; integrationAssignments: Array<{ integrationId: string; custodyReferenceId: string; allowedTools: string[] }> }): AgentRevision
 {
 	return {
 		id: row.id,
@@ -85,7 +85,7 @@ function _mapRevision(row: { id: string; agentServiceId: string; revision: numbe
 		personaRevisionId: row.personaRevisionId,
 		modelPolicyId: row.modelPolicyId,
 		skills: row.skillAssignments.map(assignment => ({ skillId: assignment.skillId, revisionId: assignment.skillRevisionId })),
-		mcpAssignments: row.mcpAssignments.map(assignment => ({ serverId: assignment.mcpServerId, allowedTools: assignment.allowedTools })),
+		integrationAssignments: row.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: assignment.allowedTools })),
 		budget: row.budget as unknown as AgentBudget,
 		authoredBy: row.authoredBy,
 		createdAt: row.createdAt.toISOString(),
@@ -122,7 +122,7 @@ export class PrismaAgentServicePublicationRepository implements AgentServicePubl
 	/** Loads one immutable revision and all executable assignments. */
 	async getRevision(agentRevisionId: string): Promise<AgentRevision | null>
 	{
-		const row = await this.prisma.agentRevision.findUnique({ where: { id: agentRevisionId }, include: { skillAssignments: true, mcpAssignments: true } });
+		const row = await this.prisma.agentRevision.findUnique({ where: { id: agentRevisionId }, include: { skillAssignments: true, integrationAssignments: true } });
 		return row === null ? null : _mapRevision(row);
 	}
 
@@ -136,14 +136,14 @@ export class PrismaAgentServicePublicationRepository implements AgentServicePubl
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${publication.agentServiceId} FOR UPDATE`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_revisions" WHERE "id" = ${publication.agentRevisionId} FOR UPDATE`);
 			const serviceRow = await transaction.agentService.findUnique({ where: { id: publication.agentServiceId } });
-			const revisionRow = await transaction.agentRevision.findUnique({ where: { id: publication.agentRevisionId }, include: { skillAssignments: true, mcpAssignments: true } });
+			const revisionRow = await transaction.agentRevision.findUnique({ where: { id: publication.agentRevisionId }, include: { skillAssignments: true, integrationAssignments: true } });
 			if (serviceRow === null || revisionRow === null || _serviceState(serviceRow.state) !== publication.expectedServiceState || serviceRow.activeRevisionId !== publication.expectedActiveRevisionId || revisionRow.agentServiceId !== publication.agentServiceId || revisionRow.state !== AgentRevisionState.Draft)
 			{
 				return { status: "conflict", currentActiveRevisionId: serviceRow?.activeRevisionId ?? null } as const;
 			}
 
 			// 2. Change both lifecycle coordinates inside the same transaction so neither can escape alone.
-			const publishedRow = await transaction.agentRevision.update({ where: { id: publication.agentRevisionId }, data: { state: AgentRevisionState.Published, publishedAt: new Date(publication.publishedAt) }, include: { skillAssignments: true, mcpAssignments: true } });
+			const publishedRow = await transaction.agentRevision.update({ where: { id: publication.agentRevisionId }, data: { state: AgentRevisionState.Published, publishedAt: new Date(publication.publishedAt) }, include: { skillAssignments: true, integrationAssignments: true } });
 			const activeRow = await transaction.agentService.update({ where: { id: publication.agentServiceId }, data: { state: AgentServiceState.Active, activeRevisionId: publication.agentRevisionId, updatedAt: new Date(publication.publishedAt) } });
 
 			// 3. Append authenticated decision evidence before commit; audit failure rolls back publication.

--- a/libs/backend/server/integrations/main/project.json
+++ b/libs/backend/server/integrations/main/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend-server-integrations",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/server/integrations/main/src",
+  "tags": ["type:lib", "layer:backend", "scope:integrations"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/server/integrations/main" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/server/integrations/main" } },
+    "test:sql": { "executor": "nx:run-commands", "options": { "command": "sh ../../../../../scripts/run-postgres-authority-tests.sh tests/integrations-authority.sql", "cwd": "libs/backend/server/integrations/main" } },
+    "test:negative": { "executor": "nx:run-commands", "options": { "command": "../../../../../scripts/integration-authority-negative-tests.sh", "cwd": "libs/backend/server/integrations/main" } }
+  }
+}

--- a/libs/backend/server/integrations/main/src/index.ts
+++ b/libs/backend/server/integrations/main/src/index.ts
@@ -1,0 +1,2 @@
+export { __SystemIntegrationAuthorityClock, PrismaIntegrationAuthorityRepository } from "./prisma-integration-authority.js";
+export type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult, ResolvedIntegrationAssignment } from "./integration-resolution.types.js";

--- a/libs/backend/server/integrations/main/src/integration-resolution.types.ts
+++ b/libs/backend/server/integrations/main/src/integration-resolution.types.ts
@@ -1,0 +1,42 @@
+/** Request to resolve one immutable integration assignment for runtime preparation. */
+export interface ResolveIntegrationAssignmentCommand
+{
+	/** Silo that owns the AgentRevision and integration. */
+	readonly siloId: string;
+	/** Immutable revision selecting the integration. */
+	readonly agentRevisionId: string;
+	/** Exact integration selected by the revision. */
+	readonly integrationId: string;
+}
+
+/** Credential-free result returned only for an active assigned integration. */
+export interface ResolvedIntegrationAssignment
+{
+	/** Silo-scoped integration identity. */
+	readonly integrationId: string;
+	/** Obot catalogue entry selected by the product authority. */
+	readonly obotCatalogEntryId: string;
+	/** Opaque Obot-issued custody handle; it is not credential material. */
+	readonly obotCustodyReference: string;
+	/** Explicit revision-scoped tool allow-list. */
+	readonly allowedTools: readonly string[];
+}
+
+/** Credential-free integration assignment resolution outcome. */
+export type ResolveIntegrationAssignmentResult =
+	| { readonly outcome: "resolved"; readonly assignment: ResolvedIntegrationAssignment }
+	| { readonly outcome: "unavailable"; readonly reason: "not_found" | "inactive" | "revoked" | "expired" };
+
+/** Read-only authority boundary for runtime integration preparation. */
+export interface IntegrationAuthorityRepository
+{
+	/** Resolves only an active same-silo revision assignment and its usable opaque custody reference. */
+	resolveAssignment(command: ResolveIntegrationAssignmentCommand): Promise<ResolveIntegrationAssignmentResult>;
+}
+
+/** Clock owned by the server authority rather than its runtime caller. */
+export interface IntegrationAuthorityClock
+{
+	/** Returns the current trusted instant for custody expiry evaluation. */
+	now(): Date;
+}

--- a/libs/backend/server/integrations/main/src/prisma-integration-authority.test.ts
+++ b/libs/backend/server/integrations/main/src/prisma-integration-authority.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaIntegrationAuthorityRepository } from "./prisma-integration-authority.js";
+
+describe("Prisma integration authority", function _suite()
+{
+	it("returns only an active same-silo assignment's opaque Obot reference and explicit tools", async function _resolved()
+	{
+		const findUnique = vi.fn().mockResolvedValue({
+			siloId: "silo-1",
+			integrationId: "integration-1",
+			allowedTools: ["calendar.read"],
+			integration: { state: "Active", obotCatalogEntryId: "obot-calendar" },
+			custodyReference: { state: "Ready", revokedAt: null, expiresAt: new Date("2026-07-19T12:00:00.000Z"), obotCustodyReference: "obot:opaque:calendar" },
+		});
+		const repository = new PrismaIntegrationAuthorityRepository({ agentRevisionIntegrationAssignment: { findUnique } } as never, { now: vi.fn().mockReturnValue(new Date("2026-07-19T11:00:00.000Z")) });
+		const result = await repository.resolveAssignment({ siloId: "silo-1", agentRevisionId: "revision-1", integrationId: "integration-1" });
+		expect(result).toEqual({ outcome: "resolved", assignment: { integrationId: "integration-1", obotCatalogEntryId: "obot-calendar", obotCustodyReference: "obot:opaque:calendar", allowedTools: ["calendar.read"] } });
+		expect(findUnique).toHaveBeenCalledWith(expect.objectContaining({ include: { integration: true, custodyReference: true } }));
+	});
+
+	it("does not resolve revoked or expired custody references", async function _unavailable()
+	{
+		const findUnique = vi.fn().mockResolvedValue({
+			siloId: "silo-1",
+			integrationId: "integration-1",
+			allowedTools: ["calendar.read"],
+			integration: { state: "Active", obotCatalogEntryId: "obot-calendar" },
+			custodyReference: { state: "Revoked", revokedAt: new Date("2026-07-19T10:00:00.000Z"), expiresAt: new Date("2026-07-19T12:00:00.000Z"), obotCustodyReference: "obot:opaque:calendar" },
+		});
+		const repository = new PrismaIntegrationAuthorityRepository({ agentRevisionIntegrationAssignment: { findUnique } } as never, { now: vi.fn().mockReturnValue(new Date("2026-07-19T11:00:00.000Z")) });
+		await expect(repository.resolveAssignment({ siloId: "silo-1", agentRevisionId: "revision-1", integrationId: "integration-1" })).resolves.toEqual({ outcome: "unavailable", reason: "revoked" });
+	});
+});

--- a/libs/backend/server/integrations/main/src/prisma-integration-authority.ts
+++ b/libs/backend/server/integrations/main/src/prisma-integration-authority.ts
@@ -1,0 +1,49 @@
+import { IntegrationCustodyState, IntegrationState, type PrismaClient } from "@prisma/client";
+
+import type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult } from "./integration-resolution.types.js";
+
+/** Production clock for integration-custody expiry checks. */
+export class __SystemIntegrationAuthorityClock implements IntegrationAuthorityClock
+{
+	/** Returns the current system instant used by the server authority. */
+	now(): Date
+	{
+		return new Date();
+	}
+}
+
+/** Prisma-backed, credential-free read authority for immutable integration assignments. */
+export class PrismaIntegrationAuthorityRepository implements IntegrationAuthorityRepository
+{
+	/** Canonical OpenCrane product database. */
+	private readonly prisma: PrismaClient;
+	/** Authority-owned clock that prevents callers from backdating custody expiry checks. */
+	private readonly clock: IntegrationAuthorityClock;
+
+	/** Creates the integration authority adapter over the product Postgres database. */
+	constructor(prisma: PrismaClient, clock: IntegrationAuthorityClock)
+	{
+		this.prisma = prisma;
+		this.clock = clock;
+	}
+
+	/** Resolves one currently usable integration assignment without exposing any credential material. */
+	async resolveAssignment(command: ResolveIntegrationAssignmentCommand): Promise<ResolveIntegrationAssignmentResult>
+	{
+		// 1. Read the immutable composite assignment so a foreign silo cannot select its own custody reference.
+		const assignment = await this.prisma.agentRevisionIntegrationAssignment.findUnique({
+			where: { agentRevisionId_integrationId: { agentRevisionId: command.agentRevisionId, integrationId: command.integrationId } },
+			include: { integration: true, custodyReference: true },
+		});
+		if (assignment === null || assignment.siloId !== command.siloId) return { outcome: "unavailable", reason: "not_found" };
+
+		// 2. Require the catalogue entry and custody reference to remain active at the requested instant.
+		if (assignment.integration.state !== IntegrationState.Active) return { outcome: "unavailable", reason: "inactive" };
+		if (assignment.custodyReference.state === IntegrationCustodyState.Revoked || assignment.custodyReference.revokedAt !== null) return { outcome: "unavailable", reason: "revoked" };
+		if (assignment.custodyReference.state === IntegrationCustodyState.Expired || assignment.custodyReference.expiresAt <= this.clock.now()) return { outcome: "unavailable", reason: "expired" };
+		if (assignment.custodyReference.state !== IntegrationCustodyState.Ready) return { outcome: "unavailable", reason: "inactive" };
+
+		// 3. Return only the opaque custody reference and explicit allow-list for the Obot PEP to redeem.
+		return { outcome: "resolved", assignment: { integrationId: assignment.integrationId, obotCatalogEntryId: assignment.integration.obotCatalogEntryId, obotCustodyReference: assignment.custodyReference.obotCustodyReference, allowedTools: assignment.allowedTools } };
+	}
+}

--- a/libs/backend/server/integrations/main/tests/integrations-authority.sql
+++ b/libs/backend/server/integrations/main/tests/integrations-authority.sql
@@ -1,0 +1,82 @@
+BEGIN;
+
+CREATE FUNCTION pg_temp.expect_failure(test_name TEXT, statement TEXT, expected_message TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE actual_message TEXT;
+BEGIN
+  BEGIN EXECUTE statement;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+    IF strpos(actual_message, expected_message) > 0 THEN RAISE NOTICE 'PASS: %', test_name; RETURN; END IF;
+    RAISE EXCEPTION 'FAIL: % returned unexpected error: %', test_name, actual_message;
+  END;
+  RAISE EXCEPTION 'FAIL: % unexpectedly succeeded', test_name;
+END;
+$$;
+
+INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "owner_scope", "owner_subject_id", "workload_profile", "updated_at")
+VALUES ('integration-service', 'silo-integrations', 'managed', 'Integration agent', 'organization', 'organization-1', 'managed-agent', clock_timestamp());
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
+VALUES ('integration-revision', 'integration-service', 1, 'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+INSERT INTO "integrations" ("id", "silo_id", "obot_catalog_entry_id", "display_name", "updated_at")
+VALUES ('integration-1', 'silo-integrations', 'obot-catalog-1', 'Calendar', clock_timestamp());
+INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "expires_at")
+VALUES ('custody-1', 'integration-1', 'silo-integrations', 'obot:opaque:one', clock_timestamp() + interval '1 hour');
+INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+VALUES ('integration-revision', 'integration-1', 'silo-integrations', 'custody-1', ARRAY['calendar.read']);
+
+SELECT pg_temp.expect_failure('duplicate integration assignment', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision', 'integration-1', 'silo-integrations', 'custody-1', ARRAY['calendar.write'])$statement$, 'agent_revision_integration_assignments_pkey');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
+VALUES ('integration-revision-tools', 'integration-service', 2, 'sha256:' || repeat('b', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+INSERT INTO "integrations" ("id", "silo_id", "obot_catalog_entry_id", "display_name", "updated_at")
+VALUES ('integration-tools', 'silo-integrations', 'obot-catalog-tools', 'Tasks', clock_timestamp());
+INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "expires_at")
+VALUES ('custody-tools', 'integration-tools', 'silo-integrations', 'obot:opaque:tools', clock_timestamp() + interval '1 hour');
+SELECT pg_temp.expect_failure('empty duplicate and null tools are rejected', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision-tools', 'integration-tools', 'silo-integrations', 'custody-tools', ARRAY['', '', NULL])$statement$, 'allowed_tools_check');
+
+INSERT INTO "integrations" ("id", "silo_id", "obot_catalog_entry_id", "display_name", "updated_at")
+VALUES ('foreign-integration', 'other-silo', 'obot-catalog-foreign', 'Foreign calendar', clock_timestamp());
+INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "expires_at")
+VALUES ('foreign-custody', 'foreign-integration', 'other-silo', 'obot:opaque:foreign', clock_timestamp() + interval '1 hour');
+SELECT pg_temp.expect_failure('cross silo integration assignment', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision', 'foreign-integration', 'other-silo', 'foreign-custody', ARRAY['calendar.read'])$statement$, 'same silo');
+
+UPDATE "agent_revisions" SET "state" = 'published', "published_at" = clock_timestamp() WHERE "id" = 'integration-revision';
+SELECT pg_temp.expect_failure('published integration assignment is immutable', $statement$
+  UPDATE "agent_revision_integration_assignments" SET "allowed_tools" = ARRAY['calendar.write']
+  WHERE "agent_revision_id" = 'integration-revision' AND "integration_id" = 'integration-1'$statement$, 'AgentRevision assignments are immutable');
+
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
+VALUES ('integration-revision-2', 'integration-service', 3, 'sha256:' || repeat('c', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+UPDATE "integration_custody_references" SET "state" = 'revoked', "revoked_at" = clock_timestamp() WHERE "id" = 'custody-1';
+SELECT pg_temp.expect_failure('revoked custody reference cannot be assigned', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision-2', 'integration-1', 'silo-integrations', 'custody-1', ARRAY['calendar.read'])$statement$, 'ready unexpired');
+
+INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "state", "expires_at")
+VALUES ('expired-custody', 'integration-1', 'silo-integrations', 'obot:opaque:expired', 'expired', clock_timestamp() - interval '1 hour');
+SELECT pg_temp.expect_failure('expired custody reference cannot be assigned', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision-2', 'integration-1', 'silo-integrations', 'expired-custody', ARRAY['calendar.read'])$statement$, 'ready unexpired');
+SELECT pg_temp.expect_failure('custody reference cannot be refilled', $statement$
+  UPDATE "integration_custody_references" SET "obot_custody_reference" = 'replacement'
+  WHERE "id" = 'custody-1'$statement$, 'custody identity is immutable');
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name IN ('integrations', 'integration_custody_references', 'agent_revision_integration_assignments')
+      AND column_name ~ '(secret|token|password|credential|oauth)'
+  ) THEN
+    RAISE EXCEPTION 'integration authority must not persist raw-secret columns';
+  END IF;
+END;
+$$;
+
+ROLLBACK;

--- a/libs/backend/server/integrations/main/tsconfig.json
+++ b/libs/backend/server/integrations/main/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/backend/server/integrations/main/vitest.config.ts
+++ b/libs/backend/server/integrations/main/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../vitest.cache.js";
+
+/** Vitest configuration for integration authority tests. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../tsconfig.vitest.json"] })] });

--- a/libs/models/agents/main/src/agent-revision.types.ts
+++ b/libs/models/agents/main/src/agent-revision.types.ts
@@ -12,12 +12,14 @@ export interface SkillRevisionReference
 	readonly revisionId: string;
 }
 
-/** Immutable reference to an MCP server assignment. */
-export interface McpAssignmentReference
+/** Immutable reference to an integration assignment. */
+export interface IntegrationAssignmentReference
 {
-	/** Stable MCP server identifier. */
-	readonly serverId: string;
-	/** Explicit tool names exposed from the server. */
+	/** Stable silo-scoped integration identifier. */
+	readonly integrationId: string;
+	/** Immutable opaque Obot custody reference selected for the revision. */
+	readonly custodyReferenceId: string;
+	/** Explicit tool identifiers exposed from the integration. */
 	readonly allowedTools: readonly string[];
 }
 
@@ -53,8 +55,8 @@ export interface AgentRevision
 	readonly modelPolicyId: string;
 	/** Immutable skill revisions available to the runtime. */
 	readonly skills: readonly SkillRevisionReference[];
-	/** Immutable MCP server and tool assignments available to the runtime. */
-	readonly mcpAssignments: readonly McpAssignmentReference[];
+	/** Immutable integration and tool assignments available to the runtime. */
+	readonly integrationAssignments: readonly IntegrationAssignmentReference[];
 	/** Resource ceilings applied to each run. */
 	readonly budget: AgentBudget;
 	/** Identifier of the user who authored the revision. */

--- a/libs/models/agents/main/src/index.ts
+++ b/libs/models/agents/main/src/index.ts
@@ -1,4 +1,4 @@
-export type { AgentBudget, AgentRevision, AgentRevisionState, McpAssignmentReference, SkillRevisionReference } from "./agent-revision.types.js";
+export type { AgentBudget, AgentRevision, AgentRevisionState, IntegrationAssignmentReference, SkillRevisionReference } from "./agent-revision.types.js";
 export type { AgentRun, AgentRunLineage, AgentRunState, AgentRunTerminalReason, AgentRunTrigger } from "./agent-run.types.js";
 export type { AgentOwner, AgentOwnerScope, AgentService, AgentServiceKind, AgentServiceState } from "./agent-service.types.js";
 export type { AgentRevisionId, AgentRunId, AgentServiceId, MessageId, PersonaProfileId, PersonaRevisionId, SiloId, ThreadId, UserId } from "./identifiers.types.js";

--- a/scripts/integration-authority-negative-tests.sh
+++ b/scripts/integration-authority-negative-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+# Resolve the repository root so this guard remains correct from its Nx package cwd.
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_root"
+
+if grep -R -n -E 'McpAssignmentReference|mcpAssignments|mcpServerId|agent_revision_mcp_assignments' \
+  apps/opencrane/prisma/schema/agent-services.prisma \
+  libs/models/agents/main/src \
+  libs/backend/server/agent-services/main/src; then
+  echo "target AgentRevision integration authority still contains MCP-assignment residue" >&2
+  exit 1
+fi
+
+if grep -R -n -E '@opencrane/backend/server/mcp|McpServer|OpenClaw|StaticFallback|credentialRef|oauth' \
+  libs/backend/server/integrations/main/src; then
+  echo "integration authority must not depend on legacy MCP, OpenClaw, or credential material" >&2
+  exit 1
+fi
+
+echo "Integration authority negative tests passed."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,9 @@
       "@opencrane/backend/server/identity": [
         "./libs/backend/server/identity/main/src/index.ts"
       ],
+      "@opencrane/backend/server/integrations": [
+        "./libs/backend/server/integrations/main/src/index.ts"
+      ],
       "@opencrane/backend/server/metrics": [
         "./libs/backend/server/metrics/main/src/index.ts"
       ],


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — the integrations ledger.** The authoritative record of which external integrations (tools and services) exist in a silo and who may use them — consulted before anything is invoked, denying by default when there is no explicit grant.

**What it adds**
- The integration-authority data model and resolution logic
- Negative tests keeping this layer free of runtime and credential coupling

<details>
<summary>Technical details (original description)</summary>

## Summary

- replace the target AgentRevision MCP-assignment contract with silo-scoped integration assignments
- add an integration authority schema and one clean migration with draft-only immutable assignments, same-silo enforcement, tool allow-list validation, and opaque Obot custody-reference lifecycle
- add a credential-free integration resolution adapter and targeted residue guard
- retain legacy MCP catalogue, UI, OpenClaw runtime, and Obot deployment until their actual target replacements exist

## Validation

- Prisma generate and validate
- integration and agent-service lint + Vitest
- integration negative-residue guard, repository boundary lint, phase-A/phase-B guards, shell syntax, diff/style checks
- SQL authority suite is registered and reaches its documented prerequisite; it cannot run on this workstation because no `psql` client or `POSTGRES_TEST_CONTAINER` is available

## Review

- independent architecture gate: PASS
- independent code review: PASS after fixing NULL tool validation, authority-owned time, and the SQL fixture
- local Claude Code review was attempted, but this machine still reports `Not logged in`; no repository content was transmitted

</details>
