### PR TITLE
🔒 Wire the governed skill workload controller

### DIFF
--- a/apps/_infra/deploy-k8s/values.yaml
+++ b/apps/_infra/deploy-k8s/values.yaml
@@ -395,6 +395,27 @@ agentController:
       limits:
         cpu: 1000m
         memory: 1Gi
+  skillWorkloadProfiles:
+    authoring:
+      image:
+        repository: ghcr.io/italanta/opencrane-skill-authoring
+        digest: ""
+        pullPolicy: IfNotPresent
+      scratchSize: 64Mi
+      activeDeadlineSeconds: 300
+      resources:
+        requests: { cpu: 100m, memory: 128Mi }
+        limits: { cpu: 500m, memory: 256Mi }
+    toolRunner:
+      image:
+        repository: ghcr.io/italanta/opencrane-tool-runner
+        digest: ""
+        pullPolicy: IfNotPresent
+      scratchSize: 64Mi
+      activeDeadlineSeconds: 300
+      resources:
+        requests: { cpu: 100m, memory: 128Mi }
+        limits: { cpu: 500m, memory: 256Mi }
   resources:
     requests:
       cpu: 25m

--- a/apps/agent-controller/README.md
+++ b/apps/agent-controller/README.md
@@ -11,6 +11,13 @@ and reports the
 Job's Kubernetes-issued identity back to OpenCrane. A separate durable claim then lets it release
 that exact Job and register the unique first Pod.
 
+The same process also projects governed skill workloads into the authoring and tool-runner
+namespaces. Those Jobs are always created suspended and their UID is committed to the durable skill
+record. This app has only `get/create` Job access there: it cannot patch, release, inspect Pods, or
+write Secrets in either skill namespace. A separate fail-closed admission policy permits that
+create verb only for the pinned, class-specific suspended worker shape, so the controller cannot use
+its Job permission to create arbitrary work.
+
 Keeping this work in a separate, narrowly privileged process prevents the API server and the runtime
 itself from becoming general Kubernetes workload launchers. OpenCrane decides *what* may run; this app
 only projects that decision into the one restricted runtime namespace named by its RoleBinding.
@@ -42,7 +49,8 @@ multiple Pods, and OpenCrane registers the first Pod before bootstrap exchange c
 ## Public surface
 
 `Entrypoint:` `src/index.ts` loads telemetry first, validates configuration, creates the narrow
-OpenCrane and Kubernetes adapters, runs the assignment and release poll loop, and flushes telemetry
+OpenCrane and Kubernetes adapters, runs the runtime assignment/release and suspended-skill-assignment
+poll loops, and flushes telemetry
 on `SIGTERM`/`SIGINT`.
 
 ## Boundary
@@ -76,6 +84,8 @@ outside the app root.
   OpenCrane and Kubernetes request; default 10 seconds. Process shutdown cancels either request type
   immediately, and each retry receives a fresh deadline.
 - `AGENT_CONTROLLER_PROFILES_JSON` — bounded immutable runtime profiles keyed by authority-owned name.
+- `AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON` — exactly one immutable authoring and tool-runner
+  profile, each using a class-bound ServiceAccount and projected-token audience.
 
 The image runs as an unprivileged numeric user with a read-only root filesystem. Helm provides two
 separate projected tokens: one for OpenCrane and one for the Kubernetes API. Structured logs go to

--- a/apps/agent-controller/helm/templates/_resources.tpl
+++ b/apps/agent-controller/helm/templates/_resources.tpl
@@ -38,6 +38,12 @@
 {{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.agentController.runtimeProfile.image.digest) }}
 {{- fail "agentController.enabled=true requires an immutable sha256 agentController.runtimeProfile.image.digest" }}
 {{- end }}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.agentController.skillWorkloadProfiles.authoring.image.digest) }}
+{{- fail "agentController.enabled=true requires an immutable sha256 authoring worker image digest" }}
+{{- end }}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.agentController.skillWorkloadProfiles.toolRunner.image.digest) }}
+{{- fail "agentController.enabled=true requires an immutable sha256 tool-runner worker image digest" }}
+{{- end }}
 {{- $controllerName := "agent-controller" -}}
 {{- $runtimeNamespace := include "opencrane.agentController.runtimeNamespace" . -}}
 {{- $runtimeNamespaceLabel := include "opencrane.agentController.runtimeNamespaceLabelValue" . -}}
@@ -49,8 +55,16 @@
 {{- $runtimeStreamUrl := default (printf "%s/api/internal/agent-runtime" $openCraneInternalUrl) .Values.agentController.runtimeProfile.runtimeStreamUrl -}}
 {{- $runtimeLiteLlmUrl := printf "http://%s-litellm.%s.svc.cluster.local:%v" (include "opencrane.fullname" .) .Release.Namespace .Values.litellm.service.port -}}
 {{- $runtimeImage := printf "%s@%s" .Values.agentController.runtimeProfile.image.repository .Values.agentController.runtimeProfile.image.digest -}}
+{{- $authoringImage := printf "%s@%s" .Values.agentController.skillWorkloadProfiles.authoring.image.repository .Values.agentController.skillWorkloadProfiles.authoring.image.digest -}}
+{{- $toolRunnerImage := printf "%s@%s" .Values.agentController.skillWorkloadProfiles.toolRunner.image.repository .Values.agentController.skillWorkloadProfiles.toolRunner.image.digest -}}
+{{- $authoringNamespace := (index .Values "opencrane-skill-authoring").skillAuthoring.namespace -}}
+{{- $toolRunnerNamespace := (index .Values "opencrane-tool-runner").toolRunner.namespace -}}
+{{- if or (eq $authoringNamespace .Release.Namespace) (eq $toolRunnerNamespace .Release.Namespace) (eq $authoringNamespace $toolRunnerNamespace) }}
+{{- fail "governed skill workload namespaces must be distinct from the server and from each other" }}
+{{- end }}
 {{- $controllerImage := printf "%s@%s" .Values.agentController.image.repository .Values.agentController.image.digest -}}
 {{- $controllerUsername := printf "system:serviceaccount:%s:%s" .Release.Namespace $controllerName -}}
+{{- $skillAdmissionName := printf "%s-skill-workloads" (include "opencrane.agentController.admissionName" .) -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -144,6 +158,41 @@ roleRef:
   kind: Role
   name: {{ $controllerName }}
 ---
+{{- range $namespace := (list $authoringNamespace $toolRunnerNamespace) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $controllerName }}-skill-workloads
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "opencrane.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: agent-controller
+rules:
+  # A governed skill Job is created or exact-adopted while suspended. No patch, Pod, Secret, or
+  # delete permission exists in these namespaces, so this controller cannot release or alter work.
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $controllerName }}-skill-workloads
+  namespace: {{ $namespace }}
+  labels:
+    {{- include "opencrane.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: agent-controller
+subjects:
+  - kind: ServiceAccount
+    name: {{ $controllerName }}
+    namespace: {{ $.Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $controllerName }}-skill-workloads
+---
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -197,6 +246,8 @@ spec:
               value: {{ .Values.agentController.outboxPruneIntervalMs | quote }}
             - name: AGENT_CONTROLLER_PROFILES_JSON
               value: {{ dict .Values.agentController.runtimeProfile.name (dict "image" $runtimeImage "imagePullPolicy" .Values.agentController.runtimeProfile.image.pullPolicy "runtimeStreamUrl" $runtimeStreamUrl "litellmBaseUrl" $runtimeLiteLlmUrl "serverNamespace" .Release.Namespace "serviceAccountName" $runtimeServiceAccount "projectedTokenTtlSeconds" .Values.agentController.runtimeProfile.projectedTokenTtlSeconds "scratchSize" .Values.agentController.runtimeProfile.scratchSize "activeDeadlineSeconds" .Values.agentController.runtimeProfile.activeDeadlineSeconds "ttlSecondsAfterFinished" .Values.agentController.runtimeProfile.ttlSecondsAfterFinished "resources" .Values.agentController.runtimeProfile.resources) | toJson | quote }}
+            - name: AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON
+              value: {{ dict "authoring" (dict "kind" "authoring" "image" $authoringImage "imagePullPolicy" .Values.agentController.skillWorkloadProfiles.authoring.image.pullPolicy "serverNamespace" .Release.Namespace "namespace" $authoringNamespace "serviceAccountName" "skill-authoring-default" "capabilityTokenAudience" "opencrane-skill-authoring" "scratchSize" .Values.agentController.skillWorkloadProfiles.authoring.scratchSize "activeDeadlineSeconds" .Values.agentController.skillWorkloadProfiles.authoring.activeDeadlineSeconds "ttlSecondsAfterFinished" 0 "resources" .Values.agentController.skillWorkloadProfiles.authoring.resources) "tool-runner" (dict "kind" "tool-runner" "image" $toolRunnerImage "imagePullPolicy" .Values.agentController.skillWorkloadProfiles.toolRunner.image.pullPolicy "serverNamespace" .Release.Namespace "namespace" $toolRunnerNamespace "serviceAccountName" "tool-runner-default" "capabilityTokenAudience" "opencrane-tool-runner" "scratchSize" .Values.agentController.skillWorkloadProfiles.toolRunner.scratchSize "activeDeadlineSeconds" .Values.agentController.skillWorkloadProfiles.toolRunner.activeDeadlineSeconds "ttlSecondsAfterFinished" 0 "resources" .Values.agentController.skillWorkloadProfiles.toolRunner.resources) | toJson | quote }}
             {{- include "opencrane.observabilityEnv" (dict "ctx" $ "component" "agent-controller") | nindent 12 }}
           volumeMounts:
             - name: opencrane-token
@@ -374,6 +425,154 @@ spec:
           port: 53
         - protocol: TCP
           port: 53
+---
+# The skill controller has Job create/get in these two namespaces only. Admission makes that generic
+# Kubernetes verb safe: it can create only the exact suspended worker envelopes produced by the
+# governed-skill builder, never arbitrary or immediately executable Jobs.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $skillAdmissionName }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: governed-skill-workloads
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    matchPolicy: Exact
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["jobs"]
+        scope: "Namespaced"
+    namespaceSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/component
+          operator: In
+          values: ["skill-authoring", "tool-runner"]
+  validations:
+    - expression: >-
+        request.userInfo.username == {{ $controllerUsername | toJson }}
+      message: only this release's controller ServiceAccount may create governed skill Jobs
+    - expression: >-
+        ((object.metadata.namespace == {{ $authoringNamespace | toJson }} &&
+          object.metadata.name.matches('^skill-author-[a-f0-9]{24}$') &&
+          object.metadata.labels.size() == 3 &&
+          object.metadata.labels['app.kubernetes.io/name'] == 'opencrane-skill-authoring' &&
+          object.metadata.labels['app.kubernetes.io/component'] == 'skill-authoring') ||
+         (object.metadata.namespace == {{ $toolRunnerNamespace | toJson }} &&
+          object.metadata.name.matches('^tool-run-[a-f0-9]{24}$') &&
+          object.metadata.labels.size() == 3 &&
+          object.metadata.labels['app.kubernetes.io/name'] == 'opencrane-tool-runner' &&
+          object.metadata.labels['app.kubernetes.io/component'] == 'tool-runner')) &&
+        object.metadata.labels['opencrane.ai/skill-workload'] == object.metadata.name &&
+        object.metadata.annotations.size() == 3 &&
+        object.metadata.annotations['opencrane.ai/silo-id'].size() > 0 &&
+        object.metadata.annotations['opencrane.ai/job-id'].size() > 0 &&
+        object.metadata.annotations['opencrane.ai/capability-reference'] == 'skill-workload-v1:' + object.metadata.annotations['opencrane.ai/job-id'] &&
+        (!has(object.metadata.ownerReferences) || object.metadata.ownerReferences.size() == 0) &&
+        (!has(object.metadata.finalizers) || object.metadata.finalizers.size() == 0) &&
+        (!has(object.metadata.generateName) || object.metadata.generateName == '')
+      message: governed skill Job identity must exactly match its isolated workload class
+    - expression: >-
+        object.spec.suspend == true && object.spec.parallelism == 1 && object.spec.completions == 1 &&
+        object.spec.backoffLimit == 0 && object.spec.ttlSecondsAfterFinished == 0 &&
+        ((object.metadata.namespace == {{ $authoringNamespace | toJson }} &&
+          object.spec.activeDeadlineSeconds == {{ .Values.agentController.skillWorkloadProfiles.authoring.activeDeadlineSeconds }} &&
+          object.spec.template.spec.serviceAccountName == 'skill-authoring-default' &&
+          object.spec.template.metadata.labels['app.kubernetes.io/component'] == 'skill-authoring' &&
+          object.spec.template.spec.containers[0].name == 'skill-authoring' &&
+          object.spec.template.spec.containers[0].image == {{ $authoringImage | toJson }} &&
+          object.spec.template.spec.containers[0].imagePullPolicy == {{ .Values.agentController.skillWorkloadProfiles.authoring.image.pullPolicy | toJson }} &&
+          object.spec.template.spec.containers[0].resources.requests.cpu == {{ .Values.agentController.skillWorkloadProfiles.authoring.resources.requests.cpu | toString | toJson }} &&
+          object.spec.template.spec.containers[0].resources.requests.memory == {{ .Values.agentController.skillWorkloadProfiles.authoring.resources.requests.memory | toString | toJson }} &&
+          object.spec.template.spec.containers[0].resources.limits.cpu == {{ .Values.agentController.skillWorkloadProfiles.authoring.resources.limits.cpu | toString | toJson }} &&
+          object.spec.template.spec.containers[0].resources.limits.memory == {{ .Values.agentController.skillWorkloadProfiles.authoring.resources.limits.memory | toString | toJson }} &&
+          object.spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.audience == 'opencrane-skill-authoring' &&
+          quantity(object.spec.template.spec.volumes[1].emptyDir.sizeLimit).compareTo(quantity({{ .Values.agentController.skillWorkloadProfiles.authoring.scratchSize | toJson }})) == 0) ||
+         (object.metadata.namespace == {{ $toolRunnerNamespace | toJson }} &&
+          object.spec.activeDeadlineSeconds == {{ .Values.agentController.skillWorkloadProfiles.toolRunner.activeDeadlineSeconds }} &&
+        object.spec.template.spec.serviceAccountName == 'tool-runner-default' &&
+          object.spec.template.metadata.labels['app.kubernetes.io/component'] == 'tool-runner' &&
+          object.spec.template.spec.containers[0].name == 'tool-runner' &&
+          object.spec.template.spec.containers[0].image == {{ $toolRunnerImage | toJson }} &&
+          object.spec.template.spec.containers[0].imagePullPolicy == {{ .Values.agentController.skillWorkloadProfiles.toolRunner.image.pullPolicy | toJson }} &&
+          object.spec.template.spec.containers[0].resources.requests.cpu == {{ .Values.agentController.skillWorkloadProfiles.toolRunner.resources.requests.cpu | toString | toJson }} &&
+          object.spec.template.spec.containers[0].resources.requests.memory == {{ .Values.agentController.skillWorkloadProfiles.toolRunner.resources.requests.memory | toString | toJson }} &&
+          object.spec.template.spec.containers[0].resources.limits.cpu == {{ .Values.agentController.skillWorkloadProfiles.toolRunner.resources.limits.cpu | toString | toJson }} &&
+          object.spec.template.spec.containers[0].resources.limits.memory == {{ .Values.agentController.skillWorkloadProfiles.toolRunner.resources.limits.memory | toString | toJson }} &&
+          object.spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.audience == 'opencrane-tool-runner' &&
+          quantity(object.spec.template.spec.volumes[1].emptyDir.sizeLimit).compareTo(quantity({{ .Values.agentController.skillWorkloadProfiles.toolRunner.scratchSize | toJson }})) == 0)) &&
+        object.spec.template.spec.containers.size() == 1 &&
+        (!has(object.spec.template.spec.initContainers) || object.spec.template.spec.initContainers.size() == 0) &&
+        (!has(object.spec.template.spec.ephemeralContainers) || object.spec.template.spec.ephemeralContainers.size() == 0) &&
+        object.spec.template.spec.automountServiceAccountToken == false &&
+        object.spec.template.spec.enableServiceLinks == false &&
+        object.spec.template.spec.restartPolicy == 'Never' &&
+        object.spec.template.spec.securityContext.runAsNonRoot == true &&
+        object.spec.template.spec.securityContext.runAsUser == 65532 &&
+        object.spec.template.spec.securityContext.runAsGroup == 65532 &&
+        object.spec.template.spec.securityContext.fsGroup == 65532 &&
+        object.spec.template.spec.securityContext.seccompProfile.type == 'RuntimeDefault' &&
+        object.spec.template.spec.terminationGracePeriodSeconds == 0 &&
+        object.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation == false &&
+        object.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem == true &&
+        object.spec.template.spec.containers[0].securityContext.capabilities.drop == ['ALL'] &&
+        (!has(object.spec.template.spec.containers[0].securityContext.capabilities.add) || object.spec.template.spec.containers[0].securityContext.capabilities.add.size() == 0) &&
+        (!has(object.spec.template.spec.containers[0].command) || object.spec.template.spec.containers[0].command.size() == 0) &&
+        (!has(object.spec.template.spec.containers[0].args) || object.spec.template.spec.containers[0].args.size() == 0) &&
+        !has(object.spec.template.spec.containers[0].lifecycle) &&
+        !has(object.spec.template.spec.containers[0].livenessProbe) &&
+        !has(object.spec.template.spec.containers[0].readinessProbe) &&
+        !has(object.spec.template.spec.containers[0].startupProbe) &&
+        !has(object.spec.template.spec.containers[0].envFrom) &&
+        object.spec.template.spec.containers[0].env.size() == 1 &&
+        object.spec.template.spec.containers[0].env[0].name == 'OPENCRANE_SKILL_CAPABILITY_REFERENCE' &&
+        object.spec.template.spec.containers[0].env[0].valueFrom.fieldRef.fieldPath == "metadata.annotations['opencrane.ai/capability-reference']" &&
+        object.spec.template.spec.containers[0].volumeMounts.size() == 2 &&
+        object.spec.template.spec.containers[0].volumeMounts[0].name == 'capability-token' &&
+        object.spec.template.spec.containers[0].volumeMounts[0].mountPath == '/var/run/opencrane/tokens' &&
+        object.spec.template.spec.containers[0].volumeMounts[0].readOnly == true &&
+        object.spec.template.spec.containers[0].volumeMounts[1].name == 'scratch' &&
+        object.spec.template.spec.containers[0].volumeMounts[1].mountPath == '/tmp' &&
+        object.spec.template.spec.volumes.size() == 2 &&
+        object.spec.template.spec.volumes[0].name == 'capability-token' &&
+        object.spec.template.spec.volumes[0].projected.defaultMode == 288 &&
+        object.spec.template.spec.volumes[0].projected.sources.size() == 1 &&
+        object.spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.path == 'capability.token' &&
+        object.spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.expirationSeconds == 600 &&
+        object.spec.template.spec.volumes[1].name == 'scratch' &&
+        object.spec.template.metadata.labels.size() == 2 &&
+        object.spec.template.metadata.labels['app.kubernetes.io/component'] == object.metadata.labels['app.kubernetes.io/component'] &&
+        object.spec.template.metadata.labels['opencrane.ai/skill-workload'] == object.metadata.labels['opencrane.ai/skill-workload'] &&
+        object.spec.template.metadata.annotations.size() == 3 &&
+        object.spec.template.metadata.annotations['opencrane.ai/silo-id'] == object.metadata.annotations['opencrane.ai/silo-id'] &&
+        object.spec.template.metadata.annotations['opencrane.ai/job-id'] == object.metadata.annotations['opencrane.ai/job-id'] &&
+        object.spec.template.metadata.annotations['opencrane.ai/capability-reference'] == object.metadata.annotations['opencrane.ai/capability-reference'] &&
+        (!has(object.spec.template.metadata.ownerReferences) || object.spec.template.metadata.ownerReferences.size() == 0) &&
+        (!has(object.spec.template.metadata.finalizers) || object.spec.template.metadata.finalizers.size() == 0) &&
+        (!has(object.spec.template.metadata.name) || object.spec.template.metadata.name == '') &&
+        (!has(object.spec.template.metadata.generateName) || object.spec.template.metadata.generateName == '') &&
+        (!has(object.spec.template.metadata.namespace) || object.spec.template.metadata.namespace == '')
+      message: governed skill Job must remain the exact suspended, class-bounded worker shape
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $skillAdmissionName }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: governed-skill-workloads
+spec:
+  policyName: {{ $skillAdmissionName }}
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/component
+          operator: In
+          values: ["skill-authoring", "tool-runner"]
 ---
 # The policy is cluster-scoped only because Kubernetes admission policies are cluster-scoped. Its
 # namespace selector binds it to this one Helm-owned namespace label; no controller RBAC covers it.

--- a/apps/agent-controller/src/__tests__/config.test.ts
+++ b/apps/agent-controller/src/__tests__/config.test.ts
@@ -22,10 +22,19 @@ function _ProfilesJson(serverNamespace = "silo-a"): string
 	});
 }
 
+/** Return both Helm-equivalent governed skill workload profiles. */
+function _SkillProfilesJson(): string
+{
+	return JSON.stringify({
+		authoring: { kind: "authoring", image: `ghcr.io/italanta/opencrane-skill-authoring@sha256:${"a".repeat(64)}`, imagePullPolicy: "IfNotPresent", serverNamespace: "silo-a", namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", capabilityTokenAudience: "opencrane-skill-authoring", scratchSize: "64Mi", activeDeadlineSeconds: 300, ttlSecondsAfterFinished: 0, resources: { requests: { cpu: "100m", memory: "128Mi" }, limits: { cpu: "500m", memory: "256Mi" } } },
+		"tool-runner": { kind: "tool-runner", image: `ghcr.io/italanta/opencrane-tool-runner@sha256:${"b".repeat(64)}`, imagePullPolicy: "IfNotPresent", serverNamespace: "silo-a", namespace: "opencrane-tools", serviceAccountName: "tool-runner-default", capabilityTokenAudience: "opencrane-tool-runner", scratchSize: "64Mi", activeDeadlineSeconds: 300, ttlSecondsAfterFinished: 0, resources: { requests: { cpu: "100m", memory: "128Mi" }, limits: { cpu: "500m", memory: "256Mi" } } },
+	});
+}
+
 /** Return the minimal complete process environment. */
 function _Environment(): NodeJS.ProcessEnv
 {
-	return { OPENCRANE_INTERNAL_URL: "http://opencrane-server.silo-a.svc.cluster.local:3001", OPENCRANE_CONTROLLER_TOKEN_PATH: "/var/run/opencrane/tokens/opencrane.token", AGENT_RUNTIME_NAMESPACE: "silo-a-runtime", AGENT_CONTROLLER_POLL_INTERVAL_MS: "1000", AGENT_CONTROLLER_PROFILES_JSON: _ProfilesJson() };
+	return { OPENCRANE_INTERNAL_URL: "http://opencrane-server.silo-a.svc.cluster.local:3001", OPENCRANE_CONTROLLER_TOKEN_PATH: "/var/run/opencrane/tokens/opencrane.token", AGENT_RUNTIME_NAMESPACE: "silo-a-runtime", AGENT_CONTROLLER_POLL_INTERVAL_MS: "1000", AGENT_CONTROLLER_PROFILES_JSON: _ProfilesJson(), AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON: _SkillProfilesJson() };
 }
 
 describe("agent-controller process config", function _Suite()
@@ -39,12 +48,14 @@ describe("agent-controller process config", function _Suite()
 		expect(config.requestTimeoutMilliseconds).toBe(10_000);
 		expect(config.outboxPruneIntervalMilliseconds).toBe(3_600_000);
 		expect(config.profiles["personal-default"]?.serviceAccountName).toBe("agent-runtime-default");
+		expect(config.skillWorkloadProfiles.authoring.serviceAccountName).toBe("skill-authoring-default");
 	});
 
 	it("rejects a collapsed namespace or moving image tag", function _RejectsUnsafeConfig()
 	{
 		expect(function _SameNamespace() { _ReadConfig({ ..._Environment(), AGENT_RUNTIME_NAMESPACE: "silo-a" }); }).toThrow(/namespaces separate/);
 		expect(function _MovingImage() { _ReadConfig({ ..._Environment(), AGENT_CONTROLLER_PROFILES_JSON: _ProfilesJson().replace(/@sha256:[a-f0-9]{64}/, ":latest") }); }).toThrow(/immutable image/);
+		expect(function _SkillProfileWrongClass() { _ReadConfig({ ..._Environment(), AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON: _SkillProfilesJson().replace("\"kind\":\"authoring\"", "\"kind\":\"tool-runner\"") }); }).toThrow(/wrong workload class/);
 	});
 
 	it("rejects an outbox-retention cadence outside the safe maintenance range", function _RejectsUnsafeRetentionInterval()

--- a/apps/agent-controller/src/config.ts
+++ b/apps/agent-controller/src/config.ts
@@ -1,6 +1,7 @@
 import { isAbsolute } from "node:path";
 
 import { __ValidateAgentControllerRuntimeProfiles } from "@opencrane/backend/agents/runtime/controller";
+import { __ValidateSkillWorkloadControllerProfiles } from "@opencrane/backend/agents/skills/controller";
 
 import type { AgentControllerProcessConfig } from "./config.types.js";
 
@@ -37,6 +38,19 @@ function _Json(value: string): unknown
 	}
 }
 
+/** Parse skill profile JSON while keeping its configuration failure distinct from runtime profiles. */
+function _SkillProfilesJson(value: string): unknown
+{
+	try
+	{
+		return JSON.parse(value) as unknown;
+	}
+	catch
+	{
+		throw new Error("AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON must contain valid JSON");
+	}
+}
+
 /** Read and fail-closed validate the complete agent-controller process configuration. */
 export function _ReadConfig(environment: NodeJS.ProcessEnv = process.env): AgentControllerProcessConfig
 {
@@ -52,6 +66,7 @@ export function _ReadConfig(environment: NodeJS.ProcessEnv = process.env): Agent
 
 	// 3. Validate the runtime/server namespace split and every immutable Job profile at startup.
 	const profiles = __ValidateAgentControllerRuntimeProfiles(_Json(_Required(environment, "AGENT_CONTROLLER_PROFILES_JSON")), runtimeNamespace);
+	const skillWorkloadProfiles = __ValidateSkillWorkloadControllerProfiles(_SkillProfilesJson(_Required(environment, "AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON")));
 	return {
 		openCraneInternalUrl: _Required(environment, "OPENCRANE_INTERNAL_URL"),
 		controllerTokenPath,
@@ -60,5 +75,6 @@ export function _ReadConfig(environment: NodeJS.ProcessEnv = process.env): Agent
 		outboxPruneIntervalMilliseconds: _Integer(environment, "AGENT_CONTROLLER_OUTBOX_PRUNE_INTERVAL_MS", 3_600_000, 60_000, 86_400_000),
 		requestTimeoutMilliseconds: _Integer(environment, "AGENT_CONTROLLER_REQUEST_TIMEOUT_MS", 10_000, 1_000, 60_000),
 		profiles,
+		skillWorkloadProfiles,
 	};
 }

--- a/apps/agent-controller/src/config.types.ts
+++ b/apps/agent-controller/src/config.types.ts
@@ -1,4 +1,5 @@
 import type { AgentControllerRuntimeProfiles } from "@opencrane/backend/agents/runtime/controller";
+import type { SkillWorkloadControllerProfiles } from "@opencrane/backend/agents/skills/controller";
 
 /** Fully validated process configuration for the per-silo agent controller. */
 export interface AgentControllerProcessConfig
@@ -17,4 +18,6 @@ export interface AgentControllerProcessConfig
 	readonly requestTimeoutMilliseconds: number;
 	/** Immutable runtime profiles keyed by authority-owned profile name. */
 	readonly profiles: AgentControllerRuntimeProfiles;
+	/** Immutable profiles for the only governed skill Job classes. */
+	readonly skillWorkloadProfiles: SkillWorkloadControllerProfiles;
 }

--- a/apps/agent-controller/src/index.ts
+++ b/apps/agent-controller/src/index.ts
@@ -3,6 +3,7 @@ import "./instrument.js";
 import * as k8s from "@kubernetes/client-node";
 
 import { __CreateHttpAgentControllerAuthority, __CreateKubernetesAgentControllerStore, __RunAgentController } from "@opencrane/backend/agents/runtime/controller";
+import { __CreateHttpSkillWorkloadControllerAuthority, __RunSkillWorkloadController } from "@opencrane/backend/agents/skills/controller";
 import { ___BindConsole, ___ShutdownTelemetry } from "@opencrane/observability";
 
 import { _ReadConfig } from "./config.js";
@@ -22,6 +23,7 @@ async function _Main(): Promise<void>
 		const kubeConfig = new k8s.KubeConfig();
 		kubeConfig.loadFromCluster();
 		const authority = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
+		const skillWorkloadAuthority = __CreateHttpSkillWorkloadControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
 		const kubernetes = __CreateKubernetesAgentControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: shutdown.signal });
 
 		// 3. Convert both Kubernetes termination signals into one abortable poll loop.
@@ -34,7 +36,10 @@ async function _Main(): Promise<void>
 		process.once("SIGTERM", function _sigterm() { _Shutdown("SIGTERM"); });
 		process.once("SIGINT", function _sigint() { _Shutdown("SIGINT"); });
 		log.info({ runtimeNamespace: config.runtimeNamespace, profiles: Object.keys(config.profiles) }, "agent controller started");
-		await __RunAgentController({ authority, kubernetes, profiles: config.profiles, runtimeNamespace: config.runtimeNamespace, pollIntervalMilliseconds: config.pollIntervalMilliseconds, outboxPruneIntervalMilliseconds: config.outboxPruneIntervalMilliseconds, log }, shutdown.signal);
+		await Promise.all([
+			__RunAgentController({ authority, kubernetes, profiles: config.profiles, runtimeNamespace: config.runtimeNamespace, pollIntervalMilliseconds: config.pollIntervalMilliseconds, outboxPruneIntervalMilliseconds: config.outboxPruneIntervalMilliseconds, log }, shutdown.signal),
+			__RunSkillWorkloadController({ authority: skillWorkloadAuthority, kubernetes, profiles: config.skillWorkloadProfiles, pollIntervalMilliseconds: config.pollIntervalMilliseconds, log }, shutdown.signal),
+		]);
 	}
 	finally
 	{

--- a/apps/agent-controller/tests/helm-contract.sh
+++ b/apps/agent-controller/tests/helm-contract.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 CHART_ROOT="${OPENCRANE_HELM_CHART_ROOT:-$ROOT/apps/_infra/deploy-k8s}"
+SOURCE_CHART_ROOT="$(mktemp -d)"
 CONFORMANCE="$ROOT/apps/agent-controller/tests/admission-conformance.sh"
 IDENTITY_CONFORMANCE="$ROOT/apps/agent-controller/tests/identity-conformance.sh"
 MANIFEST="$(mktemp)"
@@ -16,7 +17,13 @@ SERVER_POLICY="$(mktemp)"
 CONTROLLER_POLICY="$(mktemp)"
 RUNTIME_DENY="$(mktemp)"
 RUNTIME_EGRESS="$(mktemp)"
-trap 'rm -f "$MANIFEST" "$DISABLED" "$ROLE" "$BINDING" "$RUNTIME_NAMESPACE" "$RUNTIME_QUOTA" "$ADMISSION" "$SERVER_POLICY" "$CONTROLLER_POLICY" "$RUNTIME_DENY" "$RUNTIME_EGRESS"' EXIT
+trap 'rm -rf "$SOURCE_CHART_ROOT"; rm -f "$MANIFEST" "$DISABLED" "$ROLE" "$BINDING" "$RUNTIME_NAMESPACE" "$RUNTIME_QUOTA" "$ADMISSION" "$SERVER_POLICY" "$CONTROLLER_POLICY" "$RUNTIME_DENY" "$RUNTIME_EGRESS"' EXIT
+
+# The umbrella vendors chart archives. Replace only the controller archive in a disposable copy so
+# this contract always renders the source template under test without refreshing remote dependencies.
+cp -R "$CHART_ROOT/." "$SOURCE_CHART_ROOT"
+helm package "$ROOT/apps/agent-controller/helm" --destination "$SOURCE_CHART_ROOT/charts" >/dev/null
+CHART_ROOT="$SOURCE_CHART_ROOT"
 
 render_enabled() {
   helm template oc "$CHART_ROOT" \
@@ -24,6 +31,8 @@ render_enabled() {
     --set agentController.enabled=true \
     --set-string agentController.image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
     --set-string agentController.runtimeProfile.image.digest=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+    --set-string agentController.skillWorkloadProfiles.authoring.image.digest=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc \
+    --set-string agentController.skillWorkloadProfiles.toolRunner.image.digest=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd \
     --set-string 'agentController.kubernetesApiServerCidrs[0]=10.43.0.1/32' \
     --set-string 'agentController.kubernetesApiServerEndpointCidrs[0]=172.18.0.2/32' \
     --set agentController.kubernetesApiServerEndpointPort=6443 \
@@ -84,6 +93,15 @@ test -s "$BINDING"
 grep -Fq 'namespace: oc-opencrane-runtime' "$BINDING"
 grep -A4 -F 'kind: ServiceAccount' "$BINDING" | grep -Fq 'namespace: server-ns'
 
+# Governed skill namespaces are derived from their owning charts. Their controller Roles can only
+# exact-adopt or create suspended Jobs: no patch permission can release or modify a worker.
+grep -A16 -F 'namespace: opencrane-skill-authoring' "$MANIFEST" | grep -Fq 'name: agent-controller-skill-workloads'
+grep -A16 -F 'namespace: opencrane-tools' "$MANIFEST" | grep -Fq 'name: agent-controller-skill-workloads'
+if grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -Eq '"(patch|delete|update|watch|list)"'; then
+  echo "skill workload Roles exceed get/create Job authority" >&2
+  exit 1
+fi
+
 # Both processes receive the literal cross-namespace contract; neither infers it from Pod metadata.
 grep -A2 -F 'name: AGENT_RUNTIME_NAMESPACE' "$MANIFEST" | grep -Fq 'value: "oc-opencrane-runtime"'
 grep -A2 -F 'name: AGENT_RUNTIME_NAMESPACE' "$MANIFEST" | grep -Fq 'value: "oc-opencrane-runtime"'
@@ -124,6 +142,20 @@ grep -A2 -F '  matchConstraints:' "$ADMISSION" | grep -Fq '    matchPolicy: Exac
 grep -Fq 'operations: ["CREATE", "UPDATE"]' "$ADMISSION"
 grep -Fq 'resources: ["jobs"]' "$ADMISSION"
 grep -Fq 'request.userInfo.username == "system:serviceaccount:server-ns:agent-controller"' "$ADMISSION"
+# Skill namespaces also receive controller Job create/get, so their own fail-closed admission policy
+# must bind the same identity to the exact suspended, class-specific worker envelopes.
+grep -Eq 'name: .*skill-workloads' "$ADMISSION"
+grep -Fq 'values: ["skill-authoring", "tool-runner"]' "$ADMISSION"
+grep -Fq 'operations: ["CREATE"]' "$ADMISSION"
+grep -Fq "object.spec.suspend == true" "$ADMISSION"
+grep -Fq "object.spec.template.spec.containers[0].name == 'skill-authoring'" "$ADMISSION"
+grep -Fq "object.spec.template.spec.containers[0].name == 'tool-runner'" "$ADMISSION"
+grep -Fq "object.metadata.annotations['opencrane.ai/capability-reference'] == 'skill-workload-v1:' + object.metadata.annotations['opencrane.ai/job-id']" "$ADMISSION"
+grep -Fq "object.spec.template.metadata.annotations['opencrane.ai/capability-reference'] == object.metadata.annotations['opencrane.ai/capability-reference']" "$ADMISSION"
+grep -Fq 'object.spec.template.metadata.labels.size() == 2' "$ADMISSION"
+grep -Fq "object.spec.template.metadata.labels['opencrane.ai/skill-workload'] == object.metadata.labels['opencrane.ai/skill-workload']" "$ADMISSION"
+grep -Fq "object.spec.template.spec.containers[0].image == \"ghcr.io/italanta/opencrane-skill-authoring@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\"" "$ADMISSION"
+grep -Fq "object.spec.template.spec.containers[0].image == \"ghcr.io/italanta/opencrane-tool-runner@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\"" "$ADMISSION"
 if grep -Fq 'request.subResource' "$ADMISSION"; then
   echo "Job-only admission must not dereference the optional subResource request field" >&2
   exit 1
@@ -181,7 +213,7 @@ grep -Fq 'cidr: "10.43.0.1/32"' "$DISABLED"
 grep -A3 -F 'cidr: "10.43.0.1/32"' "$DISABLED" | grep -Fq 'port: 443'
 grep -Fq 'cidr: "172.18.0.2/32"' "$DISABLED"
 grep -A3 -F 'cidr: "172.18.0.2/32"' "$DISABLED" | grep -Fq 'port: 6443'
-if grep -Eq 'kind: ValidatingAdmissionPolicy|kind: Namespace|name: agent-controller|opencrane.ai/runtime-release' "$DISABLED"; then
+if grep -Eq 'kind: ValidatingAdmissionPolicy|name: oc-opencrane-runtime|name: oc-opencrane-agent-runtime|opencrane.ai/runtime-release' "$DISABLED"; then
   echo "disabled agent-controller rendered runtime authority" >&2
   exit 1
 fi

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -124,7 +124,7 @@ export default [
             { sourceTag: "scope:skills-launcher", onlyDependOnLibsWithTags: ["scope:skills-launcher", "scope:shared"] },
             { sourceTag: "scope:skills-controller", onlyDependOnLibsWithTags: ["scope:skills-controller", "scope:skills-launcher", "scope:shared"] },
             { sourceTag: "scope:agent-runtime-controller", onlyDependOnLibsWithTags: ["scope:agent-runtime-controller", "scope:agent-runtime-launcher", "scope:shared"] },
-            { sourceTag: "scope:agent-controller", onlyDependOnLibsWithTags: ["scope:agent-controller", "scope:agent-runtime-controller", "scope:shared"] },
+            { sourceTag: "scope:agent-controller", onlyDependOnLibsWithTags: ["scope:agent-controller", "scope:agent-runtime-controller", "scope:skills-controller", "scope:shared"] },
             { sourceTag: "scope:cluster-tenants", onlyDependOnLibsWithTags: ["scope:auth", "scope:cluster-tenants", "scope:k8s-api", "scope:shared"] },
             { sourceTag: "scope:company-docs", onlyDependOnLibsWithTags: ["scope:auth", "scope:company-docs", "scope:shared"] },
 			{ sourceTag: "scope:conversation-replay", onlyDependOnLibsWithTags: ["scope:channel-targets", "scope:conversation-replay", "scope:shared"] },

--- a/libs/backend/agents/skills/controller/src/__tests__/http-skill-workload-authority.test.ts
+++ b/libs/backend/agents/skills/controller/src/__tests__/http-skill-workload-authority.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __CreateHttpSkillWorkloadControllerAuthority } from "../http-skill-workload-authority.js";
+
+/** Return complete fixed adapter options with replaceable request seams. */
+function _Options(fetch: typeof globalThis.fetch)
+{
+	return { openCraneInternalUrl: "http://opencrane-server.silo-a.svc.cluster.local:3001", tokenPath: "/var/run/opencrane/tokens/opencrane.token", requestTimeoutMilliseconds: 1_000, fetch, readToken: vi.fn().mockResolvedValue("projected-token") };
+}
+
+/** Return one exact database-fenced skill workload claim response. */
+function _Claim()
+{
+	return { workloadId: "workload-1", siloId: "silo-a", kind: "authoring", skillRevisionId: "revision-1", claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, expiresAt: "2026-07-24T00:00:30.000Z" };
+}
+
+describe("HTTP governed skill workload authority", function _DescribeAuthority()
+{
+	it("claims only an exact bounded database-issued workload response", async function _Claims()
+	{
+		const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify(_Claim()), { status: 200 }));
+		const authority = __CreateHttpSkillWorkloadControllerAuthority(_Options(fetch));
+
+		expect(await authority.__Claim(new AbortController().signal)).toEqual(_Claim());
+		expect(fetch).toHaveBeenCalledWith(new URL("http://opencrane-server.silo-a.svc.cluster.local:3001/api/internal/agent-controller/skill-workloads:claim"), expect.objectContaining({ method: "POST", body: "{}" }));
+	});
+
+	it("binds an assignment response to the submitted workload and immutable Job UID", async function _Commits()
+	{
+		const command = { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" };
+		const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ outcome: "assigned", workloadId: "workload-1", workloadUid: "job-uid-1" }), { status: 200 }));
+		const authority = __CreateHttpSkillWorkloadControllerAuthority(_Options(fetch));
+
+		expect(await authority.__CommitAssignment("workload-1", command, new AbortController().signal)).toBe("assigned");
+	});
+
+	it("fails closed when the server claims a different Job UID", async function _RejectsMismatchedAssignment()
+	{
+		const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ outcome: "assigned", workloadId: "workload-1", workloadUid: "other-job" }), { status: 200 }));
+		const authority = __CreateHttpSkillWorkloadControllerAuthority(_Options(fetch));
+
+		await expect(authority.__CommitAssignment("workload-1", { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" }, new AbortController().signal)).rejects.toThrow(/mismatched/);
+	});
+});

--- a/libs/backend/agents/skills/controller/src/http-skill-workload-authority.ts
+++ b/libs/backend/agents/skills/controller/src/http-skill-workload-authority.ts
@@ -1,0 +1,143 @@
+import { readFile } from "node:fs/promises";
+import { isAbsolute } from "node:path";
+
+import { ___DoWithTrace } from "@opencrane/observability";
+import type { AgentControllerSkillWorkloadAssignmentCommand, AgentControllerSkillWorkloadClaim } from "@opencrane/contracts";
+
+import type { SkillWorkloadControllerAuthority, SkillWorkloadControllerFetch, SkillWorkloadControllerHttpAuthorityOptions, SkillWorkloadControllerTokenReader } from "./skill-workload-controller.types.js";
+
+/** Maximum JSON response accepted from one internal controller authority call. */
+const _MAX_RESPONSE_BYTES = 16 * 1024;
+
+/** Stable internal route appended to the configured OpenCrane base URL. */
+const _CLAIM_PATH = "/api/internal/agent-controller/skill-workloads:claim";
+
+/** Return whether an untrusted JSON value is a non-empty bounded identifier. */
+function _IsIdentifier(value: unknown): value is string
+{
+	return typeof value === "string" && value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+/** Return whether an untrusted JSON value is a positive safe integer. */
+function _IsPositiveInteger(value: unknown): value is number
+{
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+/** Return whether an untrusted JSON value is one canonical ISO UTC instant. */
+function _IsTime(value: unknown): value is string
+{
+	if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) return false;
+	const epochMilliseconds = Date.parse(value);
+	return Number.isSafeInteger(epochMilliseconds) && new Date(epochMilliseconds).toISOString() === value;
+}
+
+/** Return a plain object suitable for security-boundary parsing. */
+function _AsObject(value: unknown): Record<string, unknown> | null
+{
+	return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+/** Read one bounded JSON response without trusting its content type alone. */
+async function _ReadJson(response: Response): Promise<unknown>
+{
+	const text = await response.text();
+	if (Buffer.byteLength(text, "utf8") > _MAX_RESPONSE_BYTES) throw new Error("OpenCrane skill workload response exceeded the 16 KiB boundary");
+	try
+	{
+		return JSON.parse(text) as unknown;
+	}
+	catch
+	{
+		throw new Error("OpenCrane skill workload response was not valid JSON");
+	}
+}
+
+/** Parse one exact database-issued governed skill workload claim. */
+function _ParseClaim(value: unknown): AgentControllerSkillWorkloadClaim
+{
+	const claim = _AsObject(value);
+	if (!claim || !_IsIdentifier(claim.workloadId) || !_IsIdentifier(claim.siloId) || (claim.kind !== "authoring" && claim.kind !== "tool-runner") || !_IsIdentifier(claim.skillRevisionId) || !_IsTime(claim.claimedAt) || !_IsPositiveInteger(claim.deliveryCount) || !_IsTime(claim.expiresAt) || Date.parse(claim.claimedAt) >= Date.parse(claim.expiresAt))
+	{
+		throw new Error("OpenCrane returned a malformed skill workload claim");
+	}
+	return { workloadId: claim.workloadId, siloId: claim.siloId, kind: claim.kind, skillRevisionId: claim.skillRevisionId, claimedAt: claim.claimedAt, deliveryCount: claim.deliveryCount, expiresAt: claim.expiresAt };
+}
+
+/** Parse a commit result and bind it to the exact submitted workload and Job UID. */
+function _ParseAssignment(value: unknown, workloadId: string, command: AgentControllerSkillWorkloadAssignmentCommand): "assigned" | "idempotent" | "conflict"
+{
+	const result = _AsObject(value);
+	if (!result || result.workloadId !== workloadId || result.workloadUid !== command.workloadUid || (result.outcome !== "assigned" && result.outcome !== "idempotent"))
+	{
+		throw new Error("OpenCrane returned a mismatched skill workload assignment result");
+	}
+	return result.outcome;
+}
+
+/** Read the latest rotated projected token from its mounted file. */
+function _CreateTokenReader(path: string): SkillWorkloadControllerTokenReader
+{
+	return async function _ReadToken(): Promise<string>
+	{
+		const token = (await readFile(path, "utf8")).trim();
+		if (token.length === 0) throw new Error("projected agent-controller token is empty");
+		return token;
+	};
+}
+
+/** Build headers for one authenticated JSON authority call. */
+function _Headers(token: string): Headers
+{
+	return new Headers({ authorization: `Bearer ${token}`, "content-type": "application/json", accept: "application/json" });
+}
+
+/** Combine process cancellation with the hard per-request timeout. */
+function _RequestSignal(signal: AbortSignal, timeoutMilliseconds: number): AbortSignal
+{
+	return AbortSignal.any([signal, AbortSignal.timeout(timeoutMilliseconds)]);
+}
+
+/** Validate and normalize the internal OpenCrane origin. */
+function _BaseUrl(value: string): URL
+{
+	const parsed = URL.parse(value);
+	if (!parsed || parsed.protocol !== "http:" || parsed.pathname !== "/" || parsed.search !== "" || parsed.hash !== "" || parsed.username !== "" || parsed.password !== "") throw new Error("OPENCRANE_INTERNAL_URL must be one in-cluster HTTP origin with no path or credentials");
+	return parsed;
+}
+
+/** Create the projected-token-authenticated governed skill desired-state and assignment adapter. */
+export function __CreateHttpSkillWorkloadControllerAuthority(options: SkillWorkloadControllerHttpAuthorityOptions): SkillWorkloadControllerAuthority
+{
+	const baseUrl = _BaseUrl(options.openCraneInternalUrl);
+	if (!isAbsolute(options.tokenPath) || !Number.isSafeInteger(options.requestTimeoutMilliseconds) || options.requestTimeoutMilliseconds < 1_000 || options.requestTimeoutMilliseconds > 60_000)
+	{
+		throw new Error("skill workload HTTP authority requires an absolute token path and 1-60s timeout");
+	}
+	const fetchRequest: SkillWorkloadControllerFetch = options.fetch ?? fetch;
+	const readToken = options.readToken ?? _CreateTokenReader(options.tokenPath);
+	return {
+		async __Claim(signal: AbortSignal): Promise<AgentControllerSkillWorkloadClaim | null>
+		{
+			return ___DoWithTrace("agent_controller.skill_workload.claim", {}, async function _Claim(): Promise<AgentControllerSkillWorkloadClaim | null>
+			{
+				const response = await fetchRequest(new URL(_CLAIM_PATH, baseUrl), { method: "POST", headers: _Headers(await readToken()), body: "{}", signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
+				if (response.status === 204) return null;
+				if (response.status !== 200) throw new Error(`OpenCrane skill workload claim failed with HTTP ${response.status}`);
+				return _ParseClaim(await _ReadJson(response));
+			});
+		},
+		async __CommitAssignment(workloadId: string, command: AgentControllerSkillWorkloadAssignmentCommand, signal: AbortSignal): Promise<"assigned" | "idempotent" | "conflict">
+		{
+			return ___DoWithTrace("agent_controller.skill_workload.assignment", { workloadId, workloadUid: command.workloadUid }, async function _CommitAssignment(): Promise<"assigned" | "idempotent" | "conflict">
+			{
+				if (!_IsIdentifier(workloadId)) throw new Error("skill workload assignment requires one valid workload id");
+				const path = `/api/internal/agent-controller/skill-workloads/${encodeURIComponent(workloadId)}/assignment`;
+				const response = await fetchRequest(new URL(path, baseUrl), { method: "PUT", headers: _Headers(await readToken()), body: JSON.stringify(command), signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
+				if (response.status === 409) return "conflict";
+				if (response.status !== 200) throw new Error(`OpenCrane skill workload assignment failed with HTTP ${response.status}`);
+				return _ParseAssignment(await _ReadJson(response), workloadId, command);
+			});
+		},
+	};
+}

--- a/libs/backend/agents/skills/controller/src/index.ts
+++ b/libs/backend/agents/skills/controller/src/index.ts
@@ -1,2 +1,3 @@
 export { __ReconcileNextSkillWorkload, __RunSkillWorkloadController, __ValidateSkillWorkloadControllerProfiles } from "./skill-workload-controller.js";
-export type { SkillWorkloadControllerAuthority, SkillWorkloadControllerKubernetesStore, SkillWorkloadControllerOptions, SkillWorkloadControllerProfiles, SkillWorkloadControllerReconcileResult } from "./skill-workload-controller.types.js";
+export { __CreateHttpSkillWorkloadControllerAuthority } from "./http-skill-workload-authority.js";
+export type { SkillWorkloadControllerAuthority, SkillWorkloadControllerFetch, SkillWorkloadControllerHttpAuthorityOptions, SkillWorkloadControllerKubernetesStore, SkillWorkloadControllerOptions, SkillWorkloadControllerProfiles, SkillWorkloadControllerReconcileResult, SkillWorkloadControllerTokenReader } from "./skill-workload-controller.types.js";

--- a/libs/backend/agents/skills/controller/src/skill-workload-controller.types.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-controller.types.ts
@@ -23,6 +23,27 @@ export interface SkillWorkloadControllerKubernetesStore
 	__EnsureSuspendedJob(expected: V1Job): Promise<V1Job>;
 }
 
+/** Fetch-compatible function injected into the internal HTTP authority adapter. */
+export type SkillWorkloadControllerFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+/** Rotating projected-token reader injected into the internal HTTP authority adapter. */
+export type SkillWorkloadControllerTokenReader = () => Promise<string>;
+
+/** Configuration for the projected-token-authenticated governed skill authority adapter. */
+export interface SkillWorkloadControllerHttpAuthorityOptions
+{
+	/** Internal OpenCrane base URL with no path, query, or credentials. */
+	readonly openCraneInternalUrl: string;
+	/** Absolute path of the rotating projected controller token. */
+	readonly tokenPath: string;
+	/** Hard timeout for one HTTP exchange. */
+	readonly requestTimeoutMilliseconds: number;
+	/** Optional fetch seam used by focused tests. */
+	readonly fetch?: SkillWorkloadControllerFetch;
+	/** Optional rotating-token seam used by focused tests. */
+	readonly readToken?: SkillWorkloadControllerTokenReader;
+}
+
 /** Fixed policy and adapters for one governed skill workload reconciliation. */
 export interface SkillWorkloadControllerOptions
 {


### PR DESCRIPTION
## What this changes

This PR connects the governed-skill controller to the running agent-controller process. The process reads its rotating projected token, claims one durable skill workload from OpenCrane, creates or exactly adopts its deterministic suspended Job, and commits only Kubernetes’ immutable UID.

The new cross-namespace Job permission is deliberately fenced twice. Kubernetes RBAC permits only `get/create` for Jobs in the authoring and tool-runner namespaces—no patch, delete, Pod, or Secret powers. A fail-closed ValidatingAdmissionPolicy then accepts only the exact pinned, class-specific suspended worker envelopes. It binds the worker Pod template’s labels and all annotations, including the capability reference, to the Job’s durable identity, so neither a different image nor another workload’s capability can be substituted.

## Validation

- Agent-controller Helm contract render passed.
- Skill controller: 8 focused tests and TypeScript lint passed.
- Skill Job builder focused tests passed.
- Agent-controller application tests and lint passed.
- Boundary lint, TypeScript style check (0 errors/warnings), and whitespace diff check passed.
- Live Kubernetes admission remains a deployment gate on a cluster; this workstation has no cluster context.

## Review

- Independent security review found the arbitrary-Job and template-capability substitution risks. Both were fixed and independently re-verified.
- Restacked onto #396 (`feat/skill-workload-reconciliation`).