### PR TITLE
🔒 Add exact ArtifactStore read leases

### DIFF
--- a/apps/artifact-service/README.md
+++ b/apps/artifact-service/README.md
@@ -12,11 +12,12 @@ image, a generated report.
 
 ## What it owns
 
-It owns the write side of **content-addressed storage** (CAS — files are stored and named by a hash of
+It owns the byte boundary of **content-addressed storage** (CAS — files are stored and named by a hash of
 their own bytes, so identical content is stored once and every stored object is tamper-evident). Callers
-never write to that store directly. Instead the OpenCrane server first issues a signed **write lease** —
-a short-lived permission slip saying "these exact bytes, up to this size, may be stored" — and this
-service is what checks the slip and does the write.
+never mount or browse that store directly. Instead the OpenCrane server issues a signed **write lease** —
+a short-lived permission slip saying "these exact bytes, up to this size, may be stored" — or a signed
+**read lease** bound to one exact stored address and a future run/worker operation. This service checks
+that slip before it writes or streams a byte.
 
 It is one step in the artifact-promotion flow, composing three artifact libraries:
 [`store`](../../libs/backend/artifacts/store/main/README.md) (the promotion protocol),
@@ -51,15 +52,21 @@ can only refuse a legitimate upload; it can never store bytes that were not cove
 `Entrypoint: src/index.ts` (`_Main`) — reads config, prepares the mounted CAS root (mode `0700`), opens
 the listener, and binds bounded `SIGTERM`/`SIGINT` shutdown that drains requests and flushes telemetry.
 
-HTTP endpoints: `POST /v1/artifacts/promote` (the one write operation) and `/livez` · `/readyz` probes.
-Any other path or method is `404`.
+HTTP endpoints: `POST /v1/artifacts/promote` writes under a signed write lease; `GET
+/v1/artifacts/read/:contentAddress` streams one matching canonical object only under a signed read lease;
+`/livez` · `/readyz` are probes. Any other path or method is `404`.
 
 ## Boundary
 
-Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), does not
-read or list artifacts, and does not accept raw secrets as environment variables — signing keys are
-mounted PEM files, not env values. Verification and signing are delegated to the artifacts libraries;
-this process is only the HTTP adapter and byte pump around them.
+Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), list
+artifacts, or expose the disk as a file server. A read can only name the exact address signed into its
+lease. The chart currently admits **only the OpenCrane server** through the artifact-service
+NetworkPolicy; no worker is wired to this endpoint yet. The preprocessor slice must add one named
+consumer's matching egress and this chart's matching ingress before it can use a read lease, without
+widening access to arbitrary pods. That future worker will therefore not need direct PVC access. This
+process does not accept raw secrets as environment variables — signing keys are mounted PEM files, not
+env values. Verification and signing are delegated to the artifacts libraries; this process is only the
+HTTP adapter and byte pump around them.
 
 ## Dependency direction
 

--- a/apps/artifact-service/README.md
+++ b/apps/artifact-service/README.md
@@ -53,14 +53,14 @@ can only refuse a legitimate upload; it can never store bytes that were not cove
 the listener, and binds bounded `SIGTERM`/`SIGINT` shutdown that drains requests and flushes telemetry.
 
 HTTP endpoints: `POST /v1/artifacts/promote` writes under a signed write lease; `GET
-/v1/artifacts/read/:contentAddress` streams one matching canonical object only under a signed read lease;
+/v1/artifacts/read` streams the one canonical object named inside a signed read lease;
 `/livez` · `/readyz` are probes. Any other path or method is `404`.
 
 ## Boundary
 
 Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), list
-artifacts, or expose the disk as a file server. A read can only name the exact address signed into its
-lease. The chart currently admits **only the OpenCrane server** through the artifact-service
+artifacts, or expose the disk as a file server. A read has no address in its URL: the signed lease
+supplies the exact immutable address, catalog artifact revision, byte length, and media type. The chart currently admits **only the OpenCrane server** through the artifact-service
 NetworkPolicy; no worker is wired to this endpoint yet. The preprocessor slice must add one named
 consumer's matching egress and this chart's matching ingress before it can use a read lease, without
 widening access to arbitrary pods. That future worker will therefore not need direct PVC access. This

--- a/apps/artifact-service/src/__tests__/server.test.ts
+++ b/apps/artifact-service/src/__tests__/server.test.ts
@@ -79,13 +79,14 @@ describe("artifact-service promotion endpoint", function _suite()
 			const address = `sha256:${(await import("node:crypto")).createHash("sha256").update(bytes).digest("hex")}`;
 			const writeLease = __SignArtifactWriteLease({ leaseId: "lease-read-source", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: address, expectedByteLength: bytes.byteLength, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
 			await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": writeLease }, body: bytes });
-			const readLease = __SignArtifactReadLease({ leaseId: "lease-read-1", siloId: "silo-1", operationId: "run-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+			const readLease = __SignArtifactReadLease({ leaseId: "lease-read-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, byteLength: bytes.byteLength, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
 
-			const allowed = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read/${address}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			const allowed = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read`, { headers: { "x-opencrane-artifact-read-lease": readLease } });
 			expect(allowed.status).toBe(200);
 			expect(allowed.headers.get("content-type")).toBe("text/plain");
+			expect(allowed.headers.get("content-length")).toBe(String(bytes.byteLength));
 			expect(await allowed.text()).toBe(bytes.toString());
-			const denied = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read/sha256:${"b".repeat(64)}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			const denied = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read`, { headers: { "x-opencrane-artifact-lease": readLease } });
 			expect(denied.status).toBe(403);
 		}
 		finally

--- a/apps/artifact-service/src/__tests__/server.test.ts
+++ b/apps/artifact-service/src/__tests__/server.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
+import { __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
 import { __FilesystemArtifactStore } from "@opencrane/backend/artifacts/filesystem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -59,6 +59,34 @@ describe("artifact-service promotion endpoint", function _suite()
 			const lease = __SignArtifactWriteLease({ leaseId: "lease-2", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: `sha256:${"a".repeat(64)}`, expectedByteLength: 1, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
 			const response = await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": lease, "content-length": "2" }, body: "ab" });
 			expect(response.status).toBe(413);
+		}
+		finally
+		{
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("streams canonical bytes only when the exact path matches an unexpired read lease", async function _readCanonicalBytes()
+	{
+		const root = await mkdtemp(join(tmpdir(), "artifact-service-"));
+		try
+		{
+			const server = _CreateServer({ port: 0, artifactRoot: root, maxUploadDurationMilliseconds: 300_000, leasePublicKeyPem: _leasePublicKey, receiptPrivateKeyPem: _receiptPrivateKey }, new __FilesystemArtifactStore({ rootPath: root }));
+			_servers.push(server);
+			await new Promise<void>(function _listen(resolve) { server.listen(0, "127.0.0.1", function _ready() { resolve(); }); });
+			const port = (server.address() as { port: number }).port;
+			const bytes = Buffer.from("read only this exact content");
+			const address = `sha256:${(await import("node:crypto")).createHash("sha256").update(bytes).digest("hex")}`;
+			const writeLease = __SignArtifactWriteLease({ leaseId: "lease-read-source", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: address, expectedByteLength: bytes.byteLength, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+			await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": writeLease }, body: bytes });
+			const readLease = __SignArtifactReadLease({ leaseId: "lease-read-1", siloId: "silo-1", operationId: "run-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+
+			const allowed = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read/${address}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			expect(allowed.status).toBe(200);
+			expect(allowed.headers.get("content-type")).toBe("text/plain");
+			expect(await allowed.text()).toBe(bytes.toString());
+			const denied = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read/sha256:${"b".repeat(64)}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			expect(denied.status).toBe(403);
 		}
 		finally
 		{

--- a/apps/artifact-service/src/server.ts
+++ b/apps/artifact-service/src/server.ts
@@ -38,9 +38,9 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 				return;
 			}
 			// 2. Verify a read lease before looking up an address so unknown callers learn no CAS existence facts.
-			if (path.startsWith("/v1/artifacts/read/") && request.method === "GET")
+			if (path === "/v1/artifacts/read" && request.method === "GET")
 			{
-				await _writeReadOutcome(response, store, path.slice("/v1/artifacts/read/".length), request.headers["x-opencrane-artifact-lease"], config.leasePublicKeyPem);
+				await _writeReadOutcome(response, store, request.headers["x-opencrane-artifact-read-lease"], config.leasePublicKeyPem);
 				return;
 			}
 			// 3. Keep promotion on its exact verb/path pair to avoid widening the byte-write surface.
@@ -66,11 +66,18 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 }
 
 /** Verify one exact read lease, then stream only its matching canonical object to the caller. */
-async function _writeReadOutcome(response: ServerResponse, store: ArtifactStore, requestedContentAddress: string, compactLeaseHeader: string | string[] | undefined, leasePublicKeyPem: string): Promise<void>
+async function _writeReadOutcome(response: ServerResponse, store: ArtifactStore, compactLeaseHeader: string | string[] | undefined, leasePublicKeyPem: string): Promise<void>
 {
 	const compactLease = typeof compactLeaseHeader === "string" ? compactLeaseHeader : null;
 	const lease = compactLease === null ? null : __VerifyArtifactReadLease(compactLease, leasePublicKeyPem, Math.floor(Date.now() / 1_000));
-	if (lease === null || lease.contentAddress !== requestedContentAddress)
+	if (lease === null)
+	{
+		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "invalid_artifact_lease" }));
+		return;
+	}
+	const byteLength = await store.byteLength(lease.contentAddress);
+	if (byteLength === null || byteLength !== lease.byteLength)
 	{
 		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
 		response.end(JSON.stringify({ error: "invalid_artifact_lease" }));
@@ -79,24 +86,37 @@ async function _writeReadOutcome(response: ServerResponse, store: ArtifactStore,
 	const bytes = await store.read(lease.contentAddress);
 	if (bytes === null)
 	{
-		response.writeHead(404, { "content-type": "application/json", "cache-control": "no-store" });
-		response.end(JSON.stringify({ error: "artifact_not_found" }));
+		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "invalid_artifact_lease" }));
 		return;
 	}
 	response.writeHead(200, {
 		"content-type": lease.mediaType,
+		"content-length": String(lease.byteLength),
 		"cache-control": "no-store",
 		// X-Content-Type-Options: prevents MIME sniffing of an authorized but untrusted artifact body.
 		// @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options
 		"x-content-type-options": "nosniff",
 	});
+	let streamedByteLength = 0;
 	for await (const chunk of bytes)
 	{
+		streamedByteLength += chunk.byteLength;
+		if (streamedByteLength > lease.byteLength)
+		{
+			response.destroy(new Error("artifact byte stream exceeded its signed read lease length"));
+			return;
+		}
 		if (!response.write(chunk))
 		{
 			await Promise.race([once(response, "drain"), once(response, "close")]);
 			if (response.destroyed) return;
 		}
+	}
+	if (streamedByteLength !== lease.byteLength)
+	{
+		response.destroy(new Error("artifact byte stream did not match its signed read lease length"));
+		return;
 	}
 	response.end();
 }

--- a/apps/artifact-service/src/server.ts
+++ b/apps/artifact-service/src/server.ts
@@ -1,9 +1,10 @@
 import { mkdir } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import { once } from "node:events";
 
 import { __FilesystemArtifactStore } from "@opencrane/backend/artifacts/filesystem";
-import { __SignArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "@opencrane/backend/artifacts/authorization";
+import { __SignArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "@opencrane/backend/artifacts/authorization";
 import { __PromoteArtifactUpload } from "@opencrane/backend/artifacts/store";
 import type { ArtifactPromotionLeaseVerifier, ArtifactPromotionReceiptSigner, ArtifactStore, BoundedArtifactUploadByteSource, PromoteArtifactUploadResult } from "@opencrane/backend/artifacts/store";
 import { ___DoWithTrace } from "@opencrane/observability";
@@ -29,12 +30,20 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 		const path = new URL(request.url ?? "/", "http://localhost").pathname;
 		void ___DoWithTrace("artifact-service.request", { method: request.method ?? "UNKNOWN", path }, async function _handleRequest()
 		{
+			// 1. Keep health probes unauthenticated because they reveal no catalog or byte state.
 			if (path === "/livez" || path === "/readyz")
 			{
 				response.writeHead(204);
 				response.end();
 				return;
 			}
+			// 2. Verify a read lease before looking up an address so unknown callers learn no CAS existence facts.
+			if (path.startsWith("/v1/artifacts/read/") && request.method === "GET")
+			{
+				await _writeReadOutcome(response, store, path.slice("/v1/artifacts/read/".length), request.headers["x-opencrane-artifact-lease"], config.leasePublicKeyPem);
+				return;
+			}
+			// 3. Keep promotion on its exact verb/path pair to avoid widening the byte-write surface.
 			if (path !== "/v1/artifacts/promote" || request.method !== "POST")
 			{
 				response.writeHead(404, { "content-type": "application/json" });
@@ -54,6 +63,42 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 			response.destroy(err instanceof Error ? err : new Error("artifact service request failed"));
 		});
 	});
+}
+
+/** Verify one exact read lease, then stream only its matching canonical object to the caller. */
+async function _writeReadOutcome(response: ServerResponse, store: ArtifactStore, requestedContentAddress: string, compactLeaseHeader: string | string[] | undefined, leasePublicKeyPem: string): Promise<void>
+{
+	const compactLease = typeof compactLeaseHeader === "string" ? compactLeaseHeader : null;
+	const lease = compactLease === null ? null : __VerifyArtifactReadLease(compactLease, leasePublicKeyPem, Math.floor(Date.now() / 1_000));
+	if (lease === null || lease.contentAddress !== requestedContentAddress)
+	{
+		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "invalid_artifact_lease" }));
+		return;
+	}
+	const bytes = await store.read(lease.contentAddress);
+	if (bytes === null)
+	{
+		response.writeHead(404, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "artifact_not_found" }));
+		return;
+	}
+	response.writeHead(200, {
+		"content-type": lease.mediaType,
+		"cache-control": "no-store",
+		// X-Content-Type-Options: prevents MIME sniffing of an authorized but untrusted artifact body.
+		// @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options
+		"x-content-type-options": "nosniff",
+	});
+	for await (const chunk of bytes)
+	{
+		if (!response.write(chunk))
+		{
+			await Promise.race([once(response, "drain"), once(response, "close")]);
+			if (response.destroyed) return;
+		}
+	}
+	response.end();
 }
 
 /** Adapts the app-owned OpenCrane public key to the storage-neutral lease verifier port. */

--- a/libs/backend/artifacts/authorization/main/README.md
+++ b/libs/backend/artifacts/authorization/main/README.md
@@ -44,7 +44,7 @@ forged receipt can never finalise a catalog entry.
 ## Public surface
 
 - `__SignArtifactWriteLease(claims, privateKeyPem, now)` / `__VerifyArtifactWriteLease(compact, publicKeyPem, now)` — mint and check the pre-upload permission slip.
-- `__SignArtifactReadLease(claims, privateKeyPem, now)` / `__VerifyArtifactReadLease(compact, publicKeyPem, now)` — mint and check the operation-bound permission to stream one exact canonical address.
+- `__SignArtifactReadLease(claims, privateKeyPem, now)` / `__VerifyArtifactReadLease(compact, publicKeyPem, now)` — mint and check a five-minute permission to stream one exact canonical address, catalog artifact revision, byte length, and media type.
 - `__SignArtifactPromotionReceipt(claims, privateKeyPem)` / `__VerifyArtifactPromotionReceipt(compact, publicKeyPem)` — mint and check the post-upload proof.
 - `ArtifactWriteLeaseClaims` / `ArtifactReadLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
 

--- a/libs/backend/artifacts/authorization/main/README.md
+++ b/libs/backend/artifacts/authorization/main/README.md
@@ -1,4 +1,4 @@
-# @opencrane/backend/artifacts/authorization — artifact write-lease & receipt authority
+# @opencrane/backend/artifacts/authorization — artifact lease & receipt authority
 
 > [backend](../../../README.md) › [artifacts](../../README.md) › authorization
 
@@ -11,9 +11,11 @@ content). Writing one is a two-party dance between OpenCrane and a separate uplo
 tokens that make that trust concrete.
 
 A **write lease** is a short-lived signed permission slip: "this silo (one tenant's isolated running environment) may write this artifact, up to
-this size, matching this hash, until this moment." A **promotion receipt** is the signed proof that
-comes back: "the bytes with this hash and length were stored." Both are compact signed tokens (JWS
-using EdDSA, a standard signature scheme) that only OpenCrane's keys can produce and verify.
+this size, matching this hash, until this moment." A **read lease** is equally narrow: "this one
+run or worker operation may read exactly this canonical address until this moment." A **promotion
+receipt** is the signed proof that comes back: "the bytes with this hash and length were stored."
+All are compact signed tokens (JWS using EdDSA, a standard signature scheme) that only OpenCrane's
+keys can produce and verify.
 
 ```
  OpenCrane catalog wants to store an artifact
@@ -22,7 +24,8 @@ using EdDSA, a standard signature scheme) that only OpenCrane's keys can produce
  ┌──────────────────────────────┐
  │   authorization  ◄── HERE     │  sign lease  →  ... upload happens ...  →  verify receipt
  └──────────────────────────────┘
-          │  lease ──► artifact-service verifies it, then stages & promotes bytes
+          │  write lease ──► artifact-service verifies it, then stages & promotes bytes
+          │  read lease ───► artifact-service streams only that exact CAS address
           │  receipt ◄── artifact-service signs the stored facts
           ▼
  catalog finalises the artifact only after __VerifyArtifactPromotionReceipt
@@ -41,8 +44,9 @@ forged receipt can never finalise a catalog entry.
 ## Public surface
 
 - `__SignArtifactWriteLease(claims, privateKeyPem, now)` / `__VerifyArtifactWriteLease(compact, publicKeyPem, now)` — mint and check the pre-upload permission slip.
+- `__SignArtifactReadLease(claims, privateKeyPem, now)` / `__VerifyArtifactReadLease(compact, publicKeyPem, now)` — mint and check the operation-bound permission to stream one exact canonical address.
 - `__SignArtifactPromotionReceipt(claims, privateKeyPem)` / `__VerifyArtifactPromotionReceipt(compact, publicKeyPem)` — mint and check the post-upload proof.
-- `ArtifactWriteLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
+- `ArtifactWriteLeaseClaims` / `ArtifactReadLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
 
 ## Boundary
 
@@ -50,6 +54,11 @@ Used by OpenCrane (to sign leases and verify receipts) and by `artifact-service`
 sign receipts). It is pure signing and verification: it holds no filesystem, no database, and no HTTP.
 It does not decide *whether* a caller should get a lease — that authorisation happens upstream; this
 package only makes the decision unforgeable.
+
+The signed read-leases form the private contract for the future preprocessor/dispatch consumer. This
+package does not grant that workload network access or issue its lease today; the consumer's app chart,
+explicit NetworkPolicies, and server-side issuance authority are a subsequent slice. Until then,
+artifact-service remains reachable only from the OpenCrane server.
 
 ## Dependency direction
 

--- a/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
+++ b/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
@@ -35,10 +35,11 @@ describe("ArtifactStore signed internal protocol", function _suite()
 	it("binds a read lease to one operation and exact immutable content address", function _readLeaseRoundTrip()
 	{
 		const address = `sha256:${"a".repeat(64)}`;
-		const compact = __SignArtifactReadLease({ leaseId: "read-lease-1", siloId: "silo-1", operationId: "preprocess-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000);
-		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-lease-1", operationId: "preprocess-1", contentAddress: address });
+		const compact = __SignArtifactReadLease({ leaseId: "read-lease-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060, byteLength: 12, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000);
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-lease-1", artifactRevisionId: "revision-1", contentAddress: address, byteLength: 12 });
 		expect(__VerifyArtifactReadLease(compact, _receiptPublicKey, 1_750_000_001)).toBeNull();
 		expect(__VerifyArtifactWriteLease(compact, _leasePublicKey, 1_750_000_001)).toBeNull();
+		expect(function _overlongReadLease() { __SignArtifactReadLease({ leaseId: "read-lease-long", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_301, byteLength: 12, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000); }).toThrow(/invalid artifact read lease claims/);
 	});
 
 	it("keeps service promotion receipts distinct from write-lease authority", function _receiptRoundTrip()

--- a/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
+++ b/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
@@ -2,7 +2,7 @@ import { generateKeyPairSync } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
 
-import { __SignArtifactPromotionReceipt, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "../artifact-lease.js";
+import { __SignArtifactPromotionReceipt, __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "../artifact-lease.js";
 
 const _leaseKeys = generateKeyPairSync("ed25519");
 const _receiptKeys = generateKeyPairSync("ed25519");
@@ -30,6 +30,15 @@ describe("ArtifactStore signed internal protocol", function _suite()
 		expect(__VerifyArtifactWriteLease(atPastBoundary, _leasePublicKey, now)).toMatchObject({ leaseId: "lease-past-boundary" });
 		expect(__VerifyArtifactWriteLease(beforePastBoundary, _leasePublicKey, now)).toBeNull();
 		expect(__VerifyArtifactWriteLease(atFutureBoundary, _leasePublicKey, now)).toMatchObject({ leaseId: "lease-future-boundary" });
+	});
+
+	it("binds a read lease to one operation and exact immutable content address", function _readLeaseRoundTrip()
+	{
+		const address = `sha256:${"a".repeat(64)}`;
+		const compact = __SignArtifactReadLease({ leaseId: "read-lease-1", siloId: "silo-1", operationId: "preprocess-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000);
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-lease-1", operationId: "preprocess-1", contentAddress: address });
+		expect(__VerifyArtifactReadLease(compact, _receiptPublicKey, 1_750_000_001)).toBeNull();
+		expect(__VerifyArtifactWriteLease(compact, _leasePublicKey, 1_750_000_001)).toBeNull();
 	});
 
 	it("keeps service promotion receipts distinct from write-lease authority", function _receiptRoundTrip()

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
@@ -2,10 +2,11 @@ import { createPrivateKey, createPublicKey, sign, verify } from "node:crypto";
 
 import { ___CanonicalizeJson } from "@opencrane/util";
 
-import type { ArtifactPromotionReceiptClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
+import type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
 
 const _LEASE_AUDIENCE = "artifact-service";
 const _LEASE_TYPE = "opencrane.artifact-write-lease";
+const _READ_LEASE_TYPE = "opencrane.artifact-read-lease";
 const _RECEIPT_AUDIENCE = "opencrane";
 const _RECEIPT_TYPE = "opencrane.artifact-promotion-receipt";
 
@@ -24,6 +25,23 @@ export function __VerifyArtifactWriteLease(compact: string, publicKeyPem: string
 	if (payload === null || payload.typ !== _LEASE_TYPE || payload.aud !== _LEASE_AUDIENCE || typeof issuedAt !== "number" || !Number.isSafeInteger(issuedAt) || issuedAt < nowEpochSeconds - 300 || issuedAt > nowEpochSeconds + 300) return null;
 	const claims = _leaseFromPayload(payload);
 	return claims !== null && _isLease(claims, nowEpochSeconds) ? claims : null;
+}
+
+/** Sign one exact short-lived canonical-byte read lease with an OpenCrane Ed25519 private key. */
+export function __SignArtifactReadLease(claims: ArtifactReadLeaseClaims, privateKeyPem: string, nowEpochSeconds: number): string
+{
+	if (!_isReadLease(claims, nowEpochSeconds)) throw new Error("invalid artifact read lease claims");
+	return _sign({ typ: _READ_LEASE_TYPE, aud: _LEASE_AUDIENCE, iat: nowEpochSeconds, ...claims }, privateKeyPem);
+}
+
+/** Verify an artifact-service read lease before exposing any canonical bytes. */
+export function __VerifyArtifactReadLease(compact: string, publicKeyPem: string, nowEpochSeconds: number): ArtifactReadLeaseClaims | null
+{
+	const payload = _verify(compact, publicKeyPem);
+	const issuedAt = payload?.iat;
+	if (payload === null || payload.typ !== _READ_LEASE_TYPE || payload.aud !== _LEASE_AUDIENCE || typeof issuedAt !== "number" || !Number.isSafeInteger(issuedAt) || issuedAt < nowEpochSeconds - 300 || issuedAt > nowEpochSeconds + 300) return null;
+	const claims = _readLeaseFromPayload(payload);
+	return claims !== null && _isReadLease(claims, nowEpochSeconds) ? claims : null;
 }
 
 /** Sign promotion facts with the service's distinct Ed25519 receipt key. */
@@ -71,6 +89,12 @@ function _leaseFromPayload(value: Record<string, unknown>): ArtifactWriteLeaseCl
 	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.artifactId === "string" && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && (typeof value.expectedContentAddress === "string" || value.expectedContentAddress === null) && (Number.isSafeInteger(value.expectedByteLength) || value.expectedByteLength === null) && typeof value.mediaType === "string" ? value as unknown as ArtifactWriteLeaseClaims : null;
 }
 
+/** Decode only the strict field set of a read lease after its signature and envelope are valid. */
+function _readLeaseFromPayload(value: Record<string, unknown>): ArtifactReadLeaseClaims | null
+{
+	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.operationId === "string" && typeof value.contentAddress === "string" && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && typeof value.mediaType === "string" ? value as unknown as ArtifactReadLeaseClaims : null;
+}
+
 function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionReceiptClaims | null
 {
 	return typeof value.leaseId === "string" && typeof value.contentAddress === "string" && Number.isSafeInteger(value.byteLength) && typeof value.mediaType === "string" && Number.isSafeInteger(value.issuedAtEpochSeconds) ? value as unknown as ArtifactPromotionReceiptClaims : null;
@@ -79,6 +103,12 @@ function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionR
 function _isLease(value: ArtifactWriteLeaseClaims, now: number): boolean
 {
 	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && (value.expectedContentAddress === null || /^sha256:[0-9a-f]{64}$/u.test(value.expectedContentAddress)) && (value.expectedByteLength === null || (Number.isSafeInteger(value.expectedByteLength) && value.expectedByteLength >= 0)) && value.mediaType.includes("/");
+}
+
+/** Validate the narrow coordinates that bind one signed read to one immutable CAS object. */
+function _isReadLease(value: ArtifactReadLeaseClaims, now: number): boolean
+{
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.operationId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.mediaType.includes("/");
 }
 
 function _isReceipt(value: ArtifactPromotionReceiptClaims): boolean

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
@@ -7,6 +7,7 @@ import type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactW
 const _LEASE_AUDIENCE = "artifact-service";
 const _LEASE_TYPE = "opencrane.artifact-write-lease";
 const _READ_LEASE_TYPE = "opencrane.artifact-read-lease";
+const _MAX_READ_LEASE_SECONDS = 300;
 const _RECEIPT_AUDIENCE = "opencrane";
 const _RECEIPT_TYPE = "opencrane.artifact-promotion-receipt";
 
@@ -92,7 +93,7 @@ function _leaseFromPayload(value: Record<string, unknown>): ArtifactWriteLeaseCl
 /** Decode only the strict field set of a read lease after its signature and envelope are valid. */
 function _readLeaseFromPayload(value: Record<string, unknown>): ArtifactReadLeaseClaims | null
 {
-	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.operationId === "string" && typeof value.contentAddress === "string" && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && typeof value.mediaType === "string" ? value as unknown as ArtifactReadLeaseClaims : null;
+	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.artifactId === "string" && typeof value.artifactRevisionId === "string" && typeof value.contentAddress === "string" && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && Number.isSafeInteger(value.byteLength) && typeof value.mediaType === "string" ? value as unknown as ArtifactReadLeaseClaims : null;
 }
 
 function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionReceiptClaims | null
@@ -108,7 +109,7 @@ function _isLease(value: ArtifactWriteLeaseClaims, now: number): boolean
 /** Validate the narrow coordinates that bind one signed read to one immutable CAS object. */
 function _isReadLease(value: ArtifactReadLeaseClaims, now: number): boolean
 {
-	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.operationId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.mediaType.includes("/");
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.artifactRevisionId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.expiresAtEpochSeconds <= now + _MAX_READ_LEASE_SECONDS && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && value.mediaType.includes("/");
 }
 
 function _isReceipt(value: ArtifactPromotionReceiptClaims): boolean

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
@@ -18,14 +18,18 @@ export interface ArtifactReadLeaseClaims
 	readonly leaseId: string;
 	/** Silo in which the source artifact remains authoritative. */
 	readonly siloId: string;
-	/** Exact run or worker operation that may consume the bytes. */
-	readonly operationId: string;
+	/** Exact catalog artifact whose published revision owns the bytes. */
+	readonly artifactId: string;
+	/** Exact published catalog revision that approved this immutable content. */
+	readonly artifactRevisionId: string;
 	/** Exact immutable CAS address that may be read. */
 	readonly contentAddress: string;
 	/** Exact capability action accepted by artifact-service. */
 	readonly action: "artifact.read";
 	/** Epoch-second expiry after which the byte stream must not begin. */
 	readonly expiresAtEpochSeconds: number;
+	/** Exact byte count that artifact-service must stream, never infer from a pathname. */
+	readonly byteLength: number;
 	/** Catalog-approved media type returned with the canonical bytes. */
 	readonly mediaType: string;
 }

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
@@ -11,6 +11,25 @@ export interface ArtifactWriteLeaseClaims
 	readonly mediaType: string;
 }
 
+/** Signed, short-lived internal lease that permits reading one exact canonical object. */
+export interface ArtifactReadLeaseClaims
+{
+	/** Unique OpenCrane-issued lease identifier for audit correlation. */
+	readonly leaseId: string;
+	/** Silo in which the source artifact remains authoritative. */
+	readonly siloId: string;
+	/** Exact run or worker operation that may consume the bytes. */
+	readonly operationId: string;
+	/** Exact immutable CAS address that may be read. */
+	readonly contentAddress: string;
+	/** Exact capability action accepted by artifact-service. */
+	readonly action: "artifact.read";
+	/** Epoch-second expiry after which the byte stream must not begin. */
+	readonly expiresAtEpochSeconds: number;
+	/** Catalog-approved media type returned with the canonical bytes. */
+	readonly mediaType: string;
+}
+
 /** Signed artifact-service receipt that OpenCrane verifies before catalog finalization. */
 export interface ArtifactPromotionReceiptClaims
 {

--- a/libs/backend/artifacts/authorization/main/src/index.ts
+++ b/libs/backend/artifacts/authorization/main/src/index.ts
@@ -1,2 +1,2 @@
-export { __SignArtifactPromotionReceipt, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "./artifact-lease.js";
-export type { ArtifactPromotionReceiptClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
+export { __SignArtifactPromotionReceipt, __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "./artifact-lease.js";
+export type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";

--- a/libs/backend/artifacts/filesystem/main/README.md
+++ b/libs/backend/artifacts/filesystem/main/README.md
@@ -22,7 +22,7 @@ else. It owns the durability and integrity of the write, and the safety of every
  └─────────────────────────────────────────────────────────┘
           │  canonical immutable object (created: true/false)
           ▼
- read(address) streams it back · purge(address) removes it
+ byteLength(address) confirms immutable size · read(address) streams it back · purge(address) removes it
 ```
 
 **In this flow:** [store](../../store/main/README.md) *(defines the `ArtifactStore` port and validates every command)* ·
@@ -43,7 +43,7 @@ in to read or overwrite a file outside the mounted volume, and stored bytes alwa
 
 ## Public surface
 
-- `__FilesystemArtifactStore` — the POSIX `ArtifactStore` adapter (`stage` · `promote` · `read` · `purge`).
+- `__FilesystemArtifactStore` — the POSIX `ArtifactStore` adapter (`stage` · `promote` · `byteLength` · `read` · `purge`).
 - `FilesystemArtifactStoreOptions` — construction options (the absolute `rootPath` of the mounted volume).
 
 ## Boundary

--- a/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
+++ b/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
@@ -135,6 +135,26 @@ export class __FilesystemArtifactStore implements ArtifactStore
 		}
 	}
 
+	/** Returns one canonical regular file's byte count without exposing its path or directory. */
+	async byteLength(contentAddress: string): Promise<number | null>
+	{
+		if (!___IsSha256ContentAddress(contentAddress))
+		{
+			throw new Error("invalid ArtifactStore content address");
+		}
+		try
+		{
+			const metadata = await stat(this._contentPath(contentAddress));
+			if (!metadata.isFile()) throw new Error("ArtifactStore canonical object is not a regular file");
+			return metadata.size;
+		}
+		catch (error)
+		{
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+			throw error;
+		}
+	}
+
 	/** Physically purges one address after the catalog authority has completed its reference-safe gate. */
 	async purge(contentAddress: string): Promise<ArtifactStorePurgeResult>
 	{

--- a/libs/backend/artifacts/store/main/README.md
+++ b/libs/backend/artifacts/store/main/README.md
@@ -42,7 +42,7 @@ boundary, and a receipt is impossible unless the exact authorised object became 
 
 - `__PromoteArtifactUpload(store, leaseVerifier, byteSource, config)` — the end-to-end promotion protocol (verify → stage → promote → receipt).
 - `__ValidateVerifiedArtifactWriteLease`, `__ValidateStageArtifactCommand`, `__ValidateStagedArtifact`, `__ValidateArtifactStorePromotion` — the fail-closed input guards.
-- `ArtifactStore` — the storage port an adapter implements (`stage` · `promote` · `read` · `purge`).
+- `ArtifactStore` — the storage port an adapter implements (`stage` · `promote` · `byteLength` · `read` · `purge`). `byteLength` lets a read boundary reject a mismatched object before it commits response headers or bytes.
 - `ArtifactPromotionLeaseVerifier` / `ArtifactPromotionReceiptSigner` — the injected signing/verification seams.
 - `StageArtifactCommand`, `StagedArtifact`, `ArtifactStorePromotion`, `PromoteArtifactUploadResult`, `BoundedArtifactUploadByteSource`, and the related claim/config types.
 

--- a/libs/backend/artifacts/store/main/src/__tests__/artifact-promotion.test.ts
+++ b/libs/backend/artifacts/store/main/src/__tests__/artifact-promotion.test.ts
@@ -66,6 +66,7 @@ function _store(): TestStore
 				return { ...staged, created: true };
 			},
 			async read() { return null; },
+			async byteLength() { return null; },
 			async purge() { return { purged: false }; },
 		},
 		stageCount() { return stageCount; },

--- a/libs/backend/artifacts/store/main/src/artifact-store.types.ts
+++ b/libs/backend/artifacts/store/main/src/artifact-store.types.ts
@@ -147,6 +147,8 @@ export interface ArtifactStore
 	promote(staged: StagedArtifact): Promise<ArtifactStorePromotion>;
 	/** Reads canonical bytes by an already-authorized immutable content address. */
 	read(contentAddress: string): Promise<ArtifactByteStream | null>;
+	/** Returns the immutable canonical byte count without opening a stream, or null when absent. */
+	byteLength(contentAddress: string): Promise<number | null>;
 	/** Removes bytes only after the OpenCrane authority proved no active lease or reference remains. */
 	purge(contentAddress: string): Promise<ArtifactStorePurgeResult>;
 }


### PR DESCRIPTION
## Why this exists

Workers must never mount or browse the artifact disk. They need a narrow way to receive one already-authorised immutable object after a future private bootstrap exchange.

## What changed

- adds a distinct signed, five-minute read lease, separate from write leases
- binds it to one silo, catalog artifact and revision, immutable SHA-256 address, byte length, and media type
- adds a private fixed read endpoint with no address in the URL, so the signed lease is the only source of the requested object
- preflights canonical object size before returning headers or bytes, then sets the signed content type and length with no-store caching
- preserves the existing server-only network boundary; no worker ingress, egress, direct PVC access, listing, or catalog route is added

## Deliberate boundary

This is a service-verified short-lived lease, reusable only until expiry. The later skill bootstrap exchange remains the one-time admission gate and will be the only authority allowed to obtain one for a worker.

## Validation

- artifact authorization, storage-port, filesystem, and artifact-service tests
- TypeScript checks for all affected packages
- dependency-boundary lint, style check, and diff check

## Review

Independent review found a partial-response risk on byte-count mismatch. The service now preflights canonical size before writing a 200 response; the fix was independently confirmed.