### PR TITLE
🔒 Define immutable artifact read leases

### DIFF
--- a/libs/backend/artifacts/authorization/main/README.md
+++ b/libs/backend/artifacts/authorization/main/README.md
@@ -1,4 +1,4 @@
-# @opencrane/backend/artifacts/authorization — artifact write-lease & receipt authority
+# @opencrane/backend/artifacts/authorization — artifact lease & receipt authority
 
 > [backend](../../../README.md) › [artifacts](../../README.md) › authorization
 
@@ -33,6 +33,8 @@ using EdDSA, a standard signature scheme) that only OpenCrane's keys can produce
 
 The two tokens use **separate keys and audiences** on purpose: a lease is addressed to
 `artifact-service` and a receipt back to `opencrane`, so one can never be replayed as the other.
+An **immutable read lease** is a separate permission slip for one exact artifact revision, content
+address, length, and media type. It cannot be used to upload, list, or select another artifact.
 Verification is strict — wrong type, wrong audience, bad signature, or a lease outside its ±5-minute
 issue window returns `null`. Invariant: a genuine, unexpired, correctly-typed token is the only thing
 that opens each gate; anything else fails closed, so a forged slip can never authorise a write and a
@@ -41,8 +43,9 @@ forged receipt can never finalise a catalog entry.
 ## Public surface
 
 - `__SignArtifactWriteLease(claims, privateKeyPem, now)` / `__VerifyArtifactWriteLease(compact, publicKeyPem, now)` — mint and check the pre-upload permission slip.
+- `__SignArtifactReadLease(claims, privateKeyPem, now)` / `__VerifyArtifactReadLease(compact, publicKeyPem, now)` — mint and check a pinned immutable-read permission slip.
 - `__SignArtifactPromotionReceipt(claims, privateKeyPem)` / `__VerifyArtifactPromotionReceipt(compact, publicKeyPem)` — mint and check the post-upload proof.
-- `ArtifactWriteLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
+- `ArtifactWriteLeaseClaims` / `ArtifactReadLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
 
 ## Boundary
 

--- a/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
+++ b/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
@@ -2,7 +2,7 @@ import { generateKeyPairSync } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
 
-import { __SignArtifactPromotionReceipt, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "../artifact-lease.js";
+import { __SignArtifactPromotionReceipt, __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "../artifact-lease.js";
 
 const _leaseKeys = generateKeyPairSync("ed25519");
 const _receiptKeys = generateKeyPairSync("ed25519");
@@ -30,6 +30,14 @@ describe("ArtifactStore signed internal protocol", function _suite()
 		expect(__VerifyArtifactWriteLease(atPastBoundary, _leasePublicKey, now)).toMatchObject({ leaseId: "lease-past-boundary" });
 		expect(__VerifyArtifactWriteLease(beforePastBoundary, _leasePublicKey, now)).toBeNull();
 		expect(__VerifyArtifactWriteLease(atFutureBoundary, _leasePublicKey, now)).toMatchObject({ leaseId: "lease-future-boundary" });
+	});
+
+	it("keeps one immutable read lease distinct from upload authority", function _readLeaseRoundTrip()
+	{
+		const compact = __SignArtifactReadLease({ leaseId: "read-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "application/gzip", action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060 }, _leasePrivateKey, 1_750_000_000);
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-1", action: "artifact.read" });
+		expect(__VerifyArtifactWriteLease(compact, _leasePublicKey, 1_750_000_001)).toBeNull();
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_061)).toBeNull();
 	});
 
 	it("keeps service promotion receipts distinct from write-lease authority", function _receiptRoundTrip()

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
@@ -2,10 +2,11 @@ import { createPrivateKey, createPublicKey, sign, verify } from "node:crypto";
 
 import { ___CanonicalizeJson } from "@opencrane/util";
 
-import type { ArtifactPromotionReceiptClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
+import type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
 
 const _LEASE_AUDIENCE = "artifact-service";
 const _LEASE_TYPE = "opencrane.artifact-write-lease";
+const _READ_LEASE_TYPE = "opencrane.artifact-read-lease";
 const _RECEIPT_AUDIENCE = "opencrane";
 const _RECEIPT_TYPE = "opencrane.artifact-promotion-receipt";
 
@@ -24,6 +25,23 @@ export function __VerifyArtifactWriteLease(compact: string, publicKeyPem: string
 	if (payload === null || payload.typ !== _LEASE_TYPE || payload.aud !== _LEASE_AUDIENCE || typeof issuedAt !== "number" || !Number.isSafeInteger(issuedAt) || issuedAt < nowEpochSeconds - 300 || issuedAt > nowEpochSeconds + 300) return null;
 	const claims = _leaseFromPayload(payload);
 	return claims !== null && _isLease(claims, nowEpochSeconds) ? claims : null;
+}
+
+/** Sign one exact short-lived immutable artifact read lease with an OpenCrane Ed25519 private key. */
+export function __SignArtifactReadLease(claims: ArtifactReadLeaseClaims, privateKeyPem: string, nowEpochSeconds: number): string
+{
+	if (!_isReadLease(claims, nowEpochSeconds)) throw new Error("invalid artifact read lease claims");
+	return _sign({ typ: _READ_LEASE_TYPE, aud: _LEASE_AUDIENCE, iat: nowEpochSeconds, ...claims }, privateKeyPem);
+}
+
+/** Verify an artifact-service read lease before canonical bytes leave its mounted store. */
+export function __VerifyArtifactReadLease(compact: string, publicKeyPem: string, nowEpochSeconds: number): ArtifactReadLeaseClaims | null
+{
+	const payload = _verify(compact, publicKeyPem);
+	const issuedAt = payload?.iat;
+	if (payload === null || payload.typ !== _READ_LEASE_TYPE || payload.aud !== _LEASE_AUDIENCE || typeof issuedAt !== "number" || !Number.isSafeInteger(issuedAt) || issuedAt < nowEpochSeconds - 300 || issuedAt > nowEpochSeconds + 300) return null;
+	const claims = _readLeaseFromPayload(payload);
+	return claims !== null && _isReadLease(claims, nowEpochSeconds) ? claims : null;
 }
 
 /** Sign promotion facts with the service's distinct Ed25519 receipt key. */
@@ -71,6 +89,12 @@ function _leaseFromPayload(value: Record<string, unknown>): ArtifactWriteLeaseCl
 	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.artifactId === "string" && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && (typeof value.expectedContentAddress === "string" || value.expectedContentAddress === null) && (Number.isSafeInteger(value.expectedByteLength) || value.expectedByteLength === null) && typeof value.mediaType === "string" ? value as unknown as ArtifactWriteLeaseClaims : null;
 }
 
+/** Parse only the exact immutable-read claim shape from a verified JWS payload. */
+function _readLeaseFromPayload(value: Record<string, unknown>): ArtifactReadLeaseClaims | null
+{
+	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.artifactId === "string" && typeof value.artifactRevisionId === "string" && typeof value.contentAddress === "string" && Number.isSafeInteger(value.byteLength) && typeof value.mediaType === "string" && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) ? value as unknown as ArtifactReadLeaseClaims : null;
+}
+
 function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionReceiptClaims | null
 {
 	return typeof value.leaseId === "string" && typeof value.contentAddress === "string" && Number.isSafeInteger(value.byteLength) && typeof value.mediaType === "string" && Number.isSafeInteger(value.issuedAtEpochSeconds) ? value as unknown as ArtifactPromotionReceiptClaims : null;
@@ -79,6 +103,12 @@ function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionR
 function _isLease(value: ArtifactWriteLeaseClaims, now: number): boolean
 {
 	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && (value.expectedContentAddress === null || /^sha256:[0-9a-f]{64}$/u.test(value.expectedContentAddress)) && (value.expectedByteLength === null || (Number.isSafeInteger(value.expectedByteLength) && value.expectedByteLength >= 0)) && value.mediaType.includes("/");
+}
+
+/** Validate every immutable coordinate before an artifact read lease can be signed or accepted. */
+function _isReadLease(value: ArtifactReadLeaseClaims, now: number): boolean
+{
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.artifactRevisionId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && value.mediaType.includes("/") && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now;
 }
 
 function _isReceipt(value: ArtifactPromotionReceiptClaims): boolean

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
@@ -11,6 +11,29 @@ export interface ArtifactWriteLeaseClaims
 	readonly mediaType: string;
 }
 
+/** Signed, short-lived internal lease authorising one immutable artifact read. */
+export interface ArtifactReadLeaseClaims
+{
+	/** Unique server-issued correlation value for this exact read. */
+	readonly leaseId: string;
+	/** Silo that owns both the catalog row and immutable bytes. */
+	readonly siloId: string;
+	/** Logical artifact identity fixed by the server-side authority. */
+	readonly artifactId: string;
+	/** Exact immutable artifact revision the caller may read. */
+	readonly artifactRevisionId: string;
+	/** Canonical content address that artifact-service must stream. */
+	readonly contentAddress: string;
+	/** Exact canonical byte length that artifact-service must expose. */
+	readonly byteLength: number;
+	/** Media type fixed with the immutable revision. */
+	readonly mediaType: string;
+	/** Separates immutable reads from write-lease authority. */
+	readonly action: "artifact.read";
+	/** Absolute Unix expiry; consumers fail closed after it. */
+	readonly expiresAtEpochSeconds: number;
+}
+
 /** Signed artifact-service receipt that OpenCrane verifies before catalog finalization. */
 export interface ArtifactPromotionReceiptClaims
 {

--- a/libs/backend/artifacts/authorization/main/src/index.ts
+++ b/libs/backend/artifacts/authorization/main/src/index.ts
@@ -1,2 +1,2 @@
-export { __SignArtifactPromotionReceipt, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "./artifact-lease.js";
-export type { ArtifactPromotionReceiptClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
+export { __SignArtifactPromotionReceipt, __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "./artifact-lease.js";
+export type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";


### PR DESCRIPTION
## Why

Isolated authoring workers need a safe future path to validate their pinned draft artifact. This first prerequisite defines a distinct signed read permission; it does not expose ArtifactStore or artifact-service to workers yet.

## What changed

- add `ArtifactReadLeaseClaims`, pinned to one silo, logical artifact, immutable revision, content address, byte length, media type, and short expiry
- add dedicated read-lease JWS sign/verify functions with a distinct token type and `artifact.read` action
- prove a read lease cannot pass the write verifier and expires fail-closed
- document the expanded artifact-authorisation boundary

## Boundary

This is a pure contract slice. No HTTP read endpoint exists yet, no worker receives a lease, and no ArtifactStore mount or credential is introduced. The subsequent service and OpenCrane broker slices will consume this lease while preserving server-only artifact-service network access.

## Validation

- `npx nx run backend-artifacts-authorization:test --skip-nx-cache`
- `npx nx run backend-artifacts-authorization:lint --skip-nx-cache`
- `scripts/agent-style-check.sh`
- `git diff --check`

## Review

Independent review passed: type/action separation prevents read leases from authorising writes. Claude Code review is requested separately after PR creation.