### PR TITLE
🔒️ Bind agent revisions to registered models

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -217,7 +217,7 @@ CREATE TABLE "agent_revisions" (
     "digest" TEXT NOT NULL,
     "prompt_policy_version" TEXT NOT NULL,
     "persona_revision_id" TEXT,
-    "model_policy_id" TEXT NOT NULL,
+    "model_definition_id" TEXT NOT NULL,
     "budget" JSONB NOT NULL,
     "authored_by" TEXT NOT NULL,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -2464,6 +2464,9 @@ ALTER TABLE "persona_insights" ADD CONSTRAINT "persona_insights_persona_revision
 ALTER TABLE "model_definitions" ADD CONSTRAINT "model_definitions_provider_credential_id_fkey" FOREIGN KEY ("provider_credential_id") REFERENCES "provider_credentials"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
+ALTER TABLE "agent_revisions" ADD CONSTRAINT "agent_revisions_model_definition_id_fkey" FOREIGN KEY ("model_definition_id") REFERENCES "model_definitions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "tenant_dataset_memberships" ADD CONSTRAINT "tenant_dataset_memberships_tenant_fkey" FOREIGN KEY ("tenant") REFERENCES "tenants"("name") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
@@ -2591,7 +2594,7 @@ BEGIN
         OR NEW."digest" IS DISTINCT FROM OLD."digest"
         OR NEW."prompt_policy_version" IS DISTINCT FROM OLD."prompt_policy_version"
         OR NEW."persona_revision_id" IS DISTINCT FROM OLD."persona_revision_id"
-        OR NEW."model_policy_id" IS DISTINCT FROM OLD."model_policy_id"
+        OR NEW."model_definition_id" IS DISTINCT FROM OLD."model_definition_id"
         OR NEW."budget" IS DISTINCT FROM OLD."budget"
         OR NEW."authored_by" IS DISTINCT FROM OLD."authored_by"
         OR NEW."created_at" IS DISTINCT FROM OLD."created_at" THEN
@@ -2616,6 +2619,54 @@ CREATE FUNCTION "reject_agent_revision_delete"() RETURNS trigger
 LANGUAGE plpgsql AS $$
 BEGIN
     RAISE EXCEPTION 'AgentRevision rows cannot be deleted';
+END;
+$$;
+CREATE FUNCTION "enforce_referenced_model_definition_immutability"() RETURNS trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM "agent_revisions"
+        WHERE "model_definition_id" = OLD."id"
+    ) AND (
+        NEW."scope" IS DISTINCT FROM OLD."scope"
+        OR NEW."cluster_tenant" IS DISTINCT FROM OLD."cluster_tenant"
+        OR NEW."public_model_name" IS DISTINCT FROM OLD."public_model_name"
+        OR NEW."litellm_model_id" IS DISTINCT FROM OLD."litellm_model_id"
+        OR NEW."upstream_model" IS DISTINCT FROM OLD."upstream_model"
+        OR NEW."api_base" IS DISTINCT FROM OLD."api_base"
+        OR NEW."provider_credential_id" IS DISTINCT FROM OLD."provider_credential_id"
+    ) THEN
+        RAISE EXCEPTION 'A ModelDefinition referenced by an AgentRevision is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE FUNCTION "enforce_agent_revision_model_definition_availability"() RETURNS trigger
+LANGUAGE plpgsql AS $$
+DECLARE
+    service_silo_id TEXT;
+    definition_scope "ModelRoutingScope";
+    definition_cluster_tenant TEXT;
+BEGIN
+    SELECT "silo_id"
+    INTO service_silo_id
+    FROM "agent_services"
+    WHERE "id" = NEW."agent_service_id"
+    FOR KEY SHARE;
+
+    SELECT "scope", "cluster_tenant"
+    INTO definition_scope, definition_cluster_tenant
+    FROM "model_definitions"
+    WHERE "id" = NEW."model_definition_id"
+    FOR KEY SHARE;
+
+    IF definition_scope IS DISTINCT FROM 'global'::"ModelRoutingScope"
+        AND (definition_scope IS DISTINCT FROM 'clusterTenant'::"ModelRoutingScope"
+            OR definition_cluster_tenant IS DISTINCT FROM service_silo_id) THEN
+        RAISE EXCEPTION 'AgentRevision model definition is unavailable to its service tenant';
+    END IF;
+    RETURN NEW;
 END;
 $$;
 CREATE FUNCTION "enforce_agent_service_lifecycle"() RETURNS trigger
@@ -4017,7 +4068,7 @@ ALTER TABLE "agent_services" ADD CONSTRAINT "agent_services_active_revision_chec
 ALTER TABLE "agent_revisions" ADD CONSTRAINT "agent_revisions_revision_check" CHECK ("revision" > 0);
 ALTER TABLE "agent_revisions" ADD CONSTRAINT "agent_revisions_nonempty_check" CHECK (
         btrim("agent_service_id") <> '' AND btrim("digest") <> '' AND
-        btrim("prompt_policy_version") <> '' AND btrim("model_policy_id") <> '' AND
+        btrim("prompt_policy_version") <> '' AND btrim("model_definition_id") <> '' AND
         btrim("authored_by") <> '' AND "digest" ~ '^sha256:[0-9a-f]{64}$'
     );
 ALTER TABLE "agent_revision_scope_attachments" ADD CONSTRAINT "agent_revision_scope_attachments_nonempty_check" CHECK (
@@ -4329,6 +4380,12 @@ CREATE TRIGGER "agent_revisions_immutable"
 CREATE TRIGGER "agent_revisions_no_delete"
     BEFORE DELETE ON "agent_revisions"
     FOR EACH ROW EXECUTE FUNCTION "reject_agent_revision_delete"();
+CREATE TRIGGER "referenced_model_definitions_immutable"
+    BEFORE UPDATE ON "model_definitions"
+    FOR EACH ROW EXECUTE FUNCTION "enforce_referenced_model_definition_immutability"();
+CREATE TRIGGER "agent_revision_model_definition_available"
+    BEFORE INSERT OR UPDATE OF "model_definition_id", "agent_service_id" ON "agent_revisions"
+    FOR EACH ROW EXECUTE FUNCTION "enforce_agent_revision_model_definition_availability"();
 CREATE TRIGGER "agent_services_closed_lifecycle"
     BEFORE INSERT OR UPDATE OR DELETE ON "agent_services"
     FOR EACH ROW EXECUTE FUNCTION "enforce_agent_service_lifecycle"();

--- a/apps/opencrane/prisma/schema/agent-services.prisma
+++ b/apps/opencrane/prisma/schema/agent-services.prisma
@@ -59,12 +59,13 @@ model AgentRevision {
   digest              String
   promptPolicyVersion String                         @map("prompt_policy_version")
   personaRevisionId   String?                        @map("persona_revision_id")
-  modelPolicyId       String                         @map("model_policy_id")
+  modelDefinitionId   String                         @map("model_definition_id")
   budget              Json
   authoredBy          String                         @map("authored_by")
   createdAt           DateTime                       @default(now()) @map("created_at")
   publishedAt         DateTime?                      @map("published_at")
   agentService        AgentService                   @relation("AgentServiceRevisions", fields: [agentServiceId], references: [id], onDelete: Restrict)
+  modelDefinition     ModelDefinition                @relation(fields: [modelDefinitionId], references: [id], onDelete: Restrict)
   activeFor           AgentService[]                 @relation("ActiveAgentRevision")
   parentRevision      AgentRevision?                 @relation("AgentRevisionLineage", fields: [parentRevisionId], references: [id], onDelete: Restrict)
   childRevisions      AgentRevision[]                @relation("AgentRevisionLineage")

--- a/apps/opencrane/prisma/schema/providers.prisma
+++ b/apps/opencrane/prisma/schema/providers.prisma
@@ -43,6 +43,7 @@ model ModelDefinition {
   updatedAt            DateTime            @updatedAt @map("updated_at")
 
   providerCredential ProviderCredential? @relation(fields: [providerCredentialId], references: [id], onDelete: SetNull)
+  agentRevisions     AgentRevision[]
 
   @@unique([scope, clusterTenant, publicModelName])
   @@index([clusterTenant])

--- a/apps/opencrane/prisma/tests/phase-d-authority-integration.sh
+++ b/apps/opencrane/prisma/tests/phase-d-authority-integration.sh
@@ -76,6 +76,9 @@ wait_for_holder_sleeping() {
 }
 
 run_psql <<'SQL'
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('phase-d-model', 'global', 'phase-d-model', 'litellm-phase-d-model', 'phase-d-model', clock_timestamp());
+
 INSERT INTO "agent_services" (
   "id", "silo_id", "kind", "name",
   "workload_profile", "updated_at"
@@ -85,10 +88,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by"
+  "model_definition_id", "budget", "authored_by"
 ) VALUES (
   'dispatch-lock-revision', 'dispatch-lock-service', 1, 'draft',
-  'sha256:' || repeat('e', 64), 'prompt-v1', 'model-v1', '{}', 'dispatch-lock-user'
+  'sha256:' || repeat('e', 64), 'prompt-v1', 'phase-d-model', '{}', 'dispatch-lock-user'
 );
 UPDATE "agent_revisions"
 SET "state" = 'published', "published_at" = clock_timestamp()
@@ -181,10 +184,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by"
+  "model_definition_id", "budget", "authored_by"
 ) VALUES (
   'rev-race-assignment', 'svc-race-assignment', 1, 'draft', 'sha256:' || repeat('1', 64),
-  'prompt-v1', 'model-v1', '{}', 'user-race'
+  'prompt-v1', 'phase-d-model', '{}', 'user-race'
 );
 SQL
 
@@ -240,10 +243,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by"
+  "model_definition_id", "budget", "authored_by"
 ) VALUES (
   'rev-race-assignment-first', 'svc-race-assignment-first', 1, 'draft', 'sha256:' || repeat('6', 64),
-  'prompt-v1', 'model-v1', '{}', 'user-race'
+  'prompt-v1', 'phase-d-model', '{}', 'user-race'
 );
 SQL
 
@@ -298,10 +301,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by", "published_at"
+  "model_definition_id", "budget", "authored_by", "published_at"
 ) VALUES (
   'rev-race-activation', 'svc-race-activation', 1, 'published', 'sha256:' || repeat('2', 64),
-  'prompt-v1', 'model-v1', '{}', 'user-race', clock_timestamp()
+  'prompt-v1', 'phase-d-model', '{}', 'user-race', clock_timestamp()
 );
 SQL
 
@@ -355,10 +358,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by", "published_at"
+  "model_definition_id", "budget", "authored_by", "published_at"
 ) VALUES (
   'rev-race-retirement', 'svc-race-retirement', 1, 'published', 'sha256:' || repeat('3', 64),
-  'prompt-v1', 'model-v1', '{}', 'user-race', clock_timestamp()
+  'prompt-v1', 'phase-d-model', '{}', 'user-race', clock_timestamp()
 );
 SQL
 
@@ -412,12 +415,12 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by", "published_at"
+  "model_definition_id", "budget", "authored_by", "published_at"
 ) VALUES
   ('rev-race-run-rollover-1', 'svc-race-run-rollover', 1, 'published', 'sha256:' || repeat('7', 64),
-   'prompt-v1', 'model-v1', '{}', 'user-race', clock_timestamp()),
+   'prompt-v1', 'phase-d-model', '{}', 'user-race', clock_timestamp()),
   ('rev-race-run-rollover-2', 'svc-race-run-rollover', 2, 'published', 'sha256:' || repeat('8', 64),
-   'prompt-v1', 'model-v1', '{}', 'user-race', clock_timestamp());
+   'prompt-v1', 'phase-d-model', '{}', 'user-race', clock_timestamp());
 UPDATE "agent_services"
 SET "state" = 'active', "active_revision_id" = 'rev-race-run-rollover-1'
 WHERE "id" = 'svc-race-run-rollover';
@@ -480,10 +483,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by", "published_at"
+  "model_definition_id", "budget", "authored_by", "published_at"
 ) VALUES (
   'rev-race-run-first', 'svc-race-run-first', 1, 'published', 'sha256:' || repeat('b', 64),
-  'prompt-v1', 'model-v1', '{}', 'user-race', clock_timestamp()
+  'prompt-v1', 'phase-d-model', '{}', 'user-race', clock_timestamp()
 );
 UPDATE "agent_services"
 SET "state" = 'active', "active_revision_id" = 'rev-race-run-first'
@@ -672,10 +675,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by", "published_at"
+  "model_definition_id", "budget", "authored_by", "published_at"
 ) VALUES (
   'rev-race-action-authority', 'svc-race-action-authority', 1, 'published',
-  'sha256:' || repeat('e', 64), 'prompt-v1', 'model-v1', '{}', 'user-race', clock_timestamp()
+  'sha256:' || repeat('e', 64), 'prompt-v1', 'phase-d-model', '{}', 'user-race', clock_timestamp()
 );
 UPDATE "agent_services" SET "state" = 'active', "active_revision_id" = 'rev-race-action-authority'
 WHERE "id" = 'svc-race-action-authority';
@@ -862,10 +865,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
   "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-  "model_policy_id", "budget", "authored_by"
+  "model_definition_id", "budget", "authored_by"
 ) VALUES (
   'rev-race-cancel-proof', 'svc-race-cancel-proof', 1, 'draft', 'sha256:' || repeat('9', 64),
-  'prompt-v1', 'model-v1', '{}', 'user-race-cancel-proof'
+  'prompt-v1', 'phase-d-model', '{}', 'user-race-cancel-proof'
 );
 UPDATE "agent_revisions"
 SET "state" = 'published', "published_at" = clock_timestamp()

--- a/apps/opencrane/prisma/tests/phase-d-authority-integration.sql
+++ b/apps/opencrane/prisma/tests/phase-d-authority-integration.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('phase-d-model', 'global', 'phase-d-model', 'litellm-phase-d-model', 'phase-d-model', clock_timestamp());
+
 CREATE FUNCTION pg_temp.expect_failure(test_name TEXT, statement TEXT, expected_message TEXT)
 RETURNS VOID
 LANGUAGE plpgsql AS $$
@@ -55,12 +58,38 @@ SELECT pg_temp.expect_failure(
 
 INSERT INTO "agent_revisions" (
     "id", "agent_service_id", "revision", "state", "digest",
-    "prompt_policy_version", "model_policy_id", "budget", "authored_by"
+    "prompt_policy_version", "model_definition_id", "budget", "authored_by"
 ) VALUES
     ('rev-published', 'svc-main', 1, 'draft', 'sha256:' || repeat('a', 64),
-     'prompt-v1', 'model-v1', '{}', 'user-1'),
+     'prompt-v1', 'phase-d-model', '{}', 'user-1'),
     ('rev-draft', 'svc-main', 2, 'draft', 'sha256:' || repeat('b', 64),
-     'prompt-v1', 'model-v1', '{}', 'user-1');
+     'prompt-v1', 'phase-d-model', '{}', 'user-1');
+
+SELECT pg_temp.expect_failure(
+    'referenced model definition cannot change routing identity',
+    $statement$
+        UPDATE "model_definitions"
+        SET "public_model_name" = 'changed-model'
+        WHERE "id" = 'phase-d-model'
+    $statement$,
+    'A ModelDefinition referenced by an AgentRevision is immutable'
+);
+
+INSERT INTO "model_definitions" ("id", "scope", "cluster_tenant", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('foreign-phase-d-model', 'clusterTenant', 'silo-other', 'foreign-phase-d-model', 'litellm-foreign-phase-d-model', 'foreign-phase-d-model', clock_timestamp());
+SELECT pg_temp.expect_failure(
+    'foreign tenant model definition is unavailable',
+    $statement$
+        INSERT INTO "agent_revisions" (
+            "id", "agent_service_id", "revision", "state", "digest",
+            "prompt_policy_version", "model_definition_id", "budget", "authored_by"
+        ) VALUES (
+            'foreign-model-revision', 'svc-main', 3, 'draft', 'sha256:' || repeat('c', 64),
+            'prompt-v1', 'foreign-phase-d-model', '{}', 'user-1'
+        )
+    $statement$,
+    'AgentRevision model definition is unavailable to its service tenant'
+);
 
 SELECT pg_temp.expect_failure(
     'unpublished AgentService activation is rejected',
@@ -152,12 +181,12 @@ INSERT INTO "agent_services" (
 
 INSERT INTO "agent_revisions" (
     "id", "agent_service_id", "revision", "state", "digest",
-    "prompt_policy_version", "model_policy_id", "budget", "authored_by", "published_at"
+    "prompt_policy_version", "model_definition_id", "budget", "authored_by", "published_at"
 ) VALUES
     ('rev-never-published', 'svc-lifecycle', 1, 'draft', 'sha256:' || repeat('e', 64),
-     'prompt-v1', 'model-v1', '{}', 'user-1', NULL),
+     'prompt-v1', 'phase-d-model', '{}', 'user-1', NULL),
     ('rev-retirable', 'svc-lifecycle', 2, 'published', 'sha256:' || repeat('f', 64),
-     'prompt-v1', 'model-v1', '{}', 'user-1', '2026-01-01T00:00:00Z');
+     'prompt-v1', 'phase-d-model', '{}', 'user-1', '2026-01-01T00:00:00Z');
 
 SELECT pg_temp.expect_failure(
     'Draft revision cannot retire without publication evidence',
@@ -194,10 +223,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
     "id", "agent_service_id", "revision", "state", "digest",
-    "prompt_policy_version", "model_policy_id", "budget", "authored_by", "published_at"
+    "prompt_policy_version", "model_definition_id", "budget", "authored_by", "published_at"
 ) VALUES (
     'rev-run-retirement', 'svc-run-retirement', 1, 'published', 'sha256:' || repeat('7', 64),
-    'prompt-v1', 'model-v1', '{}', 'user-1', clock_timestamp()
+    'prompt-v1', 'phase-d-model', '{}', 'user-1', clock_timestamp()
 );
 UPDATE "agent_services"
 SET "active_revision_id" = 'rev-run-retirement', "state" = 'active'
@@ -257,12 +286,12 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
     "id", "agent_service_id", "revision", "state", "digest",
-    "prompt_policy_version", "model_policy_id", "budget", "authored_by", "published_at"
+    "prompt_policy_version", "model_definition_id", "budget", "authored_by", "published_at"
 ) VALUES
     ('rev-run-rollover-1', 'svc-run-rollover', 1, 'published', 'sha256:' || repeat('8', 64),
-     'prompt-v1', 'model-v1', '{}', 'user-1', clock_timestamp()),
+     'prompt-v1', 'phase-d-model', '{}', 'user-1', clock_timestamp()),
     ('rev-run-rollover-2', 'svc-run-rollover', 2, 'published', 'sha256:' || repeat('9', 64),
-     'prompt-v1', 'model-v1', '{}', 'user-1', clock_timestamp());
+     'prompt-v1', 'phase-d-model', '{}', 'user-1', clock_timestamp());
 UPDATE "agent_services"
 SET "active_revision_id" = 'rev-run-rollover-1', "state" = 'active'
 WHERE "id" = 'svc-run-rollover';

--- a/apps/opencrane/prisma/tests/run-dispatch-terminalization.sql
+++ b/apps/opencrane/prisma/tests/run-dispatch-terminalization.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('dispatch-terminal-model', 'global', 'dispatch-terminal-model', 'litellm-dispatch-terminal-model', 'dispatch-terminal-model', clock_timestamp());
+
 INSERT INTO "agent_services" (
     "id", "silo_id", "kind", "name", "workload_profile", "updated_at"
 ) VALUES (
@@ -8,10 +11,10 @@ INSERT INTO "agent_services" (
 );
 INSERT INTO "agent_revisions" (
     "id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version",
-    "model_policy_id", "budget", "authored_by"
+    "model_definition_id", "budget", "authored_by"
 ) VALUES (
     'dispatch-terminal-revision', 'dispatch-terminal-service', 1, 'draft',
-    'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'dispatch-terminal-user'
+    'sha256:' || repeat('a', 64), 'prompt-v1', 'dispatch-terminal-model', '{}', 'dispatch-terminal-user'
 );
 UPDATE "agent_revisions"
 SET "state" = 'published', "published_at" = clock_timestamp()

--- a/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
+++ b/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
@@ -1,9 +1,12 @@
 BEGIN;
 
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('snapshot-model', 'global', 'snapshot-model', 'litellm-snapshot-model', 'snapshot-model', clock_timestamp());
+
 INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "workload_profile", "updated_at")
 VALUES ('snapshot-service', 'silo-snapshot', 'managed', 'Snapshot test', 'managed-agent', clock_timestamp());
-INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
-VALUES ('snapshot-revision', 'snapshot-service', 1, 'draft', 'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'user-snapshot');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_definition_id", "budget", "authored_by")
+VALUES ('snapshot-revision', 'snapshot-service', 1, 'draft', 'sha256:' || repeat('a', 64), 'prompt-v1', 'snapshot-model', '{}', 'user-snapshot');
 UPDATE "agent_revisions" SET "state" = 'published', "published_at" = clock_timestamp() WHERE "id" = 'snapshot-revision';
 UPDATE "agent_services" SET "state" = 'active', "active_revision_id" = 'snapshot-revision' WHERE "id" = 'snapshot-service';
 INSERT INTO "conversation_threads" ("id", "silo_id", "agent_service_id", "updated_at") VALUES

--- a/apps/opencrane/src/app/__tests__/harvesting-central-agent.test.ts
+++ b/apps/opencrane/src/app/__tests__/harvesting-central-agent.test.ts
@@ -10,7 +10,7 @@ describe("harvesting central-agent definition", function _DefinitionSuite()
 {
 	it("is expressible as a valid packaged managed agent", function _Expressible()
 	{
-		const definition = _HarvestingCentralAgentDefinition("obot-ref-slack-opaque");
+		const definition = _HarvestingCentralAgentDefinition("obot-ref-slack-opaque", "global-model-definition");
 		expect(definition.content.personaRevisionId).toBeNull();
 		expect(definition.content.budget.maxTurns).toBeGreaterThan(0);
 		expect(definition.content.budget.maxTokens).toBeGreaterThan(0);
@@ -27,7 +27,7 @@ describe("harvesting Obot MCP invocation (stubbed transport)", function _McpSuit
 {
 	it("invokes only allow-listed tools through the opaque custody reference", async function _AllowList()
 	{
-		const definition = _HarvestingCentralAgentDefinition("obot-ref-slack-opaque");
+		const definition = _HarvestingCentralAgentDefinition("obot-ref-slack-opaque", "global-model-definition");
 		const assignment = definition.content.integrationAssignments[0];
 		const transport = new __FakeObotMcpInvocationAdapter({ content: { channels: ["general"] } });
 		const result = await transport.invokeTool({ siloId: "silo-1", integrationId: assignment.integrationId, obotCustodyReference: assignment.custodyReferenceId, toolName: "slack.listChannels", arguments: {}, allowedTools: assignment.allowedTools });

--- a/apps/opencrane/src/app/harvesting-central-agent.ts
+++ b/apps/opencrane/src/app/harvesting-central-agent.ts
@@ -1,4 +1,4 @@
-import type { AgentRevisionContent, CreateAgentScheduleCommand } from "@opencrane/backend/server/agents/agent-services";
+import type { HarvestingCentralAgentDefinition } from "./harvesting-central-agent.types.js";
 
 /**
  * The packaged "harvesting" central agent, expressed entirely as OpenCrane definition data.
@@ -10,18 +10,6 @@ import type { AgentRevisionContent, CreateAgentScheduleCommand } from "@opencran
  * run. The live-Obot end-to-end proof (and the subsequent deletion of `apps/feat-central-agents`,
  * its bespoke connector, and the `HarvestingCursor` table) is a NAMED LATER GATE tracked under #337.
  */
-export interface HarvestingCentralAgentDefinition
-{
-	/** Human-readable managed-service name. */
-	readonly name: string;
-	/** Named workload profile projecting the managed runtime policy. */
-	readonly workloadProfile: string;
-	/** Immutable executable content of the first Draft revision. */
-	readonly content: AgentRevisionContent;
-	/** The recurring schedule that will admit runs of the published revision. */
-	readonly schedule: Omit<CreateAgentScheduleCommand, "siloId" | "agentServiceId">;
-}
-
 /** The Obot MCP tools the harvester is permitted to invoke; nothing outside this list is callable. */
 export const HARVESTING_ALLOWED_TOOLS: readonly string[] = ["slack.listChannels", "slack.getChannelHistory"];
 
@@ -30,9 +18,10 @@ export const HARVESTING_ALLOWED_TOOLS: readonly string[] = ["slack.listChannels"
  *
  * @param obotCustodyReference - Opaque Obot custody reference for the Slack integration (never a
  *   credential); provided by the composition root once custody is provisioned.
+ * @param modelDefinitionId - Registered global model definition selected by the composition root.
  * @returns The packaged managed-agent definition and its schedule spec.
  */
-export function _HarvestingCentralAgentDefinition(obotCustodyReference: string): HarvestingCentralAgentDefinition
+export function _HarvestingCentralAgentDefinition(obotCustodyReference: string, modelDefinitionId: string): HarvestingCentralAgentDefinition
 {
 	return {
 		name: "Knowledge Harvester",
@@ -41,7 +30,7 @@ export function _HarvestingCentralAgentDefinition(obotCustodyReference: string):
 			promptPolicyVersion: "harvester-prompt-v1",
 			// A managed (central) agent never carries a persona.
 			personaRevisionId: null,
-			modelPolicyId: "managed-default",
+			modelDefinitionId,
 			budget: { maxTurns: 20, maxTokens: 200_000, maxDurationMs: 900_000 },
 			skills: [],
 			// One Obot MCP integration with a strict tool allow-list; only these tools are invocable.

--- a/apps/opencrane/src/app/harvesting-central-agent.types.ts
+++ b/apps/opencrane/src/app/harvesting-central-agent.types.ts
@@ -1,0 +1,14 @@
+import type { AgentRevisionContent, CreateAgentScheduleCommand } from "@opencrane/backend/server/agents/agent-services";
+
+/** Packaged managed-agent data for the scheduled knowledge harvester. */
+export interface HarvestingCentralAgentDefinition
+{
+	/** Human-readable managed-service name. */
+	readonly name: string;
+	/** Named workload profile projecting the managed runtime policy. */
+	readonly workloadProfile: string;
+	/** Immutable executable content of the first Draft revision. */
+	readonly content: AgentRevisionContent;
+	/** The recurring schedule that will admit runs of the published revision. */
+	readonly schedule: Omit<CreateAgentScheduleCommand, "siloId" | "agentServiceId">;
+}

--- a/docs/design/personal-agent-platform-architecture.md
+++ b/docs/design/personal-agent-platform-architecture.md
@@ -219,7 +219,7 @@ Logical modules that should **not** become separate applications initially:
 - agent, revision, run, trigger, persona, skill-catalog, and sharing domains;
 - transactional outbox and audit ledger;
 - approval and run-coordination state;
-- model-policy compilation.
+- model-definition selection and compilation.
 
 An independently deployed authorization service is justified only if the API cannot meet decision
 latency/availability or several independently deployed PEPs require online checks that signed
@@ -364,7 +364,7 @@ both personal and company-managed agents.
 | Record | Purpose |
 |---|---|
 | `AgentService` | Stable identity, kind (`personal` or `managed`), owner, lifecycle, active revision, deployment policy, workload-profile binding |
-| `AgentRevision` | Immutable prompt/persona references, model policy, skills, MCP assignments, budgets, guardrails, input/output schema, triggers |
+| `AgentRevision` | Immutable prompt/persona references, a registered model definition, skills, MCP assignments, budgets, guardrails, input/output schema, triggers |
 | `AgentRun` | Actor/trigger, revision, effective-contract hash, attempt, state, timestamps, costs, terminal reason |
 | `RunEvent` | Ordered normalized model/tool/approval/artifact/status events for reconnect, console, and audit |
 | `Thread` / `Message` | Canonical user-visible transcript independent of runtime implementation |

--- a/libs/backend/agents/execution/inputs/main/src/session-assembly.types.ts
+++ b/libs/backend/agents/execution/inputs/main/src/session-assembly.types.ts
@@ -162,7 +162,7 @@ export interface SessionAssemblyAuthorities
 	preferenceFacts: PreferenceFactSource;
 	/** Memory-scope authority. */
 	memoryScope: MemoryScopeSource;
-	/** Tool and model-policy authority. */
+	/** Tool and registered model-definition authority. */
 	toolPolicy: ToolPolicySource;
 	/** Budget authority. */
 	budgetPolicy: BudgetPolicySource;

--- a/libs/backend/agents/execution/runs/main/tests/run-input-snapshot-admission.sql
+++ b/libs/backend/agents/execution/runs/main/tests/run-input-snapshot-admission.sql
@@ -1,9 +1,12 @@
 BEGIN;
 
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('execution-snapshot-model', 'global', 'execution-snapshot-model', 'litellm-execution-snapshot-model', 'execution-snapshot-model', clock_timestamp());
+
 INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "workload_profile", "updated_at")
 VALUES ('snapshot-service', 'silo-snapshot', 'managed', 'Snapshot test', 'managed-agent', clock_timestamp());
-INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
-VALUES ('snapshot-revision', 'snapshot-service', 1, 'draft', 'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'user-snapshot');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_definition_id", "budget", "authored_by")
+VALUES ('snapshot-revision', 'snapshot-service', 1, 'draft', 'sha256:' || repeat('a', 64), 'prompt-v1', 'execution-snapshot-model', '{}', 'user-snapshot');
 UPDATE "agent_revisions" SET "state" = 'published', "published_at" = clock_timestamp() WHERE "id" = 'snapshot-revision';
 UPDATE "agent_services" SET "state" = 'active', "active_revision_id" = 'snapshot-revision' WHERE "id" = 'snapshot-service';
 

--- a/libs/backend/agents/personal/configuration/main/tests/personal-configuration-authority.sql
+++ b/libs/backend/agents/personal/configuration/main/tests/personal-configuration-authority.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('personal-configuration-model', 'global', 'personal-configuration-model', 'litellm-personal-configuration-model', 'personal-configuration-model', clock_timestamp());
+
 CREATE FUNCTION pg_temp.expect_failure(test_name TEXT, statement TEXT, expected_message TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
 DECLARE actual_message TEXT;
 BEGIN
@@ -13,7 +16,7 @@ END;
 $$;
 
 INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "workload_profile", "updated_at") VALUES ('service-1', 'silo-1', 'personal', 'Personal agent', 'personal-default', clock_timestamp());
-INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by") VALUES ('agent-1', 'service-1', 1, 'sha256:' || repeat('a',64), 'prompt-v1', 'model-policy-1', '{}', 'user-1');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_definition_id", "budget", "authored_by") VALUES ('agent-1', 'service-1', 1, 'sha256:' || repeat('a',64), 'prompt-v1', 'personal-configuration-model', '{}', 'user-1');
 INSERT INTO "persona_profiles" ("id", "silo_id", "user_id", "updated_at") VALUES ('profile-1', 'silo-1', 'user-1', clock_timestamp());
 INSERT INTO "conversation_threads" ("id", "silo_id", "agent_service_id", "updated_at") VALUES ('thread-1', 'silo-1', 'service-1', clock_timestamp());
 INSERT INTO "conversation_participants" ("thread_id", "user_id") VALUES ('thread-1', 'user-1');

--- a/libs/backend/agents/personal/conversations/main/tests/conversation-authority.sql
+++ b/libs/backend/agents/personal/conversations/main/tests/conversation-authority.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('conversation-model', 'global', 'conversation-model', 'litellm-conversation-model', 'conversation-model', clock_timestamp());
+
 CREATE FUNCTION pg_temp.expect_failure(test_name TEXT, statement TEXT, expected_message TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
 DECLARE actual_message TEXT;
 BEGIN
@@ -15,8 +18,8 @@ $$;
 
 INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "workload_profile", "updated_at")
 VALUES ('conversation-service', 'silo-conversation', 'managed', 'Conversation test', 'managed-agent', clock_timestamp());
-INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
-VALUES ('conversation-agent-revision', 'conversation-service', 1, 'draft', 'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_definition_id", "budget", "authored_by")
+VALUES ('conversation-agent-revision', 'conversation-service', 1, 'draft', 'sha256:' || repeat('a', 64), 'prompt-v1', 'conversation-model', '{}', 'user-1');
 UPDATE "agent_revisions" SET "state" = 'published', "published_at" = clock_timestamp() WHERE "id" = 'conversation-agent-revision';
 UPDATE "agent_services" SET "state" = 'active', "active_revision_id" = 'conversation-agent-revision' WHERE "id" = 'conversation-service';
 SELECT pg_temp.expect_failure('thread must bind its exact agent service', $statement$INSERT INTO "conversation_threads" ("id", "silo_id", "agent_service_id", "updated_at") VALUES ('thread-missing-service','silo-conversation','missing-service',clock_timestamp())$statement$, 'conversation_threads_agent_service_id_silo_id_fkey');

--- a/libs/backend/server/agents/agent-services/main/README.md
+++ b/libs/backend/server/agents/agent-services/main/README.md
@@ -7,8 +7,8 @@
 This package is part of the **managed-agent plane** — the side of OpenCrane that turns a saved
 agent definition into something the runtime can execute. An *agent service* is the stable identity
 of one agent (its name and lifecycle); an *agent revision* is one immutable, versioned snapshot of
-how that agent behaves (its prompt policy, model policy, budget, and the skills and integrations it
-may use). A service always points at exactly one *active* revision.
+how that agent behaves (its prompt policy, registered model definition, budget, and the skills and
+integrations it may use). A service always points at exactly one *active* revision.
 
 This package owns the whole definition plane and the authoritative management API. It creates a
 managed service with its first draft revision; appends immutable draft revisions as edits (each
@@ -24,7 +24,7 @@ read/recall and inject/write for that exact scope only, and never implies skills
 models, credentials, or a neighbouring scope.
 
 ```
- author a draft AgentRevision   (prompt policy · model policy · budget · assigned skills + integrations)
+ author a draft AgentRevision   (prompt policy · registered model · budget · assigned skills + integrations)
         │
         ▼
  ┌────────────────────────────────────┐
@@ -39,8 +39,11 @@ models, credentials, or a neighbouring scope.
 **In this flow:** [skills](../../skills/main/README.md) · [integrations](../../../gateways/integrations/main/README.md) *(a revision assigns these)*
 
 Invariant: a revision is only published when it belongs to the named service, is still a draft, and
-carries every executable field (a positive version, a digest, prompt and model policy, and positive
-turn/token/duration budgets). The publish and the pointer flip happen as a single compare-and-swap,
+carries every executable field (a positive version, a digest, prompt and registered model definition,
+and positive turn/token/duration budgets). The model is a foreign-key reference to the gateway-owned
+catalogue, so an author cannot turn an arbitrary provider alias into executable behaviour. A model
+is available only when it is platform-global or belongs to the service's tenant scope; the database
+checks the same rule as the application. The publish and the pointer flip happen as a single compare-and-swap,
 so two people publishing at once cannot both win — the second sees a conflict, and a crash never
 leaves a half-published service. Anything missing or stale is refused with a plain reason.
 
@@ -89,7 +92,7 @@ grants) both ride the compiler. Scope attachments remain silo-bounded and org-ad
 ## Data & persistence
 
 Owns the `AgentService`, `AgentRevision` (with `parentRevisionId`/`sourceRevisionId`/`changeMessage`
-lineage), `AgentRevisionScopeAttachment` (revision-scoped `{ scope, subjectType, subjectId }` reusing
+lineage and a required `ModelDefinition` reference), `AgentRevisionScopeAttachment` (revision-scoped `{ scope, subjectType, subjectId }` reusing
 the `GrantScope`/`GrantSubjectType` enums), `AgentRevisionSkillAssignment`,
 `AgentRevisionIntegrationAssignment`, and `AgentServiceSchedule` (cron, timezone, overlap policy,
 enabled, catch-up window) models in `apps/opencrane/prisma/schema/agent-services.prisma`. The retired
@@ -98,4 +101,4 @@ single-owner shape (`ownerScope`/`ownerSubjectId`/`AgentServiceOwnerScope`) is d
 ## See also
 
 - Parent index: [agents](../../README.md)
-- Siblings: [skills](../../skills/main/README.md) · [artifacts](../../artifacts/main/README.md) · [channel-targets](../../channel-targets/main/README.md)
+- Siblings: [skills](../../skills/main/README.md) · [artifacts](../../artifacts/main/README.md) · [channel-targets](../../channel-targets/main/README.md) · [model routing](../../../gateways/model-routing/main/README.md)

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/agent-publication.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/agent-publication.test.ts
@@ -34,7 +34,7 @@ function _revision(): AgentRevision
 		digest: "sha256:revision",
 		promptPolicyVersion: "prompt-v1",
 		personaRevisionId: "persona-1",
-		modelPolicyId: "model-policy-1",
+		modelDefinitionId: "model-definition-1",
 		skills: [],
 		integrationAssignments: [],
 		scopeAttachments: [],

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/agent-revision-lifecycle.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/agent-revision-lifecycle.test.ts
@@ -7,7 +7,7 @@ import type { AgentRevisionContent, AgentRevisionLifecycleRepository, AgentServi
 /** Builds valid executable content for a managed revision. */
 function _content(overrides: Partial<AgentRevisionContent> = {}): AgentRevisionContent
 {
-	return { promptPolicyVersion: "prompt-v1", personaRevisionId: null, modelPolicyId: "model-a", budget: { maxTurns: 5, maxTokens: 1000, maxDurationMs: 30000 }, skills: [], integrationAssignments: [], scopeAttachments: [{ scope: "project", subjectType: "group", subjectId: "proj-1" }], ...overrides };
+	return { promptPolicyVersion: "prompt-v1", personaRevisionId: null, modelDefinitionId: "model-definition-a", budget: { maxTurns: 5, maxTokens: 1000, maxDurationMs: 30000 }, skills: [], integrationAssignments: [], scopeAttachments: [{ scope: "project", subjectType: "group", subjectId: "proj-1" }], ...overrides };
 }
 
 /** Minimal in-memory definition-plane repository, silo-scoped like the Prisma adapter. */
@@ -56,7 +56,7 @@ class _Repository implements AgentRevisionLifecycleRepository
 		// Silo-scope the source lookup exactly like the Prisma adapter: a foreign-silo source is a 404.
 		const source = this.revisions.find(revision => revision.id === command.sourceRevisionId && this._siloService(revision.agentServiceId, command.siloId) !== null);
 		if (source === undefined) return { outcome: "denied", reason: "revision_not_found" };
-		const content: AgentRevisionContent = { promptPolicyVersion: source.promptPolicyVersion, personaRevisionId: source.personaRevisionId, modelPolicyId: source.modelPolicyId, budget: source.budget, skills: source.skills.map(skill => ({ skillId: skill.skillId, revisionId: skill.revisionId })), integrationAssignments: source.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: [...assignment.allowedTools] })), scopeAttachments: source.scopeAttachments.map(attachment => ({ ...attachment })) };
+		const content: AgentRevisionContent = { promptPolicyVersion: source.promptPolicyVersion, personaRevisionId: source.personaRevisionId, modelDefinitionId: source.modelDefinitionId, budget: source.budget, skills: source.skills.map(skill => ({ skillId: skill.skillId, revisionId: skill.revisionId })), integrationAssignments: source.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: [...assignment.allowedTools] })), scopeAttachments: source.scopeAttachments.map(attachment => ({ ...attachment })) };
 		return { outcome: "revised", revision: this._append(command.agentServiceId, head.revision + 1, head.id, source.id, content, command.authoredBy, command.changeMessage, createdAt) };
 	}
 
@@ -95,7 +95,7 @@ class _Repository implements AgentRevisionLifecycleRepository
 	/** Appends one immutable draft revision to the in-memory store. */
 	private _append(agentServiceId: string, revision: number, parentRevisionId: string | null, sourceRevisionId: string | null, content: AgentRevisionContent, authoredBy: string, changeMessage: string, createdAt: string): AgentRevision
 	{
-		const record: AgentRevision = { id: `revision-${++this.counter}`, agentServiceId, revision, parentRevisionId, sourceRevisionId, changeMessage, state: "draft", digest: `sha256:${revision}`, promptPolicyVersion: content.promptPolicyVersion, personaRevisionId: content.personaRevisionId, modelPolicyId: content.modelPolicyId, skills: content.skills.map(skill => ({ ...skill })), integrationAssignments: content.integrationAssignments.map(assignment => ({ ...assignment, allowedTools: [...assignment.allowedTools] })), scopeAttachments: content.scopeAttachments.map(attachment => ({ ...attachment })), budget: content.budget, authoredBy, createdAt, publishedAt: null };
+		const record: AgentRevision = { id: `revision-${++this.counter}`, agentServiceId, revision, parentRevisionId, sourceRevisionId, changeMessage, state: "draft", digest: `sha256:${revision}`, promptPolicyVersion: content.promptPolicyVersion, personaRevisionId: content.personaRevisionId, modelDefinitionId: content.modelDefinitionId, skills: content.skills.map(skill => ({ ...skill })), integrationAssignments: content.integrationAssignments.map(assignment => ({ ...assignment, allowedTools: [...assignment.allowedTools] })), scopeAttachments: content.scopeAttachments.map(attachment => ({ ...attachment })), budget: content.budget, authoredBy, createdAt, publishedAt: null };
 		this.revisions.push(record);
 		return record;
 	}
@@ -145,7 +145,7 @@ describe("managed agent revision lifecycle", function _suite()
 	{
 		const repository = new _Repository();
 		const seed = await _seedService(repository);
-		const revised = await __ReviseAgentRevision(repository, { siloId: _SILO, agentServiceId: seed.serviceId, expectedParentRevisionId: seed.revisionId, authoredBy: "admin-1", changeMessage: "edit", content: _content({ modelPolicyId: "model-b" }) }, _NOW);
+		const revised = await __ReviseAgentRevision(repository, { siloId: _SILO, agentServiceId: seed.serviceId, expectedParentRevisionId: seed.revisionId, authoredBy: "admin-1", changeMessage: "edit", content: _content({ modelDefinitionId: "model-definition-b" }) }, _NOW);
 		expect(revised.outcome).toBe("revised");
 		const stale = await __ReviseAgentRevision(repository, { siloId: _SILO, agentServiceId: seed.serviceId, expectedParentRevisionId: seed.revisionId, authoredBy: "admin-1", changeMessage: "edit-2", content: _content() }, _NOW);
 		expect(stale.outcome).toBe("conflict");
@@ -155,13 +155,13 @@ describe("managed agent revision lifecycle", function _suite()
 	{
 		const repository = new _Repository();
 		const seed = await _seedService(repository);
-		const revised = await __ReviseAgentRevision(repository, { siloId: _SILO, agentServiceId: seed.serviceId, expectedParentRevisionId: seed.revisionId, authoredBy: "admin-1", changeMessage: "edit", content: _content({ modelPolicyId: "model-b" }) }, _NOW);
+		const revised = await __ReviseAgentRevision(repository, { siloId: _SILO, agentServiceId: seed.serviceId, expectedParentRevisionId: seed.revisionId, authoredBy: "admin-1", changeMessage: "edit", content: _content({ modelDefinitionId: "model-definition-b" }) }, _NOW);
 		if (revised.outcome !== "revised") throw new Error("expected revised");
 		const restored = await __RestoreAgentRevision(repository, { siloId: _SILO, agentServiceId: seed.serviceId, sourceRevisionId: seed.revisionId, expectedParentRevisionId: revised.revision.id, authoredBy: "admin-1", changeMessage: "restore v1" }, _NOW);
 		if (restored.outcome !== "revised") throw new Error("expected revised");
 		expect(restored.revision.sourceRevisionId).toBe(seed.revisionId);
 		expect(restored.revision.parentRevisionId).toBe(revised.revision.id);
-		expect(restored.revision.modelPolicyId).toBe("model-a");
+		expect(restored.revision.modelDefinitionId).toBe("model-definition-a");
 	});
 
 	it("enforces legal state transitions and optimistic concurrency", async function _state()

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/prisma-agent-publication.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/prisma-agent-publication.test.ts
@@ -34,7 +34,7 @@ function _revisionRow()
 		digest: `sha256:${"1".repeat(64)}`,
 		promptPolicyVersion: "prompt-v1",
 		personaRevisionId: "persona-1",
-		modelPolicyId: "model-v1",
+		modelDefinitionId: "model-definition-1",
 		budget: { maxTurns: 8, maxTokens: 8000, maxDurationMs: 60000 },
 		authoredBy: "user-1",
 		createdAt: new Date("2026-07-18T00:00:00.000Z"),

--- a/libs/backend/server/agents/agent-services/main/src/agent-publication.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-publication.ts
@@ -17,7 +17,7 @@ function _isPublishableRevision(revision: AgentRevision): boolean
 		&& _isPresent(revision.agentServiceId)
 		&& _isPresent(revision.digest)
 		&& _isPresent(revision.promptPolicyVersion)
-		&& _isPresent(revision.modelPolicyId)
+		&& _isPresent(revision.modelDefinitionId)
 		&& Number.isSafeInteger(revision.budget.maxTurns)
 		&& revision.budget.maxTurns > 0
 		&& Number.isSafeInteger(revision.budget.maxTokens)

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.ts
@@ -29,7 +29,7 @@ function _isUniqueBy<T>(items: readonly T[], key: (item: T) => string): boolean
 function _isContentValid(content: AgentRevisionContent): boolean
 {
 	return _isPresent(content.promptPolicyVersion)
-		&& _isPresent(content.modelPolicyId)
+		&& _isPresent(content.modelDefinitionId)
 		&& (content.personaRevisionId === null || _isPresent(content.personaRevisionId))
 		&& _isPositiveInteger(content.budget.maxTurns)
 		&& _isPositiveInteger(content.budget.maxTokens)

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
@@ -7,8 +7,8 @@ export interface AgentRevisionContent
 	readonly promptPolicyVersion: string;
 	/** Approved persona revision, or null for a managed agent. */
 	readonly personaRevisionId: string | null;
-	/** Stable model-routing policy reference; carries no provider secret. */
-	readonly modelPolicyId: string;
+	/** Registered model-definition reference; carries no provider secret. */
+	readonly modelDefinitionId: string;
 	/** Immutable resource ceilings applied to each run. */
 	readonly budget: { readonly maxTurns: number; readonly maxTokens: number; readonly maxDurationMs: number };
 	/** Immutable skill revisions exposed to the runtime. */
@@ -121,6 +121,7 @@ export type AgentRevisionLifecycleDenial =
 	| "service_retired"
 	| "revision_not_found"
 	| "revision_service_mismatch"
+	| "model_definition_unavailable"
 	| "transition_not_allowed"
 	| "service_not_runnable"
 	| "run_admission_unavailable"

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
@@ -24,7 +24,7 @@ function _parseContent(raw: unknown): AgentRevisionContent | null
 	if (raw === null || typeof raw !== "object") return null;
 	const body = raw as Record<string, unknown>;
 	const budget = body.budget as Record<string, unknown> | undefined;
-	if (!_isNonEmptyString(body.promptPolicyVersion) || !_isNonEmptyString(body.modelPolicyId) || budget === undefined || typeof budget !== "object") return null;
+	if (!_isNonEmptyString(body.promptPolicyVersion) || !_isNonEmptyString(body.modelDefinitionId) || budget === undefined || typeof budget !== "object") return null;
 	if (typeof budget.maxTurns !== "number" || typeof budget.maxTokens !== "number" || typeof budget.maxDurationMs !== "number") return null;
 	const personaRevisionId = body.personaRevisionId === undefined || body.personaRevisionId === null ? null : body.personaRevisionId;
 	if (personaRevisionId !== null && !_isNonEmptyString(personaRevisionId)) return null;
@@ -32,7 +32,7 @@ function _parseContent(raw: unknown): AgentRevisionContent | null
 	const integrationAssignments = _parseIntegrations(body.integrationAssignments);
 	const scopeAttachments = _parseScopeAttachments(body.scopeAttachments);
 	if (skills === null || integrationAssignments === null || scopeAttachments === null) return null;
-	return { promptPolicyVersion: body.promptPolicyVersion, personaRevisionId, modelPolicyId: body.modelPolicyId, budget: { maxTurns: budget.maxTurns, maxTokens: budget.maxTokens, maxDurationMs: budget.maxDurationMs }, skills, integrationAssignments, scopeAttachments };
+	return { promptPolicyVersion: body.promptPolicyVersion, personaRevisionId, modelDefinitionId: body.modelDefinitionId, budget: { maxTurns: budget.maxTurns, maxTokens: budget.maxTokens, maxDurationMs: budget.maxDurationMs }, skills, integrationAssignments, scopeAttachments };
 }
 
 /** Parses the optional skill-reference array. */
@@ -93,6 +93,7 @@ function _denialStatus(reason: AgentRevisionLifecycleDenial): number
 		case "service_not_found": return 404;
 		case "revision_not_found": return 404;
 		case "revision_service_mismatch": return 409;
+		case "model_definition_unavailable": return 422;
 		case "service_retired": return 409;
 		case "transition_not_allowed": return 409;
 		case "service_not_runnable": return 409;

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-mappers.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-mappers.ts
@@ -138,7 +138,7 @@ export function _mapRevision(row: AgentRevisionRow): AgentRevision
 		digest: row.digest,
 		promptPolicyVersion: row.promptPolicyVersion,
 		personaRevisionId: row.personaRevisionId,
-		modelPolicyId: row.modelPolicyId,
+		modelDefinitionId: row.modelDefinitionId,
 		skills: row.skillAssignments.map(assignment => ({ skillId: assignment.skillId, revisionId: assignment.skillRevisionId })),
 		integrationAssignments: row.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: assignment.allowedTools })),
 		scopeAttachments: row.scopeAttachments.map(attachment => ({ scope: _grantScope(attachment.scope), subjectType: _grantSubjectType(attachment.subjectType), subjectId: attachment.subjectId })),

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-mappers.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-mappers.types.ts
@@ -27,7 +27,7 @@ export interface AgentRevisionRow
 	readonly digest: string;
 	readonly promptPolicyVersion: string;
 	readonly personaRevisionId: string | null;
-	readonly modelPolicyId: string;
+	readonly modelDefinitionId: string;
 	readonly budget: Prisma.JsonValue;
 	readonly authoredBy: string;
 	readonly createdAt: Date;

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-lifecycle.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-lifecycle.ts
@@ -55,7 +55,7 @@ function _revisionDigest(agentServiceId: string, revision: number, content: Agen
 		revision,
 		promptPolicyVersion: content.promptPolicyVersion,
 		personaRevisionId: content.personaRevisionId,
-		modelPolicyId: content.modelPolicyId,
+		modelDefinitionId: content.modelDefinitionId,
 		budget: { maxTurns: content.budget.maxTurns, maxTokens: content.budget.maxTokens, maxDurationMs: content.budget.maxDurationMs },
 		skills: content.skills.map(skill => ({ skillId: skill.skillId, revisionId: skill.revisionId })),
 		integrationAssignments: content.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: [...assignment.allowedTools] })),
@@ -77,7 +77,7 @@ function _revisionCreateData(agentServiceId: string, siloId: string, revision: n
 		digest: _revisionDigest(agentServiceId, revision, content),
 		promptPolicyVersion: content.promptPolicyVersion,
 		personaRevisionId: content.personaRevisionId,
-		modelPolicyId: content.modelPolicyId,
+		modelDefinition: { connect: { id: content.modelDefinitionId } },
 		budget: { maxTurns: content.budget.maxTurns, maxTokens: content.budget.maxTokens, maxDurationMs: content.budget.maxDurationMs },
 		authoredBy,
 		createdAt,
@@ -88,18 +88,25 @@ function _revisionCreateData(agentServiceId: string, siloId: string, revision: n
 }
 
 /** Projects an immutable revision's persisted content back into an authoring content command. */
-function _contentFromRevision(row: { promptPolicyVersion: string; personaRevisionId: string | null; modelPolicyId: string; budget: Prisma.JsonValue; skillAssignments: ReadonlyArray<{ skillId: string; skillRevisionId: string }>; integrationAssignments: ReadonlyArray<{ integrationId: string; custodyReferenceId: string; allowedTools: string[] }>; scopeAttachments: ReadonlyArray<{ scope: string; subjectType: string; subjectId: string }> }): AgentRevisionContent
+function _contentFromRevision(row: { promptPolicyVersion: string; personaRevisionId: string | null; modelDefinitionId: string; budget: Prisma.JsonValue; skillAssignments: ReadonlyArray<{ skillId: string; skillRevisionId: string }>; integrationAssignments: ReadonlyArray<{ integrationId: string; custodyReferenceId: string; allowedTools: string[] }>; scopeAttachments: ReadonlyArray<{ scope: string; subjectType: string; subjectId: string }> }): AgentRevisionContent
 {
 	const budget = row.budget as unknown as AgentBudget;
 	return {
 		promptPolicyVersion: row.promptPolicyVersion,
 		personaRevisionId: row.personaRevisionId,
-		modelPolicyId: row.modelPolicyId,
+		modelDefinitionId: row.modelDefinitionId,
 		budget: { maxTurns: budget.maxTurns, maxTokens: budget.maxTokens, maxDurationMs: budget.maxDurationMs },
 		skills: row.skillAssignments.map(assignment => ({ skillId: assignment.skillId, revisionId: assignment.skillRevisionId })),
 		integrationAssignments: row.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: [...assignment.allowedTools] })),
 		scopeAttachments: row.scopeAttachments.map(attachment => ({ scope: _grantScope(attachment.scope), subjectType: _grantSubjectType(attachment.subjectType), subjectId: attachment.subjectId })),
 	};
+}
+
+/** Returns whether a model definition is globally available or belongs to the service's tenant scope. */
+async function _isModelDefinitionAvailable(transaction: Prisma.TransactionClient, modelDefinitionId: string, siloId: string): Promise<boolean>
+{
+	const definition = await transaction.modelDefinition.findUnique({ where: { id: modelDefinitionId }, select: { scope: true, clusterTenant: true } });
+	return definition?.scope === "Global" || (definition?.scope === "ClusterTenant" && definition.clusterTenant === siloId);
 }
 
 /**
@@ -144,6 +151,7 @@ export class PrismaAgentRevisionLifecycleRepository implements AgentRevisionLife
 		const createdAtDate = new Date(createdAt);
 		return this.prisma.$transaction(async function _create(transaction: Prisma.TransactionClient): Promise<CreateManagedAgentServiceResult>
 		{
+			if (!await _isModelDefinitionAvailable(transaction, command.content.modelDefinitionId, command.siloId)) return { outcome: "denied", reason: "model_definition_unavailable" };
 			const serviceRow = await transaction.agentService.create({ data: { siloId: command.siloId, kind: AgentServiceKind.Managed, name: command.name, state: AgentServiceState.Draft, workloadProfile: command.workloadProfile, createdAt: createdAtDate, updatedAt: createdAtDate } });
 			const revisionRow = await transaction.agentRevision.create({ data: _revisionCreateData(serviceRow.id, command.siloId, 1, null, null, command.content, command.changeMessage, command.authoredBy, createdAtDate), include: _REVISION_INCLUDE });
 			return { outcome: "created", service: _mapService(serviceRow), revision: _mapRevision(revisionRow) };
@@ -158,6 +166,7 @@ export class PrismaAgentRevisionLifecycleRepository implements AgentRevisionLife
 		{
 			const guard = await _lockAndReadHead(transaction, command.agentServiceId, command.siloId, command.expectedParentRevisionId);
 			if (guard.outcome !== "ok") return guard.result;
+			if (!await _isModelDefinitionAvailable(transaction, command.content.modelDefinitionId, guard.siloId)) return { outcome: "denied", reason: "model_definition_unavailable" };
 			const revisionRow = await transaction.agentRevision.create({ data: _revisionCreateData(command.agentServiceId, guard.siloId, guard.head.revision + 1, guard.head.id, null, command.content, command.changeMessage, command.authoredBy, createdAtDate), include: _REVISION_INCLUDE });
 			return { outcome: "revised", revision: _mapRevision(revisionRow) };
 		});

--- a/libs/backend/server/agents/channel-targets/main/tests/channel-targets-authority.sql
+++ b/libs/backend/server/agents/channel-targets/main/tests/channel-targets-authority.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('channel-model', 'global', 'channel-model', 'litellm-channel-model', 'channel-model', clock_timestamp());
+
 CREATE FUNCTION pg_temp.expect_failure(test_name TEXT, statement TEXT, expected_message TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
 DECLARE actual_message TEXT;
 BEGIN
@@ -15,8 +18,8 @@ $$;
 
 INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "workload_profile", "updated_at")
 VALUES ('channel-service', 'silo-channel', 'managed', 'Channel agent', 'managed-agent', clock_timestamp());
-INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by", "published_at")
-VALUES ('channel-revision', 'channel-service', 1, 'published', 'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'user-1', clock_timestamp());
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "state", "digest", "prompt_policy_version", "model_definition_id", "budget", "authored_by", "published_at")
+VALUES ('channel-revision', 'channel-service', 1, 'published', 'sha256:' || repeat('a', 64), 'prompt-v1', 'channel-model', '{}', 'user-1', clock_timestamp());
 UPDATE "agent_services" SET "state" = 'active', "active_revision_id" = 'channel-revision' WHERE "id" = 'channel-service';
 INSERT INTO "conversation_threads" ("id", "silo_id", "agent_service_id", "updated_at") VALUES ('channel-thread', 'silo-channel', 'channel-service', clock_timestamp());
 INSERT INTO "conversation_participants" ("thread_id", "user_id") VALUES ('channel-thread', 'user-1');

--- a/libs/backend/server/gateways/integrations/main/tests/integrations-authority.sql
+++ b/libs/backend/server/gateways/integrations/main/tests/integrations-authority.sql
@@ -1,5 +1,8 @@
 BEGIN;
 
+INSERT INTO "model_definitions" ("id", "scope", "public_model_name", "litellm_model_id", "upstream_model", "updated_at")
+VALUES ('integrations-model', 'global', 'integrations-model', 'litellm-integrations-model', 'integrations-model', clock_timestamp());
+
 CREATE FUNCTION pg_temp.expect_failure(test_name TEXT, statement TEXT, expected_message TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
 DECLARE actual_message TEXT;
 BEGIN
@@ -15,8 +18,8 @@ $$;
 
 INSERT INTO "agent_services" ("id", "silo_id", "kind", "name", "workload_profile", "updated_at")
 VALUES ('integration-service', 'silo-integrations', 'managed', 'Integration agent', 'managed-agent', clock_timestamp());
-INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
-VALUES ('integration-revision', 'integration-service', 1, 'sha256:' || repeat('a', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_definition_id", "budget", "authored_by")
+VALUES ('integration-revision', 'integration-service', 1, 'sha256:' || repeat('a', 64), 'prompt-v1', 'integrations-model', '{}', 'user-1');
 INSERT INTO "integrations" ("id", "silo_id", "obot_catalog_entry_id", "display_name", "updated_at")
 VALUES ('integration-1', 'silo-integrations', 'obot-catalog-1', 'Calendar', clock_timestamp());
 INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "expires_at")
@@ -27,8 +30,8 @@ VALUES ('integration-revision', 'integration-1', 'silo-integrations', 'custody-1
 SELECT pg_temp.expect_failure('duplicate integration assignment', $statement$
   INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")
   VALUES ('integration-revision', 'integration-1', 'silo-integrations', 'custody-1', ARRAY['calendar.write'])$statement$, 'agent_revision_integration_assignments_pkey');
-INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
-VALUES ('integration-revision-tools', 'integration-service', 2, 'sha256:' || repeat('b', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_definition_id", "budget", "authored_by")
+VALUES ('integration-revision-tools', 'integration-service', 2, 'sha256:' || repeat('b', 64), 'prompt-v1', 'integrations-model', '{}', 'user-1');
 INSERT INTO "integrations" ("id", "silo_id", "obot_catalog_entry_id", "display_name", "updated_at")
 VALUES ('integration-tools', 'silo-integrations', 'obot-catalog-tools', 'Tasks', clock_timestamp());
 INSERT INTO "integration_custody_references" ("id", "integration_id", "silo_id", "obot_custody_reference", "expires_at")
@@ -50,8 +53,8 @@ SELECT pg_temp.expect_failure('published integration assignment is immutable', $
   UPDATE "agent_revision_integration_assignments" SET "allowed_tools" = ARRAY['calendar.write']
   WHERE "agent_revision_id" = 'integration-revision' AND "integration_id" = 'integration-1'$statement$, 'AgentRevision assignments are immutable');
 
-INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_policy_id", "budget", "authored_by")
-VALUES ('integration-revision-2', 'integration-service', 3, 'sha256:' || repeat('c', 64), 'prompt-v1', 'model-v1', '{}', 'user-1');
+INSERT INTO "agent_revisions" ("id", "agent_service_id", "revision", "digest", "prompt_policy_version", "model_definition_id", "budget", "authored_by")
+VALUES ('integration-revision-2', 'integration-service', 3, 'sha256:' || repeat('c', 64), 'prompt-v1', 'integrations-model', '{}', 'user-1');
 UPDATE "integration_custody_references" SET "state" = 'revoked', "revoked_at" = clock_timestamp() WHERE "id" = 'custody-1';
 SELECT pg_temp.expect_failure('revoked custody reference cannot be assigned', $statement$
   INSERT INTO "agent_revision_integration_assignments" ("agent_revision_id", "integration_id", "silo_id", "custody_reference_id", "allowed_tools")

--- a/libs/backend/server/gateways/model-routing/main/README.md
+++ b/libs/backend/server/gateways/model-routing/main/README.md
@@ -66,6 +66,8 @@ Tagged `scope:model-routing`: it may depend only on `scope:auth`, `scope:cluster
 
 Owns `ModelRoutingDefault` in `apps/opencrane/prisma/schema/model-routing.prisma`. Per-tenant model
 rows and provider credentials are owned by the [providers](../../providers/main/README.md) domain.
+An `AgentRevision` stores the provider domain's stable `ModelDefinition` identifier, rather than an
+unverified alias; this package's catalogue is therefore the allowlist source for executable models.
 
 ## See also
 

--- a/libs/models/agents/main/src/__tests__/agent-revision-diff.test.ts
+++ b/libs/models/agents/main/src/__tests__/agent-revision-diff.test.ts
@@ -17,7 +17,7 @@ function _revision(overrides: Partial<AgentRevision> = {}): AgentRevision
 		digest: "sha256:base",
 		promptPolicyVersion: "line-one\nline-two",
 		personaRevisionId: null,
-		modelPolicyId: "model-a",
+	modelDefinitionId: "model-definition-a",
 		skills: [{ skillId: "skill-a", revisionId: "rev-1" }],
 		integrationAssignments: [{ integrationId: "int-a", custodyReferenceId: "cust-1", allowedTools: ["read"] }],
 		scopeAttachments: [{ scope: "project", subjectType: "group", subjectId: "proj-1" }],

--- a/libs/models/agents/main/src/agent-revision-diff.ts
+++ b/libs/models/agents/main/src/agent-revision-diff.ts
@@ -110,7 +110,7 @@ export function __DiffAgentRevisions(base: AgentRevision, target: AgentRevision)
 	// 2. Diff scalar configuration fields semantically.
 	const scalarChanges = [
 		_scalarChange("personaRevisionId", base.personaRevisionId, target.personaRevisionId),
-		_scalarChange("modelPolicyId", base.modelPolicyId, target.modelPolicyId),
+		_scalarChange("modelDefinitionId", base.modelDefinitionId, target.modelDefinitionId),
 		_scalarChange("budget.maxTurns", String(base.budget.maxTurns), String(target.budget.maxTurns)),
 		_scalarChange("budget.maxTokens", String(base.budget.maxTokens), String(target.budget.maxTokens)),
 		_scalarChange("budget.maxDurationMs", String(base.budget.maxDurationMs), String(target.budget.maxDurationMs)),

--- a/libs/models/agents/main/src/agent-revision.types.ts
+++ b/libs/models/agents/main/src/agent-revision.types.ts
@@ -58,8 +58,8 @@ export interface AgentRevision
 	readonly promptPolicyVersion: string;
 	/** Approved persona revision for a personal agent, otherwise null. */
 	readonly personaRevisionId: PersonaRevisionId | null;
-	/** Stable model-routing policy identifier. */
-	readonly modelPolicyId: string;
+	/** Registered model definition selected for this immutable revision. */
+	readonly modelDefinitionId: string;
 	/** Immutable skill revisions available to the runtime. */
 	readonly skills: readonly SkillRevisionReference[];
 	/** Immutable integration and tool assignments available to the runtime. */


### PR DESCRIPTION
## Why

An agent revision previously stored a free-form model-policy string. That allowed an executable definition to name a model outside the registered model catalogue and gave the database nothing to enforce.

## What changed

- replace the opaque field with modelDefinitionId, a required relation to the gateway-owned ModelDefinition catalogue
- reject missing or foreign tenant-scoped definitions during create and revision, and enforce the same rule directly in the target PostgreSQL baseline
- freeze model routing identity after a revision references it; new routing behaviour requires a new model definition
- update the digest, revision diff, router, fixtures, packaged harvester, package docs, and architecture wording to use the registered definition

## Boundary

This is the referential foundation only. It does not yet derive a run snapshot's model route from the definition; that remains the next admission/materialisation slice. There is no compatibility alias or dual write.

## Validation

- Prisma generate and schema validation
- backend-server-agent-services lint and 28 tests
- models-agents tests (17)
- opencrane lint and 41 tests
- style check, shell syntax, and git diff --check
- independent architecture, residue, and correctness reviews: PASS

## Live gate

The PostgreSQL authority suite is updated with the foreign-tenant negative case, but was not run locally because this machine has no psql client. It remains a CI/live-environment gate.