### PR TITLE
💬 Phase E: freeze authorized conversation context at run admission

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -66,6 +66,9 @@ caller input.
   `Personal` memory dataset. A fact also needs active state, explicit or confirmed consent, and
   provenance naming that exact user; shared-scope, inferred, retired, and unproven facts never enter
   a run snapshot.
+- `PrismaThreadContextSource` — accepts a conversation only when its active thread is bound to the
+  exact service, silo, and authenticated participant. It freezes ordered IDs of completed messages
+  only; pending and streaming content cannot race into an immutable run input.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-thread-context-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-thread-context-source.test.ts
@@ -1,0 +1,48 @@
+import { ConversationMessageState, ConversationThreadState } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaThreadContextSource } from "../prisma-thread-context-source.js";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+/** Create one personal run bound to the target conversation service. */
+function _Run(overrides: Partial<InitialRunAuthority> = {}): InitialRunAuthority
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null, ...overrides };
+}
+
+/** Create target admission coordinates for one authenticated conversation participant. */
+function _Command(overrides: Record<string, unknown> = {})
+{
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1", ...overrides } as never;
+}
+
+/** Create the transaction façade used by the transcript authority. */
+function _Transaction(thread: unknown, messages: readonly unknown[] = []): RunAdmissionTransaction
+{
+	return { prisma: { conversationThread: { findFirst: vi.fn().mockResolvedValue(thread) }, conversationMessage: { findMany: vi.fn().mockResolvedValue(messages) } } as never, admittedAt: "2026-07-25T00:00:00.000Z", admittedAtEpochMs: Date.parse("2026-07-25T00:00:00.000Z") };
+}
+
+describe("PrismaThreadContextSource", function _DescribeThreadContextSource()
+{
+	it("loads completed message IDs in stable transcript order from the exact active participant thread", async function _LoadsThread()
+	{
+		const transaction = _Transaction({ id: "thread-1" }, [{ id: "message-1" }, { id: "message-2" }]);
+		await expect(new PrismaThreadContextSource().load(_Command(), _Run(), transaction)).resolves.toEqual({ outcome: "loaded", value: { messageIds: ["message-1", "message-2"] } });
+		expect(transaction.prisma.conversationThread.findFirst).toHaveBeenCalledWith({ where: { id: "thread-1", siloId: "silo-1", agentServiceId: "service-1", state: ConversationThreadState.Active, participants: { some: { userId: "user-1" } } }, select: { id: true } });
+		expect(transaction.prisma.conversationMessage.findMany).toHaveBeenCalledWith({ where: { threadId: "thread-1", state: ConversationMessageState.Completed }, orderBy: [{ createdAt: "asc" }, { id: "asc" }], select: { id: true } });
+	});
+
+	it("rejects a missing, archived, cross-service, or non-participant thread through the scoped query", async function _RejectsUnboundThread()
+	{
+		const transaction = _Transaction(null);
+		await expect(new PrismaThreadContextSource().load(_Command(), _Run(), transaction)).resolves.toEqual({ outcome: "denied", reason: "thread_unavailable" });
+		expect(transaction.prisma.conversationMessage.findMany).not.toHaveBeenCalled();
+	});
+
+	it("keeps non-conversational runs free of transcript inputs without querying messages", async function _KeepsNonConversationalInputEmpty()
+	{
+		const transaction = _Transaction({ id: "thread-1" });
+		await expect(new PrismaThreadContextSource().load(_Command({ threadId: null }), _Run(), transaction)).resolves.toEqual({ outcome: "loaded", value: { messageIds: [] } });
+		expect(transaction.prisma.conversationThread.findFirst).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -3,5 +3,6 @@ export { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identi
 export { PrismaRunAuthoritySource } from "./prisma-run-authority-source.js";
 export { PrismaApprovedPersonaSource } from "./prisma-approved-persona-source.js";
 export { PrismaPreferenceFactSource } from "./prisma-preference-fact-source.js";
+export { PrismaThreadContextSource } from "./prisma-thread-context-source.js";
 export { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "./prisma-revision-tool-policy-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-thread-context-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-thread-context-source.ts
@@ -1,0 +1,30 @@
+import { ConversationMessageState, ConversationThreadState } from "@prisma/client";
+
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+import type { SessionAssemblyCommand, SessionAssemblyLoad, ThreadContextInput, ThreadContextSource } from "./session-assembly.types.js";
+
+/** Transaction-fenced source for the exact completed transcript admitted into one run snapshot. */
+export class PrismaThreadContextSource implements ThreadContextSource
+{
+	/** Load completed messages only from the active bound thread the execution subject participates in. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<ThreadContextInput>>
+	{
+		if (command.threadId === null) return { outcome: "loaded", value: { messageIds: [] } };
+
+		// 1. Bind the thread to its silo, exact service, active lifecycle, and authenticated participant.
+		const thread = await transaction.prisma.conversationThread.findFirst({
+			where: { id: command.threadId, siloId: command.siloId, agentServiceId: run.agentServiceId, state: ConversationThreadState.Active, participants: { some: { userId: command.executionSubjectId } } },
+			select: { id: true },
+		});
+		if (thread === null) return { outcome: "denied", reason: "thread_unavailable" };
+
+		// 2. Freeze only terminal message coordinates; streaming and pending blocks remain mutable.
+		const messages = await transaction.prisma.conversationMessage.findMany({
+			where: { threadId: thread.id, state: ConversationMessageState.Completed },
+			orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+			select: { id: true },
+		});
+		return { outcome: "loaded", value: { messageIds: messages.map(function _messageId(message) { return message.id; }) } };
+	}
+}


### PR DESCRIPTION
## Why\n\nA run needs an immutable transcript from the exact conversation it was admitted to execute. It must not read another service's thread, an archived thread, a non-participant's thread, or messages still being written.\n\n## What changes\n\n- add a transaction-fenced thread-context source\n- require the active thread's exact silo, AgentService, and authenticated participant\n- snapshot only completed message IDs in deterministic order\n- keep non-conversational runs empty without querying a transcript\n- document the public boundary and add focused scope and lifecycle coverage\n\n## Validation\n\n- agent-style-check: 1 TypeScript file checked, 0 errors, 0 warnings\n- execution-inputs: lint and 30 tests\n\n## Review\n\nIndependent review completed with no Critical or High findings.\n\nStacked on #441; merge this after that PR.