### PR TITLE
🔒 Phase E: freeze revision budgets at run admission

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -61,6 +61,8 @@ caller input.
   execution subject's active approved persona revision inside the final admission transaction.
 - `PrismaThreadContextSource` — freezes completed message identifiers only after proving the exact
   active thread belongs to the selected service and includes the execution subject as a participant.
+- `PrismaRevisionBudgetPolicySource` — locks and rereads the selected published revision, then
+  freezes its turn, token, USD-micro cost, and wall-clock ceilings without a fallback default.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-revision-budget-policy-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-revision-budget-policy-source.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaRevisionBudgetPolicySource } from "../prisma-revision-budget-policy-source.js";
+
+/** Returns the one root-run authority already accepted by the session assembler. */
+function _run()
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "prompt-v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null } as const;
+}
+
+/** Wraps one controlled revision row in the final-admission transaction shape. */
+function _transaction(revision: unknown, admittedAtEpochMs = 1_000)
+{
+	return { prisma: { $queryRaw: vi.fn().mockResolvedValue([]), agentRevision: { findFirst: vi.fn().mockResolvedValue(revision) } }, admittedAt: "2026-07-24T00:00:00.000Z", admittedAtEpochMs } as never;
+}
+
+describe("PrismaRevisionBudgetPolicySource", function _describeRevisionBudgetPolicySource()
+{
+	it("freezes all revision ceilings into the runtime budget policy", async function _loadsBudget()
+	{
+		const transaction = _transaction({ budget: { maxTurns: 4, maxTokens: 1000, maxCostUsdMicros: 500_000, maxDurationMs: 60_000 } });
+		const result = await new PrismaRevisionBudgetPolicySource().load({ runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1" }, _run(), transaction);
+
+		expect(result).toEqual({ outcome: "loaded", value: { budgetPolicy: { maxTurns: 4, maxTotalTokens: 1000, maxCostUsdMicros: 500_000, maxToolInvocations: null, wallClockDeadlineEpochMs: 61_000 } } });
+	});
+
+	it("refuses missing, incomplete, or overflowed budgets before snapshot persistence", async function _refusesBadBudget()
+	{
+		const command = { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1" } as const;
+		const source = new PrismaRevisionBudgetPolicySource();
+		await expect(source.load(command, _run(), _transaction(null))).resolves.toEqual({ outcome: "denied", reason: "budget_unavailable" });
+		await expect(source.load(command, _run(), _transaction({ budget: { maxTurns: 4, maxTokens: 1000, maxDurationMs: 60_000 } }))).resolves.toEqual({ outcome: "denied", reason: "budget_unavailable" });
+		await expect(source.load(command, _run(), _transaction({ budget: { maxTurns: 4, maxTokens: 1000, maxCostUsdMicros: 500_000, maxDurationMs: Number.MAX_SAFE_INTEGER } }, 1))).resolves.toEqual({ outcome: "denied", reason: "budget_unavailable" });
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -4,4 +4,5 @@ export { PrismaSkillRevisionEligibilitySource } from "./prisma-skill-revision-el
 export { PrismaRootRunAuthoritySource } from "./prisma-root-run-authority-source.js";
 export { PrismaApprovedPersonaSource } from "./prisma-approved-persona-source.js";
 export { PrismaThreadContextSource } from "./prisma-thread-context-source.js";
+export { PrismaRevisionBudgetPolicySource } from "./prisma-revision-budget-policy-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PersonalConfigurationMaterialization, PersonalConfigurationMaterializationSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, SkillRevisionEligibilitySource, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-revision-budget-policy-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-revision-budget-policy-source.ts
@@ -1,0 +1,40 @@
+import { AgentRevisionState, Prisma } from "@prisma/client";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+import type { BudgetPolicyInput, BudgetPolicySource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+
+/** Reads and freezes the exact published revision's immutable run ceilings at admission. */
+export class PrismaRevisionBudgetPolicySource implements BudgetPolicySource
+{
+	/** Refuses an absent, foreign, non-published, malformed, or unrepresentable revision budget. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<BudgetPolicyInput>>
+	{
+		// 1. Lock the exact revision before rereading it, so publication/revocation cannot race snapshot admission.
+		await transaction.prisma.$queryRaw(Prisma.sql`SELECT revision."id" FROM "agent_revisions" revision JOIN "agent_services" service ON service."id" = revision."agent_service_id" WHERE revision."id" = ${run.agentRevisionId} AND revision."agent_service_id" = ${run.agentServiceId} AND service."silo_id" = ${command.siloId} FOR UPDATE OF revision`);
+
+		// 2. Revalidate the active, published revision beneath the same transaction fence.
+		const revision = await transaction.prisma.agentRevision.findFirst({ where: { id: run.agentRevisionId, agentServiceId: run.agentServiceId, state: AgentRevisionState.Published, agentService: { is: { siloId: command.siloId } } }, select: { budget: true } });
+		if (revision === null) return { outcome: "denied", reason: "budget_unavailable" };
+
+		// 3. Project only the canonical revision ceilings into the runtime's frozen policy.
+		const budget = _parseBudget(revision.budget, transaction.admittedAtEpochMs);
+		return budget === null ? { outcome: "denied", reason: "budget_unavailable" } : { outcome: "loaded", value: { budgetPolicy: budget } };
+	}
+}
+
+/** Parses complete immutable revision JSON into the runtime policy vocabulary without defaults. */
+function _parseBudget(value: Prisma.JsonValue, admittedAtEpochMs: number): BudgetPolicyInput["budgetPolicy"] | null
+{
+	if (value === null || typeof value !== "object" || Array.isArray(value) || !Number.isSafeInteger(admittedAtEpochMs)) return null;
+	const budget = value as Record<string, unknown>;
+	if (!_isPositiveSafeInteger(budget.maxTurns) || !_isPositiveSafeInteger(budget.maxTokens) || !_isPositiveSafeInteger(budget.maxCostUsdMicros) || !_isPositiveSafeInteger(budget.maxDurationMs)) return null;
+	const deadline = admittedAtEpochMs + budget.maxDurationMs;
+	if (!Number.isSafeInteger(deadline)) return null;
+	return { maxTurns: budget.maxTurns, maxTotalTokens: budget.maxTokens, maxCostUsdMicros: budget.maxCostUsdMicros, maxToolInvocations: null, wallClockDeadlineEpochMs: deadline };
+}
+
+/** Returns whether one persisted ceiling is a positive safe integer. */
+function _isPositiveSafeInteger(value: unknown): value is number
+{
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}

--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
@@ -182,7 +182,7 @@ function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; streams: Fak
 /** Deterministic fake compiler: same snapshot digest always yields byte-identical compiled input. */
 const _compileRunInput: RunInputCompiler = async function _compile(snapshot): Promise<CompiledRunInput>
 {
-	return { promptCompilerVersion: "v1", runId: snapshot.runId, attempt: 1, instructions: "compiled", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: `sha256:${snapshot.digest}` };
+	return { promptCompilerVersion: "v1", runId: snapshot.runId, attempt: 1, instructions: "compiled", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: `sha256:${snapshot.digest}` };
 };
 
 /** Build the adapter under test over a fake with the requested durable state. */

--- a/libs/backend/agents/execution/protocol/src/__tests__/runtime-protocol-authority.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/runtime-protocol-authority.test.ts
@@ -34,7 +34,7 @@ function _snapshot(): RunInputSnapshot
 /** Returns the compiled literal input carried alongside the snapshot on a start command. */
 function _compiledInput(): CompiledRunInput
 {
-	return { promptCompilerVersion: "v1", runId: "run-1", attempt: 1, instructions: "", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: "sha256:compiled" };
+	return { promptCompilerVersion: "v1", runId: "run-1", attempt: 1, instructions: "", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: "sha256:compiled" };
 }
 
 /** Returns a valid start command bound to the current authority. */

--- a/libs/backend/agents/runtime/prompt-compiler/main/README.md
+++ b/libs/backend/agents/runtime/prompt-compiler/main/README.md
@@ -7,7 +7,8 @@
 This package is the single TypeScript authority that turns an immutable `RunInputSnapshot` — which
 holds only ID references plus a `promptCompilerVersion` — into the literal `CompiledRunInput` the
 runtime executes. It dereferences persona, message, tool, memory, artifact, and skill records
-through injected control-plane read ports, resolves the model route and literal budget numbers,
+through injected control-plane read ports, resolves the model route and literal turn, token, cost,
+tool, and time budget numbers,
 orders every collection canonically, stamps its own version, and seals the result with a SHA-256
 digest over the canonical payload.
 

--- a/libs/backend/agents/runtime/prompt-compiler/main/src/__tests__/prompt-compiler.test.ts
+++ b/libs/backend/agents/runtime/prompt-compiler/main/src/__tests__/prompt-compiler.test.ts
@@ -25,7 +25,7 @@ function _snapshot(overrides: Partial<RunInputSnapshot> = {}): RunInputSnapshot
 		memoryQueryPolicy: {},
 		toolGrantIds: ["grant-b", "grant-a"],
 		modelRoute: { alias: "silo-default" },
-		budgetPolicy: { maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 },
+		budgetPolicy: { maxTurns: 4, maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 },
 		identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 3, fleetMembershipIssuer: "fleet", fleetMembershipIssuerKeyId: "k1", fleetMembershipAssertionId: "a1", fleetMembershipPayloadDigest: "sha256:c", fleetMembershipTrustedUntil: "2026-07-21T00:00:00.000Z" },
 		capabilitySetDigest: "sha256:cap",
 		effectiveContractDigest: "sha256:contract",
@@ -82,14 +82,14 @@ describe("__CompileRunInput", function _describeCompiler()
 	{
 		const compiled = await __CompileRunInput(_snapshot(), _repositories());
 
-		expect(compiled.budget).toEqual({ maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 });
+		expect(compiled.budget).toEqual({ maxTurns: 4, maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 });
 	});
 
 	it("nulls malformed or absent budget limits rather than inventing them", async function _nullsBadBudget()
 	{
 		const compiled = await __CompileRunInput(_snapshot({ budgetPolicy: { maxTotalTokens: "lots" as unknown as JsonValue } }), _repositories());
 
-		expect(compiled.budget).toEqual({ maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null });
+		expect(compiled.budget).toEqual({ maxTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null });
 	});
 
 	it("assembles persona, memory, artifact, and skill sections in canonical order", async function _assembles()

--- a/libs/backend/agents/runtime/prompt-compiler/main/src/prompt-compiler.ts
+++ b/libs/backend/agents/runtime/prompt-compiler/main/src/prompt-compiler.ts
@@ -109,6 +109,7 @@ function _resolveBudget(budgetPolicy: JsonValue): CompiledBudget
 {
 	const policy: { readonly [key: string]: JsonValue } = budgetPolicy && typeof budgetPolicy === "object" && !Array.isArray(budgetPolicy) ? budgetPolicy as { readonly [key: string]: JsonValue } : {};
 	return {
+		maxTurns: _optionalCount(policy["maxTurns"]),
 		maxTotalTokens: _optionalCount(policy["maxTotalTokens"]),
 		maxCostUsdMicros: _optionalCount(policy["maxCostUsdMicros"]),
 		maxToolInvocations: _optionalCount(policy["maxToolInvocations"]),

--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -37,7 +37,8 @@ Two halves:
 
 Invariant: the client's types are a faithful projection of the server's published spec — regenerate
 after any API change so the two never silently diverge. `RunInputSnapshot` is the cross-domain
-record of one run's frozen persona, transcript, memory references, tools, budgets, model route and
+record of one run's frozen persona, transcript, memory references, tools, budgets (turn, token,
+cost, tool, and time ceilings), model route and
 verified identity provenance; it carries only immutable coordinates and canonical JSON, never
 provider credentials or mutable source objects.
 

--- a/libs/contracts/src/compiled-run-input.types.ts
+++ b/libs/contracts/src/compiled-run-input.types.ts
@@ -67,6 +67,8 @@ export interface CompiledModelRoute
 /** Literal aggregate limits OpenCrane enforces over the bounded loop. */
 export interface CompiledBudget
 {
+	/** Maximum model turns across the attempt, or null when uncapped. */
+	readonly maxTurns: number | null;
 	/** Maximum total tokens across the attempt, or null when uncapped. */
 	readonly maxTotalTokens: number | null;
 	/** Maximum spend in micro-US-dollars across the attempt, or null when uncapped. */


### PR DESCRIPTION
## Context

A saved agent revision is only useful as an operational control if the run receives exactly those limits at the final admission boundary. This PR connects the immutable revision budget to the frozen snapshot and then to the signed runtime start-attempt input.

## What changed

- add `PrismaRevisionBudgetPolicySource`, which locks and rereads the exact published revision within the admission transaction
- refuse absent, incomplete, non-published, foreign-silo, or overflowed budget data with `budget_unavailable`
- freeze turn, token, USD-micro cost and wall-clock deadline into `RunInputSnapshot.budgetPolicy`; tool-call ceiling remains explicitly null until a revision contract owns it
- carry `maxTurns` through the compiled runtime contract, prompt compiler, and start-attempt payload

## Safety behaviour

No default budget is inferred. A malformed revision cannot admit a run. The deadline is calculated once from the admission timestamp plus the revision duration and rejected on integer overflow.

## Validation

- execution inputs: 23 tests + TypeScript check
- prompt compiler: 10 tests + TypeScript check
- execution protocol: 50 tests + TypeScript check
- contracts: TypeScript check
- style and whitespace checks

## Review

Independent review caught that the first version dropped `maxTurns` at compilation. This PR carries it through the compiled input and was re-reviewed clean.