### PR TITLE
🔒 Phase E: add durable governed skill-work authority

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -190,6 +190,12 @@ CREATE TYPE "SkillRevisionState" AS ENUM ('draft', 'review', 'published', 'rejec
 -- CreateEnum
 CREATE TYPE "SkillTrustClass" AS ENUM ('reviewed_instructions', 'sandboxed_python');
 
+-- CreateEnum
+CREATE TYPE "SkillWorkloadKind" AS ENUM ('authoring', 'tool_runner');
+
+-- CreateEnum
+CREATE TYPE "SkillWorkloadState" AS ENUM ('pending', 'cancelled');
+
 -- CreateTable
 CREATE TABLE "agent_services" (
     "id" TEXT NOT NULL,
@@ -1533,6 +1539,20 @@ CREATE TABLE "skill_revisions" (
 );
 
 -- CreateTable
+CREATE TABLE "skill_workloads" (
+    "id" TEXT NOT NULL,
+    "silo_id" TEXT NOT NULL,
+    "kind" "SkillWorkloadKind" NOT NULL,
+    "state" "SkillWorkloadState" NOT NULL DEFAULT 'pending',
+    "skill_revision_id" TEXT NOT NULL,
+    "tool_invocation_id" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "cancelled_at" TIMESTAMP(3),
+
+    CONSTRAINT "skill_workloads_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "tenant_litellm_keys" (
     "id" TEXT NOT NULL,
     "tenant" TEXT NOT NULL,
@@ -2251,6 +2271,15 @@ CREATE UNIQUE INDEX "skill_revisions_skill_id_id_key" ON "skill_revisions"("skil
 CREATE UNIQUE INDEX "skill_revisions_id_artifact_revision_id_artifact_content_ad_key" ON "skill_revisions"("id", "artifact_revision_id", "artifact_content_address");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "skill_workloads_tool_invocation_id_key" ON "skill_workloads"("tool_invocation_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "skill_workloads_one_authoring_per_revision_key" ON "skill_workloads"("skill_revision_id") WHERE "kind" = 'authoring';
+
+-- CreateIndex
+CREATE INDEX "skill_workloads_silo_id_state_created_at_idx" ON "skill_workloads"("silo_id", "state", "created_at");
+
+-- CreateIndex
 CREATE INDEX "tenant_litellm_keys_tenant_idx" ON "tenant_litellm_keys"("tenant");
 
 -- CreateIndex
@@ -2504,6 +2533,12 @@ ALTER TABLE "skills" ADD CONSTRAINT "skills_id_current_revision_id_fkey" FOREIGN
 
 -- AddForeignKey
 ALTER TABLE "skill_revisions" ADD CONSTRAINT "skill_revisions_skill_id_fkey" FOREIGN KEY ("skill_id") REFERENCES "skills"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "skill_workloads" ADD CONSTRAINT "skill_workloads_skill_revision_id_fkey" FOREIGN KEY ("skill_revision_id") REFERENCES "skill_revisions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "skill_workloads" ADD CONSTRAINT "skill_workloads_tool_invocation_id_fkey" FOREIGN KEY ("tool_invocation_id") REFERENCES "tool_invocations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "tenant_litellm_keys" ADD CONSTRAINT "tenant_litellm_keys_tenant_fkey" FOREIGN KEY ("tenant") REFERENCES "tenants"("name") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -3867,6 +3902,27 @@ BEGIN
     RETURN NEW;
 END;
 $$;
+CREATE FUNCTION "enforce_skill_workload_authority"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE revision_silo_id TEXT; revision_state "SkillRevisionState"; revision_trust "SkillTrustClass"; invocation_silo_id TEXT; invocation_state "ActionExecutionState";
+BEGIN
+    IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'SkillWorkload rows cannot be deleted'; END IF;
+    IF TG_OP = 'UPDATE' AND (NEW."silo_id" IS DISTINCT FROM OLD."silo_id" OR NEW."kind" IS DISTINCT FROM OLD."kind" OR NEW."skill_revision_id" IS DISTINCT FROM OLD."skill_revision_id" OR NEW."tool_invocation_id" IS DISTINCT FROM OLD."tool_invocation_id") THEN
+        RAISE EXCEPTION 'SkillWorkload source coordinates are immutable';
+    END IF;
+    IF TG_OP = 'UPDATE' AND OLD."state" = 'cancelled' AND (NEW."state" IS DISTINCT FROM OLD."state" OR NEW."cancelled_at" IS DISTINCT FROM OLD."cancelled_at") THEN RAISE EXCEPTION 'cancelled SkillWorkload is terminal'; END IF;
+    IF NOT ((NEW."state" = 'pending' AND NEW."cancelled_at" IS NULL) OR (NEW."state" = 'cancelled' AND NEW."cancelled_at" IS NOT NULL)) THEN RAISE EXCEPTION 'SkillWorkload state requires matching cancellation evidence'; END IF;
+    IF TG_OP = 'INSERT' THEN
+        SELECT skill."silo_id", revision."state", revision."trust_class" INTO revision_silo_id, revision_state, revision_trust FROM "skill_revisions" revision JOIN "skills" skill ON skill."id" = revision."skill_id" WHERE revision."id" = NEW."skill_revision_id" FOR UPDATE OF revision, skill;
+        IF revision_silo_id IS DISTINCT FROM NEW."silo_id" OR revision_trust IS DISTINCT FROM 'sandboxed_python' THEN RAISE EXCEPTION 'SkillWorkload requires same-silo SandboxedPython SkillRevision'; END IF;
+        IF NEW."kind" = 'authoring' AND (NEW."tool_invocation_id" IS NOT NULL OR revision_state IS DISTINCT FROM 'draft') THEN RAISE EXCEPTION 'authoring SkillWorkload requires Draft revision and no ToolInvocation'; END IF;
+        IF NEW."kind" = 'tool_runner' THEN
+            SELECT "silo_id", "state" INTO invocation_silo_id, invocation_state FROM "tool_invocations" WHERE "id" = NEW."tool_invocation_id" FOR UPDATE;
+            IF NEW."tool_invocation_id" IS NULL OR invocation_silo_id IS DISTINCT FROM NEW."silo_id" OR invocation_state IS DISTINCT FROM 'reserved' OR revision_state IS DISTINCT FROM 'published' THEN RAISE EXCEPTION 'tool-runner SkillWorkload requires same-silo Reserved ToolInvocation and Published revision'; END IF;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
 CREATE FUNCTION "enforce_skill_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
     IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'Skill rows cannot be deleted'; END IF;
@@ -4329,6 +4385,7 @@ ALTER TABLE "skill_revisions" ADD CONSTRAINT "skill_revisions_review_check" CHEC
          AND "test_report" @> '{"passed":true}'::jsonb AND "scan_result" @> '{"passed":true}'::jsonb
          AND "signature" IS NOT NULL AND btrim("signature") <> '' AND "signer_key_id" IS NOT NULL AND btrim("signer_key_id") <> '')
     );
+ALTER TABLE "skill_workloads" ADD CONSTRAINT "skill_workloads_identity_check" CHECK (btrim("silo_id") <> '');
 ALTER TABLE "memory_datasets" ADD CONSTRAINT "memory_datasets_identity_check" CHECK (btrim("silo_id") <> '' AND btrim("organization_id") <> '' AND btrim("cognee_dataset_id") <> '' AND btrim("created_by") <> '');
 ALTER TABLE "memory_datasets" ADD CONSTRAINT "memory_datasets_scope_check" CHECK (
         ("scope_kind" = 'organization' AND "scope_resource_id" IS NULL) OR
@@ -4470,6 +4527,7 @@ CREATE TRIGGER "artifact_revision_parents_immutable" BEFORE UPDATE OR DELETE ON 
 CREATE TRIGGER "artifact_revision_parents_same_silo" BEFORE INSERT ON "artifact_revision_parents"
     FOR EACH ROW EXECUTE FUNCTION "enforce_artifact_parent_silo"();
 CREATE TRIGGER "skill_revisions_closed_lifecycle" BEFORE INSERT OR UPDATE OR DELETE ON "skill_revisions" FOR EACH ROW EXECUTE FUNCTION "enforce_skill_revision_lifecycle"();
+CREATE TRIGGER "skill_workloads_authority" BEFORE INSERT OR UPDATE OR DELETE ON "skill_workloads" FOR EACH ROW EXECUTE FUNCTION "enforce_skill_workload_authority"();
 CREATE TRIGGER "skills_closed_lifecycle" BEFORE UPDATE OR DELETE ON "skills" FOR EACH ROW EXECUTE FUNCTION "enforce_skill_lifecycle"();
 CREATE TRIGGER "skills_current_revision_published" BEFORE INSERT OR UPDATE ON "skills" FOR EACH ROW EXECUTE FUNCTION "enforce_current_skill_revision"();
 CREATE CONSTRAINT TRIGGER "current_skill_revisions_remain_published" AFTER UPDATE OF "state" ON "skill_revisions" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION "protect_current_skill_revision"();

--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -3903,9 +3903,10 @@ BEGIN
 END;
 $$;
 CREATE FUNCTION "enforce_skill_workload_authority"() RETURNS trigger LANGUAGE plpgsql AS $$
-DECLARE revision_silo_id TEXT; revision_state "SkillRevisionState"; revision_trust "SkillTrustClass"; invocation_silo_id TEXT; invocation_state "ActionExecutionState";
+DECLARE revision_silo_id TEXT; revision_state "SkillRevisionState"; revision_trust "SkillTrustClass";
 BEGIN
     IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'SkillWorkload rows cannot be deleted'; END IF;
+    IF TG_OP = 'INSERT' AND (NEW."state" <> 'pending' OR NEW."cancelled_at" IS NOT NULL) THEN RAISE EXCEPTION 'SkillWorkload must begin Pending without cancellation evidence'; END IF;
     IF TG_OP = 'UPDATE' AND (NEW."silo_id" IS DISTINCT FROM OLD."silo_id" OR NEW."kind" IS DISTINCT FROM OLD."kind" OR NEW."skill_revision_id" IS DISTINCT FROM OLD."skill_revision_id" OR NEW."tool_invocation_id" IS DISTINCT FROM OLD."tool_invocation_id") THEN
         RAISE EXCEPTION 'SkillWorkload source coordinates are immutable';
     END IF;
@@ -3916,11 +3917,23 @@ BEGIN
         IF revision_silo_id IS DISTINCT FROM NEW."silo_id" OR revision_trust IS DISTINCT FROM 'sandboxed_python' THEN RAISE EXCEPTION 'SkillWorkload requires same-silo SandboxedPython SkillRevision'; END IF;
         IF NEW."kind" = 'authoring' AND (NEW."tool_invocation_id" IS NOT NULL OR revision_state IS DISTINCT FROM 'draft') THEN RAISE EXCEPTION 'authoring SkillWorkload requires Draft revision and no ToolInvocation'; END IF;
         IF NEW."kind" = 'tool_runner' THEN
-            SELECT "silo_id", "state" INTO invocation_silo_id, invocation_state FROM "tool_invocations" WHERE "id" = NEW."tool_invocation_id" FOR UPDATE;
-            IF NEW."tool_invocation_id" IS NULL OR invocation_silo_id IS DISTINCT FROM NEW."silo_id" OR invocation_state IS DISTINCT FROM 'reserved' OR revision_state IS DISTINCT FROM 'published' THEN RAISE EXCEPTION 'tool-runner SkillWorkload requires same-silo Reserved ToolInvocation and Published revision'; END IF;
+            RAISE EXCEPTION 'tool-runner SkillWorkload requires the later snapshot-bound workload admission authority';
         END IF;
     END IF;
     RETURN NEW;
+END;
+$$;
+CREATE FUNCTION "cancel_ineligible_skill_workloads"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_TABLE_NAME = 'skill_revisions' AND NEW."state" <> OLD."state" THEN
+        UPDATE "skill_workloads" SET "state"='cancelled', "cancelled_at"=clock_timestamp()
+          WHERE "state"='pending' AND "skill_revision_id"=NEW."id"
+            AND (("kind"='authoring' AND NEW."state" <> 'draft') OR ("kind"='tool_runner' AND NEW."state" <> 'published'));
+    ELSIF TG_TABLE_NAME = 'tool_invocations' AND NEW."state" <> OLD."state" AND NEW."state" <> 'reserved' THEN
+        UPDATE "skill_workloads" SET "state"='cancelled', "cancelled_at"=clock_timestamp()
+          WHERE "state"='pending' AND "kind"='tool_runner' AND "tool_invocation_id"=NEW."id";
+    END IF;
+    RETURN NULL;
 END;
 $$;
 CREATE FUNCTION "enforce_skill_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
@@ -4528,6 +4541,8 @@ CREATE TRIGGER "artifact_revision_parents_same_silo" BEFORE INSERT ON "artifact_
     FOR EACH ROW EXECUTE FUNCTION "enforce_artifact_parent_silo"();
 CREATE TRIGGER "skill_revisions_closed_lifecycle" BEFORE INSERT OR UPDATE OR DELETE ON "skill_revisions" FOR EACH ROW EXECUTE FUNCTION "enforce_skill_revision_lifecycle"();
 CREATE TRIGGER "skill_workloads_authority" BEFORE INSERT OR UPDATE OR DELETE ON "skill_workloads" FOR EACH ROW EXECUTE FUNCTION "enforce_skill_workload_authority"();
+CREATE TRIGGER "cancel_ineligible_skill_workloads_on_revision" AFTER UPDATE OF "state" ON "skill_revisions" FOR EACH ROW EXECUTE FUNCTION "cancel_ineligible_skill_workloads"();
+CREATE TRIGGER "cancel_ineligible_skill_workloads_on_invocation" AFTER UPDATE OF "state" ON "tool_invocations" FOR EACH ROW EXECUTE FUNCTION "cancel_ineligible_skill_workloads"();
 CREATE TRIGGER "skills_closed_lifecycle" BEFORE UPDATE OR DELETE ON "skills" FOR EACH ROW EXECUTE FUNCTION "enforce_skill_lifecycle"();
 CREATE TRIGGER "skills_current_revision_published" BEFORE INSERT OR UPDATE ON "skills" FOR EACH ROW EXECUTE FUNCTION "enforce_current_skill_revision"();
 CREATE CONSTRAINT TRIGGER "current_skill_revisions_remain_published" AFTER UPDATE OF "state" ON "skill_revisions" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION "protect_current_skill_revision"();

--- a/apps/opencrane/prisma/schema/authorization.prisma
+++ b/apps/opencrane/prisma/schema/authorization.prisma
@@ -153,6 +153,7 @@ model ToolInvocation {
   completedAt        DateTime?            @map("completed_at")
   run                AgentRun             @relation(fields: [runId, agentServiceId, agentRevisionId], references: [id, agentServiceId, agentRevisionId], onDelete: Restrict)
   approvalRequests   ApprovalRequest[]
+  skillWorkload      SkillWorkload?
 
   @@unique([runId, attempt, toolInvocationId])
   @@index([runId, attempt, state])

--- a/apps/opencrane/prisma/schema/skills.prisma
+++ b/apps/opencrane/prisma/schema/skills.prisma
@@ -16,6 +16,18 @@ enum SkillTrustClass {
   SandboxedPython      @map("sandboxed_python")
 }
 
+/// Isolated Job class selected by the durable skill-work authority.
+enum SkillWorkloadKind {
+  Authoring  @map("authoring")
+  ToolRunner @map("tool_runner")
+}
+
+/// Durable disposition before controller assignment and worker reply are introduced.
+enum SkillWorkloadState {
+  Pending   @map("pending")
+  Cancelled @map("cancelled")
+}
+
 model Skill {
   id                String       @id @default(cuid())
   siloId            String       @map("silo_id")
@@ -57,6 +69,7 @@ model SkillRevision {
   revokedAt              DateTime?          @map("revoked_at")
   skill                  Skill              @relation("SkillRevisions", fields: [skillId], references: [id], onDelete: Restrict)
   currentFor             Skill[]            @relation("CurrentSkillRevision")
+  workloads              SkillWorkload[]
 
   @@unique([skillId, revision])
   @@unique([skillId, id])
@@ -64,4 +77,21 @@ model SkillRevision {
   @@index([artifactRevisionId])
   @@index([state, trustClass])
   @@map("skill_revisions")
+}
+
+/// One canonical future Job request, never a Kubernetes queue or worker-owned receipt.
+model SkillWorkload {
+  id               String             @id @default(cuid())
+  siloId           String             @map("silo_id")
+  kind             SkillWorkloadKind
+  state            SkillWorkloadState @default(Pending)
+  skillRevisionId  String             @map("skill_revision_id")
+  toolInvocationId String?            @unique @map("tool_invocation_id")
+  createdAt        DateTime           @default(now()) @map("created_at")
+  cancelledAt      DateTime?          @map("cancelled_at")
+  skillRevision    SkillRevision      @relation(fields: [skillRevisionId], references: [id], onDelete: Restrict)
+  toolInvocation   ToolInvocation?    @relation(fields: [toolInvocationId], references: [id], onDelete: Restrict)
+
+  @@index([siloId, state, createdAt])
+  @@map("skill_workloads")
 }

--- a/apps/opencrane/prisma/tests/phase-d-authority-integration.sh
+++ b/apps/opencrane/prisma/tests/phase-d-authority-integration.sh
@@ -27,6 +27,7 @@ fi
 run_psql < "$TEST_FILE"
 run_psql < "$SCRIPT_DIR/run-input-snapshot-admission.sql"
 run_psql < "$SCRIPT_DIR/run-dispatch-terminalization.sql"
+run_psql < "$SCRIPT_DIR/skill-workload-authority.sql"
 
 RACE_DIR="$(mktemp -d)"
 trap 'rm -rf "$RACE_DIR"' EXIT

--- a/apps/opencrane/prisma/tests/skill-workload-authority.sql
+++ b/apps/opencrane/prisma/tests/skill-workload-authority.sql
@@ -19,18 +19,19 @@ INSERT INTO "skills" ("id", "silo_id", "owner_principal_id", "name", "updated_at
 INSERT INTO "skill_revisions" ("id", "skill_id", "revision", "artifact_id", "artifact_revision_id", "artifact_content_address", "manifest", "requirements", "trust_class", "authored_by") VALUES ('work-draft','work-skill',1,'work-artifact','work-artifact-revision','sha256:'||repeat('a',64),'{}','{}','sandboxed_python','user-1');
 
 INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('authoring-work','work-silo','authoring','work-draft');
+SELECT pg_temp.expect_failure('workload must begin pending', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "state", "skill_revision_id", "cancelled_at") VALUES ('authoring-cancelled','work-silo','authoring','cancelled','work-draft',clock_timestamp())$statement$, 'SkillWorkload must begin Pending');
 SELECT pg_temp.expect_failure('one authoring workload per revision', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('authoring-work-duplicate','work-silo','authoring','work-draft')$statement$, 'skill_workloads_one_authoring_per_revision_key');
 SELECT pg_temp.expect_failure('authoring workload has no invocation anchor', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id", "tool_invocation_id") VALUES ('authoring-bad-anchor','work-silo','authoring','work-draft','missing-invocation')$statement$, 'authoring SkillWorkload');
-SELECT pg_temp.expect_failure('runner workload requires invocation anchor', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('runner-no-anchor','work-silo','tool_runner','work-draft')$statement$, 'tool-runner SkillWorkload');
+SELECT pg_temp.expect_failure('runner workload remains unavailable before snapshot-bound admission', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('runner-no-anchor','work-silo','tool_runner','work-draft')$statement$, 'tool-runner SkillWorkload requires the later snapshot-bound workload admission authority');
 SELECT pg_temp.expect_failure('workload source is immutable', $statement$UPDATE "skill_workloads" SET "silo_id"='other-silo' WHERE "id"='authoring-work'$statement$, 'source coordinates are immutable');
-UPDATE "skill_workloads" SET "state"='cancelled', "cancelled_at"=clock_timestamp() WHERE "id"='authoring-work';
-SELECT pg_temp.expect_failure('cancelled workload is terminal', $statement$UPDATE "skill_workloads" SET "state"='pending', "cancelled_at"=NULL WHERE "id"='authoring-work'$statement$, 'cancelled SkillWorkload is terminal');
 SELECT pg_temp.expect_failure('workload evidence cannot be deleted', $statement$DELETE FROM "skill_workloads" WHERE "id"='authoring-work'$statement$, 'SkillWorkload rows cannot be deleted');
 
 UPDATE "skill_revisions" SET "state"='review' WHERE "id"='work-draft';
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM "skill_workloads" WHERE "id"='authoring-work' AND "state"='cancelled' AND "cancelled_at" IS NOT NULL) THEN RAISE EXCEPTION 'FAIL: leaving Draft must cancel pending authoring workload'; END IF; END; $$;
+SELECT pg_temp.expect_failure('cancelled workload is terminal', $statement$UPDATE "skill_workloads" SET "state"='pending', "cancelled_at"=NULL WHERE "id"='authoring-work'$statement$, 'cancelled SkillWorkload is terminal');
 UPDATE "skill_revisions" SET "state"='published', "reviewed_by"='reviewer', "test_report"='{"passed":true}', "scan_result"='{"passed":true}', "signature"='signature', "signer_key_id"='key', "published_at"=clock_timestamp() WHERE "id"='work-draft';
 SELECT pg_temp.expect_failure('authoring requires draft revision', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('authoring-published','work-silo','authoring','work-draft')$statement$, 'authoring SkillWorkload requires Draft');
 UPDATE "skill_revisions" SET "state"='revoked', "revoked_at"=clock_timestamp() WHERE "id"='work-draft';
-DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM "skill_workloads" WHERE "id"='authoring-work') THEN RAISE EXCEPTION 'FAIL: revocation must not invalidate existing workload'; END IF; END; $$;
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM "skill_workloads" WHERE "id"='authoring-work' AND "state"='cancelled') THEN RAISE EXCEPTION 'FAIL: cancelled workload evidence must remain durable'; END IF; END; $$;
 
 ROLLBACK;

--- a/apps/opencrane/prisma/tests/skill-workload-authority.sql
+++ b/apps/opencrane/prisma/tests/skill-workload-authority.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+CREATE FUNCTION pg_temp.expect_failure(test_name TEXT, statement TEXT, expected_message TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
+DECLARE actual_message TEXT;
+BEGIN
+    BEGIN EXECUTE statement;
+    EXCEPTION WHEN OTHERS THEN GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+        IF strpos(actual_message, expected_message) > 0 THEN RAISE NOTICE 'PASS: %', test_name; RETURN; END IF;
+        RAISE EXCEPTION 'FAIL: % returned unexpected error: %', test_name, actual_message;
+    END;
+    RAISE EXCEPTION 'FAIL: % unexpectedly succeeded', test_name;
+END;
+$$;
+
+INSERT INTO "artifacts" ("id", "silo_id", "owner_principal_id", "kind", "updated_at") VALUES ('work-artifact','work-silo','user-1','skill',clock_timestamp());
+INSERT INTO "artifact_revisions" ("id", "artifact_id", "revision", "content_address", "byte_length", "media_type", "provenance", "created_by") VALUES ('work-artifact-revision','work-artifact',1,'sha256:'||repeat('a',64),1,'application/gzip','{}','user-1');
+UPDATE "artifacts" SET "current_revision_id"='work-artifact-revision' WHERE "id"='work-artifact';
+INSERT INTO "skills" ("id", "silo_id", "owner_principal_id", "name", "updated_at") VALUES ('work-skill','work-silo','user-1','work skill',clock_timestamp());
+INSERT INTO "skill_revisions" ("id", "skill_id", "revision", "artifact_id", "artifact_revision_id", "artifact_content_address", "manifest", "requirements", "trust_class", "authored_by") VALUES ('work-draft','work-skill',1,'work-artifact','work-artifact-revision','sha256:'||repeat('a',64),'{}','{}','sandboxed_python','user-1');
+
+INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('authoring-work','work-silo','authoring','work-draft');
+SELECT pg_temp.expect_failure('one authoring workload per revision', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('authoring-work-duplicate','work-silo','authoring','work-draft')$statement$, 'skill_workloads_one_authoring_per_revision_key');
+SELECT pg_temp.expect_failure('authoring workload has no invocation anchor', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id", "tool_invocation_id") VALUES ('authoring-bad-anchor','work-silo','authoring','work-draft','missing-invocation')$statement$, 'authoring SkillWorkload');
+SELECT pg_temp.expect_failure('runner workload requires invocation anchor', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('runner-no-anchor','work-silo','tool_runner','work-draft')$statement$, 'tool-runner SkillWorkload');
+SELECT pg_temp.expect_failure('workload source is immutable', $statement$UPDATE "skill_workloads" SET "silo_id"='other-silo' WHERE "id"='authoring-work'$statement$, 'source coordinates are immutable');
+UPDATE "skill_workloads" SET "state"='cancelled', "cancelled_at"=clock_timestamp() WHERE "id"='authoring-work';
+SELECT pg_temp.expect_failure('cancelled workload is terminal', $statement$UPDATE "skill_workloads" SET "state"='pending', "cancelled_at"=NULL WHERE "id"='authoring-work'$statement$, 'cancelled SkillWorkload is terminal');
+SELECT pg_temp.expect_failure('workload evidence cannot be deleted', $statement$DELETE FROM "skill_workloads" WHERE "id"='authoring-work'$statement$, 'SkillWorkload rows cannot be deleted');
+
+UPDATE "skill_revisions" SET "state"='review' WHERE "id"='work-draft';
+UPDATE "skill_revisions" SET "state"='published', "reviewed_by"='reviewer', "test_report"='{"passed":true}', "scan_result"='{"passed":true}', "signature"='signature', "signer_key_id"='key', "published_at"=clock_timestamp() WHERE "id"='work-draft';
+SELECT pg_temp.expect_failure('authoring requires draft revision', $statement$INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('authoring-published','work-silo','authoring','work-draft')$statement$, 'authoring SkillWorkload requires Draft');
+UPDATE "skill_revisions" SET "state"='revoked', "revoked_at"=clock_timestamp() WHERE "id"='work-draft';
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM "skill_workloads" WHERE "id"='authoring-work') THEN RAISE EXCEPTION 'FAIL: revocation must not invalidate existing workload'; END IF; END; $$;
+
+ROLLBACK;

--- a/libs/backend/server/agents/skills/main/README.md
+++ b/libs/backend/server/agents/skills/main/README.md
@@ -71,8 +71,11 @@ domains directly.
 
 ## Data & persistence
 
-Owns `Skill` and `SkillRevision` in `apps/opencrane/prisma/schema/skills.prisma`. A companion SQL
-authority test lives in `tests/skill-authority.sql`.
+Owns `Skill`, `SkillRevision`, and the authoring-only `SkillWorkload` request in
+`apps/opencrane/prisma/schema/skills.prisma`. A workload is durable evidence, not a Kubernetes
+queue: it begins pending only for a sandboxed draft and is cancelled when that draft becomes
+ineligible. Tool-runner admission stays fail-closed until its snapshot-bound authority exists. A
+companion SQL authority test lives in `tests/skill-authority.sql`.
 
 ## See also
 


### PR DESCRIPTION
## Context

This builds the database authority required before a controller can create or release an isolated Python Job. It deliberately does not add a worker, route, Kubernetes mutation, artifact read, or result reply path yet.

## What changes

- add one durable SkillWorkload record for each candidate-skill authoring request or authorised tool invocation
- bind authoring work to an immutable SandboxedPython draft revision
- bind tool-runner work to an immutable published SandboxedPython revision and one reserved ToolInvocation
- make workload source coordinates immutable, cancellation terminal, and records append-only
- add baseline-integrated PostgreSQL proof coverage

## Why it matters

The next controller must have one database-fenced source of truth before it can create a suspended Job. This prevents a worker or Kubernetes object from becoming the authority for a skill lifecycle or tool receipt.

## Validation

- Prisma schema validation and client generation
- shell syntax and diff checks
- independent review, including fixes for cancellation revival, repeat tool use, deletion, and trigger/index evaluation order
- live PostgreSQL authority suite is retained as CI/cluster validation because this workstation has no configured psql or Docker test container

## Dependency

Depends on #392: the workload planes and suspended deterministic Job builder.