### PR TITLE
🔒 Verify and bound candidate-skill bundles

### DIFF
--- a/apps/skill-authoring/README.md
+++ b/apps/skill-authoring/README.md
@@ -26,6 +26,7 @@ OpenCrane *(bootstrap acknowledgement authority)*
 
 ## Public surface
 
+ - `src/authoring_worker.py` — private, not-yet-invoked intake primitives that verify and safely extract a candidate bundle.
 - Helm chart — restricted namespace, `skill-authoring-default` ServiceAccount, quota, and default-deny policy.
 - `values.yaml` — namespace, worker ServiceAccount, and quota defaults only; image, resource, and
   lifecycle values remain controller-owned.

--- a/apps/skill-authoring/__tests__/test_authoring_worker.py
+++ b/apps/skill-authoring/__tests__/test_authoring_worker.py
@@ -1,0 +1,134 @@
+"""Focused tests for authoring-only verified bundle intake primitives."""
+
+import hashlib
+import importlib.util
+import io
+import pathlib
+import sys
+import tarfile
+import tempfile
+import unittest
+
+
+_ROOT = pathlib.Path(__file__).parents[3]
+_BOOTSTRAP_PATH = _ROOT / "libs/backend/agents/skills/worker/src/bootstrap.py"
+_AUTHORING_PATH = _ROOT / "apps/skill-authoring/src/authoring_worker.py"
+_BOOTSTRAP_SPEC = importlib.util.spec_from_file_location("bootstrap", _BOOTSTRAP_PATH)
+assert _BOOTSTRAP_SPEC and _BOOTSTRAP_SPEC.loader
+_BOOTSTRAP = importlib.util.module_from_spec(_BOOTSTRAP_SPEC)
+sys.modules["bootstrap"] = _BOOTSTRAP
+_BOOTSTRAP_SPEC.loader.exec_module(_BOOTSTRAP)
+_AUTHORING_SPEC = importlib.util.spec_from_file_location("authoring_worker", _AUTHORING_PATH)
+assert _AUTHORING_SPEC and _AUTHORING_SPEC.loader
+_AUTHORING = importlib.util.module_from_spec(_AUTHORING_SPEC)
+_AUTHORING_SPEC.loader.exec_module(_AUTHORING)
+
+
+class _Response:
+    """In-memory bounded server response seam."""
+
+    def __init__(self, payload: bytes, address: str | None = None, length: str | None = None):
+        """Build response metadata from immutable bytes unless a negative test overrides it."""
+        self.status = 200
+        self.headers = {"content-length": length or str(len(payload)), "x-opencrane-content-address": address or f"sha256:{hashlib.sha256(payload).hexdigest()}"}
+        self._body = io.BytesIO(payload)
+
+    def read(self, amount: int = -1) -> bytes:
+        """Read the next bounded byte segment."""
+        return self._body.read(amount)
+
+
+class AuthoringWorkerTests(unittest.TestCase):
+    """Prove authoring bundle bytes cannot escape their server-selected integrity and archive bounds."""
+
+    def _token(self, directory: pathlib.Path) -> pathlib.Path:
+        """Create a non-secret projected-token equivalent for one test."""
+        token = directory / "token"
+        token.write_text("projected-token", encoding="utf-8")
+        return token
+
+    def _archive(self, path: pathlib.Path, members: dict[str, bytes]) -> None:
+        """Create one small gzip tar fixture with the supplied regular file entries."""
+        with tarfile.open(path, "w:gz") as bundle:
+            for name, content in members.items():
+                entry = tarfile.TarInfo(name)
+                entry.size = len(content)
+                bundle.addfile(entry, io.BytesIO(content))
+
+    def test_downloads_only_the_fixed_internal_route_and_atomically_verifies_hash(self) -> None:
+        """The projected token is sent only to the authoring input route and bytes become durable after hash verification."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            captured: dict[str, object] = {}
+
+            def open_request(request: object, timeout: float) -> _Response:
+                captured["url"] = request.full_url
+                captured["authorization"] = request.get_header("Authorization")
+                captured["timeout"] = timeout
+                return _Response(b"candidate")
+
+            destination = _AUTHORING.download_bundle("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), directory / "bundle.tar.gz", open_request)
+            self.assertEqual(destination.read_bytes(), b"candidate")
+            self.assertEqual(captured["url"], "http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime/skill-authoring-workloads/workload-1/input")
+            self.assertEqual(captured["authorization"], "Bearer projected-token")
+            self.assertEqual(captured["timeout"], 10.0)
+
+    def test_rejects_mismatched_or_oversized_download_without_retaining_bytes(self) -> None:
+        """Transport length and digest are both mandatory before the worker retains an archive."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            destination = directory / "bundle.tar.gz"
+            with self.assertRaisesRegex(RuntimeError, "integrity"):
+                _AUTHORING.download_bundle("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), destination, lambda request, timeout: _Response(b"candidate", address=f"sha256:{'0' * 64}"))
+            self.assertFalse(destination.exists())
+            with self.assertRaisesRegex(RuntimeError, "rejected"):
+                _AUTHORING.download_bundle("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), destination, lambda request, timeout: _Response(b"candidate", length=str(16 * 1024 * 1024 + 1)))
+            self.assertFalse(destination.exists())
+
+    def test_extracts_only_a_bounded_regular_file_bundle_with_required_files(self) -> None:
+        """A valid candidate receives a new private extracted tree after exact structural checks."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            archive = directory / "bundle.tar.gz"
+            self._archive(archive, {"SKILL.md": b"# Example", "pyproject.toml": b"[project]\nname='example'", "tests/test_example.py": b"def test_example(): pass\n"})
+            extracted = _AUTHORING.extract_bundle(archive, directory / "extracted")
+            self.assertEqual((extracted / "SKILL.md").read_bytes(), b"# Example")
+
+    def test_rejects_traversal_and_missing_contract_files(self) -> None:
+        """No archive path can escape /tmp and a candidate cannot omit the required authoring structure."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            unsafe = directory / "unsafe.tar.gz"
+            self._archive(unsafe, {"../escape": b"bad"})
+            with self.assertRaisesRegex(RuntimeError, "unsafe path"):
+                _AUTHORING.extract_bundle(unsafe, directory / "unsafe")
+            incomplete = directory / "incomplete.tar.gz"
+            self._archive(incomplete, {"SKILL.md": b"# Example"})
+            with self.assertRaisesRegex(RuntimeError, "missing required"):
+                _AUTHORING.extract_bundle(incomplete, directory / "incomplete")
+
+    def test_rejects_links_even_when_their_target_stays_inside_the_archive(self) -> None:
+        """Links are never an authoring-bundle feature because extraction must remain path-inert."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            archive = directory / "linked.tar.gz"
+            with tarfile.open(archive, "w:gz") as bundle:
+                link = tarfile.TarInfo("SKILL.md")
+                link.type = tarfile.SYMTYPE
+                link.linkname = "inside"
+                bundle.addfile(link)
+            with self.assertRaisesRegex(RuntimeError, "unsafe entry"):
+                _AUTHORING.extract_bundle(archive, directory / "linked")
+
+    def test_rejects_a_highly_compressible_oversized_member_from_its_header(self) -> None:
+        """A gzip tar bomb never reaches extraction because streaming inspection rejects its file header first."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            archive = directory / "oversized.tar.gz"
+            self._archive(archive, {"oversized.py": b"\x00" * (8 * 1024 * 1024 + 1)})
+            with self.assertRaisesRegex(RuntimeError, "unsafe entry"):
+                _AUTHORING.extract_bundle(archive, directory / "oversized")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/skill-authoring/project.json
+++ b/apps/skill-authoring/project.json
@@ -5,7 +5,8 @@
   "sourceRoot": "apps/skill-authoring",
   "tags": ["type:app", "layer:entrypoint", "scope:skill-authoring"],
   "targets": {
+    "build": { "executor": "nx:run-commands", "options": { "command": "python3 -B -c 'import ast, pathlib; [ast.parse(pathlib.Path(path).read_text()) for path in [\"libs/backend/agents/skills/worker/src/bootstrap.py\", \"apps/skill-authoring/src/authoring_worker.py\"]]'", "cwd": "." } },
     "lint": { "executor": "nx:run-commands", "options": { "command": "helm template skill-authoring helm >/dev/null", "cwd": "apps/skill-authoring" } },
-    "test": { "executor": "nx:run-commands", "options": { "command": "bash apps/skill-authoring/tests/helm-contract.sh", "cwd": "." } }
+    "test": { "executor": "nx:run-commands", "options": { "command": "python3 -B -m unittest discover -s apps/skill-authoring/__tests__ && bash apps/skill-authoring/tests/helm-contract.sh", "cwd": "." } }
   }
 }

--- a/apps/skill-authoring/src/authoring_worker.py
+++ b/apps/skill-authoring/src/authoring_worker.py
@@ -1,0 +1,153 @@
+"""Authoring-only verified bundle intake primitives.
+
+The deployment entrypoint does not invoke these functions until the image contains the complete,
+pinned offline validator suite. Keeping this intake inside the authoring app prevents the shared
+bootstrap client from becoming a tool-runner dependency.
+"""
+
+import hashlib
+import os
+import re
+import secrets
+import tarfile
+from pathlib import Path
+from typing import Callable, Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
+
+import bootstrap
+
+
+_ARCHIVE_BYTES = 16 * 1024 * 1024
+_EXTRACTED_BYTES = 32 * 1024 * 1024
+_MAX_ARCHIVE_ENTRIES = 1_000
+_MAX_FILE_BYTES = 8 * 1024 * 1024
+_READ_CHUNK_BYTES = 64 * 1024
+_CONTENT_ADDRESS_HEADER = "x-opencrane-content-address"
+
+
+class _InputResponse(Protocol):
+    """Minimal bounded HTTP response used only by the authoring input downloader."""
+
+    status: int
+    headers: object
+
+    def read(self, amount: int = -1) -> bytes:
+        """Read at most the requested response bytes."""
+
+
+def _input_url(base_url: str, workload_id: str) -> str:
+    """Derive the sole authoring input URL after validating the deployment-owned internal base URL."""
+    if not bootstrap._workload_id(workload_id):
+        raise RuntimeError("authoring workload identifier is invalid")
+    bootstrap._acknowledgement_url(base_url)
+    return f"{base_url}/skill-authoring-workloads/{workload_id}/input"
+
+
+def download_bundle(base_url: str, workload_id: str, token_path: str, destination: Path, open_request: Callable[[Request, float], _InputResponse] = bootstrap._open) -> Path:
+    """Download one server-brokered bundle, verify its fixed digest and length, then atomically retain it."""
+    token = bootstrap._read_single_line(token_path, "capability token")
+    request = Request(_input_url(base_url, workload_id), headers={"Authorization": f"Bearer {token}", "Accept": "application/gzip"}, method="GET")
+    temporary = destination.with_name(f".{destination.name}.{secrets.token_hex(16)}.part")
+    try:
+        response = open_request(request, 10.0)
+        length = _content_length(response)
+        address = _content_address(response)
+        if response.status != 200 or length is None or address is None:
+            raise RuntimeError("authoring input was rejected")
+        temporary.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        digest = hashlib.sha256()
+        written = 0
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "wb") as target:
+            while True:
+                chunk = response.read(_READ_CHUNK_BYTES)
+                if not chunk:
+                    break
+                written += len(chunk)
+                if written > length or written > _ARCHIVE_BYTES:
+                    raise RuntimeError("authoring input exceeded its bound")
+                digest.update(chunk)
+                target.write(chunk)
+        if written != length or f"sha256:{digest.hexdigest()}" != address:
+            raise RuntimeError("authoring input integrity check failed")
+        os.replace(temporary, destination)
+        return destination
+    except HTTPError as error:
+        try:
+            raise RuntimeError(f"authoring input was denied ({error.code})") from error
+        finally:
+            error.close()
+    except (OSError, URLError) as error:
+        raise RuntimeError("authoring input is unavailable") from error
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def extract_bundle(archive: Path, destination: Path) -> Path:
+    """Safely extract a bounded regular-file tar archive and require the authoring bundle contract."""
+    temporary = destination.with_name(f".{destination.name}.{secrets.token_hex(16)}.part")
+    seen: set[str] = set()
+    total = 0
+    try:
+        temporary.mkdir(mode=0o700, parents=True)
+        with tarfile.open(archive, "r|gz") as bundle:
+            count = 0
+            for member in bundle:
+                count += 1
+                path = _safe_member_path(member.name)
+                if count > _MAX_ARCHIVE_ENTRIES or path in seen or not (member.isdir() or member.isreg()) or member.size < 0 or member.size > _MAX_FILE_BYTES:
+                    raise RuntimeError("authoring bundle contains an unsafe entry")
+                seen.add(path)
+                target = temporary.joinpath(*path.split("/"))
+                if member.isdir():
+                    target.mkdir(mode=0o700, parents=True, exist_ok=False)
+                    continue
+                total += member.size
+                if total > _EXTRACTED_BYTES:
+                    raise RuntimeError("authoring bundle extraction exceeded its bound")
+                target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+                source = bundle.extractfile(member)
+                if source is None:
+                    raise RuntimeError("authoring bundle contains an unreadable entry")
+                with source, target.open("xb") as output:
+                    while chunk := source.read(_READ_CHUNK_BYTES):
+                        output.write(chunk)
+        if not (temporary / "SKILL.md").is_file() or not (temporary / "pyproject.toml").is_file() or not (temporary / "tests").is_dir():
+            raise RuntimeError("authoring bundle is missing required files")
+        os.replace(temporary, destination)
+        return destination
+    except (OSError, tarfile.TarError) as error:
+        raise RuntimeError("authoring bundle extraction failed") from error
+    finally:
+        if temporary.exists():
+            _remove_tree(temporary)
+
+
+def _content_length(response: _InputResponse) -> int | None:
+    """Parse the exact bounded decimal content length supplied by the server broker."""
+    value = getattr(response.headers, "get", lambda _: None)("content-length")
+    return int(value) if isinstance(value, str) and len(value) <= 8 and re.fullmatch(r"[1-9][0-9]*", value) and int(value) <= _ARCHIVE_BYTES else None
+
+
+def _content_address(response: _InputResponse) -> str | None:
+    """Accept only the canonical SHA-256 address from the server-owned immutable revision selection."""
+    value = getattr(response.headers, "get", lambda _: None)(_CONTENT_ADDRESS_HEADER)
+    return value if isinstance(value, str) and re.fullmatch(r"sha256:[a-f0-9]{64}", value) else None
+
+
+def _safe_member_path(value: str) -> str:
+    """Reject every archive path outside the future extracted root or with ambiguous representation."""
+    if not value or "\x00" in value or value.startswith("/") or value.endswith("/") or any(part in {"", ".", ".."} for part in value.split("/")):
+        raise RuntimeError("authoring bundle contains an unsafe path")
+    return value
+
+
+def _remove_tree(path: Path) -> None:
+    """Remove only the extractor-created regular-file tree after a failed validation step."""
+    for child in path.iterdir():
+        if child.is_dir():
+            _remove_tree(child)
+        else:
+            child.unlink()
+    path.rmdir()


### PR DESCRIPTION
## Why

The authoring validator needs a safe local candidate bundle before it can run any code checks. This PR establishes that intake without turning an incomplete validator into a false success path.

## What changed

- adds authoring-app-only primitives for fetching the exact server-brokered bundle with the projected worker token
- verifies fixed content length and canonical SHA-256 before atomically retaining bytes in `/tmp`
- safely streams `tar.gz` extraction: rejects traversal, NUL paths, duplicate paths, links, device entries, oversized members, too many entries, and expansion beyond the extraction budget
- requires `SKILL.md`, `pyproject.toml`, and a `tests/` directory
- adds regression coverage for digest/length mismatch, links, traversal, missing contract files, and highly-compressible oversized tar members

## Boundary

The new primitives are intentionally not the image entrypoint yet. A later PR must supply the pinned offline formatter/type/test/dependency/licence/secret/malware/policy validator suite and only then wire truthful completion evidence.

## Validation

- `npx nx run skill-authoring:build --skip-nx-cache`
- `npx nx run skill-authoring:test --skip-nx-cache` — 6 Python tests plus Helm contract
- `scripts/agent-style-check.sh`
- `git diff --check`

## Review

- architecture preflight passed
- independent review found and verified a fix for tar preloading that could otherwise expand a gzip tar before archive bounds ran
- Claude Code review will be attempted after PR creation.