### PR TITLE
🧩 Phase E: compose concrete run-input authorities

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -73,6 +73,9 @@ caller input.
   dataset, active explicit/confirmed facts, and complete provenance-backed content digests. It bounds
   the frozen set to 100 facts and returns an explicit no-memory policy for managed or unprovisioned
   users.
+- `__CreatePrismaSessionAssemblyAuthorities` — composes every local Prisma-backed input source with
+  the app-owned `RunAdmissionRepository`. The caller must provide the signed identity-envelope
+  source explicitly; this factory never invents membership or capability evidence.
 - `SessionAssemblyAuthorities` / `SessionAssemblyCommand` — the port bundle and the immutable run
   coordinates a caller supplies.
 - `RunAuthoritySource`, `ApprovedPersonaSource`, `ThreadContextSource`, `PreferenceFactSource`,

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-session-assembly-authorities.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-session-assembly-authorities.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { __CreatePrismaSessionAssemblyAuthorities } from "../prisma-session-assembly-authorities.js";
+import { PrismaApprovedPersonaSource } from "../prisma-approved-persona-source.js";
+import { PrismaMemoryScopeSource } from "../prisma-memory-scope-source.js";
+import { PrismaPreferenceFactSource } from "../prisma-preference-fact-source.js";
+import { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "../prisma-revision-tool-policy-source.js";
+import { PrismaRunAuthoritySource } from "../prisma-run-authority-source.js";
+import { PrismaThreadContextSource } from "../prisma-thread-context-source.js";
+import type { IdentityEnvelopeSource } from "../session-assembly.types.js";
+
+describe("__CreatePrismaSessionAssemblyAuthorities", function _DescribePrismaSessionAssemblyAuthorities()
+{
+	it("composes every local source but preserves app ownership of signed identity evidence", function _ComposesAuthorities()
+	{
+		const admission = { admit: async function _admit() { throw new Error("not invoked"); } } as never;
+		const identityEnvelope: IdentityEnvelopeSource = { load: async function _load() { return { outcome: "denied", reason: "identity_unavailable" }; } };
+		const authorities = __CreatePrismaSessionAssemblyAuthorities(admission, identityEnvelope);
+
+		expect(authorities.admission).toBe(admission);
+		expect(authorities.identityEnvelope).toBe(identityEnvelope);
+		expect(authorities.runAuthority).toBeInstanceOf(PrismaRunAuthoritySource);
+		expect(authorities.approvedPersona).toBeInstanceOf(PrismaApprovedPersonaSource);
+		expect(authorities.threadContext).toBeInstanceOf(PrismaThreadContextSource);
+		expect(authorities.preferenceFacts).toBeInstanceOf(PrismaPreferenceFactSource);
+		expect(authorities.memoryScope).toBeInstanceOf(PrismaMemoryScopeSource);
+		expect(authorities.toolPolicy).toBeInstanceOf(PrismaRevisionToolPolicySource);
+		expect(authorities.budgetPolicy).toBeInstanceOf(PrismaRevisionBudgetPolicySource);
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -5,5 +5,6 @@ export { PrismaApprovedPersonaSource } from "./prisma-approved-persona-source.js
 export { PrismaPreferenceFactSource } from "./prisma-preference-fact-source.js";
 export { PrismaThreadContextSource } from "./prisma-thread-context-source.js";
 export { PrismaMemoryScopeSource } from "./prisma-memory-scope-source.js";
+export { __CreatePrismaSessionAssemblyAuthorities } from "./prisma-session-assembly-authorities.js";
 export { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "./prisma-revision-tool-policy-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/prisma-session-assembly-authorities.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-session-assembly-authorities.ts
@@ -1,0 +1,25 @@
+import type { RunAdmissionRepository } from "@opencrane/backend/agents/execution/runs";
+
+import { PrismaApprovedPersonaSource } from "./prisma-approved-persona-source.js";
+import { PrismaMemoryScopeSource } from "./prisma-memory-scope-source.js";
+import { PrismaPreferenceFactSource } from "./prisma-preference-fact-source.js";
+import { PrismaRevisionBudgetPolicySource, PrismaRevisionToolPolicySource } from "./prisma-revision-tool-policy-source.js";
+import { PrismaRunAuthoritySource } from "./prisma-run-authority-source.js";
+import { PrismaThreadContextSource } from "./prisma-thread-context-source.js";
+import type { IdentityEnvelopeSource, SessionAssemblyAuthorities } from "./session-assembly.types.js";
+
+/** Compose all local transaction-backed inputs while keeping signed identity at the app trust boundary. */
+export function __CreatePrismaSessionAssemblyAuthorities(admission: RunAdmissionRepository, identityEnvelope: IdentityEnvelopeSource): SessionAssemblyAuthorities
+{
+	return {
+		admission,
+		runAuthority: new PrismaRunAuthoritySource(),
+		approvedPersona: new PrismaApprovedPersonaSource(),
+		threadContext: new PrismaThreadContextSource(),
+		preferenceFacts: new PrismaPreferenceFactSource(),
+		memoryScope: new PrismaMemoryScopeSource(),
+		toolPolicy: new PrismaRevisionToolPolicySource(),
+		budgetPolicy: new PrismaRevisionBudgetPolicySource(),
+		identityEnvelope,
+	};
+}


### PR DESCRIPTION
## Why\n\nThe run-input sources now have concrete, transaction-backed implementations. This composition point lets the OpenCrane application assemble them consistently without blurring the signed identity boundary.\n\n## What changed\n\n- add one factory that combines the app-owned admission repository with every local Prisma-backed input source\n- require the application to inject signed identity-envelope evidence explicitly; the factory cannot fabricate membership or capability claims\n- document and test the composition contract\n\n## Validation\n\n- npx nx lint backend-agents-execution-inputs\n- npx nx test backend-agents-execution-inputs (34 tests)\n- git diff --check\n- scripts/agent-style-check.sh\n\n## Review\n\nIndependent review found no issues.\n\nStacked on #443; merge after it.