### PR TITLE
🧱 Phase E: persist immutable child-run reservations

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -1371,6 +1371,20 @@ CREATE TABLE "run_input_snapshots" (
 );
 
 -- CreateTable
+CREATE TABLE "child_run_reservations" (
+    "child_run_id" TEXT NOT NULL,
+    "parent_run_id" TEXT NOT NULL,
+    "root_run_id" TEXT NOT NULL,
+    "depth" INTEGER NOT NULL,
+    "max_model_turns" INTEGER NOT NULL,
+    "max_total_tokens" INTEGER NOT NULL,
+    "max_duration_ms" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "child_run_reservations_pkey" PRIMARY KEY ("child_run_id")
+);
+
+-- CreateTable
 CREATE TABLE "workload_assignments" (
     "run_id" TEXT NOT NULL,
     "attempt" INTEGER NOT NULL,
@@ -2180,6 +2194,12 @@ CREATE UNIQUE INDEX "run_input_snapshots_run_id_input_digest_key" ON "run_input_
 CREATE UNIQUE INDEX "run_input_snapshot_run_identity_key" ON "run_input_snapshots"("run_id", "input_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest");
 
 -- CreateIndex
+CREATE INDEX "child_run_reservations_parent_run_id_idx" ON "child_run_reservations"("parent_run_id");
+
+-- CreateIndex
+CREATE INDEX "child_run_reservations_root_run_id_idx" ON "child_run_reservations"("root_run_id");
+
+-- CreateIndex
 CREATE INDEX "workload_assignments_silo_id_subject_id_idx" ON "workload_assignments"("silo_id", "subject_id");
 
 -- CreateIndex
@@ -2516,6 +2536,12 @@ ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_agent_service_id_agent_revis
 ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_agent_service_id_silo_id_fkey" FOREIGN KEY ("agent_service_id", "silo_id") REFERENCES "agent_services"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
+ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_parent_run_id_fkey" FOREIGN KEY ("parent_run_id") REFERENCES "agent_runs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_child_run_id_fkey" FOREIGN KEY ("child_run_id") REFERENCES "agent_runs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_run_id_input_digest_thread_id_silo_id__fkey" FOREIGN KEY ("run_id", "input_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest") REFERENCES "agent_runs"("id", "input_snapshot_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
@@ -2560,6 +2586,13 @@ ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_run_input_
     AND btrim("capability_set_digest") <> ''
     AND "capability_set_digest" ~ '^sha256:[0-9a-f]{64}$'
     AND jsonb_typeof("memory_facts") = 'array'
+);
+
+ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_positive_limits" CHECK (
+    "depth" > 0
+    AND "max_model_turns" > 0
+    AND "max_total_tokens" > 0
+    AND "max_duration_ms" > 0
 );
 
 -- Channel-target constraints cannot be represented by Prisma relations/indexes alone.
@@ -2817,6 +2850,49 @@ $$;
 CREATE FUNCTION "reject_run_input_snapshot_mutation"() RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
     RAISE EXCEPTION 'RunInputSnapshot rows are immutable';
+END;
+$$;
+CREATE FUNCTION "enforce_child_run_reservation"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    child "agent_runs"%ROWTYPE;
+    parent "agent_runs"%ROWTYPE;
+    root "agent_runs"%ROWTYPE;
+    parent_depth INTEGER;
+BEGIN
+    SELECT * INTO child FROM "agent_runs" WHERE "id" = NEW."child_run_id" FOR KEY SHARE;
+    SELECT * INTO parent FROM "agent_runs" WHERE "id" = NEW."parent_run_id" FOR UPDATE;
+    SELECT * INTO root FROM "agent_runs" WHERE "id" = NEW."root_run_id" FOR KEY SHARE;
+
+    IF child."id" IS NULL OR parent."id" IS NULL OR root."id" IS NULL
+        OR child."state" IS DISTINCT FROM 'accepted'::"AgentRunState"
+        OR child."attempt" <> 1
+        OR child."parent_run_id" IS DISTINCT FROM NEW."parent_run_id"
+        OR child."root_run_id" IS DISTINCT FROM NEW."root_run_id"
+        OR parent."root_run_id" IS DISTINCT FROM NEW."root_run_id"
+        OR root."id" IS DISTINCT FROM root."root_run_id"
+        OR root."parent_run_id" IS NOT NULL
+        OR child."silo_id" IS DISTINCT FROM parent."silo_id"
+        OR parent."silo_id" IS DISTINCT FROM root."silo_id"
+        OR NEW."child_run_id" = NEW."parent_run_id" THEN
+        RAISE EXCEPTION 'ChildRunReservation must bind one same-silo child to its exact parent and root';
+    END IF;
+
+    IF parent."parent_run_id" IS NULL THEN
+        IF parent."id" IS DISTINCT FROM NEW."root_run_id" OR NEW."depth" <> 1 THEN
+            RAISE EXCEPTION 'a direct child reservation must have the canonical root parent and depth 1';
+        END IF;
+    ELSE
+        SELECT "depth" INTO parent_depth FROM "child_run_reservations" WHERE "child_run_id" = parent."id" FOR KEY SHARE;
+        IF parent_depth IS NULL OR NEW."depth" <> parent_depth + 1 THEN
+            RAISE EXCEPTION 'a nested child reservation must continue its parent reservation depth';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE FUNCTION "reject_child_run_reservation_mutation"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'ChildRunReservation rows are immutable';
 END;
 $$;
 CREATE FUNCTION "enforce_initial_agent_run_state"() RETURNS trigger LANGUAGE plpgsql AS $$
@@ -4490,6 +4566,8 @@ CREATE TRIGGER "agent_revision_scope_attachments_immutable"
 CREATE TRIGGER "workload_assignments_current_attempt" BEFORE INSERT OR UPDATE OF "run_id", "attempt" ON "workload_assignments" FOR EACH ROW EXECUTE FUNCTION "enforce_current_workload_assignment_attempt"();
 CREATE TRIGGER "run_outbox_events_accepted_attempt" BEFORE INSERT OR UPDATE OF "run_id", "attempt" ON "run_outbox_events" FOR EACH ROW EXECUTE FUNCTION "enforce_accepted_outbox_attempt"();
 CREATE TRIGGER "run_input_snapshots_immutable" BEFORE UPDATE OR DELETE ON "run_input_snapshots" FOR EACH ROW EXECUTE FUNCTION "reject_run_input_snapshot_mutation"();
+CREATE TRIGGER "child_run_reservations_authority" BEFORE INSERT ON "child_run_reservations" FOR EACH ROW EXECUTE FUNCTION "enforce_child_run_reservation"();
+CREATE TRIGGER "child_run_reservations_immutable" BEFORE UPDATE OR DELETE ON "child_run_reservations" FOR EACH ROW EXECUTE FUNCTION "reject_child_run_reservation_mutation"();
 CREATE TRIGGER "agent_runs_initial_state"
     BEFORE INSERT ON "agent_runs"
     FOR EACH ROW EXECUTE FUNCTION "enforce_initial_agent_run_state"();

--- a/apps/opencrane/prisma/schema/runs.prisma
+++ b/apps/opencrane/prisma/schema/runs.prisma
@@ -76,6 +76,8 @@ model AgentRun {
   executionReceipts       ActionExecutionReceipt[]
   toolInvocations         ToolInvocation[]
   outboxEvents            OutboxEvent[]
+  spawnedChildReservations ChildRunReservation[] @relation("ChildRunReservationParent")
+  childReservation         ChildRunReservation?  @relation("ChildRunReservationChild")
 
   @@unique([siloId, requestIdempotencyKey])
   @@unique([id, agentServiceId, agentRevisionId])
@@ -87,6 +89,28 @@ model AgentRun {
   @@index([threadId, acceptedAt])
   @@index([rootRunId])
   @@map("agent_runs")
+}
+
+/// Immutable budget allocation and lineage proof for one governed child run.
+///
+/// The row is written with the child run in the parent's locked transaction. It makes each
+/// reservation independently auditable and lets later spawns sum only durable allocations rather
+/// than trusting a mutable counter or caller-provided remaining capacity.
+model ChildRunReservation {
+  childRunId          String   @id @map("child_run_id")
+  parentRunId         String   @map("parent_run_id")
+  rootRunId           String   @map("root_run_id")
+  depth               Int
+  maxModelTurns       Int      @map("max_model_turns")
+  maxTotalTokens      Int      @map("max_total_tokens")
+  maxDurationMs       Int      @map("max_duration_ms")
+  createdAt           DateTime @default(now()) @map("created_at")
+  parentRun           AgentRun @relation("ChildRunReservationParent", fields: [parentRunId], references: [id], onDelete: Restrict)
+  childRun            AgentRun @relation("ChildRunReservationChild", fields: [childRunId], references: [id], onDelete: Restrict)
+
+  @@index([parentRunId])
+  @@index([rootRunId])
+  @@map("child_run_reservations")
 }
 
 model RunInputSnapshot {

--- a/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
+++ b/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
@@ -93,4 +93,35 @@ BEGIN
 END;
 $$;
 
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "thread_id", "trigger", "request_idempotency_key", "root_run_id", "parent_run_id", "effective_contract_digest", "input_snapshot_digest")
+VALUES ('snapshot-child-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'managed_invocation', 'snapshot-child-request', 'snapshot-run', 'snapshot-run', 'sha256:' || repeat('9', 64), 'sha256:' || repeat('0', 64));
+INSERT INTO "run_input_snapshots" ("run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "thread_id", "memory_facts", "identity_snapshot", "model_route", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-child-run', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('9', 64), NULL, '[]', '{}', '{}', '{}', '{}', 'sha256:' || repeat('a', 64), 'prompt-v1', 'sha256:' || repeat('0', 64));
+INSERT INTO "child_run_reservations" ("child_run_id", "parent_run_id", "root_run_id", "depth", "max_model_turns", "max_total_tokens", "max_duration_ms")
+VALUES ('snapshot-child-run', 'snapshot-run', 'snapshot-run', 1, 1, 100, 1000);
+SET CONSTRAINTS ALL IMMEDIATE;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM "child_run_reservations" WHERE "child_run_id" = 'snapshot-child-run' AND "parent_run_id" = 'snapshot-run' AND "root_run_id" = 'snapshot-run') THEN
+        RAISE EXCEPTION 'FAIL: child reservation did not retain exact lineage';
+    END IF;
+    RAISE NOTICE 'PASS: a child reservation binds exact durable lineage and limits';
+END;
+$$;
+DO $$
+DECLARE
+    actual_message TEXT;
+BEGIN
+    BEGIN
+        UPDATE "child_run_reservations" SET "max_total_tokens" = 101 WHERE "child_run_id" = 'snapshot-child-run';
+    EXCEPTION WHEN raise_exception THEN
+        GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+        IF strpos(actual_message, 'ChildRunReservation rows are immutable') = 0 THEN RAISE EXCEPTION 'FAIL: expected immutable reservation rejection, got %', actual_message; END IF;
+        RAISE NOTICE 'PASS: a child reservation is immutable after durable admission';
+        RETURN;
+    END;
+    RAISE EXCEPTION 'FAIL: a child reservation unexpectedly mutated';
+END;
+$$;
+
 ROLLBACK;

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -175,6 +175,12 @@ a pure admission gate so a later repository can lock the parent, count existing 
 the budget, persist one derived child snapshot, and record lineage atomically. Until that boundary
 exists, no child-run runtime command is exposed.
 
+`ChildRunReservation` is the durable record that this later boundary will write beside a child run.
+It freezes the exact parent and root identifiers, child depth, and the turns, tokens, and duration
+carved out for that child. The database rejects a reservation whose child is not already bound to
+that same parent/root/silo and rejects every later mutation. This lets a parent-locked transaction
+derive remaining capacity from durable allocations instead of trusting a mutable counter.
+
 ## Dependency direction
 
 Tagged `scope:execution-runs`: it may depend only on `scope:agents` (shared run models),
@@ -192,6 +198,9 @@ transaction. First-Pod registration publishes the release event atomically, leav
 Pod is trusted but its release command can be reclaimed.
 Cancellation reuses the same outbox with `RunCancellationRequested` and
 `RunWorkloadCleanupRequested`; no second cleanup queue or revocation authority exists.
+
+`ChildRunReservation` is also owned here. It is one-to-one with its child run and references its
+immediate parent; it is append-only after the transaction that creates the derived child run.
 
 ## See also
 


### PR DESCRIPTION
## Why

A child-run authorization cannot rely on an in-memory budget counter. Each child needs a durable, auditable allocation that is created before dispatch and remains inseparable from its parent, root, and frozen limits.

## What changes

- add the run-owned `ChildRunReservation` clean target-schema model
- record immutable parent/root lineage, recursive depth, and reserved turns, tokens, and duration
- enforce canonical same-silo roots, continuous depth, one-attempt accepted child state, and parent-row serialization in PostgreSQL
- reject any reservation mutation and add SQL authority coverage for valid lineage plus immutability

## Validation

- `prisma validate`
- Prisma client generation
- `git diff --check`
- live Postgres authority suite is wired but unavailable locally because this machine has neither `psql` nor Docker access

## Review

Architecture gate: PASS after root/depth/locking remediation. Independent review found and verified the late-reservation fix.

Stacked on #446.