### PR TITLE
🔒️ Phase E: make persona approval atomic

### DIFF
--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -43,6 +43,8 @@ persona intact, never a half-approved one.
 - `PersonaApprovalSnapshot` — the consistent evidence read before the decision.
 - `AtomicApprovePersonaCommand` / `AtomicApprovePersonaResult` — the commit command carrying the accepted preconditions, and its raw result.
 - `PersonaAuthorityRepository` — the persistence port a caller must implement (or inject).
+- `PrismaPersonaAuthorityRepository` — the target Postgres implementation; it locks the profile,
+  approves the checked draft, and moves the active pointer in one transaction.
 
 ## Boundary
 

--- a/libs/backend/agents/personal/personas/main/src/__tests__/prisma-persona-authority-repository.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/prisma-persona-authority-repository.test.ts
@@ -1,0 +1,65 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaPersonaAuthorityRepository } from "../prisma-persona-authority-repository.js";
+
+/** Build a narrow fake Prisma client for one persona approval authority test. */
+function _Prisma(overrides: Record<string, unknown> = {}): PrismaClient
+{
+	const client: Record<string, unknown> = {
+		personaRevision: { findFirst: vi.fn().mockResolvedValue(null), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+		personaProfile: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+		personaInsight: { count: vi.fn().mockResolvedValue(3) },
+		$queryRaw: vi.fn().mockResolvedValue([{ matches: true }]),
+		...overrides,
+	};
+	client.$transaction = vi.fn(async function _transaction(callback: (transaction: unknown) => Promise<unknown>): Promise<unknown> { return callback(client); });
+	return client as unknown as PrismaClient;
+}
+
+describe("PrismaPersonaAuthorityRepository", function _describePrismaPersonaAuthorityRepository()
+{
+	it("returns a complete approval snapshot with the database-selected template check", async function _returnsApprovalSnapshot()
+	{
+		const prisma = _Prisma({
+			personaRevision: { findFirst: vi.fn().mockResolvedValue({ state: "Draft", personaProfileId: "profile-1", soulTemplateDigest: "sha256:template", durableSoulMutationPolicy: "forbidden", profile: { userId: "user-1" }, interview: { state: "Completed" }, soulTemplate: { digest: "sha256:template" }, _count: { insights: 3 } }), updateMany: vi.fn() },
+		});
+		const repository = new PrismaPersonaAuthorityRepository(prisma);
+
+		await expect(repository.getApprovalSnapshot({ personaProfileId: "profile-1", personaRevisionId: "revision-1", userId: "user-1", approvedAt: "2026-07-23T12:00:00.000Z" })).resolves.toEqual({ profileUserId: "user-1", revisionState: "draft", revisionProfileId: "profile-1", interviewState: "completed", insightCount: 3, templateDigestMatches: true, templateSelectionMatches: true, durableSoulMutationPolicy: "forbidden" });
+	});
+
+	it("locks the owner profile before approving the draft and advancing its active pointer", async function _locksThenActivates()
+	{
+		const updateRevision = vi.fn().mockResolvedValue({ count: 1 });
+		const updateProfile = vi.fn().mockResolvedValue({ count: 1 });
+		const queryRaw = vi.fn().mockResolvedValue([{ id: "profile-1" }]);
+		const prisma = _Prisma({ personaRevision: { findFirst: vi.fn(), updateMany: updateRevision }, personaProfile: { updateMany: updateProfile }, $queryRaw: queryRaw });
+		const repository = new PrismaPersonaAuthorityRepository(prisma);
+
+		await expect(repository.approveAndActivateAtomically({ personaProfileId: "profile-1", personaRevisionId: "revision-1", userId: "user-1", approvedAt: "2026-07-23T12:00:00.000Z", expectedRevisionState: "draft", expectedInterviewState: "completed", expectedInsightCount: 3 })).resolves.toEqual({ status: "approved" });
+		expect(queryRaw).toHaveBeenCalledBefore(updateRevision);
+		expect(updateRevision).toHaveBeenCalledBefore(updateProfile);
+		expect(updateProfile).toHaveBeenCalledWith({ where: { id: "profile-1", userId: "user-1" }, data: { activeRevisionId: "revision-1" } });
+	});
+
+	it("does not update a draft when the locked profile is absent or belongs to another user", async function _rejectsMissingOwner()
+	{
+		const updateRevision = vi.fn();
+		const prisma = _Prisma({ personaRevision: { findFirst: vi.fn(), updateMany: updateRevision }, $queryRaw: vi.fn().mockResolvedValue([]) });
+		const repository = new PrismaPersonaAuthorityRepository(prisma);
+
+		await expect(repository.approveAndActivateAtomically({ personaProfileId: "profile-1", personaRevisionId: "revision-1", userId: "user-1", approvedAt: "2026-07-23T12:00:00.000Z", expectedRevisionState: "draft", expectedInterviewState: "completed", expectedInsightCount: 3 })).resolves.toEqual({ status: "not_found" });
+		expect(updateRevision).not.toHaveBeenCalled();
+	});
+
+	it("does not approve when the draft evidence changed after its preflight snapshot", async function _rejectsChangedEvidence()
+	{
+		const updateRevision = vi.fn();
+		const prisma = _Prisma({ personaRevision: { findFirst: vi.fn(), updateMany: updateRevision }, personaInsight: { count: vi.fn().mockResolvedValue(4) }, $queryRaw: vi.fn().mockResolvedValue([{ id: "profile-1" }]) });
+		const repository = new PrismaPersonaAuthorityRepository(prisma);
+
+		await expect(repository.approveAndActivateAtomically({ personaProfileId: "profile-1", personaRevisionId: "revision-1", userId: "user-1", approvedAt: "2026-07-23T12:00:00.000Z", expectedRevisionState: "draft", expectedInterviewState: "completed", expectedInsightCount: 3 })).resolves.toEqual({ status: "conflict" });
+		expect(updateRevision).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/personal/personas/main/src/index.ts
+++ b/libs/backend/agents/personal/personas/main/src/index.ts
@@ -1,2 +1,3 @@
 export { __ApprovePersona } from "./persona-authority.js";
+export { PrismaPersonaAuthorityRepository } from "./prisma-persona-authority-repository.js";
 export type { ApprovePersonaCommand, ApprovePersonaResult, AtomicApprovePersonaCommand, AtomicApprovePersonaResult, PersonaApprovalSnapshot, PersonaAuthorityRepository } from "./persona-authority.types.js";

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-authority-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-authority-repository.ts
@@ -1,0 +1,129 @@
+import { PersonaInterviewState, PersonaRevisionState, Prisma, type PrismaClient } from "@prisma/client";
+
+import type { ApprovePersonaCommand, AtomicApprovePersonaCommand, AtomicApprovePersonaResult, PersonaApprovalSnapshot, PersonaAuthorityRepository } from "./persona-authority.types.js";
+
+/** Prisma-backed authority that atomically approves and activates one personal persona revision. */
+export class PrismaPersonaAuthorityRepository implements PersonaAuthorityRepository
+{
+	/** Canonical per-silo product database. */
+	private readonly prisma: PrismaClient;
+
+	/** Create the authority over the canonical product database. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Load the exact approval evidence required before an owner may activate a persona draft. */
+	async getApprovalSnapshot(command: ApprovePersonaCommand): Promise<PersonaApprovalSnapshot | null>
+	{
+		const revision = await this.prisma.personaRevision.findFirst({
+			where: { id: command.personaRevisionId, personaProfileId: command.personaProfileId },
+			select: {
+				state: true,
+				personaProfileId: true,
+				soulTemplateDigest: true,
+				durableSoulMutationPolicy: true,
+				profile: { select: { userId: true } },
+				interview: { select: { state: true } },
+				soulTemplate: { select: { digest: true } },
+				_count: { select: { insights: true } },
+			},
+		});
+		if (revision === null) return null;
+
+		// The target-baseline trigger remains the commit authority; this query gives callers a precise preflight denial.
+		const templateSelectionMatches = await this._matchesSelectedTemplate(command.personaRevisionId);
+		return {
+			profileUserId: revision.profile.userId,
+			revisionState: revision.state === PersonaRevisionState.Draft ? "draft" : "approved",
+			revisionProfileId: revision.personaProfileId,
+			interviewState: _asInterviewState(revision.interview.state),
+			insightCount: revision._count.insights,
+			templateDigestMatches: revision.soulTemplate.digest === revision.soulTemplateDigest,
+			templateSelectionMatches,
+			durableSoulMutationPolicy: revision.durableSoulMutationPolicy,
+		};
+	}
+
+	/** Approve a still-valid draft and move its profile pointer while holding the profile lock. */
+	async approveAndActivateAtomically(command: AtomicApprovePersonaCommand): Promise<AtomicApprovePersonaResult>
+	{
+		try
+		{
+			return await this.prisma.$transaction(async function _approve(transaction)
+			{
+				// 1. Lock the profile so two valid drafts cannot race to become the active persona.
+				const profiles = await transaction.$queryRaw<readonly { readonly id: string }[]>(Prisma.sql`SELECT "id" FROM "persona_profiles" WHERE "id" = ${command.personaProfileId} AND "user_id" = ${command.userId} FOR UPDATE`);
+				if (profiles.length !== 1) return { status: "not_found" } as const;
+
+				// 2. Lock the draft revision before inspecting its evidence, matching the lock used by the insight-provenance trigger.
+				const revisions = await transaction.$queryRaw<readonly { readonly id: string }[]>(Prisma.sql`SELECT "id" FROM "persona_revisions" WHERE "id" = ${command.personaRevisionId} AND "persona_profile_id" = ${command.personaProfileId} AND "state" = 'draft' FOR UPDATE`);
+				if (revisions.length !== 1) return { status: "conflict" } as const;
+
+				// 3. Rebind the exact evidence count accepted at preflight; a valid extra insight still changes the reviewed draft.
+				const insightCount = await transaction.personaInsight.count({ where: { personaRevisionId: command.personaRevisionId } });
+				if (insightCount !== command.expectedInsightCount) return { status: "conflict" } as const;
+
+				// 4. The baseline trigger rechecks interview, template, and insight evidence at this mutation fence.
+				const revision = await transaction.personaRevision.updateMany({
+					where: { id: command.personaRevisionId, personaProfileId: command.personaProfileId, state: PersonaRevisionState.Draft },
+					data: { state: PersonaRevisionState.Approved, approvedBy: command.userId, approvedAt: new Date(command.approvedAt) },
+				});
+				if (revision.count !== 1) return { status: "conflict" } as const;
+
+				// 5. Point the same locked profile at the newly approved revision; its trigger rejects an invalid target.
+				const profile = await transaction.personaProfile.updateMany({
+					where: { id: command.personaProfileId, userId: command.userId },
+					data: { activeRevisionId: command.personaRevisionId },
+				});
+				return profile.count === 1 ? { status: "approved" } as const : { status: "conflict" } as const;
+			});
+		}
+		catch (error)
+		{
+			if (error instanceof Prisma.PrismaClientKnownRequestError) return { status: "conflict" };
+			throw error;
+		}
+	}
+
+	/** Ask Postgres whether this revision still pins the deterministic winning template and answer set. */
+	private async _matchesSelectedTemplate(personaRevisionId: string): Promise<boolean>
+	{
+		const rows = await this.prisma.$queryRaw<readonly { readonly matches: boolean | null }[]>(Prisma.sql`
+			SELECT (
+				revision."soul_template_id" IS NOT DISTINCT FROM candidate."template_id"
+				AND revision."soul_template_version" IS NOT DISTINCT FROM candidate."version"
+				AND revision."soul_template_digest" IS NOT DISTINCT FROM candidate."digest"
+				AND revision."selection_rule_id" IS NOT DISTINCT FROM candidate."rule_id"
+				AND ARRAY(SELECT answer_id FROM unnest(revision."selection_answer_ids") answer_id ORDER BY answer_id) IS NOT DISTINCT FROM candidate."answer_ids"
+			) AS "matches"
+			FROM "persona_revisions" revision
+			LEFT JOIN LATERAL (
+				SELECT template."template_id", template."version", template."digest", rule ->> 'id' AS "rule_id",
+					ARRAY(
+						SELECT answer."id" FROM jsonb_object_keys(rule -> 'answers') required_question_id
+						JOIN "persona_interview_answers" answer ON answer."interview_id" = revision."interview_id" AND answer."question_id" = required_question_id
+						ORDER BY answer."id"
+					) AS "answer_ids", (rule ->> 'priority')::INTEGER AS "priority"
+				FROM "persona_soul_templates" template CROSS JOIN LATERAL jsonb_array_elements(template."selection_rules") rule
+				WHERE NOT EXISTS (
+					SELECT 1 FROM jsonb_each_text(rule -> 'answers') required_answer
+					WHERE NOT EXISTS (
+						SELECT 1 FROM "persona_interview_answers" answer
+						WHERE answer."interview_id" = revision."interview_id" AND answer."question_id" = required_answer.key AND answer."value" = required_answer.value
+					)
+				)
+				ORDER BY "priority" DESC, template."template_id", template."version" DESC, "rule_id" LIMIT 1
+			) candidate ON TRUE WHERE revision."id" = ${personaRevisionId}`);
+		return rows[0]?.matches === true;
+	}
+}
+
+/** Convert Prisma's closed interview enum into the domain approval vocabulary. */
+function _asInterviewState(state: PersonaInterviewState): "in_progress" | "completed" | "retaken"
+{
+	if (state === PersonaInterviewState.Completed) return "completed";
+	if (state === PersonaInterviewState.Retaken) return "retaken";
+	return "in_progress";
+}


### PR DESCRIPTION
## Summary

A personal persona can now be approved through the target Postgres authority, rather than relying on a caller-specific persistence implementation. The repository locks the owner profile and draft revision, rechecks the exact insight evidence that was reviewed, approves the revision, and advances the active-persona pointer in one transaction.

This makes the existing interview-backed approval rule executable for a later `persona_refresh`: only a complete, unchanged draft can become the persona used by future immutable run snapshots. Existing snapshots remain untouched.

## Safety properties

- the profile lock prevents two drafts from becoming active concurrently
- the revision lock serializes approval with insight writes
- the exact preflight insight count is rebound at commit
- baseline triggers remain the final authority for interview completeness, template selection, digest, and active-pointer validity

## Validation

- `npx nx run backend-agents-personal-personas:test` — 7 tests passed
- `npx nx run backend-agents-personal-personas:lint`
- `bash scripts/agent-style-check.sh` — 0 errors, 0 warnings
- `git diff --check`

## Review

Independent review found and verified fixes for two evidence-count races. The live Postgres authority suite remains an environment gate.