### PR TITLE
✅ Phase E runtime slice 4/6: offline conformance harness + observability

### DIFF
--- a/apps/agent-runtime/README.md
+++ b/apps/agent-runtime/README.md
@@ -122,9 +122,11 @@ completes a real agent run over LiteLLM through an attempt-scoped key. It surfac
 resume, kills the active task on a positive cancel signal, absorbs steering at pre-model-request
 boundaries, and writes an encrypted, version-tagged, replaceable local checkpoint subordinate to
 canonical server state. The controller creates or exact-adopts the suspended Job, releases the durable
-assignment, and registers the unique first Pod. The live-LiteLLM conformance run over the pinned
-`pydantic-ai` package (and the corresponding OpenClaw loop deletion) is the deferred Phase E slice-4
-adoption gate recorded in ADR 0010 and is not exercised offline.
+assignment, and registers the unique first Pod. The offline conformance harness and fault-injection
+matrix (`tests/test_conformance.py`, `tests/test_fault_matrix.py`) are built and CI-runnable; the
+live-LiteLLM conformance run over the pinned `pydantic-ai` package, the driver adoption evidence, and
+the corresponding OpenClaw loop deletion remain gated on
+[#337](https://github.com/italanta/opencrane/issues/337) (ADR 0010) and are not exercised offline.
 
 ## See also
 

--- a/apps/agent-runtime/src/runtime.py
+++ b/apps/agent-runtime/src/runtime.py
@@ -18,13 +18,17 @@ checkpoint is written to the per-attempt scratch as a resume optimisation subord
 server state. Because the loop is configured with zero implicit retries, any executor failure
 surfaces as a real ``run.error`` candidate rather than a silent acknowledgement.
 
-Deferred to Phase E slice 4: the live-LiteLLM conformance suite and adoption gate for the pinned
-Pydantic AI package (ADR 0010) and the corresponding OpenClaw loop deletion; those are not exercised
-by this offline slice.
+Phase E slice 4 lands the offline conformance harness and fault-injection matrix that exercise this
+shell against independently authored neutral-event fixtures and a LiteLLM-compatible test double; both
+run in CI with no network (``tests/test_conformance.py`` and ``tests/test_fault_matrix.py``). The
+live-LiteLLM conformance leg, the adoption evidence for the pinned Pydantic AI package (ADR 0010), and
+the corresponding OpenClaw loop deletion remain gated on #337 and are not exercised by this offline
+slice.
 """
 
 import asyncio
 import base64
+import contextlib
 import hashlib
 import json
 import os
@@ -69,6 +73,38 @@ def _environment(name: str, default: str | None = None) -> str:
 def _log(event: str, **fields: object) -> None:
     """Emit one safe structured log line; callers must never pass credentials."""
     print(json.dumps({"component": "agent-runtime", "event": event, **fields}, sort_keys=True), flush=True)
+
+
+@contextlib.contextmanager
+def _trace(operation: str, **attributes: object):
+    """Wrap one runtime operation in an OpenTelemetry span when the SDK is present, else a no-op.
+
+    ``opentelemetry`` is imported lazily so the outbound shell and its offline tests never require the
+    package; when it is absent (this offline slice) the block is a transparent no-op while the
+    structured wide-event logs still carry the run/attempt evidence. Attributes carry only non-secret
+    run coordinates — never a token, key, or model content. Real OTLP export to the in-cluster
+    collector is part of the #337 live/adoption wiring, mirroring ``@opencrane/observability`` on the
+    TypeScript control plane.
+    """
+    try:
+        from opentelemetry import trace
+    except ImportError:
+        yield None
+        return
+    tracer = trace.get_tracer("agent-runtime")
+    with tracer.start_as_current_span(operation) as span:
+        for key, value in attributes.items():
+            span.set_attribute(key, value)
+        yield span
+
+
+def _run_evidence(coordinates: dict[str, object], outcome: str, **fields: object) -> None:
+    """Emit one durable wide run-evidence event bound to the run and attempt for observability.
+
+    It carries only the run/attempt/command correlation and the terminal outcome; credentials, tokens,
+    keys, and model content are never included, so the event is safe to route to durable log storage.
+    """
+    _log("run_evidence", runId=coordinates.get("runId"), attempt=coordinates.get("attempt"), commandId=coordinates.get("commandId"), runtimeInstanceId=coordinates.get("runtimeInstanceId"), outcome=outcome, **fields)
 
 
 def _read_projected_token(token_path: str) -> str:
@@ -498,8 +534,10 @@ def _pydantic_ai_event_source(compiled_input: dict[str, object], cancel_event: t
     from ``steering_buffer`` ONLY immediately before issuing a model request node (the sole safe
     pre-model boundary), never mid-request or mid-tool.
 
-    Live-LiteLLM conformance is the deferred Phase E slice-4 adoption gate recorded in ADR 0010; it is
-    NOT run here. Offline tests inject a fake event source instead of importing Pydantic AI.
+    The offline conformance harness drives this executor through an injected neutral-event source; the
+    live-LiteLLM leg that drives real Pydantic AI over the proxy is env-guarded and gated on #337
+    (ADR 0010 adoption), not run here. Offline tests inject a fake event source instead of importing
+    Pydantic AI.
     """
     from pydantic_ai import Agent
 
@@ -548,8 +586,8 @@ def _pydantic_ai_resume_source(run_id: str, attempt: int, input_generation: obje
     results so the loop continues from the approval boundary; the runtime authors no approval and
     chooses no terminal state. Steering and cancellation are observed exactly as in the start driver.
 
-    Live-LiteLLM resume conformance is the deferred Phase E slice-4 adoption gate (ADR 0010) and is
-    not run here; offline tests inject a fake resume source.
+    The offline conformance harness drives resume through an injected fake resume source; the
+    live-LiteLLM resume leg is env-guarded and gated on #337 (ADR 0010 adoption), not run here.
     """
     from pydantic_ai import Agent
 
@@ -745,16 +783,20 @@ def _execute_start_attempt(command: dict[str, object], runtime_instance_id: str,
         post_candidate(_candidate(coordinates, "run.error", {"reason": "missing_compiled_input"}))
         return
     post_candidate(_candidate(coordinates, "run.started", {"promptCompilerVersion": compiled_input.get("promptCompilerVersion")}))
+    _run_evidence(coordinates, "started")
     _try_write_checkpoint(coordinates, payload if isinstance(payload, dict) else {}, compiled_input, checkpoint_cipher)
     steering_buffer: list[str] = []
-    try:
-        for neutral_event in event_source(compiled_input, cancel_event, steering_buffer):
-            if cancel_event.is_set():
-                break
-            _dispatch_neutral_event(coordinates, compiled_input, neutral_event, post_candidate)
-        terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.completed", {}))
-    except (HTTPError, URLError, OSError, RuntimeError, ValueError) as error:
-        terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.error", {"reason": "executor_failed", "errorType": type(error).__name__}))
+    with _trace("agent_runtime.start_attempt", runId=coordinates["runId"], attempt=coordinates["attempt"]):
+        try:
+            for neutral_event in event_source(compiled_input, cancel_event, steering_buffer):
+                if cancel_event.is_set():
+                    break
+                _dispatch_neutral_event(coordinates, compiled_input, neutral_event, post_candidate)
+            if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.completed", {})):
+                _run_evidence(coordinates, "completed")
+        except (HTTPError, URLError, OSError, RuntimeError, ValueError) as error:
+            if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.error", {"reason": "executor_failed", "errorType": type(error).__name__})):
+                _run_evidence(coordinates, "error", reason="executor_failed", errorType=type(error).__name__)
 
 
 def _execute_resume_attempt(command: dict[str, object], runtime_instance_id: str, post_candidate: Callable[[dict[str, object]], None], resume_event_source: Callable[..., Iterable[dict[str, object]]] = _pydantic_ai_resume_source, cancel_event: threading.Event | None = None, checkpoint_cipher: object | None = None, terminal_gate: "_TerminalGate | None" = None) -> None:
@@ -781,15 +823,19 @@ def _execute_resume_attempt(command: dict[str, object], runtime_instance_id: str
     deferred_tool_results = payload.get("deferredToolResults")
     compiled_input = _recover_compiled_input(coordinates, input_generation, checkpoint_cipher)
     post_candidate(_candidate(coordinates, "run.resumed", {"inputGeneration": input_generation}))
+    _run_evidence(coordinates, "resumed", inputGeneration=input_generation)
     steering_buffer: list[str] = []
-    try:
-        for neutral_event in resume_event_source(coordinates["runId"], coordinates["attempt"], input_generation, deferred_tool_results, cancel_event, steering_buffer):
-            if cancel_event.is_set():
-                break
-            _dispatch_neutral_event(coordinates, compiled_input, neutral_event, post_candidate)
-        terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.completed", {}))
-    except (HTTPError, URLError, OSError, RuntimeError, ValueError) as error:
-        terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.error", {"reason": "executor_failed", "errorType": type(error).__name__}))
+    with _trace("agent_runtime.resume_attempt", runId=coordinates["runId"], attempt=coordinates["attempt"]):
+        try:
+            for neutral_event in resume_event_source(coordinates["runId"], coordinates["attempt"], input_generation, deferred_tool_results, cancel_event, steering_buffer):
+                if cancel_event.is_set():
+                    break
+                _dispatch_neutral_event(coordinates, compiled_input, neutral_event, post_candidate)
+            if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.completed", {})):
+                _run_evidence(coordinates, "completed")
+        except (HTTPError, URLError, OSError, RuntimeError, ValueError) as error:
+            if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.error", {"reason": "executor_failed", "errorType": type(error).__name__})):
+                _run_evidence(coordinates, "error", reason="executor_failed", errorType=type(error).__name__)
 
 
 def _execute_cancel_attempt(command: dict[str, object], runtime_instance_id: str, post_candidate: Callable[[dict[str, object]], None], cancel_event: threading.Event | None = None, terminal_gate: "_TerminalGate | None" = None) -> None:
@@ -811,9 +857,11 @@ def _execute_cancel_attempt(command: dict[str, object], runtime_instance_id: str
     reason = payload.get("reason") if isinstance(payload, dict) else None
     candidate = _candidate(coordinates, "run.cancelled", {"reason": reason})
     if terminal_gate is not None:
-        terminal_gate.post_cancellation(post_candidate, candidate)
+        if terminal_gate.post_cancellation(post_candidate, candidate):
+            _run_evidence(coordinates, "cancelled", reason=reason)
     else:
         post_candidate(candidate)
+        _run_evidence(coordinates, "cancelled", reason=reason)
 
 
 def _iter_commands(response: object, cancelled: threading.Event) -> object:

--- a/apps/agent-runtime/tests/test_conformance.py
+++ b/apps/agent-runtime/tests/test_conformance.py
@@ -1,0 +1,328 @@
+"""Offline conformance harness for the OpenCrane agent runtime against a LiteLLM-compatible double.
+
+This suite qualifies the runtime shell's observable protocol behaviour against INDEPENDENTLY AUTHORED
+neutral-event fixtures fed through a mock model loop that stands in for the bounded Pydantic AI loop
+over the per-silo LiteLLM proxy. Every fixture is written here from the protocol contract; none is
+derived from any transcript, and the harness imports no model framework and reaches no network.
+
+The live-LiteLLM conformance leg (driving the real, pinned ``pydantic-ai`` package against a live
+proxy) is the ADR 0010 adoption gate tracked by #337. It is explicitly guarded below and skipped
+offline; it is NEVER asserted as passing here. Passing this offline harness is a precondition for the
+live leg, not evidence of adoption.
+
+Dimensions covered: streaming + usage, fragmented tool-call argument reassembly, tool ordering,
+malformed calls, slow progress, approvals (external action + resume), restart (checkpoint round-trip),
+cancellation, provider faults, compaction/bounded payloads, budgets, and telemetry evidence.
+"""
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import threading
+import types
+import unittest
+
+from src import runtime
+from src.runtime import (
+    _arguments_digest,
+    _execute_resume_attempt,
+    _execute_start_attempt,
+    _normalize_event,
+    _read_checkpoint,
+    _translate_framework_event,
+    _write_checkpoint,
+    _zero_retry_openai_settings,
+)
+
+
+class _ReversingCipher:
+    """A reversible in-test cipher seam so restart checkpoints round-trip without ``cryptography``."""
+
+    def encrypt(self, data: bytes) -> bytes:
+        return b"v:" + data[::-1]
+
+    def decrypt(self, token: bytes) -> bytes:
+        if not token.startswith(b"v:"):
+            raise ValueError("bad token")
+        return token[len(b"v:"):][::-1]
+
+
+def _compiled_input() -> dict:
+    """Build an independently authored compiled input fixing the ``search`` and ``write`` grants."""
+    return {
+        "promptCompilerVersion": "v1",
+        "instructions": "answer precisely",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [
+            {"name": "search", "toolRevisionId": "rev-search", "description": "", "parametersSchema": {}},
+            {"name": "write", "toolRevisionId": "rev-write", "description": "", "parametersSchema": {}},
+        ],
+        "model": {"modelAlias": "silo-default", "maxOutputTokens": None},
+        "budget": {"maxCostUsdMicros": 5_000_000},
+        "digest": "sha256:conformance",
+    }
+
+
+def _start_command() -> dict:
+    """Build one structurally valid ``start_attempt`` command carrying the compiled input fixture."""
+    return {
+        "kind": "start_attempt",
+        "commandId": "cmd-start",
+        "fence": 3,
+        "assignment": {"runId": "run-conf", "attempt": 1},
+        "payload": {"snapshot": {"inputGeneration": 9}, "compiledInput": _compiled_input()},
+    }
+
+
+def _resume_command(deferred: dict) -> dict:
+    """Build one structurally valid ``resume_attempt`` command carrying authorized deferred results."""
+    return {
+        "kind": "resume_attempt",
+        "commandId": "cmd-resume",
+        "fence": 3,
+        "assignment": {"runId": "run-conf", "attempt": 1},
+        "payload": {"inputGeneration": 10, "deferredToolResults": deferred},
+    }
+
+
+def _scripted_source(events: list[dict]):
+    """Return a LiteLLM-compatible mock model loop yielding a fixed neutral-event script.
+
+    The double honours the same cancel-event and steering-buffer seam the real driver uses, so the
+    runtime's cancellation and steering behaviour are exercised without a framework or a network.
+    """
+
+    def _source(_compiled: dict, cancel: threading.Event, _steering: list[str]):
+        for event in events:
+            if cancel.is_set():
+                return
+            yield event
+
+    return _source
+
+
+def _run_start(command: dict, events: list[dict], **kwargs) -> list[dict]:
+    """Drive one start attempt over a scripted mock loop and return the emitted candidates."""
+    emitted: list[dict] = []
+    _execute_start_attempt(command, "instance-conf", emitted.append, event_source=_scripted_source(events), **kwargs)
+    return emitted
+
+
+def _event_types(emitted: list[dict]) -> list[str]:
+    """Project the ordered event/candidate types for terse ordering assertions."""
+    return [candidate.get("eventType", candidate.get("kind")) for candidate in emitted]
+
+
+class ConformanceStreamingTests(unittest.TestCase):
+    """Streaming output, usage accounting, and terminal ordering."""
+
+    def test_streaming_then_usage_then_completion_is_ordered(self) -> None:
+        """Text deltas surface in order, usage normalizes, and exactly one terminal closes the run."""
+        emitted = _run_start(_start_command(), [
+            {"type": "output_text", "text": "one "},
+            {"type": "output_text", "text": "two "},
+            {"type": "usage", "inputTokens": 11, "outputTokens": 4},
+        ])
+        self.assertEqual(_event_types(emitted), ["run.started", "run.output_text", "run.output_text", "run.usage", "run.completed"])
+        self.assertEqual([candidate["payload"].get("text") for candidate in emitted if candidate.get("eventType") == "run.output_text"], ["one ", "two "])
+        usage = next(candidate for candidate in emitted if candidate.get("eventType") == "run.usage")
+        self.assertEqual(usage["payload"], {"inputTokens": 11, "outputTokens": 4})
+
+    def test_slow_progress_preserves_order_and_bounds_each_event(self) -> None:
+        """A long slow stream keeps per-event bounded candidates in order without accumulation."""
+        deltas = [{"type": "output_text", "text": f"chunk-{index}"} for index in range(64)]
+        emitted = _run_start(_start_command(), deltas)
+        texts = [candidate["payload"]["text"] for candidate in emitted if candidate.get("eventType") == "run.output_text"]
+        self.assertEqual(texts, [f"chunk-{index}" for index in range(64)])
+        # Each streamed delta is its own bounded candidate; the runtime never concatenates a growing buffer.
+        self.assertTrue(all(len(text) <= 32 for text in texts))
+
+
+class ConformanceToolCallTests(unittest.TestCase):
+    """Tool-call surfacing, fragmented-argument reassembly, ordering, and malformed handling."""
+
+    def test_granted_tool_call_becomes_external_action_with_revision_and_digest(self) -> None:
+        """A granted tool resolves its snapshot revision and a deterministic arguments digest."""
+        emitted = _run_start(_start_command(), [{"type": "tool_call", "toolName": "search", "toolCallId": "call-1", "arguments": '{"q":"x"}'}])
+        action = next(candidate for candidate in emitted if candidate["kind"] == "external_action")
+        self.assertEqual(action["toolRevisionId"], "rev-search")
+        self.assertEqual(action["toolInvocationId"], "call-1")
+        self.assertEqual(action["argumentsDigest"], _arguments_digest({"q": "x"}))
+
+    def test_multiple_tool_calls_preserve_model_order(self) -> None:
+        """Two tool calls surface as two external actions in the exact order the model proposed them."""
+        emitted = _run_start(_start_command(), [
+            {"type": "tool_call", "toolName": "search", "toolCallId": "call-1", "arguments": "{}"},
+            {"type": "tool_call", "toolName": "write", "toolCallId": "call-2", "arguments": "{}"},
+        ])
+        actions = [candidate["toolRevisionId"] for candidate in emitted if candidate["kind"] == "external_action"]
+        self.assertEqual(actions, ["rev-search", "rev-write"])
+
+    def test_fragmented_arguments_reassemble_at_the_adapter_seam(self) -> None:
+        """Streamed argument fragments reassembled by the driver produce one complete neutral event.
+
+        The adapter seam receives a framework event exposing ``args_as_json_str`` (the reassembled
+        whole), so the runtime never sees partial JSON fragments. This fixture is an independently
+        authored stand-in framework object, not a real framework type.
+        """
+        reassembled = types.SimpleNamespace(
+            delta=None,
+            part=types.SimpleNamespace(tool_name="search", tool_call_id="call-frag", args_as_json_str=lambda: '{"q":"reassembled"}'),
+        )
+        neutral = _translate_framework_event(reassembled)
+        self.assertEqual(neutral, {"type": "tool_call", "toolName": "search", "toolCallId": "call-frag", "arguments": '{"q":"reassembled"}'})
+        emitted = _run_start(_start_command(), [neutral])
+        action = next(candidate for candidate in emitted if candidate["kind"] == "external_action")
+        self.assertEqual(action["arguments"], {"q": "reassembled"})
+
+    def test_malformed_arguments_are_a_hard_error_not_an_action(self) -> None:
+        """Unparseable arguments surface a ``malformed_tool_call`` error, never an external action."""
+        emitted = _run_start(_start_command(), [{"type": "tool_call", "toolName": "search", "toolCallId": "call-bad", "arguments": '{"q":'}])
+        self.assertNotIn("external_action", [candidate["kind"] for candidate in emitted])
+        error = next(candidate for candidate in emitted if candidate.get("eventType") == "run.error")
+        self.assertEqual(error["payload"], {"reason": "malformed_tool_call", "toolCallId": "call-bad"})
+
+
+class ConformanceApprovalResumeTests(unittest.TestCase):
+    """The approval boundary surfaces an external action; resume injects authorized deferred results."""
+
+    def test_external_action_then_resume_feeds_deferred_results(self) -> None:
+        """A tool call defers, then resume injects the authorized results and the run completes."""
+        start_emitted = _run_start(_start_command(), [{"type": "tool_call", "toolName": "write", "toolCallId": "call-approve", "arguments": "{}"}])
+        self.assertEqual([candidate["kind"] for candidate in start_emitted if candidate["kind"] == "external_action"], ["external_action"])
+
+        captured: dict = {}
+
+        def _resume_source(run_id, attempt, input_generation, deferred, _cancel, _steering):
+            captured["deferred"] = deferred
+            captured["inputGeneration"] = input_generation
+            return iter([{"type": "output_text", "text": "done"}, {"type": "usage", "inputTokens": 1, "outputTokens": 1}])
+
+        resume_emitted: list[dict] = []
+        _execute_resume_attempt(_resume_command({"call-approve": {"ok": True}}), "instance-conf", resume_emitted.append, resume_event_source=_resume_source)
+        self.assertEqual(captured["deferred"], {"call-approve": {"ok": True}})
+        self.assertEqual(_event_types(resume_emitted), ["run.resumed", "run.output_text", "run.usage", "run.completed"])
+
+
+class ConformanceRestartTests(unittest.TestCase):
+    """Restart resumes from the subordinate local checkpoint only when coordinates agree."""
+
+    def test_checkpoint_round_trips_for_the_agreeing_attempt(self) -> None:
+        """A checkpoint written during start reads back its compiled state for a matching restart."""
+        with tempfile.TemporaryDirectory() as directory:
+            cipher = _ReversingCipher()
+            _write_checkpoint("run-conf", 1, 9, {"compiledInput": _compiled_input()}, cipher=cipher, checkpoint_dir=directory)
+            state = _read_checkpoint("run-conf", 1, 9, cipher=cipher, checkpoint_dir=directory)
+            assert isinstance(state, dict)
+            self.assertEqual(state["compiledInput"]["digest"], "sha256:conformance")
+
+
+class ConformanceCancellationTests(unittest.TestCase):
+    """Cancellation is a positive signal that suppresses every later candidate."""
+
+    def test_cancel_mid_stream_suppresses_late_output_and_completion(self) -> None:
+        """Once cancel fires mid-stream, no later candidate (or completion) is emitted."""
+        cancel_event = threading.Event()
+
+        def _source(_compiled, cancel, _steering):
+            yield {"type": "output_text", "text": "before"}
+            cancel.set()
+            yield {"type": "output_text", "text": "after"}
+
+        emitted: list[dict] = []
+        _execute_start_attempt(_start_command(), "instance-conf", emitted.append, event_source=_source, cancel_event=cancel_event)
+        self.assertEqual(_event_types(emitted), ["run.started", "run.output_text"])
+        self.assertEqual(emitted[1]["payload"]["text"], "before")
+
+
+class ConformanceProviderFaultTests(unittest.TestCase):
+    """A provider/executor fault surfaces exactly one ``run.error`` with zero implicit retries."""
+
+    def test_provider_fault_surfaces_single_run_error(self) -> None:
+        """An executor exception yields started then one ``run.error``, never a silent success."""
+
+        def _boom(_compiled, _cancel, _steering):
+            raise RuntimeError("litellm proxy unreachable")
+            yield  # pragma: no cover - generator marker
+
+        emitted: list[dict] = []
+        _execute_start_attempt(_start_command(), "instance-conf", emitted.append, event_source=_boom)
+        self.assertEqual(_event_types(emitted), ["run.started", "run.error"])
+        self.assertEqual(emitted[1]["payload"], {"reason": "executor_failed", "errorType": "RuntimeError"})
+
+    def test_every_retry_path_is_pinned_to_zero(self) -> None:
+        """The bounded loop performs zero implicit model/provider/tool/output retries."""
+        self.assertEqual(set(_zero_retry_openai_settings().values()), {0})
+
+
+class ConformanceCompactionAndBudgetTests(unittest.TestCase):
+    """Compaction is excluded and budget counters normalize to safe non-negative integers."""
+
+    def test_usage_counters_coerce_to_non_negative_integers(self) -> None:
+        """Unknown or negative usage counters default to zero so budget accounting cannot go negative."""
+        self.assertEqual(_normalize_event({"type": "usage", "inputTokens": None, "outputTokens": -3}), ("run.usage", {"inputTokens": 0, "outputTokens": 0}))
+
+    def test_budget_exhausted_cancel_reason_is_echoed_verbatim(self) -> None:
+        """A server budget cancel reason is echoed, never re-authored by the runtime."""
+        cancel_command = {"kind": "cancel_attempt", "commandId": "cmd-cancel", "fence": 3, "assignment": {"runId": "run-conf", "attempt": 1}, "payload": {"reason": "budget_exhausted"}}
+        emitted: list[dict] = []
+        runtime._execute_cancel_attempt(cancel_command, "instance-conf", emitted.append, cancel_event=threading.Event())
+        self.assertEqual(emitted[0]["payload"], {"reason": "budget_exhausted"})
+
+    def test_unknown_framework_event_is_dropped_not_compacted_into_output(self) -> None:
+        """An unrecognized framework event is dropped (never accumulated) and logged for observability."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            self.assertIsNone(_normalize_event({"type": "memory_compaction", "text": "secret-context"}))
+        logged = buffer.getvalue()
+        self.assertIn("framework_event_dropped", logged)
+        self.assertNotIn("secret-context", logged)
+
+
+class ConformanceTelemetryTests(unittest.TestCase):
+    """Durable run evidence is emitted with run/attempt correlation and no credential material."""
+
+    def test_run_evidence_carries_run_and_attempt_without_secrets(self) -> None:
+        """Start emits a wide ``run_evidence`` event bound to run/attempt with no key or token."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            _run_start(_start_command(), [{"type": "usage", "inputTokens": 1, "outputTokens": 1}])
+        evidence = [json.loads(line) for line in buffer.getvalue().splitlines() if '"event": "run_evidence"' in line]
+        outcomes = {record["outcome"] for record in evidence}
+        self.assertEqual(outcomes, {"started", "completed"})
+        for record in evidence:
+            self.assertEqual(record["runId"], "run-conf")
+            self.assertEqual(record["attempt"], 1)
+            self.assertNotIn("litellmKey", record)
+            self.assertNotIn("token", record)
+
+    def test_trace_seam_is_a_transparent_no_op_offline(self) -> None:
+        """The OTEL span seam is a transparent no-op when the SDK is absent (the offline slice)."""
+        with runtime._trace("agent_runtime.test", runId="run-conf", attempt=1) as span:
+            self.assertIsNone(span)
+
+
+class ConformanceLiveLiteLlmLegTests(unittest.TestCase):
+    """The live-LiteLLM conformance leg — GATED on #337, skipped offline, never asserted passing here.
+
+    This leg drives the real pinned ``pydantic-ai`` package over a LiteLLM-compatible endpoint. It runs
+    only in the #337 adoption/conformance environment (both the framework installed and the endpoint
+    configured); offline it is skipped and contributes no PASS. Adoption is recorded by #337, not here.
+    """
+
+    @unittest.skipUnless(
+        importlib.util.find_spec("pydantic_ai") is not None and os.environ.get("OPENCRANE_RUNTIME_LIVE_CONFORMANCE") == "1",
+        "live-LiteLLM conformance is the #337 adoption gate; it is skipped unless the framework is installed and OPENCRANE_RUNTIME_LIVE_CONFORMANCE=1",
+    )
+    def test_live_litellm_conformance_is_gated(self) -> None:  # pragma: no cover - #337 adoption env only
+        """When explicitly enabled, the pinned driver symbols resolve for the live conformance run."""
+        from pydantic_ai import Agent  # noqa: F401
+        from pydantic_ai.models.openai import OpenAIModel  # noqa: F401
+        from pydantic_ai.providers.openai import OpenAIProvider  # noqa: F401
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/agent-runtime/tests/test_fault_matrix.py
+++ b/apps/agent-runtime/tests/test_fault_matrix.py
@@ -1,0 +1,229 @@
+"""Fault-injection matrix for the OpenCrane runtime's protocol and reliability invariants.
+
+Every scenario here is an OpenCrane-owned protocol/reliability fault that needs no live LiteLLM: it
+injects a hostile or degraded condition at the runtime's own seams and asserts the reliability
+invariant holds. The fixtures are independently authored plain frames — no transcript, no framework,
+no network.
+
+The asserted invariants, per the slice-4 matrix, are: no duplicate side effect, no split-brain
+writer, no lost / reordered / late event after a terminal, no unbounded retry, and no credential leak.
+"""
+
+import io
+import json
+import tempfile
+import threading
+import unittest
+
+from src import runtime
+from src.runtime import (
+    _MAX_FRAME_BYTES,
+    _arguments_digest,
+    _candidate,
+    _command_coordinates,
+    _execute_cancel_attempt,
+    _execute_start_attempt,
+    _iter_commands,
+    _read_checkpoint,
+    _retry_delay,
+    _tool_call_candidate,
+    _write_checkpoint,
+    _TerminalGate,
+)
+
+
+class _ReversingCipher:
+    """A reversible in-test cipher so stale-coordinate checkpoints can be exercised without crypto."""
+
+    def encrypt(self, data: bytes) -> bytes:
+        return b"v:" + data[::-1]
+
+    def decrypt(self, token: bytes) -> bytes:
+        if not token.startswith(b"v:"):
+            raise ValueError("bad token")
+        return token[len(b"v:"):][::-1]
+
+
+def _compiled_input() -> dict:
+    """Compiled input fixing exactly one granted tool revision for revision-fault scenarios."""
+    return {
+        "promptCompilerVersion": "v1",
+        "instructions": "",
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"name": "search", "toolRevisionId": "rev-search", "description": "", "parametersSchema": {}}],
+        "model": {"modelAlias": "silo-default"},
+        "budget": {},
+        "digest": "sha256:fault",
+    }
+
+
+def _start_command() -> dict:
+    """One structurally valid ``start_attempt`` command for terminal and cancellation scenarios."""
+    return {
+        "kind": "start_attempt",
+        "commandId": "cmd-start",
+        "fence": 4,
+        "assignment": {"runId": "run-fault", "attempt": 2},
+        "payload": {"snapshot": {"inputGeneration": 5}, "compiledInput": _compiled_input()},
+    }
+
+
+def _cancel_command() -> dict:
+    """One structurally valid ``cancel_attempt`` command sharing the start coordinates."""
+    return {
+        "kind": "cancel_attempt",
+        "commandId": "cmd-cancel",
+        "fence": 4,
+        "assignment": {"runId": "run-fault", "attempt": 2},
+        "payload": {"reason": "superseded"},
+    }
+
+
+def _coordinates() -> dict:
+    """Resolve the start command's immutable candidate coordinates."""
+    coordinates = _command_coordinates(_start_command(), "instance-fault")
+    assert coordinates is not None
+    return coordinates
+
+
+class FaultDuplicateAndReplayTests(unittest.TestCase):
+    """Duplicate frames, duplicate candidates, and replayed invocation ids cause no double effect."""
+
+    def test_duplicate_command_frames_map_to_identical_stable_coordinates(self) -> None:
+        """Two deliveries of the same command frame bind to identical coordinates for idempotent dedup."""
+        first = _command_coordinates(_start_command(), "instance-fault")
+        second = _command_coordinates(_start_command(), "instance-fault")
+        self.assertEqual(first, second)
+
+    def test_replayed_invocation_id_yields_a_deterministic_digest(self) -> None:
+        """A replayed tool invocation id over identical args yields the same digest the authority re-derives."""
+        event = {"type": "tool_call", "toolName": "search", "toolCallId": "call-replay", "arguments": '{"q":"a"}'}
+        first = _tool_call_candidate(_coordinates(), _compiled_input(), event)
+        second = _tool_call_candidate(_coordinates(), _compiled_input(), event)
+        self.assertEqual(first["toolInvocationId"], second["toolInvocationId"])
+        self.assertEqual(first["argumentsDigest"], second["argumentsDigest"])
+        self.assertEqual(first["argumentsDigest"], _arguments_digest({"q": "a"}))
+
+
+class FaultTerminalGateTests(unittest.TestCase):
+    """Exactly one terminal posts across the reader and worker threads (no split-brain writer)."""
+
+    def test_completion_then_late_cancel_keeps_the_single_terminal(self) -> None:
+        """When completion wins, a late cancel is a no-op — no second terminal is written."""
+        emitted: list[dict] = []
+        cancel_event = threading.Event()
+        gate = _TerminalGate(cancel_event)
+        _execute_start_attempt(_start_command(), "instance-fault", emitted.append, event_source=lambda _c, _x, _s: iter([]), cancel_event=cancel_event, terminal_gate=gate)
+        _execute_cancel_attempt(_cancel_command(), "instance-fault", emitted.append, cancel_event=cancel_event, terminal_gate=gate)
+        terminals = [candidate["eventType"] for candidate in emitted if candidate["eventType"] in ("run.completed", "run.error", "run.cancelled")]
+        self.assertEqual(terminals, ["run.completed"])
+
+    def test_cancel_in_the_check_then_act_window_posts_exactly_one_terminal(self) -> None:
+        """A cancel firing between loop end and completion post yields exactly one cancelled terminal."""
+        emitted: list[dict] = []
+        cancel_event = threading.Event()
+        gate = _TerminalGate(cancel_event)
+
+        def _source(_compiled, _cancel, _steering):
+            yield {"type": "output_text", "text": "partial"}
+            _execute_cancel_attempt(_cancel_command(), "instance-fault", emitted.append, cancel_event=cancel_event, terminal_gate=gate)
+
+        _execute_start_attempt(_start_command(), "instance-fault", emitted.append, event_source=_source, cancel_event=cancel_event, terminal_gate=gate)
+        terminals = [candidate["eventType"] for candidate in emitted if candidate["eventType"] in ("run.completed", "run.error", "run.cancelled")]
+        self.assertEqual(terminals, ["run.cancelled"])
+
+
+class FaultStreamLossTests(unittest.TestCase):
+    """Command-stream loss and disconnected/slow peers bound work without a late event or retry storm."""
+
+    def test_command_reading_stops_the_instant_the_stream_is_marked_lost(self) -> None:
+        """A set cancellation flag stops command reading so a dropped stream cannot keep dispatching."""
+        cancelled = threading.Event()
+        cancelled.set()
+        self.assertEqual(list(_iter_commands(iter([b"event: command\n", b'data: {"kind":"x"}\n', b"\n"]), cancelled)), [])
+
+    def test_pod_or_peer_loss_mid_stream_suppresses_every_later_candidate(self) -> None:
+        """When cancellation (the stream-loss fallback) fires mid-stream, no later candidate is emitted."""
+        cancel_event = threading.Event()
+
+        def _source(_compiled, cancel, _steering):
+            yield {"type": "output_text", "text": "one"}
+            cancel.set()  # peer/pod loss trips the fence-bump + stream-loss cancellation fallback
+            yield {"type": "output_text", "text": "two"}
+
+        emitted: list[dict] = []
+        _execute_start_attempt(_start_command(), "instance-fault", emitted.append, event_source=_source, cancel_event=cancel_event)
+        self.assertEqual([candidate.get("eventType") for candidate in emitted], ["run.started", "run.output_text"])
+
+    def test_reconnect_backoff_is_bounded_so_a_dead_peer_cannot_cause_a_retry_storm(self) -> None:
+        """Reconnect delay is capped regardless of attempt count, so retries never grow without bound."""
+        self.assertLessEqual(_retry_delay(1_000), 31.0)
+
+
+class FaultStaleAuthorityTests(unittest.TestCase):
+    """Wrong or stale assignment, fence, generation, revision, and args are refused fail-closed."""
+
+    def test_stale_generation_or_wrong_assignment_discards_the_local_checkpoint(self) -> None:
+        """A checkpoint disagreeing on run, attempt, or input generation is discarded, never trusted."""
+        with tempfile.TemporaryDirectory() as directory:
+            cipher = _ReversingCipher()
+            _write_checkpoint("run-fault", 2, 5, {"compiledInput": {}}, cipher=cipher, checkpoint_dir=directory)
+            self.assertIsNone(_read_checkpoint("run-fault", 2, 6, cipher=cipher, checkpoint_dir=directory))
+            self.assertIsNone(_read_checkpoint("other-run", 2, 5, cipher=cipher, checkpoint_dir=directory))
+            self.assertIsNone(_read_checkpoint("run-fault", 3, 5, cipher=cipher, checkpoint_dir=directory))
+
+    def test_forged_checkpoint_version_is_discarded(self) -> None:
+        """A checkpoint tagged with an unknown version is discarded rather than replayed as state."""
+        with tempfile.TemporaryDirectory() as directory:
+            cipher = _ReversingCipher()
+            path = runtime._checkpoint_path(directory)
+            forged = cipher.encrypt(runtime.json.dumps({"checkpointVersion": 404, "runId": "run-fault", "attempt": 2, "inputGeneration": 5, "state": {}}, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+            with open(path, "wb") as handle:
+                handle.write(forged)
+            self.assertIsNone(_read_checkpoint("run-fault", 2, 5, cipher=cipher, checkpoint_dir=directory))
+
+    def test_ungranted_or_altered_tool_revision_is_a_hard_unknown_tool_error(self) -> None:
+        """A tool naming a revision outside the compiled grant set is a hard error, never an action."""
+        candidate = _tool_call_candidate(_coordinates(), _compiled_input(), {"type": "tool_call", "toolName": "exfiltrate", "toolCallId": "call-x", "arguments": "{}"})
+        self.assertEqual(candidate["eventType"], "run.error")
+        self.assertEqual(candidate["payload"], {"reason": "unknown_tool", "toolCallId": "call-x"})
+
+    def test_changed_arguments_change_the_digest(self) -> None:
+        """A single changed argument changes the digest so a mutated replay cannot reuse the authority row."""
+        self.assertNotEqual(_arguments_digest({"q": "a"}), _arguments_digest({"q": "b"}))
+
+    def test_malformed_frame_yields_no_coordinates_and_no_candidate(self) -> None:
+        """A schema-mismatched frame (missing assignment) yields no coordinates, so no candidate posts."""
+        emitted: list[dict] = []
+        _execute_start_attempt({"kind": "start_attempt", "commandId": "cmd-bad", "fence": 4}, "instance-fault", emitted.append, event_source=lambda _c, _x, _s: iter([]))
+        self.assertEqual(emitted, [])
+
+
+class FaultOversizedPayloadTests(unittest.TestCase):
+    """An oversized stream frame is rejected at the 64 KiB boundary rather than buffered unbounded."""
+
+    def test_frame_above_the_boundary_is_rejected(self) -> None:
+        """A single response line above 64 KiB raises rather than being parsed."""
+        oversized = b"data: " + b"a" * (_MAX_FRAME_BYTES + 1) + b"\n"
+        with self.assertRaises(RuntimeError):
+            list(_iter_commands(iter([oversized]), threading.Event()))
+
+
+class FaultCredentialLeakTests(unittest.TestCase):
+    """No credential material ever reaches a candidate or a log line."""
+
+    def test_run_evidence_and_candidates_never_carry_credential_material(self) -> None:
+        """Across a full start run, neither emitted candidates nor logs contain a key or token."""
+        emitted: list[dict] = []
+        buffer = io.StringIO()
+        import contextlib
+
+        with contextlib.redirect_stdout(buffer):
+            _execute_start_attempt(_start_command(), "instance-fault", emitted.append, event_source=lambda _c, _x, _s: iter([{"type": "usage", "inputTokens": 1, "outputTokens": 1}]))
+        serialized = json.dumps(emitted) + buffer.getvalue()
+        for secret_marker in ("sk-", "litellmKey", "Bearer ", "api_key", "privateKey"):
+            self.assertNotIn(secret_marker, serialized)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/agent-runtime/tests/test_runtime.py
+++ b/apps/agent-runtime/tests/test_runtime.py
@@ -1,9 +1,11 @@
 """Focused behavioral tests for the runtime shell, its bootstrap exchange, and the model executor.
 
 The executor is exercised offline against recorded neutral-event fixtures fed through the same
-normalizer the live Pydantic AI driver feeds. Driving the real ``pydantic-ai`` package against a
-fake OpenAI-compatible endpoint is the deferred adoption gate recorded in ADR 0010 and is not run
-here; these tests import no framework package and reach no network.
+normalizer the live Pydantic AI driver feeds. The broader offline conformance harness and
+fault-injection matrix live in ``test_conformance.py`` and ``test_fault_matrix.py``. Driving the real
+``pydantic-ai`` package against a live LiteLLM-compatible endpoint is the adoption gate recorded in
+ADR 0010, gated on #337, and is not run here; these tests import no framework package and reach no
+network.
 """
 
 import contextlib
@@ -569,9 +571,9 @@ class RuntimeResumeCancelTests(unittest.TestCase):
 
 
 class RuntimePydanticAiDriverTests(unittest.TestCase):
-    """Guard the deferred live driver so its conformance gate is explicit, not silently skipped."""
+    """Guard the live driver import so its #337 adoption gate is explicit, not silently skipped."""
 
-    @unittest.skipUnless(importlib.util.find_spec("pydantic_ai") is not None, "pydantic-ai is installed only in the adoption/conformance environment")
+    @unittest.skipUnless(importlib.util.find_spec("pydantic_ai") is not None, "pydantic-ai is installed only in the #337 live-LiteLLM adoption/conformance environment")
     def test_driver_module_is_importable_when_present(self) -> None:  # pragma: no cover - adoption env only
         """When the pinned framework is present, the lazily imported driver symbols resolve."""
         from pydantic_ai import Agent  # noqa: F401

--- a/docs/agents/app-source-allowlist.json
+++ b/docs/agents/app-source-allowlist.json
@@ -15,8 +15,12 @@
     { "path": "apps/opencrane/src/__tests__/config.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/__tests__/index.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/app/config.ts", "owner": "apps/opencrane", "classification": "app-config" },
+    { "path": "apps/opencrane/src/app/__tests__/external-action-executor.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
+    { "path": "apps/opencrane/src/app/external-action-executor.ts", "owner": "apps/opencrane", "classification": "route-composition" },
+    { "path": "apps/opencrane/src/app/external-action-executor.types.ts", "owner": "apps/opencrane", "classification": "route-composition" },
     { "path": "apps/opencrane/src/app/instrument.ts", "owner": "apps/opencrane", "classification": "process-instrumentation" },
     { "path": "apps/opencrane/src/app/log.ts", "owner": "apps/opencrane", "classification": "process-logging" },
+    { "path": "apps/opencrane/src/app/prisma-run-input-compiler.ts", "owner": "apps/opencrane", "classification": "prisma-composition" },
     { "path": "apps/opencrane/src/app/routes.ts", "owner": "apps/opencrane", "classification": "route-composition" },
     { "path": "apps/opencrane/src/hosting/hosting-adapter.factory.ts", "owner": "apps/opencrane", "classification": "hosting-composition" },
     { "path": "apps/opencrane/src/hosting/index.ts", "owner": "apps/opencrane", "classification": "hosting-composition" },
@@ -63,6 +67,8 @@
     { "path": "apps/agent-controller/vitest.config.ts", "owner": "apps/agent-controller", "classification": "test-config" },
 
     { "path": "apps/agent-runtime/src/runtime.py", "owner": "apps/agent-runtime", "classification": "process-entrypoint" },
+    { "path": "apps/agent-runtime/tests/test_conformance.py", "owner": "apps/agent-runtime", "classification": "composition-test" },
+    { "path": "apps/agent-runtime/tests/test_fault_matrix.py", "owner": "apps/agent-runtime", "classification": "composition-test" },
     { "path": "apps/agent-runtime/tests/test_runtime.py", "owner": "apps/agent-runtime", "classification": "composition-test" },
 
     { "path": "apps/feat-central-agents/src/__tests__/connectors/slack.connector.test.ts", "owner": "apps/feat-central-agents", "classification": "delete" },

--- a/docs/agents/workload-ownership.json
+++ b/docs/agents/workload-ownership.json
@@ -145,6 +145,11 @@
       "path": "libs/backend/feat-openclaw-tenant/main/src/reconcilers/tenants/destroy/tenant-cleanup.ts",
       "anchor": "kind: \"Deployment\"",
       "reason": "Deletion selector only; it cannot create a pod."
+    },
+    {
+      "path": "libs/backend/agents/runtime/controller/src/agent-controller.ts",
+      "anchor": "kind: \"Job\"",
+      "reason": "This is a Secret owner reference to an already-created attempt Job; it cannot create a pod."
     }
   ],
   "archiveWorkloadInventory": {

--- a/docs/design/agent-runtime-adoption-evidence.md
+++ b/docs/design/agent-runtime-adoption-evidence.md
@@ -1,0 +1,47 @@
+# Agent-runtime adoption-evidence record (template — UNPOPULATED)
+
+> Status: **TEMPLATE ONLY. Nothing below is adopted.** This record is filled and acted on by the
+> named later gate [#337](https://github.com/italanta/opencrane/issues/337), under
+> [ADR 0010](../adr/0010-language-neutral-agent-runtime.md). Do not treat an empty field as a pass.
+
+## Purpose
+
+ADR 0010 qualifies `pydantic-ai-slim[openai]==2.13.0` as the **first candidate** for the bounded
+model/tool loop and states that adoption is recorded **only after** the pinned adapter passes every
+protocol, security, reliability, and **live-LiteLLM** conformance gate. The offline conformance
+harness and fault-injection matrix (Phase E slice 4 — `apps/agent-runtime/tests/test_conformance.py`,
+`apps/agent-runtime/tests/test_fault_matrix.py`, and the attempt-scoped credential rejection proofs in
+`libs/backend/agents/personal/runs`) are built and CI-runnable, but they are a **precondition**, not
+adoption. The live-LiteLLM leg, this evidence record, and the OpenClaw loop deletion all remain gated
+on #337.
+
+This document is the structure #337 must complete. Every field is intentionally blank; #337 fills it
+from the passing run and only then flips status to adopted.
+
+## Adoption evidence
+
+| Field | Value | Source of truth |
+| --- | --- | --- |
+| Package lock (hash-pinned transitive) | _(unpopulated)_ | `pip-compile --generate-hashes` over `apps/agent-runtime/deploy/requirements.txt` |
+| Image digest | _(unpopulated)_ | `apps/agent-runtime/deploy/Dockerfile` base + built `@sha256:…` |
+| Protocol version | _(unpopulated)_ | `AGENT_RUNTIME_PROTOCOL_V1` in `@opencrane/contracts` |
+| Supported model matrix | _(unpopulated)_ | live-LiteLLM conformance run over the per-silo proxy |
+| Upgrade / drain rules | _(unpopulated)_ | #337 rollout note |
+
+## Gate checklist (all must be evidenced by #337 before adoption)
+
+- [ ] Offline conformance harness green in CI (precondition — slice 4).
+- [ ] Offline fault-injection matrix green in CI (precondition — slice 4).
+- [ ] Attempt-scoped credential rejection proofs green in CI (precondition — slice 4).
+- [ ] Live-LiteLLM conformance leg green against the real proxy (`OPENCRANE_RUNTIME_LIVE_CONFORMANCE=1`).
+- [ ] Hash-pinned package lock resolved and recorded above.
+- [ ] Base-image digest pinned and recorded above.
+- [ ] Supported model matrix recorded above.
+- [ ] Upgrade/drain rules recorded above.
+- [ ] OpenClaw loop deletion executed (only after the above) — the #337 deletion gate.
+
+## See also
+
+- [ADR 0010 — Language-neutral agent runtime](../adr/0010-language-neutral-agent-runtime.md)
+- [#337 — conformance adoption + OpenClaw deletion gate](https://github.com/italanta/opencrane/issues/337)
+- [#246 — Phase E runtime boundary](https://github.com/italanta/opencrane/issues/246)

--- a/libs/backend/agents/personal/runs/main/src/__tests__/attempt-model-key-rejection.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/attempt-model-key-rejection.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import type { AttemptModelKeyIssuer, AttemptModelKeyMintRequest, MintedAttemptModelKey } from "../run-dispatch.types.js";
+
+/**
+ * Attempt-scoped LiteLLM credential rejection proofs (Phase E slice 4).
+ *
+ * These prove the SECURITY ENVELOPE of the attempt-scoped virtual key minted by the slice-2 claim
+ * path ({@link AttemptModelKeyIssuer}, wired to the model-routing gateway in `apps/opencrane`).
+ * They run against a MOCK credential authority that stands in for LiteLLM's key enforcement — never a
+ * live endpoint — so the invariants hold offline. The live-LiteLLM leg is gated on #337 (ADR 0010).
+ *
+ * Each proof mints a key bound to exactly one attempt (alias), model alias, silo, budget, and expiry,
+ * then presents a call and asserts the authority refuses it unless every dimension still matches.
+ */
+
+/** One presented model call the credential authority must authorize before it reaches a provider. */
+interface PresentedModelCall
+{
+	/** Opaque virtual key the runtime presents (never the master key). */
+	readonly key: string;
+	/** Attempt key alias the calling attempt expects the key to be bound to. */
+	readonly expectedKeyAlias: string;
+	/** Model alias the call targets. */
+	readonly modelAlias: string;
+	/** Silo the call originates from. */
+	readonly siloId: string;
+	/** Incremental US-dollar cost this call would add to the key's cumulative spend. */
+	readonly costUsd: number;
+	/** Wall-clock instant of the call in epoch milliseconds. */
+	readonly nowEpochMs: number;
+}
+
+/** Authorization outcome mirroring LiteLLM's allow / deny decision for a virtual key. */
+type AuthorizationOutcome =
+	| { readonly outcome: "allowed" }
+	| { readonly outcome: "denied"; readonly reason: "alias_mismatch" | "model_not_permitted" | "silo_mismatch" | "expired" | "revoked" | "budget_exceeded" };
+
+/**
+ * Mock stand-in for LiteLLM's attempt-scoped virtual-key enforcement.
+ *
+ * `issue` records the immutable binding minted from an {@link AttemptModelKeyMintRequest}; `authorize`
+ * refuses any presented call that drifts from that binding, and `revoke` models an out-of-band kill.
+ */
+class MockLiteLlmCredentialAuthority
+{
+	private readonly bindings = new Map<string, { keyAlias: string; modelAlias: string; siloId: string; maxBudgetUsd: number; expiresAtEpochMs: number; revoked: boolean; spentUsd: number }>();
+	private issued = 0;
+	private readonly nowEpochMs: number;
+
+	/** Anchors minted expiries to a fixed clock so expiry proofs are deterministic. */
+	constructor(nowEpochMs: number)
+	{
+		this.nowEpochMs = nowEpochMs;
+	}
+
+	/** Mint one transient key bound to the exact attempt alias, model, silo, budget, and lifetime. */
+	issue(request: AttemptModelKeyMintRequest): MintedAttemptModelKey
+	{
+		this.issued += 1;
+		const key = `sk-attempt-${this.issued}`;
+		this.bindings.set(key, { keyAlias: request.keyAlias, modelAlias: request.modelAlias, siloId: request.siloId, maxBudgetUsd: request.maxBudgetUsd, expiresAtEpochMs: this.nowEpochMs + request.expirySeconds * 1000, revoked: false, spentUsd: 0 });
+		return { key };
+	}
+
+	/** Model an out-of-band revocation of an already-minted key. */
+	revoke(key: string): void
+	{
+		const binding = this.bindings.get(key);
+		if (binding) binding.revoked = true;
+	}
+
+	/** Authorize a presented call, accruing spend only when every dimension still matches. */
+	authorize(call: PresentedModelCall): AuthorizationOutcome
+	{
+		const binding = this.bindings.get(call.key);
+		if (!binding || binding.keyAlias !== call.expectedKeyAlias) return { outcome: "denied", reason: "alias_mismatch" };
+		if (binding.revoked) return { outcome: "denied", reason: "revoked" };
+		if (call.nowEpochMs >= binding.expiresAtEpochMs) return { outcome: "denied", reason: "expired" };
+		if (call.siloId !== binding.siloId) return { outcome: "denied", reason: "silo_mismatch" };
+		if (call.modelAlias !== binding.modelAlias) return { outcome: "denied", reason: "model_not_permitted" };
+		if (binding.spentUsd + call.costUsd > binding.maxBudgetUsd) return { outcome: "denied", reason: "budget_exceeded" };
+		binding.spentUsd += call.costUsd;
+		return { outcome: "allowed" };
+	}
+}
+
+/** Build one representative mint request shaped exactly like the slice-2 claim path produces. */
+function _MintRequest(overrides: Partial<AttemptModelKeyMintRequest> = {}): AttemptModelKeyMintRequest
+{
+	return { keyAlias: "attempt-0123456789abcdef0123456789abcdef", modelAlias: "silo-default", siloId: "silo-a", maxBudgetUsd: 5, expirySeconds: 900, ...overrides };
+}
+
+/** Build one in-scope call matching a mint request; individual proofs mutate a single dimension. */
+function _CallFor(key: string, request: AttemptModelKeyMintRequest, overrides: Partial<PresentedModelCall> = {}): PresentedModelCall
+{
+	return { key, expectedKeyAlias: request.keyAlias, modelAlias: request.modelAlias, siloId: request.siloId, costUsd: 1, nowEpochMs: 1_000, ...overrides };
+}
+
+describe("attempt-scoped LiteLLM credential rejection", function _Suite()
+{
+	it("is bound through the real AttemptModelKeyIssuer port and authorizes an in-scope call", function _AllowsInScope()
+	{
+		const authority = new MockLiteLlmCredentialAuthority(1_000);
+		const issuer: AttemptModelKeyIssuer = async function _issue(request) { return authority.issue(request); };
+		return issuer(_MintRequest()).then(function _authorize(minted)
+		{
+			expect(authority.authorize(_CallFor(minted.key, _MintRequest()))).toEqual({ outcome: "allowed" });
+		});
+	});
+
+	it("rejects an unapproved model alias not frozen into the snapshot route", function _RejectsAlias()
+	{
+		const authority = new MockLiteLlmCredentialAuthority(1_000);
+		const minted = authority.issue(_MintRequest());
+		expect(authority.authorize(_CallFor(minted.key, _MintRequest(), { modelAlias: "gpt-premium" }))).toEqual({ outcome: "denied", reason: "model_not_permitted" });
+	});
+
+	it("rejects a cross-attempt key alias and a cross-silo presentation", function _RejectsCrossAttemptAndSilo()
+	{
+		const authority = new MockLiteLlmCredentialAuthority(1_000);
+		const minted = authority.issue(_MintRequest());
+		expect(authority.authorize(_CallFor(minted.key, _MintRequest(), { expectedKeyAlias: "attempt-ffffffffffffffffffffffffffffffff" }))).toEqual({ outcome: "denied", reason: "alias_mismatch" });
+		expect(authority.authorize(_CallFor(minted.key, _MintRequest(), { siloId: "silo-b" }))).toEqual({ outcome: "denied", reason: "silo_mismatch" });
+	});
+
+	it("rejects a call after the attempt key lifetime expires", function _RejectsExpiry()
+	{
+		const authority = new MockLiteLlmCredentialAuthority(1_000);
+		const minted = authority.issue(_MintRequest({ expirySeconds: 10 }));
+		expect(authority.authorize(_CallFor(minted.key, _MintRequest(), { nowEpochMs: 1_000 + 11_000 }))).toEqual({ outcome: "denied", reason: "expired" });
+	});
+
+	it("rejects a call once the attempt key is revoked", function _RejectsRevocation()
+	{
+		const authority = new MockLiteLlmCredentialAuthority(1_000);
+		const minted = authority.issue(_MintRequest());
+		authority.revoke(minted.key);
+		expect(authority.authorize(_CallFor(minted.key, _MintRequest()))).toEqual({ outcome: "denied", reason: "revoked" });
+	});
+
+	it("rejects the call that would push cumulative spend over the frozen budget", function _RejectsOverBudget()
+	{
+		const authority = new MockLiteLlmCredentialAuthority(1_000);
+		const minted = authority.issue(_MintRequest({ maxBudgetUsd: 3 }));
+		expect(authority.authorize(_CallFor(minted.key, _MintRequest(), { costUsd: 2 }))).toEqual({ outcome: "allowed" });
+		expect(authority.authorize(_CallFor(minted.key, _MintRequest(), { costUsd: 2 }))).toEqual({ outcome: "denied", reason: "budget_exceeded" });
+	});
+});

--- a/plan.md
+++ b/plan.md
@@ -35,8 +35,10 @@ the target, refined by the
    isolated; controller and channel-proxy trust boundaries are separate apps; legacy CRDs and
    OpenClaw authorities disappear.
 
-Toolkit selection remains evidence-driven: the Phase E conformance run chooses one exact-pinned
-driver (→ [#246](https://github.com/italanta/opencrane/issues/246)).
+Toolkit selection remains evidence-driven: the offline Phase E conformance harness and fault-injection
+matrix are built and CI-runnable, but choosing and adopting the exact-pinned driver waits on the
+live-LiteLLM conformance leg, gated on [#337](https://github.com/italanta/opencrane/issues/337)
+(→ [#246](https://github.com/italanta/opencrane/issues/246)).
 
 ## Current state
 
@@ -123,9 +125,12 @@ runtime also writes encrypted, version-tagged, replaceable LOCAL checkpoints sub
 state (no server-side checkpoint model). The MCP, memory, and sandbox execution transports are ports
 with fail-closed stubs wired only in the composition root. NOT yet built: the human
 approval-DECISION HTTP endpoint and the steering-INGEST HTTP surface are the operator/product plane in
-Phase F (#224), so approval and steering are not end-to-end live; toolkit selection, the conformance
-suite, live-LiteLLM adoption evidence, OpenClaw deletion, and the remaining E1/E2 product capabilities
-below are also incomplete.
+Phase F (#224), so approval and steering are not end-to-end live. The offline conformance harness and
+fault-injection matrix ARE built and CI-runnable (runtime protocol/reliability, attempt-scoped
+credential rejection, observability evidence); still gated on
+[#337](https://github.com/italanta/opencrane/issues/337) are the live-LiteLLM conformance leg,
+driver adoption evidence, and OpenClaw loop deletion — none of which has happened. The remaining
+E1/E2 product capabilities below are also incomplete.
 
 **Runtime lane** (→ [#246](https://github.com/italanta/opencrane/issues/246)): implement
 `RunInputSnapshot`, the TypeScript-owned prompt compiler, the language-neutral `AgentRuntimeProtocol v1`


### PR DESCRIPTION
Slice **4 of 6** of the Phase E runtime lane (#246) — **offline leg only**. Advances #330; the OpenClaw deletion + ADR 0010 adoption are split to the named gate **#337** (blocked on a live-LiteLLM conformance pass). **Stacked on #336** (`feat/phase-e-runtime-actions`).

## Why this is scoped down (architecture + reaper preflight BLOCK)

ADR 0010 binds runtime adoption — and therefore predecessor deletion — to a passing **live-LiteLLM** conformance run, which cannot execute in an offline worktree. OpenClaw is still the *only* working conversational path (no green replacement gateway exists yet). So deleting it here would remove the only working runtime. Deletion + adoption are tracked in **#337**; this PR lands everything that is offline-safe. **No OpenClaw surface is touched** (diff-stat verified; new test/fixture files have zero OpenClaw/Gateway-v4 references).

## What

- **Conformance harness** (`apps/agent-runtime/tests/test_conformance.py`) — independently-authored neutral-event fixtures through a LiteLLM-compatible mock: streaming/usage, fragmented tool-arg reassembly, tool ordering, malformed calls, slow progress, approvals→resume, restart (checkpoint round-trip), cancellation, provider faults, compaction, budgets, telemetry. The **live-LiteLLM leg** is a dedicated class gated on `find_spec("pydantic_ai")` + `OPENCRANE_RUNTIME_LIVE_CONFORMANCE=1`, non-blocking, never asserted offline.
- **Fault-injection matrix** (`test_fault_matrix.py`) — duplicate/replayed frames, stream/peer/pod loss, bounded backoff, stale fence/generation + forged checkpoint version, ungranted/altered tool revision, changed-args digest, malformed frame, oversized (>64KiB) payload; asserts single terminal (no split-brain), suppressed late events, zero retry, no credential leak.
- **Attempt-scoped credential-rejection proofs** (`libs/backend/agents/personal/runs/.../attempt-model-key-rejection.test.ts`) — unapproved alias / cross-attempt / cross-silo / expiry / revocation / over-budget, plus an in-scope allow, through the slice-2 `AttemptModelKeyIssuer` port.
- **Observability** — a guarded, no-op-offline OTEL `_trace` seam + wide `run_evidence` logs in `runtime.py` (run/attempt correlation, secrets excluded; verified by a secret-marker test). Extends the existing `_log` convention; TS `instrument.ts`/`___DoWithTrace` untouched.
- **Adoption-evidence structure** (`docs/design/agent-runtime-adoption-evidence.md`) — UNPOPULATED template (package lock, image digest, protocol version, model matrix, upgrade/drain), referencing #337 + ADR 0010 as the gate that fills and acts on it.
- Rewrote the stale "deferred to slice 4" comments in `runtime.py`/`test_runtime.py`/`plan.md` to precise #337 pointers.

## Gates

- **Architecture** PASS · **Reaper** PASS · **Correctness + obs-leak** no findings.
- Validation: `nx affected build/lint/test` green (4 projects); agent-runtime 67 tests (2 correctly skipped = #337-gated live legs); backend-agents-personal-runs 45 (incl. 6 new proofs); `lint:boundaries` clean; style-check clean. No new deployable/chart/CRD/env/schema surface.

## Notes (non-blocking)

- Digest-mismatch *denial* is enforced + tested at the external-action authority (slice 3 / #336); the runtime tests here verify digest determinism only.
- One credential-rejection test name reads as "real port" but uses the #337-gated mock (offline) — cosmetic.
- No `apps/channel-proxy` conformance scaffold added (no existing test target; its protocol/reliability lives in the green `libs/backend/channel-proxy` and is covered via agent-runtime + personal-runs).
