### PR TITLE
🔒 Bound candidate-skill archive intake

### DIFF
--- a/apps/skill-authoring/README.md
+++ b/apps/skill-authoring/README.md
@@ -37,8 +37,11 @@ Kubernetes API access to the worker identity. Its default-deny namespace permits
 Pod only cluster DNS and the OpenCrane internal listener for its bootstrap acknowledgement, server-brokered
 input, and terminal completion. Every endpoint TokenReviews the fixed projected-token audience and
 registered Pod UID. The worker receives no ArtifactStore endpoint, credential, or signed lease; the server
-selects and streams only the immutable source artifact pinned on its assigned draft revision. This image
-does not author or execute a skill yet.
+selects and streams only the immutable source artifact pinned on its assigned draft revision. The server
+refuses compressed candidate bundles larger than 16 MiB before it mints an ArtifactStore read lease,
+and returns the pinned SHA-256 address alongside the length so the future validator can verify the
+downloaded bytes. The admitted Job reserves at least 64 MiB of ephemeral `/tmp` space for bounded
+extraction and offline validation. This image does not author or execute a skill yet.
 
 ## Dependency direction
 

--- a/libs/backend/agents/skills/execution/main/src/__tests__/skill-authoring-input.router.test.ts
+++ b/libs/backend/agents/skills/execution/main/src/__tests__/skill-authoring-input.router.test.ts
@@ -33,10 +33,20 @@ describe("skill authoring input router", function _DescribeAuthoringInput()
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toBe("application/gzip");
 		expect(response.headers["content-length"]).toBe("13");
+		expect(response.headers["x-opencrane-content-address"]).toBe(_INPUT.contentAddress);
 		expect(response.body.toString()).toBe("skill archive");
 		expect(dependencies.tokenReviewer.__Review).toHaveBeenCalledWith("projected-token", "opencrane-skill-authoring");
 		expect(dependencies.repository.loadForWorker).toHaveBeenCalledWith("workload-1", { namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", podUid: "pod-uid-1" });
 		expect(dependencies.artifactReader.read).toHaveBeenCalledWith(_INPUT);
+	});
+
+	it("refuses an oversized archive before the server mints a private read lease", async function _RejectsOversizedArchive()
+	{
+		const { app, dependencies } = _App({ repository: { loadForWorker: vi.fn().mockResolvedValue({ ..._INPUT, byteLength: 16 * 1024 * 1024 + 1 }) } });
+		const response = await request(app).get("/skill-authoring-workloads/workload-1/input").set("authorization", "Bearer projected-token");
+
+		expect(response.status).toBe(404);
+		expect(dependencies.artifactReader.read).not.toHaveBeenCalled();
 	});
 
 	it("denies absent or unreviewed Pod identity before selecting an artifact", async function _RejectsIdentity()

--- a/libs/backend/agents/skills/execution/main/src/skill-authoring-input.router.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-authoring-input.router.ts
@@ -7,7 +7,14 @@ import type { SkillAuthoringInputRouterDependencies } from "./skill-authoring-in
 /** Fixed projected-token audience for the isolated authoring worker class. */
 const _AUTHORING_AUDIENCE = "opencrane-skill-authoring";
 
-/** Build the authoring-only immutable skill-input boundary. */
+/** Maximum compressed candidate bundle sent through the authoring-only input path. */
+const _MAX_AUTHORING_ARCHIVE_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Build the projected-token and NetworkPolicy-protected authoring-only immutable skill-input boundary.
+ * @see apps/opencrane/helm/templates/_networkpolicy.tpl — sole worker-to-server egress allowance.
+ * @see apps/agent-controller/helm/templates/_skill-workload-admission.tpl — admitted Job identity contract.
+ */
 export function __CreateSkillAuthoringInputRouter(dependencies: SkillAuthoringInputRouterDependencies): Router
 {
 	const router = Router();
@@ -34,10 +41,15 @@ export function __CreateSkillAuthoringInputRouter(dependencies: SkillAuthoringIn
 				response.status(404).json({ error: "authoring_input_unavailable" });
 				return;
 			}
+			if (input.byteLength > _MAX_AUTHORING_ARCHIVE_BYTES)
+			{
+				response.status(404).json({ error: "authoring_input_unavailable" });
+				return;
+			}
 			const bytes = await dependencies.artifactReader.read(input);
 			const reader = bytes.getReader();
 			const first = await reader.read();
-			response.status(200).set({ "content-type": input.mediaType, "content-length": String(input.byteLength), "cache-control": "no-store" });
+			response.status(200).set({ "content-type": input.mediaType, "content-length": String(input.byteLength), "x-opencrane-content-address": input.contentAddress, "cache-control": "no-store" });
 			const stream = Readable.from(_ReadBytes(reader, first));
 			/** Terminate a half-written protected response without serialising its broker failure. */
 			function _AbortStream(err: Error): void

--- a/libs/backend/agents/skills/k8s-launcher/README.md
+++ b/libs/backend/agents/skills/k8s-launcher/README.md
@@ -30,7 +30,9 @@ filesystem, bounded temporary scratch space, no auto-mounted service-account tok
 code, artifact bytes, arguments, or credentials embedded in the manifest. The controller releases it
 only after it has durably committed the exact Kubernetes identity. The Job receives an audience-bound
 projected token and an opaque bootstrap reference in separate read-only files; the worker can use them
-only to acknowledge its own bootstrap endpoint.
+only to acknowledge its own bootstrap endpoint. Authoring Jobs require at least
+64 MiB of scratch: a future validator uses that space for a bounded archive, an extracted tree, and
+fixed offline checks without borrowing persistent storage.
 
 ## Public surface
 

--- a/libs/backend/agents/skills/k8s-launcher/src/__tests__/skill-workload-job.test.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/__tests__/skill-workload-job.test.ts
@@ -14,6 +14,12 @@ function _Assignment()
 	return { jobId: "tool-job-1", siloId: "silo-1", namespace: "opencrane-tools", capabilityReference: `skill-bootstrap-v1_${"a".repeat(64)}` };
 }
 
+/** Builds the stricter authoring profile that reserves scratch for archive validation. */
+function _AuthoringProfile()
+{
+	return { ..._Profile(), kind: "authoring" as const, image: `ghcr.io/opencrane/skill-authoring@sha256:${"b".repeat(64)}`, namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", capabilityTokenAudience: "opencrane-skill-authoring" };
+}
+
 describe("governed skill workload Job", function _describeJob()
 {
 	it("is deterministic, one-shot, unprivileged, and carries no source or credential material", function _builds()
@@ -45,5 +51,12 @@ describe("governed skill workload Job", function _describeJob()
 		const job = __BuildGovernedSkillWorkloadJob({ ..._Assignment(), namespace: "opencrane-authoring" }, profile);
 		expect(job.metadata?.name).toMatch(/^skill-author-/);
 		expect(job.spec?.template.metadata?.labels).toMatchObject({ "app.kubernetes.io/component": "skill-authoring" });
+	});
+
+	it("reserves the fixed extraction and validation scratch budget for authoring Jobs", function _reservesAuthoringScratch()
+	{
+		const assignment = { ..._Assignment(), namespace: "opencrane-skill-authoring" };
+		expect(function _smallScratch() { __BuildGovernedSkillWorkloadJob(assignment, { ..._AuthoringProfile(), scratchSize: "32Mi" }); }).toThrow(/bounded resources/);
+		expect(__BuildGovernedSkillWorkloadJob(assignment, _AuthoringProfile()).spec?.template.spec?.volumes).toEqual(expect.arrayContaining([expect.objectContaining({ name: "scratch", emptyDir: { sizeLimit: "64Mi" } })]));
 	});
 });

--- a/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts
@@ -8,6 +8,9 @@ import { __BuildToolRunnerWorkloadJob } from "./tool-runner-workload-job.js";
 /** Maximum size of the non-authoritative scratch filesystem. */
 const _MAX_SCRATCH_BYTES = 1_073_741_824n;
 
+/** Minimum scratch capacity for safe authoring archive extraction and offline validation output. */
+const _MIN_AUTHORING_SCRATCH_BYTES = 67_108_864n;
+
 /** Maximum wall-clock lifetime granted to one untrusted governed-skill Job. */
 const _MAX_ACTIVE_DEADLINE_SECONDS = 900;
 
@@ -70,7 +73,7 @@ function _AssertProfile(profile: SkillWorkloadJobProfile): void
 	const limitedCpu = _ParseCpuMillis(String(profile.resources.limits?.cpu ?? ""));
 	const requestedMemory = _ParseBinaryBytes(String(profile.resources.requests?.memory ?? ""));
 	const limitedMemory = _ParseBinaryBytes(String(profile.resources.limits?.memory ?? ""));
-	if (!/^[a-z0-9][a-z0-9._:/-]*@sha256:[a-f0-9]{64}$/.test(profile.image) || !["Always", "IfNotPresent", "Never"].includes(profile.imagePullPolicy) || profile.serviceAccountName !== expectedServiceAccountName || profile.capabilityTokenAudience !== expectedAudience || !_IsBootstrapUrl(profile.bootstrapUrl) || profile.capabilityTokenPath !== _CAPABILITY_TOKEN_PATH || profile.bootstrapReferencePath !== _BOOTSTRAP_REFERENCE_PATH || profile.namespace.length > 63 || !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(profile.namespace) || profile.namespace === profile.serverNamespace || !scratchBytes || scratchBytes > _MAX_SCRATCH_BYTES || !Number.isSafeInteger(profile.activeDeadlineSeconds) || profile.activeDeadlineSeconds < 1 || profile.activeDeadlineSeconds > _MAX_ACTIVE_DEADLINE_SECONDS || profile.ttlSecondsAfterFinished !== 0 || !requestedCpu || !limitedCpu || requestedCpu > limitedCpu || limitedCpu > _MAX_CPU_MILLICORES || !requestedMemory || !limitedMemory || requestedMemory > limitedMemory || limitedMemory > _MAX_MEMORY_BYTES)
+	if (!/^[a-z0-9][a-z0-9._:/-]*@sha256:[a-f0-9]{64}$/.test(profile.image) || !["Always", "IfNotPresent", "Never"].includes(profile.imagePullPolicy) || profile.serviceAccountName !== expectedServiceAccountName || profile.capabilityTokenAudience !== expectedAudience || !_IsBootstrapUrl(profile.bootstrapUrl) || profile.capabilityTokenPath !== _CAPABILITY_TOKEN_PATH || profile.bootstrapReferencePath !== _BOOTSTRAP_REFERENCE_PATH || profile.namespace.length > 63 || !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(profile.namespace) || profile.namespace === profile.serverNamespace || !scratchBytes || scratchBytes > _MAX_SCRATCH_BYTES || (profile.kind === "authoring" && scratchBytes < _MIN_AUTHORING_SCRATCH_BYTES) || !Number.isSafeInteger(profile.activeDeadlineSeconds) || profile.activeDeadlineSeconds < 1 || profile.activeDeadlineSeconds > _MAX_ACTIVE_DEADLINE_SECONDS || profile.ttlSecondsAfterFinished !== 0 || !requestedCpu || !limitedCpu || requestedCpu > limitedCpu || limitedCpu > _MAX_CPU_MILLICORES || !requestedMemory || !limitedMemory || requestedMemory > limitedMemory || limitedMemory > _MAX_MEMORY_BYTES)
 	{
 		throw new Error("governed skill Job profile requires one fixed bootstrap endpoint, fixed audience and paths, class-bounded identity, immutable image, bounded resources, scratch, and lifetime");
 	}


### PR DESCRIPTION
## Why

The isolated authoring worker will validate an immutable skill bundle downloaded through OpenCrane. Before an extractor or validator runs, the byte path must expose enough non-secret integrity metadata and must be bounded against scratch exhaustion.

## What changed

- returns the database-fenced canonical SHA-256 address with the existing length and media type
- rejects candidate archives above 16 MiB before the server reads from ArtifactStore or mints a private lease
- requires authoring Job profiles to reserve at least 64 MiB of ephemeral scratch, leaving room for a bounded archive, extracted tree, and validator output
- documents the enforced server-only artifact path and scratch limits

## What this does not do yet

It does not claim a candidate is valid or complete a workload. The next slice must safely extract the archive, verify the SHA-256, and run real offline validation tools with a pinned malware signature dataset.

## Validation

- `npx nx run backend-agents-skills-execution:test --skip-nx-cache` — 30 passing
- `npx nx run backend-agents-skills-execution:lint --skip-nx-cache`
- `npx nx run backend-agents-skills-k8s-launcher:test --skip-nx-cache` — 3 passing
- `npx nx run backend-agents-skills-k8s-launcher:lint --skip-nx-cache`
- `npx nx run opencrane:lint --skip-nx-cache`
- `scripts/agent-style-check.sh`
- `git diff --check`

## Review

- architecture preflight passed with placement and security constraints
- independent review passed with no findings
- Claude Code review will be attempted after PR creation.