### PR TITLE
🔧 Right-size target dev plane reservations

### DIFF
--- a/apps/_infra/deploy-k8s/platform/values/opencrane-dev.yaml
+++ b/apps/_infra/deploy-k8s/platform/values/opencrane-dev.yaml
@@ -38,6 +38,34 @@ ingress:
 gatewayProxy:
   enabled: true
 
+# Dev-plane reservations measured against gke_weownai-proto_europe-west1-b_opencrane-dev
+# on 2026-07-19. CPU requests keep six near-idle silo planes schedulable; memory requests
+# reserve observed steady-state use plus headroom so the stateful planes are not evicted first.
+# These target-plane values deliberately exclude the retired OpenClaw and skill-registry paths.
+clustertenantManager:
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+
+  cognee:
+    resources:
+      requests:
+        cpu: 25m
+        memory: 768Mi
+
+litellm:
+  resources:
+    requests:
+      cpu: 25m
+      memory: 768Mi
+
+mcpGateway:
+  resources:
+    requests:
+      cpu: 75m
+      memory: 256Mi
+
 tenant:
   gateway:
     # -- OC-2 / CONN.4 trusted-proxy allowlist for the opencrane-dev cluster.

--- a/apps/_infra/deploy-k8s/values.yaml
+++ b/apps/_infra/deploy-k8s/values.yaml
@@ -426,7 +426,7 @@ clustertenantManager:
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
     limits:
       cpu: 500m
       memory: 512Mi
@@ -494,7 +494,7 @@ clustertenantManager:
     resources:
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 768Mi
       limits:
         cpu: "1"
         memory: 1Gi
@@ -683,7 +683,7 @@ litellm:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 768Mi
     limits:
       cpu: "1"
       memory: 1Gi


### PR DESCRIPTION
<!-- roadmap-context -->
## Where this fits

**Phase D — a dev cluster that fits.** Adjusts CPU and memory reservations for the dev environment based on live measurements, so the new Phase D services schedule reliably without over-reserving capacity.

**What it adds**
- Right-sized resource requests for the dev plane (limits unchanged)

<details>
<summary>Technical details (original description)</summary>

## Summary

- reserve safe observed memory for the target OpenCrane server, Cognee, and LiteLLM defaults
- add the measured opencrane-dev profile for the target server, Cognee, LiteLLM, and Obot planes
- leave retired OpenClaw and skill-registry workloads out of the new profile

## Live evidence

Read-only measurements on Terra dev (`gke_weownai-proto_europe-west1-b_opencrane-dev`, 2026-07-19):

- four of six nodes were at 90–107% memory while CPU remained 14–67%
- Cognee used 299–619Mi and LiteLLM 600–701Mi despite both old 256Mi requests
- Obot used about 103–115Mi and 26–32m CPU; its dev request is now 256Mi / 75m

## Validation

- `helm lint apps/_infra/deploy-k8s -f apps/_infra/deploy-k8s/platform/values/opencrane-dev.yaml`
- `helm template` with base plus dev overlay
- `git diff --check`
- independent review: PASS; no critical/high issue

A scripted dev deploy and suspend/resume reschedule proof remains the follow-up; this PR does not mutate the live cluster.

Stacked on `feat/agent-platform-v2-phase-d-persona-approval-persistence`.

</details>
