### PR TITLE
🔒 Execute bounded skill-authoring validation

### DIFF
--- a/apps/skill-authoring/README.md
+++ b/apps/skill-authoring/README.md
@@ -26,8 +26,8 @@ OpenCrane *(bootstrap acknowledgement authority)*
 
 ## Public surface
 
-- `deploy/Dockerfile` — builds an inactive one-shot worker image from immutable ClamAV and Python bases. It carries a hash-locked formatter/type/test toolchain and a read-only copied malware-signature database. It starts neither the upstream FreshClam updater nor ClamD scanner daemon.
-- `src/authoring_worker.py` — private, not-yet-invoked intake, offline-validator, and terminal-completion primitives. They reject candidate dependencies and plaintext secrets, use only fixed image-owned commands, and can submit only bounded success evidence or a stable failure code to the fixed internal completion route.
+- `deploy/Dockerfile` — builds a one-shot validation worker image from immutable ClamAV and Python bases. It carries a hash-locked formatter/type/test toolchain and a read-only copied malware-signature database. Its default entrypoint runs the bounded lifecycle, but starts neither the upstream FreshClam updater nor ClamD scanner daemon.
+- `src/authoring_worker.py` — private authoring intake, offline-validator, and terminal-completion lifecycle. It rejects candidate dependencies and plaintext secrets, uses only fixed image-owned commands, and can submit only bounded success evidence or a stable failure code to the fixed internal completion route.
 - Helm chart — restricted namespace, `skill-authoring-default` ServiceAccount, quota, and default-deny policy.
 - `values.yaml` — namespace, worker ServiceAccount, and quota defaults only; image, resource, and
   lifecycle values remain controller-owned.
@@ -45,9 +45,10 @@ and returns the pinned SHA-256 address alongside the length so the future valida
 downloaded bytes. The admitted Job reserves at least 128 MiB of ephemeral `/tmp` space: 16 MiB
 compressed input, 32 MiB extracted source, and validation work cannot safely share the old 64 MiB
 budget. The authoring Job also reserves 3 GiB and caps at 4 GiB of memory because the pinned ClamAV
-signature engine must load before it can scan. The validator code remains deliberately inactive until
-a release promotes this tested image by its final digest into the controller profile. It cannot report
-successful validation before that promotion.
+signature engine must load before it can scan. Deployment remains fail-closed even though the image
+has an active default entrypoint: the controller is disabled and the authoring profile has no final
+image digest. Helm refuses to enable the controller until a release promotes this tested image by its
+final digest, so an unreviewed local build cannot become an executable tenant workload.
 
 The `container` target builds the image and proves that `clamscan`, the three fixed validator tools,
 and its read-only database work without networking for UID 65532. It scans both a clean fixture and
@@ -56,6 +57,14 @@ needs the resulting final image digest in the controller profile;
 the Dockerfile's source digests are not a substitute for that release digest.
 The database never updates in a running Job: refresh it only by building, smoke-testing, and promoting
 a new pinned image.
+
+Once a release supplies that final digest, each Job performs one closed lifecycle: it acknowledges its
+server-selected workload, downloads that workload's immutable archive, extracts it below `/tmp`, runs
+the four fixed offline checks, and submits either the two compact passing reports or one stable
+technical failure code. The worker deletes its temporary archive and extracted files on every path.
+It never sends validator output, candidate source, or file paths to the control plane.
+It retries the same terminal command a small fixed number of times for a transient authority outage;
+it never changes a possible success into a failure when delivery is uncertain.
 
 ## Dependency direction
 

--- a/apps/skill-authoring/__tests__/test_authoring_worker.py
+++ b/apps/skill-authoring/__tests__/test_authoring_worker.py
@@ -8,6 +8,7 @@ import sys
 import tarfile
 import tempfile
 import unittest
+from unittest import mock
 
 
 _ROOT = pathlib.Path(__file__).parents[3]
@@ -235,6 +236,132 @@ class AuthoringWorkerTests(unittest.TestCase):
             invalid = {"workloadId": "workload-1", "outcome": "succeeded", "testReport": {"passed": True, "summary": "checks passed", "checksRun": True}, "scanResult": {"passed": True, "summary": "scans passed", "checksRun": 3}}
             with self.assertRaisesRegex(RuntimeError, "command is invalid"):
                 _AUTHORING.complete_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", self._token(directory), invalid)
+
+    def test_runs_one_server_selected_bundle_to_a_bounded_success_and_erases_its_workspace(self) -> None:
+        """The lifecycle joins only the fixed worker primitives and leaves no candidate bytes behind."""
+        captured: dict[str, object] = {}
+
+        def download(base_url: str, workload_id: str, token_path: str, destination: pathlib.Path) -> pathlib.Path:
+            captured["download"] = (base_url, workload_id, token_path)
+            destination.write_bytes(b"bundle")
+            return destination
+
+        def extract(archive: pathlib.Path, destination: pathlib.Path) -> pathlib.Path:
+            destination.mkdir()
+            (destination / "SKILL.md").write_text("# Example", encoding="utf-8")
+            return destination
+
+        def validate(destination: pathlib.Path) -> tuple[dict[str, object], dict[str, object]]:
+            captured["workspace"] = destination.parent
+            return ({"passed": True, "summary": "checks passed", "checksRun": 3}, {"passed": True, "summary": "scan passed", "checksRun": 3})
+
+        def complete(base_url: str, workload_id: str, token_path: str, command: dict[str, object]) -> None:
+            captured["completion"] = (base_url, workload_id, token_path, command)
+
+        result = _AUTHORING.run_authoring_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token", download, extract, validate, complete)
+        self.assertEqual(result, 0)
+        self.assertEqual(captured["download"], ("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token"))
+        self.assertEqual(captured["completion"], ("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token", {"workloadId": "workload-1", "outcome": "succeeded", "testReport": {"passed": True, "summary": "checks passed", "checksRun": 3}, "scanResult": {"passed": True, "summary": "scan passed", "checksRun": 3}}))
+        self.assertFalse(captured["workspace"].exists())
+
+    def test_replaces_every_validator_failure_with_one_stable_terminal_code(self) -> None:
+        """A failed archive check cannot leak its local reason or suppress the terminal transition."""
+        completions: list[dict[str, object]] = []
+
+        def unavailable(base_url: str, workload_id: str, token_path: str, destination: pathlib.Path) -> pathlib.Path:
+            raise RuntimeError("candidate path and raw output must not cross the boundary")
+
+        def complete(base_url: str, workload_id: str, token_path: str, command: dict[str, object]) -> None:
+            completions.append(command)
+
+        result = _AUTHORING.run_authoring_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token", unavailable, _AUTHORING.extract_bundle, _AUTHORING.validate_bundle, complete)
+        self.assertEqual(result, 1)
+        self.assertEqual(completions, [{"workloadId": "workload-1", "outcome": "failed", "failureCode": "offline_validation_failed"}])
+
+    def test_main_bootstraps_before_it_can_run_the_authoring_lifecycle(self) -> None:
+        """The image entrypoint cannot choose a workload or start validation before server acknowledgement."""
+        with mock.patch.object(_AUTHORING.bootstrap, "_required_environment", side_effect=["http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "/token", "/reference"]), mock.patch.object(_AUTHORING.bootstrap, "acknowledge", return_value="workload-1") as acknowledge, mock.patch.object(_AUTHORING, "run_authoring_workload", return_value=0) as run:
+            self.assertEqual(_AUTHORING.main(), 0)
+        acknowledge.assert_called_once_with("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "/token", "/reference")
+        run.assert_called_once_with("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token")
+
+    def test_reports_a_terminal_failure_when_the_ephemeral_workspace_cannot_be_created(self) -> None:
+        """An acknowledged workload cannot be stranded by a local disk or permission failure."""
+        completions: list[dict[str, object]] = []
+
+        def complete(base_url: str, workload_id: str, token_path: str, command: dict[str, object]) -> None:
+            completions.append(command)
+
+        with mock.patch.object(_AUTHORING.tempfile, "mkdtemp", side_effect=OSError("disk unavailable")):
+            result = _AUTHORING.run_authoring_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token", complete=complete)
+        self.assertEqual(result, 1)
+        self.assertEqual(completions, [{"workloadId": "workload-1", "outcome": "failed", "failureCode": "offline_validation_failed"}])
+
+    def test_does_not_replace_an_uncertain_success_with_a_contradictory_failure(self) -> None:
+        """A dropped acknowledgement after durable success can fail the Job but must not change its outcome."""
+        completions: list[dict[str, object]] = []
+
+        def download(base_url: str, workload_id: str, token_path: str, destination: pathlib.Path) -> pathlib.Path:
+            destination.write_bytes(b"bundle")
+            return destination
+
+        def extract(archive: pathlib.Path, destination: pathlib.Path) -> pathlib.Path:
+            destination.mkdir()
+            return destination
+
+        def validate(destination: pathlib.Path) -> tuple[dict[str, object], dict[str, object]]:
+            return ({"passed": True, "summary": "checks passed", "checksRun": 3}, {"passed": True, "summary": "scan passed", "checksRun": 3})
+
+        def uncertain_complete(base_url: str, workload_id: str, token_path: str, command: dict[str, object]) -> None:
+            completions.append(command)
+            raise RuntimeError("connection closed after server commit")
+
+        with mock.patch.object(_AUTHORING, "_write_event") as write_event:
+            result = _AUTHORING.run_authoring_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token", download, extract, validate, uncertain_complete)
+        self.assertEqual(result, 1)
+        self.assertEqual(completions, [{"workloadId": "workload-1", "outcome": "succeeded", "testReport": {"passed": True, "summary": "checks passed", "checksRun": 3}, "scanResult": {"passed": True, "summary": "scan passed", "checksRun": 3}}] * 3)
+        write_event.assert_called_once_with("completion_uncertain")
+
+    def test_erases_a_candidate_tree_even_when_its_checks_remove_owner_directory_access(self) -> None:
+        """Candidate tests cannot turn a successful result into residual `/tmp` source bytes by chmodding its workspace root."""
+        captured: dict[str, pathlib.Path] = {}
+
+        def download(base_url: str, workload_id: str, token_path: str, destination: pathlib.Path) -> pathlib.Path:
+            destination.write_bytes(b"bundle")
+            return destination
+
+        def extract(archive: pathlib.Path, destination: pathlib.Path) -> pathlib.Path:
+            destination.mkdir()
+            (destination / "candidate.py").write_text("pass", encoding="utf-8")
+            captured["workspace"] = destination.parent
+            destination.parent.chmod(0)
+            return destination
+
+        def validate(destination: pathlib.Path) -> tuple[dict[str, object], dict[str, object]]:
+            return ({"passed": True, "summary": "checks passed", "checksRun": 3}, {"passed": True, "summary": "scan passed", "checksRun": 3})
+
+        def complete(base_url: str, workload_id: str, token_path: str, command: dict[str, object]) -> None:
+            return None
+
+        result = _AUTHORING.run_authoring_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token", download, extract, validate, complete)
+        self.assertEqual(result, 0)
+        self.assertFalse(captured["workspace"].exists())
+
+    def test_retries_a_transient_failure_to_deliver_one_unchanged_terminal_outcome(self) -> None:
+        """A momentary completion outage does not strand an acknowledged workload or alter its failure code."""
+        completions: list[dict[str, object]] = []
+
+        def unavailable(base_url: str, workload_id: str, token_path: str, destination: pathlib.Path) -> pathlib.Path:
+            raise RuntimeError("validator unavailable")
+
+        def eventually_complete(base_url: str, workload_id: str, token_path: str, command: dict[str, object]) -> None:
+            completions.append(command)
+            if len(completions) == 1:
+                raise RuntimeError("temporary authority outage")
+
+        result = _AUTHORING.run_authoring_workload("http://opencrane-server.silo.svc.cluster.local:8081/api/internal/agent-runtime", "workload-1", "/token", unavailable, _AUTHORING.extract_bundle, _AUTHORING.validate_bundle, eventually_complete)
+        self.assertEqual(result, 1)
+        self.assertEqual(completions, [{"workloadId": "workload-1", "outcome": "failed", "failureCode": "offline_validation_failed"}] * 2)
 
 
 if __name__ == "__main__":

--- a/apps/skill-authoring/deploy/Dockerfile
+++ b/apps/skill-authoring/deploy/Dockerfile
@@ -23,4 +23,5 @@ RUN mkdir -p /opt/opencrane/clamav-db /opt/opencrane/bin \
 # The upstream image starts freshclam/clamd by default. This one-shot Job must never update or listen.
 ENTRYPOINT []
 USER 65532:65532
-CMD ["python", "-B", "/app/bootstrap.py"]
+# The controller has no authoring image digest until this immutable image is published and promoted.
+CMD ["python", "-B", "/app/authoring_worker.py"]

--- a/apps/skill-authoring/src/authoring_worker.py
+++ b/apps/skill-authoring/src/authoring_worker.py
@@ -12,7 +12,9 @@ import re
 import secrets
 import signal
 import subprocess
+import sys
 import tarfile
+import tempfile
 import tomllib
 from pathlib import Path
 from typing import Callable, Protocol, Sequence
@@ -38,6 +40,9 @@ _VALIDATOR_COMMANDS = (
 _MALWARE_COMMAND = ("/opt/opencrane/bin/clamscan", "--database=/opt/opencrane/clamav-db", "--infected", "--no-summary", "--recursive", ".")
 _SECRET_PATTERN = re.compile(r"(?i)(?:api[_-]?key|secret|token|password)\s*[=:]\s*['\"][^'\"]{8,}['\"]")
 _MAX_COMPLETION_BODY_BYTES = 4_096
+_WORK_DIRECTORY_PREFIX = "opencrane-skill-authoring-"
+_VALIDATION_FAILURE_CODE = "offline_validation_failed"
+_TERMINAL_DELIVERY_ATTEMPTS = 3
 
 
 class _InputResponse(Protocol):
@@ -196,6 +201,65 @@ def complete_workload(base_url: str, workload_id: str, token_path: str, command:
         raise RuntimeError("authoring completion was rejected")
 
 
+def run_authoring_workload(base_url: str, workload_id: str, token_path: str, download: Callable[[str, str, str, Path], Path] = download_bundle, extract: Callable[[Path, Path], Path] = extract_bundle, validate: Callable[[Path], tuple[dict[str, object], dict[str, object]]] = validate_bundle, complete: Callable[[str, str, str, dict[str, object]], None] = complete_workload) -> int:
+    """Perform one bootstrap-bound validation and send exactly one bounded terminal outcome.
+
+    The server selected ``workload_id`` during bootstrap. This worker only obtains its immutable
+    archive through that server-owned route, runs image-owned checks, and cleans its ephemeral
+    workspace regardless of outcome. A technical failure is intentionally collapsed to one stable
+    code because raw candidate output and local paths do not cross the worker boundary.
+    """
+    work_directory: Path | None = None
+    try:
+        try:
+            work_directory = Path(tempfile.mkdtemp(prefix=_WORK_DIRECTORY_PREFIX, dir="/tmp"))
+            archive = download(base_url, workload_id, token_path, work_directory / "bundle.tar.gz")
+            extracted = extract(archive, work_directory / "bundle")
+            test_report, scan_result = validate(extracted)
+        except (OSError, RuntimeError):
+            return _complete_failed_workload(base_url, workload_id, token_path, complete)
+        if test_report.get("passed") is not True or scan_result.get("passed") is not True:
+            return _complete_failed_workload(base_url, workload_id, token_path, complete)
+        if _deliver_terminal(base_url, workload_id, token_path, {"workloadId": workload_id, "outcome": "succeeded", "testReport": test_report, "scanResult": scan_result}, complete):
+            return 0
+        _write_event("completion_uncertain")
+        return 1
+    finally:
+        if work_directory is not None:
+            _cleanup_work_directory(work_directory)
+
+
+def _complete_failed_workload(base_url: str, workload_id: str, token_path: str, complete: Callable[[str, str, str, dict[str, object]], None]) -> int:
+    """Submit the one technical failure without masking an authority outage as a successful Job."""
+    if not _deliver_terminal(base_url, workload_id, token_path, {"workloadId": workload_id, "outcome": "failed", "failureCode": _VALIDATION_FAILURE_CODE}, complete):
+        _write_event("failure_completion_unavailable")
+    return 1
+
+
+def _deliver_terminal(base_url: str, workload_id: str, token_path: str, command: dict[str, object], complete: Callable[[str, str, str, dict[str, object]], None]) -> bool:
+    """Retry one exact terminal command a small fixed number of times without changing its outcome."""
+    for _ in range(_TERMINAL_DELIVERY_ATTEMPTS):
+        try:
+            complete(base_url, workload_id, token_path, command)
+            return True
+        except (OSError, RuntimeError):
+            pass
+    return False
+
+
+def _cleanup_work_directory(path: Path) -> None:
+    """Best-effort erase the worker-owned temporary tree without changing its terminal result."""
+    try:
+        _remove_tree(path)
+    except OSError:
+        _write_event("workspace_cleanup_failed")
+
+
+def _write_event(event: str) -> None:
+    """Emit one non-sensitive structured lifecycle event for an operator-facing short-lived Job log."""
+    print(json.dumps({"component": "skill-authoring-worker", "event": event}, sort_keys=True), file=sys.stderr, flush=True)
+
+
 def _assert_dependency_policy(project: Path) -> None:
     """Reject every candidate dependency declaration until OpenCrane ships a pinned offline wheelhouse policy."""
     try:
@@ -278,10 +342,42 @@ def _safe_member_path(value: str) -> str:
 
 
 def _remove_tree(path: Path) -> None:
-    """Remove only the extractor-created regular-file tree after a failed validation step."""
-    for child in path.iterdir():
-        if child.is_dir():
-            _remove_tree(child)
-        else:
-            child.unlink()
+    """Remove a worker-owned candidate tree after restoring owner access to candidate-created directories."""
+    if path.is_symlink() or not path.is_dir():
+        path.unlink(missing_ok=True)
+        return
+    os.chmod(path, 0o700)
+    for root, directories, _ in os.walk(path, topdown=True, followlinks=False):
+        root_path = Path(root)
+        os.chmod(root_path, 0o700)
+        for directory in tuple(directories):
+            candidate = root_path / directory
+            if candidate.is_symlink():
+                candidate.unlink()
+                directories.remove(directory)
+            else:
+                os.chmod(candidate, 0o700)
+    for root, directories, files in os.walk(path, topdown=False, followlinks=False):
+        root_path = Path(root)
+        for file_name in files:
+            (root_path / file_name).unlink(missing_ok=True)
+        for directory in directories:
+            (root_path / directory).rmdir()
     path.rmdir()
+
+
+def main() -> int:
+    """Bootstrap one released authoring Job, then execute its bounded validation lifecycle."""
+    try:
+        base_url = bootstrap._required_environment("OPENCRANE_SKILL_BOOTSTRAP_URL")
+        token_path = bootstrap._required_environment("OPENCRANE_SKILL_TOKEN_PATH")
+        reference_path = bootstrap._required_environment("OPENCRANE_SKILL_BOOTSTRAP_REFERENCE_PATH")
+        workload_id = bootstrap.acknowledge(base_url, token_path, reference_path)
+        return run_authoring_workload(base_url, workload_id, token_path)
+    except RuntimeError as error:
+        print(json.dumps({"component": "skill-authoring-worker", "event": "validation_unavailable", "reason": str(error)}, sort_keys=True), file=sys.stderr, flush=True)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/skill-authoring/tests/image-contract.sh
+++ b/apps/skill-authoring/tests/image-contract.sh
@@ -12,6 +12,7 @@ grep -Fq 'cp -a /var/lib/clamav/. /opt/opencrane/clamav-db/' "$dockerfile"
 grep -Fq 'ln -s /usr/bin/clamscan /opt/opencrane/bin/clamscan' "$dockerfile"
 grep -Fq 'chmod -R a-w /opt/opencrane/clamav-db' "$dockerfile"
 grep -Fxq 'ENTRYPOINT []' "$dockerfile"
+grep -Fxq 'CMD ["python", "-B", "/app/authoring_worker.py"]' "$dockerfile"
 rg -q 'upstream image starts freshclam/clamd' "$dockerfile"
 rg -Fq 'bash apps/skill-authoring/tests/image-smoke.sh' apps/skill-authoring/project.json
 if ! rg -q -- '--hash=sha256:' apps/skill-authoring/deploy/validator.requirements.txt; then


### PR DESCRIPTION
## Why

A verified authoring image needs a closed worker lifecycle before any release may promote it. A released worker must not choose its workload, command, endpoint, output, or durable storage.

## What changed

- bootstraps only through the server-owned opaque reference, then downloads the server-selected immutable archive;
- extracts into the bounded temporary filesystem, runs fixed offline checks, and submits either compact passing evidence or one stable technical failure code;
- retries only the same terminal command for a transient authority outage, without turning a possibly committed success into a contradictory failure; and
- restores directory ownership before deleting all candidate bytes, including when candidate checks restrict their workspace.

## What this enables

After a later image-digest promotion, each authoring Job has a complete single-shot path: acknowledgement, immutable input, fixed offline validation, bounded outcome, and cleanup. It still cannot make a tenant workload executable by itself.

## Validation

- `npx nx run skill-authoring:build`, `lint`, and `test` (19 tests)
- `scripts/agent-style-check.sh` and `git diff --check`

The image container smoke test remains blocked locally because Docker and registry DNS are unavailable; it is an explicit CI/reviewer gate.

## Review

Claude Code is not authenticated on this PC, so no external Claude review was claimed or transmitted. This PR needs independent review before merge.