### PR TITLE
🔒 Phase E: seal model deployments into run snapshots

### DIFF
--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -57,8 +57,9 @@ caller input.
   sources. They accept only a current published revision with a silo-available model, live
   integration custody, published active skills, and published artifact revisions; the budget source
   turns the revision's positive turn/token/duration ceilings into the frozen compiler policy. The
-  model route carries its exact definition ID beside its public alias, preventing a same-named global
-  or tenant model from being selected later.
+  model route carries its exact definition ID and sealed LiteLLM deployment ID beside its public
+  alias. Compilation rejects a changed definition instead of silently routing a frozen run to a
+  replacement deployment.
 - `PrismaApprovedPersonaSource` — resolves a personal run only through the delegated user's profile
   in the same silo and accepts its current revision only while it remains approved. Managed runs carry
   no persona, and neither a service nor a caller can select another person's persona revision.

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-revision-tool-policy-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/prisma-revision-tool-policy-source.test.ts
@@ -18,7 +18,7 @@ function _transaction(revision: unknown, skills: unknown[] = [], artifacts: unkn
 /** Builds a current revision with one live integration and one published skill artifact. */
 function _revision(overrides: Record<string, unknown> = {})
 {
-	return { modelDefinition: { id: "model-definition-1", scope: ModelRoutingScope.ClusterTenant, clusterTenant: "silo-1", publicModelName: "tenant-model" }, integrationAssignments: [{ integrationId: "integration-1", siloId: "silo-1", allowedTools: ["calendar.read"], integration: { state: IntegrationState.Active }, custodyReference: { state: IntegrationCustodyState.Ready, expiresAt: new Date("2026-07-26T00:00:00.000Z") } }], skillAssignments: [{ skillRevisionId: "skill-revision-1" }], budget: { maxTurns: 4, maxTokens: 1024, maxDurationMs: 60_000 }, ...overrides };
+	return { modelDefinition: { id: "model-definition-1", scope: ModelRoutingScope.ClusterTenant, clusterTenant: "silo-1", publicModelName: "tenant-model", litellmModelId: "litellm-deployment-1" }, integrationAssignments: [{ integrationId: "integration-1", siloId: "silo-1", allowedTools: ["calendar.read"], integration: { state: IntegrationState.Active }, custodyReference: { state: IntegrationCustodyState.Ready, expiresAt: new Date("2026-07-26T00:00:00.000Z") } }], skillAssignments: [{ skillRevisionId: "skill-revision-1" }], budget: { maxTurns: 4, maxTokens: 1024, maxDurationMs: 60_000 }, ...overrides };
 }
 
 /** Builds one published skill revision that still belongs to an active silo-owned skill. */
@@ -32,7 +32,7 @@ describe("PrismaRevisionToolPolicySource", function _suite()
 	it("freezes only live revision-owned model, integration, skill, and artifact references", async function _loads()
 	{
 		const result = await new PrismaRevisionToolPolicySource().load(_COMMAND, _RUN, _transaction(_revision(), [_skill()], [{ id: "artifact-revision-1", state: ArtifactRevisionState.Published }]));
-		expect(result).toEqual({ outcome: "loaded", value: { modelRoute: { alias: "tenant-model", modelDefinitionId: "model-definition-1" }, integrationAssignments: [{ integrationId: "integration-1", allowedTools: ["calendar.read"] }], skillRevisionIds: ["skill-revision-1"], artifactRevisionIds: ["artifact-revision-1"] } });
+		expect(result).toEqual({ outcome: "loaded", value: { modelRoute: { alias: "tenant-model", modelDefinitionId: "model-definition-1", litellmModelId: "litellm-deployment-1" }, integrationAssignments: [{ integrationId: "integration-1", allowedTools: ["calendar.read"] }], skillRevisionIds: ["skill-revision-1"], artifactRevisionIds: ["artifact-revision-1"] } });
 	});
 
 	it("refuses expired custody and unpublished skills before snapshot assembly", async function _refuses()

--- a/libs/backend/agents/execution/inputs/main/src/prisma-revision-tool-policy-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-revision-tool-policy-source.ts
@@ -25,7 +25,7 @@ export class PrismaRevisionToolPolicySource implements ToolPolicySource
 		const artifacts = await transaction.prisma.artifactRevision.findMany({ where: { id: { in: artifactRevisionIds }, state: ArtifactRevisionState.Published, artifact: { is: { siloId: command.siloId, state: "Active" } } }, select: { id: true } });
 		if (artifacts.length !== artifactRevisionIds.length) return { outcome: "denied", reason: "tool_policy_unavailable" };
 
-		return { outcome: "loaded", value: { modelRoute: { alias: revision.modelDefinition.publicModelName, modelDefinitionId: revision.modelDefinition.id }, integrationAssignments: revision.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, allowedTools: [...assignment.allowedTools] })), skillRevisionIds, artifactRevisionIds } };
+		return { outcome: "loaded", value: { modelRoute: { alias: revision.modelDefinition.publicModelName, modelDefinitionId: revision.modelDefinition.id, litellmModelId: revision.modelDefinition.litellmModelId }, integrationAssignments: revision.integrationAssignments.map(assignment => ({ integrationId: assignment.integrationId, allowedTools: [...assignment.allowedTools] })), skillRevisionIds, artifactRevisionIds } };
 	}
 
 	/** Returns whether a model definition is global or belongs to the admission silo. */

--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-run-input-compiler.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-run-input-compiler.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PROMPT_COMPILER_VERSION } from "@opencrane/backend/agents/runtime/prompt-compiler";
+
+import { __CreatePrismaRunInputCompiler } from "../prisma-run-input-compiler.js";
+
+/** Builds the smallest sealed snapshot that reaches the model-route compiler boundary. */
+function _Snapshot(modelRoute: object): never
+{
+	return {
+		runId: "run-1",
+		snapshotVersion: 1,
+		personaRevisionId: null,
+		messageIds: [],
+		integrationAssignments: [],
+		memoryFacts: [],
+		artifactRevisionIds: [],
+		skillRevisionIds: [],
+		modelRoute,
+		budgetPolicy: {},
+		promptCompilerVersion: PROMPT_COMPILER_VERSION,
+		digest: "sha256:snapshot",
+	} as never;
+}
+
+/** Builds the transaction reads required by an empty-context snapshot compilation. */
+function _Transaction(litellmModelId: string): never
+{
+	return { modelDefinition: { findUnique: vi.fn().mockResolvedValue({ litellmModelId }) } } as never;
+}
+
+describe("Prisma run-input compiler model routes", function _DescribePrismaRunInputCompilerModelRoutes()
+{
+	it("uses the deployment sealed in the snapshot after checking the exact definition has not changed", async function _UsesSealedDeployment()
+	{
+		const compile = __CreatePrismaRunInputCompiler();
+		await expect(compile(_Snapshot({ modelDefinitionId: "model-1", litellmModelId: "deployment-a" }), _Transaction("deployment-a"))).resolves.toMatchObject({ model: { modelAlias: "deployment-a" } });
+	});
+
+	it("refuses a route whose registered definition now points to another deployment", async function _RefusesRouteDrift()
+	{
+		const compile = __CreatePrismaRunInputCompiler();
+		await expect(compile(_Snapshot({ modelDefinitionId: "model-1", litellmModelId: "deployment-a" }), _Transaction("deployment-b"))).rejects.toThrow("changed or unavailable model definition");
+	});
+});

--- a/libs/backend/agents/execution/protocol/src/prisma-run-input-compiler.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-run-input-compiler.ts
@@ -129,9 +129,10 @@ async function _resolveModelRoute(transaction: Prisma.TransactionClient, modelRo
 {
 	const route: { readonly [key: string]: JsonValue } = modelRoute && typeof modelRoute === "object" && !Array.isArray(modelRoute) ? modelRoute as { readonly [key: string]: JsonValue } : {};
 	const modelDefinitionId = typeof route["modelDefinitionId"] === "string" ? route["modelDefinitionId"] : "";
+	const litellmModelId = typeof route["litellmModelId"] === "string" ? route["litellmModelId"] : "";
 	const maxOutputTokens = typeof route["maxOutputTokens"] === "number" && Number.isSafeInteger(route["maxOutputTokens"]) && route["maxOutputTokens"] > 0 ? route["maxOutputTokens"] : null;
-	if (modelDefinitionId.trim().length === 0) throw new Error("compiled model route requires an exact model definition");
+	if (modelDefinitionId.trim().length === 0 || litellmModelId.trim().length === 0) throw new Error("compiled model route requires an exact sealed model deployment");
 	const definition = await transaction.modelDefinition.findUnique({ where: { id: modelDefinitionId } });
-	if (definition === null) throw new Error("compiled model route references an unavailable model definition");
-	return { modelAlias: definition.litellmModelId, maxOutputTokens };
+	if (definition === null || definition.litellmModelId !== litellmModelId) throw new Error("compiled model route references a changed or unavailable model definition");
+	return { modelAlias: litellmModelId, maxOutputTokens };
 }

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -66,6 +66,9 @@ model-routing gateway, which holds the LiteLLM master key) using the alias and b
 snapshot, and attaches the transient virtual key to the claim response only — it is never written to
 Postgres. Minting happens outside the database transaction so no external call holds a lock. That commit also creates an
 unconsumed bootstrap record and a second durable command asking the controller to release the Job.
+Before minting, dispatch compares the snapshot's sealed LiteLLM deployment ID with the currently
+registered definition. A changed or unavailable definition terminally fails the attempt; it never
+mints a budgeted key for a replacement deployment.
 The bootstrap reference is an opaque label, not a password: it grants nothing without the exact
 projected workload identity, assigned Job and registered first Pod. The stored integrity digest binds
 the label to every immutable assignment field, including the selected workload profile.

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-dispatch-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-dispatch-repository.test.ts
@@ -38,7 +38,7 @@ function _Event(overrides: Record<string, unknown> = {})
 /** Creates the immutable input snapshot and its time-bounded signed membership identity. */
 function _Snapshot(trustedUntil = "2026-07-20T02:00:00.000Z")
 {
-	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", effectiveContractDigest: "sha256:contract", digest: "sha256:snapshot", threadId: "thread-1", modelRoute: { modelDefinitionId: "model-definition-1" }, budgetPolicy: { maxCostUsdMicros: 5_000_000 }, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipTrustedUntil: trustedUntil } };
+	return { runId: "run-1", siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", effectiveContractDigest: "sha256:contract", digest: "sha256:snapshot", threadId: "thread-1", modelRoute: { modelDefinitionId: "model-definition-1", litellmModelId: "litellm-deployment-silo-1" }, budgetPolicy: { maxCostUsdMicros: 5_000_000 }, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipTrustedUntil: trustedUntil } };
 }
 
 /** Creates the immutable model definition that resolves one snapshot identity to one LiteLLM deployment. */
@@ -175,6 +175,29 @@ describe("PrismaRunDispatchRepository", function _DescribeDispatchRepository()
 		expect(result).toMatchObject({ status: "claimed", claim: { attempt: { litellmKey: "sk-attempt-transient" } } });
 		// The transient key rides the claim response only; it appears in no database write argument.
 		expect(JSON.stringify(writes)).not.toContain("sk-attempt-transient");
+	});
+
+	it("terminalises a route whose definition changed before it can mint a replacement deployment key", async function _RejectsModelRouteDrift()
+	{
+		const run = _Run();
+		const event = _Event();
+		const transaction = {
+			$queryRaw: vi.fn().mockResolvedValueOnce([{ eventId: event.id, runId: run.id, agentServiceId: run.agentServiceId }]).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([]).mockResolvedValueOnce([{ now: new Date("2026-07-20T00:00:00.000Z") }]),
+			agentService: { findUnique: vi.fn().mockResolvedValue(_Service()) },
+			agentRun: { findUnique: vi.fn().mockResolvedValue(run), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+			outboxEvent: { findUnique: vi.fn().mockResolvedValue(event), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+			conversationRunEvent: { aggregate: vi.fn().mockResolvedValue({ _max: { sequence: 2 } }), create: vi.fn().mockResolvedValue({}) },
+			workloadAssignment: { findUnique: vi.fn().mockResolvedValue(null) },
+			runInputSnapshot: { findUnique: vi.fn().mockResolvedValue(_Snapshot()) },
+			modelDefinition: { findUnique: vi.fn().mockResolvedValue(_ModelDefinition({ litellmModelId: "litellm-deployment-replaced" })) },
+		};
+		const prisma = { $transaction: vi.fn(async function _Transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+		const issuer = vi.fn(async function _Issue(): Promise<MintedAttemptModelKey> { return { key: "must-not-mint" }; });
+		const repository = new PrismaRunDispatchRepository(prisma, { namespace: "silo-a", claimLeaseMilliseconds: 30_000, assignmentTtlMilliseconds: 3_600_000 }, issuer);
+
+		await expect(repository.claimNextAttemptAtomically()).resolves.toEqual({ status: "none" });
+		expect(issuer).not.toHaveBeenCalled();
+		expect(transaction.outboxEvent.updateMany).toHaveBeenCalledWith({ where: { id: "event-1", claimedAt: null, deliveryCount: 0, publishedAt: null, failedAt: null }, data: { claimedAt: new Date("2026-07-20T00:00:00.000Z"), deliveryCount: 1, failedAt: new Date("2026-07-20T00:00:00.000Z"), failureCode: "RUN_DISPATCH_MODEL_ROUTE_INVALID" } });
 	});
 
 	it("terminalises an expired first event so the next valid attempt can be claimed", async function _SkipsPoisonedHead()

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
@@ -124,10 +124,11 @@ export class PrismaRunDispatchRepository implements RunDispatchRepository
 
 			// 3. Resolve the frozen definition ID under this claim lock; an alias alone can collide by scope.
 			const modelDefinitionId = _SnapshotModelDefinitionId(snapshot.modelRoute);
+			const sealedLiteLlmModelId = _SnapshotLiteLlmModelId(snapshot.modelRoute);
 			const maxBudgetUsd = _SnapshotMaxBudgetUsd(snapshot.budgetPolicy);
 			const modelDefinition = modelDefinitionId === null ? null : await transaction.modelDefinition.findUnique({ where: { id: modelDefinitionId } });
 			const modelAlias = _AttemptKeyModelId(modelDefinition, run.siloId);
-			if (modelAlias === null || maxBudgetUsd === null)
+			if (modelAlias === null || sealedLiteLlmModelId === null || modelAlias !== sealedLiteLlmModelId || maxBudgetUsd === null)
 			{
 				await _TerminalizeUndispatchableAttempt(transaction, event, run, now, "RUN_DISPATCH_MODEL_ROUTE_INVALID", AgentRunTerminalReason.InvalidInput);
 				return { status: "none" };
@@ -736,6 +737,15 @@ function _SnapshotModelDefinitionId(modelRoute: unknown): string | null
 	const route = modelRoute as Record<string, unknown>;
 	const modelDefinitionId = typeof route["modelDefinitionId"] === "string" ? route["modelDefinitionId"] : "";
 	return modelDefinitionId.trim().length > 0 && modelDefinitionId.length <= 256 ? modelDefinitionId : null;
+}
+
+/** Extract the exact LiteLLM deployment identifier sealed at snapshot admission. */
+function _SnapshotLiteLlmModelId(modelRoute: unknown): string | null
+{
+	if (!modelRoute || typeof modelRoute !== "object" || Array.isArray(modelRoute)) return null;
+	const route = modelRoute as Record<string, unknown>;
+	const litellmModelId = typeof route["litellmModelId"] === "string" ? route["litellmModelId"] : "";
+	return litellmModelId.trim().length > 0 && litellmModelId.length <= 256 ? litellmModelId : null;
 }
 
 /** Derive the one LiteLLM deployment ID that the claimed attempt may call in its own silo. */


### PR DESCRIPTION
## Why\n\nA run snapshot must retain the exact LiteLLM deployment it was admitted to use. Pinning only a mutable model-definition record could let dispatch mint a budgeted key for a later replacement deployment.\n\n## What changed\n\n- seal the exact LiteLLM deployment ID beside the immutable model-definition ID at admission\n- reject a changed or unavailable definition during both runtime input compilation and controller dispatch\n- terminally fail the attempt before a replacement deployment key can be minted\n\n## Validation\n\n- inputs lint and test: 34 tests\n- protocol lint and focused compiler test: 2 tests\n- runs lint and focused dispatch repository test: 15 tests\n- git diff --check and agent style check\n- full runs suite reaches only the existing sandbox Supertest listen EPERM restriction; its non-HTTP suites pass\n\n## Review\n\nIndependent review found no issues.\n\nStacked on #444; merge after it.