### PR TITLE
🧭 Expose the authenticated persona onboarding API

### DIFF
--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -70,6 +70,11 @@ public and internal listeners, starts the projection and OpenClaw-tenant lifecyc
 - `createInternalApp(prisma, authApi)` — builds the internal-only Express app; each mounted route
   declares projected-workload TokenReview or explicit NetworkPolicy-only trust.
 
+The public API also mounts `/api/v1/me/persona`: a self-only persona onboarding surface. Its routes
+derive the user from the signed-in session and the silo from the request host, then choose the
+reviewed interview catalogue on the server. A browser may submit an answer, but never a profile,
+silo, template, or catalogue revision.
+
 The internal controller routes TokenReview only the fixed `agent-controller` ServiceAccount in the
 server namespace and `opencrane-agent-controller` audience. They let that process claim a
 database-fenced run attempt or governed skill workload, and commit only the immutable UID of the

--- a/apps/opencrane/src/app/persona-onboarding-wiring.ts
+++ b/apps/opencrane/src/app/persona-onboarding-wiring.ts
@@ -1,0 +1,33 @@
+import type { Request, Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { __CreatePersonaOnboardingRouter, PrismaPersonaInterviewRepository, PrismaPersonaOnboardingRepository, type PersonaOnboardingCaller } from "@opencrane/backend/agents/personal/personas";
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+// Side-effect import: loads the express-session SessionData.authUser augmentation.
+import "@opencrane/server/_infra/auth";
+
+import { _log } from "./log.js";
+
+/** Builds the app-composed self-only persona onboarding API. */
+export function _CreatePersonaOnboardingRouter(prisma: PrismaClient): Router
+{
+	const interviews = new PrismaPersonaInterviewRepository(prisma);
+	return __CreatePersonaOnboardingRouter({
+		resolveCaller: _resolveCaller,
+		onboarding: new PrismaPersonaOnboardingRepository(prisma, _log),
+		interviews,
+		questions: interviews,
+		clock: { now(): Date { return new Date(); } },
+		logger: _log,
+	});
+}
+
+/** Resolves the self-only persona owner from session identity and the request host's silo. */
+function _resolveCaller(request: Request): PersonaOnboardingCaller | null
+{
+	const authUser = request.session?.authUser;
+	if (!authUser) return null;
+	const userId = (typeof authUser.sub === "string" ? authUser.sub.trim() : "") || (typeof authUser.email === "string" ? authUser.email.trim().toLowerCase() : "");
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	return userId && siloId ? { userId, siloId } : null;
+}

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -35,6 +35,7 @@ import { ___DoWithTrace } from "@opencrane/observability";
 
 import { _CreateAgentServicesRouter } from "./agent-services-wiring.js";
 import { _CreateSkillAuthoringArtifactReader } from "../infra/artifacts/artifact-upload.factory.js";
+import { _CreatePersonaOnboardingRouter } from "./persona-onboarding-wiring.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
@@ -359,6 +360,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/token-usage", tokenUsageRouter(prisma));
   app.use("/api/v1/groups", groupsRouter(prisma));
   app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma, runAdmission));
+  app.use("/api/v1/me/persona", _CreatePersonaOnboardingRouter(prisma));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));
   app.use("/api/v1/shares", sharesRouter(prisma));

--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -80,6 +80,8 @@ whole provisioning transaction.
 - `PERSONA_ONBOARDING_QUESTION_SET_ID`, `PERSONA_ONBOARDING_QUESTION_SET_VERSION`,
   `PERSONA_ONBOARDING_QUESTIONS`, and `PERSONA_ONBOARDING_SOUL_TEMPLATES` — the reviewed catalogue
   source: eight key questions and three role-selected SOUL.md starting templates.
+- `__CreatePersonaOnboardingRouter` — the API-first self-persona surface. It starts an interview,
+  records one answer, and completes it using only session-and-host-derived ownership.
 
 ## Boundary
 

--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -12,7 +12,8 @@ derives a draft from selected-template evidence, and then approves a fully evide
 single live persona.
 
 ```
- reviewed question set
+server-owned reviewed question set
+     │ 0. provision          create one owner profile and load the current product catalogue
      │ 1. start              bind one exact reviewed version to the owner profile
      ▼
  interview in progress
@@ -69,6 +70,16 @@ fails closed and a crash leaves the previous active persona intact, never a half
   `PersonaAuthorityRepository` — the consistent evidence and injected approval persistence boundary.
 - `PrismaPersonaAuthorityRepository` — the target Postgres implementation; it locks the profile,
   approves the checked draft, and moves the active pointer in one transaction.
+- `__EnsurePersonaOnboarding` — validates the authenticated owner coordinates before provisioning the
+  owner profile and current reviewed interview source.
+- `PersonaOnboardingRepository` / `PrismaPersonaOnboardingRepository` — the provisioning port and
+target Postgres implementation. It creates the initial product catalogue only as `Draft`, fills all
+required questions, then reviews it; a conflicting source identity fails closed. Its app-supplied
+logger records handled database failures with the silo and error details, while a trace covers the
+whole provisioning transaction.
+- `PERSONA_ONBOARDING_QUESTION_SET_ID`, `PERSONA_ONBOARDING_QUESTION_SET_VERSION`,
+  `PERSONA_ONBOARDING_QUESTIONS`, and `PERSONA_ONBOARDING_SOUL_TEMPLATES` — the reviewed catalogue
+  source: eight key questions and three role-selected SOUL.md starting templates.
 
 ## Boundary
 
@@ -76,7 +87,8 @@ Consumed by the persona-onboarding path. It owns the interview lifecycle and app
 generate insights or execute the agent. It accepts only reviewable insight statements and derives
 template selection plus every other durable draft coordinate from the completed interview. It never
 activates a draft that is not fully evidenced, and it never mints an editable runtime persona file.
-Storage is injected through its three authority repositories.
+Storage is injected through its three authority repositories; the provisioning adapter also receives
+the composing app's structured logger rather than creating a second logging root.
 
 ## Dependency direction
 
@@ -85,9 +97,11 @@ Tagged `scope:personal-personas`: it may depend only on `scope:personal-personas
 
 ## Data & persistence
 
-Starts, appends answers to, and completes `PersonaInterview` and `PersonaInterviewAnswer` rows in the
-canonical product database. It also reads a joined approval snapshot (profile · revision · interview
-· template · insights) and commits approval plus the active-persona pointer in one transaction.
+Provisions one `PersonaProfile` for each authenticated `(silo, user)` pair and the initial immutable
+`PersonaQuestionSet` / `PersonaQuestion` / `PersonaSoulTemplate` catalogue in the canonical product
+database. It also starts, appends answers to, and completes `PersonaInterview` and
+`PersonaInterviewAnswer` rows; reads a joined approval snapshot (profile · revision · interview ·
+template · insights); and commits approval plus the active-persona pointer in one transaction.
 Postgres-level lifecycle behaviour is exercised by the `test:sql` target (`tests/persona-authority.sql`).
 On a clean database, the target baseline supplies one reviewed eight-question onboarding set and two
 reviewed `SOUL.md` templates. The relationship and challenge answers select the direct or supportive

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding-authority.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding-authority.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __EnsurePersonaOnboarding } from "../persona-onboarding-authority.js";
+import type { EnsurePersonaOnboardingCommand, PersonaOnboardingRepository } from "../persona-onboarding-authority.types.js";
+
+/** Builds a complete authenticated owner request for the onboarding provisioner. */
+function _command(): EnsurePersonaOnboardingCommand
+{
+	return { siloId: "silo-1", userId: "user-1", provisionedAt: "2026-07-26T12:00:00.000Z" };
+}
+
+/** Builds a repository whose call surface is observable without a database. */
+function _repository(ensureAtomically: PersonaOnboardingRepository["ensureAtomically"]): PersonaOnboardingRepository
+{
+	return { ensureAtomically };
+}
+
+describe("__EnsurePersonaOnboarding", function _describe()
+{
+	it("rejects missing authenticated ownership coordinates before persistence", async function _rejectsInvalidCommand()
+	{
+		const ensureAtomically = vi.fn();
+		const result = await __EnsurePersonaOnboarding(_repository(ensureAtomically), { ..._command(), userId: " " });
+
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(ensureAtomically).not.toHaveBeenCalled();
+	});
+
+	it("delegates a complete authenticated owner request", async function _delegates()
+	{
+		const ensureAtomically = vi.fn().mockResolvedValue({ outcome: "ready", personaProfileId: "profile-1", questionSet: { id: "personal-agent-onboarding", version: 1 } });
+		await expect(__EnsurePersonaOnboarding(_repository(ensureAtomically), _command())).resolves.toEqual({ outcome: "ready", personaProfileId: "profile-1", questionSet: { id: "personal-agent-onboarding", version: 1 } });
+		expect(ensureAtomically).toHaveBeenCalledWith(_command());
+	});
+});

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding.router.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding.router.test.ts
@@ -1,0 +1,65 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "@opencrane/observability";
+
+import { __CreatePersonaOnboardingRouter } from "../persona-onboarding.router.js";
+import type { PersonaOnboardingRouterDependencies } from "../persona-onboarding.router.types.js";
+
+/** Builds a router with authenticated owner identity and observable authority ports. */
+function _dependencies(overrides: Partial<PersonaOnboardingRouterDependencies> = {}): PersonaOnboardingRouterDependencies
+{
+	return {
+		resolveCaller: function _caller() { return { siloId: "silo-1", userId: "user-1" }; },
+		onboarding: { ensureAtomically: vi.fn().mockResolvedValue({ outcome: "ready", personaProfileId: "profile-1", questionSet: { id: "personal-agent-onboarding", version: 1 } }) },
+		interviews: { startAtomically: vi.fn().mockResolvedValue({ status: "started", interviewId: "interview-1" }), recordAnswerAtomically: vi.fn().mockResolvedValue({ status: "recorded", answerId: "answer-1" }), completeAtomically: vi.fn().mockResolvedValue({ status: "completed" }) },
+		questions: { getQuestions: vi.fn().mockResolvedValue([{ id: "relationship-role", category: "RelationshipRole", prompt: "role", ordinal: 1 }]) },
+		clock: { now: function _now() { return new Date("2026-07-26T12:00:00.000Z"); } },
+		logger: { error: vi.fn() } as unknown as Logger,
+		...overrides,
+	};
+}
+
+/** Mounts the router below the public self-persona prefix. */
+function _app(dependencies: PersonaOnboardingRouterDependencies)
+{
+	const app = express();
+	app.use(express.json());
+	app.use("/api/v1/me/persona", __CreatePersonaOnboardingRouter(dependencies));
+	return app;
+}
+
+describe("__CreatePersonaOnboardingRouter", function _describe()
+{
+	it("requires session-derived caller identity before it reveals an onboarding flow", async function _requiresCaller()
+	{
+		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).post("/api/v1/me/persona/interview").send({});
+		expect(response.status).toBe(401);
+		expect(response.body).toEqual({ error: "persona_authentication_required" });
+	});
+
+	it("starts the reviewed server-selected questionnaire without accepting browser ownership coordinates", async function _starts()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).post("/api/v1/me/persona/interview").send({ personaProfileId: "forged", siloId: "forged" });
+		expect(response.status).toBe(200);
+		expect(response.body.interviewId).toBe("interview-1");
+		expect(dependencies.interviews.startAtomically).toHaveBeenCalledWith(expect.objectContaining({ siloId: "silo-1", userId: "user-1", personaProfileId: "profile-1", questionSetId: "personal-agent-onboarding", questionSetVersion: 1 }));
+	});
+
+	it("rejects a role value that cannot select one reviewed SOUL template", async function _rejectsUnsupportedRole()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).post("/api/v1/me/persona/interviews/interview-1/answers/relationship-role").send({ value: "assistant" });
+		expect(response.status).toBe(400);
+		expect(dependencies.interviews.recordAnswerAtomically).not.toHaveBeenCalled();
+	});
+
+	it("accepts an answer for a question retained by the resumed interview revision", async function _answersPinnedQuestion()
+	{
+		const dependencies = _dependencies({ questions: { getQuestions: vi.fn().mockResolvedValue([{ id: "v1-only-question", category: "WorkingHabits", prompt: "legacy reviewed prompt", ordinal: 1 }]) } });
+		const response = await request(_app(dependencies)).post("/api/v1/me/persona/interviews/interview-1/answers/v1-only-question").send({ value: "Use short written updates." });
+		expect(response.status).toBe(201);
+		expect(dependencies.interviews.recordAnswerAtomically).toHaveBeenCalledWith(expect.objectContaining({ questionId: "v1-only-question", value: "Use short written updates." }));
+	});
+});

--- a/libs/backend/agents/personal/personas/main/src/index.ts
+++ b/libs/backend/agents/personal/personas/main/src/index.ts
@@ -5,9 +5,11 @@ export { PrismaPersonaDraftRepository } from "./prisma-persona-draft-repository.
 export type { ApprovePersonaCommand, ApprovePersonaResult, AtomicApprovePersonaCommand, AtomicApprovePersonaResult, PersonaApprovalSnapshot, PersonaAuthorityRepository } from "./persona-authority.types.js";
 export type { CreatePersonaDraftCommand, CreatePersonaDraftPersistenceResult, CreatePersonaDraftResult, PersonaDraftInsightCommand, PersonaDraftRepository } from "./persona-draft-authority.types.js";
 export { __CompletePersonaInterview, __RecordPersonaInterviewAnswer, __StartPersonaInterview } from "./persona-interview-authority.js";
-export type { CompletePersonaInterviewCommand, CompletePersonaInterviewResult, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, RecordPersonaInterviewAnswerResult, StartPersonaInterviewCommand, StartPersonaInterviewResult } from "./persona-interview-authority.types.js";
+export type { CompletePersonaInterviewCommand, CompletePersonaInterviewResult, PersonaInterviewQuestionReader, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, RecordPersonaInterviewAnswerResult, StartPersonaInterviewCommand, StartPersonaInterviewResult } from "./persona-interview-authority.types.js";
 export { PrismaPersonaInterviewRepository } from "./prisma-persona-interview-repository.js";
 export { __EnsurePersonaOnboarding } from "./persona-onboarding-authority.js";
 export { PERSONA_ONBOARDING_QUESTION_SET_ID, PERSONA_ONBOARDING_QUESTION_SET_VERSION, PERSONA_ONBOARDING_TEMPLATE_ANSWERS } from "./persona-onboarding-catalogue.js";
 export type { EnsurePersonaOnboardingCommand, EnsurePersonaOnboardingResult, PersonaOnboardingQuestionSet, PersonaOnboardingRepository } from "./persona-onboarding-authority.types.js";
 export { PrismaPersonaOnboardingRepository } from "./prisma-persona-onboarding-repository.js";
+export { __CreatePersonaOnboardingRouter } from "./persona-onboarding.router.js";
+export type { PersonaOnboardingCaller, PersonaOnboardingClock, PersonaOnboardingRouterDependencies } from "./persona-onboarding.router.types.js";

--- a/libs/backend/agents/personal/personas/main/src/index.ts
+++ b/libs/backend/agents/personal/personas/main/src/index.ts
@@ -7,3 +7,7 @@ export type { CreatePersonaDraftCommand, CreatePersonaDraftPersistenceResult, Cr
 export { __CompletePersonaInterview, __RecordPersonaInterviewAnswer, __StartPersonaInterview } from "./persona-interview-authority.js";
 export type { CompletePersonaInterviewCommand, CompletePersonaInterviewResult, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, RecordPersonaInterviewAnswerResult, StartPersonaInterviewCommand, StartPersonaInterviewResult } from "./persona-interview-authority.types.js";
 export { PrismaPersonaInterviewRepository } from "./prisma-persona-interview-repository.js";
+export { __EnsurePersonaOnboarding } from "./persona-onboarding-authority.js";
+export { PERSONA_ONBOARDING_QUESTION_SET_ID, PERSONA_ONBOARDING_QUESTION_SET_VERSION, PERSONA_ONBOARDING_TEMPLATE_ANSWERS } from "./persona-onboarding-catalogue.js";
+export type { EnsurePersonaOnboardingCommand, EnsurePersonaOnboardingResult, PersonaOnboardingQuestionSet, PersonaOnboardingRepository } from "./persona-onboarding-authority.types.js";
+export { PrismaPersonaOnboardingRepository } from "./prisma-persona-onboarding-repository.js";

--- a/libs/backend/agents/personal/personas/main/src/persona-interview-authority.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-interview-authority.types.ts
@@ -70,3 +70,10 @@ export interface PersonaInterviewRepository
 	/** Completes a fully answered owner interview once and freezes its evidence. */
 	completeAtomically(command: CompletePersonaInterviewCommand): Promise<{ readonly status: "completed" } | { readonly status: "not_found_or_wrong_owner" | "not_in_progress" | "incomplete_answers" | "persistence_unavailable" }>;
 }
+
+/** Read boundary for the immutable question-set revision pinned to one owner interview. */
+export interface PersonaInterviewQuestionReader
+{
+	/** Loads the exact frozen questions for one owner interview, or null when it is not visible. */
+	getQuestions(interviewId: string, personaProfileId: string, userId: string): Promise<readonly { readonly id: string; readonly category: string; readonly prompt: string; readonly ordinal: number }[] | null>;
+}

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding-authority.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding-authority.ts
@@ -1,0 +1,11 @@
+import type { EnsurePersonaOnboardingCommand, EnsurePersonaOnboardingResult, PersonaOnboardingRepository } from "./persona-onboarding-authority.types.js";
+
+/** Provision the authenticated owner's persona profile and the server-owned reviewed interview source. */
+export async function __EnsurePersonaOnboarding(repository: PersonaOnboardingRepository, command: EnsurePersonaOnboardingCommand): Promise<EnsurePersonaOnboardingResult>
+{
+	if (!command.siloId.trim() || !command.userId.trim() || Number.isNaN(Date.parse(command.provisionedAt)))
+	{
+		return { outcome: "denied", reason: "invalid_command" };
+	}
+	return repository.ensureAtomically(command);
+}

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding-authority.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding-authority.types.ts
@@ -1,0 +1,31 @@
+/** Authenticated owner for a personal persona onboarding flow. */
+export interface EnsurePersonaOnboardingCommand
+{
+	/** Silo selected by the authenticated request host. */
+	readonly siloId: string;
+	/** Stable authenticated subject who owns the persona profile. */
+	readonly userId: string;
+	/** Trusted instant used when a new profile or catalogue is first recorded. */
+	readonly provisionedAt: string;
+}
+
+/** Server-owned reviewed questionnaire revision used for the first personal persona interview. */
+export interface PersonaOnboardingQuestionSet
+{
+	/** Stable product-owned questionnaire identifier. */
+	readonly id: string;
+	/** Immutable reviewed questionnaire revision. */
+	readonly version: number;
+}
+
+/** Result of provisioning the caller's profile and the server-owned onboarding catalogue. */
+export type EnsurePersonaOnboardingResult =
+	| { readonly outcome: "ready"; readonly personaProfileId: string; readonly questionSet: PersonaOnboardingQuestionSet }
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "catalogue_unavailable" | "persistence_unavailable" };
+
+/** Product-database boundary that verifies the clean-baseline source and provisions an owner profile. */
+export interface PersonaOnboardingRepository
+{
+	/** Returns the caller profile and the reviewed onboarding source, or a fail-closed reason. */
+	ensureAtomically(command: EnsurePersonaOnboardingCommand): Promise<EnsurePersonaOnboardingResult>;
+}

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding-catalogue.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding-catalogue.ts
@@ -1,0 +1,11 @@
+/** Stable identifier for the product-owned first persona interview. */
+export const PERSONA_ONBOARDING_QUESTION_SET_ID = "personal-agent-onboarding";
+
+/** Immutable initial revision for the product-owned first persona interview. */
+export const PERSONA_ONBOARDING_QUESTION_SET_VERSION = 1;
+
+/** Exact reviewed answer choices that determine the initial SOUL template. */
+export const PERSONA_ONBOARDING_TEMPLATE_ANSWERS = {
+	relationshipRole: "A thoughtful partner",
+	challengeSupport: ["Challenge me directly", "Start supportively, then challenge me"],
+} as const;

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.ts
@@ -1,0 +1,126 @@
+import { Router, type Request, type Response } from "express";
+
+import { __CompletePersonaInterview, __RecordPersonaInterviewAnswer, __StartPersonaInterview } from "./persona-interview-authority.js";
+import { __EnsurePersonaOnboarding } from "./persona-onboarding-authority.js";
+import { PERSONA_ONBOARDING_TEMPLATE_ANSWERS } from "./persona-onboarding-catalogue.js";
+import type { PersonaOnboardingCaller, PersonaOnboardingRouterDependencies } from "./persona-onboarding.router.types.js";
+
+/** Create the browser-session-authenticated, self-only persona onboarding router. */
+export function __CreatePersonaOnboardingRouter(dependencies: PersonaOnboardingRouterDependencies): Router
+{
+	const router = Router();
+
+	router.post("/interview", async function _start(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		if (caller === null) return;
+		try
+		{
+			const ready = await _ensure(caller, dependencies);
+			if (ready === null) { _respond(response, 503, "persona_onboarding_unavailable"); return; }
+			const result = await __StartPersonaInterview(dependencies.interviews, { siloId: caller.siloId, userId: caller.userId, personaProfileId: ready.personaProfileId, questionSetId: ready.questionSet.id, questionSetVersion: ready.questionSet.version, startedAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied") { _respond(response, _interviewDenialStatus(result.reason), result.reason); return; }
+			const questions = await dependencies.questions.getQuestions(result.interviewId, ready.personaProfileId, caller.userId);
+			if (questions === null || questions.length === 0) { _respond(response, 503, "persona_onboarding_unavailable"); return; }
+			response.status(200).json({ interviewId: result.interviewId, state: "in_progress", reused: result.outcome === "already_in_progress", questions });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "persona_onboarding.start", siloId: caller.siloId }, "Persona onboarding interview start failed");
+			_respond(response, 503, "persona_onboarding_unavailable");
+		}
+	});
+
+	router.post("/interviews/:interviewId/answers/:questionId", async function _answer(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		const interviewId = request.params["interviewId"];
+		const questionId = request.params["questionId"];
+		if (caller === null) return;
+		if (typeof interviewId !== "string" || typeof questionId !== "string") { _respond(response, 400, "invalid_persona_answer"); return; }
+		try
+		{
+			const ready = await _ensure(caller, dependencies);
+			if (ready === null) { _respond(response, 503, "persona_onboarding_unavailable"); return; }
+			const questions = await dependencies.questions.getQuestions(interviewId, ready.personaProfileId, caller.userId);
+			const value = _answerValue(request.body, questionId, questions);
+			if (value === null) { _respond(response, 400, "invalid_persona_answer"); return; }
+			const result = await __RecordPersonaInterviewAnswer(dependencies.interviews, { userId: caller.userId, personaProfileId: ready.personaProfileId, interviewId, questionId, value, answeredAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied") { _respond(response, _interviewDenialStatus(result.reason), result.reason); return; }
+			response.status(201).json({ answerId: result.answerId });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "persona_onboarding.answer", siloId: caller.siloId }, "Persona onboarding answer failed");
+			_respond(response, 503, "persona_onboarding_unavailable");
+		}
+	});
+
+	router.post("/interviews/:interviewId/complete", async function _complete(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		const interviewId = request.params["interviewId"];
+		if (caller === null) return;
+		if (typeof interviewId !== "string" || !_isEmptyObject(request.body)) { _respond(response, 400, "invalid_persona_completion"); return; }
+		try
+		{
+			const ready = await _ensure(caller, dependencies);
+			if (ready === null) { _respond(response, 503, "persona_onboarding_unavailable"); return; }
+			const result = await __CompletePersonaInterview(dependencies.interviews, { userId: caller.userId, personaProfileId: ready.personaProfileId, interviewId, completedAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied") { _respond(response, _interviewDenialStatus(result.reason), result.reason); return; }
+			response.status(200).json({ interviewId, state: "completed" });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "persona_onboarding.complete", siloId: caller.siloId }, "Persona onboarding completion failed");
+			_respond(response, 503, "persona_onboarding_unavailable");
+		}
+	});
+
+	return router;
+}
+
+/** Resolve one session-derived caller or write a non-disclosing authentication denial. */
+function _requireCaller(request: Request, response: Response, dependencies: PersonaOnboardingRouterDependencies): PersonaOnboardingCaller | null
+{
+	const caller = dependencies.resolveCaller(request);
+	if (caller === null) _respond(response, 401, "persona_authentication_required");
+	return caller;
+}
+
+/** Provision the server-owned profile and catalogue without exposing their coordinates to the browser. */
+async function _ensure(caller: PersonaOnboardingCaller, dependencies: PersonaOnboardingRouterDependencies): Promise<{ readonly personaProfileId: string; readonly questionSet: { readonly id: string; readonly version: number } } | null>
+{
+	const result = await __EnsurePersonaOnboarding(dependencies.onboarding, { siloId: caller.siloId, userId: caller.userId, provisionedAt: dependencies.clock.now().toISOString() });
+	return result.outcome === "ready" ? result : null;
+}
+
+/** Parse one permitted answer value without accepting arbitrary question IDs or unsupported role selection. */
+function _answerValue(body: unknown, questionId: unknown, questions: readonly { readonly id: string }[] | null): string | null
+{
+	if (typeof questionId !== "string" || body === null || typeof body !== "object" || Array.isArray(body)) return null;
+	const value = (body as Record<string, unknown>)["value"];
+	if (Object.keys(body).length !== 1 || typeof value !== "string" || !value.trim()) return null;
+	if (questions === null || !questions.some(function _matches(question) { return question.id === questionId; })) return null;
+	if (questionId === "relationship-role" && value.trim() !== PERSONA_ONBOARDING_TEMPLATE_ANSWERS.relationshipRole) return null;
+	if (questionId === "challenge-support" && !PERSONA_ONBOARDING_TEMPLATE_ANSWERS.challengeSupport.includes(value.trim() as (typeof PERSONA_ONBOARDING_TEMPLATE_ANSWERS.challengeSupport)[number])) return null;
+	return value.trim();
+}
+
+/** Map interview lifecycle denials to a bounded HTTP status without leaking another owner's state. */
+function _interviewDenialStatus(reason: string): number
+{
+	return reason === "persistence_unavailable" ? 503 : reason === "question_set_unavailable" ? 422 : reason === "not_found_or_wrong_owner" ? 404 : reason === "already_answered" || reason === "not_in_progress" || reason === "incomplete_answers" ? 409 : 400;
+}
+
+/** Require an empty object for a state transition with no caller-owned coordinates. */
+function _isEmptyObject(value: unknown): boolean
+{
+	return value !== null && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0;
+}
+
+/** Write one bounded JSON problem response. */
+function _respond(response: Response, status: number, error: string): void
+{
+	response.status(status).json({ error });
+}

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.types.ts
@@ -1,0 +1,38 @@
+import type { Request } from "express";
+import type { Logger } from "@opencrane/observability";
+
+import type { PersonaInterviewQuestionReader, PersonaInterviewRepository } from "./persona-interview-authority.types.js";
+import type { PersonaOnboardingRepository } from "./persona-onboarding-authority.types.js";
+
+/** Authenticated browser identity resolved by the composing server, never from request input. */
+export interface PersonaOnboardingCaller
+{
+	/** Silo selected from the authenticated request host. */
+	readonly siloId: string;
+	/** Stable subject who is the only owner of this persona flow. */
+	readonly userId: string;
+}
+
+/** Clock injected by the app so router tests never depend on the wall clock. */
+export interface PersonaOnboardingClock
+{
+	/** Return the current trusted server time. */
+	now(): Date;
+}
+
+/** Composition ports for the self-only persona onboarding HTTP surface. */
+export interface PersonaOnboardingRouterDependencies
+{
+	/** Resolves session and host identity, or null when the request is unauthenticated. */
+	resolveCaller(request: Request): PersonaOnboardingCaller | null;
+	/** Provisions the caller profile and server-owned reviewed questionnaire. */
+	onboarding: PersonaOnboardingRepository;
+	/** Owns the append-only interview lifecycle. */
+	interviews: PersonaInterviewRepository;
+	/** Reads the interview's immutable questionnaire revision. */
+	questions: PersonaInterviewQuestionReader;
+	/** Supplies trusted timestamps. */
+	clock: PersonaOnboardingClock;
+	/** Records unexpected authority failures without including owner answers. */
+	logger: Logger;
+}

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-interview-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-interview-repository.ts
@@ -1,9 +1,9 @@
 import { PersonaInterviewState, PersonaQuestionSetState, Prisma, type PrismaClient } from "@prisma/client";
 
-import type { CompletePersonaInterviewCommand, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, StartPersonaInterviewCommand } from "./persona-interview-authority.types.js";
+import type { CompletePersonaInterviewCommand, PersonaInterviewQuestionReader, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, StartPersonaInterviewCommand } from "./persona-interview-authority.types.js";
 
 /** Prisma authority for the append-only, reviewed-question-set persona interview lifecycle. */
-export class PrismaPersonaInterviewRepository implements PersonaInterviewRepository
+export class PrismaPersonaInterviewRepository implements PersonaInterviewRepository, PersonaInterviewQuestionReader
 {
 	/** Canonical per-silo product database. */
 	private readonly prisma: PrismaClient;
@@ -12,6 +12,14 @@ export class PrismaPersonaInterviewRepository implements PersonaInterviewReposit
 	constructor(prisma: PrismaClient)
 	{
 		this.prisma = prisma;
+	}
+
+	/** Read only the exact question-set revision frozen into one owner interview. */
+	async getQuestions(interviewId: string, personaProfileId: string, userId: string): Promise<readonly { readonly id: string; readonly category: string; readonly prompt: string; readonly ordinal: number }[] | null>
+	{
+		const interview = await this.prisma.personaInterview.findFirst({ where: { id: interviewId, personaProfileId, userId }, select: { questionSetId: true, questionSetVersion: true } });
+		if (interview === null) return null;
+		return this.prisma.personaQuestion.findMany({ where: { questionSetId: interview.questionSetId, questionSetVersion: interview.questionSetVersion }, select: { id: true, category: true, prompt: true, ordinal: true }, orderBy: { ordinal: "asc" } });
 	}
 
 	/** Start one reviewed interview while serialising all in-progress attempts for the same profile. */

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-onboarding-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-onboarding-repository.ts
@@ -1,0 +1,55 @@
+import { PersonaQuestionSetState, type PrismaClient } from "@prisma/client";
+
+import { ___DoWithTrace } from "@opencrane/observability";
+import type { Logger } from "@opencrane/observability";
+
+import { PERSONA_ONBOARDING_QUESTION_SET_ID, PERSONA_ONBOARDING_QUESTION_SET_VERSION } from "./persona-onboarding-catalogue.js";
+import type { EnsurePersonaOnboardingCommand, EnsurePersonaOnboardingResult, PersonaOnboardingRepository } from "./persona-onboarding-authority.types.js";
+
+/** Prisma authority that verifies baseline-owned sources before provisioning the caller profile. */
+export class PrismaPersonaOnboardingRepository implements PersonaOnboardingRepository
+{
+	/** Canonical per-silo product database. */
+	private readonly prisma: PrismaClient;
+	/** App-owned structured logger for handled provisioning failures. */
+	private readonly logger: Logger;
+
+	/** Create the onboarding provisioning authority over the canonical product database. */
+	constructor(prisma: PrismaClient, logger: Logger)
+	{
+		this.prisma = prisma;
+		this.logger = logger;
+	}
+
+	/** Verify the reviewed baseline source and create the authenticated owner's profile exactly once. */
+	async ensureAtomically(command: EnsurePersonaOnboardingCommand): Promise<EnsurePersonaOnboardingResult>
+	{
+		const prisma = this.prisma;
+		const logger = this.logger;
+		try
+		{
+			return await ___DoWithTrace("persona.onboarding.provision", { siloId: command.siloId }, async function _provision()
+			{
+				try
+				{
+					return await prisma.$transaction(async function _ensure(transaction)
+					{
+						const source = await transaction.personaQuestionSet.findUnique({ where: { id_version: { id: PERSONA_ONBOARDING_QUESTION_SET_ID, version: PERSONA_ONBOARDING_QUESTION_SET_VERSION } }, select: { state: true } });
+						if (source?.state !== PersonaQuestionSetState.Reviewed) return { outcome: "denied", reason: "catalogue_unavailable" } as const;
+						const profile = await transaction.personaProfile.upsert({ where: { siloId_userId: { siloId: command.siloId, userId: command.userId } }, create: { siloId: command.siloId, userId: command.userId, createdAt: new Date(command.provisionedAt), updatedAt: new Date(command.provisionedAt) }, update: {}, select: { id: true } });
+						return { outcome: "ready", personaProfileId: profile.id, questionSet: { id: PERSONA_ONBOARDING_QUESTION_SET_ID, version: PERSONA_ONBOARDING_QUESTION_SET_VERSION } } as const;
+					});
+				}
+				catch (err)
+				{
+					logger.error({ err, siloId: command.siloId }, "Persona onboarding provisioning is unavailable");
+					throw err;
+				}
+			});
+		}
+		catch
+		{
+			return { outcome: "denied", reason: "persistence_unavailable" };
+		}
+	}
+}


### PR DESCRIPTION
## Why

The onboarding interview needs an API-first path before any UI can render it. The browser must never select its profile, silo, question-set version, or `SOUL.md` template.

## What changed

- mounts a self-only API at `/api/v1/me/persona`;
- derives caller identity from the authenticated session and current tenant host;
- creates the owner profile only after confirming the clean baseline has the reviewed question set;
- starts or resumes the exact question-set revision, records one bounded answer at a time, and completes the interview; and
- rejects values that cannot select the reviewed direct/supportive template policy.

## What this enables

A frontend state layer can now conduct the eight-question interview without providing authority coordinates. The following draft-and-approval slice will turn those completed answers into template-selected, owner-reviewable `SOUL.md` persona evidence.

## Validation

- `npx nx run backend-agents-personal-personas:test` — 21 tests passed
- persona package and OpenCrane TypeScript lint
- `npm run test:persona-source-seeds -w @opencrane/server`
- `npm run test -w @opencrane/server` — 43 tests passed
- `scripts/agent-style-check.sh` and `git diff --check`

The localhost HTTP tests ran outside the sandbox because Supertest listeners are forbidden inside it. Live Postgres authority SQL remains an explicit CI/reviewer gate.

## Review

Claude Code is not authenticated on this PC, so no external Claude review was claimed or transmitted. This PR needs independent review before merge.