### PR TITLE
✨ Phase E: assemble immutable agent run input snapshots

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -84,6 +84,11 @@ fresh context — do not assume the author's intent was correct.
   (mechanism changes, capability stays — never propose deleting it).
 - **Contract drift**: an `openapi/spec.ts` entry that no longer matches its handler
   breaks every generated client — always a finding.
+- **Stale package README**: a diff that changes a package's exports, boundary, invariant,
+  owned Prisma models, or config without updating that package's `README.md` is incomplete
+  (`docs/agents/package-docs.md`). Missing READMEs and missing mandatory sections are caught
+  by the style script; *stale* content is yours to catch — compare the diff against the
+  README's "Public surface" and "What it owns" claims.
 - Never recommend removing a required auth/security capability before its replacement is covered by
   contract and security tests. Remove the superseded mechanism in the same replacement slice.
 - `plan.md` status changes must be backed by implemented, validated evidence.

--- a/.codex/agents/review.toml
+++ b/.codex/agents/review.toml
@@ -72,6 +72,11 @@ fresh context — do not assume the author's intent was correct.
   (mechanism changes, capability stays — never propose deleting it).
 - **Contract drift**: an `openapi/spec.ts` entry that no longer matches its handler
   breaks every generated client — always a finding.
+- **Stale package README**: a diff that changes a package's exports, boundary, invariant,
+  owned Prisma models, or config without updating that package's `README.md` is incomplete
+  (`docs/agents/package-docs.md`). Missing READMEs and missing mandatory sections are caught
+  by the style script; *stale* content is yours to catch — compare the diff against the
+  README's "Public surface" and "What it owns" claims.
 - Never recommend removing a working auth/security path before its replacement is
   validated live. Give the removal **sequence**, not just "looks unused".
 - `plan.md` status changes must be backed by implemented, validated evidence.

--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -76,7 +76,9 @@ import back into it.
 
 Owns the silo's Prisma schema, split per domain under `prisma/schema/*.prisma`, with applied migrations
 under `prisma/migrations/`. The migrate init-container runs `prisma migrate deploy` from this package
-root at rollout. This is the one place the silo's database shape is defined.
+root at rollout. This is the one place the silo's database shape is defined. The runs slice binds
+every `AgentRun` to exactly one `RunInputSnapshot` by run, digest, thread, silo, service, revision and
+effective-contract coordinates, so a partial or mismatched admission cannot commit.
 
 ## Runtime & config
 

--- a/apps/opencrane/package.json
+++ b/apps/opencrane/package.json
@@ -5,7 +5,8 @@
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {
-    "build": "rm -rf ../../dist/apps/opencrane && prisma generate && esbuild src/index.ts src/scripts/migrate.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outdir=../../dist/apps/opencrane && cp -r ../../libs/backend/feat-openclaw-tenant/main/src/reconcilers/tenants/deploy/workspace ../../dist/apps/opencrane/workspace && tsx scripts/emit-openapi.mts",
+    "build": "npm run db:generate && npm run build:bundle",
+    "build:bundle": "rm -rf ../../dist/apps/opencrane && esbuild src/index.ts src/scripts/migrate.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outdir=../../dist/apps/opencrane && cp -r ../../libs/backend/feat-openclaw-tenant/main/src/reconcilers/tenants/deploy/workspace ../../dist/apps/opencrane/workspace && tsx scripts/emit-openapi.mts",
     "emit-openapi": "tsx scripts/emit-openapi.mts",
     "dev": "tsx watch src/index.ts",
     "start": "node ../../dist/apps/opencrane/index.js",
@@ -63,8 +64,37 @@
         }
       },
       "build": {
+        "executor": "nx:run-commands",
+        "dependsOn": [
+          "db:generate",
+          "^build"
+        ],
+        "options": {
+          "command": "npm run build:bundle",
+          "cwd": "apps/opencrane"
+        },
         "outputs": [
           "{workspaceRoot}/dist/apps/opencrane"
+        ]
+      },
+      "db:generate": {
+        "executor": "nx:run-commands",
+        "cache": false,
+        "options": {
+          "command": "npm run db:generate",
+          "cwd": "apps/opencrane"
+        }
+      },
+      "lint": {
+        "dependsOn": [
+          "db:generate",
+          "^build"
+        ]
+      },
+      "test": {
+        "dependsOn": [
+          "db:generate",
+          "^build"
         ]
       },
       "emit-openapi": {

--- a/apps/opencrane/prisma/schema/runs.prisma
+++ b/apps/opencrane/prisma/schema/runs.prisma
@@ -107,12 +107,12 @@ model RunInputSnapshot {
   budgetPolicy            Json     @map("budget_policy")
   capabilitySetDigest     String   @map("capability_set_digest")
   promptCompilerVersion   String   @map("prompt_compiler_version")
-  inputDigest             String   @unique @map("input_digest")
-  createdAt               DateTime @default(now()) @map("created_at")
-  run                     AgentRun? @relation(fields: [runId, inputDigest, threadId, siloId, agentServiceId, agentRevisionId, effectiveContractDigest], references: [id, inputSnapshotDigest, threadId, siloId, agentServiceId, agentRevisionId, effectiveContractDigest], onDelete: Restrict)
+  digest                  String   @unique @map("input_digest")
+  compiledAt              DateTime @default(now()) @map("created_at")
+  run                     AgentRun? @relation(fields: [runId, digest, threadId, siloId, agentServiceId, agentRevisionId, effectiveContractDigest], references: [id, inputSnapshotDigest, threadId, siloId, agentServiceId, agentRevisionId, effectiveContractDigest], onDelete: Restrict)
 
-  @@unique([runId, inputDigest])
-  @@unique([runId, inputDigest, threadId, siloId, agentServiceId, agentRevisionId, effectiveContractDigest], map: "run_input_snapshot_run_identity_key")
+  @@unique([runId, digest])
+  @@unique([runId, digest, threadId, siloId, agentServiceId, agentRevisionId, effectiveContractDigest], map: "run_input_snapshot_run_identity_key")
   @@index([agentServiceId, agentRevisionId])
   @@map("run_input_snapshots")
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -155,6 +155,7 @@ export default [
             { sourceTag: "scope:policies", onlyDependOnLibsWithTags: ["scope:grants", "scope:k8s-api", "scope:policies", "scope:projection", "scope:shared"] },
             { sourceTag: "scope:personal-personas", onlyDependOnLibsWithTags: ["scope:personal-personas", "scope:shared"] },
             { sourceTag: "scope:projection", onlyDependOnLibsWithTags: ["scope:cluster-tenants", "scope:k8s-api", "scope:projection", "scope:shared"] },
+            { sourceTag: "scope:personal-session", onlyDependOnLibsWithTags: ["scope:agents", "scope:artifacts", "scope:membership", "scope:personal-runs", "scope:personal-session", "scope:shared"] },
             { sourceTag: "scope:providers", onlyDependOnLibsWithTags: ["scope:auth", "scope:cluster-tenants", "scope:model-routing", "scope:providers", "scope:shared"] },
             { sourceTag: "scope:retrieval", onlyDependOnLibsWithTags: ["scope:retrieval", "scope:shared"] },
             { sourceTag: "scope:personal-runs", onlyDependOnLibsWithTags: ["scope:agents", "scope:authorization", "scope:personal-runs", "scope:shared"] },

--- a/libs/backend/agents/README.md
+++ b/libs/backend/agents/README.md
@@ -17,12 +17,16 @@ are the per-employee agent looking after itself, not the operator looking after 
 | [`personal/memory`](./personal/memory/main/README.md) | Memory fact catalog. |
 | [`personal/personas`](./personal/personas/main/README.md) | Persona approval process. |
 | [`personal/runs`](./personal/runs/main/README.md) | Agent-run attempt authority. |
+| [`personal/session`](./personal/session/main/README.md) | Run input snapshot assembly. |
 
 ```
               backend/agents/personal   (one employee's agent)
    ┌────────────────┬───────────────┬──────────────┬──────────────┐
  runs           conversations     memory        personas
  (attempts)     (event history)   (learned facts) (who it is)
+   ▲
+   │ admission transaction
+ session  (freezes one immutable input snapshot per run)
 ```
 
 ## Dependency rule for this tier
@@ -34,6 +38,11 @@ authorization model, for memory the artifacts model — plus shared contracts (`
 its own scope. It may **not** import a sibling `personal-*` domain or any control-plane
 (`libs/backend/server`) domain. Cross-domain contact happens above, in the app that composes them.
 Never import an app.
+
+One deliberate exception: `personal/session` (`scope:personal-session`) is the assembly step that
+sits *across* the domains, so its constraint additionally allows `scope:personal-runs` (the
+admission transaction it compiles into), `scope:membership` (verified identity evidence), and
+`scope:artifacts` — see the `depConstraint` in `eslint.config.mjs`.
 
 ## See also
 

--- a/libs/backend/agents/personal/runs/main/README.md
+++ b/libs/backend/agents/personal/runs/main/README.md
@@ -5,27 +5,35 @@
 ## What it owns
 
 This package is part of the **personal-agent product**. A **run** is one logical execution of a
-user's agent. A run can fail or be cancelled and then be retried — but each retry is a new **attempt**
-of the *same* run, not a new run. This package is the authority over that attempt lifecycle: it decides
-when a fresh attempt may start, keeps a single run identity across all its attempts, and validates that
-the Kubernetes workload actually doing the work is the one authorised for the current attempt.
+user's agent, while an **attempt** is one try at completing that run. This package owns both ends of
+that lifecycle: it admits the first run together with the immutable input snapshot it will always
+use, then governs later attempts without changing the logical run or its frozen inputs.
 
 ```
- a terminal run (failed / cancelled)   +   retry request (expectedAttempt)
-          │
+ run request + idempotency key
+          │  session assembles inputs inside this package's transaction
           ▼
- ┌──────────────────────────────────────┐
- │   runs  ◄── HERE                       │  retryable? service active? revision current?
- │   · __StartNextRunAttempt              │  compare-and-swap attempt N → N+1
- │   · __ValidateRunWorkloadAssignment    │  Job/Pod identity == this attempt?
- └──────────────────────────────────────┘
-          │  started (attempt++, outbox event) / trusted assignment / denied
+ ┌──────────────────────────────────────────┐
+ │   runs  ◄── HERE                          │  run + one snapshot + ordered outbox
+ │   · PrismaRunAdmissionRepository          │  duplicate returns the first snapshot
+ │   · __StartNextRunAttempt                 │  terminal run: attempt N → N+1
+ │   · __ValidateRunWorkloadAssignment       │  Job/Pod identity == current attempt?
+ └──────────────────────────────────────────┘
+          │  accepted / retry started / assignment trusted / denied
           ▼
- run-owned outbox  ── dispatch picks up "RunAttemptRequested" and launches the workload
+ run-owned outbox  ── dispatcher launches the exact pinned revision and snapshot
 ```
 
-**In this flow:** [conversations](../../conversations/main/README.md) *(the started attempt appends its events there)* ·
-dispatcher *(polls the outbox and launches the workload)*
+**In this flow:** [session](../../session/main/README.md) *(assembles the snapshot through this
+package's admission boundary)* · [conversations](../../conversations/main/README.md) *(stores the
+run's ordered user-visible events)* · dispatcher *(polls the outbox and launches the workload)*
+
+Initial admission serialises the silo and request idempotency key before compiling any mutable
+input. A duplicate request therefore returns the first durable snapshot instead of recompiling at a
+later time. A new request locks the AgentService, lets the session assembler revalidate every input
+inside that transaction, and commits the `AgentRun`, its only `RunInputSnapshot`, and the ordered
+`RunAccepted` and `RunAttemptRequested` outbox events together. The canonical digest covers every
+snapshot field except its own digest.
 
 `__StartNextRunAttempt` is a **compare-and-swap** retry state machine: it reads the run and its
 AgentService authority as one snapshot, refuses unless the run is in a retryable terminal state and the
@@ -37,13 +45,21 @@ polls) so a started attempt can never be lost between deciding and launching.
 `__ValidateRunWorkloadAssignment` is the mirror check at launch time: it confirms the workload's full
 identity (who / where / which attempt) matches the expected authority exactly and has not expired.
 
-Invariant: one logical run keeps one identity; attempts only ever move forward under optimistic
-concurrency (detect conflicts at commit time); and any mismatch or staleness is a fail-closed denial with a precise reason.
+Invariant: a logical run either commits with exactly one digest-sealed snapshot and its dispatch
+event, or does not exist. Retries retain that run and snapshot identity, attempts only move forward
+under optimistic concurrency, and any authority, workload or persistence uncertainty fails closed.
 
 ## Public surface
 
 - `__StartNextRunAttempt(repository, command)` — start the next attempt of a run via compare-and-swap.
 - `__ValidateRunWorkloadAssignment(assignment, expectation)` — confirm a workload is the one authorised for this attempt.
+- `__DigestRunInputSnapshot(snapshot)` — compute the canonical SHA-256 identity of all frozen run
+  inputs without digesting the self-referential `digest` field.
+- `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial
+  run, snapshot and ordered outbox events around a caller-supplied assembly callback.
+- `RunAdmissionRepository`, `RunAdmissionCommand`, `RunAdmissionTransaction`,
+  `RunAdmissionBuildResult` and `RunAdmissionResult` — the transaction-fenced initial-admission port
+  and its input/output vocabulary.
 - `PrismaAgentRunAuthorityRepository` — the Prisma-backed adapter implementing the persistence port (atomic retry + outbox append).
 - `AgentRunAuthorityRepository` / `AgentRunAuthoritySnapshot` — the persistence port and its consistent read shape.
 - `StartNextRunAttemptCommand` / `StartNextRunAttemptResult`, `AtomicStartNextRunAttemptCommand` / `AtomicRunAttemptResult` — retry request/result and their atomic commit forms.
@@ -51,10 +67,10 @@ concurrency (detect conflicts at commit time); and any mismatch or staleness is 
 
 ## Boundary
 
-Consumed by the run-dispatch and workload-admission paths. It does not run the agent, schedule the
-Pod, or emit run events — it only governs attempt state and workload identity. Unlike its sibling
-authorities it ships its own Prisma adapter, so the atomic increment and outbox append stay in one
-transaction; pure use cases still accept an injected port for testing.
+Consumed by the [session assembler](../../session/main/README.md), run-dispatch and workload-
+admission paths. It does not choose persona, memory, tools, budgets or membership evidence; session
+supplies those through the transaction callback. It does not run the agent or schedule a Pod. It
+owns only the durable admission/attempt boundary and the outbox facts downstream execution consumes.
 
 ## Dependency direction
 
@@ -63,10 +79,12 @@ Tagged `scope:personal-runs`: it may depend only on `scope:agents` (shared run m
 
 ## Data & persistence
 
-Owns the `AgentRun` attempt counter and appends `RunOutboxEventKind.RunAttemptRequested` outbox rows,
-both committed together via `PrismaAgentRunAuthorityRepository`.
+Owns `AgentRun`, its one `RunInputSnapshot`, and run-domain outbox rows in
+`apps/opencrane/prisma/schema/runs.prisma`. Initial admission commits the run, snapshot,
+`RunAccepted`, and first `RunAttemptRequested` event together; later retries atomically advance the
+attempt counter and append another `RunAttemptRequested` event.
 
 ## See also
 
 - Parent index: [agents](../../../README.md)
-- Siblings: [conversations](../../conversations/main/README.md) · [memory](../../memory/main/README.md) · [personas](../../personas/main/README.md)
+- Siblings: [session](../../session/main/README.md) · [conversations](../../conversations/main/README.md) · [memory](../../memory/main/README.md) · [personas](../../personas/main/README.md)

--- a/libs/backend/agents/personal/runs/main/project.json
+++ b/libs/backend/agents/personal/runs/main/project.json
@@ -6,6 +6,7 @@
   "tags": ["type:lib", "layer:backend", "scope:personal-runs"],
   "targets": {
     "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/agents/personal/runs/main" } },
-    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/agents/personal/runs/main" } }
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/agents/personal/runs/main" } },
+    "test:sql": { "executor": "nx:run-commands", "options": { "command": "sh ../../../../../../scripts/run-postgres-authority-tests.sh tests/run-input-snapshot-admission.sql", "cwd": "libs/backend/agents/personal/runs/main" } }
   }
 }

--- a/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
@@ -1,4 +1,4 @@
-import type { PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import type { RunInputSnapshot } from "@opencrane/contracts";
 import type { Logger } from "@opencrane/observability";
 import { describe, expect, it, vi } from "vitest";
@@ -64,6 +64,20 @@ describe("PrismaRunAdmissionRepository", function _describeAdmissionRepository()
 
 		await expect(repository.admit(_command(), async function _UnexpectedBuild() { throw new Error("unexpected build"); })).resolves.toEqual({ outcome: "denied", reason: "persistence_unavailable" });
 		expect(error).toHaveBeenCalledWith({ err: persistenceError, runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", failureKind: "transaction_failed" }, "personal run admission persistence failed");
+		expect(error.mock.calls[0]?.[0]).not.toHaveProperty("requestIdempotencyKey");
+	});
+
+	it("fails closed and identifies a failed duplicate recovery without logging its key", async function _LogsDuplicateRecoveryFailure()
+	{
+		const duplicateError = new Prisma.PrismaClientKnownRequestError("duplicate run admission", { code: "P2002", clientVersion: "6.19.3" });
+		const recoveryError = new Error("recovery lookup unavailable");
+		const prisma = { $transaction: vi.fn().mockRejectedValue(duplicateError), agentRun: { findUnique: vi.fn().mockRejectedValue(recoveryError) }, runInputSnapshot: { findUnique: vi.fn() } } as unknown as PrismaClient;
+		const error = vi.fn();
+		const log = { error } as unknown as Logger;
+		const repository = new PrismaRunAdmissionRepository(prisma, { now: function _now() { return new Date("2026-07-20T00:00:00.000Z"); } }, log);
+
+		await expect(repository.admit(_command(), async function _UnexpectedBuild() { throw new Error("unexpected build"); })).resolves.toEqual({ outcome: "denied", reason: "persistence_unavailable" });
+		expect(error).toHaveBeenCalledWith({ err: recoveryError, runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", failureKind: "duplicate_recovery_failed" }, "personal run admission persistence failed");
 		expect(error.mock.calls[0]?.[0]).not.toHaveProperty("requestIdempotencyKey");
 	});
 });

--- a/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 import type { RunInputSnapshot } from "@opencrane/contracts";
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaRunAdmissionRepository } from "./prisma-run-admission-repository.js";
+import { PrismaRunAdmissionRepository } from "../prisma-run-admission-repository.js";
 
 /** Creates one complete canonical snapshot accepted at initial logical-run admission. */
 function _snapshot(): RunInputSnapshot

--- a/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
@@ -1,5 +1,6 @@
 import type { PrismaClient } from "@prisma/client";
 import type { RunInputSnapshot } from "@opencrane/contracts";
+import type { Logger } from "@opencrane/observability";
 import { describe, expect, it, vi } from "vitest";
 
 import { PrismaRunAdmissionRepository } from "../prisma-run-admission-repository.js";
@@ -51,5 +52,18 @@ describe("PrismaRunAdmissionRepository", function _describeAdmissionRepository()
 		expect(compiled).toBe(false);
 		expect(transaction.agentRun.create).not.toHaveBeenCalled();
 		expect(transaction.runInputSnapshot.create).not.toHaveBeenCalled();
+	});
+
+	it("fails closed and logs safe authority coordinates when persistence is unavailable", async function _LogsPersistenceFailure()
+	{
+		const persistenceError = new Error("database unavailable");
+		const prisma = { $transaction: vi.fn().mockRejectedValue(persistenceError) } as unknown as PrismaClient;
+		const error = vi.fn();
+		const log = { error } as unknown as Logger;
+		const repository = new PrismaRunAdmissionRepository(prisma, { now: function _now() { return new Date("2026-07-20T00:00:00.000Z"); } }, log);
+
+		await expect(repository.admit(_command(), async function _UnexpectedBuild() { throw new Error("unexpected build"); })).resolves.toEqual({ outcome: "denied", reason: "persistence_unavailable" });
+		expect(error).toHaveBeenCalledWith({ err: persistenceError, runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", failureKind: "transaction_failed" }, "personal run admission persistence failed");
+		expect(error.mock.calls[0]?.[0]).not.toHaveProperty("requestIdempotencyKey");
 	});
 });

--- a/libs/backend/agents/personal/runs/main/src/index.ts
+++ b/libs/backend/agents/personal/runs/main/src/index.ts
@@ -1,3 +1,6 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
+export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
+export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
+export { PrismaRunAdmissionRepository } from "./prisma-run-admission-repository.js";

--- a/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.test.ts
@@ -1,0 +1,55 @@
+import type { PrismaClient } from "@prisma/client";
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaRunAdmissionRepository } from "./prisma-run-admission-repository.js";
+
+/** Creates one complete canonical snapshot accepted at initial logical-run admission. */
+function _snapshot(): RunInputSnapshot
+{
+	return {
+		runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", snapshotVersion: 1, threadId: "thread-1", messageIds: ["message-1"], personaRevisionId: "persona-1", preferenceFactIds: ["preference-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"], memoryFacts: [{ datasetId: "dataset-1", factId: "fact-1", contentDigest: `sha256:${"e".repeat(64)}`, provenance: [{ sourceKind: "message", sourceId: "message-1", capturedAt: "2026-07-20T00:00:00.000Z" }] }], memoryQueryPolicy: { scope: "personal" }, toolGrantIds: ["grant-1"], modelRoute: { alias: "target" }, budgetPolicy: { maxTokens: 1000 }, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 4, fleetMembershipIssuer: "opencrane-fleet", fleetMembershipIssuerKeyId: "key-1", fleetMembershipAssertionId: "assertion-1", fleetMembershipPayloadDigest: `sha256:${"d".repeat(64)}`, fleetMembershipTrustedUntil: "2026-07-20T01:00:00.000Z" }, capabilitySetDigest: `sha256:${"a".repeat(64)}`, effectiveContractDigest: `sha256:${"b".repeat(64)}`, promptCompilerVersion: "prompt-v1", digest: `sha256:${"c".repeat(64)}`, compiledAt: "2026-07-20T00:00:00.000Z",
+	};
+}
+
+/** Creates a target initial-admission command matching the canonical test snapshot. */
+function _command()
+{
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1" } as const;
+}
+
+/** Creates the immutable authority facts that are revalidated within the admission transaction. */
+function _authority()
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: `sha256:${"b".repeat(64)}`, promptCompilerVersion: "prompt-v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null } as const;
+}
+
+describe("PrismaRunAdmissionRepository", function _describeAdmissionRepository()
+{
+	it("creates the logical run, immutable snapshot, and ordered acceptance/dispatch events in one transaction", async function _persistsAdmission()
+	{
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({ id: "run-1" }) }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({ id: "snapshot-1" }) }, outboxEvent: { createMany: vi.fn().mockResolvedValue({ count: 2 }) } };
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+		const repository = new PrismaRunAdmissionRepository(prisma, { now: function _now() { return new Date("2026-07-20T00:00:00.000Z"); } });
+
+		await expect(repository.admit(_command(), async function _build() { return { outcome: "ready", value: { authority: _authority(), snapshot: _snapshot() } } as const; })).resolves.toEqual({ outcome: "accepted", snapshot: _snapshot() });
+		expect(transaction.$queryRaw).toHaveBeenCalledTimes(2);
+		expect(transaction.agentRun.create).toHaveBeenCalledWith({ data: expect.objectContaining({ inputSnapshotDigest: `sha256:${"c".repeat(64)}`, acceptedAt: new Date("2026-07-20T00:00:00.000Z") }) });
+		expect(transaction.runInputSnapshot.create).toHaveBeenCalledWith({ data: expect.objectContaining({ runId: "run-1", digest: `sha256:${"c".repeat(64)}`, messageIds: ["message-1"] }) });
+		expect(transaction.outboxEvent.createMany).toHaveBeenCalledWith({ data: [expect.objectContaining({ sequence: 1, kind: "RunAccepted", idempotencyKey: "run-1:accepted" }), expect.objectContaining({ sequence: 2, kind: "RunAttemptRequested", idempotencyKey: "run-1:attempt:1" })] });
+	});
+
+	it("returns a null-thread snapshot before a later retry can load or compile a new request instant", async function _returnsIdempotent()
+	{
+		const snapshot = { ..._snapshot(), threadId: null };
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue({ id: snapshot.runId, inputSnapshotDigest: snapshot.digest }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...snapshot, compiledAt: new Date(snapshot.compiledAt) }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+		const repository = new PrismaRunAdmissionRepository(prisma, { now: function _now() { return new Date("2026-07-20T00:05:00.000Z"); } });
+		let compiled = false;
+
+		await expect(repository.admit({ ..._command(), threadId: null }, async function _build() { compiled = true; return { outcome: "ready", value: { authority: _authority(), snapshot } } as const; })).resolves.toEqual({ outcome: "idempotent", snapshot });
+		expect(compiled).toBe(false);
+		expect(transaction.agentRun.create).not.toHaveBeenCalled();
+		expect(transaction.runInputSnapshot.create).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.ts
+++ b/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.ts
@@ -1,7 +1,8 @@
 import { Prisma, RunOutboxEventKind, type PrismaClient } from "@prisma/client";
 
 import type { RunInputSnapshot } from "@opencrane/contracts";
-import { ___CanonicalizeJson } from "@opencrane/util";
+import { ___CloneCanonicalJson } from "@opencrane/util";
+import type { JsonValue } from "@opencrane/util";
 
 import type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 
@@ -110,7 +111,7 @@ function _trigger(value: InitialRunAuthority["trigger"]): "Interactive" | "Sched
 /** Deep-copies JSON through canonical form before Prisma owns the durable payload. */
 function _json(value: unknown): Prisma.InputJsonValue
 {
-	return JSON.parse(___CanonicalizeJson(value as Parameters<typeof ___CanonicalizeJson>[0])) as Prisma.InputJsonValue;
+	return ___CloneCanonicalJson(value as JsonValue) as Prisma.InputJsonValue;
 }
 
 /** Maps an immutable contract snapshot into its canonical Postgres row. */

--- a/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.ts
+++ b/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.ts
@@ -1,6 +1,7 @@
 import { Prisma, RunOutboxEventKind, type PrismaClient } from "@prisma/client";
 
 import type { RunInputSnapshot } from "@opencrane/contracts";
+import { ___CreateLogger, type Logger } from "@opencrane/observability";
 import { ___CloneCanonicalJson } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 
@@ -13,12 +14,20 @@ export class PrismaRunAdmissionRepository implements RunAdmissionRepository
 	private readonly prisma: PrismaClient;
 	/** Server-owned clock that freezes an admission instant only after a non-duplicate request reaches this boundary. */
 	private readonly clock: RunAdmissionClock;
+	/** Structured persistence-failure signal with process-wide secret redaction. */
+	private readonly log: Logger;
 
-	/** Creates an initial-admission repository over canonical Postgres. */
-	constructor(prisma: PrismaClient, clock: RunAdmissionClock = { now: function _now(): Date { return new Date(); } })
+	/**
+	 * Creates an initial-admission repository over canonical Postgres.
+	 * @param prisma - Canonical product-authority database client.
+	 * @param clock - Server-owned admission clock, replaceable only for deterministic tests.
+	 * @param log - Structured redacting logger for otherwise fail-closed persistence failures.
+	 */
+	constructor(prisma: PrismaClient, clock: RunAdmissionClock = { now: function _now(): Date { return new Date(); } }, log: Logger = ___CreateLogger("personal-run-admission"))
 	{
 		this.prisma = prisma;
 		this.clock = clock;
+		this.log = log;
 	}
 
 	/** Deduplicates before compilation or commits every initial run coordinate in one transaction. */
@@ -55,10 +64,19 @@ export class PrismaRunAdmissionRepository implements RunAdmissionRepository
 		{
 			if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")
 			{
-				const existing = await this.prisma.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
-				const existingSnapshot = existing === null ? null : await this.prisma.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
-				if (existingSnapshot !== null) return { outcome: "idempotent", snapshot: _snapshot(existingSnapshot) };
+				try
+				{
+					const existing = await this.prisma.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
+					const existingSnapshot = existing === null ? null : await this.prisma.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
+					if (existingSnapshot !== null) return { outcome: "idempotent", snapshot: _snapshot(existingSnapshot) };
+				}
+				catch (recoveryError)
+				{
+					this.log.error({ err: recoveryError, runId: command.runId, siloId: command.siloId, agentServiceId: command.agentServiceId, failureKind: "duplicate_recovery_failed" }, "personal run admission persistence failed");
+					return { outcome: "denied", reason: "persistence_unavailable" };
+				}
 			}
+			this.log.error({ err: error, runId: command.runId, siloId: command.siloId, agentServiceId: command.agentServiceId, failureKind: "transaction_failed" }, "personal run admission persistence failed");
 			return { outcome: "denied", reason: "persistence_unavailable" };
 		}
 	}

--- a/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.ts
+++ b/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.ts
@@ -1,0 +1,172 @@
+import { Prisma, RunOutboxEventKind, type PrismaClient } from "@prisma/client";
+
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { ___CanonicalizeJson } from "@opencrane/util";
+
+import type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
+
+/** Prisma-backed initial-run admission that owns the logical run, snapshot, and run outbox. */
+export class PrismaRunAdmissionRepository implements RunAdmissionRepository
+{
+	/** Canonical OpenCrane product-authority database client. */
+	private readonly prisma: PrismaClient;
+	/** Server-owned clock that freezes an admission instant only after a non-duplicate request reaches this boundary. */
+	private readonly clock: RunAdmissionClock;
+
+	/** Creates an initial-admission repository over canonical Postgres. */
+	constructor(prisma: PrismaClient, clock: RunAdmissionClock = { now: function _now(): Date { return new Date(); } })
+	{
+		this.prisma = prisma;
+		this.clock = clock;
+	}
+
+	/** Deduplicates before compilation or commits every initial run coordinate in one transaction. */
+	async admit<TDenial>(command: RunAdmissionCommand, build: (transaction: RunAdmissionTransaction) => Promise<RunAdmissionBuildResult<TDenial>>): Promise<RunAdmissionResult<TDenial>>
+	{
+		const clock = this.clock;
+		try
+		{
+			return await this.prisma.$transaction(async function _admit(transaction: Prisma.TransactionClient): Promise<RunAdmissionResult<TDenial>>
+			{
+				// 1. Serialize the user-visible key before loading inputs so a duplicate never recompiles at a later instant.
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${command.siloId}\u0000${command.requestIdempotencyKey}`}, 0))`);
+				const existing = await transaction.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
+				const existingSnapshot = existing === null ? null : await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
+				if (existingSnapshot !== null)
+				{
+					return { outcome: "idempotent", snapshot: _snapshot(existingSnapshot) };
+				}
+
+				// 2. Lock the service before every source revalidates its inputs, preserving the established run lock order.
+				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${command.agentServiceId} AND "silo_id" = ${command.siloId} FOR UPDATE`);
+				const admittedAtDate = clock.now();
+				const admittedAt = admittedAtDate.toISOString();
+				const compiled = await build({ prisma: transaction, admittedAt, admittedAtEpochMs: admittedAtDate.getTime() });
+				if (compiled.outcome === "denied") return compiled;
+				if (!_matchesCommand(compiled.value, command)) return { outcome: "denied", reason: "authority_conflict" };
+
+				// 3. Insert both sides of the deferred snapshot relation plus ordered acceptance and dispatch events in one commit.
+				await _persistInitialAdmission(transaction, command, compiled.value, admittedAtDate);
+				return { outcome: "accepted", snapshot: compiled.value.snapshot };
+			});
+		}
+		catch (error)
+		{
+			if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002")
+			{
+				const existing = await this.prisma.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
+				const existingSnapshot = existing === null ? null : await this.prisma.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
+				if (existingSnapshot !== null) return { outcome: "idempotent", snapshot: _snapshot(existingSnapshot) };
+			}
+			return { outcome: "denied", reason: "persistence_unavailable" };
+		}
+	}
+}
+
+/** Returns whether the transaction-fenced authority exactly matches immutable caller coordinates. */
+function _matchesCommand(value: RunAdmissionBuild, command: RunAdmissionCommand): boolean
+{
+	return value.authority.agentServiceId === command.agentServiceId
+		&& value.snapshot.runId === command.runId
+		&& value.snapshot.siloId === command.siloId
+		&& value.snapshot.agentServiceId === command.agentServiceId
+		&& value.snapshot.threadId === command.threadId
+		&& value.snapshot.identitySnapshot.executionSubjectId === command.executionSubjectId;
+}
+
+/** Inserts the run, its only snapshot, and the ordered initial run-domain events. */
+async function _persistInitialAdmission(transaction: Prisma.TransactionClient, command: RunAdmissionCommand, value: RunAdmissionBuild, admittedAt: Date): Promise<void>
+{
+	await transaction.agentRun.create({ data: {
+		id: command.runId,
+		siloId: command.siloId,
+		agentServiceId: value.authority.agentServiceId,
+		agentRevisionId: value.authority.agentRevisionId,
+		threadId: command.threadId,
+		trigger: _trigger(value.authority.trigger),
+		delegatedUserId: value.authority.delegatedUserId,
+		requestIdempotencyKey: command.requestIdempotencyKey,
+		rootRunId: value.authority.rootRunId,
+		parentRunId: value.authority.parentRunId,
+		effectiveContractDigest: value.authority.effectiveContractDigest,
+		inputSnapshotDigest: value.snapshot.digest,
+		acceptedAt: admittedAt,
+	} });
+	await transaction.runInputSnapshot.create({ data: _snapshotData(value.snapshot) });
+	await transaction.outboxEvent.createMany({ data: [
+		{ runId: command.runId, attempt: 1, sequence: 1, kind: RunOutboxEventKind.RunAccepted, idempotencyKey: `${command.runId}:accepted`, payload: { runId: command.runId, inputSnapshotDigest: value.snapshot.digest }, availableAt: admittedAt },
+		{ runId: command.runId, attempt: 1, sequence: 2, kind: RunOutboxEventKind.RunAttemptRequested, idempotencyKey: `${command.runId}:attempt:1`, payload: { runId: command.runId, attempt: 1, inputSnapshotDigest: value.snapshot.digest }, availableAt: admittedAt },
+	] });
+}
+
+/** Maps a dependency-light trigger to the owned database enum representation. */
+function _trigger(value: InitialRunAuthority["trigger"]): "Interactive" | "Schedule" | "ManagedInvocation"
+{
+	if (value === "interactive") return "Interactive";
+	if (value === "schedule") return "Schedule";
+	return "ManagedInvocation";
+}
+
+/** Deep-copies JSON through canonical form before Prisma owns the durable payload. */
+function _json(value: unknown): Prisma.InputJsonValue
+{
+	return JSON.parse(___CanonicalizeJson(value as Parameters<typeof ___CanonicalizeJson>[0])) as Prisma.InputJsonValue;
+}
+
+/** Maps an immutable contract snapshot into its canonical Postgres row. */
+function _snapshotData(snapshot: RunInputSnapshot): Prisma.RunInputSnapshotUncheckedCreateInput
+{
+	return {
+		runId: snapshot.runId,
+		snapshotVersion: snapshot.snapshotVersion,
+		siloId: snapshot.siloId,
+		agentServiceId: snapshot.agentServiceId,
+		agentRevisionId: snapshot.agentRevisionId,
+		effectiveContractDigest: snapshot.effectiveContractDigest,
+		personaRevisionId: snapshot.personaRevisionId,
+		threadId: snapshot.threadId,
+		messageIds: [...snapshot.messageIds],
+		preferenceFactIds: [...snapshot.preferenceFactIds],
+		artifactRevisionIds: [...snapshot.artifactRevisionIds],
+		memoryFacts: _json(snapshot.memoryFacts),
+		identitySnapshot: _json(snapshot.identitySnapshot),
+		modelRoute: _json(snapshot.modelRoute),
+		toolGrantIds: [...snapshot.toolGrantIds],
+		skillRevisionIds: [...snapshot.skillRevisionIds],
+		memoryQueryPolicy: _json(snapshot.memoryQueryPolicy),
+		budgetPolicy: _json(snapshot.budgetPolicy),
+		capabilitySetDigest: snapshot.capabilitySetDigest,
+		promptCompilerVersion: snapshot.promptCompilerVersion,
+		digest: snapshot.digest,
+		compiledAt: new Date(snapshot.compiledAt),
+	};
+}
+
+/** Maps one persisted snapshot row back into the immutable cross-domain contract. */
+function _snapshot(row: { runId: string; siloId: string; agentServiceId: string; agentRevisionId: string; snapshotVersion: number; threadId: string | null; messageIds: string[]; personaRevisionId: string | null; preferenceFactIds: string[]; artifactRevisionIds: string[]; skillRevisionIds: string[]; memoryFacts: Prisma.JsonValue; memoryQueryPolicy: Prisma.JsonValue; toolGrantIds: string[]; modelRoute: Prisma.JsonValue; budgetPolicy: Prisma.JsonValue; identitySnapshot: Prisma.JsonValue; capabilitySetDigest: string; effectiveContractDigest: string; promptCompilerVersion: string; digest: string; compiledAt: Date }): RunInputSnapshot
+{
+	return {
+		runId: row.runId,
+		siloId: row.siloId,
+		agentServiceId: row.agentServiceId,
+		agentRevisionId: row.agentRevisionId,
+		snapshotVersion: row.snapshotVersion,
+		threadId: row.threadId,
+		messageIds: row.messageIds,
+		personaRevisionId: row.personaRevisionId,
+		preferenceFactIds: row.preferenceFactIds,
+		artifactRevisionIds: row.artifactRevisionIds,
+		skillRevisionIds: row.skillRevisionIds,
+		memoryFacts: row.memoryFacts as unknown as RunInputSnapshot["memoryFacts"],
+		memoryQueryPolicy: row.memoryQueryPolicy as RunInputSnapshot["memoryQueryPolicy"],
+		toolGrantIds: row.toolGrantIds,
+		modelRoute: row.modelRoute as RunInputSnapshot["modelRoute"],
+		budgetPolicy: row.budgetPolicy as RunInputSnapshot["budgetPolicy"],
+		identitySnapshot: row.identitySnapshot as unknown as RunInputSnapshot["identitySnapshot"],
+		capabilitySetDigest: row.capabilitySetDigest,
+		effectiveContractDigest: row.effectiveContractDigest,
+		promptCompilerVersion: row.promptCompilerVersion,
+		digest: row.digest,
+		compiledAt: row.compiledAt.toISOString(),
+	};
+}

--- a/libs/backend/agents/personal/runs/main/src/run-admission.types.ts
+++ b/libs/backend/agents/personal/runs/main/src/run-admission.types.ts
@@ -1,0 +1,83 @@
+import type { Prisma } from "@prisma/client";
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import type { AgentRevisionId, AgentRunId, AgentServiceId, SiloId, ThreadId } from "@opencrane/models/agents";
+
+/** Immutable run, service, and revision facts accepted at the initial admission boundary. */
+export interface InitialRunAuthority
+{
+	/** Stable AgentService executed by the logical run. */
+	readonly agentServiceId: AgentServiceId;
+	/** Published revision locked for the complete logical run. */
+	readonly agentRevisionId: AgentRevisionId;
+	/** Product boundary deciding whether an approved persona is required. */
+	readonly agentKind: "personal" | "managed";
+	/** Effective contract digest accepted before the runtime is eligible for dispatch. */
+	readonly effectiveContractDigest: string;
+	/** Version of the prompt compiler selected by the published revision. */
+	readonly promptCompilerVersion: string;
+	/** Trigger accepted for the initial logical run. */
+	readonly trigger: "interactive" | "schedule" | "managed_invocation";
+	/** Delegated user, when an interactive run acts on a human's behalf. */
+	readonly delegatedUserId: string | null;
+	/** Root lineage identifier fixed when the logical run is admitted. */
+	readonly rootRunId: string;
+	/** Immediate parent run, or null for a root admission. */
+	readonly parentRunId: string | null;
+}
+
+/** Immutable public coordinates that identify one initial logical-run admission. */
+export interface RunAdmissionCommand
+{
+	/** Caller-provided logical run identifier created before admission begins. */
+	readonly runId: AgentRunId;
+	/** Silo containing every authority fact and the durable run. */
+	readonly siloId: SiloId;
+	/** AgentService locked before any authority input is revalidated. */
+	readonly agentServiceId: AgentServiceId;
+	/** Conversation thread permanently bound to the admitted input snapshot, or null for non-conversational work. */
+	readonly threadId: ThreadId | null;
+	/** Subject that must be verified by the signed membership assertion before the run can commit. */
+	readonly executionSubjectId: string;
+	/** User-visible key making duplicate transport delivery return the first admission. */
+	readonly requestIdempotencyKey: string;
+}
+
+/** Transaction capability supplied to every loader at the final admission fence. */
+export interface RunAdmissionTransaction
+{
+	/** Prisma transaction through which all admission reads and durable writes must occur. */
+	readonly prisma: Prisma.TransactionClient;
+	/** Canonical server-owned admission time used by every fenced authority read and immutable snapshot. */
+	readonly admittedAt: string;
+	/** Epoch-millisecond form of the same canonical server-owned admission time. */
+	readonly admittedAtEpochMs: number;
+}
+
+/** Server-side clock injected for deterministic tests without accepting a caller-controlled admission time. */
+export interface RunAdmissionClock
+{
+	/** Returns the trusted wall-clock instant used for a newly admitted logical run. */
+	now(): Date;
+}
+
+/** Ready-to-persist run facts and the single immutable snapshot assembled inside the transaction. */
+export interface RunAdmissionBuild
+{
+	/** Authoritative initial-run facts revalidated while the service lock is held. */
+	readonly authority: InitialRunAuthority;
+	/** Complete immutable runtime input whose digest will be bound to the logical run. */
+	readonly snapshot: RunInputSnapshot;
+}
+
+/** Callback result for a transaction-fenced admission compilation. */
+export type RunAdmissionBuildResult<TDenial> = { readonly outcome: "ready"; readonly value: RunAdmissionBuild } | { readonly outcome: "denied"; readonly reason: TDenial };
+
+/** Durable outcome of either accepting or deduplicating one logical run. */
+export type RunAdmissionResult<TDenial> = { readonly outcome: "accepted" | "idempotent"; readonly snapshot: RunInputSnapshot } | { readonly outcome: "denied"; readonly reason: TDenial | "persistence_unavailable" | "authority_conflict" };
+
+/** Run-owned boundary that serializes idempotency, final authority reads, and initial dispatch. */
+export interface RunAdmissionRepository
+{
+	/** Resolves a duplicate before compilation or accepts one complete run/snapshot/outbox transaction. */
+	admit<TDenial>(command: RunAdmissionCommand, build: (transaction: RunAdmissionTransaction) => Promise<RunAdmissionBuildResult<TDenial>>): Promise<RunAdmissionResult<TDenial>>;
+}

--- a/libs/backend/agents/personal/runs/main/src/run-input-snapshot-digest.ts
+++ b/libs/backend/agents/personal/runs/main/src/run-input-snapshot-digest.ts
@@ -1,0 +1,48 @@
+import { __DigestCanonicalJson } from "@opencrane/backend/server/iam/authorization";
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import type { JsonValue } from "@opencrane/util";
+
+/** Produces the canonical digest for a fully assembled input snapshot without its self-reference. */
+export function __DigestRunInputSnapshot(snapshot: Omit<RunInputSnapshot, "digest">): string
+{
+	return __DigestCanonicalJson({
+		runId: snapshot.runId,
+		siloId: snapshot.siloId,
+		agentServiceId: snapshot.agentServiceId,
+		agentRevisionId: snapshot.agentRevisionId,
+		snapshotVersion: snapshot.snapshotVersion,
+		threadId: snapshot.threadId,
+		messageIds: snapshot.messageIds,
+		personaRevisionId: snapshot.personaRevisionId,
+		preferenceFactIds: snapshot.preferenceFactIds,
+		artifactRevisionIds: snapshot.artifactRevisionIds,
+		skillRevisionIds: snapshot.skillRevisionIds,
+		memoryFacts: snapshot.memoryFacts.map(function _memoryFact(fact): JsonValue
+		{
+			return {
+				datasetId: fact.datasetId,
+				factId: fact.factId,
+				contentDigest: fact.contentDigest,
+				provenance: fact.provenance.map(function _provenance(provenance): JsonValue
+				{
+					return {
+						sourceKind: provenance.sourceKind,
+						sourceId: provenance.sourceId,
+						...(provenance.artifactRevisionId === undefined ? {} : { artifactRevisionId: provenance.artifactRevisionId }),
+						...(provenance.sourceUserId === undefined ? {} : { sourceUserId: provenance.sourceUserId }),
+						capturedAt: provenance.capturedAt,
+					};
+				}),
+			};
+		}),
+		memoryQueryPolicy: snapshot.memoryQueryPolicy,
+		toolGrantIds: snapshot.toolGrantIds,
+		modelRoute: snapshot.modelRoute,
+		budgetPolicy: snapshot.budgetPolicy,
+		identitySnapshot: snapshot.identitySnapshot,
+		capabilitySetDigest: snapshot.capabilitySetDigest,
+		effectiveContractDigest: snapshot.effectiveContractDigest,
+		promptCompilerVersion: snapshot.promptCompilerVersion,
+		compiledAt: snapshot.compiledAt,
+	} as unknown as JsonValue);
+}

--- a/libs/backend/agents/personal/runs/main/tests/run-input-snapshot-admission.sql
+++ b/libs/backend/agents/personal/runs/main/tests/run-input-snapshot-admission.sql
@@ -1,0 +1,89 @@
+BEGIN;
+
+INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "owner_scope", "owner_subject_id", "workload_profile", "updated_at")
+VALUES ('snapshot-service', 'silo-snapshot', 'managed', 'Snapshot test', 'organization', 'org-snapshot', 'managed-agent', clock_timestamp());
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
+VALUES ('snapshot-revision', 'snapshot-service', 1, 'draft', 'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'user-snapshot');
+UPDATE "agent_revisions" SET "state" = 'published', "published_at" = clock_timestamp() WHERE "id" = 'snapshot-revision';
+UPDATE "agent_services" SET "state" = 'active', "active_revision_id" = 'snapshot-revision' WHERE "id" = 'snapshot-service';
+
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "thread_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
+VALUES ('snapshot-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-thread', 'interactive', 'snapshot-request', 'snapshot-run', 'sha256:' || repeat('b', 64), 'sha256:' || repeat('c', 64));
+INSERT INTO "run_input_snapshots" ("run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "thread_id", "memory_facts", "identity_snapshot", "model_route", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-run', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('b', 64), 'snapshot-thread', '[]', '{}', '{}', '{}', '{}', 'sha256:' || repeat('d', 64), 'prompt-v1', 'sha256:' || repeat('c', 64));
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "thread_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
+VALUES ('snapshot-scheduled-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-scheduled-request', 'snapshot-scheduled-run', 'sha256:' || repeat('e', 64), 'sha256:' || repeat('f', 64));
+INSERT INTO "run_input_snapshots" ("run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "thread_id", "memory_facts", "identity_snapshot", "model_route", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-scheduled-run', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('e', 64), NULL, '[]', '{}', '{}', '{}', '{}', 'sha256:' || repeat('1', 64), 'prompt-v1', 'sha256:' || repeat('f', 64));
+SET CONSTRAINTS ALL IMMEDIATE;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM "run_input_snapshots" WHERE "run_id" = 'snapshot-scheduled-run' AND "thread_id" IS NULL) THEN
+        RAISE EXCEPTION 'FAIL: a non-conversational run did not preserve its null thread binding';
+    END IF;
+    RAISE NOTICE 'PASS: a non-conversational run can bind a null thread to its immutable snapshot';
+END;
+$$;
+SET CONSTRAINTS ALL DEFERRED;
+DO $$
+DECLARE
+    actual_message TEXT;
+BEGIN
+    BEGIN
+        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "thread_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
+        VALUES ('snapshot-missing', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'missing-thread', 'interactive', 'snapshot-missing-request', 'snapshot-missing', 'sha256:' || repeat('e', 64), 'sha256:' || repeat('f', 64));
+        SET CONSTRAINTS agent_runs_input_snapshot_complete IMMEDIATE;
+    EXCEPTION WHEN foreign_key_violation THEN
+        GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+        IF strpos(actual_message, 'AgentRun requires its exact immutable RunInputSnapshot') = 0 THEN RAISE EXCEPTION 'FAIL: expected run completeness rejection, got %', actual_message; END IF;
+        RAISE NOTICE 'PASS: a committed AgentRun requires its unique immutable input snapshot';
+        SET CONSTRAINTS ALL DEFERRED;
+        RETURN;
+    END;
+    RAISE EXCEPTION 'FAIL: a committed AgentRun unexpectedly succeeded without a snapshot';
+END;
+$$;
+SET CONSTRAINTS ALL DEFERRED;
+DO $$
+DECLARE
+    actual_message TEXT;
+BEGIN
+    BEGIN
+        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "thread_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
+        VALUES ('snapshot-mismatch', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'run-thread', 'interactive', 'snapshot-mismatch-request', 'snapshot-mismatch', 'sha256:' || repeat('1', 64), 'sha256:' || repeat('2', 64));
+        INSERT INTO "run_input_snapshots" ("run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "thread_id", "memory_facts", "identity_snapshot", "model_route", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
+        VALUES ('snapshot-mismatch', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('1', 64), 'snapshot-thread', '[]', '{}', '{}', '{}', '{}', 'sha256:' || repeat('3', 64), 'prompt-v1', 'sha256:' || repeat('2', 64));
+        SET CONSTRAINTS run_input_snapshots_run_binding IMMEDIATE;
+    EXCEPTION WHEN foreign_key_violation THEN
+        GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+        IF strpos(actual_message, 'RunInputSnapshot must bind the exact AgentRun thread and authority') = 0 THEN RAISE EXCEPTION 'FAIL: expected snapshot run-binding rejection, got %', actual_message; END IF;
+        RAISE NOTICE 'PASS: an input snapshot must bind the exact admitted run thread';
+        SET CONSTRAINTS ALL DEFERRED;
+        RETURN;
+    END;
+RAISE EXCEPTION 'FAIL: a mismatched snapshot thread unexpectedly succeeded';
+END;
+$$;
+SET CONSTRAINTS ALL DEFERRED;
+DO $$
+DECLARE
+    actual_message TEXT;
+BEGIN
+    BEGIN
+        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "thread_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
+        VALUES ('snapshot-null-mismatch', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-null-mismatch-request', 'snapshot-null-mismatch', 'sha256:' || repeat('e', 64), 'sha256:' || repeat('7', 64));
+        INSERT INTO "run_input_snapshots" ("run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "thread_id", "memory_facts", "identity_snapshot", "model_route", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
+        VALUES ('snapshot-null-mismatch', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('e', 64), 'snapshot-thread', '[]', '{}', '{}', '{}', '{}', 'sha256:' || repeat('8', 64), 'prompt-v1', 'sha256:' || repeat('7', 64));
+        SET CONSTRAINTS run_input_snapshots_run_binding IMMEDIATE;
+    EXCEPTION WHEN foreign_key_violation THEN
+        GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+        IF strpos(actual_message, 'RunInputSnapshot must bind the exact AgentRun thread and authority') = 0 THEN RAISE EXCEPTION 'FAIL: expected null-safe snapshot run-binding rejection, got %', actual_message; END IF;
+        RAISE NOTICE 'PASS: a null-thread run cannot bind a threaded snapshot';
+        SET CONSTRAINTS ALL DEFERRED;
+        RETURN;
+    END;
+    RAISE EXCEPTION 'FAIL: a null-thread run unexpectedly accepted a threaded snapshot';
+END;
+$$;
+
+ROLLBACK;

--- a/libs/backend/agents/personal/session/main/README.md
+++ b/libs/backend/agents/personal/session/main/README.md
@@ -1,7 +1,78 @@
-# Personal session assembly
+# @opencrane/backend/agents/personal/session — run input snapshot assembly
 
-This package creates the one immutable `RunInputSnapshot` consumed by a personal or managed-agent
-runtime. It reads injected authority ports and writes only through the injected snapshot store.
+> [backend](../../../../README.md) › [agents](../../../README.md) › personal › session
 
-It does not select a runtime driver, approve a persona, issue capabilities, or read mutable
-workspace files. The OpenCrane app will compose its ports with target authority adapters.
+## What it owns
+
+This package is part of the **personal-agent product**. Before an agent runtime executes a run, the
+platform freezes *everything* that run is allowed to see and use into one immutable record — the
+**`RunInputSnapshot`**: which messages, which persona, which memory facts, which tools and budgets,
+and which verified identity. This package owns the **assembly** of that snapshot: it gathers each
+input from an injected authority, validates the combination, and hands the finished snapshot to the
+run-admission transaction that persists it. After that instant nothing about the run's input can
+change — a retry, an audit, or a replay all see the exact same record, identified by its digest
+(a SHA-256 fingerprint of the canonical content).
+
+```
+ run request  (runId · silo · service · thread? · subject · idempotency key)
+          │  __AssembleRunInputSnapshot
+          ▼
+ ┌─────────────────────────────────────────┐
+ │   session  ◄── HERE                       │  load run/persona/thread/preferences/
+ │   · orchestrates 8 authority loads        │  memory/tools/budget/identity, all inside
+ │   · compiles + digests the one snapshot   │  the runs package's admission transaction
+ └─────────────────────────────────────────┘
+          │  ready (authority + snapshot) / denied (one precise reason)
+          ▼
+ runs · RunAdmissionRepository  ── persists run + snapshot + outbox events in one commit
+```
+
+**In this flow:** [runs](../../runs/main/README.md) *(owns the admission transaction, the digest
+function, and the durable rows)* · [membership](../../../../server/iam/membership/main/README.md)
+*(supplies the signed fleet-membership evidence behind the identity envelope)*
+
+Every input is loaded through a port (`RunAuthoritySource`, `ApprovedPersonaSource`, …) inside the
+**same database transaction** that admits the run, so a permission revoked or a membership expired a
+millisecond before commit can never leak into the frozen record. One refusal anywhere denies the
+whole assembly with a single precise reason; a duplicate request (same idempotency key) returns the
+previously admitted snapshot without recompiling anything.
+
+Invariant: a run either commits with its one complete, digest-sealed input snapshot, or it does not
+exist — there is no partially assembled state, and no snapshot field originates from unverified
+caller input.
+
+## Public surface
+
+- `__AssembleRunInputSnapshot(command, authorities)` — the end-to-end assembly: validate → load all
+  sources inside the admission transaction → compile, digest, and persist.
+- `FleetMembershipIdentityEnvelopeSource` — the identity port implementation: accepts only a
+  cryptographically verified fleet-membership assertion (never caller-supplied claims) and a
+  same-transaction capability-set digest.
+- `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
+  coordinates a caller supplies.
+- `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,
+  `MemoryScopeSource`, `ToolPolicySource`, `BudgetPolicySource`, `IdentityEnvelopeSource`,
+  `CapabilitySetDigestSource` — the per-input ports the OpenCrane app implements with real adapters.
+- `AssembleRunInputSnapshotResult` / `SessionAssemblyRefusalReason` — the all-or-nothing outcome and
+  its refusal vocabulary.
+
+## Boundary
+
+Consumed by the run-admission path in the OpenCrane app, which composes the ports with real
+authority adapters. It does not select a runtime driver, approve a persona, issue capabilities, or
+read mutable workspace files — and it never touches storage directly: every read goes through a
+port, and the only write goes through the [runs](../../runs/main/README.md) package's
+`RunAdmissionRepository`. Fail-closed throughout: malformed coordinates, a stale membership, a
+non-canonical digest, or any single source refusal denies the run.
+
+## Dependency direction
+
+Tagged `scope:personal-session`: it may depend only on `scope:agents`, `scope:artifacts`,
+`scope:membership`, `scope:personal-runs`, `scope:personal-session`, and `scope:shared` — never on
+apps or unrelated domains.
+
+## See also
+
+- Parent index: [agents](../../../README.md)
+- Siblings: [runs](../../runs/main/README.md) · [conversations](../../conversations/main/README.md) ·
+  [memory](../../memory/main/README.md) · [personas](../../personas/main/README.md)

--- a/libs/backend/agents/personal/session/main/README.md
+++ b/libs/backend/agents/personal/session/main/README.md
@@ -1,0 +1,7 @@
+# Personal session assembly
+
+This package creates the one immutable `RunInputSnapshot` consumed by a personal or managed-agent
+runtime. It reads injected authority ports and writes only through the injected snapshot store.
+
+It does not select a runtime driver, approve a persona, issue capabilities, or read mutable
+workspace files. The OpenCrane app will compose its ports with target authority adapters.

--- a/libs/backend/agents/personal/session/main/project.json
+++ b/libs/backend/agents/personal/session/main/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend-agents-personal-session",
+  "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/agents/personal/session/main/src",
+  "tags": ["type:lib", "layer:backend", "scope:personal-session"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/agents/personal/session/main" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/agents/personal/session/main" } }
+  }
+}

--- a/libs/backend/agents/personal/session/main/src/__tests__/fleet-membership-identity-envelope-source.test.ts
+++ b/libs/backend/agents/personal/session/main/src/__tests__/fleet-membership-identity-envelope-source.test.ts
@@ -1,9 +1,9 @@
 import type { FleetMembershipSignatureVerifier } from "@opencrane/backend/server/iam/membership";
 import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/personal/runs";
-import type { CapabilitySetDigestSource, SessionAssemblyCommand } from "./session-assembly.types.js";
+import type { CapabilitySetDigestSource, SessionAssemblyCommand } from "../session-assembly.types.js";
 import { describe, expect, it, vi } from "vitest";
 
-import { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
+import { FleetMembershipIdentityEnvelopeSource } from "../fleet-membership-identity-envelope-source.js";
 
 /** Creates one final-admission command bound to the exact signed assertion fixture. */
 function _command(): SessionAssemblyCommand

--- a/libs/backend/agents/personal/session/main/src/__tests__/session-assembly.test.ts
+++ b/libs/backend/agents/personal/session/main/src/__tests__/session-assembly.test.ts
@@ -57,6 +57,18 @@ describe("__AssembleRunInputSnapshot", function _describeSessionAssembly()
 		expect(admitted).toBe(false);
 	});
 
+	it("fails closed before persistence when a managed service carries an approved persona", async function _deniesManagedPersona()
+	{
+		let admitted = false;
+		const authorities = _Authorities(function _accept() { admitted = true; return "accepted"; });
+		authorities.runAuthority = { load: async function _load() { return { outcome: "loaded", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "managed", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "prompt-v1", trigger: "managed_invocation", delegatedUserId: null, rootRunId: "run-1", parentRunId: null } } as const; } };
+
+		const result = await __AssembleRunInputSnapshot(_COMMAND, authorities);
+
+		expect(result).toEqual({ outcome: "denied", reason: "persona_unavailable" });
+		expect(admitted).toBe(false);
+	});
+
 	it("returns a typed source refusal without accepting a partial snapshot", async function _deniesSourceRefusal()
 	{
 		let admitted = false;

--- a/libs/backend/agents/personal/session/main/src/__tests__/session-assembly.test.ts
+++ b/libs/backend/agents/personal/session/main/src/__tests__/session-assembly.test.ts
@@ -1,8 +1,8 @@
 import type { RunInputSnapshot } from "@opencrane/contracts";
-import type { SessionAssemblyAuthorities } from "./session-assembly.types.js";
+import type { SessionAssemblyAuthorities } from "../session-assembly.types.js";
 import { describe, expect, it } from "vitest";
 
-import { __AssembleRunInputSnapshot } from "./session-assembly.js";
+import { __AssembleRunInputSnapshot } from "../session-assembly.js";
 
 /** Fixed admission coordinates used to prove deterministic snapshot assembly. */
 const _COMMAND = { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1" };

--- a/libs/backend/agents/personal/session/main/src/fleet-membership-identity-envelope-source.test.ts
+++ b/libs/backend/agents/personal/session/main/src/fleet-membership-identity-envelope-source.test.ts
@@ -1,0 +1,81 @@
+import type { FleetMembershipSignatureVerifier } from "@opencrane/backend/server/iam/membership";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/personal/runs";
+import type { CapabilitySetDigestSource, SessionAssemblyCommand } from "./session-assembly.types.js";
+import { describe, expect, it, vi } from "vitest";
+
+import { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
+
+/** Creates one final-admission command bound to the exact signed assertion fixture. */
+function _command(): SessionAssemblyCommand
+{
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1" };
+}
+
+/** Creates the immutable run authority needed only to request a capability-set digest. */
+function _run(): InitialRunAuthority
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: `sha256:${"a".repeat(64)}`, promptCompilerVersion: "prompt-v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null };
+}
+
+/** Creates a verified signed revision row returned by both membership reads in one transaction. */
+function _revisionRow()
+{
+	return { id: "membership-7", revision: 7, issuerId: "fleet-1", issuerKeyId: "key-1", siloId: "silo-1", issuedAt: new Date(9000), expiresAt: new Date(20000), payloadDigest: `sha256:${"b".repeat(64)}`, signature: "signature-7", assertions: [{ assertionId: "assertion-1", siloId: "silo-1", subjectId: "user-1", scopeKind: "Project", organizationId: "org-1", scopeResourceId: "project-1" }] };
+}
+
+/** Creates the one transaction client supplied by the run-owned admission repository. */
+function _transaction(): RunAdmissionTransaction
+{
+	const row = _revisionRow();
+	return {
+		prisma: {
+			$queryRaw: vi.fn().mockResolvedValue([]),
+			verifiedFleetMembershipRevision: { findFirst: vi.fn().mockResolvedValue(row) },
+			highestAcceptedFleetMembership: { findUnique: vi.fn().mockResolvedValue(null), upsert: vi.fn().mockResolvedValue({ revision: 7 }) },
+			auditDecision: { create: vi.fn().mockResolvedValue({ id: "audit-1" }) },
+		} as never,
+		admittedAt: new Date(10000).toISOString(),
+		admittedAtEpochMs: 10000,
+	};
+}
+
+/** Verifies only a revision whose exact fields remain bound to the signature evidence. */
+class _Verifier implements FleetMembershipSignatureVerifier
+{
+	/** Returns successful evidence for the exact signed revision under test. */
+	async verify(revision: Parameters<FleetMembershipSignatureVerifier["verify"]>[0])
+	{
+		return { verified: true, issuerId: revision.issuerId, issuerKeyId: revision.issuerKeyId, revision: revision.revision, siloId: revision.siloId, payloadDigest: revision.payloadDigest, signature: revision.signature };
+	}
+}
+
+/** Capability source that returns a precomputed proof-bound digest without leaving the transaction. */
+class _CapabilitySet implements CapabilitySetDigestSource
+{
+	/** Returns the one valid digest used by this admission fixture. */
+	async load()
+	{
+		return { outcome: "loaded", value: `sha256:${"c".repeat(64)}` } as const;
+	}
+}
+
+describe("FleetMembershipIdentityEnvelopeSource", function _describeIdentityEnvelope()
+{
+	it("freezes only signed, fresh membership evidence and a same-transaction capability digest", async function _loadsVerifiedEnvelope()
+	{
+		const source = new FleetMembershipIdentityEnvelopeSource({ trustedIssuerId: "fleet-1", assertionId: "assertion-1", scope: { kind: "project", organizationId: "org-1", projectId: "project-1" }, maximumStalenessMs: 3000 }, new _Verifier(), new _CapabilitySet());
+		const transaction = _transaction();
+
+		await expect(source.load(_command(), _run(), transaction)).resolves.toEqual({ outcome: "loaded", value: { executionSubjectId: "user-1", fleetMembershipRevision: 7, fleetMembershipIssuer: "fleet-1", fleetMembershipIssuerKeyId: "key-1", fleetMembershipAssertionId: "assertion-1", fleetMembershipPayloadDigest: `sha256:${"b".repeat(64)}`, fleetMembershipTrustedUntil: new Date(12000).toISOString(), capabilitySetDigest: `sha256:${"c".repeat(64)}` } });
+		expect(transaction.prisma.$queryRaw).toHaveBeenCalledOnce();
+		expect(transaction.prisma.highestAcceptedFleetMembership.upsert).toHaveBeenCalledOnce();
+	});
+
+	it("fails closed when the capability digest is not a canonical SHA-256 value", async function _deniesInvalidCapabilityDigest()
+	{
+		const invalidCapabilitySet: CapabilitySetDigestSource = { load: async function _load() { return { outcome: "loaded", value: "not-a-digest" } as const; } };
+		const source = new FleetMembershipIdentityEnvelopeSource({ trustedIssuerId: "fleet-1", assertionId: "assertion-1", scope: { kind: "project", organizationId: "org-1", projectId: "project-1" }, maximumStalenessMs: 3000 }, new _Verifier(), invalidCapabilitySet);
+
+		await expect(source.load(_command(), _run(), _transaction())).resolves.toEqual({ outcome: "denied", reason: "identity_unavailable" });
+	});
+});

--- a/libs/backend/agents/personal/session/main/src/fleet-membership-identity-envelope-source.ts
+++ b/libs/backend/agents/personal/session/main/src/fleet-membership-identity-envelope-source.ts
@@ -1,0 +1,66 @@
+import { __VerifyCurrentFleetMembershipEvidence, PrismaFleetMembershipAuthorityRepository } from "@opencrane/backend/server/iam/membership";
+import type { FleetMembershipAdmissionExpectation, FleetMembershipSignatureVerifier } from "@opencrane/backend/server/iam/membership";
+
+import type { CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/personal/runs";
+
+/** Identity source that derives its snapshot evidence only from a signed membership revision accepted in the admission transaction. */
+export class FleetMembershipIdentityEnvelopeSource implements IdentityEnvelopeSource
+{
+	/** Signed fleet membership expectation configured by the owning control-plane composition. */
+	private readonly expectation: FleetMembershipAdmissionExpectation;
+	/** Cryptographic verifier for exact signed fleet revision envelopes. */
+	private readonly verifier: FleetMembershipSignatureVerifier;
+	/** Same-transaction capability digest authority. */
+	private readonly capabilitySet: CapabilitySetDigestSource;
+
+	/** Creates an identity source that cannot accept caller-assembled membership evidence. */
+	constructor(expectation: FleetMembershipAdmissionExpectation, verifier: FleetMembershipSignatureVerifier, capabilitySet: CapabilitySetDigestSource)
+	{
+		this.expectation = expectation;
+		this.verifier = verifier;
+		this.capabilitySet = capabilitySet;
+	}
+
+	/** Verifies membership, advances its high-watermark, and freezes the resulting signed evidence into one input. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<IdentityEnvelopeInput>>
+	{
+		// 1. Resolve the capability digest within the final transaction so a concurrent revocation cannot leave stale grants in the snapshot.
+		const capabilitySet = await this.capabilitySet.load(command, run, transaction);
+		if (capabilitySet.outcome === "denied") return capabilitySet;
+		if (!_isDigest(capabilitySet.value)) return { outcome: "denied", reason: "identity_unavailable" };
+
+		// 2. Verify the exact membership assertion and update the issuer/silo high-watermark through this same transaction client.
+		const membership = await __VerifyCurrentFleetMembershipEvidence(new PrismaFleetMembershipAuthorityRepository(transaction.prisma), this.verifier, {
+			trustedIssuerId: this.expectation.trustedIssuerId,
+			siloId: command.siloId,
+			subjectId: command.executionSubjectId,
+			assertionId: this.expectation.assertionId,
+			scope: this.expectation.scope,
+			nowEpochMs: transaction.admittedAtEpochMs,
+			maximumStalenessMs: this.expectation.maximumStalenessMs,
+		});
+		if (membership.outcome === "denied") return { outcome: "denied", reason: "membership_stale" };
+
+		// 3. Project only verifier-produced facts so the persisted snapshot cannot be fabricated by the admission caller.
+		return {
+			outcome: "loaded",
+			value: {
+				executionSubjectId: membership.evidence.subjectId,
+				fleetMembershipRevision: membership.evidence.revision,
+				fleetMembershipIssuer: membership.evidence.issuerId,
+				fleetMembershipIssuerKeyId: membership.evidence.issuerKeyId,
+				fleetMembershipAssertionId: membership.evidence.assertionId,
+				fleetMembershipPayloadDigest: membership.evidence.payloadDigest,
+				fleetMembershipTrustedUntil: new Date(membership.evidence.trustedUntilEpochMs).toISOString(),
+				capabilitySetDigest: capabilitySet.value,
+			},
+		};
+	}
+}
+
+/** Returns whether a source returned the only supported SHA-256 digest spelling. */
+function _isDigest(value: string): boolean
+{
+	return /^sha256:[0-9a-f]{64}$/.test(value);
+}

--- a/libs/backend/agents/personal/session/main/src/fleet-membership-identity-envelope-source.ts
+++ b/libs/backend/agents/personal/session/main/src/fleet-membership-identity-envelope-source.ts
@@ -1,5 +1,6 @@
 import { __VerifyCurrentFleetMembershipEvidence, PrismaFleetMembershipAuthorityRepository } from "@opencrane/backend/server/iam/membership";
 import type { FleetMembershipAdmissionExpectation, FleetMembershipSignatureVerifier } from "@opencrane/backend/server/iam/membership";
+import { ___IsSha256Digest } from "@opencrane/util";
 
 import type { CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
 import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/personal/runs";
@@ -28,7 +29,7 @@ export class FleetMembershipIdentityEnvelopeSource implements IdentityEnvelopeSo
 		// 1. Resolve the capability digest within the final transaction so a concurrent revocation cannot leave stale grants in the snapshot.
 		const capabilitySet = await this.capabilitySet.load(command, run, transaction);
 		if (capabilitySet.outcome === "denied") return capabilitySet;
-		if (!_isDigest(capabilitySet.value)) return { outcome: "denied", reason: "identity_unavailable" };
+		if (!___IsSha256Digest(capabilitySet.value)) return { outcome: "denied", reason: "identity_unavailable" };
 
 		// 2. Verify the exact membership assertion and update the issuer/silo high-watermark through this same transaction client.
 		const membership = await __VerifyCurrentFleetMembershipEvidence(new PrismaFleetMembershipAuthorityRepository(transaction.prisma), this.verifier, {
@@ -57,10 +58,4 @@ export class FleetMembershipIdentityEnvelopeSource implements IdentityEnvelopeSo
 			},
 		};
 	}
-}
-
-/** Returns whether a source returned the only supported SHA-256 digest spelling. */
-function _isDigest(value: string): boolean
-{
-	return /^sha256:[0-9a-f]{64}$/.test(value);
 }

--- a/libs/backend/agents/personal/session/main/src/fleet-membership-identity-envelope-source.ts
+++ b/libs/backend/agents/personal/session/main/src/fleet-membership-identity-envelope-source.ts
@@ -1,9 +1,9 @@
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/personal/runs";
 import { __VerifyCurrentFleetMembershipEvidence, PrismaFleetMembershipAuthorityRepository } from "@opencrane/backend/server/iam/membership";
 import type { FleetMembershipAdmissionExpectation, FleetMembershipSignatureVerifier } from "@opencrane/backend/server/iam/membership";
 import { ___IsSha256Digest } from "@opencrane/util";
 
 import type { CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
-import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/personal/runs";
 
 /** Identity source that derives its snapshot evidence only from a signed membership revision accepted in the admission transaction. */
 export class FleetMembershipIdentityEnvelopeSource implements IdentityEnvelopeSource

--- a/libs/backend/agents/personal/session/main/src/index.ts
+++ b/libs/backend/agents/personal/session/main/src/index.ts
@@ -1,0 +1,3 @@
+export { __AssembleRunInputSnapshot } from "./session-assembly.js";
+export { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
+export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/personal/session/main/src/session-assembly.test.ts
+++ b/libs/backend/agents/personal/session/main/src/session-assembly.test.ts
@@ -1,0 +1,105 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import type { SessionAssemblyAuthorities } from "./session-assembly.types.js";
+import { describe, expect, it } from "vitest";
+
+import { __AssembleRunInputSnapshot } from "./session-assembly.js";
+
+/** Fixed admission coordinates used to prove deterministic snapshot assembly. */
+const _COMMAND = { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1" };
+
+/** Builds independently fakeable authority ports with deliberately unsorted source outputs. */
+function _Authorities(onAdmission: (snapshot: RunInputSnapshot) => "accepted" | "idempotent" | "persistence_unavailable", personaRevisionId: string | null = "persona-1"): SessionAssemblyAuthorities
+{
+	return {
+		admission: {
+			admit: async function _admit(_command, build)
+			{
+				const compiled = await build({ prisma: {} as never, admittedAt: "2026-07-19T12:00:00.000Z", admittedAtEpochMs: Date.parse("2026-07-19T12:00:00.000Z") });
+				if (compiled.outcome === "denied") return { outcome: "denied", reason: compiled.reason };
+				const outcome = onAdmission(compiled.value.snapshot);
+				return outcome === "persistence_unavailable" ? { outcome: "denied", reason: outcome } as const : { outcome, snapshot: compiled.value.snapshot } as const;
+			},
+		},
+		runAuthority: { load: async function _load() { return { outcome: "loaded", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "prompt-v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null } } as const; } },
+		approvedPersona: { load: async function _load() { return { outcome: "loaded", value: { personaRevisionId } } as const; } },
+		threadContext: { load: async function _load() { return { outcome: "loaded", value: { messageIds: ["message-2", "message-1"] } } as const; } },
+		preferenceFacts: { load: async function _load() { return { outcome: "loaded", value: [{ id: "preference-2" }, { id: "preference-1" }] } as const; } },
+		memoryScope: { load: async function _load() { return { outcome: "loaded", value: { memoryQueryPolicy: { scope: "personal" }, memoryFacts: [{ datasetId: "dataset-b", factId: "fact-2", contentDigest: `sha256:${"1".repeat(64)}`, provenance: [{ sourceKind: "message", sourceId: "message-2", capturedAt: "2026-07-19T11:59:00.000Z" }] }, { datasetId: "dataset-a", factId: "fact-1", contentDigest: `sha256:${"2".repeat(64)}`, provenance: [{ sourceKind: "explicit-user-fact", sourceId: "preference-1", sourceUserId: "user-1", capturedAt: "2026-07-19T11:58:00.000Z" }] }] } } as const; } },
+		toolPolicy: { load: async function _load() { return { outcome: "loaded", value: { modelRoute: { alias: "target-model" }, toolGrantIds: ["grant-2", "grant-1"], skillRevisionIds: ["skill-2", "skill-1"], artifactRevisionIds: ["artifact-2", "artifact-1"] } } as const; } },
+		budgetPolicy: { load: async function _load() { return { outcome: "loaded", value: { budgetPolicy: { maxTokens: 1000, maxTurns: 4 } } } as const; } },
+		identityEnvelope: { load: async function _load() { return { outcome: "loaded", value: { executionSubjectId: "user-1", fleetMembershipRevision: 8, fleetMembershipIssuer: "opencrane-fleet", fleetMembershipIssuerKeyId: "key-1", fleetMembershipAssertionId: "assertion-1", fleetMembershipPayloadDigest: `sha256:${"e".repeat(64)}`, fleetMembershipTrustedUntil: "2026-07-20T13:00:00.000Z", capabilitySetDigest: `sha256:${"f".repeat(64)}` } } as const; } },
+	};
+}
+
+describe("__AssembleRunInputSnapshot", function _describeSessionAssembly()
+{
+	it("sorts independently loaded inputs and produces an identical digest for the same durable facts", async function _assemblesDeterministically()
+	{
+		const firstSnapshots: RunInputSnapshot[] = [];
+		const secondSnapshots: RunInputSnapshot[] = [];
+		const first = await __AssembleRunInputSnapshot(_COMMAND, _Authorities(function _accept(snapshot) { firstSnapshots.push(snapshot); return "accepted"; }));
+		const second = await __AssembleRunInputSnapshot(_COMMAND, _Authorities(function _accept(snapshot) { secondSnapshots.push(snapshot); return "accepted"; }));
+
+		expect(first.outcome).toBe("assembled");
+		expect(second.outcome).toBe("assembled");
+		expect(firstSnapshots[0]?.digest).toBe(secondSnapshots[0]?.digest);
+		expect(firstSnapshots[0]?.messageIds).toEqual(["message-2", "message-1"]);
+		expect(firstSnapshots[0]?.preferenceFactIds).toEqual(["preference-1", "preference-2"]);
+		expect(firstSnapshots[0]?.memoryFacts.map(function _factId(fact) { return fact.factId; })).toEqual(["fact-1", "fact-2"]);
+	});
+
+	it("fails closed before persistence when a personal service has no active approved persona", async function _deniesMissingPersona()
+	{
+		let admitted = false;
+		const result = await __AssembleRunInputSnapshot(_COMMAND, _Authorities(function _accept() { admitted = true; return "accepted"; }, null));
+
+		expect(result).toEqual({ outcome: "denied", reason: "persona_unavailable" });
+		expect(admitted).toBe(false);
+	});
+
+	it("returns a typed source refusal without accepting a partial snapshot", async function _deniesSourceRefusal()
+	{
+		let admitted = false;
+		const authorities = _Authorities(function _accept() { admitted = true; return "accepted"; });
+		authorities.memoryScope = { load: async function _load() { return { outcome: "denied", reason: "memory_scope_unavailable" } as const; } };
+
+		const result = await __AssembleRunInputSnapshot(_COMMAND, authorities);
+
+		expect(result).toEqual({ outcome: "denied", reason: "memory_scope_unavailable" });
+		expect(admitted).toBe(false);
+	});
+
+	it("accepts a non-conversational run only when it has no transcript messages", async function _assemblesNonConversationalRun()
+	{
+		const authorities = _Authorities(function _accept() { return "accepted"; });
+		authorities.threadContext = { load: async function _load() { return { outcome: "loaded", value: { messageIds: [] } } as const; } };
+
+		const result = await __AssembleRunInputSnapshot({ ..._COMMAND, threadId: null }, authorities);
+
+		expect(result.outcome).toBe("assembled");
+		if (result.outcome === "assembled") expect(result.snapshot.threadId).toBeNull();
+	});
+
+	it("returns the snapshot selected by an earlier admission without compiling a later request timestamp", async function _returnsIdempotentSnapshot()
+	{
+		let sourceLoads = 0;
+		const previous = { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", snapshotVersion: 1, threadId: "thread-1", messageIds: [], personaRevisionId: null, preferenceFactIds: [], artifactRevisionIds: [], skillRevisionIds: [], memoryFacts: [], memoryQueryPolicy: {}, toolGrantIds: [], modelRoute: {}, budgetPolicy: {}, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 1, fleetMembershipIssuer: "issuer-1", fleetMembershipIssuerKeyId: "key-1", fleetMembershipAssertionId: "assertion-1", fleetMembershipPayloadDigest: `sha256:${"a".repeat(64)}`, fleetMembershipTrustedUntil: "2026-07-21T00:00:00.000Z" }, capabilitySetDigest: `sha256:${"b".repeat(64)}`, effectiveContractDigest: `sha256:${"c".repeat(64)}`, promptCompilerVersion: "prompt-v1", digest: `sha256:${"d".repeat(64)}`, compiledAt: "2026-07-19T12:00:00.000Z" } as const;
+		const authorities = _Authorities(function _accept() { return "accepted"; });
+		authorities.admission = { admit: async function _admit() { return { outcome: "idempotent", snapshot: previous } as const; } };
+		authorities.runAuthority = { load: async function _load() { sourceLoads += 1; return { outcome: "denied", reason: "run_not_admittable" } as const; } };
+
+		await expect(__AssembleRunInputSnapshot(_COMMAND, authorities)).resolves.toEqual({ outcome: "assembled", snapshot: previous });
+		expect(sourceLoads).toBe(0);
+	});
+
+	it("rejects a blank execution subject before the admission repository starts", async function _deniesBlankSubject()
+	{
+		let admitted = false;
+		const authorities = _Authorities(function _accept() { admitted = true; return "accepted"; });
+
+		const result = await __AssembleRunInputSnapshot({ ..._COMMAND, executionSubjectId: " " }, authorities);
+
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(admitted).toBe(false);
+	});
+});

--- a/libs/backend/agents/personal/session/main/src/session-assembly.ts
+++ b/libs/backend/agents/personal/session/main/src/session-assembly.ts
@@ -1,0 +1,170 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { __DigestRunInputSnapshot } from "@opencrane/backend/agents/personal/runs";
+import { ___CanonicalizeJson } from "@opencrane/util";
+import type { JsonValue } from "@opencrane/util";
+
+import type { InitialRunAuthority } from "@opencrane/backend/agents/personal/runs";
+import type { ApprovedPersonaInput, AssembleRunInputSnapshotResult, IdentityEnvelopeInput, MemoryScopeInput, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ToolPolicyInput } from "./session-assembly.types.js";
+
+/** Stable contract version emitted by the first session assembler. */
+const _SNAPSHOT_VERSION = 1;
+
+/** Assembles and atomically persists the sole immutable runtime input for one admitted run. */
+export async function __AssembleRunInputSnapshot(command: SessionAssemblyCommand, authorities: SessionAssemblyAuthorities): Promise<AssembleRunInputSnapshotResult>
+{
+	// 1. Reject malformed coordinates before any authority read can accidentally widen its scope.
+	if (!_isCommandValid(command)) return { outcome: "denied", reason: "invalid_command" };
+
+	// 2. Resolve a duplicate before compilation, or hold the service lock while every input is revalidated.
+	const admitted = await authorities.admission.admit(command, async function _compileWithinAdmission(transaction)
+	{
+		// 3. Load the admitted run and pinned revision before any dependent authority can be resolved.
+		const run = await authorities.runAuthority.load(command, transaction);
+		if (run.outcome === "denied") return run;
+
+		// 4. Load the named approved-persona step, which is mandatory for personal runs and null for managed runs.
+		const persona = await authorities.approvedPersona.load(command, run.value, transaction);
+		if (persona.outcome === "denied") return persona;
+		if (run.value.agentKind === "personal" && persona.value.personaRevisionId === null) return { outcome: "denied", reason: "persona_unavailable" } as const;
+		if (run.value.agentKind === "managed" && persona.value.personaRevisionId !== null) return { outcome: "denied", reason: "persona_unavailable" } as const;
+
+		// 5. Freeze transcript, preferences, memory, tools, budgets, and signed identity in the same final transaction.
+		const thread = await authorities.threadContext.load(command, run.value, transaction);
+		if (thread.outcome === "denied") return thread;
+		const preferences = await authorities.preferenceFacts.load(command, run.value, transaction);
+		if (preferences.outcome === "denied") return preferences;
+		const memory = await authorities.memoryScope.load(command, run.value, transaction);
+		if (memory.outcome === "denied") return memory;
+		const tools = await authorities.toolPolicy.load(command, run.value, transaction);
+		if (tools.outcome === "denied") return tools;
+		const budget = await authorities.budgetPolicy.load(command, run.value, transaction);
+		if (budget.outcome === "denied") return budget;
+		const identity = await authorities.identityEnvelope.load(command, run.value, transaction);
+		if (identity.outcome === "denied") return identity;
+		if (command.threadId === null && thread.value.messageIds.length > 0) return { outcome: "denied", reason: "thread_unavailable" } as const;
+		if (!_isIdentityFresh(identity.value, transaction.admittedAt)) return { outcome: "denied", reason: "membership_stale" } as const;
+
+		// 6. Compile the immutable snapshot only after all source authority is revalidated at the durable fence.
+		return { outcome: "ready", value: { authority: run.value, snapshot: _compileSnapshot(command, transaction.admittedAt, run.value, persona.value, thread.value, preferences.value, memory.value, tools.value, budget.value.budgetPolicy, identity.value) } } as const;
+	});
+	if (admitted.outcome === "denied")
+	{
+		return { outcome: "denied", reason: admitted.reason === "persistence_unavailable" ? "persistence_unavailable" : admitted.reason === "authority_conflict" ? "run_not_admittable" : admitted.reason };
+	}
+	return { outcome: "assembled", snapshot: admitted.snapshot };
+}
+
+/** Returns whether a command contains valid run coordinates and one deterministic compilation instant. */
+function _isCommandValid(command: SessionAssemblyCommand): boolean
+{
+	return command.runId.trim().length > 0
+		&& command.siloId.trim().length > 0
+		&& (command.threadId === null || command.threadId.trim().length > 0)
+		&& command.executionSubjectId.trim().length > 0
+		&& command.requestIdempotencyKey.trim().length > 0;
+}
+
+/** Returns whether an instant is already the single UTC ISO-8601 representation used in a digest. */
+function _isCanonicalUtcInstant(value: string): boolean
+{
+	return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)
+		&& Number.isFinite(Date.parse(value))
+		&& new Date(value).toISOString() === value;
+}
+
+/** Verifies that pinned membership evidence is complete and remains trusted at admission time. */
+function _isIdentityFresh(identity: IdentityEnvelopeInput, requestedAt: string): boolean
+{
+	return identity.executionSubjectId.trim().length > 0
+		&& identity.fleetMembershipIssuer.trim().length > 0
+		&& identity.fleetMembershipIssuerKeyId.trim().length > 0
+		&& identity.fleetMembershipAssertionId.trim().length > 0
+		&& /^sha256:[0-9a-f]{64}$/.test(identity.fleetMembershipPayloadDigest)
+		&& /^sha256:[0-9a-f]{64}$/.test(identity.capabilitySetDigest)
+		&& Number.isSafeInteger(identity.fleetMembershipRevision)
+		&& identity.fleetMembershipRevision >= 0
+		&& _isCanonicalUtcInstant(identity.fleetMembershipTrustedUntil)
+		&& Date.parse(identity.fleetMembershipTrustedUntil) > Date.parse(requestedAt);
+}
+
+/** Maps a loader refusal into the public all-or-nothing assembly result. */
+function _denied(value: SessionAssemblyLoad<unknown>): AssembleRunInputSnapshotResult
+{
+	return value.outcome === "denied" ? { outcome: "denied", reason: value.reason } : { outcome: "denied", reason: "run_not_admittable" };
+}
+
+/** Compiles sorted source outputs into the one canonical shape and digests it without self-reference. */
+function _compileSnapshot(command: SessionAssemblyCommand, admittedAt: string, run: InitialRunAuthority, persona: ApprovedPersonaInput, thread: ThreadContextInput, preferences: readonly { readonly id: string }[], memory: MemoryScopeInput, tools: ToolPolicyInput, budgetPolicy: JsonValue, identity: IdentityEnvelopeInput): RunInputSnapshot
+{
+	const withoutDigest = {
+		runId: command.runId,
+		siloId: command.siloId,
+		agentServiceId: run.agentServiceId,
+		agentRevisionId: run.agentRevisionId,
+		snapshotVersion: _SNAPSHOT_VERSION,
+		threadId: command.threadId,
+		messageIds: [...thread.messageIds],
+		personaRevisionId: persona.personaRevisionId,
+		preferenceFactIds: _sortStrings(preferences.map(function _preferenceId(preference): string { return preference.id; })),
+		artifactRevisionIds: _sortStrings(tools.artifactRevisionIds),
+		skillRevisionIds: _sortStrings(tools.skillRevisionIds),
+		memoryFacts: _canonicalMemoryFacts(memory.memoryFacts),
+		memoryQueryPolicy: _cloneJson(memory.memoryQueryPolicy),
+		toolGrantIds: _sortStrings(tools.toolGrantIds),
+		modelRoute: _cloneJson(tools.modelRoute),
+		budgetPolicy: _cloneJson(budgetPolicy),
+		identitySnapshot: {
+			executionSubjectId: identity.executionSubjectId,
+			fleetMembershipRevision: identity.fleetMembershipRevision,
+			fleetMembershipIssuer: identity.fleetMembershipIssuer,
+			fleetMembershipIssuerKeyId: identity.fleetMembershipIssuerKeyId,
+			fleetMembershipAssertionId: identity.fleetMembershipAssertionId,
+			fleetMembershipPayloadDigest: identity.fleetMembershipPayloadDigest,
+			fleetMembershipTrustedUntil: identity.fleetMembershipTrustedUntil,
+		},
+		capabilitySetDigest: identity.capabilitySetDigest,
+		effectiveContractDigest: run.effectiveContractDigest,
+		promptCompilerVersion: run.promptCompilerVersion,
+		compiledAt: admittedAt,
+	};
+	const digest = __DigestRunInputSnapshot(withoutDigest);
+	return { ...withoutDigest, digest };
+}
+
+/** Sorts copied identifiers without mutating source-owned arrays. */
+function _sortStrings(values: readonly string[]): readonly string[]
+{
+	return [...values].sort(function _compare(left: string, right: string): number { return left.localeCompare(right); });
+}
+
+/** Sorts fact and provenance coordinates without retaining mutable authority-owned arrays. */
+function _canonicalMemoryFacts(values: RunInputSnapshot["memoryFacts"]): RunInputSnapshot["memoryFacts"]
+{
+	return [...values].sort(function _compare(left, right): number
+	{
+		return `${left.datasetId}\u0000${left.factId}\u0000${left.contentDigest}`.localeCompare(`${right.datasetId}\u0000${right.factId}\u0000${right.contentDigest}`);
+	}).map(function _canonicalFact(fact)
+	{
+		return {
+			...fact,
+			provenance: [...fact.provenance].sort(_compareProvenance).map(function _copyProvenance(provenance)
+			{
+				return { ...provenance };
+			}),
+		};
+	});
+}
+
+/** Copies JSON through RFC 8785 canonical form so later caller mutation cannot change the stored value. */
+function _cloneJson(value: JsonValue): JsonValue
+{
+	return JSON.parse(___CanonicalizeJson(value)) as JsonValue;
+}
+
+/** Orders provenance by every stable source coordinate before it contributes to the canonical digest. */
+function _compareProvenance(left: RunInputSnapshot["memoryFacts"][number]["provenance"][number], right: RunInputSnapshot["memoryFacts"][number]["provenance"][number]): number
+{
+	const leftKey = `${left.sourceKind}\u0000${left.sourceId}\u0000${left.artifactRevisionId ?? ""}\u0000${left.sourceUserId ?? ""}\u0000${left.capturedAt}`;
+	const rightKey = `${right.sourceKind}\u0000${right.sourceId}\u0000${right.artifactRevisionId ?? ""}\u0000${right.sourceUserId ?? ""}\u0000${right.capturedAt}`;
+	return leftKey.localeCompare(rightKey);
+}

--- a/libs/backend/agents/personal/session/main/src/session-assembly.ts
+++ b/libs/backend/agents/personal/session/main/src/session-assembly.ts
@@ -1,15 +1,25 @@
 import type { RunInputSnapshot } from "@opencrane/contracts";
 import { __DigestRunInputSnapshot } from "@opencrane/backend/agents/personal/runs";
-import { ___CanonicalizeJson } from "@opencrane/util";
+import { ___CloneCanonicalJson, ___SortBy } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 
 import type { InitialRunAuthority } from "@opencrane/backend/agents/personal/runs";
-import type { ApprovedPersonaInput, AssembleRunInputSnapshotResult, IdentityEnvelopeInput, MemoryScopeInput, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ToolPolicyInput } from "./session-assembly.types.js";
+import { _CanonicalMemoryFacts, _IsIdentityFresh } from "./utils/canonical-inputs.js";
+import type { ApprovedPersonaInput, AssembleRunInputSnapshotResult, IdentityEnvelopeInput, MemoryScopeInput, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyRefusalReason, ThreadContextInput, ToolPolicyInput } from "./session-assembly.types.js";
 
 /** Stable contract version emitted by the first session assembler. */
 const _SNAPSHOT_VERSION = 1;
 
-/** Assembles and atomically persists the sole immutable runtime input for one admitted run. */
+/**
+ * Admits one logical run by compiling its sole immutable `RunInputSnapshot`.
+ *
+ * The heavy lifting is delegated: this function only sequences it. Inside the admission
+ * repository's single transaction (which serializes duplicates and holds the service lock),
+ * each injected authority loads its slice of the input — run/revision, persona, thread,
+ * preferences, memory, tools, budget, signed identity — and any single refusal aborts the
+ * whole admission with that reason. Nothing is persisted unless every source loads; a
+ * duplicate `requestIdempotencyKey` returns the previously admitted snapshot untouched.
+ */
 export async function __AssembleRunInputSnapshot(command: SessionAssemblyCommand, authorities: SessionAssemblyAuthorities): Promise<AssembleRunInputSnapshotResult>
 {
 	// 1. Reject malformed coordinates before any authority read can accidentally widen its scope.
@@ -22,15 +32,17 @@ export async function __AssembleRunInputSnapshot(command: SessionAssemblyCommand
 		const run = await authorities.runAuthority.load(command, transaction);
 		if (run.outcome === "denied") return run;
 
-		// 4. Load the named approved-persona step, which is mandatory for personal runs and null for managed runs.
+		// 4. A personal run requires an approved persona; a managed run must not carry one.
 		const persona = await authorities.approvedPersona.load(command, run.value, transaction);
 		if (persona.outcome === "denied") return persona;
-		if (run.value.agentKind === "personal" && persona.value.personaRevisionId === null) return { outcome: "denied", reason: "persona_unavailable" } as const;
-		if (run.value.agentKind === "managed" && persona.value.personaRevisionId !== null) return { outcome: "denied", reason: "persona_unavailable" } as const;
+		if ((run.value.agentKind === "personal") !== (persona.value.personaRevisionId !== null)) return { outcome: "denied", reason: "persona_unavailable" } as const;
 
-		// 5. Freeze transcript, preferences, memory, tools, budgets, and signed identity in the same final transaction.
+		// 5. Freeze the transcript, rejecting messages that leaked into a non-conversational run.
 		const thread = await authorities.threadContext.load(command, run.value, transaction);
 		if (thread.outcome === "denied") return thread;
+		if (command.threadId === null && thread.value.messageIds.length > 0) return { outcome: "denied", reason: "thread_unavailable" } as const;
+
+		// 6. Freeze preferences, memory, tools, budgets, and signed identity in the same final transaction.
 		const preferences = await authorities.preferenceFacts.load(command, run.value, transaction);
 		if (preferences.outcome === "denied") return preferences;
 		const memory = await authorities.memoryScope.load(command, run.value, transaction);
@@ -41,16 +53,12 @@ export async function __AssembleRunInputSnapshot(command: SessionAssemblyCommand
 		if (budget.outcome === "denied") return budget;
 		const identity = await authorities.identityEnvelope.load(command, run.value, transaction);
 		if (identity.outcome === "denied") return identity;
-		if (command.threadId === null && thread.value.messageIds.length > 0) return { outcome: "denied", reason: "thread_unavailable" } as const;
-		if (!_isIdentityFresh(identity.value, transaction.admittedAt)) return { outcome: "denied", reason: "membership_stale" } as const;
+		if (!_IsIdentityFresh(identity.value, transaction.admittedAt)) return { outcome: "denied", reason: "membership_stale" } as const;
 
-		// 6. Compile the immutable snapshot only after all source authority is revalidated at the durable fence.
+		// 7. Compile the immutable snapshot only after all source authority is revalidated at the durable fence.
 		return { outcome: "ready", value: { authority: run.value, snapshot: _compileSnapshot(command, transaction.admittedAt, run.value, persona.value, thread.value, preferences.value, memory.value, tools.value, budget.value.budgetPolicy, identity.value) } } as const;
 	});
-	if (admitted.outcome === "denied")
-	{
-		return { outcome: "denied", reason: admitted.reason === "persistence_unavailable" ? "persistence_unavailable" : admitted.reason === "authority_conflict" ? "run_not_admittable" : admitted.reason };
-	}
+	if (admitted.outcome === "denied") return { outcome: "denied", reason: _publicReason(admitted.reason) };
 	return { outcome: "assembled", snapshot: admitted.snapshot };
 }
 
@@ -64,33 +72,10 @@ function _isCommandValid(command: SessionAssemblyCommand): boolean
 		&& command.requestIdempotencyKey.trim().length > 0;
 }
 
-/** Returns whether an instant is already the single UTC ISO-8601 representation used in a digest. */
-function _isCanonicalUtcInstant(value: string): boolean
+/** Maps the repository-internal `authority_conflict` refusal onto the public assembly vocabulary. */
+function _publicReason(reason: SessionAssemblyRefusalReason | "authority_conflict"): SessionAssemblyRefusalReason
 {
-	return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)
-		&& Number.isFinite(Date.parse(value))
-		&& new Date(value).toISOString() === value;
-}
-
-/** Verifies that pinned membership evidence is complete and remains trusted at admission time. */
-function _isIdentityFresh(identity: IdentityEnvelopeInput, requestedAt: string): boolean
-{
-	return identity.executionSubjectId.trim().length > 0
-		&& identity.fleetMembershipIssuer.trim().length > 0
-		&& identity.fleetMembershipIssuerKeyId.trim().length > 0
-		&& identity.fleetMembershipAssertionId.trim().length > 0
-		&& /^sha256:[0-9a-f]{64}$/.test(identity.fleetMembershipPayloadDigest)
-		&& /^sha256:[0-9a-f]{64}$/.test(identity.capabilitySetDigest)
-		&& Number.isSafeInteger(identity.fleetMembershipRevision)
-		&& identity.fleetMembershipRevision >= 0
-		&& _isCanonicalUtcInstant(identity.fleetMembershipTrustedUntil)
-		&& Date.parse(identity.fleetMembershipTrustedUntil) > Date.parse(requestedAt);
-}
-
-/** Maps a loader refusal into the public all-or-nothing assembly result. */
-function _denied(value: SessionAssemblyLoad<unknown>): AssembleRunInputSnapshotResult
-{
-	return value.outcome === "denied" ? { outcome: "denied", reason: value.reason } : { outcome: "denied", reason: "run_not_admittable" };
+	return reason === "authority_conflict" ? "run_not_admittable" : reason;
 }
 
 /** Compiles sorted source outputs into the one canonical shape and digests it without self-reference. */
@@ -105,14 +90,14 @@ function _compileSnapshot(command: SessionAssemblyCommand, admittedAt: string, r
 		threadId: command.threadId,
 		messageIds: [...thread.messageIds],
 		personaRevisionId: persona.personaRevisionId,
-		preferenceFactIds: _sortStrings(preferences.map(function _preferenceId(preference): string { return preference.id; })),
-		artifactRevisionIds: _sortStrings(tools.artifactRevisionIds),
-		skillRevisionIds: _sortStrings(tools.skillRevisionIds),
-		memoryFacts: _canonicalMemoryFacts(memory.memoryFacts),
-		memoryQueryPolicy: _cloneJson(memory.memoryQueryPolicy),
-		toolGrantIds: _sortStrings(tools.toolGrantIds),
-		modelRoute: _cloneJson(tools.modelRoute),
-		budgetPolicy: _cloneJson(budgetPolicy),
+		preferenceFactIds: ___SortBy(preferences.map(function _preferenceId(preference): string { return preference.id; })),
+		artifactRevisionIds: ___SortBy([...tools.artifactRevisionIds]),
+		skillRevisionIds: ___SortBy([...tools.skillRevisionIds]),
+		memoryFacts: _CanonicalMemoryFacts(memory.memoryFacts),
+		memoryQueryPolicy: ___CloneCanonicalJson(memory.memoryQueryPolicy),
+		toolGrantIds: ___SortBy([...tools.toolGrantIds]),
+		modelRoute: ___CloneCanonicalJson(tools.modelRoute),
+		budgetPolicy: ___CloneCanonicalJson(budgetPolicy),
 		identitySnapshot: {
 			executionSubjectId: identity.executionSubjectId,
 			fleetMembershipRevision: identity.fleetMembershipRevision,
@@ -129,42 +114,4 @@ function _compileSnapshot(command: SessionAssemblyCommand, admittedAt: string, r
 	};
 	const digest = __DigestRunInputSnapshot(withoutDigest);
 	return { ...withoutDigest, digest };
-}
-
-/** Sorts copied identifiers without mutating source-owned arrays. */
-function _sortStrings(values: readonly string[]): readonly string[]
-{
-	return [...values].sort(function _compare(left: string, right: string): number { return left.localeCompare(right); });
-}
-
-/** Sorts fact and provenance coordinates without retaining mutable authority-owned arrays. */
-function _canonicalMemoryFacts(values: RunInputSnapshot["memoryFacts"]): RunInputSnapshot["memoryFacts"]
-{
-	return [...values].sort(function _compare(left, right): number
-	{
-		return `${left.datasetId}\u0000${left.factId}\u0000${left.contentDigest}`.localeCompare(`${right.datasetId}\u0000${right.factId}\u0000${right.contentDigest}`);
-	}).map(function _canonicalFact(fact)
-	{
-		return {
-			...fact,
-			provenance: [...fact.provenance].sort(_compareProvenance).map(function _copyProvenance(provenance)
-			{
-				return { ...provenance };
-			}),
-		};
-	});
-}
-
-/** Copies JSON through RFC 8785 canonical form so later caller mutation cannot change the stored value. */
-function _cloneJson(value: JsonValue): JsonValue
-{
-	return JSON.parse(___CanonicalizeJson(value)) as JsonValue;
-}
-
-/** Orders provenance by every stable source coordinate before it contributes to the canonical digest. */
-function _compareProvenance(left: RunInputSnapshot["memoryFacts"][number]["provenance"][number], right: RunInputSnapshot["memoryFacts"][number]["provenance"][number]): number
-{
-	const leftKey = `${left.sourceKind}\u0000${left.sourceId}\u0000${left.artifactRevisionId ?? ""}\u0000${left.sourceUserId ?? ""}\u0000${left.capturedAt}`;
-	const rightKey = `${right.sourceKind}\u0000${right.sourceId}\u0000${right.artifactRevisionId ?? ""}\u0000${right.sourceUserId ?? ""}\u0000${right.capturedAt}`;
-	return leftKey.localeCompare(rightKey);
 }

--- a/libs/backend/agents/personal/session/main/src/session-assembly.ts
+++ b/libs/backend/agents/personal/session/main/src/session-assembly.ts
@@ -1,9 +1,9 @@
-import type { RunInputSnapshot } from "@opencrane/contracts";
 import { __DigestRunInputSnapshot } from "@opencrane/backend/agents/personal/runs";
+import type { InitialRunAuthority } from "@opencrane/backend/agents/personal/runs";
+import type { RunInputSnapshot } from "@opencrane/contracts";
 import { ___CloneCanonicalJson, ___SortBy } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 
-import type { InitialRunAuthority } from "@opencrane/backend/agents/personal/runs";
 import { _CanonicalMemoryFacts, _IsIdentityFresh } from "./utils/canonical-inputs.js";
 import type { ApprovedPersonaInput, AssembleRunInputSnapshotResult, IdentityEnvelopeInput, MemoryScopeInput, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyRefusalReason, ThreadContextInput, ToolPolicyInput } from "./session-assembly.types.js";
 

--- a/libs/backend/agents/personal/session/main/src/session-assembly.types.ts
+++ b/libs/backend/agents/personal/session/main/src/session-assembly.types.ts
@@ -1,0 +1,174 @@
+import type { MemoryFactReference, RunInputSnapshot } from "@opencrane/contracts";
+import type { InitialRunAuthority, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionTransaction } from "@opencrane/backend/agents/personal/runs";
+import type { MessageId, PersonaRevisionId } from "@opencrane/models/agents";
+import type { ArtifactRevisionId, SkillRevisionId } from "@opencrane/models/artifacts";
+import type { JsonValue } from "@opencrane/util";
+
+/** Coordinates supplied by run admission; loaders obtain every durable input themselves. */
+export type SessionAssemblyCommand = RunAdmissionCommand;
+
+/** Typed refusal that stops assembly before a partial snapshot can be persisted. */
+export type SessionAssemblyRefusalReason = "invalid_command" | "run_not_admittable" | "revision_unavailable" | "persona_unavailable" | "thread_unavailable" | "memory_scope_unavailable" | "tool_policy_unavailable" | "budget_unavailable" | "membership_stale" | "identity_unavailable" | "persistence_unavailable";
+
+/** One source read either resolves an exact input or declines it with a stable reason. */
+export type SessionAssemblyLoad<T> = { readonly outcome: "loaded"; readonly value: T } | { readonly outcome: "denied"; readonly reason: Exclude<SessionAssemblyRefusalReason, "invalid_command" | "persistence_unavailable"> };
+
+/** Approved persona evidence available to a personal runtime. */
+export interface ApprovedPersonaInput
+{
+	/** Exact active approved PersonaRevision. */
+	personaRevisionId: PersonaRevisionId | null;
+}
+
+/** Ordered persisted thread context already fenced by the conversation authority. */
+export interface ThreadContextInput
+{
+	/** Ordered message identifiers included in the runtime prompt. */
+	messageIds: readonly MessageId[];
+}
+
+/** Durable preference fact chosen for transparent prompt personalization. */
+export interface PreferenceFactInput
+{
+	/** Stable fact identifier. */
+	id: string;
+}
+
+/** Authorised memory inputs and retrieval policy frozen for a single run. */
+export interface MemoryScopeInput
+{
+	/** Policy constraining the runtime's subsequent memory recall. */
+	memoryQueryPolicy: JsonValue;
+	/** Pinned durable fact references admitted into prompt context. */
+	memoryFacts: readonly MemoryFactReference[];
+}
+
+/** Revision-assigned model, tools, skills, and immutable artifacts. */
+export interface ToolPolicyInput
+{
+	/** Server-selected model route without provider credentials. */
+	modelRoute: JsonValue;
+	/** Effective grant identifiers exposing tools to the runtime. */
+	toolGrantIds: readonly string[];
+	/** Immutable skill revisions eligible for this run. */
+	skillRevisionIds: readonly SkillRevisionId[];
+	/** Immutable artifact revisions explicitly made available to the run. */
+	artifactRevisionIds: readonly ArtifactRevisionId[];
+}
+
+/** Effective run limits resolved from service, silo, and policy. */
+export interface BudgetPolicyInput
+{
+	/** JSON-safe policy covering token, cost, duration, and tool ceilings. */
+	budgetPolicy: JsonValue;
+}
+
+/** Proof-bound identity evidence that must be fresh at admission. */
+export interface IdentityEnvelopeInput
+{
+	/** Subject authorized to cause this exact execution. */
+	executionSubjectId: string;
+	/** Highest verified fleet-membership revision used to authorize the run. */
+	fleetMembershipRevision: number;
+	/** Issuer that signed the accepted fleet-membership revision. */
+	fleetMembershipIssuer: string;
+	/** Signing key that cryptographically verified the accepted fleet-membership revision. */
+	fleetMembershipIssuerKeyId: string;
+	/** Stable signed assertion identifier bound to the execution subject. */
+	fleetMembershipAssertionId: string;
+	/** Digest of the verified signed membership payload. */
+	fleetMembershipPayloadDigest: string;
+	/** UTC expiry after which the evidence cannot admit the run. */
+	fleetMembershipTrustedUntil: string;
+	/** Digest of the effective capability set bound to the run. */
+	capabilitySetDigest: string;
+}
+
+/** Capability-set digest loaded from the same transaction that verifies membership. */
+export interface CapabilitySetDigestSource
+{
+	/** Resolves the exact proof-bound capability digest accepted for this initial run. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<string>>;
+}
+
+/** Reads run, AgentService, and published revision facts in the assembly transaction. */
+export interface RunAuthoritySource
+{
+	/** Loads only authority required to admit this exact run attempt. */
+	load(command: SessionAssemblyCommand, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<InitialRunAuthority>>;
+}
+
+/** Reads the active approved persona without reusing the persona-approval evidence path. */
+export interface ApprovedPersonaSource
+{
+	/** Loads the approved persona for a personal service or null for a managed service. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<ApprovedPersonaInput>>;
+}
+
+/** Reads the ordered transcript input for the fixed thread. */
+export interface ThreadContextSource
+{
+	/** Loads the already ordered message coordinates for this session. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<ThreadContextInput>>;
+}
+
+/** Reads explicit and accepted durable preference facts for the execution subject. */
+export interface PreferenceFactSource
+{
+	/** Loads zero or more stable preference fact identifiers. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<readonly PreferenceFactInput[]>>;
+}
+
+/** Reads authorised memory scope and pinned fact references. */
+export interface MemoryScopeSource
+{
+	/** Loads the exact memory scope allowed for this run. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<MemoryScopeInput>>;
+}
+
+/** Reads revision assignments intersected with the caller's effective grants. */
+export interface ToolPolicySource
+{
+	/** Loads only model, tool, skill, and artifact inputs the runtime may consume. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<ToolPolicyInput>>;
+}
+
+/** Reads effective resource limits for one run. */
+export interface BudgetPolicySource
+{
+	/** Loads immutable budget policy selected for this run. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<BudgetPolicyInput>>;
+}
+
+/** Reads fresh identity and membership evidence at the final admission boundary. */
+export interface IdentityEnvelopeSource
+{
+	/** Loads capability and fleet-membership facts that bind the runtime identity. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<IdentityEnvelopeInput>>;
+}
+
+/** Ports required by the one session-assembly entry point. */
+export interface SessionAssemblyAuthorities
+{
+	/** Run and snapshot admission authority. */
+	admission: RunAdmissionRepository;
+	/** Run authority revalidated only inside the admission transaction. */
+	runAuthority: RunAuthoritySource;
+	/** Approved-persona authority. */
+	approvedPersona: ApprovedPersonaSource;
+	/** Conversation transcript authority. */
+	threadContext: ThreadContextSource;
+	/** Durable preference-fact authority. */
+	preferenceFacts: PreferenceFactSource;
+	/** Memory-scope authority. */
+	memoryScope: MemoryScopeSource;
+	/** Tool and model-policy authority. */
+	toolPolicy: ToolPolicySource;
+	/** Budget authority. */
+	budgetPolicy: BudgetPolicySource;
+	/** Identity and membership authority. */
+	identityEnvelope: IdentityEnvelopeSource;
+}
+
+/** Public result from attempting to assemble and persist one immutable runtime input. */
+export type AssembleRunInputSnapshotResult = { readonly outcome: "assembled"; readonly snapshot: RunInputSnapshot } | { readonly outcome: "denied"; readonly reason: SessionAssemblyRefusalReason };

--- a/libs/backend/agents/personal/session/main/src/utils/canonical-inputs.ts
+++ b/libs/backend/agents/personal/session/main/src/utils/canonical-inputs.ts
@@ -1,0 +1,53 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { ___IsSha256Digest } from "@opencrane/util";
+
+import type { IdentityEnvelopeInput } from "../session-assembly.types.js";
+
+/** Returns whether an instant is already the single UTC ISO-8601 representation used in a digest. */
+export function _IsCanonicalUtcInstant(value: string): boolean
+{
+	return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)
+		&& Number.isFinite(Date.parse(value))
+		&& new Date(value).toISOString() === value;
+}
+
+/** Verifies that pinned membership evidence is complete and remains trusted at admission time. */
+export function _IsIdentityFresh(identity: IdentityEnvelopeInput, requestedAt: string): boolean
+{
+	return identity.executionSubjectId.trim().length > 0
+		&& identity.fleetMembershipIssuer.trim().length > 0
+		&& identity.fleetMembershipIssuerKeyId.trim().length > 0
+		&& identity.fleetMembershipAssertionId.trim().length > 0
+		&& ___IsSha256Digest(identity.fleetMembershipPayloadDigest)
+		&& ___IsSha256Digest(identity.capabilitySetDigest)
+		&& Number.isSafeInteger(identity.fleetMembershipRevision)
+		&& identity.fleetMembershipRevision >= 0
+		&& _IsCanonicalUtcInstant(identity.fleetMembershipTrustedUntil)
+		&& Date.parse(identity.fleetMembershipTrustedUntil) > Date.parse(requestedAt);
+}
+
+/** Sorts fact and provenance coordinates without retaining mutable authority-owned arrays. */
+export function _CanonicalMemoryFacts(values: RunInputSnapshot["memoryFacts"]): RunInputSnapshot["memoryFacts"]
+{
+	return [...values].sort(function _compare(left, right): number
+	{
+		return `${left.datasetId}\u0000${left.factId}\u0000${left.contentDigest}`.localeCompare(`${right.datasetId}\u0000${right.factId}\u0000${right.contentDigest}`);
+	}).map(function _canonicalFact(fact)
+	{
+		return {
+			...fact,
+			provenance: [...fact.provenance].sort(_compareProvenance).map(function _copyProvenance(provenance)
+			{
+				return { ...provenance };
+			}),
+		};
+	});
+}
+
+/** Orders provenance by every stable source coordinate before it contributes to the canonical digest. */
+function _compareProvenance(left: RunInputSnapshot["memoryFacts"][number]["provenance"][number], right: RunInputSnapshot["memoryFacts"][number]["provenance"][number]): number
+{
+	const leftKey = `${left.sourceKind}\u0000${left.sourceId}\u0000${left.artifactRevisionId ?? ""}\u0000${left.sourceUserId ?? ""}\u0000${left.capturedAt}`;
+	const rightKey = `${right.sourceKind}\u0000${right.sourceId}\u0000${right.artifactRevisionId ?? ""}\u0000${right.sourceUserId ?? ""}\u0000${right.capturedAt}`;
+	return leftKey.localeCompare(rightKey);
+}

--- a/libs/backend/agents/personal/session/main/tsconfig.json
+++ b/libs/backend/agents/personal/session/main/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/backend/agents/personal/session/main/vitest.config.ts
+++ b/libs/backend/agents/personal/session/main/vitest.config.ts
@@ -1,0 +1,14 @@
+import { createRequire } from "node:module";
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { _PackageCacheDir } from "../../../../../../vitest.cache.js";
+
+/** Node resolver used to keep one OpenTelemetry API instance in tests. */
+const require = createRequire(import.meta.url);
+
+/** Vitest configuration for deterministic session assembly. */
+export default defineConfig({
+	cacheDir: _PackageCacheDir(import.meta.url),
+	plugins: [tsconfigPaths({ projects: ["../../../../../../tsconfig.vitest.json"] })],
+	resolve: { alias: { "@opentelemetry/api": require.resolve("@opentelemetry/api") } },
+});

--- a/libs/backend/server/iam/grants/main/README.md
+++ b/libs/backend/server/iam/grants/main/README.md
@@ -33,7 +33,10 @@ Cognee — the org-memory service — in sync with those awareness grants.
 
 Invariant: the compiler is deterministic — the same grants always produce the same decision, with a
 defined precedence so overlaps never resolve ambiguously. Derived dataset membership is a projection
-of the grants, never a second source of truth.
+of the grants, never a second source of truth. Share creation, listing and revocation derive the
+sharer only from the authenticated OpenID Connect (OIDC) session subject (falling back to the email
+stored in that authenticated session when no subject is present), never from a request-body
+identity; missing identity fails with `401`.
 
 ## Public surface
 

--- a/libs/backend/server/iam/grants/main/src/routes/resource-shares.ts
+++ b/libs/backend/server/iam/grants/main/src/routes/resource-shares.ts
@@ -1,9 +1,12 @@
 import { Router, type Request } from "express";
-import { GrantScope, type PrismaClient } from "@prisma/client";
+import type { GrantScope, PrismaClient } from "@prisma/client";
 
 import { _log } from "../log.js";
 // Side-effect import: loads the express-session `SessionData.authUser` augmentation.
 import "@opencrane/server/_infra/auth";
+
+/** Prisma enum literal used as data, not a runtime value from a generated client. */
+const _PRISMA_PERSONAL_SCOPE = "Personal" as GrantScope;
 
 /** Resource kinds a user can directly share (a file or a chat/conversation). */
 const _RESOURCE_TYPES = ["file", "chat", "dataset"] as const;
@@ -90,7 +93,7 @@ export function resourceSharesRouter(prisma: PrismaClient): Router
       const created = await prisma.group.create({
         data: {
           name: groupName,
-          scope: GrantScope.Personal,
+          scope: _PRISMA_PERSONAL_SCOPE,
           description: `Direct share of ${resourceType} ${resourceId}`,
           members: Array.from(new Set([caller, recipient])),
         },
@@ -134,7 +137,7 @@ export function resourceSharesRouter(prisma: PrismaClient): Router
       return;
     }
     // Resource groups are the Personal-scoped groups named `resource:*`; filter to the caller's.
-    const groups = await prisma.group.findMany({ where: { scope: GrantScope.Personal, name: { startsWith: "resource:" } }, select: { id: true, name: true, members: true } });
+    const groups = await prisma.group.findMany({ where: { scope: _PRISMA_PERSONAL_SCOPE, name: { startsWith: "resource:" } }, select: { id: true, name: true, members: true } });
     res.json(groups.filter(function _mine(g) { return _MemberList(g.members).includes(caller); }).map(_ToResourceShare));
   });
 

--- a/libs/backend/server/iam/grants/main/src/routes/shares.ts
+++ b/libs/backend/server/iam/grants/main/src/routes/shares.ts
@@ -1,5 +1,5 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
-import { GrantAccess, GrantScope, GrantSubjectType, type GrantPayloadType, type PrismaClient } from "@prisma/client";
+import type { GrantAccess, GrantScope, GrantSubjectType, GrantPayloadType, PrismaClient } from "@prisma/client";
 
 import { compile } from "../core/grant-compiler.js";
 import { GrantCompilerAccess, GrantCompilerPayloadType } from "../core/grant-compiler.types.js";
@@ -27,11 +27,18 @@ const _PRISMA_PAYLOAD_BY_API: Record<SharePayloadType, GrantPayloadType> = {
 
 /** Map the API scope string to the Prisma GrantScope enum. */
 const _PRISMA_SCOPE_BY_API: Record<ShareScope, GrantScope> = {
-  org: GrantScope.Org,
-  department: GrantScope.Department,
-  project: GrantScope.Project,
-  personal: GrantScope.Personal,
+  org: "Org" as GrantScope,
+  department: "Department" as GrantScope,
+  project: "Project" as GrantScope,
+  personal: "Personal" as GrantScope,
 };
+
+/** Prisma enum literals used as data, not runtime values from a generated client. */
+const _GRANT_ACCESS_ALLOW = "Allow" as GrantAccess;
+/** Prisma enum literal for a reusable-group recipient. */
+const _GRANT_SUBJECT_GROUP = "Group" as GrantSubjectType;
+/** Prisma enum literal for an opaque OIDC user recipient. */
+const _GRANT_SUBJECT_USER = "User" as GrantSubjectType;
 
 /** The caller's IdP subject (OIDC sub, else verified email), or null when unauthenticated. */
 function _CallerSubject(req: Request): string | null
@@ -137,9 +144,9 @@ export function sharesRouter(prisma: PrismaClient): Router
       // 6. Idempotent on (sharedBy, payloadType, payloadId, subjectType, subjectId, scope):
       //    re-sharing the same payload to the same recipient at the same scope returns the
       //    existing grant. A different scope is a distinct share and creates a new row.
-      const subjectType = recipientType === "group" ? GrantSubjectType.Group : GrantSubjectType.User;
+      const subjectType = recipientType === "group" ? _GRANT_SUBJECT_GROUP : _GRANT_SUBJECT_USER;
       const existing = await prisma.grant.findFirst({
-        where: { sharedBy: caller, payloadType: _PRISMA_PAYLOAD_BY_API[payloadType], payloadId, subjectType, subjectId: recipientId, scope: _PRISMA_SCOPE_BY_API[scope], access: GrantAccess.Allow },
+        where: { sharedBy: caller, payloadType: _PRISMA_PAYLOAD_BY_API[payloadType], payloadId, subjectType, subjectId: recipientId, scope: _PRISMA_SCOPE_BY_API[scope], access: _GRANT_ACCESS_ALLOW },
       });
       if (existing)
       {
@@ -156,7 +163,7 @@ export function sharesRouter(prisma: PrismaClient): Router
           scope: _PRISMA_SCOPE_BY_API[scope],
           subjectType,
           subjectId: recipientId,
-          access: GrantAccess.Allow,
+          access: _GRANT_ACCESS_ALLOW,
           note: body.note,
           sharedBy: caller,
           ...(recipientType === "group" ? { groupId: recipientId } : {}),

--- a/libs/backend/server/iam/membership/main/README.md
+++ b/libs/backend/server/iam/membership/main/README.md
@@ -31,7 +31,9 @@ itself is genuine, current, and the newest one seen.
 
 **Its role:** it runs *after* identity has said who the person is and *before* authorization decides.
 It consumes the freshest locally stored signed revision plus a fresh cryptographic check of the
-signature, and hands off a trusted window (good until an expiry time) or a fail-closed denial.
+signature, and hands off either a trusted window or the complete signed evidence needed to freeze
+identity into a run snapshot. That evidence names the issuer, signing key, revision, assertion,
+subject, payload digest and trust expiry; callers cannot assemble it from request claims.
 
 It is strict in three ways worth knowing. Absence is never membership — no stored revision means
 denied, not trusted. A cached revision is trusted only until the earlier of its own signed expiry or
@@ -46,10 +48,14 @@ expired, is not stale, and is the newest accepted. If any check is uncertain, th
 
 - `__VerifyCurrentFleetMembership` — verifies the newest signed membership revision and, on success,
   atomically records its acceptance; returns a trusted window or a denial with a reason.
+- `__VerifyCurrentFleetMembershipEvidence` — performs the same fail-closed verification but returns
+  the exact signed provenance that a run may freeze into its immutable input snapshot.
 - `PrismaFleetMembershipAuthorityRepository` — the database-backed store of signed revisions and the
-  highest-accepted high-water mark, with the atomic accept-if-newer write.
+  highest-accepted high-water mark. It can own a transaction or join the run-admission transaction,
+  so the snapshot and membership high-water mark cannot commit separately.
 - Contract types: `VerifyFleetMembershipCommand`/`Result`, `FleetMembershipAuthorityRepository`,
-  `FleetMembershipSignatureVerifier`, `FleetMembershipAcceptance`/`Result`.
+  `FleetMembershipSignatureVerifier`, `FleetMembershipAcceptance`/`Result`,
+  `FleetMembershipAdmissionExpectation`, and `TrustedFleetMembershipEvidence`.
 
 ## Boundary
 
@@ -57,6 +63,10 @@ Consumed by [authorization](../../authorization/main/README.md) as its `Authoriz
 first gate. The signature verifier itself is a port supplied by the caller — this package orchestrates
 the decision but does not own the cryptography. Fail-closed: a missing revision, a verifier that
 throws, a failed check, or a concurrent-acceptance conflict all return "denied".
+
+The personal-session assembler may supply its existing Prisma transaction. In that mode this
+package must not open a nested transaction: membership acceptance, its audit decision, and the
+resulting run snapshot share one commit or rollback together.
 
 ## Dependency direction
 

--- a/libs/backend/server/iam/membership/main/src/index.ts
+++ b/libs/backend/server/iam/membership/main/src/index.ts
@@ -1,3 +1,3 @@
-export { __VerifyCurrentFleetMembership } from "./membership-authority.js";
-export type { FleetMembershipAcceptance, FleetMembershipAcceptanceResult, FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, VerifyFleetMembershipCommand, VerifyFleetMembershipResult } from "./membership-authority.types.js";
+export { __VerifyCurrentFleetMembership, __VerifyCurrentFleetMembershipEvidence } from "./membership-authority.js";
+export type { FleetMembershipAcceptance, FleetMembershipAcceptanceResult, FleetMembershipAdmissionExpectation, FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, TrustedFleetMembershipEvidence, VerifyFleetMembershipCommand, VerifyFleetMembershipEvidenceResult, VerifyFleetMembershipResult } from "./membership-authority.types.js";
 export { PrismaFleetMembershipAuthorityRepository } from "./prisma-membership-authority.js";

--- a/libs/backend/server/iam/membership/main/src/membership-authority.ts
+++ b/libs/backend/server/iam/membership/main/src/membership-authority.ts
@@ -1,6 +1,6 @@
 import { __EvaluateFleetMembershipRevision } from "@opencrane/models/authorization";
 
-import type { FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, VerifyFleetMembershipCommand, VerifyFleetMembershipResult } from "./membership-authority.types.js";
+import type { FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, VerifyFleetMembershipCommand, VerifyFleetMembershipEvidenceResult, VerifyFleetMembershipResult } from "./membership-authority.types.js";
 
 /**
  * Verifies and monotonically accepts the latest signed fleet-membership revision.
@@ -11,6 +11,14 @@ import type { FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifi
  * @returns Trusted membership window or a fail-closed denial.
  */
 export async function __VerifyCurrentFleetMembership(repository: FleetMembershipAuthorityRepository, verifier: FleetMembershipSignatureVerifier, command: VerifyFleetMembershipCommand): Promise<VerifyFleetMembershipResult>
+{
+	const result = await __VerifyCurrentFleetMembershipEvidence(repository, verifier, command);
+	if (result.outcome === "denied") return result;
+	return { outcome: "trusted", revision: result.evidence.revision, trustedUntilEpochMs: result.evidence.trustedUntilEpochMs };
+}
+
+/** Verifies current membership and returns only the signed evidence that may be frozen into a run input. */
+export async function __VerifyCurrentFleetMembershipEvidence(repository: FleetMembershipAuthorityRepository, verifier: FleetMembershipSignatureVerifier, command: VerifyFleetMembershipCommand): Promise<VerifyFleetMembershipEvidenceResult>
 {
 	// 1. Resolve only the freshest locally available signed revision; absence cannot imply membership.
 	const revision = await repository.getLatestSignedRevision(command.trustedIssuerId, command.siloId);
@@ -54,5 +62,5 @@ export async function __VerifyCurrentFleetMembership(repository: FleetMembership
 		return { outcome: "denied", reason: "acceptance_conflict", revision: revision.revision };
 	}
 
-	return { outcome: "trusted", revision: revision.revision, trustedUntilEpochMs: decision.trustedUntilEpochMs };
+	return { outcome: "trusted", evidence: { issuerId: revision.issuerId, issuerKeyId: revision.issuerKeyId, revision: revision.revision, assertionId: command.assertionId, subjectId: command.subjectId, payloadDigest: revision.payloadDigest, trustedUntilEpochMs: decision.trustedUntilEpochMs } };
 }

--- a/libs/backend/server/iam/membership/main/src/membership-authority.types.ts
+++ b/libs/backend/server/iam/membership/main/src/membership-authority.types.ts
@@ -19,6 +19,19 @@ export interface VerifyFleetMembershipCommand
 	readonly maximumStalenessMs: number;
 }
 
+/** Fixed fleet and scope policy configured before an execution subject is admitted. */
+export interface FleetMembershipAdmissionExpectation
+{
+	/** Fleet issuer trusted to sign the current membership revision. */
+	readonly trustedIssuerId: string;
+	/** Signed assertion that must authorize the execution subject. */
+	readonly assertionId: string;
+	/** Independent scope required for the admitted run. */
+	readonly scope: AuthorizationScope;
+	/** Maximum allowed age of the signed revision at the server-owned admission instant. */
+	readonly maximumStalenessMs: number;
+}
+
 /** Atomic high-watermark acceptance request after membership verification. */
 export interface FleetMembershipAcceptance
 {
@@ -55,7 +68,31 @@ export interface FleetMembershipSignatureVerifier
 	verify(revision: SignedFleetMembershipRevision): Promise<FleetSignatureVerificationEvidence>;
 }
 
+/** Complete signed membership evidence pinned by one transaction-fenced run admission. */
+export interface TrustedFleetMembershipEvidence
+{
+	/** Fleet issuer that signed and owns the accepted revision. */
+	readonly issuerId: string;
+	/** Fleet signing key that cryptographically verified the accepted revision. */
+	readonly issuerKeyId: string;
+	/** Accepted monotonic signed revision. */
+	readonly revision: number;
+	/** Exact assertion authorizing the execution subject and requested scope. */
+	readonly assertionId: string;
+	/** Subject whose membership was verified. */
+	readonly subjectId: string;
+	/** Digest of the exact signed membership payload. */
+	readonly payloadDigest: string;
+	/** UTC epoch-millisecond limit on trust for this verified evidence. */
+	readonly trustedUntilEpochMs: number;
+}
+
 /** Stable domain result for current fleet-membership trust. */
 export type VerifyFleetMembershipResult =
 	| { readonly outcome: "trusted"; readonly revision: number; readonly trustedUntilEpochMs: number }
+	| { readonly outcome: "denied"; readonly reason: FleetMembershipTrustReason | "missing_revision" | "signature_verifier_failed" | "acceptance_conflict"; readonly revision: number };
+
+/** Stable result that exposes only signed evidence produced by current membership verification. */
+export type VerifyFleetMembershipEvidenceResult =
+	| { readonly outcome: "trusted"; readonly evidence: TrustedFleetMembershipEvidence }
 	| { readonly outcome: "denied"; readonly reason: FleetMembershipTrustReason | "missing_revision" | "signature_verifier_failed" | "acceptance_conflict"; readonly revision: number };

--- a/libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts
+++ b/libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts
@@ -48,10 +48,10 @@ function _revision(row: { revision: number; issuerId: string; issuerKeyId: strin
 export class PrismaFleetMembershipAuthorityRepository implements FleetMembershipAuthorityRepository
 {
 	/** OpenCrane product-authority database client. */
-	private readonly prisma: PrismaClient;
+	private readonly prisma: PrismaClient | Prisma.TransactionClient;
 
 	/** Creates a membership adapter over canonical Postgres. */
-	constructor(prisma: PrismaClient)
+	constructor(prisma: PrismaClient | Prisma.TransactionClient)
 	{
 		this.prisma = prisma;
 	}
@@ -73,48 +73,64 @@ export class PrismaFleetMembershipAuthorityRepository implements FleetMembership
 	/** Atomically advances membership authority and appends the acceptance audit decision. */
 	async acceptRevisionAtomically(acceptance: FleetMembershipAcceptance): Promise<FleetMembershipAcceptanceResult>
 	{
-		return this.prisma.$transaction(async function _accept(transaction: Prisma.TransactionClient)
+		if (_ownsTransaction(this.prisma))
 		{
-			// 1. Serialize even the first acceptance for an issuer/silo pair, where no row exists to lock.
-			const lockKey = `${acceptance.issuerId}\u0000${acceptance.siloId}`;
-			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
-			const current = await transaction.highestAcceptedFleetMembership.findUnique({ where: { issuerId_siloId: { issuerId: acceptance.issuerId, siloId: acceptance.siloId } }, include: { verified: true } });
-			if (current !== null && (current.revision > acceptance.revision || (current.revision === acceptance.revision && current.verified.payloadDigest !== acceptance.payloadDigest)))
+			return this.prisma.$transaction(async function _accept(transaction: Prisma.TransactionClient)
 			{
-				return { status: "conflict", highestAcceptedRevision: current.revision } as const;
-			}
-			if (current?.revision === acceptance.revision) return { status: "already_accepted", highestAcceptedRevision: current.revision } as const;
-
-			// 2. Require the exact locally verified payload before moving the sole trusted projection head.
-			const revision = await transaction.verifiedFleetMembershipRevision.findFirst({ where: { issuerId: acceptance.issuerId, siloId: acceptance.siloId, revision: acceptance.revision, payloadDigest: acceptance.payloadDigest } });
-			if (revision === null) return { status: "conflict", highestAcceptedRevision: current?.revision ?? 0 } as const;
-			await transaction.highestAcceptedFleetMembership.upsert({
-				where: { issuerId_siloId: { issuerId: acceptance.issuerId, siloId: acceptance.siloId } },
-				create: { issuerId: acceptance.issuerId, siloId: acceptance.siloId, revisionId: revision.id, revision: acceptance.revision },
-				update: { revisionId: revision.id, revision: acceptance.revision, acceptedAt: new Date() },
+				return _acceptRevision(transaction, acceptance);
 			});
-
-			// 3. Append durable acceptance evidence before commit so projection and audit cannot diverge.
-			const decisionDigest = __DigestCanonicalJson({ issuerId: acceptance.issuerId, siloId: acceptance.siloId, revision: acceptance.revision, payloadDigest: acceptance.payloadDigest } as JsonValue);
-			await __AppendAuditDecision(transaction, {
-				decisionDigest,
-				siloId: acceptance.siloId,
-				actorKind: "system",
-				actorId: acceptance.issuerId,
-				resourceKind: "fleet-membership",
-				resourceId: `${acceptance.issuerId}:${acceptance.siloId}`,
-				action: "accept-revision",
-				catalogId: "fleet-membership",
-				catalogRevision: acceptance.revision,
-				catalogDigest: acceptance.payloadDigest,
-				argumentsDigest: acceptance.payloadDigest,
-				policyRevisionHash: acceptance.payloadDigest,
-				effectiveAuthorizationDigest: acceptance.payloadDigest,
-				membershipRevision: acceptance.revision,
-				outcome: "allow",
-				reasonCode: "verified_revision_accepted",
-			});
-			return { status: "accepted", highestAcceptedRevision: acceptance.revision } as const;
-		});
+		}
+		return _acceptRevision(this.prisma, acceptance);
 	}
+}
+
+/** Returns whether a Prisma endpoint can open an independent database transaction. */
+function _ownsTransaction(prisma: PrismaClient | Prisma.TransactionClient): prisma is PrismaClient
+{
+	return "$transaction" in prisma;
+}
+
+/** Advances the membership high-watermark and audit inside the caller's already selected transaction. */
+async function _acceptRevision(transaction: Prisma.TransactionClient, acceptance: FleetMembershipAcceptance): Promise<FleetMembershipAcceptanceResult>
+{
+	// 1. Serialize even the first acceptance for an issuer/silo pair, where no row exists to lock.
+	const lockKey = `${acceptance.issuerId}\u0000${acceptance.siloId}`;
+	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
+	const current = await transaction.highestAcceptedFleetMembership.findUnique({ where: { issuerId_siloId: { issuerId: acceptance.issuerId, siloId: acceptance.siloId } }, include: { verified: true } });
+	if (current !== null && (current.revision > acceptance.revision || (current.revision === acceptance.revision && current.verified.payloadDigest !== acceptance.payloadDigest)))
+	{
+		return { status: "conflict", highestAcceptedRevision: current.revision } as const;
+	}
+	if (current?.revision === acceptance.revision) return { status: "already_accepted", highestAcceptedRevision: current.revision } as const;
+
+	// 2. Require the exact locally verified payload before moving the sole trusted projection head.
+	const revision = await transaction.verifiedFleetMembershipRevision.findFirst({ where: { issuerId: acceptance.issuerId, siloId: acceptance.siloId, revision: acceptance.revision, payloadDigest: acceptance.payloadDigest } });
+	if (revision === null) return { status: "conflict", highestAcceptedRevision: current?.revision ?? 0 } as const;
+	await transaction.highestAcceptedFleetMembership.upsert({
+		where: { issuerId_siloId: { issuerId: acceptance.issuerId, siloId: acceptance.siloId } },
+		create: { issuerId: acceptance.issuerId, siloId: acceptance.siloId, revisionId: revision.id, revision: acceptance.revision },
+		update: { revisionId: revision.id, revision: acceptance.revision, acceptedAt: new Date() },
+	});
+
+	// 3. Append durable acceptance evidence before commit so projection and audit cannot diverge.
+	const decisionDigest = __DigestCanonicalJson({ issuerId: acceptance.issuerId, siloId: acceptance.siloId, revision: acceptance.revision, payloadDigest: acceptance.payloadDigest } as JsonValue);
+	await __AppendAuditDecision(transaction, {
+		decisionDigest,
+		siloId: acceptance.siloId,
+		actorKind: "system",
+		actorId: acceptance.issuerId,
+		resourceKind: "fleet-membership",
+		resourceId: `${acceptance.issuerId}:${acceptance.siloId}`,
+		action: "accept-revision",
+		catalogId: "fleet-membership",
+		catalogRevision: acceptance.revision,
+		catalogDigest: acceptance.payloadDigest,
+		argumentsDigest: acceptance.payloadDigest,
+		policyRevisionHash: acceptance.payloadDigest,
+		effectiveAuthorizationDigest: acceptance.payloadDigest,
+		membershipRevision: acceptance.revision,
+		outcome: "allow",
+		reasonCode: "verified_revision_accepted",
+	});
+	return { status: "accepted", highestAcceptedRevision: acceptance.revision } as const;
 }

--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -36,7 +36,10 @@ Two halves:
 **In this flow:** [models/agents](../models/agents/main/README.md) · [models/authorization](../models/authorization/main/README.md) *(re-exported DTOs)* · the `apps/opencrane` server *(spec producer)*
 
 Invariant: the client's types are a faithful projection of the server's published spec — regenerate
-after any API change so the two never silently diverge.
+after any API change so the two never silently diverge. `RunInputSnapshot` is the cross-domain
+record of one run's frozen persona, transcript, memory references, tools, budgets, model route and
+verified identity provenance; it carries only immutable coordinates and canonical JSON, never
+provider credentials or mutable source objects.
 
 ## Public surface
 
@@ -44,7 +47,9 @@ after any API change so the two never silently diverge.
 - Hand-written DTOs/enums: `Grant`/`GrantScope`/`GrantAccess`, `Group`, `ClusterTenant*`,
   `McpServer*`/`Mcp*` operator types (MCP — the Model Context Protocol for connecting external tools),
   model-routing types, `Memory*`, `Approval`, `ThirdPartySource*`, `RuntimeAssignment`,
-  `RunInputSnapshot`, `TenantModelSet`, domain-topology host builders.
+  `RunInputSnapshot`/`RunInputSnapshotIdentity`, `MemoryFactReference`, `TenantModelSet`, and
+  domain-topology host builders. A memory fact reference pins an immutable content digest and its
+  provenance rather than a mutable revision counter.
 - Re-exported model types: the agent, artifact, authorization, and platform-policy DTOs.
 
 ## Boundary

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -52,7 +52,7 @@ export {
   type ProviderKeyStatus,
 } from "./model-routing.types.js";
 export { type DurableStatePolicy, type PlatformPolicy, type RuntimeFilesystemPolicy, type SiloUpdatePolicy } from "@opencrane/models/platform-policy";
-export { type RunInputSnapshot } from "./run-input-snapshot.types.js";
+export { type RunInputSnapshot, type RunInputSnapshotIdentity } from "./run-input-snapshot.types.js";
 export { type RuntimeAssignment } from "./runtime-assignment.types.js";
 export { type TenantModelSet } from "./tenant-models.types.js";
 export {

--- a/libs/contracts/src/memory.types.ts
+++ b/libs/contracts/src/memory.types.ts
@@ -39,15 +39,15 @@ export interface MemoryProvenance
   capturedAt: string;
 }
 
-/** Stable reference to one revision of a durable memory fact. */
+/** Stable reference to one immutable durable memory-fact catalog row. */
 export interface MemoryFactReference
 {
   /** Dataset containing the fact. */
   datasetId: string;
   /** Stable fact identifier. */
   factId: string;
-  /** Monotonically increasing fact revision. */
-  revision: number;
+  /** Immutable content digest recorded by the authoritative memory-fact catalog row. */
+  contentDigest: string;
   /** Provenance supporting the referenced fact. */
   provenance: MemoryProvenance[];
 }
@@ -57,7 +57,7 @@ export interface MemoryMutationRequest
 {
   /** Requested mutation. */
   kind: MemoryMutationKind;
-  /** Exact fact revision being changed. */
+  /** Exact immutable memory-fact catalog coordinate being changed. */
   fact: MemoryFactReference;
   /** User requesting the mutation. */
   requestedByUserId: UserId;

--- a/libs/contracts/src/run-input-snapshot.types.ts
+++ b/libs/contracts/src/run-input-snapshot.types.ts
@@ -1,32 +1,70 @@
 import type { AgentRevisionId, AgentRunId, AgentServiceId, MessageId, PersonaRevisionId, ThreadId } from "@opencrane/models/agents";
 import type { ArtifactRevisionId, SkillRevisionId } from "@opencrane/models/artifacts";
+import type { JsonValue } from "@opencrane/util";
 import type { MemoryFactReference } from "./memory.types.js";
+
+/** Immutable identity facts resolved before a runtime receives the snapshot. */
+export interface RunInputSnapshotIdentity
+{
+  /** Subject that caused this exact run to execute. */
+  executionSubjectId: string;
+  /** Highest verified fleet-membership revision accepted for this run. */
+  fleetMembershipRevision: number;
+  /** Issuer that signed the accepted fleet-membership revision. */
+  fleetMembershipIssuer: string;
+  /** Signing key that verified the exact accepted fleet-membership revision. */
+  fleetMembershipIssuerKeyId: string;
+  /** Stable signed assertion identifier bound to the execution subject. */
+  fleetMembershipAssertionId: string;
+  /** Digest of the verified signed membership payload. */
+  fleetMembershipPayloadDigest: string;
+  /** UTC expiry after which the pinned membership evidence must not admit work. */
+  fleetMembershipTrustedUntil: string;
+}
 
 /** Deterministic, immutable inputs compiled before a runtime assignment. */
 export interface RunInputSnapshot
 {
   /** Run receiving the snapshot. */
   runId: AgentRunId;
+  /** Silo in which every identity and durable input is valid. */
+  siloId: string;
   /** AgentService receiving the run. */
   agentServiceId: AgentServiceId;
   /** Immutable AgentRevision being executed. */
   agentRevisionId: AgentRevisionId;
-  /** Thread supplying ordered conversation history. */
-  threadId: ThreadId;
+  /** Monotonically versioned snapshot contract shape. */
+  snapshotVersion: number;
+  /** Thread supplying ordered conversation history, or null for a non-conversational run. */
+  threadId: ThreadId | null;
   /** Ordered persisted messages included in the prompt. */
-  messageIds: MessageId[];
+  messageIds: readonly MessageId[];
   /** Approved persona revision compiled into the prompt, when personal. */
-  personaRevisionId?: PersonaRevisionId;
+  personaRevisionId: PersonaRevisionId | null;
+  /** Ordered durable preference facts considered for this run. */
+  preferenceFactIds: readonly string[];
   /** Immutable artifact revisions made available to the run. */
-  artifactRevisionIds: ArtifactRevisionId[];
+  artifactRevisionIds: readonly ArtifactRevisionId[];
   /** Immutable skill revisions made available to the run. */
-  skillRevisionIds: SkillRevisionId[];
+  skillRevisionIds: readonly SkillRevisionId[];
   /** Scoped durable memory facts included in the prompt. */
-  memoryFacts: MemoryFactReference[];
-  /** Highest verified fleet-membership revision used for authorization. */
-  fleetMembershipRevision: number;
+  memoryFacts: readonly MemoryFactReference[];
+  /** Authorised memory retrieval policy selected for this run. */
+  memoryQueryPolicy: JsonValue;
+  /** Immutable grants that expose tools to the selected revision. */
+  toolGrantIds: readonly string[];
+  /** Server-selected model route without provider credentials. */
+  modelRoute: JsonValue;
+  /** Immutable token, cost, time, and tool limits. */
+  budgetPolicy: JsonValue;
+  /** Execution identity and verified fleet-membership evidence. */
+  identitySnapshot: RunInputSnapshotIdentity;
   /** Digest of the effective proof-bound capability set. */
   capabilitySetDigest: string;
+  /** Digest of the effective contract accepted at run admission. */
+  effectiveContractDigest: string;
+  /** Version of the deterministic prompt compiler that will consume this input. */
+  promptCompilerVersion: string;
   /** SHA-256 digest of the complete canonical snapshot in `sha256:<hex>` form. */
   digest: string;
   /** ISO-8601 compilation time. */

--- a/libs/util/README.md
+++ b/libs/util/README.md
@@ -17,9 +17,13 @@ It owns two things:
 - **Canonical JSON** — `___CanonicalizeJson` serialises a JSON value to the one canonical string
   form defined by RFC 8785 (JSON Canonicalization Scheme): object keys sorted, whitespace and number
   formatting fixed. Two values that are equal produce byte-identical text, which is what makes a
-  stable hash possible. The type `CanonicalJsonSha256Digest` is the template-literal string type
+  stable hash possible. `___CloneCanonicalJson` round-trips through that form to produce a detached,
+  JSON-equivalent value; callers must canonicalise again when deterministic bytes or key order matter.
+  The type `CanonicalJsonSha256Digest` is the template-literal string type
   `` `sha256:${string}` `` — an explicitly encoded digest, so a hash of canonical bytes is never
   confused with an arbitrary string.
+- **Digest grammar** — `___IsSha256Digest` accepts only `sha256:` plus 64 lowercase hexadecimal
+  characters, keeping digests exchanged between authorities in one fail-closed spelling.
 
 Widely used where a **deterministic** result matters — most importantly the authorization model,
 which digests capability catalogues and request arguments so a signature can bind to exact bytes.
@@ -30,12 +34,15 @@ platform-wide API. Invariant: purity and determinism — no hidden inputs, same 
 
 - `___SortBy`, `___SomeArray`, `___SomeRecord` — collection helpers.
 - `___CanonicalizeJson` — RFC 8785 canonical JSON serialisation.
+- `___CloneCanonicalJson` — detached deep copy through the canonical JSON representation.
+- `___IsSha256Digest` — strict validator for the platform's lowercase SHA-256 digest grammar.
 - `JsonValue`, `JsonPrimitive`, `CanonicalJsonSha256Digest` — JSON and digest types.
 
 ## Boundary
 
-Pure and dependency-free: it may not import any other package, and it does no I/O. It provides
-building blocks; hashing the canonical bytes and any storage stay with the caller.
+Pure and dependency-free: it may not import any other package, and it does no I/O. It validates
+digest spelling but does not decide what a digest means; hashing canonical bytes and persistence
+remain with the owning domain.
 
 ## Dependency direction
 

--- a/libs/util/src/digest.ts
+++ b/libs/util/src/digest.ts
@@ -1,0 +1,17 @@
+/**
+ * Digest-string helpers shared by every package that exchanges content digests.
+ */
+
+/** The one supported digest spelling: `sha256:` followed by 64 lowercase hex characters. */
+const _SHA256_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+
+/**
+ * Tests whether a string is the canonical `sha256:<64 lowercase hex>` digest spelling.
+ * Uppercase hex, other algorithms, and bare hex without the prefix all fail closed.
+ * @param value - Candidate digest string.
+ * @returns True only for the canonical spelling.
+ */
+export function ___IsSha256Digest(value: string): boolean
+{
+	return _SHA256_DIGEST_PATTERN.test(value);
+}

--- a/libs/util/src/index.ts
+++ b/libs/util/src/index.ts
@@ -2,5 +2,6 @@
  * @opencrane/util — public barrel.
  */
 export * from "./collections.js";
+export * from "./digest.js";
 export * from "./json-canonicalization.js";
 export * from "./json-canonicalization.types.js";

--- a/libs/util/src/json-canonicalization.ts
+++ b/libs/util/src/json-canonicalization.ts
@@ -180,3 +180,14 @@ export function ___CanonicalizeJson(value: JsonValue): string
 {
 	return _serializeValue(value, new WeakSet<object>());
 }
+
+/**
+ * Deep-copies a JSON value through its RFC 8785 canonical form, so the copy is
+ * detached from caller-owned references and key order is deterministic.
+ * @param value - JSON value to copy.
+ * @returns An equivalent value that shares no references with the input.
+ */
+export function ___CloneCanonicalJson(value: JsonValue): JsonValue
+{
+	return JSON.parse(___CanonicalizeJson(value)) as JsonValue;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,18 @@
         "node": ">=22"
       }
     },
+    "apps/artifact-service": {
+      "name": "@opencrane/artifact-service",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/auto-instrumentations-node": "^0.78.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
+        "@opentelemetry/sdk-node": "^0.220.0",
+        "pino": "^9.6.0"
+      }
+    },
     "apps/channel-proxy": {
       "name": "@opencrane/channel-proxy",
       "version": "0.1.0",
@@ -7270,6 +7282,10 @@
         "tslib": "^2.3.0",
         "yargs-parser": "21.1.1"
       }
+    },
+    "node_modules/@opencrane/artifact-service": {
+      "resolved": "apps/artifact-service",
+      "link": true
     },
     "node_modules/@opencrane/channel-proxy": {
       "resolved": "apps/channel-proxy",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "npm run db:generate -w @opencrane/server && nx run-many -t build",
+    "build": "nx run-many -t build",
     "dev": "nx run-many -t dev --parallel=10",
     "test": "nx run-many -t test",
     "test:e2e:k3d": "./apps/_infra/deploy-k8s/platform/tests/k3d-e2e.sh",

--- a/scripts/agent-style-check.sh
+++ b/scripts/agent-style-check.sh
@@ -22,6 +22,8 @@
 #   TYPES-IN-IMPL     exported interface/type outside a *.types.ts file
 #   JSDOC             exported declaration with no JSDoc directly above (heuristic)
 #   BRACE             opening { not on its own line for a multi-line fn/class (heuristic)
+#   MISSING-README    new/changed package (project.json) with no sibling README.md
+#   README-SECTIONS   leaf package README missing a mandatory package-docs section
 
 set -euo pipefail
 
@@ -50,11 +52,6 @@ for f in "${FILES[@]:-}"; do
 	CHECKABLE+=("$f")
 done
 
-if [[ ${#CHECKABLE[@]} -eq 0 ]]; then
-	echo "agent-style-check: no checkable TypeScript files in scope."
-	exit 0
-fi
-
 ERRORS=0
 WARNS=0
 
@@ -64,6 +61,47 @@ _report()
 	printf '%s:%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"
 	if [[ "$3" == "ERROR" ]]; then ERRORS=$((ERRORS + 1)); else WARNS=$((WARNS + 1)); fi
 }
+
+# MISSING-README / README-SECTIONS — package docs (docs/agents/package-docs.md).
+# A changed package must ship a README, and a changed leaf-package README must
+# carry the mandatory sections. Diff-scoped like the .ts checks; skipped when
+# explicit files were passed.
+DOC_FILES=()
+if [[ $# -eq 0 ]]; then
+	while IFS= read -r f; do DOC_FILES+=("$f"); done < <(git diff --name-only --diff-filter=ACMR HEAD -- 'libs/**/README.md' 'apps/**/README.md' 'libs/**/project.json' 'apps/**/project.json' 2>/dev/null || true)
+elif [[ "${1:-}" == "--diff" ]]; then
+	while IFS= read -r f; do DOC_FILES+=("$f"); done < <(git diff --name-only --diff-filter=ACMR "$2" -- 'libs/**/README.md' 'apps/**/README.md' 'libs/**/project.json' 'apps/**/project.json' 2>/dev/null || true)
+fi
+for f in "${DOC_FILES[@]:-}"; do
+	[[ -z "$f" || ! -f "$f" ]] && continue
+	dir="$(dirname "$f")"
+	case "$f" in
+		*/project.json)
+			if [[ ! -f "$dir/README.md" ]]; then
+				_report "$f" 1 ERROR MISSING-README "package has no README.md — create it from docs/agents/README-TEMPLATE.md"
+			fi
+			;;
+		*/README.md)
+			# Only leaf packages (the directory owning project.json) follow the
+			# fixed section order; group/area index READMEs have their own shape.
+			[[ -f "$dir/project.json" ]] || continue
+			if ! head -5 "$f" | grep -q '^> '; then
+				_report "$f" 1 ERROR README-SECTIONS "missing breadcrumb line ('> area > group > package') — see docs/agents/package-docs.md"
+			fi
+			for section in "## What it owns" "## Public surface" "## See also"; do
+				if ! grep -q "^${section}" "$f"; then
+					_report "$f" 1 ERROR README-SECTIONS "missing mandatory section '${section}' — see docs/agents/package-docs.md"
+				fi
+			done
+			;;
+	esac
+done
+
+if [[ ${#CHECKABLE[@]} -eq 0 ]]; then
+	echo "agent-style-check: no checkable TypeScript files in scope."
+	[[ $ERRORS -gt 0 ]] && exit 1
+	exit 0
+fi
 
 for f in "${CHECKABLE[@]}"; do
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -106,6 +106,9 @@
       "@opencrane/backend/server/agents/skills": [
         "./libs/backend/server/agents/skills/main/src/index.ts"
       ],
+      "@opencrane/backend/agents/personal/session": [
+        "./libs/backend/agents/personal/session/main/src/index.ts"
+      ],
       "@opencrane/backend/server/reporting/spend": [
         "./libs/backend/server/reporting/spend/main/src/index.ts"
       ],


### PR DESCRIPTION
## Why this phase exists

An agent run must execute against one stable set of inputs. If its persona, conversation history, memory, tools, budget, membership, or model policy can change between acceptance and execution, the runtime may do something different from what the user and platform authorised.

This PR gives every logical run one immutable, digest-sealed `RunInputSnapshot`. Duplicate delivery returns the first accepted snapshot instead of silently recompiling against newer state.

## What changes for users and operators

Once a run is accepted:

- its approved persona and conversation context are fixed;
- memory and artifact references identify the exact accepted content;
- tool grants, skills, model route, capabilities, and budget are fixed;
- execution identity comes from verified signed fleet-membership evidence;
- retries keep the same logical run and frozen inputs;
- duplicate requests cannot create competing runs or snapshots.

That makes a run reproducible for execution, reconnect, audit, retry, and failure analysis.

## Admission flow

```text
verified run request + idempotency key
                |
                v
       existing admission? ---- yes ---> return first snapshot
                |
                no
                v
       lock the selected AgentService
                |
                v
revalidate persona + thread + preferences + memory + tools + budget + membership
                |
                v
      canonicalise and digest the snapshot
                |
                v
commit AgentRun + RunInputSnapshot + acceptance/dispatch events together
```

The personal-session package gathers each input through its owning authority. The personal-runs package owns the transaction and persistence boundary. Missing, stale, malformed, or conflicting authority input refuses the whole admission; no partial snapshot is stored.

## Trust and persistence boundary

- Caller-supplied identity claims never become snapshot membership evidence.
- A personal run requires an approved persona; a managed run cannot carry one.
- Non-conversational runs cannot silently include thread messages.
- The digest covers every snapshot field except the self-referential digest itself.
- A run and its matching snapshot either commit together or both roll back.
- This change does not launch a runtime, choose a runtime driver, or grant Kubernetes authority.

The clean-build Prisma baseline uses the final contract directly; no compatibility migration or legacy data path is introduced.

## Validation and review

- Focused personal-run, session, authority, contract, and OpenCrane suites passed, including both persistence-failure paths
- TypeScript compilation for all affected packages
- OpenCrane production build
- Prisma generate and validate
- Test-placement guard: all introduced TypeScript tests are under `__tests__/`
- Agent style and diff checks passed
- Nx now generates Prisma once before concurrent build/test/lint tasks, preventing transient empty-client type failures
- Independent documentation/source review passed after correcting two overstated README claims
- Local Claude Code review passed after adding structured, redacted persistence-failure logging and duplicate-recovery coverage
- The live PostgreSQL authority fixture remains part of CI

## Stack position

Base: `own-personal-ai-agent-setup`.
