### PR TITLE
🔧 Publish governed worker images through CI

### DIFF
--- a/apps/skill-authoring/README.md
+++ b/apps/skill-authoring/README.md
@@ -70,6 +70,20 @@ it never changes a possible success into a failure when delivery is uncertain.
 
 An app entrypoint owns only this workload's deployment contract; it imports no libraries.
 
+## Runtime & config
+
+The existing `Validate and publish affected deployables` workflow builds this image whenever this
+package changes on an integration branch. It publishes `ghcr.io/italanta/opencrane-skill-authoring`
+under a commit-derived tag. The workflow does not promote it: the release operator retrieves the
+manifest `sha256:` value from that published GitHub Container Registry package version and records
+it in a separate values review. A tag, local image ID, or Dockerfile base digest is never a valid
+substitute for that final published digest.
+
+The controller stays disabled until one review supplies all of these: exact immutable digests for the
+controller, personal runtime, authoring worker, and tool-runner worker; an exact Kubernetes API
+Service CIDR; Kubernetes 1.30 or later; and an instance-local LiteLLM deployment. Only then may it
+set `agentController.enabled=true`. Publishing this image alone cannot create a worker Job.
+
 ## See also
 
 - Job builder: [skills k8s launcher](../../libs/backend/agents/skills/k8s-launcher/README.md)

--- a/apps/tool-runner/README.md
+++ b/apps/tool-runner/README.md
@@ -42,6 +42,14 @@ workload data.
 
 An app entrypoint owns only this workload's deployment contract; it imports no libraries.
 
+## Runtime & config
+
+Tool execution has no image or publication workflow yet. The controller therefore remains disabled
+until a later, separate tool-runner implementation supplies an independently reviewed immutable image
+digest together with the controller, personal-runtime, and authoring-worker digests; an exact
+Kubernetes API Service CIDR; Kubernetes 1.30 or later; and an instance-local LiteLLM deployment.
+No tag, local image ID, or Dockerfile base digest can substitute for a final published image digest.
+
 ## See also
 
 - Job builder: [skills k8s launcher](../../libs/backend/agents/skills/k8s-launcher/README.md)

--- a/scripts/affected-deployables.mjs
+++ b/scripts/affected-deployables.mjs
@@ -9,6 +9,7 @@ const _deployables = [
   { project: "artifact-service", image: "opencrane-artifact-service", dockerfile: "apps/artifact-service/deploy/Dockerfile" },
   { project: "agent-runtime", image: "opencrane-agent-runtime", dockerfile: "apps/agent-runtime/deploy/Dockerfile" },
   { project: "agent-controller", image: "opencrane-agent-controller", dockerfile: "apps/agent-controller/deploy/Dockerfile" },
+  { project: "skill-authoring", image: "opencrane-skill-authoring", dockerfile: "apps/skill-authoring/deploy/Dockerfile" },
   { project: "feat-openclaw-tenant", image: "opencrane-openclaw-tenant", dockerfile: "apps/feat-openclaw-tenant/deploy/Dockerfile" },
   { project: "opencrane-ui", image: "opencrane-ui", dockerfile: "apps/opencrane-ui/deploy/Dockerfile" },
 ];


### PR DESCRIPTION
## Why

The authoring lifecycle cannot be promoted from a local Docker image. The established integration-branch pipeline must publish a registry manifest whose immutable digest can be reviewed separately.

## What changed

- registers the existing `skill-authoring` image in the affected-deployable publication matrix;
- documents the manifest-digest handoff and the fail-closed controller enablement gate; and
- makes the tool-runner boundary explicit: it has no image or publication workflow yet, so this PR does not advertise a nonexistent deployable.

## What this enables

When the authoring app changes, CI can publish `ghcr.io/italanta/opencrane-skill-authoring`. A later values review must use that published manifest digest; a tag, local image ID, or base-image digest is insufficient. This PR does not enable the controller.

## Validation

- `NX_BASE=HEAD^ NX_HEAD=HEAD node scripts/affected-deployables.mjs` selects exactly `skill-authoring`
- `npx nx run skill-authoring:build` and `test` (19 tests)
- `scripts/agent-style-check.sh` and `git diff --check`

The image smoke test remains a CI/reviewer gate because Docker and registry DNS are unavailable on this workstation.

## Review

Claude Code is not authenticated on this PC, so no external Claude review was claimed or transmitted. This PR needs independent review before merge.