### PR TITLE
🔒 Phase E: derive sealed child-run snapshots

### DIFF
--- a/libs/backend/agents/execution/runs/main/src/__tests__/child-run-snapshot.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/child-run-snapshot.test.ts
@@ -1,0 +1,30 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { describe, expect, it } from "vitest";
+
+import { __DeriveChildRunSnapshot } from "../child-run-snapshot.js";
+import type { ChildRunSnapshotCommand } from "../child-run-snapshot.types.js";
+
+/** Fixed parent snapshot with more authority than one child may receive. */
+const _parent: RunInputSnapshot = { runId: "parent-run", siloId: "silo-a", agentServiceId: "parent-service", agentRevisionId: "parent-revision", snapshotVersion: 1, threadId: "thread-1", messageIds: ["message-1", "message-2"], personaRevisionId: "persona-1", preferenceFactIds: ["preference-1"], artifactRevisionIds: ["artifact-1", "artifact-2"], skillRevisionIds: ["skill-1", "skill-2"], memoryFacts: [{ datasetId: "dataset-1", factId: "fact-1", contentDigest: `sha256:${"a".repeat(64)}`, provenance: [] }, { datasetId: "dataset-1", factId: "fact-2", contentDigest: `sha256:${"b".repeat(64)}`, provenance: [] }], memoryQueryPolicy: { allowed: true }, integrationAssignments: [{ integrationId: "integration-1", allowedTools: ["tool-1"] }], modelRoute: { modelDefinitionId: "model-1" }, budgetPolicy: { maxModelTurns: 8 }, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 2, fleetMembershipIssuer: "issuer", fleetMembershipIssuerKeyId: "key", fleetMembershipAssertionId: "assertion", fleetMembershipPayloadDigest: `sha256:${"c".repeat(64)}`, fleetMembershipTrustedUntil: "2026-07-27T00:00:00.000Z" }, capabilitySetDigest: `sha256:${"d".repeat(64)}`, effectiveContractDigest: `sha256:${"e".repeat(64)}`, promptCompilerVersion: "parent-v1", digest: `sha256:${"f".repeat(64)}`, compiledAt: "2026-07-26T00:00:00.000Z" };
+
+/** Builds a fully authorised, server-selected child snapshot command. */
+function _command(): ChildRunSnapshotCommand
+{
+	return { childRunId: "child-run", parentSnapshot: _parent, authorization: { siloId: "silo-a", rootRunId: "root-run", parentRunId: "parent-run", depth: 1, capabilitySetDigest: `sha256:${"1".repeat(64)}`, agentServiceId: "child-service", context: { messageIds: ["message-2"], memoryFactIds: ["fact-2"], artifactRevisionIds: ["artifact-2"], skillRevisionIds: ["skill-2"] }, budget: { maxModelTurns: 2, maxTotalTokens: 200, maxCostUsdMicros: 2000000, maxDurationMs: 30000 }, task: { objective: "Summarise." } }, agentRevisionId: "child-revision", effectiveContractDigest: `sha256:${"2".repeat(64)}`, promptCompilerVersion: "child-v1", compiledAt: "2026-07-26T00:01:00.000Z" };
+}
+
+describe("__DeriveChildRunSnapshot", function _describeChildRunSnapshot()
+{
+	it("copies only parent-authorised context and seals the finite child allocation", function _derivesSubset()
+	{
+		const snapshot = __DeriveChildRunSnapshot(_command());
+
+		expect(snapshot).toMatchObject({ runId: "child-run", agentServiceId: "child-service", agentRevisionId: "child-revision", messageIds: ["message-2"], artifactRevisionIds: ["artifact-2"], skillRevisionIds: ["skill-2"], memoryFacts: [expect.objectContaining({ factId: "fact-2" })], capabilitySetDigest: `sha256:${"1".repeat(64)}`, effectiveContractDigest: `sha256:${"2".repeat(64)}`, budgetPolicy: { maxModelTurns: 2, maxTotalTokens: 200, maxCostUsdMicros: 2000000, wallClockDeadlineEpochMs: Date.parse("2026-07-26T00:01:00.000Z") + 30000 } });
+		expect(snapshot.digest).toMatch(/^sha256:[0-9a-f]{64}$/u);
+	});
+
+	it("returns the same digest for the same frozen parent and server-owned command", function _isDeterministic()
+	{
+		expect(__DeriveChildRunSnapshot(_command()).digest).toBe(__DeriveChildRunSnapshot(_command()).digest);
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/child-run-snapshot.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-snapshot.ts
@@ -1,0 +1,43 @@
+import { ___CloneCanonicalJson } from "@opencrane/util";
+import type { RunInputSnapshot } from "@opencrane/contracts";
+
+import { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
+import type { ChildRunSnapshotCommand } from "./child-run-snapshot.types.js";
+
+/** Derives a digest-sealed child snapshot without reading mutable authority or widening parent inputs. */
+export function __DeriveChildRunSnapshot(command: ChildRunSnapshotCommand): RunInputSnapshot
+{
+	const parent = command.parentSnapshot;
+	const context = command.authorization.context;
+	const budget = command.authorization.budget;
+	const snapshot = _snapshot({
+		runId: command.childRunId,
+		siloId: command.authorization.siloId,
+		agentServiceId: command.authorization.agentServiceId,
+		agentRevisionId: command.agentRevisionId,
+		snapshotVersion: parent.snapshotVersion,
+		threadId: parent.threadId,
+		messageIds: [...context.messageIds],
+		personaRevisionId: parent.personaRevisionId,
+		preferenceFactIds: [...parent.preferenceFactIds],
+		artifactRevisionIds: [...context.artifactRevisionIds],
+		skillRevisionIds: [...context.skillRevisionIds],
+		memoryFacts: context.memoryFactIds.map(function _memoryFact(factId) { return parent.memoryFacts.find(function _matchesFact(fact) { return fact.factId === factId; }); }).filter(function _presentFact(fact): fact is NonNullable<typeof fact> { return fact !== undefined; }),
+		memoryQueryPolicy: ___CloneCanonicalJson(parent.memoryQueryPolicy),
+		integrationAssignments: parent.integrationAssignments.map(function _integration(assignment) { return { integrationId: assignment.integrationId, allowedTools: [...assignment.allowedTools] }; }),
+		modelRoute: ___CloneCanonicalJson(parent.modelRoute),
+		budgetPolicy: { maxModelTurns: budget.maxModelTurns, maxTotalTokens: budget.maxTotalTokens, maxCostUsdMicros: budget.maxCostUsdMicros, wallClockDeadlineEpochMs: Date.parse(command.compiledAt) + budget.maxDurationMs },
+		identitySnapshot: { executionSubjectId: parent.identitySnapshot.executionSubjectId, fleetMembershipRevision: parent.identitySnapshot.fleetMembershipRevision, fleetMembershipIssuer: parent.identitySnapshot.fleetMembershipIssuer, fleetMembershipIssuerKeyId: parent.identitySnapshot.fleetMembershipIssuerKeyId, fleetMembershipAssertionId: parent.identitySnapshot.fleetMembershipAssertionId, fleetMembershipPayloadDigest: parent.identitySnapshot.fleetMembershipPayloadDigest, fleetMembershipTrustedUntil: parent.identitySnapshot.fleetMembershipTrustedUntil },
+		capabilitySetDigest: command.authorization.capabilitySetDigest,
+		effectiveContractDigest: command.effectiveContractDigest,
+		promptCompilerVersion: command.promptCompilerVersion,
+		compiledAt: command.compiledAt,
+	});
+	return { ...snapshot, digest: __DigestRunInputSnapshot(snapshot) };
+}
+
+/** Preserves the exact cross-domain snapshot contract before its digest is calculated. */
+function _snapshot(value: Omit<RunInputSnapshot, "digest">): Omit<RunInputSnapshot, "digest">
+{
+	return value;
+}

--- a/libs/backend/agents/execution/runs/main/src/child-run-snapshot.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-snapshot.types.ts
@@ -1,0 +1,22 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+
+import type { GovernedChildRunSpawnAuthorization } from "./child-run-admission.types.js";
+
+/** Immutable server-verified facts needed to derive one child snapshot from its parent. */
+export interface ChildRunSnapshotCommand
+{
+	/** New child logical-run identifier. */
+	readonly childRunId: string;
+	/** Parent snapshot that bounds every copied child input. */
+	readonly parentSnapshot: RunInputSnapshot;
+	/** Previously authorised context, capability digest, and finite budget allocation. */
+	readonly authorization: GovernedChildRunSpawnAuthorization;
+	/** Published child revision selected by the server-side service authority. */
+	readonly agentRevisionId: string;
+	/** Effective contract digest fixed by the published child revision. */
+	readonly effectiveContractDigest: string;
+	/** Prompt compiler version fixed by the published child revision. */
+	readonly promptCompilerVersion: string;
+	/** Canonical server-owned compilation instant. */
+	readonly compiledAt: string;
+}

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -1,6 +1,8 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
 export { __AuthorizeGovernedChildRunSpawn } from "./child-run-admission.js";
+export { __DeriveChildRunSnapshot } from "./child-run-snapshot.js";
+export type { ChildRunSnapshotCommand } from "./child-run-snapshot.types.js";
 export type { GovernedChildRunBudget, GovernedChildRunCapabilityDelegation, GovernedChildRunContextSelection, GovernedChildRunParent, GovernedChildRunPolicy, GovernedChildRunSpawnAuthorization, GovernedChildRunSpawnAuthorizationResult, GovernedChildRunSpawnRefusalReason, GovernedChildRunSpawnRequest } from "./child-run-admission.types.js";
 export type { ChildRunReservationBuild, ChildRunReservationCommand, ChildRunReservationParent, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
 export { PrismaChildRunReservationRepository } from "./prisma-child-run-reservation-repository.js";


### PR DESCRIPTION
## Summary

- add a pure child snapshot compiler that copies only parent-frozen context authorised for one child
- carve the child’s exact model, token, cost, and duration allocation into its digest-sealed input
- preserve the parent identity, persona, and policy evidence without reopening initial-session assembly

## Why

A child run must not reload mutable user inputs or inherit an unconstrained parent prompt. This compiler is the bounded, deterministic build step used inside the parent-locked reservation transaction.

## Validation

- focused child snapshot tests: 2 passing
- `npx nx lint backend-agents-execution-runs`
- `scripts/agent-style-check.sh`
- `git diff --check`
- full run-domain suite has 61 passing tests; its 8 existing Express/Supertest router tests cannot bind `0.0.0.0` in this sandbox (`listen EPERM`).