### PR TITLE
✨ Reconcile governed skill workloads safely

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -122,6 +122,7 @@ export default [
             { sourceTag: "scope:agent-runtime-stream", onlyDependOnLibsWithTags: ["scope:agent-runtime-stream", "scope:shared"] },
             { sourceTag: "scope:agent-runtime-launcher", onlyDependOnLibsWithTags: ["scope:agent-runtime-launcher", "scope:shared"] },
             { sourceTag: "scope:skills-launcher", onlyDependOnLibsWithTags: ["scope:skills-launcher", "scope:shared"] },
+            { sourceTag: "scope:skills-controller", onlyDependOnLibsWithTags: ["scope:skills-controller", "scope:skills-launcher", "scope:shared"] },
             { sourceTag: "scope:agent-runtime-controller", onlyDependOnLibsWithTags: ["scope:agent-runtime-controller", "scope:agent-runtime-launcher", "scope:shared"] },
             { sourceTag: "scope:agent-controller", onlyDependOnLibsWithTags: ["scope:agent-controller", "scope:agent-runtime-controller", "scope:shared"] },
             { sourceTag: "scope:cluster-tenants", onlyDependOnLibsWithTags: ["scope:auth", "scope:cluster-tenants", "scope:k8s-api", "scope:shared"] },

--- a/libs/backend/agents/skills/README.md
+++ b/libs/backend/agents/skills/README.md
@@ -4,6 +4,7 @@
 
 | Package | What it owns |
 |---|---|
+| [controller](./controller/README.md) | The outbound reconciliation that turns a fenced workload claim into an exact still-suspended Job. |
 | [execution](./execution/main/README.md) | The controller-only Postgres claim and immutable suspended-Job assignment fence. |
 | [k8s-launcher](./k8s-launcher/README.md) | Pure, policy-validating Kubernetes Job shapes for isolated skill authoring and tool execution. |
 
@@ -14,7 +15,7 @@ talks to a registry, or grants Kubernetes API access to a worker.
 ```
  SkillRevision authority ──► execution fence ──► controller ──► k8s-launcher
                                                    │
-                                                   └──► authoring / tool Job
+                                                   └──► suspended authoring / tool Job
 ```
 
 ## See also

--- a/libs/backend/agents/skills/controller/README.md
+++ b/libs/backend/agents/skills/controller/README.md
@@ -1,0 +1,46 @@
+# @opencrane/backend/agents/skills/controller — governed skill Job reconciliation
+
+> [backend](../../../../README.md) › [agents](../../../README.md) › [skills](../README.md) › controller
+
+## What it owns
+
+This package is the outbound reconciliation step between the durable skill-work authority and
+Kubernetes. A **reconciler** repeatedly makes an external system match a durable desired state. It
+claims one authorised workload, builds a hardened but still-suspended Job from its fixed class
+profile, and commits only the Kubernetes-issued Job UID back to OpenCrane.
+
+```
+ Postgres workload claim ──► controller ◄── HERE ──► suspended Job
+          │                         │                   │
+          └──── database fence ◄────┴──── immutable UID ┘
+```
+
+**In this flow:** [execution authority](../execution/main/README.md) ·
+[Job builder](../k8s-launcher/README.md).
+
+The Job stays suspended after this package finishes. That is the safety boundary between a database
+transaction and a Kubernetes create: a crash can leave an inert Job to exact-adopt later, but cannot
+leave unrecorded Python code running.
+
+## Public surface
+
+- `__ReconcileNextSkillWorkload` — handles at most one fenced claim and suspended Job assignment.
+- `__RunSkillWorkloadController` — polls until process shutdown while isolating one failed claim.
+- `__ValidateSkillWorkloadControllerProfiles` — validates the two deployment-owned job-class profiles.
+
+## Boundary
+
+This package accepts ports for OpenCrane and Kubernetes; it does not use Prisma, issue a capability,
+release a Job, read artifact bytes, or run a worker. A later worker protocol must exchange the
+non-secret Job reference through a separately authenticated boundary before any code can run.
+
+## Dependency direction
+
+Tagged `scope:skills-controller` and `layer:infra`, it may depend only on the pure skill Job builder
+and shared contracts. The deployable agent-controller app composes its HTTP and Kubernetes adapters.
+
+## See also
+
+- Parent group: [skills](../README.md)
+- Durable authority: [execution](../execution/main/README.md)
+- Manifest policy: [k8s launcher](../k8s-launcher/README.md)

--- a/libs/backend/agents/skills/controller/project.json
+++ b/libs/backend/agents/skills/controller/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend-agents-skills-controller",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/agents/skills/controller/src",
+  "tags": ["type:lib", "layer:infra", "scope:skills-controller"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/agents/skills/controller" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/agents/skills/controller" } }
+  }
+}

--- a/libs/backend/agents/skills/controller/src/__tests__/skill-workload-controller.test.ts
+++ b/libs/backend/agents/skills/controller/src/__tests__/skill-workload-controller.test.ts
@@ -1,0 +1,97 @@
+import type { V1Job } from "@kubernetes/client-node";
+import { type Logger } from "@opencrane/observability";
+import { describe, expect, it } from "vitest";
+
+import { __ReconcileNextSkillWorkload, __RunSkillWorkloadController, __ValidateSkillWorkloadControllerProfiles } from "../skill-workload-controller.js";
+import type { SkillWorkloadControllerAuthority, SkillWorkloadControllerKubernetesStore, SkillWorkloadControllerOptions } from "../skill-workload-controller.types.js";
+
+/** Silent structured logger used by focused reconciliation tests. */
+const _Log = { info: function _Info() {}, error: function _Error() {} } as unknown as Logger;
+
+/** Return the two fixed workload-class profiles required by the controller. */
+function _Profiles()
+{
+	return {
+		authoring: { kind: "authoring" as const, image: `ghcr.io/opencrane/skill-authoring@sha256:${"a".repeat(64)}`, imagePullPolicy: "IfNotPresent" as const, serverNamespace: "opencrane", namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", capabilityTokenAudience: "opencrane-skill-authoring", scratchSize: "64Mi", activeDeadlineSeconds: 300, ttlSecondsAfterFinished: 0, resources: { requests: { cpu: "100m", memory: "128Mi" }, limits: { cpu: "500m", memory: "256Mi" } } },
+		"tool-runner": { kind: "tool-runner" as const, image: `ghcr.io/opencrane/tool-runner@sha256:${"b".repeat(64)}`, imagePullPolicy: "IfNotPresent" as const, serverNamespace: "opencrane", namespace: "opencrane-tools", serviceAccountName: "tool-runner-default", capabilityTokenAudience: "opencrane-tool-runner", scratchSize: "64Mi", activeDeadlineSeconds: 300, ttlSecondsAfterFinished: 0, resources: { requests: { cpu: "100m", memory: "128Mi" }, limits: { cpu: "500m", memory: "256Mi" } } },
+	};
+}
+
+/** Return one database-fenced authoring workload claim. */
+function _Claim()
+{
+	return { workloadId: "workload_1", siloId: "silo-a", kind: "authoring" as const, skillRevisionId: "revision-1", claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 2, expiresAt: "2026-07-24T00:00:30.000Z" };
+}
+
+/** Compose an authority with fail-fast defaults for operations a test does not use. */
+function _Authority(overrides: Partial<SkillWorkloadControllerAuthority>): SkillWorkloadControllerAuthority
+{
+	return { async __Claim() { return null; }, async __CommitAssignment() { throw new Error("unexpected assignment commit"); }, ...overrides };
+}
+
+/** Compose a Kubernetes port with a fail-fast default. */
+function _Kubernetes(overrides: Partial<SkillWorkloadControllerKubernetesStore>): SkillWorkloadControllerKubernetesStore
+{
+	return { async __EnsureSuspendedJob() { throw new Error("unexpected Job"); }, ...overrides };
+}
+
+/** Compose reconciler options from focused fake ports. */
+function _Options(authority: SkillWorkloadControllerAuthority, kubernetes: SkillWorkloadControllerKubernetesStore): SkillWorkloadControllerOptions
+{
+	return { authority, kubernetes, profiles: _Profiles(), pollIntervalMilliseconds: 1_000, log: _Log };
+}
+
+describe("governed skill workload controller", function _DescribeController()
+{
+	it("creates a suspended Job and commits only its API-issued UID for the exact claim generation", async function _AssignsSuspendedJob()
+	{
+		const calls: string[] = [];
+		let committed: unknown = null;
+		let expected: V1Job | null = null;
+		const authority = _Authority({ async __Claim() { calls.push("claim"); return _Claim(); }, async __CommitAssignment(_workloadId, command) { calls.push("commit"); committed = command; return "assigned"; } });
+		const kubernetes = _Kubernetes({ async __EnsureSuspendedJob(job) { calls.push("job"); expected = job; return { ...job, metadata: { ...job.metadata, uid: "job-uid-1" } }; } });
+
+		const result = await __ReconcileNextSkillWorkload(_Options(authority, kubernetes), new AbortController().signal);
+
+		const built = expected as unknown as V1Job;
+		expect(calls).toEqual(["claim", "job", "commit"]);
+		expect(built.spec?.suspend).toBe(true);
+		expect(built.metadata?.namespace).toBe("opencrane-skill-authoring");
+		expect(built.metadata?.annotations?.["opencrane.ai/capability-reference"]).toBe("skill-workload-v1:workload_1");
+		expect(committed).toEqual({ claimedAt: _Claim().claimedAt, deliveryCount: 2, workloadUid: "job-uid-1" });
+		expect(result).toEqual({ outcome: "assigned", workloadId: "workload_1", workloadUid: "job-uid-1" });
+	});
+
+	it("does no Kubernetes work when no fenced workload is ready", async function _IsIdle()
+	{
+		let jobs = 0;
+		const kubernetes = _Kubernetes({ async __EnsureSuspendedJob() { jobs += 1; throw new Error("unexpected Job"); } });
+
+		expect(await __ReconcileNextSkillWorkload(_Options(_Authority({}), kubernetes), new AbortController().signal)).toEqual({ outcome: "idle" });
+		expect(jobs).toBe(0);
+	});
+
+	it("fails closed without committing when Kubernetes does not issue an immutable UID", async function _RequiresUid()
+	{
+		let commits = 0;
+		const authority = _Authority({ async __Claim() { return _Claim(); }, async __CommitAssignment() { commits += 1; return "assigned"; } });
+		const kubernetes = _Kubernetes({ async __EnsureSuspendedJob(job) { return job; } });
+
+		await expect(__ReconcileNextSkillWorkload(_Options(authority, kubernetes), new AbortController().signal)).rejects.toThrow(/immutable UID/);
+		expect(commits).toBe(0);
+	});
+
+	it("rejects incomplete or class-mismatched deployment profiles before polling", function _RejectsProfiles()
+	{
+		expect(function _MissingRunner() { __ValidateSkillWorkloadControllerProfiles({ authoring: _Profiles().authoring }); }).toThrow(/exactly authoring and tool-runner/);
+		expect(function _WrongKind() { __ValidateSkillWorkloadControllerProfiles({ ..._Profiles(), authoring: { ..._Profiles().authoring, kind: "tool-runner" } }); }).toThrow(/wrong workload class/);
+	});
+
+	it("stops an idle poll promptly when shutdown interrupts its pending wait", async function _StopsIdlePollOnAbort()
+	{
+		const controller = new AbortController();
+		const authority = _Authority({ async __Claim() { setTimeout(function _AbortIdlePoll() { controller.abort(); }, 0); return null; } });
+
+		await expect(__RunSkillWorkloadController({ ..._Options(authority, _Kubernetes({})), pollIntervalMilliseconds: 60_000 }, controller.signal)).resolves.toBeUndefined();
+	});
+});

--- a/libs/backend/agents/skills/controller/src/index.ts
+++ b/libs/backend/agents/skills/controller/src/index.ts
@@ -1,0 +1,2 @@
+export { __ReconcileNextSkillWorkload, __RunSkillWorkloadController, __ValidateSkillWorkloadControllerProfiles } from "./skill-workload-controller.js";
+export type { SkillWorkloadControllerAuthority, SkillWorkloadControllerKubernetesStore, SkillWorkloadControllerOptions, SkillWorkloadControllerProfiles, SkillWorkloadControllerReconcileResult } from "./skill-workload-controller.types.js";

--- a/libs/backend/agents/skills/controller/src/skill-workload-controller.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-controller.ts
@@ -1,0 +1,119 @@
+import { __BuildGovernedSkillWorkloadJob, type SkillWorkloadJobProfile } from "@opencrane/backend/agents/skills/k8s-launcher";
+import { ___DoWithTrace } from "@opencrane/observability";
+
+import type { SkillWorkloadControllerOptions, SkillWorkloadControllerProfiles, SkillWorkloadControllerReconcileResult } from "./skill-workload-controller.types.js";
+
+/** Require the immutable Kubernetes UID returned by the API rather than a derived identifier. */
+function _RequireWorkloadUid(uid: string | undefined): string
+{
+	if (!uid || uid.trim().length === 0)
+	{
+		throw new Error("Kubernetes did not return an immutable UID for the suspended governed skill Job");
+	}
+	return uid;
+}
+
+/** Derive a stable non-secret reference that a future worker exchange can bind to its Job identity. */
+function _CapabilityReference(workloadId: string): string
+{
+	if (!/^[a-zA-Z0-9_-]{1,128}$/.test(workloadId))
+	{
+		throw new Error("governed skill workload id is not safe to project into a capability reference");
+	}
+	return `skill-workload-v1:${workloadId}`;
+}
+
+/** Validate both fixed deployment profiles through the canonical hardened Job builder. */
+export function __ValidateSkillWorkloadControllerProfiles(value: unknown): SkillWorkloadControllerProfiles
+{
+	if (typeof value !== "object" || value === null || Array.isArray(value))
+	{
+		throw new Error("skill workload controller profiles must be one object");
+	}
+	const candidate = value as Partial<Record<"authoring" | "tool-runner", unknown>>;
+	if (!("authoring" in candidate) || !("tool-runner" in candidate) || Object.keys(candidate).length !== 2)
+	{
+		throw new Error("skill workload controller requires exactly authoring and tool-runner profiles");
+	}
+	const profiles: Record<"authoring" | "tool-runner", SkillWorkloadJobProfile> = {} as Record<"authoring" | "tool-runner", SkillWorkloadJobProfile>;
+	for (const kind of ["authoring", "tool-runner"] as const)
+	{
+		const profile = structuredClone(candidate[kind]) as SkillWorkloadJobProfile;
+		if (profile.kind !== kind)
+		{
+			throw new Error(`skill workload controller ${kind} profile has the wrong workload class`);
+		}
+		__BuildGovernedSkillWorkloadJob({ jobId: "profile-validation", siloId: "profile-validation", namespace: profile.namespace, capabilityReference: "skill-workload-v1:profile-validation" }, profile);
+		profiles[kind] = profile;
+	}
+	return profiles;
+}
+
+/** Reconcile at most one database-fenced governed skill workload into a durable suspended Job. */
+export async function __ReconcileNextSkillWorkload(options: SkillWorkloadControllerOptions, signal: AbortSignal): Promise<SkillWorkloadControllerReconcileResult>
+{
+	return ___DoWithTrace("agent_controller.skill_workload.reconcile", {}, async function _ReconcileSkillWorkload(): Promise<SkillWorkloadControllerReconcileResult>
+	{
+		// 1. Read only the server-owned desired state; Kubernetes never decides which work may run.
+		const claim = await options.authority.__Claim(signal);
+		if (claim === null) return { outcome: "idle" };
+
+		// 2. Rebuild the exact hardened suspended Job from a fixed class profile and opaque reference.
+		const profile = options.profiles[claim.kind];
+		const job = __BuildGovernedSkillWorkloadJob({ jobId: claim.workloadId, siloId: claim.siloId, namespace: profile.namespace, capabilityReference: _CapabilityReference(claim.workloadId) }, profile);
+
+		// 3. Create or exact-adopt the inert Job and accept only the API-issued immutable UID.
+		const persistedJob = await options.kubernetes.__EnsureSuspendedJob(job);
+		const workloadUid = _RequireWorkloadUid(persistedJob.metadata?.uid);
+
+		// 4. Commit the same database claim generation; a stale replica can never assign this Job.
+		const outcome = await options.authority.__CommitAssignment(claim.workloadId, { claimedAt: claim.claimedAt, deliveryCount: claim.deliveryCount, workloadUid }, signal);
+		if (outcome === "conflict")
+		{
+			throw new Error("governed skill workload assignment lost its database claim fence");
+		}
+		options.log.info({ workloadId: claim.workloadId, workloadUid, outcome }, "governed skill workload assigned to suspended Job");
+		return { outcome, workloadId: claim.workloadId, workloadUid };
+	});
+}
+
+/** Poll the skill authority until shutdown, isolating failures without replacing Kubernetes objects. */
+export async function __RunSkillWorkloadController(options: SkillWorkloadControllerOptions, signal: AbortSignal): Promise<void>
+{
+	if (!Number.isSafeInteger(options.pollIntervalMilliseconds) || options.pollIntervalMilliseconds < 100 || options.pollIntervalMilliseconds > 60_000)
+	{
+		throw new Error("skill workload controller poll interval must be between 100 and 60000ms");
+	}
+	while (!signal.aborted)
+	{
+		try
+		{
+			const result = await __ReconcileNextSkillWorkload(options, signal);
+			if (result.outcome !== "idle") continue;
+		}
+		catch (err)
+		{
+			if (signal.aborted) break;
+			options.log.error({ err }, "governed skill workload reconciliation failed");
+		}
+		await _Wait(options.pollIntervalMilliseconds, signal);
+	}
+}
+
+/** Wait for one poll interval without delaying shutdown behind a timer. */
+async function _Wait(milliseconds: number, signal: AbortSignal): Promise<void>
+{
+	if (signal.aborted) return;
+	await new Promise<void>(function _WaitForPoll(resolve)
+	{
+		/** Complete one delay and release the listener retained by the controller signal. */
+		function _CompleteWait(): void
+		{
+			clearTimeout(timer);
+			signal.removeEventListener("abort", _CompleteWait);
+			resolve();
+		}
+		const timer = setTimeout(_CompleteWait, milliseconds);
+		signal.addEventListener("abort", _CompleteWait, { once: true });
+	});
+}

--- a/libs/backend/agents/skills/controller/src/skill-workload-controller.types.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-controller.types.ts
@@ -1,0 +1,44 @@
+import type { V1Job } from "@kubernetes/client-node";
+
+import type { AgentControllerSkillWorkloadAssignmentCommand, AgentControllerSkillWorkloadClaim } from "@opencrane/contracts";
+import type { SkillWorkloadJobProfile } from "@opencrane/backend/agents/skills/k8s-launcher";
+import type { Logger } from "@opencrane/observability";
+
+/** Immutable profile map keyed by the one permitted governed skill workload class. */
+export type SkillWorkloadControllerProfiles = Readonly<Record<AgentControllerSkillWorkloadClaim["kind"], SkillWorkloadJobProfile>>;
+
+/** OpenCrane operations available to the outbound-only governed-skill controller. */
+export interface SkillWorkloadControllerAuthority
+{
+	/** Claim one database-fenced pending workload, or return null when no work is ready. */
+	__Claim(signal: AbortSignal): Promise<AgentControllerSkillWorkloadClaim | null>;
+	/** Atomically bind the exact Kubernetes Job UID to the claimed workload generation. */
+	__CommitAssignment(workloadId: string, command: AgentControllerSkillWorkloadAssignmentCommand, signal: AbortSignal): Promise<"assigned" | "idempotent" | "conflict">;
+}
+
+/** Kubernetes operation permitted to the skill controller reconciliation. */
+export interface SkillWorkloadControllerKubernetesStore
+{
+	/** Create or exact-adopt one deterministic still-suspended governed skill Job. */
+	__EnsureSuspendedJob(expected: V1Job): Promise<V1Job>;
+}
+
+/** Fixed policy and adapters for one governed skill workload reconciliation. */
+export interface SkillWorkloadControllerOptions
+{
+	/** Authenticated desired-state and assignment authority. */
+	readonly authority: SkillWorkloadControllerAuthority;
+	/** Least-privilege Kubernetes creation and exact-adoption adapter. */
+	readonly kubernetes: SkillWorkloadControllerKubernetesStore;
+	/** Deployment-owned profiles for the only two governed workload classes. */
+	readonly profiles: SkillWorkloadControllerProfiles;
+	/** Delay after an idle poll or a handled reconciliation failure. */
+	readonly pollIntervalMilliseconds: number;
+	/** Process-wide structured logger. */
+	readonly log: Logger;
+}
+
+/** Result of one controller desired-state poll. */
+export type SkillWorkloadControllerReconcileResult =
+	| { readonly outcome: "idle" }
+	| { readonly outcome: "assigned" | "idempotent"; readonly workloadId: string; readonly workloadUid: string };

--- a/libs/backend/agents/skills/controller/tsconfig.json
+++ b/libs/backend/agents/skills/controller/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc/libs/backend/agents/skills/controller",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/libs/backend/agents/skills/controller/vitest.config.ts
+++ b/libs/backend/agents/skills/controller/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../vitest.cache.js";
+
+/** Vitest configuration for governed skill workload reconciliation. */
+export default defineConfig({
+	cacheDir: _PackageCacheDir(import.meta.url),
+	plugins: [tsconfigPaths({ projects: ["../../../../../tsconfig.vitest.json"] })],
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -172,6 +172,9 @@
       "@opencrane/backend/agents/skills/execution": [
         "./libs/backend/agents/skills/execution/main/src/index.ts"
       ],
+      "@opencrane/backend/agents/skills/controller": [
+        "./libs/backend/agents/skills/controller/src/index.ts"
+      ],
       "@opencrane/backend/agents/runtime/controller": [
         "./libs/backend/agents/runtime/controller/src/index.ts"
       ],


### PR DESCRIPTION
## What this changes

This PR adds the controller-side reconciliation step for governed skill workloads. It turns one database-fenced claim into one deterministic, still-suspended Kubernetes Job, then stores only Kubernetes’ immutable Job UID against that exact claim generation.

The controller never decides what is allowed to run: OpenCrane/Postgres picks the workload first, deployment-owned profiles fix the permitted authoring and tool-runner shapes, and the hardened Job builder rejects anything outside those profiles. A conflict after Job creation fails closed; the Job is kept suspended and can be exactly adopted on a later retry rather than accidentally running unrecorded work.

## Validation

- `backend-agents-skills-controller`: 5 focused tests and TypeScript lint passed.
- Boundary lint, TypeScript style check (0 errors/warnings), and whitespace diff check passed.
- Independent review found no correctness or security defect; it requested a shutdown regression test, which now proves an abort interrupts the 60-second idle wait.

## Review

- The concrete Kubernetes exact-adoption adapter is intentionally the next slice; this PR only defines the port and proves the reconciler fails closed without an API-issued UID.
- Restacked onto #395 (`feat/skill-workload-controller`).