### PR TITLE
📝 Reframe Phase E2 Slack re-expression as central agents

### DIFF
--- a/docs/agents/apps/feat-central-agents.md
+++ b/docs/agents/apps/feat-central-agents.md
@@ -6,6 +6,24 @@ A standalone **background ingestion worker** (not API-first) that pulls external
 them to the org-index schema, and pushes them into Cognee so tenant pods can query org context via
 the official `@cognee/cognee-openclaw` plugin. Currently one connector: **Slack**.
 
+## App vision
+
+This app is not a harvester — harvesting is one job it happens to do first. The target for
+`feat-central-agents` is a **host for central agents**: org-, department-, team-, or otherwise shared
+**managed AgentServices** that an administrator defines, that run on a schedule or a specific trigger,
+and that each do one bounded task. Central agents run on the **same runtime substrate as personal
+agents** (the suspended one-attempt Job, controller, and outbound-only shell) but under a **narrower,
+connector-scoped workload identity** independent of any human user, and they reach external systems
+**only through MCP connectors**. Slack becomes one such connector — instantiable per connected
+workspace — rather than a bespoke SDK loop, and each central agent reads/writes only the canonical
+scopes it is explicitly attached to.
+
+The current Slack interval worker described below is the migration starting point, not the product
+boundary: its useful behaviour (normalisation, checkpointing, scoped Cognee writes) is re-expressed as
+a packaged central-agent definition over an approved Slack MCP server, after which the bespoke
+connector and its direct credential handling are removed. See the direct-refactor plan's Phase E2 and
+issue [#129](https://github.com/italanta/opencrane/issues/129) for the full model.
+
 ## Loop (`src/index.ts`)
 
 On boot: read Slack config (`SLACK_BOT_TOKEN`, `SLACK_CHANNEL_IDS`, `SLACK_MAX_MESSAGES_PER_CYCLE`, `SLACK_SYNC_INTERVAL_MS` default 15min), `COGNEE_ENDPOINT`, `DATABASE_URL`; start a metrics HTTP server (`METRICS_PORT`, default 9090); init Prisma. Runs an immediate sync then repeats on the interval. Each cycle: load cursor → `connector.sync(cursor)` → `_IngestDocuments` → save cursor on progress → record metrics. Errors are caught per-cycle and retried next interval.

--- a/docs/agents/apps/feat-central-agents.md
+++ b/docs/agents/apps/feat-central-agents.md
@@ -14,13 +14,12 @@ This app is not a harvester — harvesting is one job it happens to do first. Th
 and that each do one bounded task. Central agents run on the **same runtime substrate as personal
 agents** (the suspended one-attempt Job, controller, and outbound-only shell) but under a **narrower,
 connector-scoped workload identity** independent of any human user, and they reach external systems
-**only through MCP connectors**. Slack becomes one such connector — instantiable per connected
-workspace — rather than a bespoke SDK loop, and each central agent reads/writes only the canonical
-scopes it is explicitly attached to.
+**only through Obot-custodied MCP servers**, instantiable per connected source rather than a bespoke
+SDK loop, and each central agent reads/writes only the canonical scopes it is explicitly attached to.
 
-The current Slack interval worker described below is the migration starting point, not the product
+The current interval worker described below is the migration starting point, not the product
 boundary: its useful behaviour (normalisation, checkpointing, scoped Cognee writes) is re-expressed as
-a packaged central-agent definition over an approved Slack MCP server, after which the bespoke
+a packaged central-agent definition over an approved Obot MCP server, after which the bespoke
 connector and its direct credential handling are removed. See the direct-refactor plan's Phase E2 and
 issue [#129](https://github.com/italanta/opencrane/issues/129) for the full model.
 

--- a/docs/design/personal-agent-platform-architecture.md
+++ b/docs/design/personal-agent-platform-architecture.md
@@ -747,7 +747,7 @@ capability with operational recovery and UI.
 | Multimodal intake | Runtime/provider-dependent, no governed pipeline | **Medium/high** | Artifact/preprocess pipeline |
 | Document authoring | Ad hoc tool/files, no versioned QA path | **Far** | Artifact and trusted authoring Jobs |
 | Skill authoring and Python code | Multiple storage paths; lifecycle issue open | **Far** | Skill catalog + artifact versions |
-| Managed agent registry | Central-agent issue/app is Slack-specific | **Far** | AgentService/Revision |
+| Managed agent registry | Central-agent issue/app is single-connector (ingestion-only) | **Far** | AgentService/Revision |
 | Scheduling | OpenClaw cron unused; generic service scheduler absent | **Medium/high** | OpenCrane run ledger + K8s trigger/Job |
 | Approvals/durable workflows | No unified run/approval ledger | **Medium/high:** toolkit pause state may help | OpenCrane Run/Approval state |
 | Run/operations console | Fragmented UI and infra consoles | **Far** | OpenCrane UI/API |

--- a/docs/design/personal-agent-platform-direct-refactor-plan.md
+++ b/docs/design/personal-agent-platform-direct-refactor-plan.md
@@ -85,7 +85,7 @@ requirement is not preserved merely because its implementation already exists.
 - Tenant and AccessPolicy CRDs as business authorities;
 - `/auth/pod-token`, pairing, BrokeredDevice, gateway-admin state, and static internal agent tokens;
 - mutable workspace persona files and `SessionScope` product state;
-- awareness/participation rollout models and the Slack-specific interval loop (its useful behaviour returns as a central agent driven by an MCP connector);
+- awareness/participation rollout models and the legacy ingestion interval loop (its useful behaviour returns as a central agent driven by an Obot MCP server);
 - `feat-skill-registry`, Zot/core OCI, shared skill files/PVC, and DB/OCI fallbacks;
 - broad secret broadcasts and arbitrary config overrides;
 - Linkerd and obsolete shared/multi-instance/billing topology switches;
@@ -229,8 +229,8 @@ Deliver:
 - scheduled AgentService identity independent of its creator;
 - central agents: org/department/team/shared managed AgentServices, schedule- or event-triggered for
   one bounded task, on the shared personal-agent runtime substrate under a narrower connector-scoped
-  identity, reaching external systems only through MCP connectors (multi-instance, e.g. one per Slack
-  workspace);
+  identity, reaching external systems only through Obot-custodied MCP servers (multi-instance, e.g.
+  one per connected source);
 - the strict personal→managed boundary;
 - approvals, effective access, audit, model/cost evidence, schedules, run status, and notifications;
 - OpenTelemetry plus durable business/run evidence;
@@ -239,9 +239,9 @@ Deliver:
 Central agents run on the same runtime substrate as personal agents (the suspended one-attempt Job,
 controller, and outbound-only shell) but under a narrower, connector-scoped workload identity that is
 independent of any human user, extending the "scheduled AgentService identity independent of its
-creator" rule above. There is no bespoke per-source worker: Slack is one MCP connector among others
-and may be instantiated per connected workspace. The legacy Slack interval worker and its direct
-Cognee writes are deleted.
+creator" rule above. There is no bespoke per-source worker: external systems are reached only through
+Obot-custodied MCP servers, which may be instantiated per connected source. The legacy ingestion
+interval worker and its direct Cognee writes are deleted.
 
 ## Phase F — product and operator surfaces
 

--- a/docs/design/personal-agent-platform-direct-refactor-plan.md
+++ b/docs/design/personal-agent-platform-direct-refactor-plan.md
@@ -85,7 +85,7 @@ requirement is not preserved merely because its implementation already exists.
 - Tenant and AccessPolicy CRDs as business authorities;
 - `/auth/pod-token`, pairing, BrokeredDevice, gateway-admin state, and static internal agent tokens;
 - mutable workspace persona files and `SessionScope` product state;
-- awareness/participation rollout models and the Slack-specific interval loop;
+- awareness/participation rollout models and the Slack-specific interval loop (its useful behaviour returns as a central agent driven by an MCP connector);
 - `feat-skill-registry`, Zot/core OCI, shared skill files/PVC, and DB/OCI fallbacks;
 - broad secret broadcasts and arbitrary config overrides;
 - Linkerd and obsolete shared/multi-instance/billing topology switches;
@@ -227,13 +227,21 @@ Deliver:
 - schedules, idempotent triggers, recorded runs/outbox, suspended one-attempt Jobs, Job/Pod-bound
   bootstrap, concurrency, deadlines, backoff, cancellation, and terminal repair;
 - scheduled AgentService identity independent of its creator;
+- central agents: org/department/team/shared managed AgentServices, schedule- or event-triggered for
+  one bounded task, on the shared personal-agent runtime substrate under a narrower connector-scoped
+  identity, reaching external systems only through MCP connectors (multi-instance, e.g. one per Slack
+  workspace);
 - the strict personal→managed boundary;
 - approvals, effective access, audit, model/cost evidence, schedules, run status, and notifications;
 - OpenTelemetry plus durable business/run evidence;
 - runbooks for pause, revoke, provider/PEP outage, restore, and forward repair.
 
-Useful Slack behavior is re-expressed as schedule + MCP + skill + checkpoint. The interval worker
-and direct Cognee writes are deleted.
+Central agents run on the same runtime substrate as personal agents (the suspended one-attempt Job,
+controller, and outbound-only shell) but under a narrower, connector-scoped workload identity that is
+independent of any human user, extending the "scheduled AgentService identity independent of its
+creator" rule above. There is no bespoke per-source worker: Slack is one MCP connector among others
+and may be instantiated per connected workspace. The legacy Slack interval worker and its direct
+Cognee writes are deleted.
 
 ## Phase F — product and operator surfaces
 

--- a/plan.md
+++ b/plan.md
@@ -109,9 +109,13 @@ and governed Python skill Jobs
 
 **AgentService lane:** implement AgentService/Revision/Run, organization/department/team/project/
 personal/user sharing, schedules, one-attempt Jobs, approvals, effective access, audit, cost, and the
-one-way personal→managed boundary ([#129](https://github.com/italanta/opencrane/issues/129)). Port
-useful Slack behavior only as schedule + MCP + skill + checkpoint; delete the interval worker and
-direct Cognee writes. Conversation-initiated config changes (always-granted `upgrade_session` tool,
+one-way personal→managed boundary ([#129](https://github.com/italanta/opencrane/issues/129)).
+**Central agents** — org-, department-, team-, or otherwise shared managed AgentServices that run on a
+schedule or a specific trigger to do one bounded task — run on the same runtime substrate as personal
+agents but under a narrower, connector-scoped workload identity independent of any human user. They
+reach external systems only through MCP connectors (Slack is one such connector, instantiable per
+connected workspace). The legacy Slack interval worker and its direct Cognee writes are deleted.
+Conversation-initiated config changes (always-granted `upgrade_session` tool,
 logged persona refresh, apply-at-next-snapshot) → [#318](https://github.com/italanta/opencrane/issues/318).
 
 Exit: the canonical runtime and managed-agent lifecycle pass failure, replay, authorization,

--- a/plan.md
+++ b/plan.md
@@ -113,8 +113,8 @@ one-way personal→managed boundary ([#129](https://github.com/italanta/opencran
 **Central agents** — org-, department-, team-, or otherwise shared managed AgentServices that run on a
 schedule or a specific trigger to do one bounded task — run on the same runtime substrate as personal
 agents but under a narrower, connector-scoped workload identity independent of any human user. They
-reach external systems only through MCP connectors (Slack is one such connector, instantiable per
-connected workspace). The legacy Slack interval worker and its direct Cognee writes are deleted.
+reach external systems only through Obot-custodied MCP servers, instantiable per connected source. The
+legacy ingestion interval worker and its direct Cognee writes are deleted.
 Conversation-initiated config changes (always-granted `upgrade_session` tool,
 logged persona refresh, apply-at-next-snapshot) → [#318](https://github.com/italanta/opencrane/issues/318).
 


### PR DESCRIPTION
## What

Removes the too-specific *"port useful Slack behavior only as schedule + MCP + skill + checkpoint"* framing from the Phase E plan and names **central agents** as a first-class capability instead.

Central agents = org/department/team/shared **managed AgentServices**, activated by a schedule or a specific idempotent trigger to do one bounded task. They run on the **same runtime substrate as personal agents** (the suspended one-attempt Job + controller + outbound-only shell) but under a **narrower, connector-scoped workload identity** independent of any human user, reaching external systems only through **MCP connectors**. Slack is demoted to one such connector, instantiable per connected workspace (multiple instances allowed).

## Files (docs/plan only — no code)

- `plan.md` — Phase E AgentService lane: Slack sentence replaced with the central-agents sentence.
- `docs/design/personal-agent-platform-direct-refactor-plan.md` — Phase E2: added a central-agents bullet to *Deliver*; replaced the trailing Slack paragraph; reworded the delete-list line so the useful behaviour is noted as returning via a central agent + MCP connector.

## Follow-ups (not in this PR)

- Issue hygiene: the lane points at #129 (central harvesting harness) — refresh #129 to carry the central-agents shape, or open a dedicated central-agents issue and repoint.
- `docs/agents/apps/feat-central-agents.md` still describes the legacy Slack interval worker; rebuilt when the app is re-implemented.