### PR TITLE
🧠 Phase E: bind personal run memory to consented facts

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -69,6 +69,10 @@ caller input.
 - `PrismaThreadContextSource` — accepts a conversation only when its active thread is bound to the
   exact service, silo, and authenticated participant. It freezes ordered IDs of completed messages
   only; pending and streaming content cannot race into an immutable run input.
+- `PrismaMemoryScopeSource` — limits personal memory to the delegated user's active `Personal`
+  dataset, active explicit/confirmed facts, and complete provenance-backed content digests. It bounds
+  the frozen set to 100 facts and returns an explicit no-memory policy for managed or unprovisioned
+  users.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-memory-scope-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-memory-scope-source.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaMemoryScopeSource } from "../prisma-memory-scope-source.js";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+/** Create one personal run delegated to its authenticated user. */
+function _Run(overrides: Partial<InitialRunAuthority> = {}): InitialRunAuthority
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentKind: "personal", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "v1", trigger: "interactive", delegatedUserId: "user-1", rootRunId: "run-1", parentRunId: null, ...overrides };
+}
+
+/** Create admission coordinates for the delegated personal user. */
+function _Command(overrides: Record<string, unknown> = {})
+{
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", threadId: "thread-1", executionSubjectId: "user-1", requestIdempotencyKey: "request-1", ...overrides } as never;
+}
+
+/** Create the narrow transaction façade used by the personal-memory source. */
+function _Transaction(dataset: unknown, facts: readonly unknown[] = []): RunAdmissionTransaction
+{
+	return { prisma: { memoryDataset: { findFirst: vi.fn().mockResolvedValue(dataset) }, memoryFactCatalog: { findMany: vi.fn().mockResolvedValue(facts) } } as never, admittedAt: "2026-07-25T00:00:00.000Z", admittedAtEpochMs: Date.parse("2026-07-25T00:00:00.000Z") };
+}
+
+describe("PrismaMemoryScopeSource", function _DescribeMemoryScopeSource()
+{
+	it("pins only active consented facts with complete digest and provenance evidence", async function _PinsProvenFacts()
+	{
+		const digest = `sha256:${"a".repeat(64)}`;
+		const transaction = _Transaction({ id: "dataset-1" }, [{ id: "fact-1", contentDigest: digest, provenance: { sourceKind: "explicit-user-fact", sourceId: "statement-1", sourceUserId: "user-1", capturedAt: "2026-07-25T00:00:00.000Z" } }, { id: "bad-fact", contentDigest: "not-a-digest", provenance: {} }, { id: "bad-time", contentDigest: digest, provenance: { sourceKind: "message", sourceId: "message-1", capturedAt: "2026" } }]);
+		await expect(new PrismaMemoryScopeSource().load(_Command(), _Run(), transaction)).resolves.toEqual({ outcome: "loaded", value: { memoryQueryPolicy: { kind: "personal", datasetId: "dataset-1", subjectId: "user-1", maxFacts: 100 }, memoryFacts: [{ datasetId: "dataset-1", factId: "fact-1", contentDigest: digest, provenance: [{ sourceKind: "explicit-user-fact", sourceId: "statement-1", sourceUserId: "user-1", capturedAt: "2026-07-25T00:00:00.000Z" }] }] } });
+	});
+
+	it("returns the explicit no-memory policy without borrowing another scope when no personal dataset exists", async function _DoesNotBroadenScope()
+	{
+		const transaction = _Transaction(null);
+		await expect(new PrismaMemoryScopeSource().load(_Command(), _Run(), transaction)).resolves.toEqual({ outcome: "loaded", value: { memoryQueryPolicy: { kind: "none" }, memoryFacts: [] } });
+		expect(transaction.prisma.memoryFactCatalog.findMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects subject mismatch and makes managed runs explicitly memory-free", async function _FencesPersonalMemory()
+	{
+		await expect(new PrismaMemoryScopeSource().load(_Command({ executionSubjectId: "user-2" }), _Run(), _Transaction({ id: "dataset-1" }))).resolves.toEqual({ outcome: "denied", reason: "memory_scope_unavailable" });
+		await expect(new PrismaMemoryScopeSource().load(_Command(), _Run({ agentKind: "managed", delegatedUserId: null }), _Transaction({ id: "dataset-1" }))).resolves.toEqual({ outcome: "loaded", value: { memoryQueryPolicy: { kind: "none" }, memoryFacts: [] } });
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -4,5 +4,6 @@ export { PrismaRunAuthoritySource } from "./prisma-run-authority-source.js";
 export { PrismaApprovedPersonaSource } from "./prisma-approved-persona-source.js";
 export { PrismaPreferenceFactSource } from "./prisma-preference-fact-source.js";
 export { PrismaThreadContextSource } from "./prisma-thread-context-source.js";
+export { PrismaMemoryScopeSource } from "./prisma-memory-scope-source.js";
 export { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "./prisma-revision-tool-policy-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-memory-scope-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-memory-scope-source.ts
@@ -1,0 +1,68 @@
+import { AuthorizationScopeKind, MemoryConsentState, MemoryDatasetState, MemoryFactState } from "@prisma/client";
+
+import type { MemoryFactReference } from "@opencrane/contracts";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+import type { MemoryScopeInput, MemoryScopeSource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+
+/** Maximum recalled personal facts frozen into one immutable prompt input. */
+const _MAX_PERSONAL_MEMORY_FACTS = 100;
+
+/** Canonical UTC timestamp required for provenance frozen into a run-input digest. */
+const _ISO_UTC_INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+
+/** Transaction-fenced source for consented, provenance-backed personal memory context. */
+export class PrismaMemoryScopeSource implements MemoryScopeSource
+{
+	/** Load a bounded personal memory scope for the delegated user, or no personal memory for managed runs. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<MemoryScopeInput>>
+	{
+		if (run.agentKind === "managed") return { outcome: "loaded", value: _NoMemoryScope() };
+		if (run.delegatedUserId === null || run.delegatedUserId !== command.executionSubjectId) return { outcome: "denied", reason: "memory_scope_unavailable" };
+
+		// 1. Discover only the user-owned Personal dataset; no shared scope is implicitly eligible.
+		const dataset = await transaction.prisma.memoryDataset.findFirst({
+			where: { siloId: command.siloId, scopeKind: AuthorizationScopeKind.Personal, scopeResourceId: run.delegatedUserId, state: MemoryDatasetState.Active },
+			select: { id: true },
+		});
+		if (dataset === null) return { outcome: "loaded", value: _NoMemoryScope() };
+
+		// 2. Pin only active, consented catalog records and discard malformed provenance rather than guessing it.
+		const facts = await transaction.prisma.memoryFactCatalog.findMany({
+			where: { datasetId: dataset.id, state: MemoryFactState.Active, consentState: { in: [MemoryConsentState.Explicit, MemoryConsentState.Confirmed] } },
+			orderBy: [{ recordedAt: "desc" }, { id: "asc" }],
+			take: _MAX_PERSONAL_MEMORY_FACTS,
+			select: { id: true, contentDigest: true, provenance: true },
+		});
+		const memoryFacts = facts.map(function _toReference(fact) { return _MemoryReference(dataset.id, fact); }).filter(function _present(fact): fact is MemoryFactReference { return fact !== null; });
+		return { outcome: "loaded", value: { memoryQueryPolicy: { kind: "personal", datasetId: dataset.id, subjectId: run.delegatedUserId, maxFacts: _MAX_PERSONAL_MEMORY_FACTS }, memoryFacts } };
+	}
+}
+
+/** Return the explicit no-memory policy used when no personal dataset is authorized for this run. */
+function _NoMemoryScope(): MemoryScopeInput
+{
+	return { memoryQueryPolicy: { kind: "none" }, memoryFacts: [] };
+}
+
+/** Convert one catalog row only when it contains a complete canonical provenance record. */
+function _MemoryReference(datasetId: string, fact: { readonly id: string; readonly contentDigest: string; readonly provenance: unknown }): MemoryFactReference | null
+{
+	const provenance = _MemoryProvenance(fact.provenance);
+	if (provenance === null || !/^sha256:[a-f0-9]{64}$/.test(fact.contentDigest)) return null;
+	return { datasetId, factId: fact.id, contentDigest: fact.contentDigest, provenance: [provenance] };
+}
+
+/** Parse the one structured provenance record required before a catalog fact can reach a prompt. */
+function _MemoryProvenance(value: unknown): MemoryFactReference["provenance"][number] | null
+{
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+	const record = value as Readonly<Record<string, unknown>>;
+	const sourceKind = record["sourceKind"];
+	const sourceId = record["sourceId"];
+	const capturedAt = record["capturedAt"];
+	if (typeof sourceKind !== "string" || sourceKind.trim().length === 0 || typeof sourceId !== "string" || sourceId.trim().length === 0 || typeof capturedAt !== "string" || !_ISO_UTC_INSTANT.test(capturedAt) || !Number.isFinite(Date.parse(capturedAt))) return null;
+	const artifactRevisionId = typeof record["artifactRevisionId"] === "string" && record["artifactRevisionId"].trim().length > 0 ? record["artifactRevisionId"] : undefined;
+	const sourceUserId = typeof record["sourceUserId"] === "string" && record["sourceUserId"].trim().length > 0 ? record["sourceUserId"] : undefined;
+	return { sourceKind, sourceId, capturedAt, ...(artifactRevisionId === undefined ? {} : { artifactRevisionId }), ...(sourceUserId === undefined ? {} : { sourceUserId }) };
+}


### PR DESCRIPTION
## Why\n\nPersonal runtime memory must be bounded, consented, and provenance-backed. A run may not infer a wider scope or include malformed durable evidence in an immutable prompt snapshot.\n\n## What changes\n\n- add a transaction-fenced personal memory-scope source\n- scope reads to the delegated user's active Personal dataset\n- admit only active explicit/confirmed facts with SHA-256 content digests and canonical UTC provenance\n- bound each snapshot to 100 facts and use an explicit no-memory policy where no personal memory is authorized\n- keep managed runs free of personal memory\n\n## Validation\n\n- agent-style-check: 1 TypeScript file checked, 0 errors, 0 warnings\n- execution-inputs: lint and 33 tests\n\n## Review\n\nIndependent review found and resolved one low canonical-timestamp issue; no Critical, High, or Medium findings remain.\n\nStacked on #442; merge this after that PR.