### PR TITLE
🔒 Phase E: authorize governed child-run spawn boundaries

### DIFF
--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -47,6 +47,15 @@ rejected with `admission_concurrency_limited`; it does not turn a hot service ro
 unbounded connection pool. The production entrypoint must use this gate before calling
 `PrismaRunAdmissionRepository.admit()` and must keep its policy aligned with the database pool budget.
 
+`__AuthorizeGovernedChildRunSpawn` is the first gate for a future governed child run. It accepts
+only parent facts that a repository has already locked, checks that a child stays in the same silo
+and under the root, bounds depth and fan-out, and asks an injected authority to prove that the
+child's capability set narrows the parent's. It permits only transcript messages, memory facts,
+artifact revisions, and skill revisions already frozen in the parent snapshot, then verifies that a
+finite child budget fits the parent remainder. It returns a detached authorization, **not a child
+run**: the following persistence slice must atomically reserve that budget, save lineage and
+idempotency facts, and compile the child snapshot before any runtime command can exist.
+
 `__StartNextRunAttempt` is a **compare-and-swap** retry state machine: it reads the run and its
 AgentService authority as one snapshot, refuses unless the run is in a retryable terminal state and the
 service is active with the exact revision the run pins, then atomically increments the attempt while
@@ -121,6 +130,11 @@ uncertainty fails closed.
 - `__ValidateRunWorkloadAssignment(assignment, expectation)` — confirm a workload is the one authorised for this attempt.
 - `__DigestRunInputSnapshot(snapshot)` — compute the canonical SHA-256 identity of all frozen run
   inputs without digesting the self-referential `digest` field.
+- `__AuthorizeGovernedChildRunSpawn(parent, request, existingChildCount, policy, delegation)` —
+  fail closed unless a proposed child stays within its locked parent's silo, hierarchy, selected
+  snapshot inputs, capability subset, fan-out, and finite budget; this does not persist a run.
+- `GovernedChildRun*` — typed parent, request, policy, capability-verifier, authorization, and
+  refusal vocabulary for the subsequent transaction-fenced child reservation boundary.
 - `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial
   run, snapshot and ordered outbox events around a caller-supplied assembly callback.
 - `RunAdmissionConcurrencyGate` — bound active and queued admissions for one silo and AgentService
@@ -155,6 +169,11 @@ Kubernetes itself. It owns only durable admission, attempts, dispatch leases, as
 integrity, release delivery, first-Pod registration, cancellation fencing, and cleanup
 confirmation. Kubernetes inspection and mutation remain in dedicated runtime processes; this
 package only says which exact work may be removed.
+
+It also does not yet reserve or create child runs. `__AuthorizeGovernedChildRunSpawn` is deliberately
+a pure admission gate so a later repository can lock the parent, count existing children, reserve
+the budget, persist one derived child snapshot, and record lineage atomically. Until that boundary
+exists, no child-run runtime command is exposed.
 
 ## Dependency direction
 

--- a/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import { __AuthorizeGovernedChildRunSpawn } from "../child-run-admission.js";
+import type { GovernedChildRunCapabilityDelegation, GovernedChildRunParent, GovernedChildRunSpawnRequest } from "../child-run-admission.types.js";
+
+const _PARENT_CAPABILITY_DIGEST = `sha256:${"a".repeat(64)}`;
+const _CHILD_CAPABILITY_DIGEST = `sha256:${"b".repeat(64)}`;
+
+/** Builds a parent whose immutable snapshot deliberately exposes several selectable inputs. */
+function _Parent(overrides: Partial<GovernedChildRunParent> = {}): GovernedChildRunParent
+{
+	return {
+		runId: "parent-run",
+		rootRunId: "root-run",
+		siloId: "silo-a",
+		snapshot: {
+			runId: "parent-run", siloId: "silo-a", agentServiceId: "parent-service", agentRevisionId: "parent-revision", snapshotVersion: 1,
+			threadId: "thread-1", messageIds: ["message-1", "message-2"], personaRevisionId: "persona-1", preferenceFactIds: [], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"],
+			memoryFacts: [{ datasetId: "dataset-1", factId: "fact-1", contentDigest: `sha256:${"c".repeat(64)}`, provenance: [] }], memoryQueryPolicy: {}, integrationAssignments: [], modelRoute: {}, budgetPolicy: {},
+			identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 1, fleetMembershipIssuer: "issuer", fleetMembershipIssuerKeyId: "key", fleetMembershipAssertionId: "assertion", fleetMembershipPayloadDigest: `sha256:${"d".repeat(64)}`, fleetMembershipTrustedUntil: "2026-07-26T00:00:00.000Z" },
+			capabilitySetDigest: _PARENT_CAPABILITY_DIGEST, effectiveContractDigest: `sha256:${"e".repeat(64)}`, promptCompilerVersion: "test-v1", digest: `sha256:${"f".repeat(64)}`, compiledAt: "2026-07-25T00:00:00.000Z",
+		},
+		depth: 0,
+		remainingBudget: { maxModelTurns: 4, maxTotalTokens: 400, maxDurationMs: 60000 },
+		...overrides,
+	};
+}
+
+/** Builds one valid untrusted candidate request. */
+function _Request(overrides: Partial<GovernedChildRunSpawnRequest> = {}): GovernedChildRunSpawnRequest
+{
+	return {
+		siloId: "silo-a",
+		agentServiceId: "child-service",
+		capabilitySetDigest: _CHILD_CAPABILITY_DIGEST,
+		context: { messageIds: ["message-1"], memoryFactIds: ["fact-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"] },
+		budget: { maxModelTurns: 2, maxTotalTokens: 200, maxDurationMs: 30000 },
+		task: { prompt: "Summarise the selected evidence." },
+		...overrides,
+	};
+}
+
+/** Proves only the expected service and child digest narrow the selected parent capability set. */
+const _Delegation: GovernedChildRunCapabilityDelegation = {
+	allows(parentCapabilitySetDigest, childAgentServiceId, childCapabilitySetDigest): boolean
+	{
+		return parentCapabilitySetDigest === _PARENT_CAPABILITY_DIGEST && childAgentServiceId === "child-service" && childCapabilitySetDigest === _CHILD_CAPABILITY_DIGEST;
+	},
+};
+
+describe("__AuthorizeGovernedChildRunSpawn", function _DescribeChildAdmission()
+{
+	it("derives a detached child authorization from locked parent authority", function _Authorize()
+	{
+		const request = _Request();
+		const result = __AuthorizeGovernedChildRunSpawn(_Parent(), request, 1, { maximumDepth: 2, maximumChildrenPerParent: 3 }, _Delegation);
+
+		expect(result).toEqual({
+			outcome: "authorized",
+			authorization: {
+				siloId: "silo-a", rootRunId: "root-run", parentRunId: "parent-run", depth: 1,
+				capabilitySetDigest: _CHILD_CAPABILITY_DIGEST, agentServiceId: "child-service",
+				context: request.context, budget: request.budget, task: request.task,
+			},
+		});
+
+		if (result.outcome !== "authorized") throw new Error("Expected an authorization.");
+		(request.context.messageIds as string[])[0] = "message-2";
+		(request.task as { prompt: string }).prompt = "Mutated after authorization.";
+		expect(result.authorization.context.messageIds).toEqual(["message-1"]);
+		expect(result.authorization.task).toEqual({ prompt: "Summarise the selected evidence." });
+	});
+
+	it("rejects context not already and uniquely frozen in the parent snapshot", function _RejectContext()
+	{
+		const sibling = __AuthorizeGovernedChildRunSpawn(_Parent(), _Request({ context: { messageIds: ["sibling-message"], memoryFactIds: [], artifactRevisionIds: [], skillRevisionIds: [] } }), 0, { maximumDepth: 2, maximumChildrenPerParent: 3 }, _Delegation);
+		const duplicate = __AuthorizeGovernedChildRunSpawn(_Parent(), _Request({ context: { messageIds: ["message-1", "message-1"], memoryFactIds: [], artifactRevisionIds: [], skillRevisionIds: [] } }), 0, { maximumDepth: 2, maximumChildrenPerParent: 3 }, _Delegation);
+
+		expect(sibling).toEqual({ outcome: "denied", reason: "context_not_parent_readable" });
+		expect(duplicate).toEqual({ outcome: "denied", reason: "context_not_parent_readable" });
+	});
+
+	it("rejects cross-silo, over-depth, fan-out, capability, and budget expansion", function _RejectEscalation()
+	{
+		const policy = { maximumDepth: 1, maximumChildrenPerParent: 1 };
+
+		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request({ siloId: "silo-b" }), 0, policy, _Delegation)).toEqual({ outcome: "denied", reason: "cross_silo" });
+		expect(__AuthorizeGovernedChildRunSpawn(_Parent({ depth: 1 }), _Request(), 0, policy, _Delegation)).toEqual({ outcome: "denied", reason: "depth_exceeded" });
+		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request(), 1, policy, _Delegation)).toEqual({ outcome: "denied", reason: "fanout_exceeded" });
+		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request(), 0, policy, { allows: function _Deny(): boolean { return false; } })).toEqual({ outcome: "denied", reason: "capability_escalation" });
+		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request({ budget: { maxModelTurns: 5, maxTotalTokens: 200, maxDurationMs: 30000 } }), 0, policy, _Delegation)).toEqual({ outcome: "denied", reason: "budget_exceeded" });
+	});
+
+	it("fails closed on malformed candidate data before it reaches the capability verifier", function _RejectMalformed()
+	{
+		const malformed = { ..._Request(), capabilitySetDigest: "not-a-digest", task: undefined } as unknown as GovernedChildRunSpawnRequest;
+		const result = __AuthorizeGovernedChildRunSpawn(_Parent(), malformed, 0, { maximumDepth: 2, maximumChildrenPerParent: 3 }, _Delegation);
+
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_request" });
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
@@ -1,0 +1,131 @@
+import { ___CloneCanonicalJson } from "@opencrane/util";
+import type { JsonValue } from "@opencrane/util";
+
+import type { GovernedChildRunBudget, GovernedChildRunCapabilityDelegation, GovernedChildRunContextSelection, GovernedChildRunParent, GovernedChildRunPolicy, GovernedChildRunSpawnAuthorizationResult, GovernedChildRunSpawnRequest } from "./child-run-admission.types.js";
+
+/**
+ * Authorizes one governed child-run request against a frozen parent snapshot.
+ *
+ * The caller supplies parent facts that a later repository must load and lock in one transaction,
+ * the direct-child count, and a verifier-produced capability-delegation authority. This function
+ * never accepts sibling context, expands a capability set, or mutates the parent. Its output is a
+ * detached authorization for the subsequent reservation-and-persistence transaction.
+ */
+export function __AuthorizeGovernedChildRunSpawn(parent: GovernedChildRunParent, request: GovernedChildRunSpawnRequest, existingChildCount: number, policy: GovernedChildRunPolicy, delegation: GovernedChildRunCapabilityDelegation): GovernedChildRunSpawnAuthorizationResult
+{
+	// 1. Normalize untrusted candidate data before examining parent authority so malformed objects cannot alias it.
+	const normalized = _NormalizeRequest(request);
+	if (normalized === null || !_IsRequestValid(parent, normalized, existingChildCount, policy)) return { outcome: "denied", reason: "invalid_request" };
+
+	// 2. Keep the complete lineage and all selected durable context inside the parent's exact silo.
+	if (parent.siloId !== normalized.siloId) return { outcome: "denied", reason: "cross_silo" };
+
+	// 3. Bound recursive work and direct fan-out before the later transaction reserves capacity.
+	if (parent.depth >= policy.maximumDepth) return { outcome: "denied", reason: "depth_exceeded" };
+	if (existingChildCount >= policy.maximumChildrenPerParent) return { outcome: "denied", reason: "fanout_exceeded" };
+
+	// 4. Let only an independent capability authority prove a narrowing delegation to the target service.
+	if (!delegation.allows(parent.snapshot.capabilitySetDigest, normalized.agentServiceId, normalized.capabilitySetDigest)) return { outcome: "denied", reason: "capability_escalation" };
+
+	// 5. Preserve sibling isolation by copying only coordinates already pinned into the parent's snapshot.
+	if (!_IsParentReadableContext(parent, normalized.context)) return { outcome: "denied", reason: "context_not_parent_readable" };
+
+	// 6. Carve finite resources before durable reservation so a child cannot overdraw its parent.
+	if (!_FitsBudget(normalized.budget, parent.remainingBudget)) return { outcome: "denied", reason: "budget_exceeded" };
+
+	return { outcome: "authorized", authorization: { siloId: parent.siloId, rootRunId: parent.rootRunId, parentRunId: parent.runId, depth: parent.depth + 1, capabilitySetDigest: normalized.capabilitySetDigest, agentServiceId: normalized.agentServiceId, context: normalized.context, budget: normalized.budget, task: normalized.task } };
+}
+
+/** Produces a detached candidate request only when every caller-controlled field has the closed shape. */
+function _NormalizeRequest(value: unknown): GovernedChildRunSpawnRequest | null
+{
+	if (!_IsRecord(value) || typeof value.siloId !== "string" || typeof value.agentServiceId !== "string" || typeof value.capabilitySetDigest !== "string" || !_IsRecord(value.context) || !_IsRecord(value.budget)) return null;
+	const context = _Context(value.context);
+	const budget = _Budget(value.budget);
+	if (context === null || budget === null) return null;
+	try
+	{
+		return { siloId: value.siloId, agentServiceId: value.agentServiceId, capabilitySetDigest: value.capabilitySetDigest, context, budget, task: ___CloneCanonicalJson(value.task as JsonValue) };
+	}
+	catch
+	{
+		return null;
+	}
+}
+
+/** Returns one context selection after validating its four immutable identifier lists. */
+function _Context(value: Record<string, unknown>): GovernedChildRunContextSelection | null
+{
+	if (!_IsStringArray(value.messageIds) || !_IsStringArray(value.memoryFactIds) || !_IsStringArray(value.artifactRevisionIds) || !_IsStringArray(value.skillRevisionIds)) return null;
+	return { messageIds: [...value.messageIds], memoryFactIds: [...value.memoryFactIds], artifactRevisionIds: [...value.artifactRevisionIds], skillRevisionIds: [...value.skillRevisionIds] };
+}
+
+/** Returns one finite budget carve-out after validating its primitive fields. */
+function _Budget(value: Record<string, unknown>): GovernedChildRunBudget | null
+{
+	return _IsPositiveInteger(value.maxModelTurns) && _IsPositiveInteger(value.maxTotalTokens) && _IsPositiveInteger(value.maxDurationMs) ? { maxModelTurns: value.maxModelTurns, maxTotalTokens: value.maxTotalTokens, maxDurationMs: value.maxDurationMs } : null;
+}
+
+/** Returns whether a request is structurally consistent with one loaded parent and bounded policy. */
+function _IsRequestValid(parent: GovernedChildRunParent, request: GovernedChildRunSpawnRequest, existingChildCount: number, policy: GovernedChildRunPolicy): boolean
+{
+	return _Present(parent.runId) && _Present(parent.rootRunId) && _Present(parent.siloId)
+		&& parent.snapshot.runId === parent.runId && parent.snapshot.siloId === parent.siloId
+		&& Number.isSafeInteger(parent.depth) && parent.depth >= 0
+		&& _Present(request.siloId) && _Present(request.agentServiceId) && /^sha256:[0-9a-f]{64}$/u.test(request.capabilitySetDigest)
+		&& Number.isSafeInteger(existingChildCount) && existingChildCount >= 0
+		&& Number.isSafeInteger(policy.maximumDepth) && policy.maximumDepth >= 0
+		&& Number.isSafeInteger(policy.maximumChildrenPerParent) && policy.maximumChildrenPerParent >= 0
+		&& _IsBudgetValid(parent.remainingBudget) && _IsBudgetValid(request.budget);
+}
+
+/** Returns whether every selected identifier is unique, non-empty, and already frozen in the parent snapshot. */
+function _IsParentReadableContext(parent: GovernedChildRunParent, context: GovernedChildRunContextSelection): boolean
+{
+	return _Subset(new Set(parent.snapshot.messageIds), context.messageIds)
+		&& _Subset(new Set(parent.snapshot.memoryFacts.map(function _FactId(fact): string { return fact.factId; })), context.memoryFactIds)
+		&& _Subset(new Set(parent.snapshot.artifactRevisionIds), context.artifactRevisionIds)
+		&& _Subset(new Set(parent.snapshot.skillRevisionIds), context.skillRevisionIds);
+}
+
+/** Returns whether the selected identifiers are unique non-empty members of their immutable allowed set. */
+function _Subset(allowed: ReadonlySet<string>, selected: readonly string[]): boolean
+{
+	return selected.every(_Present) && new Set(selected).size === selected.length && selected.every(function _Allowed(value): boolean { return allowed.has(value); });
+}
+
+/** Returns whether a child uses only finite capacity contained by its parent's remaining allocation. */
+function _FitsBudget(child: GovernedChildRunBudget, parent: GovernedChildRunBudget): boolean
+{
+	return child.maxModelTurns <= parent.maxModelTurns && child.maxTotalTokens <= parent.maxTotalTokens && child.maxDurationMs <= parent.maxDurationMs;
+}
+
+/** Returns whether one budget contains only positive safe-integer capacity. */
+function _IsBudgetValid(value: GovernedChildRunBudget): boolean
+{
+	return _IsPositiveInteger(value.maxModelTurns) && _IsPositiveInteger(value.maxTotalTokens) && _IsPositiveInteger(value.maxDurationMs);
+}
+
+/** Returns whether one unknown value is a JSON record rather than null or an array. */
+function _IsRecord(value: unknown): value is Record<string, unknown>
+{
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Returns whether every item is a string. */
+function _IsStringArray(value: unknown): value is string[]
+{
+	return Array.isArray(value) && value.every(function _String(item): boolean { return typeof item === "string"; });
+}
+
+/** Returns whether a value is positive finite resource capacity. */
+function _IsPositiveInteger(value: unknown): value is number
+{
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+/** Returns whether an identifier contains a non-whitespace value. */
+function _Present(value: string): boolean
+{
+	return value.trim().length > 0;
+}

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
@@ -1,0 +1,105 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import type { JsonValue } from "@opencrane/util";
+
+/** Finite resource allocation carved from one parent's remaining immutable run policy. */
+export interface GovernedChildRunBudget
+{
+	/** Maximum model turns the child may consume. */
+	readonly maxModelTurns: number;
+	/** Maximum provider tokens the child may consume. */
+	readonly maxTotalTokens: number;
+	/** Maximum wall-clock duration the child may occupy. */
+	readonly maxDurationMs: number;
+}
+
+/** Parent-selected immutable inputs visible to one child and no sibling. */
+export interface GovernedChildRunContextSelection
+{
+	/** Ordered parent transcript messages copied into the child snapshot. */
+	readonly messageIds: readonly string[];
+	/** Parent-pinned durable fact identifiers copied into the child snapshot. */
+	readonly memoryFactIds: readonly string[];
+	/** Parent-pinned artifact revisions copied into the child snapshot. */
+	readonly artifactRevisionIds: readonly string[];
+	/** Parent-pinned skill revisions copied into the child snapshot. */
+	readonly skillRevisionIds: readonly string[];
+}
+
+/** Immutable parent facts loaded by the authority boundary before it accepts one child request. */
+export interface GovernedChildRunParent
+{
+	/** Durable identifier of the immediate spawning run. */
+	readonly runId: string;
+	/** Root run identifier inherited by every descendant. */
+	readonly rootRunId: string;
+	/** Silo containing the complete parent and child authority tree. */
+	readonly siloId: string;
+	/** Parent snapshot constraining every selected child input. */
+	readonly snapshot: RunInputSnapshot;
+	/** Number of edges between this parent and its root run. */
+	readonly depth: number;
+	/** Parent capacity still available after all earlier durable reservations. */
+	readonly remainingBudget: GovernedChildRunBudget;
+}
+
+/** Model-proposed child request before the authority freezes derived coordinates. */
+export interface GovernedChildRunSpawnRequest
+{
+	/** Silo requested for the child; it must exactly equal the parent silo. */
+	readonly siloId: string;
+	/** AgentService selected for the independently accountable child execution. */
+	readonly agentServiceId: string;
+	/** Effective child capability-set digest accepted by a separate verifier. */
+	readonly capabilitySetDigest: string;
+	/** Parent-selected immutable context visible to this one child. */
+	readonly context: GovernedChildRunContextSelection;
+	/** Finite budget carved from the parent. */
+	readonly budget: GovernedChildRunBudget;
+	/** JSON-safe task payload retained with future spawn provenance. */
+	readonly task: JsonValue;
+}
+
+/** Bounded recursive-run policy applied before a child can reserve any authority. */
+export interface GovernedChildRunPolicy
+{
+	/** Maximum parent-to-child edges allowed below the root. */
+	readonly maximumDepth: number;
+	/** Maximum direct child runs one parent may reserve. */
+	readonly maximumChildrenPerParent: number;
+}
+
+/** Capability authority that proves a child can only narrow the parent's effective authority. */
+export interface GovernedChildRunCapabilityDelegation
+{
+	/** Returns true only when the exact child service and digest are a verified subset of the parent. */
+	allows(parentCapabilitySetDigest: string, childAgentServiceId: string, childCapabilitySetDigest: string): boolean;
+}
+
+/** Fully derived authorization supplied to the later transactional reservation and persistence boundary. */
+export interface GovernedChildRunSpawnAuthorization
+{
+	/** Silo inherited unchanged from the parent. */
+	readonly siloId: string;
+	/** Root identifier inherited unchanged from the parent. */
+	readonly rootRunId: string;
+	/** Immediate parent identifier fixed for the child. */
+	readonly parentRunId: string;
+	/** Child depth fixed before a durable reservation can commit. */
+	readonly depth: number;
+	/** Verified child capability-set digest. */
+	readonly capabilitySetDigest: string;
+	/** Target AgentService approved by the capability authority. */
+	readonly agentServiceId: string;
+	/** Context subset proven readable by the parent. */
+	readonly context: GovernedChildRunContextSelection;
+	/** Budget carve-out proven to fit the parent remainder. */
+	readonly budget: GovernedChildRunBudget;
+	/** Detached canonical task payload. */
+	readonly task: JsonValue;
+}
+
+/** Stable denial reason returned before a child can reserve durable execution authority. */
+export type GovernedChildRunSpawnRefusalReason = "invalid_request" | "cross_silo" | "depth_exceeded" | "fanout_exceeded" | "capability_escalation" | "context_not_parent_readable" | "budget_exceeded";
+
+/** Result of validating one governed child-run request against its immutable parent authority. */
+export type GovernedChildRunSpawnAuthorizationResult = { readonly outcome: "authorized"; readonly authorization: GovernedChildRunSpawnAuthorization } | { readonly outcome: "denied"; readonly reason: GovernedChildRunSpawnRefusalReason };

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -1,5 +1,7 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
+export { __AuthorizeGovernedChildRunSpawn } from "./child-run-admission.js";
+export type { GovernedChildRunBudget, GovernedChildRunCapabilityDelegation, GovernedChildRunContextSelection, GovernedChildRunParent, GovernedChildRunPolicy, GovernedChildRunSpawnAuthorization, GovernedChildRunSpawnAuthorizationResult, GovernedChildRunSpawnRefusalReason, GovernedChildRunSpawnRequest } from "./child-run-admission.types.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";


### PR DESCRIPTION
## Why

Agent runs will eventually be able to delegate bounded work to child runs. That cannot begin as a runtime convenience: each child must remain inside the parent's frozen silo, authority, selected evidence, and finite resource allocation.

## What changes

- add a fail-closed, pure child-run authorization gate over locked parent facts
- enforce same-silo lineage, maximum depth, direct fan-out, parent-snapshot-only context, and finite budget carve-outs
- require an injected capability authority to prove the exact child service and capability digest are a subset of the parent
- return detached authorization only; this PR does not persist a child, reserve a budget, or expose a runtime command
- document the required successor transaction: lock/count/reserve/persist lineage and derived snapshot atomically

## Validation

- `npx nx lint backend-agents-execution-runs`
- `npx nx test backend-agents-execution-runs` (62 tests)
- `git diff --check`
- `scripts/agent-style-check.sh`

## Review

Independent correctness/security review: no Critical, High, Medium, or Low findings.

Stacked on #445.