### PR TITLE
🔒 Phase E: bind channel commands to durable delivery keys

### DIFF
--- a/apps/channel-proxy/README.md
+++ b/apps/channel-proxy/README.md
@@ -54,6 +54,10 @@ bounded `SIGTERM`/`SIGINT` shutdown that drains in-flight requests and flushes t
 HTTP endpoints served: `POST /v1/commands` (bounded command forwarding), `GET /v1/events`
 (server-sent-event relay), and `/livez` · `/readyz` health probes. Any other path is `404`.
 
+Commands are JSON envelopes that include an opaque `threadId` and use the standard `Idempotency-Key`
+request header. The proxy validates those routing coordinates before asking OpenCrane to authorize a
+target; it otherwise leaves the command payload uninterpreted.
+
 ## Boundary
 
 Stateless and product-logic-free: it holds no database and no session, and consumers behind it (the

--- a/libs/backend/channel-proxy/main/README.md
+++ b/libs/backend/channel-proxy/main/README.md
@@ -45,6 +45,11 @@ instant the browser disconnects. Invariant: a request reaches an internal servic
 same-origin, carries no forged identity, resolves to an allowlisted live target, and stays within every
 bound — otherwise it gets a small non-sensitive error and nothing is forwarded.
 
+Every `POST /v1/commands` body must contain one opaque `threadId`, and the request must carry an
+opaque `Idempotency-Key` header. The proxy sends only those coordinates to OpenCrane before it asks for
+a route, while keeping the rest of the command body opaque. This prevents a retry from being routed
+without a canonical conversation or a durable delivery key.
+
 ## Public surface
 
 - `__ForwardCommand(request, dependencies)` — validate, authorise, rate-limit, then forward one bounded POST command.

--- a/libs/backend/channel-proxy/main/src/__tests__/channel-proxy.test.ts
+++ b/libs/backend/channel-proxy/main/src/__tests__/channel-proxy.test.ts
@@ -39,7 +39,14 @@ function _Request(path: string, init: RequestInit = {}): Request
 	headers.set("origin", "https://acme.example.com");
 	headers.set("host", "acme.example.com");
 	headers.set("cookie", "session=opaque");
+	if (!headers.has("idempotency-key")) headers.set("idempotency-key", "delivery-1");
 	return new Request(`https://acme.example.com${path}`, { ...init, headers });
+}
+
+/** Returns the smallest valid command envelope while leaving its user payload opaque to the proxy. */
+function _CommandBody(): string
+{
+	return JSON.stringify({ threadId: "thread-1", content: { text: "hello" } });
 }
 
 describe("channel proxy public boundary", () =>
@@ -73,7 +80,7 @@ describe("channel proxy public boundary", () =>
 	it("rejects forged identity before target resolution", async () =>
 	{
 		const resolve = vi.fn(async function _resolve() { return _Target(); });
-		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json", "x-forwarded-user": "admin" }, body: "{}" });
+		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json", "x-forwarded-user": "admin" }, body: _CommandBody() });
 		const response = await __ForwardCommand(request, _Dependencies(resolve, vi.fn() as unknown as typeof fetch));
 		expect(response.status).toBe(400);
 		expect(resolve).not.toHaveBeenCalled();
@@ -82,7 +89,7 @@ describe("channel proxy public boundary", () =>
 	it("fails closed when OpenCrane target resolution is unavailable", async () =>
 	{
 		const resolve = vi.fn(async function _resolve(): Promise<AuthorizedChannelTarget> { throw new Error("offline"); });
-		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: _CommandBody() });
 		const response = await __ForwardCommand(request, _Dependencies(resolve, vi.fn() as unknown as typeof fetch));
 		expect(response.status).toBe(503);
 	});
@@ -97,7 +104,7 @@ describe("channel proxy public boundary", () =>
 				init?.signal?.addEventListener("abort", function _abort() { reject(init.signal?.reason); }, { once: true });
 			});
 		}) as unknown as typeof fetch;
-		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: _CommandBody() });
 		const response = await __ForwardCommand(request, _Dependencies(resolve, transport));
 		expect(response.status).toBe(504);
 	});
@@ -106,9 +113,37 @@ describe("channel proxy public boundary", () =>
 	{
 		const resolve = vi.fn(async function _resolve() { return _Target(); });
 		const transport = vi.fn(async function _fetch() { return new Response("x".repeat(257)); }) as unknown as typeof fetch;
-		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: "{}" });
+		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: _CommandBody() });
 		const response = await __ForwardCommand(request, _Dependencies(resolve, transport));
 		expect(response.status).toBe(502);
+	});
+
+	it("binds a command route decision to its canonical thread and transport delivery key", async function _BindsCommandCoordinates()
+	{
+		let resolved: TargetResolutionRequest | undefined;
+		const resolve = vi.fn(async function _resolve(request: TargetResolutionRequest)
+		{
+			resolved = request;
+			return _Target();
+		});
+		const transport = vi.fn(async function _fetch() { return Response.json({ accepted: true }); }) as unknown as typeof fetch;
+
+		const response = await __ForwardCommand(_Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json", "idempotency-key": "delivery-77" }, body: _CommandBody() }), _Dependencies(resolve, transport));
+
+		expect(response.status).toBe(200);
+		expect(resolved).toMatchObject({ action: "command.forward", threadId: "thread-1", requestIdempotencyKey: "delivery-77" });
+	});
+
+	it("rejects a command that lacks its transport delivery key before target resolution", async function _RejectsMissingCommandCoordinates()
+	{
+		const resolve = vi.fn(async function _resolve() { return _Target(); });
+		const request = _Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: _CommandBody() });
+		request.headers.delete("idempotency-key");
+
+		const response = await __ForwardCommand(request, _Dependencies(resolve, vi.fn() as unknown as typeof fetch));
+
+		expect(response.status).toBe(400);
+		expect(resolve).not.toHaveBeenCalled();
 	});
 });
 

--- a/libs/backend/channel-proxy/main/src/__tests__/target-resolver.test.ts
+++ b/libs/backend/channel-proxy/main/src/__tests__/target-resolver.test.ts
@@ -12,6 +12,7 @@ describe("OpenCrane channel target resolver", () =>
 			expect(headers.get("authorization")).toBe("Bearer workload-token");
 			expect(headers.get("cookie")).toBe("session=opaque");
 			expect(headers.get("x-opencrane-session-authorization")).toBe("Bearer user-token");
+			expect(JSON.parse(String(init?.body))).toEqual({ action: "events.read", trustedHost: "acme.example.com", threadId: "thread-1" });
 			return Response.json({
 				subjectId: "subject-1",
 				endpoint: "http://agent-runtime.default.svc.cluster.local:8080/v1/events",
@@ -26,6 +27,20 @@ describe("OpenCrane channel target resolver", () =>
 		expect(readFile).toHaveBeenCalledOnce();
 	});
 
+	it("forwards only the command coordinates that OpenCrane must bind before admission", async function _ForwardsCommandCoordinates()
+	{
+		const transport = vi.fn(async function _fetch(_input: RequestInfo | URL, init?: RequestInit)
+		{
+			expect(JSON.parse(String(init?.body))).toEqual({ action: "command.forward", trustedHost: "acme.example.com", threadId: "thread-1", requestIdempotencyKey: "delivery-1" });
+			return Response.json({ subjectId: "subject-1", endpoint: "http://agent-runtime.default.svc.cluster.local:8080/v1/commands", invocationContext: "short-lived-context", expiresAt: new Date(Date.now() + 60_000).toISOString() });
+		}) as unknown as typeof fetch;
+		const resolver = new __OpenCraneTargetResolver({ baseUrl: "http://opencrane.default.svc.cluster.local:8081", fetch: transport, readFile: async function _readFile() { return "workload-token"; } });
+
+		await resolver.resolve({ action: "command.forward", threadId: "thread-1", requestIdempotencyKey: "delivery-1", session: { cookie: "session=opaque", trustedHost: "acme.example.com" } }, new AbortController().signal);
+
+		expect(transport).toHaveBeenCalledOnce();
+	});
+
 	it("rejects expired resolver output", async () =>
 	{
 		const transport = vi.fn(async function _fetch()
@@ -33,6 +48,6 @@ describe("OpenCrane channel target resolver", () =>
 			return Response.json({ subjectId: "subject-1", endpoint: "http://runtime.default.svc.cluster.local/events", invocationContext: "context", expiresAt: "2020-01-01T00:00:00.000Z" });
 		}) as unknown as typeof fetch;
 		const resolver = new __OpenCraneTargetResolver({ baseUrl: "http://opencrane.default.svc.cluster.local:8081", fetch: transport, readFile: async function _readFile() { return "token"; } });
-		await expect(resolver.resolve({ action: "command.forward", session: { cookie: "session=opaque", trustedHost: "acme.example.com" } }, new AbortController().signal)).rejects.toThrow("expired");
+		await expect(resolver.resolve({ action: "command.forward", threadId: "thread-1", requestIdempotencyKey: "delivery-1", session: { cookie: "session=opaque", trustedHost: "acme.example.com" } }, new AbortController().signal)).rejects.toThrow("expired");
 	});
 });

--- a/libs/backend/channel-proxy/main/src/channel-proxy.types.ts
+++ b/libs/backend/channel-proxy/main/src/channel-proxy.types.ts
@@ -39,8 +39,10 @@ export interface TargetResolutionRequest
 	session: DelegatedSession;
 	/** Stable target-neutral operation name. */
 	action: "command.forward" | "events.read";
-	/** Thread selected by the caller, when reading its events. */
-	threadId?: string;
+	/** Canonical thread selected by the caller for either a command or event read. */
+	threadId: string;
+	/** Caller-supplied key that makes one retried command delivery addressable without trusting its body. */
+	requestIdempotencyKey?: string;
 	/** Persisted event cursor selected by the caller. */
 	cursor?: string;
 }

--- a/libs/backend/channel-proxy/main/src/forwarding.ts
+++ b/libs/backend/channel-proxy/main/src/forwarding.ts
@@ -34,6 +34,11 @@ export async function __ForwardCommand(request: Request, dependencies: ChannelPr
 	{
 		return _Problem(413, "command_too_large");
 	}
+	const command = _CommandCoordinates(body, request.headers.get("idempotency-key"));
+	if (command === null)
+	{
+		return _Problem(400, "invalid_command");
+	}
 
 	// 2. Delegate identity, membership, resource and action decisions to OpenCrane.
 	let target: AuthorizedChannelTarget;
@@ -41,7 +46,7 @@ export async function __ForwardCommand(request: Request, dependencies: ChannelPr
 	{
 		target = await ___DoWithTrace("channel.authority.resolve", { action: "command.forward" }, function _resolveTarget()
 		{
-			return dependencies.resolver.resolve({ session, action: "command.forward" }, request.signal);
+			return dependencies.resolver.resolve({ session, action: "command.forward", threadId: command.threadId, requestIdempotencyKey: command.requestIdempotencyKey }, request.signal);
 		});
 	}
 	catch
@@ -89,6 +94,27 @@ export async function __ForwardCommand(request: Request, dependencies: ChannelPr
 	{
 		clearTimeout(timeoutHandle);
 	}
+}
+
+/** Parses only the command coordinates required before the proxy asks OpenCrane to authorize a route. */
+function _CommandCoordinates(body: Uint8Array, requestIdempotencyKey: string | null): { readonly threadId: string; readonly requestIdempotencyKey: string } | null
+{
+	// 1. Parse the bounded JSON body so the route authority never receives a body-only thread assertion.
+	let value: unknown;
+	try
+	{
+		value = JSON.parse(new TextDecoder().decode(body)) as unknown;
+	}
+	catch
+	{
+		return null;
+	}
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+
+	// 2. Require opaque coordinates before resolution so a retry cannot create an unaddressable run.
+	const record = value as Record<string, unknown>;
+	if (typeof record.threadId !== "string" || !_OpaqueIdentifierAllowed(record.threadId) || !requestIdempotencyKey || !_OpaqueIdentifierAllowed(requestIdempotencyKey)) return null;
+	return { threadId: record.threadId, requestIdempotencyKey };
 }
 
 /** Relay one authenticated SSE event stream from its persisted replay cursor. */

--- a/libs/backend/channel-proxy/main/src/target-resolver.ts
+++ b/libs/backend/channel-proxy/main/src/target-resolver.ts
@@ -57,7 +57,7 @@ export class __OpenCraneTargetResolver implements ChannelTargetResolver
 			const response = await this.options.fetch(new URL("/api/internal/channel-targets:resolve", this.options.baseUrl), {
 				method: "POST",
 				headers,
-				body: JSON.stringify({ action: request.action, trustedHost: request.session.trustedHost, threadId: request.threadId, cursor: request.cursor }),
+			body: JSON.stringify({ action: request.action, trustedHost: request.session.trustedHost, threadId: request.threadId, requestIdempotencyKey: request.requestIdempotencyKey, cursor: request.cursor }),
 				signal: combined,
 			});
 			if (!response.ok)

--- a/libs/backend/server/agents/channel-targets/main/README.md
+++ b/libs/backend/server/agents/channel-targets/main/README.md
@@ -38,6 +38,10 @@ customer's isolated tenancy) and a current signed membership; requires an active
 same silo and participant; and only then authorizes the full action set. A forwarded command also
 requires a real, ready run before a target is issued.
 
+For commands, the proxy also supplies a canonical thread id and an opaque transport idempotency key.
+The run-start authority must bind that key to the durable command before creating or reusing a run; the
+resolver never accepts a command route that lacks either coordinate.
+
 Invariant: it stores only the *digest* of the invocation context, never the token itself, and the
 context expires at the sooner of its configured lifetime or the membership's own expiry. The issued
 endpoint must be a credential-free HTTP(S) address inside a configured internal DNS suffix. Every

--- a/libs/backend/server/agents/channel-targets/main/src/__tests__/channel-target-resolution.test.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/__tests__/channel-target-resolution.test.ts
@@ -39,7 +39,7 @@ function _dependencies(): ChannelTargetResolutionDependencies
 /** Constructs the common workload-authenticated browser request. */
 function _command(action: "command.forward" | "events.read" = "events.read")
 {
-	return { workloadToken: "projected-token", cookie: "session=opaque", delegatedAuthorization: "Bearer browser-token", trustedHost: "acme.example.com", action, threadId: "thread-1" } as const;
+	return { workloadToken: "projected-token", cookie: "session=opaque", delegatedAuthorization: "Bearer browser-token", trustedHost: "acme.example.com", action, threadId: "thread-1", requestIdempotencyKey: action === "command.forward" ? "delivery-1" : undefined } as const;
 }
 
 describe("channel target resolution", () =>
@@ -104,6 +104,33 @@ describe("channel target resolution", () =>
 		expect(requiredActions).toEqual(["agent.run.start", "thread.message.create"]);
 		expect(result).toEqual({ outcome: "denied", reason: "run_unavailable" });
 		expect(issue).not.toHaveBeenCalled();
+	});
+
+	it("requires a transport idempotency key before a command may create a durable run", async function _RequiresCommandDeliveryKey()
+	{
+		const dependencies = _dependencies();
+		const runStart = vi.spyOn(dependencies.runStart, "prepareInteractiveRun");
+
+		const result = await __ResolveChannelTarget(dependencies, { ..._command("command.forward"), requestIdempotencyKey: undefined });
+
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_request" });
+		expect(runStart).not.toHaveBeenCalled();
+	});
+
+	it("passes the accepted transport delivery key to the durable run-start authority", async function _BindsCommandDeliveryKey()
+	{
+		const dependencies = _dependencies();
+		let prepared: unknown;
+		dependencies.runStart.prepareInteractiveRun = async function _prepare(command)
+		{
+			prepared = command;
+			return { outcome: "ready", runId: "run-1" };
+		};
+
+		const result = await __ResolveChannelTarget(dependencies, _command("command.forward"));
+
+		expect(result.outcome).toBe("authorized");
+		expect(prepared).toMatchObject({ threadId: "thread-1", requestIdempotencyKey: "delivery-1" });
 	});
 
 	it("fails closed when the thread is outside the host silo or subject participation", async () =>

--- a/libs/backend/server/agents/channel-targets/main/src/__tests__/channel-targets.router.test.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/__tests__/channel-targets.router.test.ts
@@ -1,0 +1,57 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import { __CreateChannelTargetsRouter } from "../channel-targets.router.js";
+import type { ChannelTargetResolutionDependencies, PrepareInteractiveRunCommand } from "../channel-target-resolution.types.js";
+
+/** Builds one router with trusted narrow ports and a caller-visible run-start capture seam. */
+function _App(onPrepare: (command: PrepareInteractiveRunCommand) => void)
+{
+	const dependencies: ChannelTargetResolutionDependencies = {
+		config: { workloadAudience: "opencrane", channelProxyServiceAccountName: "channel-proxy", channelProxyNamespace: "silo-a", invocationContextTtlMs: 60_000, allowedRouteHostSuffixes: [".svc.cluster.local"] },
+		workloadIdentity: { review: async function _Review() { return { outcome: "trusted", identity: { username: "system:serviceaccount:silo-a:channel-proxy", serviceAccountName: "channel-proxy", namespace: "silo-a", audiences: ["opencrane"] } }; } },
+		delegatedIdentity: { resolveCookie: async function _ResolveCookie() { return { outcome: "trusted", identity: { subjectId: "user-1", source: "cookie", trustworthySubject: true } }; }, resolveBearer: async function _ResolveBearer() { return { outcome: "denied", reason: "unexpected_bearer" }; } },
+		hostSilo: { resolveExactHost: async function _ResolveExactHost() { return { siloId: "silo-1", authorizationScope: { kind: "organization", organizationId: "org-1" } }; } },
+		membership: { verifyCurrentMembership: async function _VerifyCurrentMembership() { return { outcome: "trusted", revision: 1, trustedUntilEpochMs: 2_000_000 }; } },
+		authorization: { authorize: async function _Authorize() { return { outcome: "allowed", authorizationDigest: `sha256:${"a".repeat(64)}` }; } },
+		runStart: { prepareInteractiveRun: async function _PrepareInteractiveRun(command) { onPrepare(command); return { outcome: "ready", runId: "run-1" }; } },
+		repository: {
+			getThreadAuthority: async function _GetThreadAuthority() { return { threadId: "thread-1", siloId: "silo-1", agentServiceId: "service-1", state: "active", participantUserIds: ["user-1"] }; },
+			issueInvocationContextAtomically: async function _IssueInvocationContext() { return { status: "issued", context: { id: "context-1", routeId: "route-1", endpoint: "http://agent-runtime.silo-a.svc.cluster.local:8080/v1/commands" } }; },
+			consumeInvocationContextAtomically: async function _ConsumeInvocationContext() { return { status: "denied", reason: "not_found" }; },
+		},
+		clock: { nowEpochMs: function _NowEpochMs() { return 1_000_000; } },
+		opaqueContext: { create: function _Create() { return "a".repeat(43); } },
+	};
+	const app = express();
+	app.use(express.json());
+	app.use(__CreateChannelTargetsRouter(dependencies));
+	return app;
+}
+
+describe("channel-targets router", function _DescribeChannelTargetsRouter()
+{
+	it("forwards only a command's validated delivery key to durable run admission", async function _ForwardsDeliveryKey()
+	{
+		let prepared: PrepareInteractiveRunCommand | undefined;
+		const app = _App(function _Capture(command) { prepared = command; });
+
+		const response = await request(app).post("/").set("authorization", "Bearer proxy-token").set("cookie", "session=opaque").send({ action: "command.forward", trustedHost: "acme.example.com", threadId: "thread-1", requestIdempotencyKey: "delivery-1" });
+
+		expect(response.status).toBe(200);
+		expect(prepared).toMatchObject({ subjectId: "user-1", siloId: "silo-1", threadId: "thread-1", agentServiceId: "service-1", requestIdempotencyKey: "delivery-1" });
+	});
+
+	it("rejects a command without a transport idempotency key before run admission", async function _RejectsMissingDeliveryKey()
+	{
+		let prepares = 0;
+		const app = _App(function _CountPrepare() { prepares += 1; });
+
+		const response = await request(app).post("/").set("authorization", "Bearer proxy-token").set("cookie", "session=opaque").send({ action: "command.forward", trustedHost: "acme.example.com", threadId: "thread-1" });
+
+		expect(response.status).toBe(403);
+		expect(response.body).toEqual({ error: "invalid_request" });
+		expect(prepares).toBe(0);
+	});
+});

--- a/libs/backend/server/agents/channel-targets/main/src/channel-target-resolution.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/channel-target-resolution.ts
@@ -93,7 +93,7 @@ export async function __ResolveChannelTarget(dependencies: ChannelTargetResoluti
 	let runId: string | null = null;
 	if (command.action === "command.forward")
 	{
-		const run = await dependencies.runStart.prepareInteractiveRun({ subjectId, siloId: hostBinding.siloId, threadId: thread.threadId, agentServiceId: thread.agentServiceId, authorizationDigest: authorization.authorizationDigest });
+		const run = await dependencies.runStart.prepareInteractiveRun({ subjectId, siloId: hostBinding.siloId, threadId: thread.threadId, agentServiceId: thread.agentServiceId, authorizationDigest: authorization.authorizationDigest, requestIdempotencyKey: command.requestIdempotencyKey! });
 		if (run.outcome === "unavailable") return { outcome: "denied", reason: "run_unavailable" };
 		if (run.outcome !== "ready" || !run.runId.trim()) return { outcome: "denied", reason: "run_denied" };
 		runId = run.runId;
@@ -152,6 +152,7 @@ function _commandIsValid(command: ResolveChannelTargetCommand): boolean
 		&& /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?(?::[0-9]{1,5})?$/u.test(command.trustedHost)
 		&& /^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/u.test(command.threadId)
 		&& (command.action === "command.forward" || command.action === "events.read")
+		&& (command.action !== "command.forward" || (command.requestIdempotencyKey !== undefined && /^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/u.test(command.requestIdempotencyKey)))
 		&& (command.cursor === undefined || /^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/u.test(command.cursor));
 }
 

--- a/libs/backend/server/agents/channel-targets/main/src/channel-target-resolution.types.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/channel-target-resolution.types.ts
@@ -21,6 +21,8 @@ export interface ResolveChannelTargetCommand
 	readonly action: ChannelResolutionAction;
 	/** Existing canonical thread selected by the browser. */
 	readonly threadId: string;
+	/** Opaque client delivery key that a real command-admission authority must deduplicate. */
+	readonly requestIdempotencyKey?: string;
 	/** Optional persisted replay cursor for event reads. */
 	readonly cursor?: string;
 }
@@ -179,6 +181,8 @@ export interface PrepareInteractiveRunCommand
 	readonly agentServiceId: string;
 	/** Authorization evidence accepted for run creation. */
 	readonly authorizationDigest: string;
+	/** Stable transport key that the run authority must bind to the durable user command. */
+	readonly requestIdempotencyKey: string;
 }
 
 /** Explicit outcome from the real run authority. */

--- a/libs/backend/server/agents/channel-targets/main/src/channel-targets.router.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/channel-targets.router.ts
@@ -54,9 +54,9 @@ function _parseCommand(request: Request, workloadToken: string): ResolveChannelT
 {
 	if (!request.body || typeof request.body !== "object" || Array.isArray(request.body)) return null;
 	const body = request.body as Record<string, unknown>;
-	if (!_isAction(body["action"]) || typeof body["trustedHost"] !== "string" || typeof body["threadId"] !== "string" || (body["cursor"] !== undefined && typeof body["cursor"] !== "string")) return null;
+	if (!_isAction(body["action"]) || typeof body["trustedHost"] !== "string" || typeof body["threadId"] !== "string" || (body["requestIdempotencyKey"] !== undefined && typeof body["requestIdempotencyKey"] !== "string") || (body["cursor"] !== undefined && typeof body["cursor"] !== "string")) return null;
 	const delegatedAuthorization = request.header("x-opencrane-session-authorization");
-	return { workloadToken, cookie: request.header("cookie"), delegatedAuthorization, trustedHost: body["trustedHost"], action: body["action"], threadId: body["threadId"], cursor: body["cursor"] as string | undefined };
+	return { workloadToken, cookie: request.header("cookie"), delegatedAuthorization, trustedHost: body["trustedHost"], action: body["action"], threadId: body["threadId"], requestIdempotencyKey: body["requestIdempotencyKey"] as string | undefined, cursor: body["cursor"] as string | undefined };
 }
 
 /** Returns a bearer value only for one unambiguous standard Authorization header. */


### PR DESCRIPTION
## Why

A command cannot truthfully become an interactive run unless its target decision is tied to one canonical conversation and a retriable delivery identity. Previously the channel proxy forwarded commands without either coordinate, while the internal resolver required a thread and the future run-admission path had no durable delivery key.

## What changed

- require an opaque threadId in every POST /v1/commands JSON envelope
- require the standard Idempotency-Key header and pass it through the channel-proxy resolver to ChannelRunStartPort
- reject missing or malformed command coordinates before authority resolution or run admission
- add proxy, resolver, and internal-router tests for propagation and fail-closed rejection
- document the command contract at the app and package boundaries

This is the first live-admission boundary slice. It does not yet persist the message or create the run; the follow-up composes durable command staging, snapshot assembly, and atomic invocation-context issuance.

## Validation

- npx nx test backend-channel-proxy
- npx nx test backend-server-channel-targets
- npx nx lint backend-channel-proxy
- npx nx lint backend-server-channel-targets
- scripts/agent-style-check.sh
- git diff --check

## Review

- independent repository review completed with one low test gap; fixed and revalidated
- local Claude Code review could not run because its CLI session is signed out; the ready-to-paste prompt is in ignored .agent-reviews/review-phase-e-live-command-boundary.md
