### PR TITLE
📝 enforce tests under __tests__/, not co-located

### DIFF
--- a/docs/agents/typescript.md
+++ b/docs/agents/typescript.md
@@ -69,9 +69,9 @@ line). Use its output to populate the table; do **not** rely on "it feels right"
 
 When a coding turn writes or edits `.ts` files, include a compact compliance table in the response:
 
-| File | No standalone `=>` | Imports single-line at top | All declarations JSDoc (incl. properties) | Types in `*.types.ts` | Naming convention |
-|---|---|---|---|---|---|
-| `example.ts` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| File | No standalone `=>` | Imports single-line at top | All declarations JSDoc (incl. properties) | Types in `*.types.ts` | Naming convention | New test under `__tests__/` |
+|---|---|---|---|---|---|---|
+| `example.ts` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 Rules to check:
 
@@ -80,6 +80,7 @@ Rules to check:
 3. **JSDoc on every declaration, including every interface property and every class field** — not just the enclosing type or class.
 4. **Exported interfaces and type aliases in `*.types.ts`** — not in the implementation file.
 5. **Function naming** — file-private: `_camelCase`; same-package export: `_PascalCase`; same-domain: `__PascalCase`; wide/global: `___PascalCase`.
+6. **New tests under `__tests__/`** — a `*.test.ts` co-located next to the source file it tests, instead of under a `__tests__` directory, is a violation. See [Test File Location](#test-file-location).
 
 The compliance table is **not** optional when TypeScript files were modified. If the table would be incomplete, fix the violations first.
 
@@ -206,6 +207,27 @@ export function _Resolve(): ResolveResult
 {
 	return { status: "ok" };
 }
+```
+
+## Test File Location
+
+Test files live under a `__tests__` directory next to the source they cover, never co-located as
+a sibling `*.test.ts` file.
+
+- `src/foo.ts` is tested by `src/__tests__/foo.test.ts`, not `src/foo.test.ts`.
+- Fix relative imports accordingly (`./foo.js` becomes `../foo.js` once the test moves down a
+  directory level).
+- Checked mechanically by `scripts/agent-style-check.sh` (`TEST-LOCATION`) — a co-located
+  `*.test.ts` is an ERROR, not a style suggestion.
+
+```typescript
+// WRONG
+// libs/backend/example/main/src/widget.test.ts
+import { Widget } from "./widget.js";
+
+// CORRECT
+// libs/backend/example/main/src/__tests__/widget.test.ts
+import { Widget } from "../widget.js";
 ```
 
 ## Custom HTTP Response Headers

--- a/scripts/agent-style-check.sh
+++ b/scripts/agent-style-check.sh
@@ -22,6 +22,7 @@
 #   TYPES-IN-IMPL     exported interface/type outside a *.types.ts file
 #   JSDOC             exported declaration with no JSDoc directly above (heuristic)
 #   BRACE             opening { not on its own line for a multi-line fn/class (heuristic)
+#   TEST-LOCATION     *.test.ts file not placed under a __tests__ directory
 
 set -euo pipefail
 
@@ -50,11 +51,6 @@ for f in "${FILES[@]:-}"; do
 	CHECKABLE+=("$f")
 done
 
-if [[ ${#CHECKABLE[@]} -eq 0 ]]; then
-	echo "agent-style-check: no checkable TypeScript files in scope."
-	exit 0
-fi
-
 ERRORS=0
 WARNS=0
 
@@ -64,6 +60,27 @@ _report()
 	printf '%s:%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5"
 	if [[ "$3" == "ERROR" ]]; then ERRORS=$((ERRORS + 1)); else WARNS=$((WARNS + 1)); fi
 }
+
+# TEST-LOCATION — every *.test.ts must live under a __tests__ directory,
+# never co-located next to the source file it tests. Runs against the raw
+# FILES list since test files are otherwise excluded from CHECKABLE below.
+for f in "${FILES[@]:-}"; do
+	[[ -z "$f" || ! -f "$f" ]] && continue
+	case "$f" in
+		*.test.ts)
+			case "$f" in
+				*/__tests__/*) : ;;
+				*) _report "$f" 1 ERROR TEST-LOCATION "test file not under __tests__/ — move it there and fix relative imports" ;;
+			esac
+			;;
+	esac
+done
+
+if [[ ${#CHECKABLE[@]} -eq 0 ]]; then
+	echo "agent-style-check: no checkable TypeScript files in scope."
+	[[ $ERRORS -gt 0 ]] && exit 1
+	exit 0
+fi
 
 for f in "${CHECKABLE[@]}"; do
 


### PR DESCRIPTION
## Summary

- PR #312 added three `*.test.ts` files co-located next to their source (`prisma-run-admission-repository.test.ts`, `fleet-membership-identity-envelope-source.test.ts`, `session-assembly.test.ts`) instead of under `__tests__/`, which every other package in the repo follows (110 existing tests vs. 1 pre-existing exception). Moved those three in #312 directly and fixed the resulting relative imports.
- This PR closes the gap that let it happen: documents the convention in `docs/agents/typescript.md` (new "Test File Location" section + rule 6 + compliance-table column) and adds a mechanical `TEST-LOCATION` check to `scripts/agent-style-check.sh`, so both Codex and Claude Code agents get an ERROR instead of relying on eyeballing.

## Test plan

- `bash -n scripts/agent-style-check.sh`
- Ran the script against a fixture with a co-located `*.test.ts` — flags `TEST-LOCATION` ERROR; a `__tests__/`-placed test in the same fixture passes clean.
- Ran the script against the now-fixed PR #312 branch diff (`--diff HEAD~1`) — zero findings.