### PR TITLE
🧪 Phase D D4: enforce test directory layout

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,33 @@ import nx from "@nx/eslint-plugin";
 import tsEslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
 
+/** Enforces the package test-layout convention independently of Vitest discovery. */
+const testLayout = {
+  rules: {
+    "require-tests-directory": {
+      meta: {
+        type: "problem",
+        docs: { description: "require TypeScript tests to live below __tests__" },
+        schema: [],
+        messages: { misplacedTest: "Move this test below a __tests__ directory." },
+      },
+      create(context) {
+        const filename = context.filename.replaceAll("\\", "/");
+
+        if (filename.includes("/__tests__/")) {
+          return {};
+        }
+
+        return {
+          Program(node) {
+            context.report({ node, messageId: "misplacedTest" });
+          },
+        };
+      },
+    },
+  },
+};
+
 export default [
   {
     ignores: [
@@ -198,6 +225,11 @@ export default [
         },
       ],
     },
+  },
+  {
+    files: ["**/*.test.ts"],
+    plugins: { "test-layout": testLayout },
+    rules: { "test-layout/require-tests-directory": "error" },
   },
   {
     // Vitest configs are build tooling, not product modules: every one imports the

--- a/libs/backend/agents/personal/conversations/main/src/__tests__/conversation-authority.test.ts
+++ b/libs/backend/agents/personal/conversations/main/src/__tests__/conversation-authority.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __AppendRunEvent } from "./conversation-authority.js";
-import type { ConversationAuthorityRepository } from "./conversation-authority.types.js";
+import { __AppendRunEvent } from "../conversation-authority.js";
+import type { ConversationAuthorityRepository } from "../conversation-authority.types.js";
 
 describe("conversation authority", function ()
 {

--- a/libs/backend/agents/personal/memory/main/src/__tests__/memory-catalog.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/__tests__/memory-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __RecordMemoryFact } from "./memory-catalog.js";
+import { __RecordMemoryFact } from "../memory-catalog.js";
 
 describe("memory catalog", function ()
 {

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-authority.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-authority.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __ApprovePersona } from "./persona-authority.js";
+import { __ApprovePersona } from "../persona-authority.js";
 
 describe("persona authority", function ()
 {

--- a/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-authority.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-authority.test.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
+import { PrismaAgentRunAuthorityRepository } from "../prisma-run-authority.js";
 
 /** Creates one retryable Prisma run row. */
 function _runRow()

--- a/libs/backend/agents/personal/runs/main/src/__tests__/run-authority.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/run-authority.test.ts
@@ -1,8 +1,8 @@
 import type { AgentRevisionId, AgentRun, AgentRunId, AgentServiceState, SiloId } from "@opencrane/models/agents";
 import { describe, expect, it } from "vitest";
 
-import { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
-import type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentExpectation } from "./run-authority.types.js";
+import { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "../run-authority.js";
+import type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentExpectation } from "../run-authority.types.js";
 
 /** Creates a failed first attempt for one logical run. */
 function _run(): AgentRun

--- a/libs/backend/channel-proxy/main/src/__tests__/channel-proxy.test.ts
+++ b/libs/backend/channel-proxy/main/src/__tests__/channel-proxy.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { AuthorizedChannelTarget, ChannelProxyDependencies, ChannelTargetResolver, SubjectRateLimiter, TargetResolutionRequest } from "./channel-proxy.types.js";
-import { __ForwardCommand, __RelayEvents } from "./forwarding.js";
-import { __HasForgedIdentityHeaders, __ValidateOrigin } from "./origin-policy.js";
-import { __FixedWindowRateLimiter } from "./rate-limiter.js";
+import type { AuthorizedChannelTarget, ChannelProxyDependencies, ChannelTargetResolver, SubjectRateLimiter, TargetResolutionRequest } from "../channel-proxy.types.js";
+import { __ForwardCommand, __RelayEvents } from "../forwarding.js";
+import { __HasForgedIdentityHeaders, __ValidateOrigin } from "../origin-policy.js";
+import { __FixedWindowRateLimiter } from "../rate-limiter.js";
 
 /** Construct a live authorized target for one focused test. */
 function _Target(endpoint = "http://agent-runtime.default.svc.cluster.local:8080/v1/channel"): AuthorizedChannelTarget

--- a/libs/backend/channel-proxy/main/src/__tests__/target-resolver.test.ts
+++ b/libs/backend/channel-proxy/main/src/__tests__/target-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __OpenCraneTargetResolver } from "./target-resolver.js";
+import { __OpenCraneTargetResolver } from "../target-resolver.js";
 
 describe("OpenCrane channel target resolver", () =>
 {

--- a/libs/backend/server/agent-services/main/src/__tests__/agent-publication.test.ts
+++ b/libs/backend/server/agent-services/main/src/__tests__/agent-publication.test.ts
@@ -1,8 +1,8 @@
 import type { AgentRevision, AgentRevisionId, AgentService } from "@opencrane/models/agents";
 import { describe, expect, it } from "vitest";
 
-import { __PublishAgentRevision } from "./agent-publication.js";
-import type { AgentServicePublicationRepository, AtomicAgentRevisionPublication, AtomicAgentRevisionPublicationResult } from "./agent-publication.types.js";
+import { __PublishAgentRevision } from "../agent-publication.js";
+import type { AgentServicePublicationRepository, AtomicAgentRevisionPublication, AtomicAgentRevisionPublicationResult } from "../agent-publication.types.js";
 
 /** Creates a stable personal AgentService fixture. */
 function _service(): AgentService

--- a/libs/backend/server/agent-services/main/src/__tests__/prisma-agent-publication.test.ts
+++ b/libs/backend/server/agent-services/main/src/__tests__/prisma-agent-publication.test.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AuditDecisionRecord } from "@opencrane/backend/server/audit";
-import { PrismaAgentServicePublicationRepository } from "./prisma-agent-publication.js";
+import { PrismaAgentServicePublicationRepository } from "../prisma-agent-publication.js";
 
 /** Creates one locked Prisma service row. */
 function _serviceRow()

--- a/libs/backend/server/artifacts/main/src/__tests__/artifact-finalization.test.ts
+++ b/libs/backend/server/artifacts/main/src/__tests__/artifact-finalization.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __FinalizeArtifactRevision } from "./artifact-finalization.js";
+import { __FinalizeArtifactRevision } from "../artifact-finalization.js";
 
 describe("artifact finalization", function ()
 {

--- a/libs/backend/server/audit/main/src/__tests__/audit-decision.test.ts
+++ b/libs/backend/server/audit/main/src/__tests__/audit-decision.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __AppendAuditDecision } from "./audit-decision.js";
+import { __AppendAuditDecision } from "../audit-decision.js";
 
 describe("target audit decision append port", function _suite()
 {

--- a/libs/backend/server/authorization/main/src/__tests__/canonical-json-digest.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/canonical-json-digest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { __DigestCanonicalJson } from "./canonical-json-digest.js";
+import { __DigestCanonicalJson } from "../canonical-json-digest.js";
 
 describe("backend canonical JSON digest", function _suite()
 {

--- a/libs/backend/server/authorization/main/src/__tests__/capability-proof.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/capability-proof.test.ts
@@ -4,8 +4,8 @@ import { ___CanonicalizeJson } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 import { describe, expect, it } from "vitest";
 
-import { __ComputeEs256JwkThumbprint, __NormalizeDpopTargetUri, __VerifyCapabilityProof } from "./capability-proof.js";
-import { __DigestCanonicalJson } from "./canonical-json-digest.js";
+import { __ComputeEs256JwkThumbprint, __NormalizeDpopTargetUri, __VerifyCapabilityProof } from "../capability-proof.js";
+import { __DigestCanonicalJson } from "../canonical-json-digest.js";
 
 /** Fixed trusted clock used by proof fixtures. */
 const NOW = 1_750_000_000;

--- a/libs/backend/server/authorization/main/src/__tests__/effective-access.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/effective-access.test.ts
@@ -1,8 +1,8 @@
 import type { AuthorizationGrant, CapabilityReference } from "@opencrane/models/authorization";
 import { describe, expect, it } from "vitest";
 
-import { __ResolveEffectiveAccess } from "./effective-access.js";
-import type { AuthorizationGrantRepository, AuthorizationMembershipAuthority, AuthorizationMembershipDecision, AuthorizationMembershipRequirement, ResolveEffectiveAccessCommand } from "./effective-access.types.js";
+import { __ResolveEffectiveAccess } from "../effective-access.js";
+import type { AuthorizationGrantRepository, AuthorizationMembershipAuthority, AuthorizationMembershipDecision, AuthorizationMembershipRequirement, ResolveEffectiveAccessCommand } from "../effective-access.types.js";
 
 /** Creates one immutable capability reference. */
 function _capability(capabilityId: string): CapabilityReference

--- a/libs/backend/server/authorization/main/src/__tests__/prisma-authorization-grants.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/prisma-authorization-grants.test.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaAuthorizationGrantRepository } from "./prisma-authorization-grants.js";
+import { PrismaAuthorizationGrantRepository } from "../prisma-authorization-grants.js";
 
 describe("Prisma authorization grant reader", function _suite()
 {

--- a/libs/backend/server/authorization/main/src/__tests__/prisma-runtime-authority.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/prisma-runtime-authority.test.ts
@@ -1,8 +1,8 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaRuntimeAuthorityRepository } from "./prisma-runtime-authority.js";
-import type { CapabilityActionIntent, RuntimeBootstrapClaim } from "./runtime-proof.types.js";
+import { PrismaRuntimeAuthorityRepository } from "../prisma-runtime-authority.js";
+import type { CapabilityActionIntent, RuntimeBootstrapClaim } from "../runtime-proof.types.js";
 
 /** Creates one exact runtime bootstrap claim. */
 function _bootstrap(): RuntimeBootstrapClaim

--- a/libs/backend/server/authorization/main/src/__tests__/runtime-proof.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/runtime-proof.test.ts
@@ -4,10 +4,10 @@ import { ___CanonicalizeJson } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 import { describe, expect, it } from "vitest";
 
-import { __ComputeEs256JwkThumbprint } from "./capability-proof.js";
-import { __DigestCanonicalJson } from "./canonical-json-digest.js";
-import { __ConsumeRuntimeBootstrap, __ExecuteCapabilityAction } from "./runtime-proof.js";
-import type { CapabilityActionExecutor, CapabilityActionFailureResult, CapabilityActionIntent, CapabilityActionReceipt, CapabilityActionReceiptRepository, CapabilityActionReservationResult, CapabilityActionSuccessResult, ExecuteCapabilityActionCommand, RuntimeBootstrapClaim, RuntimeBootstrapConsumptionResult, RuntimeBootstrapExpectation, RuntimeBootstrapRepository } from "./runtime-proof.types.js";
+import { __ComputeEs256JwkThumbprint } from "../capability-proof.js";
+import { __DigestCanonicalJson } from "../canonical-json-digest.js";
+import { __ConsumeRuntimeBootstrap, __ExecuteCapabilityAction } from "../runtime-proof.js";
+import type { CapabilityActionExecutor, CapabilityActionFailureResult, CapabilityActionIntent, CapabilityActionReceipt, CapabilityActionReceiptRepository, CapabilityActionReservationResult, CapabilityActionSuccessResult, ExecuteCapabilityActionCommand, RuntimeBootstrapClaim, RuntimeBootstrapConsumptionResult, RuntimeBootstrapExpectation, RuntimeBootstrapRepository } from "../runtime-proof.types.js";
 
 /** Fixed trusted NumericDate used by action-proof fixtures. */
 const NOW = 1_750_000_000;

--- a/libs/backend/server/channel-targets/main/src/__tests__/channel-target-resolution.test.ts
+++ b/libs/backend/server/channel-targets/main/src/__tests__/channel-target-resolution.test.ts
@@ -2,8 +2,8 @@ import { createHash } from "node:crypto";
 
 import { describe, expect, it, vi } from "vitest";
 
-import type { ChannelTargetResolutionDependencies, IssueChannelInvocationContextCommand } from "./channel-target-resolution.types.js";
-import { __ResolveChannelTarget } from "./channel-target-resolution.js";
+import type { ChannelTargetResolutionDependencies, IssueChannelInvocationContextCommand } from "../channel-target-resolution.types.js";
+import { __ResolveChannelTarget } from "../channel-target-resolution.js";
 
 /** Stable test instant. */
 const _NOW = Date.parse("2026-07-18T12:00:00.000Z");

--- a/libs/backend/server/channel-targets/main/src/__tests__/prisma-channel-target-authority.test.ts
+++ b/libs/backend/server/channel-targets/main/src/__tests__/prisma-channel-target-authority.test.ts
@@ -1,7 +1,7 @@
 import { AgentRunState, AgentRunTrigger, ChannelInvocationAction } from "@prisma/client";
 import { describe, expect, it } from "vitest";
 
-import { PrismaChannelTargetAuthorityRepository } from "./prisma-channel-target-authority.js";
+import { PrismaChannelTargetAuthorityRepository } from "../prisma-channel-target-authority.js";
 
 /** Builds the minimum transaction facade needed to reject a run during issuance. */
 function _issueTransaction(trigger: AgentRunTrigger, state: AgentRunState): Record<string, unknown>

--- a/libs/backend/server/membership/main/src/__tests__/membership-authority.test.ts
+++ b/libs/backend/server/membership/main/src/__tests__/membership-authority.test.ts
@@ -1,8 +1,8 @@
 import type { FleetSignatureVerificationEvidence, SignedFleetMembershipRevision } from "@opencrane/models/authorization";
 import { describe, expect, it } from "vitest";
 
-import { __VerifyCurrentFleetMembership } from "./membership-authority.js";
-import type { FleetMembershipAcceptance, FleetMembershipAcceptanceResult, FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, VerifyFleetMembershipCommand } from "./membership-authority.types.js";
+import { __VerifyCurrentFleetMembership } from "../membership-authority.js";
+import type { FleetMembershipAcceptance, FleetMembershipAcceptanceResult, FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, VerifyFleetMembershipCommand } from "../membership-authority.types.js";
 
 /** Creates a signed fleet revision whose assertion matches the command fixture. */
 function _revision(issuedAtEpochMs = 1000, revision = 7): SignedFleetMembershipRevision

--- a/libs/backend/server/membership/main/src/__tests__/prisma-membership-authority.test.ts
+++ b/libs/backend/server/membership/main/src/__tests__/prisma-membership-authority.test.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaFleetMembershipAuthorityRepository } from "./prisma-membership-authority.js";
+import { PrismaFleetMembershipAuthorityRepository } from "../prisma-membership-authority.js";
 
 /** Creates one verified signed membership revision row. */
 function _revisionRow()

--- a/libs/backend/server/skills/main/src/__tests__/skill-publication.test.ts
+++ b/libs/backend/server/skills/main/src/__tests__/skill-publication.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __PublishSkillRevision } from "./skill-publication.js";
+import { __PublishSkillRevision } from "../skill-publication.js";
 
 describe("skill publication", function ()
 {

--- a/libs/models/artifacts/main/src/__tests__/artifact-invariants.test.ts
+++ b/libs/models/artifacts/main/src/__tests__/artifact-invariants.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { ___IsArtifact, ___IsArtifactRevision, ___IsSha256ContentAddress, ___IsSkillRevision, ___SkillRevisionMatchesArtifactRevision } from "./artifact-invariants.js";
-import type { Artifact, ArtifactRevision, SkillRevision } from "./artifact.types.js";
+import { ___IsArtifact, ___IsArtifactRevision, ___IsSha256ContentAddress, ___IsSkillRevision, ___SkillRevisionMatchesArtifactRevision } from "../artifact-invariants.js";
+import type { Artifact, ArtifactRevision, SkillRevision } from "../artifact.types.js";
 
 const _DIGEST = `sha256:${"a".repeat(64)}`;
 

--- a/libs/models/platform-policy/main/src/__tests__/platform-policy.test.ts
+++ b/libs/models/platform-policy/main/src/__tests__/platform-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { ___IsDurableStatePolicy, ___IsPlatformPolicy, ___IsRuntimeFilesystemPolicy, ___IsSiloUpdateDurationAllowed, ___IsSiloUpdatePolicy, ___MAXIMUM_SILO_UPDATE_DURATION_MS, ___PLATFORM_POLICY } from "./platform-policy.js";
+import { ___IsDurableStatePolicy, ___IsPlatformPolicy, ___IsRuntimeFilesystemPolicy, ___IsSiloUpdateDurationAllowed, ___IsSiloUpdatePolicy, ___MAXIMUM_SILO_UPDATE_DURATION_MS, ___PLATFORM_POLICY } from "../platform-policy.js";
 
 describe("platform policy", function _suite()
 {

--- a/libs/server/_infra/api/src/__tests__/watch-runner.test.ts
+++ b/libs/server/_infra/api/src/__tests__/watch-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "pino";
 
-import { _RunWatchLoop } from "./watch-runner.js";
+import { _RunWatchLoop } from "../watch-runner.js";
 
 type WatchEventCallback = (type: string, resource: unknown) => void;
 type WatchDoneCallback = (err: unknown) => void;

--- a/nx.json
+++ b/nx.json
@@ -12,8 +12,7 @@
     ],
     "production": [
       "default",
-      "!{projectRoot}/src/__tests__/**",
-      "!{projectRoot}/**/*.test.ts"
+      "!{projectRoot}/src/__tests__/**"
     ]
   },
   "targetDefaults": {


### PR DESCRIPTION
## Summary

- move all 25 co-located TypeScript test files present on the D5 base under package `src/__tests__/` directories
- repair their relative imports and leave SQL authority tests in package `tests/`
- enforce the convention with a custom ESLint rule plus a negative probe
- simplify Nx production inputs now that test placement is enforced

## Validation

- targeted moved-package test/lint gate
- `npm run lint:boundaries`
- ESLint negative probe for a misplaced test
- `npx nx affected -t build test lint --base=feat/phase-d-d5-agent-lib-namespaces --head=HEAD`

## Review

- independent review: no findings
- local Claude Code reports `Not logged in`; no repository content was transmitted

This is intentionally stacked on #293 so its review is limited to D4. It will be rebased and retargeted to `own-personal-ai-agent-setup` after #293 merges.