### PR TITLE
🔒 Phase E: verify child capability-set narrowing

### DIFF
--- a/libs/backend/server/iam/authorization/main/README.md
+++ b/libs/backend/server/iam/authorization/main/README.md
@@ -59,6 +59,8 @@ legitimate request — never hand out access it should not.
 - `__CancelPendingRunApprovalAuthority` — closes only pending approvals for an exact run attempt on
   a caller-owned database transaction, clearing every late-resume token atomically with cancellation.
 - `__DigestCanonicalJson` — a stable hash of a request used across the checks above.
+- `__CreateCapabilitySet`, `__IsCapabilitySetSubset` — preserve an ordered, content-addressed
+  capability set for a run and prove that a child run's set can only be narrower than its parent.
 - `PrismaRuntimeAuthorityRepository`, `PrismaAuthorizationGrantRepository` — the database-backed
   stores for accepted proofs/receipts and for candidate grants.
 - Contract types: `ResolveEffectiveAccessCommand`/`Result`, `AuthorizationGrantRepository`,

--- a/libs/backend/server/iam/authorization/main/src/__tests__/capability-set.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/__tests__/capability-set.test.ts
@@ -1,0 +1,126 @@
+import type { CapabilityReference } from "@opencrane/models/authorization";
+import { describe, expect, it } from "vitest";
+
+import { __CreateCapabilitySet, __IsCapabilitySetSubset } from "../capability-set.js";
+import type { CapabilitySet } from "../capability-set.types.js";
+
+/** First immutable reference used by capability-set tests. */
+const FIRST_CAPABILITY: CapabilityReference = {
+	catalog: {
+		catalogId: "catalog-main",
+		revision: 2,
+		digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	},
+	capabilityId: "artifact.read",
+};
+
+/** Second immutable reference used by capability-set tests. */
+const SECOND_CAPABILITY: CapabilityReference = {
+	catalog: {
+		catalogId: "catalog-main",
+		revision: 2,
+		digest: "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+	},
+	capabilityId: "artifact.write",
+};
+
+describe("capability sets", function _suite()
+{
+	it("orders copied references and derives one stable digest", function _canonicalises()
+	{
+		const source = [_copyFixture(SECOND_CAPABILITY), _copyFixture(FIRST_CAPABILITY)];
+		const result = __CreateCapabilitySet(source);
+
+		expect(result).toEqual({
+			capabilities: [FIRST_CAPABILITY, SECOND_CAPABILITY],
+			digest: "sha256:b523deae6406cc1f8e068b422dfac8c11cd39b908019fe38a52f47694e1fd855",
+		});
+		source[0]!.capabilityId = "mutated";
+		expect(result?.capabilities[1]?.capabilityId).toBe("artifact.write");
+	});
+
+	it("retains a valid empty capability set without granting a capability", function _empty()
+	{
+		const result = __CreateCapabilitySet([]);
+
+		expect(result).toEqual({
+			capabilities: [],
+			digest: "sha256:4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+		});
+	});
+
+	it("rejects malformed and repeated immutable identities", function _rejects()
+	{
+		const malformed: CapabilityReference = { ...FIRST_CAPABILITY, capabilityId: " " };
+
+		expect(__CreateCapabilitySet([FIRST_CAPABILITY, FIRST_CAPABILITY])).toBeNull();
+		expect(__CreateCapabilitySet([malformed])).toBeNull();
+	});
+
+	it("accepts only a child set which is a strict narrowing or equal subset", function _narrows()
+	{
+		const parent = _requireCapabilitySet([FIRST_CAPABILITY, SECOND_CAPABILITY]);
+		const child = _requireCapabilitySet([FIRST_CAPABILITY]);
+		const broader = _requireCapabilitySet([SECOND_CAPABILITY, {
+			catalog: {
+				catalogId: "catalog-extra",
+				revision: 1,
+				digest: "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+			},
+			capabilityId: "memory.read",
+		}]);
+
+		expect(__IsCapabilitySetSubset(parent, child)).toBe(true);
+		expect(__IsCapabilitySetSubset(parent, broader)).toBe(false);
+	});
+
+	it("rejects a child whose supplied digest does not bind its actual references", function _rejectsForgedDigest()
+	{
+		const parent = _requireCapabilitySet([FIRST_CAPABILITY, SECOND_CAPABILITY]);
+		const forgedChild: CapabilitySet = {
+			capabilities: [FIRST_CAPABILITY],
+			digest: parent.digest,
+		};
+
+		expect(__IsCapabilitySetSubset(parent, forgedChild)).toBe(false);
+	});
+
+	it("uses code-unit ordering instead of a host locale for durable digests", function _usesStableOrdering()
+	{
+		const zed = _withCapabilityId(FIRST_CAPABILITY, "z");
+		const aUmlaut = _withCapabilityId(SECOND_CAPABILITY, "ä");
+		const result = _requireCapabilitySet([aUmlaut, zed]);
+
+		expect(result.capabilities.map(function _capabilityId(value): string { return value.capabilityId; })).toEqual(["z", "ä"]);
+	});
+});
+
+/** Returns the valid set expected by tests, failing immediately if a fixture violates the contract. */
+function _requireCapabilitySet(values: readonly CapabilityReference[]): CapabilitySet
+{
+	const result = __CreateCapabilitySet(values);
+	if (!result)
+	{
+		throw new Error("Expected a valid capability-set fixture.");
+	}
+	return result;
+}
+
+/** Copies a mutable model fixture so one test cannot alter another test's input. */
+function _copyFixture(value: CapabilityReference): CapabilityReference
+{
+	return {
+		catalog: {
+			catalogId: value.catalog.catalogId,
+			revision: value.catalog.revision,
+			digest: value.catalog.digest,
+		},
+		capabilityId: value.capabilityId,
+	};
+}
+
+/** Copies a fixture while assigning one capability identifier for ordering coverage. */
+function _withCapabilityId(value: CapabilityReference, capabilityId: string): CapabilityReference
+{
+	return { ..._copyFixture(value), capabilityId };
+}

--- a/libs/backend/server/iam/authorization/main/src/capability-set.ts
+++ b/libs/backend/server/iam/authorization/main/src/capability-set.ts
@@ -1,0 +1,107 @@
+import type { CapabilityReference } from "@opencrane/models/authorization";
+
+import { __DigestCanonicalJson } from "./canonical-json-digest.js";
+import type { CapabilitySet } from "./capability-set.types.js";
+
+/**
+ * Canonicalises a capability set and returns the only digest accepted for that exact set.
+ * @param values - Candidate immutable catalog references to preserve for a run.
+ * @returns An immutable ordered set, or `null` when a reference is malformed or duplicated.
+ */
+export function __CreateCapabilitySet(values: readonly CapabilityReference[]): CapabilitySet | null
+{
+	// 1. Reject invalid source identities before they can become durable authorization evidence.
+	if (values.some(_isInvalidCapability))
+	{
+		return null;
+	}
+
+	// 2. Copy and order the references so later caller mutation cannot alter the retained meaning.
+	const capabilities = values.map(_copyCapability).sort(_compareCapability);
+	if (capabilities.some(_isDuplicateCapability))
+	{
+		return null;
+	}
+
+	// 3. Bind exactly that ordered content, including a valid empty no-capability set, to its digest.
+	return { capabilities: Object.freeze(capabilities), digest: __DigestCanonicalJson(capabilities.map(_canonicalCapability)) };
+}
+
+/**
+ * Returns whether every exact child reference belongs to the parent capability set.
+ * @param parent - Capability set frozen for the parent run.
+ * @param child - Candidate narrowed set for a child run.
+ * @returns Whether the child set cannot broaden the parent's authority.
+ */
+export function __IsCapabilitySetSubset(parent: CapabilitySet, child: CapabilitySet): boolean
+{
+	// 1. Rebuild both sets so a caller cannot pair valid references with a forged durable digest.
+	const canonicalParent = __CreateCapabilitySet(parent.capabilities);
+	const canonicalChild = __CreateCapabilitySet(child.capabilities);
+	if (!canonicalParent || !canonicalChild || canonicalParent.digest !== parent.digest || canonicalChild.digest !== child.digest)
+	{
+		return false;
+	}
+
+	// 2. Compare the verified parent identity with every verified child identity.
+	const parentKeys = new Set(canonicalParent.capabilities.map(_key));
+	return canonicalChild.capabilities.every(_isIncludedInParent);
+
+	/** Checks the current child reference against the parent's complete immutable identity. */
+	function _isIncludedInParent(capability: CapabilityReference): boolean
+	{
+		return parentKeys.has(_key(capability));
+	}
+}
+
+/** Builds the stable comparison key for one immutable capability reference. */
+function _key(value: CapabilityReference): string
+{
+	return `${value.catalog.catalogId}\u0000${value.catalog.revision}\u0000${value.catalog.digest}\u0000${value.capabilityId}`;
+}
+
+/** Copies one reference into the immutable in-memory representation retained by the run. */
+function _copyCapability(value: CapabilityReference): CapabilityReference
+{
+	return Object.freeze({
+		catalog: Object.freeze({
+			catalogId: value.catalog.catalogId,
+			revision: value.catalog.revision,
+			digest: value.catalog.digest,
+		}),
+		capabilityId: value.capabilityId,
+	});
+}
+
+/** Converts one typed reference into the JSON-only representation covered by the durable digest. */
+function _canonicalCapability(value: CapabilityReference): { readonly catalog: { readonly catalogId: string; readonly revision: number; readonly digest: string }; readonly capabilityId: string }
+{
+	return {
+		catalog: {
+			catalogId: value.catalog.catalogId,
+			revision: value.catalog.revision,
+			digest: value.catalog.digest,
+		},
+		capabilityId: value.capabilityId,
+	};
+}
+
+/** Detects one repeated immutable identity in an already sorted capability set. */
+function _isDuplicateCapability(value: CapabilityReference, index: number, values: readonly CapabilityReference[]): boolean
+{
+	return index > 0 && _key(value) === _key(values[index - 1]!);
+}
+
+/** Rejects any non-canonical reference before it contributes to a durable set digest. */
+function _isInvalidCapability(value: CapabilityReference): boolean
+{
+	return value.capabilityId.trim().length === 0 || value.catalog.catalogId.trim().length === 0 || !Number.isSafeInteger(value.catalog.revision) || value.catalog.revision < 1 || !/^sha256:[0-9a-f]{64}$/u.test(value.catalog.digest);
+}
+
+/** Compares capability references by their complete immutable identity. */
+function _compareCapability(first: CapabilityReference, second: CapabilityReference): number
+{
+	const firstKey = _key(first);
+	const secondKey = _key(second);
+	return firstKey === secondKey ? 0 : firstKey < secondKey ? -1 : 1;
+}

--- a/libs/backend/server/iam/authorization/main/src/capability-set.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/capability-set.types.ts
@@ -1,0 +1,10 @@
+import type { CanonicalJsonSha256Digest, CapabilityReference } from "@opencrane/models/authorization";
+
+/** Canonical immutable capability set with its content-addressed digest. */
+export interface CapabilitySet
+{
+	/** Deterministically ordered unique capability references. */
+	readonly capabilities: readonly CapabilityReference[];
+	/** SHA-256 digest of the complete ordered capability set. */
+	readonly digest: CanonicalJsonSha256Digest;
+}

--- a/libs/backend/server/iam/authorization/main/src/index.ts
+++ b/libs/backend/server/iam/authorization/main/src/index.ts
@@ -1,5 +1,7 @@
 export { __ComputeEs256JwkThumbprint, __NormalizeDpopTargetUri, __VerifyCapabilityProof } from "./capability-proof.js";
 export { __DigestCanonicalJson } from "./canonical-json-digest.js";
+export { __CreateCapabilitySet, __IsCapabilitySetSubset } from "./capability-set.js";
+export type { CapabilitySet } from "./capability-set.types.js";
 export { __ResolveEffectiveAccess } from "./effective-access.js";
 export type { AuthorizationGrantRepository, AuthorizationMembershipAuthority, AuthorizationMembershipDecision, AuthorizationMembershipRequirement, EffectiveCapabilityEvidence, ResolveEffectiveAccessCommand, ResolveEffectiveAccessResult } from "./effective-access.types.js";
 export { __ConsumeRuntimeBootstrap, __ExecuteCapabilityAction } from "./runtime-proof.js";


### PR DESCRIPTION
## Why this matters

A parent agent may create a child run only when the child cannot gain any capability the parent did not already have. That rule needs a durable, exact representation of a run's allowed capabilities before the child-run runner can be made live.

## What changed

- Adds one canonical capability-set value: ordered, copied, frozen and content-addressed.
- Makes child delegation fail closed unless both supplied digests actually bind their references.
- Proves a child set is a subset of the verified parent set.
- Uses host-independent ordering, so the same capabilities always produce the same digest.
- Documents the new authorization public surface and keeps tests under `src/__tests__/`.

## Safety properties

- Malformed or duplicate capability identities are rejected.
- An empty set remains valid but grants no capability.
- A forged digest or a broadened child set is denied.
- Caller mutation after construction cannot change the retained set.

## Validation

- `npx vitest run src/__tests__/capability-set.test.ts` — 6 passed.
- `npx nx lint backend-server-authorization`.
- `scripts/agent-style-check.sh`.
- `git diff --check`.
- Full authorization tests remain sandbox-limited: six existing Supertest router tests cannot bind `0.0.0.0` (`listen EPERM`); the focused suite passed.

## Review

Independent authorization review found and this PR fixes: forged-digest acceptance and locale-dependent ordering. The reviewer rechecked the fix with no remaining Critical or High findings.

## Stack

Base: #450 (child-run input snapshot). This PR is the capability-set foundation; the next slice will persist and consume it with the child reservation transaction.
