### PR TITLE
🔗 Reintegrate Phase D integration authority and custody fixes

### DIFF
--- a/apps/opencrane/prisma/migrations/0049_integrations_authority/migration.sql
+++ b/apps/opencrane/prisma/migrations/0049_integrations_authority/migration.sql
@@ -1,0 +1,162 @@
+-- Fresh integration authority. Target AgentRevision assignments replace their isolated MCP seam;
+-- no MCP catalogue, credential, OAuth, token, or assignment row is copied or bridged.
+
+DROP TABLE "agent_revision_mcp_assignments";
+
+CREATE TYPE "IntegrationState" AS ENUM ('active', 'retired');
+CREATE TYPE "IntegrationCustodyState" AS ENUM ('ready', 'revoked', 'expired');
+
+CREATE FUNCTION "has_nonempty_distinct_tool_ids"(TEXT[]) RETURNS BOOLEAN LANGUAGE sql IMMUTABLE AS $$
+  SELECT COALESCE(
+    cardinality($1) > 0 AND NOT EXISTS (
+      SELECT 1
+      FROM unnest($1) AS tool("value")
+      GROUP BY tool."value"
+      HAVING tool."value" IS NULL OR btrim(tool."value") = '' OR count(*) > 1
+    ),
+    FALSE
+  );
+$$;
+
+CREATE TABLE "integrations" (
+  "id" TEXT NOT NULL,
+  "silo_id" TEXT NOT NULL,
+  "obot_catalog_entry_id" TEXT NOT NULL,
+  "display_name" TEXT NOT NULL,
+  "state" "IntegrationState" NOT NULL DEFAULT 'active',
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "integrations_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "integrations_identity_nonempty" CHECK (
+    btrim("silo_id") <> '' AND btrim("obot_catalog_entry_id") <> '' AND btrim("display_name") <> ''
+  )
+);
+
+CREATE UNIQUE INDEX "integrations_id_silo_id_key" ON "integrations"("id", "silo_id");
+CREATE UNIQUE INDEX "integrations_silo_id_obot_catalog_entry_id_key" ON "integrations"("silo_id", "obot_catalog_entry_id");
+CREATE INDEX "integrations_silo_id_state_idx" ON "integrations"("silo_id", "state");
+
+CREATE TABLE "integration_custody_references" (
+  "id" TEXT NOT NULL,
+  "integration_id" TEXT NOT NULL,
+  "silo_id" TEXT NOT NULL,
+  "obot_custody_reference" TEXT NOT NULL,
+  "state" "IntegrationCustodyState" NOT NULL DEFAULT 'ready',
+  "expires_at" TIMESTAMP(3) NOT NULL,
+  "revoked_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "integration_custody_references_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "integration_custody_references_identity_nonempty" CHECK (
+    btrim("integration_id") <> '' AND btrim("silo_id") <> '' AND btrim("obot_custody_reference") <> ''
+  ),
+  CONSTRAINT "integration_custody_references_revocation_evidence" CHECK (
+    ("state" = 'revoked' AND "revoked_at" IS NOT NULL) OR ("state" <> 'revoked' AND "revoked_at" IS NULL)
+  ),
+  CONSTRAINT "integration_custody_references_integration_fkey" FOREIGN KEY ("integration_id", "silo_id")
+    REFERENCES "integrations"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "integration_custody_references_id_integration_id_silo_id_key"
+  ON "integration_custody_references"("id", "integration_id", "silo_id");
+CREATE UNIQUE INDEX "integration_custody_references_obot_custody_reference_key"
+  ON "integration_custody_references"("obot_custody_reference");
+CREATE INDEX "integration_custody_references_integration_id_state_expires_at_idx"
+  ON "integration_custody_references"("integration_id", "state", "expires_at");
+CREATE UNIQUE INDEX "integration_custody_references_one_ready_per_integration"
+  ON "integration_custody_references"("integration_id") WHERE "state" = 'ready' AND "revoked_at" IS NULL;
+
+CREATE TABLE "agent_revision_integration_assignments" (
+  "agent_revision_id" TEXT NOT NULL,
+  "integration_id" TEXT NOT NULL,
+  "silo_id" TEXT NOT NULL,
+  "custody_reference_id" TEXT NOT NULL,
+  "allowed_tools" TEXT[] NOT NULL,
+
+  CONSTRAINT "agent_revision_integration_assignments_pkey" PRIMARY KEY ("agent_revision_id", "integration_id"),
+  CONSTRAINT "agent_revision_integration_assignments_allowed_tools_check" CHECK ("has_nonempty_distinct_tool_ids"("allowed_tools")),
+  CONSTRAINT "agent_revision_integration_assignments_revision_fkey" FOREIGN KEY ("agent_revision_id")
+    REFERENCES "agent_revisions"("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "agent_revision_integration_assignments_integration_fkey" FOREIGN KEY ("integration_id", "silo_id")
+    REFERENCES "integrations"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "agent_revision_integration_assignments_custody_fkey" FOREIGN KEY ("custody_reference_id", "integration_id", "silo_id")
+    REFERENCES "integration_custody_references"("id", "integration_id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "agent_revision_integration_assignments_integration_id_silo_id_idx"
+  ON "agent_revision_integration_assignments"("integration_id", "silo_id");
+
+CREATE FUNCTION "enforce_integration_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW."state" <> 'active' THEN RAISE EXCEPTION 'a new Integration must begin Active'; END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'Integration rows cannot be deleted'; END IF;
+  IF OLD."state" = 'retired' THEN RAISE EXCEPTION 'a Retired Integration is closed'; END IF;
+  IF NEW."id" IS DISTINCT FROM OLD."id" OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id"
+    OR NEW."obot_catalog_entry_id" IS DISTINCT FROM OLD."obot_catalog_entry_id" OR NEW."created_at" IS DISTINCT FROM OLD."created_at" THEN
+    RAISE EXCEPTION 'Integration identity is immutable';
+  END IF;
+  IF NEW."state" NOT IN ('active', 'retired') THEN RAISE EXCEPTION 'invalid Integration lifecycle transition'; END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "integrations_closed_lifecycle"
+  BEFORE INSERT OR UPDATE OR DELETE ON "integrations"
+  FOR EACH ROW EXECUTE FUNCTION "enforce_integration_lifecycle"();
+
+CREATE FUNCTION "enforce_integration_custody_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW."state" = 'ready' AND NEW."expires_at" <= NEW."created_at" THEN
+      RAISE EXCEPTION 'a Ready custody reference must expire after creation';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'Integration custody references cannot be deleted'; END IF;
+  IF NEW."id" IS DISTINCT FROM OLD."id" OR NEW."integration_id" IS DISTINCT FROM OLD."integration_id"
+    OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id" OR NEW."obot_custody_reference" IS DISTINCT FROM OLD."obot_custody_reference"
+    OR NEW."expires_at" IS DISTINCT FROM OLD."expires_at" OR NEW."created_at" IS DISTINCT FROM OLD."created_at" THEN
+    RAISE EXCEPTION 'Integration custody identity is immutable';
+  END IF;
+  IF OLD."state" <> 'ready' OR NEW."state" NOT IN ('ready', 'revoked', 'expired') THEN
+    RAISE EXCEPTION 'invalid Integration custody lifecycle transition';
+  END IF;
+  IF NEW."state" = 'expired' AND NEW."expires_at" > clock_timestamp() THEN
+    RAISE EXCEPTION 'a custody reference expires only after its expiry instant';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "integration_custody_references_closed_lifecycle"
+  BEFORE INSERT OR UPDATE OR DELETE ON "integration_custody_references"
+  FOR EACH ROW EXECUTE FUNCTION "enforce_integration_custody_lifecycle"();
+
+CREATE FUNCTION "enforce_agent_revision_integration_assignment_authority"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE agent_silo_id TEXT; integration_state "IntegrationState"; custody_state "IntegrationCustodyState"; custody_expiry TIMESTAMP(3); custody_revoked_at TIMESTAMP(3);
+BEGIN
+  SELECT service."silo_id" INTO agent_silo_id
+    FROM "agent_revisions" revision JOIN "agent_services" service ON service."id" = revision."agent_service_id"
+    WHERE revision."id" = NEW."agent_revision_id" FOR UPDATE OF revision, service;
+  SELECT integration."state" INTO integration_state FROM "integrations" integration
+    WHERE integration."id" = NEW."integration_id" AND integration."silo_id" = NEW."silo_id" FOR UPDATE;
+  SELECT custody."state", custody."expires_at", custody."revoked_at"
+    INTO custody_state, custody_expiry, custody_revoked_at FROM "integration_custody_references" custody
+    WHERE custody."id" = NEW."custody_reference_id" AND custody."integration_id" = NEW."integration_id" AND custody."silo_id" = NEW."silo_id" FOR UPDATE;
+  IF agent_silo_id IS DISTINCT FROM NEW."silo_id" OR integration_state IS DISTINCT FROM 'active'::"IntegrationState" THEN
+    RAISE EXCEPTION 'AgentRevision may assign only an Active Integration from the same silo';
+  END IF;
+  IF custody_state IS DISTINCT FROM 'ready'::"IntegrationCustodyState" OR custody_revoked_at IS NOT NULL OR custody_expiry <= clock_timestamp() THEN
+    RAISE EXCEPTION 'AgentRevision may assign only a ready unexpired Integration custody reference';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "agent_revision_integration_assignments_authority"
+  BEFORE INSERT OR UPDATE ON "agent_revision_integration_assignments"
+  FOR EACH ROW EXECUTE FUNCTION "enforce_agent_revision_integration_assignment_authority"();
+CREATE TRIGGER "agent_revision_integration_assignments_immutable"
+  BEFORE INSERT OR UPDATE OR DELETE ON "agent_revision_integration_assignments"
+  FOR EACH ROW EXECUTE FUNCTION "enforce_agent_revision_assignment_immutability"();

--- a/apps/opencrane/prisma/schema/agent-services.prisma
+++ b/apps/opencrane/prisma/schema/agent-services.prisma
@@ -67,7 +67,7 @@ model AgentRevision {
   agentService        AgentService                   @relation("AgentServiceRevisions", fields: [agentServiceId], references: [id], onDelete: Restrict)
   activeFor           AgentService[]                 @relation("ActiveAgentRevision")
   skillAssignments    AgentRevisionSkillAssignment[]
-  mcpAssignments      AgentRevisionMcpAssignment[]
+  integrationAssignments AgentRevisionIntegrationAssignment[]
   runs                AgentRun[]
 
   @@unique([agentServiceId, revision])
@@ -88,12 +88,18 @@ model AgentRevisionSkillAssignment {
   @@map("agent_revision_skill_assignments")
 }
 
-model AgentRevisionMcpAssignment {
-  agentRevisionId String        @map("agent_revision_id")
-  mcpServerId     String        @map("mcp_server_id")
-  allowedTools    String[]      @map("allowed_tools")
-  agentRevision   AgentRevision @relation(fields: [agentRevisionId], references: [id], onDelete: Restrict)
+/// Immutable tool allow-list for one integration on one draft AgentRevision.
+model AgentRevisionIntegrationAssignment {
+  agentRevisionId      String                       @map("agent_revision_id")
+  integrationId        String                       @map("integration_id")
+  siloId               String                       @map("silo_id")
+  custodyReferenceId   String                       @map("custody_reference_id")
+  allowedTools         String[]                     @map("allowed_tools")
+  agentRevision        AgentRevision                @relation(fields: [agentRevisionId], references: [id], onDelete: Restrict)
+  integration          Integration                  @relation(fields: [integrationId, siloId], references: [id, siloId], onDelete: Restrict)
+  custodyReference     IntegrationCustodyReference  @relation(fields: [custodyReferenceId, integrationId, siloId], references: [id, integrationId, siloId], onDelete: Restrict)
 
-  @@id([agentRevisionId, mcpServerId])
-  @@map("agent_revision_mcp_assignments")
+  @@id([agentRevisionId, integrationId])
+  @@index([integrationId, siloId])
+  @@map("agent_revision_integration_assignments")
 }

--- a/apps/opencrane/prisma/schema/integrations.prisma
+++ b/apps/opencrane/prisma/schema/integrations.prisma
@@ -1,0 +1,49 @@
+/// Lifecycle of a silo-scoped integration catalogue entry.
+enum IntegrationState {
+  Active  @map("active")
+  Retired @map("retired")
+}
+
+/// Lifecycle of one opaque Obot custody reference.
+enum IntegrationCustodyState {
+  Ready   @map("ready")
+  Revoked @map("revoked")
+  Expired @map("expired")
+}
+
+/// Silo-scoped catalogue record for one integration whose credentials remain with Obot.
+model Integration {
+  id                  String                              @id @default(cuid())
+  siloId              String                              @map("silo_id")
+  obotCatalogEntryId  String                              @map("obot_catalog_entry_id")
+  displayName         String                              @map("display_name")
+  state               IntegrationState                    @default(Active)
+  createdAt           DateTime                            @default(now()) @map("created_at")
+  updatedAt           DateTime                            @updatedAt @map("updated_at")
+  custodyReferences   IntegrationCustodyReference[]
+  assignments         AgentRevisionIntegrationAssignment[]
+
+  @@unique([id, siloId])
+  @@unique([siloId, obotCatalogEntryId])
+  @@index([siloId, state])
+  @@map("integrations")
+}
+
+/// Opaque Obot-issued custody handle. This database never stores the underlying credential.
+model IntegrationCustodyReference {
+  id                    String                  @id @default(cuid())
+  integrationId         String                  @map("integration_id")
+  siloId                String                  @map("silo_id")
+  obotCustodyReference  String                  @map("obot_custody_reference")
+  state                 IntegrationCustodyState @default(Ready)
+  expiresAt             DateTime                @map("expires_at")
+  revokedAt             DateTime?               @map("revoked_at")
+  createdAt             DateTime                @default(now()) @map("created_at")
+  integration           Integration             @relation(fields: [integrationId, siloId], references: [id, siloId], onDelete: Restrict)
+  assignments           AgentRevisionIntegrationAssignment[]
+
+  @@unique([id, integrationId, siloId])
+  @@unique([obotCustodyReference])
+  @@index([integrationId, state, expiresAt])
+  @@map("integration_custody_references")
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,6 +108,7 @@ export default [
             { sourceTag: "scope:grants", onlyDependOnLibsWithTags: ["scope:auth", "scope:grants", "scope:retrieval", "scope:shared"] },
             { sourceTag: "scope:groups", onlyDependOnLibsWithTags: ["scope:groups", "scope:shared"] },
             { sourceTag: "scope:http", onlyDependOnLibsWithTags: ["scope:http", "scope:shared"] },
+            { sourceTag: "scope:integrations", onlyDependOnLibsWithTags: ["scope:integrations", "scope:obot-custody", "scope:shared"] },
             { sourceTag: "scope:k8s-api", onlyDependOnLibsWithTags: ["scope:k8s-api", "scope:shared"] },
             {
               sourceTag: "scope:identity",
@@ -124,6 +125,7 @@ export default [
             { sourceTag: "scope:metrics", onlyDependOnLibsWithTags: ["scope:awareness", "scope:metrics", "scope:projection", "scope:shared"] },
             { sourceTag: "scope:membership", onlyDependOnLibsWithTags: ["scope:audit", "scope:authorization", "scope:membership", "scope:shared"] },
             { sourceTag: "scope:personal-memory", onlyDependOnLibsWithTags: ["scope:artifacts", "scope:personal-memory", "scope:shared"] },
+            { sourceTag: "scope:obot-custody", onlyDependOnLibsWithTags: ["scope:obot-custody", "scope:shared"] },
             { sourceTag: "scope:model-routing", onlyDependOnLibsWithTags: ["scope:auth", "scope:cluster-tenants", "scope:model-routing", "scope:shared"] },
             { sourceTag: "scope:policies", onlyDependOnLibsWithTags: ["scope:grants", "scope:k8s-api", "scope:policies", "scope:projection", "scope:shared"] },
             { sourceTag: "scope:personal-personas", onlyDependOnLibsWithTags: ["scope:personal-personas", "scope:shared"] },

--- a/libs/backend/README.md
+++ b/libs/backend/README.md
@@ -33,7 +33,8 @@ flattening unrelated responsibilities together.
 - Tenant and runtime lifecycle: tenants, connections, effective contracts, and projection repair.
 - Models and economics: providers, model routing, spend, and budgets.
 - Knowledge and memory: awareness, retrieval sources, and company documents.
-- Tools and integrations: skills and MCP servers.
+- Tools and integrations: skills and silo-scoped integrations; the legacy MCP catalogue remains
+  isolated until a target browser/runtime integration path replaces it.
 - Operations and API composition: audit, metrics, and the generated API specification.
 
 These are current code ownership boundaries, not promises that legacy Tenant, AccessPolicy,

--- a/libs/backend/server/agent-services/main/src/agent-publication.test.ts
+++ b/libs/backend/server/agent-services/main/src/agent-publication.test.ts
@@ -34,7 +34,7 @@ function _revision(): AgentRevision
 		personaRevisionId: "persona-1",
 		modelPolicyId: "model-policy-1",
 		skills: [],
-		mcpAssignments: [],
+		integrationAssignments: [],
 		budget: { maxTurns: 10, maxTokens: 10000, maxDurationMs: 60000 },
 		authoredBy: "user-1",
 		createdAt: "2026-07-18T00:00:00.000Z",

--- a/libs/backend/server/agent-services/main/src/prisma-agent-publication.test.ts
+++ b/libs/backend/server/agent-services/main/src/prisma-agent-publication.test.ts
@@ -39,7 +39,7 @@ function _revisionRow()
 		createdAt: new Date("2026-07-18T00:00:00.000Z"),
 		publishedAt: null,
 		skillAssignments: [],
-		mcpAssignments: [],
+		integrationAssignments: [],
 	};
 }
 

--- a/libs/backend/server/agent-services/main/src/prisma-agent-publication.ts
+++ b/libs/backend/server/agent-services/main/src/prisma-agent-publication.ts
@@ -73,7 +73,7 @@ function _mapService(row: { id: string; siloId: string; kind: string; name: stri
 }
 
 /** Maps one locked Prisma revision row and its immutable assignments to the target contract. */
-function _mapRevision(row: { id: string; agentServiceId: string; revision: number; state: string; digest: string; promptPolicyVersion: string; personaRevisionId: string | null; modelPolicyId: string; budget: Prisma.JsonValue; authoredBy: string; createdAt: Date; publishedAt: Date | null; skillAssignments: Array<{ skillId: string; skillRevisionId: string }>; mcpAssignments: Array<{ mcpServerId: string; allowedTools: string[] }> }): AgentRevision
+function _mapRevision(row: { id: string; agentServiceId: string; revision: number; state: string; digest: string; promptPolicyVersion: string; personaRevisionId: string | null; modelPolicyId: string; budget: Prisma.JsonValue; authoredBy: string; createdAt: Date; publishedAt: Date | null; skillAssignments: Array<{ skillId: string; skillRevisionId: string }>; integrationAssignments: Array<{ integrationId: string; custodyReferenceId: string; allowedTools: string[] }> }): AgentRevision
 {
 	return {
 		id: row.id,
@@ -85,7 +85,7 @@ function _mapRevision(row: { id: string; agentServiceId: string; revision: numbe
 		personaRevisionId: row.personaRevisionId,
 		modelPolicyId: row.modelPolicyId,
 		skills: row.skillAssignments.map(assignment => ({ skillId: assignment.skillId, revisionId: assignment.skillRevisionId })),
-		mcpAssignments: row.mcpAssignments.map(assignment => ({ serverId: assignment.mcpServerId, allowedTools: assignment.allowedTools })),
+		integrationAssignments: row.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: assignment.allowedTools })),
 		budget: row.budget as unknown as AgentBudget,
 		authoredBy: row.authoredBy,
 		createdAt: row.createdAt.toISOString(),
@@ -122,7 +122,7 @@ export class PrismaAgentServicePublicationRepository implements AgentServicePubl
 	/** Loads one immutable revision and all executable assignments. */
 	async getRevision(agentRevisionId: string): Promise<AgentRevision | null>
 	{
-		const row = await this.prisma.agentRevision.findUnique({ where: { id: agentRevisionId }, include: { skillAssignments: true, mcpAssignments: true } });
+		const row = await this.prisma.agentRevision.findUnique({ where: { id: agentRevisionId }, include: { skillAssignments: true, integrationAssignments: true } });
 		return row === null ? null : _mapRevision(row);
 	}
 
@@ -136,14 +136,14 @@ export class PrismaAgentServicePublicationRepository implements AgentServicePubl
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${publication.agentServiceId} FOR UPDATE`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_revisions" WHERE "id" = ${publication.agentRevisionId} FOR UPDATE`);
 			const serviceRow = await transaction.agentService.findUnique({ where: { id: publication.agentServiceId } });
-			const revisionRow = await transaction.agentRevision.findUnique({ where: { id: publication.agentRevisionId }, include: { skillAssignments: true, mcpAssignments: true } });
+			const revisionRow = await transaction.agentRevision.findUnique({ where: { id: publication.agentRevisionId }, include: { skillAssignments: true, integrationAssignments: true } });
 			if (serviceRow === null || revisionRow === null || _serviceState(serviceRow.state) !== publication.expectedServiceState || serviceRow.activeRevisionId !== publication.expectedActiveRevisionId || revisionRow.agentServiceId !== publication.agentServiceId || revisionRow.state !== AgentRevisionState.Draft)
 			{
 				return { status: "conflict", currentActiveRevisionId: serviceRow?.activeRevisionId ?? null } as const;
 			}
 
 			// 2. Change both lifecycle coordinates inside the same transaction so neither can escape alone.
-			const publishedRow = await transaction.agentRevision.update({ where: { id: publication.agentRevisionId }, data: { state: AgentRevisionState.Published, publishedAt: new Date(publication.publishedAt) }, include: { skillAssignments: true, mcpAssignments: true } });
+			const publishedRow = await transaction.agentRevision.update({ where: { id: publication.agentRevisionId }, data: { state: AgentRevisionState.Published, publishedAt: new Date(publication.publishedAt) }, include: { skillAssignments: true, integrationAssignments: true } });
 			const activeRow = await transaction.agentService.update({ where: { id: publication.agentServiceId }, data: { state: AgentServiceState.Active, activeRevisionId: publication.agentRevisionId, updatedAt: new Date(publication.publishedAt) } });
 
 			// 3. Append authenticated decision evidence before commit; audit failure rolls back publication.

--- a/libs/backend/server/integrations/main/project.json
+++ b/libs/backend/server/integrations/main/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend-server-integrations",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/server/integrations/main/src",
+  "tags": ["type:lib", "layer:backend", "scope:integrations"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/server/integrations/main" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/server/integrations/main" } },
+    "test:sql": { "executor": "nx:run-commands", "options": { "command": "sh ../../../../../scripts/run-postgres-authority-tests.sh tests/integrations-authority.sql", "cwd": "libs/backend/server/integrations/main" } },
+    "test:negative": { "executor": "nx:run-commands", "options": { "command": "../../../../../scripts/integration-authority-negative-tests.sh", "cwd": "libs/backend/server/integrations/main" } }
+  }
+}

--- a/libs/backend/server/integrations/main/src/index.ts
+++ b/libs/backend/server/integrations/main/src/index.ts
@@ -1,5 +1,5 @@
 export { __SystemIntegrationAuthorityClock, PrismaIntegrationAuthorityRepository } from "./prisma-integration-authority.js";
 export { __ProvisionIntegrationCustody } from "./integration-custody-provisioning.js";
 export { PrismaIntegrationCustodyRepository } from "./prisma-integration-custody-repository.js";
-export type { IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
+export type { IntegrationCustodyLogger, IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
 export type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult, ResolvedIntegrationAssignment } from "./integration-resolution.types.js";

--- a/libs/backend/server/integrations/main/src/index.ts
+++ b/libs/backend/server/integrations/main/src/index.ts
@@ -1,2 +1,5 @@
 export { __SystemIntegrationAuthorityClock, PrismaIntegrationAuthorityRepository } from "./prisma-integration-authority.js";
+export { __ProvisionIntegrationCustody } from "./integration-custody-provisioning.js";
+export { PrismaIntegrationCustodyRepository } from "./prisma-integration-custody-repository.js";
+export type { IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
 export type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult, ResolvedIntegrationAssignment } from "./integration-resolution.types.js";

--- a/libs/backend/server/integrations/main/src/index.ts
+++ b/libs/backend/server/integrations/main/src/index.ts
@@ -1,0 +1,2 @@
+export { __SystemIntegrationAuthorityClock, PrismaIntegrationAuthorityRepository } from "./prisma-integration-authority.js";
+export type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult, ResolvedIntegrationAssignment } from "./integration-resolution.types.js";

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
@@ -13,6 +13,12 @@ describe("integration custody provisioning", function _suite()
 		expect(JSON.stringify(log.warn.mock.calls)).not.toContain("write-only");
 	});
 
+	it("keeps a remote failure closed when diagnostic logging itself fails", async function _throwingLogger()
+	{
+		const log = { warn: vi.fn().mockImplementation(function _throw() { throw new Error("logger unavailable"); }), error: vi.fn() };
+		await expect(__ProvisionIntegrationCustody({ provision: vi.fn().mockRejectedValue(new Error("timeout")), revoke: vi.fn() }, { persistReady: vi.fn() }, log, _Command())).resolves.toEqual({ outcome: "unavailable", reason: "remote_unavailable" });
+	});
+
 	it("revokes remote custody when persistence fails", async function _compensation()
 	{
 		const revoke = vi.fn().mockResolvedValue(undefined);

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
@@ -6,22 +6,51 @@ describe("integration custody provisioning", function _suite()
 {
 	it("fails closed when Obot is unavailable", async function _remoteUnavailable()
 	{
-		const result = await __ProvisionIntegrationCustody({ provision: vi.fn().mockRejectedValue(new Error("timeout")), revoke: vi.fn() }, { persistReady: vi.fn() }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] });
+		const log = _CreateLog();
+		const result = await __ProvisionIntegrationCustody({ provision: vi.fn().mockRejectedValue(new Error("Bearer write-only")), revoke: vi.fn() }, { persistReady: vi.fn() }, log, _Command());
 		expect(result).toEqual({ outcome: "unavailable", reason: "remote_unavailable" });
+		expect(log.warn).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Obot custody provisioning failed");
+		expect(JSON.stringify(log.warn.mock.calls)).not.toContain("write-only");
 	});
 
 	it("revokes remote custody when persistence fails", async function _compensation()
 	{
 		const revoke = vi.fn().mockResolvedValue(undefined);
 		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke };
-		const result = await __ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] });
+		const log = _CreateLog();
+		const result = await __ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, log, _Command());
 		expect(result).toEqual({ outcome: "unavailable", reason: "persistence_failed" });
 		expect(revoke).toHaveBeenCalledWith("obot:issued:one");
+		expect(log.warn).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Integration custody persistence failed; starting compensation");
+	});
+
+	it("logs an invalid remote response compensation failure without the custody reference", async function _invalidResponseCompensationFailure()
+	{
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "different-catalog", obotCustodyReference: "obot:issued:invalid", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
+		const log = _CreateLog();
+		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn() }, log, _Command())).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
+		expect(log.error).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Obot custody compensation failed after an invalid response");
+		expect(JSON.stringify(log.error.mock.calls)).not.toContain("obot:issued:invalid");
 	});
 
 	it("reports compensation failure without exposing remote custody", async function _compensationFailure()
 	{
 		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
-		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] })).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
+		const log = _CreateLog();
+		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, log, _Command())).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
+		expect(log.error).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Obot custody compensation failed after a persistence failure");
+		expect(JSON.stringify(log.error.mock.calls)).not.toContain("obot:issued:one");
 	});
+
+	/** Create a focused capture logger for custody failure assertions. */
+	function _CreateLog()
+	{
+		return { warn: vi.fn(), error: vi.fn() };
+	}
+
+	/** Create a write-only custody command with deterministic non-secret identifiers. */
+	function _Command()
+	{
+		return { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] };
+	}
 });

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __ProvisionIntegrationCustody } from "./integration-custody-provisioning.js";
+
+describe("integration custody provisioning", function _suite()
+{
+	it("fails closed when Obot is unavailable", async function _remoteUnavailable()
+	{
+		const result = await __ProvisionIntegrationCustody({ provision: vi.fn().mockRejectedValue(new Error("timeout")), revoke: vi.fn() }, { persistReady: vi.fn() }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] });
+		expect(result).toEqual({ outcome: "unavailable", reason: "remote_unavailable" });
+	});
+
+	it("revokes remote custody when persistence fails", async function _compensation()
+	{
+		const revoke = vi.fn().mockResolvedValue(undefined);
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke };
+		const result = await __ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] });
+		expect(result).toEqual({ outcome: "unavailable", reason: "persistence_failed" });
+		expect(revoke).toHaveBeenCalledWith("obot:issued:one");
+	});
+
+	it("reports compensation failure without exposing remote custody", async function _compensationFailure()
+	{
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
+		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, { siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", credential: [{ name: "Authorization", value: "write-only" }] })).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
+	});
+});

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
@@ -13,7 +13,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 	}
 	catch (err)
 	{
-		log.warn(_FailureLogFields(command, err), "Obot custody provisioning failed");
+		_Warn(log, command, err, "Obot custody provisioning failed");
 		return { outcome: "unavailable", reason: "remote_unavailable" };
 	}
 	if (provisioned.obotCatalogEntryId !== command.obotCatalogEntryId || !provisioned.obotCustodyReference.trim() || provisioned.expiresAt <= new Date())
@@ -24,7 +24,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 		}
 		catch (err)
 		{
-			log.error(_FailureLogFields(command, err), "Obot custody compensation failed after an invalid response");
+			_Error(log, command, err, "Obot custody compensation failed after an invalid response");
 			return { outcome: "unavailable", reason: "compensation_failed" };
 		}
 		return { outcome: "unavailable", reason: "remote_unavailable" };
@@ -39,7 +39,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 	catch (err)
 	{
 		// 3. Revoke the remote result so a persistence failure never leaves usable untracked custody.
-		log.warn(_FailureLogFields(command, err), "Integration custody persistence failed; starting compensation");
+		_Warn(log, command, err, "Integration custody persistence failed; starting compensation");
 		try
 		{
 			await custody.revoke(provisioned.obotCustodyReference);
@@ -47,7 +47,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 		}
 		catch (compensationError)
 		{
-			log.error(_FailureLogFields(command, compensationError), "Obot custody compensation failed after a persistence failure");
+			_Error(log, command, compensationError, "Obot custody compensation failed after a persistence failure");
 			return { outcome: "unavailable", reason: "compensation_failed" };
 		}
 	}
@@ -67,4 +67,24 @@ function _FailureLogFields(command: ProvisionIntegrationCustodyCommand, err: unk
 		obotCatalogEntryId: command.obotCatalogEntryId,
 		errorType: err instanceof Error ? err.constructor.name : typeof err,
 	};
+}
+
+/** Emits a warning without allowing observability failures to change the fail-closed custody result. */
+function _Warn(log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand, err: unknown, message: string): void
+{
+	try
+	{
+		log.warn(_FailureLogFields(command, err), message);
+	}
+	catch { /* Logging is diagnostic only; custody failure handling must remain fail closed. */ }
+}
+
+/** Emits an error without allowing observability failures to change the fail-closed custody result. */
+function _Error(log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand, err: unknown, message: string): void
+{
+	try
+	{
+		log.error(_FailureLogFields(command, err), message);
+	}
+	catch { /* Logging is diagnostic only; custody failure handling must remain fail closed. */ }
 }

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
@@ -1,0 +1,31 @@
+import type { ObotCustodyPort } from "@opencrane/server/_infra/obot-custody";
+
+import type { IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
+
+/** Provisions remote Obot custody and compensates if its product projection cannot persist. */
+export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, repository: IntegrationCustodyRepository, command: ProvisionIntegrationCustodyCommand): Promise<ProvisionIntegrationCustodyResult>
+{
+	// 1. Obtain the opaque custody reference from Obot; this process never invents one.
+	let provisioned;
+	try { provisioned = await custody.provision(command); }
+	catch { return { outcome: "unavailable", reason: "remote_unavailable" }; }
+	if (provisioned.obotCatalogEntryId !== command.obotCatalogEntryId || !provisioned.obotCustodyReference.trim() || provisioned.expiresAt <= new Date())
+	{
+		try { await custody.revoke(provisioned.obotCustodyReference); }
+		catch { return { outcome: "unavailable", reason: "compensation_failed" }; }
+		return { outcome: "unavailable", reason: "remote_unavailable" };
+	}
+
+	// 2. Persist only Obot-confirmed coordinates, preserving Postgres as a lifecycle projection.
+	try
+	{
+		const persisted = await repository.persistReady({ siloId: command.siloId, integrationId: command.integrationId, obotCatalogEntryId: provisioned.obotCatalogEntryId, obotCustodyReference: provisioned.obotCustodyReference, expiresAt: provisioned.expiresAt });
+		return { outcome: "provisioned", custodyReferenceId: persisted.custodyReferenceId };
+	}
+	catch
+	{
+		// 3. Revoke the remote result so a persistence failure never leaves usable untracked custody.
+		try { await custody.revoke(provisioned.obotCustodyReference); return { outcome: "unavailable", reason: "persistence_failed" }; }
+		catch { return { outcome: "unavailable", reason: "compensation_failed" }; }
+	}
+}

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.ts
@@ -1,18 +1,32 @@
 import type { ObotCustodyPort } from "@opencrane/server/_infra/obot-custody";
 
-import type { IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
+import type { IntegrationCustodyLogger, IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
 
 /** Provisions remote Obot custody and compensates if its product projection cannot persist. */
-export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, repository: IntegrationCustodyRepository, command: ProvisionIntegrationCustodyCommand): Promise<ProvisionIntegrationCustodyResult>
+export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, repository: IntegrationCustodyRepository, log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand): Promise<ProvisionIntegrationCustodyResult>
 {
 	// 1. Obtain the opaque custody reference from Obot; this process never invents one.
 	let provisioned;
-	try { provisioned = await custody.provision(command); }
-	catch { return { outcome: "unavailable", reason: "remote_unavailable" }; }
+	try
+	{
+		provisioned = await custody.provision(command);
+	}
+	catch (err)
+	{
+		log.warn(_FailureLogFields(command, err), "Obot custody provisioning failed");
+		return { outcome: "unavailable", reason: "remote_unavailable" };
+	}
 	if (provisioned.obotCatalogEntryId !== command.obotCatalogEntryId || !provisioned.obotCustodyReference.trim() || provisioned.expiresAt <= new Date())
 	{
-		try { await custody.revoke(provisioned.obotCustodyReference); }
-		catch { return { outcome: "unavailable", reason: "compensation_failed" }; }
+		try
+		{
+			await custody.revoke(provisioned.obotCustodyReference);
+		}
+		catch (err)
+		{
+			log.error(_FailureLogFields(command, err), "Obot custody compensation failed after an invalid response");
+			return { outcome: "unavailable", reason: "compensation_failed" };
+		}
 		return { outcome: "unavailable", reason: "remote_unavailable" };
 	}
 
@@ -22,10 +36,35 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 		const persisted = await repository.persistReady({ siloId: command.siloId, integrationId: command.integrationId, obotCatalogEntryId: provisioned.obotCatalogEntryId, obotCustodyReference: provisioned.obotCustodyReference, expiresAt: provisioned.expiresAt });
 		return { outcome: "provisioned", custodyReferenceId: persisted.custodyReferenceId };
 	}
-	catch
+	catch (err)
 	{
 		// 3. Revoke the remote result so a persistence failure never leaves usable untracked custody.
-		try { await custody.revoke(provisioned.obotCustodyReference); return { outcome: "unavailable", reason: "persistence_failed" }; }
-		catch { return { outcome: "unavailable", reason: "compensation_failed" }; }
+		log.warn(_FailureLogFields(command, err), "Integration custody persistence failed; starting compensation");
+		try
+		{
+			await custody.revoke(provisioned.obotCustodyReference);
+			return { outcome: "unavailable", reason: "persistence_failed" };
+		}
+		catch (compensationError)
+		{
+			log.error(_FailureLogFields(command, compensationError), "Obot custody compensation failed after a persistence failure");
+			return { outcome: "unavailable", reason: "compensation_failed" };
+		}
 	}
+}
+
+/**
+ * Build a secret-safe failure record for custody operations.
+ * @param command - Non-secret identifiers for the failed operation.
+ * @param err - Original error, classified without serialising its untrusted message or payload.
+ * @returns Stable fields safe for structured logs.
+ */
+function _FailureLogFields(command: ProvisionIntegrationCustodyCommand, err: unknown): Record<string, string>
+{
+	return {
+		siloId: command.siloId,
+		integrationId: command.integrationId,
+		obotCatalogEntryId: command.obotCatalogEntryId,
+		errorType: err instanceof Error ? err.constructor.name : typeof err,
+	};
 }

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.types.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.types.ts
@@ -1,0 +1,24 @@
+import type { ObotCustodyCredential } from "@opencrane/server/_infra/obot-custody";
+
+/** Request to provision remote custody for an integration. */
+export interface ProvisionIntegrationCustodyCommand
+{
+	/** Silo owning the integration. */
+	readonly siloId: string;
+	/** Integration receiving custody. */
+	readonly integrationId: string;
+	/** Obot catalogue entry. */
+	readonly obotCatalogEntryId: string;
+	/** Write-only credential material. */
+	readonly credential: readonly ObotCustodyCredential[];
+}
+
+/** Product persistence boundary for remote custody confirmation. */
+export interface IntegrationCustodyRepository
+{
+	/** Stores an Obot-issued reference after remote provisioning succeeds. */
+	persistReady(command: { readonly siloId: string; readonly integrationId: string; readonly obotCatalogEntryId: string; readonly obotCustodyReference: string; readonly expiresAt: Date }): Promise<{ readonly custodyReferenceId: string }>;
+}
+
+/** Fail-closed custody provisioning outcome. */
+export type ProvisionIntegrationCustodyResult = { readonly outcome: "provisioned"; readonly custodyReferenceId: string } | { readonly outcome: "unavailable"; readonly reason: "remote_unavailable" | "persistence_failed" | "compensation_failed" };

--- a/libs/backend/server/integrations/main/src/integration-custody-provisioning.types.ts
+++ b/libs/backend/server/integrations/main/src/integration-custody-provisioning.types.ts
@@ -1,4 +1,8 @@
 import type { ObotCustodyCredential } from "@opencrane/server/_infra/obot-custody";
+import type { Logger } from "@opencrane/observability";
+
+/** Structured logger methods used by the custody provisioning operation. */
+export type IntegrationCustodyLogger = Pick<Logger, "warn" | "error">;
 
 /** Request to provision remote custody for an integration. */
 export interface ProvisionIntegrationCustodyCommand

--- a/libs/backend/server/integrations/main/src/integration-resolution.types.ts
+++ b/libs/backend/server/integrations/main/src/integration-resolution.types.ts
@@ -1,0 +1,42 @@
+/** Request to resolve one immutable integration assignment for runtime preparation. */
+export interface ResolveIntegrationAssignmentCommand
+{
+	/** Silo that owns the AgentRevision and integration. */
+	readonly siloId: string;
+	/** Immutable revision selecting the integration. */
+	readonly agentRevisionId: string;
+	/** Exact integration selected by the revision. */
+	readonly integrationId: string;
+}
+
+/** Credential-free result returned only for an active assigned integration. */
+export interface ResolvedIntegrationAssignment
+{
+	/** Silo-scoped integration identity. */
+	readonly integrationId: string;
+	/** Obot catalogue entry selected by the product authority. */
+	readonly obotCatalogEntryId: string;
+	/** Opaque Obot-issued custody handle; it is not credential material. */
+	readonly obotCustodyReference: string;
+	/** Explicit revision-scoped tool allow-list. */
+	readonly allowedTools: readonly string[];
+}
+
+/** Credential-free integration assignment resolution outcome. */
+export type ResolveIntegrationAssignmentResult =
+	| { readonly outcome: "resolved"; readonly assignment: ResolvedIntegrationAssignment }
+	| { readonly outcome: "unavailable"; readonly reason: "not_found" | "inactive" | "revoked" | "expired" };
+
+/** Read-only authority boundary for runtime integration preparation. */
+export interface IntegrationAuthorityRepository
+{
+	/** Resolves only an active same-silo revision assignment and its usable opaque custody reference. */
+	resolveAssignment(command: ResolveIntegrationAssignmentCommand): Promise<ResolveIntegrationAssignmentResult>;
+}
+
+/** Clock owned by the server authority rather than its runtime caller. */
+export interface IntegrationAuthorityClock
+{
+	/** Returns the current trusted instant for custody expiry evaluation. */
+	now(): Date;
+}

--- a/libs/backend/server/integrations/main/src/prisma-integration-authority.test.ts
+++ b/libs/backend/server/integrations/main/src/prisma-integration-authority.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaIntegrationAuthorityRepository } from "./prisma-integration-authority.js";
+
+describe("Prisma integration authority", function _suite()
+{
+	it("returns only an active same-silo assignment's opaque Obot reference and explicit tools", async function _resolved()
+	{
+		const findUnique = vi.fn().mockResolvedValue({
+			siloId: "silo-1",
+			integrationId: "integration-1",
+			allowedTools: ["calendar.read"],
+			integration: { state: "Active", obotCatalogEntryId: "obot-calendar" },
+			custodyReference: { state: "Ready", revokedAt: null, expiresAt: new Date("2026-07-19T12:00:00.000Z"), obotCustodyReference: "obot:opaque:calendar" },
+		});
+		const repository = new PrismaIntegrationAuthorityRepository({ agentRevisionIntegrationAssignment: { findUnique } } as never, { now: vi.fn().mockReturnValue(new Date("2026-07-19T11:00:00.000Z")) });
+		const result = await repository.resolveAssignment({ siloId: "silo-1", agentRevisionId: "revision-1", integrationId: "integration-1" });
+		expect(result).toEqual({ outcome: "resolved", assignment: { integrationId: "integration-1", obotCatalogEntryId: "obot-calendar", obotCustodyReference: "obot:opaque:calendar", allowedTools: ["calendar.read"] } });
+		expect(findUnique).toHaveBeenCalledWith(expect.objectContaining({ include: { integration: true, custodyReference: true } }));
+	});
+
+	it("does not resolve revoked or expired custody references", async function _unavailable()
+	{
+		const findUnique = vi.fn().mockResolvedValue({
+			siloId: "silo-1",
+			integrationId: "integration-1",
+			allowedTools: ["calendar.read"],
+			integration: { state: "Active", obotCatalogEntryId: "obot-calendar" },
+			custodyReference: { state: "Revoked", revokedAt: new Date("2026-07-19T10:00:00.000Z"), expiresAt: new Date("2026-07-19T12:00:00.000Z"), obotCustodyReference: "obot:opaque:calendar" },
+		});
+		const repository = new PrismaIntegrationAuthorityRepository({ agentRevisionIntegrationAssignment: { findUnique } } as never, { now: vi.fn().mockReturnValue(new Date("2026-07-19T11:00:00.000Z")) });
+		await expect(repository.resolveAssignment({ siloId: "silo-1", agentRevisionId: "revision-1", integrationId: "integration-1" })).resolves.toEqual({ outcome: "unavailable", reason: "revoked" });
+	});
+});

--- a/libs/backend/server/integrations/main/src/prisma-integration-authority.ts
+++ b/libs/backend/server/integrations/main/src/prisma-integration-authority.ts
@@ -1,0 +1,49 @@
+import { IntegrationCustodyState, IntegrationState, type PrismaClient } from "@prisma/client";
+
+import type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult } from "./integration-resolution.types.js";
+
+/** Production clock for integration-custody expiry checks. */
+export class __SystemIntegrationAuthorityClock implements IntegrationAuthorityClock
+{
+	/** Returns the current system instant used by the server authority. */
+	now(): Date
+	{
+		return new Date();
+	}
+}
+
+/** Prisma-backed, credential-free read authority for immutable integration assignments. */
+export class PrismaIntegrationAuthorityRepository implements IntegrationAuthorityRepository
+{
+	/** Canonical OpenCrane product database. */
+	private readonly prisma: PrismaClient;
+	/** Authority-owned clock that prevents callers from backdating custody expiry checks. */
+	private readonly clock: IntegrationAuthorityClock;
+
+	/** Creates the integration authority adapter over the product Postgres database. */
+	constructor(prisma: PrismaClient, clock: IntegrationAuthorityClock)
+	{
+		this.prisma = prisma;
+		this.clock = clock;
+	}
+
+	/** Resolves one currently usable integration assignment without exposing any credential material. */
+	async resolveAssignment(command: ResolveIntegrationAssignmentCommand): Promise<ResolveIntegrationAssignmentResult>
+	{
+		// 1. Read the immutable composite assignment so a foreign silo cannot select its own custody reference.
+		const assignment = await this.prisma.agentRevisionIntegrationAssignment.findUnique({
+			where: { agentRevisionId_integrationId: { agentRevisionId: command.agentRevisionId, integrationId: command.integrationId } },
+			include: { integration: true, custodyReference: true },
+		});
+		if (assignment === null || assignment.siloId !== command.siloId) return { outcome: "unavailable", reason: "not_found" };
+
+		// 2. Require the catalogue entry and custody reference to remain active at the requested instant.
+		if (assignment.integration.state !== IntegrationState.Active) return { outcome: "unavailable", reason: "inactive" };
+		if (assignment.custodyReference.state === IntegrationCustodyState.Revoked || assignment.custodyReference.revokedAt !== null) return { outcome: "unavailable", reason: "revoked" };
+		if (assignment.custodyReference.state === IntegrationCustodyState.Expired || assignment.custodyReference.expiresAt <= this.clock.now()) return { outcome: "unavailable", reason: "expired" };
+		if (assignment.custodyReference.state !== IntegrationCustodyState.Ready) return { outcome: "unavailable", reason: "inactive" };
+
+		// 3. Return only the opaque custody reference and explicit allow-list for the Obot PEP to redeem.
+		return { outcome: "resolved", assignment: { integrationId: assignment.integrationId, obotCatalogEntryId: assignment.integration.obotCatalogEntryId, obotCustodyReference: assignment.custodyReference.obotCustodyReference, allowedTools: assignment.allowedTools } };
+	}
+}

--- a/libs/backend/server/integrations/main/src/prisma-integration-custody-repository.test.ts
+++ b/libs/backend/server/integrations/main/src/prisma-integration-custody-repository.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaIntegrationCustodyRepository } from "./prisma-integration-custody-repository.js";
+
+describe("Prisma integration custody repository", function _suite()
+{
+	it("rejects a foreign-silo integration before writing a ready custody reference", async function _foreignSilo()
+	{
+		const transaction = { $queryRaw: vi.fn(), integration: { findUnique: vi.fn().mockResolvedValue({ siloId: "other-silo", state: "Active", obotCatalogEntryId: "catalog-1" }) }, integrationCustodyReference: { create: vi.fn() } };
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as never;
+		await expect(new PrismaIntegrationCustodyRepository(prisma).persistReady({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") })).rejects.toThrow("integration authority changed");
+		expect(transaction.integrationCustodyReference.create).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/integrations/main/src/prisma-integration-custody-repository.ts
+++ b/libs/backend/server/integrations/main/src/prisma-integration-custody-repository.ts
@@ -1,0 +1,29 @@
+import { IntegrationCustodyState, IntegrationState, Prisma, type PrismaClient } from "@prisma/client";
+
+import type { IntegrationCustodyRepository } from "./integration-custody-provisioning.types.js";
+
+/** Prisma persistence adapter that accepts custody only for an active exact-silo Integration. */
+export class PrismaIntegrationCustodyRepository implements IntegrationCustodyRepository
+{
+	/** Canonical product database authority. */
+	private readonly prisma: PrismaClient;
+
+	/** Creates the custody projection adapter. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Rechecks active same-silo integration authority before recording a remotely issued reference. */
+	async persistReady(command: Parameters<IntegrationCustodyRepository["persistReady"]>[0]): Promise<{ readonly custodyReferenceId: string }>
+	{
+		return this.prisma.$transaction(async function _persist(transaction: Prisma.TransactionClient)
+		{
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "integrations" WHERE "id" = ${command.integrationId} FOR UPDATE`);
+			const integration = await transaction.integration.findUnique({ where: { id: command.integrationId } });
+			if (integration === null || integration.siloId !== command.siloId || integration.state !== IntegrationState.Active || integration.obotCatalogEntryId !== command.obotCatalogEntryId) throw new Error("integration authority changed");
+			const reference = await transaction.integrationCustodyReference.create({ data: { integrationId: command.integrationId, siloId: command.siloId, obotCustodyReference: command.obotCustodyReference, state: IntegrationCustodyState.Ready, expiresAt: command.expiresAt } });
+			return { custodyReferenceId: reference.id };
+		});
+	}
+}

--- a/libs/backend/server/integrations/main/tests/integrations-authority.sql
+++ b/libs/backend/server/integrations/main/tests/integrations-authority.sql
@@ -1,0 +1,82 @@
+BEGIN;
+
+CREATE FUNCTION pg_temp.expect_failure(test_name TEXT, statement TEXT, expected_message TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE actual_message TEXT;
+BEGIN
+  BEGIN EXECUTE statement;
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+    IF strpos(actual_message, expected_message) > 0 THEN RAISE NOTICE 'PASS: %', test_name; RETURN; END IF;
+    RAISE EXCEPTION 'FAIL: % returned unexpected error: %', test_name, actual_message;
+  END;
+  RAISE EXCEPTION 'FAIL: % unexpectedly succeeded', test_name;
+END;
+$$;
+
+INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "owner_scope", "owner_subject_id", "workload_profile", "updated_at")
+VALUES ('integration-service', 'silo-integrations', 'managed', 'Integration agent', 'organization', 'organization-1', 'managed-agent', clock_timestamp());
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
+VALUES ('integration-revision', 'integration-service', 1, 'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+INSERT INTO "integrations" ("id", "silo_id", "obot_catalog_entry_id", "display_name", "updated_at")
+VALUES ('integration-1', 'silo-integrations', 'obot-catalog-1', 'Calendar', clock_timestamp());
+INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "expires_at")
+VALUES ('custody-1', 'integration-1', 'silo-integrations', 'obot:opaque:one', clock_timestamp() + interval '1 hour');
+INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+VALUES ('integration-revision', 'integration-1', 'silo-integrations', 'custody-1', ARRAY['calendar.read']);
+
+SELECT pg_temp.expect_failure('duplicate integration assignment', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision', 'integration-1', 'silo-integrations', 'custody-1', ARRAY['calendar.write'])$statement$, 'agent_revision_integration_assignments_pkey');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
+VALUES ('integration-revision-tools', 'integration-service', 2, 'sha256:' || repeat('b', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+INSERT INTO "integrations" ("id", "silo_id", "obot_catalog_entry_id", "display_name", "updated_at")
+VALUES ('integration-tools', 'silo-integrations', 'obot-catalog-tools', 'Tasks', clock_timestamp());
+INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "expires_at")
+VALUES ('custody-tools', 'integration-tools', 'silo-integrations', 'obot:opaque:tools', clock_timestamp() + interval '1 hour');
+SELECT pg_temp.expect_failure('empty duplicate and null tools are rejected', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision-tools', 'integration-tools', 'silo-integrations', 'custody-tools', ARRAY['', '', NULL])$statement$, 'allowed_tools_check');
+
+INSERT INTO "integrations" ("id", "silo_id", "obot_catalog_entry_id", "display_name", "updated_at")
+VALUES ('foreign-integration', 'other-silo', 'obot-catalog-foreign', 'Foreign calendar', clock_timestamp());
+INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "expires_at")
+VALUES ('foreign-custody', 'foreign-integration', 'other-silo', 'obot:opaque:foreign', clock_timestamp() + interval '1 hour');
+SELECT pg_temp.expect_failure('cross silo integration assignment', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision', 'foreign-integration', 'other-silo', 'foreign-custody', ARRAY['calendar.read'])$statement$, 'same silo');
+
+UPDATE "agent_revisions" SET "state" = 'published', "published_at" = clock_timestamp() WHERE "id" = 'integration-revision';
+SELECT pg_temp.expect_failure('published integration assignment is immutable', $statement$
+  UPDATE "agent_revision_integration_assignments" SET "allowed_tools" = ARRAY['calendar.write']
+  WHERE "agent_revision_id" = 'integration-revision' AND "integration_id" = 'integration-1'$statement$, 'AgentRevision assignments are immutable');
+
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
+VALUES ('integration-revision-2', 'integration-service', 3, 'sha256:' || repeat('c', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+UPDATE "integration_custody_references" SET "state" = 'revoked', "revoked_at" = clock_timestamp() WHERE "id" = 'custody-1';
+SELECT pg_temp.expect_failure('revoked custody reference cannot be assigned', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision-2', 'integration-1', 'silo-integrations', 'custody-1', ARRAY['calendar.read'])$statement$, 'ready unexpired');
+
+INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "state", "expires_at")
+VALUES ('expired-custody', 'integration-1', 'silo-integrations', 'obot:opaque:expired', 'expired', clock_timestamp() - interval '1 hour');
+SELECT pg_temp.expect_failure('expired custody reference cannot be assigned', $statement$
+  INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
+  VALUES ('integration-revision-2', 'integration-1', 'silo-integrations', 'expired-custody', ARRAY['calendar.read'])$statement$, 'ready unexpired');
+SELECT pg_temp.expect_failure('custody reference cannot be refilled', $statement$
+  UPDATE "integration_custody_references" SET "obot_custody_reference" = 'replacement'
+  WHERE "id" = 'custody-1'$statement$, 'custody identity is immutable');
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name IN ('integrations', 'integration_custody_references', 'agent_revision_integration_assignments')
+      AND column_name ~ '(secret|token|password|credential|oauth)'
+  ) THEN
+    RAISE EXCEPTION 'integration authority must not persist raw-secret columns';
+  END IF;
+END;
+$$;
+
+ROLLBACK;

--- a/libs/backend/server/integrations/main/tsconfig.json
+++ b/libs/backend/server/integrations/main/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/backend/server/integrations/main/vitest.config.ts
+++ b/libs/backend/server/integrations/main/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../vitest.cache.js";
+
+/** Vitest configuration for integration authority tests. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../tsconfig.vitest.json"] })] });

--- a/libs/models/agents/main/src/agent-revision.types.ts
+++ b/libs/models/agents/main/src/agent-revision.types.ts
@@ -12,12 +12,14 @@ export interface SkillRevisionReference
 	readonly revisionId: string;
 }
 
-/** Immutable reference to an MCP server assignment. */
-export interface McpAssignmentReference
+/** Immutable reference to an integration assignment. */
+export interface IntegrationAssignmentReference
 {
-	/** Stable MCP server identifier. */
-	readonly serverId: string;
-	/** Explicit tool names exposed from the server. */
+	/** Stable silo-scoped integration identifier. */
+	readonly integrationId: string;
+	/** Immutable opaque Obot custody reference selected for the revision. */
+	readonly custodyReferenceId: string;
+	/** Explicit tool identifiers exposed from the integration. */
 	readonly allowedTools: readonly string[];
 }
 
@@ -53,8 +55,8 @@ export interface AgentRevision
 	readonly modelPolicyId: string;
 	/** Immutable skill revisions available to the runtime. */
 	readonly skills: readonly SkillRevisionReference[];
-	/** Immutable MCP server and tool assignments available to the runtime. */
-	readonly mcpAssignments: readonly McpAssignmentReference[];
+	/** Immutable integration and tool assignments available to the runtime. */
+	readonly integrationAssignments: readonly IntegrationAssignmentReference[];
 	/** Resource ceilings applied to each run. */
 	readonly budget: AgentBudget;
 	/** Identifier of the user who authored the revision. */

--- a/libs/models/agents/main/src/index.ts
+++ b/libs/models/agents/main/src/index.ts
@@ -1,4 +1,4 @@
-export type { AgentBudget, AgentRevision, AgentRevisionState, McpAssignmentReference, SkillRevisionReference } from "./agent-revision.types.js";
+export type { AgentBudget, AgentRevision, AgentRevisionState, IntegrationAssignmentReference, SkillRevisionReference } from "./agent-revision.types.js";
 export type { AgentRun, AgentRunLineage, AgentRunState, AgentRunTerminalReason, AgentRunTrigger } from "./agent-run.types.js";
 export type { AgentOwner, AgentOwnerScope, AgentService, AgentServiceKind, AgentServiceState } from "./agent-service.types.js";
 export type { AgentRevisionId, AgentRunId, AgentServiceId, MessageId, PersonaProfileId, PersonaRevisionId, SiloId, ThreadId, UserId } from "./identifiers.types.js";

--- a/libs/server/_infra/obot-custody/project.json
+++ b/libs/server/_infra/obot-custody/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "server-infra-obot-custody",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/server/_infra/obot-custody/src",
+  "tags": ["type:lib", "layer:infra", "scope:obot-custody"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/server/_infra/obot-custody" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/server/_infra/obot-custody" } }
+  }
+}

--- a/libs/server/_infra/obot-custody/src/index.ts
+++ b/libs/server/_infra/obot-custody/src/index.ts
@@ -1,0 +1,2 @@
+export { __UnavailableObotCustodyAdapter, ObotCustodyUnavailableError } from "./unavailable-obot-custody.js";
+export type { ObotCustodyCredential, ObotCustodyPort, ProvisionObotCustodyCommand, ProvisionedObotCustody } from "./obot-custody.types.js";

--- a/libs/server/_infra/obot-custody/src/obot-custody.types.ts
+++ b/libs/server/_infra/obot-custody/src/obot-custody.types.ts
@@ -1,0 +1,41 @@
+/** Write-only credential material accepted only for the duration of a custody request. */
+export interface ObotCustodyCredential
+{
+	/** Header name or provider-specific credential field. */
+	readonly name: string;
+	/** Secret value that must never be persisted, logged, or returned. */
+	readonly value: string;
+}
+
+/** Request to provision one remote Obot custody reference. */
+export interface ProvisionObotCustodyCommand
+{
+	/** Silo that owns the integration. */
+	readonly siloId: string;
+	/** Product integration identity used as remote correlation context. */
+	readonly integrationId: string;
+	/** Obot catalogue entry to configure. */
+	readonly obotCatalogEntryId: string;
+	/** Write-only credential material passed directly to Obot. */
+	readonly credential: readonly ObotCustodyCredential[];
+}
+
+/** Remote-only custody result issued by Obot after successful configuration. */
+export interface ProvisionedObotCustody
+{
+	/** Obot catalogue entry confirmed by the remote authority. */
+	readonly obotCatalogEntryId: string;
+	/** Opaque reference minted by Obot; never locally synthesized. */
+	readonly obotCustodyReference: string;
+	/** Remote expiry governing later redemption. */
+	readonly expiresAt: Date;
+}
+
+/** Runtime-neutral boundary for the Obot credential custody authority. */
+export interface ObotCustodyPort
+{
+	/** Provisions custody remotely and returns only Obot-originated opaque coordinates. */
+	provision(command: ProvisionObotCustodyCommand): Promise<ProvisionedObotCustody>;
+	/** Revokes one remotely issued custody reference. */
+	revoke(obotCustodyReference: string): Promise<void>;
+}

--- a/libs/server/_infra/obot-custody/src/unavailable-obot-custody.test.ts
+++ b/libs/server/_infra/obot-custody/src/unavailable-obot-custody.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { __UnavailableObotCustodyAdapter, ObotCustodyUnavailableError } from "./unavailable-obot-custody.js";
+
+describe("unavailable Obot custody adapter", function _suite()
+{
+	it("fails closed without inventing a custody reference", async function _provision()
+	{
+		const adapter = new __UnavailableObotCustodyAdapter();
+		await expect(adapter.provision({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalogue-1", credential: [{ name: "Authorization", value: "never-persisted" }] })).rejects.toBeInstanceOf(ObotCustodyUnavailableError);
+	});
+});

--- a/libs/server/_infra/obot-custody/src/unavailable-obot-custody.ts
+++ b/libs/server/_infra/obot-custody/src/unavailable-obot-custody.ts
@@ -1,0 +1,28 @@
+import type { ObotCustodyPort, ProvisionObotCustodyCommand, ProvisionedObotCustody } from "./obot-custody.types.js";
+
+/** Typed failure emitted when no authenticated Obot management transport is configured. */
+export class ObotCustodyUnavailableError extends Error
+{
+	/** Creates a failure that cannot be mistaken for successful custody provisioning. */
+	constructor()
+	{
+		super("Obot custody authority is unavailable");
+		this.name = "ObotCustodyUnavailableError";
+	}
+}
+
+/** Fail-closed adapter used until an authenticated Obot API contract is verified. */
+export class __UnavailableObotCustodyAdapter implements ObotCustodyPort
+{
+	/** Rejects provisioning rather than minting a local custody handle. */
+	async provision(_command: ProvisionObotCustodyCommand): Promise<ProvisionedObotCustody>
+	{
+		throw new ObotCustodyUnavailableError();
+	}
+
+	/** Rejects revocation because no remote authority can be contacted. */
+	async revoke(_obotCustodyReference: string): Promise<void>
+	{
+		throw new ObotCustodyUnavailableError();
+	}
+}

--- a/libs/server/_infra/obot-custody/tsconfig.json
+++ b/libs/server/_infra/obot-custody/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/server/_infra/obot-custody/vitest.config.ts
+++ b/libs/server/_infra/obot-custody/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../vitest.cache.js";
+
+/** Vitest configuration for the Obot custody boundary. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../tsconfig.vitest.json"] })] });

--- a/scripts/integration-authority-negative-tests.sh
+++ b/scripts/integration-authority-negative-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+# Resolve the repository root so this guard remains correct from its Nx package cwd.
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$repo_root"
+
+if grep -R -n -E 'McpAssignmentReference|mcpAssignments|mcpServerId|agent_revision_mcp_assignments' \
+  apps/opencrane/prisma/schema/agent-services.prisma \
+  libs/models/agents/main/src \
+  libs/backend/server/agent-services/main/src; then
+  echo "target AgentRevision integration authority still contains MCP-assignment residue" >&2
+  exit 1
+fi
+
+if grep -R -n -E '@opencrane/backend/server/mcp|McpServer|OpenClaw|StaticFallback|credentialRef|oauth' \
+  libs/backend/server/integrations/main/src; then
+  echo "integration authority must not depend on legacy MCP, OpenClaw, or credential material" >&2
+  exit 1
+fi
+
+echo "Integration authority negative tests passed."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -70,6 +70,9 @@
       "@opencrane/backend/server/identity": [
         "./libs/backend/server/identity/main/src/index.ts"
       ],
+      "@opencrane/backend/server/integrations": [
+        "./libs/backend/server/integrations/main/src/index.ts"
+      ],
       "@opencrane/backend/server/metrics": [
         "./libs/backend/server/metrics/main/src/index.ts"
       ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -148,6 +148,9 @@
       "@opencrane/server/_infra/http": [
         "./libs/server/_infra/http/src/index.ts"
       ],
+      "@opencrane/server/_infra/obot-custody": [
+        "./libs/server/_infra/obot-custody/src/index.ts"
+      ],
       "@opencrane/server/_infra/tenant-hosting": [
         "./libs/server/_infra/tenant-hosting/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

- propagate the exact merged #286 integration authority foundation and #287 Obot custody/logging fixes to the Phase D root branch
- include migration 0049, completing the schema-settle prerequisite for the integration authority
- preserve the D5 personal-agent namespace boundary while adding the independent Obot-custody scope rule

## Validation

- Prisma generation
- focused integration authority lint, tests, and negative guard
- focused Obot custody lint and tests
- boundary lint and diff check
- live PostgreSQL authority suite remains pending because Docker/psql are unavailable here

## Review

- architecture postflight: PASS
- independent correctness/security review: no findings
- local Claude Code review remains pending because claude --bare reports Not logged in; no repository content was sent to Anthropic

## Recovery evidence

- replayed #286/#287 onto the current root, preserving the D5 personal-memory rule in the only conflict
- 0049 references the assignment-immutability function defined in migration 0034

This PR must merge before D2 can freeze and squash the complete 50-migration schema.