### PR TITLE
🔒️ Fail-closed Obot custody foundation

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,6 +108,7 @@ export default [
             { sourceTag: "scope:grants", onlyDependOnLibsWithTags: ["scope:auth", "scope:grants", "scope:retrieval", "scope:shared"] },
             { sourceTag: "scope:groups", onlyDependOnLibsWithTags: ["scope:groups", "scope:shared"] },
             { sourceTag: "scope:http", onlyDependOnLibsWithTags: ["scope:http", "scope:shared"] },
+            { sourceTag: "scope:integrations", onlyDependOnLibsWithTags: ["scope:integrations", "scope:obot-custody", "scope:shared"] },
             { sourceTag: "scope:k8s-api", onlyDependOnLibsWithTags: ["scope:k8s-api", "scope:shared"] },
             {
               sourceTag: "scope:identity",
@@ -124,6 +125,7 @@ export default [
             { sourceTag: "scope:metrics", onlyDependOnLibsWithTags: ["scope:awareness", "scope:metrics", "scope:projection", "scope:shared"] },
             { sourceTag: "scope:membership", onlyDependOnLibsWithTags: ["scope:audit", "scope:authorization", "scope:membership", "scope:shared"] },
             { sourceTag: "scope:memory", onlyDependOnLibsWithTags: ["scope:artifacts", "scope:memory", "scope:shared"] },
+            { sourceTag: "scope:obot-custody", onlyDependOnLibsWithTags: ["scope:obot-custody", "scope:shared"] },
             { sourceTag: "scope:model-routing", onlyDependOnLibsWithTags: ["scope:auth", "scope:cluster-tenants", "scope:model-routing", "scope:shared"] },
             { sourceTag: "scope:policies", onlyDependOnLibsWithTags: ["scope:grants", "scope:k8s-api", "scope:policies", "scope:projection", "scope:shared"] },
             { sourceTag: "scope:personas", onlyDependOnLibsWithTags: ["scope:personas", "scope:shared"] },

--- a/libs/backend/server/integrations/main/src/index.ts
+++ b/libs/backend/server/integrations/main/src/index.ts
@@ -1,5 +1,5 @@
 export { __SystemIntegrationAuthorityClock, PrismaIntegrationAuthorityRepository } from "./prisma-integration-authority.js";
 export { __ProvisionIntegrationCustody } from "./integration-custody-provisioning.js";
 export { PrismaIntegrationCustodyRepository } from "./prisma-integration-custody-repository.js";
-export type { IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
+export type { IntegrationCustodyLogger, IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
 export type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult, ResolvedIntegrationAssignment } from "./integration-resolution.types.js";

--- a/libs/backend/server/integrations/main/src/index.ts
+++ b/libs/backend/server/integrations/main/src/index.ts
@@ -1,2 +1,5 @@
 export { __SystemIntegrationAuthorityClock, PrismaIntegrationAuthorityRepository } from "./prisma-integration-authority.js";
+export { __ProvisionIntegrationCustody } from "./integration-custody-provisioning.js";
+export { PrismaIntegrationCustodyRepository } from "./prisma-integration-custody-repository.js";
+export type { IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
 export type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult, ResolvedIntegrationAssignment } from "./integration-resolution.types.js";

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
@@ -13,6 +13,12 @@ describe("integration custody provisioning", function _suite()
 		expect(JSON.stringify(log.warn.mock.calls)).not.toContain("write-only");
 	});
 
+	it("keeps a remote failure closed when diagnostic logging itself fails", async function _throwingLogger()
+	{
+		const log = { warn: vi.fn().mockImplementation(function _throw() { throw new Error("logger unavailable"); }), error: vi.fn() };
+		await expect(__ProvisionIntegrationCustody({ provision: vi.fn().mockRejectedValue(new Error("timeout")), revoke: vi.fn() }, { persistReady: vi.fn() }, log, _Command())).resolves.toEqual({ outcome: "unavailable", reason: "remote_unavailable" });
+	});
+
 	it("revokes remote custody when persistence fails", async function _compensation()
 	{
 		const revoke = vi.fn().mockResolvedValue(undefined);

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
@@ -6,22 +6,51 @@ describe("integration custody provisioning", function _suite()
 {
 	it("fails closed when Obot is unavailable", async function _remoteUnavailable()
 	{
-		const result = await __ProvisionIntegrationCustody({ provision: vi.fn().mockRejectedValue(new Error("timeout")), revoke: vi.fn() }, { persistReady: vi.fn() }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] });
+		const log = _CreateLog();
+		const result = await __ProvisionIntegrationCustody({ provision: vi.fn().mockRejectedValue(new Error("Bearer write-only")), revoke: vi.fn() }, { persistReady: vi.fn() }, log, _Command());
 		expect(result).toEqual({ outcome: "unavailable", reason: "remote_unavailable" });
+		expect(log.warn).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Obot custody provisioning failed");
+		expect(JSON.stringify(log.warn.mock.calls)).not.toContain("write-only");
 	});
 
 	it("revokes remote custody when persistence fails", async function _compensation()
 	{
 		const revoke = vi.fn().mockResolvedValue(undefined);
 		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke };
-		const result = await __ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] });
+		const log = _CreateLog();
+		const result = await __ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, log, _Command());
 		expect(result).toEqual({ outcome: "unavailable", reason: "persistence_failed" });
 		expect(revoke).toHaveBeenCalledWith("obot:issued:one");
+		expect(log.warn).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Integration custody persistence failed; starting compensation");
+	});
+
+	it("logs an invalid remote response compensation failure without the custody reference", async function _invalidResponseCompensationFailure()
+	{
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "different-catalog", obotCustodyReference: "obot:issued:invalid", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
+		const log = _CreateLog();
+		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn() }, log, _Command())).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
+		expect(log.error).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Obot custody compensation failed after an invalid response");
+		expect(JSON.stringify(log.error.mock.calls)).not.toContain("obot:issued:invalid");
 	});
 
 	it("reports compensation failure without exposing remote custody", async function _compensationFailure()
 	{
 		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
-		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] })).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
+		const log = _CreateLog();
+		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, log, _Command())).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
+		expect(log.error).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Obot custody compensation failed after a persistence failure");
+		expect(JSON.stringify(log.error.mock.calls)).not.toContain("obot:issued:one");
 	});
+
+	/** Create a focused capture logger for custody failure assertions. */
+	function _CreateLog()
+	{
+		return { warn: vi.fn(), error: vi.fn() };
+	}
+
+	/** Create a write-only custody command with deterministic non-secret identifiers. */
+	function _Command()
+	{
+		return { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] };
+	}
 });

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __ProvisionIntegrationCustody } from "./integration-custody-provisioning.js";
+
+describe("integration custody provisioning", function _suite()
+{
+	it("fails closed when Obot is unavailable", async function _remoteUnavailable()
+	{
+		const result = await __ProvisionIntegrationCustody({ provision: vi.fn().mockRejectedValue(new Error("timeout")), revoke: vi.fn() }, { persistReady: vi.fn() }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] });
+		expect(result).toEqual({ outcome: "unavailable", reason: "remote_unavailable" });
+	});
+
+	it("revokes remote custody when persistence fails", async function _compensation()
+	{
+		const revoke = vi.fn().mockResolvedValue(undefined);
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke };
+		const result = await __ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] });
+		expect(result).toEqual({ outcome: "unavailable", reason: "persistence_failed" });
+		expect(revoke).toHaveBeenCalledWith("obot:issued:one");
+	});
+
+	it("reports compensation failure without exposing remote custody", async function _compensationFailure()
+	{
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
+		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] })).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
+	});
+});

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
@@ -13,7 +13,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 	}
 	catch (err)
 	{
-		log.warn(_FailureLogFields(command, err), "Obot custody provisioning failed");
+		_Warn(log, command, err, "Obot custody provisioning failed");
 		return { outcome: "unavailable", reason: "remote_unavailable" };
 	}
 	if (provisioned.obotCatalogEntryId !== command.obotCatalogEntryId || !provisioned.obotCustodyReference.trim() || provisioned.expiresAt <= new Date())
@@ -24,7 +24,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 		}
 		catch (err)
 		{
-			log.error(_FailureLogFields(command, err), "Obot custody compensation failed after an invalid response");
+			_Error(log, command, err, "Obot custody compensation failed after an invalid response");
 			return { outcome: "unavailable", reason: "compensation_failed" };
 		}
 		return { outcome: "unavailable", reason: "remote_unavailable" };
@@ -39,7 +39,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 	catch (err)
 	{
 		// 3. Revoke the remote result so a persistence failure never leaves usable untracked custody.
-		log.warn(_FailureLogFields(command, err), "Integration custody persistence failed; starting compensation");
+		_Warn(log, command, err, "Integration custody persistence failed; starting compensation");
 		try
 		{
 			await custody.revoke(provisioned.obotCustodyReference);
@@ -47,7 +47,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 		}
 		catch (compensationError)
 		{
-			log.error(_FailureLogFields(command, compensationError), "Obot custody compensation failed after a persistence failure");
+			_Error(log, command, compensationError, "Obot custody compensation failed after a persistence failure");
 			return { outcome: "unavailable", reason: "compensation_failed" };
 		}
 	}
@@ -67,4 +67,24 @@ function _FailureLogFields(command: ProvisionIntegrationCustodyCommand, err: unk
 		obotCatalogEntryId: command.obotCatalogEntryId,
 		errorType: err instanceof Error ? err.constructor.name : typeof err,
 	};
+}
+
+/** Emits a warning without allowing observability failures to change the fail-closed custody result. */
+function _Warn(log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand, err: unknown, message: string): void
+{
+	try
+	{
+		log.warn(_FailureLogFields(command, err), message);
+	}
+	catch { /* Logging is diagnostic only; custody failure handling must remain fail closed. */ }
+}
+
+/** Emits an error without allowing observability failures to change the fail-closed custody result. */
+function _Error(log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand, err: unknown, message: string): void
+{
+	try
+	{
+		log.error(_FailureLogFields(command, err), message);
+	}
+	catch { /* Logging is diagnostic only; custody failure handling must remain fail closed. */ }
 }

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
@@ -1,0 +1,31 @@
+import type { ObotCustodyPort } from "@opencrane/server/_infra/obot-custody";
+
+import type { IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
+
+/** Provisions remote Obot custody and compensates if its product projection cannot persist. */
+export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, repository: IntegrationCustodyRepository, command: ProvisionIntegrationCustodyCommand): Promise<ProvisionIntegrationCustodyResult>
+{
+	// 1. Obtain the opaque custody reference from Obot; this process never invents one.
+	let provisioned;
+	try { provisioned = await custody.provision(command); }
+	catch { return { outcome: "unavailable", reason: "remote_unavailable" }; }
+	if (provisioned.obotCatalogEntryId !== command.obotCatalogEntryId || !provisioned.obotCustodyReference.trim() || provisioned.expiresAt <= new Date())
+	{
+		try { await custody.revoke(provisioned.obotCustodyReference); }
+		catch { return { outcome: "unavailable", reason: "compensation_failed" }; }
+		return { outcome: "unavailable", reason: "remote_unavailable" };
+	}
+
+	// 2. Persist only Obot-confirmed coordinates, preserving Postgres as a lifecycle projection.
+	try
+	{
+		const persisted = await repository.persistReady({ siloId: command.siloId, integrationId: command.integrationId, obotCatalogEntryId: provisioned.obotCatalogEntryId, obotCustodyReference: provisioned.obotCustodyReference, expiresAt: provisioned.expiresAt });
+		return { outcome: "provisioned", custodyReferenceId: persisted.custodyReferenceId };
+	}
+	catch
+	{
+		// 3. Revoke the remote result so a persistence failure never leaves usable untracked custody.
+		try { await custody.revoke(provisioned.obotCustodyReference); return { outcome: "unavailable", reason: "persistence_failed" }; }
+		catch { return { outcome: "unavailable", reason: "compensation_failed" }; }
+	}
+}

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
@@ -1,18 +1,32 @@
 import type { ObotCustodyPort } from "@opencrane/server/_infra/obot-custody";
 
-import type { IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
+import type { IntegrationCustodyLogger, IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
 
 /** Provisions remote Obot custody and compensates if its product projection cannot persist. */
-export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, repository: IntegrationCustodyRepository, command: ProvisionIntegrationCustodyCommand): Promise<ProvisionIntegrationCustodyResult>
+export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, repository: IntegrationCustodyRepository, log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand): Promise<ProvisionIntegrationCustodyResult>
 {
 	// 1. Obtain the opaque custody reference from Obot; this process never invents one.
 	let provisioned;
-	try { provisioned = await custody.provision(command); }
-	catch { return { outcome: "unavailable", reason: "remote_unavailable" }; }
+	try
+	{
+		provisioned = await custody.provision(command);
+	}
+	catch (err)
+	{
+		log.warn(_FailureLogFields(command, err), "Obot custody provisioning failed");
+		return { outcome: "unavailable", reason: "remote_unavailable" };
+	}
 	if (provisioned.obotCatalogEntryId !== command.obotCatalogEntryId || !provisioned.obotCustodyReference.trim() || provisioned.expiresAt <= new Date())
 	{
-		try { await custody.revoke(provisioned.obotCustodyReference); }
-		catch { return { outcome: "unavailable", reason: "compensation_failed" }; }
+		try
+		{
+			await custody.revoke(provisioned.obotCustodyReference);
+		}
+		catch (err)
+		{
+			log.error(_FailureLogFields(command, err), "Obot custody compensation failed after an invalid response");
+			return { outcome: "unavailable", reason: "compensation_failed" };
+		}
 		return { outcome: "unavailable", reason: "remote_unavailable" };
 	}
 
@@ -22,10 +36,35 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 		const persisted = await repository.persistReady({ siloId: command.siloId, integrationId: command.integrationId, obotCatalogEntryId: provisioned.obotCatalogEntryId, obotCustodyReference: provisioned.obotCustodyReference, expiresAt: provisioned.expiresAt });
 		return { outcome: "provisioned", custodyReferenceId: persisted.custodyReferenceId };
 	}
-	catch
+	catch (err)
 	{
 		// 3. Revoke the remote result so a persistence failure never leaves usable untracked custody.
-		try { await custody.revoke(provisioned.obotCustodyReference); return { outcome: "unavailable", reason: "persistence_failed" }; }
-		catch { return { outcome: "unavailable", reason: "compensation_failed" }; }
+		log.warn(_FailureLogFields(command, err), "Integration custody persistence failed; starting compensation");
+		try
+		{
+			await custody.revoke(provisioned.obotCustodyReference);
+			return { outcome: "unavailable", reason: "persistence_failed" };
+		}
+		catch (compensationError)
+		{
+			log.error(_FailureLogFields(command, compensationError), "Obot custody compensation failed after a persistence failure");
+			return { outcome: "unavailable", reason: "compensation_failed" };
+		}
 	}
+}
+
+/**
+ * Build a secret-safe failure record for custody operations.
+ * @param command - Non-secret identifiers for the failed operation.
+ * @param err - Original error, classified without serialising its untrusted message or payload.
+ * @returns Stable fields safe for structured logs.
+ */
+function _FailureLogFields(command: ProvisionIntegrationCustodyCommand, err: unknown): Record<string, string>
+{
+	return {
+		siloId: command.siloId,
+		integrationId: command.integrationId,
+		obotCatalogEntryId: command.obotCatalogEntryId,
+		errorType: err instanceof Error ? err.constructor.name : typeof err,
+	};
 }

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.types.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.types.ts
@@ -1,0 +1,24 @@
+import type { ObotCustodyCredential } from "@opencrane/server/_infra/obot-custody";
+
+/** Request to provision remote custody for an integration. */
+export interface ProvisionIntegrationCustodyCommand
+{
+	/** Silo owning the integration. */
+	readonly siloId: string;
+	/** Integration receiving custody. */
+	readonly integrationId: string;
+	/** Obot catalogue entry. */
+	readonly obotCatalogEntryId: string;
+	/** Write-only credential material. */
+	readonly credential: readonly ObotCustodyCredential[];
+}
+
+/** Product persistence boundary for remote custody confirmation. */
+export interface IntegrationCustodyRepository
+{
+	/** Stores an Obot-issued reference after remote provisioning succeeds. */
+	persistReady(command: { readonly siloId: string; readonly integrationId: string; readonly obotCatalogEntryId: string; readonly obotCustodyReference: string; readonly expiresAt: Date }): Promise<{ readonly custodyReferenceId: string }>;
+}
+
+/** Fail-closed custody provisioning outcome. */
+export type ProvisionIntegrationCustodyResult = { readonly outcome: "provisioned"; readonly custodyReferenceId: string } | { readonly outcome: "unavailable"; readonly reason: "remote_unavailable" | "persistence_failed" | "compensation_failed" };

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.types.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.types.ts
@@ -1,4 +1,8 @@
 import type { ObotCustodyCredential } from "@opencrane/server/_infra/obot-custody";
+import type { Logger } from "@opencrane/observability";
+
+/** Structured logger methods used by the custody provisioning operation. */
+export type IntegrationCustodyLogger = Pick<Logger, "warn" | "error">;
 
 /** Request to provision remote custody for an integration. */
 export interface ProvisionIntegrationCustodyCommand

--- a/libs/backend/server/integrations/main/src/prisma-integration-custody-repository.test.ts
+++ b/libs/backend/server/integrations/main/src/prisma-integration-custody-repository.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaIntegrationCustodyRepository } from "./prisma-integration-custody-repository.js";
+
+describe("Prisma integration custody repository", function _suite()
+{
+	it("rejects a foreign-silo integration before writing a ready custody reference", async function _foreignSilo()
+	{
+		const transaction = { $queryRaw: vi.fn(), integration: { findUnique: vi.fn().mockResolvedValue({ siloId: "other-silo", state: "Active", obotCatalogEntryId: "catalog-1" }) }, integrationCustodyReference: { create: vi.fn() } };
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as never;
+		await expect(new PrismaIntegrationCustodyRepository(prisma).persistReady({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") })).rejects.toThrow("integration authority changed");
+		expect(transaction.integrationCustodyReference.create).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/integrations/main/src/prisma-integration-custody-repository.ts
+++ b/libs/backend/server/integrations/main/src/prisma-integration-custody-repository.ts
@@ -1,0 +1,29 @@
+import { IntegrationCustodyState, IntegrationState, Prisma, type PrismaClient } from "@prisma/client";
+
+import type { IntegrationCustodyRepository } from "./integration-custody-provisioning.types.js";
+
+/** Prisma persistence adapter that accepts custody only for an active exact-silo Integration. */
+export class PrismaIntegrationCustodyRepository implements IntegrationCustodyRepository
+{
+	/** Canonical product database authority. */
+	private readonly prisma: PrismaClient;
+
+	/** Creates the custody projection adapter. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Rechecks active same-silo integration authority before recording a remotely issued reference. */
+	async persistReady(command: Parameters<IntegrationCustodyRepository["persistReady"]>[0]): Promise<{ readonly custodyReferenceId: string }>
+	{
+		return this.prisma.$transaction(async function _persist(transaction: Prisma.TransactionClient)
+		{
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "integrations" WHERE "id" = ${command.integrationId} FOR UPDATE`);
+			const integration = await transaction.integration.findUnique({ where: { id: command.integrationId } });
+			if (integration === null || integration.siloId !== command.siloId || integration.state !== IntegrationState.Active || integration.obotCatalogEntryId !== command.obotCatalogEntryId) throw new Error("integration authority changed");
+			const reference = await transaction.integrationCustodyReference.create({ data: { integrationId: command.integrationId, siloId: command.siloId, obotCustodyReference: command.obotCustodyReference, state: IntegrationCustodyState.Ready, expiresAt: command.expiresAt } });
+			return { custodyReferenceId: reference.id };
+		});
+	}
+}

--- a/libs/server/_infra/obot-custody/project.json
+++ b/libs/server/_infra/obot-custody/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "server-infra-obot-custody",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/server/_infra/obot-custody/src",
+  "tags": ["type:lib", "layer:infra", "scope:obot-custody"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/server/_infra/obot-custody" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/server/_infra/obot-custody" } }
+  }
+}

--- a/libs/server/_infra/obot-custody/src/index.ts
+++ b/libs/server/_infra/obot-custody/src/index.ts
@@ -1,0 +1,2 @@
+export { __UnavailableObotCustodyAdapter, ObotCustodyUnavailableError } from "./unavailable-obot-custody.js";
+export type { ObotCustodyCredential, ObotCustodyPort, ProvisionObotCustodyCommand, ProvisionedObotCustody } from "./obot-custody.types.js";

--- a/libs/server/_infra/obot-custody/src/obot-custody.types.ts
+++ b/libs/server/_infra/obot-custody/src/obot-custody.types.ts
@@ -1,0 +1,41 @@
+/** Write-only credential material accepted only for the duration of a custody request. */
+export interface ObotCustodyCredential
+{
+	/** Header name or provider-specific credential field. */
+	readonly name: string;
+	/** Secret value that must never be persisted, logged, or returned. */
+	readonly value: string;
+}
+
+/** Request to provision one remote Obot custody reference. */
+export interface ProvisionObotCustodyCommand
+{
+	/** Silo that owns the integration. */
+	readonly siloId: string;
+	/** Product integration identity used as remote correlation context. */
+	readonly integrationId: string;
+	/** Obot catalogue entry to configure. */
+	readonly obotCatalogEntryId: string;
+	/** Write-only credential material passed directly to Obot. */
+	readonly credential: readonly ObotCustodyCredential[];
+}
+
+/** Remote-only custody result issued by Obot after successful configuration. */
+export interface ProvisionedObotCustody
+{
+	/** Obot catalogue entry confirmed by the remote authority. */
+	readonly obotCatalogEntryId: string;
+	/** Opaque reference minted by Obot; never locally synthesized. */
+	readonly obotCustodyReference: string;
+	/** Remote expiry governing later redemption. */
+	readonly expiresAt: Date;
+}
+
+/** Runtime-neutral boundary for the Obot credential custody authority. */
+export interface ObotCustodyPort
+{
+	/** Provisions custody remotely and returns only Obot-originated opaque coordinates. */
+	provision(command: ProvisionObotCustodyCommand): Promise<ProvisionedObotCustody>;
+	/** Revokes one remotely issued custody reference. */
+	revoke(obotCustodyReference: string): Promise<void>;
+}

--- a/libs/server/_infra/obot-custody/src/unavailable-obot-custody.test.ts
+++ b/libs/server/_infra/obot-custody/src/unavailable-obot-custody.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { __UnavailableObotCustodyAdapter, ObotCustodyUnavailableError } from "./unavailable-obot-custody.js";
+
+describe("unavailable Obot custody adapter", function _suite()
+{
+	it("fails closed without inventing a custody reference", async function _provision()
+	{
+		const adapter = new __UnavailableObotCustodyAdapter();
+		await expect(adapter.provision({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalogue-1", credential: [{ name: "Authorization", value: "never-persisted" }] })).rejects.toBeInstanceOf(ObotCustodyUnavailableError);
+	});
+});

--- a/libs/server/_infra/obot-custody/src/unavailable-obot-custody.ts
+++ b/libs/server/_infra/obot-custody/src/unavailable-obot-custody.ts
@@ -1,0 +1,28 @@
+import type { ObotCustodyPort, ProvisionObotCustodyCommand, ProvisionedObotCustody } from "./obot-custody.types.js";
+
+/** Typed failure emitted when no authenticated Obot management transport is configured. */
+export class ObotCustodyUnavailableError extends Error
+{
+	/** Creates a failure that cannot be mistaken for successful custody provisioning. */
+	constructor()
+	{
+		super("Obot custody authority is unavailable");
+		this.name = "ObotCustodyUnavailableError";
+	}
+}
+
+/** Fail-closed adapter used until an authenticated Obot API contract is verified. */
+export class __UnavailableObotCustodyAdapter implements ObotCustodyPort
+{
+	/** Rejects provisioning rather than minting a local custody handle. */
+	async provision(_command: ProvisionObotCustodyCommand): Promise<ProvisionedObotCustody>
+	{
+		throw new ObotCustodyUnavailableError();
+	}
+
+	/** Rejects revocation because no remote authority can be contacted. */
+	async revoke(_obotCustodyReference: string): Promise<void>
+	{
+		throw new ObotCustodyUnavailableError();
+	}
+}

--- a/libs/server/_infra/obot-custody/tsconfig.json
+++ b/libs/server/_infra/obot-custody/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/server/_infra/obot-custody/vitest.config.ts
+++ b/libs/server/_infra/obot-custody/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../vitest.cache.js";
+
+/** Vitest configuration for the Obot custody boundary. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../tsconfig.vitest.json"] })] });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -157,6 +157,9 @@
       "@opencrane/server/_infra/http": [
         "./libs/server/_infra/http/src/index.ts"
       ],
+      "@opencrane/server/_infra/obot-custody": [
+        "./libs/server/_infra/obot-custody/src/index.ts"
+      ],
       "@opencrane/server/_infra/tenant-hosting": [
         "./libs/server/_infra/tenant-hosting/src/index.ts"
       ],


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — credential custody, honestly.** The foundation for handing credential custody to Obot (the MCP gateway): the platform itself never holds raw secrets, and when custody cannot be confirmed the answer is "unavailable" — never a faked success. This replaces the old fake-success paths the roadmap explicitly deletes.

**What it adds**
- A fail-closed custody provisioning flow, with automatic compensation when a step fails partway

<details>
<summary>Technical details (original description)</summary>

## Summary

- add a runtime-neutral, fail-closed Obot custody boundary under server infrastructure
- persist only Obot-originated opaque references after an active same-silo catalogue recheck
- compensate remote provisioning when persistence or remote-response validation fails
- enforce the new integration and Obot-custody dependency scopes

## Validation

- integration and Obot custody TypeScript lint + Vitest
- boundary lint, style check, diff check

## Review

- architecture gate: PASS after dependency-scope enforcement and row-lock fixes
- independent review: PASS for intentionally unpublished, fail-closed foundation
- no public route or live Obot transport is claimed by this PR

</details>
