### PR TITLE
🛠️ Add tenant database-admin role

### DIFF
--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -29,6 +29,7 @@
 #                            --obot-postgres-credentials-secret NAME [--obot-postgres-owner OWNER]
 #                            --litellm-postgres-credentials-secret NAME [--litellm-postgres-owner OWNER]
 #                            --langfuse-postgres-credentials-secret NAME [--langfuse-postgres-owner OWNER]
+#                            --postgres-admin-credentials-secret NAME [--postgres-admin-name NAME]
 #                            [--postgres-values FILE]
 #                            [--no-ingress-nginx]
 #                            [--no-external-dns]
@@ -242,6 +243,8 @@ LITELLM_POSTGRES_CREDENTIALS_SECRET="${OPENCRANE_LITELLM_POSTGRES_CREDENTIALS_SE
 LITELLM_POSTGRES_OWNER="${OPENCRANE_LITELLM_POSTGRES_OWNER:-litellm}"
 LANGFUSE_POSTGRES_CREDENTIALS_SECRET="${OPENCRANE_LANGFUSE_POSTGRES_CREDENTIALS_SECRET:-}"
 LANGFUSE_POSTGRES_OWNER="${OPENCRANE_LANGFUSE_POSTGRES_OWNER:-langfuse}"
+POSTGRES_ADMIN_CREDENTIALS_SECRET="${OPENCRANE_POSTGRES_ADMIN_CREDENTIALS_SECRET:-}"
+POSTGRES_ADMIN_NAME="${OPENCRANE_POSTGRES_ADMIN_NAME:-opencrane_database_admin}"
 # The central fleet profile owns a separate registry database. Silo wrappers disable
 # it through fleetManager.enabled=false; an explicit environment override exists for
 # other thin profiles that do not render the fleet manager.
@@ -322,6 +325,8 @@ while [[ $# -gt 0 ]]; do
     --litellm-postgres-owner) LITELLM_POSTGRES_OWNER="$2"; shift 2 ;;
     --langfuse-postgres-credentials-secret) LANGFUSE_POSTGRES_CREDENTIALS_SECRET="$2"; shift 2 ;;
     --langfuse-postgres-owner) LANGFUSE_POSTGRES_OWNER="$2"; shift 2 ;;
+    --postgres-admin-credentials-secret) POSTGRES_ADMIN_CREDENTIALS_SECRET="$2"; shift 2 ;;
+    --postgres-admin-name) POSTGRES_ADMIN_NAME="$2"; shift 2 ;;
     --postgres-values) POSTGRES_VALUES_FILE="$2"; shift 2 ;;
     --dns-writer-gsa)   DNS_WRITER_GSA="$2"; shift 2 ;;
     --cert-manager)  CERT_MANAGER="on"; shift ;;
@@ -413,6 +418,7 @@ _run_preflight() {
   _preflight_postgres_bootstrap obot "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER"
   _preflight_postgres_bootstrap litellm "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER"
   _preflight_postgres_bootstrap langfuse "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_OWNER"
+  _preflight_postgres_bootstrap database-admin "$POSTGRES_ADMIN_CREDENTIALS_SECRET" "$POSTGRES_ADMIN_NAME"
 
   # 2. NetworkPolicy-enforcing CNI — the platform's isolation model is built on
   #    NetworkPolicy; a CNI that silently ignores them (e.g. stock kindnet/flannel) makes
@@ -632,6 +638,7 @@ _require_postgres_bootstrap opencrane "$POSTGRES_CREDENTIALS_SECRET" "$POSTGRES_
 _require_postgres_bootstrap obot "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_OWNER"
 _require_postgres_bootstrap litellm "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_OWNER"
 _require_postgres_bootstrap langfuse "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_OWNER"
+_require_postgres_bootstrap database-admin "$POSTGRES_ADMIN_CREDENTIALS_SECRET" "$POSTGRES_ADMIN_NAME"
 
 POSTGRES_RELEASE="${RELEASE}-postgres"
 _install_postgres_server() {
@@ -644,6 +651,8 @@ _install_postgres_server() {
   local postgres_args=(upgrade --install "$POSTGRES_RELEASE" "$POSTGRES_CHART_DIR"
     --namespace "$NAMESPACE"
     --set-json "databases=$databases_json"
+    --set-string "databaseAdmin.name=$POSTGRES_ADMIN_NAME"
+    --set-string "databaseAdmin.credentialsSecret=$POSTGRES_ADMIN_CREDENTIALS_SECRET"
     --set-json "networkPolicy.clientPodSelectors=$client_selectors_json")
   [[ -n "$POSTGRES_VALUES_FILE" ]] && postgres_args+=(--values "$POSTGRES_VALUES_FILE")
   [[ -n "$STORAGE_CLASS" ]] && postgres_args+=(--set-string "storage.storageClass=$STORAGE_CLASS")
@@ -689,10 +698,12 @@ POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-opencrane-app"
 OBOT_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-obot-app"
 LITELLM_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-litellm-app"
 LANGFUSE_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-langfuse-app"
+POSTGRES_ADMIN_APP_SECRET="${POSTGRES_RELEASE}-admin"
 _publish_database_connection "$POSTGRES_CREDENTIALS_SECRET" "$POSTGRES_APP_SECRET" opencrane
 _publish_database_connection "$OBOT_POSTGRES_CREDENTIALS_SECRET" "$OBOT_POSTGRES_APP_SECRET" obot
 _publish_database_connection "$LITELLM_POSTGRES_CREDENTIALS_SECRET" "$LITELLM_POSTGRES_APP_SECRET" litellm
 _publish_database_connection "$LANGFUSE_POSTGRES_CREDENTIALS_SECRET" "$LANGFUSE_POSTGRES_APP_SECRET" langfuse
+_publish_database_connection "$POSTGRES_ADMIN_CREDENTIALS_SECRET" "$POSTGRES_ADMIN_APP_SECRET" opencrane
 if [[ "$INSTALL_FLEET_DATABASE" == "1" ]]; then
   FLEET_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-fleet-app"
   _publish_database_connection "$FLEET_POSTGRES_CREDENTIALS_SECRET" "$FLEET_POSTGRES_APP_SECRET" fleet

--- a/apps/postgres/helm/templates/cluster.yaml
+++ b/apps/postgres/helm/templates/cluster.yaml
@@ -5,6 +5,9 @@
 {{- $databaseNames := dict -}}
 {{- $databaseOwners := dict -}}
 {{- $credentialSecrets := dict -}}
+{{- if or (not .Values.databaseAdmin.name) (not .Values.databaseAdmin.credentialsSecret) -}}
+{{- fail "databaseAdmin.name and databaseAdmin.credentialsSecret are required; OpenCrane never generates database credentials" -}}
+{{- end -}}
 {{- range $database := .Values.databases }}
 {{- if or (not .name) (not .owner) (not .credentialsSecret) -}}
 {{- fail "every databases entry requires name, owner, and credentialsSecret; OpenCrane never generates database credentials" -}}
@@ -21,6 +24,12 @@
 {{- $_ := set $databaseNames $database.name true -}}
 {{- $_ := set $databaseOwners $database.owner true -}}
 {{- $_ := set $credentialSecrets $database.credentialsSecret true -}}
+{{- end -}}
+{{- if hasKey $databaseOwners .Values.databaseAdmin.name -}}
+{{- fail (printf "databaseAdmin.name must not equal a database owner; duplicate %q" .Values.databaseAdmin.name) -}}
+{{- end -}}
+{{- if hasKey $credentialSecrets .Values.databaseAdmin.credentialsSecret -}}
+{{- fail (printf "databaseAdmin.credentialsSecret must be distinct from database credentials; duplicate %q" .Values.databaseAdmin.credentialsSecret) -}}
 {{- end -}}
 {{- if and .Values.backup.enabled (not .Values.backup.plugin.name) -}}
 {{- fail "backup.plugin.name is required when backup.enabled=true" -}}
@@ -95,9 +104,21 @@ spec:
       secret:
         name: {{ $primary.credentialsSecret | quote }}
   {{- end }}
-  {{- if gt (len .Values.databases) 1 }}
   managed:
     roles:
+      - name: {{ .Values.databaseAdmin.name | quote }}
+        ensure: present
+        login: true
+        superuser: false
+        createdb: false
+        createrole: false
+        replication: false
+        bypassrls: false
+        inRoles:
+          - pg_monitor
+          - pg_read_all_data
+        passwordSecret:
+          name: {{ .Values.databaseAdmin.credentialsSecret | quote }}
       {{- range $index, $database := .Values.databases }}
       {{- if gt $index 0 }}
       - name: {{ $database.owner | quote }}
@@ -112,7 +133,6 @@ spec:
           name: {{ $database.credentialsSecret | quote }}
       {{- end }}
       {{- end }}
-  {{- end }}
   {{- if .Values.backup.enabled }}
   plugins:
     - name: {{ .Values.backup.plugin.name | quote }}

--- a/apps/postgres/helm/templates/database-privileges-job.yaml
+++ b/apps/postgres/helm/templates/database-privileges-job.yaml
@@ -36,9 +36,17 @@ spec:
                 fi
                 sleep 2
               done
-              psql -v ON_ERROR_STOP=1 -d "$PGDATABASE" -v database="$PGDATABASE" -v owner="$PGUSER" <<'SQL'
+              until psql -v ON_ERROR_STOP=1 -d "$PGDATABASE" -v database_admin="{{ $.Values.databaseAdmin.name }}" -tAc "SELECT 1 FROM pg_roles WHERE rolname = :'database_admin'" | grep -qx '1'; do
+                if [ "$(date +%s)" -ge "$deadline" ]; then
+                  echo "Timed out waiting for database admin role '{{ $.Values.databaseAdmin.name }}'" >&2
+                  exit 1
+                fi
+                sleep 2
+              done
+              psql -v ON_ERROR_STOP=1 -d "$PGDATABASE" -v database="$PGDATABASE" -v owner="$PGUSER" -v database_admin="{{ $.Values.databaseAdmin.name }}" <<'SQL'
               REVOKE CONNECT, TEMPORARY ON DATABASE :"database" FROM PUBLIC;
               GRANT CONNECT, TEMPORARY ON DATABASE :"database" TO :"owner";
+              GRANT CONNECT, TEMPORARY ON DATABASE :"database" TO :"database_admin";
               SQL
           env:
             - name: PGUSER

--- a/apps/postgres/helm/values.yaml
+++ b/apps/postgres/helm/values.yaml
@@ -18,6 +18,13 @@ databases:
     owner: langfuse
     credentialsSecret: ""
 
+# A separate operational role may inspect every logical database in this one tenant
+# server. It is not an application credential and never receives superuser, DDL, or
+# RLS-bypass power; owners retain write/schema authority for their own database.
+databaseAdmin:
+  name: opencrane_database_admin
+  credentialsSecret: ""
+
 storage:
   size: 20Gi
   storageClass: ""

--- a/apps/postgres/project.json
+++ b/apps/postgres/project.json
@@ -6,7 +6,7 @@
   "targets": {
     "helm-lint": {
       "executor": "nx:run-commands",
-      "options": { "command": "helm lint apps/postgres/helm --set-json 'databases=[{\"name\":\"opencrane\",\"owner\":\"opencrane\",\"credentialsSecret\":\"lint-opencrane\"},{\"name\":\"obot\",\"owner\":\"obot\",\"credentialsSecret\":\"lint-obot\"},{\"name\":\"litellm\",\"owner\":\"litellm\",\"credentialsSecret\":\"lint-litellm\"},{\"name\":\"langfuse\",\"owner\":\"langfuse\",\"credentialsSecret\":\"lint-langfuse\"}]'" }
+      "options": { "command": "helm lint apps/postgres/helm --set-json 'databases=[{\"name\":\"opencrane\",\"owner\":\"opencrane\",\"credentialsSecret\":\"lint-opencrane\"},{\"name\":\"obot\",\"owner\":\"obot\",\"credentialsSecret\":\"lint-obot\"},{\"name\":\"litellm\",\"owner\":\"litellm\",\"credentialsSecret\":\"lint-litellm\"},{\"name\":\"langfuse\",\"owner\":\"langfuse\",\"credentialsSecret\":\"lint-langfuse\"}]' --set-string databaseAdmin.name=lint-admin --set-string databaseAdmin.credentialsSecret=lint-admin-secret" }
     },
     "test": {
       "executor": "nx:run-commands",

--- a/apps/postgres/tests/helm-contract.sh
+++ b/apps/postgres/tests/helm-contract.sh
@@ -7,7 +7,7 @@ OUTPUT="$(mktemp)"
 trap 'rm -f "$OUTPUT"' EXIT
 
 DATABASES_JSON='[{"name":"opencrane","owner":"opencrane","credentialsSecret":"postgres-opencrane-bootstrap"},{"name":"obot","owner":"obot","credentialsSecret":"postgres-obot-bootstrap"},{"name":"litellm","owner":"litellm","credentialsSecret":"postgres-litellm-bootstrap"},{"name":"langfuse","owner":"langfuse","credentialsSecret":"postgres-langfuse-bootstrap"}]'
-COMMON_VALUES=(--set-json "databases=$DATABASES_JSON")
+COMMON_VALUES=(--set-json "databases=$DATABASES_JSON" --set-string databaseAdmin.name=opencrane_database_admin --set-string databaseAdmin.credentialsSecret=postgres-admin-bootstrap)
 
 helm lint "$CHART" "${COMMON_VALUES[@]}" >/dev/null
 helm template opencrane-postgres "$CHART" \
@@ -28,6 +28,11 @@ grep -q 'helm.sh/hook: post-install,post-upgrade' "$OUTPUT"
 test "$(grep -c 'app.kubernetes.io/component: postgres-database-privileges' "$OUTPUT")" -ge 2
 grep -q 'REVOKE CONNECT, TEMPORARY ON DATABASE' "$OUTPUT"
 grep -q 'GRANT CONNECT, TEMPORARY ON DATABASE' "$OUTPUT"
+grep -q 'name: "postgres-admin-bootstrap"' "$OUTPUT"
+grep -q 'name: "opencrane_database_admin"' "$OUTPUT"
+grep -q 'pg_read_all_data' "$OUTPUT"
+grep -q 'pg_monitor' "$OUTPUT"
+grep -q 'TO :"database_admin"' "$OUTPUT"
 grep -q '^kind: ScheduledBackup$' "$OUTPUT"
 grep -q '^kind: NetworkPolicy$' "$OUTPUT"
 grep -q 'helm.sh/resource-policy: keep' "$OUTPUT"
@@ -72,6 +77,14 @@ function _assert_invalid_databases()
 _assert_invalid_databases duplicate-name '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"opencrane-secret"},{"name":"opencrane","owner":"obot","credentialsSecret":"obot-secret"}]'
 _assert_invalid_databases duplicate-owner '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"opencrane-secret"},{"name":"obot","owner":"opencrane","credentialsSecret":"obot-secret"}]'
 _assert_invalid_databases duplicate-credentials '[{"name":"opencrane","owner":"opencrane","credentialsSecret":"shared-secret"},{"name":"obot","owner":"obot","credentialsSecret":"shared-secret"}]'
+
+helm template one-database "$CHART" \
+  --set-json 'databases=[{"name":"opencrane","owner":"opencrane","credentialsSecret":"postgres-opencrane-bootstrap"}]' \
+  --set-string databaseAdmin.name=opencrane_database_admin \
+  --set-string databaseAdmin.credentialsSecret=postgres-admin-bootstrap \
+  >"$OUTPUT"
+grep -q 'name: "opencrane_database_admin"' "$OUTPUT"
+grep -q 'pg_read_all_data' "$OUTPUT"
 
 helm template restored "$CHART" \
   "${COMMON_VALUES[@]}" \


### PR DESCRIPTION
## Summary

- add one separately credentialed database-admin role per ClusterTenant server
- grant it explicit CONNECT to every logical database plus PostgreSQL read/monitor predefined roles
- keep it non-superuser, non-DDL-owning, non-RLS-bypassing, and separate from application credentials
- publish an admin connection secret for operational work

## Reliability

- privilege hook waits for CNPG managed-role reconciliation before granting access
- the admin role is rendered even for a one-database configuration

## Validation

- PostgreSQL Helm lint and contract, including one-database render
- deploy-script shell syntax and diff check
- independent review plus re-review: no remaining findings

This is a follow-up to merged #299, deliberately opened as a new root-based PR.