### PR TITLE
🧪 Phase E: restore topology ownership guard coverage

### DIFF
--- a/docs/agents/app-source-allowlist.json
+++ b/docs/agents/app-source-allowlist.json
@@ -11,6 +11,7 @@
   ],
   "allowedFiles": [
     { "path": "apps/opencrane/prisma.config.ts", "owner": "apps/opencrane", "classification": "prisma-composition" },
+    { "path": "apps/opencrane/prisma/bootstrap/verify-persona-source-seeds.mjs", "owner": "apps/opencrane", "classification": "prisma-composition" },
     { "path": "apps/opencrane/scripts/emit-openapi.mts", "owner": "apps/opencrane", "classification": "build-entrypoint" },
     { "path": "apps/opencrane/src/__tests__/config.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/__tests__/index.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
@@ -80,6 +81,9 @@
     { "path": "apps/agent-runtime/tests/test_conformance.py", "owner": "apps/agent-runtime", "classification": "composition-test" },
     { "path": "apps/agent-runtime/tests/test_fault_matrix.py", "owner": "apps/agent-runtime", "classification": "composition-test" },
     { "path": "apps/agent-runtime/tests/test_runtime.py", "owner": "apps/agent-runtime", "classification": "composition-test" },
+
+    { "path": "apps/skill-authoring/src/authoring_worker.py", "owner": "apps/skill-authoring", "classification": "process-entrypoint" },
+    { "path": "apps/skill-authoring/__tests__/test_authoring_worker.py", "owner": "apps/skill-authoring", "classification": "composition-test" },
 
     { "path": "apps/feat-central-agents/src/__tests__/connectors/slack.connector.test.ts", "owner": "apps/feat-central-agents", "classification": "delete" },
     { "path": "apps/feat-central-agents/src/__tests__/ingestion.test.ts", "owner": "apps/feat-central-agents", "classification": "delete" },

--- a/docs/agents/workload-ownership.json
+++ b/docs/agents/workload-ownership.json
@@ -56,7 +56,9 @@
         "agentController.enabled=true",
         "agentController.kubernetesApiServerCidrs[0]=10.43.0.1/32",
         "agentController.image.digest=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "agentController.runtimeProfile.image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        "agentController.runtimeProfile.image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "agentController.skillWorkloadProfiles.authoring.image.digest=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        "agentController.skillWorkloadProfiles.toolRunner.image.digest=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
       ],
       "expectedRenderedPodClasses": [
         "Deployment/opencrane-s3",
@@ -100,6 +102,11 @@
     {
       "path": "libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts",
       "anchor": "kind: \"Job\"",
+      "workloadIds": ["skill-authoring", "tool-runner"]
+    },
+    {
+      "path": "libs/backend/agents/skills/controller/src/kubernetes-skill-workload-controller-store.ts",
+      "anchor": "options.batchApi.createNamespacedJob({ namespace, body: expected }, _RequestOptions(options.shutdownSignal, options.requestTimeoutMilliseconds))",
       "workloadIds": ["skill-authoring", "tool-runner"]
     },
     {
@@ -272,7 +279,7 @@
       "image": "ghcr.io/italanta/opencrane-skill-authoring@sha256:<release-digest>",
       "owner": "apps/skill-authoring",
       "localOwner": true,
-      "source": { "type": "file", "path": "libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts", "anchor": "kind: \"Job\"" },
+      "source": { "type": "file", "path": "libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts", "anchor": "\"app.kubernetes.io/component\": \"skill-authoring\"" },
       "classification": "survivor",
       "reason": "The agent controller will create isolated draft-capability authoring Jobs only after a durable claim exists."
     },
@@ -282,7 +289,7 @@
       "image": "ghcr.io/italanta/opencrane-tool-runner@sha256:<release-digest>",
       "owner": "apps/tool-runner",
       "localOwner": true,
-      "source": { "type": "file", "path": "libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts", "anchor": "kind: \"Job\"" },
+      "source": { "type": "file", "path": "libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts", "anchor": "\"app.kubernetes.io/component\": \"tool-runner\"" },
       "classification": "survivor",
       "reason": "The agent controller will create isolated capability-bound tool Jobs only after a durable claim and reply protocol exists."
     },

--- a/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts
@@ -114,14 +114,19 @@ export function __BuildGovernedSkillWorkloadJob(assignment: SkillWorkloadJobAssi
 
 	// 2. Derive metadata without placing source, artifact bytes, arguments, or credentials in the manifest.
 	const name = _JobName(assignment, profile);
+	/** Keep the container name aligned with the exact, profile-selected workload identity. */
 	const component = profile.kind === "authoring" ? "skill-authoring" : "tool-runner";
+	/** Keep the two workload identities explicit so each job class has one auditable product owner. */
+	const labels = profile.kind === "authoring"
+		? { "app.kubernetes.io/name": "opencrane-skill-authoring", "app.kubernetes.io/component": "skill-authoring", "opencrane.ai/skill-workload": name }
+		: { "app.kubernetes.io/name": "opencrane-tool-runner", "app.kubernetes.io/component": "tool-runner", "opencrane.ai/skill-workload": name };
 	const annotations = { "opencrane.ai/silo-id": assignment.siloId, "opencrane.ai/job-id": assignment.jobId, [_BOOTSTRAP_REFERENCE_ANNOTATION]: assignment.capabilityReference };
 
 	// 3. Return a zero-retry, terminally cleaned Job; its worker exchanges the opaque reference at runtime.
 	return {
 		apiVersion: "batch/v1",
 		kind: "Job",
-		metadata: { name, namespace: assignment.namespace, labels: { "app.kubernetes.io/name": `opencrane-${component}`, "app.kubernetes.io/component": component, "opencrane.ai/skill-workload": name }, annotations },
+		metadata: { name, namespace: assignment.namespace, labels, annotations },
 		spec: {
 			suspend: true,
 			backoffLimit: 0,
@@ -130,7 +135,7 @@ export function __BuildGovernedSkillWorkloadJob(assignment: SkillWorkloadJobAssi
 			activeDeadlineSeconds: profile.activeDeadlineSeconds,
 			ttlSecondsAfterFinished: 0,
 			template: {
-				metadata: { labels: { "app.kubernetes.io/component": component, "opencrane.ai/skill-workload": name }, annotations },
+				metadata: { labels, annotations },
 				spec: {
 					serviceAccountName: profile.serviceAccountName,
 					automountServiceAccountToken: false,

--- a/scripts/phase-b-topology-negative-tests.sh
+++ b/scripts/phase-b-topology-negative-tests.sh
@@ -18,15 +18,24 @@ ARCHIVE_PROBE="$ROOT/apps/_infra/deploy-k8s/charts/.phase-b-langfuse-probe.tgz"
 GENERATED_DIST_PROBE="$ROOT/apps/opencrane/dist/phase-b-generated-guard-probe.js"
 GENERATED_CACHE_PROBE="$ROOT/apps/opencrane/node_modules/.cache/phase-b-generated-guard-probe.mjs"
 
-cleanup()
+cleanup_probes()
 {
   rm -f "$RENDER_PROBE" "$COMPUTED_KIND_PROBE" "$RUNTIME_PROBE" "$RUNTIME_COMMAND_PROBE"
   rm -f "$RUNTIME_DUPLICATE_PROBE" "$RUNTIME_NONPRODUCING_DUPLICATE_PROBE"
   rm -f "$APP_SOURCE_PROBE" "$BUILD_SOURCE_PROBE" "$ARCHIVE_PROBE"
   rm -f "$GENERATED_DIST_PROBE" "$GENERATED_CACHE_PROBE"
   rmdir "$(dirname "$BUILD_SOURCE_PROBE")" 2>/dev/null || true
+}
+
+cleanup()
+{
+  cleanup_probes
   if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then rm -rf "$TMP_DIR"; fi
 }
+
+# Remove only this suite's fixed probe names before the initial positive check.
+# This lets a new invocation recover safely if a prior invocation was interrupted.
+cleanup_probes
 trap cleanup EXIT
 
 expect_failure()


### PR DESCRIPTION
## Why this exists

Phase E added the two governed skill-job classes and persona seed verification, but the structural topology gate had not caught up with those new sources and required immutable render inputs. That left the guard unable to run to completion.

## What changed

- register the actual skill-worker sources and the persona seed verifier under the closed app-source contract;
- give authoring and tool-runner Jobs explicit, distinct workload labels so their two product owners remain independently auditable;
- register the controller Job-creation sink and provide both immutable worker image digests in the full Helm profile;
- make the negative test suite clear only its own fixed probes before it begins, so an interrupted prior run cannot cause a false failure.

## Result

The topology guard again verifies the complete rendered workload inventory and rejects 18 intentional topology/registry regressions. This PR changes no runtime policy or deployment authority; it repairs the evidence and validation around the existing governed-job design.

## Validation

- `bash scripts/phase-b-topology-negative-tests.sh` — passed (18 rejection paths)
- `npx nx run backend-agents-skills-k8s-launcher:test --skip-nx-cache` — 3 passed
- `scripts/agent-style-check.sh` — 0 errors, 0 warnings
- `git diff --check`

## Review

- independent review: PASS; no correctness, security, regression, or fail-closed findings
- local Claude review remains unavailable because Claude Code is not logged in; no repository data was sent