### PR TITLE
🧠 Phase E: bind personal runs to the owner-approved persona

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -59,6 +59,9 @@ caller input.
   turns the revision's positive turn/token/duration ceilings into the frozen compiler policy. The
   model route carries its exact definition ID beside its public alias, preventing a same-named global
   or tenant model from being selected later.
+- `PrismaApprovedPersonaSource` — resolves a personal run only through the delegated user's profile
+  in the same silo and accepts its current revision only while it remains approved. Managed runs carry
+  no persona, and neither a service nor a caller can select another person's persona revision.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-approved-persona-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-approved-persona-source.test.ts
@@ -1,0 +1,55 @@
+import { PersonaRevisionState } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaApprovedPersonaSource } from "../prisma-approved-persona-source.js";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+/** Create a personal interactive run delegated to the current execution subject. */
+function _PersonalRun(overrides: Partial<InitialRunAuthority> = {}): InitialRunAuthority
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null, ...overrides };
+}
+
+/** Create the narrow admission command whose subject owns the personal profile. */
+function _Command(overrides: Record<string, unknown> = {})
+{
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1", ...overrides } as never;
+}
+
+/** Create the minimal transaction façade expected by this read-only authority source. */
+function _Transaction(activeRevision: unknown): RunAdmissionTransaction
+{
+	return { prisma: { personaProfile: { findUnique: vi.fn().mockResolvedValue(activeRevision === undefined ? null : { activeRevision }) } } as never, admittedAt: "2026-07-25T00:00:00.000Z", admittedAtEpochMs: Date.parse("2026-07-25T00:00:00.000Z") };
+}
+
+describe("PrismaApprovedPersonaSource", function _DescribeApprovedPersonaSource()
+{
+	it("loads only the delegated user's currently approved profile revision in the command silo", async function _LoadsApprovedPersona()
+	{
+		const transaction = _Transaction({ id: "persona-1", state: PersonaRevisionState.Approved, personaProfileId: "profile-1" });
+		const result = await new PrismaApprovedPersonaSource().load(_Command(), _PersonalRun(), transaction);
+
+		expect(result).toEqual({ outcome: "loaded", value: { personaRevisionId: "persona-1" } });
+		expect(transaction.prisma.personaProfile.findUnique).toHaveBeenCalledWith({ where: { siloId_userId: { siloId: "silo-1", userId: "user-1" } }, select: { activeRevision: { select: { id: true, state: true, personaProfileId: true } } } });
+	});
+
+	it("rejects a personal run whose delegated user does not match its authenticated execution subject", async function _RejectsImpersonation()
+	{
+		const transaction = _Transaction({ id: "persona-1", state: PersonaRevisionState.Approved, personaProfileId: "profile-1" });
+		await expect(new PrismaApprovedPersonaSource().load(_Command({ executionSubjectId: "user-2" }), _PersonalRun(), transaction)).resolves.toEqual({ outcome: "denied", reason: "persona_unavailable" });
+		expect(transaction.prisma.personaProfile.findUnique).not.toHaveBeenCalled();
+	});
+
+	it("rejects a missing or non-approved active revision instead of snapshotting a draft persona", async function _RejectsUnapprovedPersona()
+	{
+		await expect(new PrismaApprovedPersonaSource().load(_Command(), _PersonalRun(), _Transaction({ id: "persona-1", state: PersonaRevisionState.Draft, personaProfileId: "profile-1" }))).resolves.toEqual({ outcome: "denied", reason: "persona_unavailable" });
+		await expect(new PrismaApprovedPersonaSource().load(_Command(), _PersonalRun(), _Transaction(null))).resolves.toEqual({ outcome: "denied", reason: "persona_unavailable" });
+	});
+
+	it("keeps managed runs persona-free without reading a personal profile", async function _KeepsManagedPersonaFree()
+	{
+		const transaction = _Transaction({ id: "persona-1", state: PersonaRevisionState.Approved, personaProfileId: "profile-1" });
+		await expect(new PrismaApprovedPersonaSource().load(_Command(), _PersonalRun({ agentKind: "managed", delegatedUserId: null }), transaction)).resolves.toEqual({ outcome: "loaded", value: { personaRevisionId: null } });
+		expect(transaction.prisma.personaProfile.findUnique).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -1,5 +1,6 @@
 export { __AssembleRunInputSnapshot } from "./session-assembly.js";
 export { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
 export { PrismaRunAuthoritySource } from "./prisma-run-authority-source.js";
+export { PrismaApprovedPersonaSource } from "./prisma-approved-persona-source.js";
 export { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "./prisma-revision-tool-policy-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-approved-persona-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-approved-persona-source.ts
@@ -1,0 +1,27 @@
+import { PersonaRevisionState } from "@prisma/client";
+
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+import type { ApprovedPersonaInput, ApprovedPersonaSource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+
+/** Transaction-fenced source for the single approved persona a personal run may compile. */
+export class PrismaApprovedPersonaSource implements ApprovedPersonaSource
+{
+	/** Load an active approved persona for a personal delegated user, or none for a managed run. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<ApprovedPersonaInput>>
+	{
+		if (run.agentKind === "managed") return { outcome: "loaded", value: { personaRevisionId: null } };
+		if (run.delegatedUserId === null || run.delegatedUserId !== command.executionSubjectId) return { outcome: "denied", reason: "persona_unavailable" };
+
+		// 1. Bind the profile to the exact delegated user and silo rather than accepting a service-selected persona.
+		const profile = await transaction.prisma.personaProfile.findUnique({
+			where: { siloId_userId: { siloId: command.siloId, userId: run.delegatedUserId } },
+			select: { activeRevision: { select: { id: true, state: true, personaProfileId: true } } },
+		});
+		// 2. Require the profile's current revision to remain approved at the same admission fence.
+		const revision = profile?.activeRevision;
+		if (revision === null || revision === undefined || revision.state !== PersonaRevisionState.Approved || revision.personaProfileId.trim().length === 0) return { outcome: "denied", reason: "persona_unavailable" };
+
+		return { outcome: "loaded", value: { personaRevisionId: revision.id } };
+	}
+}


### PR DESCRIPTION
## Why\n\nThe onboarding interview and persona approval flow already creates durable, reviewable persona revisions. A personal run must use only the owning user's currently approved result; it must never accept a persona chosen by a service or another caller.\n\n## What changes\n\n- add the transaction-fenced approved-persona input source\n- scope personal persona resolution to the delegated execution subject and current silo\n- accept only the profile's current approved revision\n- keep managed runs explicitly persona-free\n- document the public authority and add owner, draft, absence, and managed-run regression coverage\n\n## Validation\n\n- agent-style-check: 1 TypeScript file checked, 0 errors, 0 warnings\n- execution-inputs: lint and 23 tests\n\n## Review\n\nIndependent review completed with no findings.\n\nStacked on #439; merge this after that PR.