### PR TITLE
Phase E: bind immutable capability ceilings to agent revisions

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -221,6 +221,7 @@ CREATE TABLE "agent_revisions" (
     "prompt_policy_version" TEXT NOT NULL,
     "persona_revision_id" TEXT,
     "model_definition_id" TEXT NOT NULL,
+    "capability_ceiling" JSONB NOT NULL DEFAULT '[]',
     "budget" JSONB NOT NULL,
     "authored_by" TEXT NOT NULL,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -2631,6 +2632,7 @@ BEGIN
         OR NEW."prompt_policy_version" IS DISTINCT FROM OLD."prompt_policy_version"
         OR NEW."persona_revision_id" IS DISTINCT FROM OLD."persona_revision_id"
         OR NEW."model_definition_id" IS DISTINCT FROM OLD."model_definition_id"
+        OR NEW."capability_ceiling" IS DISTINCT FROM OLD."capability_ceiling"
         OR NEW."budget" IS DISTINCT FROM OLD."budget"
         OR NEW."authored_by" IS DISTINCT FROM OLD."authored_by"
         OR NEW."created_at" IS DISTINCT FROM OLD."created_at" THEN
@@ -4142,6 +4144,7 @@ ALTER TABLE "agent_services" ADD CONSTRAINT "agent_services_active_revision_chec
         "state" <> 'active' OR "active_revision_id" IS NOT NULL
     );
 ALTER TABLE "agent_revisions" ADD CONSTRAINT "agent_revisions_revision_check" CHECK ("revision" > 0);
+ALTER TABLE "agent_revisions" ADD CONSTRAINT "agent_revisions_capability_ceiling_check" CHECK (jsonb_typeof("capability_ceiling") = 'array');
 ALTER TABLE "agent_revisions" ADD CONSTRAINT "agent_revisions_nonempty_check" CHECK (
         btrim("agent_service_id") <> '' AND btrim("digest") <> '' AND
         btrim("prompt_policy_version") <> '' AND btrim("model_definition_id") <> '' AND

--- a/apps/opencrane/prisma/schema/agent-services.prisma
+++ b/apps/opencrane/prisma/schema/agent-services.prisma
@@ -60,6 +60,7 @@ model AgentRevision {
   promptPolicyVersion String                         @map("prompt_policy_version")
   personaRevisionId   String?                        @map("persona_revision_id")
   modelDefinitionId   String                         @map("model_definition_id")
+  capabilityCeiling   Json                           @default("[]") @map("capability_ceiling")
   budget              Json
   authoredBy          String                         @map("authored_by")
   createdAt           DateTime                       @default(now()) @map("created_at")

--- a/libs/backend/server/agents/agent-services/main/README.md
+++ b/libs/backend/server/agents/agent-services/main/README.md
@@ -7,7 +7,8 @@
 This package is part of the **managed-agent plane** — the side of OpenCrane that turns a saved
 agent definition into something the runtime can execute. An *agent service* is the stable identity
 of one agent (its name and lifecycle); an *agent revision* is one immutable, versioned snapshot of
-how that agent behaves (its prompt policy, registered model definition, budget, and the skills and
+how that agent behaves (its prompt policy, registered model definition, exact capability ceiling,
+budget, and the skills and
 integrations it may use). A service always points at exactly one *active* revision.
 
 This package owns the whole definition plane and the authoritative management API. It creates a
@@ -24,7 +25,7 @@ read/recall and inject/write for that exact scope only, and never implies skills
 models, credentials, or a neighbouring scope.
 
 ```
- author a draft AgentRevision   (prompt policy · registered model · budget · assigned skills + integrations)
+ author a draft AgentRevision   (prompt policy · registered model · capability ceiling · budget · assigned skills + integrations)
         │
         ▼
  ┌────────────────────────────────────┐
@@ -39,7 +40,8 @@ models, credentials, or a neighbouring scope.
 **In this flow:** [skills](../../skills/main/README.md) · [integrations](../../../gateways/integrations/main/README.md) *(a revision assigns these)*
 
 Invariant: a revision is only published when it belongs to the named service, is still a draft, and
-carries every executable field (a positive version, a digest, prompt and registered model definition,
+carries every executable field (a positive version, a digest, prompt, registered model definition,
+exact capability ceiling,
 and positive turn/token/duration budgets). The model is a foreign-key reference to the gateway-owned
 catalogue, so an author cannot turn an arbitrary provider alias into executable behaviour. A model
 is available only when it is platform-global or belongs to the service's tenant scope; the database
@@ -92,7 +94,7 @@ grants) both ride the compiler. Scope attachments remain silo-bounded and org-ad
 ## Data & persistence
 
 Owns the `AgentService`, `AgentRevision` (with `parentRevisionId`/`sourceRevisionId`/`changeMessage`
-lineage and a required `ModelDefinition` reference), `AgentRevisionScopeAttachment` (revision-scoped `{ scope, subjectType, subjectId }` reusing
+lineage, a required `ModelDefinition` reference, and an immutable JSON capability ceiling whose entries use the authorization-compatible `{ catalog: { catalogId, revision, digest }, capabilityId }` shape), `AgentRevisionScopeAttachment` (revision-scoped `{ scope, subjectType, subjectId }` reusing
 the `GrantScope`/`GrantSubjectType` enums), `AgentRevisionSkillAssignment`,
 `AgentRevisionIntegrationAssignment`, and `AgentServiceSchedule` (cron, timezone, overlap policy,
 enabled, catch-up window) models in `apps/opencrane/prisma/schema/agent-services.prisma`. The retired

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/agent-publication.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/agent-publication.test.ts
@@ -35,6 +35,7 @@ function _revision(): AgentRevision
 		promptPolicyVersion: "prompt-v1",
 		personaRevisionId: "persona-1",
 		modelDefinitionId: "model-definition-1",
+		capabilityCeiling: [],
 		skills: [],
 		integrationAssignments: [],
 		scopeAttachments: [],

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/agent-revision-lifecycle.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/agent-revision-lifecycle.test.ts
@@ -7,7 +7,7 @@ import type { AgentRevisionContent, AgentRevisionLifecycleRepository, AgentServi
 /** Builds valid executable content for a managed revision. */
 function _content(overrides: Partial<AgentRevisionContent> = {}): AgentRevisionContent
 {
-	return { promptPolicyVersion: "prompt-v1", personaRevisionId: null, modelDefinitionId: "model-definition-a", budget: { maxTurns: 5, maxTokens: 1000, maxDurationMs: 30000 }, skills: [], integrationAssignments: [], scopeAttachments: [{ scope: "project", subjectType: "group", subjectId: "proj-1" }], ...overrides };
+	return { promptPolicyVersion: "prompt-v1", personaRevisionId: null, modelDefinitionId: "model-definition-a", capabilityCeiling: [], budget: { maxTurns: 5, maxTokens: 1000, maxDurationMs: 30000 }, skills: [], integrationAssignments: [], scopeAttachments: [{ scope: "project", subjectType: "group", subjectId: "proj-1" }], ...overrides };
 }
 
 /** Minimal in-memory definition-plane repository, silo-scoped like the Prisma adapter. */
@@ -56,7 +56,7 @@ class _Repository implements AgentRevisionLifecycleRepository
 		// Silo-scope the source lookup exactly like the Prisma adapter: a foreign-silo source is a 404.
 		const source = this.revisions.find(revision => revision.id === command.sourceRevisionId && this._siloService(revision.agentServiceId, command.siloId) !== null);
 		if (source === undefined) return { outcome: "denied", reason: "revision_not_found" };
-		const content: AgentRevisionContent = { promptPolicyVersion: source.promptPolicyVersion, personaRevisionId: source.personaRevisionId, modelDefinitionId: source.modelDefinitionId, budget: source.budget, skills: source.skills.map(skill => ({ skillId: skill.skillId, revisionId: skill.revisionId })), integrationAssignments: source.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: [...assignment.allowedTools] })), scopeAttachments: source.scopeAttachments.map(attachment => ({ ...attachment })) };
+		const content: AgentRevisionContent = { promptPolicyVersion: source.promptPolicyVersion, personaRevisionId: source.personaRevisionId, modelDefinitionId: source.modelDefinitionId, capabilityCeiling: source.capabilityCeiling.map(capability => ({ ...capability })), budget: source.budget, skills: source.skills.map(skill => ({ skillId: skill.skillId, revisionId: skill.revisionId })), integrationAssignments: source.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: [...assignment.allowedTools] })), scopeAttachments: source.scopeAttachments.map(attachment => ({ ...attachment })) };
 		return { outcome: "revised", revision: this._append(command.agentServiceId, head.revision + 1, head.id, source.id, content, command.authoredBy, command.changeMessage, createdAt) };
 	}
 
@@ -95,7 +95,7 @@ class _Repository implements AgentRevisionLifecycleRepository
 	/** Appends one immutable draft revision to the in-memory store. */
 	private _append(agentServiceId: string, revision: number, parentRevisionId: string | null, sourceRevisionId: string | null, content: AgentRevisionContent, authoredBy: string, changeMessage: string, createdAt: string): AgentRevision
 	{
-		const record: AgentRevision = { id: `revision-${++this.counter}`, agentServiceId, revision, parentRevisionId, sourceRevisionId, changeMessage, state: "draft", digest: `sha256:${revision}`, promptPolicyVersion: content.promptPolicyVersion, personaRevisionId: content.personaRevisionId, modelDefinitionId: content.modelDefinitionId, skills: content.skills.map(skill => ({ ...skill })), integrationAssignments: content.integrationAssignments.map(assignment => ({ ...assignment, allowedTools: [...assignment.allowedTools] })), scopeAttachments: content.scopeAttachments.map(attachment => ({ ...attachment })), budget: content.budget, authoredBy, createdAt, publishedAt: null };
+		const record: AgentRevision = { id: `revision-${++this.counter}`, agentServiceId, revision, parentRevisionId, sourceRevisionId, changeMessage, state: "draft", digest: `sha256:${revision}`, promptPolicyVersion: content.promptPolicyVersion, personaRevisionId: content.personaRevisionId, modelDefinitionId: content.modelDefinitionId, capabilityCeiling: content.capabilityCeiling.map(capability => ({ ...capability })), skills: content.skills.map(skill => ({ ...skill })), integrationAssignments: content.integrationAssignments.map(assignment => ({ ...assignment, allowedTools: [...assignment.allowedTools] })), scopeAttachments: content.scopeAttachments.map(attachment => ({ ...attachment })), budget: content.budget, authoredBy, createdAt, publishedAt: null };
 		this.revisions.push(record);
 		return record;
 	}
@@ -139,6 +139,16 @@ describe("managed agent revision lifecycle", function _suite()
 		const repository = new _Repository();
 		const created = await __CreateManagedAgentService(repository, { siloId: _SILO, name: "Reporter", workloadProfile: "managed-default", authoredBy: "admin-1", changeMessage: "initial", content: _content({ scopeAttachments: [{ scope: "project", subjectType: "group", subjectId: "proj-1" }, { scope: "project", subjectType: "group", subjectId: "proj-1" }] }) }, _NOW);
 		expect(created).toEqual({ outcome: "denied", reason: "invalid_command" });
+	});
+
+	it("rejects malformed and duplicate capability ceiling entries before persistence", async function _capabilityCeiling()
+	{
+		const repository = new _Repository();
+		const capability = { catalog: { catalogId: "core", revision: 1, digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const }, capabilityId: "artifact.read" };
+		const duplicate = await __CreateManagedAgentService(repository, { siloId: _SILO, name: "Reporter", workloadProfile: "managed-default", authoredBy: "admin-1", changeMessage: "initial", content: _content({ capabilityCeiling: [capability, capability] }) }, _NOW);
+		expect(duplicate).toEqual({ outcome: "denied", reason: "invalid_command" });
+		const malformed = await __CreateManagedAgentService(repository, { siloId: _SILO, name: "Reporter", workloadProfile: "managed-default", authoredBy: "admin-1", changeMessage: "initial", content: _content({ capabilityCeiling: [{ ...capability, catalog: { ...capability.catalog, revision: 0 } }] }) }, _NOW);
+		expect(malformed).toEqual({ outcome: "denied", reason: "invalid_command" });
 	});
 
 	it("appends a revision on the expected head and conflicts on a stale parent", async function _revise()

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/agent-revision.router.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/agent-revision.router.test.ts
@@ -1,0 +1,35 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { __CreateAgentServicesRouter } from "../agent-revision.router.js";
+import type { AgentServicesRouterDependencies } from "../agent-revision.router.types.js";
+
+/** Builds the management API with dependencies that must remain untouched for invalid input. */
+function _app(): express.Express
+{
+	const dependencies = {
+		lifecycle: { createManagedService: vi.fn() },
+		publicationFor: vi.fn(),
+		runAdmission: { admitManagedRun: vi.fn() },
+		schedules: {},
+		scopeGrantResolver: {},
+		resolveCaller: vi.fn().mockReturnValue({ subjectId: "admin-1", siloId: "silo-1", isOrgAdmin: true }),
+		clock: { now: vi.fn().mockReturnValue(new Date("2026-07-25T00:00:00.000Z")) },
+		logger: { error: vi.fn() },
+	} as unknown as AgentServicesRouterDependencies;
+	const app = express();
+	app.use(express.json());
+	app.use("/", __CreateAgentServicesRouter(dependencies));
+	return app;
+}
+
+describe("managed agent revision router", function _suite()
+{
+	it("rejects a null capability ceiling entry as a validation error", async function _nullCapability()
+	{
+		const response = await request(_app()).post("/").send({ name: "Reporter", workloadProfile: "managed-default", changeMessage: "initial", content: { promptPolicyVersion: "prompt-v1", modelDefinitionId: "model-1", budget: { maxTurns: 1, maxTokens: 1, maxDurationMs: 1 }, capabilityCeiling: [null] } });
+		expect(response.status).toBe(400);
+		expect(response.body.code).toBe("VALIDATION_ERROR");
+	});
+});

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.ts
@@ -21,6 +21,16 @@ function _isUniqueBy<T>(items: readonly T[], key: (item: T) => string): boolean
 	return new Set(items.map(key)).size === items.length;
 }
 
+/** Returns whether one capability ceiling entry identifies a valid exact catalogue capability. */
+function _isCapabilityCeilingEntryValid(entry: AgentRevisionContent["capabilityCeiling"][number]): boolean
+{
+	return _isPresent(entry.catalog.catalogId)
+		&& Number.isSafeInteger(entry.catalog.revision)
+		&& entry.catalog.revision > 0
+		&& /^sha256:[0-9a-f]{64}$/.test(entry.catalog.digest)
+		&& _isPresent(entry.capabilityId);
+}
+
 /**
  * Returns whether executable revision content is structurally valid before persistence.
  * Duplicate composite keys (a skill, an integration, or an exact scope attachment) are rejected
@@ -34,11 +44,13 @@ function _isContentValid(content: AgentRevisionContent): boolean
 		&& _isPositiveInteger(content.budget.maxTurns)
 		&& _isPositiveInteger(content.budget.maxTokens)
 		&& _isPositiveInteger(content.budget.maxDurationMs)
+		&& content.capabilityCeiling.every(_isCapabilityCeilingEntryValid)
 		&& content.skills.every(skill => _isPresent(skill.skillId) && _isPresent(skill.revisionId))
 		&& content.integrationAssignments.every(assignment => _isPresent(assignment.integrationId) && _isPresent(assignment.custodyReferenceId) && assignment.allowedTools.every(_isPresent))
 		&& content.scopeAttachments.every(attachment => _isPresent(attachment.subjectId))
 		&& _isUniqueBy(content.skills, skill => skill.skillId)
 		&& _isUniqueBy(content.integrationAssignments, assignment => assignment.integrationId)
+		&& _isUniqueBy(content.capabilityCeiling, entry => `${entry.catalog.catalogId}\u0000${entry.catalog.revision}\u0000${entry.catalog.digest}\u0000${entry.capabilityId}`)
 		&& _isUniqueBy(content.scopeAttachments, attachment => `${attachment.scope}\u0000${attachment.subjectType}\u0000${attachment.subjectId}`);
 }
 

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
@@ -1,4 +1,4 @@
-import type { AgentRevision, AgentRevisionDiff, AgentRevisionId, AgentRun, AgentService, AgentServiceId, AgentServiceState, RevisionScopeAttachment, SiloId } from "@opencrane/models/agents";
+import type { AgentRevision, AgentRevisionCapabilityCeilingEntry, AgentRevisionDiff, AgentRevisionId, AgentRun, AgentService, AgentServiceId, AgentServiceState, RevisionScopeAttachment, SiloId } from "@opencrane/models/agents";
 
 /** Immutable executable content authored for one managed-agent revision. */
 export interface AgentRevisionContent
@@ -9,6 +9,8 @@ export interface AgentRevisionContent
 	readonly personaRevisionId: string | null;
 	/** Registered model-definition reference; carries no provider secret. */
 	readonly modelDefinitionId: string;
+	/** Immutable upper capability bound; a run may only further narrow this list. */
+	readonly capabilityCeiling: readonly AgentRevisionCapabilityCeilingEntry[];
 	/** Immutable resource ceilings applied to each run. */
 	readonly budget: { readonly maxTurns: number; readonly maxTokens: number; readonly maxDurationMs: number };
 	/** Immutable skill revisions exposed to the runtime. */

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
@@ -31,8 +31,26 @@ function _parseContent(raw: unknown): AgentRevisionContent | null
 	const skills = _parseSkills(body.skills);
 	const integrationAssignments = _parseIntegrations(body.integrationAssignments);
 	const scopeAttachments = _parseScopeAttachments(body.scopeAttachments);
-	if (skills === null || integrationAssignments === null || scopeAttachments === null) return null;
-	return { promptPolicyVersion: body.promptPolicyVersion, personaRevisionId, modelDefinitionId: body.modelDefinitionId, budget: { maxTurns: budget.maxTurns, maxTokens: budget.maxTokens, maxDurationMs: budget.maxDurationMs }, skills, integrationAssignments, scopeAttachments };
+	const capabilityCeiling = _parseCapabilityCeiling(body.capabilityCeiling);
+	if (skills === null || integrationAssignments === null || scopeAttachments === null || capabilityCeiling === null) return null;
+	return { promptPolicyVersion: body.promptPolicyVersion, personaRevisionId, modelDefinitionId: body.modelDefinitionId, capabilityCeiling, budget: { maxTurns: budget.maxTurns, maxTokens: budget.maxTokens, maxDurationMs: budget.maxDurationMs }, skills, integrationAssignments, scopeAttachments };
+}
+
+/** Parses the optional exact-catalogue capability ceiling array. */
+function _parseCapabilityCeiling(raw: unknown): AgentRevisionContent["capabilityCeiling"] | null
+{
+	if (raw === undefined) return [];
+	if (!Array.isArray(raw)) return null;
+	const entries = raw.map(function _entry(value)
+	{
+		if (value === null || typeof value !== "object") return null;
+		const entry = value as Record<string, unknown>;
+		const catalog = entry.catalog as Record<string, unknown> | undefined;
+		const revision = catalog?.revision;
+		if (!_isNonEmptyString(catalog?.catalogId) || typeof revision !== "number" || !Number.isSafeInteger(revision) || revision <= 0 || !_isNonEmptyString(catalog?.digest) || !/^sha256:[0-9a-f]{64}$/.test(catalog.digest) || !_isNonEmptyString(entry?.capabilityId)) return null;
+		return { catalog: { catalogId: catalog.catalogId, revision, digest: catalog.digest }, capabilityId: entry.capabilityId };
+	});
+	return entries.some(entry => entry === null) ? null : entries as AgentRevisionContent["capabilityCeiling"];
 }
 
 /** Parses the optional skill-reference array. */

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-mappers.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-mappers.ts
@@ -139,6 +139,7 @@ export function _mapRevision(row: AgentRevisionRow): AgentRevision
 		promptPolicyVersion: row.promptPolicyVersion,
 		personaRevisionId: row.personaRevisionId,
 		modelDefinitionId: row.modelDefinitionId,
+		capabilityCeiling: row.capabilityCeiling as unknown as AgentRevision["capabilityCeiling"],
 		skills: row.skillAssignments.map(assignment => ({ skillId: assignment.skillId, revisionId: assignment.skillRevisionId })),
 		integrationAssignments: row.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: assignment.allowedTools })),
 		scopeAttachments: row.scopeAttachments.map(attachment => ({ scope: _grantScope(attachment.scope), subjectType: _grantSubjectType(attachment.subjectType), subjectId: attachment.subjectId })),

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-mappers.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-mappers.types.ts
@@ -28,6 +28,7 @@ export interface AgentRevisionRow
 	readonly promptPolicyVersion: string;
 	readonly personaRevisionId: string | null;
 	readonly modelDefinitionId: string;
+	readonly capabilityCeiling: Prisma.JsonValue;
 	readonly budget: Prisma.JsonValue;
 	readonly authoredBy: string;
 	readonly createdAt: Date;

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-lifecycle.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-lifecycle.ts
@@ -56,6 +56,10 @@ function _revisionDigest(agentServiceId: string, revision: number, content: Agen
 		promptPolicyVersion: content.promptPolicyVersion,
 		personaRevisionId: content.personaRevisionId,
 		modelDefinitionId: content.modelDefinitionId,
+		capabilityCeiling: content.capabilityCeiling.map(capability => ({ catalog: { catalogId: capability.catalog.catalogId, revision: capability.catalog.revision, digest: capability.catalog.digest }, capabilityId: capability.capabilityId })).sort(function _byCapability(first, second)
+		{
+			return `${first.catalog.catalogId}\u0000${first.catalog.revision}\u0000${first.catalog.digest}\u0000${first.capabilityId}`.localeCompare(`${second.catalog.catalogId}\u0000${second.catalog.revision}\u0000${second.catalog.digest}\u0000${second.capabilityId}`);
+		}),
 		budget: { maxTurns: content.budget.maxTurns, maxTokens: content.budget.maxTokens, maxDurationMs: content.budget.maxDurationMs },
 		skills: content.skills.map(skill => ({ skillId: skill.skillId, revisionId: skill.revisionId })),
 		integrationAssignments: content.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: [...assignment.allowedTools] })),
@@ -78,6 +82,7 @@ function _revisionCreateData(agentServiceId: string, siloId: string, revision: n
 		promptPolicyVersion: content.promptPolicyVersion,
 		personaRevisionId: content.personaRevisionId,
 		modelDefinition: { connect: { id: content.modelDefinitionId } },
+		capabilityCeiling: content.capabilityCeiling as unknown as Prisma.InputJsonValue,
 		budget: { maxTurns: content.budget.maxTurns, maxTokens: content.budget.maxTokens, maxDurationMs: content.budget.maxDurationMs },
 		authoredBy,
 		createdAt,
@@ -88,13 +93,14 @@ function _revisionCreateData(agentServiceId: string, siloId: string, revision: n
 }
 
 /** Projects an immutable revision's persisted content back into an authoring content command. */
-function _contentFromRevision(row: { promptPolicyVersion: string; personaRevisionId: string | null; modelDefinitionId: string; budget: Prisma.JsonValue; skillAssignments: ReadonlyArray<{ skillId: string; skillRevisionId: string }>; integrationAssignments: ReadonlyArray<{ integrationId: string; custodyReferenceId: string; allowedTools: string[] }>; scopeAttachments: ReadonlyArray<{ scope: string; subjectType: string; subjectId: string }> }): AgentRevisionContent
+function _contentFromRevision(row: { promptPolicyVersion: string; personaRevisionId: string | null; modelDefinitionId: string; capabilityCeiling: Prisma.JsonValue; budget: Prisma.JsonValue; skillAssignments: ReadonlyArray<{ skillId: string; skillRevisionId: string }>; integrationAssignments: ReadonlyArray<{ integrationId: string; custodyReferenceId: string; allowedTools: string[] }>; scopeAttachments: ReadonlyArray<{ scope: string; subjectType: string; subjectId: string }> }): AgentRevisionContent
 {
 	const budget = row.budget as unknown as AgentBudget;
 	return {
 		promptPolicyVersion: row.promptPolicyVersion,
 		personaRevisionId: row.personaRevisionId,
 		modelDefinitionId: row.modelDefinitionId,
+		capabilityCeiling: row.capabilityCeiling as unknown as AgentRevisionContent["capabilityCeiling"],
 		budget: { maxTurns: budget.maxTurns, maxTokens: budget.maxTokens, maxDurationMs: budget.maxDurationMs },
 		skills: row.skillAssignments.map(assignment => ({ skillId: assignment.skillId, revisionId: assignment.skillRevisionId })),
 		integrationAssignments: row.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, custodyReferenceId: assignment.custodyReferenceId, allowedTools: [...assignment.allowedTools] })),

--- a/libs/models/agents/main/README.md
+++ b/libs/models/agents/main/README.md
@@ -13,12 +13,15 @@ It owns two kinds of thing:
 - **Types** for an `AgentService` (a named, reusable agent), its immutable `AgentRevision`
   (a published, frozen version of that agent, carrying revision lineage — `parentRevisionId`,
   `sourceRevisionId`, `changeMessage` — and revision-scoped `RevisionScopeAttachment`s over the
-  canonical `GrantScope`/`GrantSubjectType` vocabulary), an `AgentRun` (one execution attempt), the
+  canonical `GrantScope`/`GrantSubjectType` vocabulary), an `AgentRun` (one execution attempt), and
+  an authorization-compatible, catalogue-qualified capability ceiling that bounds what a revision
+  may ever receive at run time; the
   conversation record — `Thread`, `Message`, `RunEvent` — and the `Persona` family (the saved
   personality and onboarding interview an agent runs with).
 - A **pure revision diff** (`__DiffAgentRevisions`): line-level prompt diff plus semantic
   field-level configuration diff, flagging security-relevant widening (broader scopes, tools,
-  credentials, or budgets) for reviewer confirmation. It reads only stable references, never secrets.
+  credentials, capability ceilings, or budgets) for reviewer confirmation. It reads only stable
+  references, never secrets.
 - **Pure decision functions** over those types:
   - `state-transitions` holds the small lookup tables of which state may legally follow which (for
     example a run may go `running → completed` but never `completed → running`), and answers a plain

--- a/libs/models/agents/main/src/__tests__/agent-revision-diff.test.ts
+++ b/libs/models/agents/main/src/__tests__/agent-revision-diff.test.ts
@@ -17,7 +17,8 @@ function _revision(overrides: Partial<AgentRevision> = {}): AgentRevision
 		digest: "sha256:base",
 		promptPolicyVersion: "line-one\nline-two",
 		personaRevisionId: null,
-	modelDefinitionId: "model-definition-a",
+		modelDefinitionId: "model-definition-a",
+		capabilityCeiling: [],
 		skills: [{ skillId: "skill-a", revisionId: "rev-1" }],
 		integrationAssignments: [{ integrationId: "int-a", custodyReferenceId: "cust-1", allowedTools: ["read"] }],
 		scopeAttachments: [{ scope: "project", subjectType: "group", subjectId: "proj-1" }],
@@ -52,6 +53,7 @@ describe("agent revision diff", function _suite()
 				{ integrationId: "int-a", custodyReferenceId: "cust-1", allowedTools: ["read", "write"] },
 				{ integrationId: "int-b", custodyReferenceId: "cust-2", allowedTools: ["send"] },
 			],
+			capabilityCeiling: [{ catalog: { catalogId: "core", revision: 1, digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }, capabilityId: "artifact.read" }],
 			budget: { maxTurns: 20, maxTokens: 1000, maxDurationMs: 30000 },
 		});
 		const diff = __DiffAgentRevisions(_revision(), target);
@@ -60,6 +62,7 @@ describe("agent revision diff", function _suite()
 		expect(kinds).toContain("tools");
 		expect(kinds).toContain("credentials");
 		expect(kinds).toContain("budget");
+		expect(kinds).toContain("capabilities");
 	});
 
 	it("does not flag budget widening when a ceiling is lowered", function _narrower()

--- a/libs/models/agents/main/src/agent-revision-diff.ts
+++ b/libs/models/agents/main/src/agent-revision-diff.ts
@@ -83,6 +83,15 @@ function _scopeAttachmentKeys(revision: AgentRevision): string[]
 	return revision.scopeAttachments.map(function _key(attachment) { return `${attachment.scope}:${attachment.subjectType}:${attachment.subjectId}`; });
 }
 
+/** Renders a capability ceiling entry as one catalogue-qualified stable key. */
+function _capabilityCeilingKeys(revision: AgentRevision): string[]
+{
+	return revision.capabilityCeiling.map(function _key(capability)
+	{
+		return `${capability.catalog.catalogId}@${capability.catalog.revision}:${capability.catalog.digest}:${capability.capabilityId}`;
+	});
+}
+
 /** Flags a budget ceiling as widened when the target permits strictly more than the base. */
 function _budgetWidening(field: string, before: number, after: number): RevisionWidening | null
 {
@@ -122,6 +131,7 @@ export function __DiffAgentRevisions(base: AgentRevision, target: AgentRevision)
 		_setChange("integrationTools", _integrationToolKeys(base), _integrationToolKeys(target)),
 		_setChange("integrationCustody", _integrationCustodyKeys(base), _integrationCustodyKeys(target)),
 		_setChange("scopeAttachments", _scopeAttachmentKeys(base), _scopeAttachmentKeys(target)),
+		_setChange("capabilityCeiling", _capabilityCeilingKeys(base), _capabilityCeilingKeys(target)),
 	].filter(_isPresent);
 
 	// 4. Flag every security-relevant widening for reviewer confirmation.
@@ -152,6 +162,11 @@ function _collectWidenings(base: AgentRevision, target: AgentRevision, setChange
 	if (toolChange && toolChange.added.length > 0)
 	{
 		widenings.push({ kind: "tools", field: "integrationTools", detail: `granted ${toolChange.added.length} integration tool(s): ${toolChange.added.join(", ")}` });
+	}
+	const capabilityChange = setChanges.find(function _capabilities(change) { return change.field === "capabilityCeiling"; });
+	if (capabilityChange && capabilityChange.added.length > 0)
+	{
+		widenings.push({ kind: "capabilities", field: "capabilityCeiling", detail: `added ${capabilityChange.added.length} capability ceiling entry/entries: ${capabilityChange.added.join(", ")}` });
 	}
 
 	// New credentials: any integration bound in the target that the base did not carry.

--- a/libs/models/agents/main/src/agent-revision-diff.types.ts
+++ b/libs/models/agents/main/src/agent-revision-diff.types.ts
@@ -32,7 +32,7 @@ export interface RevisionSetChange
 }
 
 /** Security-relevant category widened by a revision change. */
-export type RevisionWideningKind = "scope" | "tools" | "credentials" | "budget";
+export type RevisionWideningKind = "scope" | "tools" | "credentials" | "budget" | "capabilities";
 
 /** One security-relevant widening flagged for reviewer attention. */
 export interface RevisionWidening

--- a/libs/models/agents/main/src/agent-revision.types.ts
+++ b/libs/models/agents/main/src/agent-revision.types.ts
@@ -1,3 +1,5 @@
+import type { CanonicalJsonSha256Digest } from "@opencrane/util";
+
 import type { AgentRevisionId, AgentServiceId, PersonaRevisionId, UserId } from "./identifiers.types.js";
 import type { RevisionScopeAttachment } from "./scope-attachment.types.js";
 
@@ -35,6 +37,26 @@ export interface AgentBudget
 	readonly maxDurationMs: number;
 }
 
+/** Immutable catalogue revision used to bound an agent capability. */
+export interface AgentRevisionCapabilityCatalogueReference
+{
+	/** Stable capability catalogue identifier. */
+	readonly catalogId: string;
+	/** Positive immutable catalogue revision number. */
+	readonly revision: number;
+	/** Digest binding the entry to its exact catalogue revision. */
+	readonly digest: CanonicalJsonSha256Digest;
+}
+
+/** Immutable catalog-qualified capability that bounds one agent revision. */
+export interface AgentRevisionCapabilityCeilingEntry
+{
+	/** Exact immutable catalogue revision defining this capability. */
+	readonly catalog: AgentRevisionCapabilityCatalogueReference;
+	/** Stable capability identifier inside the referenced catalogue. */
+	readonly capabilityId: string;
+}
+
 /** Immutable executable configuration of an agent service. */
 export interface AgentRevision
 {
@@ -60,6 +82,8 @@ export interface AgentRevision
 	readonly personaRevisionId: PersonaRevisionId | null;
 	/** Registered model definition selected for this immutable revision. */
 	readonly modelDefinitionId: string;
+	/** Immutable upper bound on capabilities that a run may receive. */
+	readonly capabilityCeiling: readonly AgentRevisionCapabilityCeilingEntry[];
 	/** Immutable skill revisions available to the runtime. */
 	readonly skills: readonly SkillRevisionReference[];
 	/** Immutable integration and tool assignments available to the runtime. */

--- a/libs/models/agents/main/src/index.ts
+++ b/libs/models/agents/main/src/index.ts
@@ -1,6 +1,6 @@
 export { __DiffAgentRevisions } from "./agent-revision-diff.js";
 export type { AgentRevisionDiff, RevisionLineDiff, RevisionScalarChange, RevisionSetChange, RevisionWidening, RevisionWideningKind } from "./agent-revision-diff.types.js";
-export type { AgentBudget, AgentRevision, AgentRevisionState, IntegrationAssignmentReference, SkillRevisionReference } from "./agent-revision.types.js";
+export type { AgentBudget, AgentRevision, AgentRevisionCapabilityCatalogueReference, AgentRevisionCapabilityCeilingEntry, AgentRevisionState, IntegrationAssignmentReference, SkillRevisionReference } from "./agent-revision.types.js";
 export type { AgentRun, AgentRunLineage, AgentRunState, AgentRunTerminalReason, AgentRunTrigger } from "./agent-run.types.js";
 export type { AgentService, AgentServiceKind, AgentServiceState } from "./agent-service.types.js";
 export type { GrantScope, GrantSubjectType, RevisionScopeAttachment } from "./scope-attachment.types.js";


### PR DESCRIPTION
## Summary

An agent revision now owns an immutable, exact capability ceiling. Each entry uses the same catalogue-qualified shape as authorization capability references, so later run admission can only narrow this bound.

This slice persists the ceiling in the fresh Prisma schema and target baseline, includes it in revision digests and comparison/widening evidence, validates management API input, and protects it with the existing immutable revision trigger. The database default is an empty ceiling, keeping existing raw-SQL authority fixtures valid while preserving a fail-closed no-capability default.

## Why this matters

This establishes the durable upper authority limit before session assembly is wired. A future run can receive fewer capabilities based on the member, scope, and policy evidence, but it cannot gain a capability absent from the revision that was reviewed and published.

## Validation

- Prisma generate and schema validation
- npx nx lint models-agents
- npx nx lint backend-server-agent-services
- npx nx test models-agents (17 tests)
- npx nx test backend-server-agent-services (30 tests)
- agent-style-check and git diff --check
- Independent review; malformed null input regression and SQL fixture compatibility findings fixed and re-verified

## Stack

Base: feat/phase-e-admission-authorities (#436), itself above #435 and #434.