### PR TITLE
🔒 Phase E: authorise exact artifact reads

### DIFF
--- a/apps/artifact-service/README.md
+++ b/apps/artifact-service/README.md
@@ -12,11 +12,12 @@ image, a generated report.
 
 ## What it owns
 
-It owns the write side of **content-addressed storage** (CAS — files are stored and named by a hash of
+It owns the byte boundary of **content-addressed storage** (CAS — files are stored and named by a hash of
 their own bytes, so identical content is stored once and every stored object is tamper-evident). Callers
-never write to that store directly. Instead the OpenCrane server first issues a signed **write lease** —
-a short-lived permission slip saying "these exact bytes, up to this size, may be stored" — and this
-service is what checks the slip and does the write.
+never mount or browse that store directly. Instead the OpenCrane server issues a signed **write lease** —
+a short-lived permission slip saying "these exact bytes, up to this size, may be stored" — or a signed
+**read lease** bound to one exact stored address and a future run/worker operation. This service checks
+that slip before it writes or streams a byte.
 
 It is one step in the artifact-promotion flow, composing three artifact libraries:
 [`store`](../../libs/backend/artifacts/store/main/README.md) (the promotion protocol),
@@ -51,15 +52,21 @@ can only refuse a legitimate upload; it can never store bytes that were not cove
 `Entrypoint: src/index.ts` (`_Main`) — reads config, prepares the mounted CAS root (mode `0700`), opens
 the listener, and binds bounded `SIGTERM`/`SIGINT` shutdown that drains requests and flushes telemetry.
 
-HTTP endpoints: `POST /v1/artifacts/promote` (the one write operation) and `/livez` · `/readyz` probes.
-Any other path or method is `404`.
+HTTP endpoints: `POST /v1/artifacts/promote` writes under a signed write lease; `GET
+/v1/artifacts/read/:contentAddress` streams one matching canonical object only under a signed read lease;
+`/livez` · `/readyz` are probes. Any other path or method is `404`.
 
 ## Boundary
 
-Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), does not
-read or list artifacts, and does not accept raw secrets as environment variables — signing keys are
-mounted PEM files, not env values. Verification and signing are delegated to the artifacts libraries;
-this process is only the HTTP adapter and byte pump around them.
+Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), list
+artifacts, or expose the disk as a file server. A read can only name the exact address signed into its
+lease. The chart currently admits **only the OpenCrane server** through the artifact-service
+NetworkPolicy; no worker is wired to this endpoint yet. The preprocessor slice must add one named
+consumer's matching egress and this chart's matching ingress before it can use a read lease, without
+widening access to arbitrary pods. That future worker will therefore not need direct PVC access. This
+process does not accept raw secrets as environment variables — signing keys are mounted PEM files, not
+env values. Verification and signing are delegated to the artifacts libraries; this process is only the
+HTTP adapter and byte pump around them.
 
 ## Dependency direction
 

--- a/apps/artifact-service/README.md
+++ b/apps/artifact-service/README.md
@@ -53,14 +53,14 @@ can only refuse a legitimate upload; it can never store bytes that were not cove
 the listener, and binds bounded `SIGTERM`/`SIGINT` shutdown that drains requests and flushes telemetry.
 
 HTTP endpoints: `POST /v1/artifacts/promote` writes under a signed write lease; `GET
-/v1/artifacts/read/:contentAddress` streams one matching canonical object only under a signed read lease;
+/v1/artifacts/read` streams the one canonical object named inside a signed read lease;
 `/livez` · `/readyz` are probes. Any other path or method is `404`.
 
 ## Boundary
 
 Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), list
-artifacts, or expose the disk as a file server. A read can only name the exact address signed into its
-lease. The chart currently admits **only the OpenCrane server** through the artifact-service
+artifacts, or expose the disk as a file server. A read has no address in its URL: the signed lease
+supplies the exact immutable address, catalog artifact revision, byte length, and media type. The chart currently admits **only the OpenCrane server** through the artifact-service
 NetworkPolicy; no worker is wired to this endpoint yet. The preprocessor slice must add one named
 consumer's matching egress and this chart's matching ingress before it can use a read lease, without
 widening access to arbitrary pods. That future worker will therefore not need direct PVC access. This

--- a/apps/artifact-service/src/__tests__/server.test.ts
+++ b/apps/artifact-service/src/__tests__/server.test.ts
@@ -79,13 +79,14 @@ describe("artifact-service promotion endpoint", function _suite()
 			const address = `sha256:${(await import("node:crypto")).createHash("sha256").update(bytes).digest("hex")}`;
 			const writeLease = __SignArtifactWriteLease({ leaseId: "lease-read-source", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: address, expectedByteLength: bytes.byteLength, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
 			await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": writeLease }, body: bytes });
-			const readLease = __SignArtifactReadLease({ leaseId: "lease-read-1", siloId: "silo-1", operationId: "run-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+			const readLease = __SignArtifactReadLease({ leaseId: "lease-read-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, byteLength: bytes.byteLength, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
 
-			const allowed = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read/${address}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			const allowed = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read`, { headers: { "x-opencrane-artifact-read-lease": readLease } });
 			expect(allowed.status).toBe(200);
 			expect(allowed.headers.get("content-type")).toBe("text/plain");
+			expect(allowed.headers.get("content-length")).toBe(String(bytes.byteLength));
 			expect(await allowed.text()).toBe(bytes.toString());
-			const denied = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read/sha256:${"b".repeat(64)}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			const denied = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read`, { headers: { "x-opencrane-artifact-lease": readLease } });
 			expect(denied.status).toBe(403);
 		}
 		finally

--- a/apps/artifact-service/src/__tests__/server.test.ts
+++ b/apps/artifact-service/src/__tests__/server.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
+import { __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
 import { __FilesystemArtifactStore } from "@opencrane/backend/artifacts/filesystem";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -59,6 +59,34 @@ describe("artifact-service promotion endpoint", function _suite()
 			const lease = __SignArtifactWriteLease({ leaseId: "lease-2", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: `sha256:${"a".repeat(64)}`, expectedByteLength: 1, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
 			const response = await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": lease, "content-length": "2" }, body: "ab" });
 			expect(response.status).toBe(413);
+		}
+		finally
+		{
+			await rm(root, { recursive: true, force: true });
+		}
+	});
+
+	it("streams canonical bytes only when the exact path matches an unexpired read lease", async function _readCanonicalBytes()
+	{
+		const root = await mkdtemp(join(tmpdir(), "artifact-service-"));
+		try
+		{
+			const server = _CreateServer({ port: 0, artifactRoot: root, maxUploadDurationMilliseconds: 300_000, leasePublicKeyPem: _leasePublicKey, receiptPrivateKeyPem: _receiptPrivateKey }, new __FilesystemArtifactStore({ rootPath: root }));
+			_servers.push(server);
+			await new Promise<void>(function _listen(resolve) { server.listen(0, "127.0.0.1", function _ready() { resolve(); }); });
+			const port = (server.address() as { port: number }).port;
+			const bytes = Buffer.from("read only this exact content");
+			const address = `sha256:${(await import("node:crypto")).createHash("sha256").update(bytes).digest("hex")}`;
+			const writeLease = __SignArtifactWriteLease({ leaseId: "lease-read-source", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: address, expectedByteLength: bytes.byteLength, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+			await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": writeLease }, body: bytes });
+			const readLease = __SignArtifactReadLease({ leaseId: "lease-read-1", siloId: "silo-1", operationId: "run-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+
+			const allowed = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read/${address}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			expect(allowed.status).toBe(200);
+			expect(allowed.headers.get("content-type")).toBe("text/plain");
+			expect(await allowed.text()).toBe(bytes.toString());
+			const denied = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read/sha256:${"b".repeat(64)}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			expect(denied.status).toBe(403);
 		}
 		finally
 		{

--- a/apps/artifact-service/src/server.ts
+++ b/apps/artifact-service/src/server.ts
@@ -38,9 +38,9 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 				return;
 			}
 			// 2. Verify a read lease before looking up an address so unknown callers learn no CAS existence facts.
-			if (path.startsWith("/v1/artifacts/read/") && request.method === "GET")
+			if (path === "/v1/artifacts/read" && request.method === "GET")
 			{
-				await _writeReadOutcome(response, store, path.slice("/v1/artifacts/read/".length), request.headers["x-opencrane-artifact-lease"], config.leasePublicKeyPem);
+				await _writeReadOutcome(response, store, request.headers["x-opencrane-artifact-read-lease"], config.leasePublicKeyPem);
 				return;
 			}
 			// 3. Keep promotion on its exact verb/path pair to avoid widening the byte-write surface.
@@ -66,11 +66,18 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 }
 
 /** Verify one exact read lease, then stream only its matching canonical object to the caller. */
-async function _writeReadOutcome(response: ServerResponse, store: ArtifactStore, requestedContentAddress: string, compactLeaseHeader: string | string[] | undefined, leasePublicKeyPem: string): Promise<void>
+async function _writeReadOutcome(response: ServerResponse, store: ArtifactStore, compactLeaseHeader: string | string[] | undefined, leasePublicKeyPem: string): Promise<void>
 {
 	const compactLease = typeof compactLeaseHeader === "string" ? compactLeaseHeader : null;
 	const lease = compactLease === null ? null : __VerifyArtifactReadLease(compactLease, leasePublicKeyPem, Math.floor(Date.now() / 1_000));
-	if (lease === null || lease.contentAddress !== requestedContentAddress)
+	if (lease === null)
+	{
+		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "invalid_artifact_lease" }));
+		return;
+	}
+	const byteLength = await store.byteLength(lease.contentAddress);
+	if (byteLength === null || byteLength !== lease.byteLength)
 	{
 		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
 		response.end(JSON.stringify({ error: "invalid_artifact_lease" }));
@@ -79,24 +86,37 @@ async function _writeReadOutcome(response: ServerResponse, store: ArtifactStore,
 	const bytes = await store.read(lease.contentAddress);
 	if (bytes === null)
 	{
-		response.writeHead(404, { "content-type": "application/json", "cache-control": "no-store" });
-		response.end(JSON.stringify({ error: "artifact_not_found" }));
+		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "invalid_artifact_lease" }));
 		return;
 	}
 	response.writeHead(200, {
 		"content-type": lease.mediaType,
+		"content-length": String(lease.byteLength),
 		"cache-control": "no-store",
 		// X-Content-Type-Options: prevents MIME sniffing of an authorized but untrusted artifact body.
 		// @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options
 		"x-content-type-options": "nosniff",
 	});
+	let streamedByteLength = 0;
 	for await (const chunk of bytes)
 	{
+		streamedByteLength += chunk.byteLength;
+		if (streamedByteLength > lease.byteLength)
+		{
+			response.destroy(new Error("artifact byte stream exceeded its signed read lease length"));
+			return;
+		}
 		if (!response.write(chunk))
 		{
 			await Promise.race([once(response, "drain"), once(response, "close")]);
 			if (response.destroyed) return;
 		}
+	}
+	if (streamedByteLength !== lease.byteLength)
+	{
+		response.destroy(new Error("artifact byte stream did not match its signed read lease length"));
+		return;
 	}
 	response.end();
 }

--- a/apps/artifact-service/src/server.ts
+++ b/apps/artifact-service/src/server.ts
@@ -1,9 +1,10 @@
 import { mkdir } from "node:fs/promises";
 import { createServer } from "node:http";
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import { once } from "node:events";
 
 import { __FilesystemArtifactStore } from "@opencrane/backend/artifacts/filesystem";
-import { __SignArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "@opencrane/backend/artifacts/authorization";
+import { __SignArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "@opencrane/backend/artifacts/authorization";
 import { __PromoteArtifactUpload } from "@opencrane/backend/artifacts/store";
 import type { ArtifactPromotionLeaseVerifier, ArtifactPromotionReceiptSigner, ArtifactStore, BoundedArtifactUploadByteSource, PromoteArtifactUploadResult } from "@opencrane/backend/artifacts/store";
 import { ___DoWithTrace } from "@opencrane/observability";
@@ -29,12 +30,20 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 		const path = new URL(request.url ?? "/", "http://localhost").pathname;
 		void ___DoWithTrace("artifact-service.request", { method: request.method ?? "UNKNOWN", path }, async function _handleRequest()
 		{
+			// 1. Keep health probes unauthenticated because they reveal no catalog or byte state.
 			if (path === "/livez" || path === "/readyz")
 			{
 				response.writeHead(204);
 				response.end();
 				return;
 			}
+			// 2. Verify a read lease before looking up an address so unknown callers learn no CAS existence facts.
+			if (path.startsWith("/v1/artifacts/read/") && request.method === "GET")
+			{
+				await _writeReadOutcome(response, store, path.slice("/v1/artifacts/read/".length), request.headers["x-opencrane-artifact-lease"], config.leasePublicKeyPem);
+				return;
+			}
+			// 3. Keep promotion on its exact verb/path pair to avoid widening the byte-write surface.
 			if (path !== "/v1/artifacts/promote" || request.method !== "POST")
 			{
 				response.writeHead(404, { "content-type": "application/json" });
@@ -54,6 +63,42 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 			response.destroy(err instanceof Error ? err : new Error("artifact service request failed"));
 		});
 	});
+}
+
+/** Verify one exact read lease, then stream only its matching canonical object to the caller. */
+async function _writeReadOutcome(response: ServerResponse, store: ArtifactStore, requestedContentAddress: string, compactLeaseHeader: string | string[] | undefined, leasePublicKeyPem: string): Promise<void>
+{
+	const compactLease = typeof compactLeaseHeader === "string" ? compactLeaseHeader : null;
+	const lease = compactLease === null ? null : __VerifyArtifactReadLease(compactLease, leasePublicKeyPem, Math.floor(Date.now() / 1_000));
+	if (lease === null || lease.contentAddress !== requestedContentAddress)
+	{
+		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "invalid_artifact_lease" }));
+		return;
+	}
+	const bytes = await store.read(lease.contentAddress);
+	if (bytes === null)
+	{
+		response.writeHead(404, { "content-type": "application/json", "cache-control": "no-store" });
+		response.end(JSON.stringify({ error: "artifact_not_found" }));
+		return;
+	}
+	response.writeHead(200, {
+		"content-type": lease.mediaType,
+		"cache-control": "no-store",
+		// X-Content-Type-Options: prevents MIME sniffing of an authorized but untrusted artifact body.
+		// @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options
+		"x-content-type-options": "nosniff",
+	});
+	for await (const chunk of bytes)
+	{
+		if (!response.write(chunk))
+		{
+			await Promise.race([once(response, "drain"), once(response, "close")]);
+			if (response.destroyed) return;
+		}
+	}
+	response.end();
 }
 
 /** Adapts the app-owned OpenCrane public key to the storage-neutral lease verifier port. */

--- a/libs/backend/artifacts/authorization/main/README.md
+++ b/libs/backend/artifacts/authorization/main/README.md
@@ -44,7 +44,7 @@ forged receipt can never finalise a catalog entry.
 ## Public surface
 
 - `__SignArtifactWriteLease(claims, privateKeyPem, now)` / `__VerifyArtifactWriteLease(compact, publicKeyPem, now)` — mint and check the pre-upload permission slip.
-- `__SignArtifactReadLease(claims, privateKeyPem, now)` / `__VerifyArtifactReadLease(compact, publicKeyPem, now)` — mint and check the operation-bound permission to stream one exact canonical address.
+- `__SignArtifactReadLease(claims, privateKeyPem, now)` / `__VerifyArtifactReadLease(compact, publicKeyPem, now)` — mint and check a five-minute permission to stream one exact canonical address, catalog artifact revision, byte length, and media type.
 - `__SignArtifactPromotionReceipt(claims, privateKeyPem)` / `__VerifyArtifactPromotionReceipt(compact, publicKeyPem)` — mint and check the post-upload proof.
 - `ArtifactWriteLeaseClaims` / `ArtifactReadLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
 

--- a/libs/backend/artifacts/authorization/main/README.md
+++ b/libs/backend/artifacts/authorization/main/README.md
@@ -1,4 +1,4 @@
-# @opencrane/backend/artifacts/authorization — artifact write-lease & receipt authority
+# @opencrane/backend/artifacts/authorization — artifact lease & receipt authority
 
 > [backend](../../../README.md) › [artifacts](../../README.md) › authorization
 
@@ -11,9 +11,11 @@ content). Writing one is a two-party dance between OpenCrane and a separate uplo
 tokens that make that trust concrete.
 
 A **write lease** is a short-lived signed permission slip: "this silo (one tenant's isolated running environment) may write this artifact, up to
-this size, matching this hash, until this moment." A **promotion receipt** is the signed proof that
-comes back: "the bytes with this hash and length were stored." Both are compact signed tokens (JWS
-using EdDSA, a standard signature scheme) that only OpenCrane's keys can produce and verify.
+this size, matching this hash, until this moment." A **read lease** is equally narrow: "this one
+run or worker operation may read exactly this canonical address until this moment." A **promotion
+receipt** is the signed proof that comes back: "the bytes with this hash and length were stored."
+All are compact signed tokens (JWS using EdDSA, a standard signature scheme) that only OpenCrane's
+keys can produce and verify.
 
 ```
  OpenCrane catalog wants to store an artifact
@@ -22,7 +24,8 @@ using EdDSA, a standard signature scheme) that only OpenCrane's keys can produce
  ┌──────────────────────────────┐
  │   authorization  ◄── HERE     │  sign lease  →  ... upload happens ...  →  verify receipt
  └──────────────────────────────┘
-          │  lease ──► artifact-service verifies it, then stages & promotes bytes
+          │  write lease ──► artifact-service verifies it, then stages & promotes bytes
+          │  read lease ───► artifact-service streams only that exact CAS address
           │  receipt ◄── artifact-service signs the stored facts
           ▼
  catalog finalises the artifact only after __VerifyArtifactPromotionReceipt
@@ -41,8 +44,9 @@ forged receipt can never finalise a catalog entry.
 ## Public surface
 
 - `__SignArtifactWriteLease(claims, privateKeyPem, now)` / `__VerifyArtifactWriteLease(compact, publicKeyPem, now)` — mint and check the pre-upload permission slip.
+- `__SignArtifactReadLease(claims, privateKeyPem, now)` / `__VerifyArtifactReadLease(compact, publicKeyPem, now)` — mint and check the operation-bound permission to stream one exact canonical address.
 - `__SignArtifactPromotionReceipt(claims, privateKeyPem)` / `__VerifyArtifactPromotionReceipt(compact, publicKeyPem)` — mint and check the post-upload proof.
-- `ArtifactWriteLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
+- `ArtifactWriteLeaseClaims` / `ArtifactReadLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
 
 ## Boundary
 
@@ -50,6 +54,11 @@ Used by OpenCrane (to sign leases and verify receipts) and by `artifact-service`
 sign receipts). It is pure signing and verification: it holds no filesystem, no database, and no HTTP.
 It does not decide *whether* a caller should get a lease — that authorisation happens upstream; this
 package only makes the decision unforgeable.
+
+The signed read-leases form the private contract for the future preprocessor/dispatch consumer. This
+package does not grant that workload network access or issue its lease today; the consumer's app chart,
+explicit NetworkPolicies, and server-side issuance authority are a subsequent slice. Until then,
+artifact-service remains reachable only from the OpenCrane server.
 
 ## Dependency direction
 

--- a/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
+++ b/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
@@ -37,9 +37,11 @@ describe("ArtifactStore signed internal protocol", function _suite()
 		const address = `sha256:${"a".repeat(64)}`;
 		const compact = __SignArtifactReadLease({ leaseId: "read-lease-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060, byteLength: 12, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000);
 		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-lease-1", artifactRevisionId: "revision-1", contentAddress: address, byteLength: 12 });
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_061)).toBeNull();
 		expect(__VerifyArtifactReadLease(compact, _receiptPublicKey, 1_750_000_001)).toBeNull();
 		expect(__VerifyArtifactWriteLease(compact, _leasePublicKey, 1_750_000_001)).toBeNull();
 		expect(function _overlongReadLease() { __SignArtifactReadLease({ leaseId: "read-lease-long", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_301, byteLength: 12, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000); }).toThrow(/invalid artifact read lease claims/);
+		expect(function _headerInjectionMediaType() { __SignArtifactReadLease({ leaseId: "read-lease-invalid-media", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060, byteLength: 12, mediaType: "text/plain\r\nx-injected: value" }, _leasePrivateKey, 1_750_000_000); }).toThrow(/invalid artifact read lease claims/);
 	});
 
 	it("keeps service promotion receipts distinct from write-lease authority", function _receiptRoundTrip()

--- a/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
+++ b/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
@@ -35,10 +35,11 @@ describe("ArtifactStore signed internal protocol", function _suite()
 	it("binds a read lease to one operation and exact immutable content address", function _readLeaseRoundTrip()
 	{
 		const address = `sha256:${"a".repeat(64)}`;
-		const compact = __SignArtifactReadLease({ leaseId: "read-lease-1", siloId: "silo-1", operationId: "preprocess-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000);
-		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-lease-1", operationId: "preprocess-1", contentAddress: address });
+		const compact = __SignArtifactReadLease({ leaseId: "read-lease-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060, byteLength: 12, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000);
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-lease-1", artifactRevisionId: "revision-1", contentAddress: address, byteLength: 12 });
 		expect(__VerifyArtifactReadLease(compact, _receiptPublicKey, 1_750_000_001)).toBeNull();
 		expect(__VerifyArtifactWriteLease(compact, _leasePublicKey, 1_750_000_001)).toBeNull();
+		expect(function _overlongReadLease() { __SignArtifactReadLease({ leaseId: "read-lease-long", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_301, byteLength: 12, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000); }).toThrow(/invalid artifact read lease claims/);
 	});
 
 	it("keeps service promotion receipts distinct from write-lease authority", function _receiptRoundTrip()

--- a/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
+++ b/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
@@ -2,7 +2,7 @@ import { generateKeyPairSync } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
 
-import { __SignArtifactPromotionReceipt, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "../artifact-lease.js";
+import { __SignArtifactPromotionReceipt, __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "../artifact-lease.js";
 
 const _leaseKeys = generateKeyPairSync("ed25519");
 const _receiptKeys = generateKeyPairSync("ed25519");
@@ -30,6 +30,15 @@ describe("ArtifactStore signed internal protocol", function _suite()
 		expect(__VerifyArtifactWriteLease(atPastBoundary, _leasePublicKey, now)).toMatchObject({ leaseId: "lease-past-boundary" });
 		expect(__VerifyArtifactWriteLease(beforePastBoundary, _leasePublicKey, now)).toBeNull();
 		expect(__VerifyArtifactWriteLease(atFutureBoundary, _leasePublicKey, now)).toMatchObject({ leaseId: "lease-future-boundary" });
+	});
+
+	it("binds a read lease to one operation and exact immutable content address", function _readLeaseRoundTrip()
+	{
+		const address = `sha256:${"a".repeat(64)}`;
+		const compact = __SignArtifactReadLease({ leaseId: "read-lease-1", siloId: "silo-1", operationId: "preprocess-1", contentAddress: address, action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060, mediaType: "application/pdf" }, _leasePrivateKey, 1_750_000_000);
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-lease-1", operationId: "preprocess-1", contentAddress: address });
+		expect(__VerifyArtifactReadLease(compact, _receiptPublicKey, 1_750_000_001)).toBeNull();
+		expect(__VerifyArtifactWriteLease(compact, _leasePublicKey, 1_750_000_001)).toBeNull();
 	});
 
 	it("keeps service promotion receipts distinct from write-lease authority", function _receiptRoundTrip()

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
@@ -2,10 +2,11 @@ import { createPrivateKey, createPublicKey, sign, verify } from "node:crypto";
 
 import { ___CanonicalizeJson } from "@opencrane/util";
 
-import type { ArtifactPromotionReceiptClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
+import type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
 
 const _LEASE_AUDIENCE = "artifact-service";
 const _LEASE_TYPE = "opencrane.artifact-write-lease";
+const _READ_LEASE_TYPE = "opencrane.artifact-read-lease";
 const _RECEIPT_AUDIENCE = "opencrane";
 const _RECEIPT_TYPE = "opencrane.artifact-promotion-receipt";
 
@@ -24,6 +25,23 @@ export function __VerifyArtifactWriteLease(compact: string, publicKeyPem: string
 	if (payload === null || payload.typ !== _LEASE_TYPE || payload.aud !== _LEASE_AUDIENCE || typeof issuedAt !== "number" || !Number.isSafeInteger(issuedAt) || issuedAt < nowEpochSeconds - 300 || issuedAt > nowEpochSeconds + 300) return null;
 	const claims = _leaseFromPayload(payload);
 	return claims !== null && _isLease(claims, nowEpochSeconds) ? claims : null;
+}
+
+/** Sign one exact short-lived canonical-byte read lease with an OpenCrane Ed25519 private key. */
+export function __SignArtifactReadLease(claims: ArtifactReadLeaseClaims, privateKeyPem: string, nowEpochSeconds: number): string
+{
+	if (!_isReadLease(claims, nowEpochSeconds)) throw new Error("invalid artifact read lease claims");
+	return _sign({ typ: _READ_LEASE_TYPE, aud: _LEASE_AUDIENCE, iat: nowEpochSeconds, ...claims }, privateKeyPem);
+}
+
+/** Verify an artifact-service read lease before exposing any canonical bytes. */
+export function __VerifyArtifactReadLease(compact: string, publicKeyPem: string, nowEpochSeconds: number): ArtifactReadLeaseClaims | null
+{
+	const payload = _verify(compact, publicKeyPem);
+	const issuedAt = payload?.iat;
+	if (payload === null || payload.typ !== _READ_LEASE_TYPE || payload.aud !== _LEASE_AUDIENCE || typeof issuedAt !== "number" || !Number.isSafeInteger(issuedAt) || issuedAt < nowEpochSeconds - 300 || issuedAt > nowEpochSeconds + 300) return null;
+	const claims = _readLeaseFromPayload(payload);
+	return claims !== null && _isReadLease(claims, nowEpochSeconds) ? claims : null;
 }
 
 /** Sign promotion facts with the service's distinct Ed25519 receipt key. */
@@ -71,6 +89,12 @@ function _leaseFromPayload(value: Record<string, unknown>): ArtifactWriteLeaseCl
 	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.artifactId === "string" && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && (typeof value.expectedContentAddress === "string" || value.expectedContentAddress === null) && (Number.isSafeInteger(value.expectedByteLength) || value.expectedByteLength === null) && typeof value.mediaType === "string" ? value as unknown as ArtifactWriteLeaseClaims : null;
 }
 
+/** Decode only the strict field set of a read lease after its signature and envelope are valid. */
+function _readLeaseFromPayload(value: Record<string, unknown>): ArtifactReadLeaseClaims | null
+{
+	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.operationId === "string" && typeof value.contentAddress === "string" && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && typeof value.mediaType === "string" ? value as unknown as ArtifactReadLeaseClaims : null;
+}
+
 function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionReceiptClaims | null
 {
 	return typeof value.leaseId === "string" && typeof value.contentAddress === "string" && Number.isSafeInteger(value.byteLength) && typeof value.mediaType === "string" && Number.isSafeInteger(value.issuedAtEpochSeconds) ? value as unknown as ArtifactPromotionReceiptClaims : null;
@@ -79,6 +103,12 @@ function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionR
 function _isLease(value: ArtifactWriteLeaseClaims, now: number): boolean
 {
 	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && (value.expectedContentAddress === null || /^sha256:[0-9a-f]{64}$/u.test(value.expectedContentAddress)) && (value.expectedByteLength === null || (Number.isSafeInteger(value.expectedByteLength) && value.expectedByteLength >= 0)) && value.mediaType.includes("/");
+}
+
+/** Validate the narrow coordinates that bind one signed read to one immutable CAS object. */
+function _isReadLease(value: ArtifactReadLeaseClaims, now: number): boolean
+{
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.operationId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.mediaType.includes("/");
 }
 
 function _isReceipt(value: ArtifactPromotionReceiptClaims): boolean

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
@@ -7,6 +7,7 @@ import type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactW
 const _LEASE_AUDIENCE = "artifact-service";
 const _LEASE_TYPE = "opencrane.artifact-write-lease";
 const _READ_LEASE_TYPE = "opencrane.artifact-read-lease";
+const _MAX_READ_LEASE_SECONDS = 300;
 const _RECEIPT_AUDIENCE = "opencrane";
 const _RECEIPT_TYPE = "opencrane.artifact-promotion-receipt";
 
@@ -92,7 +93,7 @@ function _leaseFromPayload(value: Record<string, unknown>): ArtifactWriteLeaseCl
 /** Decode only the strict field set of a read lease after its signature and envelope are valid. */
 function _readLeaseFromPayload(value: Record<string, unknown>): ArtifactReadLeaseClaims | null
 {
-	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.operationId === "string" && typeof value.contentAddress === "string" && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && typeof value.mediaType === "string" ? value as unknown as ArtifactReadLeaseClaims : null;
+	return typeof value.leaseId === "string" && typeof value.siloId === "string" && typeof value.artifactId === "string" && typeof value.artifactRevisionId === "string" && typeof value.contentAddress === "string" && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && Number.isSafeInteger(value.byteLength) && typeof value.mediaType === "string" ? value as unknown as ArtifactReadLeaseClaims : null;
 }
 
 function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionReceiptClaims | null
@@ -108,7 +109,7 @@ function _isLease(value: ArtifactWriteLeaseClaims, now: number): boolean
 /** Validate the narrow coordinates that bind one signed read to one immutable CAS object. */
 function _isReadLease(value: ArtifactReadLeaseClaims, now: number): boolean
 {
-	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.operationId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.mediaType.includes("/");
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.artifactRevisionId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.expiresAtEpochSeconds <= now + _MAX_READ_LEASE_SECONDS && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && value.mediaType.includes("/");
 }
 
 function _isReceipt(value: ArtifactPromotionReceiptClaims): boolean

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
@@ -103,16 +103,22 @@ function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionR
 
 function _isLease(value: ArtifactWriteLeaseClaims, now: number): boolean
 {
-	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && (value.expectedContentAddress === null || /^sha256:[0-9a-f]{64}$/u.test(value.expectedContentAddress)) && (value.expectedByteLength === null || (Number.isSafeInteger(value.expectedByteLength) && value.expectedByteLength >= 0)) && value.mediaType.includes("/");
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && (value.expectedContentAddress === null || /^sha256:[0-9a-f]{64}$/u.test(value.expectedContentAddress)) && (value.expectedByteLength === null || (Number.isSafeInteger(value.expectedByteLength) && value.expectedByteLength >= 0)) && _isSafeMediaType(value.mediaType);
 }
 
 /** Validate the narrow coordinates that bind one signed read to one immutable CAS object. */
 function _isReadLease(value: ArtifactReadLeaseClaims, now: number): boolean
 {
-	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.artifactRevisionId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.expiresAtEpochSeconds <= now + _MAX_READ_LEASE_SECONDS && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && value.mediaType.includes("/");
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.artifactRevisionId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.expiresAtEpochSeconds <= now + _MAX_READ_LEASE_SECONDS && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && _isSafeMediaType(value.mediaType);
+}
+
+/** Accept an RFC 9110 token subtype only, never text that could alter an HTTP header. */
+function _isSafeMediaType(value: string): boolean
+{
+	return /^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/u.test(value);
 }
 
 function _isReceipt(value: ArtifactPromotionReceiptClaims): boolean
 {
-	return value.leaseId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && value.mediaType.includes("/") && Number.isSafeInteger(value.issuedAtEpochSeconds) && value.issuedAtEpochSeconds >= 0;
+	return value.leaseId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && _isSafeMediaType(value.mediaType) && Number.isSafeInteger(value.issuedAtEpochSeconds) && value.issuedAtEpochSeconds >= 0;
 }

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
@@ -18,14 +18,18 @@ export interface ArtifactReadLeaseClaims
 	readonly leaseId: string;
 	/** Silo in which the source artifact remains authoritative. */
 	readonly siloId: string;
-	/** Exact run or worker operation that may consume the bytes. */
-	readonly operationId: string;
+	/** Exact catalog artifact whose published revision owns the bytes. */
+	readonly artifactId: string;
+	/** Exact published catalog revision that approved this immutable content. */
+	readonly artifactRevisionId: string;
 	/** Exact immutable CAS address that may be read. */
 	readonly contentAddress: string;
 	/** Exact capability action accepted by artifact-service. */
 	readonly action: "artifact.read";
 	/** Epoch-second expiry after which the byte stream must not begin. */
 	readonly expiresAtEpochSeconds: number;
+	/** Exact byte count that artifact-service must stream, never infer from a pathname. */
+	readonly byteLength: number;
 	/** Catalog-approved media type returned with the canonical bytes. */
 	readonly mediaType: string;
 }

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.types.ts
@@ -11,6 +11,25 @@ export interface ArtifactWriteLeaseClaims
 	readonly mediaType: string;
 }
 
+/** Signed, short-lived internal lease that permits reading one exact canonical object. */
+export interface ArtifactReadLeaseClaims
+{
+	/** Unique OpenCrane-issued lease identifier for audit correlation. */
+	readonly leaseId: string;
+	/** Silo in which the source artifact remains authoritative. */
+	readonly siloId: string;
+	/** Exact run or worker operation that may consume the bytes. */
+	readonly operationId: string;
+	/** Exact immutable CAS address that may be read. */
+	readonly contentAddress: string;
+	/** Exact capability action accepted by artifact-service. */
+	readonly action: "artifact.read";
+	/** Epoch-second expiry after which the byte stream must not begin. */
+	readonly expiresAtEpochSeconds: number;
+	/** Catalog-approved media type returned with the canonical bytes. */
+	readonly mediaType: string;
+}
+
 /** Signed artifact-service receipt that OpenCrane verifies before catalog finalization. */
 export interface ArtifactPromotionReceiptClaims
 {

--- a/libs/backend/artifacts/authorization/main/src/index.ts
+++ b/libs/backend/artifacts/authorization/main/src/index.ts
@@ -1,2 +1,2 @@
-export { __SignArtifactPromotionReceipt, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactWriteLease } from "./artifact-lease.js";
-export type { ArtifactPromotionReceiptClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
+export { __SignArtifactPromotionReceipt, __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "./artifact-lease.js";
+export type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";

--- a/libs/backend/artifacts/filesystem/main/README.md
+++ b/libs/backend/artifacts/filesystem/main/README.md
@@ -22,7 +22,7 @@ else. It owns the durability and integrity of the write, and the safety of every
  └─────────────────────────────────────────────────────────┘
           │  canonical immutable object (created: true/false)
           ▼
- read(address) streams it back · purge(address) removes it
+ byteLength(address) confirms immutable size · read(address) streams it back · purge(address) removes it
 ```
 
 **In this flow:** [store](../../store/main/README.md) *(defines the `ArtifactStore` port and validates every command)* ·
@@ -43,7 +43,7 @@ in to read or overwrite a file outside the mounted volume, and stored bytes alwa
 
 ## Public surface
 
-- `__FilesystemArtifactStore` — the POSIX `ArtifactStore` adapter (`stage` · `promote` · `read` · `purge`).
+- `__FilesystemArtifactStore` — the POSIX `ArtifactStore` adapter (`stage` · `promote` · `byteLength` · `read` · `purge`).
 - `FilesystemArtifactStoreOptions` — construction options (the absolute `rootPath` of the mounted volume).
 
 ## Boundary

--- a/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
+++ b/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
@@ -135,6 +135,26 @@ export class __FilesystemArtifactStore implements ArtifactStore
 		}
 	}
 
+	/** Returns one canonical regular file's byte count without exposing its path or directory. */
+	async byteLength(contentAddress: string): Promise<number | null>
+	{
+		if (!___IsSha256ContentAddress(contentAddress))
+		{
+			throw new Error("invalid ArtifactStore content address");
+		}
+		try
+		{
+			const metadata = await stat(this._contentPath(contentAddress));
+			if (!metadata.isFile()) throw new Error("ArtifactStore canonical object is not a regular file");
+			return metadata.size;
+		}
+		catch (error)
+		{
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+			throw error;
+		}
+	}
+
 	/** Physically purges one address after the catalog authority has completed its reference-safe gate. */
 	async purge(contentAddress: string): Promise<ArtifactStorePurgeResult>
 	{

--- a/libs/backend/artifacts/store/main/README.md
+++ b/libs/backend/artifacts/store/main/README.md
@@ -42,7 +42,7 @@ boundary, and a receipt is impossible unless the exact authorised object became 
 
 - `__PromoteArtifactUpload(store, leaseVerifier, byteSource, config)` — the end-to-end promotion protocol (verify → stage → promote → receipt).
 - `__ValidateVerifiedArtifactWriteLease`, `__ValidateStageArtifactCommand`, `__ValidateStagedArtifact`, `__ValidateArtifactStorePromotion` — the fail-closed input guards.
-- `ArtifactStore` — the storage port an adapter implements (`stage` · `promote` · `read` · `purge`).
+- `ArtifactStore` — the storage port an adapter implements (`stage` · `promote` · `byteLength` · `read` · `purge`). `byteLength` lets a read boundary reject a mismatched object before it commits response headers or bytes.
 - `ArtifactPromotionLeaseVerifier` / `ArtifactPromotionReceiptSigner` — the injected signing/verification seams.
 - `StageArtifactCommand`, `StagedArtifact`, `ArtifactStorePromotion`, `PromoteArtifactUploadResult`, `BoundedArtifactUploadByteSource`, and the related claim/config types.
 

--- a/libs/backend/artifacts/store/main/src/__tests__/artifact-promotion.test.ts
+++ b/libs/backend/artifacts/store/main/src/__tests__/artifact-promotion.test.ts
@@ -66,6 +66,7 @@ function _store(): TestStore
 				return { ...staged, created: true };
 			},
 			async read() { return null; },
+			async byteLength() { return null; },
 			async purge() { return { purged: false }; },
 		},
 		stageCount() { return stageCount; },

--- a/libs/backend/artifacts/store/main/src/artifact-store.types.ts
+++ b/libs/backend/artifacts/store/main/src/artifact-store.types.ts
@@ -147,6 +147,8 @@ export interface ArtifactStore
 	promote(staged: StagedArtifact): Promise<ArtifactStorePromotion>;
 	/** Reads canonical bytes by an already-authorized immutable content address. */
 	read(contentAddress: string): Promise<ArtifactByteStream | null>;
+	/** Returns the immutable canonical byte count without opening a stream, or null when absent. */
+	byteLength(contentAddress: string): Promise<number | null>;
 	/** Removes bytes only after the OpenCrane authority proved no active lease or reference remains. */
 	purge(contentAddress: string): Promise<ArtifactStorePurgeResult>;
 }

--- a/libs/backend/server/agents/artifacts/main/README.md
+++ b/libs/backend/server/agents/artifacts/main/README.md
@@ -39,6 +39,8 @@ result instead of creating a duplicate. A stale, replayed, or already-consumed r
 
 ## Public surface
 
+- `__IssueArtifactReadLease` — re-checks one active artifact's exact published revision before issuing a five-minute internal read lease; it exposes no HTTP route or storage path.
+
 - `__FinalizeArtifactRevision` — commit promoted bytes into a visible, immutable revision.
 - `__UploadArtifact` — orchestrate the full verified upload (lease → promote → finalize).
 - `PrismaArtifactAuthorityRepository` — the Postgres-backed persistence adapter.

--- a/libs/backend/server/agents/artifacts/main/src/__tests__/artifact-read-lease.test.ts
+++ b/libs/backend/server/agents/artifacts/main/src/__tests__/artifact-read-lease.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __IssueArtifactReadLease } from "../artifact-read-lease.js";
+
+/** Build one exact active published revision returned by the server-owned repository. */
+function _Target()
+{
+	return { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "text/plain" };
+}
+
+describe("ArtifactStore read lease issuer", function _suite()
+{
+	it("issues only server-loaded active published revision facts with a five-minute lifetime", async function _issues()
+	{
+		const signer = { sign: vi.fn().mockReturnValue("compact-read-lease") };
+		const result = await __IssueArtifactReadLease({ loadPublishedReadTarget: vi.fn().mockResolvedValue(_Target()) }, signer, { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" }, 1_750_000_000);
+
+		expect(result).toMatchObject({ outcome: "issued", compactLease: "compact-read-lease", claims: { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: _Target().contentAddress, byteLength: 12, expiresAtEpochSeconds: 1_750_000_300 } });
+		expect(signer.sign).toHaveBeenCalledWith(expect.objectContaining({ action: "artifact.read" }));
+	});
+
+	it("fails closed when the repository cannot prove the requested active published revision", async function _denies()
+	{
+		const signer = { sign: vi.fn() };
+		const result = await __IssueArtifactReadLease({ loadPublishedReadTarget: vi.fn().mockResolvedValue({ ..._Target(), artifactRevisionId: "other-revision" }) }, signer, { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" }, 1_750_000_000);
+
+		expect(result).toEqual({ outcome: "denied", reason: "revision_not_readable" });
+		expect(signer.sign).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/agents/artifacts/main/src/__tests__/prisma-artifact-authority.test.ts
+++ b/libs/backend/server/agents/artifacts/main/src/__tests__/prisma-artifact-authority.test.ts
@@ -9,6 +9,15 @@ function _command()
 
 describe("Prisma artifact authority", function _suite()
 {
+	it("loads a read target only through the active artifact and exact published revision relation", async function _loadsReadTarget()
+	{
+		const artifactRevision = { findFirst: vi.fn().mockResolvedValue({ id: "revision-1", artifactId: "artifact-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12n, mediaType: "text/plain", artifact: { siloId: "silo-1" } }) };
+		const repository = new PrismaArtifactAuthorityRepository({ artifactRevision } as never);
+
+		expect(await repository.loadPublishedReadTarget({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" })).toEqual({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "text/plain" });
+		expect(artifactRevision.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ state: "Published", artifact: { siloId: "silo-1", state: "Active" } }) }));
+	});
+
 	it("commits promotion receipt, immutable revision, current pointer, outbox, and final lease state together", async function _finalize()
 	{
 		const transaction = {

--- a/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.ts
@@ -1,0 +1,40 @@
+import { randomUUID } from "node:crypto";
+
+import type { ArtifactReadLeaseRepository, ArtifactReadLeaseSigner, IssueArtifactReadLeaseCommand, IssueArtifactReadLeaseResult, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
+
+/** Maximum lifetime for a service-verified internal artifact read lease. */
+const _READ_LEASE_SECONDS = 300;
+
+/** Issue one exact short-lived read lease from independently loaded active catalog facts. */
+export async function __IssueArtifactReadLease(repository: ArtifactReadLeaseRepository, signer: ArtifactReadLeaseSigner, command: IssueArtifactReadLeaseCommand, nowEpochSeconds: number): Promise<IssueArtifactReadLeaseResult>
+{
+	if (!_IsCommand(command) || !Number.isSafeInteger(nowEpochSeconds) || nowEpochSeconds < 0)
+	{
+		return { outcome: "denied", reason: "invalid_command" };
+	}
+
+	// 1. Re-read the exact artifact revision under its silo; no caller metadata becomes lease content.
+	const target = await repository.loadPublishedReadTarget(command);
+	if (!_MatchesCommand(target, command))
+	{
+		return { outcome: "denied", reason: "revision_not_readable" };
+	}
+
+	// 2. Bind a new opaque lease to the immutable revision facts for one bounded service read.
+	const claims = { leaseId: randomUUID(), siloId: target.siloId, artifactId: target.artifactId, artifactRevisionId: target.artifactRevisionId, contentAddress: target.contentAddress, action: "artifact.read" as const, expiresAtEpochSeconds: nowEpochSeconds + _READ_LEASE_SECONDS, byteLength: target.byteLength, mediaType: target.mediaType };
+
+	// 3. Let only the composed signing authority turn reviewed catalog facts into a compact lease.
+	return { outcome: "issued", compactLease: signer.sign(claims), claims };
+}
+
+/** Reject malformed coordinates before they can probe a catalog repository. */
+function _IsCommand(value: IssueArtifactReadLeaseCommand): boolean
+{
+	return [value.siloId, value.artifactId, value.artifactRevisionId].every(function _isIdentifier(part): boolean { return /^[A-Za-z0-9_-]{1,128}$/.test(part); });
+}
+
+/** Prove the repository returned the requested immutable coordinates and safe exact byte facts. */
+function _MatchesCommand(target: PublishedArtifactReadTarget | null, command: IssueArtifactReadLeaseCommand): target is PublishedArtifactReadTarget
+{
+	return target !== null && target.siloId === command.siloId && target.artifactId === command.artifactId && target.artifactRevisionId === command.artifactRevisionId && /^sha256:[a-f0-9]{64}$/.test(target.contentAddress) && Number.isSafeInteger(target.byteLength) && target.byteLength >= 0 && target.mediaType.includes("/");
+}

--- a/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.types.ts
@@ -1,0 +1,48 @@
+import type { ArtifactReadLeaseClaims } from "@opencrane/backend/artifacts/authorization";
+
+/** Server-owned coordinates for one exact published revision that may be read internally. */
+export interface IssueArtifactReadLeaseCommand
+{
+	/** Silo whose artifact authority must contain the requested revision. */
+	readonly siloId: string;
+	/** Logical artifact that owns the revision. */
+	readonly artifactId: string;
+	/** Immutable published revision that owns the canonical bytes. */
+	readonly artifactRevisionId: string;
+}
+
+/** Immutable catalog facts loaded only after active-silo and published-revision checks. */
+export interface PublishedArtifactReadTarget
+{
+	/** Silo independently re-read from the active artifact record. */
+	readonly siloId: string;
+	/** Logical artifact independently re-read from the revision relation. */
+	readonly artifactId: string;
+	/** Exact immutable revision independently re-read from the catalog. */
+	readonly artifactRevisionId: string;
+	/** Canonical SHA-256 object address approved by that revision. */
+	readonly contentAddress: string;
+	/** Exact canonical byte count approved by that revision. */
+	readonly byteLength: number;
+	/** Catalog-approved media type for the immutable bytes. */
+	readonly mediaType: string;
+}
+
+/** Persistence boundary that exposes no artifact path, list, or caller-controlled metadata. */
+export interface ArtifactReadLeaseRepository
+{
+	/** Loads one active artifact's exact published revision, or null for every other state. */
+	loadPublishedReadTarget(command: IssueArtifactReadLeaseCommand): Promise<PublishedArtifactReadTarget | null>;
+}
+
+/** Narrow signing port owned by server composition and backed by the mounted lease key. */
+export interface ArtifactReadLeaseSigner
+{
+	/** Signs only validated server-owned artifact-read claims. */
+	sign(claims: ArtifactReadLeaseClaims): string;
+}
+
+/** Result of one server-internal read-lease issuance attempt. */
+export type IssueArtifactReadLeaseResult =
+	| { readonly outcome: "issued"; readonly compactLease: string; readonly claims: ArtifactReadLeaseClaims }
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "revision_not_readable" };

--- a/libs/backend/server/agents/artifacts/main/src/index.ts
+++ b/libs/backend/server/agents/artifacts/main/src/index.ts
@@ -1,5 +1,7 @@
 export { __FinalizeArtifactRevision } from "./artifact-finalization.js";
+export { __IssueArtifactReadLease } from "./artifact-read-lease.js";
 export { PrismaArtifactAuthorityRepository } from "./prisma-artifact-authority.js";
 export { __UploadArtifact } from "./artifact-upload.js";
 export type { ArtifactAuthorityRepository, ArtifactStorePromotionReceipt, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand, FinalizeArtifactRevisionResult } from "./artifact-finalization.types.js";
+export type { ArtifactReadLeaseRepository, ArtifactReadLeaseSigner, IssueArtifactReadLeaseCommand, IssueArtifactReadLeaseResult, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
 export type { ArtifactServicePromotionPort, ArtifactUploadCryptoPort, ArtifactUploadLeaseRepository, ArtifactUploadResult, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
@@ -2,11 +2,12 @@ import { randomUUID } from "node:crypto";
 
 import { ArtifactUploadLeaseState, Prisma, type PrismaClient } from "@prisma/client";
 
+import type { ArtifactReadLeaseRepository, IssueArtifactReadLeaseCommand, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
 import type { ArtifactAuthorityRepository, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand } from "./artifact-finalization.types.js";
 import type { ArtifactUploadLeaseRepository, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";
 
 /** Postgres authority for receipt consumption, immutable revision publication, and outbox creation. */
-export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactUploadLeaseRepository
+export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactReadLeaseRepository, ArtifactUploadLeaseRepository
 {
 	/** Canonical OpenCrane catalog database client. */
 	private readonly prisma: PrismaClient;
@@ -15,6 +16,17 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 	constructor(prisma: PrismaClient)
 	{
 		this.prisma = prisma;
+	}
+
+	/** Loads only an active artifact's exact published revision as a storage-neutral read target. */
+	async loadPublishedReadTarget(command: IssueArtifactReadLeaseCommand): Promise<PublishedArtifactReadTarget | null>
+	{
+		const revision = await this.prisma.artifactRevision.findFirst({
+			where: { id: command.artifactRevisionId, artifactId: command.artifactId, state: "Published", artifact: { siloId: command.siloId, state: "Active" } },
+			select: { id: true, artifactId: true, contentAddress: true, byteLength: true, mediaType: true, artifact: { select: { siloId: true } } },
+		});
+		if (revision === null || revision.byteLength > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+		return { siloId: revision.artifact.siloId, artifactId: revision.artifactId, artifactRevisionId: revision.id, contentAddress: revision.contentAddress, byteLength: Number(revision.byteLength), mediaType: revision.mediaType };
 	}
 
 	/** Creates or returns the one durable, proof-bound lease for one exact capability JTI. */


### PR DESCRIPTION
## Why this matters

Phase E gives agents and bounded workers access to documents and other artifacts. Those processes must never receive direct storage access or be able to browse a tenant's artifact disk.

## What this delivers

- a short-lived, signed read lease for one published artifact revision and its exact immutable bytes
- server-side catalog checks before a lease is issued, so deleted, unpublished, cross-silo, or mismatched content cannot be read
- artifact-service enforcement that streams only the lease-bound byte length and media type, without exposing a storage path
- MIME validation that rejects header-injection input, plus explicit lease-expiry coverage

## Boundaries

This is an internal runtime authority, not a user-facing file browser. The artifact preprocessor remains a separate follow-up because its recovered historical schema contract needs a clean reconciliation before it is safe to wire.

## Validation

- backend artifact authorization tests (4)
- artifact-service tests (5)
- backend server artifact tests (10)
- TypeScript lint for all three projects
- diff and repository style checks

The local HTTP suites were run with loopback binding enabled; all passed.