### PR TITLE
🧭 Seed reviewed personal-agent onboarding sources

### DIFF
--- a/apps/opencrane/package.json
+++ b/apps/opencrane/package.json
@@ -12,7 +12,8 @@
     "start": "node ../../dist/apps/opencrane/index.js",
     "test": "vitest run",
     "lint": "tsc --noEmit",
-    "db:generate": "prisma generate"
+    "db:generate": "prisma generate",
+    "test:persona-source-seeds": "node prisma/bootstrap/verify-persona-source-seeds.mjs"
   },
   "dependencies": {
     "@kubernetes/client-node": "^1.0.0",

--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -4699,3 +4699,21 @@ CREATE CONSTRAINT TRIGGER run_input_snapshots_run_binding
 AFTER INSERT OR UPDATE OF "run_id", "input_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest"
 ON "run_input_snapshots" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW
 EXECUTE FUNCTION enforce_run_input_snapshot_run_binding();
+
+-- Clean-build persona onboarding sources. They are created as Draft, populated, and reviewed in
+-- this immutable baseline so no runtime path can edit questions or SOUL.md template rules.
+INSERT INTO "persona_question_sets" ("question_set_id", "version") VALUES ('personal-agent-onboarding', 1);
+INSERT INTO "persona_questions" ("question_set_id", "question_set_version", "question_id", "category", "prompt", "ordinal") VALUES
+    ('personal-agent-onboarding', 1, 'relationship-role', 'relationship_role', 'What role should your agent take? Choose: A thoughtful partner.', 1),
+    ('personal-agent-onboarding', 1, 'tone-language', 'tone_language', 'Which tone and language should it normally use?', 2),
+    ('personal-agent-onboarding', 1, 'answer-structure', 'answer_structure', 'How should it structure answers: concise first, detailed first, or another approach?', 3),
+    ('personal-agent-onboarding', 1, 'challenge-support', 'challenge_support', 'How should it challenge you? Choose: Challenge me directly, or Start supportively, then challenge me.', 4),
+    ('personal-agent-onboarding', 1, 'initiative', 'initiative', 'When may it take initiative instead of waiting for a request?', 5),
+    ('personal-agent-onboarding', 1, 'approval-risk', 'approval_risk', 'Which external actions always require your approval?', 6),
+    ('personal-agent-onboarding', 1, 'working-habits', 'working_habits', 'Which working habits should it reinforce?', 7),
+    ('personal-agent-onboarding', 1, 'memory-boundaries', 'memory_boundaries', 'What should it remember, and what must it not retain?', 8);
+UPDATE "persona_question_sets" SET "state" = 'reviewed', "reviewed_by" = 'opencrane-clean-build', "reviewed_at" = clock_timestamp()
+WHERE "question_set_id" = 'personal-agent-onboarding' AND "version" = 1;
+INSERT INTO "persona_soul_templates" ("template_id", "version", "digest", "content", "selection_rules", "reviewed_by", "reviewed_at") VALUES
+    ('direct-partner', 1, 'sha256:ffe3cf4b656e733d0eaf0a8d65d6e330c1e3bc2710f90e026ed30662022b2354', E'# SOUL.md\n\nYou are a thoughtful personal AI partner. Ground advice in the user''s stated goals, preserve their control over external actions, and be clear about uncertainty.\n\n## Working agreement\n\nUse the selected interview insights below as durable guidance. Ask before consequential external actions or sharing information outside the user''s project.\n', '[{"id":"direct-challenge","priority":20,"answers":{"relationship-role":"A thoughtful partner","challenge-support":"Challenge me directly"}}]', 'opencrane-clean-build', clock_timestamp()),
+    ('supportive-partner', 1, 'sha256:ffe3cf4b656e733d0eaf0a8d65d6e330c1e3bc2710f90e026ed30662022b2354', E'# SOUL.md\n\nYou are a thoughtful personal AI partner. Ground advice in the user''s stated goals, preserve their control over external actions, and be clear about uncertainty.\n\n## Working agreement\n\nUse the selected interview insights below as durable guidance. Ask before consequential external actions or sharing information outside the user''s project.\n', '[{"id":"supportive-challenge","priority":20,"answers":{"relationship-role":"A thoughtful partner","challenge-support":"Start supportively, then challenge me"}}]', 'opencrane-clean-build', clock_timestamp());

--- a/apps/opencrane/prisma/bootstrap/verify-persona-source-seeds.mjs
+++ b/apps/opencrane/prisma/bootstrap/verify-persona-source-seeds.mjs
@@ -1,0 +1,32 @@
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+
+const _BASELINE = new URL("./target-baseline.sql", import.meta.url);
+const _EXPECTED_TEMPLATES = new Set(["direct-partner", "supportive-partner"]);
+
+/** Decode the limited PostgreSQL E-string escape vocabulary used by the reviewed persona source. */
+function _DecodeEString(value)
+{
+	return value.replace(/''/gu, "'").replace(/\\n/gu, "\n");
+}
+
+/** Verify every clean-build SOUL template has an exact digest over its stored source content. */
+function _Verify()
+{
+	const baseline = readFileSync(_BASELINE, "utf8");
+	const matches = [...baseline.matchAll(/\('(?<id>direct-partner|supportive-partner)', 1, 'sha256:(?<digest>[a-f0-9]{64})', E'(?<content>(?:[^']|'')*)', '\[\{/gu)];
+	if (matches.length !== _EXPECTED_TEMPLATES.size) throw new Error("clean baseline must contain exactly the two reviewed persona SOUL templates");
+	const found = new Set();
+	for (const match of matches)
+	{
+		const id = match.groups?.id;
+		const digest = match.groups?.digest;
+		const content = match.groups?.content;
+		if (!id || !digest || content === undefined || !_EXPECTED_TEMPLATES.has(id) || found.has(id)) throw new Error("clean baseline persona template shape is invalid");
+		found.add(id);
+		const actual = createHash("sha256").update(_DecodeEString(content), "utf8").digest("hex");
+		if (actual !== digest) throw new Error(`persona template ${id} has a stale content digest`);
+	}
+}
+
+_Verify();

--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -89,6 +89,9 @@ Starts, appends answers to, and completes `PersonaInterview` and `PersonaIntervi
 canonical product database. It also reads a joined approval snapshot (profile · revision · interview
 · template · insights) and commits approval plus the active-persona pointer in one transaction.
 Postgres-level lifecycle behaviour is exercised by the `test:sql` target (`tests/persona-authority.sql`).
+On a clean database, the target baseline supplies one reviewed eight-question onboarding set and two
+reviewed `SOUL.md` templates. The relationship and challenge answers select the direct or supportive
+template deterministically; profiles and interview evidence remain user-owned runtime records.
 
 ## See also
 

--- a/libs/backend/agents/personal/personas/main/tests/persona-authority.sql
+++ b/libs/backend/agents/personal/personas/main/tests/persona-authority.sql
@@ -12,6 +12,16 @@ BEGIN
 END;
 $$;
 
+CREATE FUNCTION pg_temp.assert_true(condition BOOLEAN, message TEXT) RETURNS VOID LANGUAGE plpgsql AS $$
+BEGIN
+    IF condition IS DISTINCT FROM true THEN RAISE EXCEPTION 'FAIL: %', message; END IF;
+END;
+$$;
+
+SELECT pg_temp.assert_true((SELECT count(*) = 8 FROM "persona_questions" WHERE "question_set_id" = 'personal-agent-onboarding' AND "question_set_version" = 1), 'clean baseline seeds all eight onboarding questions');
+SELECT pg_temp.assert_true((SELECT "state" = 'reviewed' AND "reviewed_by" = 'opencrane-clean-build' FROM "persona_question_sets" WHERE "question_set_id" = 'personal-agent-onboarding' AND "version" = 1), 'clean baseline freezes the onboarding question set as reviewed');
+SELECT pg_temp.assert_true((SELECT count(*) = 2 AND bool_and("digest" = 'sha256:ffe3cf4b656e733d0eaf0a8d65d6e330c1e3bc2710f90e026ed30662022b2354') FROM "persona_soul_templates" WHERE "template_id" IN ('direct-partner', 'supportive-partner') AND "version" = 1), 'clean baseline seeds two content-addressed SOUL templates');
+
 INSERT INTO "persona_question_sets" ("question_set_id", "version") VALUES ('onboarding', 1);
 INSERT INTO "persona_questions" ("question_set_id", "question_set_version", "question_id", "category", "prompt", "ordinal") VALUES
 ('onboarding',1,'q1','relationship_role','Role?',1), ('onboarding',1,'q2','tone_language','Tone?',2),


### PR DESCRIPTION
## Why

Every new personal agent needs a durable, reviewable starting point for the onboarding interview the product will use to create its first `SOUL.md`. The interview source and template rules must be product-owned, not browser-provided.

## What changed

- seeds one reviewed eight-question personal-agent interview in the clean target baseline;
- seeds the direct and supportive `SOUL.md` templates, each content-addressed by SHA-256;
- selects the template from the declared relationship and challenge style in the reviewed rules; and
- adds a source-integrity check that fails when stored template content no longer matches its digest.

## What this enables

The following onboarding API and approval slices can safely use one server-owned questionnaire and choose a starting `SOUL.md` template. The user answers will later supply the personal insights that complete the persona draft. No UI is introduced here.

## Validation

- `npm run test:persona-source-seeds -w @opencrane/server`
- Prisma schema validation with a local placeholder `DATABASE_URL`
- `npm run test -w @opencrane/server` — 43 tests passed (rerun outside the sandbox because Supertest needs a localhost listener)
- `git diff --check`

Live Postgres authority SQL remains an explicit CI/reviewer gate because this workstation has neither a local Postgres service nor Docker access.

## Review

Claude Code is not authenticated on this PC, so no external Claude review was claimed or transmitted. This PR needs independent review before merge.