### PR TITLE
🔒 Stream only the artifact bytes named by an immutable lease

### DIFF
--- a/apps/artifact-service/README.md
+++ b/apps/artifact-service/README.md
@@ -12,7 +12,7 @@ image, a generated report.
 
 ## What it owns
 
-It owns the write side of **content-addressed storage** (CAS — files are stored and named by a hash of
+It owns the private read and write side of **content-addressed storage** (CAS — files are stored and named by a hash of
 their own bytes, so identical content is stored once and every stored object is tamper-evident). Callers
 never write to that store directly. Instead the OpenCrane server first issues a signed **write lease** —
 a short-lived permission slip saying "these exact bytes, up to this size, may be stored" — and this
@@ -51,13 +51,15 @@ can only refuse a legitimate upload; it can never store bytes that were not cove
 `Entrypoint: src/index.ts` (`_Main`) — reads config, prepares the mounted CAS root (mode `0700`), opens
 the listener, and binds bounded `SIGTERM`/`SIGINT` shutdown that drains requests and flushes telemetry.
 
-HTTP endpoints: `POST /v1/artifacts/promote` (the one write operation) and `/livez` · `/readyz` probes.
-Any other path or method is `404`.
+HTTP endpoints: `POST /v1/artifacts/promote` writes bounded bytes; `GET /v1/artifacts/content/:sha256`
+streams only the exact canonical bytes named by a separately signed immutable-read lease; and `/livez`
+· `/readyz` probes. Any other path or method is `404`.
 
 ## Boundary
 
-Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), does not
-read or list artifacts, and does not accept raw secrets as environment variables — signing keys are
+Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), list
+artifacts, or accept a caller-selected content address: a read path must equal the signed lease. It
+does not accept raw secrets as environment variables — signing keys are
 mounted PEM files, not env values. Verification and signing are delegated to the artifacts libraries;
 this process is only the HTTP adapter and byte pump around them.
 

--- a/apps/artifact-service/src/__tests__/server.test.ts
+++ b/apps/artifact-service/src/__tests__/server.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
+import { __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
 import { __FilesystemArtifactStore } from "@opencrane/backend/artifacts/filesystem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -59,6 +59,34 @@ describe("artifact-service promotion endpoint", function _suite()
 			const lease = __SignArtifactWriteLease({ leaseId: "lease-2", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: `sha256:${"a".repeat(64)}`, expectedByteLength: 1, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
 			const response = await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": lease, "content-length": "2" }, body: "ab" });
 			expect(response.status).toBe(413);
+		}
+		finally
+		{
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("streams only the canonical address pinned by a signed immutable read lease", async function _readCanonicalBytes()
+	{
+		const root = await mkdtemp(join(tmpdir(), "artifact-service-"));
+		try
+		{
+			const server = _CreateServer({ port: 0, artifactRoot: root, maxUploadDurationMilliseconds: 300_000, leasePublicKeyPem: _leasePublicKey, receiptPrivateKeyPem: _receiptPrivateKey }, new __FilesystemArtifactStore({ rootPath: root }));
+			_servers.push(server);
+			await new Promise<void>(function _listen(resolve) { server.listen(0, "127.0.0.1", function _ready() { resolve(); }); });
+			const port = (server.address() as { port: number }).port;
+			const bytes = Buffer.from("opencrane");
+			const digest = `sha256:${(await import("node:crypto")).createHash("sha256").update(bytes).digest("hex")}`;
+			const writeLease = __SignArtifactWriteLease({ leaseId: "write-1", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: digest, expectedByteLength: bytes.byteLength, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+			await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": writeLease }, body: bytes });
+			const readLease = __SignArtifactReadLease({ leaseId: "read-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: digest, byteLength: bytes.byteLength, mediaType: "text/plain", action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60 }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+			const response = await fetch(`http://127.0.0.1:${port}/v1/artifacts/content/${digest.slice("sha256:".length)}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+
+			expect(response.status).toBe(200);
+			expect(response.headers.get("content-length")).toBe(String(bytes.byteLength));
+			expect(response.headers.get("cache-control")).toBe("no-store");
+			expect(await response.text()).toBe("opencrane");
+			expect((await fetch(`http://127.0.0.1:${port}/v1/artifacts/content/${"b".repeat(64)}`, { headers: { "x-opencrane-artifact-lease": readLease } })).status).toBe(403);
 		}
 		finally
 		{

--- a/apps/artifact-service/src/server.ts
+++ b/apps/artifact-service/src/server.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
 
 import { __FilesystemArtifactStore } from "@opencrane/backend/artifacts/filesystem";
-import { __SignArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "@opencrane/backend/artifacts/authorization";
+import { __SignArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "@opencrane/backend/artifacts/authorization";
 import { __PromoteArtifactUpload } from "@opencrane/backend/artifacts/store";
 import type { ArtifactPromotionLeaseVerifier, ArtifactPromotionReceiptSigner, ArtifactStore, BoundedArtifactUploadByteSource, PromoteArtifactUploadResult } from "@opencrane/backend/artifacts/store";
 import { ___DoWithTrace } from "@opencrane/observability";
@@ -35,24 +35,81 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 				response.end();
 				return;
 			}
-			if (path !== "/v1/artifacts/promote" || request.method !== "POST")
+			if (path === "/v1/artifacts/promote" && request.method === "POST")
 			{
-				response.writeHead(404, { "content-type": "application/json" });
-				response.end(JSON.stringify({ error: "not_found" }));
+				const byteSource = _byteSource(request);
+				const outcome = await __PromoteArtifactUpload(store, _leaseVerifier(config.leasePublicKeyPem), byteSource, { maxUploadDurationMilliseconds: config.maxUploadDurationMilliseconds, nowEpochMilliseconds: Date.now, receiptSigner: _receiptSigner(config.receiptPrivateKeyPem) });
+				_writePromotionOutcome(response, outcome);
+				if (outcome.outcome === "rejected" && outcome.reason === "artifact_body_exceeds_lease")
+				{
+					byteSource.abort(new Error("artifact body exceeds its signed lease byte limit"));
+				}
 				return;
 			}
-			const byteSource = _byteSource(request);
-			const outcome = await __PromoteArtifactUpload(store, _leaseVerifier(config.leasePublicKeyPem), byteSource, { maxUploadDurationMilliseconds: config.maxUploadDurationMilliseconds, nowEpochMilliseconds: Date.now, receiptSigner: _receiptSigner(config.receiptPrivateKeyPem) });
-			_writePromotionOutcome(response, outcome);
-			if (outcome.outcome === "rejected" && outcome.reason === "artifact_body_exceeds_lease")
+			if (path.startsWith("/v1/artifacts/content/") && request.method === "GET")
 			{
-				byteSource.abort(new Error("artifact body exceeds its signed lease byte limit"));
+				await _ReadCanonicalArtifact(request, response, store, config.leasePublicKeyPem, path.slice("/v1/artifacts/content/".length));
+				return;
 			}
+			response.writeHead(404, { "content-type": "application/json" });
+			response.end(JSON.stringify({ error: "not_found" }));
 		}).catch(function _onRequestFailure(err)
 		{
 			log.error({ err, method: request.method, path }, "artifact service request failed");
 			response.destroy(err instanceof Error ? err : new Error("artifact service request failed"));
 		});
+	});
+}
+
+/** Verify one exact immutable read lease, then stream only its pinned canonical bytes. */
+async function _ReadCanonicalArtifact(request: IncomingMessage, response: ServerResponse, store: ArtifactStore, leasePublicKeyPem: string, digest: string): Promise<void>
+{
+	// 1. Verify the private-server lease before trusting the requested content coordinate.
+	const compactLease = request.headers["x-opencrane-artifact-lease"];
+	const lease = typeof compactLease === "string" ? __VerifyArtifactReadLease(compactLease, leasePublicKeyPem, Math.floor(Date.now() / 1_000)) : null;
+	const contentAddress = `sha256:${digest}`;
+	if (lease === null || !/^[a-f0-9]{64}$/u.test(digest) || lease.contentAddress !== contentAddress)
+	{
+		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "artifact_read_denied" }));
+		return;
+	}
+
+	// 2. Read only the lease-pinned address; a missing object must never widen the read scope.
+	const stream = await store.read(lease.contentAddress);
+	if (stream === null)
+	{
+		response.writeHead(404, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "artifact_not_found" }));
+		return;
+	}
+
+	// 3. Send signed metadata, never request-controlled headers or inferred catalog details.
+	response.writeHead(200, { "content-type": lease.mediaType, "content-length": String(lease.byteLength), "cache-control": "no-store" });
+	for await (const chunk of stream)
+	{
+		if (!response.write(chunk) && !await _WaitForWritableResponse(response)) return;
+	}
+	response.end();
+}
+
+/** Wait for downstream backpressure to drain, but stop reading when the private client disconnects. */
+async function _WaitForWritableResponse(response: ServerResponse): Promise<boolean>
+{
+	return new Promise<boolean>(function _Wait(resolve)
+	{
+		function _Cleanup(): void
+		{
+			response.off("drain", _Drained);
+			response.off("close", _Closed);
+			response.off("error", _Errored);
+		}
+		function _Drained(): void { _Cleanup(); resolve(true); }
+		function _Closed(): void { _Cleanup(); resolve(false); }
+		function _Errored(): void { _Cleanup(); resolve(false); }
+		response.once("drain", _Drained);
+		response.once("close", _Closed);
+		response.once("error", _Errored);
 	});
 }
 


### PR DESCRIPTION
## Why

A governed worker must be able to fetch one approved candidate-skill bundle without gaining a general object-store read capability. The artifact service is the byte boundary, so it must independently enforce the OpenCrane lease.

## What changes

- adds a private lease-authenticated read endpoint that verifies the signed immutable-read lease before opening storage
- streams only the exact content address, media type, and byte length fixed in that lease
- rejects a missing, expired, malformed, or mismatched lease before any bytes leave ArtifactStore
- documents the service responsibility and adds focused HTTP boundary coverage

## Validation

- `npx nx run artifact-service:lint`
- `npx nx test artifact-service` — 5 tests
- TypeScript style and diff checks

## Review

Claude CLI remains logged out locally. Its review command therefore sends no repository content; independent Claude review is pending login.