### PR TITLE
🔒 Add bounded authoring terminal completion

### DIFF
--- a/apps/skill-authoring/README.md
+++ b/apps/skill-authoring/README.md
@@ -26,7 +26,7 @@ OpenCrane *(bootstrap acknowledgement authority)*
 
 ## Public surface
 
- - `src/authoring_worker.py` — private, not-yet-invoked intake and offline-validator primitives. They reject candidate dependencies and plaintext secrets, use only fixed image-owned commands, and return bounded evidence.
+ - `src/authoring_worker.py` — private, not-yet-invoked intake, offline-validator, and terminal-completion primitives. They reject candidate dependencies and plaintext secrets, use only fixed image-owned commands, and can submit only bounded success evidence or a stable failure code to the fixed internal completion route.
 - Helm chart — restricted namespace, `skill-authoring-default` ServiceAccount, quota, and default-deny policy.
 - `values.yaml` — namespace, worker ServiceAccount, and quota defaults only; image, resource, and
   lifecycle values remain controller-owned.

--- a/apps/skill-authoring/__tests__/test_authoring_worker.py
+++ b/apps/skill-authoring/__tests__/test_authoring_worker.py
@@ -38,6 +38,19 @@ class _Response:
         return self._body.read(amount)
 
 
+class _CompletionResponse:
+    """In-memory response seam for the fixed terminal completion route."""
+
+    def __init__(self, body: bytes = b'{"completed":true}', status: int = 200):
+        """Build one terminal authority reply without including source or credential material."""
+        self.status = status
+        self._body = io.BytesIO(body)
+
+    def read(self, amount: int = -1) -> bytes:
+        """Read the bounded JSON response body."""
+        return self._body.read(amount)
+
+
 class AuthoringWorkerTests(unittest.TestCase):
     """Prove authoring bundle bytes cannot escape their server-selected integrity and archive bounds."""
 
@@ -180,6 +193,48 @@ class AuthoringWorkerTests(unittest.TestCase):
             project.write_text("[project]\nname='example'\n[tool.poetry]\ndependencies={ requests = '^2.0' }", encoding="utf-8")
             with self.assertRaisesRegex(RuntimeError, "unsupported dependencies"):
                 _AUTHORING._assert_dependency_policy(project)
+
+    def test_posts_only_a_bounded_terminal_outcome_to_the_fixed_completion_route(self) -> None:
+        """Completion rereads the projected token and accepts only the server's exact acknowledgement shape."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            captured: dict[str, object] = {}
+
+            def open_request(request: object, timeout: float) -> _CompletionResponse:
+                captured["url"] = request.full_url
+                captured["authorization"] = request.get_header("Authorization")
+                captured["body"] = request.data
+                captured["timeout"] = timeout
+                return _CompletionResponse()
+
+            command = {"workloadId": "workload-1", "outcome": "succeeded", "testReport": {"passed": True, "summary": "checks passed", "checksRun": 3}, "scanResult": {"passed": True, "summary": "scans passed", "checksRun": 3}}
+            _AUTHORING.complete_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), command, open_request)
+            self.assertEqual(captured["url"], "http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime/skill-authoring-workloads:complete")
+            self.assertEqual(captured["authorization"], "Bearer projected-token")
+            self.assertEqual(captured["body"], b'{"workloadId":"workload-1","outcome":"succeeded","testReport":{"passed":true,"summary":"checks passed","checksRun":3},"scanResult":{"passed":true,"summary":"scans passed","checksRun":3}}')
+            self.assertEqual(captured["timeout"], 10.0)
+
+    def test_refuses_unbounded_completion_evidence_or_a_noncanonical_authority_reply(self) -> None:
+        """The worker neither sends raw validator output nor turns an ambiguous terminal reply into success."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            command = {"workloadId": "workload-1", "outcome": "succeeded", "testReport": {"passed": True, "summary": "checks passed\nraw output", "checksRun": 3}, "scanResult": {"passed": True, "summary": "scans passed", "checksRun": 3}}
+            with self.assertRaisesRegex(RuntimeError, "command is invalid"):
+                _AUTHORING.complete_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), command)
+            failed = {"workloadId": "workload-1", "outcome": "failed", "failureCode": "validator_unavailable"}
+            with self.assertRaisesRegex(RuntimeError, "completion was rejected"):
+                _AUTHORING.complete_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), failed, lambda request, timeout: _CompletionResponse(b'{"completed":false}'))
+
+    def test_rejects_oversized_authority_replies_and_boolean_check_counts(self) -> None:
+        """The completion exchange keeps both incoming authority data and outgoing evidence within their exact bounds."""
+        with tempfile.TemporaryDirectory() as raw:
+            directory = pathlib.Path(raw)
+            succeeded = {"workloadId": "workload-1", "outcome": "succeeded", "testReport": {"passed": True, "summary": "checks passed", "checksRun": 3}, "scanResult": {"passed": True, "summary": "scans passed", "checksRun": 3}}
+            with self.assertRaisesRegex(RuntimeError, "response exceeded"):
+                _AUTHORING.complete_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), succeeded, lambda request, timeout: _CompletionResponse(b"x" * 4097))
+            invalid = {"workloadId": "workload-1", "outcome": "succeeded", "testReport": {"passed": True, "summary": "checks passed", "checksRun": True}, "scanResult": {"passed": True, "summary": "scans passed", "checksRun": 3}}
+            with self.assertRaisesRegex(RuntimeError, "command is invalid"):
+                _AUTHORING.complete_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), invalid)
 
 
 if __name__ == "__main__":

--- a/apps/skill-authoring/src/authoring_worker.py
+++ b/apps/skill-authoring/src/authoring_worker.py
@@ -6,6 +6,7 @@ bootstrap client from becoming a tool-runner dependency.
 """
 
 import hashlib
+import json
 import os
 import re
 import secrets
@@ -36,6 +37,7 @@ _VALIDATOR_COMMANDS = (
 )
 _MALWARE_COMMAND = ("/opt/opencrane/bin/clamscan", "--database=/opt/opencrane/clamav-db", "--infected", "--no-summary", "--recursive", ".")
 _SECRET_PATTERN = re.compile(r"(?i)(?:api[_-]?key|secret|token|password)\s*[=:]\s*['\"][^'\"]{8,}['\"]")
+_MAX_COMPLETION_BODY_BYTES = 4_096
 
 
 class _InputResponse(Protocol):
@@ -54,6 +56,12 @@ def _input_url(base_url: str, workload_id: str) -> str:
         raise RuntimeError("authoring workload identifier is invalid")
     bootstrap._acknowledgement_url(base_url)
     return f"{base_url}/skill-authoring-workloads/{workload_id}/input"
+
+
+def _completion_url(base_url: str) -> str:
+    """Derive the sole terminal authoring completion URL after validating the deployment-owned internal base URL."""
+    bootstrap._acknowledgement_url(base_url)
+    return f"{base_url}/skill-authoring-workloads:complete"
 
 
 def download_bundle(base_url: str, workload_id: str, token_path: str, destination: Path, open_request: Callable[[Request, float], _InputResponse] = bootstrap._open) -> Path:
@@ -165,6 +173,29 @@ def validate_bundle(destination: Path, execute: Callable[[Sequence[str], Path, i
     return _report(True, "format, type, and test checks passed", test_checks), _report(True, "dependency policy, secret scan, and offline malware scan passed", 3)
 
 
+def complete_workload(base_url: str, workload_id: str, token_path: str, command: dict[str, object], open_request: Callable[[Request, float], _InputResponse] = bootstrap._open) -> None:
+    """Send one exact bounded terminal outcome using a freshly read projected token and reject every ambiguous response."""
+    if not bootstrap._workload_id(workload_id) or not _completion_command(command, workload_id):
+        raise RuntimeError("authoring completion command is invalid")
+    token = bootstrap._read_single_line(token_path, "capability token")
+    request = Request(_completion_url(base_url), data=json.dumps(command, separators=(",", ":")).encode("utf-8"), headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json", "Accept": "application/json"}, method="POST")
+    try:
+        response = open_request(request, 10.0)
+        body = response.read(_MAX_COMPLETION_BODY_BYTES + 1)
+        if len(body) > _MAX_COMPLETION_BODY_BYTES:
+            raise RuntimeError("authoring completion response exceeded its bound")
+        payload = json.loads(body.decode("utf-8"))
+    except HTTPError as error:
+        try:
+            raise RuntimeError(f"authoring completion was denied ({error.code})") from error
+        finally:
+            error.close()
+    except (OSError, URLError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RuntimeError("authoring completion is unavailable") from error
+    if response.status != 200 or payload != {"completed": True}:
+        raise RuntimeError("authoring completion was rejected")
+
+
 def _assert_dependency_policy(project: Path) -> None:
     """Reject every candidate dependency declaration until OpenCrane ships a pinned offline wheelhouse policy."""
     try:
@@ -218,6 +249,25 @@ def _contains_dependency_declaration(value: object) -> bool:
     if isinstance(value, list):
         return any(_contains_dependency_declaration(child) for child in value)
     return False
+
+
+def _completion_command(command: dict[str, object], workload_id: str) -> bool:
+    """Keep completion payloads within the server-owned two-outcome contract and never forward raw validator output."""
+    if command.get("workloadId") != workload_id:
+        return False
+    if command.get("outcome") == "failed":
+        failure_code = command.get("failureCode")
+        return set(command) == {"workloadId", "outcome", "failureCode"} and isinstance(failure_code, str) and re.fullmatch(r"[a-z][a-z0-9_]{0,63}", failure_code) is not None
+    if command.get("outcome") == "succeeded":
+        return set(command) == {"workloadId", "outcome", "testReport", "scanResult"} and _completion_report(command.get("testReport")) and _completion_report(command.get("scanResult"))
+    return False
+
+
+def _completion_report(value: object) -> bool:
+    """Validate the exact bounded report shape enforced by the completion router before any network call starts."""
+    if not isinstance(value, dict) or set(value) != {"passed", "summary", "checksRun"}:
+        return False
+    return value.get("passed") is True and isinstance(value.get("summary"), str) and 0 < len(value["summary"]) <= 2_000 and not any(character in value["summary"] for character in "\x00\n\r") and type(value.get("checksRun")) is int and 0 <= value["checksRun"] <= 10_000
 
 
 def _safe_member_path(value: str) -> str:


### PR DESCRIPTION
## Why this matters

A validation worker must not be able to turn a partial check, a malformed server reply, or raw diagnostic output into a published candidate. This PR prepares the one terminal exchange the future offline validator will use after it has actually completed its checks.

## What changes

- add an authoring-only completion client that always derives the fixed internal route and rereads the projected capability token immediately before posting
- accept only the server’s exact `{ completed: true }` acknowledgement and cap that reply at 4 KiB
- reject unbounded output, control characters, Boolean `checksRun` values, mismatched workload IDs, and any extra completion fields before a request begins
- retain the two terminal choices only: bounded passing reports, or a stable lower-case failure code

## Boundary

This remains inactive. It does not change the worker entrypoint or report any successful validation. PR #414 must first be followed by a digest-pinned offline scanner/toolchain image and an offline smoke test before the full bootstrap → input → validate → complete flow is enabled.

## Validation

- `npx nx run skill-authoring:test --skip-nx-cache` (12 Python tests plus Helm contract)
- `npx nx run skill-authoring:build --skip-nx-cache`
- `git diff --check`

## Review

Independent review identified and this PR fixes two issues before publication: a bounded completion-authority reply and rejecting Python Boolean values as numeric check counts. Claude Code review remains unavailable locally because its CLI is not logged in; no repository content was sent.