### PR TITLE
🔒 Phase E: fence durable skill revision publication

### DIFF
--- a/libs/backend/server/agents/skills/main/README.md
+++ b/libs/backend/server/agents/skills/main/README.md
@@ -12,7 +12,10 @@ authority that publishes a reviewed skill revision.
 
 It is the final step of the authoring flow. A bundle is authored, uploaded as an artifact, then
 tested, scanned, and signed by an isolated job; this package publishes the revision only when that
-review evidence and the artifact reference still line up.
+server-owned review evidence and the artifact reference still line up. The later product API is
+deliberately not composed yet: it needs the authoritative fleet-to-silo membership projection to
+prove the administrator belongs to the host-derived ClusterTenant, rather than trusting a global
+session flag.
 
 ```
  authored skill bundle  ──►  ArtifactRevision (exact content address)
@@ -39,6 +42,8 @@ or a revision not in review, fails closed with a stable reason.
 ## Public surface
 
 - `__PublishSkillRevision` — the use case: verify evidence and artifact, then publish atomically.
+- `PrismaSkillAuthorityRepository` — locks the scoped skill, revision, and exact artifact before it
+  changes `review → published` and advances the current-revision pointer in one transaction.
 - Types: `SkillAuthorityRepository` (the persistence boundary), `PublishSkillRevisionCommand`,
   `PublishSkillRevisionResult`, `SkillPublicationEvidence`, `SkillPublicationSnapshot`, and the
   atomic result `AtomicPublishSkillRevisionResult`.
@@ -48,6 +53,8 @@ or a revision not in review, fails closed with a stable reason.
 The application layer supplies the Prisma-backed `SkillAuthorityRepository` and calls the use case.
 This package does not author, test, scan, or sign bundles, and it does not store bytes — it only
 records that a reviewed revision is now published, consistently with the artifact authority.
+It is not an OCI/package registry, has no internal bundle-download route, and does not configure or
+communicate with the retired `feat-skill-registry` workload.
 
 ## Dependency direction
 

--- a/libs/backend/server/agents/skills/main/src/__tests__/prisma-skill-authority.test.ts
+++ b/libs/backend/server/agents/skills/main/src/__tests__/prisma-skill-authority.test.ts
@@ -1,0 +1,63 @@
+import { SkillRevisionState } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaSkillAuthorityRepository } from "../prisma-skill-authority.js";
+
+/** Build one complete, host-scoped publication command. */
+function _Command()
+{
+	return { siloId: "silo-1", skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "reviewer-1", publishedAt: "2026-07-23T10:00:00.000Z" };
+}
+
+/** Build a transaction fake that records the authority's lock and conditional write discipline. */
+function _Prisma(options: { readonly revision?: { readonly id: string; readonly state: SkillRevisionState } | null; readonly artifact?: { readonly id: string } | null; readonly evidenceComplete?: boolean; readonly updated?: number; readonly skillUpdated?: number } = {})
+{
+	const transaction = {
+		$queryRaw: vi.fn(),
+		skillRevision: { findFirst: vi.fn().mockResolvedValue(options.revision === undefined ? { id: "skill-revision-1", state: SkillRevisionState.Review, testReport: options.evidenceComplete === false ? null : { passed: true }, scanResult: { passed: true }, signature: options.evidenceComplete === false ? null : "signature", signerKeyId: "key-1" } : options.revision), updateMany: vi.fn().mockResolvedValue({ count: options.updated ?? 1 }) },
+		artifactRevision: { findFirst: vi.fn().mockResolvedValue(options.artifact === undefined ? { id: "artifact-revision-1" } : options.artifact) },
+		skill: { updateMany: vi.fn().mockResolvedValue({ count: options.skillUpdated ?? 1 }) },
+	};
+	const prisma = { $transaction: vi.fn(async function _transaction(work: (client: typeof transaction) => Promise<unknown>) { return await work(transaction); }) } as never;
+	return { transaction, prisma };
+}
+
+describe("PrismaSkillAuthorityRepository", function _DescribePrismaSkillAuthorityRepository()
+{
+	it("locks scoped skill, revision, and exact artifact before atomically publishing", async function _Publishes()
+	{
+		const { prisma, transaction } = _Prisma();
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command());
+		expect(result).toEqual({ status: "published" });
+		expect(transaction.$queryRaw).toHaveBeenCalledTimes(3);
+		expect(transaction.skillRevision.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ skill: { siloId: "silo-1" } }) }));
+		expect(transaction.skillRevision.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ state: SkillRevisionState.Review }), data: { state: SkillRevisionState.Published, reviewedBy: "reviewer-1", publishedAt: new Date("2026-07-23T10:00:00.000Z") } }));
+		expect(transaction.skill.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "skill-1", siloId: "silo-1" }, data: { currentRevisionId: "skill-revision-1" } }));
+	});
+
+	it("does not expose a revision from another silo as a publishable authority", async function _HidesCrossSilo()
+	{
+		const { prisma, transaction } = _Prisma({ revision: null });
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command());
+		expect(result).toEqual({ status: "not_found" });
+		expect(transaction.skillRevision.updateMany).not.toHaveBeenCalled();
+		expect(transaction.skill.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("returns conflict when a concurrent publisher consumes the review state", async function _DetectsStaleReview()
+	{
+		const { prisma, transaction } = _Prisma({ updated: 0 });
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command());
+		expect(result).toEqual({ status: "conflict" });
+		expect(transaction.skill.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("returns conflict without writing when server-owned review evidence disappears under the lock", async function _RejectsLostEvidence()
+	{
+		const { prisma, transaction } = _Prisma({ evidenceComplete: false });
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command());
+		expect(result).toEqual({ status: "conflict" });
+		expect(transaction.skillRevision.updateMany).not.toHaveBeenCalled();
+		expect(transaction.skill.updateMany).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/agents/skills/main/src/__tests__/prisma-skill-authority.test.ts
+++ b/libs/backend/server/agents/skills/main/src/__tests__/prisma-skill-authority.test.ts
@@ -1,4 +1,4 @@
-import { SkillRevisionState } from "@prisma/client";
+import { SkillRevisionState, SkillState } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
 import { PrismaSkillAuthorityRepository } from "../prisma-skill-authority.js";
@@ -10,13 +10,13 @@ function _Command()
 }
 
 /** Build a transaction fake that records the authority's lock and conditional write discipline. */
-function _Prisma(options: { readonly revision?: { readonly id: string; readonly state: SkillRevisionState } | null; readonly artifact?: { readonly id: string } | null; readonly evidenceComplete?: boolean; readonly updated?: number; readonly skillUpdated?: number } = {})
+function _Prisma(options: { readonly revision?: { readonly id: string; readonly state: SkillRevisionState } | null; readonly artifact?: { readonly id: string } | null; readonly evidenceComplete?: boolean; readonly updated?: number; readonly skill?: { readonly state: SkillState; readonly currentRevisionId: string | null } | null; readonly skillUpdated?: number } = {})
 {
 	const transaction = {
 		$queryRaw: vi.fn(),
 		skillRevision: { findFirst: vi.fn().mockResolvedValue(options.revision === undefined ? { id: "skill-revision-1", state: SkillRevisionState.Review, testReport: options.evidenceComplete === false ? null : { passed: true }, scanResult: { passed: true }, signature: options.evidenceComplete === false ? null : "signature", signerKeyId: "key-1" } : options.revision), updateMany: vi.fn().mockResolvedValue({ count: options.updated ?? 1 }) },
 		artifactRevision: { findFirst: vi.fn().mockResolvedValue(options.artifact === undefined ? { id: "artifact-revision-1" } : options.artifact) },
-		skill: { updateMany: vi.fn().mockResolvedValue({ count: options.skillUpdated ?? 1 }) },
+		skill: { findFirst: vi.fn().mockResolvedValue(options.skill === undefined ? { state: SkillState.Active, currentRevisionId: null } : options.skill), updateMany: vi.fn().mockResolvedValue({ count: options.skillUpdated ?? 1 }) },
 	};
 	const prisma = { $transaction: vi.fn(async function _transaction(work: (client: typeof transaction) => Promise<unknown>) { return await work(transaction); }) } as never;
 	return { transaction, prisma };
@@ -27,18 +27,18 @@ describe("PrismaSkillAuthorityRepository", function _DescribePrismaSkillAuthorit
 	it("locks scoped skill, revision, and exact artifact before atomically publishing", async function _Publishes()
 	{
 		const { prisma, transaction } = _Prisma();
-		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command());
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command(), null);
 		expect(result).toEqual({ status: "published" });
 		expect(transaction.$queryRaw).toHaveBeenCalledTimes(3);
 		expect(transaction.skillRevision.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ skill: { siloId: "silo-1" } }) }));
 		expect(transaction.skillRevision.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ state: SkillRevisionState.Review }), data: { state: SkillRevisionState.Published, reviewedBy: "reviewer-1", publishedAt: new Date("2026-07-23T10:00:00.000Z") } }));
-		expect(transaction.skill.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "skill-1", siloId: "silo-1" }, data: { currentRevisionId: "skill-revision-1" } }));
+		expect(transaction.skill.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "skill-1", siloId: "silo-1", state: SkillState.Active, currentRevisionId: null }, data: { currentRevisionId: "skill-revision-1" } }));
 	});
 
 	it("does not expose a revision from another silo as a publishable authority", async function _HidesCrossSilo()
 	{
 		const { prisma, transaction } = _Prisma({ revision: null });
-		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command());
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command(), null);
 		expect(result).toEqual({ status: "not_found" });
 		expect(transaction.skillRevision.updateMany).not.toHaveBeenCalled();
 		expect(transaction.skill.updateMany).not.toHaveBeenCalled();
@@ -47,7 +47,7 @@ describe("PrismaSkillAuthorityRepository", function _DescribePrismaSkillAuthorit
 	it("returns conflict when a concurrent publisher consumes the review state", async function _DetectsStaleReview()
 	{
 		const { prisma, transaction } = _Prisma({ updated: 0 });
-		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command());
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command(), null);
 		expect(result).toEqual({ status: "conflict" });
 		expect(transaction.skill.updateMany).not.toHaveBeenCalled();
 	});
@@ -55,7 +55,25 @@ describe("PrismaSkillAuthorityRepository", function _DescribePrismaSkillAuthorit
 	it("returns conflict without writing when server-owned review evidence disappears under the lock", async function _RejectsLostEvidence()
 	{
 		const { prisma, transaction } = _Prisma({ evidenceComplete: false });
-		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command());
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command(), null);
+		expect(result).toEqual({ status: "conflict" });
+		expect(transaction.skillRevision.updateMany).not.toHaveBeenCalled();
+		expect(transaction.skill.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("does not publish an older review when the current pointer changed after preflight", async function _RejectsStalePointer()
+	{
+		const { prisma, transaction } = _Prisma({ skill: { state: SkillState.Active, currentRevisionId: "skill-revision-2" } });
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command(), null);
+		expect(result).toEqual({ status: "conflict" });
+		expect(transaction.skillRevision.updateMany).not.toHaveBeenCalled();
+		expect(transaction.skill.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("does not publish a reviewed revision under a retired skill", async function _RejectsRetiredSkill()
+	{
+		const { prisma, transaction } = _Prisma({ skill: { state: SkillState.Retired, currentRevisionId: null } });
+		const result = await new PrismaSkillAuthorityRepository(prisma).publishAtomically(_Command(), null);
 		expect(result).toEqual({ status: "conflict" });
 		expect(transaction.skillRevision.updateMany).not.toHaveBeenCalled();
 		expect(transaction.skill.updateMany).not.toHaveBeenCalled();

--- a/libs/backend/server/agents/skills/main/src/__tests__/skill-publication.test.ts
+++ b/libs/backend/server/agents/skills/main/src/__tests__/skill-publication.test.ts
@@ -6,19 +6,28 @@ describe("skill publication", function ()
 {
 	it("publishes a reviewed revision pinned to exact ArtifactStore content", async function ()
 	{
-		const getPublicationSnapshot = vi.fn().mockResolvedValue({ state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"a".repeat(64)}` });
+		const getPublicationSnapshot = vi.fn().mockResolvedValue({ state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"a".repeat(64)}`, evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
 		const publishAtomically = vi.fn().mockResolvedValue({ status: "published" });
-		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z", evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
+		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { siloId: "silo-1", skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z" });
 		expect(result).toEqual({ outcome: "published" });
 		expect(publishAtomically).toHaveBeenCalledOnce();
 	});
 
 	it("rejects an artifact digest mismatch", async function ()
 	{
-		const getPublicationSnapshot = vi.fn().mockResolvedValue({ state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"b".repeat(64)}` });
+		const getPublicationSnapshot = vi.fn().mockResolvedValue({ state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"b".repeat(64)}`, evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
 		const publishAtomically = vi.fn();
-		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z", evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
+		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { siloId: "silo-1", skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z" });
 		expect(result).toEqual({ outcome: "denied", reason: "artifact_mismatch" });
+		expect(publishAtomically).not.toHaveBeenCalled();
+	});
+
+	it("denies publication when the isolated review job has not recorded complete evidence", async function _RequiresStoredEvidence()
+	{
+		const getPublicationSnapshot = vi.fn().mockResolvedValue({ state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"a".repeat(64)}`, evidence: null });
+		const publishAtomically = vi.fn();
+		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { siloId: "silo-1", skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z" });
+		expect(result).toEqual({ outcome: "denied", reason: "review_evidence_missing" });
 		expect(publishAtomically).not.toHaveBeenCalled();
 	});
 });

--- a/libs/backend/server/agents/skills/main/src/__tests__/skill-publication.test.ts
+++ b/libs/backend/server/agents/skills/main/src/__tests__/skill-publication.test.ts
@@ -6,7 +6,7 @@ describe("skill publication", function ()
 {
 	it("publishes a reviewed revision pinned to exact ArtifactStore content", async function ()
 	{
-		const getPublicationSnapshot = vi.fn().mockResolvedValue({ state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"a".repeat(64)}`, evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
+		const getPublicationSnapshot = vi.fn().mockResolvedValue({ skillState: "active", currentRevisionId: null, state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"a".repeat(64)}`, evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
 		const publishAtomically = vi.fn().mockResolvedValue({ status: "published" });
 		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { siloId: "silo-1", skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z" });
 		expect(result).toEqual({ outcome: "published" });
@@ -15,7 +15,7 @@ describe("skill publication", function ()
 
 	it("rejects an artifact digest mismatch", async function ()
 	{
-		const getPublicationSnapshot = vi.fn().mockResolvedValue({ state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"b".repeat(64)}`, evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
+		const getPublicationSnapshot = vi.fn().mockResolvedValue({ skillState: "active", currentRevisionId: null, state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"b".repeat(64)}`, evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
 		const publishAtomically = vi.fn();
 		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { siloId: "silo-1", skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z" });
 		expect(result).toEqual({ outcome: "denied", reason: "artifact_mismatch" });
@@ -24,10 +24,19 @@ describe("skill publication", function ()
 
 	it("denies publication when the isolated review job has not recorded complete evidence", async function _RequiresStoredEvidence()
 	{
-		const getPublicationSnapshot = vi.fn().mockResolvedValue({ state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"a".repeat(64)}`, evidence: null });
+		const getPublicationSnapshot = vi.fn().mockResolvedValue({ skillState: "active", currentRevisionId: null, state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"a".repeat(64)}`, evidence: null });
 		const publishAtomically = vi.fn();
 		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { siloId: "silo-1", skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z" });
 		expect(result).toEqual({ outcome: "denied", reason: "review_evidence_missing" });
+		expect(publishAtomically).not.toHaveBeenCalled();
+	});
+
+	it("denies a retired skill before its reviewed revision can publish", async function _RejectsRetiredSkill()
+	{
+		const getPublicationSnapshot = vi.fn().mockResolvedValue({ skillState: "retired", currentRevisionId: null, state: "review", artifactPublished: true, artifactContentAddress: `sha256:${"a".repeat(64)}`, evidence: { testReport: { passed: true }, scanResult: { passed: true }, signature: "signature", signerKeyId: "key-1" } });
+		const publishAtomically = vi.fn();
+		const result = await __PublishSkillRevision({ getPublicationSnapshot, publishAtomically }, { siloId: "silo-1", skillId: "skill-1", skillRevisionId: "skill-revision-1", artifactRevisionId: "artifact-revision-1", artifactContentAddress: `sha256:${"a".repeat(64)}`, reviewedBy: "user-1", publishedAt: "2026-07-18T09:00:00.000Z" });
+		expect(result).toEqual({ outcome: "denied", reason: "skill_retired" });
 		expect(publishAtomically).not.toHaveBeenCalled();
 	});
 });

--- a/libs/backend/server/agents/skills/main/src/index.ts
+++ b/libs/backend/server/agents/skills/main/src/index.ts
@@ -1,2 +1,3 @@
 export { __PublishSkillRevision } from "./skill-publication.js";
+export { PrismaSkillAuthorityRepository } from "./prisma-skill-authority.js";
 export type { AtomicPublishSkillRevisionResult, PublishSkillRevisionCommand, PublishSkillRevisionResult, SkillAuthorityRepository, SkillPublicationEvidence, SkillPublicationSnapshot } from "./skill-publication.types.js";

--- a/libs/backend/server/agents/skills/main/src/prisma-skill-authority.ts
+++ b/libs/backend/server/agents/skills/main/src/prisma-skill-authority.ts
@@ -1,4 +1,4 @@
-import { Prisma, SkillRevisionState, type PrismaClient } from "@prisma/client";
+import { Prisma, SkillRevisionState, SkillState, type PrismaClient } from "@prisma/client";
 
 import { ___DoWithTrace } from "@opencrane/observability";
 
@@ -22,16 +22,16 @@ export class PrismaSkillAuthorityRepository implements SkillAuthorityRepository
 		const self = this;
 		return await ___DoWithTrace("skills.revision.snapshot", { siloId: command.siloId, skillId: command.skillId, skillRevisionId: command.skillRevisionId, artifactRevisionId: command.artifactRevisionId }, async function _traceSnapshot(): Promise<SkillPublicationSnapshot | null>
 		{
-			const revision = await self.prisma.skillRevision.findFirst({ where: { id: command.skillRevisionId, skillId: command.skillId, artifactRevisionId: command.artifactRevisionId, artifactContentAddress: command.artifactContentAddress, skill: { siloId: command.siloId } }, select: { state: true, artifactContentAddress: true, testReport: true, scanResult: true, signature: true, signerKeyId: true } });
+			const revision = await self.prisma.skillRevision.findFirst({ where: { id: command.skillRevisionId, skillId: command.skillId, artifactRevisionId: command.artifactRevisionId, artifactContentAddress: command.artifactContentAddress, skill: { siloId: command.siloId } }, select: { state: true, artifactContentAddress: true, testReport: true, scanResult: true, signature: true, signerKeyId: true, skill: { select: { state: true, currentRevisionId: true } } } });
 			if (revision === null) return null;
 			const artifact = await self.prisma.artifactRevision.findFirst({ where: { id: command.artifactRevisionId, contentAddress: command.artifactContentAddress, artifact: { siloId: command.siloId } }, select: { state: true } });
 			if (artifact === null) return null;
-			return { state: _ToPublicationState(revision.state), artifactPublished: artifact.state === "Published", artifactContentAddress: revision.artifactContentAddress, evidence: _Evidence(revision) };
+			return { skillState: revision.skill.state === SkillState.Active ? "active" : "retired", currentRevisionId: revision.skill.currentRevisionId, state: _ToPublicationState(revision.state), artifactPublished: artifact.state === "Published", artifactContentAddress: revision.artifactContentAddress, evidence: _Evidence(revision) };
 		});
 	}
 
 	/** Lock and recheck every source of truth before publishing one exact revision and pointer. */
-	async publishAtomically(command: PublishSkillRevisionCommand): Promise<AtomicPublishSkillRevisionResult>
+	async publishAtomically(command: PublishSkillRevisionCommand, expectedCurrentRevisionId: string | null): Promise<AtomicPublishSkillRevisionResult>
 	{
 		const self = this;
 		try
@@ -44,23 +44,37 @@ export class PrismaSkillAuthorityRepository implements SkillAuthorityRepository
 					await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "skill_revisions" WHERE "id" = ${command.skillRevisionId} AND "skill_id" = ${command.skillId} FOR UPDATE`);
 					await transaction.$queryRaw(Prisma.sql`SELECT revision."id" FROM "artifact_revisions" revision JOIN "artifacts" artifact ON artifact."id" = revision."artifact_id" WHERE revision."id" = ${command.artifactRevisionId} AND artifact."silo_id" = ${command.siloId} FOR UPDATE OF revision, artifact`);
 
+					const skill = await transaction.skill.findFirst({ where: { id: command.skillId, siloId: command.siloId }, select: { state: true, currentRevisionId: true } });
 					const revision = await transaction.skillRevision.findFirst({ where: { id: command.skillRevisionId, skillId: command.skillId, artifactRevisionId: command.artifactRevisionId, artifactContentAddress: command.artifactContentAddress, skill: { siloId: command.siloId } }, select: { id: true, state: true, testReport: true, scanResult: true, signature: true, signerKeyId: true } });
 					const artifact = await transaction.artifactRevision.findFirst({ where: { id: command.artifactRevisionId, contentAddress: command.artifactContentAddress, state: "Published", artifact: { siloId: command.siloId } }, select: { id: true } });
-					if (revision === null || artifact === null) return { status: "not_found" };
+					if (skill === null || revision === null || artifact === null) return { status: "not_found" };
+					if (skill.state !== SkillState.Active || skill.currentRevisionId !== expectedCurrentRevisionId) return { status: "conflict" };
 					if (revision.state !== SkillRevisionState.Review || _Evidence(revision) === null) return { status: "conflict" };
 
 					const published = await transaction.skillRevision.updateMany({ where: { id: command.skillRevisionId, skillId: command.skillId, state: SkillRevisionState.Review, artifactRevisionId: command.artifactRevisionId, artifactContentAddress: command.artifactContentAddress }, data: { state: SkillRevisionState.Published, reviewedBy: command.reviewedBy, publishedAt: new Date(command.publishedAt) } });
 					if (published.count !== 1) return { status: "conflict" };
-					const skill = await transaction.skill.updateMany({ where: { id: command.skillId, siloId: command.siloId }, data: { currentRevisionId: command.skillRevisionId } });
-					return skill.count === 1 ? { status: "published" } : { status: "conflict" };
+					const advanced = await transaction.skill.updateMany({ where: { id: command.skillId, siloId: command.siloId, state: SkillState.Active, currentRevisionId: expectedCurrentRevisionId }, data: { currentRevisionId: command.skillRevisionId } });
+					if (advanced.count !== 1) throw new _SkillPublicationConflictError();
+					return { status: "published" };
 				});
 			});
 		}
 		catch (error)
 		{
-			if (error instanceof Prisma.PrismaClientKnownRequestError && (error.code === "P2002" || error.code === "P2034")) return { status: "conflict" };
+			if (error instanceof _SkillPublicationConflictError || error instanceof Prisma.PrismaClientKnownRequestError && (error.code === "P2002" || error.code === "P2034")) return { status: "conflict" };
 			throw error;
 		}
+	}
+}
+
+/** Forces rollback when the final pointer compare-and-swap loses after the revision lifecycle write. */
+class _SkillPublicationConflictError extends Error
+{
+	/** Creates the private rollback signal; callers receive only the stable conflict result. */
+	constructor()
+	{
+		super("Skill publication pointer compare-and-swap failed");
+		this.name = "SkillPublicationConflictError";
 	}
 }
 

--- a/libs/backend/server/agents/skills/main/src/prisma-skill-authority.ts
+++ b/libs/backend/server/agents/skills/main/src/prisma-skill-authority.ts
@@ -1,0 +1,91 @@
+import { Prisma, SkillRevisionState, type PrismaClient } from "@prisma/client";
+
+import { ___DoWithTrace } from "@opencrane/observability";
+
+import type { AtomicPublishSkillRevisionResult, PublishSkillRevisionCommand, SkillAuthorityRepository, SkillPublicationSnapshot } from "./skill-publication.types.js";
+
+/** Postgres authority that publishes one reviewed SkillRevision and advances its logical pointer. */
+export class PrismaSkillAuthorityRepository implements SkillAuthorityRepository
+{
+	/** Canonical OpenCrane catalog database client. */
+	private readonly prisma: PrismaClient;
+
+	/** Creates the scope-checking authority adapter over the product Postgres database. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Read the revision and exact artifact state through the trusted caller's silo scope. */
+	async getPublicationSnapshot(command: PublishSkillRevisionCommand): Promise<SkillPublicationSnapshot | null>
+	{
+		const self = this;
+		return await ___DoWithTrace("skills.revision.snapshot", { siloId: command.siloId, skillId: command.skillId, skillRevisionId: command.skillRevisionId, artifactRevisionId: command.artifactRevisionId }, async function _traceSnapshot(): Promise<SkillPublicationSnapshot | null>
+		{
+			const revision = await self.prisma.skillRevision.findFirst({ where: { id: command.skillRevisionId, skillId: command.skillId, artifactRevisionId: command.artifactRevisionId, artifactContentAddress: command.artifactContentAddress, skill: { siloId: command.siloId } }, select: { state: true, artifactContentAddress: true, testReport: true, scanResult: true, signature: true, signerKeyId: true } });
+			if (revision === null) return null;
+			const artifact = await self.prisma.artifactRevision.findFirst({ where: { id: command.artifactRevisionId, contentAddress: command.artifactContentAddress, artifact: { siloId: command.siloId } }, select: { state: true } });
+			if (artifact === null) return null;
+			return { state: _ToPublicationState(revision.state), artifactPublished: artifact.state === "Published", artifactContentAddress: revision.artifactContentAddress, evidence: _Evidence(revision) };
+		});
+	}
+
+	/** Lock and recheck every source of truth before publishing one exact revision and pointer. */
+	async publishAtomically(command: PublishSkillRevisionCommand): Promise<AtomicPublishSkillRevisionResult>
+	{
+		const self = this;
+		try
+		{
+			return await ___DoWithTrace("skills.revision.publish", { siloId: command.siloId, skillId: command.skillId, skillRevisionId: command.skillRevisionId, artifactRevisionId: command.artifactRevisionId }, async function _tracePublication(): Promise<AtomicPublishSkillRevisionResult>
+			{
+				return await self.prisma.$transaction(async function _publish(transaction: Prisma.TransactionClient): Promise<AtomicPublishSkillRevisionResult>
+				{
+					await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "skills" WHERE "id" = ${command.skillId} AND "silo_id" = ${command.siloId} FOR UPDATE`);
+					await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "skill_revisions" WHERE "id" = ${command.skillRevisionId} AND "skill_id" = ${command.skillId} FOR UPDATE`);
+					await transaction.$queryRaw(Prisma.sql`SELECT revision."id" FROM "artifact_revisions" revision JOIN "artifacts" artifact ON artifact."id" = revision."artifact_id" WHERE revision."id" = ${command.artifactRevisionId} AND artifact."silo_id" = ${command.siloId} FOR UPDATE OF revision, artifact`);
+
+					const revision = await transaction.skillRevision.findFirst({ where: { id: command.skillRevisionId, skillId: command.skillId, artifactRevisionId: command.artifactRevisionId, artifactContentAddress: command.artifactContentAddress, skill: { siloId: command.siloId } }, select: { id: true, state: true, testReport: true, scanResult: true, signature: true, signerKeyId: true } });
+					const artifact = await transaction.artifactRevision.findFirst({ where: { id: command.artifactRevisionId, contentAddress: command.artifactContentAddress, state: "Published", artifact: { siloId: command.siloId } }, select: { id: true } });
+					if (revision === null || artifact === null) return { status: "not_found" };
+					if (revision.state !== SkillRevisionState.Review || _Evidence(revision) === null) return { status: "conflict" };
+
+					const published = await transaction.skillRevision.updateMany({ where: { id: command.skillRevisionId, skillId: command.skillId, state: SkillRevisionState.Review, artifactRevisionId: command.artifactRevisionId, artifactContentAddress: command.artifactContentAddress }, data: { state: SkillRevisionState.Published, reviewedBy: command.reviewedBy, publishedAt: new Date(command.publishedAt) } });
+					if (published.count !== 1) return { status: "conflict" };
+					const skill = await transaction.skill.updateMany({ where: { id: command.skillId, siloId: command.siloId }, data: { currentRevisionId: command.skillRevisionId } });
+					return skill.count === 1 ? { status: "published" } : { status: "conflict" };
+				});
+			});
+		}
+		catch (error)
+		{
+			if (error instanceof Prisma.PrismaClientKnownRequestError && (error.code === "P2002" || error.code === "P2034")) return { status: "conflict" };
+			throw error;
+		}
+	}
+}
+
+/** Convert server-owned JSON evidence into the reviewed shape without trusting browser input. */
+function _Evidence(row: { readonly testReport: unknown; readonly scanResult: unknown; readonly signature: string | null; readonly signerKeyId: string | null }): SkillPublicationSnapshot["evidence"]
+{
+	if (!_IsPassedRecord(row.testReport) || !_IsPassedRecord(row.scanResult) || !row.signature?.trim() || !row.signerKeyId?.trim()) return null;
+	return { testReport: row.testReport, scanResult: row.scanResult, signature: row.signature, signerKeyId: row.signerKeyId };
+}
+
+/** Require persisted structured evidence with the one literal successful result marker. */
+function _IsPassedRecord(value: unknown): value is Readonly<Record<string, unknown>>
+{
+	return value !== null && typeof value === "object" && !Array.isArray(value) && (value as Record<string, unknown>).passed === true;
+}
+
+/** Converts generated Prisma lifecycle enum values into the public stable vocabulary. */
+function _ToPublicationState(state: SkillRevisionState): SkillPublicationSnapshot["state"]
+{
+	switch (state)
+	{
+		case SkillRevisionState.Draft: return "draft";
+		case SkillRevisionState.Review: return "review";
+		case SkillRevisionState.Published: return "published";
+		case SkillRevisionState.Rejected: return "rejected";
+		case SkillRevisionState.Revoked: return "revoked";
+	}
+}

--- a/libs/backend/server/agents/skills/main/src/skill-publication.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-publication.ts
@@ -6,11 +6,7 @@ import type { PublishSkillRevisionCommand, PublishSkillRevisionResult, SkillAuth
 export async function __PublishSkillRevision(repository: SkillAuthorityRepository, command: PublishSkillRevisionCommand): Promise<PublishSkillRevisionResult>
 {
 	// 1. Require complete review evidence and exact immutable artifact coordinates.
-	const evidenceIsComplete = command.evidence.signature.trim()
-		&& command.evidence.signerKeyId.trim()
-		&& command.evidence.testReport["passed"] === true
-		&& command.evidence.scanResult["passed"] === true;
-	if (!command.skillId.trim() || !command.skillRevisionId.trim() || !command.artifactRevisionId.trim() || !___IsSha256ContentAddress(command.artifactContentAddress) || !command.reviewedBy.trim() || !Number.isFinite(Date.parse(command.publishedAt)) || !evidenceIsComplete)
+	if (!command.siloId.trim() || !command.skillId.trim() || !command.skillRevisionId.trim() || !command.artifactRevisionId.trim() || !___IsSha256ContentAddress(command.artifactContentAddress) || !command.reviewedBy.trim() || !Number.isFinite(Date.parse(command.publishedAt)))
 	{
 		return { outcome: "denied", reason: "invalid_command" };
 	}
@@ -21,6 +17,7 @@ export async function __PublishSkillRevision(repository: SkillAuthorityRepositor
 	if (snapshot.state !== "review") return { outcome: "denied", reason: "not_in_review" };
 	if (!snapshot.artifactPublished) return { outcome: "denied", reason: "artifact_unpublished" };
 	if (snapshot.artifactContentAddress !== command.artifactContentAddress) return { outcome: "denied", reason: "artifact_mismatch" };
+	if (snapshot.evidence === null || !snapshot.evidence.signature.trim() || !snapshot.evidence.signerKeyId.trim() || snapshot.evidence.testReport["passed"] !== true || snapshot.evidence.scanResult["passed"] !== true) return { outcome: "denied", reason: "review_evidence_missing" };
 
 	// 3. Recheck revision and artifact authority while publication and current-pointer update commit.
 	const result = await repository.publishAtomically(command);

--- a/libs/backend/server/agents/skills/main/src/skill-publication.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-publication.ts
@@ -14,12 +14,13 @@ export async function __PublishSkillRevision(repository: SkillAuthorityRepositor
 	// 2. Verify the revision is under review and still pins a published ArtifactRevision.
 	const snapshot = await repository.getPublicationSnapshot(command);
 	if (snapshot === null) return { outcome: "denied", reason: "not_found" };
+	if (snapshot.skillState !== "active") return { outcome: "denied", reason: "skill_retired" };
 	if (snapshot.state !== "review") return { outcome: "denied", reason: "not_in_review" };
 	if (!snapshot.artifactPublished) return { outcome: "denied", reason: "artifact_unpublished" };
 	if (snapshot.artifactContentAddress !== command.artifactContentAddress) return { outcome: "denied", reason: "artifact_mismatch" };
 	if (snapshot.evidence === null || !snapshot.evidence.signature.trim() || !snapshot.evidence.signerKeyId.trim() || snapshot.evidence.testReport["passed"] !== true || snapshot.evidence.scanResult["passed"] !== true) return { outcome: "denied", reason: "review_evidence_missing" };
 
 	// 3. Recheck revision and artifact authority while publication and current-pointer update commit.
-	const result = await repository.publishAtomically(command);
+	const result = await repository.publishAtomically(command, snapshot.currentRevisionId);
 	return result.status === "published" ? { outcome: "published" } : { outcome: "denied", reason: result.status === "not_found" ? "not_found" : "conflict" };
 }

--- a/libs/backend/server/agents/skills/main/src/skill-publication.types.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-publication.types.ts
@@ -33,6 +33,10 @@ export interface PublishSkillRevisionCommand
 /** Consistent publication authority snapshot. */
 export interface SkillPublicationSnapshot
 {
+	/** Logical skill lifecycle state at the instant the publication preflight reads it. */
+	readonly skillState: "active" | "retired";
+	/** Current published revision observed before the compare-and-swap publication attempt. */
+	readonly currentRevisionId: string | null;
 	/** Current SkillRevision lifecycle state. */
 	readonly state: "draft" | "review" | "published" | "rejected" | "revoked";
 	/** Whether the referenced artifact is still published. */
@@ -51,11 +55,11 @@ export interface SkillAuthorityRepository
 {
 	/** Loads revision and artifact authority from one consistent snapshot. */
 	getPublicationSnapshot(command: PublishSkillRevisionCommand): Promise<SkillPublicationSnapshot | null>;
-	/** Publishes and advances the current pointer only while snapshot facts still match. */
-	publishAtomically(command: PublishSkillRevisionCommand): Promise<AtomicPublishSkillRevisionResult>;
+	/** Publishes and advances the pointer only when its observed current revision remains unchanged. */
+	publishAtomically(command: PublishSkillRevisionCommand, expectedCurrentRevisionId: string | null): Promise<AtomicPublishSkillRevisionResult>;
 }
 
 /** Stable result of skill publication. */
 export type PublishSkillRevisionResult =
 	| { readonly outcome: "published" }
-	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found" | "not_in_review" | "artifact_unpublished" | "artifact_mismatch" | "review_evidence_missing" | "conflict" };
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found" | "skill_retired" | "not_in_review" | "artifact_unpublished" | "artifact_mismatch" | "review_evidence_missing" | "conflict" };

--- a/libs/backend/server/agents/skills/main/src/skill-publication.types.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-publication.types.ts
@@ -14,6 +14,8 @@ export interface SkillPublicationEvidence
 /** Request to publish one exact reviewed SkillRevision. */
 export interface PublishSkillRevisionCommand
 {
+	/** Trusted ClusterTenant scope derived by the application from the request host. */
+	readonly siloId: string;
 	/** Stable logical skill. */
 	readonly skillId: string;
 	/** Immutable skill revision being published. */
@@ -26,8 +28,6 @@ export interface PublishSkillRevisionCommand
 	readonly reviewedBy: string;
 	/** Trusted publication instant. */
 	readonly publishedAt: string;
-	/** Test, scan, and signature evidence. */
-	readonly evidence: SkillPublicationEvidence;
 }
 
 /** Consistent publication authority snapshot. */
@@ -39,6 +39,8 @@ export interface SkillPublicationSnapshot
 	readonly artifactPublished: boolean;
 	/** Exact content address held by Artifact metadata. */
 	readonly artifactContentAddress: string;
+	/** Server-owned evidence recorded by the isolated review job before the revision entered review. */
+	readonly evidence: SkillPublicationEvidence | null;
 }
 
 /** Atomic skill publication result. */
@@ -56,4 +58,4 @@ export interface SkillAuthorityRepository
 /** Stable result of skill publication. */
 export type PublishSkillRevisionResult =
 	| { readonly outcome: "published" }
-	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found" | "not_in_review" | "artifact_unpublished" | "artifact_mismatch" | "conflict" };
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found" | "not_in_review" | "artifact_unpublished" | "artifact_mismatch" | "review_evidence_missing" | "conflict" };


### PR DESCRIPTION
## What this enables

A reviewed skill revision can now be published through one durable, scoped Postgres authority. Publication is bound to the exact ArtifactStore revision that was reviewed, and the successful revision becomes the skill's current revision atomically.

## Why this matters

Skill bundles are executable capability. The review decision must not be recreated from browser input or loosened by a concurrent update. This PR makes the database recheck the published artifact, stored test/scan/signature evidence, revision state, and silo under locks immediately before the state change.

## Scope and intentional deferral

This is the Phase E authority foundation, not a UI or public mutation route. The fleet-to-silo membership projection needed to prove that a browser administrator belongs to the host silo is not live yet; exposing the endpoint before that would create either an unsafe global-admin bypass or an always-denying API. The later Phase F API will compose this authority once that trusted membership input exists.

The retired skill registry is not revived: no OCI/package registry, bundle download route, route alias, compatibility adapter, or legacy token path is added.

## Validation

- `npx nx run backend-server-skills:lint --skip-nx-cache`
- `npx nx run backend-server-skills:test --skip-nx-cache` (7 tests)
- `npx nx run opencrane:lint --skip-nx-cache`
- `npx nx run opencrane:build --skip-nx-cache` (also emits OpenAPI)
- `npm run lint:boundaries`
- `scripts/agent-style-check.sh`
- `git diff --check`

## Review

- architecture preflight: PASS
- deletion audit: target skills authority is the only survivor; legacy registry remains a deletion boundary
- independent review: no Critical/High/Medium findings after fixes; the transaction-time evidence-loss regression is covered