### PR TITLE
🔒 Phase E: authorize runtime child runs under lock

### DIFF
--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -90,6 +90,13 @@ For personal conversation snapshots, this composition also adds the reserved `up
 after normal MCP grants are compiled and reseals the delivered input. The call itself is not deferred;
 it uses the same durable `ToolInvocation` ledger to record a future-only configuration proposal. A
 later explicit user decision and a later run snapshot own any actual change.
+An admitted `child_run_spawn` candidate now reaches the same control plane through a separate,
+transaction-fenced runner: it locks the spawning run and the target AgentService, derives the exact
+capability intersection from the frozen parent snapshot and published target revision, and persists
+the child run, its sealed snapshot, its finite reservation, and its first dispatch events together.
+The runtime supplies only a candidate; it cannot select a revision, expand capabilities, or create a
+child directly. `AGENT_RUNTIME_CHILD_MAX_DEPTH` (default `2`) and
+`AGENT_RUNTIME_CHILD_MAX_CHILDREN` (default `4`) bound recursive work per parent.
 Idle runtime streams do not create a database transaction every second. An accepted runtime
 candidate wakes local streams to check the durable command state immediately; a bounded recovery
 check still runs afterwards in case that in-process hint was lost. PostgreSQL remains the source of
@@ -162,6 +169,8 @@ Read from the environment at startup.
 | `AGENT_RUNTIME_ASSIGNMENT_TTL_SECONDS` | Hard lifetime of a pending runtime workload assignment | `3600` |
 | `AGENT_RUNTIME_OUTBOX_RETENTION_SECONDS` | Time to retain successfully delivered runtime handshakes before bounded cleanup | `604800` |
 | `AGENT_RUNTIME_OUTBOX_PRUNE_BATCH_SIZE` | Maximum successful handshakes removed by one controller maintenance pass | `100` |
+| `AGENT_RUNTIME_CHILD_MAX_DEPTH` | Maximum parent-to-child delegation edges below one root run | `2` |
+| `AGENT_RUNTIME_CHILD_MAX_CHILDREN` | Maximum direct child runs one parent may reserve | `4` |
 | `AGENT_RUNTIME_COMMAND_RECOVERY_POLL_SECONDS` | Bounded durable recovery check for an otherwise idle runtime stream | `5` |
 | `CHANNEL_REPLAY_ROUTE_ID` | Controller-registered `events.read` route accepted by the internal replay endpoint; unset disables replay | *(unset)* |
 | `ARTIFACT_LEASE_PRIVATE_KEY_PATH` | Read-only mounted Ed25519 key that signs exact ArtifactStore read/write leases | *(required for artifact preprocessing)* |

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -20,7 +20,7 @@ import { _CheckDbHealth, _OpenapiRouter } from "@opencrane/server/_infra/http";
 import { _CreateRuntimeTokenReviewer, _RegisterInternalAgentRuntimeStream } from "@opencrane/server/_infra/agent-runtime-stream";
 import { AGENT_CONTROLLER_PROJECTED_TOKEN_AUDIENCE, AGENT_CONTROLLER_SERVICE_ACCOUNT_NAME, ARTIFACT_PREPROCESSOR_PROJECTED_TOKEN_AUDIENCE, ARTIFACT_PREPROCESSOR_SERVICE_ACCOUNT_NAME, type RunInputSnapshot } from "@opencrane/contracts";
 import { spec } from "@opencrane/backend/server/api-spec";
-import { PrismaRunDispatchRepository, __CreateAgentControllerRunDispatchRouter, type AgentControllerTokenReviewer, type AttemptModelKeyMintRequest, type MintedAttemptModelKey, type ReviewedAgentControllerIdentity } from "@opencrane/backend/agents/execution/runs";
+import { PrismaRunDispatchRepository, PrismaRuntimeChildRunSpawnRunner, __CreateAgentControllerRunDispatchRouter, type AgentControllerTokenReviewer, type AttemptModelKeyMintRequest, type MintedAttemptModelKey, type ReviewedAgentControllerIdentity } from "@opencrane/backend/agents/execution/runs";
 import { __CreateExternalActionExecutor, __CreatePrismaRunInputCompiler, PrismaRuntimeDispatchAuthority, __ExecuteExternalAction, type RunInputCompiler, type RuntimeExternalActionRunner } from "@opencrane/backend/agents/execution/protocol";
 import { __IsUpgradeSessionAvailable, PrismaPersonalConfigurationChangeRepository, UPGRADE_SESSION_TOOL, UPGRADE_SESSION_TOOL_REVISION } from "@opencrane/backend/agents/personal/configuration";
 import { __AppendCompiledTool } from "@opencrane/backend/agents/runtime/prompt-compiler";
@@ -292,9 +292,12 @@ export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, auth
 	const publishedOutboxRetentionMilliseconds = _ReadBoundedSeconds("AGENT_RUNTIME_OUTBOX_RETENTION_SECONDS", 604_800, 3_600, 7_776_000);
 	const outboxPruneBatchSize = _ReadBoundedInteger("AGENT_RUNTIME_OUTBOX_PRUNE_BATCH_SIZE", 100, 1, 1_000);
 	const commandTtlMilliseconds = _ReadBoundedSeconds("AGENT_RUNTIME_COMMAND_TTL_SECONDS", 60, 1, 300);
+	const childRunMaximumDepth = _ReadBoundedInteger("AGENT_RUNTIME_CHILD_MAX_DEPTH", 2, 1, 16);
+	const childRunMaximumChildren = _ReadBoundedInteger("AGENT_RUNTIME_CHILD_MAX_CHILDREN", 4, 1, 64);
 	const runDispatchRepository = new PrismaRunDispatchRepository(prisma, { namespace: runtimeNamespace, claimLeaseMilliseconds, assignmentTtlMilliseconds, publishedOutboxRetentionMilliseconds, outboxPruneBatchSize }, _IssueAttemptModelKey);
 	const runtimeTokenReviewer = _CreateRuntimeTokenReviewer(authApi, runtimeNamespace);
-	const runtimeDispatchAuthority = new PrismaRuntimeDispatchAuthority(prisma, { namespace: runtimeNamespace, commandTtlMilliseconds, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _CreatePersonalRunInputCompiler(), _CreateExternalActionRunner(prisma));
+	const childRunSpawnRunner = new PrismaRuntimeChildRunSpawnRunner(prisma, { maximumDepth: childRunMaximumDepth, maximumChildrenPerParent: childRunMaximumChildren });
+	const runtimeDispatchAuthority = new PrismaRuntimeDispatchAuthority(prisma, { namespace: runtimeNamespace, commandTtlMilliseconds, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _CreatePersonalRunInputCompiler(), _CreateExternalActionRunner(prisma), undefined, undefined, childRunSpawnRunner);
 	const artifactPreprocessorCrypto = _CreateArtifactPreprocessorCrypto();
 	const replayRouteId = _ReadChannelReplayRouteId();
 	if (replayRouteId !== null)

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -48,14 +48,15 @@ rejected with `admission_concurrency_limited`; it does not turn a hot service ro
 unbounded connection pool. The production entrypoint must use this gate before calling
 `PrismaRunAdmissionRepository.admit()` and must keep its policy aligned with the database pool budget.
 
-`__AuthorizeGovernedChildRunSpawn` is the first gate for a future governed child run. It accepts
+`__AuthorizeGovernedChildRunSpawn` is the pure gate for a governed child run. It accepts
 only parent facts that a repository has already locked, checks that a child stays in the same silo
 and under the root, bounds depth and fan-out, and asks an injected authority to prove that the
 child's capability set narrows the parent's. It permits only transcript messages, memory facts,
 artifact revisions, and skill revisions already frozen in the parent snapshot, then verifies that a
 finite child budget fits the parent remainder. It returns a detached authorization, **not a child
-run**: the following persistence slice must atomically reserve that budget, save lineage and
-idempotency facts, and compile the child snapshot before any runtime command can exist.
+run**: `PrismaRuntimeChildRunSpawnRunner` invokes it only after the reservation repository has
+locked the parent, derived its exact remaining capacity, and locked the target AgentService. The
+same transaction then saves the lineage, sealed snapshot, reservation, and first dispatch events.
 
 `__StartNextRunAttempt` is a **compare-and-swap** retry state machine: it reads the run and its
 AgentService authority as one snapshot, refuses unless the run is in a retryable terminal state and the
@@ -138,8 +139,12 @@ uncertainty fails closed.
   refusal vocabulary for the subsequent transaction-fenced child reservation boundary.
 - `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial
   run, snapshot and ordered outbox events around a caller-supplied assembly callback.
-- `PrismaChildRunReservationRepository` — lock a parent, validate its frozen snapshot and detached
-  child authority, then atomically persist the child run, snapshot, reservation and initial outbox.
+- `PrismaChildRunReservationRepository` — lock a parent, expose only its current remaining capacity
+  to an in-transaction authorization callback, then atomically persist the verified child run,
+  snapshot, reservation and initial outbox.
+- `PrismaRuntimeChildRunSpawnRunner` — the app-composable runtime boundary: lock the active target
+  service, intersect its published capability ceiling with the frozen parent set, derive the child
+  snapshot, and reserve it in the parent transaction.
 - `RunAdmissionConcurrencyGate` — bound active and queued admissions for one silo and AgentService
   before the caller can acquire a persistence connection.
 - `RunAdmissionRepository`, `RunAdmissionCommand`, `RunAdmissionTransaction`,
@@ -174,9 +179,10 @@ confirmation. Kubernetes inspection and mutation remain in dedicated runtime pro
 package only says which exact work may be removed.
 
 `__AuthorizeGovernedChildRunSpawn` is deliberately a pure admission gate. Its detached authority
-reaches `PrismaChildRunReservationRepository`, which locks the parent, rechecks the parent digest
-and lineage coordinates, and persists one child snapshot and allocation atomically. Until an app
-composes that repository into a runtime entrypoint, no child-run runtime command is exposed.
+reaches `PrismaChildRunReservationRepository` only from `PrismaRuntimeChildRunSpawnRunner`, which
+locks the parent, rechecks the parent digest and lineage coordinates, locks the active target
+service, and persists one child snapshot and allocation atomically. The OpenCrane app composes this
+runner into the authenticated runtime stream; a runtime candidate never receives a direct write path.
 
 `ChildRunReservation` is the durable record that this later boundary will write beside a child run.
 It freezes the exact parent and root identifiers, child depth, and the turns, tokens, and duration

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-reservation-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-reservation-repository.test.ts
@@ -22,23 +22,35 @@ function _childSnapshot(): RunInputSnapshot
 /** Creates one detached child-run authority that exactly matches the test parent. */
 function _command()
 {
-	const capabilitySet = __CreateCapabilitySet([])!;
 	return {
-		childRunId: "child-run-1", requestIdempotencyKey: "child-request-1", parentRunId: "parent-run-1", parentSnapshotDigest: `sha256:${"c".repeat(64)}`, maximumChildrenPerParent: 2,
-		authorization: { siloId: "silo-1", rootRunId: "root-run-1", parentRunId: "parent-run-1", depth: 1, capabilitySetDigest: capabilitySet.digest, capabilitySet, agentServiceId: "child-service-1", context: { messageIds: ["message-1"], memoryFactIds: ["fact-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"] }, budget: { maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200000, maxDurationMs: 60000 }, task: { goal: "research" } },
+		childRunId: "child-run-1", requestIdempotencyKey: "child-request-1", parentRunId: "parent-run-1", parentSnapshotDigest: `sha256:${"c".repeat(64)}`, parentAttempt: 1, maximumChildrenPerParent: 2,
+		request: { siloId: "silo-1", agentServiceId: "child-service-1", capabilitySetDigest: __CreateCapabilitySet([])!.digest, context: { messageIds: ["message-1"], memoryFactIds: ["fact-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"] }, budget: { maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200000, maxDurationMs: 60000 }, task: { goal: "research" } },
 	} as const;
+}
+
+/** Creates the exact authorization a lock-held callback derives from the test runtime request. */
+function _authorization()
+{
+	const capabilitySet = __CreateCapabilitySet([])!;
+	return { siloId: "silo-1", rootRunId: "root-run-1", parentRunId: "parent-run-1", depth: 1, capabilitySetDigest: capabilitySet.digest, capabilitySet, agentServiceId: "child-service-1", context: { messageIds: ["message-1"], memoryFactIds: ["fact-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"] }, budget: { maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200000, maxDurationMs: 60000 }, task: { goal: "research" } } as const;
 }
 
 /** Creates one parent AgentRun row returned after the repository obtains its row lock. */
 function _parentRun()
 {
-	return { id: "parent-run-1", siloId: "silo-1", agentServiceId: "parent-service-1", rootRunId: "root-run-1", inputSnapshotDigest: `sha256:${"c".repeat(64)}` };
+	return { id: "parent-run-1", siloId: "silo-1", agentServiceId: "parent-service-1", parentRunId: null, rootRunId: "root-run-1", state: "Running", attempt: 1, inputSnapshotDigest: `sha256:${"c".repeat(64)}` };
 }
 
 /** Creates a persistence mock whose transaction callback receives the supplied authority operations. */
 function _prisma(transaction: object): PrismaClient
 {
 	return { $transaction: vi.fn(async function _transaction(callback: (client: object) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+}
+
+/** Creates a reservation repository with a stable server clock for immutable deadline assertions. */
+function _repository(transaction: object): PrismaChildRunReservationRepository
+{
+	return new PrismaChildRunReservationRepository(_prisma(transaction), undefined, function _now(): number { return Date.parse("2026-07-20T00:00:00.000Z"); });
 }
 
 describe("PrismaChildRunReservationRepository", function _describeChildRunReservationRepository()
@@ -48,8 +60,8 @@ describe("PrismaChildRunReservationRepository", function _describeChildRunReserv
 		const parentSnapshot = _snapshot("parent-run-1", "parent-service-1", "parent-revision-1", `sha256:${"c".repeat(64)}`);
 		const childSnapshot = _childSnapshot();
 		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce(null), create: vi.fn().mockResolvedValue({ id: "child-run-1" }) }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }), create: vi.fn().mockResolvedValue({ id: "snapshot-1" }) }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 0 }, _sum: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxDurationMs: null } }), create: vi.fn().mockResolvedValue({ childRunId: "child-run-1" }) }, outboxEvent: { createMany: vi.fn().mockResolvedValue({ count: 2 }) } };
-		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
-		const build = vi.fn(async function _build(parent) { expect(parent.snapshot).toEqual(parentSnapshot); expect(parent.agentServiceId).toBe("parent-service-1"); return { snapshot: childSnapshot, agentRevisionId: "child-revision-1", effectiveContractDigest: childSnapshot.effectiveContractDigest }; });
+		const repository = _repository(transaction);
+		const build = vi.fn(async function _build(parent) { expect(parent.snapshot).toEqual(parentSnapshot); expect(parent.agentServiceId).toBe("parent-service-1"); expect(parent.remainingBudget).toEqual({ maxModelTurns: 4, maxTotalTokens: 1000, maxCostUsdMicros: 500000, maxDurationMs: 120000 }); return { authorization: _authorization(), snapshot: childSnapshot, agentRevisionId: "child-revision-1", effectiveContractDigest: childSnapshot.effectiveContractDigest }; });
 
 		await expect(repository.reserve(_command(), build)).resolves.toEqual({ outcome: "reserved", snapshot: childSnapshot });
 		expect(transaction.$queryRaw).toHaveBeenCalledTimes(2);
@@ -64,7 +76,7 @@ describe("PrismaChildRunReservationRepository", function _describeChildRunReserv
 		const parentSnapshot = _snapshot("parent-run-1", "parent-service-1", "parent-revision-1", `sha256:${"c".repeat(64)}`);
 		const childSnapshot = _childSnapshot();
 		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce({ id: "child-run-1", siloId: "silo-1", agentServiceId: "child-service-1", parentRunId: "parent-run-1", rootRunId: "root-run-1", trigger: "ManagedInvocation", inputSnapshotDigest: childSnapshot.digest }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValueOnce({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }).mockResolvedValueOnce({ ...childSnapshot, compiledAt: new Date(childSnapshot.compiledAt) }), create: vi.fn() }, childRunReservation: { findUnique: vi.fn().mockResolvedValue({ childRunId: "child-run-1", parentRunId: "parent-run-1", rootRunId: "root-run-1", depth: 1, maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200000n, maxDurationMs: 60000, task: { goal: "research" }, taskDigest: __DigestCanonicalJson({ goal: "research" }) }), aggregate: vi.fn(), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
-		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+		const repository = _repository(transaction);
 		const build = vi.fn();
 
 		await expect(repository.reserve(_command(), build)).resolves.toEqual({ outcome: "idempotent", snapshot: childSnapshot });
@@ -76,7 +88,7 @@ describe("PrismaChildRunReservationRepository", function _describeChildRunReserv
 	it("rejects a stale parent digest before callback compilation or child writes", async function _rejectsStaleParent()
 	{
 		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValue({ ..._parentRun(), inputSnapshotDigest: `sha256:${"9".repeat(64)}` }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn(), create: vi.fn() }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn(), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
-		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+		const repository = _repository(transaction);
 		const build = vi.fn();
 
 		await expect(repository.reserve(_command(), build)).resolves.toEqual({ outcome: "denied", reason: "parent_snapshot_stale" });
@@ -87,8 +99,8 @@ describe("PrismaChildRunReservationRepository", function _describeChildRunReserv
 	it("denies sibling fan-out or durable allocation overdraw before compiling a new child", async function _deniesExhaustedParentCapacity()
 	{
 		const parentSnapshot = _snapshot("parent-run-1", "parent-service-1", "parent-revision-1", `sha256:${"c".repeat(64)}`);
-		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce(null), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }), create: vi.fn() }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 1 }, _sum: { maxModelTurns: 1, maxTotalTokens: 200, maxCostUsdMicros: 400000n, maxDurationMs: 30000 } }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
-		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce(null), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }), create: vi.fn() }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 2 }, _sum: { maxModelTurns: 1, maxTotalTokens: 200, maxCostUsdMicros: 400000n, maxDurationMs: 30000 } }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const repository = _repository(transaction);
 		const build = vi.fn();
 
 		await expect(repository.reserve(_command(), build)).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
@@ -101,9 +113,9 @@ describe("PrismaChildRunReservationRepository", function _describeChildRunReserv
 		const parentSnapshot = _snapshot("parent-run-1", "parent-service-1", "parent-revision-1", `sha256:${"c".repeat(64)}`);
 		const childSnapshot = { ..._childSnapshot(), threadId: "thread-2" };
 		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce(null), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parentSnapshot, compiledAt: new Date(parentSnapshot.compiledAt) }), create: vi.fn() }, childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 0 }, _sum: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxDurationMs: null } }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
-		const repository = new PrismaChildRunReservationRepository(_prisma(transaction));
+		const repository = _repository(transaction);
 
-		await expect(repository.reserve(_command(), async function _build() { return { snapshot: childSnapshot, agentRevisionId: "child-revision-1", effectiveContractDigest: childSnapshot.effectiveContractDigest }; })).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
+		await expect(repository.reserve(_command(), async function _build() { return { authorization: _authorization(), snapshot: childSnapshot, agentRevisionId: "child-revision-1", effectiveContractDigest: childSnapshot.effectiveContractDigest }; })).resolves.toEqual({ outcome: "denied", reason: "authority_conflict" });
 		expect(transaction.agentRun.create).not.toHaveBeenCalled();
 		expect(transaction.runInputSnapshot.create).not.toHaveBeenCalled();
 	});

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-runtime-child-run-spawn-runner.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-runtime-child-run-spawn-runner.test.ts
@@ -1,0 +1,88 @@
+import type { PrismaClient } from "@prisma/client";
+import { __CreateCapabilitySet } from "@opencrane/backend/server/iam/authorization";
+import { AGENT_RUNTIME_PROTOCOL_V1, type RunInputSnapshot, type RuntimeChildRunSpawnCandidate } from "@opencrane/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaRuntimeChildRunSpawnRunner } from "../prisma-runtime-child-run-spawn-runner.js";
+
+const _PARENT_CAPABILITY_SET = __CreateCapabilitySet([{ catalog: { catalogId: "catalog-1", revision: 1, digest: `sha256:${"a".repeat(64)}` }, capabilityId: "artifact.read" }, { catalog: { catalogId: "catalog-1", revision: 1, digest: `sha256:${"a".repeat(64)}` }, capabilityId: "artifact.write" }])!;
+const _CHILD_CAPABILITY_SET = __CreateCapabilitySet([_PARENT_CAPABILITY_SET.capabilities[0]!])!;
+
+/** Builds a complete frozen parent snapshot with both a readable and a non-delegable capability. */
+function _snapshot(): RunInputSnapshot
+{
+	return {
+		runId: "parent-run-1", siloId: "silo-1", agentServiceId: "parent-service-1", agentRevisionId: "parent-revision-1", snapshotVersion: 1, threadId: "thread-1", messageIds: ["message-1"], personaRevisionId: "persona-1", preferenceFactIds: ["preference-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"], memoryFacts: [{ datasetId: "dataset-1", factId: "fact-1", contentDigest: `sha256:${"b".repeat(64)}`, provenance: [] }], memoryQueryPolicy: {}, integrationAssignments: [], modelRoute: {}, budgetPolicy: { maxModelTurns: 4, maxTotalTokens: 1_000, maxCostUsdMicros: 500_000, wallClockDeadlineEpochMs: Date.parse("2026-07-26T00:02:00.000Z") }, identitySnapshot: { executionSubjectId: "user-1", fleetMembershipRevision: 1, fleetMembershipIssuer: "issuer", fleetMembershipIssuerKeyId: "key", fleetMembershipAssertionId: "assertion", fleetMembershipPayloadDigest: `sha256:${"c".repeat(64)}`, fleetMembershipTrustedUntil: "2026-07-27T00:00:00.000Z" }, capabilitySetDigest: _PARENT_CAPABILITY_SET.digest, capabilitySet: _PARENT_CAPABILITY_SET.capabilities, effectiveContractDigest: `sha256:${"d".repeat(64)}`, promptCompilerVersion: "prompt-v1", digest: `sha256:${"e".repeat(64)}`, compiledAt: "2026-07-26T00:00:00.000Z",
+	};
+}
+
+/** Builds one runtime candidate whose digest names only the target's narrower capability ceiling. */
+function _candidate(): RuntimeChildRunSpawnCandidate
+{
+	return { protocolVersion: AGENT_RUNTIME_PROTOCOL_V1, runtimeInstanceId: "runtime-1", commandId: "command-1", candidateId: "candidate-1", runId: "parent-run-1", attempt: 1, fence: 1, kind: "child_run_spawn", agentServiceId: "child-service-1", capabilitySetDigest: _CHILD_CAPABILITY_SET.digest, context: { messageIds: ["message-1"], memoryFactIds: ["fact-1"], artifactRevisionIds: ["artifact-1"], skillRevisionIds: ["skill-1"] }, budget: { maxModelTurns: 2, maxTotalTokens: 300, maxCostUsdMicros: 200_000, maxDurationMs: 60_000 }, task: { goal: "summarise" } };
+}
+
+/** Creates the locked parent row returned by the reservation repository. */
+function _parentRun()
+{
+	return { id: "parent-run-1", siloId: "silo-1", agentServiceId: "parent-service-1", parentRunId: null, rootRunId: "parent-run-1", state: "Running", attempt: 1, inputSnapshotDigest: `sha256:${"e".repeat(64)}` };
+}
+
+/** Creates one Prisma mock that exposes the parent, target revision, and atomic persistence sinks. */
+function _prisma()
+{
+	const parent = _snapshot();
+	const transaction = {
+		$queryRaw: vi.fn().mockResolvedValue([]),
+		agentRun: { findUnique: vi.fn().mockResolvedValueOnce(_parentRun()).mockResolvedValueOnce(null), create: vi.fn().mockResolvedValue({ id: "child-run-1" }) },
+		runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parent, compiledAt: new Date(parent.compiledAt) }), create: vi.fn().mockResolvedValue({ id: "snapshot-1" }) },
+		childRunReservation: { findUnique: vi.fn(), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 0 }, _sum: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxDurationMs: null } }), create: vi.fn().mockResolvedValue({ childRunId: "child-run-1" }) },
+		agentService: { findFirst: vi.fn().mockResolvedValue({ id: "child-service-1", activeRevision: { id: "child-revision-1", state: "Published", digest: `sha256:${"f".repeat(64)}`, promptPolicyVersion: "prompt-v1", capabilityCeiling: _CHILD_CAPABILITY_SET.capabilities } }) },
+		outboxEvent: { createMany: vi.fn().mockResolvedValue({ count: 2 }) },
+	};
+	return { client: { $transaction: vi.fn(async function _transaction(callback: (client: object) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient, transaction };
+}
+
+describe("PrismaRuntimeChildRunSpawnRunner", function _describeRuntimeChildRunSpawnRunner()
+{
+	it("locks the target revision, verifies the narrowed capability set, and persists the child under its parent lock", async function _runsChildAuthority()
+	{
+		const prisma = _prisma();
+		const runner = new PrismaRuntimeChildRunSpawnRunner(prisma.client, { maximumDepth: 2, maximumChildrenPerParent: 3 }, function _now(): number { return Date.parse("2026-07-26T00:00:00.000Z"); });
+
+		await expect(runner.run(_candidate(), _snapshot())).resolves.toEqual({ outcome: "completed" });
+		expect(prisma.transaction.$queryRaw).toHaveBeenCalledTimes(3);
+		expect(prisma.transaction.agentService.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ id: "child-service-1", siloId: "silo-1", state: "Active" }) }));
+		expect(prisma.transaction.agentRun.create).toHaveBeenCalledWith({ data: expect.objectContaining({ agentServiceId: "child-service-1", agentRevisionId: "child-revision-1", parentRunId: "parent-run-1", rootRunId: "parent-run-1" }) });
+		expect(prisma.transaction.runInputSnapshot.create).toHaveBeenCalledWith({ data: expect.objectContaining({ capabilitySetDigest: _CHILD_CAPABILITY_SET.digest, capabilitySet: _CHILD_CAPABILITY_SET.capabilities }) });
+	});
+
+	it("denies an unverified child capability digest without creating a child run", async function _deniesCapabilityExpansion()
+	{
+		const prisma = _prisma();
+		const runner = new PrismaRuntimeChildRunSpawnRunner(prisma.client, { maximumDepth: 2, maximumChildrenPerParent: 3 }, function _now(): number { return Date.parse("2026-07-26T00:00:00.000Z"); });
+
+		await expect(runner.run({ ..._candidate(), capabilitySetDigest: _PARENT_CAPABILITY_SET.digest }, _snapshot())).resolves.toEqual({ outcome: "denied" });
+		expect(prisma.transaction.agentRun.create).not.toHaveBeenCalled();
+	});
+
+	it("denies a late child whose requested duration extends beyond the frozen parent deadline", async function _deniesLateChild()
+	{
+		const prisma = _prisma();
+		const runner = new PrismaRuntimeChildRunSpawnRunner(prisma.client, { maximumDepth: 2, maximumChildrenPerParent: 3 }, function _now(): number { return Date.parse("2026-07-26T00:01:59.000Z"); });
+
+		await expect(runner.run(_candidate(), _snapshot())).resolves.toEqual({ outcome: "denied" });
+		expect(prisma.transaction.agentRun.create).not.toHaveBeenCalled();
+	});
+
+	it("denies a candidate after its locked parent has left the running attempt", async function _deniesTerminalParent()
+	{
+		const prisma = _prisma();
+		prisma.transaction.agentRun.findUnique.mockReset().mockResolvedValue({ ..._parentRun(), state: "Completed" });
+		const runner = new PrismaRuntimeChildRunSpawnRunner(prisma.client, { maximumDepth: 2, maximumChildrenPerParent: 3 }, function _now(): number { return Date.parse("2026-07-26T00:00:00.000Z"); });
+
+		await expect(runner.run(_candidate(), _snapshot())).resolves.toEqual({ outcome: "denied" });
+		expect(prisma.transaction.agentRun.create).not.toHaveBeenCalled();
+		expect(prisma.transaction.agentService.findFirst).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/child-run-reservation.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-reservation.types.ts
@@ -1,6 +1,7 @@
 import type { RunInputSnapshot } from "@opencrane/contracts";
+import type { Prisma } from "@prisma/client";
 
-import type { GovernedChildRunSpawnAuthorization } from "./child-run-admission.types.js";
+import type { GovernedChildRunBudget, GovernedChildRunSpawnAuthorization, GovernedChildRunSpawnRequest } from "./child-run-admission.types.js";
 
 /** Immutable caller coordinates for one transaction-fenced governed child-run reservation. */
 export interface ChildRunReservationCommand
@@ -13,24 +14,40 @@ export interface ChildRunReservationCommand
 	readonly parentRunId: string;
 	/** Expected parent snapshot digest, preventing stale-parent compilation. */
 	readonly parentSnapshotDigest: string;
+	/** Exact running attempt whose runtime candidate is allowed to create this child. */
+	readonly parentAttempt: number;
 	/** Maximum direct children permitted by the immutable policy evaluated for this reservation. */
 	readonly maximumChildrenPerParent: number;
-	/** Previously authorized child coordinates and finite allocation. */
-	readonly authorization: GovernedChildRunSpawnAuthorization;
+	/** Untrusted runtime request that the locked callback must authorize before persistence. */
+	readonly request: GovernedChildRunSpawnRequest;
 }
 
 /** Immutable authority supplied to derive one child snapshot under the parent lock. */
 export interface ChildRunReservationParent
 {
+	/** The exact transaction holding the parent lock for all child authority reads. */
+	readonly transaction: Prisma.TransactionClient;
 	/** Parent run and exact frozen snapshot used by the authorization gate. */
 	readonly snapshot: RunInputSnapshot;
 	/** Parent's immutable logical-run coordinates. */
 	readonly agentServiceId: string;
+	/** Root run identifier inherited by every descendant reservation. */
+	readonly rootRunId: string;
+	/** Number of parent-to-child edges from the root to the locked parent. */
+	readonly depth: number;
+	/** Direct children already durably reserved below the locked parent. */
+	readonly existingChildCount: number;
+	/** Finite parent capacity left after every earlier durable reservation. */
+	readonly remainingBudget: GovernedChildRunBudget;
+	/** Server-owned instant that fixes the child deadline inside the parent's immutable deadline. */
+	readonly authorizedAt: string;
 }
 
 /** One derived child snapshot ready for atomic persistence. */
 export interface ChildRunReservationBuild
 {
+	/** Authorization derived from the untrusted request while the parent remains locked. */
+	readonly authorization: GovernedChildRunSpawnAuthorization;
 	/** Complete digest-sealed child input snapshot. */
 	readonly snapshot: RunInputSnapshot;
 	/** Published target service revision fixed for the child logical run. */
@@ -46,5 +63,5 @@ export type ChildRunReservationResult = { readonly outcome: "reserved" | "idempo
 export interface ChildRunReservationRepository
 {
 	/** Locks parent authority, reserves finite capacity, and persists child/run snapshot/outbox as one commit. */
-	reserve(command: ChildRunReservationCommand, build: (parent: ChildRunReservationParent) => Promise<ChildRunReservationBuild>): Promise<ChildRunReservationResult>;
+	reserve(command: ChildRunReservationCommand, build: (parent: ChildRunReservationParent) => Promise<ChildRunReservationBuild | null>): Promise<ChildRunReservationResult>;
 }

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -6,6 +6,8 @@ export type { ChildRunSnapshotCommand } from "./child-run-snapshot.types.js";
 export type { GovernedChildRunBudget, GovernedChildRunCapabilityDelegation, GovernedChildRunContextSelection, GovernedChildRunParent, GovernedChildRunPolicy, GovernedChildRunSpawnAuthorization, GovernedChildRunSpawnAuthorizationResult, GovernedChildRunSpawnRefusalReason, GovernedChildRunSpawnRequest } from "./child-run-admission.types.js";
 export type { ChildRunReservationBuild, ChildRunReservationCommand, ChildRunReservationParent, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
 export { PrismaChildRunReservationRepository } from "./prisma-child-run-reservation-repository.js";
+export { PrismaRuntimeChildRunSpawnRunner } from "./prisma-runtime-child-run-spawn-runner.js";
+export type { RuntimeChildRunSpawnPolicy } from "./prisma-runtime-child-run-spawn-runner.types.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";

--- a/libs/backend/agents/execution/runs/main/src/prisma-child-run-reservation-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-child-run-reservation-repository.ts
@@ -1,4 +1,4 @@
-import { Prisma, RunOutboxEventKind, type PrismaClient } from "@prisma/client";
+import { AgentRunState, Prisma, RunOutboxEventKind, type PrismaClient } from "@prisma/client";
 
 import { __DigestCanonicalJson } from "@opencrane/backend/server/iam/authorization";
 import type { RunInputSnapshot } from "@opencrane/contracts";
@@ -6,6 +6,7 @@ import { ___CreateLogger, type Logger } from "@opencrane/observability";
 import { ___CloneCanonicalJson } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 
+import type { GovernedChildRunBudget, GovernedChildRunSpawnAuthorization } from "./child-run-admission.types.js";
 import type { ChildRunReservationBuild, ChildRunReservationCommand, ChildRunReservationParent, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
 
 /**
@@ -21,24 +22,29 @@ export class PrismaChildRunReservationRepository implements ChildRunReservationR
 	private readonly prisma: PrismaClient;
 	/** Structured persistence-failure signal with process-wide secret redaction. */
 	private readonly log: Logger;
+	/** Server-owned clock used to bind every delegated duration to an absolute parent deadline. */
+	private readonly nowEpochMs: () => number;
 
 	/**
 	 * Creates a child-run reservation authority over canonical Postgres.
 	 * @param prisma - Canonical product-authority database client.
 	 * @param log - Structured redacting logger for otherwise fail-closed persistence failures.
+	 * @param nowEpochMs - Server-owned clock, injectable only to make authority boundary tests deterministic.
 	 */
-	constructor(prisma: PrismaClient, log: Logger = ___CreateLogger("child-run-reservation"))
+	constructor(prisma: PrismaClient, log: Logger = ___CreateLogger("child-run-reservation"), nowEpochMs: () => number = Date.now)
 	{
 		this.prisma = prisma;
 		this.log = log;
+		this.nowEpochMs = nowEpochMs;
 	}
 
 	/**
 	 * Locks one parent, revalidates its frozen authority, and atomically reserves one derived child.
 	 */
-	async reserve(command: ChildRunReservationCommand, build: (parent: ChildRunReservationParent) => Promise<ChildRunReservationBuild>): Promise<ChildRunReservationResult>
+	async reserve(command: ChildRunReservationCommand, build: (parent: ChildRunReservationParent) => Promise<ChildRunReservationBuild | null>): Promise<ChildRunReservationResult>
 	{
 		if (!_isCommandValid(command)) return { outcome: "denied", reason: "invalid_command" };
+		const nowEpochMs = this.nowEpochMs;
 		try
 		{
 			return await this.prisma.$transaction(async function _reserve(transaction: Prisma.TransactionClient): Promise<ChildRunReservationResult>
@@ -48,21 +54,27 @@ export class PrismaChildRunReservationRepository implements ChildRunReservationR
 				const parentRun = await transaction.agentRun.findUnique({ where: { id: command.parentRunId } });
 				if (parentRun === null) return { outcome: "denied", reason: "parent_unavailable" };
 				if (parentRun.inputSnapshotDigest !== command.parentSnapshotDigest) return { outcome: "denied", reason: "parent_snapshot_stale" };
+				if (parentRun.state !== AgentRunState.Running || parentRun.attempt !== command.parentAttempt) return { outcome: "denied", reason: "authority_conflict" };
 
 				// 2. Serialize the silo key while the parent remains locked, so duplicate delivery never builds a second child.
-				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${command.authorization.siloId}\u0000${command.requestIdempotencyKey}`}, 0))`);
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${command.request.siloId}\u0000${command.requestIdempotencyKey}`}, 0))`);
 				const parentSnapshot = await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: parentRun.id, digest: parentRun.inputSnapshotDigest } } });
 				if (parentSnapshot === null) return { outcome: "denied", reason: "persistence_unavailable" };
 				if (!_matchesParent(parentRun, parentSnapshot, command)) return { outcome: "denied", reason: "authority_conflict" };
 
-				const existing = await transaction.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.authorization.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
+				const existing = await transaction.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.request.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
 				if (existing !== null) return _idempotentResult(transaction, existing, command);
 				const aggregate = await transaction.childRunReservation.aggregate({ where: { parentRunId: parentRun.id }, _count: { childRunId: true }, _sum: { maxModelTurns: true, maxTotalTokens: true, maxCostUsdMicros: true, maxDurationMs: true } });
-				if (!_hasRemainingCapacity(parentSnapshot, aggregate, command)) return { outcome: "denied", reason: "authority_conflict" };
+				const authorizedAtEpochMs = nowEpochMs();
+				const remainingBudget = _remainingBudget(parentSnapshot, aggregate, authorizedAtEpochMs);
+				if (remainingBudget === null || aggregate._count.childRunId >= command.maximumChildrenPerParent) return { outcome: "denied", reason: "authority_conflict" };
+				const depth = await _parentDepth(transaction, parentRun);
+				if (depth === null) return { outcome: "denied", reason: "authority_conflict" };
 
 				// 3. Build only after locks and exact parent evidence are held, preventing stale or sibling-expanded compilation.
-				const value = await build({ snapshot: _snapshot(parentSnapshot), agentServiceId: parentRun.agentServiceId });
-				if (!_matchesBuild(value, _snapshot(parentSnapshot), command)) return { outcome: "denied", reason: "authority_conflict" };
+				const value = await build({ transaction, snapshot: _snapshot(parentSnapshot), agentServiceId: parentRun.agentServiceId, rootRunId: parentRun.rootRunId, depth, existingChildCount: aggregate._count.childRunId, remainingBudget, authorizedAt: new Date(authorizedAtEpochMs).toISOString() });
+				if (value === null) return { outcome: "denied", reason: "authority_conflict" };
+				if (!_matchesBuild(value, _snapshot(parentSnapshot), parentRun, command, depth, remainingBudget)) return { outcome: "denied", reason: "authority_conflict" };
 
 				// 4. Commit every durable child authority record and initial dispatch events in this same parent-fenced transaction.
 				await _persistReservation(transaction, command, value);
@@ -71,7 +83,7 @@ export class PrismaChildRunReservationRepository implements ChildRunReservationR
 		}
 		catch (error)
 		{
-			this.log.error({ err: error, childRunId: command.childRunId, parentRunId: command.parentRunId, siloId: command.authorization.siloId, failureKind: "transaction_failed" }, "child run reservation persistence failed");
+			this.log.error({ err: error, childRunId: command.childRunId, parentRunId: command.parentRunId, siloId: command.request.siloId, failureKind: "transaction_failed" }, "child run reservation persistence failed");
 			return { outcome: "denied", reason: "persistence_unavailable" };
 		}
 	}
@@ -80,63 +92,68 @@ export class PrismaChildRunReservationRepository implements ChildRunReservationR
 /** Returns whether a caller provided enough well-formed coordinates for a fail-closed reservation attempt. */
 function _isCommandValid(command: ChildRunReservationCommand): boolean
 {
-	const authorization = command.authorization;
 	return _present(command.childRunId) && _present(command.requestIdempotencyKey) && _present(command.parentRunId) && _digest(command.parentSnapshotDigest)
-		&& _present(authorization.siloId) && _present(authorization.rootRunId) && authorization.parentRunId === command.parentRunId
-		&& _present(authorization.agentServiceId) && _digest(authorization.capabilitySetDigest) && Number.isSafeInteger(authorization.depth) && authorization.depth > 0
+		&& Number.isSafeInteger(command.parentAttempt) && command.parentAttempt > 0
+		&& _present(command.request.siloId) && _present(command.request.agentServiceId) && _digest(command.request.capabilitySetDigest)
 		&& Number.isSafeInteger(command.maximumChildrenPerParent) && command.maximumChildrenPerParent >= 0
-		&& _positiveBudget(authorization.budget.maxModelTurns) && _positiveBudget(authorization.budget.maxTotalTokens) && _positiveBudget(authorization.budget.maxCostUsdMicros) && _positiveBudget(authorization.budget.maxDurationMs);
+		&& _positiveBudget(command.request.budget.maxModelTurns) && _positiveBudget(command.request.budget.maxTotalTokens) && _positiveBudget(command.request.budget.maxCostUsdMicros) && _positiveBudget(command.request.budget.maxDurationMs);
 }
 
-/** Returns whether durable sibling allocations and fan-out leave capacity in the immutable parent policy. */
-function _hasRemainingCapacity(parentSnapshot: { budgetPolicy: Prisma.JsonValue; compiledAt: Date }, aggregate: { _count: { childRunId: number }; _sum: { maxModelTurns: number | null; maxTotalTokens: number | null; maxCostUsdMicros: bigint | null; maxDurationMs: number | null } }, command: ChildRunReservationCommand): boolean
+/** Calculates capacity left after each earlier sibling reservation under the same parent lock. */
+function _remainingBudget(parentSnapshot: { budgetPolicy: Prisma.JsonValue }, aggregate: { _sum: { maxModelTurns: number | null; maxTotalTokens: number | null; maxCostUsdMicros: bigint | null; maxDurationMs: number | null } }, authorizedAtEpochMs: number): GovernedChildRunBudget | null
 {
-	const capacity = _parentCapacity(parentSnapshot.budgetPolicy, parentSnapshot.compiledAt);
-	if (capacity === null || aggregate._count.childRunId >= command.maximumChildrenPerParent) return false;
-	const allocation = command.authorization.budget;
-	return _within(capacity.maxModelTurns, aggregate._sum.maxModelTurns, allocation.maxModelTurns)
-		&& _within(capacity.maxTotalTokens, aggregate._sum.maxTotalTokens, allocation.maxTotalTokens)
-		&& _withinBigInt(capacity.maxCostUsdMicros, aggregate._sum.maxCostUsdMicros, allocation.maxCostUsdMicros)
-		&& _within(capacity.maxDurationMs, aggregate._sum.maxDurationMs, allocation.maxDurationMs);
+	const capacity = _parentCapacity(parentSnapshot.budgetPolicy, authorizedAtEpochMs);
+	if (capacity === null || !_validConsumed(aggregate)) return null;
+	const maxCostUsdMicros = BigInt(capacity.maxCostUsdMicros) - (aggregate._sum.maxCostUsdMicros ?? 0n);
+	if (maxCostUsdMicros <= 0n || maxCostUsdMicros > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+	const remaining = {
+		maxModelTurns: capacity.maxModelTurns - (aggregate._sum.maxModelTurns ?? 0), maxTotalTokens: capacity.maxTotalTokens - (aggregate._sum.maxTotalTokens ?? 0), maxCostUsdMicros: Number(maxCostUsdMicros), maxDurationMs: capacity.maxDurationMs - (aggregate._sum.maxDurationMs ?? 0),
+	};
+	return _positiveBudget(remaining.maxModelTurns) && _positiveBudget(remaining.maxTotalTokens) && _positiveBudget(remaining.maxCostUsdMicros) && _positiveBudget(remaining.maxDurationMs) ? remaining : null;
 }
 
 /** Parses the frozen parent budget policy into the four finite capacities that children may reserve. */
-function _parentCapacity(value: Prisma.JsonValue, compiledAt: Date): { readonly maxModelTurns: number; readonly maxTotalTokens: number; readonly maxCostUsdMicros: number; readonly maxDurationMs: number } | null
+function _parentCapacity(value: Prisma.JsonValue, authorizedAtEpochMs: number): { readonly maxModelTurns: number; readonly maxTotalTokens: number; readonly maxCostUsdMicros: number; readonly maxDurationMs: number } | null
 {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
 	const policy = value as Record<string, unknown>;
 	const deadline = policy["wallClockDeadlineEpochMs"];
-	const duration = typeof deadline === "number" ? deadline - compiledAt.getTime() : NaN;
+	const duration = typeof deadline === "number" ? deadline - authorizedAtEpochMs : NaN;
 	return _positiveBudget(policy["maxModelTurns"]) && _positiveBudget(policy["maxTotalTokens"]) && _positiveBudget(policy["maxCostUsdMicros"]) && _positiveBudget(duration)
 		? { maxModelTurns: policy["maxModelTurns"], maxTotalTokens: policy["maxTotalTokens"], maxCostUsdMicros: policy["maxCostUsdMicros"], maxDurationMs: duration }
 		: null;
 }
 
-/** Returns whether an existing total plus one candidate allocation remains inside one finite capacity. */
-function _within(capacity: number, consumed: number | null, requested: number): boolean
+/** Returns whether every aggregate total is a non-negative safe value before it informs an authority decision. */
+function _validConsumed(aggregate: { _sum: { maxModelTurns: number | null; maxTotalTokens: number | null; maxCostUsdMicros: bigint | null; maxDurationMs: number | null } }): boolean
 {
-	return Number.isSafeInteger(consumed ?? 0) && (consumed ?? 0) >= 0 && requested <= capacity - (consumed ?? 0);
+	return Number.isSafeInteger(aggregate._sum.maxModelTurns ?? 0) && (aggregate._sum.maxModelTurns ?? 0) >= 0
+		&& Number.isSafeInteger(aggregate._sum.maxTotalTokens ?? 0) && (aggregate._sum.maxTotalTokens ?? 0) >= 0
+		&& (aggregate._sum.maxCostUsdMicros === null || aggregate._sum.maxCostUsdMicros >= 0n)
+		&& Number.isSafeInteger(aggregate._sum.maxDurationMs ?? 0) && (aggregate._sum.maxDurationMs ?? 0) >= 0;
 }
 
-/** Returns whether an existing bigint cost allocation plus one candidate remains within the parent ceiling. */
-function _withinBigInt(capacity: number, consumed: bigint | null, requested: number): boolean
+/** Loads the locked parent depth from its reservation, treating every incomplete child lineage as unavailable. */
+async function _parentDepth(transaction: Prisma.TransactionClient, parentRun: { id: string; parentRunId: string | null }): Promise<number | null>
 {
-	return consumed !== null && consumed < 0n ? false : BigInt(requested) <= BigInt(capacity) - (consumed ?? 0n);
+	if (parentRun.parentRunId === null) return 0;
+	const reservation = await transaction.childRunReservation.findUnique({ where: { childRunId: parentRun.id }, select: { depth: true } });
+	return reservation !== null && Number.isSafeInteger(reservation.depth) && reservation.depth > 0 ? reservation.depth : null;
 }
 
 /** Returns whether the locked parent and its snapshot exactly bind the detached authorization coordinates. */
 function _matchesParent(parentRun: { id: string; siloId: string; rootRunId: string; inputSnapshotDigest: string }, parentSnapshot: { runId: string; siloId: string; digest: string }, command: ChildRunReservationCommand): boolean
 {
-	return parentRun.id === command.authorization.parentRunId && parentRun.siloId === command.authorization.siloId
-		&& parentRun.rootRunId === command.authorization.rootRunId && parentRun.inputSnapshotDigest === command.parentSnapshotDigest
+	return parentRun.id === command.parentRunId && parentRun.siloId === command.request.siloId
+		&& parentRun.inputSnapshotDigest === command.parentSnapshotDigest
 		&& parentSnapshot.runId === parentRun.id && parentSnapshot.siloId === parentRun.siloId && parentSnapshot.digest === command.parentSnapshotDigest;
 }
 
 /** Returns an existing first child only when all durable reservation coordinates match this request exactly. */
 async function _idempotentResult(transaction: Prisma.TransactionClient, existing: { id: string; siloId: string; agentServiceId: string; parentRunId: string | null; rootRunId: string; trigger: string; inputSnapshotDigest: string }, command: ChildRunReservationCommand): Promise<ChildRunReservationResult>
 {
-	if (existing.id !== command.childRunId || existing.siloId !== command.authorization.siloId || existing.agentServiceId !== command.authorization.agentServiceId
-		|| existing.parentRunId !== command.authorization.parentRunId || existing.rootRunId !== command.authorization.rootRunId || existing.trigger !== "ManagedInvocation") return { outcome: "denied", reason: "authority_conflict" };
+	if (existing.id !== command.childRunId || existing.siloId !== command.request.siloId || existing.agentServiceId !== command.request.agentServiceId
+		|| existing.parentRunId !== command.parentRunId || existing.trigger !== "ManagedInvocation") return { outcome: "denied", reason: "authority_conflict" };
 	const reservation = await transaction.childRunReservation.findUnique({ where: { childRunId: existing.id } });
 	if (!_matchesReservation(reservation, command)) return { outcome: "denied", reason: "authority_conflict" };
 	const snapshot = await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
@@ -147,27 +164,53 @@ async function _idempotentResult(transaction: Prisma.TransactionClient, existing
 /** Returns whether the immutable reservation retained exactly the parent-authorised finite allocation. */
 function _matchesReservation(reservation: { childRunId: string; parentRunId: string; rootRunId: string; depth: number; maxModelTurns: number; maxTotalTokens: number; maxCostUsdMicros: bigint; maxDurationMs: number; task: Prisma.JsonValue; taskDigest: string } | null, command: ChildRunReservationCommand): boolean
 {
-	return reservation !== null && reservation.childRunId === command.childRunId && reservation.parentRunId === command.authorization.parentRunId && reservation.rootRunId === command.authorization.rootRunId
-		&& reservation.depth === command.authorization.depth && reservation.maxModelTurns === command.authorization.budget.maxModelTurns
-		&& reservation.maxTotalTokens === command.authorization.budget.maxTotalTokens && reservation.maxCostUsdMicros === BigInt(command.authorization.budget.maxCostUsdMicros) && reservation.maxDurationMs === command.authorization.budget.maxDurationMs
-		&& reservation.taskDigest === __DigestCanonicalJson(command.authorization.task) && _sameJson(reservation.task, command.authorization.task);
+	return reservation !== null && reservation.childRunId === command.childRunId && reservation.parentRunId === command.parentRunId
+		&& reservation.maxModelTurns === command.request.budget.maxModelTurns
+		&& reservation.maxTotalTokens === command.request.budget.maxTotalTokens && reservation.maxCostUsdMicros === BigInt(command.request.budget.maxCostUsdMicros) && reservation.maxDurationMs === command.request.budget.maxDurationMs
+		&& reservation.taskDigest === __DigestCanonicalJson(command.request.task) && _sameJson(reservation.task, command.request.task);
 }
 
 /** Returns whether a rebuilt child has the exact reservation-bound coordinates and context subset. */
-function _matchesBuild(value: ChildRunReservationBuild, parent: RunInputSnapshot, command: ChildRunReservationCommand): boolean
+function _matchesBuild(value: ChildRunReservationBuild, parent: RunInputSnapshot, parentRun: { id: string; siloId: string; rootRunId: string }, command: ChildRunReservationCommand, parentDepth: number, remainingBudget: GovernedChildRunBudget): boolean
 {
 	const snapshot = value.snapshot;
-	const context = command.authorization.context;
-	return snapshot.runId === command.childRunId && snapshot.siloId === command.authorization.siloId && snapshot.agentServiceId === command.authorization.agentServiceId
+	const authorization = value.authorization;
+	const context = authorization.context;
+	return _matchesAuthorization(authorization, parentRun, command, parentDepth, remainingBudget)
+		&& snapshot.runId === command.childRunId && snapshot.siloId === authorization.siloId && snapshot.agentServiceId === authorization.agentServiceId
 		&& snapshot.agentRevisionId === value.agentRevisionId && snapshot.effectiveContractDigest === value.effectiveContractDigest
-		&& snapshot.capabilitySetDigest === command.authorization.capabilitySetDigest && _sameStrings(snapshot.messageIds, context.messageIds)
+		&& snapshot.capabilitySetDigest === authorization.capabilitySetDigest && _sameJson(snapshot.capabilitySet, authorization.capabilitySet.capabilities) && _sameStrings(snapshot.messageIds, context.messageIds)
 		&& _sameStrings(snapshot.memoryFacts.map(function _factId(fact): string { return fact.factId; }), context.memoryFactIds)
 		&& _sameStrings(snapshot.artifactRevisionIds, context.artifactRevisionIds) && _sameStrings(snapshot.skillRevisionIds, context.skillRevisionIds)
 		&& snapshot.threadId === parent.threadId
 		&& snapshot.personaRevisionId === parent.personaRevisionId && _sameStrings(snapshot.preferenceFactIds, parent.preferenceFactIds)
 		&& _sameJson(snapshot.memoryQueryPolicy, parent.memoryQueryPolicy) && _sameJson(snapshot.integrationAssignments, parent.integrationAssignments)
 		&& _sameJson(snapshot.modelRoute, parent.modelRoute) && _sameJson(snapshot.identitySnapshot, parent.identitySnapshot)
-		&& _matchesChildBudget(snapshot, command.authorization.budget);
+		&& _matchesChildBudget(snapshot, authorization.budget);
+}
+
+/** Returns whether the lock-held callback preserved the raw request while adding only verified parent coordinates. */
+function _matchesAuthorization(authorization: GovernedChildRunSpawnAuthorization, parentRun: { id: string; siloId: string; rootRunId: string }, command: ChildRunReservationCommand, parentDepth: number, remainingBudget: GovernedChildRunBudget): boolean
+{
+	const request = command.request;
+	return authorization.siloId === parentRun.siloId && authorization.rootRunId === parentRun.rootRunId && authorization.parentRunId === parentRun.id && authorization.depth === parentDepth + 1
+		&& authorization.agentServiceId === request.agentServiceId && authorization.capabilitySetDigest === request.capabilitySetDigest
+		&& _sameStrings(authorization.context.messageIds, request.context.messageIds) && _sameStrings(authorization.context.memoryFactIds, request.context.memoryFactIds)
+		&& _sameStrings(authorization.context.artifactRevisionIds, request.context.artifactRevisionIds) && _sameStrings(authorization.context.skillRevisionIds, request.context.skillRevisionIds)
+		&& _sameJson(authorization.task, request.task) && _sameBudget(authorization.budget, request.budget) && _fitsRemainingBudget(authorization.budget, remainingBudget);
+}
+
+/** Returns whether two finite allocations have exactly the same authority coordinates. */
+function _sameBudget(left: GovernedChildRunBudget, right: GovernedChildRunBudget): boolean
+{
+	return left.maxModelTurns === right.maxModelTurns && left.maxTotalTokens === right.maxTotalTokens && left.maxCostUsdMicros === right.maxCostUsdMicros && left.maxDurationMs === right.maxDurationMs;
+}
+
+/** Returns whether the verified allocation remains inside the capacity calculated under the parent lock. */
+function _fitsRemainingBudget(allocation: GovernedChildRunBudget, remaining: GovernedChildRunBudget): boolean
+{
+	return allocation.maxModelTurns <= remaining.maxModelTurns && allocation.maxTotalTokens <= remaining.maxTotalTokens
+		&& allocation.maxCostUsdMicros <= remaining.maxCostUsdMicros && allocation.maxDurationMs <= remaining.maxDurationMs;
 }
 
 /** Returns whether the runtime-visible child budget exactly represents the durable reservation allocation. */
@@ -188,23 +231,24 @@ function _sameJson(left: unknown, right: unknown): boolean
 /** Returns whether a recovered child snapshot still proves the immutable idempotency authority scope. */
 function _matchesExistingSnapshot(snapshot: { runId: string; siloId: string; agentServiceId: string; capabilitySetDigest: string }, command: ChildRunReservationCommand): boolean
 {
-	return snapshot.runId === command.childRunId && snapshot.siloId === command.authorization.siloId
-		&& snapshot.agentServiceId === command.authorization.agentServiceId && snapshot.capabilitySetDigest === command.authorization.capabilitySetDigest;
+	return snapshot.runId === command.childRunId && snapshot.siloId === command.request.siloId
+		&& snapshot.agentServiceId === command.request.agentServiceId && snapshot.capabilitySetDigest === command.request.capabilitySetDigest;
 }
 
 /** Persists one child run, its frozen snapshot, immutable reservation, and initial dispatch events. */
 async function _persistReservation(transaction: Prisma.TransactionClient, command: ChildRunReservationCommand, value: ChildRunReservationBuild): Promise<void>
 {
+	const authorization = value.authorization;
 	await transaction.agentRun.create({ data: {
-		id: command.childRunId, siloId: command.authorization.siloId, agentServiceId: command.authorization.agentServiceId, agentRevisionId: value.agentRevisionId,
+		id: command.childRunId, siloId: authorization.siloId, agentServiceId: authorization.agentServiceId, agentRevisionId: value.agentRevisionId,
 		threadId: value.snapshot.threadId, trigger: "ManagedInvocation", delegatedUserId: null, requestIdempotencyKey: command.requestIdempotencyKey,
-		rootRunId: command.authorization.rootRunId, parentRunId: command.authorization.parentRunId, effectiveContractDigest: value.effectiveContractDigest, inputSnapshotDigest: value.snapshot.digest,
+		rootRunId: authorization.rootRunId, parentRunId: authorization.parentRunId, effectiveContractDigest: value.effectiveContractDigest, inputSnapshotDigest: value.snapshot.digest,
 	} });
 	await transaction.runInputSnapshot.create({ data: _snapshotData(value.snapshot) });
 	await transaction.childRunReservation.create({ data: {
-		childRunId: command.childRunId, parentRunId: command.authorization.parentRunId, rootRunId: command.authorization.rootRunId, depth: command.authorization.depth,
-		maxModelTurns: command.authorization.budget.maxModelTurns, maxTotalTokens: command.authorization.budget.maxTotalTokens, maxCostUsdMicros: BigInt(command.authorization.budget.maxCostUsdMicros), maxDurationMs: command.authorization.budget.maxDurationMs,
-		task: _json(command.authorization.task), taskDigest: __DigestCanonicalJson(command.authorization.task),
+		childRunId: command.childRunId, parentRunId: authorization.parentRunId, rootRunId: authorization.rootRunId, depth: authorization.depth,
+		maxModelTurns: authorization.budget.maxModelTurns, maxTotalTokens: authorization.budget.maxTotalTokens, maxCostUsdMicros: BigInt(authorization.budget.maxCostUsdMicros), maxDurationMs: authorization.budget.maxDurationMs,
+		task: _json(authorization.task), taskDigest: __DigestCanonicalJson(authorization.task),
 	} });
 	await transaction.outboxEvent.createMany({ data: [
 		{ runId: command.childRunId, attempt: 1, sequence: 1, kind: RunOutboxEventKind.RunAccepted, idempotencyKey: `${command.childRunId}:accepted`, payload: { runId: command.childRunId, inputSnapshotDigest: value.snapshot.digest } },

--- a/libs/backend/agents/execution/runs/main/src/prisma-runtime-child-run-spawn-runner.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-runtime-child-run-spawn-runner.ts
@@ -1,0 +1,135 @@
+import { AgentRevisionState, AgentServiceState, Prisma, type PrismaClient } from "@prisma/client";
+
+import { __CreateCapabilitySet, __DigestCanonicalJson, __IsCapabilitySetSubset } from "@opencrane/backend/server/iam/authorization";
+import type { CapabilitySet } from "@opencrane/backend/server/iam/authorization";
+import type { CapabilityReference } from "@opencrane/models/authorization";
+import type { RunInputSnapshot, RuntimeChildRunSpawnCandidate } from "@opencrane/contracts";
+
+import { __AuthorizeGovernedChildRunSpawn } from "./child-run-admission.js";
+import { __DeriveChildRunSnapshot } from "./child-run-snapshot.js";
+import { PrismaChildRunReservationRepository } from "./prisma-child-run-reservation-repository.js";
+import type { RuntimeChildRunSpawnPolicy } from "./prisma-runtime-child-run-spawn-runner.types.js";
+
+/**
+ * App-composable authority that turns an admitted runtime child request into one durable child run.
+ *
+ * The runner never trusts a runtime-provided capability list, revision, or parent capacity. Its
+ * reservation callback holds the parent lock while it resolves the active target revision,
+ * intersects its fixed ceiling with the parent snapshot, derives the frozen child snapshot, and
+ * commits every child authority record together.
+ */
+export class PrismaRuntimeChildRunSpawnRunner
+{
+	/** Canonical product-authority client used only through the reservation transaction. */
+	private readonly prisma: PrismaClient;
+	/** Immutable bounds for recursive child execution. */
+	private readonly policy: RuntimeChildRunSpawnPolicy;
+	/** Server-owned clock shared with the reservation so child deadlines cannot outlive their parent. */
+	private readonly nowEpochMs: () => number;
+
+	/** Creates one child-run runner over the canonical product-authority database. */
+	constructor(prisma: PrismaClient, policy: RuntimeChildRunSpawnPolicy, nowEpochMs: () => number = Date.now)
+	{
+		this.prisma = prisma;
+		this.policy = policy;
+		this.nowEpochMs = nowEpochMs;
+	}
+
+	/** Reserves the candidate only when the locked parent and active child revision prove every bound. */
+	async run(candidate: RuntimeChildRunSpawnCandidate, snapshot: RunInputSnapshot): Promise<{ readonly outcome: "completed" | "denied" }>
+	{
+		if (!_isPolicyValid(this.policy) || candidate.runId !== snapshot.runId) return { outcome: "denied" };
+		const command = {
+			childRunId: _childRunId(candidate), requestIdempotencyKey: _idempotencyKey(candidate), parentRunId: candidate.runId, parentSnapshotDigest: snapshot.digest, parentAttempt: candidate.attempt,
+			maximumChildrenPerParent: this.policy.maximumChildrenPerParent,
+			request: { siloId: snapshot.siloId, agentServiceId: candidate.agentServiceId, capabilitySetDigest: candidate.capabilitySetDigest, context: candidate.context, budget: candidate.budget, task: candidate.task },
+		};
+		const policy = this.policy;
+		const result = await new PrismaChildRunReservationRepository(this.prisma, undefined, this.nowEpochMs).reserve(command, async function _build(parent)
+		{
+			// 1. Reconfirm that the runtime frame names the exact snapshot currently locked for its parent.
+			if (parent.snapshot.digest !== snapshot.digest) return null;
+
+			// 2. Resolve only an active same-silo service and its published active revision under that lock.
+			const target = await _targetRevision(parent.transaction, snapshot.siloId, candidate.agentServiceId);
+			if (target === null) return null;
+
+			// 3. Derive a verifier-owned child set by intersecting immutable parent evidence with the target ceiling.
+			const childCapabilitySet = _narrowedCapabilitySet(parent.snapshot, target.capabilityCeiling);
+			if (childCapabilitySet === null) return null;
+			const admission = __AuthorizeGovernedChildRunSpawn({ runId: candidate.runId, rootRunId: parent.rootRunId, siloId: snapshot.siloId, snapshot: parent.snapshot, depth: parent.depth, remainingBudget: parent.remainingBudget }, command.request, parent.existingChildCount, policy, { resolve: function _resolve(parentCapabilitySet, childAgentServiceId, childCapabilitySetDigest) { return childAgentServiceId === target.id && childCapabilitySetDigest === childCapabilitySet.digest && __IsCapabilitySetSubset(parentCapabilitySet, childCapabilitySet) ? childCapabilitySet : null; } });
+			if (admission.outcome === "denied") return null;
+
+			// 4. Seal the verified target revision, capability set, and parent-bounded context into the child snapshot.
+			const childSnapshot = __DeriveChildRunSnapshot({ childRunId: command.childRunId, parentSnapshot: parent.snapshot, authorization: admission.authorization, agentRevisionId: target.activeRevision.id, effectiveContractDigest: target.activeRevision.digest, promptCompilerVersion: target.activeRevision.promptPolicyVersion, compiledAt: parent.authorizedAt });
+			return { authorization: admission.authorization, snapshot: childSnapshot, agentRevisionId: target.activeRevision.id, effectiveContractDigest: target.activeRevision.digest };
+		});
+		return result.outcome === "reserved" || result.outcome === "idempotent" ? { outcome: "completed" } : { outcome: "denied" };
+	}
+}
+
+/** Reads the exact published active revision that may receive one same-silo child run. */
+async function _targetRevision(transaction: Prisma.TransactionClient, siloId: string, agentServiceId: string): Promise<{ readonly id: string; readonly capabilityCeiling: Prisma.JsonValue; readonly activeRevision: { readonly id: string; readonly digest: string; readonly promptPolicyVersion: string } } | null>
+{
+	// 1. Hold the target service state stable until the same transaction commits its child authority.
+	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${agentServiceId} AND "silo_id" = ${siloId} FOR SHARE`);
+
+	// 2. Load only an active service and published active revision after that lock has closed the state race.
+	const service = await transaction.agentService.findFirst({ where: { id: agentServiceId, siloId, state: AgentServiceState.Active, activeRevisionId: { not: null } }, select: { id: true, activeRevision: { select: { id: true, digest: true, promptPolicyVersion: true, state: true, capabilityCeiling: true } } } });
+	if (service?.activeRevision === null || service?.activeRevision === undefined || service.activeRevision.state !== AgentRevisionState.Published) return null;
+	return { id: service.id, capabilityCeiling: service.activeRevision.capabilityCeiling, activeRevision: { id: service.activeRevision.id, digest: service.activeRevision.digest, promptPolicyVersion: service.activeRevision.promptPolicyVersion } };
+}
+
+/** Returns the exact intersection of parent evidence and a published target ceiling, or null for malformed authority. */
+function _narrowedCapabilitySet(parent: RunInputSnapshot, ceiling: Prisma.JsonValue): CapabilitySet | null
+{
+	const parentSet = __CreateCapabilitySet(parent.capabilitySet);
+	const targetReferences = _capabilityReferences(ceiling);
+	const targetSet = targetReferences === null ? null : __CreateCapabilitySet(targetReferences);
+	if (parentSet === null || targetSet === null) return null;
+	const targetKeys = new Set(targetSet.capabilities.map(_capabilityKey));
+	return __CreateCapabilitySet(parentSet.capabilities.filter(function _allowed(capability): boolean { return targetKeys.has(_capabilityKey(capability)); }));
+}
+
+/** Decodes a database JSON value only when every entry is a complete immutable capability reference. */
+function _capabilityReferences(value: Prisma.JsonValue): CapabilityReference[] | null
+{
+	if (!Array.isArray(value)) return null;
+	const references: CapabilityReference[] = [];
+	for (const entry of value)
+	{
+		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) return null;
+		const record = entry as Record<string, unknown>;
+		const catalog = record["catalog"];
+		if (typeof catalog !== "object" || catalog === null || Array.isArray(catalog)) return null;
+		const catalogRecord = catalog as Record<string, unknown>;
+		if (typeof catalogRecord["catalogId"] !== "string" || typeof catalogRecord["revision"] !== "number" || typeof catalogRecord["digest"] !== "string" || typeof record["capabilityId"] !== "string") return null;
+		references.push({ catalog: { catalogId: catalogRecord["catalogId"], revision: catalogRecord["revision"], digest: catalogRecord["digest"] as `sha256:${string}` }, capabilityId: record["capabilityId"] });
+	}
+	return references;
+}
+
+/** Builds the stable immutable key used for set intersection. */
+function _capabilityKey(value: CapabilityReference): string
+{
+	return `${value.catalog.catalogId}\u0000${value.catalog.revision}\u0000${value.catalog.digest}\u0000${value.capabilityId}`;
+}
+
+/** Derives a deterministic child identifier so a crashed runner can safely reserve the same child on replay. */
+function _childRunId(candidate: RuntimeChildRunSpawnCandidate): string
+{
+	return `child-${__DigestCanonicalJson({ runId: candidate.runId, attempt: candidate.attempt, candidateId: candidate.candidateId }).slice("sha256:".length)}`;
+}
+
+/** Derives a deterministic scope-bound idempotency key for the admitted runtime candidate. */
+function _idempotencyKey(candidate: RuntimeChildRunSpawnCandidate): string
+{
+	return `runtime-child:${candidate.runId}:${candidate.attempt}:${candidate.candidateId}`;
+}
+
+/** Returns whether bounded recursive policy values can safely enter the reservation authority. */
+function _isPolicyValid(policy: RuntimeChildRunSpawnPolicy): boolean
+{
+	return Number.isSafeInteger(policy.maximumDepth) && policy.maximumDepth >= 1 && policy.maximumDepth <= 16
+		&& Number.isSafeInteger(policy.maximumChildrenPerParent) && policy.maximumChildrenPerParent >= 1 && policy.maximumChildrenPerParent <= 64;
+}

--- a/libs/backend/agents/execution/runs/main/src/prisma-runtime-child-run-spawn-runner.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-runtime-child-run-spawn-runner.types.ts
@@ -1,0 +1,8 @@
+/** Fixed, server-owned limits for recursive runtime child-run requests. */
+export interface RuntimeChildRunSpawnPolicy
+{
+	/** Maximum number of parent-to-child edges allowed below a root run. */
+	readonly maximumDepth: number;
+	/** Maximum direct children a single parent run may reserve. */
+	readonly maximumChildrenPerParent: number;
+}


### PR DESCRIPTION
## Outcome

Runtime child-run candidates now become durable children only through a server-owned, transaction-fenced authorization path. The runtime can propose a target, a narrow capability digest, selected parent inputs, and a finite budget; it cannot write a child run, pick a revision, or enlarge authority.

The server locks the running parent attempt, calculates remaining capacity against the parent absolute deadline, locks the active target service, intersects the parent capability set with the target revision ceiling, seals the child snapshot, and commits the child run, reservation, and first dispatch events together.

## Important limits

- AGENT_RUNTIME_CHILD_MAX_DEPTH defaults to 2.
- AGENT_RUNTIME_CHILD_MAX_CHILDREN defaults to 4 direct children per parent.
- A child is denied when the parent is terminal, cancelling, stale, on a different attempt, out of budget, or too near its immutable deadline.

## Validation

- Focused child-run tests: 9 passing tests.
- Execution-runs package typecheck.
- Repository style and diff checks.
- Independent review and re-review: no Critical or High findings remain.

The OpenCrane app typecheck is currently blocked by an existing harvesting-central-agent fixture missing capabilityCeiling in AgentRevisionContent. This branch does not modify that file.