### PR TITLE
📝 Website: child runs + agent skills (target design)

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -34,7 +34,8 @@ export default defineConfig({
         items: [
           { text: 'Employee assistants', link: '/guide/first-tenant' },
           { text: 'Organize your company', link: '/guide/organize' },
-          { text: 'Share skills', link: '/guide/skills' },
+          { text: 'Agent skills', link: '/guide/skills' },
+          { text: 'Agent delegation (child runs)', link: '/guide/child-runs' },
           { text: 'Manage tools (MCP)', link: '/guide/tools' },
           { text: 'Organizational knowledge', link: '/guide/knowledge' },
           { text: 'Control access', link: '/guide/permissions' },
@@ -81,7 +82,8 @@ export default defineConfig({
         items: [
           { text: 'Employee assistants', link: '/guide/first-tenant' },
           { text: 'Organize your company', link: '/guide/organize' },
-          { text: 'Share skills across teams', link: '/guide/skills' },
+          { text: 'Agent skills', link: '/guide/skills' },
+          { text: 'Agent delegation (child runs)', link: '/guide/child-runs' },
           { text: 'Manage tools (MCP)', link: '/guide/tools' },
           { text: 'Organizational knowledge', link: '/guide/knowledge' },
           { text: 'Control who can access what', link: '/guide/permissions' },

--- a/website/advanced/architecture.md
+++ b/website/advanced/architecture.md
@@ -102,7 +102,7 @@ A new assistant can chat, but it can't reach any skill, tool, or knowledge until
 </svg>
 </figure>
 
-→ Learn how in [Control access](/guide/permissions), [Share skills](/guide/skills),
+→ Learn how in [Control access](/guide/permissions), [Agent skills](/guide/skills),
 [Manage tools](/guide/tools), and [Organizational knowledge](/guide/knowledge).
 
 ## Built identity-first

--- a/website/guide/child-runs.md
+++ b/website/guide/child-runs.md
@@ -1,0 +1,112 @@
+# Agent delegation (child runs)
+
+Your assistant does not have to do everything itself. It can delegate a task to another agent —
+a specialist, a restricted sandbox, or a copy of itself working on a slice of a bigger job. In
+OpenCrane every such delegation is a **child run**: a full agent run with its own identity, its
+own budget, its own capability set, and its own audit trail, linked to the run that spawned it.
+
+::: info Target design
+Child runs build on the run authority that is already implemented (run trees, capability proofs,
+input snapshots). The spawn tool and runtime behaviour land with the personal-agent runtime
+(Phase E of the [platform architecture](https://github.com/italanta/opencrane/blob/own-personal-ai-agent-setup/docs/design/personal-agent-platform-architecture.md);
+tracked in [#320](https://github.com/italanta/opencrane/issues/320)).
+:::
+
+## Two ways to "use another agent"
+
+Not every sub-task deserves a child run. The platform distinguishes two flavours, and the
+difference is a security boundary, not a style choice:
+
+| | In-process specialist (agent-as-tool) | Governed child run |
+| --- | --- | --- |
+| What it is | A focused sub-context inside the **same** run | A **separate** `AgentRun` in the run tree |
+| Identity & capabilities | The parent's, unchanged | Its own, always **smaller** than the parent's |
+| Budget | The parent's | Carved from the parent's remaining budget |
+| Lifetime | Dies with the parent's attempt | Independent; survives the parent's pod |
+| Audit trail | Part of the parent's record | Its own runs, approvals, and receipts |
+| Typical use | Lens switches, summaries, judging, clean-context skill execution | Different authority, real spend, long-running or untrusted work |
+
+**Rule of thumb:** if the sub-task only changes *what's in context* (a prompt, a persona lens, a
+slice of documents), keep it in-process. If it changes **who** (capabilities), **how much**
+(budget), or **how long** (lifetime), it must be a child run. The in-process kind is a toolkit
+convenience; the governed child run is the architecture feature.
+
+A third case — the user consciously *entering* another agent — is a true handoff and is
+deliberately rare: specialist agents are normally invoked as tools so the personal assistant
+remains the manager and final voice.
+
+## The run tree
+
+Every run records its place in a tree: a required root and an optional parent. A child can spawn
+its own children under the same rules, so delegation forks recursively — and the whole tree stays
+accountable:
+
+- **Cost rolls up.** Every node shares the root run's identity, so "what did this task cost,
+  including everything it delegated" is one query. See [Manage cost](/guide/budgets).
+- **Limits are enforced at spawn time**: depth cap, fan-out cap, and child budgets carved from
+  the parent's remainder. A runaway delegation tree cannot drain the parent.
+- **Audit sees the tree.** Each child's proposals, approvals, and execution receipts are recorded
+  against *its* identity, not blurred into the parent's. See [Review activity](/guide/audit).
+
+## The parent brokers all context
+
+There is no agent-to-agent channel. The run tree is the protocol:
+
+1. **Context in.** A child sees exactly what its parent puts in its immutable input snapshot —
+   selected messages, memory facts, artifact and skill revisions. Nothing else. The snapshot
+   digest makes that choice permanent and auditable.
+2. **Context out.** The child's result — terminal state, output, artifact receipts — returns to
+   the parent as the spawn tool's result. A child failure surfaces as a tool error, so a parent
+   cannot silently ignore what it delegated. Fire-and-forget does not exist.
+3. **Siblings are isolated.** One child's output reaches another child only if the parent
+   explicitly includes it in the second child's snapshot. The parent brokers all context between
+   its children.
+
+Because a child can never *read* anything — it can only *be given* things — the question "which
+agents can access context from which agent" is answered at spawn time: the parent may only share
+what its own capabilities and the content's access rules allow it to read, and the grant is
+recorded in the snapshot.
+
+## Capabilities only shrink
+
+Delegation is monotonic. The effective rights of any run are:
+
+```text
+agent revision ceiling
+  intersect triggering-user delegation, when interactive
+  intersect current resource grants
+  intersect immutable short-lived run capability
+```
+
+A child receives a capability set no larger than its parent's — usually much smaller. Two
+consequences worth designing around:
+
+- **Least-privilege specialists.** The personal assistant does not need the accounting
+  integration; the finance specialist it delegates to does — and only that.
+- **Untrusted-input containment.** Process an inbound email or uploaded document in a child with
+  near-zero capabilities. If the content carries injected instructions, there is nothing for them
+  to act with; the parent receives only the sanitised result.
+
+The personal/managed boundary stays one-way: a personal assistant may invoke a managed agent
+through an authorised tool contract, but that managed agent cannot inspect the personal
+workspace, thread, memory, or files. It receives only explicitly shared artifact versions and
+declared input fields.
+
+## When agents reach for a child run
+
+- **A different capability profile** — the task needs an integration or scope the parent
+  deliberately does not hold.
+- **Untrusted input** — containment, as above.
+- **Long-running or scheduled work** — research jobs and batch processing that outlive the
+  conversation and survive restarts, because a child has its own fenced attempts.
+- **Budget isolation** — give a speculative task a fixed allowance.
+- **Fan-out** — split a large job across parallel children, each seeing only its slice, then
+  merge; recursively if needed.
+- **Separate accountability** — high-stakes actions whose approvals should bind to the child's
+  identity and be independently auditable.
+
+Skills interact with all of this — a skill picks its execution tier by what it demands. See
+[Agent skills](/guide/skills#how-skills-execute).
+
+> See also: [Control access](/guide/permissions) · [Manage cost](/guide/budgets) ·
+> [Review activity](/guide/audit) · [Architecture](/advanced/architecture)

--- a/website/guide/child-runs.md
+++ b/website/guide/child-runs.md
@@ -8,7 +8,7 @@ own budget, its own capability set, and its own audit trail, linked to the run t
 ::: info Target design
 Child runs build on the run authority that is already implemented (run trees, capability proofs,
 input snapshots). The spawn tool and runtime behaviour land with the personal-agent runtime
-(Phase E of the [platform architecture](https://github.com/italanta/opencrane/blob/own-personal-ai-agent-setup/docs/design/personal-agent-platform-architecture.md);
+(Phase E of the [platform architecture](https://github.com/italanta/opencrane/blob/main/docs/design/personal-agent-platform-architecture.md);
 tracked in [#320](https://github.com/italanta/opencrane/issues/320)).
 :::
 

--- a/website/guide/connect.md
+++ b/website/guide/connect.md
@@ -34,5 +34,5 @@ you don't need it to get started.
 
 Right now it's a capable chat assistant. Give it real powers:
 
-- **[Share skills](/guide/skills)** · **[Connect tools](/guide/tools)** ·
+- **[Agent skills](/guide/skills)** · **[Connect tools](/guide/tools)** ·
   **[Add knowledge](/guide/knowledge)** · **[Control access](/guide/permissions)**

--- a/website/guide/first-tenant.md
+++ b/website/guide/first-tenant.md
@@ -31,7 +31,7 @@ A brand-new assistant starts locked down — it can chat, but it can't reach com
 tools, skills, or knowledge until you allow it. Build it up:
 
 - **[Let Alice sign in](/guide/connect)**
-- **[Share skills with her](/guide/skills)** — reusable abilities
+- **[Give her agent skills](/guide/skills)** — reusable abilities
 - **[Connect tools](/guide/tools)** — Slack, Jira, your CRM
 - **[Add company knowledge](/guide/knowledge)** — so it answers with real facts
 - **[Control access](/guide/permissions)** — decide exactly what it can use

--- a/website/guide/how-it-works.md
+++ b/website/guide/how-it-works.md
@@ -24,7 +24,7 @@ a *tenant* — same thing.) → [Create one](/guide/first-tenant)
 ### Skill
 A **reusable ability** you can give to assistants — like installing an app. A skill
 might be "write a sales follow-up" or "review a pull request." You build a skill
-once and share it with whoever should have it. → [Share skills](/guide/skills)
+once and share it with whoever should have it. → [Agent skills](/guide/skills)
 
 ### Tool (MCP)
 A **connection to another system** — Slack, Jira, your CRM — so an assistant can

--- a/website/guide/organize.md
+++ b/website/guide/organize.md
@@ -29,7 +29,7 @@ The same four scopes appear everywhere you share or restrict something:
 
 - **Skills** are published at a scope and promoted to wider ones — a skill that starts
   *personal* can be promoted to *project*, then *department*, then *org*.
-  → [Share skills](/guide/skills)
+  → [Agent skills](/guide/skills)
 - **Knowledge** is organized into datasets by scope, so a department's documents only
   reach that department. → [Organizational knowledge](/guide/knowledge)
 - **Access grants** allow or deny something for a person, team, or whole department.

--- a/website/guide/skills.md
+++ b/website/guide/skills.md
@@ -28,8 +28,11 @@ revision pins the skill revisions it was reviewed with.
 
 Skills move from draft to shared ability through a governed pipeline:
 
-1. **Author.** The personal assistant (or a person) creates a candidate skill bundle from a
-   conversation or from scratch.
+1. **Author.** Every personal assistant carries **skill-builder** as a tool: ask it to turn a
+   working conversation — a procedure you refined together, a prompt that finally worked — into
+   a candidate skill bundle, or draft one from scratch. Invoking skill-builder starts this
+   pipeline; it never shortcuts it. Drafting is cheap and conversational, but the draft holds no
+   authority until it has passed the steps below.
 2. **Isolated authoring job.** A dedicated Job with only a draft-workspace capability — no
    production MCP credentials, default-deny egress — runs formatting, types and tests,
    dependency and licence checks, secret and malware scans, and policy validation.

--- a/website/guide/skills.md
+++ b/website/guide/skills.md
@@ -28,11 +28,11 @@ revision pins the skill revisions it was reviewed with.
 
 Skills move from draft to shared ability through a governed pipeline:
 
-1. **Author.** Every personal assistant carries **skill-builder** as a tool: ask it to turn a
-   working conversation — a procedure you refined together, a prompt that finally worked — into
-   a candidate skill bundle, or draft one from scratch. Invoking skill-builder starts this
-   pipeline; it never shortcuts it. Drafting is cheap and conversational, but the draft holds no
-   authority until it has passed the steps below.
+1. **Author (🔶 planned product surface).** The target workflow gives a personal assistant a
+   governed **skill-builder** tool: ask it to turn a working conversation — a procedure you refined
+   together, a prompt that finally worked — into a candidate skill bundle, or draft one from
+   scratch. Invoking that tool will start this pipeline; it will never shortcut it. Drafting can be
+   cheap and conversational, but the draft holds no authority until it has passed the steps below.
 2. **Isolated authoring job.** A dedicated Job with only a draft-workspace capability — no
    production MCP credentials, default-deny egress — runs formatting, types and tests,
    dependency and licence checks, secret and malware scans, and policy validation.

--- a/website/guide/skills.md
+++ b/website/guide/skills.md
@@ -1,35 +1,98 @@
-# Share skills across teams
+# Agent skills
 
-OpenCrane is building **versioned, reviewed skills** that can be shared without trusting mutable
-runtime-local files.
-
-::: tip What's a skill?
-A **reusable ability** you give to assistants — such as drafting a sales follow-up, reviewing a
-pull request, or summarising a support ticket.
-:::
+A **skill** is a reusable ability you give to assistants — drafting a sales follow-up, reviewing
+a pull request, summarising a support ticket. In OpenCrane a skill is a **versioned, reviewed,
+signed artifact**, not an executable snippet appended to someone's workspace: it can be shared
+across a team or the whole organisation without trusting mutable runtime-local files.
 
 ::: info Foundation in progress
 The ArtifactStore-backed publication authority is implemented, but the end-user catalogue,
-authoring, and sharing API and UI are not mounted yet. The retired bundle-registry endpoints are not
-a supported path.
+authoring, and sharing API and UI are not mounted yet. The retired bundle-registry endpoints are
+not a supported path.
 :::
 
-## What publication enforces
+## What a skill contains
 
-The current publication service accepts only an exact `SkillRevision` and `ArtifactRevision` pair.
-It requires successful test and scan evidence, a signature and signer key, and a revision already in
-review. It then publishes the revision and advances the skill's current pointer atomically.
+A skill bundle carries everything needed to review and trust it:
 
-The implementation lives in
-[`libs/backend/server/agents/skills/main`](https://github.com/italanta/opencrane/blob/main/libs/backend/server/agents/skills/main).
-The public product workflow will build on that authority rather than restoring an OCI bundle
+- `SKILL.md` — the instructions the agent follows, and when to use them;
+- optional Python code and its tests;
+- declared requirements: which MCP tools, models, and network access it needs;
+- provenance — who authored it, from what.
+
+Published, a skill is an immutable **SkillRevision** whose content digest is what runtime
+contracts reference. There is no "latest" that can drift underneath a running agent: an agent
+revision pins the skill revisions it was reviewed with.
+
+## The publication lifecycle
+
+Skills move from draft to shared ability through a governed pipeline:
+
+1. **Author.** The personal assistant (or a person) creates a candidate skill bundle from a
+   conversation or from scratch.
+2. **Isolated authoring job.** A dedicated Job with only a draft-workspace capability — no
+   production MCP credentials, default-deny egress — runs formatting, types and tests,
+   dependency and licence checks, secret and malware scans, and policy validation.
+3. **Review.** A human or an authorised publishing workflow reviews the diff and the test and
+   scan evidence.
+4. **Sign and publish.** OpenCrane signs and publishes the immutable SkillRevision and advances
+   the skill's current pointer atomically. The publication service accepts only an exact
+   `SkillRevision`/`ArtifactRevision` pair with successful evidence, a signature, and a revision
+   already in review.
+
+The implementation of the publication authority lives in
+[`libs/backend/server/agents/skills/main`](https://github.com/italanta/opencrane/blob/own-personal-ai-agent-setup/libs/backend/server/agents/skills/main).
+The public product workflow builds on that authority rather than restoring an OCI bundle
 registry or compatibility route.
+
+Sharing follows the platform's scope model — personal, project, department, organisation — and
+promotion across scopes is an explicit review boundary: a skill drafted from a personal
+conversation never silently becomes a company asset, and publishing it never grants it
+retroactive access to the conversation that produced it. See
+[Control access](/guide/permissions).
+
+## How skills execute
+
+A skill is a context ingredient, not an agent. Loading one changes what an agent *knows how to
+do*; it does not by itself create any new identity or authority. Which execution tier a skill
+uses is decided by what the skill demands:
+
+### Tier 0 — inline load
+
+The default. The agent pulls the SkillRevision's instructions into its **current** context and
+follows them right there — same run, same capabilities, same budget. Right for procedures the
+agent should apply in place: a formatting standard, a runbook, a checklist. The only cost is
+context space, which motivates the next tier.
+
+### Tier 1 — in-process specialist (agent-as-tool)
+
+The agent runs the skill in a **fresh sub-context inside the same run** and gets back only the
+result — useful when a skill's instructions and intermediate work are heavy and would pollute the
+main conversation. Same identity, same capabilities, same budget, part of the same audit record;
+if the specialist proposes a governed action, it surfaces through the *parent's* approval path.
+This tier is a convenience for context hygiene — it is **not** a security boundary.
+
+### Tier 2 — governed child run or tool job
+
+When a skill demands more than instructions, execution crosses a real boundary:
+
+- A skill that needs **capabilities the agent shouldn't hold open**, **its own budget**, or a
+  **lifetime beyond the conversation** runs as a [child run](/guide/child-runs) — its own
+  identity, its own (smaller) capability set, its own audit trail.
+- **Tenant-authored Python never executes inside the conversational pod.** Trusted image-baked
+  tools may run in-process, but user-authored code executes through an isolated tool Job with
+  exactly the capability its declared requirements were reviewed against.
+
+**Rule of thumb:** pure instructions → tier 0 or 1; capabilities, spend, or code execution →
+tier 2. The tier is a property of what the skill was reviewed to need — an agent cannot quietly
+upgrade a checklist into a code-executing specialist.
 
 ## What comes next
 
-The product surface still needs catalogue browsing, isolated authoring jobs, review and publication,
-and governed sharing across personal, project, department and organisation scopes. Until those
-surfaces are mounted, there is no supported end-user skill-publishing workflow.
+The product surface still needs catalogue browsing, isolated authoring jobs mounted end-to-end,
+review and publication workflows, and governed sharing across personal, project, department and
+organisation scopes. Until those surfaces are mounted, there is no supported end-user
+skill-publishing workflow.
 
-> See also: [Control access](/guide/permissions) (how governed sharing is expressed) and
-> [Architecture](/advanced/architecture) (where skills fit in the platform).
+> See also: [Agent delegation (child runs)](/guide/child-runs) ·
+> [Control access](/guide/permissions) · [Architecture](/advanced/architecture)

--- a/website/integrators/agent-workspace.md
+++ b/website/integrators/agent-workspace.md
@@ -7,7 +7,7 @@ trusted as a security boundary.
 
 > See also: [Architecture](/advanced/architecture) (how the pieces fit together),
 > [Obot MCP gateway](/integrators/mcp-gateway) (the tool-execution boundary),
-> [Share skills](/guide/skills), and [Authentication](/security/identity)
+> [Agent skills](/guide/skills), and [Authentication](/security/identity)
 > (the token audiences referenced below).
 
 ## Two kinds of control


### PR DESCRIPTION
## Why these guides are needed

OpenCrane is moving from one agent doing everything inside one conversation to a system where an agent can use specialist skills and, when necessary, delegate a bounded piece of work to another governed run.

Those two mechanisms can look similar from the outside but have very different trust, cost, and context boundaries. These guides give users, operators, and implementers one shared mental model before the Phase E runtime makes them executable.

## The distinction readers can now make

```text
task stays inside the current identity/context/budget?
            |
       yes  |  no - changes who acts, how long, or how much budget
            |
            v
in-process skill/specialist       governed child run
same run and authority            new run with explicit delegated limits
```

- A skill packages reusable instructions and code. Depending on its risk, it may load inline, run as an in-process specialist, or execute in an isolated governed boundary.
- A child run is a new, auditable run with its own immutable input snapshot, depth/fan-out/budget limits, and permissions that can only be narrower than its parent.
- Context moves deliberately: the parent supplies the child's input and receives a mandatory result; siblings do not automatically share hidden context.
- Tenant-authored Python never executes in the conversational runtime Pod.

## What changed on the website

- Added **Agent delegation (child runs)**: when delegation needs a child run, how run trees and cost roll-up work, how context enters/leaves, and how permissions remain monotonic.
- Reworked **Agent skills**: bundle anatomy, immutable revisions, author/review/sign/publish lifecycle, scope promotion, and the execution tiers.
- Added both pages to the Guides navigation and cross-linked the related concepts.

## Design status and boundary

These pages describe the accepted target design and are labelled accordingly. They do not claim the Phase E runtime, spawn tool, or execution tiers are already shipped. The runtime conversation/AG-UI projection remains intentionally undocumented until its protocol shape settles.

## Validation

- VitePress production build passes with dead-link checking enabled
- Existing `/guide/skills` links remain stable
- Terminology matches the personal-agent architecture and runtime identity decisions
- Local Claude Code review passed after marking skill-builder as planned and aligning Agent skills labels across the site

## Related work

- Child-run design: #320
- Phase E runtime foundation: #312, #313, #316, #317, #321
