### PR TITLE
🛡️ Phase E: bound admission before database work

### DIFF
--- a/apps/_infra/deploy-k8s/values.yaml
+++ b/apps/_infra/deploy-k8s/values.yaml
@@ -429,6 +429,12 @@ clustertenantManager:
     tag: latest
     pullPolicy: IfNotPresent
   replicas: 1
+  # -- Bound run admission before snapshot assembly can take a pooled PostgreSQL connection.
+  # These apply per silo and AgentService; keep the active limit below the server's five-connection
+  # Prisma budget so a hot service cannot starve unrelated control-plane work.
+  runAdmission:
+    maxConcurrent: 2
+    maxQueued: 10
   service:
     # -- Public API port (ingress-facing): /api/v1/*, /auth. Session-authed.
     port: 8080

--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -52,6 +52,13 @@ projected Kubernetes identity through TokenReview; explicitly network-only route
 NetworkPolicy. If either layer were collapsed, platform-only or runtime authority could become
 internet-facing.
 
+The server also composes one bounded managed-run admission port for both an administrator's
+**run-now** request and the scheduler. It limits work per silo and AgentService before immutable
+snapshot assembly can consume a PostgreSQL connection; overload is rejected rather than allowed to
+form a database-lock convoy. Helm exposes the conservative `runAdmission.maxConcurrent` and
+`runAdmission.maxQueued` settings: one silo is limited to that policy and the whole process to
+twice that policy, which remains below the server's five-connection database pool budget.
+
 ## Public surface
 
 `Entrypoint: src/index.ts` — boots the process: creates the Prisma and Kubernetes clients, starts the

--- a/apps/opencrane/helm/templates/_deployment.tpl
+++ b/apps/opencrane/helm/templates/_deployment.tpl
@@ -57,6 +57,10 @@ spec:
               value: {{ .Values.agentController.outboxRetentionSeconds | quote }}
             - name: AGENT_RUNTIME_OUTBOX_PRUNE_BATCH_SIZE
               value: {{ .Values.agentController.outboxPruneBatchSize | quote }}
+            - name: AGENT_RUN_ADMISSION_MAX_CONCURRENT
+              value: {{ .Values.clustertenantManager.runAdmission.maxConcurrent | quote }}
+            - name: AGENT_RUN_ADMISSION_MAX_QUEUED
+              value: {{ .Values.clustertenantManager.runAdmission.maxQueued | quote }}
             # The server accepts runtime assignments only for this Helm-owned restricted namespace.
             - name: AGENT_RUNTIME_NAMESPACE
               value: {{ include "opencrane.agentController.runtimeNamespace" . | quote }}

--- a/apps/opencrane/src/app/__tests__/run-admission-wiring.test.ts
+++ b/apps/opencrane/src/app/__tests__/run-admission-wiring.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { RunAdmissionConcurrencyGate } from "@opencrane/backend/agents/personal/runs";
+import type { ManagedRunNowCommand } from "@opencrane/backend/server/agents/agent-services";
+
+import { __CreateRunAdmissionCapacityGate, _CreateManagedRunAdmissionPortWithGate, _ReadRunAdmissionConcurrencyPolicy } from "../run-admission-wiring.js";
+
+/** Produce one valid managed admission command, varying only the authority coordinates under test. */
+function _Command(agentServiceId: string, siloId = "silo-a"): ManagedRunNowCommand
+{
+	return { agentServiceId, siloId, requestedBy: "user-a", requestIdempotencyKey: `${siloId}:${agentServiceId}`, trigger: "managed_invocation", scheduledSlot: null };
+}
+
+describe("managed run admission composition", function _describeManagedRunAdmissionComposition()
+{
+	it("rejects an overloaded service before it starts another persistence admission", async function _rejectsBeforePersistence()
+	{
+		let release: (() => void) | undefined;
+		const held = new Promise<void>(function _hold(resolve) { release = resolve; });
+		const admit = vi.fn(async function _admit()
+		{
+			await held;
+			return { outcome: "denied", reason: "run_admission_unavailable" } as const;
+		});
+		const port = _CreateManagedRunAdmissionPortWithGate({ admit } as never, new RunAdmissionConcurrencyGate({ maxConcurrentAdmissions: 1, maxQueuedAdmissions: 0 }));
+
+		const first = port.admitManagedRun(_Command("service-a"));
+		await vi.waitFor(function _waitForFirstAdmission() { expect(admit).toHaveBeenCalledTimes(1); });
+		await expect(port.admitManagedRun(_Command("service-a"))).resolves.toEqual({ outcome: "denied", reason: "admission_concurrency_limited" });
+		expect(admit).toHaveBeenCalledTimes(1);
+		release?.();
+		await expect(first).resolves.toEqual({ outcome: "denied", reason: "run_admission_unavailable" });
+	});
+
+	it("bounds different services below the process database budget", async function _boundsProcessCapacity()
+	{
+		let release: (() => void) | undefined;
+		const held = new Promise<void>(function _hold(resolve) { release = resolve; });
+		const admit = vi.fn(async function _admit()
+		{
+			await held;
+			return { outcome: "denied", reason: "run_admission_unavailable" } as const;
+		});
+		const port = _CreateManagedRunAdmissionPortWithGate({ admit } as never, __CreateRunAdmissionCapacityGate({ maxConcurrentAdmissions: 1, maxQueuedAdmissions: 0 }));
+
+		const first = port.admitManagedRun(_Command("service-a", "silo-a"));
+		const second = port.admitManagedRun(_Command("service-a", "silo-b"));
+		await vi.waitFor(function _waitForProcessCapacity() { expect(admit).toHaveBeenCalledTimes(2); });
+		await expect(port.admitManagedRun(_Command("service-b", "silo-c"))).resolves.toEqual({ outcome: "denied", reason: "admission_concurrency_limited" });
+		release?.();
+		await expect(Promise.all([first, second])).resolves.toEqual([
+			{ outcome: "denied", reason: "run_admission_unavailable" },
+			{ outcome: "denied", reason: "run_admission_unavailable" },
+		]);
+	});
+
+	it("reads only bounded server-owned capacity settings", function _readsBoundedSettings()
+	{
+		expect(_ReadRunAdmissionConcurrencyPolicy({ AGENT_RUN_ADMISSION_MAX_CONCURRENT: "2", AGENT_RUN_ADMISSION_MAX_QUEUED: "20" })).toEqual({ maxConcurrentAdmissions: 2, maxQueuedAdmissions: 20 });
+		expect(function _rejectsOversizedActiveLimit() { _ReadRunAdmissionConcurrencyPolicy({ AGENT_RUN_ADMISSION_MAX_CONCURRENT: "3" }); }).toThrow("AGENT_RUN_ADMISSION_MAX_CONCURRENT must be an integer from 1 through 2");
+	});
+});

--- a/apps/opencrane/src/app/agent-services-wiring.ts
+++ b/apps/opencrane/src/app/agent-services-wiring.ts
@@ -1,13 +1,11 @@
-import { randomUUID } from "node:crypto";
 import type { Request, Router } from "express";
 import type { PrismaClient } from "@prisma/client";
 
 import type { AgentRevision, AgentService } from "@opencrane/models/agents";
 import { __CreateAgentServicesRouter, PrismaAgentRevisionLifecycleRepository, PrismaAgentScheduleRepository, PrismaAgentServicePublicationRepository, PrismaScopeGrantResolver } from "@opencrane/backend/server/agents/agent-services";
-import type { AgentPublicationAuditEvidencePort, AgentServicePublicationRepository, AtomicAgentRevisionPublication, ManagedRunAdmissionPort, ManagedRunAdmissionResult, ManagedRunNowCommand, ManagementCaller } from "@opencrane/backend/server/agents/agent-services";
+import type { AgentPublicationAuditEvidencePort, AgentServicePublicationRepository, AtomicAgentRevisionPublication, ManagedRunAdmissionPort, ManagementCaller } from "@opencrane/backend/server/agents/agent-services";
 import type { AuditDecisionRecord } from "@opencrane/backend/server/iam/audit";
 import { __DigestCanonicalJson } from "@opencrane/backend/server/iam/authorization";
-import { PrismaRunAdmissionRepository } from "@opencrane/backend/agents/personal/runs";
 import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
 // Side-effect import: loads the express-session `SessionData.authUser` augmentation.
 import "@opencrane/server/_infra/auth";
@@ -67,49 +65,17 @@ function _publicationFor(prisma: PrismaClient, caller: ManagementCaller): AgentS
 }
 
 /**
- * Build the managed run-now admission port.
- *
- * run-now AND the scheduler both record an admission through the EXISTING run-admission repository
- * (`trigger: managed_invocation` or `schedule`); it never dispatches a Job or executes anything.
- * Assembling a managed run's immutable snapshot needs signed fleet-membership identity and
- * effective-capability compilation — the managed executor, which lands with the #337 live-Obot
- * adoption gate. Until then this fails closed inside the admission transaction rather than
- * fabricating signed identity evidence — mirroring the app's other `__Unavailable*` composition-root
- * defaults. Nothing is persisted while it is unavailable.
- *
- * @param prisma - Canonical product-authority client.
- * @returns A fail-closed managed run admission port bound to the real admission repository.
- */
-export function _createManagedRunAdmissionPort(prisma: PrismaClient): ManagedRunAdmissionPort
-{
-	const admission = new PrismaRunAdmissionRepository(prisma);
-	return {
-		async admitManagedRun(command: ManagedRunNowCommand): Promise<ManagedRunAdmissionResult>
-		{
-			const runId = randomUUID();
-			const result = await admission.admit(
-				{ runId, siloId: command.siloId, agentServiceId: command.agentServiceId, threadId: null, executionSubjectId: `agent-service:${command.agentServiceId}`, requestIdempotencyKey: command.requestIdempotencyKey },
-				// The managed executor (fleet-membership + capability-set snapshot assembly) lands with the
-				// #337 live-Obot adoption gate; until then managed execution stays fail-closed here.
-				async function _assembleManagedSnapshot() { return { outcome: "denied", reason: "run_admission_unavailable" } as const; },
-			);
-			if (result.outcome === "denied") return { outcome: "denied", reason: result.reason };
-			return { outcome: result.outcome, runId };
-		},
-	};
-}
-
-/**
  * Compose the authoritative managed-agent management router for the app.
  * @param prisma - Canonical product-authority client.
+	* @param runAdmission - Shared, capacity-bounded managed run admission boundary.
  * @returns The configured `/api/v1/agent-services` router.
  */
-export function _CreateAgentServicesRouter(prisma: PrismaClient): Router
+export function _CreateAgentServicesRouter(prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort): Router
 {
 	return __CreateAgentServicesRouter({
 		lifecycle: new PrismaAgentRevisionLifecycleRepository(prisma),
 		publicationFor(caller: ManagementCaller): AgentServicePublicationRepository { return _publicationFor(prisma, caller); },
-		runAdmission: _createManagedRunAdmissionPort(prisma),
+		runAdmission,
 		schedules: new PrismaAgentScheduleRepository(prisma),
 		scopeGrantResolver: new PrismaScopeGrantResolver(prisma),
 		resolveCaller: _resolveCaller,

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -29,6 +29,7 @@ import { __UnavailableMemoryGatewayClient } from "@opencrane/server/_infra/memor
 import { ___DoWithTrace } from "@opencrane/observability";
 
 import { _CreateAgentServicesRouter } from "./agent-services-wiring.js";
+import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
 /** Read a bounded, server-owned seconds setting and return milliseconds. */
@@ -333,9 +334,10 @@ export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, auth
  * @param customApi - Kubernetes custom objects client.
  * @param coreApi - Kubernetes core API client.
  * @param authApi - Kubernetes authentication API client.
+ * @param runAdmission - Shared, capacity-bounded admission path for managed run-now requests.
  * @returns The configured Express application.
  */
-export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k8s.CustomObjectsApi, coreApi: k8s.CoreV1Api, authApi: k8s.AuthenticationV1Api): Express
+export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k8s.CustomObjectsApi, coreApi: k8s.CoreV1Api, authApi: k8s.AuthenticationV1Api, runAdmission: ManagedRunAdmissionPort): Express
 {
   // NOTE: the internal (`/api/internal/*`) routers are mounted separately by
   // `_RegisterInternalRoutes`, which index.ts calls BEFORE `___AuthMiddleware` so the
@@ -348,7 +350,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/ai-budget", aiBudgetRouter(coreApi, prisma));
   app.use("/api/v1/token-usage", tokenUsageRouter(prisma));
   app.use("/api/v1/groups", groupsRouter(prisma));
-  app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma));
+  app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma, runAdmission));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));
   app.use("/api/v1/shares", sharesRouter(prisma));

--- a/apps/opencrane/src/app/run-admission-wiring.ts
+++ b/apps/opencrane/src/app/run-admission-wiring.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "node:crypto";
+
+import type { PrismaClient } from "@prisma/client";
+
+import { PrismaRunAdmissionRepository, RunAdmissionConcurrencyGate } from "@opencrane/backend/agents/personal/runs";
+import type { RunAdmissionCommand, RunAdmissionConcurrencyPolicy, RunAdmissionConcurrencyResult } from "@opencrane/backend/agents/personal/runs";
+import type { ManagedRunAdmissionPort, ManagedRunAdmissionResult, ManagedRunNowCommand } from "@opencrane/backend/server/agents/agent-services";
+
+import type { RunAdmissionCapacityGate } from "./run-admission-wiring.types.js";
+
+/** Conservative server-process limits aligned to the five-connection Prisma budget. */
+const _DEFAULT_POLICY: RunAdmissionConcurrencyPolicy = { maxConcurrentAdmissions: 2, maxQueuedAdmissions: 10 };
+
+/**
+ * Read the server-owned admission capacity policy at startup.
+ *
+ * The limits apply before snapshot assembly or a Prisma transaction starts. They therefore bound
+ * one hot AgentService without consuming every connection in the silo's small database pool.
+ *
+ * @param environment - Environment map, injectable only for focused configuration tests.
+ * @returns A validated per-service active and waiting admission policy.
+ */
+export function _ReadRunAdmissionConcurrencyPolicy(environment: NodeJS.ProcessEnv = process.env): RunAdmissionConcurrencyPolicy
+{
+	return {
+		maxConcurrentAdmissions: _ReadBoundedPositiveInteger(environment, "AGENT_RUN_ADMISSION_MAX_CONCURRENT", _DEFAULT_POLICY.maxConcurrentAdmissions, 1, 2),
+		maxQueuedAdmissions: _ReadBoundedPositiveInteger(environment, "AGENT_RUN_ADMISSION_MAX_QUEUED", _DEFAULT_POLICY.maxQueuedAdmissions, 0, 100),
+	};
+}
+
+/**
+ * Compose the one shared managed run-admission boundary for this server process.
+ *
+ * Run-now and the scheduler receive this same port. A single gate is essential: separate gates
+ * would let those two entrypoints each exceed the capacity budget for one silo and AgentService.
+ *
+ * @param prisma - Canonical product-authority client.
+ * @param policy - Validated server capacity policy.
+ * @returns A fail-closed, capacity-bounded managed run admission port.
+ */
+export function _CreateManagedRunAdmissionPort(prisma: PrismaClient, policy: RunAdmissionConcurrencyPolicy): ManagedRunAdmissionPort
+{
+	const admission = new PrismaRunAdmissionRepository(prisma);
+	const gate = __CreateRunAdmissionCapacityGate(policy);
+	return _CreateManagedRunAdmissionPortWithGate(admission, gate);
+}
+
+/** Build the shared global, silo, and service capacity gate for this server process. */
+export function __CreateRunAdmissionCapacityGate(policy: RunAdmissionConcurrencyPolicy): RunAdmissionCapacityGate
+{
+	return new _HierarchicalRunAdmissionCapacityGate(policy);
+}
+
+/**
+ * Build a managed admission adapter over one supplied gate.
+ *
+ * Kept separate from Prisma composition so the overload boundary can be proved without a database.
+ *
+ * @param admission - Canonical run/snapshot/outbox persistence authority.
+ * @param gate - Shared process-local capacity boundary.
+ * @returns The managed-agent run admission port.
+ */
+export function _CreateManagedRunAdmissionPortWithGate(admission: Pick<PrismaRunAdmissionRepository, "admit">, gate: RunAdmissionCapacityGate): ManagedRunAdmissionPort
+{
+	return {
+		async admitManagedRun(command: ManagedRunNowCommand): Promise<ManagedRunAdmissionResult>
+		{
+			const bounded = await gate.execute(
+				{ siloId: command.siloId, agentServiceId: command.agentServiceId },
+				async function _admitAfterCapacityGrant()
+				{
+					const runId = randomUUID();
+					const result = await admission.admit(
+						{ runId, siloId: command.siloId, agentServiceId: command.agentServiceId, threadId: null, executionSubjectId: `agent-service:${command.agentServiceId}`, requestIdempotencyKey: command.requestIdempotencyKey },
+						// The managed executor (fleet-membership + capability-set snapshot assembly) is a
+						// live-Obot gate. Until then the shared persistence authority fails closed.
+						async function _assembleManagedSnapshot() { return { outcome: "denied", reason: "run_admission_unavailable" } as const; },
+					);
+					if (result.outcome === "denied") return { outcome: "denied", reason: result.reason } as const;
+					return { outcome: result.outcome, runId } as const;
+				},
+			);
+			return bounded.outcome === "rejected" ? { outcome: "denied", reason: bounded.reason } : bounded.value;
+		},
+	};
+}
+
+/** Apply a process ceiling before silo and exact-service fairness gates. */
+class _HierarchicalRunAdmissionCapacityGate implements RunAdmissionCapacityGate
+{
+	private readonly globalGate: RunAdmissionConcurrencyGate;
+	private readonly siloGate: RunAdmissionConcurrencyGate;
+	private readonly serviceGate: RunAdmissionConcurrencyGate;
+
+	constructor(policy: RunAdmissionConcurrencyPolicy)
+	{
+		this.globalGate = new RunAdmissionConcurrencyGate({ maxConcurrentAdmissions: policy.maxConcurrentAdmissions * 2, maxQueuedAdmissions: policy.maxQueuedAdmissions * 2 });
+		this.siloGate = new RunAdmissionConcurrencyGate(policy);
+		this.serviceGate = new RunAdmissionConcurrencyGate(policy);
+	}
+
+	/** Grant work only when process, silo, and service budgets all have capacity. */
+	async execute<TResult>(command: Pick<RunAdmissionCommand, "siloId" | "agentServiceId">, work: () => Promise<TResult>): Promise<RunAdmissionConcurrencyResult<TResult>>
+	{
+		const global = await this.globalGate.execute(_GLOBAL_ADMISSION_COORDINATE, async () => await this.siloGate.execute({ siloId: command.siloId, agentServiceId: "__silo_capacity__" }, async () => await this.serviceGate.execute(command, work)));
+		if (global.outcome === "rejected") return global;
+		if (global.value.outcome === "rejected") return global.value;
+		return global.value.value;
+	}
+}
+
+/** Synthetic, non-user-visible coordinate that serializes every managed admission in one process. */
+const _GLOBAL_ADMISSION_COORDINATE = { siloId: "__opencrane_process__", agentServiceId: "__managed_run_admission__" };
+
+/** Read one bounded non-negative integer without silently coercing malformed deployment config. */
+function _ReadBoundedPositiveInteger(environment: NodeJS.ProcessEnv, name: string, fallback: number, minimum: number, maximum: number): number
+{
+	const raw = environment[name]?.trim();
+	if (!raw) return fallback;
+	const value = Number(raw);
+	if (!Number.isSafeInteger(value) || value < minimum || value > maximum) throw new Error(`${name} must be an integer from ${minimum} through ${maximum}`);
+	return value;
+}

--- a/apps/opencrane/src/app/run-admission-wiring.types.ts
+++ b/apps/opencrane/src/app/run-admission-wiring.types.ts
@@ -1,0 +1,8 @@
+import type { RunAdmissionCommand, RunAdmissionConcurrencyResult } from "@opencrane/backend/agents/personal/runs";
+
+/** Hierarchical capacity boundary applied before run admission can begin persistence work. */
+export interface RunAdmissionCapacityGate
+{
+	/** Run work only after the global, silo, and service budgets all grant capacity. */
+	execute<TResult>(command: Pick<RunAdmissionCommand, "siloId" | "agentServiceId">, work: () => Promise<TResult>): Promise<RunAdmissionConcurrencyResult<TResult>>;
+}

--- a/apps/opencrane/src/app/scheduler-wiring.ts
+++ b/apps/opencrane/src/app/scheduler-wiring.ts
@@ -4,7 +4,6 @@ import { __RunScheduleTick } from "@opencrane/backend/server/agents/scheduling";
 import type { ActiveScheduledRunLookup, AgentServiceSchedule, RetryBackoffPolicy, ScheduleTickResult } from "@opencrane/backend/server/agents/scheduling";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 
-import { _createManagedRunAdmissionPort } from "./agent-services-wiring.js";
 import { _log } from "./log.js";
 import type { ScheduleTicker } from "./scheduler-wiring.types.js";
 
@@ -35,11 +34,11 @@ function _createActiveScheduledRunLookup(prisma: PrismaClient): ActiveScheduledR
 /**
  * Compose the schedule ticker over canonical Postgres and the shared admission port.
  * @param prisma - Canonical product-authority client.
+ * @param admission - The shared, capacity-bounded admission port used by run-now too.
  * @returns A ticker whose `runOnce` performs one full scheduling pass.
  */
-export function _CreateScheduleTicker(prisma: PrismaClient): ScheduleTicker
+export function _CreateScheduleTicker(prisma: PrismaClient, admission: ManagedRunAdmissionPort): ScheduleTicker
 {
-	const admission: ManagedRunAdmissionPort = _createManagedRunAdmissionPort(prisma);
 	const activeRuns = _createActiveScheduledRunLookup(prisma);
 	return {
 		async runOnce(now: Date): Promise<readonly { readonly scheduleId: string; readonly result: ScheduleTickResult }[]>

--- a/apps/opencrane/src/index.ts
+++ b/apps/opencrane/src/index.ts
@@ -16,10 +16,12 @@ import { ___AuthMiddleware } from "@opencrane/server/_infra/auth";
 import { _ErrorHandler, _RateLimit, _TransportSecurity } from "@opencrane/server/_infra/http";
 
 import { ___AuthRouter, ___CreateOidcAuthService } from "@opencrane/backend/server/iam/identity";
+import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { ___CreatePrismaClient } from "./infra/db/db.js";
 import { _CreateArtifactUploadGateway } from "./infra/artifacts/artifact-upload.factory.js";
 import { _log as log } from "./app/log.js";
 import { _RegisterInternalRoutes, _RegisterRoutes } from "./app/routes.js";
+import { _CreateManagedRunAdmissionPort, _ReadRunAdmissionConcurrencyPolicy } from "./app/run-admission-wiring.js";
 import { _CreateScheduleTicker } from "./app/scheduler-wiring.js";
 import { OpenClawTenantLifecycle } from "@opencrane/backend/feat-openclaw-tenant";
 
@@ -40,9 +42,10 @@ const _unbindConsole = ___BindConsole(log);
  * @param customApi - Kubernetes Custom Objects API client
  * @param coreApi   - Kubernetes Core V1 API client
  * @param authApi   - Kubernetes Authentication API for tenant contract TokenReview
+ * @param runAdmission - Process-shared, capacity-bounded managed run admission port.
  * @returns Configured Express application
  */
-export function createApp(prisma: PrismaClient, customApi: k8s.CustomObjectsApi, coreApi: k8s.CoreV1Api, authApi: k8s.AuthenticationV1Api): Express
+export function createApp(prisma: PrismaClient, customApi: k8s.CustomObjectsApi, coreApi: k8s.CoreV1Api, authApi: k8s.AuthenticationV1Api, runAdmission: ManagedRunAdmissionPort): Express
 {
   const app = express();
   // First-login member workspaces are seeded into the TenantOperator's watch namespace
@@ -83,7 +86,7 @@ export function createApp(prisma: PrismaClient, customApi: k8s.CustomObjectsApi,
   app.use(___AuthMiddleware());
 
   // Register API routes
-  _RegisterRoutes(app, prisma, customApi, coreApi, authApi);
+  _RegisterRoutes(app, prisma, customApi, coreApi, authApi, runAdmission);
 
   // Global error handler — must be registered after all routes.
   app.use(_ErrorHandler(log));
@@ -141,8 +144,11 @@ const coreApi = kc.makeApiClient(k8s.CoreV1Api);
 /** Kubernetes Authentication API client — used for tenant contract TokenReview validation. */
 const authApi = kc.makeApiClient(k8s.AuthenticationV1Api);
 
+/** One process-wide capacity boundary shared by run-now and scheduled managed admissions. */
+const managedRunAdmission = _CreateManagedRunAdmissionPort(prisma, _ReadRunAdmissionConcurrencyPolicy());
+
 // Build and start the PUBLIC app (ingress-facing: /api/v1/*, /auth — session-authed).
-const app = createApp(prisma, customApi, coreApi, authApi);
+const app = createApp(prisma, customApi, coreApi, authApi, managedRunAdmission);
 app.locals.artifactUploadGateway = artifactUploadGateway;
 
 log.info({ port }, "starting opencrane control plane");
@@ -169,7 +175,7 @@ const internalServer = internalApp.listen(internalPort, function _onInternalList
 // harvesting-central-agent live-Obot proof gated under #337. The interval is unref'd so it never
 // holds the process open, and it is cleared on shutdown.
 /** Managed-agent schedule ticker bound to canonical Postgres and the shared admission port. */
-const scheduleTicker = _CreateScheduleTicker(prisma);
+const scheduleTicker = _CreateScheduleTicker(prisma, managedRunAdmission);
 /** Milliseconds between schedule passes when the scheduler is enabled. */
 const schedulerIntervalMs = Math.max(1_000, Number(process.env.OPENCRANE_SCHEDULER_INTERVAL_MS ?? "60000"));
 const schedulerHandle = process.env.OPENCRANE_SCHEDULER_ENABLED === "true"

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
@@ -123,7 +123,10 @@ export type AgentRevisionLifecycleDenial =
 	| "revision_service_mismatch"
 	| "transition_not_allowed"
 	| "service_not_runnable"
-	| "run_admission_unavailable";
+	| "run_admission_unavailable"
+	| "persistence_unavailable"
+	| "authority_conflict"
+	| "admission_concurrency_limited";
 
 /** Result of creating a managed service. */
 export type CreateManagedAgentServiceResult =
@@ -179,7 +182,7 @@ export interface AgentRevisionLifecycleRepository
 export type ManagedRunAdmissionResult =
 	| { readonly outcome: "accepted"; readonly runId: string }
 	| { readonly outcome: "idempotent"; readonly runId: string }
-	| { readonly outcome: "denied"; readonly reason: string };
+	| { readonly outcome: "denied"; readonly reason: AgentRevisionLifecycleDenial };
 
 /** App-owned boundary that records a managed run admission on the shared run substrate. */
 export interface ManagedRunAdmissionPort

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
@@ -258,7 +258,12 @@ export function __CreateAgentServicesRouter(dependencies: AgentServicesRouterDep
 			const body = (req.body ?? {}) as Record<string, unknown>;
 			if (!_isNonEmptyString(body.requestIdempotencyKey)) { res.status(400).json({ error: "requestIdempotencyKey is required.", code: "VALIDATION_ERROR" }); return; }
 			const result = await __AdmitManagedRunNow(lifecycle, runAdmission, { agentServiceId: String(req.params.serviceId), siloId: caller.siloId, requestedBy: caller.subjectId, requestIdempotencyKey: body.requestIdempotencyKey, trigger: "managed_invocation", scheduledSlot: null });
-			if (result.outcome === "denied") { res.status(_runDenialStatus(result.reason)).json({ error: "Run-now denied.", code: result.reason.toUpperCase() }); return; }
+			if (result.outcome === "denied")
+			{
+				if (result.reason === "admission_concurrency_limited") res.set("Retry-After", "1");
+				res.status(_runDenialStatus(result.reason)).json({ error: "Run-now denied.", code: result.reason.toUpperCase() });
+				return;
+			}
 			res.status(result.outcome === "accepted" ? 202 : 200).json({ outcome: result.outcome, runId: result.runId });
 		}
 		catch (error) { _fail(res, error, "run-now"); }
@@ -376,11 +381,12 @@ export function __CreateAgentServicesRouter(dependencies: AgentServicesRouterDep
 }
 
 /** Maps a run-now denial reason to a fail-closed HTTP status. */
-function _runDenialStatus(reason: string): number
+function _runDenialStatus(reason: AgentRevisionLifecycleDenial): number
 {
 	if (reason === "service_not_found") return 404;
 	if (reason === "service_not_runnable") return 409;
 	if (reason === "run_admission_unavailable") return 503;
+	if (reason === "admission_concurrency_limited") return 503;
 	return 400;
 }
 

--- a/libs/backend/server/agents/scheduling/main/src/__tests__/schedule-tick.test.ts
+++ b/libs/backend/server/agents/scheduling/main/src/__tests__/schedule-tick.test.ts
@@ -159,6 +159,15 @@ describe("schedule tick", function _TickSuite()
 		expect(admission.commands).toHaveLength(1);
 	});
 
+	it("retries a capacity rejection without advancing the schedule cursor", async function _CapacityRetry()
+	{
+		const admission = new _DenyingAdmission("admission_concurrency_limited");
+		const result = await __RunScheduleTick(_schedule(), "rev-1", _deps(admission, "2026-07-01T02:30:00.000Z"));
+		if (result.status !== "ticked") throw new Error("expected ticked");
+		expect(result.outcomes[0]).toMatchObject({ outcome: "retry_hint", reason: "admission_concurrency_limited", retryAfterMs: 1_000 });
+		expect(result.nextLastScheduledAt).toBe("2026-07-01T00:00:00.000Z");
+	});
+
 	it("records a permanent denial and advances past it", async function _PermanentDeny()
 	{
 		const admission = new _DenyingAdmission("service_not_runnable");

--- a/libs/backend/server/agents/scheduling/main/src/schedule-tick.ts
+++ b/libs/backend/server/agents/scheduling/main/src/schedule-tick.ts
@@ -4,7 +4,7 @@ import { __DueScheduledSlots, __IsValidTimezone, __ParseCronExpression } from ".
 import type { AgentServiceSchedule, RetryBackoffPolicy, ScheduleTickDependencies, ScheduleTickResult, ScheduledSlotOutcome } from "./schedule-tick.types.js";
 
 /** Admission denial reasons that are transient and warrant a backed-off retry rather than a drop. */
-const _RETRYABLE_DENIALS = new Set(["run_admission_unavailable", "persistence_unavailable", "authority_conflict"]);
+const _RETRYABLE_DENIALS = new Set(["run_admission_unavailable", "admission_concurrency_limited", "persistence_unavailable", "authority_conflict"]);
 
 /**
  * Derive the deterministic idempotency key for one scheduled slot.


### PR DESCRIPTION
## Why this matters

A burst of run-now or scheduled managed-agent requests could previously reach the run-admission transaction without one shared server-process capacity boundary. That risked consuming the small PostgreSQL connection pool while requests waited on the AgentService lock.

## What changed

- compose one admission port shared by run-now and the scheduler
- enforce global, silo, and AgentService capacity before snapshot assembly or Prisma work starts
- expose a bounded Helm configuration that keeps the global active limit below the five-connection server pool
- return a typed, retryable overload response and preserve the scheduled slot for retry
- document the deployment contract and add focused concurrency and scheduler tests

## Validation

- full opencrane test suite: 41 tests
- opencrane TypeScript lint
- agent scheduling: 22 tests
- agent services: 28 tests plus lint
- personal run authority: 57 tests
- style and whitespace checks

## Review

- independent correctness/security review passed after fixing global-capacity and overload-propagation findings
- local Claude CLI review could not run because this shell is not authenticated