### PR TITLE
🧠 Phase E: freeze personal memory facts at admission

### DIFF
--- a/libs/backend/agents/personal/memory/main/README.md
+++ b/libs/backend/agents/personal/memory/main/README.md
@@ -46,6 +46,9 @@ idempotency key, while a retired dataset or a conflicting correction fails close
 - `MemoryFactSource` — the one-of-three provenance reference (artifact revision · message · explicit statement).
 - `AtomicRecordMemoryFactResult` — the raw persistence outcome the repository returns.
 - `MemoryCatalogRepository` — the persistence port a caller must implement (or inject).
+- `PrismaMemoryScopeSource` — the admission-time adapter that freezes only active, consented facts
+  recorded by the personal-run owner. Its policy is explicitly `pinned-only`: this slice never gives
+  the runtime a broad dataset search capability.
 
 ## Boundary
 

--- a/libs/backend/agents/personal/memory/main/src/__tests__/prisma-memory-scope-source.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/__tests__/prisma-memory-scope-source.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaMemoryScopeSource } from "../prisma-memory-scope-source.js";
+
+describe("PrismaMemoryScopeSource", function _describeMemoryScope()
+{
+	it("freezes only the caller's active consented facts into a pinned-only policy", async function _loadsPersonalFacts()
+	{
+		const findMany = vi.fn().mockResolvedValue([{ id: "fact-1", datasetId: "dataset-1", contentDigest: `sha256:${"a".repeat(64)}`, sourceArtifactRevisionId: null, sourceMessageId: "message-1", recordedAt: new Date("2026-07-24T00:00:00.000Z") }]);
+		const result = await new PrismaMemoryScopeSource().load({ siloId: "silo-1", executionSubjectId: "user-1" } as never, { agentKind: "personal" } as never, { prisma: { memoryFactCatalog: { findMany } } } as never);
+		expect(result).toEqual({ outcome: "loaded", value: { memoryFacts: [{ datasetId: "dataset-1", factId: "fact-1", contentDigest: `sha256:${"a".repeat(64)}`, provenance: [{ sourceKind: "message", sourceId: "message-1", capturedAt: "2026-07-24T00:00:00.000Z" }] }], memoryQueryPolicy: { mode: "pinned-only", datasetIds: ["dataset-1"] } } });
+		expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ recordedBy: "user-1", dataset: expect.objectContaining({ scopeKind: "Personal", scopeResourceId: "user-1" }) }) }));
+	});
+
+	it("gives managed work no personal facts or broad retrieval authority", async function _emptiesManagedScope()
+	{
+		expect(await new PrismaMemoryScopeSource().load({} as never, { agentKind: "managed" } as never, {} as never)).toEqual({ outcome: "loaded", value: { memoryFacts: [], memoryQueryPolicy: { mode: "pinned-only", datasetIds: [] } } });
+	});
+});

--- a/libs/backend/agents/personal/memory/main/src/index.ts
+++ b/libs/backend/agents/personal/memory/main/src/index.ts
@@ -1,2 +1,3 @@
 export { __RecordMemoryFact } from "./memory-catalog.js";
+export { PrismaMemoryScopeSource } from "./prisma-memory-scope-source.js";
 export type { AtomicRecordMemoryFactResult, MemoryCatalogRepository, MemoryFactSource, RecordMemoryFactCommand, RecordMemoryFactResult } from "./memory-catalog.types.js";

--- a/libs/backend/agents/personal/memory/main/src/prisma-memory-scope-source.ts
+++ b/libs/backend/agents/personal/memory/main/src/prisma-memory-scope-source.ts
@@ -1,0 +1,38 @@
+import { AuthorizationScopeKind, MemoryConsentState, MemoryDatasetState, MemoryFactState } from "@prisma/client";
+import type { MemoryFactReference } from "@opencrane/contracts";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+import type { MemoryScopeInput, MemoryScopeSource, SessionAssemblyCommand, SessionAssemblyLoad } from "@opencrane/backend/agents/execution/inputs";
+
+/** Freezes only active, consented personal facts into a personal run's immutable input snapshot. */
+export class PrismaMemoryScopeSource implements MemoryScopeSource
+{
+	/** Loads same-silo facts recorded by the execution subject and forbids broad runtime retrieval. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<MemoryScopeInput>>
+	{
+		// 1. Managed work has no personal-memory authority in this first target slice.
+		if (run.agentKind !== "personal") return { outcome: "loaded", value: { memoryFacts: [], memoryQueryPolicy: { mode: "pinned-only", datasetIds: [] } } };
+
+		// 2. Select only facts that are active, consented, in this silo, and personally recorded.
+		const rows = await transaction.prisma.memoryFactCatalog.findMany({
+			where: {
+				recordedBy: command.executionSubjectId,
+				state: MemoryFactState.Active,
+				consentState: { in: [MemoryConsentState.Explicit, MemoryConsentState.Confirmed] },
+				dataset: { siloId: command.siloId, state: MemoryDatasetState.Active, scopeKind: AuthorizationScopeKind.Personal, scopeResourceId: command.executionSubjectId },
+			},
+			select: { id: true, datasetId: true, contentDigest: true, sourceArtifactRevisionId: true, sourceMessageId: true, recordedAt: true },
+			orderBy: [{ datasetId: "asc" }, { id: "asc" }],
+		});
+
+		// 3. Rebuild typed provenance from immutable coordinates; no raw catalog JSON reaches the runtime.
+		const memoryFacts = rows.map(function _toReference(row): MemoryFactReference
+		{
+			const capturedAt = row.recordedAt.toISOString();
+			if (row.sourceArtifactRevisionId !== null) return { datasetId: row.datasetId, factId: row.id, contentDigest: row.contentDigest, provenance: [{ sourceKind: "artifact", sourceId: row.sourceArtifactRevisionId, artifactRevisionId: row.sourceArtifactRevisionId, capturedAt }] };
+			if (row.sourceMessageId !== null) return { datasetId: row.datasetId, factId: row.id, contentDigest: row.contentDigest, provenance: [{ sourceKind: "message", sourceId: row.sourceMessageId, capturedAt }] };
+			return { datasetId: row.datasetId, factId: row.id, contentDigest: row.contentDigest, provenance: [{ sourceKind: "explicit-user-fact", sourceId: row.id, sourceUserId: command.executionSubjectId, capturedAt }] };
+		});
+		const datasetIds = [...new Set(memoryFacts.map(function _datasetId(fact): string { return fact.datasetId; }))];
+		return { outcome: "loaded", value: { memoryFacts, memoryQueryPolicy: { mode: "pinned-only", datasetIds } } };
+	}
+}


### PR DESCRIPTION
## Why

Run input must include only durable memory that the personal agent is actually authorised to use. A catalog recording principal alone is not an access boundary: the dataset itself must be personal and owned by the execution subject.

## What changed

- adds `PrismaMemoryScopeSource` for the session-assembly `MemoryScopeSource` port
- selects only active, consented facts recorded by the execution subject in an active personal dataset owned by that same subject
- reconstructs typed provenance from immutable source coordinates rather than passing raw catalog JSON to the runtime
- produces an explicit `pinned-only` policy with sorted dataset identifiers; it never grants broad memory retrieval
- returns an empty personal-memory scope for managed runs

## Safety

The dataset predicate requires the exact `Personal` scope and `scopeResourceId == executionSubjectId`. This closes same-silo organisation/team/project dataset leakage; `recordedBy` is provenance, not authority.

## Validation

- `npx nx run backend-agents-personal-memory:lint`
- `npx nx run backend-agents-personal-memory:test` — 4 passed
- `bash scripts/agent-style-check.sh`
- `git diff --check`

## Review

Independent review found and then verified the dataset-scope fence. Final review: PASS.