### PR TITLE
🔒 Phase E: atomically reserve and persist governed child runs

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -1378,7 +1378,10 @@ CREATE TABLE "child_run_reservations" (
     "depth" INTEGER NOT NULL,
     "max_model_turns" INTEGER NOT NULL,
     "max_total_tokens" INTEGER NOT NULL,
+    "max_cost_usd_micros" BIGINT NOT NULL,
     "max_duration_ms" INTEGER NOT NULL,
+    "task" JSONB NOT NULL,
+    "task_digest" TEXT NOT NULL,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "child_run_reservations_pkey" PRIMARY KEY ("child_run_id")
@@ -2592,7 +2595,9 @@ ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_posi
     "depth" > 0
     AND "max_model_turns" > 0
     AND "max_total_tokens" > 0
+    AND "max_cost_usd_micros" > 0
     AND "max_duration_ms" > 0
+    AND "task_digest" ~ '^sha256:[0-9a-f]{64}$'
 );
 
 -- Channel-target constraints cannot be represented by Prisma relations/indexes alone.

--- a/apps/opencrane/prisma/schema/runs.prisma
+++ b/apps/opencrane/prisma/schema/runs.prisma
@@ -103,7 +103,10 @@ model ChildRunReservation {
   depth               Int
   maxModelTurns       Int      @map("max_model_turns")
   maxTotalTokens      Int      @map("max_total_tokens")
+  maxCostUsdMicros    BigInt   @map("max_cost_usd_micros")
   maxDurationMs       Int      @map("max_duration_ms")
+  task                Json
+  taskDigest          String   @map("task_digest")
   createdAt           DateTime @default(now()) @map("created_at")
   parentRun           AgentRun @relation("ChildRunReservationParent", fields: [parentRunId], references: [id], onDelete: Restrict)
   childRun            AgentRun @relation("ChildRunReservationChild", fields: [childRunId], references: [id], onDelete: Restrict)

--- a/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
+++ b/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
@@ -97,8 +97,8 @@ INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_i
 VALUES ('snapshot-child-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'managed_invocation', 'snapshot-child-request', 'snapshot-run', 'snapshot-run', 'sha256:' || repeat('9', 64), 'sha256:' || repeat('0', 64));
 INSERT INTO "run_input_snapshots" ("run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "thread_id", "memory_facts", "identity_snapshot", "model_route", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
 VALUES ('snapshot-child-run', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('9', 64), NULL, '[]', '{}', '{}', '{}', '{}', 'sha256:' || repeat('a', 64), 'prompt-v1', 'sha256:' || repeat('0', 64));
-INSERT INTO "child_run_reservations" ("child_run_id", "parent_run_id", "root_run_id", "depth", "max_model_turns", "max_total_tokens", "max_duration_ms")
-VALUES ('snapshot-child-run', 'snapshot-run', 'snapshot-run', 1, 1, 100, 1000);
+INSERT INTO "child_run_reservations" ("child_run_id", "parent_run_id", "root_run_id", "depth", "max_model_turns", "max_total_tokens", "max_cost_usd_micros", "max_duration_ms", "task", "task_digest")
+VALUES ('snapshot-child-run', 'snapshot-run', 'snapshot-run', 1, 1, 100, 100000, 1000, '{"goal":"test"}', 'sha256:' || repeat('f', 64));
 SET CONSTRAINTS ALL IMMEDIATE;
 DO $$
 BEGIN

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -17,6 +17,7 @@ its frozen inputs.
  ┌──────────────────────────────────────────┐
  │   runs  ◄── HERE                          │  run + one snapshot + ordered outbox
  │   · PrismaRunAdmissionRepository          │  duplicate returns the first snapshot
+	│   · PrismaChildRunReservationRepository    │  parent-fenced child reservation
  │   · RunAdmissionConcurrencyGate            │  bounded wait before a DB connection
  │   · PrismaRunCancellationRepository       │  fence first; clean exact Job; then terminal
  │   · __StartNextRunAttempt                 │  terminal run: attempt N → N+1
@@ -137,6 +138,8 @@ uncertainty fails closed.
   refusal vocabulary for the subsequent transaction-fenced child reservation boundary.
 - `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial
   run, snapshot and ordered outbox events around a caller-supplied assembly callback.
+- `PrismaChildRunReservationRepository` — lock a parent, validate its frozen snapshot and detached
+  child authority, then atomically persist the child run, snapshot, reservation and initial outbox.
 - `RunAdmissionConcurrencyGate` — bound active and queued admissions for one silo and AgentService
   before the caller can acquire a persistence connection.
 - `RunAdmissionRepository`, `RunAdmissionCommand`, `RunAdmissionTransaction`,
@@ -170,10 +173,10 @@ integrity, release delivery, first-Pod registration, cancellation fencing, and c
 confirmation. Kubernetes inspection and mutation remain in dedicated runtime processes; this
 package only says which exact work may be removed.
 
-It also does not yet reserve or create child runs. `__AuthorizeGovernedChildRunSpawn` is deliberately
-a pure admission gate so a later repository can lock the parent, count existing children, reserve
-the budget, persist one derived child snapshot, and record lineage atomically. Until that boundary
-exists, no child-run runtime command is exposed.
+`__AuthorizeGovernedChildRunSpawn` is deliberately a pure admission gate. Its detached authority
+reaches `PrismaChildRunReservationRepository`, which locks the parent, rechecks the parent digest
+and lineage coordinates, and persists one child snapshot and allocation atomically. Until an app
+composes that repository into a runtime entrypoint, no child-run runtime command is exposed.
 
 `ChildRunReservation` is the durable record that this later boundary will write beside a child run.
 It freezes the exact parent and root identifiers, child depth, and the turns, tokens, and duration

--- a/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
@@ -21,7 +21,7 @@ function _Parent(overrides: Partial<GovernedChildRunParent> = {}): GovernedChild
 			capabilitySetDigest: _PARENT_CAPABILITY_DIGEST, effectiveContractDigest: `sha256:${"e".repeat(64)}`, promptCompilerVersion: "test-v1", digest: `sha256:${"f".repeat(64)}`, compiledAt: "2026-07-25T00:00:00.000Z",
 		},
 		depth: 0,
-		remainingBudget: { maxModelTurns: 4, maxTotalTokens: 400, maxDurationMs: 60000 },
+		remainingBudget: { maxModelTurns: 4, maxTotalTokens: 400, maxCostUsdMicros: 4000000, maxDurationMs: 60000 },
 		...overrides,
 	};
 }
@@ -34,7 +34,7 @@ function _Request(overrides: Partial<GovernedChildRunSpawnRequest> = {}): Govern
 		agentServiceId: "child-service",
 		capabilitySetDigest: _CHILD_CAPABILITY_DIGEST,
 		context: { messageIds: ["message-1"], memoryFactIds: ["fact-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"] },
-		budget: { maxModelTurns: 2, maxTotalTokens: 200, maxDurationMs: 30000 },
+		budget: { maxModelTurns: 2, maxTotalTokens: 200, maxCostUsdMicros: 2000000, maxDurationMs: 30000 },
 		task: { prompt: "Summarise the selected evidence." },
 		...overrides,
 	};
@@ -88,7 +88,8 @@ describe("__AuthorizeGovernedChildRunSpawn", function _DescribeChildAdmission()
 		expect(__AuthorizeGovernedChildRunSpawn(_Parent({ depth: 1 }), _Request(), 0, policy, _Delegation)).toEqual({ outcome: "denied", reason: "depth_exceeded" });
 		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request(), 1, policy, _Delegation)).toEqual({ outcome: "denied", reason: "fanout_exceeded" });
 		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request(), 0, policy, { allows: function _Deny(): boolean { return false; } })).toEqual({ outcome: "denied", reason: "capability_escalation" });
-		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request({ budget: { maxModelTurns: 5, maxTotalTokens: 200, maxDurationMs: 30000 } }), 0, policy, _Delegation)).toEqual({ outcome: "denied", reason: "budget_exceeded" });
+		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request({ budget: { maxModelTurns: 5, maxTotalTokens: 200, maxCostUsdMicros: 2000000, maxDurationMs: 30000 } }), 0, policy, _Delegation)).toEqual({ outcome: "denied", reason: "budget_exceeded" });
+		expect(__AuthorizeGovernedChildRunSpawn(_Parent(), _Request({ budget: { maxModelTurns: 2, maxTotalTokens: 200, maxCostUsdMicros: 4000001, maxDurationMs: 30000 } }), 0, policy, _Delegation)).toEqual({ outcome: "denied", reason: "budget_exceeded" });
 	});
 
 	it("fails closed on malformed candidate data before it reaches the capability verifier", function _RejectMalformed()

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-reservation-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-reservation-repository.test.ts
@@ -1,0 +1,109 @@
+import type { PrismaClient } from "@prisma/client";
+import { __DigestCanonicalJson } from "@opencrane/backend/server/iam/authorization";
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaChildRunReservationRepository } from "../prisma-child-run-reservation-repository.js";
+
+/** Creates a complete immutable snapshot for either the locked parent or the derived child. */
+function _snapshot(runId: string, agentServiceId: string, agentRevisionId: string, digest: string): RunInputSnapshot
+{
+	return {
+		runId, siloId: "silo-1", agentServiceId, agentRevisionId, snapshotVersion: 1, threadId: "thread-1", messageIds: ["message-1"], personaRevisionId: "persona-1", preferenceFactIds: ["preference-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"], memoryFacts: [{ datasetId: "dataset-1", factId: "fact-1", contentDigest: `sha256:${"e".repeat(64)}`, provenance: [{ sourceKind: "message", sourceId: "message-1", capturedAt: "2026-07-20T00:00:00.000Z" }] }], memoryQueryPolicy: { scope: "personal" }, integrationAssignments: [{ integrationId: "integration-1", allowedTools: ["tool-1"] }], modelRoute: { alias: "target" }, budgetPolicy: { maxModelTurns: 4, maxTotalTokens: 1000, maxCostUsdMicros: 500000, wallClockDeadlineEpochMs: Date.parse("2026-07-20T00:02:00.000Z") }, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 4, fleetMembershipIssuer: "opencrane-fleet", fleetMembershipIssuerKeyId: "key-1", fleetMembershipAssertionId: "assertion-1", fleetMembershipPayloadDigest: `sha256:${"d".repeat(64)}`, fleetMembershipTrustedUntil: "2026-07-20T01:00:00.000Z" }, capabilitySetDigest: `sha256:${"a".repeat(64)}`, effectiveContractDigest: `sha256:${"b".repeat(64)}`, promptCompilerVersion: "prompt-v1", digest, compiledAt: "2026-07-20T00:00:00.000Z",
+	};
+}
+
+/** Creates a child snapshot whose runtime-visible ceiling exactly matches the reservation allocation. */
+function _childSnapshot(): RunInputSnapshot
+{
+	return { ..._snapshot("child-run-1", "child-service-1", "child-revision-1", `sha256:${"f".repeat(64)}`), budgetPolicy: { maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200000, wallClockDeadlineEpochMs: Date.parse("2026-07-20T00:01:00.000Z") } };
+}
+
+/** Creates one detached child-run authority that exactly matches the test parent. */
+function _command()
+{
+	return {
+		childRunId: "child-run-1", requestIdempotencyKey: "child-request-1", parentRunId: "parent-run-1", parentSnapshotDigest: `sha256:${"c".repeat(64)}`, maximumChildrenPerParent: 2,
+		authorization: { siloId: "silo-1", rootRunId: "root-run-1", parentRunId: "parent-run-1", depth: 1, capabilitySetDigest: `sha256:${"a".repeat(64)}`, agentServiceId: "child-service-1", context: { messageIds: ["message-1"], memoryFactIds: ["fact-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"] }, budget: { maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200000, maxDurationMs: 60000 }, task: { goal: "research" } },
+	} as const;
+}
+
+/** Creates one parent AgentRun row returned after the repository obtains its row lock. */
+function _parentRun()
+{
+	return { id: "parent-run-1", siloId: "silo-1", agentServiceId: "parent-service-1", rootRunId: "root-run-1", inputSnapshotDigest: `sha256:${"c".repeat(64)}` };
+}
+
+/** Creates a persistence mock whose transaction callback receives the supplied authority operations. */
+function _prisma(transaction: object): PrismaClient
+{
+	return { $transaction: vi.fn(async function _transaction(callback: (client: object) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+}
+
+describe("PrismaChildRunReservationRepository", function _describeChildRunReservationRepository()
+{
+	it("locks the parent, builds under that lock, and atomically writes child, snapshot, reservation and initial outbox", async function _persistsChildReservation()
+	{
+		const parentSnapshot = _snapshot("parent-run-1", "parent-service-1", "parent-revision-1", `sha256:${"c".repeat(64)}`);
+		const childSnapshot = _childSnapshot();
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce(null), create: vi.fn().mockResolvedValue({ id: "child-run-1" }) }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }), create: vi.fn().mockResolvedValue({ id: "snapshot-1" }) }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 0 }, _sum: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxDurationMs: null } }), create: vi.fn().mockResolvedValue({ childRunId: "child-run-1" }) }, outboxEvent: { createMany: vi.fn().mockResolvedValue({ count: 2 }) } };
+		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+		const build = vi.fn(async function _build(parent) { expect(parent.snapshot).toEqual(parentSnapshot); expect(parent.agentServiceId).toBe("parent-service-1"); return { snapshot: childSnapshot, agentRevisionId: "child-revision-1", effectiveContractDigest: childSnapshot.effectiveContractDigest }; });
+
+		await expect(repository.reserve(_command(), build)).resolves.toEqual({ outcome: "reserved", snapshot: childSnapshot });
+		expect(transaction.$queryRaw).toHaveBeenCalledTimes(2);
+		expect(transaction.agentRun.create).toHaveBeenCalledWith({ data: expect.objectContaining({ id: "child-run-1", trigger: "ManagedInvocation", parentRunId: "parent-run-1", rootRunId: "root-run-1", requestIdempotencyKey: "child-request-1" }) });
+		expect(transaction.runInputSnapshot.create).toHaveBeenCalledWith({ data: expect.objectContaining({ runId: "child-run-1", digest: childSnapshot.digest }) });
+		expect(transaction.childRunReservation.create).toHaveBeenCalledWith({ data: { childRunId: "child-run-1", parentRunId: "parent-run-1", rootRunId: "root-run-1", depth: 1, maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200000n, maxDurationMs: 60000, task: { goal: "research" }, taskDigest: __DigestCanonicalJson({ goal: "research" }) } });
+		expect(transaction.outboxEvent.createMany).toHaveBeenCalledWith({ data: [expect.objectContaining({ sequence: 1, kind: "RunAccepted", idempotencyKey: "child-run-1:accepted" }), expect.objectContaining({ sequence: 2, kind: "RunAttemptRequested", idempotencyKey: "child-run-1:attempt:1" })] });
+	});
+
+	it("returns the first child only when its immutable reservation and snapshot scope match the duplicate request", async function _returnsIdempotentChild()
+	{
+		const parentSnapshot = _snapshot("parent-run-1", "parent-service-1", "parent-revision-1", `sha256:${"c".repeat(64)}`);
+		const childSnapshot = _childSnapshot();
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce({ id: "child-run-1", siloId: "silo-1", agentServiceId: "child-service-1", parentRunId: "parent-run-1", rootRunId: "root-run-1", trigger: "ManagedInvocation", inputSnapshotDigest: childSnapshot.digest }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValueOnce({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }).mockResolvedValueOnce({ ...childSnapshot, compiledAt: new Date(childSnapshot.compiledAt) }), create: vi.fn() }, childRunReservation: { findUnique: vi.fn().mockResolvedValue({ childRunId: "child-run-1", parentRunId: "parent-run-1", rootRunId: "root-run-1", depth: 1, maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200000n, maxDurationMs: 60000, task: { goal: "research" }, taskDigest: __DigestCanonicalJson({ goal: "research" }) }), aggregate: vi.fn(), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+		const build = vi.fn();
+
+		await expect(repository.reserve(_command(), build)).resolves.toEqual({ outcome: "idempotent", snapshot: childSnapshot });
+		expect(build).not.toHaveBeenCalled();
+		expect(transaction.agentRun.create).not.toHaveBeenCalled();
+		expect(transaction.childRunReservation.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects a stale parent digest before callback compilation or child writes", async function _rejectsStaleParent()
+	{
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue({ ..._parentRun(), inputSnapshotDigest: `sha256:${"9".repeat(64)}` }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn(), create: vi.fn() }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn(), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+		const build = vi.fn();
+
+		await expect(repository.reserve(_command(), build)).resolves.toEqual({ outcome: "denied", reason: "parent_snapshot_stale" });
+		expect(build).not.toHaveBeenCalled();
+		expect(transaction.agentRun.create).not.toHaveBeenCalled();
+	});
+
+	it("denies sibling fan-out or durable allocation overdraw before compiling a new child", async function _deniesExhaustedParentCapacity()
+	{
+		const parentSnapshot = _snapshot("parent-run-1", "parent-service-1", "parent-revision-1", `sha256:${"c".repeat(64)}`);
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce(null), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }), create: vi.fn() }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 1 }, _sum: { maxModelTurns: 1, maxTotalTokens: 200, maxCostUsdMicros: 400000n, maxDurationMs: 30000 } }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+		const build = vi.fn();
+
+		await expect(repository.reserve(_command(), build)).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
+		expect(transaction.childRunReservation.aggregate).toHaveBeenCalledWith({ where: { parentRunId: "parent-run-1" }, _count: { childRunId: true }, _sum: { maxModelTurns: true, maxTotalTokens: true, maxCostUsdMicros: true, maxDurationMs: true } });
+		expect(build).not.toHaveBeenCalled();
+	});
+
+	it("rejects a derived snapshot that changes the locked parent thread before persistence", async function _rejectsThreadEscalation()
+	{
+		const parentSnapshot = _snapshot("parent-run-1", "parent-service-1", "parent-revision-1", `sha256:${"c".repeat(64)}`);
+		const childSnapshot = { ..._childSnapshot(), threadId: "thread-2" };
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce(null), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }), create: vi.fn() }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 0 }, _sum: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxDurationMs: null } }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+
+		await expect(repository.reserve(_command(), async function _build() { return { snapshot: childSnapshot, agentRevisionId: "child-revision-1", effectiveContractDigest: childSnapshot.effectiveContractDigest }; })).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
+		expect(transaction.agentRun.create).not.toHaveBeenCalled();
+		expect(transaction.runInputSnapshot.create).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
@@ -63,7 +63,7 @@ function _Context(value: Record<string, unknown>): GovernedChildRunContextSelect
 /** Returns one finite budget carve-out after validating its primitive fields. */
 function _Budget(value: Record<string, unknown>): GovernedChildRunBudget | null
 {
-	return _IsPositiveInteger(value.maxModelTurns) && _IsPositiveInteger(value.maxTotalTokens) && _IsPositiveInteger(value.maxDurationMs) ? { maxModelTurns: value.maxModelTurns, maxTotalTokens: value.maxTotalTokens, maxDurationMs: value.maxDurationMs } : null;
+	return _IsPositiveInteger(value.maxModelTurns) && _IsPositiveInteger(value.maxTotalTokens) && _IsPositiveInteger(value.maxCostUsdMicros) && _IsPositiveInteger(value.maxDurationMs) ? { maxModelTurns: value.maxModelTurns, maxTotalTokens: value.maxTotalTokens, maxCostUsdMicros: value.maxCostUsdMicros, maxDurationMs: value.maxDurationMs } : null;
 }
 
 /** Returns whether a request is structurally consistent with one loaded parent and bounded policy. */
@@ -97,13 +97,14 @@ function _Subset(allowed: ReadonlySet<string>, selected: readonly string[]): boo
 /** Returns whether a child uses only finite capacity contained by its parent's remaining allocation. */
 function _FitsBudget(child: GovernedChildRunBudget, parent: GovernedChildRunBudget): boolean
 {
-	return child.maxModelTurns <= parent.maxModelTurns && child.maxTotalTokens <= parent.maxTotalTokens && child.maxDurationMs <= parent.maxDurationMs;
+	return child.maxModelTurns <= parent.maxModelTurns && child.maxTotalTokens <= parent.maxTotalTokens
+		&& child.maxCostUsdMicros <= parent.maxCostUsdMicros && child.maxDurationMs <= parent.maxDurationMs;
 }
 
 /** Returns whether one budget contains only positive safe-integer capacity. */
 function _IsBudgetValid(value: GovernedChildRunBudget): boolean
 {
-	return _IsPositiveInteger(value.maxModelTurns) && _IsPositiveInteger(value.maxTotalTokens) && _IsPositiveInteger(value.maxDurationMs);
+	return _IsPositiveInteger(value.maxModelTurns) && _IsPositiveInteger(value.maxTotalTokens) && _IsPositiveInteger(value.maxCostUsdMicros) && _IsPositiveInteger(value.maxDurationMs);
 }
 
 /** Returns whether one unknown value is a JSON record rather than null or an array. */
@@ -123,6 +124,7 @@ function _IsPositiveInteger(value: unknown): value is number
 {
 	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
+
 
 /** Returns whether an identifier contains a non-whitespace value. */
 function _Present(value: string): boolean

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
@@ -8,6 +8,8 @@ export interface GovernedChildRunBudget
 	readonly maxModelTurns: number;
 	/** Maximum provider tokens the child may consume. */
 	readonly maxTotalTokens: number;
+	/** Maximum provider cost in integer USD micros the child may consume. */
+	readonly maxCostUsdMicros: number;
 	/** Maximum wall-clock duration the child may occupy. */
 	readonly maxDurationMs: number;
 }

--- a/libs/backend/agents/execution/runs/main/src/child-run-reservation.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-reservation.types.ts
@@ -1,0 +1,50 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+
+import type { GovernedChildRunSpawnAuthorization } from "./child-run-admission.types.js";
+
+/** Immutable caller coordinates for one transaction-fenced governed child-run reservation. */
+export interface ChildRunReservationCommand
+{
+	/** New durable child run identifier. */
+	readonly childRunId: string;
+	/** Same-silo idempotency key that returns the first durable child only. */
+	readonly requestIdempotencyKey: string;
+	/** Locked parent run identifier. */
+	readonly parentRunId: string;
+	/** Expected parent snapshot digest, preventing stale-parent compilation. */
+	readonly parentSnapshotDigest: string;
+	/** Maximum direct children permitted by the immutable policy evaluated for this reservation. */
+	readonly maximumChildrenPerParent: number;
+	/** Previously authorized child coordinates and finite allocation. */
+	readonly authorization: GovernedChildRunSpawnAuthorization;
+}
+
+/** Immutable authority supplied to derive one child snapshot under the parent lock. */
+export interface ChildRunReservationParent
+{
+	/** Parent run and exact frozen snapshot used by the authorization gate. */
+	readonly snapshot: RunInputSnapshot;
+	/** Parent's immutable logical-run coordinates. */
+	readonly agentServiceId: string;
+}
+
+/** One derived child snapshot ready for atomic persistence. */
+export interface ChildRunReservationBuild
+{
+	/** Complete digest-sealed child input snapshot. */
+	readonly snapshot: RunInputSnapshot;
+	/** Published target service revision fixed for the child logical run. */
+	readonly agentRevisionId: string;
+	/** Effective contract digest fixed for the selected child revision. */
+	readonly effectiveContractDigest: string;
+}
+
+/** Result of the one child-run reservation transaction. */
+export type ChildRunReservationResult = { readonly outcome: "reserved" | "idempotent"; readonly snapshot: RunInputSnapshot } | { readonly outcome: "denied"; readonly reason: "invalid_command" | "parent_unavailable" | "parent_snapshot_stale" | "authority_conflict" | "persistence_unavailable" };
+
+/** Transaction-fenced child-run persistence port. */
+export interface ChildRunReservationRepository
+{
+	/** Locks parent authority, reserves finite capacity, and persists child/run snapshot/outbox as one commit. */
+	reserve(command: ChildRunReservationCommand, build: (parent: ChildRunReservationParent) => Promise<ChildRunReservationBuild>): Promise<ChildRunReservationResult>;
+}

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -2,6 +2,8 @@ export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-au
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
 export { __AuthorizeGovernedChildRunSpawn } from "./child-run-admission.js";
 export type { GovernedChildRunBudget, GovernedChildRunCapabilityDelegation, GovernedChildRunContextSelection, GovernedChildRunParent, GovernedChildRunPolicy, GovernedChildRunSpawnAuthorization, GovernedChildRunSpawnAuthorizationResult, GovernedChildRunSpawnRefusalReason, GovernedChildRunSpawnRequest } from "./child-run-admission.types.js";
+export type { ChildRunReservationBuild, ChildRunReservationCommand, ChildRunReservationParent, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
+export { PrismaChildRunReservationRepository } from "./prisma-child-run-reservation-repository.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";

--- a/libs/backend/agents/execution/runs/main/src/prisma-child-run-reservation-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-child-run-reservation-repository.ts
@@ -1,0 +1,267 @@
+import { Prisma, RunOutboxEventKind, type PrismaClient } from "@prisma/client";
+
+import { __DigestCanonicalJson } from "@opencrane/backend/server/iam/authorization";
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { ___CreateLogger, type Logger } from "@opencrane/observability";
+import { ___CloneCanonicalJson } from "@opencrane/util";
+import type { JsonValue } from "@opencrane/util";
+
+import type { ChildRunReservationBuild, ChildRunReservationCommand, ChildRunReservationParent, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
+
+/**
+ * Prisma-backed authority for one governed child run.
+ *
+ * It serialises every prospective sibling on the parent row, then commits the derived child,
+ * immutable snapshot, immutable reservation, and initial dispatch events together. Any incomplete
+ * parent authority or persistence failure is a denial rather than a partially visible child.
+ */
+export class PrismaChildRunReservationRepository implements ChildRunReservationRepository
+{
+	/** Canonical OpenCrane product-authority database client. */
+	private readonly prisma: PrismaClient;
+	/** Structured persistence-failure signal with process-wide secret redaction. */
+	private readonly log: Logger;
+
+	/**
+	 * Creates a child-run reservation authority over canonical Postgres.
+	 * @param prisma - Canonical product-authority database client.
+	 * @param log - Structured redacting logger for otherwise fail-closed persistence failures.
+	 */
+	constructor(prisma: PrismaClient, log: Logger = ___CreateLogger("child-run-reservation"))
+	{
+		this.prisma = prisma;
+		this.log = log;
+	}
+
+	/**
+	 * Locks one parent, revalidates its frozen authority, and atomically reserves one derived child.
+	 */
+	async reserve(command: ChildRunReservationCommand, build: (parent: ChildRunReservationParent) => Promise<ChildRunReservationBuild>): Promise<ChildRunReservationResult>
+	{
+		if (!_isCommandValid(command)) return { outcome: "denied", reason: "invalid_command" };
+		try
+		{
+			return await this.prisma.$transaction(async function _reserve(transaction: Prisma.TransactionClient): Promise<ChildRunReservationResult>
+			{
+				// 1. Lock the parent before checking siblings so every accepted allocation observes the same durable lineage.
+				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.parentRunId} FOR UPDATE`);
+				const parentRun = await transaction.agentRun.findUnique({ where: { id: command.parentRunId } });
+				if (parentRun === null) return { outcome: "denied", reason: "parent_unavailable" };
+				if (parentRun.inputSnapshotDigest !== command.parentSnapshotDigest) return { outcome: "denied", reason: "parent_snapshot_stale" };
+
+				// 2. Serialize the silo key while the parent remains locked, so duplicate delivery never builds a second child.
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${command.authorization.siloId}\u0000${command.requestIdempotencyKey}`}, 0))`);
+				const parentSnapshot = await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: parentRun.id, digest: parentRun.inputSnapshotDigest } } });
+				if (parentSnapshot === null) return { outcome: "denied", reason: "persistence_unavailable" };
+				if (!_matchesParent(parentRun, parentSnapshot, command)) return { outcome: "denied", reason: "authority_conflict" };
+
+				const existing = await transaction.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.authorization.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
+				if (existing !== null) return _idempotentResult(transaction, existing, command);
+				const aggregate = await transaction.childRunReservation.aggregate({ where: { parentRunId: parentRun.id }, _count: { childRunId: true }, _sum: { maxModelTurns: true, maxTotalTokens: true, maxCostUsdMicros: true, maxDurationMs: true } });
+				if (!_hasRemainingCapacity(parentSnapshot, aggregate, command)) return { outcome: "denied", reason: "authority_conflict" };
+
+				// 3. Build only after locks and exact parent evidence are held, preventing stale or sibling-expanded compilation.
+				const value = await build({ snapshot: _snapshot(parentSnapshot), agentServiceId: parentRun.agentServiceId });
+				if (!_matchesBuild(value, _snapshot(parentSnapshot), command)) return { outcome: "denied", reason: "authority_conflict" };
+
+				// 4. Commit every durable child authority record and initial dispatch events in this same parent-fenced transaction.
+				await _persistReservation(transaction, command, value);
+				return { outcome: "reserved", snapshot: value.snapshot };
+			});
+		}
+		catch (error)
+		{
+			this.log.error({ err: error, childRunId: command.childRunId, parentRunId: command.parentRunId, siloId: command.authorization.siloId, failureKind: "transaction_failed" }, "child run reservation persistence failed");
+			return { outcome: "denied", reason: "persistence_unavailable" };
+		}
+	}
+}
+
+/** Returns whether a caller provided enough well-formed coordinates for a fail-closed reservation attempt. */
+function _isCommandValid(command: ChildRunReservationCommand): boolean
+{
+	const authorization = command.authorization;
+	return _present(command.childRunId) && _present(command.requestIdempotencyKey) && _present(command.parentRunId) && _digest(command.parentSnapshotDigest)
+		&& _present(authorization.siloId) && _present(authorization.rootRunId) && authorization.parentRunId === command.parentRunId
+		&& _present(authorization.agentServiceId) && _digest(authorization.capabilitySetDigest) && Number.isSafeInteger(authorization.depth) && authorization.depth > 0
+		&& Number.isSafeInteger(command.maximumChildrenPerParent) && command.maximumChildrenPerParent >= 0
+		&& _positiveBudget(authorization.budget.maxModelTurns) && _positiveBudget(authorization.budget.maxTotalTokens) && _positiveBudget(authorization.budget.maxCostUsdMicros) && _positiveBudget(authorization.budget.maxDurationMs);
+}
+
+/** Returns whether durable sibling allocations and fan-out leave capacity in the immutable parent policy. */
+function _hasRemainingCapacity(parentSnapshot: { budgetPolicy: Prisma.JsonValue; compiledAt: Date }, aggregate: { _count: { childRunId: number }; _sum: { maxModelTurns: number | null; maxTotalTokens: number | null; maxCostUsdMicros: bigint | null; maxDurationMs: number | null } }, command: ChildRunReservationCommand): boolean
+{
+	const capacity = _parentCapacity(parentSnapshot.budgetPolicy, parentSnapshot.compiledAt);
+	if (capacity === null || aggregate._count.childRunId >= command.maximumChildrenPerParent) return false;
+	const allocation = command.authorization.budget;
+	return _within(capacity.maxModelTurns, aggregate._sum.maxModelTurns, allocation.maxModelTurns)
+		&& _within(capacity.maxTotalTokens, aggregate._sum.maxTotalTokens, allocation.maxTotalTokens)
+		&& _withinBigInt(capacity.maxCostUsdMicros, aggregate._sum.maxCostUsdMicros, allocation.maxCostUsdMicros)
+		&& _within(capacity.maxDurationMs, aggregate._sum.maxDurationMs, allocation.maxDurationMs);
+}
+
+/** Parses the frozen parent budget policy into the four finite capacities that children may reserve. */
+function _parentCapacity(value: Prisma.JsonValue, compiledAt: Date): { readonly maxModelTurns: number; readonly maxTotalTokens: number; readonly maxCostUsdMicros: number; readonly maxDurationMs: number } | null
+{
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+	const policy = value as Record<string, unknown>;
+	const deadline = policy["wallClockDeadlineEpochMs"];
+	const duration = typeof deadline === "number" ? deadline - compiledAt.getTime() : NaN;
+	return _positiveBudget(policy["maxModelTurns"]) && _positiveBudget(policy["maxTotalTokens"]) && _positiveBudget(policy["maxCostUsdMicros"]) && _positiveBudget(duration)
+		? { maxModelTurns: policy["maxModelTurns"], maxTotalTokens: policy["maxTotalTokens"], maxCostUsdMicros: policy["maxCostUsdMicros"], maxDurationMs: duration }
+		: null;
+}
+
+/** Returns whether an existing total plus one candidate allocation remains inside one finite capacity. */
+function _within(capacity: number, consumed: number | null, requested: number): boolean
+{
+	return Number.isSafeInteger(consumed ?? 0) && (consumed ?? 0) >= 0 && requested <= capacity - (consumed ?? 0);
+}
+
+/** Returns whether an existing bigint cost allocation plus one candidate remains within the parent ceiling. */
+function _withinBigInt(capacity: number, consumed: bigint | null, requested: number): boolean
+{
+	return consumed !== null && consumed < 0n ? false : BigInt(requested) <= BigInt(capacity) - (consumed ?? 0n);
+}
+
+/** Returns whether the locked parent and its snapshot exactly bind the detached authorization coordinates. */
+function _matchesParent(parentRun: { id: string; siloId: string; rootRunId: string; inputSnapshotDigest: string }, parentSnapshot: { runId: string; siloId: string; digest: string }, command: ChildRunReservationCommand): boolean
+{
+	return parentRun.id === command.authorization.parentRunId && parentRun.siloId === command.authorization.siloId
+		&& parentRun.rootRunId === command.authorization.rootRunId && parentRun.inputSnapshotDigest === command.parentSnapshotDigest
+		&& parentSnapshot.runId === parentRun.id && parentSnapshot.siloId === parentRun.siloId && parentSnapshot.digest === command.parentSnapshotDigest;
+}
+
+/** Returns an existing first child only when all durable reservation coordinates match this request exactly. */
+async function _idempotentResult(transaction: Prisma.TransactionClient, existing: { id: string; siloId: string; agentServiceId: string; parentRunId: string | null; rootRunId: string; trigger: string; inputSnapshotDigest: string }, command: ChildRunReservationCommand): Promise<ChildRunReservationResult>
+{
+	if (existing.id !== command.childRunId || existing.siloId !== command.authorization.siloId || existing.agentServiceId !== command.authorization.agentServiceId
+		|| existing.parentRunId !== command.authorization.parentRunId || existing.rootRunId !== command.authorization.rootRunId || existing.trigger !== "ManagedInvocation") return { outcome: "denied", reason: "authority_conflict" };
+	const reservation = await transaction.childRunReservation.findUnique({ where: { childRunId: existing.id } });
+	if (!_matchesReservation(reservation, command)) return { outcome: "denied", reason: "authority_conflict" };
+	const snapshot = await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
+	if (snapshot === null || !_matchesExistingSnapshot(snapshot, command)) return { outcome: "denied", reason: "authority_conflict" };
+	return { outcome: "idempotent", snapshot: _snapshot(snapshot) };
+}
+
+/** Returns whether the immutable reservation retained exactly the parent-authorised finite allocation. */
+function _matchesReservation(reservation: { childRunId: string; parentRunId: string; rootRunId: string; depth: number; maxModelTurns: number; maxTotalTokens: number; maxCostUsdMicros: bigint; maxDurationMs: number; task: Prisma.JsonValue; taskDigest: string } | null, command: ChildRunReservationCommand): boolean
+{
+	return reservation !== null && reservation.childRunId === command.childRunId && reservation.parentRunId === command.authorization.parentRunId && reservation.rootRunId === command.authorization.rootRunId
+		&& reservation.depth === command.authorization.depth && reservation.maxModelTurns === command.authorization.budget.maxModelTurns
+		&& reservation.maxTotalTokens === command.authorization.budget.maxTotalTokens && reservation.maxCostUsdMicros === BigInt(command.authorization.budget.maxCostUsdMicros) && reservation.maxDurationMs === command.authorization.budget.maxDurationMs
+		&& reservation.taskDigest === __DigestCanonicalJson(command.authorization.task) && _sameJson(reservation.task, command.authorization.task);
+}
+
+/** Returns whether a rebuilt child has the exact reservation-bound coordinates and context subset. */
+function _matchesBuild(value: ChildRunReservationBuild, parent: RunInputSnapshot, command: ChildRunReservationCommand): boolean
+{
+	const snapshot = value.snapshot;
+	const context = command.authorization.context;
+	return snapshot.runId === command.childRunId && snapshot.siloId === command.authorization.siloId && snapshot.agentServiceId === command.authorization.agentServiceId
+		&& snapshot.agentRevisionId === value.agentRevisionId && snapshot.effectiveContractDigest === value.effectiveContractDigest
+		&& snapshot.capabilitySetDigest === command.authorization.capabilitySetDigest && _sameStrings(snapshot.messageIds, context.messageIds)
+		&& _sameStrings(snapshot.memoryFacts.map(function _factId(fact): string { return fact.factId; }), context.memoryFactIds)
+		&& _sameStrings(snapshot.artifactRevisionIds, context.artifactRevisionIds) && _sameStrings(snapshot.skillRevisionIds, context.skillRevisionIds)
+		&& snapshot.threadId === parent.threadId
+		&& snapshot.personaRevisionId === parent.personaRevisionId && _sameStrings(snapshot.preferenceFactIds, parent.preferenceFactIds)
+		&& _sameJson(snapshot.memoryQueryPolicy, parent.memoryQueryPolicy) && _sameJson(snapshot.integrationAssignments, parent.integrationAssignments)
+		&& _sameJson(snapshot.modelRoute, parent.modelRoute) && _sameJson(snapshot.identitySnapshot, parent.identitySnapshot)
+		&& _matchesChildBudget(snapshot, command.authorization.budget);
+}
+
+/** Returns whether the runtime-visible child budget exactly represents the durable reservation allocation. */
+function _matchesChildBudget(snapshot: RunInputSnapshot, budget: { readonly maxModelTurns: number; readonly maxTotalTokens: number; readonly maxCostUsdMicros: number; readonly maxDurationMs: number }): boolean
+{
+	if (snapshot.budgetPolicy === null || typeof snapshot.budgetPolicy !== "object" || Array.isArray(snapshot.budgetPolicy)) return false;
+	const policy = snapshot.budgetPolicy as Record<string, unknown>;
+	const expectedDeadline = Date.parse(snapshot.compiledAt) + budget.maxDurationMs;
+	return policy["maxModelTurns"] === budget.maxModelTurns && policy["maxTotalTokens"] === budget.maxTotalTokens && policy["maxCostUsdMicros"] === budget.maxCostUsdMicros && policy["wallClockDeadlineEpochMs"] === expectedDeadline;
+}
+
+/** Returns whether two JSON values are equal after canonicalisation removes object-key ordering ambiguity. */
+function _sameJson(left: unknown, right: unknown): boolean
+{
+	return JSON.stringify(___CloneCanonicalJson(left as JsonValue)) === JSON.stringify(___CloneCanonicalJson(right as JsonValue));
+}
+
+/** Returns whether a recovered child snapshot still proves the immutable idempotency authority scope. */
+function _matchesExistingSnapshot(snapshot: { runId: string; siloId: string; agentServiceId: string; capabilitySetDigest: string }, command: ChildRunReservationCommand): boolean
+{
+	return snapshot.runId === command.childRunId && snapshot.siloId === command.authorization.siloId
+		&& snapshot.agentServiceId === command.authorization.agentServiceId && snapshot.capabilitySetDigest === command.authorization.capabilitySetDigest;
+}
+
+/** Persists one child run, its frozen snapshot, immutable reservation, and initial dispatch events. */
+async function _persistReservation(transaction: Prisma.TransactionClient, command: ChildRunReservationCommand, value: ChildRunReservationBuild): Promise<void>
+{
+	await transaction.agentRun.create({ data: {
+		id: command.childRunId, siloId: command.authorization.siloId, agentServiceId: command.authorization.agentServiceId, agentRevisionId: value.agentRevisionId,
+		threadId: value.snapshot.threadId, trigger: "ManagedInvocation", delegatedUserId: null, requestIdempotencyKey: command.requestIdempotencyKey,
+		rootRunId: command.authorization.rootRunId, parentRunId: command.authorization.parentRunId, effectiveContractDigest: value.effectiveContractDigest, inputSnapshotDigest: value.snapshot.digest,
+	} });
+	await transaction.runInputSnapshot.create({ data: _snapshotData(value.snapshot) });
+	await transaction.childRunReservation.create({ data: {
+		childRunId: command.childRunId, parentRunId: command.authorization.parentRunId, rootRunId: command.authorization.rootRunId, depth: command.authorization.depth,
+		maxModelTurns: command.authorization.budget.maxModelTurns, maxTotalTokens: command.authorization.budget.maxTotalTokens, maxCostUsdMicros: BigInt(command.authorization.budget.maxCostUsdMicros), maxDurationMs: command.authorization.budget.maxDurationMs,
+		task: _json(command.authorization.task), taskDigest: __DigestCanonicalJson(command.authorization.task),
+	} });
+	await transaction.outboxEvent.createMany({ data: [
+		{ runId: command.childRunId, attempt: 1, sequence: 1, kind: RunOutboxEventKind.RunAccepted, idempotencyKey: `${command.childRunId}:accepted`, payload: { runId: command.childRunId, inputSnapshotDigest: value.snapshot.digest } },
+		{ runId: command.childRunId, attempt: 1, sequence: 2, kind: RunOutboxEventKind.RunAttemptRequested, idempotencyKey: `${command.childRunId}:attempt:1`, payload: { runId: command.childRunId, attempt: 1, inputSnapshotDigest: value.snapshot.digest } },
+	] });
+}
+
+/** Returns whether two ordered immutable identifier lists are equal without accepting reordering or duplicates. */
+function _sameStrings(actual: readonly string[], expected: readonly string[]): boolean
+{
+	return actual.length === expected.length && actual.every(function _matches(value, index): boolean { return value === expected[index]; });
+}
+
+/** Maps an immutable contract snapshot into its canonical Postgres row. */
+function _snapshotData(snapshot: RunInputSnapshot): Prisma.RunInputSnapshotUncheckedCreateInput
+{
+	return {
+		runId: snapshot.runId, snapshotVersion: snapshot.snapshotVersion, siloId: snapshot.siloId, agentServiceId: snapshot.agentServiceId, agentRevisionId: snapshot.agentRevisionId,
+		effectiveContractDigest: snapshot.effectiveContractDigest, personaRevisionId: snapshot.personaRevisionId, threadId: snapshot.threadId, messageIds: [...snapshot.messageIds],
+		preferenceFactIds: [...snapshot.preferenceFactIds], artifactRevisionIds: [...snapshot.artifactRevisionIds], memoryFacts: _json(snapshot.memoryFacts), identitySnapshot: _json(snapshot.identitySnapshot),
+		modelRoute: _json(snapshot.modelRoute), integrationAssignments: _json(snapshot.integrationAssignments), skillRevisionIds: [...snapshot.skillRevisionIds], memoryQueryPolicy: _json(snapshot.memoryQueryPolicy),
+		budgetPolicy: _json(snapshot.budgetPolicy), capabilitySetDigest: snapshot.capabilitySetDigest, promptCompilerVersion: snapshot.promptCompilerVersion, digest: snapshot.digest, compiledAt: new Date(snapshot.compiledAt),
+	};
+}
+
+/** Deep-copies JSON through canonical form before Prisma owns the durable payload. */
+function _json(value: unknown): Prisma.InputJsonValue
+{
+	return ___CloneCanonicalJson(value as JsonValue) as Prisma.InputJsonValue;
+}
+
+/** Maps one persisted snapshot row back into the immutable cross-domain contract. */
+function _snapshot(row: { runId: string; siloId: string; agentServiceId: string; agentRevisionId: string; snapshotVersion: number; threadId: string | null; messageIds: string[]; personaRevisionId: string | null; preferenceFactIds: string[]; artifactRevisionIds: string[]; skillRevisionIds: string[]; memoryFacts: Prisma.JsonValue; memoryQueryPolicy: Prisma.JsonValue; integrationAssignments: Prisma.JsonValue; modelRoute: Prisma.JsonValue; budgetPolicy: Prisma.JsonValue; identitySnapshot: Prisma.JsonValue; capabilitySetDigest: string; effectiveContractDigest: string; promptCompilerVersion: string; digest: string; compiledAt: Date }): RunInputSnapshot
+{
+	return {
+		runId: row.runId, siloId: row.siloId, agentServiceId: row.agentServiceId, agentRevisionId: row.agentRevisionId, snapshotVersion: row.snapshotVersion, threadId: row.threadId,
+		messageIds: row.messageIds, personaRevisionId: row.personaRevisionId, preferenceFactIds: row.preferenceFactIds, artifactRevisionIds: row.artifactRevisionIds, skillRevisionIds: row.skillRevisionIds,
+		memoryFacts: row.memoryFacts as unknown as RunInputSnapshot["memoryFacts"], memoryQueryPolicy: row.memoryQueryPolicy as RunInputSnapshot["memoryQueryPolicy"], integrationAssignments: row.integrationAssignments as unknown as RunInputSnapshot["integrationAssignments"],
+		modelRoute: row.modelRoute as RunInputSnapshot["modelRoute"], budgetPolicy: row.budgetPolicy as RunInputSnapshot["budgetPolicy"], identitySnapshot: row.identitySnapshot as unknown as RunInputSnapshot["identitySnapshot"],
+		capabilitySetDigest: row.capabilitySetDigest, effectiveContractDigest: row.effectiveContractDigest, promptCompilerVersion: row.promptCompilerVersion, digest: row.digest, compiledAt: row.compiledAt.toISOString(),
+	};
+}
+
+/** Returns whether a value is a non-whitespace identifier. */
+function _present(value: string): boolean
+{
+	return value.trim().length > 0;
+}
+
+/** Returns whether a value is a canonical SHA-256 content digest. */
+function _digest(value: string): boolean
+{
+	return /^sha256:[0-9a-f]{64}$/u.test(value);
+}
+
+/** Returns whether a finite delegated allocation is a positive safe integer. */
+function _positiveBudget(value: unknown): value is number
+{
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}


### PR DESCRIPTION
## Why

A child run must never be an in-memory delegation. Before it can dispatch, its exact lineage, task, selected inputs, and finite resource allocation must be durably committed together under its parent lock.

## What changes

- add `PrismaChildRunReservationRepository`, which locks the parent and atomically creates the child run, immutable input snapshot, reservation, and initial outbox events
- re-check direct fan-out and cumulative turns, tokens, cost, and duration from durable sibling allocations under that lock
- bind every child runtime input to the parent snapshot except the explicitly authorised selected context; bind the thread exactly to its parent
- persist canonical child-task provenance and digest, and require it on idempotent replay
- extend clean target schema/baseline and SQL fixture with immutable task/digest and cost allocation fields
- require runtime budget policy to exactly match the reserved ceilings

## Validation

- Prisma validation and client generation
- uncached `npx nx lint backend-agents-execution-runs`
- focused child admission/reservation tests: 9 passing
- `git diff --check` and repository style gate
- full run-domain suite: 59 passing; 8 existing Supertest router tests cannot bind `0.0.0.0` in this sandbox (`listen EPERM`)

## Review

Architecture and independent security/correctness review completed. Review findings on lineage locks, accounting, runtime budget parity, input binding, task provenance, cost ceilings, and thread binding were corrected and re-verified.

Stacked on #447.