### PR TITLE
✨ Phase E: expose governed persona onboarding API

### DIFF
--- a/apps/opencrane/src/app/__tests__/persona-onboarding-wiring.test.ts
+++ b/apps/opencrane/src/app/__tests__/persona-onboarding-wiring.test.ts
@@ -1,0 +1,50 @@
+import type { PrismaClient } from "@prisma/client";
+import type { NextFunction, Request, Response } from "express";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { _CreatePersonaOnboardingRouter } from "../persona-onboarding-wiring.js";
+
+/** Build the public router with an authenticated session and a membership read-model response. */
+function _App(membership: { readonly status: "Active" | "Suspended" } | null)
+{
+	const prisma = { orgMembership: { findUnique: vi.fn().mockResolvedValue(membership) } } as unknown as PrismaClient;
+	const app = express();
+	app.use(express.json());
+	app.use(function _Session(request: Request, response: Response, next: NextFunction): void
+	{
+		request.session = { authUser: { sub: "oidc-subject" } } as never;
+		next();
+	});
+	app.use(_CreatePersonaOnboardingRouter(prisma));
+	return { app, prisma };
+}
+
+describe("persona onboarding app wiring", function _DescribePersonaOnboardingWiring()
+{
+	it("denies a valid session that lacks membership in the silo selected by its host", async function _DeniesForeignSilo()
+	{
+		const { app, prisma } = _App(null);
+		const response = await request(app).post("/onboarding/interviews").set("host", "silo-1.example.test").send({});
+		expect(response.status).toBe(401);
+		expect(prisma.orgMembership.findUnique).toHaveBeenCalledWith({ where: { clusterTenant_subject: { clusterTenant: "silo-1", subject: "oidc-subject" } }, select: { status: true } });
+	});
+
+	it("denies a suspended member before any persona profile can be resolved", async function _DeniesSuspendedMember()
+	{
+		const { app } = _App({ status: "Suspended" });
+		expect((await request(app).get("/onboarding/questions").set("host", "silo-1.example.test")).status).toBe(401);
+	});
+
+	it("reports membership-read failure as unavailable rather than pretending the session is invalid", async function _ReportsMembershipUnavailable()
+	{
+		const rejected = vi.fn().mockRejectedValue(new Error("database unavailable"));
+		const prisma = { orgMembership: { findUnique: rejected } } as unknown as PrismaClient;
+		const failureApp = express();
+		failureApp.use(express.json());
+		failureApp.use(function _Session(request: Request, response: Response, next: NextFunction): void { request.session = { authUser: { sub: "oidc-subject" } } as never; next(); });
+		failureApp.use(_CreatePersonaOnboardingRouter(prisma));
+		expect((await request(failureApp).get("/onboarding/questions").set("host", "silo-1.example.test")).status).toBe(503);
+	});
+});

--- a/apps/opencrane/src/app/persona-onboarding-wiring.ts
+++ b/apps/opencrane/src/app/persona-onboarding-wiring.ts
@@ -1,0 +1,43 @@
+import { OrgMemberStatus, type PrismaClient } from "@prisma/client";
+import type { Request, Router } from "express";
+
+import { PrismaPersonaAuthorityRepository, PrismaPersonaDraftRepository, PrismaPersonaInterviewRepository, PrismaPersonaOnboardingRepository, __CreatePersonaOnboardingRouter, type PersonaOnboardingCaller } from "@opencrane/backend/agents/personal/personas";
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+// Side-effect import: loads the express-session `SessionData.authUser` augmentation.
+import "@opencrane/server/_infra/auth";
+
+import { _log } from "./log.js";
+
+/** Resolve an active personal member from the authenticated session and host-derived ClusterTenant silo. */
+async function _resolveCaller(prisma: PrismaClient, request: Request): Promise<PersonaOnboardingCaller | null>
+{
+	const authUser = request.session?.authUser;
+	const userId = typeof authUser?.sub === "string" ? authUser.sub.trim() : "";
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	if (!userId || !siloId) return null;
+	try
+	{
+		const membership = await prisma.orgMembership.findUnique({ where: { clusterTenant_subject: { clusterTenant: siloId, subject: userId } }, select: { status: true } });
+		return membership?.status === OrgMemberStatus.Active ? { userId, siloId } : null;
+	}
+	catch (err)
+	{
+		throw err;
+	}
+}
+
+/** Compose the app's thin authenticated persona-onboarding route with canonical Prisma authorities. */
+export function _CreatePersonaOnboardingRouter(prisma: PrismaClient): Router
+{
+	const onboarding = new PrismaPersonaOnboardingRepository(prisma);
+	return __CreatePersonaOnboardingRouter({
+		resolveCaller: function _ResolveCaller(request: Request): Promise<PersonaOnboardingCaller | null> { return _resolveCaller(prisma, request); },
+		profiles: onboarding,
+		source: onboarding,
+		interviews: new PrismaPersonaInterviewRepository(prisma),
+		drafts: new PrismaPersonaDraftRepository(prisma),
+		personas: new PrismaPersonaAuthorityRepository(prisma),
+		clock: { now: function _Now(): Date { return new Date(); } },
+		logger: _log,
+	});
+}

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -34,6 +34,7 @@ import { PrismaChannelTargetAuthorityRepository } from "@opencrane/backend/serve
 import { ___DoWithTrace } from "@opencrane/observability";
 
 import { _CreateAgentServicesRouter } from "./agent-services-wiring.js";
+import { _CreatePersonaOnboardingRouter } from "./persona-onboarding-wiring.js";
 import { _CreateSkillAuthoringArtifactReader } from "../infra/artifacts/artifact-upload.factory.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
@@ -359,6 +360,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/token-usage", tokenUsageRouter(prisma));
   app.use("/api/v1/groups", groupsRouter(prisma));
   app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma, runAdmission));
+  app.use("/api/v1/personas", _CreatePersonaOnboardingRouter(prisma));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));
   app.use("/api/v1/shares", sharesRouter(prisma));

--- a/docs/agents/app-source-allowlist.json
+++ b/docs/agents/app-source-allowlist.json
@@ -16,6 +16,8 @@
     { "path": "apps/opencrane/src/__tests__/index.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/app/config.ts", "owner": "apps/opencrane", "classification": "app-config" },
     { "path": "apps/opencrane/src/app/agent-services-wiring.ts", "owner": "apps/opencrane", "classification": "route-composition" },
+    { "path": "apps/opencrane/src/app/persona-onboarding-wiring.ts", "owner": "apps/opencrane", "classification": "route-composition" },
+    { "path": "apps/opencrane/src/app/__tests__/persona-onboarding-wiring.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/app/instrument.ts", "owner": "apps/opencrane", "classification": "process-instrumentation" },
     { "path": "apps/opencrane/src/app/log.ts", "owner": "apps/opencrane", "classification": "process-logging" },
     { "path": "apps/opencrane/src/app/routes.ts", "owner": "apps/opencrane", "classification": "route-composition" },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -104,6 +104,7 @@ export default [
                 "scope:mcp",
                 "scope:metrics",
                 "scope:model-routing",
+                "scope:personal-personas",
                 "scope:policies",
                 "scope:projection",
                 "scope:providers",

--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -69,14 +69,23 @@ fails closed and a crash leaves the previous active persona intact, never a half
   `PersonaAuthorityRepository` — the consistent evidence and injected approval persistence boundary.
 - `PrismaPersonaAuthorityRepository` — the target Postgres implementation; it locks the profile,
   approves the checked draft, and moves the active pointer in one transaction.
+- `__CreatePersonaOnboardingRouter` — the authenticated HTTP composition for reading the reviewed
+  questions, starting and answering an interview, deriving a draft, and approving it. It receives
+  the OIDC subject and host-derived silo from the app; none of those ownership coordinates are HTTP
+  inputs.
+- `PrismaPersonaOnboardingRepository` — resolves the one profile for that server-derived caller and
+  reads the clean-build reviewed onboarding source (`personal-agent-onboarding`, version 1).
 
 ## Boundary
 
 Consumed by the persona-onboarding path. It owns the interview lifecycle and approval, but does not
-generate insights or execute the agent. It accepts only reviewable insight statements and derives
-template selection plus every other durable draft coordinate from the completed interview. It never
-activates a draft that is not fully evidenced, and it never mints an editable runtime persona file.
-Storage is injected through its three authority repositories.
+ generate insights or execute the agent. Its HTTP router is deliberately only a parser and identity
+ composition layer: it derives the person from the authenticated session, derives the silo from the
+ request host, verifies an active membership in that exact silo, and resolves the profile server-side.
+ It accepts only reviewable insight statements
+and derives template selection plus every other durable draft coordinate from the completed
+interview. It never activates a draft that is not fully evidenced, and it never mints an editable
+runtime persona file. Storage is injected through its authority repositories.
 
 ## Dependency direction
 

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-draft-authority.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-draft-authority.test.ts
@@ -30,6 +30,14 @@ function _Prisma(rawResults: readonly unknown[]): PrismaClient
 
 describe("persona draft authority", function _describePersonaDraftAuthority()
 {
+	it("rejects an insight statement beyond the durable four-thousand-character limit", async function _RejectsOversizedInsight()
+	{
+		const createAtomically = vi.fn();
+		const repository = { createAtomically };
+		const result = await __CreatePersonaDraft(repository, { ..._COMMAND, insights: [{ answerId: "answer-1", statement: "a".repeat(4_001) }, ..._COMMAND.insights.slice(1)] });
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(createAtomically).not.toHaveBeenCalled();
+	});
 	it("does not call persistence for duplicate answer evidence", async function _rejectsDuplicateAnswer()
 	{
 		const createAtomically = vi.fn();

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding.router.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding.router.test.ts
@@ -1,0 +1,129 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { __CreatePersonaOnboardingRouter } from "../persona-onboarding.router.js";
+import type { PersonaOnboardingRouterDependencies } from "../persona-onboarding.types.js";
+
+/** The reviewed source returned to an authenticated first-run client. */
+const _SOURCE = { id: "personal-agent-onboarding", version: 1, questions: [{ id: "relationship", category: "RelationshipRole", prompt: "How should I work with you?", ordinal: 1 }] } as const;
+
+/** Build an isolated Express app with spyable, server-owned onboarding dependencies. */
+function _App(overrides: Partial<PersonaOnboardingRouterDependencies> = {})
+{
+	const dependencies: PersonaOnboardingRouterDependencies = {
+		resolveCaller: vi.fn().mockReturnValue({ userId: "oidc-subject", siloId: "silo-1" }),
+		profiles: { resolveForCaller: vi.fn().mockResolvedValue({ id: "profile-1" }) },
+		source: { getReviewedQuestionSet: vi.fn().mockResolvedValue(_SOURCE) },
+		interviews: { startAtomically: vi.fn().mockResolvedValue({ status: "started", interviewId: "interview-1" }), recordAnswerAtomically: vi.fn().mockResolvedValue({ status: "recorded", answerId: "answer-1" }), completeAtomically: vi.fn().mockResolvedValue({ status: "completed" }) },
+		drafts: { createAtomically: vi.fn().mockResolvedValue({ status: "created", personaRevisionId: "revision-1" }) },
+		personas: { getApprovalSnapshot: vi.fn().mockResolvedValue({ profileUserId: "oidc-subject", revisionState: "draft", revisionProfileId: "profile-1", interviewState: "completed", insightCount: 3, templateDigestMatches: true, templateSelectionMatches: true, durableSoulMutationPolicy: "forbidden" }), approveAndActivateAtomically: vi.fn().mockResolvedValue({ status: "approved" }) },
+		clock: { now: function _Now(): Date { return new Date("2026-07-24T12:00:00.000Z"); } },
+		logger: { error: vi.fn() },
+		...overrides,
+	};
+	const app = express();
+	app.use(express.json());
+	app.use(__CreatePersonaOnboardingRouter(dependencies));
+	return { app, dependencies };
+}
+
+/** Valid three-insight payload, each insight bound to one persisted answer identifier. */
+function _DraftBody()
+{
+	return { insights: [{ answerId: "answer-1", statement: "Be direct." }, { answerId: "answer-2", statement: "Explain tradeoffs." }, { answerId: "answer-3", statement: "Ask before acting." }] };
+}
+
+describe("persona onboarding router", function _DescribePersonaOnboardingRouter()
+{
+	it("returns the server-selected reviewed questions only to an authenticated owner", async function _ReadsReviewedSource()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).get("/onboarding/questions");
+		expect(response.status).toBe(200);
+		expect(response.body.questionSet).toEqual(_SOURCE);
+		expect(dependencies.profiles.resolveForCaller).not.toHaveBeenCalled();
+	});
+
+	it("does not accept browser-selected profile or question-set coordinates when starting", async function _RejectsCallerCoordinates()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).post("/onboarding/interviews").send({ userId: "other-user" });
+		expect(response.status).toBe(400);
+		expect(dependencies.interviews.startAtomically).not.toHaveBeenCalled();
+	});
+
+	it("starts with the session and host-derived caller plus the fixed reviewed source", async function _StartsInterview()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).post("/onboarding/interviews").send({});
+		expect(response.status).toBe(201);
+		expect(response.body).toEqual({ interviewId: "interview-1", reused: false, questionSet: _SOURCE });
+		expect(dependencies.profiles.resolveForCaller).toHaveBeenCalledWith({ userId: "oidc-subject", siloId: "silo-1" });
+		expect(dependencies.interviews.startAtomically).toHaveBeenCalledWith(expect.objectContaining({ userId: "oidc-subject", siloId: "silo-1", personaProfileId: "profile-1", questionSetId: _SOURCE.id, questionSetVersion: _SOURCE.version }));
+	});
+
+	it("fails closed before all persona operations when authenticated caller resolution fails", async function _RejectsUnauthenticated()
+	{
+		const { app, dependencies } = _App({ resolveCaller: vi.fn().mockReturnValue(null) });
+		expect((await request(app).post("/onboarding/interviews").send({})).status).toBe(401);
+		expect((await request(app).post("/onboarding/interviews/interview-1/answers").send({ questionId: "relationship", value: "Direct" })).status).toBe(401);
+		expect((await request(app).post("/onboarding/interviews/interview-1/complete").send({})).status).toBe(401);
+		expect((await request(app).post("/onboarding/interviews/interview-1/draft").send(_DraftBody())).status).toBe(401);
+		expect((await request(app).post("/revisions/revision-1/approve").send({})).status).toBe(401);
+		expect(dependencies.profiles.resolveForCaller).not.toHaveBeenCalled();
+	});
+
+	it("distinguishes unavailable membership authority from an unauthenticated caller", async function _ReportsMembershipUnavailable()
+	{
+		const { app, dependencies } = _App({ resolveCaller: vi.fn().mockRejectedValue(new Error("database unavailable")) });
+		const response = await request(app).post("/onboarding/interviews").send({});
+		expect(response.status).toBe(503);
+		expect(response.body.code).toBe("persona_membership_authority_unavailable");
+		expect(dependencies.logger.error).toHaveBeenCalledWith(expect.objectContaining({ operation: "persona_onboarding.resolve_caller" }), expect.any(String));
+	});
+
+	it("records only bounded answer fields for the caller's resolved profile", async function _Answers()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).post("/onboarding/interviews/interview-1/answers").send({ questionId: "relationship", value: "Challenge me directly" });
+		expect(response.status).toBe(201);
+		expect(response.body).toEqual({ answerId: "answer-1" });
+		expect(dependencies.interviews.recordAnswerAtomically).toHaveBeenCalledWith(expect.objectContaining({ userId: "oidc-subject", personaProfileId: "profile-1", interviewId: "interview-1", questionId: "relationship" }));
+	});
+
+	it("returns conflict rather than completing an interview with missing answers", async function _RejectsIncomplete()
+	{
+		const { app } = _App({ interviews: { startAtomically: vi.fn(), recordAnswerAtomically: vi.fn(), completeAtomically: vi.fn().mockResolvedValue({ status: "incomplete_answers" }) } });
+		const response = await request(app).post("/onboarding/interviews/interview-1/complete").send({});
+		expect(response.status).toBe(409);
+		expect(response.body.code).toBe("persona_interview_incomplete_answers");
+	});
+
+	it("creates a draft only from three through five answer-bound insights", async function _CreatesDraft()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).post("/onboarding/interviews/interview-1/draft").send(_DraftBody());
+		expect(response.status).toBe(201);
+		expect(response.body).toEqual({ personaRevisionId: "revision-1" });
+		expect(dependencies.drafts.createAtomically).toHaveBeenCalledWith(expect.objectContaining({ userId: "oidc-subject", siloId: "silo-1", personaProfileId: "profile-1", interviewId: "interview-1", insights: _DraftBody().insights }));
+	});
+
+	it("rejects an insight statement beyond the documented four-thousand-character contract", async function _RejectsOversizedInsight()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).post("/onboarding/interviews/interview-1/draft").send({ insights: [{ answerId: "answer-1", statement: "a".repeat(4_001) }, { answerId: "answer-2", statement: "Valid." }, { answerId: "answer-3", statement: "Valid." }] });
+		expect(response.status).toBe(400);
+		expect(dependencies.drafts.createAtomically).not.toHaveBeenCalled();
+	});
+
+	it("approves through the existing atomic evidence authority and does not accept a profile id", async function _Approves()
+	{
+		const { app, dependencies } = _App();
+		const response = await request(app).post("/revisions/revision-1/approve").send({});
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ approved: true });
+		expect(dependencies.personas.approveAndActivateAtomically).toHaveBeenCalledWith(expect.objectContaining({ userId: "oidc-subject", personaProfileId: "profile-1", personaRevisionId: "revision-1" }));
+		expect((await request(app).post("/revisions/revision-1/approve").send({ personaProfileId: "other" })).status).toBe(400);
+	});
+});

--- a/libs/backend/agents/personal/personas/main/src/__tests__/prisma-persona-onboarding-repository.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/prisma-persona-onboarding-repository.test.ts
@@ -1,0 +1,40 @@
+import { PersonaQuestionSetState } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaPersonaOnboardingRepository } from "../prisma-persona-onboarding-repository.js";
+
+/** Build the narrow Prisma fake required to test the onboarding composition adapter. */
+function _Prisma(overrides: Record<string, unknown> = {})
+{
+	return {
+		personaProfile: { upsert: vi.fn().mockResolvedValue({ id: "profile-1" }) },
+		personaQuestionSet: { findUnique: vi.fn().mockResolvedValue({ id: "personal-agent-onboarding", version: 1, state: PersonaQuestionSetState.Reviewed, questions: [{ id: "relationship", category: "RelationshipRole", prompt: "How should I work with you?", ordinal: 1 }] }) },
+		...overrides,
+	};
+}
+
+describe("Prisma persona onboarding repository", function _DescribePrismaPersonaOnboardingRepository()
+{
+	it("creates or resolves a profile only from the silo and user selected by the server", async function _ResolvesProfile()
+	{
+		const prisma = _Prisma();
+		const repository = new PrismaPersonaOnboardingRepository(prisma as never);
+		await expect(repository.resolveForCaller({ siloId: "silo-1", userId: "oidc-subject" })).resolves.toEqual({ id: "profile-1" });
+		expect(prisma.personaProfile.upsert).toHaveBeenCalledWith({ where: { siloId_userId: { siloId: "silo-1", userId: "oidc-subject" } }, create: { siloId: "silo-1", userId: "oidc-subject" }, update: {}, select: { id: true } });
+	});
+
+	it("exposes only the fixed reviewed clean-build source in ordinal order", async function _ReadsReviewedSource()
+	{
+		const prisma = _Prisma();
+		const repository = new PrismaPersonaOnboardingRepository(prisma as never);
+		await expect(repository.getReviewedQuestionSet()).resolves.toEqual({ id: "personal-agent-onboarding", version: 1, questions: [{ id: "relationship", category: "RelationshipRole", prompt: "How should I work with you?", ordinal: 1 }] });
+		expect(prisma.personaQuestionSet.findUnique).toHaveBeenCalledWith({ where: { id_version: { id: "personal-agent-onboarding", version: 1 } }, select: { id: true, version: true, state: true, questions: { orderBy: { ordinal: "asc" }, select: { id: true, category: true, prompt: true, ordinal: true } } } });
+	});
+
+	it("withholds a draft or empty source until clean provisioning marks it reviewed", async function _WithholdsUnavailableSource()
+	{
+		const prisma = _Prisma({ personaQuestionSet: { findUnique: vi.fn().mockResolvedValue({ id: "personal-agent-onboarding", version: 1, state: PersonaQuestionSetState.Draft, questions: [] }) } });
+		const repository = new PrismaPersonaOnboardingRepository(prisma as never);
+		await expect(repository.getReviewedQuestionSet()).resolves.toBeNull();
+	});
+});

--- a/libs/backend/agents/personal/personas/main/src/index.ts
+++ b/libs/backend/agents/personal/personas/main/src/index.ts
@@ -7,3 +7,7 @@ export type { CreatePersonaDraftCommand, CreatePersonaDraftPersistenceResult, Cr
 export { __CompletePersonaInterview, __RecordPersonaInterviewAnswer, __StartPersonaInterview } from "./persona-interview-authority.js";
 export type { CompletePersonaInterviewCommand, CompletePersonaInterviewResult, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, RecordPersonaInterviewAnswerResult, StartPersonaInterviewCommand, StartPersonaInterviewResult } from "./persona-interview-authority.types.js";
 export { PrismaPersonaInterviewRepository } from "./prisma-persona-interview-repository.js";
+export { __CreatePersonaOnboardingRouter } from "./persona-onboarding.router.js";
+export { PrismaPersonaOnboardingRepository } from "./prisma-persona-onboarding-repository.js";
+export type { CreatePersonaOnboardingRouter, PersonaOnboardingCaller, PersonaOnboardingQuestion, PersonaOnboardingQuestionSet, PersonaOnboardingRouterDependencies, PersonaOnboardingSourceRepository, PersonaProfileRepository } from "./persona-onboarding.types.js";
+export { _PersonaOnboardingOpenapiPaths } from "./openapi.js";

--- a/libs/backend/agents/personal/personas/main/src/openapi.ts
+++ b/libs/backend/agents/personal/personas/main/src/openapi.ts
@@ -1,0 +1,82 @@
+/** Build one JSON response entry referencing the central error envelope. */
+function _Error(description: string)
+{
+	return { description, content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } };
+}
+
+/** Build one successful JSON response entry from a bounded schema. */
+function _Json(description: string, schema: object)
+{
+	return { description, content: { "application/json": { schema } } };
+}
+
+/** OpenAPI path fragments owned by the personal persona onboarding domain. */
+export const _PersonaOnboardingOpenapiPaths = {
+	"/personas/onboarding/questions": {
+		get: {
+			operationId: "getPersonaOnboardingQuestions",
+			summary: "Read the reviewed personal-agent onboarding questions",
+			tags: ["Personal personas"],
+			responses: {
+				200: _Json("Reviewed onboarding question set.", { type: "object", required: ["questionSet"], properties: { questionSet: { $ref: "#/components/schemas/PersonaOnboardingQuestionSet" } } }),
+				401: _Error("No authenticated personal owner."),
+				503: _Error("The clean-build reviewed onboarding source is unavailable."),
+			},
+		},
+	},
+	"/personas/onboarding/interviews": {
+		post: {
+			operationId: "startPersonaOnboardingInterview",
+			summary: "Start or resume the caller's reviewed persona interview",
+			tags: ["Personal personas"],
+			requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: false } } } },
+			responses: {
+				200: _Json("Existing in-progress interview reused.", { $ref: "#/components/schemas/PersonaInterviewStart" }),
+				201: _Json("New reviewed interview started.", { $ref: "#/components/schemas/PersonaInterviewStart" }),
+				400: _Error("The request must not supply owner or source coordinates."),
+				401: _Error("No authenticated personal owner."),
+				503: _Error("Persona onboarding authority or source unavailable."),
+			},
+		},
+	},
+	"/personas/onboarding/interviews/{interviewId}/answers": {
+		post: {
+			operationId: "recordPersonaOnboardingAnswer",
+			summary: "Append one answer to the caller's in-progress persona interview",
+			tags: ["Personal personas"],
+			parameters: [{ name: "interviewId", in: "path", required: true, schema: { type: "string" } }],
+			requestBody: { required: true, content: { "application/json": { schema: { $ref: "#/components/schemas/PersonaInterviewAnswerInput" } } } },
+			responses: { 201: _Json("Answer appended once.", { type: "object", required: ["answerId"], properties: { answerId: { type: "string" } } }), 400: _Error("Invalid bounded answer input."), 401: _Error("No authenticated personal owner."), 404: _Error("Interview or question unavailable."), 409: _Error("Interview no longer accepts this answer."), 503: _Error("Persona authority unavailable.") },
+		},
+	},
+	"/personas/onboarding/interviews/{interviewId}/complete": {
+		post: {
+			operationId: "completePersonaOnboardingInterview",
+			summary: "Freeze the caller's fully answered persona interview",
+			tags: ["Personal personas"],
+			parameters: [{ name: "interviewId", in: "path", required: true, schema: { type: "string" } }],
+			requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: false } } } },
+			responses: { 200: _Json("Interview frozen for draft derivation.", { type: "object", required: ["completed"], properties: { completed: { type: "boolean", const: true } } }), 400: _Error("Invalid completion request."), 401: _Error("No authenticated personal owner."), 404: _Error("Interview unavailable."), 409: _Error("Interview is incomplete or no longer in progress."), 503: _Error("Persona authority unavailable.") },
+		},
+	},
+	"/personas/onboarding/interviews/{interviewId}/draft": {
+		post: {
+			operationId: "createPersonaDraft",
+			summary: "Create a reviewable persona draft from three to five answer-bound insights",
+			tags: ["Personal personas"],
+			parameters: [{ name: "interviewId", in: "path", required: true, schema: { type: "string" } }],
+			requestBody: { required: true, content: { "application/json": { schema: { $ref: "#/components/schemas/PersonaDraftInput" } } } },
+			responses: { 201: _Json("Reviewable draft created.", { type: "object", required: ["personaRevisionId"], properties: { personaRevisionId: { type: "string" } } }), 400: _Error("Invalid insight input."), 401: _Error("No authenticated personal owner."), 404: _Error("Interview unavailable."), 409: _Error("Completed evidence cannot derive a draft."), 503: _Error("Persona authority unavailable.") },
+		},
+	},
+	"/personas/revisions/{personaRevisionId}/approve": {
+		post: {
+			operationId: "approvePersonaRevision",
+			summary: "Approve and atomically activate the caller's fully evidenced persona draft",
+			tags: ["Personal personas"],
+			parameters: [{ name: "personaRevisionId", in: "path", required: true, schema: { type: "string" } }],
+			requestBody: { required: false, content: { "application/json": { schema: { type: "object", additionalProperties: false } } } },
+			responses: { 200: _Json("Draft approved and activated.", { type: "object", required: ["approved"], properties: { approved: { type: "boolean", const: true } } }), 400: _Error("Invalid approval request."), 401: _Error("No authenticated personal owner."), 404: _Error("Draft unavailable."), 409: _Error("Draft evidence no longer permits approval.") },
+		},
+	},
+};

--- a/libs/backend/agents/personal/personas/main/src/persona-draft-authority.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-draft-authority.ts
@@ -21,7 +21,7 @@ function _isValidCommand(command: CreatePersonaDraftCommand): boolean
 	const answerIds = new Set<string>();
 	return command.insights.every(function _isValidInsight(insight)
 	{
-		if (!insight.answerId.trim() || !insight.statement.trim() || answerIds.has(insight.answerId)) return false;
+		if (!insight.answerId.trim() || !insight.statement.trim() || insight.statement.length > 4_000 || answerIds.has(insight.answerId)) return false;
 		answerIds.add(insight.answerId);
 		return true;
 	});

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.ts
@@ -1,0 +1,276 @@
+import { Router, type Request, type Response } from "express";
+
+import { __ApprovePersona } from "./persona-authority.js";
+import { __CreatePersonaDraft } from "./persona-draft-authority.js";
+import { __CompletePersonaInterview, __RecordPersonaInterviewAnswer, __StartPersonaInterview } from "./persona-interview-authority.js";
+import type { PersonaOnboardingCaller, PersonaOnboardingRouterDependencies } from "./persona-onboarding.types.js";
+
+/** Build the authenticated, owner-only persona onboarding API. */
+export function __CreatePersonaOnboardingRouter(dependencies: PersonaOnboardingRouterDependencies): Router
+{
+	const router = Router();
+
+	router.get("/onboarding/questions", async function _Questions(request: Request, response: Response): Promise<void>
+	{
+		const caller = await _Caller(dependencies, request, response);
+		if (!caller) return;
+		try
+		{
+			const source = await dependencies.source.getReviewedQuestionSet();
+			if (!source)
+			{
+				_Problem(response, 503, "persona_onboarding_source_unavailable");
+				return;
+			}
+			response.status(200).json({ questionSet: source });
+		}
+		catch (err)
+		{
+			_Failed(dependencies, err, "persona_onboarding.questions");
+			_Problem(response, 503, "persona_onboarding_authority_unavailable");
+		}
+	});
+
+	router.post("/onboarding/interviews", async function _Start(request: Request, response: Response): Promise<void>
+	{
+		const caller = await _Caller(dependencies, request, response);
+		if (!caller) return;
+		if (!_IsEmptyObject(request.body))
+		{
+			_Problem(response, 400, "invalid_persona_onboarding_request");
+			return;
+		}
+		try
+		{
+			// 1. Load the fixed reviewed source before creating evidence so an unavailable seed cannot start an unusable interview.
+			const source = await dependencies.source.getReviewedQuestionSet();
+			if (!source)
+			{
+				_Problem(response, 503, "persona_onboarding_source_unavailable");
+				return;
+			}
+			// 2. Resolve the owner profile entirely from authenticated identity and the request host.
+			const profile = await dependencies.profiles.resolveForCaller(caller);
+			const result = await __StartPersonaInterview(dependencies.interviews, { siloId: caller.siloId, userId: caller.userId, personaProfileId: profile.id, questionSetId: source.id, questionSetVersion: source.version, startedAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied")
+			{
+				_InterviewDenial(response, result.reason);
+				return;
+			}
+			response.status(result.outcome === "started" ? 201 : 200).json({ interviewId: result.interviewId, reused: result.outcome === "already_in_progress", questionSet: source });
+		}
+		catch (err)
+		{
+			_Failed(dependencies, err, "persona_onboarding.start");
+			_Problem(response, 503, "persona_onboarding_authority_unavailable");
+		}
+	});
+
+	router.post("/onboarding/interviews/:interviewId/answers", async function _Answer(request: Request, response: Response): Promise<void>
+	{
+		const caller = await _Caller(dependencies, request, response);
+		const command = _AnswerCommand(request.body);
+		const interviewId = request.params["interviewId"];
+		if (!caller) return;
+		if (!command || !_Identifier(interviewId))
+		{
+			_Problem(response, 400, "invalid_persona_answer");
+			return;
+		}
+		try
+		{
+			const profile = await dependencies.profiles.resolveForCaller(caller);
+			const result = await __RecordPersonaInterviewAnswer(dependencies.interviews, { userId: caller.userId, personaProfileId: profile.id, interviewId, questionId: command.questionId, value: command.value, answeredAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied")
+			{
+				_InterviewDenial(response, result.reason);
+				return;
+			}
+			response.status(201).json({ answerId: result.answerId });
+		}
+		catch (err)
+		{
+			_Failed(dependencies, err, "persona_onboarding.answer");
+			_Problem(response, 503, "persona_onboarding_authority_unavailable");
+		}
+	});
+
+	router.post("/onboarding/interviews/:interviewId/complete", async function _Complete(request: Request, response: Response): Promise<void>
+	{
+		const caller = await _Caller(dependencies, request, response);
+		const interviewId = request.params["interviewId"];
+		if (!caller) return;
+		if (!_Identifier(interviewId) || !_IsEmptyObject(request.body))
+		{
+			_Problem(response, 400, "invalid_persona_completion");
+			return;
+		}
+		try
+		{
+			const profile = await dependencies.profiles.resolveForCaller(caller);
+			const result = await __CompletePersonaInterview(dependencies.interviews, { userId: caller.userId, personaProfileId: profile.id, interviewId, completedAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied")
+			{
+				_InterviewDenial(response, result.reason);
+				return;
+			}
+			response.status(200).json({ completed: true });
+		}
+		catch (err)
+		{
+			_Failed(dependencies, err, "persona_onboarding.complete");
+			_Problem(response, 503, "persona_onboarding_authority_unavailable");
+		}
+	});
+
+	router.post("/onboarding/interviews/:interviewId/draft", async function _Draft(request: Request, response: Response): Promise<void>
+	{
+		const caller = await _Caller(dependencies, request, response);
+		const insights = _Insights(request.body);
+		const interviewId = request.params["interviewId"];
+		if (!caller) return;
+		if (!insights || !_Identifier(interviewId))
+		{
+			_Problem(response, 400, "invalid_persona_draft");
+			return;
+		}
+		try
+		{
+			const profile = await dependencies.profiles.resolveForCaller(caller);
+			const result = await __CreatePersonaDraft(dependencies.drafts, { siloId: caller.siloId, userId: caller.userId, personaProfileId: profile.id, interviewId, insights, authoredAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied")
+			{
+				_DraftDenial(response, result.reason);
+				return;
+			}
+			response.status(201).json({ personaRevisionId: result.personaRevisionId });
+		}
+		catch (err)
+		{
+			_Failed(dependencies, err, "persona_onboarding.draft");
+			_Problem(response, 503, "persona_onboarding_authority_unavailable");
+		}
+	});
+
+	router.post("/revisions/:personaRevisionId/approve", async function _Approve(request: Request, response: Response): Promise<void>
+	{
+		const caller = await _Caller(dependencies, request, response);
+		const personaRevisionId = request.params["personaRevisionId"];
+		if (!caller) return;
+		if (!_Identifier(personaRevisionId) || !_IsEmptyObject(request.body))
+		{
+			_Problem(response, 400, "invalid_persona_approval");
+			return;
+		}
+		try
+		{
+			const profile = await dependencies.profiles.resolveForCaller(caller);
+			const result = await __ApprovePersona(dependencies.personas, { personaProfileId: profile.id, personaRevisionId, userId: caller.userId, approvedAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied")
+			{
+				_ApprovalDenial(response, result.reason);
+				return;
+			}
+			response.status(200).json({ approved: true });
+		}
+		catch (err)
+		{
+			_Failed(dependencies, err, "persona_onboarding.approve");
+			_Problem(response, 503, "persona_onboarding_authority_unavailable");
+		}
+	});
+
+	return router;
+}
+
+/** Resolve one authenticated caller and keep an unavailable membership authority distinguishable from denial. */
+async function _Caller(dependencies: PersonaOnboardingRouterDependencies, request: Request, response: Response): Promise<PersonaOnboardingCaller | null>
+{
+	try
+	{
+		const caller = await dependencies.resolveCaller(request);
+		if (caller) return caller;
+		_Problem(response, 401, "persona_identity_denied");
+		return null;
+	}
+	catch (err)
+	{
+		_Failed(dependencies, err, "persona_onboarding.resolve_caller");
+		_Problem(response, 503, "persona_membership_authority_unavailable");
+		return null;
+	}
+}
+
+/** Parse the only fields accepted while appending one interview answer. */
+function _AnswerCommand(value: unknown): { readonly questionId: string; readonly value: string } | null
+{
+	if (!_ExactObject(value, ["questionId", "value"])) return null;
+	const body = value as Record<string, unknown>;
+	return _Identifier(body["questionId"]) && typeof body["value"] === "string" ? { questionId: body["questionId"], value: body["value"] } : null;
+}
+
+/** Parse three through five answer-bound insight statements without accepting future policy fields. */
+function _Insights(value: unknown): readonly { readonly answerId: string; readonly statement: string }[] | null
+{
+	if (!_ExactObject(value, ["insights"])) return null;
+	const insights = (value as Record<string, unknown>)["insights"];
+	if (!Array.isArray(insights) || insights.length < 3 || insights.length > 5) return null;
+	const parsed = insights.map(function _Insight(item): { readonly answerId: string; readonly statement: string } | null
+	{
+		if (!_ExactObject(item, ["answerId", "statement"])) return null;
+		const insight = item as Record<string, unknown>;
+		return _Identifier(insight["answerId"]) && typeof insight["statement"] === "string" && insight["statement"].length <= 4_000 ? { answerId: insight["answerId"], statement: insight["statement"] } : null;
+	});
+	return parsed.every(function _Valid(insight): insight is { readonly answerId: string; readonly statement: string } { return insight !== null; }) ? parsed : null;
+}
+
+/** Require a small exact JSON object so the public API cannot silently gain authority fields. */
+function _ExactObject(value: unknown, keys: readonly string[]): boolean
+{
+	return value !== null && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === keys.length && keys.every(function _Has(key): boolean { return key in value; });
+}
+
+/** Recognise an opaque durable identifier without accepting control characters or unbounded values. */
+function _Identifier(value: unknown): value is string
+{
+	return typeof value === "string" && value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/u.test(value);
+}
+
+/** Treat an omitted JSON body as an empty request for endpoint contracts that take no body. */
+function _IsEmptyObject(value: unknown): boolean
+{
+	return value === undefined || _ExactObject(value, []);
+}
+
+/** Translate lifecycle authority denials into stable HTTP semantics without exposing ownership details. */
+function _InterviewDenial(response: Response, reason: string): void
+{
+	const status = reason === "invalid_command" ? 400 : reason === "persistence_unavailable" ? 503 : reason === "question_set_unavailable" ? 503 : reason === "not_found_or_wrong_owner" || reason === "question_unavailable" ? 404 : 409;
+	_Problem(response, status, `persona_interview_${reason}`);
+}
+
+/** Translate draft derivation denials while retaining the authoritative reason code. */
+function _DraftDenial(response: Response, reason: string): void
+{
+	const status = reason === "invalid_command" ? 400 : reason === "persistence_unavailable" ? 503 : reason === "not_found_or_wrong_owner" ? 404 : 409;
+	_Problem(response, status, `persona_draft_${reason}`);
+}
+
+/** Translate approval evidence denials without leaking another owner's profile or revision existence. */
+function _ApprovalDenial(response: Response, reason: string): void
+{
+	const status = reason === "invalid_command" ? 400 : reason === "not_found" || reason === "wrong_owner" ? 404 : 409;
+	_Problem(response, status, `persona_approval_${reason}`);
+}
+
+/** Emit one bounded HTTP error envelope. */
+function _Problem(response: Response, status: number, code: string): void
+{
+	response.status(status).json({ error: "Persona onboarding request could not be completed.", code });
+}
+
+/** Log an unexpected persistence failure without logging answers, insights, or identity values. */
+function _Failed(dependencies: PersonaOnboardingRouterDependencies, err: unknown, operation: string): void
+{
+	dependencies.logger.error({ err, operation }, "Persona onboarding authority failed");
+}

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding.types.ts
@@ -1,0 +1,78 @@
+import type { Request, Router } from "express";
+
+import type { PersonaInterviewCategory } from "@prisma/client";
+
+import type { PersonaAuthorityRepository } from "./persona-authority.types.js";
+import type { PersonaDraftRepository } from "./persona-draft-authority.types.js";
+import type { PersonaInterviewRepository } from "./persona-interview-authority.types.js";
+
+/** The authenticated, host-scoped owner permitted to operate one personal persona. */
+export interface PersonaOnboardingCaller
+{
+	/** Stable OIDC subject of the authenticated person. */
+	readonly userId: string;
+	/** ClusterTenant-derived silo that contains this personal profile. */
+	readonly siloId: string;
+}
+
+/** One immutable prompt from the reviewed server-owned onboarding source. */
+export interface PersonaOnboardingQuestion
+{
+	/** Stable identifier used when appending the answer. */
+	readonly id: string;
+	/** Product-defined category used for template selection and insight provenance. */
+	readonly category: PersonaInterviewCategory;
+	/** Human-readable question presented to the person. */
+	readonly prompt: string;
+	/** Stable display order within the reviewed question set. */
+	readonly ordinal: number;
+}
+
+/** The only reviewed onboarding source exposed by the initial personal-agent flow. */
+export interface PersonaOnboardingQuestionSet
+{
+	/** Stable reviewed question-set identifier. */
+	readonly id: string;
+	/** Exact immutable question-set revision. */
+	readonly version: number;
+	/** Questions in their durable ordinal order. */
+	readonly questions: readonly PersonaOnboardingQuestion[];
+}
+
+/** Resolves a personal profile from server-derived silo and authenticated user coordinates. */
+export interface PersonaProfileRepository
+{
+	/** Returns the existing profile or creates the one clean-build profile for this caller. */
+	resolveForCaller(caller: PersonaOnboardingCaller): Promise<{ readonly id: string }>;
+}
+
+/** Reads the fixed reviewed onboarding source without allowing caller-selected content. */
+export interface PersonaOnboardingSourceRepository
+{
+	/** Returns the reviewed initial source, or null until clean provisioning is complete. */
+	getReviewedQuestionSet(): Promise<PersonaOnboardingQuestionSet | null>;
+}
+
+/** Dependencies injected into the public persona-onboarding HTTP router. */
+export interface PersonaOnboardingRouterDependencies
+{
+	/** Resolves the authenticated OIDC subject and host-derived silo; null fails closed. */
+	readonly resolveCaller: (request: Request) => Promise<PersonaOnboardingCaller | null>;
+	/** Resolves the caller's single profile without taking a profile identifier from HTTP. */
+	readonly profiles: PersonaProfileRepository;
+	/** Reads the reviewed, server-selected onboarding source. */
+	readonly source: PersonaOnboardingSourceRepository;
+	/** Starts, answers, and completes immutable interview evidence. */
+	readonly interviews: PersonaInterviewRepository;
+	/** Derives a reviewable persona draft from completed evidence. */
+	readonly drafts: PersonaDraftRepository;
+	/** Approves and atomically activates a fully evidenced draft. */
+	readonly personas: PersonaAuthorityRepository;
+	/** Supplies server-authoritative timestamps. */
+	readonly clock: { readonly now: () => Date };
+	/** Records structured failures without including persona answers. */
+	readonly logger: { readonly error: (attributes: object, message: string) => void };
+}
+
+/** Factory for the authenticated persona-onboarding router mounted by the OpenCrane app. */
+export type CreatePersonaOnboardingRouter = (dependencies: PersonaOnboardingRouterDependencies) => Router;

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-onboarding-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-onboarding-repository.ts
@@ -1,0 +1,45 @@
+import type { PrismaClient } from "@prisma/client";
+import { PersonaQuestionSetState } from "@prisma/client";
+
+import type { PersonaOnboardingCaller, PersonaOnboardingQuestionSet, PersonaOnboardingSourceRepository, PersonaProfileRepository } from "./persona-onboarding.types.js";
+
+/** Fixed reviewed source selected by the product rather than an HTTP caller. */
+const _INITIAL_QUESTION_SET_ID = "personal-agent-onboarding";
+
+/** Fixed version of the clean-build onboarding source. */
+const _INITIAL_QUESTION_SET_VERSION = 1;
+
+/** Prisma adapter for server-side persona-profile resolution and reviewed source reads. */
+export class PrismaPersonaOnboardingRepository implements PersonaProfileRepository, PersonaOnboardingSourceRepository
+{
+	/** Canonical product-database client injected by the composing application. */
+	private readonly prisma: PrismaClient;
+
+	/** Construct the adapter over the canonical product database. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Find or create exactly one profile for the authenticated person in the current silo. */
+	async resolveForCaller(caller: PersonaOnboardingCaller): Promise<{ readonly id: string }>
+	{
+		return this.prisma.personaProfile.upsert({
+			where: { siloId_userId: { siloId: caller.siloId, userId: caller.userId } },
+			create: { siloId: caller.siloId, userId: caller.userId },
+			update: {},
+			select: { id: true },
+		});
+	}
+
+	/** Load the exact reviewed clean-build interview source in durable display order. */
+	async getReviewedQuestionSet(): Promise<PersonaOnboardingQuestionSet | null>
+	{
+		const questionSet = await this.prisma.personaQuestionSet.findUnique({
+			where: { id_version: { id: _INITIAL_QUESTION_SET_ID, version: _INITIAL_QUESTION_SET_VERSION } },
+			select: { id: true, version: true, state: true, questions: { orderBy: { ordinal: "asc" }, select: { id: true, category: true, prompt: true, ordinal: true } } },
+		});
+		if (questionSet?.state !== PersonaQuestionSetState.Reviewed || questionSet.questions.length === 0) return null;
+		return { id: questionSet.id, version: questionSet.version, questions: questionSet.questions };
+	}
+}

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -27,6 +27,7 @@ import { _ModelRoutingOpenapiPaths } from "@opencrane/backend/server/gateways/mo
 import { _SpendOpenapiPaths } from "@opencrane/backend/server/reporting/spend";
 import { _AuditOpenapiPaths } from "@opencrane/backend/server/iam/audit";
 import { _MetricsOpenapiPaths } from "@opencrane/backend/server/reporting/metrics";
+import { _PersonaOnboardingOpenapiPaths } from "@opencrane/backend/agents/personal/personas";
 
 // ---------------------------------------------------------------------------
 // Reusable schema components
@@ -684,6 +685,32 @@ export const spec = {
       Budget: BudgetSchema,
       ThirdPartySource: ThirdPartySourceSchema,
       TokenUsage: TokenUsageSchema,
+      PersonaOnboardingQuestionSet: {
+        type: "object",
+        required: ["id", "version", "questions"],
+        properties: {
+          id: { type: "string", description: "Reviewed question-set identifier selected by the server." },
+          version: { type: "integer", minimum: 1, description: "Exact immutable reviewed source revision." },
+          questions: { type: "array", items: { type: "object", required: ["id", "category", "prompt", "ordinal"], properties: { id: { type: "string" }, category: { type: "string", enum: ["RelationshipRole", "ToneLanguage", "AnswerStructure", "ChallengeSupport", "Initiative", "ApprovalRisk", "WorkingHabits", "MemoryBoundaries"] }, prompt: { type: "string" }, ordinal: { type: "integer", minimum: 1 } } } },
+        },
+      },
+      PersonaInterviewStart: {
+        type: "object",
+        required: ["interviewId", "reused", "questionSet"],
+        properties: { interviewId: { type: "string" }, reused: { type: "boolean" }, questionSet: { $ref: "#/components/schemas/PersonaOnboardingQuestionSet" } },
+      },
+      PersonaInterviewAnswerInput: {
+        type: "object",
+        additionalProperties: false,
+        required: ["questionId", "value"],
+        properties: { questionId: { type: "string" }, value: { type: "string", minLength: 1, maxLength: 4000 } },
+      },
+      PersonaDraftInput: {
+        type: "object",
+        additionalProperties: false,
+        required: ["insights"],
+        properties: { insights: { type: "array", minItems: 3, maxItems: 5, items: { type: "object", additionalProperties: false, required: ["answerId", "statement"], properties: { answerId: { type: "string" }, statement: { type: "string", minLength: 1, maxLength: 4000 } } } } },
+      },
       ZitadelCandidateKeyValidation: {
         type: "object",
         required: ["tokenExchangeOk", "instanceScopeOk", "keyId", "detail"],
@@ -768,6 +795,7 @@ export const spec = {
     ..._SpendOpenapiPaths,
     ..._AuditOpenapiPaths,
     ..._MetricsOpenapiPaths,
+    ..._PersonaOnboardingOpenapiPaths,
 
     // ------------------------------------------------------------------
     // Auth — OIDC browser flow and session introspection

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1065,6 +1065,108 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/personas/onboarding/questions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read the reviewed personal-agent onboarding questions */
+        get: operations["getPersonaOnboardingQuestions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/personas/onboarding/interviews": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Start or resume the caller's reviewed persona interview */
+        post: operations["startPersonaOnboardingInterview"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/personas/onboarding/interviews/{interviewId}/answers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Append one answer to the caller's in-progress persona interview */
+        post: operations["recordPersonaOnboardingAnswer"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/personas/onboarding/interviews/{interviewId}/complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Freeze the caller's fully answered persona interview */
+        post: operations["completePersonaOnboardingInterview"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/personas/onboarding/interviews/{interviewId}/draft": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a reviewable persona draft from three to five answer-bound insights */
+        post: operations["createPersonaDraft"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/personas/revisions/{personaRevisionId}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Approve and atomically activate the caller's fully evidenced persona draft */
+        post: operations["approvePersonaRevision"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -1716,6 +1818,34 @@ export interface components {
             totalCostUsd?: number;
             /** Format: date-time */
             recordedAt?: string;
+        };
+        PersonaOnboardingQuestionSet: {
+            /** @description Reviewed question-set identifier selected by the server. */
+            id: string;
+            /** @description Exact immutable reviewed source revision. */
+            version: number;
+            questions: {
+                id: string;
+                /** @enum {string} */
+                category: "RelationshipRole" | "ToneLanguage" | "AnswerStructure" | "ChallengeSupport" | "Initiative" | "ApprovalRisk" | "WorkingHabits" | "MemoryBoundaries";
+                prompt: string;
+                ordinal: number;
+            }[];
+        };
+        PersonaInterviewStart: {
+            interviewId: string;
+            reused: boolean;
+            questionSet: components["schemas"]["PersonaOnboardingQuestionSet"];
+        };
+        PersonaInterviewAnswerInput: {
+            questionId: string;
+            value: string;
+        };
+        PersonaDraftInput: {
+            insights: {
+                answerId: string;
+                statement: string;
+            }[];
         };
         ZitadelCandidateKeyValidation: {
             /** @description Whether the candidate key's jwt-bearer token exchange succeeded. */
@@ -4882,6 +5012,391 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenUsage"][];
+                };
+            };
+        };
+    };
+    getPersonaOnboardingQuestions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Reviewed onboarding question set. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        questionSet: components["schemas"]["PersonaOnboardingQuestionSet"];
+                    };
+                };
+            };
+            /** @description No authenticated personal owner. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The clean-build reviewed onboarding source is unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    startPersonaOnboardingInterview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Existing in-progress interview reused. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PersonaInterviewStart"];
+                };
+            };
+            /** @description New reviewed interview started. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PersonaInterviewStart"];
+                };
+            };
+            /** @description The request must not supply owner or source coordinates. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated personal owner. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Persona onboarding authority or source unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    recordPersonaOnboardingAnswer: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                interviewId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PersonaInterviewAnswerInput"];
+            };
+        };
+        responses: {
+            /** @description Answer appended once. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        answerId: string;
+                    };
+                };
+            };
+            /** @description Invalid bounded answer input. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated personal owner. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Interview or question unavailable. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Interview no longer accepts this answer. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Persona authority unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    completePersonaOnboardingInterview: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                interviewId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Interview frozen for draft derivation. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        completed: true;
+                    };
+                };
+            };
+            /** @description Invalid completion request. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated personal owner. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Interview unavailable. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Interview is incomplete or no longer in progress. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Persona authority unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createPersonaDraft: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                interviewId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PersonaDraftInput"];
+            };
+        };
+        responses: {
+            /** @description Reviewable draft created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        personaRevisionId: string;
+                    };
+                };
+            };
+            /** @description Invalid insight input. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated personal owner. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Interview unavailable. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Completed evidence cannot derive a draft. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Persona authority unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    approvePersonaRevision: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                personaRevisionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Draft approved and activated. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @constant */
+                        approved: true;
+                    };
+                };
+            };
+            /** @description Invalid approval request. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated personal owner. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Draft unavailable. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Draft evidence no longer permits approval. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };


### PR DESCRIPTION
## Why this exists

A new personal agent needs a durable, user-controlled persona before it can run. This slice makes the already-governed interview and persona-approval authority usable through the authenticated API, without UI work or browser-selected ownership coordinates.

## What changed

- add the full onboarding API: read reviewed questions, start/resume, answer, complete, derive a 3–5-insight draft, then approve and atomically activate it
- derive the OIDC subject and ClusterTenant silo on the server; resolve the persona profile only after exact active org-membership verification
- return `503` with structured logging when membership authority is unavailable; absent or suspended membership fails closed with `401`
- expose a server-selected clean-build question set and two deterministic SOUL.md template choices; no caller can select source, user, silo, or profile identifiers
- enforce the 4,000-character insight limit in both HTTP parsing and the reusable draft authority
- compose domain-owned OpenAPI paths, regenerate the typed client, and permit the API-spec package to import the persona domain fragment
- update the persona README and add router, Prisma adapter, app-wiring, ownership, and contract-boundary tests

## Validation

- `npx nx run backend-agents-personal-personas:test --skip-nx-cache` — 29 passed
- focused `persona-onboarding-wiring.test.ts` — 3 passed
- persona domain, server app, OpenAPI spec, and generated-contract TypeScript lint
- `scripts/agent-style-check.sh` — 0 errors, 0 warnings
- `git diff --check`

## Review

- independent review found and verified fixes for cross-silo membership enforcement, unavailable-membership distinction, and the insight length contract; final pass found no residual correctness or security issues
- Claude Code CLI was invoked for the requested local-subscription review but remains logged out (`/login` required); it did not receive repository content or a diff