### PR TITLE
🛡️ Phase E: make each run use only its live approved inputs

### DIFF
--- a/apps/agent-runtime/README.md
+++ b/apps/agent-runtime/README.md
@@ -18,7 +18,7 @@ candidates as the attempt runs. A model tool call is surfaced as a bounded `exte
 candidate for the control plane to authorize — the runtime never executes the tool itself. It also
 handles `resume_attempt` (feeding control-plane-authorized deferred tool results back into the paused
 loop) and `cancel_attempt` (a positive signal that kills the active task and acknowledges the
-server-chosen reason), absorbs steering only at pre-model-request boundaries, and writes an encrypted,
+server-chosen reason), enforces the compiled model-turn ceiling immediately before every provider request and durably records consumed turns in its encrypted resume checkpoint before opening that request, absorbs steering only at pre-model-request boundaries, and writes an encrypted,
 version-tagged, replaceable local checkpoint subordinate to canonical server state.
 
 ```text

--- a/apps/agent-runtime/src/runtime.py
+++ b/apps/agent-runtime/src/runtime.py
@@ -377,6 +377,39 @@ def _non_negative_int(value: object) -> int:
     return value if isinstance(value, int) and value >= 0 else 0
 
 
+class _ModelTurnBudget:
+    """Count model requests locally so one compiled input cannot exceed its server-selected ceiling."""
+
+    def __init__(self, maximum: int | None, used: int) -> None:
+        """Create a bounded or unlimited counter from the immutable compiled budget."""
+        self._maximum = maximum
+        self._used = used
+
+    @property
+    def used(self) -> int:
+        """Return the number of provider requests consumed across this resumable attempt."""
+        return self._used
+
+    def consume(self) -> None:
+        """Reserve one model request, failing before a request could exceed the configured maximum."""
+        if self._maximum is not None and self._used >= self._maximum:
+            raise RuntimeError("model turn budget exhausted")
+        self._used += 1
+
+
+def _model_turn_budget(compiled_input: dict[str, object], used: int = 0) -> _ModelTurnBudget:
+    """Read the optional positive model-turn ceiling and prior checkpoint consumption."""
+    budget = compiled_input.get("budget")
+    maximum = budget.get("maxModelTurns") if isinstance(budget, dict) else None
+    if isinstance(used, bool) or not isinstance(used, int) or used < 0:
+        raise RuntimeError("checkpoint has an invalid model turn count")
+    if maximum is None:
+        return _ModelTurnBudget(None, used)
+    if isinstance(maximum, bool) or not isinstance(maximum, int) or maximum <= 0:
+        raise RuntimeError("compiled input has an invalid model turn budget")
+    return _ModelTurnBudget(maximum, used)
+
+
 def _process_cipher() -> object:
     """Return the process-lifetime symmetric cipher, generating its key in memory on first use.
 
@@ -518,7 +551,7 @@ def _build_zero_retry_agent(
     return agent_cls(model, system_prompt=instructions, retries=settings["tool_validation_retries"], output_retries=settings["output_validation_retries"])
 
 
-def _pydantic_ai_event_source(compiled_input: dict[str, object], cancel_event: threading.Event, steering_buffer: list[str]) -> Iterator[dict[str, object]]:
+def _pydantic_ai_event_source(compiled_input: dict[str, object], cancel_event: threading.Event, steering_buffer: list[str], checkpoint_model_turns: Callable[[int], None] | None = None) -> Iterator[dict[str, object]]:
     """Drive the bounded Pydantic AI model/tool loop and yield neutral framework events.
 
     Pydantic AI is imported lazily so the outbound shell and its offline tests never require the
@@ -552,6 +585,10 @@ def _pydantic_ai_event_source(compiled_input: dict[str, object], cancel_event: t
     instructions = compiled_input.get("instructions")
     agent = _build_zero_retry_agent(model_alias, base_url, attempt_key, instructions if isinstance(instructions, str) else "")
 
+    # The budget is consumed immediately before each request node so a tool-driven loop cannot
+    # make an additional provider call after spending the control plane's per-run turn ceiling.
+    model_turn_budget = _model_turn_budget(compiled_input)
+
     async def _collect() -> list[dict[str, object]]:
         events: list[dict[str, object]] = []
         async with agent.iter(_prompt(compiled_input)) as run:
@@ -559,6 +596,9 @@ def _pydantic_ai_event_source(compiled_input: dict[str, object], cancel_event: t
                 if cancel_event.is_set():
                     break
                 if Agent.is_model_request_node(node):
+                    model_turn_budget.consume()
+                    if checkpoint_model_turns is not None:
+                        checkpoint_model_turns(model_turn_budget.used)
                     # Safe pre-model boundary: absorb any buffered steering into the next request
                     # context. Steering arriving after this point waits for the next boundary.
                     _apply_steering_to_request(node, _absorb_steering(steering_buffer))
@@ -607,6 +647,9 @@ def _pydantic_ai_resume_source(run_id: str, attempt: int, input_generation: obje
     instructions = compiled_input.get("instructions")
     agent = _build_zero_retry_agent(model_alias, base_url, attempt_key, instructions if isinstance(instructions, str) else "")
 
+    # Resume enters the same bounded request loop and independently rejects any malformed ceiling.
+    model_turn_budget = _model_turn_budget(compiled_input, _checkpoint_model_turns_used(state))
+
     async def _collect() -> list[dict[str, object]]:
         events: list[dict[str, object]] = []
         # The control-plane-authorized deferred results are injected as prior tool results so the
@@ -616,6 +659,8 @@ def _pydantic_ai_resume_source(run_id: str, attempt: int, input_generation: obje
                 if cancel_event.is_set():
                     break
                 if Agent.is_model_request_node(node):
+                    model_turn_budget.consume()
+                    _write_checkpoint_state(run_id, attempt, input_generation, compiled_input, checkpoint_cipher, model_turn_budget.used)
                     for steer in _absorb_steering(steering_buffer):
                         run.ctx.deps.steering.append(steer) if hasattr(getattr(run.ctx, "deps", None), "steering") else None
                     async with node.stream(run.ctx) as request_stream:
@@ -695,17 +740,37 @@ def _snapshot_input_generation(payload: dict[str, object]) -> object:
     return 0
 
 
-def _try_write_checkpoint(coordinates: dict[str, object], payload: dict[str, object], compiled_input: dict[str, object], cipher: object | None) -> None:
+def _try_write_checkpoint(coordinates: dict[str, object], payload: dict[str, object], compiled_input: dict[str, object], cipher: object | None, model_turns_used: int = 0) -> None:
     """Best-effort write of the SUBORDINATE local resume checkpoint; never blocks or fails the attempt.
 
     The checkpoint is a local optimisation only (never a source of truth). Any failure — including the
     absence of the crypto backend offline — is swallowed and logged so a missing checkpoint never
     turns a live attempt into an error.
     """
+    _try_write_checkpoint_state(coordinates["runId"], coordinates["attempt"], _snapshot_input_generation(payload), compiled_input, cipher, model_turns_used)
+
+
+def _try_write_checkpoint_state(run_id: object, attempt: object, input_generation: object, compiled_input: dict[str, object], cipher: object | None, model_turns_used: int) -> None:
+    """Best-effort persist initial local resume state before any model request has been issued."""
     try:
-        _write_checkpoint(coordinates["runId"], coordinates["attempt"], _snapshot_input_generation(payload), {"compiledInput": compiled_input}, cipher=cipher)
-    except Exception:  # noqa: BLE001 - the checkpoint is a subordinate optimisation, never load-bearing
-        _log("checkpoint_skipped", runId=coordinates.get("runId"), attempt=coordinates.get("attempt"))
+        _write_checkpoint_state(run_id, attempt, input_generation, compiled_input, cipher, model_turns_used)
+    except Exception:  # noqa: BLE001 - no model request has started, so this initial local cache remains optional
+        _log("checkpoint_skipped", runId=run_id, attempt=attempt)
+
+
+def _write_checkpoint_state(run_id: object, attempt: object, input_generation: object, compiled_input: dict[str, object], cipher: object | None, model_turns_used: int) -> None:
+    """Persist one resume state and let a per-turn caller fail closed when the write cannot complete."""
+    _write_checkpoint(run_id, attempt, input_generation, {"compiledInput": compiled_input, "modelTurnsUsed": model_turns_used}, cipher=cipher)
+
+
+def _checkpoint_model_turns_used(state: object) -> int:
+    """Read the non-negative cumulative turn count from a decrypted local checkpoint state."""
+    if not isinstance(state, dict):
+        return 0
+    used = state.get("modelTurnsUsed", 0)
+    if isinstance(used, bool) or not isinstance(used, int) or used < 0:
+        raise RuntimeError("checkpoint has an invalid model turn count")
+    return used
 
 
 def _recover_compiled_input(coordinates: dict[str, object], input_generation: object, cipher: object | None) -> dict[str, object]:
@@ -788,7 +853,15 @@ def _execute_start_attempt(command: dict[str, object], runtime_instance_id: str,
     steering_buffer: list[str] = []
     with _trace("agent_runtime.start_attempt", runId=coordinates["runId"], attempt=coordinates["attempt"]):
         try:
-            for neutral_event in event_source(compiled_input, cancel_event, steering_buffer):
+            if event_source is _pydantic_ai_event_source:
+                def _checkpoint_model_turns(used: int) -> None:
+                    """Persist consumption before the next provider request can become resumable state."""
+                    _write_checkpoint_state(coordinates["runId"], coordinates["attempt"], _snapshot_input_generation(payload if isinstance(payload, dict) else {}), compiled_input, checkpoint_cipher, used)
+
+                events = event_source(compiled_input, cancel_event, steering_buffer, _checkpoint_model_turns)
+            else:
+                events = event_source(compiled_input, cancel_event, steering_buffer)
+            for neutral_event in events:
                 if cancel_event.is_set():
                     break
                 _dispatch_neutral_event(coordinates, compiled_input, neutral_event, post_candidate)

--- a/apps/agent-runtime/tests/test_runtime.py
+++ b/apps/agent-runtime/tests/test_runtime.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import threading
 import unittest
+from unittest import mock
 from urllib.error import HTTPError
 
 from src import runtime
@@ -28,6 +29,8 @@ from src.runtime import (
     _execute_resume_attempt,
     _execute_start_attempt,
     _iter_commands,
+    _model_turn_budget,
+    _write_checkpoint_state,
     _normalize_event,
     _post_candidate_with_retry,
     _read_checkpoint,
@@ -307,6 +310,35 @@ class RuntimeSteeringTests(unittest.TestCase):
         buffer.append("do Y")
         self.assertEqual(_absorb_steering(buffer), ["do Y"])
         self.assertEqual(_absorb_steering(buffer), [])
+
+
+class RuntimeModelTurnBudgetTests(unittest.TestCase):
+    """Validate the pre-model-request request ceiling used by both start and resume loops."""
+
+    def test_turn_budget_rejects_the_first_request_past_the_compiled_ceiling(self) -> None:
+        """A tool-driven loop cannot issue a third request when the server selected two turns."""
+        budget = _model_turn_budget({"budget": {"maxModelTurns": 2}})
+        budget.consume()
+        budget.consume()
+        with self.assertRaisesRegex(RuntimeError, "model turn budget exhausted"):
+            budget.consume()
+
+    def test_turn_budget_preserves_consumption_from_a_resume_checkpoint(self) -> None:
+        """A resumed loop cannot obtain another model request after the initial loop spent its only turn."""
+        budget = _model_turn_budget({"budget": {"maxModelTurns": 1}}, used=1)
+        with self.assertRaisesRegex(RuntimeError, "model turn budget exhausted"):
+            budget.consume()
+
+    def test_turn_budget_rejects_a_malformed_ceiling_before_a_model_request(self) -> None:
+        """The runtime fails closed rather than treating a malformed authority value as unlimited."""
+        with self.assertRaisesRegex(RuntimeError, "invalid model turn budget"):
+            _model_turn_budget({"budget": {"maxModelTurns": 0}})
+
+    def test_consumed_turn_checkpoint_write_is_required_before_a_provider_request(self) -> None:
+        """A failed count update stops the loop instead of leaving a stale resume checkpoint behind."""
+        with mock.patch.object(runtime, "_write_checkpoint", side_effect=OSError("disk unavailable")):
+            with self.assertRaisesRegex(OSError, "disk unavailable"):
+                _write_checkpoint_state("run-1", 1, 2, _compiled_input(), None, 1)
 
 
 class RuntimeCheckpointTests(unittest.TestCase):

--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -53,6 +53,12 @@ caller input.
   the service, it accepts only an active service whose exact active pointer still names a published
   revision in the same silo. It derives the revision digest and prompt-compiler version from that
   immutable revision; it never trusts a revision identifier from the request.
+- `PrismaRevisionToolPolicySource` / `PrismaRevisionBudgetPolicySource` — concrete revision-input
+  sources. They accept only a current published revision with a silo-available model, live
+  integration custody, published active skills, and published artifact revisions; the budget source
+  turns the revision's positive turn/token/duration ceilings into the frozen compiler policy. The
+  model route carries its exact definition ID beside its public alias, preventing a same-named global
+  or tenant model from being selected later.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-revision-tool-policy-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-revision-tool-policy-source.test.ts
@@ -1,0 +1,78 @@
+import { AgentRevisionState, ArtifactRevisionState, IntegrationCustodyState, IntegrationState, ModelRoutingScope, SkillRevisionState, SkillState } from "@prisma/client";
+import type { RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "../prisma-revision-tool-policy-source.js";
+
+/** Fixed active managed revision facts shared by policy-source tests. */
+const _RUN = { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "managed", effectiveContractDigest: `sha256:${"a".repeat(64)}`, promptCompilerVersion: "opencrane.prompt-compiler/2026-07-21.1", trigger: "managed_invocation", delegatedUserId: null, rootRunId: "run-1", parentRunId: null } as const;
+/** Fixed assembly coordinates used by policy-source tests. */
+const _COMMAND = { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: null, executionSubjectId: "agent-service:service-1", requestIdempotencyKey: "request-1" };
+
+/** Builds a Prisma transaction fake around supplied revision and dependent authority rows. */
+function _transaction(revision: unknown, skills: unknown[] = [], artifacts: unknown[] = []): RunAdmissionTransaction
+{
+	return { prisma: { agentRevision: { findFirst: vi.fn().mockResolvedValue(revision) }, skillRevision: { findMany: vi.fn().mockResolvedValue(skills) }, artifactRevision: { findMany: vi.fn().mockResolvedValue(artifacts) } } as never, admittedAt: "2026-07-25T00:00:00.000Z", admittedAtEpochMs: Date.parse("2026-07-25T00:00:00.000Z") };
+}
+
+/** Builds a current revision with one live integration and one published skill artifact. */
+function _revision(overrides: Record<string, unknown> = {})
+{
+	return { modelDefinition: { id: "model-definition-1", scope: ModelRoutingScope.ClusterTenant, clusterTenant: "silo-1", publicModelName: "tenant-model" }, integrationAssignments: [{ integrationId: "integration-1", siloId: "silo-1", allowedTools: ["calendar.read"], integration: { state: IntegrationState.Active }, custodyReference: { state: IntegrationCustodyState.Ready, expiresAt: new Date("2026-07-26T00:00:00.000Z") } }], skillAssignments: [{ skillRevisionId: "skill-revision-1" }], budget: { maxTurns: 4, maxTokens: 1024, maxDurationMs: 60_000 }, ...overrides };
+}
+
+/** Builds one published skill revision that still belongs to an active silo-owned skill. */
+function _skill(overrides: Record<string, unknown> = {})
+{
+	return { id: "skill-revision-1", artifactRevisionId: "artifact-revision-1", state: SkillRevisionState.Published, skill: { state: SkillState.Active, siloId: "silo-1" }, ...overrides };
+}
+
+describe("PrismaRevisionToolPolicySource", function _suite()
+{
+	it("freezes only live revision-owned model, integration, skill, and artifact references", async function _loads()
+	{
+		const result = await new PrismaRevisionToolPolicySource().load(_COMMAND, _RUN, _transaction(_revision(), [_skill()], [{ id: "artifact-revision-1", state: ArtifactRevisionState.Published }]));
+		expect(result).toEqual({ outcome: "loaded", value: { modelRoute: { alias: "tenant-model", modelDefinitionId: "model-definition-1" }, integrationAssignments: [{ integrationId: "integration-1", allowedTools: ["calendar.read"] }], skillRevisionIds: ["skill-revision-1"], artifactRevisionIds: ["artifact-revision-1"] } });
+	});
+
+	it("refuses expired custody and unpublished skills before snapshot assembly", async function _refuses()
+	{
+		const expired = _revision({ integrationAssignments: [{ integrationId: "integration-1", siloId: "silo-1", allowedTools: ["calendar.read"], integration: { state: IntegrationState.Active }, custodyReference: { state: IntegrationCustodyState.Ready, expiresAt: new Date("2026-07-24T00:00:00.000Z") } }] });
+		await expect(new PrismaRevisionToolPolicySource().load(_COMMAND, _RUN, _transaction(expired))).resolves.toEqual({ outcome: "denied", reason: "tool_policy_unavailable" });
+		await expect(new PrismaRevisionToolPolicySource().load(_COMMAND, _RUN, _transaction(_revision(), [_skill({ state: SkillRevisionState.Draft })], [{ id: "artifact-revision-1" }]))).resolves.toEqual({ outcome: "denied", reason: "tool_policy_unavailable" });
+	});
+
+	it("denies a live integration projected from another silo", async function _foreignIntegration()
+	{
+		const foreign = _revision({ integrationAssignments: [{ integrationId: "integration-1", siloId: "silo-other", allowedTools: ["calendar.read"], integration: { state: IntegrationState.Active }, custodyReference: { state: IntegrationCustodyState.Ready, expiresAt: new Date("2026-07-26T00:00:00.000Z") } }] });
+		await expect(new PrismaRevisionToolPolicySource().load(_COMMAND, _RUN, _transaction(foreign))).resolves.toEqual({ outcome: "denied", reason: "tool_policy_unavailable" });
+	});
+
+	it("deduplicates a shared artifact revision assigned through two published skills", async function _sharedArtifact()
+	{
+		const revision = _revision({ skillAssignments: [{ skillRevisionId: "skill-revision-1" }, { skillRevisionId: "skill-revision-2" }] });
+		const secondSkill = _skill({ id: "skill-revision-2" });
+		const result = await new PrismaRevisionToolPolicySource().load(_COMMAND, _RUN, _transaction(revision, [_skill(), secondSkill], [{ id: "artifact-revision-1" }]));
+		if (result.outcome !== "loaded") throw new Error("expected live shared artifact");
+		expect(result.value.artifactRevisionIds).toEqual(["artifact-revision-1"]);
+	});
+});
+
+describe("PrismaRevisionBudgetPolicySource", function _suite()
+{
+	it("converts immutable positive revision limits into a deadline-bound compiler policy", async function _loads()
+	{
+		const result = await new PrismaRevisionBudgetPolicySource().load(_COMMAND, _RUN, _transaction(_revision()));
+		expect(result).toEqual({ outcome: "loaded", value: { budgetPolicy: { maxModelTurns: 4, maxTotalTokens: 1024, wallClockDeadlineEpochMs: Date.parse("2026-07-25T00:01:00.000Z") } } });
+	});
+
+	it("refuses a malformed revision budget", async function _refuses()
+	{
+		await expect(new PrismaRevisionBudgetPolicySource().load(_COMMAND, _RUN, _transaction(_revision({ budget: { maxTurns: 0, maxTokens: 1024, maxDurationMs: 60_000 } })))).resolves.toEqual({ outcome: "denied", reason: "budget_unavailable" });
+	});
+
+	it("refuses a duration whose deadline overflows the safe integer range", async function _overflow()
+	{
+		await expect(new PrismaRevisionBudgetPolicySource().load(_COMMAND, _RUN, _transaction(_revision({ budget: { maxTurns: 4, maxTokens: 1024, maxDurationMs: Number.MAX_SAFE_INTEGER } })))).resolves.toEqual({ outcome: "denied", reason: "budget_unavailable" });
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -1,4 +1,5 @@
 export { __AssembleRunInputSnapshot } from "./session-assembly.js";
 export { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
 export { PrismaRunAuthoritySource } from "./prisma-run-authority-source.js";
+export { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "./prisma-revision-tool-policy-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-revision-tool-policy-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-revision-tool-policy-source.ts
@@ -1,0 +1,58 @@
+import { AgentRevisionState, ArtifactRevisionState, IntegrationCustodyState, IntegrationState, ModelRoutingScope, SkillRevisionState, SkillState } from "@prisma/client";
+
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+import type { JsonValue } from "@opencrane/util";
+
+import type { BudgetPolicyInput, BudgetPolicySource, SessionAssemblyCommand, SessionAssemblyLoad, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";
+
+/** Revision-owned tool and budget policy frozen only after every referenced item remains live. */
+export class PrismaRevisionToolPolicySource implements ToolPolicySource
+{
+	/** Resolves the secret-free model route, live integration allowances, and pinned skill artifacts. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<ToolPolicyInput>>
+	{
+		const revision = await transaction.prisma.agentRevision.findFirst({
+			where: { id: run.agentRevisionId, agentServiceId: run.agentServiceId, state: AgentRevisionState.Published, agentService: { is: { id: run.agentServiceId, siloId: command.siloId, state: "Active", activeRevisionId: run.agentRevisionId } } },
+			include: { modelDefinition: true, integrationAssignments: { include: { integration: true, custodyReference: true } }, skillAssignments: true },
+		});
+		if (revision === null || !this._isModelAvailable(revision.modelDefinition, command.siloId)) return { outcome: "denied", reason: "tool_policy_unavailable" };
+		if (revision.integrationAssignments.some(assignment => assignment.siloId !== command.siloId || assignment.integration.state !== IntegrationState.Active || assignment.custodyReference.state !== IntegrationCustodyState.Ready || assignment.custodyReference.expiresAt.getTime() <= transaction.admittedAtEpochMs || assignment.allowedTools.length === 0 || assignment.allowedTools.some(tool => tool.trim().length === 0) || new Set(assignment.allowedTools).size !== assignment.allowedTools.length)) return { outcome: "denied", reason: "tool_policy_unavailable" };
+
+		const skillRevisionIds = revision.skillAssignments.map(assignment => assignment.skillRevisionId);
+		const skills = await transaction.prisma.skillRevision.findMany({ where: { id: { in: skillRevisionIds } }, include: { skill: true } });
+		if (skills.length !== skillRevisionIds.length || skills.some(skill => skill.state !== SkillRevisionState.Published || skill.skill.state !== SkillState.Active || skill.skill.siloId !== command.siloId)) return { outcome: "denied", reason: "tool_policy_unavailable" };
+		const artifactRevisionIds = [...new Set(skills.map(skill => skill.artifactRevisionId))];
+		const artifacts = await transaction.prisma.artifactRevision.findMany({ where: { id: { in: artifactRevisionIds }, state: ArtifactRevisionState.Published, artifact: { is: { siloId: command.siloId, state: "Active" } } }, select: { id: true } });
+		if (artifacts.length !== artifactRevisionIds.length) return { outcome: "denied", reason: "tool_policy_unavailable" };
+
+		return { outcome: "loaded", value: { modelRoute: { alias: revision.modelDefinition.publicModelName, modelDefinitionId: revision.modelDefinition.id }, integrationAssignments: revision.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, allowedTools: [...assignment.allowedTools] })), skillRevisionIds, artifactRevisionIds } };
+	}
+
+	/** Returns whether a model definition is global or belongs to the admission silo. */
+	private _isModelAvailable(model: { scope: ModelRoutingScope; clusterTenant: string | null }, siloId: string): boolean
+	{
+		return model.scope === ModelRoutingScope.Global || (model.scope === ModelRoutingScope.ClusterTenant && model.clusterTenant === siloId);
+	}
+
+}
+
+/** Reads immutable revision resource ceilings as compiler-readable per-run budget policy. */
+export class PrismaRevisionBudgetPolicySource implements BudgetPolicySource
+{
+	/** Resolves budget only when the exact active published revision remains current. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<BudgetPolicyInput>>
+	{
+		const revision = await transaction.prisma.agentRevision.findFirst({ where: { id: run.agentRevisionId, agentServiceId: run.agentServiceId, state: AgentRevisionState.Published, agentService: { is: { id: run.agentServiceId, siloId: command.siloId, state: "Active", activeRevisionId: run.agentRevisionId } } }, select: { budget: true } });
+		const budget = revision?.budget as Record<string, JsonValue> | undefined;
+		if (budget === undefined || !_isPositiveInteger(budget.maxTurns) || !_isPositiveInteger(budget.maxTokens) || !_isPositiveInteger(budget.maxDurationMs)) return { outcome: "denied", reason: "budget_unavailable" };
+		const deadline = transaction.admittedAtEpochMs + budget.maxDurationMs;
+		if (!Number.isSafeInteger(deadline)) return { outcome: "denied", reason: "budget_unavailable" };
+		return { outcome: "loaded", value: { budgetPolicy: { maxModelTurns: budget.maxTurns, maxTotalTokens: budget.maxTokens, wallClockDeadlineEpochMs: deadline } } };
+	}
+}
+
+/** Returns whether a JSON value is a positive safe-integer resource ceiling. */
+function _isPositiveInteger(value: JsonValue | undefined): value is number
+{
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}

--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
@@ -182,7 +182,7 @@ function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; streams: Fak
 /** Deterministic fake compiler: same snapshot digest always yields byte-identical compiled input. */
 const _compileRunInput: RunInputCompiler = async function _compile(snapshot): Promise<CompiledRunInput>
 {
-	return { promptCompilerVersion: "v1", runId: snapshot.runId, attempt: 1, instructions: "compiled", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: `sha256:${snapshot.digest}` };
+	return { promptCompilerVersion: "v1", runId: snapshot.runId, attempt: 1, instructions: "compiled", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: `sha256:${snapshot.digest}` };
 };
 
 /** Build the adapter under test over a fake with the requested durable state. */

--- a/libs/backend/agents/execution/protocol/src/__tests__/runtime-protocol-authority.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/runtime-protocol-authority.test.ts
@@ -34,7 +34,7 @@ function _snapshot(): RunInputSnapshot
 /** Returns the compiled literal input carried alongside the snapshot on a start command. */
 function _compiledInput(): CompiledRunInput
 {
-	return { promptCompilerVersion: "v1", runId: "run-1", attempt: 1, instructions: "", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: "sha256:compiled" };
+	return { promptCompilerVersion: "v1", runId: "run-1", attempt: 1, instructions: "", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: "sha256:compiled" };
 }
 
 /** Returns a valid start command bound to the current authority. */

--- a/libs/backend/agents/execution/protocol/src/prisma-run-input-compiler.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-run-input-compiler.ts
@@ -124,12 +124,14 @@ async function _loadSkillSummaries(transaction: Prisma.TransactionClient, skillR
 	return rows.map(function _summary(row) { return `skill ${row.skillId} revision ${row.id}`; }).sort();
 }
 
-/** Resolve the server-selected model route to a literal alias and output ceiling, never a credential. */
+/** Resolve the server-selected route to the exact LiteLLM deployment ID and output ceiling. */
 async function _resolveModelRoute(transaction: Prisma.TransactionClient, modelRoute: JsonValue): Promise<CompiledModelRoute>
 {
 	const route: { readonly [key: string]: JsonValue } = modelRoute && typeof modelRoute === "object" && !Array.isArray(modelRoute) ? modelRoute as { readonly [key: string]: JsonValue } : {};
-	const requested = typeof route["alias"] === "string" ? route["alias"] : typeof route["publicModelName"] === "string" ? route["publicModelName"] : "";
+	const modelDefinitionId = typeof route["modelDefinitionId"] === "string" ? route["modelDefinitionId"] : "";
 	const maxOutputTokens = typeof route["maxOutputTokens"] === "number" && Number.isSafeInteger(route["maxOutputTokens"]) && route["maxOutputTokens"] > 0 ? route["maxOutputTokens"] : null;
-	const definition = requested.length > 0 ? await transaction.modelDefinition.findFirst({ where: { publicModelName: requested } }) : null;
-	return { modelAlias: definition?.publicModelName ?? requested, maxOutputTokens };
+	if (modelDefinitionId.trim().length === 0) throw new Error("compiled model route requires an exact model definition");
+	const definition = await transaction.modelDefinition.findUnique({ where: { id: modelDefinitionId } });
+	if (definition === null) throw new Error("compiled model route references an unavailable model definition");
+	return { modelAlias: definition.litellmModelId, maxOutputTokens };
 }

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-dispatch-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-dispatch-repository.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { AgentRunState, AgentRunTerminalReason, AgentServiceKind, AgentServiceState, RunOutboxEventKind, WorkloadAssignmentState, WorkloadKind, type PrismaClient } from "@prisma/client";
+import { AgentRunState, AgentRunTerminalReason, AgentServiceKind, AgentServiceState, ModelRoutingScope, RunOutboxEventKind, WorkloadAssignmentState, WorkloadKind, type PrismaClient } from "@prisma/client";
 import { ___GetContext } from "@opencrane/observability";
 import { describe, expect, it, vi } from "vitest";
 
@@ -38,7 +38,13 @@ function _Event(overrides: Record<string, unknown> = {})
 /** Creates the immutable input snapshot and its time-bounded signed membership identity. */
 function _Snapshot(trustedUntil = "2026-07-20T02:00:00.000Z")
 {
-	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", effectiveContractDigest: "sha256:contract", digest: "sha256:snapshot", threadId: "thread-1", modelRoute: { alias: "silo-default" }, budgetPolicy: { maxCostUsdMicros: 5_000_000 }, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipTrustedUntil: trustedUntil } };
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", effectiveContractDigest: "sha256:contract", digest: "sha256:snapshot", threadId: "thread-1", modelRoute: { modelDefinitionId: "model-definition-1" }, budgetPolicy: { maxCostUsdMicros: 5_000_000 }, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipTrustedUntil: trustedUntil } };
+}
+
+/** Creates the immutable model definition that resolves one snapshot identity to one LiteLLM deployment. */
+function _ModelDefinition(overrides: Record<string, unknown> = {})
+{
+	return { id: "model-definition-1", scope: ModelRoutingScope.ClusterTenant, clusterTenant: "silo-1", publicModelName: "shared-name", litellmModelId: "litellm-deployment-silo-1", ...overrides };
 }
 
 /** Creates the exact suspended-Job assignment command returned after a claim. */
@@ -113,6 +119,7 @@ describe("PrismaRunDispatchRepository", function _DescribeDispatchRepository()
 			outboxEvent: { findUnique: vi.fn().mockResolvedValue(event), updateMany: vi.fn().mockResolvedValue({ count: 1 }), aggregate: vi.fn().mockResolvedValue({ _max: { sequence: 2 } }), create: vi.fn().mockResolvedValue(_ReleaseEvent()) },
 			workloadAssignment: { findUnique: vi.fn().mockResolvedValue(null) },
 			runInputSnapshot: { findUnique: vi.fn().mockResolvedValue(_Snapshot()) },
+			modelDefinition: { findUnique: vi.fn().mockResolvedValue(_ModelDefinition()) },
 		};
 		const prisma = { $transaction: vi.fn(async function _Transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
 		const repository = new PrismaRunDispatchRepository(prisma, { namespace: "silo-a", claimLeaseMilliseconds: 30_000, assignmentTtlMilliseconds: 3_600_000 }, _Issuer());
@@ -131,6 +138,7 @@ describe("PrismaRunDispatchRepository", function _DescribeDispatchRepository()
 		expect(_SqlText(queryRaw.mock.calls[4]?.[0])).toContain("run_outbox_events");
 		expect(transaction.outboxEvent.updateMany).toHaveBeenCalledWith({ where: expect.objectContaining({ id: "event-1", deliveryCount: 0 }), data: { claimedAt: new Date("2026-07-20T00:00:00.000Z"), deliveryCount: 1 } });
 		expect(transaction.agentRun.updateMany).toHaveBeenCalledWith({ where: expect.objectContaining({ state: AgentRunState.Accepted }), data: { state: AgentRunState.Queued } });
+		expect(transaction.modelDefinition.findUnique).toHaveBeenCalledWith({ where: { id: "model-definition-1" } });
 		expect(JSON.stringify(result)).not.toContain("executionSubjectId");
 	});
 
@@ -153,6 +161,7 @@ describe("PrismaRunDispatchRepository", function _DescribeDispatchRepository()
 			outboxEvent: { findUnique: vi.fn().mockResolvedValue(event), updateMany: vi.fn(async function _eventUpdate(args: unknown) { writes.push(args); return { count: 1 }; }) },
 			runInputSnapshot: { findUnique: vi.fn().mockResolvedValue(_Snapshot()) },
 			workloadAssignment: { findUnique: vi.fn().mockResolvedValue(null) },
+			modelDefinition: { findUnique: vi.fn().mockResolvedValue(_ModelDefinition()) },
 		};
 		const prisma = { $transaction: vi.fn(async function _Transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
 		const requests: AttemptModelKeyMintRequest[] = [];
@@ -162,7 +171,7 @@ describe("PrismaRunDispatchRepository", function _DescribeDispatchRepository()
 
 		// The issuer is called with the frozen alias, budget, and expiry; minting happens after the
 		// transaction so no external call holds a lock.
-		expect(requests).toEqual([{ keyAlias: expect.stringMatching(/^attempt-[0-9a-f]{32}$/), modelAlias: "silo-default", siloId: "silo-1", maxBudgetUsd: 5, expirySeconds: 3_600 }]);
+		expect(requests).toEqual([{ keyAlias: expect.stringMatching(/^attempt-[0-9a-f]{32}$/), modelAlias: "litellm-deployment-silo-1", siloId: "silo-1", maxBudgetUsd: 5, expirySeconds: 3_600 }]);
 		expect(result).toMatchObject({ status: "claimed", claim: { attempt: { litellmKey: "sk-attempt-transient" } } });
 		// The transient key rides the claim response only; it appears in no database write argument.
 		expect(JSON.stringify(writes)).not.toContain("sk-attempt-transient");
@@ -193,6 +202,7 @@ describe("PrismaRunDispatchRepository", function _DescribeDispatchRepository()
 			conversationRunEvent: { aggregate: vi.fn(), create: vi.fn() },
 			workloadAssignment: { findUnique: vi.fn().mockResolvedValue(null) },
 			runInputSnapshot: { findUnique: vi.fn().mockResolvedValue(secondSnapshot) },
+			modelDefinition: { findUnique: vi.fn().mockResolvedValue(_ModelDefinition({ id: "model-definition-2" })) },
 		};
 		const transactions = [firstTransaction, secondTransaction];
 		const prisma = { $transaction: vi.fn(async function _Transaction(callback: (client: typeof firstTransaction) => Promise<unknown>) { return callback(transactions.shift()!); }) } as unknown as PrismaClient;

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
@@ -1,6 +1,6 @@
 import { createHash } from "node:crypto";
 
-import { AgentRunState, AgentRunTerminalReason, AgentServiceKind, AgentServiceState, Prisma, RunOutboxEventKind, WorkloadAssignmentState, WorkloadKind, type AgentRun, type OutboxEvent, type PrismaClient, type WorkloadAssignment, type WorkloadBootstrap } from "@prisma/client";
+import { AgentRunState, AgentRunTerminalReason, AgentServiceKind, AgentServiceState, ModelRoutingScope, Prisma, RunOutboxEventKind, WorkloadAssignmentState, WorkloadKind, type AgentRun, type OutboxEvent, type PrismaClient, type WorkloadAssignment, type WorkloadBootstrap } from "@prisma/client";
 
 import { AGENT_RUNTIME_PROJECTED_TOKEN_AUDIENCE, ___IsAgentRuntimeServiceAccountName, type AgentControllerRunAttemptAssignmentCommand, type AgentControllerRunAttemptClaimLease, type AgentControllerRunAttemptProjection, type AgentControllerRunWorkloadRegistrationCommand, type AgentControllerRunWorkloadReleaseProjection } from "@opencrane/contracts";
 import { ___DoWithTrace } from "@opencrane/observability";
@@ -25,7 +25,7 @@ interface ClaimedAttemptWithMintInputs
 	readonly attempt: Omit<AgentControllerRunAttemptProjection, "litellmKey">;
 	/** Attempt- and delivery-unique alias the minted key is bound to. */
 	readonly keyAlias: string;
-	/** Single model alias frozen into the snapshot's server-selected route. */
+	/** Exact LiteLLM deployment identifier derived from the frozen model-definition identity. */
 	readonly modelAlias: string;
 	/** Positive US-dollar spend ceiling derived from the snapshot's budget policy. */
 	readonly maxBudgetUsd: number;
@@ -122,9 +122,11 @@ export class PrismaRunDispatchRepository implements RunDispatchRepository
 				return { status: "none" };
 			}
 
-			// 3. Read the frozen model alias and cost ceiling; fail closed when either cannot bound a key.
-			const modelAlias = _SnapshotModelAlias(snapshot.modelRoute);
+			// 3. Resolve the frozen definition ID under this claim lock; an alias alone can collide by scope.
+			const modelDefinitionId = _SnapshotModelDefinitionId(snapshot.modelRoute);
 			const maxBudgetUsd = _SnapshotMaxBudgetUsd(snapshot.budgetPolicy);
+			const modelDefinition = modelDefinitionId === null ? null : await transaction.modelDefinition.findUnique({ where: { id: modelDefinitionId } });
+			const modelAlias = _AttemptKeyModelId(modelDefinition, run.siloId);
 			if (modelAlias === null || maxBudgetUsd === null)
 			{
 				await _TerminalizeUndispatchableAttempt(transaction, event, run, now, "RUN_DISPATCH_MODEL_ROUTE_INVALID", AgentRunTerminalReason.InvalidInput);
@@ -727,13 +729,22 @@ async function _TerminalizePoisonedRelease(transaction: Prisma.TransactionClient
 	}
 }
 
-/** Extract the single model alias frozen into the snapshot's server-selected route. */
-function _SnapshotModelAlias(modelRoute: unknown): string | null
+/** Extract the immutable model-definition identity frozen into the snapshot's server-selected route. */
+function _SnapshotModelDefinitionId(modelRoute: unknown): string | null
 {
 	if (!modelRoute || typeof modelRoute !== "object" || Array.isArray(modelRoute)) return null;
 	const route = modelRoute as Record<string, unknown>;
-	const alias = typeof route["alias"] === "string" ? route["alias"] : typeof route["publicModelName"] === "string" ? route["publicModelName"] : "";
-	return alias.trim().length > 0 && alias.length <= 128 ? alias : null;
+	const modelDefinitionId = typeof route["modelDefinitionId"] === "string" ? route["modelDefinitionId"] : "";
+	return modelDefinitionId.trim().length > 0 && modelDefinitionId.length <= 256 ? modelDefinitionId : null;
+}
+
+/** Derive the one LiteLLM deployment ID that the claimed attempt may call in its own silo. */
+function _AttemptKeyModelId(modelDefinition: { readonly scope: ModelRoutingScope; readonly clusterTenant: string | null; readonly litellmModelId: string } | null, siloId: string): string | null
+{
+	if (modelDefinition === null) return null;
+	if (modelDefinition.scope !== ModelRoutingScope.Global && (modelDefinition.scope !== ModelRoutingScope.ClusterTenant || modelDefinition.clusterTenant !== siloId)) return null;
+	const modelId = modelDefinition.litellmModelId.trim();
+	return modelId.length > 0 && modelId.length <= 256 ? modelId : null;
 }
 
 /** Derive the positive US-dollar spend ceiling from the snapshot's micro-dollar cost policy. */

--- a/libs/backend/agents/runtime/prompt-compiler/main/src/__tests__/prompt-compiler.test.ts
+++ b/libs/backend/agents/runtime/prompt-compiler/main/src/__tests__/prompt-compiler.test.ts
@@ -25,7 +25,7 @@ function _snapshot(overrides: Partial<RunInputSnapshot> = {}): RunInputSnapshot
 		memoryQueryPolicy: {},
 		integrationAssignments: [{ integrationId: "integration-b", allowedTools: ["tool-b"] }, { integrationId: "integration-a", allowedTools: ["tool-a"] }],
 		modelRoute: { alias: "silo-default" },
-		budgetPolicy: { maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 },
+		budgetPolicy: { maxModelTurns: 6, maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 },
 		identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 3, fleetMembershipIssuer: "fleet", fleetMembershipIssuerKeyId: "k1", fleetMembershipAssertionId: "a1", fleetMembershipPayloadDigest: "sha256:c", fleetMembershipTrustedUntil: "2026-07-21T00:00:00.000Z" },
 		capabilitySetDigest: "sha256:cap",
 		effectiveContractDigest: "sha256:contract",
@@ -82,14 +82,14 @@ describe("__CompileRunInput", function _describeCompiler()
 	{
 		const compiled = await __CompileRunInput(_snapshot(), _repositories());
 
-		expect(compiled.budget).toEqual({ maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 });
+		expect(compiled.budget).toEqual({ maxModelTurns: 6, maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 });
 	});
 
 	it("nulls malformed or absent budget limits rather than inventing them", async function _nullsBadBudget()
 	{
 		const compiled = await __CompileRunInput(_snapshot({ budgetPolicy: { maxTotalTokens: "lots" as unknown as JsonValue } }), _repositories());
 
-		expect(compiled.budget).toEqual({ maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null });
+		expect(compiled.budget).toEqual({ maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null });
 	});
 
 	it("assembles persona, memory, artifact, and skill sections in canonical order", async function _assembles()

--- a/libs/backend/agents/runtime/prompt-compiler/main/src/prompt-compiler.ts
+++ b/libs/backend/agents/runtime/prompt-compiler/main/src/prompt-compiler.ts
@@ -109,6 +109,7 @@ function _resolveBudget(budgetPolicy: JsonValue): CompiledBudget
 {
 	const policy: { readonly [key: string]: JsonValue } = budgetPolicy && typeof budgetPolicy === "object" && !Array.isArray(budgetPolicy) ? budgetPolicy as { readonly [key: string]: JsonValue } : {};
 	return {
+		maxModelTurns: _optionalCount(policy["maxModelTurns"]),
 		maxTotalTokens: _optionalCount(policy["maxTotalTokens"]),
 		maxCostUsdMicros: _optionalCount(policy["maxCostUsdMicros"]),
 		maxToolInvocations: _optionalCount(policy["maxToolInvocations"]),

--- a/libs/contracts/src/compiled-run-input.types.ts
+++ b/libs/contracts/src/compiled-run-input.types.ts
@@ -67,6 +67,8 @@ export interface CompiledModelRoute
 /** Literal aggregate limits OpenCrane enforces over the bounded loop. */
 export interface CompiledBudget
 {
+	/** Maximum model turns across the attempt, or null when uncapped. */
+	readonly maxModelTurns: number | null;
 	/** Maximum total tokens across the attempt, or null when uncapped. */
 	readonly maxTotalTokens: number | null;
 	/** Maximum spend in micro-US-dollars across the attempt, or null when uncapped. */


### PR DESCRIPTION
## Why\n\nA run must be assembled from the exact published agent revision that is active for its service and silo. This PR turns that requirement into concrete admission sources and carries the resulting ceilings all the way to the isolated runtime.\n\n## What changes\n\n- load the selected revision's model, integration, skill, artifact, and budget policy only when every referenced authority is still live\n- pin the exact model-definition identity through dispatch and mint the attempt key for its single LiteLLM deployment, not an ambiguous public alias\n- enforce the revision's model-turn ceiling before every provider request, preserving spent turns across resume and failing closed if the count cannot be checkpointed\n- document the public boundary and add focused refusal and regression coverage\n\n## Validation\n\n- agent-style-check: 5 TypeScript files checked, 0 errors, 0 warnings\n- inputs: lint and 19 tests\n- prompt compiler: lint and 10 tests\n- execution protocol: lint and 50 tests\n- execution runs: lint and focused dispatch repository test (14 tests)\n- agent runtime: 75 Python tests (2 skipped)\n\nThe broader execution-runs test target remains blocked locally only by the sandbox preventing Supertest from binding a listener (listen EPERM); its non-HTTP tests pass.\n\n## Review\n\nIndependent review completed with no Critical or High findings remaining.\n\nStacked on #438; merge this after that PR.