### PR TITLE
🗄️ Phase D D1: one PostgreSQL server per tenant

### DIFF
--- a/apps/_infra/deploy-k8s/deploy.sh
+++ b/apps/_infra/deploy-k8s/deploy.sh
@@ -5,13 +5,14 @@
 # A thin profile over the shared install core (k8s-deploy.sh). It installs ONE
 # per-ClusterTenant silo — the dedicated stack a single ClusterTenant runs on shared
 # nodes: its own operator + channel proxy + Obot + LiteLLM + Cognee + opencrane-ui,
-# per-CT networking, and separate app-owned PostgreSQL releases for OpenCrane,
-# Obot, and DB-backed LiteLLM, with self-service
+# per-CT networking, and one app-owned PostgreSQL server with isolated logical databases
+# and credentials for OpenCrane, Obot, LiteLLM, and Langfuse, with self-service
 # manager/billing OFF.
 #
 # The CLUSTER-WIDE infra (ingress-nginx, external-dns, CloudNativePG, cert-manager) is an
 # external prerequisite. A silo never installs these shared controllers. It creates only
-# its namespaced app releases and requires a pre-created PostgreSQL credentials Secret.
+# its namespaced app releases and requires one pre-created PostgreSQL basic-auth credentials
+# Secret for each logical database.
 #
 # The self-service ClusterTenant manager + billing are OFF (a silo serves exactly one
 # ClusterTenant; the fleet is managed by the central super-admin opencrane-ui).
@@ -21,6 +22,9 @@
 #       --base-domain dev.opencrane.ai \
 #       --cluster-tenant acme \
 #       --postgres-credentials-secret opencrane-postgres-bootstrap \
+#       --obot-postgres-credentials-secret opencrane-obot-postgres-bootstrap \
+#       --litellm-postgres-credentials-secret opencrane-litellm-postgres-bootstrap \
+#       --langfuse-postgres-credentials-secret opencrane-langfuse-postgres-bootstrap \
 #       [--namespace opencrane-acme] [--ingress-ip 34.1.2.3] \
 #       [ANY k8s-deploy.sh flag]
 #
@@ -29,7 +33,7 @@
 # omitted the core auto-derives it from the cluster-wide ingress-nginx LoadBalancer.
 #
 # Prereqs: kubectl, helm, the cluster-wide controllers, and the PostgreSQL credentials
-# Secret already present in the target namespace.
+# Secrets already present in the target namespace.
 # =============================================================================
 set -euo pipefail
 
@@ -69,8 +73,9 @@ if ! kubectl get crd clusters.postgresql.cnpg.io >/dev/null 2>&1; then
 fi
 
 # The silo lives in its own namespace so its per-CT DB + planes are isolated from every other
-# silo and from the central release. Its OpenCrane, Obot, and LiteLLM databases are separate
-# CNPG Clusters inside that namespace. Default `opencrane-<cluster-tenant>`; --namespace overrides.
+# silo and from the central release. One CNPG Cluster in that namespace hosts its isolated
+# OpenCrane, Obot, LiteLLM, and Langfuse logical databases. Default `opencrane-<cluster-tenant>`;
+# --namespace overrides.
 [[ -n "$NAMESPACE" ]] || NAMESPACE="opencrane-${CLUSTER_TENANT}"
 
 # Per-org OIDC (org-admin login). opencrane-server resolves the per-org CLIENT from the

--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -28,6 +28,7 @@
 #                            [--fleet-postgres-credentials-secret NAME] [--fleet-postgres-owner OWNER]
 #                            --obot-postgres-credentials-secret NAME [--obot-postgres-owner OWNER]
 #                            --litellm-postgres-credentials-secret NAME [--litellm-postgres-owner OWNER]
+#                            --langfuse-postgres-credentials-secret NAME [--langfuse-postgres-owner OWNER]
 #                            [--postgres-values FILE]
 #                            [--no-ingress-nginx]
 #                            [--no-external-dns]
@@ -239,6 +240,8 @@ OBOT_POSTGRES_CREDENTIALS_SECRET="${OPENCRANE_OBOT_POSTGRES_CREDENTIALS_SECRET:-
 OBOT_POSTGRES_OWNER="${OPENCRANE_OBOT_POSTGRES_OWNER:-obot}"
 LITELLM_POSTGRES_CREDENTIALS_SECRET="${OPENCRANE_LITELLM_POSTGRES_CREDENTIALS_SECRET:-}"
 LITELLM_POSTGRES_OWNER="${OPENCRANE_LITELLM_POSTGRES_OWNER:-litellm}"
+LANGFUSE_POSTGRES_CREDENTIALS_SECRET="${OPENCRANE_LANGFUSE_POSTGRES_CREDENTIALS_SECRET:-}"
+LANGFUSE_POSTGRES_OWNER="${OPENCRANE_LANGFUSE_POSTGRES_OWNER:-langfuse}"
 # The central fleet profile owns a separate registry database. Silo wrappers disable
 # it through fleetManager.enabled=false; an explicit environment override exists for
 # other thin profiles that do not render the fleet manager.
@@ -317,6 +320,8 @@ while [[ $# -gt 0 ]]; do
     --obot-postgres-owner) OBOT_POSTGRES_OWNER="$2"; shift 2 ;;
     --litellm-postgres-credentials-secret) LITELLM_POSTGRES_CREDENTIALS_SECRET="$2"; shift 2 ;;
     --litellm-postgres-owner) LITELLM_POSTGRES_OWNER="$2"; shift 2 ;;
+    --langfuse-postgres-credentials-secret) LANGFUSE_POSTGRES_CREDENTIALS_SECRET="$2"; shift 2 ;;
+    --langfuse-postgres-owner) LANGFUSE_POSTGRES_OWNER="$2"; shift 2 ;;
     --postgres-values) POSTGRES_VALUES_FILE="$2"; shift 2 ;;
     --dns-writer-gsa)   DNS_WRITER_GSA="$2"; shift 2 ;;
     --cert-manager)  CERT_MANAGER="on"; shift ;;
@@ -376,6 +381,7 @@ _run_preflight() {
   # 1b. PostgreSQL is app-owned, while its operator and bootstrap credentials are external
   # prerequisites. Validate both without installing, generating, rotating, or repairing them.
   kubectl get crd clusters.postgresql.cnpg.io >/dev/null 2>&1 || PF_FAILS+=("CloudNativePG operator is absent (clusters.postgresql.cnpg.io CRD not found). Install it before OpenCrane.")
+  kubectl get crd databases.postgresql.cnpg.io >/dev/null 2>&1 || PF_FAILS+=("CloudNativePG Database CRD is absent (databases.postgresql.cnpg.io not found). Install a compatible operator before OpenCrane.")
   _preflight_postgres_bootstrap() {
     local authority="$1"
     local credentials_secret="$2"
@@ -406,6 +412,7 @@ _run_preflight() {
   [[ "$INSTALL_FLEET_DATABASE" == "0" ]] || _preflight_postgres_bootstrap fleet "$FLEET_POSTGRES_CREDENTIALS_SECRET" "$FLEET_POSTGRES_OWNER"
   _preflight_postgres_bootstrap obot "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER"
   _preflight_postgres_bootstrap litellm "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER"
+  _preflight_postgres_bootstrap langfuse "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_OWNER"
 
   # 2. NetworkPolicy-enforcing CNI — the platform's isolation model is built on
   #    NetworkPolicy; a CNI that silently ignores them (e.g. stock kindnet/flannel) makes
@@ -579,11 +586,15 @@ LANGFUSE_REDIS_PASSWORD="${LANGFUSE_REDIS_PASSWORD:-$(_gen_secret)}"
 log "Target cluster: $(kubectl config current-context)"
 log "Namespace: $NAMESPACE   Release: $RELEASE   Image tag: $IMAGE_TAG"
 
-# 1. Install app-owned PostgreSQL releases. Each authority gets its own CNPG Cluster,
-# application Secret, PVC lifecycle, and migration history. This is a clean target layout:
-# no shared sibling databases, dual writes, or legacy database import.
+# 1. Install one app-owned PostgreSQL server for this ClusterTenant. Logical databases
+# share its pod/PVC but never credentials: each has its own login role, basic-auth input,
+# and published application connection Secret.
 if ! kubectl get crd clusters.postgresql.cnpg.io >/dev/null 2>&1; then
   err "CloudNativePG is required (clusters.postgresql.cnpg.io is absent). Install the operator before OpenCrane."
+  exit 1
+fi
+if ! kubectl get crd databases.postgresql.cnpg.io >/dev/null 2>&1; then
+  err "CloudNativePG Database CRD is required (databases.postgresql.cnpg.io is absent). Install a compatible operator before OpenCrane."
   exit 1
 fi
 _require_postgres_bootstrap() {
@@ -620,30 +631,44 @@ _require_postgres_bootstrap opencrane "$POSTGRES_CREDENTIALS_SECRET" "$POSTGRES_
 [[ "$INSTALL_FLEET_DATABASE" == "0" ]] || _require_postgres_bootstrap fleet "$FLEET_POSTGRES_CREDENTIALS_SECRET" "$FLEET_POSTGRES_OWNER"
 _require_postgres_bootstrap obot "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER"
 _require_postgres_bootstrap litellm "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER"
+_require_postgres_bootstrap langfuse "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_OWNER"
 
-_install_postgres_target() {
-  local target_release="$1"
-  local database_name="$2"
-  local credentials_secret="$3"
-  local database_owner="$4"
-  local client_selectors_json="$5"
-  local postgres_args=(upgrade --install "$target_release" "$POSTGRES_CHART_DIR"
+POSTGRES_RELEASE="${RELEASE}-postgres"
+_install_postgres_server() {
+  local client_selectors_json='[{"matchLabels":{"app.kubernetes.io/component":"opencrane-server"}},{"matchLabels":{"app.kubernetes.io/component":"opencrane-server-migrate"}},{"matchLabels":{"app.kubernetes.io/component":"mcp-gateway"}},{"matchLabels":{"app.kubernetes.io/component":"litellm"}},{"matchLabels":{"app.kubernetes.io/name":"langfuse"}},{"matchLabels":{"app.kubernetes.io/component":"postgres-database-privileges"}}]'
+  local databases_json="[{\"name\":\"opencrane\",\"owner\":\"$POSTGRES_OWNER\",\"credentialsSecret\":\"$POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"obot\",\"owner\":\"$OBOT_POSTGRES_OWNER\",\"credentialsSecret\":\"$OBOT_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"litellm\",\"owner\":\"$LITELLM_POSTGRES_OWNER\",\"credentialsSecret\":\"$LITELLM_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"langfuse\",\"owner\":\"$LANGFUSE_POSTGRES_OWNER\",\"credentialsSecret\":\"$LANGFUSE_POSTGRES_CREDENTIALS_SECRET\"}]"
+  if [[ "$INSTALL_FLEET_DATABASE" == "1" ]]; then
+    client_selectors_json='[{"matchLabels":{"app.kubernetes.io/component":"opencrane-server"}},{"matchLabels":{"app.kubernetes.io/component":"opencrane-server-migrate"}},{"matchLabels":{"app.kubernetes.io/component":"mcp-gateway"}},{"matchLabels":{"app.kubernetes.io/component":"litellm"}},{"matchLabels":{"app.kubernetes.io/name":"langfuse"}},{"matchLabels":{"app.kubernetes.io/component":"postgres-database-privileges"}},{"matchLabels":{"app.kubernetes.io/component":"fleet-manager"}},{"matchLabels":{"app.kubernetes.io/component":"fleet-manager-migrate"}}]'
+    databases_json="[{\"name\":\"opencrane\",\"owner\":\"$POSTGRES_OWNER\",\"credentialsSecret\":\"$POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"obot\",\"owner\":\"$OBOT_POSTGRES_OWNER\",\"credentialsSecret\":\"$OBOT_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"litellm\",\"owner\":\"$LITELLM_POSTGRES_OWNER\",\"credentialsSecret\":\"$LITELLM_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"langfuse\",\"owner\":\"$LANGFUSE_POSTGRES_OWNER\",\"credentialsSecret\":\"$LANGFUSE_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"fleet\",\"owner\":\"$FLEET_POSTGRES_OWNER\",\"credentialsSecret\":\"$FLEET_POSTGRES_CREDENTIALS_SECRET\"}]"
+  fi
+  local postgres_args=(upgrade --install "$POSTGRES_RELEASE" "$POSTGRES_CHART_DIR"
     --namespace "$NAMESPACE"
-    --set-string "credentials.existingSecret=$credentials_secret"
-    --set-string "database.name=$database_name"
-    --set-string "database.owner=$database_owner"
+    --set-json "databases=$databases_json"
     --set-json "networkPolicy.clientPodSelectors=$client_selectors_json")
   [[ -n "$POSTGRES_VALUES_FILE" ]] && postgres_args+=(--values "$POSTGRES_VALUES_FILE")
   [[ -n "$STORAGE_CLASS" ]] && postgres_args+=(--set-string "storage.storageClass=$STORAGE_CLASS")
-  if helm status "$target_release" -n "$NAMESPACE" >/dev/null 2>&1; then
+  if helm status "$POSTGRES_RELEASE" -n "$NAMESPACE" >/dev/null 2>&1; then
     postgres_args+=(--reset-then-reuse-values)
   fi
 
-  log "Installing PostgreSQL target '$database_name' as release '$target_release'…"
+  log "Installing PostgreSQL server with isolated logical databases…"
   helm "${postgres_args[@]}"
-  kubectl wait --for=condition=Ready "cluster/${target_release}" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+  kubectl wait --for=condition=Ready "cluster/${POSTGRES_RELEASE}" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+  for database_resource in "${POSTGRES_RELEASE}-obot" "${POSTGRES_RELEASE}-litellm" "${POSTGRES_RELEASE}-langfuse"; do
+    kubectl wait --for=jsonpath='{.status.applied}'=true "database/${database_resource}" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+  done
+  if [[ "$INSTALL_FLEET_DATABASE" == "1" ]]; then
+    kubectl wait --for=jsonpath='{.status.applied}'=true "database/${POSTGRES_RELEASE}-fleet" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+  fi
+  kubectl wait --for=condition=complete "job/${POSTGRES_RELEASE}-database-privileges" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
+}
+
+_publish_database_connection() {
+  local credentials_secret="$1"
+  local app_secret="$2"
+  local database_name="$3"
   bash "$POSTGRES_CONNECTION_PUBLISHER" \
-    "$NAMESPACE" "$credentials_secret" "${target_release}-app" "${target_release}-rw" "$database_name"
+    "$NAMESPACE" "$credentials_secret" "$app_secret" "${POSTGRES_RELEASE}-rw" "$database_name"
 }
 
 _copy_cnpg_uri_secret() {
@@ -659,21 +684,19 @@ _copy_cnpg_uri_secret() {
     | kubectl apply -f -
 }
 
-POSTGRES_RELEASE="${RELEASE}-postgres"
-FLEET_POSTGRES_RELEASE="${RELEASE}-fleet-postgres"
-OBOT_POSTGRES_RELEASE="${RELEASE}-obot-postgres"
-LITELLM_POSTGRES_RELEASE="${RELEASE}-litellm-postgres"
-
-_install_postgres_target "$POSTGRES_RELEASE" "opencrane" "$POSTGRES_CREDENTIALS_SECRET" "$POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"opencrane-server"}},{"matchLabels":{"app.kubernetes.io/component":"opencrane-server-migrate"}}]'
+_install_postgres_server
+POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-opencrane-app"
+OBOT_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-obot-app"
+LITELLM_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-litellm-app"
+LANGFUSE_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-langfuse-app"
+_publish_database_connection "$POSTGRES_CREDENTIALS_SECRET" "$POSTGRES_APP_SECRET" opencrane
+_publish_database_connection "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_APP_SECRET" obot
+_publish_database_connection "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_APP_SECRET" litellm
+_publish_database_connection "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_APP_SECRET" langfuse
 if [[ "$INSTALL_FLEET_DATABASE" == "1" ]]; then
-  _install_postgres_target "$FLEET_POSTGRES_RELEASE" "fleet" "$FLEET_POSTGRES_CREDENTIALS_SECRET" "$FLEET_POSTGRES_OWNER" \
-    '[{"matchLabels":{"app.kubernetes.io/component":"fleet-manager"}},{"matchLabels":{"app.kubernetes.io/component":"fleet-manager-migrate"}}]'
+  FLEET_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-fleet-app"
+  _publish_database_connection "$FLEET_POSTGRES_CREDENTIALS_SECRET" "$FLEET_POSTGRES_APP_SECRET" fleet
 fi
-_install_postgres_target "$OBOT_POSTGRES_RELEASE" "obot" "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"mcp-gateway"}}]'
-_install_postgres_target "$LITELLM_POSTGRES_RELEASE" "litellm" "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"litellm"}}]'
 
 _assert_distinct_cnpg_app_credentials() {
   local app_secrets=("$@")
@@ -697,19 +720,16 @@ _assert_distinct_cnpg_app_credentials() {
   done
 }
 if [[ "$INSTALL_FLEET_DATABASE" == "1" ]]; then
-  _assert_distinct_cnpg_app_credentials "${POSTGRES_RELEASE}-app" "${FLEET_POSTGRES_RELEASE}-app" "${OBOT_POSTGRES_RELEASE}-app" "${LITELLM_POSTGRES_RELEASE}-app"
+  _assert_distinct_cnpg_app_credentials "$POSTGRES_APP_SECRET" "$FLEET_POSTGRES_APP_SECRET" "$OBOT_POSTGRES_APP_SECRET" "$LITELLM_POSTGRES_APP_SECRET" "$LANGFUSE_POSTGRES_APP_SECRET"
 else
-  _assert_distinct_cnpg_app_credentials "${POSTGRES_RELEASE}-app" "${OBOT_POSTGRES_RELEASE}-app" "${LITELLM_POSTGRES_RELEASE}-app"
+  _assert_distinct_cnpg_app_credentials "$POSTGRES_APP_SECRET" "$OBOT_POSTGRES_APP_SECRET" "$LITELLM_POSTGRES_APP_SECRET" "$LANGFUSE_POSTGRES_APP_SECRET"
 fi
 
-# CNPG's `<cluster>-app` Secret is canonical. Adapt only the key/name required by
-# third-party charts, without creating databases inside another authority's Cluster.
-POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-app"
-FLEET_POSTGRES_APP_SECRET="${FLEET_POSTGRES_RELEASE}-app"
+# Per-database app secrets are canonical. Adapt only the key/name required by third-party charts.
 OBOT_DSN_SECRET="${RELEASE}-obot"
 LITELLM_DATABASE_SECRET="${RELEASE}-litellm-db"
-_copy_cnpg_uri_secret "${OBOT_POSTGRES_RELEASE}-app" "$OBOT_DSN_SECRET" dsn
-_copy_cnpg_uri_secret "${LITELLM_POSTGRES_RELEASE}-app" "$LITELLM_DATABASE_SECRET" DATABASE_URL
+_copy_cnpg_uri_secret "$OBOT_POSTGRES_APP_SECRET" "$OBOT_DSN_SECRET" dsn
+_copy_cnpg_uri_secret "$LITELLM_POSTGRES_APP_SECRET" "$LITELLM_DATABASE_SECRET" DATABASE_URL
 
 # ArtifactStore uses two distinct per-silo Ed25519 roles: the catalog signs bounded write leases
 # and verifies promotion receipts; artifact-service verifies leases and signs receipts. The two
@@ -1166,17 +1186,20 @@ TN_TAG="${TENANT_TAG:-$IMAGE_TAG}"
 # controlPlaneHost) are derived from it. Setting it explicitly here keeps a single
 # source of truth across the chart, the issuer, and the operator's per-org provisioning.
 [[ -n "$BASE_DOMAIN" ]] && helm_args+=(--set "ingress.domain=$BASE_DOMAIN")
-# Langfuse endpoint wiring is independent from PostgreSQL. Its storage must be supplied by
-# its own deployable contract when enabled; the OpenCrane database is not a shared SQL host.
+# Langfuse has its own database and role on this ClusterTenant's shared PostgreSQL server.
+# It never receives the OpenCrane, Obot, or LiteLLM credential.
+helm_args+=(--set-string "langfuse.postgresql.host=${POSTGRES_RELEASE}-rw.${NAMESPACE}.svc.cluster.local")
+helm_args+=(--set-string "langfuse.postgresql.auth.username=$LANGFUSE_POSTGRES_OWNER")
+helm_args+=(--set-string "langfuse.postgresql.auth.existingSecret=$LANGFUSE_POSTGRES_APP_SECRET")
+helm_args+=(--set-string "langfuse.postgresql.auth.secretKeys.userPasswordKey=password")
+helm_args+=(--set-string "langfuse.postgresql.auth.secretKeys.adminPasswordKey=password")
+helm_args+=(--set-string "langfuse.postgresql.auth.database=langfuse")
 helm_args+=(--set "langfuse.s3.auth.rootPassword=$LANGFUSE_S3_ROOT_PASSWORD")
 helm_args+=(--set "global.valkey.password=$LANGFUSE_REDIS_PASSWORD")
 helm_args+=(--set "langfuse.clickhouse.auth.password=$LANGFUSE_CH_PASSWORD")
 # Bitnami sub-subchart conditions default to deploy:true in the Langfuse chart even
 # when langfuse.inCluster.enabled=false; pass passwords unconditionally so Bitnami's
 # upgrade password-validation templates are satisfied regardless of Langfuse state.
-# Also re-assert the condition flag so --reuse-values can never accidentally carry
-# a stale true from a previous in-cluster install.
-helm_args+=(--set "langfuse.inCluster.enabled=false")
 [[ -n "$BASE_DOMAIN" ]] && helm_args+=(--set-string "langfuse.langfuse.nextauth.url=https://langfuse.${BASE_DOMAIN}")
 # OIDC human-login (opencrane-ui silo). Rendered iff an issuer URL is given; otherwise
 # the chart emits no OIDC env and the opencrane-ui stays in token/development mode.

--- a/apps/_infra/deploy-k8s/platform/templates/_helpers.tpl
+++ b/apps/_infra/deploy-k8s/platform/templates/_helpers.tpl
@@ -174,11 +174,11 @@ and the migration Job all share it so they can never drift).
 
 Both roles wire the opencrane-ui to the database the installer provisions via
 `controlPlane.database.existingSecret` (or `.url`). Per-ClusterTenant isolation (S6 / ADR 0002)
-comes from the SILO deploying a dedicated CNPG cluster IN ITS OWN NAMESPACE — one Postgres per
-silo serving that silo's opencrane-ui + runtime planes — so the silo opencrane-ui's DB already
-holds exactly one ClusterTenant's data and never has to infer which tenant a row belongs to. The
-deploy scripts (`apps/_infra/deploy-k8s/deploy.sh` → `k8s-deploy.sh`) provision that per-namespace cluster + secret;
-this helper just consumes whatever secret the installer points at, identically for both roles.
+comes from the SILO deploying one dedicated CNPG server IN ITS OWN NAMESPACE. That server has
+separate logical databases and credentials per plane; this helper receives only the OpenCrane
+database Secret, so the silo opencrane-ui never shares a database role or needs to infer a tenant.
+The deploy scripts (`apps/_infra/deploy-k8s/deploy.sh` → `k8s-deploy.sh`) provision the server +
+per-database Secrets; this helper just consumes the OpenCrane one for both roles.
 
 With no explicit DB this renders no DATABASE_URL (the opencrane-ui stays in its no-DB mode); a
 real deploy always supplies one.

--- a/apps/_infra/deploy-k8s/platform/tests/k3d-e2e.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/k3d-e2e.sh
@@ -42,17 +42,18 @@ DB_STORAGE_GB="${DB_STORAGE_GB:-20}"
 DISK_HEADROOM_GB="${DISK_HEADROOM_GB:-2}"
 MIN_FREE_GB="${MIN_FREE_GB:-$(( DB_STORAGE_GB + DISK_HEADROOM_GB ))}"
 OPENCRANE_DB_RELEASE_NAME="${OPENCRANE_DB_RELEASE_NAME:-opencrane-postgres}"
-OBOT_DB_RELEASE_NAME="${OBOT_DB_RELEASE_NAME:-opencrane-obot-postgres}"
-LITELLM_DB_RELEASE_NAME="${LITELLM_DB_RELEASE_NAME:-opencrane-litellm-postgres}"
 POSTGRES_CREDENTIALS_SECRET="${POSTGRES_CREDENTIALS_SECRET:-opencrane-postgres-credentials}"
 OBOT_POSTGRES_CREDENTIALS_SECRET="${OBOT_POSTGRES_CREDENTIALS_SECRET:-opencrane-obot-postgres-credentials}"
 LITELLM_POSTGRES_CREDENTIALS_SECRET="${LITELLM_POSTGRES_CREDENTIALS_SECRET:-opencrane-litellm-postgres-credentials}"
+LANGFUSE_POSTGRES_CREDENTIALS_SECRET="${LANGFUSE_POSTGRES_CREDENTIALS_SECRET:-opencrane-langfuse-postgres-credentials}"
 POSTGRES_OWNER="${POSTGRES_OWNER:-opencrane_e2e}"
 OBOT_POSTGRES_OWNER="${OBOT_POSTGRES_OWNER:-obot_e2e}"
 LITELLM_POSTGRES_OWNER="${LITELLM_POSTGRES_OWNER:-litellm_e2e}"
+LANGFUSE_POSTGRES_OWNER="${LANGFUSE_POSTGRES_OWNER:-langfuse_e2e}"
 DB_PASSWORD="${DB_PASSWORD:-opencrane-e2e-password}"
 OBOT_DB_PASSWORD="${OBOT_DB_PASSWORD:-obot-e2e-password}"
 LITELLM_DB_PASSWORD="${LITELLM_DB_PASSWORD:-litellm-e2e-password}"
+LANGFUSE_DB_PASSWORD="${LANGFUSE_DB_PASSWORD:-langfuse-e2e-password}"
 CNPG_CHART_VERSION="${CNPG_CHART_VERSION:-0.29.0}"
 CNPG_SYSTEM_NAMESPACE="cnpg-system"
 CERT_MANAGER_CHART_VERSION="${CERT_MANAGER_CHART_VERSION:-v1.15.1}"
@@ -334,6 +335,8 @@ echo "[e2e] Bootstrapping one credentials Secret per PostgreSQL authority"
 _create_database_credentials "$POSTGRES_CREDENTIALS_SECRET" "$POSTGRES_OWNER" "$DB_PASSWORD"
 _create_database_credentials "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER" "$OBOT_DB_PASSWORD"
 _create_database_credentials "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER" "$LITELLM_DB_PASSWORD"
+_create_database_credentials "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_OWNER" "$LANGFUSE_DB_PASSWORD"
+DATABASES_JSON="[{\"name\":\"opencrane\",\"owner\":\"$POSTGRES_OWNER\",\"credentialsSecret\":\"$POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"obot\",\"owner\":\"$OBOT_POSTGRES_OWNER\",\"credentialsSecret\":\"$OBOT_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"litellm\",\"owner\":\"$LITELLM_POSTGRES_OWNER\",\"credentialsSecret\":\"$LITELLM_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"langfuse\",\"owner\":\"$LANGFUSE_POSTGRES_OWNER\",\"credentialsSecret\":\"$LANGFUSE_POSTGRES_CREDENTIALS_SECRET\"}]"
 
 echo "[e2e] Installing pinned MinIO backup target"
 kubectl create secret generic opencrane-backup-object-store-credentials \
@@ -476,7 +479,7 @@ function _validate_cnpg_backup_recovery_schema()
   echo "[e2e] Validating backup contract against the pinned CNPG API server schema"
   helm template postgres-backup-contract "$ROOT_DIR/apps/postgres/helm" \
     --namespace "$NAMESPACE" \
-    --set "credentials.existingSecret=$POSTGRES_CREDENTIALS_SECRET" \
+    --set-json "databases=$DATABASES_JSON" \
     --set "networkPolicy.operatorNamespace=$CNPG_SYSTEM_NAMESPACE" \
     --set backup.enabled=true \
     --set backup.plugin.name=barman-cloud.cloudnative-pg.io \
@@ -486,7 +489,7 @@ function _validate_cnpg_backup_recovery_schema()
   echo "[e2e] Validating recovery contract against the pinned CNPG API server schema"
   helm template postgres-recovery-contract "$ROOT_DIR/apps/postgres/helm" \
     --namespace "$NAMESPACE" \
-    --set "credentials.existingSecret=$POSTGRES_CREDENTIALS_SECRET" \
+    --set-json "databases=$DATABASES_JSON" \
     --set "networkPolicy.operatorNamespace=$CNPG_SYSTEM_NAMESPACE" \
     --set restore.enabled=true \
     --set restore.plugin.name=barman-cloud.cloudnative-pg.io \
@@ -496,27 +499,30 @@ function _validate_cnpg_backup_recovery_schema()
   rm -f "$rendered"
 }
 
-function _install_database()
+function _install_postgres_server()
 {
-  local release_name="$1"
-  local database_name="$2"
-  local credentials_secret="$3"
-  local database_owner="$4"
-  local client_selectors_json="$5"
-
-  echo "[e2e] Installing PostgreSQL target '$database_name' as '$release_name'"
-  helm upgrade --install "$release_name" "$ROOT_DIR/apps/postgres/helm" \
+  echo "[e2e] Installing one PostgreSQL server with isolated logical databases"
+  helm upgrade --install "$OPENCRANE_DB_RELEASE_NAME" "$ROOT_DIR/apps/postgres/helm" \
     --namespace "$NAMESPACE" \
-    --set "credentials.existingSecret=$credentials_secret" \
-    --set-string "database.name=$database_name" \
-    --set-string "database.owner=$database_owner" \
+    --set-json "databases=$DATABASES_JSON" \
     --set "storage.size=${DB_STORAGE_GB}Gi" \
     --set "storage.storageClass=local-path" \
     --set "networkPolicy.operatorNamespace=$CNPG_SYSTEM_NAMESPACE" \
-    --set-json "networkPolicy.clientPodSelectors=$client_selectors_json"
-  kubectl wait --for=condition=Ready "cluster/$release_name" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+    --set-json 'networkPolicy.clientPodSelectors=[{"matchLabels":{"app.kubernetes.io/component":"opencrane-server"}},{"matchLabels":{"app.kubernetes.io/component":"opencrane-server-migrate"}},{"matchLabels":{"app.kubernetes.io/component":"mcp-gateway"}},{"matchLabels":{"app.kubernetes.io/component":"litellm"}},{"matchLabels":{"app.kubernetes.io/name":"langfuse"}},{"matchLabels":{"app.kubernetes.io/component":"postgres-database-privileges"}}]'
+  kubectl wait --for=condition=Ready "cluster/$OPENCRANE_DB_RELEASE_NAME" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+  for database_resource in obot litellm langfuse; do
+    kubectl wait --for=jsonpath='{.status.applied}'=true "database/${OPENCRANE_DB_RELEASE_NAME}-${database_resource}" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+  done
+  kubectl wait --for=condition=complete "job/${OPENCRANE_DB_RELEASE_NAME}-database-privileges" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+}
+
+function _publish_database_connection()
+{
+  local credentials_secret="$1"
+  local app_secret="$2"
+  local database_name="$3"
   bash "$ROOT_DIR/apps/postgres/scripts/publish-app-connection-secret.sh" \
-    "$NAMESPACE" "$credentials_secret" "${release_name}-app" "${release_name}-rw" "$database_name"
+    "$NAMESPACE" "$credentials_secret" "$app_secret" "${OPENCRANE_DB_RELEASE_NAME}-rw" "$database_name"
 }
 
 function _copy_cnpg_uri_secret()
@@ -564,7 +570,7 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: ${OPENCRANE_DB_RELEASE_NAME}-app
+                  name: ${OPENCRANE_POSTGRES_APP_SECRET}
                   key: uri
 EOF
   kubectl wait --for=condition=Complete job/opencrane-backup-schema-migrate \
@@ -625,12 +631,53 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: ${OPENCRANE_DB_RELEASE_NAME}-app
+                  name: ${OPENCRANE_POSTGRES_APP_SECRET}
                   key: uri
 EOF
   kubectl wait --for=condition=Complete job/opencrane-backup-marker-writer \
     -n "$NAMESPACE" \
     --timeout="${TIMEOUT_SECONDS}s"
+
+  _write_logical_database_marker() {
+    local database_name="$1"
+    local app_secret="$2"
+    local job_name="opencrane-backup-marker-writer-${database_name}"
+    cat <<EOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: ${NAMESPACE}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: mcp-gateway
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: writer
+          image: ghcr.io/cloudnative-pg/postgresql:17.5
+          command: ["/bin/sh", "-ceu"]
+          args:
+            - |
+              psql "\$DATABASE_URL" -v ON_ERROR_STOP=1 -c 'CREATE TABLE IF NOT EXISTS backup_restore_smoke (marker text PRIMARY KEY);'
+              psql "\$DATABASE_URL" -v ON_ERROR_STOP=1 -c "INSERT INTO backup_restore_smoke(marker) VALUES ('${BACKUP_MARKER}-${database_name}') ON CONFLICT (marker) DO NOTHING;"
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ${app_secret}
+                  key: uri
+EOF
+    kubectl wait --for=condition=Complete "job/${job_name}" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+  }
+
+  _write_logical_database_marker obot "$OBOT_POSTGRES_APP_SECRET"
+  _write_logical_database_marker litellm "$LITELLM_POSTGRES_APP_SECRET"
+  _write_logical_database_marker langfuse "$LANGFUSE_POSTGRES_APP_SECRET"
 
   echo "[e2e] Taking an on-demand plugin backup"
   cat <<EOF | kubectl apply -f -
@@ -654,13 +701,11 @@ EOF
   echo "[e2e] Recovering the backup into fresh Cluster '$RESTORE_DB_RELEASE_NAME'"
   helm upgrade --install "$RESTORE_DB_RELEASE_NAME" "$ROOT_DIR/apps/postgres/helm" \
     --namespace "$NAMESPACE" \
-    --set "credentials.existingSecret=$POSTGRES_CREDENTIALS_SECRET" \
-    --set-string database.name=opencrane \
-    --set-string "database.owner=$POSTGRES_OWNER" \
+    --set-json "databases=$DATABASES_JSON" \
     --set "storage.size=${DB_STORAGE_GB}Gi" \
     --set storage.storageClass=local-path \
     --set "networkPolicy.operatorNamespace=$CNPG_SYSTEM_NAMESPACE" \
-    --set-json 'networkPolicy.clientPodSelectors=[{"matchLabels":{"app.kubernetes.io/component":"postgres-restore-smoke"}}]' \
+    --set-json 'networkPolicy.clientPodSelectors=[{"matchLabels":{"app.kubernetes.io/component":"postgres-restore-smoke"}},{"matchLabels":{"app.kubernetes.io/component":"postgres-database-privileges"}}]' \
     --set restore.enabled=true \
     --set restore.plugin.name=barman-cloud.cloudnative-pg.io \
     --set-string "restore.plugin.parameters.barmanObjectName=$BACKUP_OBJECT_STORE_NAME" \
@@ -668,8 +713,21 @@ EOF
   kubectl wait --for=condition=Ready "cluster/$RESTORE_DB_RELEASE_NAME" \
     -n "$NAMESPACE" \
     --timeout="${TIMEOUT_SECONDS}s"
-  bash "$ROOT_DIR/apps/postgres/scripts/publish-app-connection-secret.sh" \
-    "$NAMESPACE" "$POSTGRES_CREDENTIALS_SECRET" "${RESTORE_DB_RELEASE_NAME}-app" "${RESTORE_DB_RELEASE_NAME}-rw" opencrane
+  for database_resource in obot litellm langfuse; do
+    kubectl wait --for=jsonpath='{.status.applied}'=true "database/${RESTORE_DB_RELEASE_NAME}-${database_resource}" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+  done
+  kubectl wait --for=condition=complete "job/${RESTORE_DB_RELEASE_NAME}-database-privileges" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+  _publish_restored_connection() {
+    local credentials_secret="$1"
+    local app_secret="$2"
+    local database_name="$3"
+    bash "$ROOT_DIR/apps/postgres/scripts/publish-app-connection-secret.sh" \
+      "$NAMESPACE" "$credentials_secret" "$app_secret" "${RESTORE_DB_RELEASE_NAME}-rw" "$database_name"
+  }
+  _publish_restored_connection "$POSTGRES_CREDENTIALS_SECRET" "${RESTORE_DB_RELEASE_NAME}-opencrane-app" opencrane
+  _publish_restored_connection "$OBOT_POSTGRES_CREDENTIALS_SECRET" "${RESTORE_DB_RELEASE_NAME}-obot-app" obot
+  _publish_restored_connection "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "${RESTORE_DB_RELEASE_NAME}-litellm-app" litellm
+  _publish_restored_connection "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "${RESTORE_DB_RELEASE_NAME}-langfuse-app" langfuse
 
   echo "[e2e] Verifying the restored marker through the recovered application Secret"
   cat <<EOF | kubectl apply -f -
@@ -702,27 +760,126 @@ spec:
                 fi
                 sleep 2
               done
-              restored_marker="\$(psql "\$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc 'SELECT marker FROM backup_restore_smoke LIMIT 1')"
+              restored_marker="\$(psql "\$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc "SELECT marker FROM backup_restore_smoke WHERE marker = '${BACKUP_MARKER}'")"
               test "\$restored_marker" = "${BACKUP_MARKER}"
           env:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: ${RESTORE_DB_RELEASE_NAME}-app
+                  name: ${RESTORE_DB_RELEASE_NAME}-opencrane-app
                   key: uri
 EOF
   kubectl wait --for=condition=Complete job/opencrane-backup-restore-verifier \
     -n "$NAMESPACE" \
     --timeout="${TIMEOUT_SECONDS}s"
+
+  _verify_restored_logical_marker() {
+    local database_name="$1"
+    local app_secret="$2"
+    local job_name="opencrane-backup-restore-verifier-${database_name}"
+    cat <<EOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: ${NAMESPACE}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: postgres-restore-smoke
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: verifier
+          image: ghcr.io/cloudnative-pg/postgresql:17.5
+          command: ["/bin/sh", "-ceu"]
+          args:
+            - |
+              restored_marker="\$(psql "\$DATABASE_URL" -v ON_ERROR_STOP=1 -Atc "SELECT marker FROM backup_restore_smoke WHERE marker = '${BACKUP_MARKER}-${database_name}'")"
+              test "\$restored_marker" = "${BACKUP_MARKER}-${database_name}"
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ${app_secret}
+                  key: uri
+EOF
+    kubectl wait --for=condition=Complete "job/${job_name}" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+  }
+
+  _verify_restored_logical_marker obot "${RESTORE_DB_RELEASE_NAME}-obot-app"
+  _verify_restored_logical_marker litellm "${RESTORE_DB_RELEASE_NAME}-litellm-app"
+  _verify_restored_logical_marker langfuse "${RESTORE_DB_RELEASE_NAME}-langfuse-app"
 }
 
 _validate_cnpg_backup_recovery_schema
-_install_database "$OPENCRANE_DB_RELEASE_NAME" opencrane "$POSTGRES_CREDENTIALS_SECRET" "$POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"opencrane-server"}},{"matchLabels":{"app.kubernetes.io/component":"opencrane-server-migrate"}}]'
-_install_database "$OBOT_DB_RELEASE_NAME" obot "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"mcp-gateway"}}]'
-_install_database "$LITELLM_DB_RELEASE_NAME" litellm "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"litellm"}}]'
+_install_postgres_server
+OPENCRANE_POSTGRES_APP_SECRET="${OPENCRANE_DB_RELEASE_NAME}-opencrane-app"
+OBOT_POSTGRES_APP_SECRET="${OPENCRANE_DB_RELEASE_NAME}-obot-app"
+LITELLM_POSTGRES_APP_SECRET="${OPENCRANE_DB_RELEASE_NAME}-litellm-app"
+LANGFUSE_POSTGRES_APP_SECRET="${OPENCRANE_DB_RELEASE_NAME}-langfuse-app"
+_publish_database_connection "$POSTGRES_CREDENTIALS_SECRET" "$OPENCRANE_POSTGRES_APP_SECRET" opencrane
+_publish_database_connection "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_APP_SECRET" obot
+_publish_database_connection "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_APP_SECRET" litellm
+_publish_database_connection "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_APP_SECRET" langfuse
+
+function _assert_cross_database_denied()
+{
+  local source_name="$1"
+  local source_secret="$2"
+  local target_name="$3"
+  local job_name="postgres-cross-db-${source_name}-${target_name}"
+
+  echo "[e2e] Verifying $source_name cannot connect to $target_name"
+  cat <<EOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: ${NAMESPACE}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: mcp-gateway
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: cross-database-denial
+          image: ghcr.io/cloudnative-pg/postgresql:17.5
+          command: ["/bin/sh", "-ceu"]
+          args:
+            - |
+              if psql -v ON_ERROR_STOP=1 -d "${target_name}" -c 'SELECT 1' >/dev/null 2>&1; then
+                echo "${source_name} unexpectedly connected to ${target_name}" >&2
+                exit 1
+              fi
+              psql -v ON_ERROR_STOP=1 -d "${source_name}" -c 'SELECT 1' >/dev/null
+          env:
+            - name: PGHOST
+              value: ${OPENCRANE_DB_RELEASE_NAME}-rw
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: ${source_secret}
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${source_secret}
+                  key: password
+EOF
+  kubectl wait --for=condition=complete "job/${job_name}" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+}
+
+_assert_cross_database_denied obot "$OBOT_POSTGRES_CREDENTIALS_SECRET" opencrane
+_assert_cross_database_denied litellm "$LITELLM_POSTGRES_CREDENTIALS_SECRET" obot
+_assert_cross_database_denied langfuse "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" litellm
 
 _migrate_opencrane_database
 _run_backup_restore_smoke
@@ -749,10 +906,10 @@ function _assert_distinct_cnpg_app_credentials()
     done
   done
 }
-_assert_distinct_cnpg_app_credentials "${OPENCRANE_DB_RELEASE_NAME}-app" "${OBOT_DB_RELEASE_NAME}-app" "${LITELLM_DB_RELEASE_NAME}-app"
+_assert_distinct_cnpg_app_credentials "$OPENCRANE_POSTGRES_APP_SECRET" "$OBOT_POSTGRES_APP_SECRET" "$LITELLM_POSTGRES_APP_SECRET" "$LANGFUSE_POSTGRES_APP_SECRET"
 
-_copy_cnpg_uri_secret "${OBOT_DB_RELEASE_NAME}-app" "${RELEASE_NAME}-obot" dsn
-_copy_cnpg_uri_secret "${LITELLM_DB_RELEASE_NAME}-app" opencrane-litellm-db DATABASE_URL
+_copy_cnpg_uri_secret "$OBOT_POSTGRES_APP_SECRET" "${RELEASE_NAME}-obot" dsn
+_copy_cnpg_uri_secret "$LITELLM_POSTGRES_APP_SECRET" opencrane-litellm-db DATABASE_URL
 
 # Boot-time BYOK bootstrap key — seeds a model so the default-tenant seed's ≥1-model gate passes.
 kubectl create secret generic "$BOOTSTRAP_SECRET_NAME" \
@@ -777,7 +934,7 @@ helm upgrade --install "$RELEASE_NAME" "$ROOT_DIR/apps/_infra/deploy-k8s" \
   --set "clustertenantManager.standaloneSeed.displayName=$ORG_DISPLAY_NAME" \
   --set "clustertenantManager.standaloneSeed.ownerEmail=$OWNER_EMAIL" \
   --set "clustertenantManager.standaloneSeed.tier=$ORG_TIER" \
-  --set "clustertenantManager.database.existingSecret=${OPENCRANE_DB_RELEASE_NAME}-app" \
+  --set "clustertenantManager.database.existingSecret=${OPENCRANE_POSTGRES_APP_SECRET}" \
   --set "clustertenantManager.database.secretKey=uri" \
   --set "litellm.existingDatabaseSecret=opencrane-litellm-db" \
   --set "litellm.databaseSecretKey=DATABASE_URL" \

--- a/apps/_infra/deploy-k8s/platform/tests/k3d-local.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/k3d-local.sh
@@ -9,22 +9,22 @@ KEEP_CLUSTER="${KEEP_CLUSTER:-1}"
 LOCAL_PROFILE="${LOCAL_PROFILE:-default}"
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-300}"
 MIN_FREE_GB="${MIN_FREE_GB:-12}"
-SILO_DB_RELEASE_NAME="${SILO_DB_RELEASE_NAME:-opencrane-silo-postgres}"
-FLEET_DB_RELEASE_NAME="${FLEET_DB_RELEASE_NAME:-opencrane-fleet-postgres}"
-OBOT_DB_RELEASE_NAME="${OBOT_DB_RELEASE_NAME:-opencrane-obot-postgres}"
-LITELLM_DB_RELEASE_NAME="${LITELLM_DB_RELEASE_NAME:-opencrane-litellm-postgres}"
+POSTGRES_RELEASE_NAME="${POSTGRES_RELEASE_NAME:-opencrane-postgres}"
 POSTGRES_CREDENTIALS_SECRET="${POSTGRES_CREDENTIALS_SECRET:-opencrane-postgres-credentials}"
 FLEET_POSTGRES_CREDENTIALS_SECRET="${FLEET_POSTGRES_CREDENTIALS_SECRET:-opencrane-fleet-postgres-credentials}"
 OBOT_POSTGRES_CREDENTIALS_SECRET="${OBOT_POSTGRES_CREDENTIALS_SECRET:-opencrane-obot-postgres-credentials}"
 LITELLM_POSTGRES_CREDENTIALS_SECRET="${LITELLM_POSTGRES_CREDENTIALS_SECRET:-opencrane-litellm-postgres-credentials}"
+LANGFUSE_POSTGRES_CREDENTIALS_SECRET="${LANGFUSE_POSTGRES_CREDENTIALS_SECRET:-opencrane-langfuse-postgres-credentials}"
 SILO_POSTGRES_OWNER="${SILO_POSTGRES_OWNER:-opencrane_local}"
 FLEET_POSTGRES_OWNER="${FLEET_POSTGRES_OWNER:-opencrane_fleet_local}"
 OBOT_POSTGRES_OWNER="${OBOT_POSTGRES_OWNER:-obot_local}"
 LITELLM_POSTGRES_OWNER="${LITELLM_POSTGRES_OWNER:-litellm_local}"
+LANGFUSE_POSTGRES_OWNER="${LANGFUSE_POSTGRES_OWNER:-langfuse_local}"
 DB_PASSWORD="${DB_PASSWORD:-opencrane-local-password}"
 FLEET_DB_PASSWORD="${FLEET_DB_PASSWORD:-opencrane-fleet-local-password}"
 OBOT_DB_PASSWORD="${OBOT_DB_PASSWORD:-obot-local-password}"
 LITELLM_DB_PASSWORD="${LITELLM_DB_PASSWORD:-litellm-local-password}"
+LANGFUSE_DB_PASSWORD="${LANGFUSE_DB_PASSWORD:-langfuse-local-password}"
 CNPG_CHART_VERSION="${CNPG_CHART_VERSION:-0.29.0}"
 LITELLM_SECRET_NAME="${LITELLM_SECRET_NAME:-opencrane-litellm}"
 LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-opencrane-local-master-key}"
@@ -154,8 +154,8 @@ k3d image import ghcr.io/cloudnative-pg/postgresql:17.5 --cluster "$CLUSTER_NAME
 
 echo "[local] Using profile '$LOCAL_PROFILE' with values '$VALUES_FILE'"
 
-# 5. Install the pinned external CNPG test substrate, then one app-owned Cluster per
-# database authority. Fleet and silo deliberately never share a Prisma migration history.
+# 5. Install the pinned external CNPG test substrate, then one app-owned Cluster with
+# isolated logical databases and credentials. Fleet and silo remain separate databases.
 echo "[local] Installing CloudNativePG Engine Operator into control plane"
 helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update >/dev/null
 helm upgrade --install cnpg cnpg/cloudnative-pg \
@@ -185,27 +185,23 @@ _create_database_credentials "$POSTGRES_CREDENTIALS_SECRET" "$SILO_POSTGRES_OWNE
 _create_database_credentials "$FLEET_POSTGRES_CREDENTIALS_SECRET" "$FLEET_POSTGRES_OWNER" "$FLEET_DB_PASSWORD"
 _create_database_credentials "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER" "$OBOT_DB_PASSWORD"
 _create_database_credentials "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER" "$LITELLM_DB_PASSWORD"
+_create_database_credentials "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_OWNER" "$LANGFUSE_DB_PASSWORD"
 
-function _install_database()
+function _install_postgres_server()
 {
-  local release_name="$1"
-  local database_name="$2"
-  local credentials_secret="$3"
-  local database_owner="$4"
-  local client_selectors_json="$5"
-
-  echo "[local] Installing PostgreSQL target '$database_name' as '$release_name'"
-  helm upgrade --install "$release_name" "$ROOT_DIR/apps/postgres/helm" \
+  local databases_json="[{\"name\":\"opencrane\",\"owner\":\"$SILO_POSTGRES_OWNER\",\"credentialsSecret\":\"$POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"fleet\",\"owner\":\"$FLEET_POSTGRES_OWNER\",\"credentialsSecret\":\"$FLEET_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"obot\",\"owner\":\"$OBOT_POSTGRES_OWNER\",\"credentialsSecret\":\"$OBOT_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"litellm\",\"owner\":\"$LITELLM_POSTGRES_OWNER\",\"credentialsSecret\":\"$LITELLM_POSTGRES_CREDENTIALS_SECRET\"},{\"name\":\"langfuse\",\"owner\":\"$LANGFUSE_POSTGRES_OWNER\",\"credentialsSecret\":\"$LANGFUSE_POSTGRES_CREDENTIALS_SECRET\"}]"
+  echo "[local] Installing one PostgreSQL server with isolated logical databases"
+  helm upgrade --install "$POSTGRES_RELEASE_NAME" "$ROOT_DIR/apps/postgres/helm" \
     --namespace "$NAMESPACE" \
-    --set "credentials.existingSecret=$credentials_secret" \
-    --set-string "database.name=$database_name" \
-    --set-string "database.owner=$database_owner" \
+    --set-json "databases=$databases_json" \
     --set "storage.storageClass=local-path" \
     --set "networkPolicy.operatorNamespace=$NAMESPACE" \
-    --set-json "networkPolicy.clientPodSelectors=$client_selectors_json"
-  kubectl wait --for=condition=Ready "cluster/$release_name" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
-  bash "$ROOT_DIR/apps/postgres/scripts/publish-app-connection-secret.sh" \
-    "$NAMESPACE" "$credentials_secret" "${release_name}-app" "${release_name}-rw" "$database_name"
+    --set-json 'networkPolicy.clientPodSelectors=[{"matchLabels":{"app.kubernetes.io/component":"opencrane-server"}},{"matchLabels":{"app.kubernetes.io/component":"opencrane-server-migrate"}},{"matchLabels":{"app.kubernetes.io/component":"fleet-manager"}},{"matchLabels":{"app.kubernetes.io/component":"fleet-manager-migrate"}},{"matchLabels":{"app.kubernetes.io/component":"mcp-gateway"}},{"matchLabels":{"app.kubernetes.io/component":"litellm"}},{"matchLabels":{"app.kubernetes.io/name":"langfuse"}},{"matchLabels":{"app.kubernetes.io/component":"postgres-database-privileges"}}]'
+  kubectl wait --for=condition=Ready "cluster/$POSTGRES_RELEASE_NAME" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+  for database_resource in fleet obot litellm langfuse; do
+    kubectl wait --for=jsonpath='{.status.applied}'=true "database/${POSTGRES_RELEASE_NAME}-${database_resource}" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+  done
+  kubectl wait --for=condition=complete "job/${POSTGRES_RELEASE_NAME}-database-privileges" -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
 }
 
 function _copy_cnpg_uri_secret()
@@ -221,14 +217,26 @@ function _copy_cnpg_uri_secret()
     | kubectl apply -f -
 }
 
-_install_database "$SILO_DB_RELEASE_NAME" opencrane "$POSTGRES_CREDENTIALS_SECRET" "$SILO_POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"opencrane-server"}},{"matchLabels":{"app.kubernetes.io/component":"opencrane-server-migrate"}}]'
-_install_database "$FLEET_DB_RELEASE_NAME" fleet "$FLEET_POSTGRES_CREDENTIALS_SECRET" "$FLEET_POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"fleet-manager"}},{"matchLabels":{"app.kubernetes.io/component":"fleet-manager-migrate"}}]'
-_install_database "$OBOT_DB_RELEASE_NAME" obot "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"mcp-gateway"}}]'
-_install_database "$LITELLM_DB_RELEASE_NAME" litellm "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER" \
-  '[{"matchLabels":{"app.kubernetes.io/component":"litellm"}}]'
+_install_postgres_server
+function _publish_database_connection()
+{
+  local credentials_secret="$1"
+  local app_secret="$2"
+  local database_name="$3"
+  bash "$ROOT_DIR/apps/postgres/scripts/publish-app-connection-secret.sh" \
+    "$NAMESPACE" "$credentials_secret" "$app_secret" "${POSTGRES_RELEASE_NAME}-rw" "$database_name"
+}
+
+OPENCRANE_POSTGRES_APP_SECRET="${POSTGRES_RELEASE_NAME}-opencrane-app"
+FLEET_POSTGRES_APP_SECRET="${POSTGRES_RELEASE_NAME}-fleet-app"
+OBOT_POSTGRES_APP_SECRET="${POSTGRES_RELEASE_NAME}-obot-app"
+LITELLM_POSTGRES_APP_SECRET="${POSTGRES_RELEASE_NAME}-litellm-app"
+LANGFUSE_POSTGRES_APP_SECRET="${POSTGRES_RELEASE_NAME}-langfuse-app"
+_publish_database_connection "$POSTGRES_CREDENTIALS_SECRET" "$OPENCRANE_POSTGRES_APP_SECRET" opencrane
+_publish_database_connection "$FLEET_POSTGRES_CREDENTIALS_SECRET" "$FLEET_POSTGRES_APP_SECRET" fleet
+_publish_database_connection "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_APP_SECRET" obot
+_publish_database_connection "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_APP_SECRET" litellm
+_publish_database_connection "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_APP_SECRET" langfuse
 
 function _assert_distinct_cnpg_app_credentials()
 {
@@ -252,11 +260,11 @@ function _assert_distinct_cnpg_app_credentials()
     done
   done
 }
-_assert_distinct_cnpg_app_credentials "${SILO_DB_RELEASE_NAME}-app" "${FLEET_DB_RELEASE_NAME}-app" "${OBOT_DB_RELEASE_NAME}-app" "${LITELLM_DB_RELEASE_NAME}-app"
+_assert_distinct_cnpg_app_credentials "$OPENCRANE_POSTGRES_APP_SECRET" "$FLEET_POSTGRES_APP_SECRET" "$OBOT_POSTGRES_APP_SECRET" "$LITELLM_POSTGRES_APP_SECRET" "$LANGFUSE_POSTGRES_APP_SECRET"
 
-_copy_cnpg_uri_secret "${OBOT_DB_RELEASE_NAME}-app" "${RELEASE_NAME}-obot" dsn
-_copy_cnpg_uri_secret "${OBOT_DB_RELEASE_NAME}-app" opencrane-silo-obot dsn
-_copy_cnpg_uri_secret "${LITELLM_DB_RELEASE_NAME}-app" opencrane-litellm-db DATABASE_URL
+_copy_cnpg_uri_secret "$OBOT_POSTGRES_APP_SECRET" "${RELEASE_NAME}-obot" dsn
+_copy_cnpg_uri_secret "$OBOT_POSTGRES_APP_SECRET" opencrane-silo-obot dsn
+_copy_cnpg_uri_secret "$LITELLM_POSTGRES_APP_SECRET" opencrane-litellm-db DATABASE_URL
 
 if [[ "$LOCAL_PROFILE" == "strict" ]]; then
   kubectl create secret generic "$LITELLM_SECRET_NAME" \
@@ -290,7 +298,7 @@ helm_args=(
   --values
   "$VALUES_FILE"
   --set
-  "fleetManager.database.existingSecret=${FLEET_DB_RELEASE_NAME}-app"
+  "fleetManager.database.existingSecret=${FLEET_POSTGRES_APP_SECRET}"
   --set
   "fleetManager.database.secretKey=uri"
   --set
@@ -329,7 +337,7 @@ silo_args=(
   --values
   "$VALUES_FILE"
   --set
-  "clustertenantManager.database.existingSecret=${SILO_DB_RELEASE_NAME}-app"
+  "clustertenantManager.database.existingSecret=${OPENCRANE_POSTGRES_APP_SECRET}"
   --set
   "clustertenantManager.database.secretKey=uri"
   --set

--- a/apps/_infra/deploy-k8s/values.yaml
+++ b/apps/_infra/deploy-k8s/values.yaml
@@ -9,14 +9,13 @@ global:
   # -- Deployment environment used for Helm validations (`dev`, `staging`, `prod`).
   environment: dev
 
-# -- Per-ClusterTenant tenant DB (S6 / ADR 0002 decision 3). Each silo runs ONE CNPG cluster
-#    IN ITS OWN NAMESPACE, serving that silo's opencrane-ui + runtime planes — so the silo's
-#    database holds exactly one ClusterTenant's data and the opencrane-ui API never has to
-#    disambiguate which tenant a row belongs to (the silo IS the scope). That per-namespace
-#    cluster + its credentials Secret are provisioned by the deploy scripts (apps/_infra/deploy-k8s/deploy.sh →
-#    k8s-deploy.sh), and the opencrane-ui consumes it via controlPlane.database.existingSecret —
-#    identically to the central release, just scoped to the silo namespace. No chart-side
-#    per-CT DB block is needed.
+# -- Per-ClusterTenant tenant DB (S6 / ADR 0002 decision 3). Each silo runs ONE CNPG server
+#    IN ITS OWN NAMESPACE. It hosts isolated logical databases and credentials for OpenCrane,
+#    Obot, LiteLLM, and Langfuse (and fleet when that plane is present), while retaining one
+#    pod/PVC footprint per silo. The per-namespace Cluster + per-database connection Secrets are
+#    provisioned by the deploy scripts (apps/_infra/deploy-k8s/deploy.sh → k8s-deploy.sh); the
+#    opencrane-ui consumes only its OpenCrane connection Secret. The silo is still the tenant scope,
+#    so the tenant-facing API never disambiguates ClusterTenant rows.
 
 # -- Multi-ClusterTenant profile switch (issue #127). The EXPLICIT predicate (never
 #    inferred) that this install hosts MANY tenants — many orgs (ClusterTenants) and/or
@@ -1275,7 +1274,7 @@ clusterTenant:
 #    inside this release. The opencrane-ui metrics proxy and LiteLLM trace callback
 #    are auto-wired to the in-cluster service — no manual host/key configuration needed.
 #    k8s-deploy.sh creates the `opencrane-langfuse` Secret (stable across upgrades) and
-#    adds the `langfuse` database to the shared CNPG cluster before the Helm install.
+#    supplies Langfuse's own role and database on the per-silo CNPG server before the Helm install.
 #
 #    Structure: `langfuse.inCluster` is an OpenCrane-level switch consumed by our templates.
 #    All other keys (`langfuse.langfuse`, `langfuse.postgresql`, etc.) are forwarded verbatim
@@ -1353,16 +1352,16 @@ langfuse:
       signUpDisabled: true
 
   # -- PostgreSQL: DISABLED bundled instance. k8s-deploy.sh provisions the `langfuse`
-  #    database inside the shared CNPG cluster; host is injected via --set at deploy time.
+  #    database and its distinct role on the per-silo CNPG server; host and credentials are
+  #    injected via --set at deploy time.
   postgresql:
     deploy: false
     # -- Hostname injected by k8s-deploy.sh: <release>-postgres-rw.<namespace>.svc.cluster.local
     host: ""
     auth:
       username: "opencrane"
-      # -- Reuse the CNPG cluster creds Secret (created by k8s-deploy.sh, never rotated
-      #    without also recreating the CNPG cluster).
-      existingSecret: "opencrane-postgres-creds"
+      # -- Langfuse's own published connection Secret (not an OpenCrane credential).
+      existingSecret: "opencrane-postgres-langfuse-app"
       secretKeys:
         userPasswordKey: "password"
         adminPasswordKey: "password"

--- a/apps/postgres/README.md
+++ b/apps/postgres/README.md
@@ -11,13 +11,15 @@ a release-side effect.
 The chart expects three cluster-level prerequisites:
 
 - a compatible CloudNativePG operator and CRDs, installed outside the OpenCrane release;
-- a pre-created `kubernetes.io/basic-auth` Secret containing `username` and `password`, where
-  `username` exactly equals `database.owner` (the default is `opencrane`);
+- one pre-created `kubernetes.io/basic-auth` Secret per logical database, containing `username`
+  and `password`, where `username` exactly equals that database's owner;
 - a mounted `ReadWriteOnce` StorageClass with volume expansion enabled.
 
 OpenCrane does not install or upgrade the operator and does not generate, rotate, or repair database
-credentials. The deployment flow publishes one authority-local application connection Secret from
-the supplied basic-auth Secret via `scripts/publish-app-connection-secret.sh`; it adds the connection
+credentials. One CNPG Cluster hosts `opencrane`, `obot`, `litellm`, and `langfuse` (and `fleet` in
+the fleet profile). CNPG bootstraps the first database, then declaratively reconciles the remaining
+least-privilege roles and `Database` CRs. The deployment flow publishes one application connection
+Secret per logical database via `scripts/publish-app-connection-secret.sh`; it adds the connection
 URI without sharing credentials across authorities or exposing them in command arguments or logs.
 There is one narrow workload-identity exception to normal app ownership: CloudNativePG, as the
 database Pod controller, generates the instance-manager `ServiceAccount` and its narrowly scoped
@@ -32,14 +34,17 @@ Install the database before the server release:
 ```bash
 helm upgrade --install opencrane-postgres apps/postgres/helm \
   --namespace opencrane --create-namespace \
-  --set credentials.existingSecret=opencrane-postgres-bootstrap
+  --set databases[0].credentialsSecret=opencrane-postgres-bootstrap \
+  --set databases[1].credentialsSecret=opencrane-obot-postgres-bootstrap \
+  --set databases[2].credentialsSecret=opencrane-litellm-postgres-bootstrap \
+  --set databases[3].credentialsSecret=opencrane-langfuse-postgres-bootstrap
 kubectl wait --for=condition=Ready cluster/opencrane-postgres \
   --namespace opencrane --timeout=5m
 ```
 
-`scripts/publish-app-connection-secret.sh` creates `<cluster>-app`; its `uri` key is the canonical
-connection URI for that one database target. OpenCrane, fleet, Obot, and DB-backed LiteLLM use
-separate CNPG Cluster releases rather than sibling databases or shared migration histories. Backup
+`scripts/publish-app-connection-secret.sh` creates an application Secret for one logical database;
+its `uri` key is that database's canonical connection URI. Each application role can authenticate
+only to its own database; there are no shared owner roles or credentials. Backup
 and restore stay disabled until a CNPG-I plugin and its object-store resource are installed and
 explicitly selected in values. The k3d acceptance path server-dry-runs both contracts against the
 pinned CNPG CRDs, then installs a pinned Barman Cloud plugin and MinIO test target, writes a marker,

--- a/apps/postgres/helm/templates/cluster.yaml
+++ b/apps/postgres/helm/templates/cluster.yaml
@@ -1,5 +1,26 @@
-{{- if not .Values.credentials.existingSecret -}}
-{{- fail "credentials.existingSecret is required; OpenCrane never generates database credentials" -}}
+{{- if eq (len .Values.databases) 0 -}}
+{{- fail "databases must contain at least the initdb database" -}}
+{{- end -}}
+{{- $primary := index .Values.databases 0 -}}
+{{- $databaseNames := dict -}}
+{{- $databaseOwners := dict -}}
+{{- $credentialSecrets := dict -}}
+{{- range $database := .Values.databases }}
+{{- if or (not .name) (not .owner) (not .credentialsSecret) -}}
+{{- fail "every databases entry requires name, owner, and credentialsSecret; OpenCrane never generates database credentials" -}}
+{{- end -}}
+{{- if hasKey $databaseNames $database.name -}}
+{{- fail (printf "databases entries must have unique names; duplicate %q" $database.name) -}}
+{{- end -}}
+{{- if hasKey $databaseOwners $database.owner -}}
+{{- fail (printf "databases entries must have unique owners; duplicate %q" $database.owner) -}}
+{{- end -}}
+{{- if hasKey $credentialSecrets $database.credentialsSecret -}}
+{{- fail (printf "databases entries must have unique credentialsSecret values; duplicate %q" $database.credentialsSecret) -}}
+{{- end -}}
+{{- $_ := set $databaseNames $database.name true -}}
+{{- $_ := set $databaseOwners $database.owner true -}}
+{{- $_ := set $credentialSecrets $database.credentialsSecret true -}}
 {{- end -}}
 {{- if and .Values.backup.enabled (not .Values.backup.plugin.name) -}}
 {{- fail "backup.plugin.name is required when backup.enabled=true" -}}
@@ -50,10 +71,10 @@ spec:
   bootstrap:
     recovery:
       source: {{ .Values.restore.sourceName | quote }}
-      database: {{ .Values.database.name | quote }}
-      owner: {{ .Values.database.owner | quote }}
+      database: {{ $primary.name | quote }}
+      owner: {{ $primary.owner | quote }}
       secret:
-        name: {{ .Values.credentials.existingSecret | quote }}
+        name: {{ $primary.credentialsSecret | quote }}
       {{- with .Values.restore.targetTime }}
       recoveryTarget:
         targetTime: {{ . | quote }}
@@ -69,10 +90,28 @@ spec:
   {{- else }}
   bootstrap:
     initdb:
-      database: {{ .Values.database.name | quote }}
-      owner: {{ .Values.database.owner | quote }}
+      database: {{ $primary.name | quote }}
+      owner: {{ $primary.owner | quote }}
       secret:
-        name: {{ .Values.credentials.existingSecret | quote }}
+        name: {{ $primary.credentialsSecret | quote }}
+  {{- end }}
+  {{- if gt (len .Values.databases) 1 }}
+  managed:
+    roles:
+      {{- range $index, $database := .Values.databases }}
+      {{- if gt $index 0 }}
+      - name: {{ $database.owner | quote }}
+        ensure: present
+        login: true
+        superuser: false
+        createdb: false
+        createrole: false
+        replication: false
+        bypassrls: false
+        passwordSecret:
+          name: {{ $database.credentialsSecret | quote }}
+      {{- end }}
+      {{- end }}
   {{- end }}
   {{- if .Values.backup.enabled }}
   plugins:

--- a/apps/postgres/helm/templates/database-privileges-job.yaml
+++ b/apps/postgres/helm/templates/database-privileges-job.yaml
@@ -1,0 +1,58 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "opencrane.postgres.fullname" . }}-database-privileges
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+  labels:
+    {{- include "opencrane.postgres.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ .Values.privileges.timeoutSeconds }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "opencrane.postgres.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/part-of: opencrane
+        app.kubernetes.io/component: postgres-database-privileges
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        {{- range $database := .Values.databases }}
+        - name: {{ printf "%s-privileges" $database.name | trunc 63 | trimSuffix "-" }}
+          image: {{ $.Values.image | quote }}
+          command: ["/bin/sh", "-ceu"]
+          args:
+            - |
+              deadline="$(( $(date +%s) + {{ $.Values.privileges.timeoutSeconds }} ))"
+              until psql -v ON_ERROR_STOP=1 -d "$PGDATABASE" -c 'SELECT 1' >/dev/null 2>&1; do
+                if [ "$(date +%s)" -ge "$deadline" ]; then
+                  echo "Timed out waiting for logical database '$PGDATABASE'" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+              psql -v ON_ERROR_STOP=1 -d "$PGDATABASE" -v database="$PGDATABASE" -v owner="$PGUSER" <<'SQL'
+              REVOKE CONNECT, TEMPORARY ON DATABASE :"database" FROM PUBLIC;
+              GRANT CONNECT, TEMPORARY ON DATABASE :"database" TO :"owner";
+              SQL
+          env:
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $database.credentialsSecret | quote }}
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $database.credentialsSecret | quote }}
+                  key: password
+            - name: PGHOST
+              value: {{ printf "%s-rw" (include "opencrane.postgres.fullname" $) | quote }}
+            - name: PGDATABASE
+              value: {{ $database.name | quote }}
+        {{- end }}

--- a/apps/postgres/helm/templates/databases.yaml
+++ b/apps/postgres/helm/templates/databases.yaml
@@ -1,0 +1,20 @@
+{{- range $index, $database := .Values.databases }}
+{{- if gt $index 0 }}
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: {{ printf "%s-%s" (include "opencrane.postgres.fullname" $) $database.name | trunc 63 | trimSuffix "-" }}
+  annotations:
+    # Sibling logical database data is retained with its CNPG Cluster; deletion requires
+    # an explicit operator action, never Helm uninstall.
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "opencrane.postgres.labels" $ | nindent 4 }}
+spec:
+  name: {{ $database.name | quote }}
+  owner: {{ $database.owner | quote }}
+  cluster:
+    name: {{ include "opencrane.postgres.fullname" $ }}
+{{- end }}
+{{- end }}

--- a/apps/postgres/helm/values.yaml
+++ b/apps/postgres/helm/values.yaml
@@ -1,15 +1,22 @@
 instances: 1
 image: ghcr.io/cloudnative-pg/postgresql:17.5
 
-database:
-  name: opencrane
-  owner: opencrane
-
-credentials:
-  # Required. The Secret must be type kubernetes.io/basic-auth with username/password keys.
-  # Its decoded username must equal database.owner; deploy entrypoints enforce this
-  # before installing the Cluster.
-  existingSecret: ""
+# One physical CNPG Cluster hosts these isolated logical databases. The first item is
+# bootstrapped by CNPG initdb; each later item becomes a CNPG Database CR and a managed
+# PostgreSQL role. Every item must use its own basic-auth Secret (username/password).
+databases:
+  - name: opencrane
+    owner: opencrane
+    credentialsSecret: ""
+  - name: obot
+    owner: obot
+    credentialsSecret: ""
+  - name: litellm
+    owner: litellm
+    credentialsSecret: ""
+  - name: langfuse
+    owner: langfuse
+    credentialsSecret: ""
 
 storage:
   size: 20Gi
@@ -29,12 +36,20 @@ networkPolicy:
   operatorNamespace: cnpg-system
   operatorPodLabels:
     app.kubernetes.io/name: cloudnative-pg
-  # Only the canonical server and its migration hook connect to this database.
+  # All database clients in this ClusterTenant namespace. PostgreSQL roles and
+  # per-database credentials, not NetworkPolicy, enforce logical-database isolation.
   clientPodSelectors:
     - matchLabels:
         app.kubernetes.io/component: opencrane-server
     - matchLabels:
         app.kubernetes.io/component: opencrane-server-migrate
+    - matchLabels:
+        app.kubernetes.io/component: postgres-database-privileges
+
+privileges:
+  # A bounded in-cluster psql Job runs after each Cluster/Database reconciliation to
+  # remove PostgreSQL's default PUBLIC CONNECT/TEMPORARY grants from every logical DB.
+  timeoutSeconds: 300
 
 backup:
   enabled: false

--- a/apps/postgres/project.json
+++ b/apps/postgres/project.json
@@ -6,7 +6,7 @@
   "targets": {
     "helm-lint": {
       "executor": "nx:run-commands",
-      "options": { "command": "helm lint apps/postgres/helm --set credentials.existingSecret=lint-only" }
+      "options": { "command": "helm lint apps/postgres/helm --set-json 'databases=[{\"name\":\"opencrane\",\"owner\":\"opencrane\",\"credentialsSecret\":\"lint-opencrane\"},{\"name\":\"obot\",\"owner\":\"obot\",\"credentialsSecret\":\"lint-obot\"},{\"name\":\"litellm\",\"owner\":\"litellm\",\"credentialsSecret\":\"lint-litellm\"},{\"name\":\"langfuse\",\"owner\":\"langfuse\",\"credentialsSecret\":\"lint-langfuse\"}]'" }
     },
     "test": {
       "executor": "nx:run-commands",

--- a/apps/postgres/tests/helm-contract.sh
+++ b/apps/postgres/tests/helm-contract.sh
@@ -6,10 +6,13 @@ CHART="$ROOT_DIR/apps/postgres/helm"
 OUTPUT="$(mktemp)"
 trap 'rm -f "$OUTPUT"' EXIT
 
-helm lint "$CHART" --set credentials.existingSecret=postgres-bootstrap >/dev/null
+DATABASES_JSON='[{"name":"opencrane","owner":"opencrane","credentialsSecret":"postgres-opencrane-bootstrap"},{"name":"obot","owner":"obot","credentialsSecret":"postgres-obot-bootstrap"},{"name":"litellm","owner":"litellm","credentialsSecret":"postgres-litellm-bootstrap"},{"name":"langfuse","owner":"langfuse","credentialsSecret":"postgres-langfuse-bootstrap"}]'
+COMMON_VALUES=(--set-json "databases=$DATABASES_JSON")
+
+helm lint "$CHART" "${COMMON_VALUES[@]}" >/dev/null
 helm template opencrane-postgres "$CHART" \
   --namespace opencrane \
-  --set credentials.existingSecret=postgres-bootstrap \
+  "${COMMON_VALUES[@]}" \
   --set storage.storageClass=expandable-rwo \
   --set backup.enabled=true \
   --set backup.plugin.name=barman-cloud.cloudnative-pg.io \
@@ -17,6 +20,14 @@ helm template opencrane-postgres "$CHART" \
   >"$OUTPUT"
 
 grep -q '^kind: Cluster$' "$OUTPUT"
+test "$(grep -c '^kind: Cluster$' "$OUTPUT")" -eq 1
+test "$(grep -c '^kind: Database$' "$OUTPUT")" -eq 3
+test "$(grep -c 'helm.sh/resource-policy: keep' "$OUTPUT")" -eq 4
+grep -q '^kind: Job$' "$OUTPUT"
+grep -q 'helm.sh/hook: post-install,post-upgrade' "$OUTPUT"
+test "$(grep -c 'app.kubernetes.io/component: postgres-database-privileges' "$OUTPUT")" -ge 2
+grep -q 'REVOKE CONNECT, TEMPORARY ON DATABASE' "$OUTPUT"
+grep -q 'GRANT CONNECT, TEMPORARY ON DATABASE' "$OUTPUT"
 grep -q '^kind: ScheduledBackup$' "$OUTPUT"
 grep -q '^kind: NetworkPolicy$' "$OUTPUT"
 grep -q 'helm.sh/resource-policy: keep' "$OUTPUT"
@@ -25,7 +36,15 @@ grep -q 'size: "20Gi"' "$OUTPUT"
 grep -q 'resizeInUseVolumes: true' "$OUTPUT"
 grep -q -- '- ReadWriteOnce' "$OUTPUT"
 grep -q 'storageClass: "expandable-rwo"' "$OUTPUT"
-grep -q 'name: "postgres-bootstrap"' "$OUTPUT"
+grep -q 'name: "postgres-opencrane-bootstrap"' "$OUTPUT"
+grep -q 'name: "postgres-obot-bootstrap"' "$OUTPUT"
+grep -q 'name: "postgres-litellm-bootstrap"' "$OUTPUT"
+grep -q 'name: "postgres-langfuse-bootstrap"' "$OUTPUT"
+grep -q 'name: "obot"' "$OUTPUT"
+grep -q 'name: "litellm"' "$OUTPUT"
+grep -q 'name: "langfuse"' "$OUTPUT"
+grep -q 'createdb: false' "$OUTPUT"
+grep -q 'createrole: false' "$OUTPUT"
 grep -q 'method: plugin' "$OUTPUT"
 grep -q 'app.kubernetes.io/component: opencrane-server' "$OUTPUT"
 grep -q 'app.kubernetes.io/component: opencrane-server-migrate' "$OUTPUT"
@@ -36,12 +55,26 @@ if grep -qE '^kind: (ServiceAccount|Role|RoleBinding|ClusterRole|ClusterRoleBind
 fi
 
 if helm template invalid "$CHART" >/dev/null 2>&1; then
-  echo "postgres chart accepted missing credentials.existingSecret" >&2
+  echo "postgres chart accepted missing database credentials" >&2
   exit 1
 fi
 
+function _assert_invalid_databases()
+{
+  local label="$1"
+  local databases_json="$2"
+  if helm template "$label" "$CHART" --set-json "databases=$databases_json" >/dev/null 2>&1; then
+    echo "postgres chart accepted $label database configuration" >&2
+    exit 1
+  fi
+}
+
+_assert_invalid_databases duplicate-name '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"opencrane-secret"},{"name":"opencrane","owner":"obot","credentialsSecret":"obot-secret"}]'
+_assert_invalid_databases duplicate-owner '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"opencrane-secret"},{"name":"obot","owner":"opencrane","credentialsSecret":"obot-secret"}]'
+_assert_invalid_databases duplicate-credentials '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"shared-secret"},{"name":"obot","owner":"obot","credentialsSecret":"shared-secret"}]'
+
 helm template restored "$CHART" \
-  --set credentials.existingSecret=postgres-bootstrap \
+  "${COMMON_VALUES[@]}" \
   --set restore.enabled=true \
   --set restore.plugin.name=barman-cloud.cloudnative-pg.io \
   --set restore.plugin.parameters.barmanObjectName=opencrane-postgres \

--- a/docs/adr/0002-per-clustertenant-silo-architecture.md
+++ b/docs/adr/0002-per-clustertenant-silo-architecture.md
@@ -51,7 +51,8 @@ Each ClusterTenant runs its **own dedicated instances** of the full per-tenant s
 - **LiteLLM**
 - its own **operator**
 - its own **per-CT networking** (the S2 NetworkPolicy silo + S5 Linkerd identity)
-- its own **tenant DB** (a dedicated Postgres database for the tenant)
+- its own **tenant DB server** (one dedicated Postgres server for the tenant, with separate
+  logical databases and credentials for its runtime planes)
 
 Planes are **never shared singletons multiplexing tenants behind an ACL**. The **only central
 (shared, cross-silo) components are the opencrane-api and Zitadel** — nothing else. (Other
@@ -87,7 +88,7 @@ construction** (no resolution needed; the CT name is the input). What moves out 
 
 ### 3. Per-CT API + DB retires the resolution-ambiguity class — uniformly
 
-Because every tier has a **dedicated per-CT tenant-facing API + DB instance** (decision 1),
+Because every tier has a **dedicated per-CT tenant-facing API + DB server** (decision 1),
 the resolution-ambiguity class is killed **the same way at every tier**: the silo *is* the
 scope, so the tenant-facing plane never infers a caller's tenant from request shape. The only
 cross-silo plane left (the super-admin opencrane-api, decision 2) acts on **named** CTs, which
@@ -117,11 +118,11 @@ them does not block this ADR.
 
 1. **Provisioner reparent** — model **every** ClusterTenant as a `multiInstance` instance the
    `ClusterTenantProvisioner` stamps out (namespace + scoped operator + `mode=instance` planes
-   incl. LiteLLM + per-CT DB), on shared nodes.
+   incl. LiteLLM + one per-CT DB server), on shared nodes.
 2. **Per-CT operator** — provision the namespace-scoped operator per CT; move per-org
    ingress/DNS ownership into it (fail-closed).
 3. **Tenant API/DB split** — separate the central super-admin (cross-silo, named-CT) surface
-   from the per-CT tenant-facing (silo-scoped) API + DB instance; delete the #68 resolution shim.
+   from the per-CT tenant-facing (silo-scoped) API + DB server; delete the #68 resolution shim.
 
 (Isolation-tier scheduling — dedicated nodes / vcluster — and the S7 cost model are
 [`future-work.md`](../../future-work.md), not part of this split.)

--- a/docs/agents/workload-ownership.json
+++ b/docs/agents/workload-ownership.json
@@ -13,6 +13,7 @@
     "openclaw-tenant-runtime",
     "obot-dynamic-mcp-child",
     "postgres-database",
+    "postgres-database-privileges",
     "ingress-nginx-controller",
     "ingress-nginx-admission-create",
     "ingress-nginx-admission-patch",
@@ -86,7 +87,7 @@
     },
     {
       "path": "apps/_infra/deploy-k8s/platform/k8s-deploy.sh",
-      "anchor": "local postgres_args=(upgrade --install \"$target_release\" \"$POSTGRES_CHART_DIR\"",
+      "anchor": "local postgres_args=(upgrade --install \"$POSTGRES_RELEASE\" \"$POSTGRES_CHART_DIR\"",
       "workloadIds": ["postgres-database"]
     },
     {
@@ -288,6 +289,16 @@
       "source": { "type": "file", "path": "apps/postgres/helm/templates/cluster.yaml", "anchor": "kind: Cluster" },
       "classification": "survivor",
       "reason": "apps/postgres owns the durable CNPG Cluster contract over a separately supplied CNPG operator."
+    },
+    {
+      "id": "postgres-database-privileges",
+      "podClass": "Job/postgres-database-privileges",
+      "image": "ghcr.io/cloudnative-pg/postgresql:17.5",
+      "owner": "apps/postgres",
+      "localOwner": true,
+      "source": { "type": "file", "path": "apps/postgres/helm/templates/database-privileges-job.yaml", "anchor": "kind: Job", "coversLocalTemplate": true },
+      "classification": "survivor",
+      "reason": "apps/postgres owns the bounded credential-fed hook that removes PostgreSQL PUBLIC access from each logical database."
     },
     {
       "id": "ingress-nginx-controller",

--- a/website/operators/silo-deployment.md
+++ b/website/operators/silo-deployment.md
@@ -57,8 +57,8 @@ The silo model eliminates both problems in the same move: each ClusterTenant get
 │  └───────────────────┘               └─────────────────┘    │
 │  ┌───────────────────┐               ┌─────────────────┐    │
 │  │  CNPG Postgres    │               │ LiteLLM         │    │
-│  │  (per-CT DB,      │               └─────────────────┘    │
-│  │   this NS only)   │               ┌─────────────────┐    │
+│  │  (one per-CT      │               └─────────────────┘    │
+│  │   server, this NS)│               ┌─────────────────┐    │
 │  └───────────────────┘               │ Cognee          │    │
 │                                      └─────────────────┘    │
 │  fleetManager.clusterTenantApi.enabled: false                 │
@@ -78,7 +78,7 @@ The silo model eliminates both problems in the same move: each ClusterTenant get
 | Fleet registry DB | Yes (`fleetManager.database.*`) | No |
 | Runtime planes (Obot, feat-skill-registry, LiteLLM, Cognee) | No | Yes |
 | Operator | No (fleet-manager reconciles ClusterTenants) | Yes (namespace-scoped to this silo) |
-| Per-silo Postgres | No | Yes — one CNPG `Cluster` CR per silo namespace |
+| Per-silo Postgres | No | Yes — one CNPG `Cluster` CR with isolated logical DBs per silo namespace |
 | Cluster-wide infra (ingress-nginx, external-dns, CNPG operator, cert-manager) | Installed here (once) | Reused from fleet release |
 
 ::: tip Two charts, two install profiles
@@ -120,11 +120,11 @@ Repeat this command for each ClusterTenant. Each invocation:
 
 - installs into the silo namespace (`opencrane-<cluster-tenant>` by default);
 - passes `--no-ingress-nginx --no-external-dns --no-db-operator` so the cluster-wide singletons are not re-installed;
-- applies a dedicated CNPG `Cluster` CR in the silo namespace — one Postgres per silo, reconciled by the cluster-wide CNPG operator;
+- applies a dedicated CNPG `Cluster` CR in the silo namespace — one Postgres server per silo, with separate OpenCrane, Obot, LiteLLM, and Langfuse databases and credentials, reconciled by the cluster-wide CNPG operator;
 - sets `fleetManager.clusterTenantApi.enabled=false` and `billing.enabled=false`.
 
 ::: info One Postgres per silo
-Each silo gets its own CNPG `Cluster` in its own namespace. The silo's clustertenant-manager connects to its own database — there is no shared database and no cross-tenant query path. The cluster-wide CloudNativePG operator (installed by the fleet release) watches all namespaces and reconciles every silo's `Cluster` CR.
+Each silo gets its own CNPG `Cluster` in its own namespace. The server hosts separate databases and login roles for its planes; the clustertenant-manager receives only its OpenCrane credential. There is no cross-tenant server or query path. The cluster-wide CloudNativePG operator (installed by the fleet release) watches all namespaces and reconciles every silo's `Cluster` CR.
 :::
 
 ### Upgrade


### PR DESCRIPTION
## Summary

- replace the per-authority CNPG release split with one tenant-scoped server and isolated OpenCrane, Obot, LiteLLM, Langfuse (and fleet-profile) logical databases
- enforce distinct roles and secrets, retained database resources, and an owner-authenticated hook that removes PostgreSQL PUBLIC access
- publish per-database connection secrets, restore Langfuse to its dedicated database, and extend recovery/cross-database-denial verification

## Validation

- Helm lint and Helm contract, including duplicate-role/secret rejection and privilege-hook assertions
- deploy and k3d shell syntax
- Phase B topology guard and negative tests
- diff check
- live k3d/CNPG validation remains pending because this workstation has no Docker substrate

## Review

- architecture postflight: PASS after two contract fixes
- reaper postflight: PASS
- independent security/correctness review: no remaining findings after adding the privilege hook and multi-database restore checks
- local Claude Code review remains pending: claude --bare reports Not logged in; no repository content was sent to Anthropic

## Base

Rebased onto own-personal-ai-agent-setup after D5 and recovery #296 merged. #302 must also merge before D2 can freeze and squash the complete schema.