### PR TITLE
🔒 Phase E: seal the harvester capability ceiling

### DIFF
--- a/apps/opencrane/src/app/__tests__/harvesting-central-agent.test.ts
+++ b/apps/opencrane/src/app/__tests__/harvesting-central-agent.test.ts
@@ -12,6 +12,7 @@ describe("harvesting central-agent definition", function _DefinitionSuite()
 	{
 		const definition = _HarvestingCentralAgentDefinition("obot-ref-slack-opaque", "global-model-definition");
 		expect(definition.content.personaRevisionId).toBeNull();
+		expect(definition.content.capabilityCeiling).toEqual([]);
 		expect(definition.content.budget.maxTurns).toBeGreaterThan(0);
 		expect(definition.content.budget.maxTokens).toBeGreaterThan(0);
 		expect(definition.content.integrationAssignments).toHaveLength(1);

--- a/apps/opencrane/src/app/harvesting-central-agent.ts
+++ b/apps/opencrane/src/app/harvesting-central-agent.ts
@@ -31,6 +31,8 @@ export function _HarvestingCentralAgentDefinition(obotCustodyReference: string, 
 			// A managed (central) agent never carries a persona.
 			personaRevisionId: null,
 			modelDefinitionId,
+			// The packaged harvester cannot delegate or invoke capability-catalog actions until one is explicitly published for it.
+			capabilityCeiling: [],
 			budget: { maxTurns: 20, maxTokens: 200_000, maxDurationMs: 900_000 },
 			skills: [],
 			// One Obot MCP integration with a strict tool allow-list; only these tools are invocable.


### PR DESCRIPTION
## Outcome

The packaged Knowledge Harvester now declares its capability ceiling explicitly. It grants no capability-catalog actions by default, so the managed agent remains fail-closed until a bounded capability catalogue is deliberately assigned.

This completes the AgentRevisionContent contract and restores the OpenCrane server typecheck, while leaving the harvester separate Obot integration allow-list unchanged.

## Validation

- OpenCrane app typecheck passes.
- Focused harvester tests: 5 passing tests.
- Repository style and diff checks.
- Independent review: no Critical or High findings.