### PR TITLE
🗄️ Phase D D3: wire backup retention to Barman ObjectStore

### DIFF
--- a/apps/_infra/deploy-k8s/platform/tests/k3d-e2e.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/k3d-e2e.sh
@@ -444,32 +444,10 @@ kubectl wait --for=condition=Complete job/opencrane-backup-bucket \
   -n "$NAMESPACE" \
   --timeout="${TIMEOUT_SECONDS}s"
 
-cat <<EOF | kubectl apply -f -
-apiVersion: barmancloud.cnpg.io/v1
-kind: ObjectStore
-metadata:
-  name: ${BACKUP_OBJECT_STORE_NAME}
-  namespace: ${NAMESPACE}
-spec:
-  configuration:
-    destinationPath: s3://backups/
-    endpointURL: http://${BACKUP_MINIO_NAME}.${NAMESPACE}.svc.cluster.local:9000
-    s3Credentials:
-      accessKeyId:
-        name: opencrane-backup-object-store-credentials
-        key: ACCESS_KEY_ID
-      secretAccessKey:
-        name: opencrane-backup-object-store-credentials
-        key: ACCESS_SECRET_KEY
-    wal:
-      compression: gzip
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
-      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
-        value: when_required
-EOF
+# The chart, rather than this harness, owns the Barman ObjectStore. This exact
+# value is also supplied to the static server-side API check below, so a future
+# Phase F policy cannot accidentally leave retention in an out-of-band manifest.
+BACKUP_OBJECT_STORE_JSON="{\"name\":\"$BACKUP_OBJECT_STORE_NAME\",\"configuration\":{\"destinationPath\":\"s3://backups/\",\"endpointURL\":\"http://$BACKUP_MINIO_NAME.$NAMESPACE.svc.cluster.local:9000\",\"s3Credentials\":{\"accessKeyId\":{\"name\":\"opencrane-backup-object-store-credentials\",\"key\":\"ACCESS_KEY_ID\"},\"secretAccessKey\":{\"name\":\"opencrane-backup-object-store-credentials\",\"key\":\"ACCESS_SECRET_KEY\"}},\"wal\":{\"compression\":\"gzip\"}},\"instanceSidecarConfiguration\":{\"env\":[{\"name\":\"AWS_REQUEST_CHECKSUM_CALCULATION\",\"value\":\"when_required\"},{\"name\":\"AWS_RESPONSE_CHECKSUM_VALIDATION\",\"value\":\"when_required\"}]}}"
 
 function _validate_cnpg_backup_recovery_schema()
 {
@@ -482,8 +460,9 @@ function _validate_cnpg_backup_recovery_schema()
     --set-json "databases=$DATABASES_JSON" \
     --set "networkPolicy.operatorNamespace=$CNPG_SYSTEM_NAMESPACE" \
     --set backup.enabled=true \
-    --set backup.plugin.name=barman-cloud.cloudnative-pg.io \
-    --set backup.plugin.parameters.barmanObjectName=contract-only >"$rendered"
+    --set backup.frequency=daily \
+    --set backup.retainedCopies=7 \
+    --set-json "backup.objectStore=$BACKUP_OBJECT_STORE_JSON" >"$rendered"
   kubectl apply --server-side --dry-run=server -n "$NAMESPACE" -f "$rendered" >/dev/null
 
   echo "[e2e] Validating recovery contract against the pinned CNPG API server schema"
@@ -585,8 +564,9 @@ function _run_backup_restore_smoke()
     --namespace "$NAMESPACE" \
     --reuse-values \
     --set backup.enabled=true \
-    --set backup.plugin.name=barman-cloud.cloudnative-pg.io \
-    --set-string "backup.plugin.parameters.barmanObjectName=$BACKUP_OBJECT_STORE_NAME"
+    --set backup.frequency=daily \
+    --set backup.retainedCopies=7 \
+    --set-json "backup.objectStore=$BACKUP_OBJECT_STORE_JSON"
 
   kubectl wait --for=condition=ContinuousArchiving "cluster/$OPENCRANE_DB_RELEASE_NAME" \
     -n "$NAMESPACE" \

--- a/apps/postgres/README.md
+++ b/apps/postgres/README.md
@@ -44,9 +44,25 @@ kubectl wait --for=condition=Ready cluster/opencrane-postgres \
 
 `scripts/publish-app-connection-secret.sh` creates an application Secret for one logical database;
 its `uri` key is that database's canonical connection URI. Each application role can authenticate
-only to its own database; there are no shared owner roles or credentials. Backup
-and restore stay disabled until a CNPG-I plugin and its object-store resource are installed and
-explicitly selected in values. The k3d acceptance path server-dry-runs both contracts against the
-pinned CNPG CRDs, then installs a pinned Barman Cloud plugin and MinIO test target, writes a marker,
-completes an on-demand physical backup, recovers a fresh Cluster, and verifies the marker through the
-recovered application Secret.
+only to its own database; there are no shared owner roles or credentials.
+
+Backup and restore stay disabled until the cluster has the CNPG-I Barman Cloud plugin. When backup is
+enabled, this chart owns the per-ClusterTenant `ObjectStore` and its Barman retention policy; the
+destination configuration references pre-created credential Secrets and must be unique to that
+ClusterTenant. The infrastructure policy contract is deliberately small:
+
+- `backup.enabled` switches scheduled backup and WAL archiving on or off;
+- `backup.frequency` is one of `daily`, `weekly`, or `monthly` and selects the generated
+  `ScheduledBackup` cadence;
+- `backup.retainedCopies` is at least one and maps to Barman's retention window: for example,
+  seven daily copies becomes `7d`, while four weekly copies becomes `4w`.
+
+Barman enforces a point-in-time recovery window, including required WAL; it is not an exact
+base-backup-count deleter, so immediate/manual backups can make the physical count differ at the
+window edge. Phase F / #224 owns the ClusterTenant-admin UI and its storage-cost explanation; its
+reconciler writes this chart contract rather than leaving retention in a hand-managed ObjectStore.
+Enabling backups without an object-store name and destination fails Helm rendering.
+
+The k3d acceptance path server-dry-runs both contracts against the pinned CNPG CRDs, then installs a
+pinned Barman Cloud plugin and MinIO test target, writes a marker, completes an on-demand physical
+backup, recovers a fresh Cluster, and verifies the marker through the recovered application Secret.

--- a/apps/postgres/helm/templates/_helpers.tpl
+++ b/apps/postgres/helm/templates/_helpers.tpl
@@ -14,3 +14,14 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: opencrane
 app.kubernetes.io/component: postgres
 {{- end -}}
+
+{{/* A finite cadence maps retained copies to Barman's supported recovery-window units. */}}
+{{- define "opencrane.postgres.backupSchedule" -}}
+{{- $schedules := dict "daily" "0 0 2 * * *" "weekly" "0 0 2 * * 1" "monthly" "0 0 2 1 * *" -}}
+{{- index $schedules .Values.backup.frequency -}}
+{{- end -}}
+
+{{- define "opencrane.postgres.backupRetentionPolicy" -}}
+{{- $units := dict "daily" "d" "weekly" "w" "monthly" "m" -}}
+{{- printf "%d%s" (int .Values.backup.retainedCopies) (index $units .Values.backup.frequency) -}}
+{{- end -}}

--- a/apps/postgres/helm/templates/cluster.yaml
+++ b/apps/postgres/helm/templates/cluster.yaml
@@ -22,8 +22,17 @@
 {{- $_ := set $databaseOwners $database.owner true -}}
 {{- $_ := set $credentialSecrets $database.credentialsSecret true -}}
 {{- end -}}
-{{- if and .Values.backup.enabled (not .Values.backup.plugin.name) -}}
-{{- fail "backup.plugin.name is required when backup.enabled=true" -}}
+{{- if and .Values.backup.enabled (not (has .Values.backup.frequency (list "daily" "weekly" "monthly"))) -}}
+{{- fail "backup.frequency must be daily, weekly, or monthly when backup.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.backup.enabled (lt (int .Values.backup.retainedCopies) 1) -}}
+{{- fail "backup.retainedCopies must be at least 1 when backup.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.backup.enabled (not .Values.backup.objectStore.name) -}}
+{{- fail "backup.objectStore.name is required when backup.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.backup.enabled (not .Values.backup.objectStore.configuration.destinationPath) -}}
+{{- fail "backup.objectStore.configuration.destinationPath is required when backup.enabled=true" -}}
 {{- end -}}
 {{- if and .Values.restore.enabled (not .Values.restore.plugin.name) -}}
 {{- fail "restore.plugin.name is required when restore.enabled=true" -}}
@@ -115,10 +124,8 @@ spec:
   {{- end }}
   {{- if .Values.backup.enabled }}
   plugins:
-    - name: {{ .Values.backup.plugin.name | quote }}
+    - name: "barman-cloud.cloudnative-pg.io"
       isWALArchiver: true
-      {{- with .Values.backup.plugin.parameters }}
       parameters:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        barmanObjectName: {{ .Values.backup.objectStore.name | quote }}
   {{- end }}

--- a/apps/postgres/helm/templates/object-store.yaml
+++ b/apps/postgres/helm/templates/object-store.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.backup.enabled }}
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: {{ .Values.backup.objectStore.name | quote }}
+  annotations:
+    # Backup enablement controls scheduling and WAL archiving. The recovery
+    # destination survives a disable/uninstall so restore can still name it.
+    helm.sh/resource-policy: keep
+  labels:
+    {{- include "opencrane.postgres.labels" . | nindent 4 }}
+spec:
+  # CNPG-I/Barman retains a recovery window, including WAL needed for point-in-time recovery.
+  # The finite cadence maps retained copies to that window (seven daily copies => 7d).
+  retentionPolicy: {{ include "opencrane.postgres.backupRetentionPolicy" . | quote }}
+  configuration:
+    {{- toYaml .Values.backup.objectStore.configuration | nindent 4 }}
+  {{- with .Values.backup.objectStore.instanceSidecarConfiguration }}
+  instanceSidecarConfiguration:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/apps/postgres/helm/templates/scheduled-backup.yaml
+++ b/apps/postgres/helm/templates/scheduled-backup.yaml
@@ -8,14 +8,12 @@ metadata:
 spec:
   cluster:
     name: {{ include "opencrane.postgres.fullname" . }}
-  schedule: {{ .Values.backup.schedule | quote }}
+  schedule: {{ include "opencrane.postgres.backupSchedule" . | quote }}
   immediate: {{ .Values.backup.immediate }}
   backupOwnerReference: cluster
   method: plugin
   pluginConfiguration:
-    name: {{ .Values.backup.plugin.name | quote }}
-    {{- with .Values.backup.plugin.parameters }}
+    name: "barman-cloud.cloudnative-pg.io"
     parameters:
-      {{- toYaml . | nindent 6 }}
-    {{- end }}
+      barmanObjectName: {{ .Values.backup.objectStore.name | quote }}
 {{- end }}

--- a/apps/postgres/helm/values.yaml
+++ b/apps/postgres/helm/values.yaml
@@ -52,12 +52,21 @@ privileges:
   timeoutSeconds: 300
 
 backup:
+  # This is the infrastructure contract that Phase F/#224's ClusterTenant policy
+  # reconciles into. It deliberately has no UI or product API here.
   enabled: false
-  schedule: "0 0 2 * * *"
+  # A bounded cadence makes retainedCopies convertible to the Barman ObjectStore
+  # recovery-window policy: daily => Nd, weekly => Nw, monthly => Nm.
+  frequency: daily
+  retainedCopies: 7
   immediate: false
-  plugin:
+  # The Barman Cloud CNPG-I ObjectStore is app-owned when backups are enabled.
+  # Configuration contains references to pre-created credential Secrets; it never
+  # contains credential values. destinationPath must be unique per ClusterTenant.
+  objectStore:
     name: ""
-    parameters: {}
+    configuration: {}
+    instanceSidecarConfiguration: {}
 
 restore:
   enabled: false

--- a/apps/postgres/tests/helm-contract.sh
+++ b/apps/postgres/tests/helm-contract.sh
@@ -15,20 +15,23 @@ helm template opencrane-postgres "$CHART" \
   "${COMMON_VALUES[@]}" \
   --set storage.storageClass=expandable-rwo \
   --set backup.enabled=true \
-  --set backup.plugin.name=barman-cloud.cloudnative-pg.io \
-  --set backup.plugin.parameters.barmanObjectName=opencrane-postgres \
+  --set backup.frequency=weekly \
+  --set backup.retainedCopies=4 \
+  --set backup.objectStore.name=opencrane-postgres-backups \
+  --set backup.objectStore.configuration.destinationPath=s3://opencrane-postgres/ \
   >"$OUTPUT"
 
 grep -q '^kind: Cluster$' "$OUTPUT"
 test "$(grep -c '^kind: Cluster$' "$OUTPUT")" -eq 1
 test "$(grep -c '^kind: Database$' "$OUTPUT")" -eq 3
-test "$(grep -c 'helm.sh/resource-policy: keep' "$OUTPUT")" -eq 4
+test "$(grep -c 'helm.sh/resource-policy: keep' "$OUTPUT")" -eq 5
 grep -q '^kind: Job$' "$OUTPUT"
 grep -q 'helm.sh/hook: post-install,post-upgrade' "$OUTPUT"
 test "$(grep -c 'app.kubernetes.io/component: postgres-database-privileges' "$OUTPUT")" -ge 2
 grep -q 'REVOKE CONNECT, TEMPORARY ON DATABASE' "$OUTPUT"
 grep -q 'GRANT CONNECT, TEMPORARY ON DATABASE' "$OUTPUT"
 grep -q '^kind: ScheduledBackup$' "$OUTPUT"
+grep -q '^kind: ObjectStore$' "$OUTPUT"
 grep -q '^kind: NetworkPolicy$' "$OUTPUT"
 grep -q 'helm.sh/resource-policy: keep' "$OUTPUT"
 grep -q 'opencrane.ai/cnpg-service-account: "opencrane-postgres"' "$OUTPUT"
@@ -45,6 +48,11 @@ grep -q 'name: "litellm"' "$OUTPUT"
 grep -q 'name: "langfuse"' "$OUTPUT"
 grep -q 'createdb: false' "$OUTPUT"
 grep -q 'createrole: false' "$OUTPUT"
+grep -q 'schedule: "0 0 2 \* \* 1"' "$OUTPUT"
+grep -q 'retentionPolicy: "4w"' "$OUTPUT"
+grep -q 'barmanObjectName: "opencrane-postgres-backups"' "$OUTPUT"
+grep -q 'destinationPath: s3://opencrane-postgres/' "$OUTPUT"
+grep -A 12 '^kind: ObjectStore$' "$OUTPUT" | grep -q 'helm.sh/resource-policy: keep'
 grep -q 'method: plugin' "$OUTPUT"
 grep -q 'app.kubernetes.io/component: opencrane-server' "$OUTPUT"
 grep -q 'app.kubernetes.io/component: opencrane-server-migrate' "$OUTPUT"
@@ -72,6 +80,43 @@ function _assert_invalid_databases()
 _assert_invalid_databases duplicate-name '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"opencrane-secret"},{"name":"opencrane","owner":"obot","credentialsSecret":"obot-secret"}]'
 _assert_invalid_databases duplicate-owner '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"opencrane-secret"},{"name":"obot","owner":"opencrane","credentialsSecret":"obot-secret"}]'
 _assert_invalid_databases duplicate-credentials '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"shared-secret"},{"name":"obot","owner":"obot","credentialsSecret":"shared-secret"}]'
+
+function _assert_invalid_backup()
+{
+  local label="$1"
+  shift
+  if helm template "$label" "$CHART" "${COMMON_VALUES[@]}" --set backup.enabled=true "$@" >/dev/null 2>&1; then
+    echo "postgres chart accepted $label backup configuration" >&2
+    exit 1
+  fi
+}
+
+_assert_invalid_backup missing-object-store
+_assert_invalid_backup zero-retained-copies \
+  --set backup.retainedCopies=0 \
+  --set backup.objectStore.name=backups \
+  --set backup.objectStore.configuration.destinationPath=s3://backups/
+_assert_invalid_backup unsupported-frequency \
+  --set backup.frequency=hourly \
+  --set backup.objectStore.name=backups \
+  --set backup.objectStore.configuration.destinationPath=s3://backups/
+
+# Disabling a policy must remove new backup work, not the Barman recovery
+# destination that a later restore names. Helm honours `resource-policy: keep`
+# from the prior enabled release; this static contract proves both sides of the
+# transition without requiring a live release history.
+helm template backups-disabled "$CHART" \
+  "${COMMON_VALUES[@]}" \
+  --set backup.enabled=false \
+  --set restore.enabled=true \
+  --set restore.plugin.name=barman-cloud.cloudnative-pg.io \
+  --set restore.plugin.parameters.barmanObjectName=opencrane-postgres-backups \
+  >"$OUTPUT"
+if grep -qE '^kind: (ScheduledBackup|ObjectStore)$' "$OUTPUT"; then
+  echo "postgres chart left scheduling or a new ObjectStore manifest when backups are disabled" >&2
+  exit 1
+fi
+grep -q 'barmanObjectName: opencrane-postgres-backups' "$OUTPUT"
 
 helm template restored "$CHART" \
   "${COMMON_VALUES[@]}" \


### PR DESCRIPTION
## Summary

- make the CNPG-I Barman ObjectStore an explicit app-owned PostgreSQL chart contract
- map backup frequency and retained copies to Barman recovery-window retention
- preserve the ObjectStore across a backup-off toggle so retained recovery remains possible

## Validation

- PostgreSQL Helm lint and contract, including invalid policy and disable-to-restore lifecycle cases
- relevant deploy and k3d shell syntax
- diff check
- live k3d/CNPG remains pending because Docker is unavailable

## Review

- independent review found and verified the ObjectStore-retention lifecycle fix
- local Claude Code review remains pending because claude --bare reports Not logged in; no repository content was sent to Anthropic

## Scope

This is plumbing only. The user-facing toggle/frequency/retained-copy policy surface belongs to Phase F/#224.