### PR TITLE
🔒 Phase E: revalidate root session inputs at admission

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -54,6 +54,13 @@ caller input.
 - `PrismaSkillRevisionEligibilitySource` — locks the AgentRevision's skill assignments
   at admission and refuses an invented, foreign, revoked, or unpublished revision with
   `skill_unavailable`.
+- `PrismaRootRunAuthoritySource` — revalidates an active service and its published revision at the
+  final admission fence, then fixes root-run lineage. It intentionally cannot admit a child run;
+  child lineage requires a dedicated locked parent authority.
+- `PrismaApprovedPersonaSource` — returns no persona for managed work and otherwise accepts only the
+  execution subject's active approved persona revision inside the final admission transaction.
+- `PrismaThreadContextSource` — freezes completed message identifiers only after proving the exact
+  active thread belongs to the selected service and includes the execution subject as a participant.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-root-run-authority-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-root-run-authority-source.test.ts
@@ -1,0 +1,37 @@
+import { AgentRevisionState, AgentServiceKind, AgentServiceState } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { PrismaRootRunAuthoritySource } from "../prisma-root-run-authority-source.js";
+
+/** Builds the fixed root admission command used for source revalidation. */
+function _command()
+{
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1" };
+}
+
+/** Wraps one controlled service row in the final-admission transaction shape. */
+function _transaction(service: unknown)
+{
+	return { prisma: { agentService: { findFirst: async function _findFirst() { return service; } } }, admittedAt: "2026-07-24T00:00:00.000Z", admittedAtEpochMs: 1 } as never;
+}
+
+describe("PrismaRootRunAuthoritySource", function _describePrismaRootRunAuthoritySource()
+{
+	it("freezes the active published personal revision into root interactive lineage", async function _loadsPublishedPersonalRevision()
+	{
+		const source = new PrismaRootRunAuthoritySource();
+		const service = { id: "service-1", kind: AgentServiceKind.Personal, state: AgentServiceState.Active, activeRevisionId: "revision-1", activeRevision: { id: "revision-1", state: AgentRevisionState.Published, digest: "sha256:contract", promptPolicyVersion: "prompt-v1", personaRevisionId: "persona-1" } };
+		await expect(source.load(_command(), _transaction(service))).resolves.toEqual({ outcome: "loaded", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "prompt-v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null } });
+	});
+
+	it("refuses missing, inactive, draft, or mismatched active revisions", async function _deniesUnavailableRevision()
+	{
+		const source = new PrismaRootRunAuthoritySource();
+		await expect(source.load(_command(), _transaction(null))).resolves.toEqual({ outcome: "denied", reason: "revision_unavailable" });
+		const draft = { id: "service-1", kind: AgentServiceKind.Personal, state: AgentServiceState.Active, activeRevisionId: "revision-1", activeRevision: { id: "revision-1", state: AgentRevisionState.Draft, digest: "sha256:contract", promptPolicyVersion: "prompt-v1", personaRevisionId: "persona-1" } };
+		await expect(source.load(_command(), _transaction(draft))).resolves.toEqual({ outcome: "denied", reason: "revision_unavailable" });
+		await expect(source.load({ ..._command(), threadId: null }, _transaction({ ...draft, activeRevision: { ...draft.activeRevision, state: AgentRevisionState.Published } }))).resolves.toEqual({ outcome: "denied", reason: "run_not_admittable" });
+		await expect(source.load(_command(), _transaction({ ...draft, kind: AgentServiceKind.Managed, activeRevision: { ...draft.activeRevision, state: AgentRevisionState.Published } }))).resolves.toEqual({ outcome: "denied", reason: "run_not_admittable" });
+		await expect(source.load({ ..._command(), threadId: null }, _transaction({ ...draft, kind: AgentServiceKind.Managed, activeRevision: { ...draft.activeRevision, state: AgentRevisionState.Published } }))).resolves.toEqual({ outcome: "denied", reason: "run_not_admittable" });
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-session-content-sources.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-session-content-sources.test.ts
@@ -1,0 +1,59 @@
+import { ConversationMessageState, ConversationThreadState, PersonaRevisionState } from "@prisma/client";
+import { describe, expect, it } from "vitest";
+
+import { PrismaApprovedPersonaSource } from "../prisma-approved-persona-source.js";
+import { PrismaThreadContextSource } from "../prisma-thread-context-source.js";
+
+/** Builds one personal interactive authority already admitted at the root-run boundary. */
+function _personalRun()
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "prompt-v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null } as const;
+}
+
+/** Builds the caller-derived command used by every personal source. */
+function _command(threadId: string | null = "thread-1")
+{
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId, executionSubjectId: "user-1", requestIdempotencyKey: "request-1" };
+}
+
+/** Creates a transaction fixture whose read ports return only the supplied product rows. */
+function _transaction(profile: unknown, thread: unknown)
+{
+	return { prisma: { personaProfile: { findFirst: async function _profile() { return profile; } }, agentRevision: { findFirst: async function _revision() { return { personaRevisionId: "persona-1" }; } }, conversationThread: { findFirst: async function _thread() { return thread; } }, $queryRaw: async function _lock() { return [{ userId: "user-1" }]; } }, admittedAt: "2026-07-24T00:00:00.000Z", admittedAtEpochMs: 1 } as never;
+}
+
+describe("Prisma session content sources", function _describePrismaSessionContentSources()
+{
+	it("freezes only the caller's active approved persona revision", async function _loadsApprovedPersona()
+	{
+		const source = new PrismaApprovedPersonaSource();
+		const profile = { activeRevisionId: "persona-1", activeRevision: { id: "persona-1", state: PersonaRevisionState.Approved } };
+		await expect(source.load(_command(), _personalRun(), _transaction(profile, null))).resolves.toEqual({ outcome: "loaded", value: { personaRevisionId: "persona-1" } });
+		await expect(source.load(_command(), _personalRun(), _transaction({ activeRevisionId: "persona-1", activeRevision: { id: "persona-1", state: PersonaRevisionState.Draft } }, null))).resolves.toEqual({ outcome: "denied", reason: "persona_unavailable" });
+		const mismatch = { prisma: { personaProfile: { findFirst: async function _profile() { return profile; } }, agentRevision: { findFirst: async function _revision() { return { personaRevisionId: "persona-2" }; } } }, admittedAt: "2026-07-24T00:00:00.000Z", admittedAtEpochMs: 1 } as never;
+		await expect(source.load(_command(), _personalRun(), mismatch)).resolves.toEqual({ outcome: "denied", reason: "persona_unavailable" });
+	});
+
+	it("returns no persona for managed work", async function _omitsManagedPersona()
+	{
+		const source = new PrismaApprovedPersonaSource();
+		await expect(source.load(_command(), { ..._personalRun(), agentKind: "managed", delegatedUserId: null, trigger: "managed_invocation" }, _transaction(null, null))).resolves.toEqual({ outcome: "loaded", value: { personaRevisionId: null } });
+	});
+
+	it("freezes completed messages only after the exact participant thread is authoritative", async function _loadsCompletedThread()
+	{
+		const source = new PrismaThreadContextSource();
+		const thread = { messages: [{ id: "message-1" }, { id: "message-2" }] };
+		await expect(source.load(_command(), _personalRun(), _transaction(null, thread))).resolves.toEqual({ outcome: "loaded", value: { messageIds: ["message-1", "message-2"] } });
+		await expect(source.load(_command(), _personalRun(), _transaction(null, null))).resolves.toEqual({ outcome: "denied", reason: "thread_unavailable" });
+		await expect(source.load(_command(null), _personalRun(), _transaction(null, thread))).resolves.toEqual({ outcome: "loaded", value: { messageIds: [] } });
+	});
+
+	it("uses the reviewed active and completed-state query constraints", async function _usesNarrowThreadQuery()
+	{
+		const calls: unknown[] = [];
+		const transaction = { prisma: { conversationThread: { findFirst: async function _thread(query: unknown) { calls.push(query); return { messages: [] }; } }, $queryRaw: async function _lock() { return [{ userId: "user-1" }]; } }, admittedAt: "2026-07-24T00:00:00.000Z", admittedAtEpochMs: 1 } as never;
+		await new PrismaThreadContextSource().load(_command(), _personalRun(), transaction);
+		expect(calls[0]).toEqual(expect.objectContaining({ where: expect.objectContaining({ state: ConversationThreadState.Active, participants: { some: { userId: "user-1" } } }), select: expect.objectContaining({ messages: expect.objectContaining({ where: { state: ConversationMessageState.Completed } }) }) }));
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -1,4 +1,7 @@
 export { __AssembleRunInputSnapshot } from "./session-assembly.js";
 export { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
 export { PrismaSkillRevisionEligibilitySource } from "./prisma-skill-revision-eligibility-source.js";
+export { PrismaRootRunAuthoritySource } from "./prisma-root-run-authority-source.js";
+export { PrismaApprovedPersonaSource } from "./prisma-approved-persona-source.js";
+export { PrismaThreadContextSource } from "./prisma-thread-context-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PersonalConfigurationMaterialization, PersonalConfigurationMaterializationSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, SkillRevisionEligibilitySource, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-approved-persona-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-approved-persona-source.ts
@@ -1,0 +1,24 @@
+import { PersonaRevisionState } from "@prisma/client";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+import type { ApprovedPersonaInput, ApprovedPersonaSource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+
+/** Revalidates the active approved persona for a personal run inside final snapshot admission. */
+export class PrismaApprovedPersonaSource implements ApprovedPersonaSource
+{
+	/** Returns no persona for managed work and otherwise accepts only the caller's active approved revision. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<ApprovedPersonaInput>>
+	{
+		// 1. Managed services must never inherit a human persona merely because their caller has one.
+		if (run.agentKind === "managed") return { outcome: "loaded", value: { personaRevisionId: null } };
+		// 2. Read the caller-owned profile and its active revision in the same final transaction as the run.
+		const profile = await transaction.prisma.personaProfile.findFirst({
+			where: { siloId: command.siloId, userId: command.executionSubjectId },
+			select: { activeRevisionId: true, activeRevision: { select: { id: true, state: true } } },
+		});
+		const revision = await transaction.prisma.agentRevision.findFirst({ where: { id: run.agentRevisionId, agentServiceId: run.agentServiceId }, select: { personaRevisionId: true } });
+		// 3. Refuse drafts, stale pointers, and missing onboarding approval before the immutable snapshot exists.
+		if (profile === null || revision === null || revision.personaRevisionId === null || profile.activeRevisionId === null || profile.activeRevision === null || profile.activeRevision.id !== profile.activeRevisionId || profile.activeRevision.state !== PersonaRevisionState.Approved || revision.personaRevisionId !== profile.activeRevision.id) return { outcome: "denied", reason: "persona_unavailable" };
+		return { outcome: "loaded", value: { personaRevisionId: profile.activeRevision.id } };
+	}
+}

--- a/libs/backend/agents/execution/inputs/main/src/prisma-root-run-authority-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-root-run-authority-source.ts
@@ -1,0 +1,31 @@
+import { AgentRevisionState, AgentServiceKind, AgentServiceState } from "@prisma/client";
+
+import type { RunAuthoritySource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+/**
+ * Revalidates the published active revision for an initial root-run admission.
+ *
+ * It deliberately emits a root lineage only: a governed-child adapter must load and lock its parent
+ * independently, then supply the inherited root and parent identifier through its own source.
+ */
+export class PrismaRootRunAuthoritySource implements RunAuthoritySource
+{
+	/** Loads the active, published service revision at the final admission fence. */
+	async load(command: SessionAssemblyCommand, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<InitialRunAuthority>>
+	{
+		// 1. Read the exact same-silo service and active revision inside the caller's admission transaction.
+		const service = await transaction.prisma.agentService.findFirst({
+			where: { id: command.agentServiceId, siloId: command.siloId },
+			select: { id: true, kind: true, state: true, activeRevisionId: true, activeRevision: { select: { id: true, state: true, digest: true, promptPolicyVersion: true, personaRevisionId: true } } },
+		});
+		// 2. Reject unavailable or unpublished heads so a run cannot pin a draft, retired, or replaced service.
+		if (service === null || service.state !== AgentServiceState.Active || service.activeRevisionId === null || service.activeRevision === null || service.activeRevision.id !== service.activeRevisionId || service.activeRevision.state !== AgentRevisionState.Published) return { outcome: "denied", reason: "revision_unavailable" };
+		if (service.kind !== AgentServiceKind.Personal && service.kind !== AgentServiceKind.Managed) return { outcome: "denied", reason: "run_not_admittable" };
+		if (service.kind === AgentServiceKind.Personal && command.threadId === null) return { outcome: "denied", reason: "run_not_admittable" };
+		if (service.kind === AgentServiceKind.Managed && command.threadId !== null) return { outcome: "denied", reason: "run_not_admittable" };
+		if (service.kind === AgentServiceKind.Managed && service.activeRevision.personaRevisionId !== null) return { outcome: "denied", reason: "run_not_admittable" };
+		// 3. Freeze root lineage at the caller-provided run ID; only a dedicated child authority may inherit it.
+		return { outcome: "loaded", value: { agentServiceId: service.id, agentRevisionId: service.activeRevision.id, agentKind: service.kind === AgentServiceKind.Personal ? "personal" : "managed", effectiveContractDigest: service.activeRevision.digest, promptCompilerVersion: service.activeRevision.promptPolicyVersion, trigger: service.kind === AgentServiceKind.Personal ? "interactive" : "managed_invocation", delegatedUserId: service.kind === AgentServiceKind.Personal ? command.executionSubjectId : null, rootRunId: command.runId, parentRunId: null } };
+	}
+}

--- a/libs/backend/agents/execution/inputs/main/src/prisma-thread-context-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-thread-context-source.ts
@@ -1,0 +1,25 @@
+import { ConversationMessageState, ConversationThreadState, Prisma } from "@prisma/client";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+import type { SessionAssemblyCommand, SessionAssemblyLoad, ThreadContextInput, ThreadContextSource } from "./session-assembly.types.js";
+
+/** Loads only the execution subject's completed messages from the exact active conversation thread. */
+export class PrismaThreadContextSource implements ThreadContextSource
+{
+	/** Returns an empty transcript for non-conversational work or freezes the participant-authorized thread order. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<ThreadContextInput>>
+	{
+		// 1. Non-conversational work carries no transcript and must not trigger a broad message query.
+		if (command.threadId === null) return { outcome: "loaded", value: { messageIds: [] } };
+		await transaction.prisma.$queryRaw(Prisma.sql`SELECT "id" FROM "conversation_threads" WHERE "id" = ${command.threadId} AND "silo_id" = ${command.siloId} AND "agent_service_id" = ${run.agentServiceId} AND "state" = 'active'::"ConversationThreadState" FOR UPDATE`);
+		const participants = await transaction.prisma.$queryRaw<readonly { readonly userId: string }[]>(Prisma.sql`SELECT "user_id" AS "userId" FROM "conversation_participants" WHERE "thread_id" = ${command.threadId} AND "user_id" = ${command.executionSubjectId} FOR UPDATE`);
+		// 2. Revalidate exact silo, service, activity, and participant authority before exposing any message identifier.
+		const thread = await transaction.prisma.conversationThread.findFirst({
+			where: { id: command.threadId, siloId: command.siloId, agentServiceId: run.agentServiceId, state: ConversationThreadState.Active, participants: { some: { userId: command.executionSubjectId } } },
+			select: { messages: { where: { state: ConversationMessageState.Completed }, select: { id: true }, orderBy: [{ createdAt: "asc" }, { id: "asc" }] } },
+		});
+		// 3. Freeze only completed canonical messages so partial or cancelled output cannot leak into a run input.
+		if (participants.length !== 1 || thread === null) return { outcome: "denied", reason: "thread_unavailable" };
+		return { outcome: "loaded", value: { messageIds: thread.messages.map(function _messageId(message): string { return message.id; }) } };
+	}
+}


### PR DESCRIPTION
## Context

A run snapshot is only trustworthy when its root service, persona, and conversation input are revalidated in the same final transaction that persists it. This slice begins the concrete Prisma source bundle required before interactive admission and governed child-run persistence can be composed.

## What changes

- add a root-run authority source that accepts only active services with published revisions and fixes root-only lineage
- bind interactive personal runs to a delegated subject and thread; reject invalid personal/managed thread shapes
- enforce the strict personal-to-managed boundary: a managed revision may not carry a persona
- add an approved-persona source that requires the active AgentRevision and the caller profile to point at the same approved persona
- add a thread-context source that locks the active thread and caller participant before freezing only completed messages

## Validation

- `npx nx run backend-agents-execution-inputs:test --skip-nx-cache` (21 passing)
- `npx nx run backend-agents-execution-inputs:lint --skip-nx-cache`
- `scripts/agent-style-check.sh`
- `git diff --cached --check`
- `npm run check:phase-b-topology`

## Review

Independent review passed after fixes for trigger/delegation shape, active revision/persona equality, thread-participant locking, and managed-revision persona rejection.