### PR TITLE
✨ Phase E: derive persona drafts from interviews

### DIFF
--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -6,8 +6,8 @@
 
 This package is part of the **personal-agent product**. A **persona** is the saved personality and
 instructions an agent runs with — who it is and how it should behave. A user builds one through an
-onboarding interview, producing a **draft**. This package owns the **approval process** end to end:
-the checks that turn a fully evidenced draft into the single live persona, atomically.
+onboarding interview, producing a **draft**. This package owns the **draft and approval process**:
+derive a draft from interview evidence, then turn a fully evidenced draft into the live persona.
 
 ```
  draft persona
@@ -38,7 +38,11 @@ persona intact, never a half-approved one.
 
 ## Public surface
 
-- `__ApprovePersona(repository, command)` — the single use case: validate evidence, then approve and activate atomically.
+- `__CreatePersonaDraft(repository, command)` — derives the selected template, next revision, and
+  answer provenance from a completed interview; callers supply only reviewable insight statements.
+- `PrismaPersonaDraftRepository` — locks profile and interview evidence, then persists the derived
+  template and three-to-five answer-bound insights as one draft.
+- `__ApprovePersona(repository, command)` — validates evidence, then approves and activates atomically.
 - `ApprovePersonaCommand` / `ApprovePersonaResult` — the request and the stable allow/deny outcome.
 - `PersonaApprovalSnapshot` — the consistent evidence read before the decision.
 - `AtomicApprovePersonaCommand` / `AtomicApprovePersonaResult` — the commit command carrying the accepted preconditions, and its raw result.
@@ -48,8 +52,9 @@ persona intact, never a half-approved one.
 
 ## Boundary
 
-Consumed by the persona-onboarding path. It only approves — it does not run the interview, generate
-insights, or execute the agent. It never activates a draft that is not fully evidenced, and it never
+Consumed by the persona-onboarding path. It does not run the interview or execute the agent. It only
+accepts explicit reviewable insight statements and derives every durable coordinate itself. It never
+activates a draft that is not fully evidenced, and it never
 mints an editable runtime persona file. Storage is injected through `PersonaAuthorityRepository`.
 
 ## Dependency direction

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-draft-authority.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-draft-authority.test.ts
@@ -1,0 +1,65 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { __CreatePersonaDraft } from "../persona-draft-authority.js";
+import { PrismaPersonaDraftRepository } from "../prisma-persona-draft-repository.js";
+
+/** Shared valid owner command with three distinct persisted-answer references. */
+const _COMMAND = {
+	siloId: "silo-1",
+	userId: "user-1",
+	personaProfileId: "profile-1",
+	interviewId: "interview-1",
+	insights: [{ answerId: "answer-1", statement: "Challenge my assumptions." }, { answerId: "answer-2", statement: "Use concise paragraphs." }, { answerId: "answer-3", statement: "Ask before external actions." }],
+	authoredAt: "2026-07-23T12:00:00.000Z",
+} as const;
+
+/** Build a narrow Prisma fake whose raw reads follow the draft-creation transaction order. */
+function _Prisma(rawResults: readonly unknown[]): PrismaClient
+{
+	const client: Record<string, unknown> = {
+		$queryRaw: vi.fn(),
+		personaRevision: { create: vi.fn().mockResolvedValue({ id: "persona-2" }) },
+		personaInsight: { createMany: vi.fn().mockResolvedValue({ count: 3 }) },
+	};
+	client.$queryRaw = vi.fn();
+	for (const result of rawResults) (client.$queryRaw as ReturnType<typeof vi.fn>).mockResolvedValueOnce(result);
+	client.$transaction = vi.fn(async function _transaction(callback: (transaction: unknown) => Promise<unknown>): Promise<unknown> { return callback(client); });
+	return client as unknown as PrismaClient;
+}
+
+describe("persona draft authority", function _describePersonaDraftAuthority()
+{
+	it("does not call persistence for duplicate answer evidence", async function _rejectsDuplicateAnswer()
+	{
+		const createAtomically = vi.fn();
+		const result = await __CreatePersonaDraft({ createAtomically }, { ..._COMMAND, insights: [{ answerId: "answer-1", statement: "First" }, { answerId: "answer-1", statement: "Second" }, { answerId: "answer-3", statement: "Third" }] });
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(createAtomically).not.toHaveBeenCalled();
+	});
+
+	it("derives the selected template and question provenance rather than accepting caller-selected coordinates", async function _derivesDraftCoordinates()
+	{
+		const prisma = _Prisma([
+			[{ activeRevisionId: "persona-1" }],
+			[{ id: "interview-1" }],
+			[{ templateId: "template-1", templateVersion: 2, templateDigest: `sha256:${"a".repeat(64)}`, content: "# Collaborator", selectionRuleId: "rule-1", selectionAnswerIds: ["answer-1"] }],
+			[{ answerId: "answer-1", category: "RelationshipRole", questionSetId: "set-1", questionSetVersion: 1, questionId: "question-1" }, { answerId: "answer-2", category: "ToneLanguage", questionSetId: "set-1", questionSetVersion: 1, questionId: "question-2" }, { answerId: "answer-3", category: "ApprovalRisk", questionSetId: "set-1", questionSetVersion: 1, questionId: "question-3" }],
+			[{ nextRevision: 2 }],
+		]);
+		const repository = new PrismaPersonaDraftRepository(prisma);
+
+		await expect(repository.createAtomically(_COMMAND)).resolves.toEqual({ status: "created", personaRevisionId: "persona-2" });
+		expect(prisma.personaRevision.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ revision: 2, soulTemplateId: "template-1", selectionRuleId: "rule-1", previousRevisionId: "persona-1" }) }));
+		expect(prisma.personaInsight.createMany).toHaveBeenCalledWith(expect.objectContaining({ data: expect.arrayContaining([expect.objectContaining({ answerId: "answer-1", questionId: "question-1", category: "RelationshipRole" })]) }));
+	});
+
+	it("fails closed when the owner profile cannot be locked in the supplied silo", async function _rejectsMissingOwner()
+	{
+		const prisma = _Prisma([[]]);
+		const repository = new PrismaPersonaDraftRepository(prisma);
+
+		await expect(repository.createAtomically(_COMMAND)).resolves.toEqual({ status: "not_found_or_wrong_owner" });
+		expect(prisma.personaRevision.create).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/personal/personas/main/src/index.ts
+++ b/libs/backend/agents/personal/personas/main/src/index.ts
@@ -1,3 +1,6 @@
 export { __ApprovePersona } from "./persona-authority.js";
 export { PrismaPersonaAuthorityRepository } from "./prisma-persona-authority-repository.js";
+export { __CreatePersonaDraft } from "./persona-draft-authority.js";
+export { PrismaPersonaDraftRepository } from "./prisma-persona-draft-repository.js";
 export type { ApprovePersonaCommand, ApprovePersonaResult, AtomicApprovePersonaCommand, AtomicApprovePersonaResult, PersonaApprovalSnapshot, PersonaAuthorityRepository } from "./persona-authority.types.js";
+export type { CreatePersonaDraftCommand, CreatePersonaDraftPersistenceResult, CreatePersonaDraftResult, PersonaDraftInsightCommand, PersonaDraftRepository } from "./persona-draft-authority.types.js";

--- a/libs/backend/agents/personal/personas/main/src/persona-draft-authority.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-draft-authority.ts
@@ -1,0 +1,28 @@
+import type { CreatePersonaDraftCommand, CreatePersonaDraftResult, PersonaDraftRepository } from "./persona-draft-authority.types.js";
+
+/** Create one immutable, reviewable persona draft from completed onboarding evidence. */
+export async function __CreatePersonaDraft(repository: PersonaDraftRepository, command: CreatePersonaDraftCommand): Promise<CreatePersonaDraftResult>
+{
+	// 1. Reject malformed owner and evidence coordinates before the repository can read a broader scope.
+	if (!_isValidCommand(command)) return { outcome: "denied", reason: "invalid_command" };
+
+	// 2. Delegate all template, revision, and provenance derivation to the one atomic persistence authority.
+	const result = await repository.createAtomically(command);
+	return result.status === "created" ? { outcome: "created", personaRevisionId: result.personaRevisionId } : { outcome: "denied", reason: result.status };
+}
+
+/** Return whether a draft request contains closed, user-reviewable insight evidence. */
+function _isValidCommand(command: CreatePersonaDraftCommand): boolean
+{
+	if (!command.siloId.trim() || !command.userId.trim() || !command.personaProfileId.trim() || !command.interviewId.trim() || !Number.isFinite(Date.parse(command.authoredAt)) || command.insights.length < 3 || command.insights.length > 5)
+	{
+		return false;
+	}
+	const answerIds = new Set<string>();
+	return command.insights.every(function _isValidInsight(insight)
+	{
+		if (!insight.answerId.trim() || !insight.statement.trim() || answerIds.has(insight.answerId)) return false;
+		answerIds.add(insight.answerId);
+		return true;
+	});
+}

--- a/libs/backend/agents/personal/personas/main/src/persona-draft-authority.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-draft-authority.types.ts
@@ -1,0 +1,42 @@
+/** One user-visible insight proposed for a completed onboarding answer. */
+export interface PersonaDraftInsightCommand
+{
+	/** Exact persisted interview answer from which this statement is derived. */
+	readonly answerId: string;
+	/** Concise statement the owner will review before approving the persona. */
+	readonly statement: string;
+}
+
+/** Request to create one reviewable persona draft from a completed onboarding interview. */
+export interface CreatePersonaDraftCommand
+{
+	/** Silo that owns the profile and interview evidence. */
+	readonly siloId: string;
+	/** Profile owner and only allowed draft author. */
+	readonly userId: string;
+	/** Personal persona profile receiving the next draft revision. */
+	readonly personaProfileId: string;
+	/** Completed interview whose answers deterministically select the template. */
+	readonly interviewId: string;
+	/** Three to five statements, each bound to a distinct stored interview answer. */
+	readonly insights: readonly PersonaDraftInsightCommand[];
+	/** Trusted instant at which this reviewable draft is authored. */
+	readonly authoredAt: string;
+}
+
+/** Stable outcome from creating a reviewable interview-backed persona draft. */
+export type CreatePersonaDraftResult =
+	| { readonly outcome: "created"; readonly personaRevisionId: string }
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found_or_wrong_owner" | "interview_incomplete" | "invalid_insights" | "template_not_selected" | "conflict" | "persistence_unavailable" };
+
+/** Raw persistence result before the public use case adds local command validation. */
+export type CreatePersonaDraftPersistenceResult =
+	| { readonly status: "created"; readonly personaRevisionId: string }
+	| { readonly status: "not_found_or_wrong_owner" | "interview_incomplete" | "invalid_insights" | "template_not_selected" | "conflict" | "persistence_unavailable" };
+
+/** Persistence boundary that creates one immutable, reviewable persona draft. */
+export interface PersonaDraftRepository
+{
+	/** Atomically derives and persists a draft from exact completed-interview evidence. */
+	createAtomically(command: CreatePersonaDraftCommand): Promise<CreatePersonaDraftPersistenceResult>;
+}

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-draft-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-draft-repository.ts
@@ -1,0 +1,83 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+import type { CreatePersonaDraftCommand, CreatePersonaDraftPersistenceResult, PersonaDraftRepository } from "./persona-draft-authority.types.js";
+
+/** Prisma authority that derives a draft persona only from one locked completed interview. */
+export class PrismaPersonaDraftRepository implements PersonaDraftRepository
+{
+	/** Canonical per-silo product database. */
+	private readonly prisma: PrismaClient;
+
+	/** Create the draft authority over the canonical product database. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Lock source evidence, derive the winning template, and persist the next reviewable revision. */
+	async createAtomically(command: CreatePersonaDraftCommand): Promise<CreatePersonaDraftPersistenceResult>
+	{
+		try
+		{
+			return await this.prisma.$transaction(async function _create(transaction)
+			{
+				// 1. Lock the owner profile to serialize both revision numbering and its immutable lineage.
+				const profiles = await transaction.$queryRaw<readonly { readonly activeRevisionId: string | null }[]>(Prisma.sql`SELECT "active_revision_id" AS "activeRevisionId" FROM "persona_profiles" WHERE "id" = ${command.personaProfileId} AND "silo_id" = ${command.siloId} AND "user_id" = ${command.userId} FOR UPDATE`);
+				if (profiles.length !== 1) return { status: "not_found_or_wrong_owner" } as const;
+
+				// 2. Lock the completed interview so selected answers and the next draft share one exact evidence view.
+				const interviews = await transaction.$queryRaw<readonly { readonly id: string }[]>(Prisma.sql`SELECT "id" FROM "persona_interviews" WHERE "id" = ${command.interviewId} AND "persona_profile_id" = ${command.personaProfileId} AND "user_id" = ${command.userId} AND "state" = 'completed' FOR UPDATE`);
+				if (interviews.length !== 1) return { status: "interview_incomplete" } as const;
+
+				// 3. Derive the deterministic winning reviewed SOUL template and validate every proposed insight answer.
+				const template = await _selectedTemplate(transaction, command.interviewId);
+				if (template === null) return { status: "template_not_selected" } as const;
+				const evidence = await _insightEvidence(transaction, command);
+				if (evidence === null) return { status: "invalid_insights" } as const;
+
+				// 4. Allocate the next profile-local revision, then store only the derived template and evidence coordinates.
+				const revisions = await transaction.$queryRaw<readonly { readonly nextRevision: number }[]>(Prisma.sql`SELECT COALESCE(MAX("revision"), 0) + 1 AS "nextRevision" FROM "persona_revisions" WHERE "persona_profile_id" = ${command.personaProfileId}`);
+				const revision = await transaction.personaRevision.create({ data: { personaProfileId: command.personaProfileId, revision: revisions[0]?.nextRevision ?? 1, soulTemplateId: template.templateId, soulTemplateVersion: template.templateVersion, soulTemplateDigest: template.templateDigest, interviewId: command.interviewId, selectionRuleId: template.selectionRuleId, selectionAnswerIds: [...template.selectionAnswerIds], compiledInstructions: _compiledInstructions(template.content, command.insights), previousRevisionId: profiles[0].activeRevisionId, authoredBy: command.userId, createdAt: new Date(command.authoredAt) }, select: { id: true } });
+				await transaction.personaInsight.createMany({ data: evidence.map(function _toInsight(item) { return { personaRevisionId: revision.id, category: item.category, statement: item.statement, interviewId: command.interviewId, questionSetId: item.questionSetId, questionSetVersion: item.questionSetVersion, questionId: item.questionId, answerId: item.answerId }; }) });
+				return { status: "created", personaRevisionId: revision.id } as const;
+			});
+		}
+		catch (error)
+		{
+			if (error instanceof Prisma.PrismaClientKnownRequestError) return { status: "conflict" };
+			return { status: "persistence_unavailable" };
+		}
+	}
+}
+
+/** Load Postgres's same deterministic selected-template candidate that the approval trigger enforces. */
+async function _selectedTemplate(transaction: Prisma.TransactionClient, interviewId: string): Promise<{ readonly templateId: string; readonly templateVersion: number; readonly templateDigest: string; readonly content: string; readonly selectionRuleId: string; readonly selectionAnswerIds: readonly string[] } | null>
+{
+	const rows = await transaction.$queryRaw<readonly { readonly templateId: string; readonly templateVersion: number; readonly templateDigest: string; readonly content: string; readonly selectionRuleId: string; readonly selectionAnswerIds: readonly string[] }[]>(Prisma.sql`
+		SELECT template."template_id" AS "templateId", template."version" AS "templateVersion", template."digest" AS "templateDigest", template."content", rule ->> 'id' AS "selectionRuleId",
+			ARRAY(SELECT answer."id" FROM jsonb_object_keys(rule -> 'answers') required_question_id JOIN "persona_interview_answers" answer ON answer."interview_id" = ${interviewId} AND answer."question_id" = required_question_id ORDER BY answer."id") AS "selectionAnswerIds"
+		FROM "persona_soul_templates" template CROSS JOIN LATERAL jsonb_array_elements(template."selection_rules") rule
+		WHERE NOT EXISTS (SELECT 1 FROM jsonb_each_text(rule -> 'answers') required_answer WHERE NOT EXISTS (SELECT 1 FROM "persona_interview_answers" answer WHERE answer."interview_id" = ${interviewId} AND answer."question_id" = required_answer.key AND answer."value" = required_answer.value))
+		ORDER BY (rule ->> 'priority')::INTEGER DESC, template."template_id", template."version" DESC, "selectionRuleId" LIMIT 1`);
+	return rows[0] ?? null;
+}
+
+/** Return exact persisted question provenance for each proposed insight answer, or null on any mismatch. */
+async function _insightEvidence(transaction: Prisma.TransactionClient, command: CreatePersonaDraftCommand): Promise<readonly { readonly answerId: string; readonly statement: string; readonly category: "RelationshipRole" | "ToneLanguage" | "AnswerStructure" | "ChallengeSupport" | "Initiative" | "ApprovalRisk" | "WorkingHabits" | "MemoryBoundaries"; readonly questionSetId: string; readonly questionSetVersion: number; readonly questionId: string }[] | null>
+{
+	const answerIds = command.insights.map(function _answerId(insight) { return insight.answerId; });
+	const rows = await transaction.$queryRaw<readonly { readonly answerId: string; readonly category: "RelationshipRole" | "ToneLanguage" | "AnswerStructure" | "ChallengeSupport" | "Initiative" | "ApprovalRisk" | "WorkingHabits" | "MemoryBoundaries"; readonly questionSetId: string; readonly questionSetVersion: number; readonly questionId: string }[]>(Prisma.sql`SELECT answer."id" AS "answerId", question."category", answer."question_set_id" AS "questionSetId", answer."question_set_version" AS "questionSetVersion", answer."question_id" AS "questionId" FROM "persona_interview_answers" answer JOIN "persona_questions" question ON question."question_set_id" = answer."question_set_id" AND question."question_set_version" = answer."question_set_version" AND question."question_id" = answer."question_id" WHERE answer."interview_id" = ${command.interviewId} AND answer."id" IN (${Prisma.join(answerIds)})`);
+	if (rows.length !== command.insights.length) return null;
+	const evidence = new Map(rows.map(function _byAnswer(item) { return [item.answerId, item]; }));
+	return command.insights.map(function _toEvidence(insight)
+	{
+		const row = evidence.get(insight.answerId);
+		return row === undefined ? null : { ...row, statement: insight.statement };
+	}).every(function _isPresent(item) { return item !== null; }) ? command.insights.map(function _toExactEvidence(insight) { const row = evidence.get(insight.answerId); return { ...row!, statement: insight.statement }; }) : null;
+}
+
+/** Compile the reviewed SOUL source and explicit owner-visible interview insights into draft instructions. */
+function _compiledInstructions(templateContent: string, insights: readonly { readonly statement: string }[]): string
+{
+	return `${templateContent.trim()}\n\n## Interview insights\n${insights.map(function _renderInsight(insight) { return `- ${insight.statement.trim()}`; }).join("\n")}\n`;
+}


### PR DESCRIPTION
## Summary

This adds the missing durable bridge between a completed onboarding interview and a reviewable persona draft. The caller supplies only three to five visible insight statements, each tied to an existing answer. The server derives every durable coordinate: the selected `SOUL.md` template, template digest, winning selection rule, exact answer set, profile-local revision number, and prior-revision lineage.

The result is a draft only. It cannot affect an in-flight run or become active until the existing owner-approval authority accepts it.

## Safety properties

- locks the owner profile before assigning the next revision and lineage
- locks the completed interview before reading answers
- rejects cross-profile, cross-user, incomplete, duplicate, or unknown answer evidence
- uses the same deterministic template-selection ordering as the target Postgres approval trigger
- derives question category and provenance from persisted answers rather than client input

## Validation

- `npx nx run backend-agents-personal-personas:test` — 6 tests passed
- `npx nx run backend-agents-personal-personas:lint`
- `bash scripts/agent-style-check.sh` — 0 errors, 0 warnings
- `git diff --check`

## Review

Independent review passed. The live Postgres authority suite remains an environment gate.