### PR TITLE
🧪 Reintegrate D4 test layout and backend guides

### DIFF
--- a/apps/artifact-service/src/__tests__/server.test.ts
+++ b/apps/artifact-service/src/__tests__/server.test.ts
@@ -7,7 +7,7 @@ import { __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@ope
 import { __FilesystemArtifactStore } from "@opencrane/backend/artifacts/filesystem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { _CreateServer } from "./server.js";
+import { _CreateServer } from "../server.js";
 
 const _leaseKeys = generateKeyPairSync("ed25519");
 const _receiptKeys = generateKeyPairSync("ed25519");

--- a/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
+++ b/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { _CreateArtifactServicePromotionPort, _CreateArtifactUploadGateway } from "./artifact-upload.factory.js";
+import { _CreateArtifactServicePromotionPort, _CreateArtifactUploadGateway } from "../artifact-upload.factory.js";
 
 const _serviceUrl = "http://opencrane-artifact-service.default.svc.cluster.local:8080";
 

--- a/docs/agents/app-source-allowlist.json
+++ b/docs/agents/app-source-allowlist.json
@@ -23,7 +23,7 @@
     { "path": "apps/opencrane/src/index.ts", "owner": "apps/opencrane", "classification": "process-entrypoint" },
     { "path": "apps/opencrane/src/infra/db/db.ts", "owner": "apps/opencrane", "classification": "prisma-composition" },
     { "path": "apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts", "owner": "apps/opencrane", "classification": "route-composition" },
-    { "path": "apps/opencrane/src/infra/artifacts/artifact-upload.factory.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
+    { "path": "apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/scripts/migrate.ts", "owner": "apps/opencrane", "classification": "migration-entrypoint" },
     { "path": "apps/opencrane/vitest.config.ts", "owner": "apps/opencrane", "classification": "test-config" },
 
@@ -52,7 +52,7 @@
     { "path": "apps/artifact-service/src/instrument.ts", "owner": "apps/artifact-service", "classification": "process-instrumentation" },
     { "path": "apps/artifact-service/src/log.ts", "owner": "apps/artifact-service", "classification": "process-logging" },
     { "path": "apps/artifact-service/src/server.ts", "owner": "apps/artifact-service", "classification": "route-composition" },
-    { "path": "apps/artifact-service/src/server.test.ts", "owner": "apps/artifact-service", "classification": "composition-test" },
+    { "path": "apps/artifact-service/src/__tests__/server.test.ts", "owner": "apps/artifact-service", "classification": "composition-test" },
     { "path": "apps/artifact-service/vitest.config.ts", "owner": "apps/artifact-service", "classification": "test-config" },
 
     { "path": "apps/feat-central-agents/src/__tests__/connectors/slack.connector.test.ts", "owner": "apps/feat-central-agents", "classification": "delete" },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,6 +20,33 @@ import nx from "@nx/eslint-plugin";
 import tsEslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
 
+/** Enforces the package test-layout convention independently of Vitest discovery. */
+const testLayout = {
+  rules: {
+    "require-tests-directory": {
+      meta: {
+        type: "problem",
+        docs: { description: "require TypeScript tests to live below __tests__" },
+        schema: [],
+        messages: { misplacedTest: "Move this test below a __tests__ directory." },
+      },
+      create(context) {
+        const filename = context.filename.replaceAll("\\", "/");
+
+        if (filename.includes("/__tests__/")) {
+          return {};
+        }
+
+        return {
+          Program(node) {
+            context.report({ node, messageId: "misplacedTest" });
+          },
+        };
+      },
+    },
+  },
+};
+
 export default [
   {
     ignores: [
@@ -198,6 +225,11 @@ export default [
         },
       ],
     },
+  },
+  {
+    files: ["**/*.test.ts"],
+    plugins: { "test-layout": testLayout },
+    rules: { "test-layout/require-tests-directory": "error" },
   },
   {
     // Vitest configs are build tooling, not product modules: every one imports the

--- a/libs/backend/README.md
+++ b/libs/backend/README.md
@@ -1,10 +1,15 @@
-# libs/backend — server-owned capabilities
+# libs/backend — product and control-plane capabilities
 
-Backend libraries are grouped first by the application that owns their composition boundary. The
-OpenCrane API server owns the capabilities under `server/`. Its process-only transport and platform
-support lives separately under [`libs/server/_infra`](../server/_infra/) so business capabilities
-do not become mixed with server machinery. Apps remain thin entrypoints that mount routers,
-construct clients, and manage process lifecycle.
+Backend libraries are grouped by the capability they provide. The agent product lives under
+[`agents/`](agents/): these authorities shape a person's assistant, its conversations, durable
+memory catalogue, and logical runs. The OpenCrane server's control-plane capabilities live under
+[`server/`](server/): they establish identities, membership, authorization, agent-service
+publication, and the boundaries that connect the product to deployed runtimes.
+
+`apps/opencrane` is the intended composition boundary for both groups. Its process-only transport
+and platform support lives separately under [`libs/server/_infra`](../server/_infra/) so business
+capabilities do not become mixed with server machinery. Apps remain thin entrypoints that mount
+routers, construct clients, and manage process lifecycle.
 
 `feat-openclaw-tenant/` is the one temporary exception. It is a direct-deletion boundary for the
 retired personal-agent runtime and must not receive new functionality.
@@ -13,12 +18,11 @@ retired personal-agent runtime and must not receive new functionality.
 
 ```text
 libs/backend/
-  server/<domain>/main/       OpenCrane server capability
+  agents/personal/<domain>/main/  Personal-agent product capability
+  server/<domain>/main/           OpenCrane control-plane capability
+  channel-proxy/main/             Target-neutral channel forwarding capability
     project.json              Nx project metadata and targets
     src/index.ts              public barrel
-    src/routes/               Express transport adapters
-    src/core/                 domain services and use cases
-    src/__tests__/             capability tests
   feat-openclaw-tenant/       deletion boundary; do not extend
 ```
 
@@ -27,8 +31,13 @@ flattening unrelated responsibilities together.
 
 ## Current functional domains
 
-- Target agent authority: agent services and immutable revisions, logical runs and workload
-  assignments, proof-bound authorization, and verified fleet membership.
+- Personal agent: personas built from an onboarding interview, conversations, durable-memory
+  metadata, and logical run attempts. See [`agents/`](agents/).
+- Control plane: identity and access, fleet membership, agent-service publication, channel target
+  resolution, artifacts, and the established server capabilities. See [`server/`](server/).
+- Channel proxy: a target-neutral browser-facing forwarding boundary that asks the control plane
+  for each authorized destination.
+
 - Identity and access: access tokens, identity, grants, groups, policies, and cluster membership.
 - Tenant and runtime lifecycle: tenants, connections, effective contracts, and projection repair.
 - Models and economics: providers, model routing, spend, and budgets.
@@ -50,13 +59,15 @@ OpenClaw, rollout, or projection behavior survives the direct target refactor.
 - Database models remain in the OpenCrane app's per-domain Prisma schema files; see
   [`docs/agents/prisma.md`](../../docs/agents/prisma.md).
 
-## Adding a server capability
+## Adding a backend capability
 
-1. Create `libs/backend/server/<domain>/main` by copying a small peer such as
-   `libs/backend/server/audit/main`.
-2. Name its Nx project `backend-server-<domain>` and update `sourceRoot`, target working
+1. Put a user-facing personal-agent capability under
+   `libs/backend/agents/personal/<domain>/main`; put a server control-plane capability under
+   `libs/backend/server/<domain>/main`.
+2. Name the Nx project after that bounded capability and update `sourceRoot`, target working
    directories, and its root-relative TypeScript and Vitest paths.
-3. Add `@opencrane/backend/server/<domain>` to the root `tsconfig.json` paths.
+3. Add the matching `@opencrane/backend/agents/...` or
+   `@opencrane/backend/server/...` public path to the root `tsconfig.json` paths.
 4. Export only the public capability surface from `src/index.ts` and mount transport adapters from
    `apps/opencrane`.
 5. Add or update the app-owned Prisma schema slice when the capability owns durable models.

--- a/libs/backend/agents/README.md
+++ b/libs/backend/agents/README.md
@@ -1,0 +1,10 @@
+# Agent product capabilities
+
+This namespace owns the backend capabilities that make an employee's assistant useful. They are
+separate from the OpenCrane control plane so product behaviour does not become tangled with fleet,
+identity, or deployment administration.
+
+`personal/` is the current product family. It owns the personal assistant's approved persona,
+conversation history, durable-memory catalogue, and logical run lifecycle.
+
+See [`libs/backend/README.md`](../README.md) for the broader backend layout and dependency rules.

--- a/libs/backend/agents/personal/README.md
+++ b/libs/backend/agents/personal/README.md
@@ -1,0 +1,14 @@
+# Personal agent capabilities
+
+Each package here owns one part of an employee's personal assistant:
+
+- [`personas/`](personas/main/) approves the interview-informed persona that becomes the assistant's
+  SOUL document.
+- [`conversations/`](conversations/main/) records the ordered events that explain a run to the user.
+- [`memory/`](memory/main/) records durable-memory metadata and provenance after the memory store
+  accepts a fact.
+- [`runs/`](runs/main/) owns logical run attempts and their workload assignments.
+
+`apps/opencrane` is the intended composition boundary for these capabilities; they do not own HTTP
+process setup or cluster administration. See [`../../README.md`](../../README.md) for the
+product/control-plane split.

--- a/libs/backend/agents/personal/conversations/main/README.md
+++ b/libs/backend/agents/personal/conversations/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/agents/personal/conversations — Conversations
+
+Owns the ordered event history for a personal-agent run. It appends a valid next event exactly once
+and refuses missing, terminal, or out-of-sequence runs, so callers can present an accurate
+conversation timeline.
+
+The public surface is `src/index.ts`; persistence is supplied through `ConversationAuthorityRepository`.
+See [`../../README.md`](../../README.md) for the other personal-agent capabilities.

--- a/libs/backend/agents/personal/conversations/main/src/__tests__/conversation-authority.test.ts
+++ b/libs/backend/agents/personal/conversations/main/src/__tests__/conversation-authority.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __AppendRunEvent } from "./conversation-authority.js";
-import type { ConversationAuthorityRepository } from "./conversation-authority.types.js";
+import { __AppendRunEvent } from "../conversation-authority.js";
+import type { ConversationAuthorityRepository } from "../conversation-authority.types.js";
 
 describe("conversation authority", function ()
 {

--- a/libs/backend/agents/personal/memory/main/README.md
+++ b/libs/backend/agents/personal/memory/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/agents/personal/memory — Memory catalogue
+
+Owns the durable-memory catalogue for a personal agent. It records consent, provenance, and a
+content digest after the memory store accepts a fact; the fact content itself stays in the durable
+memory store rather than being copied into this authority.
+
+The public surface is `src/index.ts`; persistence and outbox commitment are supplied through
+`MemoryCatalogRepository`. See [`../../README.md`](../../README.md) for the other personal-agent
+capabilities.

--- a/libs/backend/agents/personal/memory/main/src/__tests__/memory-catalog.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/__tests__/memory-catalog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __RecordMemoryFact } from "./memory-catalog.js";
+import { __RecordMemoryFact } from "../memory-catalog.js";
 
 describe("memory catalog", function ()
 {

--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/agents/personal/personas — Personas
+
+Owns approval and activation of a person's assistant persona. A completed onboarding interview,
+its selected template, and the supporting insights must agree before the approved revision becomes
+the active SOUL source for that person.
+
+The public surface is `src/index.ts`; persistence is supplied through `PersonaAuthorityRepository`.
+See [`../../README.md`](../../README.md) for the other personal-agent capabilities.

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-authority.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-authority.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __ApprovePersona } from "./persona-authority.js";
+import { __ApprovePersona } from "../persona-authority.js";
 
 describe("persona authority", function ()
 {

--- a/libs/backend/agents/personal/runs/main/README.md
+++ b/libs/backend/agents/personal/runs/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/agents/personal/runs — Runs
+
+Owns a personal agent's logical run attempts. It starts a retry only while the intended agent
+service and revision are still active, and validates that a workload assignment belongs to that
+exact attempt.
+
+The public surface is `src/index.ts`; `PrismaAgentRunAuthorityRepository` supplies the durable
+authority implementation. See [`../../README.md`](../../README.md) for the other personal-agent
+capabilities.

--- a/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-authority.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-authority.test.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
+import { PrismaAgentRunAuthorityRepository } from "../prisma-run-authority.js";
 
 /** Creates one retryable Prisma run row. */
 function _runRow()

--- a/libs/backend/agents/personal/runs/main/src/__tests__/run-authority.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/run-authority.test.ts
@@ -1,8 +1,8 @@
 import type { AgentRevisionId, AgentRun, AgentRunId, AgentServiceState, SiloId } from "@opencrane/models/agents";
 import { describe, expect, it } from "vitest";
 
-import { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
-import type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentExpectation } from "./run-authority.types.js";
+import { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "../run-authority.js";
+import type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentExpectation } from "../run-authority.types.js";
 
 /** Creates a failed first attempt for one logical run. */
 function _run(): AgentRun

--- a/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
+++ b/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
@@ -2,7 +2,7 @@ import { generateKeyPairSync } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
 
-import { __SignArtifactPromotionReceipt, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "./artifact-lease.js";
+import { __SignArtifactPromotionReceipt, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "../artifact-lease.js";
 
 const _leaseKeys = generateKeyPairSync("ed25519");
 const _receiptKeys = generateKeyPairSync("ed25519");

--- a/libs/backend/artifacts/filesystem/main/src/__tests__/filesystem-artifact-store.test.ts
+++ b/libs/backend/artifacts/filesystem/main/src/__tests__/filesystem-artifact-store.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { __FilesystemArtifactStore } from "./filesystem-artifact-store.js";
+import { __FilesystemArtifactStore } from "../filesystem-artifact-store.js";
 
 /** Builds an authorized upload lease that remains valid through the test. */
 function _lease(id: string): { readonly leaseId: string; readonly siloId: string; readonly artifactId: string; readonly action: "artifact.write"; readonly expiresAtEpochSeconds: number }

--- a/libs/backend/artifacts/store/main/src/__tests__/artifact-promotion.test.ts
+++ b/libs/backend/artifacts/store/main/src/__tests__/artifact-promotion.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { __PromoteArtifactUpload } from "./artifact-promotion.js";
-import type { ArtifactPromotionLeaseClaims, ArtifactPromotionLeaseVerifier, ArtifactPromotionReceiptSigner, ArtifactStore, BoundedArtifactUploadByteSource } from "./artifact-store.types.js";
+import { __PromoteArtifactUpload } from "../artifact-promotion.js";
+import type { ArtifactPromotionLeaseClaims, ArtifactPromotionLeaseVerifier, ArtifactPromotionReceiptSigner, ArtifactStore, BoundedArtifactUploadByteSource } from "../artifact-store.types.js";
 
 /** Builds one valid write lease for protocol tests. */
 function _lease(expiresAtEpochSeconds: number): ArtifactPromotionLeaseClaims

--- a/libs/backend/artifacts/store/main/src/__tests__/artifact-store.test.ts
+++ b/libs/backend/artifacts/store/main/src/__tests__/artifact-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { __ValidateArtifactStorePromotion, __ValidateStageArtifactCommand, __ValidateStagedArtifact, __ValidateVerifiedArtifactWriteLease } from "./artifact-store.js";
+import { __ValidateArtifactStorePromotion, __ValidateStageArtifactCommand, __ValidateStagedArtifact, __ValidateVerifiedArtifactWriteLease } from "../artifact-store.js";
 
 /** Builds one valid durable write lease. */
 function _lease(): { readonly leaseId: string; readonly siloId: string; readonly artifactId: string; readonly action: "artifact.write"; readonly expiresAtEpochSeconds: number }

--- a/libs/backend/channel-proxy/main/README.md
+++ b/libs/backend/channel-proxy/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/channel-proxy — Channel proxy
+
+Owns target-neutral forwarding for browser channel traffic. For every command or event request it
+asks OpenCrane for an authorized destination, forwards only to that result, and applies origin,
+identity-header, size, timeout, and per-subject rate limits.
+
+This library is not a policy authority and does not choose agent endpoints itself. The corresponding
+control-plane decision lives in [`server/channel-targets`](../../server/channel-targets/main/).
+Its public surface is `src/index.ts`.

--- a/libs/backend/channel-proxy/main/src/__tests__/channel-proxy.test.ts
+++ b/libs/backend/channel-proxy/main/src/__tests__/channel-proxy.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { AuthorizedChannelTarget, ChannelProxyDependencies, ChannelTargetResolver, SubjectRateLimiter, TargetResolutionRequest } from "./channel-proxy.types.js";
-import { __ForwardCommand, __RelayEvents } from "./forwarding.js";
-import { __HasForgedIdentityHeaders, __ValidateOrigin } from "./origin-policy.js";
-import { __FixedWindowRateLimiter } from "./rate-limiter.js";
+import type { AuthorizedChannelTarget, ChannelProxyDependencies, ChannelTargetResolver, SubjectRateLimiter, TargetResolutionRequest } from "../channel-proxy.types.js";
+import { __ForwardCommand, __RelayEvents } from "../forwarding.js";
+import { __HasForgedIdentityHeaders, __ValidateOrigin } from "../origin-policy.js";
+import { __FixedWindowRateLimiter } from "../rate-limiter.js";
 
 /** Construct a live authorized target for one focused test. */
 function _Target(endpoint = "http://agent-runtime.default.svc.cluster.local:8080/v1/channel"): AuthorizedChannelTarget

--- a/libs/backend/channel-proxy/main/src/__tests__/target-resolver.test.ts
+++ b/libs/backend/channel-proxy/main/src/__tests__/target-resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __OpenCraneTargetResolver } from "./target-resolver.js";
+import { __OpenCraneTargetResolver } from "../target-resolver.js";
 
 describe("OpenCrane channel target resolver", () =>
 {

--- a/libs/backend/server/README.md
+++ b/libs/backend/server/README.md
@@ -1,0 +1,19 @@
+# OpenCrane server control-plane capabilities
+
+This namespace owns capabilities the OpenCrane server uses to administer the product and safely
+connect it to deployed agent runtimes. It does not own an employee's personal-agent state; that
+lives in [`../agents/personal/`](../agents/personal/).
+
+The newer Phase D authorities are deliberately separate:
+
+- `authorization/` evaluates effective access and proof-bound actions.
+- `membership/` verifies current signed fleet membership.
+- `agent-services/` publishes immutable agent revisions.
+- `artifacts/` finalizes promoted artifact metadata.
+- `channel-targets/` authorizes a browser channel operation and resolves its target.
+- `identity/` establishes browser identity and turns verified sign-in claims into server facts.
+- `api-spec/` assembles the public HTTP contract from the server capabilities.
+
+Other packages retain established server capabilities such as tenant lifecycle, integrations,
+knowledge, policies, reporting, and API composition. See [`../README.md`](../README.md) for the
+backend-wide ownership and dependency rules.

--- a/libs/backend/server/access-tokens/main/README.md
+++ b/libs/backend/server/access-tokens/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/access-tokens`.
 Owns personal access token management. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/access-tokens.prisma` where this domain owns models).

--- a/libs/backend/server/agent-services/main/README.md
+++ b/libs/backend/server/agent-services/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/server/agent-services — Agent-service publication
+
+Owns publication of an immutable agent revision as the active revision for an agent service. It
+keeps the service, revision, and audit evidence aligned when a draft becomes available to run.
+
+The public surface is `src/index.ts`; `PrismaAgentServicePublicationRepository` provides the
+durable authority implementation. See [`../../README.md`](../../README.md) for the control-plane
+map.

--- a/libs/backend/server/agent-services/main/src/__tests__/agent-publication.test.ts
+++ b/libs/backend/server/agent-services/main/src/__tests__/agent-publication.test.ts
@@ -1,8 +1,8 @@
 import type { AgentRevision, AgentRevisionId, AgentService } from "@opencrane/models/agents";
 import { describe, expect, it } from "vitest";
 
-import { __PublishAgentRevision } from "./agent-publication.js";
-import type { AgentServicePublicationRepository, AtomicAgentRevisionPublication, AtomicAgentRevisionPublicationResult } from "./agent-publication.types.js";
+import { __PublishAgentRevision } from "../agent-publication.js";
+import type { AgentServicePublicationRepository, AtomicAgentRevisionPublication, AtomicAgentRevisionPublicationResult } from "../agent-publication.types.js";
 
 /** Creates a stable personal AgentService fixture. */
 function _service(): AgentService

--- a/libs/backend/server/agent-services/main/src/__tests__/prisma-agent-publication.test.ts
+++ b/libs/backend/server/agent-services/main/src/__tests__/prisma-agent-publication.test.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AuditDecisionRecord } from "@opencrane/backend/server/audit";
-import { PrismaAgentServicePublicationRepository } from "./prisma-agent-publication.js";
+import { PrismaAgentServicePublicationRepository } from "../prisma-agent-publication.js";
 
 /** Creates one locked Prisma service row. */
 function _serviceRow()

--- a/libs/backend/server/api-spec/main/README.md
+++ b/libs/backend/server/api-spec/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/server/api-spec — API specification
+
+Owns the assembled OpenAPI contract for the OpenCrane server. It brings each server capability's
+public paths into one specification from which the published API description and client contracts
+are generated.
+
+The public surface is `src/index.ts`. When a capability changes its HTTP contract, update its
+contribution here and regenerate the API outputs through the server's documented contract tasks.
+See [`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/artifacts/main/README.md
+++ b/libs/backend/server/artifacts/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/server/artifacts — Artifact revisions
+
+Owns finalization of visible artifact metadata after ArtifactStore has promoted the bytes. It
+checks the promotion evidence and commits the revision, current pointer, and delivery intent as
+one durable result; it does not perform artifact byte I/O itself.
+
+The public surface is `src/index.ts`; persistence is supplied through `ArtifactAuthorityRepository`.
+See [`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/artifacts/main/src/__tests__/artifact-finalization.test.ts
+++ b/libs/backend/server/artifacts/main/src/__tests__/artifact-finalization.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __FinalizeArtifactRevision } from "./artifact-finalization.js";
+import { __FinalizeArtifactRevision } from "../artifact-finalization.js";
 
 describe("artifact finalization", function ()
 {

--- a/libs/backend/server/artifacts/main/src/__tests__/artifact-upload.test.ts
+++ b/libs/backend/server/artifacts/main/src/__tests__/artifact-upload.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __UploadArtifact } from "./artifact-upload.js";
+import { __UploadArtifact } from "../artifact-upload.js";
 
 const _address = `sha256:${"a".repeat(64)}`;
 const _receiptDigest = `sha256:${"b".repeat(64)}`;

--- a/libs/backend/server/artifacts/main/src/__tests__/prisma-artifact-authority.test.ts
+++ b/libs/backend/server/artifacts/main/src/__tests__/prisma-artifact-authority.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaArtifactAuthorityRepository } from "./prisma-artifact-authority.js";
+import { PrismaArtifactAuthorityRepository } from "../prisma-artifact-authority.js";
 
 function _command()
 {

--- a/libs/backend/server/audit/main/README.md
+++ b/libs/backend/server/audit/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/audit`.
 Owns the audit-trail read API. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/audit.prisma` where this domain owns models).

--- a/libs/backend/server/audit/main/src/__tests__/audit-decision.test.ts
+++ b/libs/backend/server/audit/main/src/__tests__/audit-decision.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __AppendAuditDecision } from "./audit-decision.js";
+import { __AppendAuditDecision } from "../audit-decision.js";
 
 describe("target audit decision append port", function _suite()
 {

--- a/libs/backend/server/authorization/main/README.md
+++ b/libs/backend/server/authorization/main/README.md
@@ -1,0 +1,8 @@
+# @opencrane/backend/server/authorization — Authorization
+
+Owns effective access decisions and proof-bound runtime actions. It evaluates the grants and
+membership evidence required for an action, verifies its proof, and records a one-time outcome
+through an explicit persistence boundary.
+
+The public surface is `src/index.ts`; Prisma repositories implement the durable authorization and
+runtime authorities. See [`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/authorization/main/src/__tests__/canonical-json-digest.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/canonical-json-digest.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { __DigestCanonicalJson } from "./canonical-json-digest.js";
+import { __DigestCanonicalJson } from "../canonical-json-digest.js";
 
 describe("backend canonical JSON digest", function _suite()
 {

--- a/libs/backend/server/authorization/main/src/__tests__/capability-proof.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/capability-proof.test.ts
@@ -4,8 +4,8 @@ import { ___CanonicalizeJson } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 import { describe, expect, it } from "vitest";
 
-import { __ComputeEs256JwkThumbprint, __NormalizeDpopTargetUri, __VerifyCapabilityProof } from "./capability-proof.js";
-import { __DigestCanonicalJson } from "./canonical-json-digest.js";
+import { __ComputeEs256JwkThumbprint, __NormalizeDpopTargetUri, __VerifyCapabilityProof } from "../capability-proof.js";
+import { __DigestCanonicalJson } from "../canonical-json-digest.js";
 
 /** Fixed trusted clock used by proof fixtures. */
 const NOW = 1_750_000_000;

--- a/libs/backend/server/authorization/main/src/__tests__/effective-access.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/effective-access.test.ts
@@ -1,8 +1,8 @@
 import type { AuthorizationGrant, CapabilityReference } from "@opencrane/models/authorization";
 import { describe, expect, it } from "vitest";
 
-import { __ResolveEffectiveAccess } from "./effective-access.js";
-import type { AuthorizationGrantRepository, AuthorizationMembershipAuthority, AuthorizationMembershipDecision, AuthorizationMembershipRequirement, ResolveEffectiveAccessCommand } from "./effective-access.types.js";
+import { __ResolveEffectiveAccess } from "../effective-access.js";
+import type { AuthorizationGrantRepository, AuthorizationMembershipAuthority, AuthorizationMembershipDecision, AuthorizationMembershipRequirement, ResolveEffectiveAccessCommand } from "../effective-access.types.js";
 
 /** Creates one immutable capability reference. */
 function _capability(capabilityId: string): CapabilityReference

--- a/libs/backend/server/authorization/main/src/__tests__/prisma-authorization-grants.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/prisma-authorization-grants.test.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaAuthorizationGrantRepository } from "./prisma-authorization-grants.js";
+import { PrismaAuthorizationGrantRepository } from "../prisma-authorization-grants.js";
 
 describe("Prisma authorization grant reader", function _suite()
 {

--- a/libs/backend/server/authorization/main/src/__tests__/prisma-runtime-authority.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/prisma-runtime-authority.test.ts
@@ -1,8 +1,8 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaRuntimeAuthorityRepository } from "./prisma-runtime-authority.js";
-import type { CapabilityActionIntent, RuntimeBootstrapClaim } from "./runtime-proof.types.js";
+import { PrismaRuntimeAuthorityRepository } from "../prisma-runtime-authority.js";
+import type { CapabilityActionIntent, RuntimeBootstrapClaim } from "../runtime-proof.types.js";
 
 /** Creates one exact runtime bootstrap claim. */
 function _bootstrap(): RuntimeBootstrapClaim

--- a/libs/backend/server/authorization/main/src/__tests__/runtime-proof.test.ts
+++ b/libs/backend/server/authorization/main/src/__tests__/runtime-proof.test.ts
@@ -4,10 +4,10 @@ import { ___CanonicalizeJson } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 import { describe, expect, it } from "vitest";
 
-import { __ComputeEs256JwkThumbprint } from "./capability-proof.js";
-import { __DigestCanonicalJson } from "./canonical-json-digest.js";
-import { __ConsumeRuntimeBootstrap, __ExecuteCapabilityAction } from "./runtime-proof.js";
-import type { CapabilityActionExecutor, CapabilityActionFailureResult, CapabilityActionIntent, CapabilityActionReceipt, CapabilityActionReceiptRepository, CapabilityActionReservationResult, CapabilityActionSuccessResult, ExecuteCapabilityActionCommand, RuntimeBootstrapClaim, RuntimeBootstrapConsumptionResult, RuntimeBootstrapExpectation, RuntimeBootstrapRepository } from "./runtime-proof.types.js";
+import { __ComputeEs256JwkThumbprint } from "../capability-proof.js";
+import { __DigestCanonicalJson } from "../canonical-json-digest.js";
+import { __ConsumeRuntimeBootstrap, __ExecuteCapabilityAction } from "../runtime-proof.js";
+import type { CapabilityActionExecutor, CapabilityActionFailureResult, CapabilityActionIntent, CapabilityActionReceipt, CapabilityActionReceiptRepository, CapabilityActionReservationResult, CapabilityActionSuccessResult, ExecuteCapabilityActionCommand, RuntimeBootstrapClaim, RuntimeBootstrapConsumptionResult, RuntimeBootstrapExpectation, RuntimeBootstrapRepository } from "../runtime-proof.types.js";
 
 /** Fixed trusted NumericDate used by action-proof fixtures. */
 const NOW = 1_750_000_000;

--- a/libs/backend/server/awareness/main/README.md
+++ b/libs/backend/server/awareness/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/awareness/*`, `/api/internal/awareness/participation`.
 Owns awareness rollout waves, fleet participation reporting, participation events. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/awareness.prisma` where this domain owns models).

--- a/libs/backend/server/channel-targets/main/README.md
+++ b/libs/backend/server/channel-targets/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/server/channel-targets — Channel targets
+
+Owns the control-plane decision behind a browser channel operation. It verifies the calling
+workload and browser identity, checks current membership and required actions, then issues a
+short-lived target context for the selected thread or declines the request.
+
+The public surface is `src/index.ts`; the router composes the HTTP boundary and
+`PrismaChannelTargetAuthorityRepository` provides durable target authority. See
+[`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/channel-targets/main/src/__tests__/channel-target-resolution.test.ts
+++ b/libs/backend/server/channel-targets/main/src/__tests__/channel-target-resolution.test.ts
@@ -2,8 +2,8 @@ import { createHash } from "node:crypto";
 
 import { describe, expect, it, vi } from "vitest";
 
-import type { ChannelTargetResolutionDependencies, IssueChannelInvocationContextCommand } from "./channel-target-resolution.types.js";
-import { __ResolveChannelTarget } from "./channel-target-resolution.js";
+import type { ChannelTargetResolutionDependencies, IssueChannelInvocationContextCommand } from "../channel-target-resolution.types.js";
+import { __ResolveChannelTarget } from "../channel-target-resolution.js";
 
 /** Stable test instant. */
 const _NOW = Date.parse("2026-07-18T12:00:00.000Z");

--- a/libs/backend/server/channel-targets/main/src/__tests__/prisma-channel-target-authority.test.ts
+++ b/libs/backend/server/channel-targets/main/src/__tests__/prisma-channel-target-authority.test.ts
@@ -1,7 +1,7 @@
 import { AgentRunState, AgentRunTrigger, ChannelInvocationAction } from "@prisma/client";
 import { describe, expect, it } from "vitest";
 
-import { PrismaChannelTargetAuthorityRepository } from "./prisma-channel-target-authority.js";
+import { PrismaChannelTargetAuthorityRepository } from "../prisma-channel-target-authority.js";
 
 /** Builds the minimum transaction facade needed to reject a run during issuance. */
 function _issueTransaction(trigger: AgentRunTrigger, state: AgentRunState): Record<string, unknown>

--- a/libs/backend/server/cluster-tenants/main/README.md
+++ b/libs/backend/server/cluster-tenants/main/README.md
@@ -5,6 +5,6 @@ Mounted at: (no routes — middleware + seeding).
 Owns ClusterTenant/OrgMembership read-models, own-cluster-tenant resolution, default-tenant seeding, the cluster-tenant scope middleware. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/cluster-tenants.prisma` where this domain owns models).

--- a/libs/backend/server/company-docs/main/README.md
+++ b/libs/backend/server/company-docs/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/org/workspace-docs`.
 Owns company doc versions, tenant doc reconciliation proposals, L0 personalisation guard. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/company-docs.prisma` where this domain owns models).

--- a/libs/backend/server/connections/main/README.md
+++ b/libs/backend/server/connections/main/README.md
@@ -7,6 +7,6 @@ org namespace helpers. Routes live in `src/routes/`, services in `src/core/`, te
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`). This domain owns no Prisma
 model after the legacy connection registry deletion.
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership rules.

--- a/libs/backend/server/contract/main/README.md
+++ b/libs/backend/server/contract/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/internal/contract`.
 Owns the effective-contract assembly served to tenant pods (grants + awareness + skill models + TOOLS.md rendering). Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/contract.prisma` where this domain owns models).

--- a/libs/backend/server/grants/main/README.md
+++ b/libs/backend/server/grants/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/shares`, `/api/v1/resource-shares`.
 Owns the grant compiler, inter-user shares, derived dataset membership, Cognee awareness grant sync. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/grants.prisma` where this domain owns models).

--- a/libs/backend/server/groups/main/README.md
+++ b/libs/backend/server/groups/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/groups`.
 Owns group CRUD used as grant subjects. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/groups.prisma` where this domain owns models).

--- a/libs/backend/server/identity/main/README.md
+++ b/libs/backend/server/identity/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/server/identity — Identity
+
+Owns the server's browser identity workflows: OpenID Connect login and logout, session status,
+and the server-side facts derived after a verified sign-in. It can adopt a member into the
+appropriate workspace and mirror identity-provider group claims without making the browser a
+source of authority.
+
+The public surface is `src/index.ts`; the auth router is composed by the OpenCrane server. See
+[`../../README.md`](../../README.md) for the control-plane map.

--- a/libs/backend/server/mcp/main/README.md
+++ b/libs/backend/server/mcp/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/mcp-servers`, `/api/v1/mcp`.
 Owns MCP server registry + credentials, the operator-facing MCP directory/install/approval/OAuth surface. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/mcp.prisma` where this domain owns models).

--- a/libs/backend/server/membership/main/README.md
+++ b/libs/backend/server/membership/main/README.md
@@ -1,0 +1,9 @@
+# @opencrane/backend/server/membership — Fleet membership
+
+Owns verification of a person's current signed membership in an agent fleet. Callers receive an
+explicit trusted or denied result, including the accepted revision and expiry when membership is
+current.
+
+The public surface is `src/index.ts`; `PrismaFleetMembershipAuthorityRepository` provides the
+durable authority implementation. See [`../../README.md`](../../README.md) for the control-plane
+map.

--- a/libs/backend/server/membership/main/src/__tests__/membership-authority.test.ts
+++ b/libs/backend/server/membership/main/src/__tests__/membership-authority.test.ts
@@ -1,8 +1,8 @@
 import type { FleetSignatureVerificationEvidence, SignedFleetMembershipRevision } from "@opencrane/models/authorization";
 import { describe, expect, it } from "vitest";
 
-import { __VerifyCurrentFleetMembership } from "./membership-authority.js";
-import type { FleetMembershipAcceptance, FleetMembershipAcceptanceResult, FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, VerifyFleetMembershipCommand } from "./membership-authority.types.js";
+import { __VerifyCurrentFleetMembership } from "../membership-authority.js";
+import type { FleetMembershipAcceptance, FleetMembershipAcceptanceResult, FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, VerifyFleetMembershipCommand } from "../membership-authority.types.js";
 
 /** Creates a signed fleet revision whose assertion matches the command fixture. */
 function _revision(issuedAtEpochMs = 1000, revision = 7): SignedFleetMembershipRevision

--- a/libs/backend/server/membership/main/src/__tests__/prisma-membership-authority.test.ts
+++ b/libs/backend/server/membership/main/src/__tests__/prisma-membership-authority.test.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaFleetMembershipAuthorityRepository } from "./prisma-membership-authority.js";
+import { PrismaFleetMembershipAuthorityRepository } from "../prisma-membership-authority.js";
 
 /** Creates one verified signed membership revision row. */
 function _revisionRow()

--- a/libs/backend/server/metrics/main/README.md
+++ b/libs/backend/server/metrics/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/metrics`, `/prom`.
 Owns opencrane-ui metrics API + Prometheus exposition (fleet, awareness, projection drift). Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/metrics.prisma` where this domain owns models).

--- a/libs/backend/server/model-routing/main/README.md
+++ b/libs/backend/server/model-routing/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/model-routing/*`, `/api/internal/tenant-models`.
 Owns routing defaults, eval cases, shadow measurements, proposals, recommendations, metrics, per-tenant model allowlists. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/model-routing.prisma` where this domain owns models).

--- a/libs/backend/server/policies/main/README.md
+++ b/libs/backend/server/policies/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/policies`.
 Owns AccessPolicy CRUD + projection to the cluster and Cognee awareness sync. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/policies.prisma` where this domain owns models).

--- a/libs/backend/server/projection/main/README.md
+++ b/libs/backend/server/projection/main/README.md
@@ -5,6 +5,6 @@ Mounted at: (no routes — consumed by tenants/policies/metrics).
 Owns tenant/policy projection drift detection and repair. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/projection.prisma` where this domain owns models).

--- a/libs/backend/server/providers/main/README.md
+++ b/libs/backend/server/providers/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/providers/*`, `/api/v1/models`.
 Owns provider API keys, scoped credentials, BYOK provisioning, LiteLLM model registration. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/providers.prisma` where this domain owns models).

--- a/libs/backend/server/retrieval/main/README.md
+++ b/libs/backend/server/retrieval/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/third-party-sources`.
 Owns third-party source registry and dataset scope types. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/retrieval.prisma` where this domain owns models).

--- a/libs/backend/server/skills/main/src/__tests__/skill-publication.test.ts
+++ b/libs/backend/server/skills/main/src/__tests__/skill-publication.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { __PublishSkillRevision } from "./skill-publication.js";
+import { __PublishSkillRevision } from "../skill-publication.js";
 
 describe("skill publication", function ()
 {

--- a/libs/backend/server/spend/main/README.md
+++ b/libs/backend/server/spend/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/spend`, `/api/v1/token-usage`, `/api/v1/ai-budget`.
 Owns spend aggregation, token-usage snapshots, global/account budgets, LiteLLM virtual keys. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/spend.prisma` where this domain owns models).

--- a/libs/backend/server/tenants/main/README.md
+++ b/libs/backend/server/tenants/main/README.md
@@ -5,6 +5,6 @@ Mounted at: `/api/v1/tenants`.
 Owns tenant CRUD over the Tenant CRD, dataset membership, suspension, effective-contract compilation inputs. Routes live in `src/routes/`, services in `src/core/`, tests in
 `src/__tests__/`; the public surface is the barrel (`src/index.ts`).
 
-See [`libs/backend/README.md`](../../README.md) for the layout, boundary rules and
-how to add a peer package, and [`docs/agents/prisma.md`](../../../../docs/agents/prisma.md)
+See [`libs/backend/README.md`](../../../README.md) for the layout, boundary rules and
+how to add a peer package, and [`docs/agents/prisma.md`](../../../../../docs/agents/prisma.md)
 for schema ownership (`prisma/schema/tenants.prisma` where this domain owns models).

--- a/libs/models/artifacts/main/src/__tests__/artifact-invariants.test.ts
+++ b/libs/models/artifacts/main/src/__tests__/artifact-invariants.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { ___IsArtifact, ___IsArtifactRevision, ___IsSha256ContentAddress, ___IsSkillRevision, ___SkillRevisionMatchesArtifactRevision } from "./artifact-invariants.js";
-import type { Artifact, ArtifactRevision, SkillRevision } from "./artifact.types.js";
+import { ___IsArtifact, ___IsArtifactRevision, ___IsSha256ContentAddress, ___IsSkillRevision, ___SkillRevisionMatchesArtifactRevision } from "../artifact-invariants.js";
+import type { Artifact, ArtifactRevision, SkillRevision } from "../artifact.types.js";
 
 const _DIGEST = `sha256:${"a".repeat(64)}`;
 

--- a/libs/models/platform-policy/main/src/__tests__/platform-policy.test.ts
+++ b/libs/models/platform-policy/main/src/__tests__/platform-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { ___IsDurableStatePolicy, ___IsPlatformPolicy, ___IsRuntimeFilesystemPolicy, ___IsSiloUpdateDurationAllowed, ___IsSiloUpdatePolicy, ___MAXIMUM_SILO_UPDATE_DURATION_MS, ___PLATFORM_POLICY } from "./platform-policy.js";
+import { ___IsDurableStatePolicy, ___IsPlatformPolicy, ___IsRuntimeFilesystemPolicy, ___IsSiloUpdateDurationAllowed, ___IsSiloUpdatePolicy, ___MAXIMUM_SILO_UPDATE_DURATION_MS, ___PLATFORM_POLICY } from "../platform-policy.js";
 
 describe("platform policy", function _suite()
 {

--- a/libs/server/_infra/api/src/__tests__/watch-runner.test.ts
+++ b/libs/server/_infra/api/src/__tests__/watch-runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Logger } from "pino";
 
-import { _RunWatchLoop } from "./watch-runner.js";
+import { _RunWatchLoop } from "../watch-runner.js";
 
 type WatchEventCallback = (type: string, resource: unknown) => void;
 type WatchDoneCallback = (err: unknown) => void;

--- a/nx.json
+++ b/nx.json
@@ -12,8 +12,7 @@
     ],
     "production": [
       "default",
-      "!{projectRoot}/src/__tests__/**",
-      "!{projectRoot}/**/*.test.ts"
+      "!{projectRoot}/src/__tests__/**"
     ]
   },
   "targetDefaults": {


### PR DESCRIPTION
## Summary

- propagate the already-reviewed D4 test-layout and backend README commits that merged only into the old D5 branch
- move the eight artifact tests added by recovery #296 into __tests__ so the global D4 layout rule remains enforceable
- retain the package README map that explains personal-agent, operator, and channel-proxy boundaries

## Validation

- personal-agent namespace negative guard
- focused artifact test/lint suite across six projects
- boundary lint and test-layout lint
- diff check

## Review

- prior D4 and README reviews are preserved in #294/#295
- independent review of the newly recovered eight test moves: no findings
- local Claude Code review remains pending because claude --bare reports Not logged in; no repository content was sent to Anthropic

## Recovery evidence

#294 and #295 merged into D5 after D5 had already merged to own-personal-ai-agent-setup. This root-targeted PR replays their rebased commits and closes the recovery-only test-layout gap.