### PR TITLE
🛡️ Phase E: bound per-service admission concurrency

### DIFF
--- a/libs/backend/agents/personal/runs/main/README.md
+++ b/libs/backend/agents/personal/runs/main/README.md
@@ -16,6 +16,7 @@ use, then governs later attempts without changing the logical run or its frozen 
  ┌──────────────────────────────────────────┐
  │   runs  ◄── HERE                          │  run + one snapshot + ordered outbox
  │   · PrismaRunAdmissionRepository          │  duplicate returns the first snapshot
+ │   · RunAdmissionConcurrencyGate            │  bounded wait before a DB connection
  │   · PrismaRunCancellationRepository       │  fence first; clean exact Job; then terminal
  │   · __StartNextRunAttempt                 │  terminal run: attempt N → N+1
  │   · __ValidateRunWorkloadAssignment       │  Job/Pod identity == current attempt?
@@ -35,6 +36,13 @@ later time. A new request locks the AgentService, lets the session assembler rev
 inside that transaction, and commits the `AgentRun`, its only `RunInputSnapshot`, and the ordered
 `RunAccepted` and `RunAttemptRequested` outbox events together. The canonical digest covers every
 snapshot field except its own digest.
+
+`RunAdmissionConcurrencyGate` is the upstream overload boundary for a live admission entrypoint.
+It partitions capacity by `(siloId, AgentServiceId)`, starts only the configured number of admissions,
+and holds a bounded FIFO queue **before** its work can open a PostgreSQL transaction. A full queue is
+rejected with `admission_concurrency_limited`; it does not turn a hot service row lock into an
+unbounded connection pool. The production entrypoint must use this gate before calling
+`PrismaRunAdmissionRepository.admit()` and must keep its policy aligned with the database pool budget.
 
 `__StartNextRunAttempt` is a **compare-and-swap** retry state machine: it reads the run and its
 AgentService authority as one snapshot, refuses unless the run is in a retryable terminal state and the
@@ -109,6 +117,8 @@ uncertainty fails closed.
   inputs without digesting the self-referential `digest` field.
 - `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial
   run, snapshot and ordered outbox events around a caller-supplied assembly callback.
+- `RunAdmissionConcurrencyGate` — bound active and queued admissions for one silo and AgentService
+  before the caller can acquire a persistence connection.
 - `RunAdmissionRepository`, `RunAdmissionCommand`, `RunAdmissionTransaction`,
   `RunAdmissionBuildResult` and `RunAdmissionResult` — the transaction-fenced initial-admission port
   and its input/output vocabulary.

--- a/libs/backend/agents/personal/runs/main/src/__tests__/run-admission-concurrency.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/run-admission-concurrency.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { RunAdmissionConcurrencyGate } from "../run-admission-concurrency.js";
+
+/** Creates fixed admission coordinates with optional silo and service overrides. */
+function _command(siloId = "silo-1", agentServiceId = "service-1")
+{
+	return { siloId, agentServiceId } as const;
+}
+
+/** Deferred promise controls used to observe whether a queued admission has started. */
+interface _Deferred<TValue>
+{
+	/** Promise settled only by this test's explicit resolve or reject function. */
+	readonly promise: Promise<TValue>;
+	/** Completes the controlled promise with one value. */
+	resolve(value: TValue): void;
+}
+
+/** Creates a deferred value without exposing a database or timer dependency to the concurrency test. */
+function _deferred<TValue>(): _Deferred<TValue>
+{
+	let resolve: ((value: TValue) => void) | undefined;
+	const promise = new Promise<TValue>(function _createDeferred(nextResolve)
+	{
+		resolve = nextResolve;
+	});
+	return { promise, resolve: function _resolve(value: TValue): void { resolve?.(value); } };
+}
+
+describe("RunAdmissionConcurrencyGate", function _describeRunAdmissionConcurrencyGate()
+{
+	it("queues one same-service admission before persistence and rejects later overload without running it", async function _boundsOneService()
+	{
+		const gate = new RunAdmissionConcurrencyGate({ maxConcurrentAdmissions: 1, maxQueuedAdmissions: 1 });
+		const first = _deferred<string>();
+		const second = _deferred<string>();
+		let firstStarted = false;
+		let secondStarted = false;
+		let rejectedStarted = false;
+
+		const firstResult = gate.execute(_command(), async function _runFirst() { firstStarted = true; return await first.promise; });
+		const secondResult = gate.execute(_command(), async function _runSecond() { secondStarted = true; return await second.promise; });
+		const rejectedResult = gate.execute(_command(), async function _runRejected() { rejectedStarted = true; return "must-not-run"; });
+
+		expect(firstStarted).toBe(true);
+		expect(secondStarted).toBe(false);
+		await expect(rejectedResult).resolves.toEqual({ outcome: "rejected", reason: "admission_concurrency_limited" });
+		expect(rejectedStarted).toBe(false);
+
+		first.resolve("first");
+		await expect(firstResult).resolves.toEqual({ outcome: "completed", value: "first" });
+		expect(secondStarted).toBe(true);
+		second.resolve("second");
+		await expect(secondResult).resolves.toEqual({ outcome: "completed", value: "second" });
+	});
+
+	it("does not let one service consume another service or silo's admission capacity", async function _partitionsAuthority()
+	{
+		const gate = new RunAdmissionConcurrencyGate({ maxConcurrentAdmissions: 1, maxQueuedAdmissions: 0 });
+		const first = _deferred<string>();
+		const second = _deferred<string>();
+		const third = _deferred<string>();
+		let starts = 0;
+
+		const firstResult = gate.execute(_command("silo-1", "service-1"), async function _runFirst() { starts += 1; return await first.promise; });
+		const secondResult = gate.execute(_command("silo-1", "service-2"), async function _runSecond() { starts += 1; return await second.promise; });
+		const thirdResult = gate.execute(_command("silo-2", "service-1"), async function _runThird() { starts += 1; return await third.promise; });
+
+		expect(starts).toBe(3);
+		first.resolve("first");
+		second.resolve("second");
+		third.resolve("third");
+		await expect(Promise.all([firstResult, secondResult, thirdResult])).resolves.toEqual([
+			{ outcome: "completed", value: "first" },
+			{ outcome: "completed", value: "second" },
+			{ outcome: "completed", value: "third" },
+		]);
+	});
+
+	it("releases the next waiter when active admission work fails", async function _releasesAfterFailure()
+	{
+		const gate = new RunAdmissionConcurrencyGate({ maxConcurrentAdmissions: 1, maxQueuedAdmissions: 1 });
+		const first = _deferred<void>();
+		let secondStarted = false;
+		const firstResult = gate.execute(_command(), async function _runFirst() { await first.promise; throw new Error("persistence unavailable"); });
+		const secondResult = gate.execute(_command(), async function _runSecond() { secondStarted = true; return "second"; });
+
+		first.resolve();
+		await expect(firstResult).rejects.toThrow("persistence unavailable");
+		await expect(secondResult).resolves.toEqual({ outcome: "completed", value: "second" });
+		expect(secondStarted).toBe(true);
+	});
+
+	it("rejects invalid capacity policies before accepting any admission", function _rejectsInvalidPolicy()
+	{
+		expect(function _invalidConcurrent() { return new RunAdmissionConcurrencyGate({ maxConcurrentAdmissions: 0, maxQueuedAdmissions: 1 }); }).toThrow("maxConcurrentAdmissions must be a positive integer");
+		expect(function _invalidQueue() { return new RunAdmissionConcurrencyGate({ maxConcurrentAdmissions: 1, maxQueuedAdmissions: -1 }); }).toThrow("maxQueuedAdmissions must be a non-negative integer");
+	});
+});

--- a/libs/backend/agents/personal/runs/main/src/index.ts
+++ b/libs/backend/agents/personal/runs/main/src/index.ts
@@ -9,3 +9,5 @@ export { PrismaRunDispatchRepository } from "./prisma-run-dispatch-repository.js
 export { __CreateAgentControllerRunDispatchRouter } from "./run-dispatch.router.js";
 export type { AgentControllerRunDispatchRouterDependencies, AgentControllerTokenReviewer, AttemptModelKeyIssuer, AttemptModelKeyMintRequest, ClaimNextRunAttemptResult, ClaimNextRunWorkloadReleaseResult, CommitRunAttemptAssignmentResult, MintedAttemptModelKey, RegisterRunWorkloadPodResult, ReviewedAgentControllerIdentity, RunDispatchRepository, RunDispatchRepositoryConfig } from "./run-dispatch.types.js";
 export type { ClaimNextRunWorkloadCleanupResult, ConfirmRunWorkloadCleanupCommand, ConfirmRunWorkloadCleanupResult, RequestRunCancellationCommand, RequestRunCancellationResult, RunCancellationRepository, RunCancellationRepositoryConfig, RunWorkloadCleanupClaim, RunWorkloadCleanupClaimLease, RunWorkloadCleanupMode, RunWorkloadCleanupProjection } from "./run-cancellation.types.js";
+export { RunAdmissionConcurrencyGate } from "./run-admission-concurrency.js";
+export type { RunAdmissionConcurrencyPolicy, RunAdmissionConcurrencyResult } from "./run-admission-concurrency.types.js";

--- a/libs/backend/agents/personal/runs/main/src/run-admission-concurrency.ts
+++ b/libs/backend/agents/personal/runs/main/src/run-admission-concurrency.ts
@@ -1,0 +1,119 @@
+import type { RunAdmissionCommand } from "./run-admission.types.js";
+import type { RunAdmissionConcurrencyPolicy, RunAdmissionConcurrencyResult } from "./run-admission-concurrency.types.js";
+
+/** Bounds admission work by silo and service before a caller can take a PostgreSQL connection. */
+export class RunAdmissionConcurrencyGate
+{
+	/** Immutable capacity policy applied to every independent silo/service queue. */
+	private readonly policy: RunAdmissionConcurrencyPolicy;
+	/** Active and waiting admissions indexed by a non-user-visible authority key. */
+	private readonly queues = new Map<string, _AdmissionQueue>();
+
+	/**
+	 * Creates an in-process admission gate for the server process that owns admission.
+	 * @param policy - Per-service active and waiting capacity limits.
+	 */
+	constructor(policy: RunAdmissionConcurrencyPolicy)
+	{
+		if (!_isPositiveInteger(policy.maxConcurrentAdmissions)) throw new Error("maxConcurrentAdmissions must be a positive integer");
+		if (!_isNonNegativeInteger(policy.maxQueuedAdmissions)) throw new Error("maxQueuedAdmissions must be a non-negative integer");
+		this.policy = policy;
+	}
+
+	/**
+	 * Runs work after one bounded service slot is available, or rejects before the caller can begin persistence.
+	 * @param command - Immutable admission coordinates used only to partition capacity.
+	 * @param work - Admission assembly and persistence work that may acquire a database connection only after a slot is granted.
+	 * @returns The completed value or a fail-closed overload rejection.
+	 */
+	async execute<TResult>(command: Pick<RunAdmissionCommand, "siloId" | "agentServiceId">, work: () => Promise<TResult>): Promise<RunAdmissionConcurrencyResult<TResult>>
+	{
+		const key = _queueKey(command);
+		const queue = this.queues.get(key) ?? { active: 0, waiting: [] };
+		this.queues.set(key, queue);
+
+		// 1. Start immediately only while this service has capacity, so excess callers never reach Postgres.
+		if (queue.active < this.policy.maxConcurrentAdmissions)
+		{
+			return await this._executeActive(key, queue, work);
+		}
+
+		// 2. Bound waiting work in memory so an overloaded service cannot turn into an unbounded process queue.
+		if (queue.waiting.length >= this.policy.maxQueuedAdmissions)
+		{
+			return { outcome: "rejected", reason: "admission_concurrency_limited" };
+		}
+
+		// 3. Preserve FIFO order while waiting outside the database pool, then run exactly one released admission.
+		const gate = this;
+		return await new Promise<RunAdmissionConcurrencyResult<TResult>>(function _waitForAdmission(resolve, reject)
+		{
+			queue.waiting.push({ start: function _startWaitingAdmission(): void
+			{
+				void gate._executeActive(key, queue, work).then(resolve, reject);
+			} });
+		});
+	}
+
+	/** Runs one active admission and releases the next FIFO waiter after its work settles. */
+	private async _executeActive<TResult>(key: string, queue: _AdmissionQueue, work: () => Promise<TResult>): Promise<RunAdmissionConcurrencyResult<TResult>>
+	{
+		queue.active += 1;
+		try
+		{
+			return { outcome: "completed", value: await work() };
+		}
+		finally
+		{
+			queue.active -= 1;
+			this._startNext(key, queue);
+		}
+	}
+
+	/** Starts the next FIFO admission only after an active slot is released, then removes idle queue state. */
+	private _startNext(key: string, queue: _AdmissionQueue): void
+	{
+		const next = queue.waiting.shift();
+		if (next === undefined)
+		{
+			if (queue.active === 0) this.queues.delete(key);
+			return;
+		}
+
+		next.start();
+	}
+}
+
+/** One pending admission callback that has not yet entered the caller's persistence path. */
+interface _AdmissionWaiter
+{
+	/** Starts the waiter with its original generic result type once the gate grants a capacity slot. */
+	start(): void;
+}
+
+/** Mutable queue state isolated to one silo and AgentService. */
+interface _AdmissionQueue
+{
+	/** Number of admissions currently allowed to execute for this authority key. */
+	active: number;
+	/** FIFO callers that have not yet begun persistence work. */
+	waiting: _AdmissionWaiter[];
+}
+
+/** Derives an internal queue key that cannot collide between a silo or service boundary. */
+function _queueKey(command: Pick<RunAdmissionCommand, "siloId" | "agentServiceId">): string
+{
+	return `${command.siloId}\u0000${command.agentServiceId}`;
+}
+
+/** Returns whether a capacity field is a safe positive whole number. */
+function _isPositiveInteger(value: number): boolean
+{
+	return Number.isSafeInteger(value) && value > 0;
+}
+
+/** Returns whether a queue bound is a safe whole number, including an intentionally disabled queue. */
+function _isNonNegativeInteger(value: number): boolean
+{
+	return Number.isSafeInteger(value) && value >= 0;
+}

--- a/libs/backend/agents/personal/runs/main/src/run-admission-concurrency.types.ts
+++ b/libs/backend/agents/personal/runs/main/src/run-admission-concurrency.types.ts
@@ -1,0 +1,11 @@
+/** Bounded per-service concurrency and queue policy applied before admission opens a database transaction. */
+export interface RunAdmissionConcurrencyPolicy
+{
+	/** Maximum active admissions for one `(siloId, agentServiceId)` key. */
+	readonly maxConcurrentAdmissions: number;
+	/** Maximum waiting admissions for the same key; later requests are rejected without a database connection. */
+	readonly maxQueuedAdmissions: number;
+}
+
+/** Outcome returned after a caller either receives a bounded admission slot or is rejected before persistence begins. */
+export type RunAdmissionConcurrencyResult<TResult> = { readonly outcome: "completed"; readonly value: TResult } | { readonly outcome: "rejected"; readonly reason: "admission_concurrency_limited" };


### PR DESCRIPTION
## Why this matters

Initial run admission intentionally locks one AgentService while it assembles and persists an immutable input snapshot. A burst against that service must wait before it opens PostgreSQL connections; otherwise the service-row lock creates a connection-pool convoy.

This is the second #323 safeguard, following the database pooler in #343.

## What changed

- add `RunAdmissionConcurrencyGate` to the personal-runs authority package
- partition capacity by `(siloId, AgentServiceId)` so one hot service cannot consume another service or tenant’s admission budget
- allow a bounded FIFO wait queue and reject overflow with `admission_concurrency_limited` before its supplied work begins
- release the next waiter after both successful and failed work, and discard idle queue state
- document the required production composition: call the gate before `PrismaRunAdmissionRepository.admit()`

## Validation

- `npx nx test backend-agents-personal-runs` — 18 tests
- `npx nx lint backend-agents-personal-runs`
- `scripts/agent-style-check.sh` — 0 errors, 0 warnings
- `git diff --check`

## Review

Independent review found no Critical, High, Medium, or Low findings. It confirmed FIFO, per-key isolation, failure-release, policy validation, type separation, README accuracy, and test placement.

## Scope boundary

This is the reusable authority primitive. It does not claim live entrypoint protection yet: the next admission-wiring slice must compose it before the Prisma repository, and production capacity values must be supplied from deployment configuration.