### PR TITLE
✨ Phase E: persist the persona interview lifecycle

### DIFF
--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -58,8 +58,9 @@ fails closed and a crash leaves the previous active persona intact, never a half
   and its canonical product-database implementation.
 - `__CreatePersonaDraft(repository, command)` — derives the selected template, next revision, and
   answer provenance from a completed interview; callers supply only reviewable insight statements.
-- `CreatePersonaDraftCommand` / `CreatePersonaDraftResult`, `PersonaDraftInsightCommand`, and
-  `PersonaDraftRepository` — the request, stable outcome, insight evidence, and draft persistence port.
+- `CreatePersonaDraftCommand` / `CreatePersonaDraftResult`, `CreatePersonaDraftPersistenceResult`,
+  `PersonaDraftInsightCommand`, and `PersonaDraftRepository` — the request, stable outcome, raw
+  persistence result, insight evidence, and draft persistence port.
 - `PrismaPersonaDraftRepository` — locks profile and interview evidence, then persists the derived
   template and three-to-five answer-bound insights as one draft.
 - `__ApprovePersona(repository, command)` — validates evidence, then approves and activates atomically.

--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -1,4 +1,4 @@
-# @opencrane/backend/agents/personal/personas — persona approval process
+# @opencrane/backend/agents/personal/personas — persona interview and approval process
 
 > [backend](../../../../README.md) › [agents](../../../README.md) › personal › personas
 
@@ -6,17 +6,22 @@
 
 This package is part of the **personal-agent product**. A **persona** is the saved personality and
 instructions an agent runs with — who it is and how it should behave. A user builds one through an
-onboarding interview, producing a **draft**. This package owns the **draft and approval process**:
-derive a draft from interview evidence, then turn a fully evidenced draft into the live persona.
+onboarding interview, producing a **draft**. This package owns the full durable lifecycle: it starts
+an interview from a reviewed question set, captures each answer once, freezes the completed evidence,
+derives a draft from selected-template evidence, and then approves a fully evidenced draft into the
+single live persona.
 
 ```
+ reviewed question set
+     │ 1. start              bind one exact reviewed version to the owner profile
+     ▼
+ interview in progress
+     │ 2. answer             append each answer once, with question provenance
+     ▼
+ completed interview
+     │ 3. derive draft       record 3–5 insights + exact SOUL template selection
+     ▼
  draft persona
-     │ 1. interview          capture the onboarding Q&A
-     ▼
-     │ 2. snapshot           gather the approval evidence
-     ▼                       (owner · 3–5 insights · exact template used)
-     │ 3. validate ─────────► evidence incomplete?  →  denied
-     ▼
      │ 4. approve + activate atomically swap in the new persona
      ▼
  active persona
@@ -24,38 +29,53 @@ derive a draft from interview evidence, then turn a fully evidenced draft into t
 
 **In this flow:** [runs](../../runs/main/README.md) *(runs execute against the persona this activates)*
 
-Step 3 is where the strictness lives. From one consistent database snapshot the use case confirms:
-the caller owns the profile; the revision is still a `draft`; the interview is `completed`; there are
-between **three and five** provenance-linked insights; the reviewed template's fingerprint (digest)
-still matches and its selection rule still matches the interview answers; and the policy forbidding a
-mutable runtime "SOUL" file (a legacy editable personality file — deliberately not created here) holds.
-Any failure is a specific denial (`not_draft`, `interview_incomplete`, `invalid_insights`,
+The interview half locks the profile while it starts, so duplicate browser requests reuse the one
+in-progress interview instead of discarding answers. It locks that interview again for each answer
+and for completion, ensuring a late answer cannot race a completed record. Answers name the exact
+question-set revision and question they answered; completion is refused until every question in that
+reviewed revision has exactly one answer.
+
+The approval half takes one consistent database snapshot and confirms the caller owns the profile;
+the revision is still a `draft`; the interview is `completed`; there are between **three and five**
+provenance-linked insights; the reviewed template's fingerprint (digest) and selection rule still
+match the interview answers; and the policy forbidding a mutable runtime "SOUL" file holds. Any
+failure is a specific denial (`not_draft`, `interview_incomplete`, `invalid_insights`,
 `template_mismatch`, …).
 
-Invariant: only a fully evidenced draft becomes active, and the swap is atomic — step 4 rebinds every
-precondition at commit time, so a concurrent edit fails closed and a crash leaves the previous active
-persona intact, never a half-approved one.
+Invariant: onboarding evidence is append-only until completion, and only a fully evidenced draft
+becomes active. The approval swap rebinds every precondition at commit time, so a concurrent edit
+fails closed and a crash leaves the previous active persona intact, never a half-approved one.
 
 ## Public surface
 
+- `__StartPersonaInterview`, `__RecordPersonaInterviewAnswer`, `__CompletePersonaInterview` — start,
+  append to, and complete the reviewed onboarding interview lifecycle.
+- `StartPersonaInterviewCommand` / `StartPersonaInterviewResult`,
+  `RecordPersonaInterviewAnswerCommand` / `RecordPersonaInterviewAnswerResult`, and
+  `CompletePersonaInterviewCommand` / `CompletePersonaInterviewResult` — the lifecycle requests and
+  stable outcomes.
+- `PersonaInterviewRepository` / `PrismaPersonaInterviewRepository` — the lifecycle persistence port
+  and its canonical product-database implementation.
 - `__CreatePersonaDraft(repository, command)` — derives the selected template, next revision, and
   answer provenance from a completed interview; callers supply only reviewable insight statements.
+- `CreatePersonaDraftCommand` / `CreatePersonaDraftResult`, `PersonaDraftInsightCommand`, and
+  `PersonaDraftRepository` — the request, stable outcome, insight evidence, and draft persistence port.
 - `PrismaPersonaDraftRepository` — locks profile and interview evidence, then persists the derived
   template and three-to-five answer-bound insights as one draft.
 - `__ApprovePersona(repository, command)` — validates evidence, then approves and activates atomically.
-- `ApprovePersonaCommand` / `ApprovePersonaResult` — the request and the stable allow/deny outcome.
-- `PersonaApprovalSnapshot` — the consistent evidence read before the decision.
-- `AtomicApprovePersonaCommand` / `AtomicApprovePersonaResult` — the commit command carrying the accepted preconditions, and its raw result.
-- `PersonaAuthorityRepository` — the persistence port a caller must implement (or inject).
+- `ApprovePersonaCommand` / `ApprovePersonaResult` — the request and stable allow/deny outcome.
+- `PersonaApprovalSnapshot`, `AtomicApprovePersonaCommand`, `AtomicApprovePersonaResult`, and
+  `PersonaAuthorityRepository` — the consistent evidence and injected approval persistence boundary.
 - `PrismaPersonaAuthorityRepository` — the target Postgres implementation; it locks the profile,
   approves the checked draft, and moves the active pointer in one transaction.
 
 ## Boundary
 
-Consumed by the persona-onboarding path. It does not run the interview or execute the agent. It only
-accepts explicit reviewable insight statements and derives every durable coordinate itself. It never
-activates a draft that is not fully evidenced, and it never
-mints an editable runtime persona file. Storage is injected through `PersonaAuthorityRepository`.
+Consumed by the persona-onboarding path. It owns the interview lifecycle and approval, but does not
+generate insights or execute the agent. It accepts only reviewable insight statements and derives
+template selection plus every other durable draft coordinate from the completed interview. It never
+activates a draft that is not fully evidenced, and it never mints an editable runtime persona file.
+Storage is injected through its three authority repositories.
 
 ## Dependency direction
 
@@ -64,9 +84,10 @@ Tagged `scope:personal-personas`: it may depend only on `scope:personal-personas
 
 ## Data & persistence
 
-Reads a joined snapshot (profile · revision · interview · template · insights) and commits the
-approval plus the active-persona pointer in one transaction through the injected repository.
-Postgres-level behaviour is exercised by the `test:sql` target (`tests/persona-authority.sql`).
+Starts, appends answers to, and completes `PersonaInterview` and `PersonaInterviewAnswer` rows in the
+canonical product database. It also reads a joined approval snapshot (profile · revision · interview
+· template · insights) and commits approval plus the active-persona pointer in one transaction.
+Postgres-level lifecycle behaviour is exercised by the `test:sql` target (`tests/persona-authority.sql`).
 
 ## See also
 

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-interview-authority.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-interview-authority.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "@prisma/client";
+
+import { __CompletePersonaInterview, __RecordPersonaInterviewAnswer, __StartPersonaInterview } from "../persona-interview-authority.js";
+import type { PersonaInterviewRepository } from "../persona-interview-authority.types.js";
+import { PrismaPersonaInterviewRepository } from "../prisma-persona-interview-repository.js";
+
+/** Creates a repository that records lifecycle calls without using a database. */
+function _repository(overrides: Partial<PersonaInterviewRepository> = {}): PersonaInterviewRepository
+{
+	return {
+		startAtomically: async function _start() { return { status: "started", interviewId: "interview-1" } as const; },
+		recordAnswerAtomically: async function _record() { return { status: "recorded", answerId: "answer-1" } as const; },
+		completeAtomically: async function _complete() { return { status: "completed" } as const; },
+		...overrides,
+	};
+}
+
+/** Creates the valid exact reviewed-question-set request used by lifecycle tests. */
+function _startCommand()
+{
+	return { siloId: "silo-1", userId: "user-1", personaProfileId: "profile-1", questionSetId: "onboarding", questionSetVersion: 1, startedAt: "2026-07-23T09:00:00.000Z" } as const;
+}
+
+/** Wraps one fake transactional client in the narrow Prisma interface this authority needs. */
+function _prisma(transaction: unknown): PrismaClient
+{
+	return { $transaction: async function _transaction(callback: (client: unknown) => Promise<unknown>) { return await callback(transaction); } } as unknown as PrismaClient;
+}
+
+describe("persona interview authority", function _describePersonaInterviewAuthority()
+{
+	it("reuses an owner's active interview rather than starting a competing one", async function _reusesInProgress()
+	{
+		const startAtomically = vi.fn().mockResolvedValue({ status: "already_in_progress", interviewId: "interview-existing" });
+		const result = await __StartPersonaInterview(_repository({ startAtomically }), _startCommand());
+
+		expect(result).toEqual({ outcome: "already_in_progress", interviewId: "interview-existing" });
+		expect(startAtomically).toHaveBeenCalledWith(_startCommand());
+	});
+
+	it("rejects a blank answer before it can reach the append-only repository", async function _rejectsBlankAnswer()
+	{
+		const recordAnswerAtomically = vi.fn();
+		const result = await __RecordPersonaInterviewAnswer(_repository({ recordAnswerAtomically }), { userId: "user-1", personaProfileId: "profile-1", interviewId: "interview-1", questionId: "q1", value: " ", answeredAt: "2026-07-23T09:01:00.000Z" });
+
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(recordAnswerAtomically).not.toHaveBeenCalled();
+	});
+
+	it("preserves the incomplete-evidence denial returned by the atomic completion fence", async function _preservesCompletionDenial()
+	{
+		const completeAtomically = vi.fn().mockResolvedValue({ status: "incomplete_answers" });
+		const result = await __CompletePersonaInterview(_repository({ completeAtomically }), { userId: "user-1", personaProfileId: "profile-1", interviewId: "interview-1", completedAt: "2026-07-23T09:02:00.000Z" });
+
+		expect(result).toEqual({ outcome: "denied", reason: "incomplete_answers" });
+		expect(completeAtomically).toHaveBeenCalledOnce();
+	});
+
+	it("starts only after the profile and exact reviewed question-set revision are fenced", async function _startsExactReviewedSet()
+	{
+		const transaction = {
+			$queryRaw: vi.fn().mockResolvedValue([{ id: "profile-1" }]),
+			personaInterview: { findFirst: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({ id: "interview-created" }) },
+			personaQuestionSet: { findUnique: vi.fn().mockResolvedValue({ state: "Reviewed" }) },
+		};
+		const repository = new PrismaPersonaInterviewRepository(_prisma(transaction));
+
+		await expect(repository.startAtomically(_startCommand())).resolves.toEqual({ status: "started", interviewId: "interview-created" });
+		expect(transaction.personaQuestionSet.findUnique).toHaveBeenCalledWith({ where: { id_version: { id: "onboarding", version: 1 } }, select: { state: true } });
+		expect(transaction.personaInterview.create).toHaveBeenCalledWith({ data: expect.objectContaining({ personaProfileId: "profile-1", userId: "user-1", questionSetId: "onboarding", questionSetVersion: 1 }), select: { id: true } });
+	});
+
+	it("accepts PostgreSQL's in_progress label while appending an answer", async function _acceptsDatabaseLifecycleLabel()
+	{
+		const transaction = {
+			$queryRaw: vi.fn().mockResolvedValue([{ questionSetId: "onboarding", questionSetVersion: 1, state: "in_progress" }]),
+			personaQuestion: { findUnique: vi.fn().mockResolvedValue({ id: "q1" }) },
+			personaInterviewAnswer: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({ id: "answer-created" }) },
+		};
+		const repository = new PrismaPersonaInterviewRepository(_prisma(transaction));
+
+		await expect(repository.recordAnswerAtomically({ userId: "user-1", personaProfileId: "profile-1", interviewId: "interview-1", questionId: "q1", value: "A considered answer", answeredAt: "2026-07-23T09:01:00.000Z" })).resolves.toEqual({ status: "recorded", answerId: "answer-created" });
+		expect(transaction.personaInterviewAnswer.create).toHaveBeenCalledWith({ data: expect.objectContaining({ interviewId: "interview-1", questionSetId: "onboarding", questionSetVersion: 1, questionId: "q1" }), select: { id: true } });
+	});
+});

--- a/libs/backend/agents/personal/personas/main/src/index.ts
+++ b/libs/backend/agents/personal/personas/main/src/index.ts
@@ -4,3 +4,6 @@ export { __CreatePersonaDraft } from "./persona-draft-authority.js";
 export { PrismaPersonaDraftRepository } from "./prisma-persona-draft-repository.js";
 export type { ApprovePersonaCommand, ApprovePersonaResult, AtomicApprovePersonaCommand, AtomicApprovePersonaResult, PersonaApprovalSnapshot, PersonaAuthorityRepository } from "./persona-authority.types.js";
 export type { CreatePersonaDraftCommand, CreatePersonaDraftPersistenceResult, CreatePersonaDraftResult, PersonaDraftInsightCommand, PersonaDraftRepository } from "./persona-draft-authority.types.js";
+export { __CompletePersonaInterview, __RecordPersonaInterviewAnswer, __StartPersonaInterview } from "./persona-interview-authority.js";
+export type { CompletePersonaInterviewCommand, CompletePersonaInterviewResult, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, RecordPersonaInterviewAnswerResult, StartPersonaInterviewCommand, StartPersonaInterviewResult } from "./persona-interview-authority.types.js";
+export { PrismaPersonaInterviewRepository } from "./prisma-persona-interview-repository.js";

--- a/libs/backend/agents/personal/personas/main/src/persona-interview-authority.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-interview-authority.ts
@@ -1,0 +1,55 @@
+import type { CompletePersonaInterviewCommand, CompletePersonaInterviewResult, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, RecordPersonaInterviewAnswerResult, StartPersonaInterviewCommand, StartPersonaInterviewResult } from "./persona-interview-authority.types.js";
+
+/** Start one reviewed onboarding interview without exposing question-set authority to callers. */
+export async function __StartPersonaInterview(repository: PersonaInterviewRepository, command: StartPersonaInterviewCommand): Promise<StartPersonaInterviewResult>
+{
+	if (!_validStart(command)) return { outcome: "denied", reason: "invalid_command" };
+	const result = await repository.startAtomically(command);
+	return result.status === "started" || result.status === "already_in_progress" ? { outcome: result.status, interviewId: result.interviewId } : { outcome: "denied", reason: result.status };
+}
+
+/** Record one immutable owner answer against an in-progress onboarding interview. */
+export async function __RecordPersonaInterviewAnswer(repository: PersonaInterviewRepository, command: RecordPersonaInterviewAnswerCommand): Promise<RecordPersonaInterviewAnswerResult>
+{
+	if (!_validAnswer(command)) return { outcome: "denied", reason: "invalid_command" };
+	const result = await repository.recordAnswerAtomically(command);
+	return result.status === "recorded" ? { outcome: "recorded", answerId: result.answerId } : { outcome: "denied", reason: result.status };
+}
+
+/** Complete an owner interview only after the persistence authority has rechecked every answer. */
+export async function __CompletePersonaInterview(repository: PersonaInterviewRepository, command: CompletePersonaInterviewCommand): Promise<CompletePersonaInterviewResult>
+{
+	if (!_validCompletion(command)) return { outcome: "denied", reason: "invalid_command" };
+	const result = await repository.completeAtomically(command);
+	return result.status === "completed" ? { outcome: "completed" } : { outcome: "denied", reason: result.status };
+}
+
+/** Return whether every start coordinate and instant is safely present. */
+function _validStart(command: StartPersonaInterviewCommand): boolean
+{
+	return _validIdentifier(command.siloId) && _validIdentifier(command.userId) && _validIdentifier(command.personaProfileId) && _validIdentifier(command.questionSetId) && Number.isSafeInteger(command.questionSetVersion) && command.questionSetVersion > 0 && _validInstant(command.startedAt);
+}
+
+/** Return whether one answer remains bounded enough for durable interview evidence. */
+function _validAnswer(command: RecordPersonaInterviewAnswerCommand): boolean
+{
+	return _validIdentifier(command.userId) && _validIdentifier(command.personaProfileId) && _validIdentifier(command.interviewId) && _validIdentifier(command.questionId) && command.value.trim().length > 0 && command.value.length <= 4_000 && _validInstant(command.answeredAt);
+}
+
+/** Return whether an owner completion request names one valid frozen instant. */
+function _validCompletion(command: CompletePersonaInterviewCommand): boolean
+{
+	return _validIdentifier(command.userId) && _validIdentifier(command.personaProfileId) && _validIdentifier(command.interviewId) && _validInstant(command.completedAt);
+}
+
+/** Validate a bounded opaque durable identifier without inventing its syntax. */
+function _validIdentifier(value: string): boolean
+{
+	return value.trim().length > 0 && value.length <= 200;
+}
+
+/** Validate an ISO-compatible trusted instant before any authority read. */
+function _validInstant(value: string): boolean
+{
+	return Number.isFinite(Date.parse(value));
+}

--- a/libs/backend/agents/personal/personas/main/src/persona-interview-authority.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-interview-authority.types.ts
@@ -1,0 +1,72 @@
+/** Request to start the reviewed onboarding interview for one personal persona profile. */
+export interface StartPersonaInterviewCommand
+{
+	/** Silo that owns the profile and reviewed question set. */
+	readonly siloId: string;
+	/** Profile owner who is starting the interview. */
+	readonly userId: string;
+	/** Personal persona profile that will receive the interview evidence. */
+	readonly personaProfileId: string;
+	/** Reviewed question-set identifier selected for this interview. */
+	readonly questionSetId: string;
+	/** Exact reviewed question-set version. */
+	readonly questionSetVersion: number;
+	/** Trusted start instant. */
+	readonly startedAt: string;
+}
+
+/** Request to record one immutable answer while an interview remains in progress. */
+export interface RecordPersonaInterviewAnswerCommand
+{
+	/** Profile owner who is answering the question. */
+	readonly userId: string;
+	/** Profile that owns the interview. */
+	readonly personaProfileId: string;
+	/** In-progress interview receiving the answer. */
+	readonly interviewId: string;
+	/** Question from the interview's exact reviewed question set. */
+	readonly questionId: string;
+	/** Non-empty user answer. */
+	readonly value: string;
+	/** Trusted answer instant. */
+	readonly answeredAt: string;
+}
+
+/** Request to make a fully answered interview immutable and ready for persona-draft derivation. */
+export interface CompletePersonaInterviewCommand
+{
+	/** Profile owner who completes the interview. */
+	readonly userId: string;
+	/** Profile that owns the interview. */
+	readonly personaProfileId: string;
+	/** In-progress interview becoming completed. */
+	readonly interviewId: string;
+	/** Trusted completion instant. */
+	readonly completedAt: string;
+}
+
+/** Stable outcome from starting a reviewed persona interview. */
+export type StartPersonaInterviewResult =
+	| { readonly outcome: "started" | "already_in_progress"; readonly interviewId: string }
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found_or_wrong_owner" | "question_set_unavailable" | "persistence_unavailable" };
+
+/** Stable outcome from recording one interview answer. */
+export type RecordPersonaInterviewAnswerResult =
+	| { readonly outcome: "recorded"; readonly answerId: string }
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found_or_wrong_owner" | "not_in_progress" | "question_unavailable" | "already_answered" | "persistence_unavailable" };
+
+/** Stable outcome from completing one onboarding interview. */
+export type CompletePersonaInterviewResult =
+	| { readonly outcome: "completed" }
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found_or_wrong_owner" | "not_in_progress" | "incomplete_answers" | "persistence_unavailable" };
+
+/** Persistence boundary for the append-only onboarding interview lifecycle. */
+export interface PersonaInterviewRepository
+{
+	/** Starts one reviewed interview or returns the owner's existing in-progress interview. */
+	startAtomically(command: StartPersonaInterviewCommand): Promise<{ readonly status: "started" | "already_in_progress"; readonly interviewId: string } | { readonly status: "not_found_or_wrong_owner" | "question_set_unavailable" | "persistence_unavailable" }>;
+	/** Appends one answer only while the owner interview remains in progress. */
+	recordAnswerAtomically(command: RecordPersonaInterviewAnswerCommand): Promise<{ readonly status: "recorded"; readonly answerId: string } | { readonly status: "not_found_or_wrong_owner" | "not_in_progress" | "question_unavailable" | "already_answered" | "persistence_unavailable" }>;
+	/** Completes a fully answered owner interview once and freezes its evidence. */
+	completeAtomically(command: CompletePersonaInterviewCommand): Promise<{ readonly status: "completed" } | { readonly status: "not_found_or_wrong_owner" | "not_in_progress" | "incomplete_answers" | "persistence_unavailable" }>;
+}

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-interview-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-interview-repository.ts
@@ -1,0 +1,104 @@
+import { PersonaInterviewState, PersonaQuestionSetState, Prisma, type PrismaClient } from "@prisma/client";
+
+import type { CompletePersonaInterviewCommand, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, StartPersonaInterviewCommand } from "./persona-interview-authority.types.js";
+
+/** Prisma authority for the append-only, reviewed-question-set persona interview lifecycle. */
+export class PrismaPersonaInterviewRepository implements PersonaInterviewRepository
+{
+	/** Canonical per-silo product database. */
+	private readonly prisma: PrismaClient;
+
+	/** Create the interview authority over the canonical product database. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Start one reviewed interview while serialising all in-progress attempts for the same profile. */
+	async startAtomically(command: StartPersonaInterviewCommand): Promise<{ readonly status: "started" | "already_in_progress"; readonly interviewId: string } | { readonly status: "not_found_or_wrong_owner" | "question_set_unavailable" | "persistence_unavailable" }>
+	{
+		try
+		{
+			return await this.prisma.$transaction(async function _start(transaction)
+			{
+				// 1. Lock the owner profile so two browser requests cannot create competing active interviews.
+				const profiles = await transaction.$queryRaw<readonly { readonly id: string }[]>(Prisma.sql`SELECT "id" FROM "persona_profiles" WHERE "id" = ${command.personaProfileId} AND "silo_id" = ${command.siloId} AND "user_id" = ${command.userId} FOR UPDATE`);
+				if (profiles.length !== 1) return { status: "not_found_or_wrong_owner" } as const;
+
+				// 2. Reuse a still-active interview; starting again must not discard unreviewed user answers.
+				const existing = await transaction.personaInterview.findFirst({ where: { personaProfileId: command.personaProfileId, userId: command.userId, state: PersonaInterviewState.InProgress }, select: { id: true } });
+				if (existing !== null) return { status: "already_in_progress", interviewId: existing.id } as const;
+
+				// 3. Accept only an exact reviewed question-set revision before recording the interview attempt.
+				const questionSet = await transaction.personaQuestionSet.findUnique({ where: { id_version: { id: command.questionSetId, version: command.questionSetVersion } }, select: { state: true } });
+				if (questionSet?.state !== PersonaQuestionSetState.Reviewed) return { status: "question_set_unavailable" } as const;
+				const interview = await transaction.personaInterview.create({ data: { personaProfileId: command.personaProfileId, userId: command.userId, questionSetId: command.questionSetId, questionSetVersion: command.questionSetVersion, startedAt: new Date(command.startedAt) }, select: { id: true } });
+				return { status: "started", interviewId: interview.id } as const;
+			});
+		}
+		catch
+		{
+			return { status: "persistence_unavailable" };
+		}
+	}
+
+	/** Append one answer only after locking the exact owner interview and question-set revision. */
+	async recordAnswerAtomically(command: RecordPersonaInterviewAnswerCommand): Promise<{ readonly status: "recorded"; readonly answerId: string } | { readonly status: "not_found_or_wrong_owner" | "not_in_progress" | "question_unavailable" | "already_answered" | "persistence_unavailable" }>
+	{
+		try
+		{
+			return await this.prisma.$transaction(async function _record(transaction)
+			{
+				// 1. Lock the interview, proving its owner and keeping completion from racing an answer append.
+				const interviews = await transaction.$queryRaw<readonly { readonly questionSetId: string; readonly questionSetVersion: number; readonly state: "in_progress" | "completed" | "retaken" }[]>(Prisma.sql`SELECT "question_set_id" AS "questionSetId", "question_set_version" AS "questionSetVersion", "state" FROM "persona_interviews" WHERE "id" = ${command.interviewId} AND "persona_profile_id" = ${command.personaProfileId} AND "user_id" = ${command.userId} FOR UPDATE`);
+				if (interviews.length !== 1) return { status: "not_found_or_wrong_owner" } as const;
+				const interview = interviews[0];
+				if (interview.state !== "in_progress") return { status: "not_in_progress" } as const;
+
+				// 2. Check the question belongs to the exact reviewed set that was frozen when this interview began.
+				const question = await transaction.personaQuestion.findUnique({ where: { questionSetId_questionSetVersion_id: { questionSetId: interview.questionSetId, questionSetVersion: interview.questionSetVersion, id: command.questionId } }, select: { id: true } });
+				if (question === null) return { status: "question_unavailable" } as const;
+				const existing = await transaction.personaInterviewAnswer.findUnique({ where: { interviewId_questionId: { interviewId: command.interviewId, questionId: command.questionId } }, select: { id: true } });
+				if (existing !== null) return { status: "already_answered" } as const;
+
+				// 3. Persist the immutable answer with the question-set provenance the baseline trigger independently verifies.
+				const answer = await transaction.personaInterviewAnswer.create({ data: { interviewId: command.interviewId, questionSetId: interview.questionSetId, questionSetVersion: interview.questionSetVersion, questionId: command.questionId, value: command.value.trim(), answeredAt: new Date(command.answeredAt) }, select: { id: true } });
+				return { status: "recorded", answerId: answer.id } as const;
+			});
+		}
+		catch (error)
+		{
+			if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") return { status: "already_answered" };
+			return { status: "persistence_unavailable" };
+		}
+	}
+
+	/** Freeze one interview only once its exact reviewed-question set has every answer. */
+	async completeAtomically(command: CompletePersonaInterviewCommand): Promise<{ readonly status: "completed" } | { readonly status: "not_found_or_wrong_owner" | "not_in_progress" | "incomplete_answers" | "persistence_unavailable" }>
+	{
+		try
+		{
+			return await this.prisma.$transaction(async function _complete(transaction)
+			{
+				// 1. Lock the interview before counting evidence, sharing the same fence as answer append.
+				const interviews = await transaction.$queryRaw<readonly { readonly questionSetId: string; readonly questionSetVersion: number; readonly state: "in_progress" | "completed" | "retaken" }[]>(Prisma.sql`SELECT "question_set_id" AS "questionSetId", "question_set_version" AS "questionSetVersion", "state" FROM "persona_interviews" WHERE "id" = ${command.interviewId} AND "persona_profile_id" = ${command.personaProfileId} AND "user_id" = ${command.userId} FOR UPDATE`);
+				if (interviews.length !== 1) return { status: "not_found_or_wrong_owner" } as const;
+				const interview = interviews[0];
+				if (interview.state !== "in_progress") return { status: "not_in_progress" } as const;
+
+				// 2. Compare the exact reviewed question count with the immutable answers before completion.
+				const expectedAnswers = await transaction.personaQuestion.count({ where: { questionSetId: interview.questionSetId, questionSetVersion: interview.questionSetVersion } });
+				const actualAnswers = await transaction.personaInterviewAnswer.count({ where: { interviewId: command.interviewId } });
+				if (expectedAnswers === 0 || actualAnswers !== expectedAnswers) return { status: "incomplete_answers" } as const;
+
+				// 3. Change only the closed lifecycle state; the target-baseline trigger repeats the answer fence at commit.
+				const updated = await transaction.personaInterview.updateMany({ where: { id: command.interviewId, personaProfileId: command.personaProfileId, userId: command.userId, state: PersonaInterviewState.InProgress }, data: { state: PersonaInterviewState.Completed, completedAt: new Date(command.completedAt) } });
+				return updated.count === 1 ? { status: "completed" } as const : { status: "not_in_progress" } as const;
+			});
+		}
+		catch
+		{
+			return { status: "persistence_unavailable" };
+		}
+	}
+}


### PR DESCRIPTION
## Why this matters

A personal agent needs onboarding evidence that can be trusted later. This PR makes that evidence durable: one owner starts an interview from an exact reviewed question set, records each answer once, and completes it only when every question has been answered. The existing draft and approval flow can now consume a stable, provenance-bound interview instead of assuming one exists.

## What changed

- adds explicit start, answer, and completion authority use cases with stable refusal reasons
- provides the canonical Prisma repository with profile/interview locks to prevent competing starts and answer-versus-completion races
- binds every answer to the exact reviewed question-set revision and question
- documents the complete onboarding-to-approved-persona lifecycle in the package README

## Safety properties

- repeated starts reuse the owner’s active interview rather than replacing evidence
- completed interviews are never accepted until the full reviewed question set is answered
- repository checks remain inside one transaction; Postgres triggers independently enforce the same lifecycle on a live database
- raw PostgreSQL lifecycle values are handled using their database labels, covered by a regression test

## Validation

- `npx nx run backend-agents-personal-personas:test` (8 tests)
- `npx nx run backend-agents-personal-personas:lint`
- `bash scripts/agent-style-check.sh` (0 errors, 0 warnings)
- `git diff --check`
- `test:sql` is a live gate and remains pending: this workstation has neither `psql` nor a Docker-backed test container

## Review

- independent review identified the raw Postgres enum-label mismatch in answer/completion handling
- fixed with a repository regression test; reviewer re-verified PASS