### PR TITLE
🔒 Bind governed skill bootstrap references atomically

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -3981,7 +3981,7 @@ BEGIN
     SELECT "kind", "state", "workload_uid", "worker_pod_uid" INTO workload_kind, workload_state, assigned_uid, assigned_pod_uid FROM "skill_workloads" WHERE "id" = NEW."skill_workload_id" FOR UPDATE;
     IF workload_state IS DISTINCT FROM 'assigned' OR assigned_uid IS DISTINCT FROM NEW."workload_uid" THEN RAISE EXCEPTION 'SkillWorkloadBootstrap requires its exact assigned workload UID'; END IF;
     IF TG_OP = 'UPDATE' AND assigned_pod_uid IS DISTINCT FROM NEW."consumed_by_pod_uid" THEN RAISE EXCEPTION 'bootstrap consumer Pod is not the registered workload Pod'; END IF;
-    IF (workload_kind = 'authoring' AND (NEW."audience" <> 'opencrane-skill-authoring' OR NEW."service_account_name" <> 'skill-authoring-default' OR NEW."namespace" <> 'opencrane-skill-authoring')) OR (workload_kind = 'tool_runner' AND (NEW."audience" <> 'opencrane-tool-runner' OR NEW."service_account_name" <> 'tool-runner-default' OR NEW."namespace" <> 'opencrane-tools')) THEN RAISE EXCEPTION 'SkillWorkloadBootstrap identity must match its workload class'; END IF;
+    IF NEW."namespace" !~ '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' OR length(NEW."namespace") > 63 OR (workload_kind = 'authoring' AND (NEW."audience" <> 'opencrane-skill-authoring' OR NEW."service_account_name" <> 'skill-authoring-default')) OR (workload_kind = 'tool_runner' AND (NEW."audience" <> 'opencrane-tool-runner' OR NEW."service_account_name" <> 'tool-runner-default')) THEN RAISE EXCEPTION 'SkillWorkloadBootstrap identity must match its workload class'; END IF;
     RETURN NEW;
 END;
 $$;

--- a/libs/backend/agents/skills/controller/README.md
+++ b/libs/backend/agents/skills/controller/README.md
@@ -7,7 +7,8 @@
 This package is the outbound reconciliation step between the durable skill-work authority and
 Kubernetes. A **reconciler** repeatedly makes an external system match a durable desired state. It
 claims one authorised workload, builds a hardened but still-suspended Job from its fixed class
-profile, and commits only the Kubernetes-issued Job UID back to OpenCrane.
+profile, and commits the Kubernetes-issued Job UID plus the Job's stable opaque reference back to
+OpenCrane.
 
 ```
  Postgres workload claim ──► controller ◄── HERE ──► suspended Job

--- a/libs/backend/agents/skills/controller/src/__tests__/http-skill-workload-authority.test.ts
+++ b/libs/backend/agents/skills/controller/src/__tests__/http-skill-workload-authority.test.ts
@@ -27,7 +27,7 @@ describe("HTTP governed skill workload authority", function _DescribeAuthority()
 
 	it("binds an assignment response to the submitted workload and immutable Job UID", async function _Commits()
 	{
-		const command = { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" };
+		const command = { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1", bootstrapReference: `skill-bootstrap-v1_${"a".repeat(64)}`, namespace: "opencrane-tools" };
 		const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ outcome: "assigned", workloadId: "workload-1", workloadUid: "job-uid-1" }), { status: 200 }));
 		const authority = __CreateHttpSkillWorkloadControllerAuthority(_Options(fetch));
 
@@ -39,6 +39,6 @@ describe("HTTP governed skill workload authority", function _DescribeAuthority()
 		const fetch = vi.fn().mockResolvedValue(new Response(JSON.stringify({ outcome: "assigned", workloadId: "workload-1", workloadUid: "other-job" }), { status: 200 }));
 		const authority = __CreateHttpSkillWorkloadControllerAuthority(_Options(fetch));
 
-		await expect(authority.__CommitAssignment("workload-1", { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" }, new AbortController().signal)).rejects.toThrow(/mismatched/);
+		await expect(authority.__CommitAssignment("workload-1", { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1", bootstrapReference: `skill-bootstrap-v1_${"a".repeat(64)}`, namespace: "opencrane-tools" }, new AbortController().signal)).rejects.toThrow(/mismatched/);
 	});
 });

--- a/libs/backend/agents/skills/controller/src/__tests__/skill-workload-controller.test.ts
+++ b/libs/backend/agents/skills/controller/src/__tests__/skill-workload-controller.test.ts
@@ -43,7 +43,7 @@ function _Options(authority: SkillWorkloadControllerAuthority, kubernetes: Skill
 
 describe("governed skill workload controller", function _DescribeController()
 {
-	it("creates a suspended Job and commits only its API-issued UID for the exact claim generation", async function _AssignsSuspendedJob()
+	it("creates a suspended Job and atomically binds its API-issued UID and opaque bootstrap reference", async function _AssignsSuspendedJob()
 	{
 		const calls: string[] = [];
 		let committed: unknown = null;
@@ -57,8 +57,8 @@ describe("governed skill workload controller", function _DescribeController()
 		expect(calls).toEqual(["claim", "job", "commit"]);
 		expect(built.spec?.suspend).toBe(true);
 		expect(built.metadata?.namespace).toBe("opencrane-skill-authoring");
-		expect(built.metadata?.annotations?.["opencrane.ai/capability-reference"]).toBe("skill-workload-v1:workload_1");
-		expect(committed).toEqual({ claimedAt: _Claim().claimedAt, deliveryCount: 2, workloadUid: "job-uid-1" });
+		expect(built.metadata?.annotations?.["opencrane.ai/capability-reference"]).toMatch(/^skill-bootstrap-v1_[a-f0-9]{64}$/);
+		expect(committed).toEqual({ claimedAt: _Claim().claimedAt, deliveryCount: 2, workloadUid: "job-uid-1", bootstrapReference: built.metadata?.annotations?.["opencrane.ai/capability-reference"], namespace: built.metadata?.namespace });
 		expect(result).toEqual({ outcome: "assigned", workloadId: "workload_1", workloadUid: "job-uid-1" });
 	});
 

--- a/libs/backend/agents/skills/controller/src/skill-workload-controller.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-controller.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { __BuildGovernedSkillWorkloadJob, type SkillWorkloadJobProfile } from "@opencrane/backend/agents/skills/k8s-launcher";
 import { ___DoWithTrace } from "@opencrane/observability";
 
@@ -13,14 +15,14 @@ function _RequireWorkloadUid(uid: string | undefined): string
 	return uid;
 }
 
-/** Derive a stable non-secret reference that a future worker exchange can bind to its Job identity. */
+/** Derive a stable opaque reference without projecting the workload's durable identifier into Kubernetes. */
 function _CapabilityReference(workloadId: string): string
 {
 	if (!/^[a-zA-Z0-9_-]{1,128}$/.test(workloadId))
 	{
 		throw new Error("governed skill workload id is not safe to project into a capability reference");
 	}
-	return `skill-workload-v1:${workloadId}`;
+	return `skill-bootstrap-v1_${createHash("sha256").update(workloadId, "utf8").digest("hex")}`;
 }
 
 /** Validate both fixed deployment profiles through the canonical hardened Job builder. */
@@ -43,7 +45,7 @@ export function __ValidateSkillWorkloadControllerProfiles(value: unknown): Skill
 		{
 			throw new Error(`skill workload controller ${kind} profile has the wrong workload class`);
 		}
-		__BuildGovernedSkillWorkloadJob({ jobId: "profile-validation", siloId: "profile-validation", namespace: profile.namespace, capabilityReference: "skill-workload-v1:profile-validation" }, profile);
+		__BuildGovernedSkillWorkloadJob({ jobId: "profile-validation", siloId: "profile-validation", namespace: profile.namespace, capabilityReference: _CapabilityReference("profile-validation") }, profile);
 		profiles[kind] = profile;
 	}
 	return profiles;
@@ -67,7 +69,7 @@ export async function __ReconcileNextSkillWorkload(options: SkillWorkloadControl
 		const workloadUid = _RequireWorkloadUid(persistedJob.metadata?.uid);
 
 		// 4. Commit the same database claim generation; a stale replica can never assign this Job.
-		const outcome = await options.authority.__CommitAssignment(claim.workloadId, { claimedAt: claim.claimedAt, deliveryCount: claim.deliveryCount, workloadUid }, signal);
+		const outcome = await options.authority.__CommitAssignment(claim.workloadId, { claimedAt: claim.claimedAt, deliveryCount: claim.deliveryCount, workloadUid, bootstrapReference: _CapabilityReference(claim.workloadId), namespace: profile.namespace }, signal);
 		if (outcome === "conflict")
 		{
 			throw new Error("governed skill workload assignment lost its database claim fence");

--- a/libs/backend/agents/skills/execution/main/README.md
+++ b/libs/backend/agents/skills/execution/main/README.md
@@ -22,8 +22,10 @@ Kubernetes-issued Job UID for an exact durable assignment.
 [agent controller](../../../../../../../apps/agent-controller/README.md).
 
 A claim identifies one durable delivery generation; an assignment can bind only the Kubernetes Job
-UID created for that exact generation. This order makes a crash safe: an uncommitted Job remains
-suspended and is safe to adopt later, while a stale controller cannot attach a different Job.
+UID created for that exact generation. At that same durable step it hashes the opaque reference
+already projected into the Job and creates the one-use bootstrap record. This order makes a crash
+safe: an uncommitted Job remains suspended and is safe to adopt later, while a stale controller
+cannot attach a different Job or replace its reference.
 
 It does not create Kubernetes resources, exchange worker capabilities, read ArtifactStore bytes, or
 complete tool invocations. Those responsibilities remain downstream of the durable authority.
@@ -31,7 +33,7 @@ complete tool invocations. Those responsibilities remain downstream of the durab
 ## Public surface
 
 - `SkillWorkloadClaim` — one database-issued delivery generation.
-- `SkillWorkloadAssignmentCommand` — the controller's exact suspended-Job UID fence.
+- `SkillWorkloadAssignmentCommand` — the controller's exact suspended-Job UID and opaque-reference fence.
 - `PrismaSkillWorkloadClaimsRepository` — Postgres implementation of the fenced claim and commit.
 - `__CreateSkillWorkloadDispatchRouter` — projected-token-authenticated internal claim and assignment API.
 

--- a/libs/backend/agents/skills/execution/main/src/__tests__/prisma-skill-workload-claims-repository.test.ts
+++ b/libs/backend/agents/skills/execution/main/src/__tests__/prisma-skill-workload-claims-repository.test.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
+
 import { Prisma } from "@prisma/client";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { PrismaSkillWorkloadClaimsRepository } from "../prisma-skill-workload-claims-repository.js";
 
@@ -15,6 +17,12 @@ function _RejectingPrisma(error: Error): never
 	return { $transaction: async function _rejectTransaction(): Promise<never> { throw error; } } as never;
 }
 
+/** Derives the controller-visible opaque reference accepted by one exact workload. */
+function _BootstrapReference(workloadId: string): string
+{
+	return `skill-bootstrap-v1_${createHash("sha256").update(workloadId, "utf8").digest("hex")}`;
+}
+
 describe("governed skill workload claims", function _describeClaims()
 {
 	it("rejects unbounded claim leases before a database transaction starts", function _rejectsLease()
@@ -26,13 +34,30 @@ describe("governed skill workload claims", function _describeClaims()
 	it("rejects malformed controller assignment generations before a database transaction starts", async function _rejectsMalformedAssignment()
 	{
 		const repository = new PrismaSkillWorkloadClaimsRepository(_Prisma(), 30_000);
-		await expect(repository.commitAssignmentAtomically("", { claimedAt: "not-a-time", deliveryCount: 0, workloadUid: "" })).resolves.toBe("conflict");
+		await expect(repository.commitAssignmentAtomically("", { claimedAt: "not-a-time", deliveryCount: 0, workloadUid: "", bootstrapReference: "", namespace: "" })).resolves.toBe("conflict");
 	});
 
 	it("maps a duplicate immutable Kubernetes Job identity to the documented conflict result", async function _mapsDuplicateJobIdentity()
 	{
 		const duplicateIdentity = new Prisma.PrismaClientKnownRequestError("unique workload identity", { code: "P2002", clientVersion: "test" });
 		const repository = new PrismaSkillWorkloadClaimsRepository(_RejectingPrisma(duplicateIdentity), 30_000);
-		await expect(repository.commitAssignmentAtomically("workload-1", { claimedAt: "2026-07-26T05:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" })).resolves.toBe("conflict");
+		await expect(repository.commitAssignmentAtomically("workload-1", { claimedAt: "2026-07-26T05:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1", bootstrapReference: _BootstrapReference("workload-1"), namespace: "tenant-a-authoring" })).resolves.toBe("conflict");
+	});
+
+	it("persists only the opaque bootstrap-reference hash with an exact successful Job assignment", async function _writesBootstrapHash()
+	{
+		const bootstrapCreate = vi.fn().mockResolvedValue({});
+		const transaction = {
+			$queryRaw: vi.fn().mockResolvedValueOnce([{ skillRevisionId: "revision-1" }]).mockResolvedValueOnce([{ state: "Draft" }]).mockResolvedValueOnce([]).mockResolvedValueOnce([{ now: new Date("2026-07-26T05:00:01.000Z") }]),
+			skillWorkload: { findUnique: vi.fn().mockResolvedValue({ id: "workload-1", state: "Pending", kind: "Authoring", claimedAt: new Date("2026-07-26T05:00:00.000Z"), deliveryCount: 1, workloadUid: null }), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+			skillWorkloadBootstrap: { create: bootstrapCreate },
+		};
+		const prisma = { $transaction: async function _transaction(callback: (value: typeof transaction) => Promise<unknown>) { return callback(transaction); } } as never;
+		const repository = new PrismaSkillWorkloadClaimsRepository(prisma, 30_000);
+		const bootstrapReference = _BootstrapReference("workload-1");
+
+		expect(await repository.commitAssignmentAtomically("workload-1", { claimedAt: "2026-07-26T05:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1", bootstrapReference, namespace: "tenant-a-authoring" })).toBe("assigned");
+		expect(bootstrapCreate).toHaveBeenCalledWith({ data: expect.objectContaining({ skillWorkloadId: "workload-1", referenceHash: expect.stringMatching(/^sha256:[a-f0-9]{64}$/), audience: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", namespace: "tenant-a-authoring", workloadUid: "job-uid-1" }) });
+		expect(JSON.stringify(bootstrapCreate.mock.calls)).not.toContain(bootstrapReference);
 	});
 });

--- a/libs/backend/agents/skills/execution/main/src/__tests__/skill-workload-dispatch.router.test.ts
+++ b/libs/backend/agents/skills/execution/main/src/__tests__/skill-workload-dispatch.router.test.ts
@@ -72,12 +72,12 @@ describe("agent-controller skill-workload dispatch router", function _DescribeRo
 
 	it("forwards exact assignment evidence and rejects caller-selected extensions", async function _CommitsAssignment()
 	{
-		const command = { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" };
+		const command = { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1", bootstrapReference: `skill-bootstrap-v1_${"a".repeat(64)}`, namespace: "tenant-a-authoring" };
 		const repository = { claimNextAtomically: vi.fn(), commitAssignmentAtomically: vi.fn().mockResolvedValue("assigned" as const) };
 		const { app } = _App({ repository });
 
 		const response = await request(app).put("/skill-workloads/workload-1/assignment").set("authorization", "Bearer projected-token").send(command);
-		const invalid = await request(app).put("/skill-workloads/workload-1/assignment").set("authorization", "Bearer projected-token").send({ ...command, namespace: "attacker-chosen" });
+		const invalid = await request(app).put("/skill-workloads/workload-1/assignment").set("authorization", "Bearer projected-token").send({ ...command, callerSelectedExtension: "attacker-chosen" });
 
 		expect(response.status).toBe(200);
 		expect(response.body).toEqual({ outcome: "assigned", workloadId: "workload-1", workloadUid: "job-uid-1" });

--- a/libs/backend/agents/skills/execution/main/src/prisma-skill-workload-claims-repository.ts
+++ b/libs/backend/agents/skills/execution/main/src/prisma-skill-workload-claims-repository.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { Prisma, SkillRevisionState, SkillWorkloadKind, SkillWorkloadState, type PrismaClient } from "@prisma/client";
 
 import type { SkillWorkloadAssignmentCommand, SkillWorkloadClaim, SkillWorkloadClaimsRepository } from "./skill-workload-claims.types.js";
@@ -5,6 +7,8 @@ import type { SkillWorkloadAssignmentCommand, SkillWorkloadClaim, SkillWorkloadC
 /** Postgres authority for controller-only claim generations and immutable Job identity binding. */
 export class PrismaSkillWorkloadClaimsRepository implements SkillWorkloadClaimsRepository
 {
+	/** Maximum worker lifetime and opaque-reference validity after assignment. */
+	private static readonly bootstrapLifetimeMilliseconds = 900_000;
 	/** Canonical OpenCrane authority database. */
 	private readonly prisma: PrismaClient;
 	/** Maximum time a controller may hold one uncommitted claim. */
@@ -49,7 +53,7 @@ export class PrismaSkillWorkloadClaimsRepository implements SkillWorkloadClaimsR
 	/** Commits only one unexpired exact claim generation, or returns its immutable replay result. */
 	async commitAssignmentAtomically(workloadId: string, command: SkillWorkloadAssignmentCommand): Promise<"assigned" | "idempotent" | "conflict">
 	{
-		if (!workloadId || !command.workloadUid || !Number.isSafeInteger(command.deliveryCount) || command.deliveryCount < 1 || !Number.isFinite(Date.parse(command.claimedAt))) return "conflict";
+		if (!workloadId || !command.workloadUid || !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(command.namespace) || command.namespace.length > 63 || command.bootstrapReference !== _BootstrapReference(workloadId) || !Number.isSafeInteger(command.deliveryCount) || command.deliveryCount < 1 || !Number.isFinite(Date.parse(command.claimedAt))) return "conflict";
 		const lease = this.claimLeaseMilliseconds;
 		try
 		{
@@ -66,14 +70,28 @@ export class PrismaSkillWorkloadClaimsRepository implements SkillWorkloadClaimsR
 				const workload = await transaction.skillWorkload.findUnique({ where: { id: workloadId } });
 				const revision = revisions[0];
 				if (!workload || !revision || !_IsEligibleRevisionForKind(workload.kind, revision.state)) return "conflict";
-				if (workload.state === SkillWorkloadState.Assigned) return workload.workloadUid === command.workloadUid && workload.claimedAt?.getTime() === Date.parse(command.claimedAt) && workload.deliveryCount === command.deliveryCount ? "idempotent" : "conflict";
+				if (workload.state === SkillWorkloadState.Assigned)
+				{
+					const bootstrap = await transaction.skillWorkloadBootstrap.findUnique({ where: { skillWorkloadId: workloadId } });
+					return workload.workloadUid === command.workloadUid && workload.claimedAt?.getTime() === Date.parse(command.claimedAt) && workload.deliveryCount === command.deliveryCount && bootstrap?.referenceHash === _ReferenceHash(command.bootstrapReference) ? "idempotent" : "conflict";
+				}
 				const nowRows = await transaction.$queryRaw<Array<{ now: Date }>>(Prisma.sql`SELECT clock_timestamp()::timestamp(3) AS "now"`);
 				const now = nowRows[0]?.now;
 				if (!now || workload.state !== SkillWorkloadState.Pending || workload.claimedAt?.getTime() !== Date.parse(command.claimedAt) || workload.deliveryCount !== command.deliveryCount || now.getTime() >= workload.claimedAt.getTime() + lease) return "conflict";
 
 				// 3. Assignment CAS — the database rejects a replay, expired lease, or competing Job identity.
 				const updated = await transaction.skillWorkload.updateMany({ where: { id: workloadId, state: SkillWorkloadState.Pending, claimedAt: workload.claimedAt, deliveryCount: workload.deliveryCount, workloadUid: null }, data: { state: SkillWorkloadState.Assigned, workloadUid: command.workloadUid } });
-				return updated.count === 1 ? "assigned" : "conflict";
+				if (updated.count !== 1) return "conflict";
+				await transaction.skillWorkloadBootstrap.create({ data: {
+					skillWorkloadId: workloadId,
+					referenceHash: _ReferenceHash(command.bootstrapReference),
+					audience: workload.kind === "Authoring" ? "opencrane-skill-authoring" : "opencrane-tool-runner",
+					serviceAccountName: workload.kind === "Authoring" ? "skill-authoring-default" : "tool-runner-default",
+					namespace: command.namespace,
+					workloadUid: command.workloadUid,
+					expiresAt: new Date(now.getTime() + PrismaSkillWorkloadClaimsRepository.bootstrapLifetimeMilliseconds),
+				} });
+				return "assigned";
 			});
 		}
 		catch (error)
@@ -82,6 +100,18 @@ export class PrismaSkillWorkloadClaimsRepository implements SkillWorkloadClaimsR
 			throw error;
 		}
 	}
+}
+
+/** Convert the transient controller reference into the only durable bootstrap lookup coordinate. */
+function _ReferenceHash(reference: string): string
+{
+	return `sha256:${createHash("sha256").update(reference, "utf8").digest("hex")}`;
+}
+
+/** Derive the one deterministic opaque reference that the server accepts for a skill workload. */
+function _BootstrapReference(workloadId: string): string
+{
+	return `skill-bootstrap-v1_${createHash("sha256").update(workloadId, "utf8").digest("hex")}`;
 }
 
 /** Returns whether a workload class may still run for the locked revision lifecycle state. */

--- a/libs/backend/agents/skills/execution/main/src/skill-workload-claims.types.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-workload-claims.types.ts
@@ -26,6 +26,10 @@ export interface SkillWorkloadAssignmentCommand
 	readonly deliveryCount: number;
 	/** API-issued immutable Kubernetes Job UID. */
 	readonly workloadUid: string;
+	/** Opaque reference received transiently from the controller and persisted only as a hash. */
+	readonly bootstrapReference: string;
+	/** Deployment-owned namespace selected by the reviewed controller profile. */
+	readonly namespace: string;
 }
 
 /** Persistence authority for controller-only workload claim and suspended-Job assignment. */

--- a/libs/backend/agents/skills/execution/main/src/skill-workload-dispatch.router.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-workload-dispatch.router.ts
@@ -120,10 +120,10 @@ function _ParseAssignmentCommand(value: unknown): AgentControllerSkillWorkloadAs
 {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
 	const body = value as Record<string, unknown>;
-	const expectedKeys = ["claimedAt", "deliveryCount", "workloadUid"];
+	const expectedKeys = ["claimedAt", "deliveryCount", "workloadUid", "bootstrapReference", "namespace"];
 	if (Object.keys(body).length !== expectedKeys.length || !expectedKeys.every(function _HasExpectedKey(key): boolean { return key in body; })) return null;
-	if (typeof body["claimedAt"] !== "string" || typeof body["deliveryCount"] !== "number" || typeof body["workloadUid"] !== "string") return null;
-	return { claimedAt: body["claimedAt"], deliveryCount: body["deliveryCount"], workloadUid: body["workloadUid"] };
+	if (typeof body["claimedAt"] !== "string" || typeof body["deliveryCount"] !== "number" || typeof body["workloadUid"] !== "string" || typeof body["bootstrapReference"] !== "string" || typeof body["namespace"] !== "string") return null;
+	return { claimedAt: body["claimedAt"], deliveryCount: body["deliveryCount"], workloadUid: body["workloadUid"], bootstrapReference: body["bootstrapReference"], namespace: body["namespace"] };
 }
 
 /** Write one bounded, non-sensitive internal problem response. */

--- a/libs/backend/agents/skills/k8s-launcher/README.md
+++ b/libs/backend/agents/skills/k8s-launcher/README.md
@@ -42,8 +42,9 @@ reference for later exchange by a worker protocol.
 
 The agent controller consumes this builder. It does not make a tool executable, contact the
 ArtifactStore, or provide a worker transport; those require the later durable claim/result protocol.
-Malformed identity, image, lifetime, namespace, or resource inputs fail before Kubernetes sees a
-manifest.
+Malformed identity, image, lifetime, namespace, resource, or bootstrap-reference inputs fail before
+Kubernetes sees a manifest. The reference must use the fixed opaque grammar, so durable workload
+identifiers are never copied into the Job annotation.
 
 ## Dependency direction
 

--- a/libs/backend/agents/skills/k8s-launcher/src/__tests__/skill-workload-job.test.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/__tests__/skill-workload-job.test.ts
@@ -11,7 +11,7 @@ function _Profile()
 /** Builds the opaque authority coordinates for one worker Job. */
 function _Assignment()
 {
-	return { jobId: "tool-job-1", siloId: "silo-1", namespace: "opencrane-tools", capabilityReference: "tool-capability-1" };
+	return { jobId: "tool-job-1", siloId: "silo-1", namespace: "opencrane-tools", capabilityReference: `skill-bootstrap-v1_${"a".repeat(64)}` };
 }
 
 describe("governed skill workload Job", function _describeJob()
@@ -33,6 +33,7 @@ describe("governed skill workload Job", function _describeJob()
 		expect(function _wrongAudience() { __BuildGovernedSkillWorkloadJob(_Assignment(), { ..._Profile(), capabilityTokenAudience: "opencrane-server" }); }).toThrow(/fixed audience/);
 		expect(function _oversizedResources() { __BuildGovernedSkillWorkloadJob(_Assignment(), { ..._Profile(), activeDeadlineSeconds: 901, resources: { requests: { cpu: "3", memory: "3Gi" }, limits: { cpu: "3", memory: "3Gi" } } }); }).toThrow(/bounded resources/);
 		expect(function _oversizedNamespace() { __BuildGovernedSkillWorkloadJob({ ..._Assignment(), namespace: "a".repeat(64) }, { ..._Profile(), namespace: "a".repeat(64) }); }).toThrow(/bounded resources/);
+		expect(function _nonOpaqueReference() { __BuildGovernedSkillWorkloadJob({ ..._Assignment(), capabilityReference: "workload-identifier" }, _Profile()); }).toThrow(/opaque bootstrap reference/);
 	});
 
 	it("builds the separately owned authoring Job class", function _buildsAuthoring()

--- a/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts
@@ -60,9 +60,9 @@ function _AssertProfile(profile: SkillWorkloadJobProfile): void
 /** Validate controller-supplied durable coordinates before they become labels or annotations. */
 function _AssertAssignment(assignment: SkillWorkloadJobAssignment, profile: SkillWorkloadJobProfile): void
 {
-	if (![assignment.jobId, assignment.siloId, assignment.namespace, assignment.capabilityReference].every(function _isValid(value): boolean { return _IsBoundedCoordinate(value); }) || assignment.namespace !== profile.namespace)
+	if (![assignment.jobId, assignment.siloId, assignment.namespace, assignment.capabilityReference].every(function _isValid(value): boolean { return _IsBoundedCoordinate(value); }) || !/^skill-bootstrap-v1_[a-f0-9]{64}$/.test(assignment.capabilityReference) || assignment.namespace !== profile.namespace)
 	{
-		throw new Error("governed skill Job assignment requires bounded coordinates and its deployment-owned namespace");
+		throw new Error("governed skill Job assignment requires bounded coordinates, an opaque bootstrap reference, and its deployment-owned namespace");
 	}
 }
 

--- a/libs/contracts/src/agent-controller.types.ts
+++ b/libs/contracts/src/agent-controller.types.ts
@@ -45,6 +45,10 @@ export interface AgentControllerSkillWorkloadAssignmentCommand
 	readonly deliveryCount: number;
 	/** Immutable Kubernetes UID of the controller-created suspended Job. */
 	readonly workloadUid: string;
+	/** Opaque stable reference projected into the Job and stored only as a database hash. */
+	readonly bootstrapReference: string;
+	/** Deployment-owned namespace selected by the controller's reviewed workload profile. */
+	readonly namespace: string;
 }
 
 /** Narrow desired-state projection needed to build one suspended runtime Job. */


### PR DESCRIPTION
## Why this exists

A suspended governed-skill Job needs a stable reference that lets a later private exchange identify exactly that workload without exposing durable workload IDs in Kubernetes metadata. The reference is an identifier only, never a credential.

## What changed

- derives one deterministic opaque reference per skill workload and rejects any controller-submitted substitute
- carries the reference with the existing Job-UID assignment evidence
- writes only its SHA-256 hash, fixed worker identity, exact Job UID, bounded expiry, and the controller profile namespace in the same database transaction as the assignment
- preserves deployment-owned namespaces: the controller supplies the namespace from its validated profile; the server accepts only a bounded Kubernetes namespace, while the baseline retains the fixed workload-class service account and audience guards
- adds regression tests for cross-workload reference substitution, hash-only persistence in a non-default namespace, and non-opaque manifest references

## Deliberate boundary

The worker still cannot read ArtifactStore data, obtain a credential, release a Job, or execute a skill. Those need a separately governed artifact-read lease and a private worker exchange route.

## Validation

- focused execution (10 tests), controller (8), and Kubernetes-manifest (3) tests
- TypeScript checks for the affected packages
- repository style and diff checks

## Review

Independent review identified a hardcoded-namespace defect in the first restack. The final implementation carries the reviewed deployment profile namespace through the controller boundary and verifies a non-default namespace in the persistence test. No other correctness or security finding was confirmed.