### PR TITLE
📚 Phase D: document backend capability boundaries

### DIFF
--- a/libs/backend/README.md
+++ b/libs/backend/README.md
@@ -1,10 +1,15 @@
-# libs/backend — server-owned capabilities
+# libs/backend — product and control-plane capabilities
 
-Backend libraries are grouped first by the application that owns their composition boundary. The
-OpenCrane API server owns the capabilities under `server/`. Its process-only transport and platform
-support lives separately under [`libs/server/_infra`](../server/_infra/) so business capabilities
-do not become mixed with server machinery. Apps remain thin entrypoints that mount routers,
-construct clients, and manage process lifecycle.
+Backend libraries are grouped by the capability they provide. The agent product lives under
+[`agents/`](agents/): these authorities shape a person's assistant, its conversations, durable
+memory catalogue, and logical runs. The OpenCrane server's control-plane capabilities live under
+[`server/`](server/): they establish identities, membership, authorization, agent-service
+publication, and the boundaries that connect the product to deployed runtimes.
+
+`apps/opencrane` is the intended composition boundary for both groups. Its process-only transport
+and platform support lives separately under [`libs/server/_infra`](../server/_infra/) so business
+capabilities do not become mixed with server machinery. Apps remain thin entrypoints that mount
+routers, construct clients, and manage process lifecycle.
 
 `feat-openclaw-tenant/` is the one temporary exception. It is a direct-deletion boundary for the
 retired personal-agent runtime and must not receive new functionality.
@@ -13,12 +18,11 @@ retired personal-agent runtime and must not receive new functionality.
 
 ```text
 libs/backend/
-  server/<domain>/main/       OpenCrane server capability
+  agents/personal/<domain>/main/  Personal-agent product capability
+  server/<domain>/main/           OpenCrane control-plane capability
+  channel-proxy/main/             Target-neutral channel forwarding capability
     project.json              Nx project metadata and targets
     src/index.ts              public barrel
-    src/routes/               Express transport adapters
-    src/core/                 domain services and use cases
-    src/__tests__/             capability tests
   feat-openclaw-tenant/       deletion boundary; do not extend
 ```
 
@@ -27,8 +31,13 @@ flattening unrelated responsibilities together.
 
 ## Current functional domains
 
-- Target agent authority: agent services and immutable revisions, logical runs and workload
-  assignments, proof-bound authorization, and verified fleet membership.
+- Personal agent: personas built from an onboarding interview, conversations, durable-memory
+  metadata, and logical run attempts. See [`agents/`](agents/).
+- Control plane: identity and access, fleet membership, agent-service publication, channel target
+  resolution, artifacts, and the established server capabilities. See [`server/`](server/).
+- Channel proxy: a target-neutral browser-facing forwarding boundary that asks the control plane
+  for each authorized destination.
+
 - Identity and access: access tokens, identity, grants, groups, policies, and cluster membership.
 - Tenant and runtime lifecycle: tenants, connections, effective contracts, and projection repair.
 - Models and economics: providers, model routing, spend, and budgets.
@@ -50,13 +59,15 @@ OpenClaw, rollout, or projection behavior survives the direct target refactor.
 - Database models remain in the OpenCrane app's per-domain Prisma schema files; see
   [`docs/agents/prisma.md`](../../docs/agents/prisma.md).
 
-## Adding a server capability
+## Adding a backend capability
 
-1. Create `libs/backend/server/<domain>/main` by copying a small peer such as
-   `libs/backend/server/audit/main`.
-2. Name its Nx project `backend-server-<domain>` and update `sourceRoot`, target working
+1. Put a user-facing personal-agent capability under
+   `libs/backend/agents/personal/<domain>/main`; put a server control-plane capability under
+   `libs/backend/server/<domain>/main`.
+2. Name the Nx project after that bounded capability and update `sourceRoot`, target working
    directories, and its root-relative TypeScript and Vitest paths.
-3. Add `@opencrane/backend/server/<domain>` to the root `tsconfig.json` paths.
+3. Add the matching `@opencrane/backend/agents/...` or
+   `@opencrane/backend/server/...` public path to the root `tsconfig.json` paths.
 4. Export only the public capability surface from `src/index.ts` and mount transport adapters from
    `apps/opencrane`.
 5. Add or update the app-owned Prisma schema slice when the capability owns durable models.

--- a/libs/backend/agents/README.md
+++ b/libs/backend/agents/README.md
@@ -1,0 +1,10 @@
+# Agent product capabilities
+
+This namespace owns the backend capabilities that make an employee's assistant useful. They are
+separate from the OpenCrane control plane so product behaviour does not become tangled with fleet,
+identity, or deployment administration.
+
+`personal/` is the current product family. It owns the personal assistant's approved persona,
+conversation history, durable-memory catalogue, and logical run lifecycle.
+
+See [`libs/backend/README.md`](../README.md) for the broader backend layout and dependency rules.

--- a/libs/backend/agents/personal/README.md
+++ b/libs/backend/agents/personal/README.md
@@ -1,0 +1,14 @@
+# Personal agent capabilities
+
+Each package here owns one part of an employee's personal assistant:
+
+- [`personas/`](personas/main/) approves the interview-informed persona that becomes the assistant's
+  SOUL document.
+- [`conversations/`](conversations/main/) records the ordered events that explain a run to the user.
+- [`memory/`](memory/main/) records durable-memory metadata and provenance after the memory store
+  accepts a fact.
+- [`runs/`](runs/main/) owns logical run attempts and their workload assignments.
+
+`apps/opencrane` is the intended composition boundary for these capabilities; they do not own HTTP
+process setup or cluster administration. See [`../../README.md`](../../README.md) for the
+product/control-plane split.

--- a/libs/backend/agents/personal/conversations/main/README.md
+++ b/libs/backend/agents/personal/conversations/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/agents/personal/conversations — Conversations
+
+Owns the ordered event history for a personal-agent run. It appends a valid next event exactly once
+and refuses missing, terminal, or out-of-sequence runs, so callers can present an accurate
+conversation timeline.
+
+The public surface is `src/index.ts`; persistence is supplied through `ConversationAuthorityRepository`.
+See [`../../README.md`](../../README.md) for the other personal-agent capabilities.

--- a/libs/backend/agents/personal/memory/main/README.md
+++ b/libs/backend/agents/personal/memory/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/agents/personal/memory — Memory catalogue
+
+Owns the durable-memory catalogue for a personal agent. It records consent, provenance, and a
+content digest after the memory store accepts a fact; the fact content itself stays in the durable
+memory store rather than being copied into this authority.
+
+The public surface is `src/index.ts`; persistence and outbox commitment are supplied through
+`MemoryCatalogRepository`. See [`../../README.md`](../../README.md) for the other personal-agent
+capabilities.

--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/agents/personal/personas — Personas
+
+Owns approval and activation of a person's assistant persona. A completed onboarding interview,
+its selected template, and the supporting insights must agree before the approved revision becomes
+the active SOUL source for that person.
+
+The public surface is `src/index.ts`; persistence is supplied through `PersonaAuthorityRepository`.
+See [`../../README.md`](../../README.md) for the other personal-agent capabilities.

--- a/libs/backend/agents/personal/runs/main/README.md
+++ b/libs/backend/agents/personal/runs/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/agents/personal/runs — Runs
+
+Owns a personal agent's logical run attempts. It starts a retry only while the intended agent
+service and revision are still active, and validates that a workload assignment belongs to that
+exact attempt.
+
+The public surface is `src/index.ts`; `PrismaAgentRunAuthorityRepository` supplies the durable
+authority implementation. See [`../../README.md`](../../README.md) for the other personal-agent
+capabilities.

--- a/libs/backend/channel-proxy/main/README.md
+++ b/libs/backend/channel-proxy/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/channel-proxy — Channel proxy
+
+Owns target-neutral forwarding for browser channel traffic. For every command or event request it
+asks OpenCrane for an authorized destination, forwards only to that result, and applies origin,
+identity-header, size, timeout, and per-subject rate limits.
+
+This library is not a policy authority and does not choose agent endpoints itself. The corresponding
+control-plane decision lives in [`server/channel-targets`](../../server/channel-targets/main/).
+Its public surface is `src/index.ts`.

--- a/libs/backend/server/README.md
+++ b/libs/backend/server/README.md
@@ -1,0 +1,19 @@
+# OpenCrane server control-plane capabilities
+
+This namespace owns capabilities the OpenCrane server uses to administer the product and safely
+connect it to deployed agent runtimes. It does not own an employee's personal-agent state; that
+lives in [`../agents/personal/`](../agents/personal/).
+
+The newer Phase D authorities are deliberately separate:
+
+- `authorization/` evaluates effective access and proof-bound actions.
+- `membership/` verifies current signed fleet membership.
+- `agent-services/` publishes immutable agent revisions.
+- `artifacts/` finalizes promoted artifact metadata.
+- `channel-targets/` authorizes a browser channel operation and resolves its target.
+- `identity/` establishes browser identity and turns verified sign-in claims into server facts.
+- `api-spec/` assembles the public HTTP contract from the server capabilities.
+
+Other packages retain established server capabilities such as tenant lifecycle, integrations,
+knowledge, policies, reporting, and API composition. See [`../README.md`](../README.md) for the
+backend-wide ownership and dependency rules.

--- a/libs/backend/server/access-tokens/main/README.md
+++ b/libs/backend/server/access-tokens/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/access-tokens`.
 Owns personal access token management. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/access-tokens.prisma` where this domain owns models).

--- a/libs/backend/server/agent-services/main/README.md
+++ b/libs/backend/server/agent-services/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/server/agent-services — Agent-service publication
+
+Owns publication of an immutable agent revision as the active revision for an agent service. It
+keeps the service, revision, and audit evidence aligned when a draft becomes available to run.
+
+The public surface is `src/index.ts`; `PrismaAgentServicePublicationRepository` provides the
+durable authority implementation. See [`../../README.md`](../../README.md) for the control-plane
+map.

--- a/libs/backend/server/api-spec/main/README.md
+++ b/libs/backend/server/api-spec/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/server/api-spec — API specification
+
+Owns the assembled OpenAPI contract for the OpenCrane server. It brings each server capability's
+public paths into one specification from which the published API description and client contracts
+are generated.
+
+The public surface is `src/index.ts`. When a capability changes its HTTP contract, update its
+contribution here and regenerate the API outputs through the server's documented contract tasks.
+See [`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/artifacts/main/README.md
+++ b/libs/backend/server/artifacts/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/server/artifacts — Artifact revisions
+
+Owns finalization of visible artifact metadata after ArtifactStore has promoted the bytes. It
+checks the promotion evidence and commits the revision, current pointer, and delivery intent as
+one durable result; it does not perform artifact byte I/O itself.
+
+The public surface is `src/index.ts`; persistence is supplied through `ArtifactAuthorityRepository`.
+See [`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/audit/main/README.md
+++ b/libs/backend/server/audit/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/audit`.
 Owns the audit-trail read API. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/audit.prisma` where this domain owns models).

--- a/libs/backend/server/authorization/main/README.md
+++ b/libs/backend/server/authorization/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/server/authorization — Authorization
+
+Owns effective access decisions and proof-bound runtime actions. It evaluates the grants and
+membership evidence required for an action, verifies its proof, and records a one-time outcome
+through an explicit persistence boundary.
+
+The public surface is `src/index.ts`; Prisma repositories implement the durable authorization and
+runtime authorities. See [`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/awareness/main/README.md
+++ b/libs/backend/server/awareness/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/awareness/*`, `/api/internal/awareness/participation`.
 Owns awareness rollout waves, fleet participation reporting, participation events. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/awareness.prisma` where this domain owns models).

--- a/libs/backend/server/channel-targets/main/README.md
+++ b/libs/backend/server/channel-targets/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/server/channel-targets — Channel targets
+
+Owns the control-plane decision behind a browser channel operation. It verifies the calling
+workload and browser identity, checks current membership and required actions, then issues a
+short-lived target context for the selected thread or declines the request.
+
+The public surface is `src/index.ts`; the router composes the HTTP boundary and
+`PrismaChannelTargetAuthorityRepository` provides durable target authority. See
+[`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/cluster-tenants/main/README.md
+++ b/libs/backend/server/cluster-tenants/main/README.md
@@ -5,6 +5,6 @@ Mounted at: (no routes — middleware + seeding).
 Owns ClusterTenant/OrgMembership read-models, own-cluster-tenant resolution, default-tenant seeding, the cluster-tenant scope middleware. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/cluster-tenants.prisma` where this domain owns models).

--- a/libs/backend/server/company-docs/main/README.md
+++ b/libs/backend/server/company-docs/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/org/workspace-docs`.
 Owns company doc versions, tenant doc reconciliation proposals, L0 personalisation guard. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/company-docs.prisma` where this domain owns models).

--- a/libs/backend/server/connections/main/README.md
+++ b/libs/backend/server/connections/main/README.md
@@ -7,6 +7,6 @@ org namespace helpers. Routes live in `src/routes/`, services in `src/core/`, te
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`). This domain owns no Prisma
 model after the legacy connection registry deletion.
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership rules.

--- a/libs/backend/server/contract/main/README.md
+++ b/libs/backend/server/contract/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/internal/contract`.
 Owns the effective-contract assembly served to tenant pods (grants + awareness + skill models + TOOLS.md rendering). Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/contract.prisma` where this domain owns models).

--- a/libs/backend/server/grants/main/README.md
+++ b/libs/backend/server/grants/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/shares`, `/api/v1/resource-shares`.
 Owns the grant compiler, inter-user shares, derived dataset membership, Cognee awareness grant sync. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/grants.prisma` where this domain owns models).

--- a/libs/backend/server/groups/main/README.md
+++ b/libs/backend/server/groups/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/groups`.
 Owns group CRUD used as grant subjects. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/groups.prisma` where this domain owns models).

--- a/libs/backend/server/identity/main/README.md
+++ b/libs/backend/server/identity/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/server/identity — Identity
+
+Owns the server's browser identity workflows: OpenID Connect login and logout, session status,
+and the server-side facts derived after a verified sign-in. It can adopt a member into the
+appropriate workspace and mirror identity-provider group claims without making the browser a
+source of authority.
+
+The public surface is `src/index.ts`; the auth router is composed by the OpenCrane server. See
+[`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/mcp/main/README.md
+++ b/libs/backend/server/mcp/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/mcp-servers`, `/api/v1/mcp`.
 Owns MCP server registry + credentials, the operator-facing MCP directory/install/approval/OAuth surface. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/mcp.prisma` where this domain owns models).

--- a/libs/backend/server/membership/main/README.md
+++ b/libs/backend/server/membership/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/server/membership — Fleet membership
+
+Owns verification of a person's current signed membership in an agent fleet. Callers receive an
+explicit trusted or denied result, including the accepted revision and expiry when membership is
+current.
+
+The public surface is `src/index.ts`; `PrismaFleetMembershipAuthorityRepository` provides the
+durable authority implementation. See [`../../README.md`](../../README.md) for the control-plane
+map.

--- a/libs/backend/server/metrics/main/README.md
+++ b/libs/backend/server/metrics/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/metrics`, `/prom`.
 Owns opencrane-ui metrics API + Prometheus exposition (fleet, awareness, projection drift). Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/metrics.prisma` where this domain owns models).

--- a/libs/backend/server/model-routing/main/README.md
+++ b/libs/backend/server/model-routing/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/model-routing/*`, `/api/internal/tenant-models`.
 Owns routing defaults, eval cases, shadow measurements, proposals, recommendations, metrics, per-tenant model allowlists. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/model-routing.prisma` where this domain owns models).

--- a/libs/backend/server/policies/main/README.md
+++ b/libs/backend/server/policies/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/policies`.
 Owns AccessPolicy CRUD + projection to the cluster and Cognee awareness sync. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/policies.prisma` where this domain owns models).

--- a/libs/backend/server/projection/main/README.md
+++ b/libs/backend/server/projection/main/README.md
@@ -5,6 +5,6 @@ Mounted at: (no routes — consumed by tenants/policies/metrics).
 Owns tenant/policy projection drift detection and repair. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/projection.prisma` where this domain owns models).

--- a/libs/backend/server/providers/main/README.md
+++ b/libs/backend/server/providers/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/providers/*`, `/api/v1/models`.
 Owns provider API keys, scoped credentials, BYOK provisioning, LiteLLM model registration. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/providers.prisma` where this domain owns models).

--- a/libs/backend/server/retrieval/main/README.md
+++ b/libs/backend/server/retrieval/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/third-party-sources`.
 Owns third-party source registry and dataset scope types. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/retrieval.prisma` where this domain owns models).

--- a/libs/backend/server/spend/main/README.md
+++ b/libs/backend/server/spend/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/spend`, `/api/v1/token-usage`, `/api/v1/ai-budget`.
 Owns spend aggregation, token-usage snapshots, global/account budgets, LiteLLM virtual keys. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/spend.prisma` where this domain owns models).

--- a/libs/backend/server/tenants/main/README.md
+++ b/libs/backend/server/tenants/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/tenants`.
 Owns tenant CRUD over the Tenant CRD, dataset membership, suspension, effective-contract compilation inputs. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/tenants.prisma` where this domain owns models).


### PR DESCRIPTION
## Summary

- document the new personal-agent versus server/control-plane split
- add concise maps for backend namespaces and package-level READMEs for active Phase D authorities
- repair broken backend and Prisma guidance links in established server package READMEs
- preserve the direct-replacement boundary: the retired OpenClaw tenant package remains untouched

## Validation

- whitespace and diff checks
- local-link validation across 35 active backend READMEs
- inventory proving every active server domain has a README

## Review

- independent review found one premature claim that the server already composes personal-agent packages; corrected to describe `apps/opencrane` as the intended D18 composition boundary
- local Claude Code reports `Not logged in`; no repository content was transmitted

This is intentionally stacked on #293 so its review is limited to documentation. It will be rebased and retargeted to `own-personal-ai-agent-setup` after #293 merges.