### PR TITLE
🔒 Issue exact ArtifactStore read leases from catalog authority

### DIFF
--- a/libs/backend/server/agents/artifacts/main/README.md
+++ b/libs/backend/server/agents/artifacts/main/README.md
@@ -39,6 +39,8 @@ result instead of creating a duplicate. A stale, replayed, or already-consumed r
 
 ## Public surface
 
+- `__IssueArtifactReadLease` — re-checks one active artifact's exact published revision before issuing a five-minute internal read lease; it exposes no HTTP route or storage path.
+
 - `__FinalizeArtifactRevision` — commit promoted bytes into a visible, immutable revision.
 - `__UploadArtifact` — orchestrate the full verified upload (lease → promote → finalize).
 - `PrismaArtifactAuthorityRepository` — the Postgres-backed persistence adapter.

--- a/libs/backend/server/agents/artifacts/main/src/__tests__/artifact-read-lease.test.ts
+++ b/libs/backend/server/agents/artifacts/main/src/__tests__/artifact-read-lease.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __IssueArtifactReadLease } from "../artifact-read-lease.js";
+
+/** Build one exact active published revision returned by the server-owned repository. */
+function _Target()
+{
+	return { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "text/plain" };
+}
+
+describe("ArtifactStore read lease issuer", function _suite()
+{
+	it("issues only server-loaded active published revision facts with a five-minute lifetime", async function _issues()
+	{
+		const signer = { sign: vi.fn().mockReturnValue("compact-read-lease") };
+		const result = await __IssueArtifactReadLease({ loadPublishedReadTarget: vi.fn().mockResolvedValue(_Target()) }, signer, { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" }, 1_750_000_000);
+
+		expect(result).toMatchObject({ outcome: "issued", compactLease: "compact-read-lease", claims: { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: _Target().contentAddress, byteLength: 12, expiresAtEpochSeconds: 1_750_000_300 } });
+		expect(signer.sign).toHaveBeenCalledWith(expect.objectContaining({ action: "artifact.read" }));
+	});
+
+	it("fails closed when the repository cannot prove the requested active published revision", async function _denies()
+	{
+		const signer = { sign: vi.fn() };
+		const result = await __IssueArtifactReadLease({ loadPublishedReadTarget: vi.fn().mockResolvedValue({ ..._Target(), artifactRevisionId: "other-revision" }) }, signer, { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" }, 1_750_000_000);
+
+		expect(result).toEqual({ outcome: "denied", reason: "revision_not_readable" });
+		expect(signer.sign).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from "node:crypto";
+
+import type { ArtifactReadLeaseRepository, ArtifactReadLeaseSigner, IssueArtifactReadLeaseCommand, IssueArtifactReadLeaseResult, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
+
+/** Maximum lifetime for a service-verified internal artifact read lease. */
+const _READ_LEASE_SECONDS = 300;
+
+/** Issue one exact short-lived read lease from independently loaded active catalog facts. */
+export async function __IssueArtifactReadLease(repository: ArtifactReadLeaseRepository, signer: ArtifactReadLeaseSigner, command: IssueArtifactReadLeaseCommand, nowEpochSeconds: number): Promise<IssueArtifactReadLeaseResult>
+{
+	if (!_IsCommand(command) || !Number.isSafeInteger(nowEpochSeconds) || nowEpochSeconds < 0)
+	{
+		return { outcome: "denied", reason: "invalid_command" };
+	}
+
+	// 1. Re-read the exact artifact revision under its silo; no caller metadata becomes lease content.
+	const target = await repository.loadPublishedReadTarget(command);
+	if (!_MatchesCommand(target, command))
+	{
+		return { outcome: "denied", reason: "revision_not_readable" };
+	}
+
+	// 2. Bind a new opaque lease to the immutable revision facts for one bounded service read.
+	const claims = { leaseId: randomUUID(), siloId: target.siloId, artifactId: target.artifactId, artifactRevisionId: target.artifactRevisionId, contentAddress: target.contentAddress, action: "artifact.read" as const, expiresAtEpochSeconds: nowEpochSeconds + _READ_LEASE_SECONDS, byteLength: target.byteLength, mediaType: target.mediaType };
+
+	// 3. Let only the composed signing authority turn reviewed catalog facts into a compact lease.
+	return { outcome: "issued", compactLease: signer.sign(claims), claims };
+}
+
+/** Reject malformed coordinates before they can probe a catalog repository. */
+function _IsCommand(value: IssueArtifactReadLeaseCommand): boolean
+{
+	return [value.siloId, value.artifactId, value.artifactRevisionId].every(function _isIdentifier(part): boolean { return /^[A-Za-z0-9_-]{1,128}$/.test(part); });
+}
+
+/** Prove the repository returned the requested immutable coordinates and safe exact byte facts. */
+function _MatchesCommand(target: PublishedArtifactReadTarget | null, command: IssueArtifactReadLeaseCommand): target is PublishedArtifactReadTarget
+{
+	return target !== null && target.siloId === command.siloId && target.artifactId === command.artifactId && target.artifactRevisionId === command.artifactRevisionId && /^sha256:[a-f0-9]{64}$/.test(target.contentAddress) && Number.isSafeInteger(target.byteLength) && target.byteLength >= 0 && target.mediaType.includes("/");
+}

--- a/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.types.ts
@@ -1,0 +1,48 @@
+import type { ArtifactReadLeaseClaims } from "@opencrane/backend/artifacts/authorization";
+
+/** Server-owned coordinates for one exact published revision that may be read internally. */
+export interface IssueArtifactReadLeaseCommand
+{
+	/** Silo whose artifact authority must contain the requested revision. */
+	readonly siloId: string;
+	/** Logical artifact that owns the revision. */
+	readonly artifactId: string;
+	/** Immutable published revision that owns the canonical bytes. */
+	readonly artifactRevisionId: string;
+}
+
+/** Immutable catalog facts loaded only after active-silo and published-revision checks. */
+export interface PublishedArtifactReadTarget
+{
+	/** Silo independently re-read from the active artifact record. */
+	readonly siloId: string;
+	/** Logical artifact independently re-read from the revision relation. */
+	readonly artifactId: string;
+	/** Exact immutable revision independently re-read from the catalog. */
+	readonly artifactRevisionId: string;
+	/** Canonical SHA-256 object address approved by that revision. */
+	readonly contentAddress: string;
+	/** Exact canonical byte count approved by that revision. */
+	readonly byteLength: number;
+	/** Catalog-approved media type for the immutable bytes. */
+	readonly mediaType: string;
+}
+
+/** Persistence boundary that exposes no artifact path, list, or caller-controlled metadata. */
+export interface ArtifactReadLeaseRepository
+{
+	/** Loads one active artifact's exact published revision, or null for every other state. */
+	loadPublishedReadTarget(command: IssueArtifactReadLeaseCommand): Promise<PublishedArtifactReadTarget | null>;
+}
+
+/** Narrow signing port owned by server composition and backed by the mounted lease key. */
+export interface ArtifactReadLeaseSigner
+{
+	/** Signs only validated server-owned artifact-read claims. */
+	sign(claims: ArtifactReadLeaseClaims): string;
+}
+
+/** Result of one server-internal read-lease issuance attempt. */
+export type IssueArtifactReadLeaseResult =
+	| { readonly outcome: "issued"; readonly compactLease: string; readonly claims: ArtifactReadLeaseClaims }
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "revision_not_readable" };

--- a/libs/backend/server/agents/artifacts/main/src/index.ts
+++ b/libs/backend/server/agents/artifacts/main/src/index.ts
@@ -1,5 +1,7 @@
 export { __FinalizeArtifactRevision } from "./artifact-finalization.js";
+export { __IssueArtifactReadLease } from "./artifact-read-lease.js";
 export { PrismaArtifactAuthorityRepository } from "./prisma-artifact-authority.js";
 export { __UploadArtifact } from "./artifact-upload.js";
 export type { ArtifactAuthorityRepository, ArtifactStorePromotionReceipt, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand, FinalizeArtifactRevisionResult } from "./artifact-finalization.types.js";
+export type { ArtifactReadLeaseRepository, ArtifactReadLeaseSigner, IssueArtifactReadLeaseCommand, IssueArtifactReadLeaseResult, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
 export type { ArtifactServicePromotionPort, ArtifactUploadCryptoPort, ArtifactUploadLeaseRepository, ArtifactUploadResult, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";


### PR DESCRIPTION
## Why this exists

The read service verifies a signed lease but must never decide which artifact a worker may access. This server authority is the only bridge from durable artifact catalog facts to that narrow lease.

## What changed

- adds a server-internal issuer for one active artifact and exact published revision
- re-checks silo, artifact, revision, SHA-256 address, byte length, and media type before signing
- issues a fresh opaque five-minute artifact.read lease only from those loaded facts
- exposes no HTTP route, artifact path, listing capability, worker identity, or network-policy change

## Deliberate boundary

A later one-time skill bootstrap exchange will be the sole caller. Until that lands, this is an uncomposed authority and does not grant any worker access.

## Validation

- focused server artifact-authority tests and TypeScript check
- style and diff checks

## Review

Independent review found no Critical or High findings; the README public-surface omission was fixed before publication.