### PR TITLE
🛡️ Phase E: authorize governed child-run spawning

### DIFF
--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -114,6 +114,12 @@ uncertainty fails closed.
 
 ## Public surface
 
+- `__AuthorizeGovernedChildRunSpawn(parent, request, childCount, policy, delegation)` — pure
+  fail-closed child-run authorization gate. It preserves one same-silo run tree, bounds depth and
+  fan-out, requires a legal target-service/capability delegation, permits only an explicit subset of
+  the parent's frozen snapshot, and checks that the child's budget fits within the parent's remaining
+  allowance. It binds every reviewed request field for the following transaction; it neither reserves
+  budget or fan-out nor creates a run. The durable adapter must lock, count, reserve, and persist.
 - `__StartNextRunAttempt(repository, command)` — start the next attempt of a run via compare-and-swap.
 - `__ValidateRunWorkloadAssignment(assignment, expectation)` — confirm a workload is the one authorised for this attempt.
 - `__DigestRunInputSnapshot(snapshot)` — compute the canonical SHA-256 identity of all frozen run

--- a/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
@@ -1,0 +1,81 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { describe, expect, it } from "vitest";
+
+import { __AuthorizeGovernedChildRunSpawn } from "../child-run-admission.js";
+import type { GovernedChildRunParent, GovernedChildRunPolicy, GovernedChildRunSpawnRequest } from "../child-run-admission.types.js";
+
+/** Creates the immutable parent snapshot used to constrain every child selection. */
+function _snapshot(): RunInputSnapshot
+{
+	return {
+		runId: "parent-run", siloId: "silo-a", agentServiceId: "parent-service", agentRevisionId: "parent-revision", snapshotVersion: 1, threadId: "thread-1", messageIds: ["message-1", "message-2"], personaRevisionId: "persona-1", preferenceFactIds: [], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"], memoryFacts: [{ datasetId: "dataset-1", factId: "fact-1", contentDigest: "sha256:fact", provenance: [] }], memoryQueryPolicy: {}, toolGrantIds: [], modelRoute: {}, budgetPolicy: {}, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 1, fleetMembershipIssuer: "issuer-1", fleetMembershipIssuerKeyId: "key-1", fleetMembershipAssertionId: "assertion-1", fleetMembershipPayloadDigest: "sha256:membership", fleetMembershipTrustedUntil: "2026-07-25T00:00:00.000Z" }, capabilitySetDigest: "sha256:parent-capabilities", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "v1", digest: "sha256:parent-snapshot", compiledAt: "2026-07-24T00:00:00.000Z",
+	};
+}
+
+/** Creates a valid parent with enough remaining budget for a bounded child. */
+function _parent(): GovernedChildRunParent
+{
+	return { runId: "parent-run", rootRunId: "root-run", siloId: "silo-a", snapshot: _snapshot(), depth: 1, remainingBudget: { maxTotalTokens: 100, maxCostUsdMicros: 500, maxToolInvocations: 3 } };
+}
+
+/** Creates one legal same-silo child proposal. */
+function _request(): GovernedChildRunSpawnRequest
+{
+	return { siloId: "silo-a", agentServiceId: "child-service", capabilitySetDigest: "sha256:child-capabilities", context: { messageIds: ["message-1"], memoryFactIds: ["fact-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"] }, budget: { maxTotalTokens: 50, maxCostUsdMicros: 200, maxToolInvocations: 1 }, task: { task: "summarize" } };
+}
+
+/** Returns the bounded policy used by all child-run admission tests. */
+function _policy(): GovernedChildRunPolicy
+{
+	return { maximumDepth: 3, maximumChildrenPerParent: 2 };
+}
+
+/** Capability authority allowing exactly the reviewed child digest. */
+const _delegation = { allows: function _allows(parentDigest: string, childAgentServiceId: string, childDigest: string): boolean { return parentDigest === "sha256:parent-capabilities" && childAgentServiceId === "child-service" && childDigest === "sha256:child-capabilities"; } };
+
+describe("governed child-run admission", function _describeGovernedChildRunAdmission()
+{
+	it("inherits lineage and permits only the parent-selected context subset", function _admitsBoundedChild()
+	{
+		expect(__AuthorizeGovernedChildRunSpawn(_parent(), _request(), 0, _policy(), _delegation)).toEqual({ outcome: "authorized", authorization: { siloId: "silo-a", rootRunId: "root-run", parentRunId: "parent-run", depth: 2, context: _request().context, budget: _request().budget, agentServiceId: "child-service", capabilitySetDigest: "sha256:child-capabilities", task: { task: "summarize" } } });
+	});
+
+	it("rejects a sibling's unbrokered message even when it names the same thread", function _rejectsSiblingContext()
+	{
+		const request = { ..._request(), context: { ..._request().context, messageIds: ["message-1", "sibling-message"] } };
+		expect(__AuthorizeGovernedChildRunSpawn(_parent(), request, 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "context_not_parent_readable" });
+	});
+
+	it("rejects capability escalation, depth overflow, fan-out overflow, and budget overdraw before persistence", function _rejectsUnsafeChild()
+	{
+		expect(__AuthorizeGovernedChildRunSpawn(_parent(), { ..._request(), capabilitySetDigest: "sha256:escalated" }, 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "capability_escalation" });
+		expect(__AuthorizeGovernedChildRunSpawn(_parent(), { ..._request(), agentServiceId: "swapped-service" }, 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "capability_escalation" });
+		expect(__AuthorizeGovernedChildRunSpawn({ ..._parent(), depth: 3 }, _request(), 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "depth_exceeded" });
+		expect(__AuthorizeGovernedChildRunSpawn(_parent(), _request(), 2, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "fanout_exceeded" });
+		expect(__AuthorizeGovernedChildRunSpawn(_parent(), { ..._request(), budget: { maxTotalTokens: 101, maxCostUsdMicros: 200, maxToolInvocations: 1 } }, 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "budget_exceeded" });
+	});
+
+	it("rejects a child in another silo", function _rejectsCrossSiloChild()
+	{
+		expect(__AuthorizeGovernedChildRunSpawn(_parent(), { ..._request(), siloId: "silo-b" }, 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "cross_silo" });
+		expect(__AuthorizeGovernedChildRunSpawn({ ..._parent(), snapshot: { ..._snapshot(), runId: "different-run" } }, _request(), 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "invalid_request" });
+		expect(__AuthorizeGovernedChildRunSpawn({ ..._parent(), snapshot: { ..._snapshot(), siloId: "silo-b" } }, _request(), 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "invalid_request" });
+	});
+
+	it("detaches the returned authorization from caller-owned request objects", function _detachesCallerRequest()
+	{
+		const request = _request();
+		const result = __AuthorizeGovernedChildRunSpawn(_parent(), request, 0, _policy(), _delegation);
+		(request.context.messageIds as string[]).push("message-2");
+		(request.budget as { maxTotalTokens: number }).maxTotalTokens = 99;
+		(request.task as { task: string }).task = "unsafe";
+
+		expect(result).toEqual({ outcome: "authorized", authorization: { siloId: "silo-a", rootRunId: "root-run", parentRunId: "parent-run", depth: 2, context: _request().context, budget: _request().budget, agentServiceId: "child-service", capabilitySetDigest: "sha256:child-capabilities", task: { task: "summarize" } } });
+	});
+
+	it("fails closed instead of throwing on malformed boundary input", function _deniesMalformedInput()
+	{
+		const malformed = { ..._request(), context: { messageIds: "not-an-array", memoryFactIds: [], artifactRevisionIds: [], skillRevisionIds: [] } } as unknown as GovernedChildRunSpawnRequest;
+		expect(__AuthorizeGovernedChildRunSpawn(_parent(), malformed, 0, _policy(), _delegation)).toEqual({ outcome: "denied", reason: "invalid_request" });
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
@@ -1,0 +1,131 @@
+import type { GovernedChildRunBudget, GovernedChildRunCapabilityDelegation, GovernedChildRunParent, GovernedChildRunPolicy, GovernedChildRunSpawnAuthorizationResult, GovernedChildRunSpawnRequest } from "./child-run-admission.types.js";
+import { ___CloneCanonicalJson } from "@opencrane/util";
+import type { JsonValue } from "@opencrane/util";
+
+/**
+ * Evaluates the pure, fail-closed parent boundary for one governed child-run request.
+ *
+ * This is deliberately not a durable admission and does not reserve fan-out or budget. The owning
+ * repository must lock the parent, count its children, load its remaining budget, call this
+ * function, then atomically reserve and persist the returned complete authorization.
+ */
+export function __AuthorizeGovernedChildRunSpawn(parent: GovernedChildRunParent, request: GovernedChildRunSpawnRequest, existingChildCount: number, policy: GovernedChildRunPolicy, delegation: GovernedChildRunCapabilityDelegation): GovernedChildRunSpawnAuthorizationResult
+{
+	// 1. Validate caller-controlled bounds before examining authority so malformed requests cannot widen a read.
+	const normalizedRequest = _normalizeRequest(request);
+	if (normalizedRequest === null || !_isRequestValid(parent, normalizedRequest, existingChildCount, policy)) return { outcome: "denied", reason: "invalid_request" };
+	// 2. Keep a run tree inside one silo; cross-silo execution needs an explicit external adapter, not a child edge.
+	if (parent.siloId !== normalizedRequest.siloId) return { outcome: "denied", reason: "cross_silo" };
+	// 3. Bound recursion and direct fan-out before a durable child can consume capacity.
+	if (parent.depth >= policy.maximumDepth) return { outcome: "denied", reason: "depth_exceeded" };
+	if (existingChildCount >= policy.maximumChildrenPerParent) return { outcome: "denied", reason: "fanout_exceeded" };
+	// 4. Require a proof that the requested child capability set is a legal delegation.
+	if (!delegation.allows(parent.snapshot.capabilitySetDigest, normalizedRequest.agentServiceId, normalizedRequest.capabilitySetDigest)) return { outcome: "denied", reason: "capability_escalation" };
+	// 5. Preserve sibling isolation by allowing only context coordinates the parent snapshot contains.
+	if (!_isContextSubset(parent, normalizedRequest)) return { outcome: "denied", reason: "context_not_parent_readable" };
+	// 6. Carve finite child limits from the parent's remaining budget before durable admission accounts for them.
+	if (!_fitsBudget(normalizedRequest.budget, parent.remainingBudget)) return { outcome: "denied", reason: "budget_exceeded" };
+	return { outcome: "authorized", authorization: { siloId: parent.siloId, rootRunId: parent.rootRunId, parentRunId: parent.runId, depth: parent.depth + 1, context: normalizedRequest.context, budget: normalizedRequest.budget, agentServiceId: normalizedRequest.agentServiceId, capabilitySetDigest: normalizedRequest.capabilitySetDigest, task: normalizedRequest.task } };
+}
+
+/** Deep-copies only structurally valid request data so the authorization cannot alias a caller's objects. */
+function _normalizeRequest(value: unknown): GovernedChildRunSpawnRequest | null
+{
+	if (!_isRecord(value) || typeof value.siloId !== "string" || typeof value.agentServiceId !== "string" || typeof value.capabilitySetDigest !== "string" || !_isRecord(value.context) || !_isRecord(value.budget)) return null;
+	const context = value.context;
+	const budget = value.budget;
+	if (!_isStringArray(context.messageIds) || !_isStringArray(context.memoryFactIds) || !_isStringArray(context.artifactRevisionIds) || !_isStringArray(context.skillRevisionIds) || !_isBudgetShape(budget)) return null;
+	try
+	{
+		return {
+			siloId: value.siloId,
+			agentServiceId: value.agentServiceId,
+			capabilitySetDigest: value.capabilitySetDigest,
+			context: { messageIds: [...context.messageIds], memoryFactIds: [...context.memoryFactIds], artifactRevisionIds: [...context.artifactRevisionIds], skillRevisionIds: [...context.skillRevisionIds] },
+			budget: { maxTotalTokens: budget.maxTotalTokens, maxCostUsdMicros: budget.maxCostUsdMicros, maxToolInvocations: budget.maxToolInvocations },
+			task: ___CloneCanonicalJson(value.task as JsonValue),
+		};
+	}
+	catch
+	{
+		return null;
+	}
+}
+
+/** Returns whether one unknown value is a non-null object with string-addressable fields. */
+function _isRecord(value: unknown): value is Record<string, unknown>
+{
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Returns whether one unknown value is an array whose every item is a string. */
+function _isStringArray(value: unknown): value is string[]
+{
+	return Array.isArray(value) && value.every(function _isString(item) { return typeof item === "string"; });
+}
+
+/** Returns whether a plain object contains the three budget fields with their expected primitive shapes. */
+function _isBudgetShape(value: Record<string, unknown>): value is Record<keyof GovernedChildRunBudget, number | null>
+{
+	return _isLimitShape(value.maxTotalTokens) && _isLimitShape(value.maxCostUsdMicros) && _isLimitShape(value.maxToolInvocations);
+}
+
+/** Returns whether one unknown budget field is explicitly null or a number for later range validation. */
+function _isLimitShape(value: unknown): value is number | null
+{
+	return value === null || typeof value === "number";
+}
+
+/** Returns whether the request and policy contain finite non-negative coordinates. */
+function _isRequestValid(parent: GovernedChildRunParent, request: GovernedChildRunSpawnRequest, existingChildCount: number, policy: GovernedChildRunPolicy): boolean
+{
+	return parent.runId.trim().length > 0 && parent.rootRunId.trim().length > 0 && parent.siloId.trim().length > 0
+		&& parent.snapshot.runId === parent.runId && parent.snapshot.siloId === parent.siloId
+		&& Number.isSafeInteger(parent.depth) && parent.depth >= 0 && request.siloId.trim().length > 0
+		&& request.agentServiceId.trim().length > 0 && request.capabilitySetDigest.trim().length > 0
+		&& Number.isSafeInteger(existingChildCount) && existingChildCount >= 0
+		&& Number.isSafeInteger(policy.maximumDepth) && policy.maximumDepth >= 0
+		&& Number.isSafeInteger(policy.maximumChildrenPerParent) && policy.maximumChildrenPerParent >= 0
+		&& _isBudgetValid(request.budget) && _isBudgetValid(parent.remainingBudget);
+}
+
+/** Returns whether each proposed context coordinate was already included in the parent's frozen snapshot. */
+function _isContextSubset(parent: GovernedChildRunParent, request: GovernedChildRunSpawnRequest): boolean
+{
+	const parentMessages = new Set(parent.snapshot.messageIds);
+	const parentMemoryFacts = new Set(parent.snapshot.memoryFacts.map(function _factId(fact) { return fact.factId; }));
+	return _containsOnly(parentMessages, request.context.messageIds)
+		&& _containsOnly(parentMemoryFacts, request.context.memoryFactIds)
+		&& _containsOnly(new Set(parent.snapshot.artifactRevisionIds), request.context.artifactRevisionIds)
+		&& _containsOnly(new Set(parent.snapshot.skillRevisionIds), request.context.skillRevisionIds);
+}
+
+/** Returns whether every selected identifier is non-empty and present in the parent-owned set. */
+function _containsOnly(allowed: ReadonlySet<string>, selected: readonly string[]): boolean
+{
+	return selected.every(function _isAllowed(id) { return id.trim().length > 0 && allowed.has(id); });
+}
+
+/** Returns whether a budget uses only finite non-negative integer limits or an explicit unlimited null. */
+function _isBudgetValid(budget: GovernedChildRunBudget): boolean
+{
+	return _isLimitValid(budget.maxTotalTokens) && _isLimitValid(budget.maxCostUsdMicros) && _isLimitValid(budget.maxToolInvocations);
+}
+
+/** Returns whether one optional numeric limit is representable without coercion. */
+function _isLimitValid(value: number | null): boolean
+{
+	return value === null || (Number.isSafeInteger(value) && value >= 0);
+}
+
+/** Returns whether every finite child limit fits in its corresponding finite parent allowance. */
+function _fitsBudget(child: GovernedChildRunBudget, parent: GovernedChildRunBudget): boolean
+{
+	return _fitsLimit(child.maxTotalTokens, parent.maxTotalTokens) && _fitsLimit(child.maxCostUsdMicros, parent.maxCostUsdMicros) && _fitsLimit(child.maxToolInvocations, parent.maxToolInvocations);
+}
+
+/** Returns whether a child either stays bounded by its parent or both explicitly retain no ceiling. */
+function _fitsLimit(child: number | null, parent: number | null): boolean
+{
+	return parent === null ? true : child !== null && child <= parent;
+}

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
@@ -1,0 +1,105 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import type { JsonValue } from "@opencrane/util";
+
+/** Immutable parent facts required to admit one governed child run. */
+export interface GovernedChildRunParent
+{
+	/** Durable identifier of the immediate spawning run. */
+	readonly runId: string;
+	/** Stable root identifier shared by every node in the governed tree. */
+	readonly rootRunId: string;
+	/** Silo that must contain both parent and child authority. */
+	readonly siloId: string;
+	/** Parent snapshot that bounds every child context selection. */
+	readonly snapshot: RunInputSnapshot;
+	/** Depth of the parent below its root, where a root has depth zero. */
+	readonly depth: number;
+	/** Remaining parent budget available to carve into children. */
+	readonly remainingBudget: GovernedChildRunBudget;
+}
+
+/** Explicit finite budget carved out of a parent run for one child. */
+export interface GovernedChildRunBudget
+{
+	/** Maximum model tokens available to the child. */
+	readonly maxTotalTokens: number | null;
+	/** Maximum cost in USD micros available to the child. */
+	readonly maxCostUsdMicros: number | null;
+	/** Maximum tool calls available to the child. */
+	readonly maxToolInvocations: number | null;
+}
+
+/** Parent-selected snapshot coordinates visible to one child and no sibling. */
+export interface GovernedChildRunContextSelection
+{
+	/** Ordered transcript messages copied from the parent snapshot. */
+	readonly messageIds: readonly string[];
+	/** Memory facts copied from the parent snapshot. */
+	readonly memoryFactIds: readonly string[];
+	/** Immutable artifact revisions copied from the parent snapshot. */
+	readonly artifactRevisionIds: readonly string[];
+	/** Immutable skill revisions copied from the parent snapshot. */
+	readonly skillRevisionIds: readonly string[];
+}
+
+/** Proposed governed child run before durable admission assigns its run identifier. */
+export interface GovernedChildRunSpawnRequest
+{
+	/** Silo in which the child would be admitted. */
+	readonly siloId: string;
+	/** Target AgentService selected by the parent through its granted spawn tool. */
+	readonly agentServiceId: string;
+	/** Capability digest selected for the child, never inferred from its target service. */
+	readonly capabilitySetDigest: string;
+	/** Explicit subset of the parent snapshot available to the child. */
+	readonly context: GovernedChildRunContextSelection;
+	/** Budget carved from the parent's remaining budget. */
+	readonly budget: GovernedChildRunBudget;
+	/** Canonical JSON-safe task payload retained with the spawn receipt. */
+	readonly task: JsonValue;
+}
+
+/** Bounded policy evaluated before a parent is allowed to create a child. */
+export interface GovernedChildRunPolicy
+{
+	/** Maximum number of parent-to-child edges below one root run. */
+	readonly maximumDepth: number;
+	/** Maximum direct children that one parent may create. */
+	readonly maximumChildrenPerParent: number;
+}
+
+/** Capability delegation proof evaluated by an owning authorization authority. */
+export interface GovernedChildRunCapabilityDelegation
+{
+	/** Returns whether the parent may delegate exactly this target service and capability set. */
+	allows(parentCapabilitySetDigest: string, childAgentServiceId: string, childCapabilitySetDigest: string): boolean;
+}
+
+/** Fully-bound request that a later transactional reservation must persist without substitutions. */
+export interface GovernedChildRunSpawnAuthorization
+{
+	/** Reviewed silo that contains the complete parent-child authority tree. */
+	readonly siloId: string;
+	/** Root identifier inherited unchanged from the parent. */
+	readonly rootRunId: string;
+	/** Immediate parent identifier fixed for the child. */
+	readonly parentRunId: string;
+	/** Child depth fixed before it can execute. */
+	readonly depth: number;
+	/** Child's explicit snapshot subset. */
+	readonly context: GovernedChildRunContextSelection;
+	/** Child's bounded independently-accountable budget. */
+	readonly budget: GovernedChildRunBudget;
+	/** Reviewed target AgentService identifier. */
+	readonly agentServiceId: string;
+	/** Reviewed delegated capability-set digest. */
+	readonly capabilitySetDigest: string;
+	/** Reviewed canonical task payload. */
+	readonly task: JsonValue;
+}
+
+/** Stable reason a proposed governed child run is refused before persistence. */
+export type GovernedChildRunRefusalReason = "invalid_request" | "cross_silo" | "depth_exceeded" | "fanout_exceeded" | "capability_escalation" | "context_not_parent_readable" | "budget_exceeded";
+
+/** Result of evaluating a governed child-run request at the parent boundary. */
+export type GovernedChildRunSpawnAuthorizationResult = { readonly outcome: "authorized"; readonly authorization: GovernedChildRunSpawnAuthorization } | { readonly outcome: "denied"; readonly reason: GovernedChildRunRefusalReason };

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -1,5 +1,7 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
+export { __AuthorizeGovernedChildRunSpawn } from "./child-run-admission.js";
+export type { GovernedChildRunBudget, GovernedChildRunCapabilityDelegation, GovernedChildRunContextSelection, GovernedChildRunParent, GovernedChildRunPolicy, GovernedChildRunRefusalReason, GovernedChildRunSpawnAuthorization, GovernedChildRunSpawnAuthorizationResult, GovernedChildRunSpawnRequest } from "./child-run-admission.types.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";


### PR DESCRIPTION
## Context

A governed child run is an independently accountable run, not an in-process handoff. Before a later transactional adapter can reserve budget and persist a child, it needs one fail-closed decision that fixes exactly what the parent is allowed to delegate.

## What changes

- add a pure child-run spawn authorization boundary that keeps run trees in one silo and inherits the root and parent lineage
- require target-service-aware capability delegation, and bound recursion, direct fan-out, and child budgets
- permit only context already present in the parent’s immutable snapshot, so siblings cannot exchange context without parent mediation
- normalize and canonical-clone incoming request data, bind every reviewed coordinate (including silo, service, capability, task, context, and budget), and fail closed on malformed input
- document explicitly that this layer does not reserve or persist anything; the next slice must lock the parent and atomically reserve fan-out and budget

## Validation

- `npx nx run backend-agents-execution-runs:test --skip-nx-cache` (63 passing)
- `npx nx run backend-agents-execution-runs:lint --skip-nx-cache`
- `scripts/agent-style-check.sh`
- `git diff --cached --check`

## Review

- independent review passed after fixes for complete coordinate binding, target-service delegation, snapshot coherence, mutable request aliases, malformed input, and silo binding.