### PR TITLE
🧪 Fix time-bomb expiry fixtures in custody provisioning tests

### DIFF
--- a/libs/backend/server/gateways/integrations/main/src/__tests__/integration-custody-provisioning.test.ts
+++ b/libs/backend/server/gateways/integrations/main/src/__tests__/integration-custody-provisioning.test.ts
@@ -22,7 +22,7 @@ describe("integration custody provisioning", function _suite()
 	it("revokes remote custody when persistence fails", async function _compensation()
 	{
 		const revoke = vi.fn().mockResolvedValue(undefined);
-		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke };
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2099-01-01T00:00:00.000Z") }), revoke };
 		const log = _CreateLog();
 		const result = await __ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, log, _Command());
 		expect(result).toEqual({ outcome: "unavailable", reason: "persistence_failed" });
@@ -32,7 +32,7 @@ describe("integration custody provisioning", function _suite()
 
 	it("logs an invalid remote response compensation failure without the custody reference", async function _invalidResponseCompensationFailure()
 	{
-		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "different-catalog", obotCustodyReference: "obot:issued:invalid", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "different-catalog", obotCustodyReference: "obot:issued:invalid", expiresAt: new Date("2099-01-01T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
 		const log = _CreateLog();
 		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn() }, log, _Command())).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
 		expect(log.error).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Obot custody compensation failed after an invalid response");
@@ -41,7 +41,7 @@ describe("integration custody provisioning", function _suite()
 
 	it("reports compensation failure without exposing remote custody", async function _compensationFailure()
 	{
-		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2026-07-20T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
+		const custody = { provision: vi.fn().mockResolvedValue({ obotCatalogEntryId: "catalog-1", obotCustodyReference: "obot:issued:one", expiresAt: new Date("2099-01-01T00:00:00.000Z") }), revoke: vi.fn().mockRejectedValue(new Error("remote unavailable")) };
 		const log = _CreateLog();
 		await expect(__ProvisionIntegrationCustody(custody, { persistReady: vi.fn().mockRejectedValue(new Error("database unavailable")) }, log, _Command())).resolves.toEqual({ outcome: "unavailable", reason: "compensation_failed" });
 		expect(log.error).toHaveBeenCalledWith({ siloId: "silo-1", integrationId: "integration-1", obotCatalogEntryId: "catalog-1", errorType: "Error" }, "Obot custody compensation failed after a persistence failure");


### PR DESCRIPTION
## Problem

`integration-custody-provisioning.test.ts` began failing on 2026-07-20 and is now red on `own-personal-ai-agent-setup` (it merged into the base via #307's test-layout relocation), which blocks every PR built on the base — including the docs-standard PR #309.

Root cause is a **time-bomb fixture**, not logic drift: three valid-provision fixtures hardcode `expiresAt: 2026-07-20T00:00:00Z`. Once "now" reached that timestamp, the implementation's `expiresAt <= now` guard treated the provisions as already-expired and diverted them down the invalid-response compensation path, so the two assertions that expect the persistence-failure path/reason ("persistence_failed" / "…after a persistence failure") failed with the invalid-response message instead.

## Fix

Bump the three fixtures' `expiresAt` to `2099-01-01T00:00:00Z` so they represent live (unexpired) provisions, as the tests intend. Test-only; no implementation change.

## Effect

Turns the base green and unblocks PR #309 (docs-standard) and any other PR on this base. Supersedes the flagged out-of-scope failure noted in #307 and the spawned custody-drift task.