### PR TITLE
🔒 Phase E: scope duplicate run admission to identity

### DIFF
--- a/libs/backend/agents/personal/runs/main/README.md
+++ b/libs/backend/agents/personal/runs/main/README.md
@@ -31,9 +31,11 @@ package's admission boundary)* · [conversations](../../conversations/main/READM
 run's ordered user-visible events)* · dispatcher *(polls the outbox and launches the workload)*
 
 Initial admission serialises the silo and request idempotency key before compiling any mutable
-input. A duplicate request therefore returns the first durable snapshot instead of recompiling at a
-later time. A new request locks the AgentService, lets the session assembler revalidate every input
-inside that transaction, and commits the `AgentRun`, its only `RunInputSnapshot`, and the ordered
+input. A duplicate returns the first durable snapshot only when the AgentService, conversation
+thread and signed execution subject are the same; an interactive run also proves that its delegated
+user is that exact subject. A same-silo key from any other authority scope fails closed without
+exposing a run. A new request locks the AgentService, lets the session assembler
+revalidate every input inside that transaction, and commits the `AgentRun`, its only `RunInputSnapshot`, and the ordered
 `RunAccepted` and `RunAttemptRequested` outbox events together. The canonical digest covers every
 snapshot field except its own digest.
 

--- a/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
+++ b/libs/backend/agents/personal/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
@@ -43,7 +43,7 @@ describe("PrismaRunAdmissionRepository", function _describeAdmissionRepository()
 	it("returns a null-thread snapshot before a later retry can load or compile a new request instant", async function _returnsIdempotent()
 	{
 		const snapshot = { ..._snapshot(), threadId: null };
-		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue({ id: snapshot.runId, inputSnapshotDigest: snapshot.digest }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...snapshot, compiledAt: new Date(snapshot.compiledAt) }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue({ id: snapshot.runId, siloId: snapshot.siloId, agentServiceId: snapshot.agentServiceId, threadId: snapshot.threadId, trigger: "Interactive", delegatedUserId: snapshot.identitySnapshot.executionSubjectId, inputSnapshotDigest: snapshot.digest }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...snapshot, compiledAt: new Date(snapshot.compiledAt) }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
 		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
 		const repository = new PrismaRunAdmissionRepository(prisma, { now: function _now() { return new Date("2026-07-20T00:05:00.000Z"); } });
 		let compiled = false;
@@ -52,6 +52,66 @@ describe("PrismaRunAdmissionRepository", function _describeAdmissionRepository()
 		expect(compiled).toBe(false);
 		expect(transaction.agentRun.create).not.toHaveBeenCalled();
 		expect(transaction.runInputSnapshot.create).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["another agent service", { agentServiceId: "service-2" }],
+		["another conversation thread", { threadId: "thread-2" }],
+		["another execution subject", { delegatedUserId: "user-2" }],
+	])("denies a same-silo delivery key already used by %s", async function _deniesCrossScopeDuplicate(_description: string, difference: object)
+	{
+		const snapshot = _snapshot();
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue({ id: snapshot.runId, siloId: snapshot.siloId, agentServiceId: snapshot.agentServiceId, threadId: snapshot.threadId, trigger: "Interactive", delegatedUserId: snapshot.identitySnapshot.executionSubjectId, inputSnapshotDigest: snapshot.digest, ...difference }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn(), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+		const repository = new PrismaRunAdmissionRepository(prisma);
+		const build = vi.fn();
+
+		await expect(repository.admit(_command(), build)).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
+		expect(build).not.toHaveBeenCalled();
+		expect(transaction.runInputSnapshot.findUnique).not.toHaveBeenCalled();
+		expect(transaction.agentRun.create).not.toHaveBeenCalled();
+	});
+
+	it("fails closed after a unique-conflict recovery finds a same-silo key from another subject", async function _deniesCrossScopeConflictRecovery()
+	{
+		const duplicateError = new Prisma.PrismaClientKnownRequestError("duplicate run admission", { code: "P2002", clientVersion: "6.19.3" });
+		const snapshot = _snapshot();
+		const prisma = { $transaction: vi.fn().mockRejectedValue(duplicateError), agentRun: { findUnique: vi.fn().mockResolvedValue({ id: snapshot.runId, siloId: snapshot.siloId, agentServiceId: snapshot.agentServiceId, threadId: snapshot.threadId, trigger: "Interactive", delegatedUserId: "user-2", inputSnapshotDigest: snapshot.digest }) }, runInputSnapshot: { findUnique: vi.fn() } } as unknown as PrismaClient;
+		const repository = new PrismaRunAdmissionRepository(prisma);
+
+		await expect(repository.admit(_command(), async function _unexpectedBuild() { throw new Error("unexpected build"); })).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
+		expect(prisma.runInputSnapshot.findUnique).not.toHaveBeenCalled();
+	});
+
+	it("rejects an interactive authority whose delegated user differs from the signed snapshot subject", async function _rejectsDelegationMismatch()
+	{
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn(), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+		const repository = new PrismaRunAdmissionRepository(prisma);
+
+		await expect(repository.admit(_command(), async function _build() { return { outcome: "ready", value: { authority: { ..._authority(), delegatedUserId: "user-2" }, snapshot: _snapshot() } } as const; })).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
+		expect(transaction.agentRun.create).not.toHaveBeenCalled();
+	});
+
+	it("returns the first snapshot after a same-scope unique-conflict recovery", async function _returnsSameScopeConflictRecovery()
+	{
+		const duplicateError = new Prisma.PrismaClientKnownRequestError("duplicate run admission", { code: "P2002", clientVersion: "6.19.3" });
+		const snapshot = _snapshot();
+		const prisma = { $transaction: vi.fn().mockRejectedValue(duplicateError), agentRun: { findUnique: vi.fn().mockResolvedValue({ id: snapshot.runId, siloId: snapshot.siloId, agentServiceId: snapshot.agentServiceId, threadId: snapshot.threadId, trigger: "Interactive", delegatedUserId: snapshot.identitySnapshot.executionSubjectId, inputSnapshotDigest: snapshot.digest }) }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...snapshot, compiledAt: new Date(snapshot.compiledAt) }) } } as unknown as PrismaClient;
+		const repository = new PrismaRunAdmissionRepository(prisma);
+
+		await expect(repository.admit(_command(), async function _unexpectedBuild() { throw new Error("unexpected build"); })).resolves.toEqual({ outcome: "idempotent", snapshot });
+	});
+
+	it("denies a recovered snapshot that names another execution subject", async function _deniesSnapshotSubjectMismatch()
+	{
+		const snapshot = { ..._snapshot(), identitySnapshot: { ..._snapshot().identitySnapshot, executionSubjectId: "user-2" } };
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue({ id: snapshot.runId, siloId: snapshot.siloId, agentServiceId: snapshot.agentServiceId, threadId: snapshot.threadId, trigger: "Interactive", delegatedUserId: "user-1", inputSnapshotDigest: snapshot.digest }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...snapshot, compiledAt: new Date(snapshot.compiledAt) }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+		const repository = new PrismaRunAdmissionRepository(prisma);
+
+		await expect(repository.admit(_command(), async function _unexpectedBuild() { throw new Error("unexpected build"); })).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
+		expect(transaction.agentRun.create).not.toHaveBeenCalled();
 	});
 
 	it("fails closed and logs safe authority coordinates when persistence is unavailable", async function _LogsPersistenceFailure()

--- a/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.ts
+++ b/libs/backend/agents/personal/runs/main/src/prisma-run-admission-repository.ts
@@ -48,10 +48,15 @@ export class PrismaRunAdmissionRepository implements RunAdmissionRepository
 				// 1. Serialize the user-visible key before loading inputs so a duplicate never recompiles at a later instant.
 				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${command.siloId}\u0000${command.requestIdempotencyKey}`}, 0))`);
 				const existing = await transaction.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
-				const existingSnapshot = existing === null ? null : await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
-				if (existingSnapshot !== null)
+				if (existing !== null)
 				{
-					return { outcome: "idempotent", snapshot: _snapshot(existingSnapshot) };
+					if (!_matchesIdempotencyScope(existing, command)) return { outcome: "denied", reason: "authority_conflict" };
+					const existingSnapshot = await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
+					if (existingSnapshot !== null)
+					{
+						if (!_matchesSnapshotScope(existingSnapshot, command)) return { outcome: "denied", reason: "authority_conflict" };
+						return { outcome: "idempotent", snapshot: _snapshot(existingSnapshot) };
+					}
 				}
 
 				// 2. Lock the service before every source revalidates its inputs, preserving the established run lock order.
@@ -60,7 +65,7 @@ export class PrismaRunAdmissionRepository implements RunAdmissionRepository
 				const admittedAt = admittedAtDate.toISOString();
 				const compiled = await build({ prisma: transaction, admittedAt, admittedAtEpochMs: admittedAtDate.getTime() });
 				if (compiled.outcome === "denied") return compiled;
-				if (!_matchesCommand(compiled.value, command)) return { outcome: "denied", reason: "authority_conflict" };
+				if (!_matchesCommand(compiled.value, command) || !_matchesInteractiveDelegation(compiled.value.authority, command)) return { outcome: "denied", reason: "authority_conflict" };
 
 				// 3. Insert both sides of the deferred snapshot relation plus ordered acceptance and dispatch events in one commit.
 				await _persistInitialAdmission(transaction, command, compiled.value, admittedAtDate);
@@ -74,8 +79,16 @@ export class PrismaRunAdmissionRepository implements RunAdmissionRepository
 				try
 				{
 					const existing = await this.prisma.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
-					const existingSnapshot = existing === null ? null : await this.prisma.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
-					if (existingSnapshot !== null) return { outcome: "idempotent", snapshot: _snapshot(existingSnapshot) };
+					if (existing !== null)
+					{
+						if (!_matchesIdempotencyScope(existing, command)) return { outcome: "denied", reason: "authority_conflict" };
+						const existingSnapshot = await this.prisma.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
+						if (existingSnapshot !== null)
+						{
+							if (!_matchesSnapshotScope(existingSnapshot, command)) return { outcome: "denied", reason: "authority_conflict" };
+							return { outcome: "idempotent", snapshot: _snapshot(existingSnapshot) };
+						}
+					}
 				}
 				catch (recoveryError)
 				{
@@ -87,6 +100,29 @@ export class PrismaRunAdmissionRepository implements RunAdmissionRepository
 			return { outcome: "denied", reason: "persistence_unavailable" };
 		}
 	}
+}
+
+/** Returns whether an existing same-key row has the durable coordinates needed before loading its snapshot. */
+function _matchesIdempotencyScope(existing: { siloId: string; agentServiceId: string; threadId: string | null; trigger: string; delegatedUserId: string | null }, command: RunAdmissionCommand): boolean
+{
+	return existing.siloId === command.siloId
+		&& existing.agentServiceId === command.agentServiceId
+		&& existing.threadId === command.threadId
+		&& (existing.trigger !== "Interactive" || existing.delegatedUserId === command.executionSubjectId);
+}
+
+/** Returns whether a recovered immutable snapshot belongs to the exact execution subject requesting it. */
+function _matchesSnapshotScope(snapshot: { siloId: string; agentServiceId: string; threadId: string | null; identitySnapshot: Prisma.JsonValue }, command: RunAdmissionCommand): boolean
+{
+	if (snapshot.siloId !== command.siloId || snapshot.agentServiceId !== command.agentServiceId || snapshot.threadId !== command.threadId) return false;
+	if (!snapshot.identitySnapshot || typeof snapshot.identitySnapshot !== "object" || Array.isArray(snapshot.identitySnapshot)) return false;
+	return snapshot.identitySnapshot["executionSubjectId"] === command.executionSubjectId;
+}
+
+/** Returns whether interactive run custody and its signed snapshot are bound to the same subject. */
+function _matchesInteractiveDelegation(authority: InitialRunAuthority, command: RunAdmissionCommand): boolean
+{
+	return authority.trigger !== "interactive" || authority.delegatedUserId === command.executionSubjectId;
 }
 
 /** Returns whether the transaction-fenced authority exactly matches immutable caller coordinates. */


### PR DESCRIPTION
## Why this change exists

Channel messages carry a delivery key so a retry can return the original run instead of creating a
second one. That key is client-visible and, at the current database boundary, unique only inside a
silo. Without a scope check, one user or conversation could receive the immutable snapshot belonging
to another if they happened to use the same key.

## What this changes

- replay an existing run only when its AgentService, conversation thread and signed execution subject
  match the new command;
- bind an interactive run's delegated user to that same signed subject before the run can persist;
- apply the same checks after a PostgreSQL unique-conflict recovery, so concurrent retries do not
  reopen the disclosure path;
- retain the existing fail-closed response for an incompatible same-silo key; and
- repair inherited controller-router mocks so the runs package remains type-checkable.

This is intentionally a narrow guard. The following Phase E slice will atomically persist the inbound
conversation message, run, immutable snapshot and invocation context.

## Validation

- `npx nx test backend-agents-personal-runs` — 46 passing
- `npx nx lint backend-agents-personal-runs`
- `scripts/agent-style-check.sh` — 0 errors, 0 warnings
- `git diff --check`
- Independent review — PASS, including a follow-up review after the subject/delegation invariant fix

## Local Claude review

The repository review prompt is saved locally at
`.agent-reviews/review-phase-e-admission-idempotency.md`. Claude Code is currently signed out on this
machine, so no repository content was sent to Anthropic from this worktree.
