### PR TITLE
🔐 Phase E: route revision tools through Obot custody

### DIFF
--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -27,6 +27,8 @@ import { __IsUpgradeSessionAvailable, PrismaPersonalConfigurationChangeRepositor
 import { __AppendCompiledTool } from "@opencrane/backend/agents/runtime/prompt-compiler";
 import { PrismaRuntimeBootstrapExchange, PrismaToolInvocationRepository, __CreateRuntimeBootstrapRouter, __DeferToolRequest } from "@opencrane/backend/server/iam/authorization";
 import { __UnavailableObotCustodyAdapter } from "@opencrane/server/_infra/obot-custody";
+import { __UnavailableObotMcpInvocationAdapter } from "@opencrane/server/_infra/obot-custody";
+import { PrismaIntegrationAuthorityRepository, __SystemIntegrationAuthorityClock } from "@opencrane/backend/server/gateways/integrations";
 import { __UnavailableSandboxJobExecutor } from "@opencrane/server/_infra/sandbox-execution";
 import { __UnavailableMemoryGatewayClient } from "@opencrane/server/_infra/memory-gateway-client";
 import { __CreateConversationReplayRouter, PrismaConversationReplayRepository } from "@opencrane/backend/server/agents/conversation-replay";
@@ -184,6 +186,8 @@ function _CreateExternalActionRunner(prisma: PrismaClient): RuntimeExternalActio
 	const repository = new PrismaToolInvocationRepository(prisma);
 	const personalConfiguration = new PrismaPersonalConfigurationChangeRepository(prisma);
 	const obotCustody = new __UnavailableObotCustodyAdapter();
+	const obotMcpInvocation = new __UnavailableObotMcpInvocationAdapter();
+	const integrations = new PrismaIntegrationAuthorityRepository(prisma, new __SystemIntegrationAuthorityClock());
 	const sandboxExecutor = new __UnavailableSandboxJobExecutor();
 	const memoryGateway = new __UnavailableMemoryGatewayClient();
 	return {
@@ -197,7 +201,7 @@ function _CreateExternalActionRunner(prisma: PrismaClient): RuntimeExternalActio
 			{
 				executor = candidate.toolRevisionId === UPGRADE_SESSION_TOOL_REVISION
 					? { execute: function _proposeUpgradeSession() { return personalConfiguration.proposeUpgradeSession(candidate, snapshot, new Date().toISOString()); } }
-					: __CreateExternalActionExecutor(candidate, { siloId: snapshot.siloId, subjectId: snapshot.identitySnapshot.executionSubjectId, obotCustody, sandboxExecutor, memoryGateway });
+					: __CreateExternalActionExecutor(candidate, { siloId: snapshot.siloId, subjectId: snapshot.identitySnapshot.executionSubjectId, agentRevisionId: snapshot.agentRevisionId, integrations, obotMcpInvocation, obotCustody, sandboxExecutor, memoryGateway });
 			}
 			catch (error)
 			{

--- a/libs/backend/agents/execution/protocol/src/__tests__/external-action-executor.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/external-action-executor.test.ts
@@ -1,5 +1,5 @@
 import type { RuntimeExternalActionCandidate } from "@opencrane/contracts";
-import { __UnavailableObotCustodyAdapter } from "@opencrane/server/_infra/obot-custody";
+import { __FakeObotMcpInvocationAdapter, __UnavailableObotCustodyAdapter, __UnavailableObotMcpInvocationAdapter } from "@opencrane/server/_infra/obot-custody";
 import { __UnavailableSandboxJobExecutor } from "@opencrane/server/_infra/sandbox-execution";
 import { __UnavailableMemoryGatewayClient } from "@opencrane/server/_infra/memory-gateway-client";
 import { describe, expect, it } from "vitest";
@@ -13,7 +13,7 @@ function _candidate(toolRevisionId: string): RuntimeExternalActionCandidate
 }
 
 /** The composition root wires only fail-closed transports until a real one is verified. */
-const DEPENDENCIES = { siloId: "silo-1", subjectId: "user-1", obotCustody: new __UnavailableObotCustodyAdapter(), sandboxExecutor: new __UnavailableSandboxJobExecutor(), memoryGateway: new __UnavailableMemoryGatewayClient() };
+const DEPENDENCIES = { siloId: "silo-1", subjectId: "user-1", agentRevisionId: "revision-1", integrations: { resolveAssignment: async function _resolve() { return { outcome: "resolved" as const, assignment: { integrationId: "calendar", obotCatalogEntryId: "calendar", obotCustodyReference: "obot:calendar", allowedTools: ["calendar.read"] } }; } }, obotMcpInvocation: new __UnavailableObotMcpInvocationAdapter(), obotCustody: new __UnavailableObotCustodyAdapter(), sandboxExecutor: new __UnavailableSandboxJobExecutor(), memoryGateway: new __UnavailableMemoryGatewayClient() };
 
 describe("composition-root external action executor", function _suite()
 {
@@ -21,6 +21,12 @@ describe("composition-root external action executor", function _suite()
 	{
 		const executor = __CreateExternalActionExecutor(_candidate("mcp-server:server-1"), DEPENDENCIES);
 		await expect(executor.execute()).rejects.toThrow(/Obot custody authority is unavailable/);
+	});
+
+	it("resolves a revision integration and invokes only its allowed tool through Obot", async function _integration()
+	{
+		const executor = __CreateExternalActionExecutor(_candidate("integration:calendar:calendar.read"), { ...DEPENDENCIES, obotMcpInvocation: new __FakeObotMcpInvocationAdapter({ content: { result: "ok" } }) });
+		await expect(executor.execute()).resolves.toEqual({ result: "ok" });
 	});
 
 	it("fails closed for a sandbox tool call when no sandbox transport is available", async function _sandbox()

--- a/libs/backend/agents/execution/protocol/src/external-action-executor.ts
+++ b/libs/backend/agents/execution/protocol/src/external-action-executor.ts
@@ -23,6 +23,14 @@ function _stringArgument(candidate: RuntimeExternalActionCandidate, key: string)
 	return typeof value === "string" ? value : null;
 }
 
+/** Parse the exact integration/tool identity minted by the target prompt compiler. */
+function _integrationTool(toolRevisionId: string): { readonly integrationId: string; readonly toolName: string } | null
+{
+	const parts = toolRevisionId.split(":");
+	if (parts.length !== 3 || parts[0] !== "integration" || !parts[1] || !parts[2]) return null;
+	return { integrationId: parts[1], toolName: parts[2] };
+}
+
 /**
  * Build the concrete external-action executor for one admitted candidate, in the composition root.
  *
@@ -44,6 +52,14 @@ export function __CreateExternalActionExecutor(candidate: RuntimeExternalActionC
 		async execute(): Promise<JsonValue>
 		{
 			const toolRevisionId = candidate.toolRevisionId;
+			const integrationTool = _integrationTool(toolRevisionId);
+			if (integrationTool !== null)
+			{
+				const resolved = await dependencies.integrations.resolveAssignment({ siloId: dependencies.siloId, agentRevisionId: dependencies.agentRevisionId, integrationId: integrationTool.integrationId });
+				if (resolved.outcome !== "resolved") throw new UnsupportedExternalActionError(toolRevisionId);
+				const result = await dependencies.obotMcpInvocation.invokeTool({ siloId: dependencies.siloId, integrationId: resolved.assignment.integrationId, obotCustodyReference: resolved.assignment.obotCustodyReference, toolName: integrationTool.toolName, arguments: candidate.arguments, allowedTools: resolved.assignment.allowedTools });
+				return result.content;
+			}
 			if (toolRevisionId.startsWith("mcp-server:"))
 			{
 				// An MCP tool call needs Obot-held custody first; the unavailable adapter fails closed here.

--- a/libs/backend/agents/execution/protocol/src/external-action-executor.types.ts
+++ b/libs/backend/agents/execution/protocol/src/external-action-executor.types.ts
@@ -1,6 +1,8 @@
 import type { ObotCustodyPort } from "@opencrane/server/_infra/obot-custody";
+import type { ObotMcpInvocationPort } from "@opencrane/server/_infra/obot-custody";
 import type { SandboxJobExecutor } from "@opencrane/server/_infra/sandbox-execution";
 import type { MemoryGatewayClient } from "@opencrane/server/_infra/memory-gateway-client";
+import type { IntegrationAuthorityRepository } from "@opencrane/backend/server/gateways/integrations";
 
 /** Concrete transport ports the composition root injects into the external-action router. */
 export interface ExternalActionExecutorDependencies
@@ -9,6 +11,12 @@ export interface ExternalActionExecutorDependencies
 	readonly siloId: string;
 	/** Subject on whose behalf the action runs. */
 	readonly subjectId: string;
+	/** Immutable revision whose integration assignment the action must resolve through. */
+	readonly agentRevisionId: string;
+	/** Credential-free authority resolving an active revision integration assignment. */
+	readonly integrations: IntegrationAuthorityRepository;
+	/** Obot MCP invocation transport enforcing the resolved assignment's allow-list. */
+	readonly obotMcpInvocation: ObotMcpInvocationPort;
 	/** Obot credential-custody transport backing MCP tool calls (fail-closed until verified). */
 	readonly obotCustody: ObotCustodyPort;
 	/** Sandbox Job transport backing sandboxed tool calls (fail-closed until verified). */


### PR DESCRIPTION
## Why

A runtime tool candidate must resolve through its immutable AgentRevision integration assignment, not the unrelated MCP catalogue grant model.

## What changed

- adds integration-prefixed tool routing in the external-action executor
- resolves the same-silo active revision assignment through the credential-free integration authority
- invokes Obot with only the opaque custody reference and immutable allow-list
- composes the Prisma resolver while retaining the unavailable invocation adapter until live Obot verification
- adds focused integration routing coverage

## Safety

The candidate is bound to the snapshot compiled tool set, then the resolver independently rechecks the revision, silo, integration state, custody state and expiry, and allow-list. No provider credential crosses this path.

## Validation

- protocol lint and 51 tests
- OpenCrane typecheck including Prisma generation
- style and diff checks

## Review

Independent repository review: PASS.