### PR TITLE
🔒 Give an authoring worker only its server-brokered candidate bundle

### DIFF
--- a/apps/opencrane/helm/templates/_networkpolicy.tpl
+++ b/apps/opencrane/helm/templates/_networkpolicy.tpl
@@ -14,8 +14,9 @@
 #         inside the handler is the identity check, this is defence-in-depth).
 #       - Per-attempt agent-runtime Job: outbound `/api/internal/agent-runtime/*` only; its projected
 #         ServiceAccount token is TokenReviewed inside the route, so this rule is only the L3/4 floor.
-#       - Governed skill Jobs: a one-use bootstrap acknowledgement only. Their default-deny namespaces
-#         permit this single server destination and DNS; TokenReview binds the request to the registered Pod.
+#       - Governed skill Jobs: bootstrap acknowledgement, authoring input, and terminal completion only.
+#         Their default-deny namespaces permit this single server destination and DNS; TokenReview binds
+#         each request to the registered Pod. ArtifactStore remains unreachable from worker namespaces.
 #   The operator's own /api/internal/tenant-models fetch is a localhost call within the
 #   opencrane-ui pod, so it is not subject to this NetworkPolicy at all.
 #
@@ -256,7 +257,8 @@ spec:
 {{- end }}
 {{- if .Values.agentController.enabled }}
 # Worker charts own namespace-wide default-deny. The server owns this strictly additive path because
-# it is the bootstrap endpoint's identity authority and knows the internal listener contract.
+# it owns the worker-facing bootstrap, authoring-input, and completion identity boundaries and knows the
+# internal listener contract.
 {{- $serverSelector := include "opencrane.selectorLabels" . }}
 {{- $internalPort := .Values.clustertenantManager.service.internalPort }}
 {{- range $worker := (list
@@ -277,7 +279,7 @@ spec:
   policyTypes:
     - Egress
   egress:
-    # A worker can acknowledge its one-use bootstrap only to the internal server listener.
+    # A worker can bootstrap, read its server-brokered authoring input, and complete only through the internal listener.
     - to:
         - namespaceSelector:
             matchLabels:

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -21,7 +21,7 @@ import { _CreateRuntimeTokenReviewer, _RegisterInternalAgentRuntimeStream } from
 import { AGENT_CONTROLLER_PROJECTED_TOKEN_AUDIENCE, AGENT_CONTROLLER_SERVICE_ACCOUNT_NAME, type RunInputSnapshot } from "@opencrane/contracts";
 import { spec } from "@opencrane/backend/server/api-spec";
 import { PrismaRunDispatchRepository, __CreateAgentControllerRunDispatchRouter, type AgentControllerTokenReviewer, type AttemptModelKeyMintRequest, type MintedAttemptModelKey, type ReviewedAgentControllerIdentity } from "@opencrane/backend/agents/execution/runs";
-import { PrismaSkillAuthoringCompletionRepository, PrismaSkillWorkloadBootstrapRepository, PrismaSkillWorkloadClaimsRepository, __CreateSkillAuthoringCompletionRouter, __CreateSkillWorkloadBootstrapRouter, __CreateSkillWorkloadDispatchRouter, type SkillWorkloadBootstrapIdentity, type SkillWorkloadBootstrapTokenReviewer } from "@opencrane/backend/agents/skills/execution";
+import { PrismaSkillAuthoringCompletionRepository, PrismaSkillAuthoringInputRepository, PrismaSkillWorkloadBootstrapRepository, PrismaSkillWorkloadClaimsRepository, __CreateSkillAuthoringCompletionRouter, __CreateSkillAuthoringInputRouter, __CreateSkillWorkloadBootstrapRouter, __CreateSkillWorkloadDispatchRouter, type SkillWorkloadBootstrapIdentity, type SkillWorkloadBootstrapTokenReviewer } from "@opencrane/backend/agents/skills/execution";
 import { __CreateExternalActionExecutor, __CreatePrismaRunInputCompiler, PrismaRuntimeDispatchAuthority, __ExecuteExternalAction, type RunInputCompiler, type RuntimeExternalActionRunner } from "@opencrane/backend/agents/execution/protocol";
 import { __IsUpgradeSessionAvailable, PrismaPersonalConfigurationChangeRepository, UPGRADE_SESSION_TOOL, UPGRADE_SESSION_TOOL_REVISION } from "@opencrane/backend/agents/personal/configuration";
 import { __AppendCompiledTool } from "@opencrane/backend/agents/runtime/prompt-compiler";
@@ -34,6 +34,7 @@ import { PrismaChannelTargetAuthorityRepository } from "@opencrane/backend/serve
 import { ___DoWithTrace } from "@opencrane/observability";
 
 import { _CreateAgentServicesRouter } from "./agent-services-wiring.js";
+import { _CreateSkillAuthoringArtifactReader } from "../infra/artifacts/artifact-upload.factory.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
@@ -305,6 +306,7 @@ export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, auth
 	app.use("/api/internal/agent-controller", __CreateAgentControllerRunDispatchRouter({ tokenReviewer: _CreateAgentControllerTokenReviewer(authApi, serverNamespace), namespace: serverNamespace, repository: runDispatchRepository, logger: _log }));
 	app.use("/api/internal/agent-controller", __CreateSkillWorkloadDispatchRouter({ tokenReviewer: _CreateAgentControllerTokenReviewer(authApi, serverNamespace), namespace: serverNamespace, repository: skillWorkloadClaimsRepository, logger: _log }));
 	app.use("/api/internal/agent-runtime", __CreateSkillWorkloadBootstrapRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillWorkloadBootstrapRepository(prisma), logger: _log }));
+	app.use("/api/internal/agent-runtime", __CreateSkillAuthoringInputRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillAuthoringInputRepository(prisma), artifactReader: _CreateSkillAuthoringArtifactReader(), logger: _log }));
 	app.use("/api/internal/agent-runtime", __CreateSkillAuthoringCompletionRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillAuthoringCompletionRepository(prisma), logger: _log }));
   // NetworkPolicy-only (no auth/TokenReview): the operator fetches a tenant's
   // allowed model set + effective default at reconcile. Best-effort — never 404/500.

--- a/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
+++ b/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { _CreateArtifactServicePromotionPort, _CreateArtifactUploadGateway } from "../artifact-upload.factory.js";
+import { _CreateArtifactServicePromotionPort, _CreateArtifactServiceReadPort, _CreateArtifactUploadGateway } from "../artifact-upload.factory.js";
 
 const _serviceUrl = "http://opencrane-artifact-service.default.svc.cluster.local:8080";
 
@@ -39,5 +39,17 @@ describe("artifact upload app composition", function _suite()
 		await expect(port.promote("signed-lease", _bytes())).rejects.toThrow("promotion failed with 403");
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 201 })));
 		await expect(port.promote("signed-lease", _bytes())).rejects.toThrow("returned no receipt");
+	});
+
+	it("uses a signed server lease only for the exact canonical read path", async function _readsPinnedArtifact()
+	{
+		const fetchMock = vi.fn().mockResolvedValue(new Response("artifact", { status: 200 }));
+		vi.stubGlobal("fetch", fetchMock);
+		const port = _CreateArtifactServiceReadPort(_serviceUrl);
+		const address = `sha256:${"a".repeat(64)}`;
+
+		await expect(port.read("signed-read-lease", address)).resolves.toBeInstanceOf(Response);
+		expect(fetchMock).toHaveBeenCalledWith(`${_serviceUrl}/v1/artifacts/content/${"a".repeat(64)}`, { redirect: "error", headers: { "x-opencrane-artifact-lease": "signed-read-lease" } });
+		await expect(port.read("signed-read-lease", "../../etc/passwd")).rejects.toThrow("canonical content address");
 	});
 });

--- a/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
+++ b/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
@@ -1,6 +1,11 @@
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { _CreateArtifactServicePromotionPort, _CreateArtifactServiceReadPort, _CreateArtifactUploadGateway } from "../artifact-upload.factory.js";
+import { _CreateArtifactServicePromotionPort, _CreateArtifactServiceReadPort, _CreateArtifactUploadGateway, _CreateSkillAuthoringArtifactReader } from "../artifact-upload.factory.js";
 
 const _serviceUrl = "http://opencrane-artifact-service.default.svc.cluster.local:8080";
 
@@ -51,5 +56,23 @@ describe("artifact upload app composition", function _suite()
 		await expect(port.read("signed-read-lease", address)).resolves.toBeInstanceOf(Response);
 		expect(fetchMock).toHaveBeenCalledWith(`${_serviceUrl}/v1/artifacts/content/${"a".repeat(64)}`, { redirect: "error", headers: { "x-opencrane-artifact-lease": "signed-read-lease" } });
 		await expect(port.read("signed-read-lease", "../../etc/passwd")).rejects.toThrow("canonical content address");
+	});
+
+	it("refuses artifact bytes whose transport metadata does not match the fenced revision", async function _rejectsMismatchedMetadata()
+	{
+		const directory = mkdtempSync(join(tmpdir(), "opencrane-artifact-read-"));
+		const keyPath = join(directory, "lease.pem");
+		const key = generateKeyPairSync("ed25519").privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+		writeFileSync(keyPath, key, "utf8");
+		try
+		{
+			vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("artifact", { status: 200, headers: { "content-length": "8", "content-type": "text/plain" } })));
+			const reader = _CreateSkillAuthoringArtifactReader({ ARTIFACT_SERVICE_URL: _serviceUrl, ARTIFACT_LEASE_PRIVATE_KEY_PATH: keyPath });
+			await expect(reader.read({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 9, mediaType: "application/gzip" })).rejects.toThrow("metadata did not match");
+		}
+		finally
+		{
+			rmSync(directory, { recursive: true, force: true });
+		}
 	});
 });

--- a/apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts
+++ b/apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts
@@ -4,7 +4,7 @@ import { Readable } from "node:stream";
 
 import type { PrismaClient } from "@prisma/client";
 
-import { __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
+import { __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
 import { __UploadArtifact, PrismaArtifactAuthorityRepository } from "@opencrane/backend/server/agents/artifacts";
 import type { ArtifactUploadResult, VerifiedArtifactUploadCommand } from "@opencrane/backend/server/agents/artifacts";
 
@@ -40,6 +40,27 @@ export function _CreateArtifactServicePromotionPort(serviceUrl: string): { promo
 			return { receipt: body.receipt };
 		},
 	};
+}
+
+/** Build the server-only HTTP client that retrieves bytes covered by one immutable read lease. */
+export function _CreateArtifactServiceReadPort(serviceUrl: string): { read(lease: string, contentAddress: string): Promise<Response> }
+{
+	return {
+		async read(lease: string, contentAddress: string): Promise<Response>
+		{
+			if (!/^sha256:[a-f0-9]{64}$/u.test(contentAddress)) throw new Error("artifact read requires a canonical content address");
+			const response = await fetch(`${serviceUrl}/v1/artifacts/content/${contentAddress.slice("sha256:".length)}`, { redirect: "error", headers: { "x-opencrane-artifact-lease": lease } });
+			if (!response.ok || response.body === null) throw new Error(`artifact service read failed with ${response.status}`);
+			return response;
+		},
+	};
+}
+
+/** Mint one read lease from server-owned mounted key material; workers never receive this token. */
+export function _CreateArtifactReadLeaseSigner(environment: NodeJS.ProcessEnv = process.env): (claims: Parameters<typeof __SignArtifactReadLease>[0]) => string
+{
+	const leasePrivateKey = _ReadPem(environment.ARTIFACT_LEASE_PRIVATE_KEY_PATH, "ARTIFACT_LEASE_PRIVATE_KEY_PATH");
+	return function _SignReadLease(claims): string { return __SignArtifactReadLease(claims, leasePrivateKey, Math.floor(Date.now() / 1_000)); };
 }
 
 /** Require a credential-free, cluster-local HTTP endpoint. */

--- a/apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts
+++ b/apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { Readable } from "node:stream";
 
@@ -7,6 +7,7 @@ import type { PrismaClient } from "@prisma/client";
 import { __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
 import { __UploadArtifact, PrismaArtifactAuthorityRepository } from "@opencrane/backend/server/agents/artifacts";
 import type { ArtifactUploadResult, VerifiedArtifactUploadCommand } from "@opencrane/backend/server/agents/artifacts";
+import type { SkillAuthoringArtifactReader, SkillAuthoringInputRecord } from "@opencrane/backend/agents/skills/execution";
 
 /** Build the app-owned bridge from a proof-authorized command to the private artifact service. */
 export function _CreateArtifactUploadGateway(prisma: PrismaClient, environment: NodeJS.ProcessEnv = process.env): { upload(command: VerifiedArtifactUploadCommand): Promise<ArtifactUploadResult> }
@@ -61,6 +62,23 @@ export function _CreateArtifactReadLeaseSigner(environment: NodeJS.ProcessEnv = 
 {
 	const leasePrivateKey = _ReadPem(environment.ARTIFACT_LEASE_PRIVATE_KEY_PATH, "ARTIFACT_LEASE_PRIVATE_KEY_PATH");
 	return function _SignReadLease(claims): string { return __SignArtifactReadLease(claims, leasePrivateKey, Math.floor(Date.now() / 1_000)); };
+}
+
+/** Build the only server-side bridge from a fenced authoring input to verified ArtifactStore bytes. */
+export function _CreateSkillAuthoringArtifactReader(environment: NodeJS.ProcessEnv = process.env): SkillAuthoringArtifactReader
+{
+	return {
+		async read(input: SkillAuthoringInputRecord): Promise<ReadableStream<Uint8Array>>
+		{
+			const serviceUrl = _InternalServiceUrl(environment.ARTIFACT_SERVICE_URL ?? "");
+			const signLease = _CreateArtifactReadLeaseSigner(environment);
+			const readPort = _CreateArtifactServiceReadPort(serviceUrl);
+			const lease = signLease({ leaseId: randomUUID(), siloId: input.siloId, artifactId: input.artifactId, artifactRevisionId: input.artifactRevisionId, contentAddress: input.contentAddress, byteLength: input.byteLength, mediaType: input.mediaType, action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60 });
+			const response = await readPort.read(lease, input.contentAddress);
+			if (response.headers.get("content-length") !== String(input.byteLength) || response.headers.get("content-type") !== input.mediaType) throw new Error("artifact service read metadata did not match the fenced revision");
+			return response.body as ReadableStream<Uint8Array>;
+		},
+	};
 }
 
 /** Require a credential-free, cluster-local HTTP endpoint. */

--- a/apps/skill-authoring/README.md
+++ b/apps/skill-authoring/README.md
@@ -32,11 +32,13 @@ OpenCrane *(bootstrap acknowledgement authority)*
 
 ## Boundary
 
-The agent controller is the only Kubernetes mutator. This chart deliberately exposes no route and
-does not grant Kubernetes API access to the worker identity. Its default-deny namespace permits a
-released authoring Pod only cluster DNS and the OpenCrane internal listener for a one-use bootstrap
-acknowledgement. That endpoint TokenReviews the fixed projected-token audience and canonical worker Pod
-UID; it returns no capability or workload data.
+The agent controller is the only Kubernetes mutator. This app exposes no listener and grants no
+Kubernetes API access to the worker identity. Its default-deny namespace permits a released authoring
+Pod only cluster DNS and the OpenCrane internal listener for its bootstrap acknowledgement, server-brokered
+input, and terminal completion. Every endpoint TokenReviews the fixed projected-token audience and
+registered Pod UID. The worker receives no ArtifactStore endpoint, credential, or signed lease; the server
+selects and streams only the immutable source artifact pinned on its assigned draft revision. This image
+does not author or execute a skill yet.
 
 ## Dependency direction
 

--- a/libs/backend/agents/skills/execution/main/README.md
+++ b/libs/backend/agents/skills/execution/main/README.md
@@ -27,11 +27,13 @@ already projected into the Job and creates the one-use bootstrap record. This or
 safe: an uncommitted Job remains suspended and is safe to adopt later, while a stale controller
 cannot attach a different Job or replace its reference.
 
-It does not create Kubernetes resources, issue worker capabilities, read ArtifactStore bytes, or
-complete tool invocations. A released worker may acknowledge its one-use bootstrap only after its
-projected-token identity matches the canonical Pod UID recorded for the Job. An authoring worker can
-then write one terminal receipt: a passed bounded test-and-scan report, or a stable failure code.
-Tool-runner results remain a separate ToolInvocation authority.
+It does not create Kubernetes resources, grant a worker capability, hold ArtifactStore credentials,
+or complete tool invocations. It exposes the narrow one-use acknowledgement route: the shared worker
+can consume its hash-addressed record only after TokenReview confirms the exact registered Pod. It
+also selects a pinned, active source artifact for that same Pod and asks an app-owned broker to stream
+the bytes; the worker never learns an ArtifactStore lease or endpoint. The authoring terminal route
+accepts only two bounded review records on the already-selected draft revision. A tool-runner result
+remains a separate authority: it must complete its linked `ToolInvocation`, not write authoring evidence.
 
 ## Public surface
 
@@ -43,6 +45,8 @@ Tool-runner results remain a separate ToolInvocation authority.
   exact TokenReview-confirmed worker Pod.
 - `PrismaSkillAuthoringCompletionRepository` — atomic authoring receipt and Draft-evidence write.
 - `__CreateSkillAuthoringCompletionRouter` — authoring-audience-only receipt API with strict input bounds.
+- `PrismaSkillAuthoringInputRepository` — exact-worker selection of an active, published, pinned source artifact.
+- `__CreateSkillAuthoringInputRouter` — authoring-audience-only byte broker route with no ArtifactStore credential response.
 
 ## Boundary
 
@@ -68,8 +72,10 @@ TypeScript adapter. It also owns the one-use
 `SkillWorkloadBootstrap` record: only a SHA-256 hash of the worker reference is stored, and it is
 bound to the exact assigned Job UID plus the fixed namespace, ServiceAccount, audience, expiry, and
 the controller-registered canonical worker Pod UID. A successful authoring receipt can write only
-two passed bounded reports to its still-Draft revision; it cannot turn the record into a general
-artifact or runtime credential.
+two passed bounded reports to its still-Draft revision. The input query also binds that draft
+revision's three artifact coordinates to an active Artifact and published ArtifactRevision in the same
+silo before the app signs a short-lived read lease and validates returned metadata. It cannot turn the
+record into a general artifact or runtime credential.
 
 ## See also
 

--- a/libs/backend/agents/skills/execution/main/src/__tests__/prisma-skill-authoring-input-repository.test.ts
+++ b/libs/backend/agents/skills/execution/main/src/__tests__/prisma-skill-authoring-input-repository.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaSkillAuthoringInputRepository } from "../prisma-skill-authoring-input-repository.js";
+
+/** Exact reviewed worker identity that must match registration and bootstrap consumption. */
+const _IDENTITY = { namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", podUid: "pod-uid-1" };
+
+/** Builds a narrow Prisma raw-query double for the immutable input selection fence. */
+function _Prisma(rows: readonly unknown[])
+{
+	const prisma = { $queryRaw: vi.fn().mockResolvedValue(rows) } as never;
+	return { repository: new PrismaSkillAuthoringInputRepository(prisma), prisma };
+}
+
+describe("Prisma skill authoring input authority", function _DescribeAuthoringInput()
+{
+	it("returns only the fully-pinned active published artifact selected for the reviewed worker", async function _SelectsInput()
+	{
+		const { repository } = _Prisma([{ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 13n, mediaType: "application/gzip" }]);
+
+		expect(await repository.loadForWorker("workload-1", _IDENTITY)).toEqual({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 13, mediaType: "application/gzip" });
+	});
+
+	it("fails closed when the exact authoring, consumed-bootstrap, active-artifact join finds no row", async function _RejectsForeignOrStaleWorker()
+	{
+		const { repository } = _Prisma([]);
+
+		expect(await repository.loadForWorker("workload-1", _IDENTITY)).toBeNull();
+	});
+
+	it("rejects an artifact length that cannot be represented safely in a signed read lease", async function _RejectsUnsafeLength()
+	{
+		const { repository } = _Prisma([{ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: BigInt(Number.MAX_SAFE_INTEGER) + 1n, mediaType: "application/gzip" }]);
+
+		expect(await repository.loadForWorker("workload-1", _IDENTITY)).toBeNull();
+	});
+});

--- a/libs/backend/agents/skills/execution/main/src/__tests__/skill-authoring-input.router.test.ts
+++ b/libs/backend/agents/skills/execution/main/src/__tests__/skill-authoring-input.router.test.ts
@@ -1,0 +1,90 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { __CreateSkillAuthoringInputRouter } from "../skill-authoring-input.router.js";
+import type { SkillAuthoringInputRouterDependencies } from "../skill-authoring-input.types.js";
+
+/** Immutable artifact record selected by the database fence, never by the worker request. */
+const _INPUT = { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 13, mediaType: "application/gzip" };
+
+/** Builds an authoring input route whose security dependencies can be independently denied. */
+function _App(overrides: Partial<SkillAuthoringInputRouterDependencies> = {})
+{
+	const dependencies: SkillAuthoringInputRouterDependencies = {
+		tokenReviewer: { __Review: vi.fn().mockResolvedValue({ namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", podUid: "pod-uid-1" }) },
+		repository: { loadForWorker: vi.fn().mockResolvedValue(_INPUT) },
+		artifactReader: { read: vi.fn().mockResolvedValue(new ReadableStream<Uint8Array>({ start(controller): void { controller.enqueue(Buffer.from("skill archive")); controller.close(); } })) },
+		logger: { error: vi.fn() },
+		...overrides,
+	};
+	const app = express();
+	app.use(__CreateSkillAuthoringInputRouter(dependencies));
+	return { app, dependencies };
+}
+
+describe("skill authoring input router", function _DescribeAuthoringInput()
+{
+	it("reviews the fixed audience and streams only the database-selected artifact", async function _ReadsInput()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).get("/skill-authoring-workloads/workload-1/input").set("authorization", "Bearer projected-token");
+
+		expect(response.status).toBe(200);
+		expect(response.headers["content-type"]).toBe("application/gzip");
+		expect(response.headers["content-length"]).toBe("13");
+		expect(response.body.toString()).toBe("skill archive");
+		expect(dependencies.tokenReviewer.__Review).toHaveBeenCalledWith("projected-token", "opencrane-skill-authoring");
+		expect(dependencies.repository.loadForWorker).toHaveBeenCalledWith("workload-1", { namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", podUid: "pod-uid-1" });
+		expect(dependencies.artifactReader.read).toHaveBeenCalledWith(_INPUT);
+	});
+
+	it("denies absent or unreviewed Pod identity before selecting an artifact", async function _RejectsIdentity()
+	{
+		const { app, dependencies } = _App({ tokenReviewer: { __Review: vi.fn().mockResolvedValue(null) } });
+		expect((await request(app).get("/skill-authoring-workloads/workload-1/input")).status).toBe(401);
+		expect((await request(app).get("/skill-authoring-workloads/workload-1/input").set("authorization", "Bearer projected-token")).status).toBe(401);
+		expect(dependencies.repository.loadForWorker).not.toHaveBeenCalled();
+	});
+
+	it("returns no artifact details when the exact workload and consumed bootstrap fence is unavailable", async function _RejectsStaleWorker()
+	{
+		const { app, dependencies } = _App({ repository: { loadForWorker: vi.fn().mockResolvedValue(null) } });
+		const response = await request(app).get("/skill-authoring-workloads/workload-1/input").set("authorization", "Bearer projected-token");
+
+		expect(response.status).toBe(404);
+		expect(response.body).toEqual({ error: "authoring_input_unavailable" });
+		expect(dependencies.artifactReader.read).not.toHaveBeenCalled();
+	});
+
+	it("fails closed without exposing broker failures or read leases", async function _HidesReaderFailure()
+	{
+		const { app, dependencies } = _App({ artifactReader: { read: vi.fn().mockRejectedValue(new Error("lease secret must not escape")) } });
+		const response = await request(app).get("/skill-authoring-workloads/workload-1/input").set("authorization", "Bearer projected-token");
+
+		expect(response.status).toBe(503);
+		expect(response.text).not.toContain("lease secret");
+		expect(dependencies.logger.error).toHaveBeenCalled();
+	});
+
+	it("returns a clean unavailable response when the private stream fails before its first byte", async function _RejectsPreHeaderStreamFailure()
+	{
+		const broken = new ReadableStream<Uint8Array>({ start(controller): void { controller.error(new Error("lease secret must not escape")); } });
+		const { app, dependencies } = _App({ artifactReader: { read: vi.fn().mockResolvedValue(broken) } });
+		const response = await request(app).get("/skill-authoring-workloads/workload-1/input").set("authorization", "Bearer projected-token");
+
+		expect(response.status).toBe(503);
+		expect(response.text).not.toContain("lease secret");
+		expect(dependencies.logger.error).toHaveBeenCalled();
+	});
+
+	it("aborts a half-written response and logs when the private stream fails after its first byte", async function _AbortsMidStreamFailure()
+	{
+		const broken = new ReadableStream<Uint8Array>({ start(controller): void { controller.enqueue(Buffer.from("skill archive")); }, pull(controller): void { controller.error(new Error("private connection reset")); } });
+		const { app, dependencies } = _App({ artifactReader: { read: vi.fn().mockResolvedValue(broken) } });
+
+		const response = await request(app).get("/skill-authoring-workloads/workload-1/input").set("authorization", "Bearer projected-token");
+		expect(response.status).toBe(200);
+		await vi.waitFor(function _WaitForStreamFailure(): void { expect(dependencies.logger.error).toHaveBeenCalled(); });
+	});
+});

--- a/libs/backend/agents/skills/execution/main/src/index.ts
+++ b/libs/backend/agents/skills/execution/main/src/index.ts
@@ -5,6 +5,9 @@ export type { SkillWorkloadBootstrapIdentity, SkillWorkloadBootstrapLogger, Skil
 export { __CreateSkillAuthoringCompletionRouter } from "./skill-authoring-completion.router.js";
 export { PrismaSkillAuthoringCompletionRepository } from "./prisma-skill-authoring-completion-repository.js";
 export type { CreateSkillAuthoringCompletionRouter, SkillAuthoringCheckReport, SkillAuthoringCompletionCommand, SkillAuthoringCompletionRepository, SkillAuthoringCompletionRouterDependencies } from "./skill-authoring-completion.types.js";
+export { __CreateSkillAuthoringInputRouter } from "./skill-authoring-input.router.js";
+export { PrismaSkillAuthoringInputRepository } from "./prisma-skill-authoring-input-repository.js";
+export type { CreateSkillAuthoringInputRouter, SkillAuthoringArtifactReader, SkillAuthoringInputRecord, SkillAuthoringInputRepository, SkillAuthoringInputRouterDependencies } from "./skill-authoring-input.types.js";
 export { PrismaSkillWorkloadClaimsRepository } from "./prisma-skill-workload-claims-repository.js";
 export type { SkillWorkloadClaimsRepository } from "./skill-workload-claims.types.js";
 export { __CreateSkillWorkloadDispatchRouter } from "./skill-workload-dispatch.router.js";

--- a/libs/backend/agents/skills/execution/main/src/prisma-skill-authoring-input-repository.ts
+++ b/libs/backend/agents/skills/execution/main/src/prisma-skill-authoring-input-repository.ts
@@ -1,0 +1,64 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+import type { SkillAuthoringInputRecord, SkillAuthoringInputRepository } from "./skill-authoring-input.types.js";
+import type { SkillWorkloadBootstrapIdentity } from "./skill-workload-bootstrap.types.js";
+
+/** Prisma authority selecting one draft skill's immutable source only for its exact authoring Pod. */
+export class PrismaSkillAuthoringInputRepository implements SkillAuthoringInputRepository
+{
+	/** Canonical OpenCrane product-authority database client. */
+	private readonly prisma: PrismaClient;
+
+	/** Creates the authoring input authority over canonical Postgres. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Reads one active, published, fully-pinned artifact while sharing every relevant durable row lock. */
+	async loadForWorker(workloadId: string, identity: SkillWorkloadBootstrapIdentity): Promise<SkillAuthoringInputRecord | null>
+	{
+		const rows = await this.prisma.$queryRaw<readonly _InputRow[]>(Prisma.sql`
+			SELECT workload."silo_id" AS "siloId", revision."artifact_id" AS "artifactId", revision."artifact_revision_id" AS "artifactRevisionId", revision."artifact_content_address" AS "contentAddress", artifact_revision."byte_length" AS "byteLength", artifact_revision."media_type" AS "mediaType"
+			FROM "skill_workloads" workload
+			JOIN "skill_workload_bootstraps" bootstrap ON bootstrap."skill_workload_id" = workload."id"
+			JOIN "skill_revisions" revision ON revision."id" = workload."skill_revision_id"
+			JOIN "artifact_revisions" artifact_revision ON artifact_revision."id" = revision."artifact_revision_id" AND artifact_revision."artifact_id" = revision."artifact_id" AND artifact_revision."content_address" = revision."artifact_content_address"
+			JOIN "artifacts" artifact ON artifact."id" = artifact_revision."artifact_id" AND artifact."silo_id" = workload."silo_id"
+			WHERE workload."id" = ${workloadId}
+				AND workload."kind" = 'authoring'
+				AND workload."state" = 'assigned'
+				AND workload."released_at" IS NOT NULL
+				AND workload."registered_pod_uid" = ${identity.podUid}
+				AND bootstrap."consumed_at" IS NOT NULL
+				AND bootstrap."consumed_by_pod_uid" = ${identity.podUid}
+				AND bootstrap."namespace" = ${identity.namespace}
+				AND bootstrap."service_account_name" = ${identity.serviceAccountName}
+				AND bootstrap."audience" = 'opencrane-skill-authoring'
+				AND bootstrap."workload_uid" = workload."workload_uid"
+				AND revision."state" = 'draft'
+				AND artifact."state" = 'active'
+				AND artifact_revision."state" = 'published'
+			FOR SHARE OF workload, bootstrap, revision, artifact_revision, artifact
+		`);
+		if (rows.length !== 1 || !Number.isSafeInteger(Number(rows[0].byteLength)) || Number(rows[0].byteLength) < 0) return null;
+		return { siloId: rows[0].siloId, artifactId: rows[0].artifactId, artifactRevisionId: rows[0].artifactRevisionId, contentAddress: rows[0].contentAddress, byteLength: Number(rows[0].byteLength), mediaType: rows[0].mediaType };
+	}
+}
+
+/** Raw Postgres projection retained narrow so product records never expose unrelated source metadata. */
+interface _InputRow
+{
+	/** Durable silo coordinate. */
+	readonly siloId: string;
+	/** Pinned artifact coordinate. */
+	readonly artifactId: string;
+	/** Pinned artifact revision coordinate. */
+	readonly artifactRevisionId: string;
+	/** Pinned canonical content address. */
+	readonly contentAddress: string;
+	/** Immutable byte length from Postgres bigint. */
+	readonly byteLength: bigint;
+	/** Immutable media type. */
+	readonly mediaType: string;
+}

--- a/libs/backend/agents/skills/execution/main/src/skill-authoring-input.router.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-authoring-input.router.ts
@@ -1,0 +1,88 @@
+import { Readable } from "node:stream";
+
+import { Router, type Request, type Response } from "express";
+
+import type { SkillAuthoringInputRouterDependencies } from "./skill-authoring-input.types.js";
+
+/** Fixed projected-token audience for the isolated authoring worker class. */
+const _AUTHORING_AUDIENCE = "opencrane-skill-authoring";
+
+/** Build the authoring-only immutable skill-input boundary. */
+export function __CreateSkillAuthoringInputRouter(dependencies: SkillAuthoringInputRouterDependencies): Router
+{
+	const router = Router();
+	router.get("/skill-authoring-workloads/:workloadId/input", async function _ReadInput(request: Request, response: Response): Promise<void>
+	{
+		const token = _Bearer(request.header("authorization"));
+		const workloadId = _Coordinate(request.params.workloadId);
+		if (token === null || workloadId === null)
+		{
+			response.status(401).json({ error: "worker_identity_denied" });
+			return;
+		}
+		try
+		{
+			const identity = await dependencies.tokenReviewer.__Review(token, _AUTHORING_AUDIENCE);
+			if (identity === null)
+			{
+				response.status(401).json({ error: "worker_identity_denied" });
+				return;
+			}
+			const input = await dependencies.repository.loadForWorker(workloadId, identity);
+			if (input === null)
+			{
+				response.status(404).json({ error: "authoring_input_unavailable" });
+				return;
+			}
+			const bytes = await dependencies.artifactReader.read(input);
+			const reader = bytes.getReader();
+			const first = await reader.read();
+			response.status(200).set({ "content-type": input.mediaType, "content-length": String(input.byteLength), "cache-control": "no-store" });
+			const stream = Readable.from(_ReadBytes(reader, first));
+			/** Terminate a half-written protected response without serialising its broker failure. */
+			function _AbortStream(err: Error): void
+			{
+				dependencies.logger.error({ err, operation: "skill_authoring.input" }, "Skill authoring input stream failed");
+				response.destroy(err);
+			}
+			/** Cancel the private upstream fetch when the worker closes its internal response. */
+			function _CancelSource(): void
+			{
+				void reader.cancel().catch(function _IgnoreCancellationFailure(): void {});
+			}
+			response.once("close", _CancelSource);
+			stream.once("error", _AbortStream).pipe(response);
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "skill_authoring.input" }, "Skill authoring input failed");
+			if (!response.headersSent) response.status(503).json({ error: "authoring_input_unavailable" });
+			else response.destroy(err instanceof Error ? err : new Error("authoring input stream failed"));
+		}
+	});
+	return router;
+}
+
+/** Yield a prefetched chunk, then relay the remaining private response while preserving its errors. */
+async function* _ReadBytes(reader: ReadableStreamDefaultReader<Uint8Array>, first: ReadableStreamReadResult<Uint8Array>): AsyncGenerator<Uint8Array>
+{
+	if (!first.done) yield first.value;
+	while (true)
+	{
+		const next = await reader.read();
+		if (next.done) return;
+		yield next.value;
+	}
+}
+
+/** Parse one standard bearer value without accepting multiple credentials. */
+function _Bearer(value: string | undefined): string | null
+{
+	return value && /^Bearer ([^\s,]+)$/u.test(value) ? /^Bearer ([^\s,]+)$/u.exec(value)?.[1] ?? null : null;
+}
+
+/** Validate a durable workload coordinate before it reaches the persistence adapter. */
+function _Coordinate(value: unknown): string | null
+{
+	return typeof value === "string" && value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/.test(value) ? value : null;
+}

--- a/libs/backend/agents/skills/execution/main/src/skill-authoring-input.types.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-authoring-input.types.ts
@@ -1,0 +1,50 @@
+import type { Router } from "express";
+
+import type { SkillWorkloadBootstrapIdentity, SkillWorkloadBootstrapLogger, SkillWorkloadBootstrapTokenReviewer } from "./skill-workload-bootstrap.types.js";
+
+/** Immutable artifact coordinates selected only after authoring-workload fencing succeeds. */
+export interface SkillAuthoringInputRecord
+{
+	/** Silo that owns the workload and the immutable artifact. */
+	readonly siloId: string;
+	/** Logical ArtifactStore catalog identity. */
+	readonly artifactId: string;
+	/** Published immutable artifact revision selected by the draft skill revision. */
+	readonly artifactRevisionId: string;
+	/** Canonical SHA-256 address pinned on the draft skill revision. */
+	readonly contentAddress: string;
+	/** Exact immutable byte count that the broker must verify before forwarding. */
+	readonly byteLength: number;
+	/** Immutable media type that the broker must verify before forwarding. */
+	readonly mediaType: string;
+}
+
+/** Postgres boundary that selects an authoring input only for its exact reviewed worker Pod. */
+export interface SkillAuthoringInputRepository
+{
+	/** Loads the still-eligible draft artifact after all workload, bootstrap, and artifact fences hold. */
+	loadForWorker(workloadId: string, identity: SkillWorkloadBootstrapIdentity): Promise<SkillAuthoringInputRecord | null>;
+}
+
+/** Server-owned byte broker; it mints and consumes the ArtifactStore lease without exposing it to workers. */
+export interface SkillAuthoringArtifactReader
+{
+	/** Returns validated immutable bytes whose metadata matches the selected input record. */
+	read(input: SkillAuthoringInputRecord): Promise<ReadableStream<Uint8Array>>;
+}
+
+/** Dependencies of the worker-authenticated authoring input route. */
+export interface SkillAuthoringInputRouterDependencies
+{
+	/** Reviews the worker projected token against the route-owned authoring audience. */
+	readonly tokenReviewer: SkillWorkloadBootstrapTokenReviewer;
+	/** Selects the only durable artifact coordinates that worker may read. */
+	readonly repository: SkillAuthoringInputRepository;
+	/** Brokers bytes through the server without returning a lease or ArtifactStore endpoint. */
+	readonly artifactReader: SkillAuthoringArtifactReader;
+	/** Emits structured authority failures without worker credential data. */
+	readonly logger: SkillWorkloadBootstrapLogger;
+}
+
+/** Factory producing the authoring-only immutable input route. */
+export type CreateSkillAuthoringInputRouter = (dependencies: SkillAuthoringInputRouterDependencies) => Router;


### PR DESCRIPTION
## Why

An isolated authoring worker needs its candidate skill bundle, but must never gain an object-store credential, endpoint, or reusable signed lease. This slice turns the worker input into a server-brokered, exact-byte delivery.

## What changes

- selects only the active, published artifact revision pinned to the worker's still-Draft skill revision
- TokenReviews the exact authoring worker Pod before selecting input
- has OpenCrane obtain and verify the short-lived immutable ArtifactStore lease itself, then stream the verified bytes to that Pod
- adds the narrow network permission required for the server-to-ArtifactStore read path
- leaves workers without ArtifactStore addresses, credentials, or leases

## Validation

- execution lint and 24 tests
- full OpenCrane lint and 43 tests
- style and whitespace checks

## Review

Claude CLI remains logged out locally; no repository content was sent to it. Independent Claude review remains pending login.