### PR TITLE
🔒 Persist an authoring receipt only from its canonical worker Pod

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -194,7 +194,7 @@ CREATE TYPE "SkillTrustClass" AS ENUM ('reviewed_instructions', 'sandboxed_pytho
 CREATE TYPE "SkillWorkloadKind" AS ENUM ('authoring', 'tool_runner');
 
 -- CreateEnum
-CREATE TYPE "SkillWorkloadState" AS ENUM ('pending', 'assigned', 'cancelled');
+CREATE TYPE "SkillWorkloadState" AS ENUM ('pending', 'assigned', 'succeeded', 'failed', 'cancelled');
 
 -- CreateTable
 CREATE TABLE "agent_services" (
@@ -1555,6 +1555,8 @@ CREATE TABLE "skill_workloads" (
     "release_expires_at" TIMESTAMP(3),
     "released_at" TIMESTAMP(3),
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completed_at" TIMESTAMP(3),
+    "failure_code" TEXT,
     "cancelled_at" TIMESTAMP(3),
 
     CONSTRAINT "skill_workloads_pkey" PRIMARY KEY ("id")
@@ -3952,11 +3954,11 @@ CREATE FUNCTION "enforce_skill_workload_authority"() RETURNS trigger LANGUAGE pl
 DECLARE revision_silo_id TEXT; revision_state "SkillRevisionState"; revision_trust "SkillTrustClass";
 BEGIN
     IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'SkillWorkload rows cannot be deleted'; END IF;
-    IF TG_OP = 'INSERT' AND (NEW."state" <> 'pending' OR NEW."claimed_at" IS NOT NULL OR NEW."delivery_count" <> 0 OR NEW."workload_uid" IS NOT NULL OR NEW."worker_pod_uid" IS NOT NULL OR NEW."release_claimed_at" IS NOT NULL OR NEW."release_delivery_count" <> 0 OR NEW."release_expires_at" IS NOT NULL OR NEW."released_at" IS NOT NULL OR NEW."cancelled_at" IS NOT NULL) THEN RAISE EXCEPTION 'SkillWorkload must begin pending without claim or assignment'; END IF;
+    IF TG_OP = 'INSERT' AND (NEW."state" <> 'pending' OR NEW."claimed_at" IS NOT NULL OR NEW."delivery_count" <> 0 OR NEW."workload_uid" IS NOT NULL OR NEW."worker_pod_uid" IS NOT NULL OR NEW."release_claimed_at" IS NOT NULL OR NEW."release_delivery_count" <> 0 OR NEW."release_expires_at" IS NOT NULL OR NEW."released_at" IS NOT NULL OR NEW."completed_at" IS NOT NULL OR NEW."failure_code" IS NOT NULL OR NEW."cancelled_at" IS NOT NULL) THEN RAISE EXCEPTION 'SkillWorkload must begin pending without claim or assignment'; END IF;
     IF TG_OP = 'UPDATE' AND (NEW."silo_id" IS DISTINCT FROM OLD."silo_id" OR NEW."kind" IS DISTINCT FROM OLD."kind" OR NEW."skill_revision_id" IS DISTINCT FROM OLD."skill_revision_id" OR NEW."tool_invocation_id" IS DISTINCT FROM OLD."tool_invocation_id") THEN
         RAISE EXCEPTION 'SkillWorkload source coordinates are immutable';
     END IF;
-    IF TG_OP = 'UPDATE' AND OLD."state" = 'cancelled' AND (NEW."state" IS DISTINCT FROM OLD."state" OR NEW."cancelled_at" IS DISTINCT FROM OLD."cancelled_at") THEN RAISE EXCEPTION 'cancelled SkillWorkload is terminal'; END IF;
+    IF TG_OP = 'UPDATE' AND OLD."state" IN ('succeeded', 'failed', 'cancelled') AND (NEW."state" IS DISTINCT FROM OLD."state" OR NEW."completed_at" IS DISTINCT FROM OLD."completed_at" OR NEW."failure_code" IS DISTINCT FROM OLD."failure_code" OR NEW."cancelled_at" IS DISTINCT FROM OLD."cancelled_at") THEN RAISE EXCEPTION 'terminal SkillWorkload is immutable'; END IF;
     IF TG_OP = 'UPDATE' AND OLD."workload_uid" IS NOT NULL AND NEW."workload_uid" IS DISTINCT FROM OLD."workload_uid" THEN RAISE EXCEPTION 'SkillWorkload assignment identity is immutable'; END IF;
     IF TG_OP = 'UPDATE' AND OLD."worker_pod_uid" IS NOT NULL AND NEW."worker_pod_uid" IS DISTINCT FROM OLD."worker_pod_uid" THEN RAISE EXCEPTION 'SkillWorkload worker Pod identity is immutable'; END IF;
     IF NEW."worker_pod_uid" IS NOT NULL AND (NEW."state" NOT IN ('assigned', 'cancelled') OR btrim(NEW."worker_pod_uid") = '') THEN RAISE EXCEPTION 'SkillWorkload worker Pod requires its assigned workload'; END IF;
@@ -3966,7 +3968,8 @@ BEGIN
     IF TG_OP = 'UPDATE' AND NEW."released_at" IS NULL AND (NEW."release_claimed_at" IS DISTINCT FROM OLD."release_claimed_at" OR NEW."release_delivery_count" IS DISTINCT FROM OLD."release_delivery_count" OR NEW."release_expires_at" IS DISTINCT FROM OLD."release_expires_at") AND (NEW."release_claimed_at" IS NULL OR NEW."release_expires_at" IS NULL OR NEW."release_expires_at" <= NEW."release_claimed_at" OR NEW."release_delivery_count" <> OLD."release_delivery_count" + 1 OR (OLD."release_claimed_at" IS NOT NULL AND NEW."release_claimed_at" <= OLD."release_claimed_at")) THEN RAISE EXCEPTION 'SkillWorkload release claim generation must advance monotonically'; END IF;
     IF TG_OP = 'UPDATE' AND OLD."state" = 'pending' AND NEW."state" = 'pending' AND (NEW."delivery_count" < OLD."delivery_count" OR (NEW."delivery_count" = OLD."delivery_count" AND NEW."claimed_at" IS DISTINCT FROM OLD."claimed_at") OR (NEW."delivery_count" > OLD."delivery_count" AND (NEW."delivery_count" <> OLD."delivery_count" + 1 OR NEW."claimed_at" IS NULL OR (OLD."claimed_at" IS NOT NULL AND NEW."claimed_at" <= OLD."claimed_at")))) THEN RAISE EXCEPTION 'SkillWorkload claim generation must advance monotonically'; END IF;
     IF TG_OP = 'UPDATE' AND NEW."state" = 'assigned' AND NOT (OLD."state" = 'pending' AND OLD."claimed_at" IS NOT NULL AND NEW."claimed_at" = OLD."claimed_at" AND NEW."delivery_count" = OLD."delivery_count" AND NEW."workload_uid" IS NOT NULL) THEN RAISE EXCEPTION 'SkillWorkload assignment requires exact prior claim'; END IF;
-    IF NEW."delivery_count" < 0 OR NEW."release_delivery_count" < 0 OR ((NEW."release_claimed_at" IS NULL) <> (NEW."release_expires_at" IS NULL)) OR (NEW."released_at" IS NOT NULL AND (NEW."state" <> 'assigned' OR NEW."release_claimed_at" IS NULL OR NEW."release_expires_at" IS NULL OR NEW."release_delivery_count" < 1)) OR NOT ((NEW."state" = 'pending' AND NEW."cancelled_at" IS NULL AND NEW."workload_uid" IS NULL AND NEW."worker_pod_uid" IS NULL) OR (NEW."state" = 'assigned' AND NEW."cancelled_at" IS NULL AND NEW."claimed_at" IS NOT NULL AND NEW."delivery_count" > 0 AND NEW."workload_uid" IS NOT NULL) OR (NEW."state" = 'cancelled' AND NEW."cancelled_at" IS NOT NULL)) THEN RAISE EXCEPTION 'SkillWorkload state requires matching claim, assignment, release, registration, and cancellation evidence'; END IF;
+    IF TG_OP = 'UPDATE' AND NEW."state" IN ('succeeded', 'failed') AND NOT (OLD."state" = 'assigned' AND OLD."released_at" IS NOT NULL AND OLD."worker_pod_uid" IS NOT NULL AND NEW."completed_at" IS NOT NULL AND NEW."completed_at" >= OLD."released_at") THEN RAISE EXCEPTION 'SkillWorkload completion requires released registered assignment'; END IF;
+    IF NEW."delivery_count" < 0 OR NEW."release_delivery_count" < 0 OR ((NEW."release_claimed_at" IS NULL) <> (NEW."release_expires_at" IS NULL)) OR (NEW."released_at" IS NOT NULL AND (NEW."state" NOT IN ('assigned', 'succeeded', 'failed') OR NEW."release_claimed_at" IS NULL OR NEW."release_expires_at" IS NULL OR NEW."release_delivery_count" < 1)) OR NOT ((NEW."state" = 'pending' AND NEW."cancelled_at" IS NULL AND NEW."workload_uid" IS NULL AND NEW."worker_pod_uid" IS NULL AND NEW."completed_at" IS NULL AND NEW."failure_code" IS NULL) OR (NEW."state" = 'assigned' AND NEW."cancelled_at" IS NULL AND NEW."claimed_at" IS NOT NULL AND NEW."delivery_count" > 0 AND NEW."workload_uid" IS NOT NULL AND NEW."completed_at" IS NULL AND NEW."failure_code" IS NULL) OR (NEW."state" = 'succeeded' AND NEW."cancelled_at" IS NULL AND NEW."claimed_at" IS NOT NULL AND NEW."delivery_count" > 0 AND NEW."workload_uid" IS NOT NULL AND NEW."worker_pod_uid" IS NOT NULL AND NEW."completed_at" IS NOT NULL AND NEW."failure_code" IS NULL) OR (NEW."state" = 'failed' AND NEW."cancelled_at" IS NULL AND NEW."claimed_at" IS NOT NULL AND NEW."delivery_count" > 0 AND NEW."workload_uid" IS NOT NULL AND NEW."worker_pod_uid" IS NOT NULL AND NEW."completed_at" IS NOT NULL AND NEW."failure_code" IS NOT NULL AND btrim(NEW."failure_code") <> '') OR (NEW."state" = 'cancelled' AND NEW."cancelled_at" IS NOT NULL)) THEN RAISE EXCEPTION 'SkillWorkload state requires matching claim, assignment, completion, and cancellation evidence'; END IF;
     IF TG_OP = 'INSERT' THEN
         SELECT skill."silo_id", revision."state", revision."trust_class" INTO revision_silo_id, revision_state, revision_trust FROM "skill_revisions" revision JOIN "skills" skill ON skill."id" = revision."skill_id" WHERE revision."id" = NEW."skill_revision_id" FOR UPDATE OF revision, skill;
         IF revision_silo_id IS DISTINCT FROM NEW."silo_id" OR revision_trust IS DISTINCT FROM 'sandboxed_python' THEN RAISE EXCEPTION 'SkillWorkload requires same-silo SandboxedPython SkillRevision'; END IF;
@@ -3974,6 +3977,11 @@ BEGIN
         IF NEW."kind" = 'tool_runner' THEN
             RAISE EXCEPTION 'tool-runner SkillWorkload requires the later snapshot-bound workload admission authority';
         END IF;
+    END IF;
+    IF TG_OP = 'UPDATE' AND NEW."state" IN ('succeeded', 'failed') THEN
+        IF NOT EXISTS (SELECT 1 FROM "skill_workload_bootstraps" bootstrap WHERE bootstrap."skill_workload_id" = NEW."id" AND bootstrap."consumed_at" IS NOT NULL AND bootstrap."consumed_by_pod_uid" = OLD."worker_pod_uid") THEN RAISE EXCEPTION 'SkillWorkload completion requires its consumed canonical worker bootstrap'; END IF;
+        IF NEW."kind" <> 'authoring' THEN RAISE EXCEPTION 'tool runner completion has its own ToolInvocation authority'; END IF;
+        IF NEW."state" = 'succeeded' AND NOT EXISTS (SELECT 1 FROM "skill_revisions" revision WHERE revision."id" = NEW."skill_revision_id" AND revision."state" = 'draft' AND jsonb_typeof(revision."test_report") = 'object' AND (SELECT count(*) FROM jsonb_object_keys(revision."test_report")) = 3 AND revision."test_report" @> '{"passed":true}'::jsonb AND jsonb_typeof(revision."test_report"->'summary') = 'string' AND length(revision."test_report"->>'summary') BETWEEN 1 AND 2000 AND jsonb_typeof(revision."test_report"->'checksRun') = 'number' AND (revision."test_report"->>'checksRun') ~ '^(0|[1-9][0-9]{0,3}|10000)$' AND jsonb_typeof(revision."scan_result") = 'object' AND (SELECT count(*) FROM jsonb_object_keys(revision."scan_result")) = 3 AND revision."scan_result" @> '{"passed":true}'::jsonb AND jsonb_typeof(revision."scan_result"->'summary') = 'string' AND length(revision."scan_result"->>'summary') BETWEEN 1 AND 2000 AND jsonb_typeof(revision."scan_result"->'checksRun') = 'number' AND (revision."scan_result"->>'checksRun') ~ '^(0|[1-9][0-9]{0,3}|10000)$') THEN RAISE EXCEPTION 'authoring completion requires bounded passed draft test and scan reports'; END IF;
     END IF;
     RETURN NEW;
 END;

--- a/apps/opencrane/prisma/schema/skills.prisma
+++ b/apps/opencrane/prisma/schema/skills.prisma
@@ -22,10 +22,12 @@ enum SkillWorkloadKind {
   ToolRunner @map("tool_runner")
 }
 
-/// Durable disposition before controller assignment and worker reply are introduced.
+/// Durable lifecycle of one governed worker request; Kubernetes reports identity, never terminal state.
 enum SkillWorkloadState {
   Pending    @map("pending")
   Assigned   @map("assigned")
+  Succeeded  @map("succeeded")
+  Failed     @map("failed")
   Cancelled  @map("cancelled")
 }
 
@@ -97,6 +99,8 @@ model SkillWorkload {
   releaseExpiresAt DateTime?           @map("release_expires_at")
   releasedAt        DateTime?          @map("released_at")
   createdAt        DateTime           @default(now()) @map("created_at")
+  completedAt      DateTime?          @map("completed_at")
+  failureCode      String?            @map("failure_code")
   cancelledAt      DateTime?          @map("cancelled_at")
   skillRevision    SkillRevision      @relation(fields: [skillRevisionId], references: [id], onDelete: Restrict)
   toolInvocation   ToolInvocation?    @relation(fields: [toolInvocationId], references: [id], onDelete: Restrict)

--- a/apps/opencrane/prisma/tests/skill-workload-authority.sql
+++ b/apps/opencrane/prisma/tests/skill-workload-authority.sql
@@ -41,7 +41,20 @@ UPDATE "skill_workload_bootstraps" SET "consumed_at"=clock_timestamp(), "consume
 SELECT pg_temp.expect_failure('consumed bootstrap is terminal', $statement$UPDATE "skill_workload_bootstraps" SET "consumed_by_pod_uid"='other-pod' WHERE "id"='bootstrap-1'$statement$, 'consumed SkillWorkloadBootstrap is terminal');
 SELECT pg_temp.expect_failure('worker Pod identity is immutable', $statement$UPDATE "skill_workloads" SET "worker_pod_uid"='other-pod' WHERE "id"='authoring-work'$statement$, 'worker Pod identity is immutable');
 
-INSERT INTO "skill_revisions" ("id", "skill_id", "revision", "artifact_id", "artifact_revision_id", "artifact_content_address", "manifest", "requirements", "trust_class", "authored_by") VALUES ('work-draft-unconsumed','work-skill',2,'work-artifact','work-artifact-revision','sha256:'||repeat('a',64),'{}','{}','sandboxed_python','user-1');
+INSERT INTO "skill_revisions" ("id", "skill_id", "revision", "artifact_id", "artifact_revision_id", "artifact_content_address", "manifest", "requirements", "trust_class", "authored_by") VALUES ('work-draft-completion','work-skill',2,'work-artifact','work-artifact-revision','sha256:'||repeat('a',64),'{}','{}','sandboxed_python','user-1');
+INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('authoring-work-completion','work-silo','authoring','work-draft-completion');
+UPDATE "skill_workloads" SET "claimed_at"=clock_timestamp(), "delivery_count"=1 WHERE "id"='authoring-work-completion';
+UPDATE "skill_workloads" SET "state"='assigned', "workload_uid"='job-uid-completion' WHERE "id"='authoring-work-completion';
+INSERT INTO "skill_workload_bootstraps" ("id", "skill_workload_id", "reference_hash", "audience", "service_account_name", "namespace", "workload_uid", "expires_at") VALUES ('bootstrap-completion','authoring-work-completion','sha256:'||repeat('f',64),'opencrane-skill-authoring','skill-authoring-default','opencrane-skill-authoring','job-uid-completion',clock_timestamp()+interval '5 minutes');
+UPDATE "skill_workloads" SET "release_claimed_at"=clock_timestamp(), "release_delivery_count"=1, "release_expires_at"=clock_timestamp()+interval '1 minute' WHERE "id"='authoring-work-completion';
+UPDATE "skill_workloads" SET "released_at"=clock_timestamp(), "worker_pod_uid"='pod-uid-completion' WHERE "id"='authoring-work-completion';
+UPDATE "skill_workload_bootstraps" SET "consumed_at"=clock_timestamp(), "consumed_by_pod_uid"='pod-uid-completion' WHERE "id"='bootstrap-completion';
+SELECT pg_temp.expect_failure('completion requires passed bounded evidence', $statement$UPDATE "skill_workloads" SET "state"='succeeded', "completed_at"=clock_timestamp() WHERE "id"='authoring-work-completion'$statement$, 'bounded passed draft test and scan reports');
+UPDATE "skill_revisions" SET "test_report"='{"passed":true,"summary":"checks passed","checksRun":1}', "scan_result"='{"passed":true,"summary":"scan passed","checksRun":1}' WHERE "id"='work-draft-completion';
+UPDATE "skill_workloads" SET "state"='succeeded', "completed_at"=clock_timestamp() WHERE "id"='authoring-work-completion';
+SELECT pg_temp.expect_failure('completed workload is terminal', $statement$UPDATE "skill_workloads" SET "state"='failed', "failure_code"='late_failure' WHERE "id"='authoring-work-completion'$statement$, 'terminal SkillWorkload is immutable');
+
+INSERT INTO "skill_revisions" ("id", "skill_id", "revision", "artifact_id", "artifact_revision_id", "artifact_content_address", "manifest", "requirements", "trust_class", "authored_by") VALUES ('work-draft-unconsumed','work-skill',3,'work-artifact','work-artifact-revision','sha256:'||repeat('a',64),'{}','{}','sandboxed_python','user-1');
 INSERT INTO "skill_workloads" ("id", "silo_id", "kind", "skill_revision_id") VALUES ('authoring-work-unconsumed','work-silo','authoring','work-draft-unconsumed');
 UPDATE "skill_workloads" SET "claimed_at"=clock_timestamp(), "delivery_count"=1 WHERE "id"='authoring-work-unconsumed';
 UPDATE "skill_workloads" SET "state"='assigned', "workload_uid"='job-uid-2' WHERE "id"='authoring-work-unconsumed';

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -21,7 +21,7 @@ import { _CreateRuntimeTokenReviewer, _RegisterInternalAgentRuntimeStream } from
 import { AGENT_CONTROLLER_PROJECTED_TOKEN_AUDIENCE, AGENT_CONTROLLER_SERVICE_ACCOUNT_NAME, type RunInputSnapshot } from "@opencrane/contracts";
 import { spec } from "@opencrane/backend/server/api-spec";
 import { PrismaRunDispatchRepository, __CreateAgentControllerRunDispatchRouter, type AgentControllerTokenReviewer, type AttemptModelKeyMintRequest, type MintedAttemptModelKey, type ReviewedAgentControllerIdentity } from "@opencrane/backend/agents/execution/runs";
-import { PrismaSkillWorkloadBootstrapRepository, PrismaSkillWorkloadClaimsRepository, __CreateSkillWorkloadBootstrapRouter, __CreateSkillWorkloadDispatchRouter, type SkillWorkloadBootstrapIdentity, type SkillWorkloadBootstrapTokenReviewer } from "@opencrane/backend/agents/skills/execution";
+import { PrismaSkillAuthoringCompletionRepository, PrismaSkillWorkloadBootstrapRepository, PrismaSkillWorkloadClaimsRepository, __CreateSkillAuthoringCompletionRouter, __CreateSkillWorkloadBootstrapRouter, __CreateSkillWorkloadDispatchRouter, type SkillWorkloadBootstrapIdentity, type SkillWorkloadBootstrapTokenReviewer } from "@opencrane/backend/agents/skills/execution";
 import { __CreateExternalActionExecutor, __CreatePrismaRunInputCompiler, PrismaRuntimeDispatchAuthority, __ExecuteExternalAction, type RunInputCompiler, type RuntimeExternalActionRunner } from "@opencrane/backend/agents/execution/protocol";
 import { __IsUpgradeSessionAvailable, PrismaPersonalConfigurationChangeRepository, UPGRADE_SESSION_TOOL, UPGRADE_SESSION_TOOL_REVISION } from "@opencrane/backend/agents/personal/configuration";
 import { __AppendCompiledTool } from "@opencrane/backend/agents/runtime/prompt-compiler";
@@ -305,6 +305,7 @@ export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, auth
 	app.use("/api/internal/agent-controller", __CreateAgentControllerRunDispatchRouter({ tokenReviewer: _CreateAgentControllerTokenReviewer(authApi, serverNamespace), namespace: serverNamespace, repository: runDispatchRepository, logger: _log }));
 	app.use("/api/internal/agent-controller", __CreateSkillWorkloadDispatchRouter({ tokenReviewer: _CreateAgentControllerTokenReviewer(authApi, serverNamespace), namespace: serverNamespace, repository: skillWorkloadClaimsRepository, logger: _log }));
 	app.use("/api/internal/agent-runtime", __CreateSkillWorkloadBootstrapRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillWorkloadBootstrapRepository(prisma), logger: _log }));
+	app.use("/api/internal/agent-runtime", __CreateSkillAuthoringCompletionRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillAuthoringCompletionRepository(prisma), logger: _log }));
   // NetworkPolicy-only (no auth/TokenReview): the operator fetches a tenant's
   // allowed model set + effective default at reconcile. Best-effort — never 404/500.
   app.use("/api/internal/tenant-models", _RegisterInternalTenantModels(prisma));

--- a/libs/backend/agents/skills/execution/main/README.md
+++ b/libs/backend/agents/skills/execution/main/README.md
@@ -29,7 +29,9 @@ cannot attach a different Job or replace its reference.
 
 It does not create Kubernetes resources, issue worker capabilities, read ArtifactStore bytes, or
 complete tool invocations. A released worker may acknowledge its one-use bootstrap only after its
-projected-token identity matches the canonical Pod UID recorded for the Job.
+projected-token identity matches the canonical Pod UID recorded for the Job. An authoring worker can
+then write one terminal receipt: a passed bounded test-and-scan report, or a stable failure code.
+Tool-runner results remain a separate ToolInvocation authority.
 
 ## Public surface
 
@@ -39,6 +41,8 @@ projected-token identity matches the canonical Pod UID recorded for the Job.
 - `__CreateSkillWorkloadDispatchRouter` — projected-token-authenticated internal claim and assignment API.
 - `__CreateSkillWorkloadBootstrapRouter` — consumes one opaque bootstrap reference only for the
   exact TokenReview-confirmed worker Pod.
+- `PrismaSkillAuthoringCompletionRepository` — atomic authoring receipt and Draft-evidence write.
+- `__CreateSkillAuthoringCompletionRouter` — authoring-audience-only receipt API with strict input bounds.
 
 ## Boundary
 
@@ -57,13 +61,15 @@ composes the HTTP route; the controller consumes it through an outbound adapter.
 
 ## Data & persistence
 
-The package owns the claim and assignment transitions on `SkillWorkload`. The clean target baseline
-enforces its pending → assigned state fence, monotonic delivery generation, immutable Job UID, and
-terminal cancellation independently of this TypeScript adapter. It also owns the one-use
+The package owns the claim, assignment, and authoring terminal transitions on `SkillWorkload`. The
+clean target baseline enforces its pending → assigned → terminal state fence, monotonic delivery
+generation, immutable Job UID, canonical worker Pod, and terminal receipt independently of this
+TypeScript adapter. It also owns the one-use
 `SkillWorkloadBootstrap` record: only a SHA-256 hash of the worker reference is stored, and it is
 bound to the exact assigned Job UID plus the fixed namespace, ServiceAccount, audience, expiry, and
-the controller-registered canonical worker Pod UID. The later worker exchange may consume that record, but cannot turn it into a
-general artifact or runtime credential.
+the controller-registered canonical worker Pod UID. A successful authoring receipt can write only
+two passed bounded reports to its still-Draft revision; it cannot turn the record into a general
+artifact or runtime credential.
 
 ## See also
 

--- a/libs/backend/agents/skills/execution/main/src/__tests__/skill-authoring-completion.router.test.ts
+++ b/libs/backend/agents/skills/execution/main/src/__tests__/skill-authoring-completion.router.test.ts
@@ -1,0 +1,40 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { __CreateSkillAuthoringCompletionRouter } from "../skill-authoring-completion.router.js";
+import type { SkillAuthoringCompletionRouterDependencies } from "../skill-authoring-completion.types.js";
+
+/** Bounded passed evidence from the isolated authoring worker. */
+const _SUCCESS = { workloadId: "workload-1", outcome: "succeeded", testReport: { passed: true, summary: "all checks passed", checksRun: 2 }, scanResult: { passed: true, summary: "no findings", checksRun: 3 } };
+
+/** Builds one route with the exact authoring Pod identity reviewed. */
+function _App(overrides: Partial<SkillAuthoringCompletionRouterDependencies> = {})
+{
+	const dependencies: SkillAuthoringCompletionRouterDependencies = { tokenReviewer: { __Review: vi.fn().mockResolvedValue({ namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", podUid: "pod-uid-1" }) }, repository: { completeAtomically: vi.fn().mockResolvedValue("completed") }, logger: { error: vi.fn() }, ...overrides };
+	const app = express();
+	app.use(express.json());
+	app.use(__CreateSkillAuthoringCompletionRouter(dependencies));
+	return { app, dependencies };
+}
+
+describe("skill authoring completion router", function _DescribeAuthoringCompletion()
+{
+	it("reviews the route-owned authoring audience then forwards only bounded evidence", async function _Completes()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).post("/skill-authoring-workloads:complete").set("authorization", "Bearer projected-token").send(_SUCCESS);
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ completed: true });
+		expect(dependencies.tokenReviewer.__Review).toHaveBeenCalledWith("projected-token", "opencrane-skill-authoring");
+	});
+
+	it("rejects unauthenticated, extended, and stale worker reports", async function _Rejects()
+	{
+		const { app, dependencies } = _App({ repository: { completeAtomically: vi.fn().mockResolvedValue("conflict") } });
+		expect((await request(app).post("/skill-authoring-workloads:complete").send(_SUCCESS)).status).toBe(401);
+		expect((await request(app).post("/skill-authoring-workloads:complete").set("authorization", "Bearer projected-token").send({ ..._SUCCESS, output: "source" })).status).toBe(400);
+		expect((await request(app).post("/skill-authoring-workloads:complete").set("authorization", "Bearer projected-token").send({ workloadId: "workload-1", outcome: "failed", failureCode: "test_process_failed" })).status).toBe(409);
+		expect(dependencies.repository.completeAtomically).toHaveBeenCalledTimes(1);
+	});
+});

--- a/libs/backend/agents/skills/execution/main/src/__tests__/skill-workload-bootstrap.router.test.ts
+++ b/libs/backend/agents/skills/execution/main/src/__tests__/skill-workload-bootstrap.router.test.ts
@@ -31,7 +31,7 @@ describe("governed skill worker bootstrap router", function _DescribeBootstrap()
 		const response = await request(app).post("/skill-workloads:bootstrap").set("authorization", "Bearer projected-token").send({ bootstrapReference: _REFERENCE });
 
 		expect(response.status).toBe(200);
-		expect(response.body).toEqual({ acknowledged: true });
+		expect(response.body).toEqual({ acknowledged: true, workloadId: "workload-1" });
 		expect(dependencies.tokenReviewer.__Review).toHaveBeenCalledWith("projected-token", "opencrane-skill-authoring");
 		expect(dependencies.repository.consumeAtomically).toHaveBeenCalledWith(expect.stringMatching(/^sha256:[a-f0-9]{64}$/), { namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", podUid: "pod-uid-1" });
 	});

--- a/libs/backend/agents/skills/execution/main/src/index.ts
+++ b/libs/backend/agents/skills/execution/main/src/index.ts
@@ -2,6 +2,9 @@ export type { SkillWorkloadAssignmentCommand, SkillWorkloadClaim, SkillWorkloadP
 export { __CreateSkillWorkloadBootstrapRouter } from "./skill-workload-bootstrap.router.js";
 export { PrismaSkillWorkloadBootstrapRepository } from "./prisma-skill-workload-bootstrap-repository.js";
 export type { SkillWorkloadBootstrapIdentity, SkillWorkloadBootstrapLogger, SkillWorkloadBootstrapRecord, SkillWorkloadBootstrapRepository, SkillWorkloadBootstrapRouterDependencies, SkillWorkloadBootstrapTokenReviewer } from "./skill-workload-bootstrap.types.js";
+export { __CreateSkillAuthoringCompletionRouter } from "./skill-authoring-completion.router.js";
+export { PrismaSkillAuthoringCompletionRepository } from "./prisma-skill-authoring-completion-repository.js";
+export type { CreateSkillAuthoringCompletionRouter, SkillAuthoringCheckReport, SkillAuthoringCompletionCommand, SkillAuthoringCompletionRepository, SkillAuthoringCompletionRouterDependencies } from "./skill-authoring-completion.types.js";
 export { PrismaSkillWorkloadClaimsRepository } from "./prisma-skill-workload-claims-repository.js";
 export type { SkillWorkloadClaimsRepository } from "./skill-workload-claims.types.js";
 export { __CreateSkillWorkloadDispatchRouter } from "./skill-workload-dispatch.router.js";

--- a/libs/backend/agents/skills/execution/main/src/prisma-skill-authoring-completion-repository.ts
+++ b/libs/backend/agents/skills/execution/main/src/prisma-skill-authoring-completion-repository.ts
@@ -1,0 +1,43 @@
+import { Prisma, SkillWorkloadState, type PrismaClient } from "@prisma/client";
+
+import type { SkillAuthoringCompletionCommand, SkillAuthoringCompletionRepository } from "./skill-authoring-completion.types.js";
+import type { SkillWorkloadBootstrapIdentity } from "./skill-workload-bootstrap.types.js";
+
+/** Prisma authority for one exact authoring worker's terminal evidence report. */
+export class PrismaSkillAuthoringCompletionRepository implements SkillAuthoringCompletionRepository
+{
+	/** Canonical OpenCrane product-authority database client. */
+	private readonly prisma: PrismaClient;
+
+	/** Creates the authoring completion authority over canonical Postgres. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Completes one bootstrap-consumed Draft authoring workload and persists only bounded evidence. */
+	async completeAtomically(command: SkillAuthoringCompletionCommand, identity: SkillWorkloadBootstrapIdentity): Promise<"completed" | "conflict">
+	{
+		return this.prisma.$transaction(async function _Complete(transaction: Prisma.TransactionClient): Promise<"completed" | "conflict">
+		{
+			// 1. Lock the workload so a duplicate report cannot alter its revision after a competing completion.
+			const locked = await transaction.$queryRaw<readonly { readonly id: string }[]>(Prisma.sql`SELECT "id" FROM "skill_workloads" WHERE "id" = ${command.workloadId} FOR UPDATE`);
+			if (locked.length !== 1) return "conflict";
+
+			// 2. Fence against the exact canonical worker Pod and consumed bootstrap before any revision evidence changes.
+			const workload = await transaction.skillWorkload.findFirst({ where: { id: command.workloadId, kind: "Authoring", state: SkillWorkloadState.Assigned, releasedAt: { not: null }, workerPodUid: identity.podUid, bootstrap: { is: { consumedAt: { not: null }, consumedByPodUid: identity.podUid, namespace: identity.namespace, serviceAccountName: identity.serviceAccountName } } }, include: { skillRevision: true } });
+			if (workload === null || workload.skillRevision.state !== "Draft") return "conflict";
+
+			// 3. Store passed reports before terminalising the locked row; a failure records only a stable code.
+			if (command.outcome === "succeeded")
+			{
+				if (!command.testReport.passed || !command.scanResult.passed) return "conflict";
+				const revision = await transaction.skillRevision.updateMany({ where: { id: workload.skillRevisionId, state: "Draft", testReport: { equals: Prisma.DbNull }, scanResult: { equals: Prisma.DbNull } }, data: { testReport: command.testReport as unknown as Prisma.InputJsonValue, scanResult: command.scanResult as unknown as Prisma.InputJsonValue } });
+				if (revision.count !== 1) return "conflict";
+			}
+
+			const completed = await transaction.skillWorkload.updateMany({ where: { id: workload.id, state: SkillWorkloadState.Assigned }, data: command.outcome === "succeeded" ? { state: SkillWorkloadState.Succeeded, completedAt: new Date(), failureCode: null } : { state: SkillWorkloadState.Failed, completedAt: new Date(), failureCode: command.failureCode } });
+			return completed.count === 1 ? "completed" : "conflict";
+		});
+	}
+}

--- a/libs/backend/agents/skills/execution/main/src/skill-authoring-completion.router.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-authoring-completion.router.ts
@@ -1,0 +1,111 @@
+import { Router, type Request, type Response } from "express";
+
+import type { SkillAuthoringCheckReport, SkillAuthoringCompletionCommand, SkillAuthoringCompletionRouterDependencies } from "./skill-authoring-completion.types.js";
+
+/** Fixed projected-token audience for the isolated authoring worker class. */
+const _AUTHORING_AUDIENCE = "opencrane-skill-authoring";
+
+/**
+ * Build the authoring-only worker completion boundary.
+ *
+ * **This router is NOT behind `___AuthMiddleware`.** It TokenReviews a rotating projected
+ * ServiceAccount token, while Helm allows only governed authoring Pods to reach this listener.
+ *
+ * @see apps/opencrane/helm/templates/_networkpolicy.tpl — server ingress and worker egress floor.
+ * @see apps/agent-controller/helm/templates/_resources.tpl — projected authoring-token audience.
+ */
+export function __CreateSkillAuthoringCompletionRouter(dependencies: SkillAuthoringCompletionRouterDependencies): Router
+{
+	const router = Router();
+	router.post("/skill-authoring-workloads:complete", async function _Complete(request: Request, response: Response): Promise<void>
+	{
+		// 1. Review the route-owned authoring audience before a worker-selected coordinate reaches Postgres.
+		const token = _Bearer(request.header("authorization"));
+		if (token === null)
+		{
+			response.status(401).json({ error: "worker_identity_denied" });
+			return;
+		}
+		try
+		{
+			const identity = await dependencies.tokenReviewer.__Review(token, _AUTHORING_AUDIENCE);
+			const command = _Command(request.body);
+			if (identity === null)
+			{
+				response.status(401).json({ error: "worker_identity_denied" });
+				return;
+			}
+			if (command === null)
+			{
+				response.status(400).json({ error: "invalid_completion" });
+				return;
+			}
+
+			// 2. Atomically compare the reviewed Pod to the canonical bootstrap consumer before terminalising.
+			const outcome = await dependencies.repository.completeAtomically(command, identity);
+			if (outcome !== "completed")
+			{
+				response.status(409).json({ error: "completion_unavailable" });
+				return;
+			}
+			response.status(200).json({ completed: true });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "skill_authoring.completion" }, "Skill authoring completion failed");
+			response.status(503).json({ error: "completion_authority_unavailable" });
+		}
+	});
+	return router;
+}
+
+/** Parse one standard bearer value without accepting multiple credentials. */
+function _Bearer(value: string | undefined): string | null
+{
+	return value && /^Bearer ([^\s,]+)$/u.test(value) ? /^Bearer ([^\s,]+)$/u.exec(value)?.[1] ?? null : null;
+}
+
+/** Parse the small authoring-specific terminal contract, refusing arbitrary result JSON. */
+function _Command(value: unknown): SkillAuthoringCompletionCommand | null
+{
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+	const body = value as Record<string, unknown>;
+	if (body["outcome"] === "succeeded" && _HasKeys(body, ["workloadId", "outcome", "testReport", "scanResult"]) && _Coordinate(body["workloadId"]) && _Report(body["testReport"]) && _Report(body["scanResult"])) return { workloadId: body["workloadId"], outcome: "succeeded", testReport: body["testReport"], scanResult: body["scanResult"] };
+	if (body["outcome"] === "failed" && _HasKeys(body, ["workloadId", "outcome", "failureCode"]) && _Coordinate(body["workloadId"]) && _FailureCode(body["failureCode"])) return { workloadId: body["workloadId"], outcome: "failed", failureCode: body["failureCode"] };
+	return null;
+}
+
+/** Require exactly the listed keys so a worker cannot smuggle future policy through the boundary. */
+function _HasKeys(value: Record<string, unknown>, expected: readonly string[]): boolean
+{
+	return Object.keys(value).length === expected.length && expected.every(function _HasKey(key): boolean { return key in value; });
+}
+
+/** Validate the durable workload coordinate before it reaches the persistence adapter. */
+function _Coordinate(value: unknown): value is string
+{
+	return typeof value === "string" && value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/.test(value);
+}
+
+/** Validate bounded, reviewable evidence rather than accepting a free-form worker JSON blob. */
+function _Report(value: unknown): value is SkillAuthoringCheckReport
+{
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+	const report = value as Record<string, unknown>;
+	return _HasKeys(report, ["passed", "summary", "checksRun"])
+		&& typeof report["passed"] === "boolean"
+		&& typeof report["summary"] === "string"
+		&& report["summary"].length > 0
+		&& report["summary"].length <= 2_000
+		&& !/[\u0000-\u001f\u007f]/.test(report["summary"])
+		&& typeof report["checksRun"] === "number"
+		&& Number.isSafeInteger(report["checksRun"])
+		&& report["checksRun"] >= 0
+		&& report["checksRun"] <= 10_000;
+}
+
+/** Restrict a terminal technical failure to a portable stable code. */
+function _FailureCode(value: unknown): value is string
+{
+	return typeof value === "string" && /^[a-z][a-z0-9_]{0,63}$/.test(value);
+}

--- a/libs/backend/agents/skills/execution/main/src/skill-authoring-completion.types.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-authoring-completion.types.ts
@@ -1,0 +1,56 @@
+import type { Router } from "express";
+
+import type { SkillWorkloadBootstrapIdentity, SkillWorkloadBootstrapLogger, SkillWorkloadBootstrapTokenReviewer } from "./skill-workload-bootstrap.types.js";
+
+/** Bounded evidence from the isolated checks performed against one draft skill revision. */
+export interface SkillAuthoringCheckReport
+{
+	/** Whether every check in this report passed. */
+	readonly passed: boolean;
+	/** Short worker-produced explanation suitable for later human review. */
+	readonly summary: string;
+	/** Number of individual checks represented by the report. */
+	readonly checksRun: number;
+}
+
+/** One exact authoring-worker terminal report with no caller-selected identity or workload class. */
+export type SkillAuthoringCompletionCommand =
+	| {
+		/** Durable authoring workload selected before its worker Job was released. */
+		readonly workloadId: string;
+		/** Records a completed candidate validation with both required reports. */
+		readonly outcome: "succeeded";
+		/** Test evidence to persist on the draft SkillRevision. */
+		readonly testReport: SkillAuthoringCheckReport;
+		/** Scan evidence to persist on the draft SkillRevision. */
+		readonly scanResult: SkillAuthoringCheckReport;
+	}
+	| {
+		/** Durable authoring workload selected before its worker Job was released. */
+		readonly workloadId: string;
+		/** Records a terminal worker failure without accepting unbounded output. */
+		readonly outcome: "failed";
+		/** Stable server-recognised failure code, never a worker stack trace. */
+		readonly failureCode: string;
+	};
+
+/** Postgres boundary for one authoring worker's exact terminal transition and evidence write. */
+export interface SkillAuthoringCompletionRepository
+{
+	/** Completes only the released, canonical-worker-Pod, bootstrap-consumed authoring workload. */
+	completeAtomically(command: SkillAuthoringCompletionCommand, identity: SkillWorkloadBootstrapIdentity): Promise<"completed" | "conflict">;
+}
+
+/** Dependencies of the worker-authenticated authoring completion route. */
+export interface SkillAuthoringCompletionRouterDependencies
+{
+	/** Reviews the worker's projected token against the route-owned authoring audience. */
+	readonly tokenReviewer: SkillWorkloadBootstrapTokenReviewer;
+	/** Executes the one terminal state and evidence transition against Postgres. */
+	readonly repository: SkillAuthoringCompletionRepository;
+	/** Emits only structured, non-sensitive authority failures. */
+	readonly logger: SkillWorkloadBootstrapLogger;
+}
+
+/** Factory producing the authoring-only worker completion route. */
+export type CreateSkillAuthoringCompletionRouter = (dependencies: SkillAuthoringCompletionRouterDependencies) => Router;

--- a/libs/backend/agents/skills/execution/main/src/skill-workload-bootstrap.router.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-workload-bootstrap.router.ts
@@ -45,14 +45,14 @@ export function __CreateSkillWorkloadBootstrapRouter(dependencies: SkillWorkload
 				return;
 			}
 
-			// 3. Consume under the same reviewed identity; no secret or capability is returned by this gate.
+			// 3. Consume under the same reviewed identity; return only the already-bound completion coordinate.
 			const outcome = await dependencies.repository.consumeAtomically(hash, identity);
 			if (outcome !== "consumed")
 			{
 				response.status(409).json({ error: "bootstrap_unavailable" });
 				return;
 			}
-			response.status(200).json({ acknowledged: true });
+			response.status(200).json({ acknowledged: true, workloadId: record.workloadId });
 		}
 		catch (err)
 		{

--- a/libs/backend/agents/skills/worker/src/bootstrap.py
+++ b/libs/backend/agents/skills/worker/src/bootstrap.py
@@ -65,8 +65,8 @@ def _open(request: Request, timeout: float) -> _Response:
     return build_opener(_NoRedirect()).open(request, timeout=timeout)  # type: ignore[return-value]
 
 
-def acknowledge(base_url: str, token_path: str, reference_path: str, open_request: Callable[[Request, float], _Response] = _open) -> None:
-    """Consume one opaque bootstrap reference and accept only a minimal positive receipt."""
+def acknowledge(base_url: str, token_path: str, reference_path: str, open_request: Callable[[Request, float], _Response] = _open) -> str:
+    """Consume one opaque bootstrap reference and return only its server-bound workload coordinate."""
     token = _read_single_line(token_path, "capability token")
     reference = _read_single_line(reference_path, "bootstrap reference")
     if len(reference) != 83 or not reference.startswith("skill-bootstrap-v1_") or any(character not in "0123456789abcdef" for character in reference.removeprefix("skill-bootstrap-v1_")):
@@ -85,8 +85,14 @@ def acknowledge(base_url: str, token_path: str, reference_path: str, open_reques
             error.close()
     except (OSError, URLError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise RuntimeError("bootstrap acknowledgement is unavailable") from error
-    if response.status != 200 or payload != {"acknowledged": True}:
+    if response.status != 200 or not isinstance(payload, dict) or set(payload) != {"acknowledged", "workloadId"} or payload.get("acknowledged") is not True or not _workload_id(payload.get("workloadId")):
         raise RuntimeError("bootstrap acknowledgement was rejected")
+    return payload["workloadId"]
+
+
+def _workload_id(value: object) -> bool:
+    """Accept the bounded opaque coordinate required by the later class-specific completion report."""
+    return isinstance(value, str) and 0 < len(value) <= 256 and not any(character in value for character in "\x00\n\r")
 
 
 def main() -> int:

--- a/libs/backend/agents/skills/worker/tests/test_bootstrap.py
+++ b/libs/backend/agents/skills/worker/tests/test_bootstrap.py
@@ -44,12 +44,13 @@ class BootstrapTests(unittest.TestCase):
                 captured["body"] = request.data
                 captured["authorization"] = request.get_header("Authorization")
                 captured["timeout"] = timeout
-                return _Response(200, {"acknowledged": True})
+                return _Response(200, {"acknowledged": True, "workloadId": "workload-1"})
 
-            _WORKER.acknowledge("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", str(token), str(reference), _Open)
+            workload_id = _WORKER.acknowledge("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", str(token), str(reference), _Open)
             self.assertEqual(captured["url"], "http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime/skill-workloads:bootstrap")
             self.assertEqual(json.loads(captured["body"]), {"bootstrapReference": "skill-bootstrap-v1_" + "a" * 64})
             self.assertEqual(captured["authorization"], "Bearer projected-token")
+            self.assertEqual(workload_id, "workload-1")
 
     def test_rejects_an_external_bootstrap_endpoint(self) -> None:
         """A worker profile must never redirect the acknowledgement to an arbitrary host."""


### PR DESCRIPTION
## Why

A governed authoring worker needs to report whether validation completed, without turning its Job into a general-purpose result channel. This slice gives it one narrow, replay-safe receipt path.

## What changes

- adds a TokenReview-authenticated authoring completion route that accepts only a bounded pass report or stable failure code
- atomically compares the reviewed Pod against the canonical `workerPodUid` and the already-consumed bootstrap before changing durable state
- records successful test and scan evidence only on the still-Draft revision; rejects free-form output and all tool-runner completion attempts
- extends the clean target baseline and live-Postgres fixture with terminal state, evidence shape, replay, and immutability fences
- lets bootstrap return only the already-bound workload ID needed for that later receipt

## Validation

- Prisma schema validation and generation
- `npx nx run backend-agents-skills-execution:lint`
- `npx nx test backend-agents-skills-execution` — 15 tests
- `npx nx run backend-agents-skills-worker:lint` and worker tests — 3 tests
- `npx nx run opencrane:lint`
- style and whitespace checks

The live PostgreSQL authority runner is included but unavailable on this workstation because neither `psql` nor a Docker test container is present.

## Review

Claude CLI remains logged out locally, so no repository content was transmitted and independent Claude review is pending login.