### PR TITLE
🧠 Phase E: admit only consented personal preference facts

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -62,6 +62,10 @@ caller input.
 - `PrismaApprovedPersonaSource` — resolves a personal run only through the delegated user's profile
   in the same silo and accepts its current revision only while it remains approved. Managed runs carry
   no persona, and neither a service nor a caller can select another person's persona revision.
+- `PrismaPreferenceFactSource` — admits optional personalisation only from the user's active
+  `Personal` memory dataset. A fact also needs active state, explicit or confirmed consent, and
+  provenance naming that exact user; shared-scope, inferred, retired, and unproven facts never enter
+  a run snapshot.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-preference-fact-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-preference-fact-source.test.ts
@@ -1,0 +1,55 @@
+import { AuthorizationScopeKind, MemoryConsentState, MemoryDatasetState, MemoryFactState } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaPreferenceFactSource } from "../prisma-preference-fact-source.js";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+/** Create one personal interactive run delegated to its authenticated user. */
+function _PersonalRun(overrides: Partial<InitialRunAuthority> = {}): InitialRunAuthority
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null, ...overrides };
+}
+
+/** Create minimal command coordinates scoped to the same personal owner. */
+function _Command(overrides: Record<string, unknown> = {})
+{
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1", ...overrides } as never;
+}
+
+/** Create the narrow memory-query transaction façade. */
+function _Transaction(dataset: unknown, facts: readonly unknown[] = []): RunAdmissionTransaction
+{
+	return { prisma: { memoryDataset: { findFirst: vi.fn().mockResolvedValue(dataset) }, memoryFactCatalog: { findMany: vi.fn().mockResolvedValue(facts) } } as never, admittedAt: "2026-07-25T00:00:00.000Z", admittedAtEpochMs: Date.parse("2026-07-25T00:00:00.000Z") };
+}
+
+describe("PrismaPreferenceFactSource", function _DescribePreferenceFactSource()
+{
+	it("loads only active consented facts with explicit provenance for the delegated owner", async function _LoadsOwnerPreferences()
+	{
+		const transaction = _Transaction({ id: "dataset-1" }, [{ id: "fact-1", provenance: { sourceKind: "explicit-user-fact", sourceUserId: "user-1" } }, { id: "fact-2", provenance: { sourceKind: "message", sourceUserId: "user-1" } }, { id: "fact-3", provenance: { sourceKind: "explicit-user-fact", sourceUserId: "user-2" } }]);
+		await expect(new PrismaPreferenceFactSource().load(_Command(), _PersonalRun(), transaction)).resolves.toEqual({ outcome: "loaded", value: [{ id: "fact-1" }] });
+		expect(transaction.prisma.memoryDataset.findFirst).toHaveBeenCalledWith({ where: { siloId: "silo-1", scopeKind: AuthorizationScopeKind.Personal, scopeResourceId: "user-1", state: MemoryDatasetState.Active }, select: { id: true } });
+		expect(transaction.prisma.memoryFactCatalog.findMany).toHaveBeenCalledWith({ where: { datasetId: "dataset-1", state: MemoryFactState.Active, consentState: { in: [MemoryConsentState.Explicit, MemoryConsentState.Confirmed] } }, select: { id: true, provenance: true } });
+	});
+
+	it("treats a missing personal dataset as no optional preferences rather than borrowing a shared dataset", async function _DoesNotBroadenScope()
+	{
+		const transaction = _Transaction(null);
+		await expect(new PrismaPreferenceFactSource().load(_Command(), _PersonalRun(), transaction)).resolves.toEqual({ outcome: "loaded", value: [] });
+		expect(transaction.prisma.memoryFactCatalog.findMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects a personal run when delegation and authenticated subject disagree", async function _RejectsImpersonation()
+	{
+		const transaction = _Transaction({ id: "dataset-1" });
+		await expect(new PrismaPreferenceFactSource().load(_Command({ executionSubjectId: "user-2" }), _PersonalRun(), transaction)).resolves.toEqual({ outcome: "denied", reason: "memory_scope_unavailable" });
+		expect(transaction.prisma.memoryDataset.findFirst).not.toHaveBeenCalled();
+	});
+
+	it("keeps managed runs free of personal facts", async function _KeepsManagedRunsFree()
+	{
+		const transaction = _Transaction({ id: "dataset-1" });
+		await expect(new PrismaPreferenceFactSource().load(_Command(), _PersonalRun({ agentKind: "managed", delegatedUserId: null }), transaction)).resolves.toEqual({ outcome: "loaded", value: [] });
+		expect(transaction.prisma.memoryDataset.findFirst).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -2,5 +2,6 @@ export { __AssembleRunInputSnapshot } from "./session-assembly.js";
 export { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
 export { PrismaRunAuthoritySource } from "./prisma-run-authority-source.js";
 export { PrismaApprovedPersonaSource } from "./prisma-approved-persona-source.js";
+export { PrismaPreferenceFactSource } from "./prisma-preference-fact-source.js";
 export { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "./prisma-revision-tool-policy-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-preference-fact-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-preference-fact-source.ts
@@ -1,0 +1,37 @@
+import { AuthorizationScopeKind, MemoryConsentState, MemoryDatasetState, MemoryFactState } from "@prisma/client";
+
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+import type { PreferenceFactInput, PreferenceFactSource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+
+/** Transaction-fenced source for explicit, consented personal facts used as run preferences. */
+export class PrismaPreferenceFactSource implements PreferenceFactSource
+{
+	/** Load active consented facts from the delegated user's own personal dataset, or none for managed runs. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<readonly PreferenceFactInput[]>>
+	{
+		if (run.agentKind === "managed") return { outcome: "loaded", value: [] };
+		if (run.delegatedUserId === null || run.delegatedUserId !== command.executionSubjectId) return { outcome: "denied", reason: "memory_scope_unavailable" };
+
+		// 1. Find only the user's Personal dataset; organization, department, and project facts cannot personalize this run.
+		const dataset = await transaction.prisma.memoryDataset.findFirst({
+			where: { siloId: command.siloId, scopeKind: AuthorizationScopeKind.Personal, scopeResourceId: run.delegatedUserId, state: MemoryDatasetState.Active },
+			select: { id: true },
+		});
+		if (dataset === null) return { outcome: "loaded", value: [] };
+
+		// 2. Accept only retained, consented facts whose provenance explicitly identifies this user.
+		const facts = await transaction.prisma.memoryFactCatalog.findMany({
+			where: { datasetId: dataset.id, state: MemoryFactState.Active, consentState: { in: [MemoryConsentState.Explicit, MemoryConsentState.Confirmed] } },
+			select: { id: true, provenance: true },
+		});
+		return { outcome: "loaded", value: facts.filter(function _isOwnerPreference(fact) { return _IsExplicitOwnerPreference(fact.provenance, run.delegatedUserId!); }).map(function _toPreference(fact) { return { id: fact.id }; }) };
+	}
+}
+
+/** Return whether structured provenance proves the fact is an explicit preference of this exact user. */
+function _IsExplicitOwnerPreference(provenance: unknown, userId: string): boolean
+{
+	if (provenance === null || typeof provenance !== "object" || Array.isArray(provenance)) return false;
+	const record = provenance as Readonly<Record<string, unknown>>;
+	return record["sourceKind"] === "explicit-user-fact" && record["sourceUserId"] === userId;
+}


### PR DESCRIPTION
## Why\n\nA run may personalize only from durable facts the user explicitly or confirmably consented to retain. It must not infer preferences from content, borrow organization data, or receive facts intended for another user.\n\n## What changes\n\n- add a transaction-fenced preference-fact source\n- read only the delegated user's active Personal memory dataset in the current silo\n- require active state, explicit or confirmed consent, and explicit owner provenance\n- keep an absent optional dataset empty and keep managed runs free of personal facts\n- document the authority and add scope, consent/provenance, absence, impersonation, and managed-run coverage\n\n## Validation\n\n- agent-style-check: 1 TypeScript file checked, 0 errors, 0 warnings\n- execution-inputs: lint and 27 tests\n\n## Review\n\nIndependent review completed with no findings.\n\nStacked on #440; merge this after that PR.