### PR TITLE
Phase E: verify the active revision at run admission

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -49,6 +49,10 @@ caller input.
 - `FleetMembershipIdentityEnvelopeSource` — the identity port implementation: accepts only a
   cryptographically verified fleet-membership assertion (never caller-supplied claims) and a
   same-transaction capability-set digest.
+- `PrismaRunAuthoritySource` — the first concrete admission source: after the run repository locks
+  the service, it accepts only an active service whose exact active pointer still names a published
+  revision in the same silo. It derives the revision digest and prompt-compiler version from that
+  immutable revision; it never trusts a revision identifier from the request.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-run-authority-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-run-authority-source.test.ts
@@ -1,0 +1,50 @@
+import { AgentRevisionState, AgentServiceKind } from "@prisma/client";
+import type { RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaRunAuthoritySource } from "../prisma-run-authority-source.js";
+
+/** Immutable command used for source-level authority checks. */
+const _COMMAND = { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: null, executionSubjectId: "user-1", requestIdempotencyKey: "request-1" };
+
+/** Builds a transaction whose active-service read can be controlled per test. */
+function _transaction(service: unknown): RunAdmissionTransaction
+{
+	return { prisma: { agentService: { findFirst: vi.fn().mockResolvedValue(service) } } as never, admittedAt: "2026-07-25T00:00:00.000Z", admittedAtEpochMs: Date.parse("2026-07-25T00:00:00.000Z") };
+}
+
+/** Builds the minimal active service and active revision row returned by Prisma. */
+function _service(overrides: Record<string, unknown> = {})
+{
+	return {
+		id: "service-1",
+		kind: AgentServiceKind.Managed,
+		activeRevisionId: "revision-1",
+		activeRevision: { id: "revision-1", state: AgentRevisionState.Published, digest: `sha256:${"a".repeat(64)}`, promptPolicyVersion: "opencrane.prompt-compiler/1" },
+		...overrides,
+	};
+}
+
+describe("PrismaRunAuthoritySource", function _suite()
+{
+	it("loads the exact active published managed revision at the admission fence", async function _loadsManaged()
+	{
+		const result = await new PrismaRunAuthoritySource().load(_COMMAND, _transaction(_service()));
+		expect(result).toEqual({ outcome: "loaded", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "managed", effectiveContractDigest: `sha256:${"a".repeat(64)}`, promptCompilerVersion: "opencrane.prompt-compiler/1", trigger: "managed_invocation", delegatedUserId: null, rootRunId: "run-1", parentRunId: null } });
+	});
+
+	it("denies an absent active service and a stale active revision", async function _deniesStale()
+	{
+		await expect(new PrismaRunAuthoritySource().load(_COMMAND, _transaction(null))).resolves.toEqual({ outcome: "denied", reason: "run_not_admittable" });
+		const stale = _service({ activeRevision: { id: "revision-1", state: AgentRevisionState.Draft, digest: `sha256:${"a".repeat(64)}`, promptPolicyVersion: "opencrane.prompt-compiler/1" } });
+		await expect(new PrismaRunAuthoritySource().load(_COMMAND, _transaction(stale))).resolves.toEqual({ outcome: "denied", reason: "revision_unavailable" });
+	});
+
+	it("uses interactive delegation only for personal services", async function _loadsPersonal()
+	{
+		const result = await new PrismaRunAuthoritySource().load(_COMMAND, _transaction(_service({ kind: AgentServiceKind.Personal })));
+		if (result.outcome !== "loaded") throw new Error("expected loaded result");
+		expect(result.value.trigger).toBe("interactive");
+		expect(result.value.delegatedUserId).toBe("user-1");
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -1,3 +1,4 @@
 export { __AssembleRunInputSnapshot } from "./session-assembly.js";
 export { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
+export { PrismaRunAuthoritySource } from "./prisma-run-authority-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-run-authority-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-run-authority-source.ts
@@ -1,0 +1,46 @@
+import { AgentRevisionState, AgentServiceKind, AgentServiceState } from "@prisma/client";
+
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+import type { RunAuthoritySource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+
+/**
+ * Reads the one active published revision that may admit a new logical run.
+ *
+ * This source deliberately re-reads the service after the admission repository has locked it. A
+ * stale service state or an active pointer that no longer names a published revision is therefore
+ * a refusal, never a best-effort admission of an older revision.
+ */
+export class PrismaRunAuthoritySource implements RunAuthoritySource
+{
+	/** Loads the service and its exact active revision through the admission transaction. */
+	async load(command: SessionAssemblyCommand, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<InitialRunAuthority>>
+	{
+		const service = await transaction.prisma.agentService.findFirst({
+			where: { id: command.agentServiceId, siloId: command.siloId, state: AgentServiceState.Active, activeRevisionId: { not: null } },
+			select: {
+				id: true,
+				kind: true,
+				activeRevisionId: true,
+				activeRevision: { select: { id: true, state: true, digest: true, promptPolicyVersion: true } },
+			},
+		});
+		if (service === null || service.activeRevisionId === null || service.activeRevision === null) return { outcome: "denied", reason: "run_not_admittable" };
+		if (service.activeRevision.id !== service.activeRevisionId || service.activeRevision.state !== AgentRevisionState.Published) return { outcome: "denied", reason: "revision_unavailable" };
+
+		return {
+			outcome: "loaded",
+			value: {
+				agentServiceId: service.id,
+				agentRevisionId: service.activeRevision.id,
+				agentKind: service.kind === AgentServiceKind.Personal ? "personal" : "managed",
+				effectiveContractDigest: service.activeRevision.digest,
+				promptCompilerVersion: service.activeRevision.promptPolicyVersion,
+				trigger: service.kind === AgentServiceKind.Personal ? "interactive" : "managed_invocation",
+				delegatedUserId: service.kind === AgentServiceKind.Personal ? command.executionSubjectId : null,
+				rootRunId: command.runId,
+				parentRunId: null,
+			},
+		};
+	}
+}


### PR DESCRIPTION
## Summary

Adds the first concrete session-assembly source: PrismaRunAuthoritySource. Under the admission repository's existing service lock, it resolves only an active service in the requested silo whose active pointer still names a published revision. It then derives the effective contract digest and prompt compiler version from that immutable revision.

## Why this matters

This prevents caller-supplied or stale revision coordinates from becoming a frozen RunInputSnapshot. A paused service, a missing active pointer, or a draft/retired revision is refused before persona, tool, budget, or membership reads begin.

## Validation

- npx nx lint backend-agents-execution-inputs
- npx nx test backend-agents-execution-inputs (12 tests)
- agent-style-check and git diff --check
- Independent review: no critical, high, medium, or low findings

## Stack

Base: feat/phase-e-capability-ceilings (#437). This branch remains fail-closed in app composition until the remaining concrete sources and the membership signature verifier are wired.