### PR TITLE
🔒 Load exact published ArtifactStore read targets

### DIFF
--- a/libs/backend/server/agents/artifacts/main/src/__tests__/prisma-artifact-authority.test.ts
+++ b/libs/backend/server/agents/artifacts/main/src/__tests__/prisma-artifact-authority.test.ts
@@ -9,6 +9,15 @@ function _command()
 
 describe("Prisma artifact authority", function _suite()
 {
+	it("loads a read target only through the active artifact and exact published revision relation", async function _loadsReadTarget()
+	{
+		const artifactRevision = { findFirst: vi.fn().mockResolvedValue({ id: "revision-1", artifactId: "artifact-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12n, mediaType: "text/plain", artifact: { siloId: "silo-1" } }) };
+		const repository = new PrismaArtifactAuthorityRepository({ artifactRevision } as never);
+
+		expect(await repository.loadPublishedReadTarget({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" })).toEqual({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "text/plain" });
+		expect(artifactRevision.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ state: "Published", artifact: { siloId: "silo-1", state: "Active" } }) }));
+	});
+
 	it("commits promotion receipt, immutable revision, current pointer, outbox, and final lease state together", async function _finalize()
 	{
 		const transaction = {

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
@@ -2,11 +2,12 @@ import { randomUUID } from "node:crypto";
 
 import { ArtifactUploadLeaseState, Prisma, type PrismaClient } from "@prisma/client";
 
+import type { ArtifactReadLeaseRepository, IssueArtifactReadLeaseCommand, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
 import type { ArtifactAuthorityRepository, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand } from "./artifact-finalization.types.js";
 import type { ArtifactUploadLeaseRepository, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";
 
 /** Postgres authority for receipt consumption, immutable revision publication, and outbox creation. */
-export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactUploadLeaseRepository
+export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactReadLeaseRepository, ArtifactUploadLeaseRepository
 {
 	/** Canonical OpenCrane catalog database client. */
 	private readonly prisma: PrismaClient;
@@ -15,6 +16,17 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 	constructor(prisma: PrismaClient)
 	{
 		this.prisma = prisma;
+	}
+
+	/** Loads only an active artifact's exact published revision as a storage-neutral read target. */
+	async loadPublishedReadTarget(command: IssueArtifactReadLeaseCommand): Promise<PublishedArtifactReadTarget | null>
+	{
+		const revision = await this.prisma.artifactRevision.findFirst({
+			where: { id: command.artifactRevisionId, artifactId: command.artifactId, state: "Published", artifact: { siloId: command.siloId, state: "Active" } },
+			select: { id: true, artifactId: true, contentAddress: true, byteLength: true, mediaType: true, artifact: { select: { siloId: true } } },
+		});
+		if (revision === null || revision.byteLength > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+		return { siloId: revision.artifact.siloId, artifactId: revision.artifactId, artifactRevisionId: revision.id, contentAddress: revision.contentAddress, byteLength: Number(revision.byteLength), mediaType: revision.mediaType };
 	}
 
 	/** Creates or returns the one durable, proof-bound lease for one exact capability JTI. */


### PR DESCRIPTION
## Why this exists

The server-side read-lease issuer needs a concrete catalog adapter that proves an immutable object still belongs to the requested active silo and published revision before any lease can be signed.

## What changed

- adds the Prisma implementation of the issuer repository
- loads only the requested revision ID and owning artifact ID
- requires a published revision and active artifact in the requested silo
- returns only canonical address, byte length, media type, and immutable coordinates
- rejects unsafe BigInt byte lengths rather than silently truncating them

## Boundary

This is internal catalog reading only. It adds no user route, list API, artifact path, worker permission, storage mount, or network-policy change.

## Validation

- focused server artifact authority tests and TypeScript check
- style and diff checks

## Review

Independent review found no findings.