### PR TITLE
🧱 Phase D D8: document artifact lifecycle invariants

### DIFF
--- a/apps/artifact-service/src/server.ts
+++ b/apps/artifact-service/src/server.ts
@@ -21,7 +21,13 @@ export async function _PrepareArtifactStore(config: ArtifactServiceProcessConfig
 	});
 }
 
-/** Create the private server, which accepts only OpenCrane-signed, bounded write leases. */
+/**
+ * Create the private server, which accepts only OpenCrane-signed, bounded write leases.
+ *
+ * The app is transport only: lease verification, byte bounding, deadline, stage-to-promote, and
+ * receipt signing belong to `@opencrane/backend/artifacts/*`. This shell adapts HTTP in and typed
+ * outcomes out; it intentionally exposes no read, list, or delete surface.
+ */
 export function _CreateServer(config: ArtifactServiceProcessConfig, store: ArtifactStore): Server
 {
 	return createServer(function _handle(request, response)
@@ -81,7 +87,13 @@ function _byteSource(request: IncomingMessage): BoundedArtifactUploadByteSource
 	};
 }
 
-/** Translates stable storage-domain outcomes into the private HTTP endpoint contract. */
+/**
+ * Translates stable storage-domain outcomes into the private HTTP endpoint contract.
+ *
+ * Deadline expiry destroys the socket because responding would keep a streaming client consuming
+ * disk past its lease bound. Oversize maps to 413 so a compliant client stops resending a body that
+ * can never fit; other protocol rejections are 403s with their stable typed reason.
+ */
 function _writePromotionOutcome(response: ServerResponse, outcome: PromoteArtifactUploadResult): void
 {
 	if (outcome.outcome === "promoted")

--- a/docs/agents/app-specific.md
+++ b/docs/agents/app-specific.md
@@ -13,6 +13,7 @@ linked below** — read it before non-trivial work in that package. The whole-cl
 | Package | Deep-dive | One-liner |
 |---------|-----------|-----------|
 | `@opencrane/server` | [apps/opencrane.md](./apps/opencrane.md) | API-first hub (**Express 5** + Prisma + K8s client). The app owns process bootstrap, configuration, route/lifecycle composition, Prisma, and its Helm unit; HTTP capabilities and reconcilers live in libraries. Listens `:8080`. |
+| `@opencrane/artifact-service` | [apps/artifact-service.md](./apps/artifact-service.md) | Guarded write-only boundary for the per-silo content-addressed ArtifactStore. |
 | `@opencrane/feat-central-agents` | [apps/feat-central-agents.md](./apps/feat-central-agents.md) | Background ingestion worker (not API-first). Slack → normalise → Cognee; cursor in Postgres. `/healthz`, `/metrics`. |
 | _(apps/opencrane-ui)_ | — | Org-admin Angular SPA, ported in from WeOwnAI (#152). PrimeNG, zoneless/signals, standalone components — see [`angular.md`](./angular.md). Just another client of the opencrane-api (API-First Rule below). `npx nx build\|serve opencrane-ui`. |
 | `cognee`, `litellm`, `obot` | Local `README.md` | Deployment-only Nx apps under `apps/_infra/<name>`. Each owns its pinned image contract, identity, service, policy, and Helm templates; the upstream product source remains external. |

--- a/docs/agents/apps/artifact-service.md
+++ b/docs/agents/apps/artifact-service.md
@@ -1,0 +1,30 @@
+# App: artifact-service (`@opencrane/artifact-service`)
+
+> Deep-dive for `apps/artifact-service`. Index: [`../app-specific.md`](../app-specific.md).
+
+The guarded write path into OpenCrane's per-silo content-addressed artifact store (CAS). It is the
+only process that admits artifact bytes, and only against a signed, short-lived write lease for one
+exact artifact. The app is a deployable transport shell: store mechanics, lease/receipt
+cryptography, and the promotion protocol live in `libs/backend/artifacts/{store,filesystem,authorization}`.
+
+## Surface
+
+The private listener exposes `POST /v1/artifacts/promote` and `/livez`/`/readyz`; every other route
+is 404. The handler adapts an HTTP stream to `__PromoteArtifactUpload`, returning `201` with a
+signed receipt on success, `413` for a body above its lease ceiling, and `403` with a typed reason
+for other rejections. An absolute deadline destroys a still-streaming socket instead of extending
+its disk-consumption window.
+
+## Trust boundary
+
+The service has no catalog database access or session state. An OpenCrane-signed lease binds the
+action, artifact, expected digest, byte length, media type, and expiry. The service stages and
+atomically promotes verified bytes, then signs the receipt that the catalog authority consumes to
+publish immutable metadata. It cannot choose catalog state, and the catalog cannot claim a byte
+write without the receipt.
+
+## Deployment boundary
+
+One deployment per silo mounts the durable CAS volume. It receives no Kubernetes RBAC and does not
+auto-mount a service-account token. Its NetworkPolicy admits the OpenCrane server as a client and
+allows only explicitly selected egress peers; `tests/helm-contract.sh` protects that boundary.

--- a/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
+++ b/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
@@ -9,7 +9,21 @@ import type { ArtifactByteStream, ArtifactStore, ArtifactStorePromotion, Artifac
 import { ___IsSha256ContentAddress } from "@opencrane/models/artifacts";
 import type { FilesystemArtifactStoreOptions } from "./filesystem-artifact-store.types.js";
 
-/** POSIX-backed ArtifactStore adapter with private staging and atomic content-addressed promotion. */
+/**
+ * POSIX-backed ArtifactStore adapter with private staging and atomic content-addressed promotion.
+ *
+ * Crash-durability model: untrusted bytes are first written and fsynced under a private
+ * `staging/` directory, then published by hard-linking the staged inode at its canonical
+ * `sha256/ab/<digest>` path and fsyncing that directory. A crash therefore leaves either no
+ * canonical entry or the complete verified bytes at their address; partial bytes stay private.
+ *
+ * Integrity model: this adapter computes the canonical address from durable bytes. A caller's
+ * digest or length is only cross-checked, never trusted. Promotion is idempotent per address,
+ * but an existing object is re-verified before the repeat request succeeds.
+ *
+ * Path confinement: no caller-controlled string becomes a filesystem path. Staging paths derive
+ * from a SHA-256 lease-id hash and canonical paths from a strict `sha256:<hex64>` address.
+ */
 export class __FilesystemArtifactStore implements ArtifactStore
 {
 	/** Mounted volume root owned only by the artifact-service process. */
@@ -33,7 +47,8 @@ export class __FilesystemArtifactStore implements ArtifactStore
 			throw new Error("invalid or expired ArtifactStore stage command");
 		}
 
-		// 1. Create only private, deterministic staging directories under the mounted artifact volume.
+		// 1. Create private deterministic staging below the mounted root. The hashed handle cannot
+		// shape a path; exclusive create prevents concurrent writers from interleaving one lease.
 		await mkdir(this._stagingDirectory(), { recursive: true });
 		const stagingHandle = createHash("sha256").update(command.lease.leaseId, "utf8").digest("hex");
 		const stagingPath = this._stagingPath(stagingHandle);
@@ -43,7 +58,8 @@ export class __FilesystemArtifactStore implements ArtifactStore
 
 		try
 		{
-			// 2. Hash and fsync every supplied chunk before accepting any promotion metadata.
+			// 2. Hash and fsync every supplied chunk before accepting metadata. Promotion hard-links this
+			// inode, so bytes must be durable before acknowledging their canonical address.
 			for await (const chunk of command.bytes)
 			{
 				const bytes = Buffer.from(chunk);
@@ -103,7 +119,8 @@ export class __FilesystemArtifactStore implements ArtifactStore
 				throw error;
 			}
 
-			// 2. Never trust a same-size pathname: it must still be a regular file at the exact digest.
+			// 2. EEXIST is idempotent promotion: re-verify type, size, and digest so a corrupt survivor
+			// never becomes a successful canonical object merely because it has the same pathname.
 			const existing = await lstat(targetPath);
 			if (!existing.isFile() || existing.size !== staged.byteLength || await this._hashFile(targetPath) !== staged.contentAddress)
 			{
@@ -111,7 +128,8 @@ export class __FilesystemArtifactStore implements ArtifactStore
 			}
 		}
 
-		// 3. Remove only the private staging link after the canonical link is durable or confirmed present.
+		// 3. Remove private staging only after the canonical link is durable or confirmed present. A
+		// crash before publication must leave the verified staged bytes available for a retry.
 		await unlink(sourcePath);
 		return { leaseId: staged.leaseId, contentAddress: staged.contentAddress, byteLength: staged.byteLength, mediaType: staged.mediaType, created };
 	}
@@ -197,7 +215,12 @@ export class __FilesystemArtifactStore implements ArtifactStore
 		return `sha256:${hash.digest("hex")}`;
 	}
 
-	/** Persist a newly linked canonical directory entry before an acknowledged promotion. */
+	/**
+	 * Persist a newly linked canonical directory entry before acknowledging promotion.
+	 *
+	 * fsyncing a file alone does not persist its new directory entry on POSIX. Without syncing the
+	 * containing directory, a crash could lose an acknowledged hard link while its receipt survives.
+	 */
 	private async _syncDirectory(directory: string): Promise<void>
 	{
 		const handle = await open(directory, "r");
@@ -211,7 +234,12 @@ export class __FilesystemArtifactStore implements ArtifactStore
 		}
 	}
 
-	/** Converts a deterministic internal staging handle into a path below the private staging root. */
+	/**
+	 * Converts a deterministic internal staging handle into a path below the private staging root.
+	 *
+	 * Strict lowercase hex is the traversal guard: a public `StagedArtifact` cannot contain `/`,
+	 * `..`, or other path syntax that could name a file outside `staging/`.
+	 */
 	private _stagingPath(stagingHandle: string): string
 	{
 		if (!/^[a-f0-9]{64}$/u.test(stagingHandle))
@@ -235,7 +263,12 @@ export class __FilesystemArtifactStore implements ArtifactStore
 		return join(this._contentDirectory(contentAddress), digest);
 	}
 
-	/** Strips the validated address prefix without accepting arbitrary filesystem path input. */
+	/**
+	 * Strips the validated address prefix without accepting arbitrary filesystem path input.
+	 *
+	 * All canonical path derivation funnels through this strict check, keeping read, promote, and
+	 * purge confined to the mounted store root.
+	 */
 	private _digest(contentAddress: string): string
 	{
 		if (!___IsSha256ContentAddress(contentAddress))

--- a/libs/backend/artifacts/store/main/src/artifact-promotion.ts
+++ b/libs/backend/artifacts/store/main/src/artifact-promotion.ts
@@ -1,6 +1,14 @@
 import type { ArtifactPromotionProtocolConfig, ArtifactPromotionLeaseVerifier, ArtifactStore, BoundedArtifactUploadByteSource, PromoteArtifactUploadResult } from "./artifact-store.types.js";
 
-/** Promotes one verified, bounded artifact upload and creates its catalog-consumable receipt. */
+/**
+ * Promotes one verified, bounded artifact upload and creates its catalog-consumable receipt.
+ *
+ * This is signed-lease in, signed-receipt out because artifact-service has neither session state
+ * nor product-database access. The OpenCrane-signed lease is the complete authorization for one
+ * write; the service-signed receipt is the only evidence the catalog accepts for finalization.
+ * Every failure is typed and fails closed: bytes are not staged before verification and no receipt
+ * is signed after the lease-bound deadline.
+ */
 export async function __PromoteArtifactUpload(store: ArtifactStore, leaseVerifier: ArtifactPromotionLeaseVerifier, byteSource: BoundedArtifactUploadByteSource, config: ArtifactPromotionProtocolConfig): Promise<PromoteArtifactUploadResult>
 {
 	// 1. Verify the caller's compact lease before consuming or staging any untrusted request bytes.

--- a/libs/backend/artifacts/store/main/src/artifact-store.ts
+++ b/libs/backend/artifacts/store/main/src/artifact-store.ts
@@ -2,7 +2,12 @@ import { ___IsSha256ContentAddress } from "@opencrane/models/artifacts";
 
 import type { ArtifactStorePromotion, StageArtifactCommand, StagedArtifact, VerifiedArtifactWriteLease } from "./artifact-store.types.js";
 
-/** Validates an OpenCrane-issued lease before an adapter creates temporary bytes. */
+/**
+ * Validates an OpenCrane-issued lease before an adapter creates temporary bytes.
+ *
+ * Invariant: a lease authorizes exactly one `artifact.write` for one silo and artifact and must be
+ * unexpired at the supplied clock. Any failure rejects before a single staging byte is created.
+ */
 export function __ValidateVerifiedArtifactWriteLease(lease: VerifiedArtifactWriteLease, nowEpochSeconds: number): boolean
 {
 	return lease.leaseId.trim().length > 0
@@ -13,7 +18,12 @@ export function __ValidateVerifiedArtifactWriteLease(lease: VerifiedArtifactWrit
 		&& lease.expiresAtEpochSeconds >= nowEpochSeconds;
 }
 
-/** Validates stage coordinates before untrusted bytes are accepted by an ArtifactStore adapter. */
+/**
+ * Validates stage coordinates before untrusted bytes are accepted by an ArtifactStore adapter.
+ *
+ * Invariant: declared digest and length must be strictly shaped so the adapter's byte-for-byte
+ * cross-check cannot be bypassed with an ambiguously parsed value. Failure performs no staging I/O.
+ */
 export function __ValidateStageArtifactCommand(command: StageArtifactCommand, nowEpochSeconds: number): boolean
 {
 	const expectedAddressIsValid = command.expectedContentAddress === null || ___IsSha256ContentAddress(command.expectedContentAddress);
@@ -25,7 +35,12 @@ export function __ValidateStageArtifactCommand(command: StageArtifactCommand, no
 		&& command.mediaType.includes("/");
 }
 
-/** Validates a staged handle before immutable promotion. */
+/**
+ * Validates a staged handle before immutable promotion.
+ *
+ * Invariant: promotion can target only a strict content address, preventing a public handle from
+ * steering the filesystem adapter to an arbitrary path. Invalid metadata never links or deletes.
+ */
 export function __ValidateStagedArtifact(staged: StagedArtifact): boolean
 {
 	return staged.leaseId.trim().length > 0
@@ -37,7 +52,12 @@ export function __ValidateStagedArtifact(staged: StagedArtifact): boolean
 		&& staged.mediaType.includes("/");
 }
 
-/** Validates metadata returned by an idempotent canonical promotion. */
+/**
+ * Validates metadata returned by an idempotent canonical promotion.
+ *
+ * Invariant: only complete canonical metadata may be signed into a receipt or committed by the
+ * catalog authority; malformed promotion output is rejected rather than repaired.
+ */
 export function __ValidateArtifactStorePromotion(promotion: ArtifactStorePromotion): boolean
 {
 	return promotion.leaseId.trim().length > 0

--- a/libs/backend/server/artifacts/main/src/artifact-finalization.ts
+++ b/libs/backend/server/artifacts/main/src/artifact-finalization.ts
@@ -2,7 +2,13 @@ import { ___IsSha256ContentAddress } from "@opencrane/models/artifacts";
 
 import type { ArtifactAuthorityRepository, FinalizeArtifactRevisionCommand, FinalizeArtifactRevisionResult } from "./artifact-finalization.types.js";
 
-/** Finalizes ArtifactStore-promoted bytes into canonical metadata and an outbox event. */
+/**
+ * Finalizes ArtifactStore-promoted bytes into canonical metadata and an outbox event.
+ *
+ * This authority never touches bytes: it accepts only the receipt facts produced by ArtifactStore
+ * and delegates their single-use, transactional consumption to persistence. Keeping byte I/O out
+ * of the transaction prevents a slow store operation from widening the catalog lock window.
+ */
 export async function __FinalizeArtifactRevision(repository: ArtifactAuthorityRepository, command: FinalizeArtifactRevisionCommand): Promise<FinalizeArtifactRevisionResult>
 {
 	// 1. Validate storage-neutral metadata and authenticated receipt coordinates before persistence.
@@ -17,7 +23,8 @@ export async function __FinalizeArtifactRevision(repository: ArtifactAuthorityRe
 		return { outcome: "denied", reason: "invalid_command" };
 	}
 
-	// 2. Commit only metadata, current pointer, receipt consumption, and outbox; bytes stay behind ArtifactStore.
+	// 2. Commit only metadata, current pointer, receipt consumption, and outbox. Bytes stay behind
+	// ArtifactStore so a durable catalog event can never claim it also owns mutable byte storage.
 	const result = await repository.finalizeRevisionAtomically(command);
 
 	// 3. Expose idempotent success while keeping stale or replayed receipts fail closed.

--- a/libs/backend/server/artifacts/main/src/artifact-upload.ts
+++ b/libs/backend/server/artifacts/main/src/artifact-upload.ts
@@ -4,20 +4,33 @@ import { __FinalizeArtifactRevision } from "./artifact-finalization.js";
 import type { ArtifactAuthorityRepository } from "./artifact-finalization.types.js";
 import type { ArtifactServicePromotionPort, ArtifactUploadCryptoPort, ArtifactUploadLeaseRepository, ArtifactUploadResult, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";
 
-/** Execute a proof-authorized upload without giving artifact-service catalog authority. */
+/**
+ * Executes a proof-authorized upload without giving artifact-service catalog authority.
+ *
+ * The catalog creates one durable lease before handing bytes to artifact-service, then accepts only
+ * a receipt that is cryptographically bound to that lease's exact digest, byte length, and media
+ * type. This prevents a transport service from choosing catalog state or a replayed receipt from
+ * finalizing a different artifact revision.
+ */
 export async function __UploadArtifact(repository: ArtifactUploadLeaseRepository & ArtifactAuthorityRepository, service: ArtifactServicePromotionPort, crypto: ArtifactUploadCryptoPort, command: VerifiedArtifactUploadCommand): Promise<ArtifactUploadResult>
 {
+	// 1. Atomically issue or recover the capability-JTI lease before bytes leave the authority.
 	const issued = await repository.issueLeaseAtomically(command);
 	if (issued.status !== "issued") return { outcome: "denied", reason: "lease_issue_failed" };
+
+	// 2. Delegate storage to the narrow service port; tracing joins catalog authority to CAS I/O.
 	const receipt = await ___DoWithTrace("artifact.upload.promote", { artifactId: command.artifactId, leaseId: issued.lease.leaseId }, function _promote()
 	{
 		return service.promote(crypto.signLease(issued.lease), command.bytes);
 	});
+
+	// 3. Require the signed receipt to restate every lease-bound storage fact before finalization.
 	const promotion = crypto.verifyReceipt(receipt.receipt);
 	if (promotion === null || promotion.leaseId !== issued.lease.leaseId || promotion.contentAddress !== issued.lease.expectedContentAddress || promotion.byteLength !== issued.lease.expectedByteLength || promotion.mediaType !== issued.lease.mediaType)
 	{
 		return { outcome: "denied", reason: "promotion_invalid" };
 	}
+	// 4. Consume the verified receipt in the same authority that publishes immutable catalog state.
 	const finalized = await __FinalizeArtifactRevision(repository, { artifactId: command.artifactId, revision: command.revision, artifactRevisionId: command.artifactRevisionId, createdBy: command.createdBy, provenance: command.provenance, idempotencyKey: command.idempotencyKey, promotion: { ...promotion, receiptDigest: crypto.digestReceipt(receipt.receipt) } });
 	return finalized.outcome === "finalized" ? finalized : { outcome: "denied", reason: "finalization_failed" };
 }

--- a/libs/backend/server/artifacts/main/src/prisma-artifact-authority.ts
+++ b/libs/backend/server/artifacts/main/src/prisma-artifact-authority.ts
@@ -5,7 +5,14 @@ import { ArtifactUploadLeaseState, Prisma, type PrismaClient } from "@prisma/cli
 import type { ArtifactAuthorityRepository, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand } from "./artifact-finalization.types.js";
 import type { ArtifactUploadLeaseRepository, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";
 
-/** Postgres authority for receipt consumption, immutable revision publication, and outbox creation. */
+/**
+ * Postgres authority for lease consumption, immutable revision publication, and outbox creation.
+ *
+ * It is the sole writer of artifact lifecycle state. The transaction lock order is always artifact
+ * then lease, so issue and finalize operations serialize over one catalog authority; byte I/O and
+ * receipt signing stay outside this adapter. Every collision resolves to a typed denial rather than
+ * a best-effort retry that could publish a second revision or consume a receipt twice.
+ */
 export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactUploadLeaseRepository
 {
 	/** Canonical OpenCrane catalog database client. */
@@ -24,15 +31,21 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 		{
 			return await this.prisma.$transaction(async function _issue(transaction: Prisma.TransactionClient)
 			{
+				// 1. Lock the artifact first so all issuance/finalization paths share one lock order.
 				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "artifacts" WHERE "id" = ${command.artifactId} FOR UPDATE`);
 				const artifact = await transaction.artifact.findUnique({ where: { id: command.artifactId } });
 				if (artifact === null || artifact.state !== "Active" || artifact.siloId !== command.siloId) return { status: "artifact_not_found" } as const;
+
+				// 2. Treat capability JTI as the replay key: a matching active lease is idempotent, while
+				// any changed coordinate is a conflict rather than a broadened authorization.
 				const existing = await transaction.artifactUploadLease.findUnique({ where: { capabilityJti: command.capabilityJti } });
 				if (existing !== null)
 				{
 					if (existing.state !== ArtifactUploadLeaseState.Active || existing.expiresAt <= new Date() || existing.artifactId !== command.artifactId || existing.siloId !== command.siloId || existing.expectedContentAddress !== command.expectedContentAddress || existing.expectedByteLength !== BigInt(command.expectedByteLength) || existing.mediaType !== command.mediaType || Math.floor(existing.expiresAt.getTime() / 1_000) !== command.expiresAtEpochSeconds) return { status: "conflict" } as const;
 					return { status: "issued", lease: { leaseId: existing.id, siloId: existing.siloId, artifactId: existing.artifactId, action: "artifact.write", expiresAtEpochSeconds: Math.floor(existing.expiresAt.getTime() / 1_000), expectedContentAddress: existing.expectedContentAddress, expectedByteLength: Number(existing.expectedByteLength), mediaType: existing.mediaType } } as const;
 				}
+				// 3. Persist the exact proof coordinates only after rejecting replay drift; the unique JTI
+				// constraint remains the final race-safe fence if concurrent issuers reach this point.
 				const lease = await transaction.artifactUploadLease.create({ data: { id: randomUUID(), artifactId: command.artifactId, siloId: command.siloId, capabilityJti: command.capabilityJti, expectedContentAddress: command.expectedContentAddress, expectedByteLength: BigInt(command.expectedByteLength), mediaType: command.mediaType, expiresAt: new Date(command.expiresAtEpochSeconds * 1_000) } });
 				return { status: "issued", lease: { leaseId: lease.id, siloId: lease.siloId, artifactId: lease.artifactId, action: "artifact.write", expiresAtEpochSeconds: Math.floor(lease.expiresAt.getTime() / 1_000), expectedContentAddress: lease.expectedContentAddress, expectedByteLength: Number(lease.expectedByteLength), mediaType: lease.mediaType } } as const;
 			});
@@ -51,15 +64,18 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 		{
 			return await this.prisma.$transaction(async function _finalize(transaction: Prisma.TransactionClient)
 			{
-				// 1. Lock the artifact and lease first: every path serializes on the same catalog authority.
+				// 1. Lock artifact then lease: every path serializes in the same catalog lock order.
 				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "artifacts" WHERE "id" = ${command.artifactId} FOR UPDATE`);
 				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "artifact_upload_leases" WHERE "id" = ${command.promotion.leaseId} FOR UPDATE`);
+
+				// 2. A matching outbox row makes a retried finalization a stable success, never a duplicate.
 				const existingOutbox = await transaction.artifactOutboxEvent.findUnique({ where: { idempotencyKey: command.idempotencyKey } });
 				if (existingOutbox !== null && existingOutbox.artifactId === command.artifactId && existingOutbox.revisionId === command.artifactRevisionId)
 				{
 					return { status: "idempotent" } as const;
 				}
 
+				// 3. Re-read locked state and require an active, exact, unexpired, unconsumed lease.
 				const artifact = await transaction.artifact.findUnique({ where: { id: command.artifactId } });
 				if (artifact === null || artifact.state !== "Active") return { status: "artifact_not_found" } as const;
 				const lease = await transaction.artifactUploadLease.findUnique({ where: { id: command.promotion.leaseId } });
@@ -70,7 +86,8 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 					return { status: "conflict" } as const;
 				}
 
-				// 2. Record promotion before finalization so database lifecycle triggers preserve receipt immutability.
+				// 4. Persist the receipt facts before publication so lifecycle triggers can preserve their
+				// immutability; no artifact revision exists without its exact promoted-byte evidence.
 				await transaction.artifactUploadLease.update({
 					where: { id: lease.id },
 					data: { state: ArtifactUploadLeaseState.Promoted, promotionReceiptDigest: command.promotion.receiptDigest, promotedContentAddress: command.promotion.contentAddress, promotedByteLength: BigInt(command.promotion.byteLength), promotedAt: new Date() },
@@ -78,6 +95,7 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 				await transaction.artifactRevision.create({
 					data: { id: command.artifactRevisionId, artifactId: command.artifactId, revision: command.revision, contentAddress: command.promotion.contentAddress, byteLength: BigInt(command.promotion.byteLength), mediaType: command.promotion.mediaType, provenance: command.provenance as Prisma.InputJsonValue, createdBy: command.createdBy },
 				});
+				// 5. Advance the current pointer, emit delivery intent, and consume the receipt atomically.
 				await transaction.artifact.update({ where: { id: command.artifactId }, data: { currentRevisionId: command.artifactRevisionId } });
 				await transaction.artifactOutboxEvent.create({
 					data: { artifactId: command.artifactId, revisionId: command.artifactRevisionId, kind: "RevisionPublished", idempotencyKey: command.idempotencyKey, payload: { contentAddress: command.promotion.contentAddress, byteLength: command.promotion.byteLength, mediaType: command.promotion.mediaType } },


### PR DESCRIPTION
## Summary

- document the CAS durability, integrity, path-confinement, signed-lease, receipt, and transaction-lock invariants
- add the focused artifact-service operator guide and index it from app-specific guidance
- retain the recovered ArtifactStore implementation unchanged; this PR closes the D6/D8 quality documentation gap

## Validation

- 22 focused artifact tests across filesystem, store, server-artifacts, and artifact-service
- focused lint for the four projects
- artifact-service Helm contract
- style gate and diff check

## Review

- independent fresh-context review: no findings
- local Claude Code review is pending because this workstation remains unauthenticated (`claude --bare` reports Not logged in); no repository content was sent to Anthropic

## Dependency

Base is #296, the exact reintegration of the previously merged-but-unpropagated artifact stack. Retarget to own-personal-ai-agent-setup after #296 merges.