### PR TITLE
⚡ Phase E: seal runtime input for reconnect delivery

### DIFF
--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -218,10 +218,10 @@ function _CreateExternalActionRunner(prisma: PrismaClient): RuntimeExternalActio
 function _CreatePersonalRunInputCompiler(): RunInputCompiler
 {
 	const compile = __CreatePrismaRunInputCompiler();
-	return async function _compilePersonalInput(snapshot: RunInputSnapshot, transaction: Prisma.TransactionClient)
+	return async function _compilePersonalInput(snapshot: RunInputSnapshot, attempt: number, transaction: Prisma.TransactionClient)
 	{
 		// 1. Compile the immutable snapshot normally before composition adds any built-in descriptor.
-		const input = await compile(snapshot, transaction);
+		const input = await compile(snapshot, attempt, transaction);
 		// 2. Exclude non-conversation and non-persona snapshots without inferring a personal service.
 		if (!__IsUpgradeSessionAvailable(snapshot)) return input;
 		// 3. Prove the current service kind in the same compiler transaction; snapshot fields alone are insufficient.

--- a/libs/backend/agents/execution/protocol/README.md
+++ b/libs/backend/agents/execution/protocol/README.md
@@ -90,7 +90,10 @@ records needed to compile a dispatch. The dispatch adapter owns two Postgres mod
 `runtime.prisma`: `RuntimeCommandStream` (one per run
 attempt — the lease fence, the bound runtime instance, the next command sequence, and accepted
 candidate ids) and `RuntimeDispatchedCommand` (one row per minted command, whose ids are exactly the
-attempt's accepted command set). Their clean-database schema lives in the OpenCrane-owned target
+attempt's accepted command set). A start command stores its sealed compiled input with that row, so a
+reconnecting runtime receives the identical command without re-reading or recompiling persona, prompt,
+tools, or model routing. Its execution attempt is supplied from the locked `AgentRun`; it is never
+derived from the snapshot schema version. Their clean-database schema lives in the OpenCrane-owned target
 baseline. `RuntimeChildRunSpawnDispatch` is created as pending in the same transaction as candidate
 admission, then stores the terminal completion or refusal; a reconnect sees pending or replays that
 exact outcome instead of reconsidering it. It reads the assignment, run, and immutable snapshot rows owned by the execution-run and

--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-run-input-compiler.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-run-input-compiler.test.ts
@@ -35,12 +35,12 @@ describe("Prisma run-input compiler model routes", function _DescribePrismaRunIn
 	it("uses the deployment sealed in the snapshot after checking the exact definition has not changed", async function _UsesSealedDeployment()
 	{
 		const compile = __CreatePrismaRunInputCompiler();
-		await expect(compile(_Snapshot({ modelDefinitionId: "model-1", litellmModelId: "deployment-a" }), _Transaction("deployment-a"))).resolves.toMatchObject({ model: { modelAlias: "deployment-a" } });
+		await expect(compile(_Snapshot({ modelDefinitionId: "model-1", litellmModelId: "deployment-a" }), 1, _Transaction("deployment-a"))).resolves.toMatchObject({ model: { modelAlias: "deployment-a" } });
 	});
 
 	it("refuses a route whose registered definition now points to another deployment", async function _RefusesRouteDrift()
 	{
 		const compile = __CreatePrismaRunInputCompiler();
-		await expect(compile(_Snapshot({ modelDefinitionId: "model-1", litellmModelId: "deployment-a" }), _Transaction("deployment-b"))).rejects.toThrow("changed or unavailable model definition");
+		await expect(compile(_Snapshot({ modelDefinitionId: "model-1", litellmModelId: "deployment-a" }), 1, _Transaction("deployment-b"))).rejects.toThrow("changed or unavailable model definition");
 	});
 });

--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
@@ -1,8 +1,11 @@
+import { createHash } from "node:crypto";
+
 import type { PrismaClient } from "@prisma/client";
 import type { Logger } from "@opencrane/observability";
 import { describe, expect, it, vi } from "vitest";
 
 import { AGENT_RUNTIME_PROTOCOL_V1, type CompiledRunInput, type RuntimeCandidate, type RuntimeCommandEnvelope } from "@opencrane/contracts";
+import { ___CanonicalizeJson } from "@opencrane/util";
 
 import { PrismaRuntimeDispatchAuthority } from "../prisma-runtime-dispatch-authority.js";
 import type { RunInputCompiler, RuntimeChildRunSpawnRunner, RuntimeExternalActionRunner, RuntimeStreamWorkloadIdentity } from "../prisma-runtime-dispatch-authority.types.js";
@@ -112,6 +115,8 @@ interface FakeOptions
 	readonly snapshotVersion?: number;
 	/** Makes the persisted identity omit its required organization coordinate. */
 	readonly omitOrganizationId?: boolean;
+	/** Optional compiler used to prove durable start-command redelivery does not rehydrate input. */
+	readonly compileRunInput?: RunInputCompiler;
 }
 
 /** Minimal in-memory Prisma double covering only the reads and writes the adapter performs. */
@@ -222,16 +227,17 @@ function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; streams: Fak
 }
 
 /** Deterministic fake compiler: same snapshot digest always yields byte-identical compiled input. */
-const _compileRunInput: RunInputCompiler = async function _compile(snapshot): Promise<CompiledRunInput>
+const _compileRunInput: RunInputCompiler = async function _compile(snapshot, attempt): Promise<CompiledRunInput>
 {
-	return { promptCompilerVersion: "v1", runId: snapshot.runId, attempt: 1, instructions: "compiled", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null }, digest: `sha256:${snapshot.digest}` };
+	const unsealed = { promptCompilerVersion: "v1", runId: snapshot.runId, attempt, instructions: "compiled", messages: [], tools: [], model: { modelAlias: "silo-default", maxOutputTokens: null }, budget: { maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null } };
+	return { ...unsealed, digest: `sha256:${createHash("sha256").update(___CanonicalizeJson(unsealed), "utf8").digest("hex")}` };
 };
 
 /** Build the adapter under test over a fake with the requested durable state. */
 function _authority(options: FakeOptions)
 {
 	const fake = _fakePrisma(options);
-	return { authority: new PrismaRuntimeDispatchAuthority(fake.prisma, { namespace: "runtime-ns", commandTtlMilliseconds: 60_000, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _compileRunInput, options.externalActionRunner, options.clock ?? _clock, options.logger, options.childRunSpawnRunner), ...fake };
+	return { authority: new PrismaRuntimeDispatchAuthority(fake.prisma, { namespace: "runtime-ns", commandTtlMilliseconds: 60_000, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, options.compileRunInput ?? _compileRunInput, options.externalActionRunner, options.clock ?? _clock, options.logger, options.childRunSpawnRunner), ...fake };
 }
 
 /** Build a runtime event candidate bound to a dispatched command. */
@@ -258,7 +264,7 @@ describe("PrismaRuntimeDispatchAuthority", function _describeDispatchAuthority()
 		expect(command?.sequence).toBe(1);
 		expect(context.commands).toHaveLength(1);
 		expect(context.streams[0]?.nextCommandSequence).toBe(2);
-		expect(command?.kind === "start_attempt" ? command.payload.compiledInput.digest : null).toBe("sha256:sha256:snap");
+		expect(command?.kind === "start_attempt" ? command.payload.compiledInput.digest : null).toMatch(/^sha256:[a-f0-9]{64}$/);
 	});
 
 	it("refuses legacy or organization-less persisted snapshots before issuing runtime work", async function _refusesLegacySnapshot()
@@ -274,14 +280,35 @@ describe("PrismaRuntimeDispatchAuthority", function _describeDispatchAuthority()
 
 	it("idempotently redelivers the same start command to a reconnecting instance", async function _redelivers()
 	{
-		const context = _authority({ runState: "Running" });
+		let compilationCount = 0;
+		const context = _authority({ runState: "Running", compileRunInput: async function _countedCompile(snapshot, attempt, transaction): Promise<CompiledRunInput>
+		{
+			compilationCount += 1;
+			return _compileRunInput(snapshot, attempt, transaction);
+		} });
 
 		const first = await context.authority.__NextCommand(_identity, _open, 0);
 		const redelivered = await context.authority.__NextCommand(_identity, _open, 0);
 
 		expect(redelivered).toEqual(first);
+		expect(compilationCount).toBe(1);
 		expect(context.commands).toHaveLength(1);
 		expect(context.streams[0]?.nextCommandSequence).toBe(2);
+	});
+
+	it("refuses and logs a digest-mismatched stored start payload instead of recompiling it", async function _refusesInvalidStoredPayload()
+	{
+		const logger = { warn: vi.fn() } as unknown as Logger;
+		const context = _authority({ runState: "Running", logger });
+		await context.authority.__NextCommand(_identity, _open, 0);
+		const stored = context.commands[0];
+		if (stored === undefined || stored.payload === undefined || typeof stored.payload !== "object" || Array.isArray(stored.payload)) throw new Error("expected stored start command payload");
+		const compiledInput = (stored.payload as { readonly compiledInput?: Record<string, unknown> }).compiledInput;
+		if (compiledInput === undefined) throw new Error("expected stored compiled input");
+		stored.payload = { ...stored.payload, compiledInput: { ...compiledInput, instructions: "altered" } };
+
+		expect(await context.authority.__NextCommand(_identity, _open, 0)).toBeNull();
+		expect(logger.warn).toHaveBeenCalledWith({ runId: "run-1", attempt: 1, commandId: stored.commandId, sequence: 1, failureKind: "stored_command_payload_invalid" }, "runtime dispatch refused invalid persisted command payload");
 	});
 
 	it("returns null once the sole start command is already at the connection frontier", async function _noneDue()

--- a/libs/backend/agents/execution/protocol/src/prisma-run-input-compiler.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-run-input-compiler.ts
@@ -21,9 +21,9 @@ const _MESSAGE_ROLE: Record<string, CompiledMessage["role"]> = { User: "user", A
  */
 export function __CreatePrismaRunInputCompiler(): RunInputCompiler
 {
-	return function _compile(snapshot: RunInputSnapshot, transaction: Prisma.TransactionClient): Promise<CompiledRunInput>
+	return function _compile(snapshot: RunInputSnapshot, attempt: number, transaction: Prisma.TransactionClient): Promise<CompiledRunInput>
 	{
-		return __CompileRunInput(snapshot, _repositories(transaction));
+		return __CompileRunInput(snapshot, attempt, _repositories(transaction));
 	};
 }
 

--- a/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
@@ -5,6 +5,7 @@ import { AgentRunState as PrismaAgentRunState, AgentRunTerminalReason, ApprovalR
 import { AGENT_RUNTIME_PROTOCOL_V1, type CancelAttemptCommand, type CompiledRunInput, type ResumeAttemptCommand, type RunInputSnapshot, type RunInputSnapshotIdentity, type RuntimeAssignment, type RuntimeCandidate, type RuntimeChildRunSpawnCandidate, type RuntimeCommand, type RuntimeCommandEnvelope, type RuntimeExternalActionCandidate, type RuntimeStreamOpen } from "@opencrane/contracts";
 import type { JsonValue } from "@opencrane/util";
 import { ___CreateLogger, ___DoWithTrace, type Logger } from "@opencrane/observability";
+import { __VerifyCompiledRunInput } from "@opencrane/backend/agents/runtime/prompt-compiler";
 
 import { __AdmitRuntimeCandidate, __AdmitRuntimeCommand } from "./runtime-protocol-authority.js";
 import type { RuntimeAdmissionRunState, RuntimeAttemptAuthority, RuntimeProtocolClock } from "./runtime-protocol-authority.types.js";
@@ -70,7 +71,7 @@ interface DispatchedCommandRow
 	readonly kind: RuntimeCommandKind;
 	/** Server-owned lease fence carried by the frame. */
 	readonly fence: number;
-	/** Persisted resume payload for a resume frame, so redelivery survives resume-token consumption. */
+	/** Persisted start input or resume payload, so redelivery avoids mutable-source rehydration. */
 	readonly payload: Prisma.JsonValue | null;
 	/** Canonical issuance instant of the minted frame. */
 	readonly issuedAt: Date;
@@ -125,9 +126,10 @@ export class PrismaRuntimeDispatchAuthority
 		const config = this.config;
 		const clock = this.clock;
 		const compileRunInput = this.compileRunInput;
+		const log = this.log;
 		return ___DoWithTrace("runtime_dispatch.command.next", { namespace: identity.namespace }, async function _traceNext(): Promise<RuntimeCommandEnvelope | null>
 		{
-			return _nextCommand(prisma, config, clock, compileRunInput, identity, open, afterSequence);
+			return _nextCommand(prisma, config, clock, compileRunInput, log, identity, open, afterSequence);
 		});
 	}
 
@@ -275,7 +277,7 @@ function _configIsValid(config: RuntimeDispatchAuthorityConfig): boolean
 }
 
 /** Mint or redeliver one command for the connected runtime inside a single locked transaction. */
-async function _nextCommand(prisma: PrismaClient, config: RuntimeDispatchAuthorityConfig, clock: RuntimeProtocolClock, compileRunInput: RunInputCompiler, identity: RuntimeStreamWorkloadIdentity, open: RuntimeStreamOpen, afterSequence: number): Promise<RuntimeCommandEnvelope | null>
+async function _nextCommand(prisma: PrismaClient, config: RuntimeDispatchAuthorityConfig, clock: RuntimeProtocolClock, compileRunInput: RunInputCompiler, log: Logger, identity: RuntimeStreamWorkloadIdentity, open: RuntimeStreamOpen, afterSequence: number): Promise<RuntimeCommandEnvelope | null>
 {
 	if (!Number.isSafeInteger(afterSequence) || afterSequence < 0) return null;
 	return prisma.$transaction(async function _dispatch(transaction: Prisma.TransactionClient): Promise<RuntimeCommandEnvelope | null>
@@ -297,10 +299,14 @@ async function _nextCommand(prisma: PrismaClient, config: RuntimeDispatchAuthori
 		const stored = commands.find(function _atTarget(row) { return row.sequence === targetSequence; });
 		if (stored)
 		{
-			// Rebuild the exact body from immutable state (or the stored resume payload) so a redelivered
-			// frame is byte-identical even after the single-use resume token has been consumed.
-			const extras = await _storedCommandExtras(transaction, context, stored, compileRunInput);
-			if (extras === null) return null;
+			// Rebuild the exact body from immutable state and the stored payload so a redelivered frame is
+			// byte-identical without recompiling its frozen start input or reusing a consumed resume token.
+			const extras = _storedCommandExtras(context, stored);
+			if (extras === null)
+			{
+				log.warn({ runId: context.runId, attempt: context.attempt, commandId: stored.commandId, sequence: stored.sequence, failureKind: "stored_command_payload_invalid" }, "runtime dispatch refused invalid persisted command payload");
+				return null;
+			}
 			const envelope = _rebuildEnvelope(context, runtimeInstanceId, stored, extras);
 			const admission = __AdmitRuntimeCommand({ authority, command: envelope, clock });
 			return admission.outcome === "idempotent" ? envelope : null;
@@ -318,8 +324,8 @@ async function _nextCommand(prisma: PrismaClient, config: RuntimeDispatchAuthori
 		const admission = __AdmitRuntimeCommand({ authority, command: envelope, clock });
 		if (admission.outcome !== "accepted") return null;
 
-		// 5. Persist the accepted command (with any resume payload) and advance the sequence under lock.
-		await transaction.runtimeDispatchedCommand.create({ data: { runId: context.runId, attempt: context.attempt, sequence: envelope.sequence, commandId: envelope.commandId, kind, fence: envelope.fence, payload: extras.resume === null ? Prisma.DbNull : extras.resume as unknown as Prisma.InputJsonValue, issuedAt: new Date(envelope.issuedAt), expiresAt: new Date(envelope.expiresAt) } });
+		// 5. Persist the accepted command body and advance the sequence under lock for exact reconnect replay.
+		await transaction.runtimeDispatchedCommand.create({ data: { runId: context.runId, attempt: context.attempt, sequence: envelope.sequence, commandId: envelope.commandId, kind, fence: envelope.fence, payload: _payloadForPersistence(kind, extras), issuedAt: new Date(envelope.issuedAt), expiresAt: new Date(envelope.expiresAt) } });
 		const advanced = await transaction.runtimeCommandStream.updateMany({ where: { runId: context.runId, attempt: context.attempt, nextCommandSequence: stream.nextCommandSequence }, data: { nextCommandSequence: admission.nextCommandSequence } });
 		if (advanced.count !== 1) throw new Error("runtime dispatch lost its command sequence fence");
 		// Consume the single-use resume tokens so a duplicate resume can never re-dispatch the results.
@@ -366,7 +372,7 @@ async function _dispatchExternalAction(prisma: PrismaClient, compileRunInput: Ru
 		{
 			const context = await _loadContext(transaction, identity);
 			if (context === null || context.runId !== candidate.runId || context.attempt !== candidate.attempt) return null;
-			const compiled = await compileRunInput(context.snapshot, transaction);
+			const compiled = await compileRunInput(context.snapshot, context.attempt, transaction);
 			return { snapshot: context.snapshot, tools: compiled.tools };
 		});
 	}
@@ -568,7 +574,7 @@ async function _mintCommandExtras(transaction: Prisma.TransactionClient, context
 {
 	if (kind === RuntimeCommandKind.StartAttempt)
 	{
-		const compiledInput = await compileRunInput(context.snapshot, transaction);
+		const compiledInput = await compileRunInput(context.snapshot, context.attempt, transaction);
 		return { compiledInput, resume: null, resumeApprovalIds: [], cancelReason: "cancelled" };
 	}
 	if (kind === RuntimeCommandKind.CancelAttempt) return { compiledInput: null, resume: null, resumeApprovalIds: [], cancelReason: _cancelReason(context.terminalReason) };
@@ -577,18 +583,44 @@ async function _mintCommandExtras(transaction: Prisma.TransactionClient, context
 	return { compiledInput: null, resume: loaded.resume, resumeApprovalIds: loaded.approvalIds, cancelReason: "cancelled" };
 }
 
-/** Rebuild the body data for a stored command on redelivery, reading a resume payload from its row. */
-async function _storedCommandExtras(transaction: Prisma.TransactionClient, context: RuntimeDispatchContext, row: DispatchedCommandRow, compileRunInput: RunInputCompiler): Promise<CommandExtras | null>
+/** Rebuild the body data for a stored command on redelivery without compiling mutable source records. */
+function _storedCommandExtras(context: RuntimeDispatchContext, row: DispatchedCommandRow): CommandExtras | null
 {
 	if (row.kind === RuntimeCommandKind.StartAttempt)
 	{
-		const compiledInput = await compileRunInput(context.snapshot, transaction);
+		const compiledInput = _compiledInputFromPayload(row.payload, context);
+		if (compiledInput === null) return null;
 		return { compiledInput, resume: null, resumeApprovalIds: [], cancelReason: "cancelled" };
 	}
 	if (row.kind === RuntimeCommandKind.CancelAttempt) return { compiledInput: null, resume: null, resumeApprovalIds: [], cancelReason: _cancelReason(context.terminalReason) };
 	const resume = _resumeFromPayload(row.payload);
 	if (resume === null) return null;
 	return { compiledInput: null, resume, resumeApprovalIds: [], cancelReason: "cancelled" };
+}
+
+/** Store only the command-specific body required for byte-identical redelivery. */
+function _payloadForPersistence(kind: RuntimeCommandKind, extras: CommandExtras): Prisma.InputJsonValue | typeof Prisma.DbNull
+{
+	if (kind === RuntimeCommandKind.StartAttempt)
+	{
+		if (extras.compiledInput === null) throw new Error("runtime dispatch requires compiled input for persisted start command");
+		return { compiledInput: extras.compiledInput } as unknown as Prisma.InputJsonValue;
+	}
+	if (kind === RuntimeCommandKind.ResumeAttempt)
+	{
+		if (extras.resume === null) throw new Error("runtime dispatch requires resume input for persisted resume command");
+		return extras.resume as unknown as Prisma.InputJsonValue;
+	}
+	return Prisma.DbNull;
+}
+
+/** Parse the sealed start payload and refuse database corruption rather than recompiling it differently. */
+function _compiledInputFromPayload(payload: Prisma.JsonValue | null, context: RuntimeDispatchContext): CompiledRunInput | null
+{
+	if (payload === null || typeof payload !== "object" || Array.isArray(payload)) return null;
+	const compiledInput = (payload as { readonly [key: string]: JsonValue })["compiledInput"];
+	const verified = __VerifyCompiledRunInput(compiledInput);
+	return verified !== null && verified.runId === context.runId && verified.attempt === context.attempt ? verified : null;
 }
 
 /** Parse a persisted resume payload back into the exact frame it was minted from. */

--- a/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.types.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.types.ts
@@ -6,11 +6,11 @@ import type { CompiledRunInput, CompiledToolDefinition, RunInputSnapshot, Runtim
  * Injected control-plane compiler that hydrates an immutable snapshot into the literal compiled
  * input carried on `start_attempt`.
  *
- * The dispatch authority calls it inside the same locked transaction that loads the snapshot, so it
+ * The dispatch authority calls it inside the same locked transaction that loads the snapshot and run attempt, so it
  * reads only immutable records and must return byte-identical output for a given snapshot on every
  * mint and idempotent redelivery. The runtime treats the returned payload as opaque.
  */
-export type RunInputCompiler = (snapshot: RunInputSnapshot, transaction: Prisma.TransactionClient) => Promise<CompiledRunInput>;
+export type RunInputCompiler = (snapshot: RunInputSnapshot, attempt: number, transaction: Prisma.TransactionClient) => Promise<CompiledRunInput>;
 
 /** Fixed, server-owned policy for minting and expiring runtime command frames. */
 export interface RuntimeDispatchAuthorityConfig

--- a/libs/backend/agents/runtime/prompt-compiler/main/README.md
+++ b/libs/backend/agents/runtime/prompt-compiler/main/README.md
@@ -9,7 +9,8 @@ holds only ID references plus a `promptCompilerVersion` — into the literal `Co
 runtime executes. It dereferences persona, message, tool, memory, artifact, and skill records
 through injected control-plane read ports, resolves the model route and literal budget numbers,
 orders every collection canonically, stamps its own version, and seals the result with a SHA-256
-digest over the canonical payload.
+digest over the canonical payload. The caller supplies the current `AgentRun` attempt separately:
+the snapshot schema version describes the record format and is never used as an execution attempt.
 
 Because every referenced record is immutable, the same snapshot compiles to byte-identical output
 across process restarts. The compiler holds no database of its own: the app injects the read ports
@@ -33,9 +34,12 @@ than being silently compiled by a mismatched version.
 
 ## Public surface
 
-- `__CompileRunInput` — hydrate a snapshot into the literal, digest-sealed `CompiledRunInput`.
+- `__CompileRunInput` — hydrate a snapshot and its current run attempt into the literal, digest-sealed
+  `CompiledRunInput`.
 - `__AppendCompiledTool` — append one composition-owned first-party tool, canonically re-order it,
   and re-seal the literal input without mutating the snapshot.
+- `__VerifyCompiledRunInput` — verify a persisted literal input's complete wire shape and digest before
+  a reconnecting runtime receives it.
 - `PROMPT_COMPILER_VERSION` — the exact version this compiler stamps and requires on every snapshot.
 - `PromptCompilerRepositories` — the injected read ports the runtime authority implements over control-plane
   persona, conversation, tool, memory, artifact, skill, and model-routing records.

--- a/libs/backend/agents/runtime/prompt-compiler/main/src/__tests__/prompt-compiler.test.ts
+++ b/libs/backend/agents/runtime/prompt-compiler/main/src/__tests__/prompt-compiler.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { CompiledModelRoute, CompiledToolDefinition, RunInputSnapshot } from "@opencrane/contracts";
 import type { JsonValue } from "@opencrane/util";
 
-import { PROMPT_COMPILER_VERSION, __AppendCompiledTool, __CompileRunInput } from "../prompt-compiler.js";
+import { PROMPT_COMPILER_VERSION, __AppendCompiledTool, __CompileRunInput, __VerifyCompiledRunInput } from "../prompt-compiler.js";
 import type { PromptCompilerRepositories } from "../prompt-compiler.types.js";
 
 /** Build a snapshot fixture whose references the fake repositories can resolve. */
@@ -66,36 +66,43 @@ describe("__CompileRunInput", function _describeCompiler()
 {
 	it("stamps the compiler version and preserves message order", async function _stampsVersion()
 	{
-		const compiled = await __CompileRunInput(_snapshot(), _repositories());
+		const compiled = await __CompileRunInput(_snapshot(), 1, _repositories());
 
 		expect(compiled.promptCompilerVersion).toBe(PROMPT_COMPILER_VERSION);
 		expect(compiled.messages.map(function _content(m): string { return m.content; })).toEqual(["msg:m-1", "msg:m-2"]);
 	});
 
+	it("uses the run attempt rather than the independent snapshot schema version", async function _usesRunAttempt()
+	{
+		const compiled = await __CompileRunInput(_snapshot({ snapshotVersion: 2 }), 1, _repositories());
+
+		expect(compiled.attempt).toBe(1);
+	});
+
 	it("orders tools by name regardless of grant iteration order", async function _ordersTools()
 	{
-		const compiled = await __CompileRunInput(_snapshot(), _repositories());
+		const compiled = await __CompileRunInput(_snapshot(), 1, _repositories());
 
 		expect(compiled.tools.map(function _name(t): string { return t.name; })).toEqual(["alpha", "zulu"]);
 	});
 
 	it("resolves literal budget numbers from the opaque budget policy", async function _resolvesBudget()
 	{
-		const compiled = await __CompileRunInput(_snapshot(), _repositories());
+		const compiled = await __CompileRunInput(_snapshot(), 1, _repositories());
 
 		expect(compiled.budget).toEqual({ maxModelTurns: 6, maxTotalTokens: 4096, maxCostUsdMicros: 500000, maxToolInvocations: 8, wallClockDeadlineEpochMs: 1_800_000_000_000 });
 	});
 
 	it("nulls malformed or absent budget limits rather than inventing them", async function _nullsBadBudget()
 	{
-		const compiled = await __CompileRunInput(_snapshot({ budgetPolicy: { maxTotalTokens: "lots" as unknown as JsonValue } }), _repositories());
+		const compiled = await __CompileRunInput(_snapshot({ budgetPolicy: { maxTotalTokens: "lots" as unknown as JsonValue } }), 1, _repositories());
 
 		expect(compiled.budget).toEqual({ maxModelTurns: null, maxTotalTokens: null, maxCostUsdMicros: null, maxToolInvocations: null, wallClockDeadlineEpochMs: null });
 	});
 
 	it("assembles persona, memory, artifact, and skill sections in canonical order", async function _assembles()
 	{
-		const compiled = await __CompileRunInput(_snapshot(), _repositories());
+		const compiled = await __CompileRunInput(_snapshot(), 1, _repositories());
 
 		expect(compiled.instructions).toBe(
 			"You are a careful assistant.\n\n"
@@ -107,8 +114,8 @@ describe("__CompileRunInput", function _describeCompiler()
 
 	it("produces byte-identical output for the same snapshot across repeated compilations", async function _deterministic()
 	{
-		const first = await __CompileRunInput(_snapshot(), _repositories());
-		const second = await __CompileRunInput(_snapshot(), _repositories());
+		const first = await __CompileRunInput(_snapshot(), 1, _repositories());
+		const second = await __CompileRunInput(_snapshot(), 1, _repositories());
 
 		expect(JSON.stringify(second)).toBe(JSON.stringify(first));
 		expect(second.digest).toBe(first.digest);
@@ -117,15 +124,15 @@ describe("__CompileRunInput", function _describeCompiler()
 
 	it("changes the digest when any compiled input changes", async function _digestSensitive()
 	{
-		const base = await __CompileRunInput(_snapshot(), _repositories());
-		const changed = await __CompileRunInput(_snapshot(), _repositories({ loadPersonaInstructions: async function _other(): Promise<string> { return "Different persona."; } }));
+		const base = await __CompileRunInput(_snapshot(), 1, _repositories());
+		const changed = await __CompileRunInput(_snapshot(), 1, _repositories({ loadPersonaInstructions: async function _other(): Promise<string> { return "Different persona."; } }));
 
 		expect(changed.digest).not.toBe(base.digest);
 	});
 
 	it("fails closed when the snapshot targets a different compiler version", async function _versionMismatch()
 	{
-		await expect(__CompileRunInput(_snapshot({ promptCompilerVersion: "opencrane.prompt-compiler/other" }), _repositories())).rejects.toThrow(/cannot compile snapshot version/);
+		await expect(__CompileRunInput(_snapshot({ promptCompilerVersion: "opencrane.prompt-compiler/other" }), 1, _repositories())).rejects.toThrow(/requires its own snapshot version/);
 	});
 });
 
@@ -133,7 +140,7 @@ describe("__AppendCompiledTool", function _describeAppend()
 {
 	it("orders the added first-party tool and reseals the changed payload", async function _Reseals()
 	{
-		const input = await __CompileRunInput(_snapshot(), _repositories());
+		const input = await __CompileRunInput(_snapshot(), 1, _repositories());
 		const updated = __AppendCompiledTool(input, { name: "upgrade_session", toolRevisionId: "opencrane:personal:upgrade_session:v1", description: "future change", requiresApproval: false, parametersSchema: { type: "object" } });
 
 		expect(updated.tools.map(function _name(tool): string { return tool.name; })).toEqual(["alpha", "upgrade_session", "zulu"]);
@@ -142,7 +149,31 @@ describe("__AppendCompiledTool", function _describeAppend()
 
 	it("rejects a duplicate tool name so an MCP descriptor cannot shadow a first-party tool", async function _RejectsDuplicateName()
 	{
-		const input = await __CompileRunInput(_snapshot(), _repositories());
+		const input = await __CompileRunInput(_snapshot(), 1, _repositories());
 		expect(function _appendDuplicateName(): void { __AppendCompiledTool(input, { name: "alpha", toolRevisionId: "opencrane:personal:upgrade_session:v1", description: "shadow", requiresApproval: false, parametersSchema: { type: "object" } }); }).toThrow(/already contains tool/);
+	});
+});
+
+describe("__VerifyCompiledRunInput", function _describeVerification()
+{
+	it("accepts a complete literal compiled by this authority", async function _acceptsSealedInput()
+	{
+		const compiled = await __CompileRunInput(_snapshot(), 1, _repositories());
+
+		expect(__VerifyCompiledRunInput(compiled)).toEqual(compiled);
+	});
+
+	it("refuses a persisted input whose literal instructions no longer match its digest", async function _refusesChangedInput()
+	{
+		const compiled = await __CompileRunInput(_snapshot(), 1, _repositories());
+
+		expect(__VerifyCompiledRunInput({ ...compiled, instructions: "altered" })).toBeNull();
+	});
+
+	it("refuses incomplete nested model and budget payloads", async function _refusesIncompleteNestedPayload()
+	{
+		const compiled = await __CompileRunInput(_snapshot(), 1, _repositories());
+
+		expect(__VerifyCompiledRunInput({ ...compiled, model: {}, budget: {} })).toBeNull();
 	});
 });

--- a/libs/backend/agents/runtime/prompt-compiler/main/src/index.ts
+++ b/libs/backend/agents/runtime/prompt-compiler/main/src/index.ts
@@ -1,2 +1,2 @@
-export { PROMPT_COMPILER_VERSION, __AppendCompiledTool, __CompileRunInput } from "./prompt-compiler.js";
+export { PROMPT_COMPILER_VERSION, __AppendCompiledTool, __CompileRunInput, __VerifyCompiledRunInput } from "./prompt-compiler.js";
 export type { PromptCompilerRepositories } from "./prompt-compiler.types.js";

--- a/libs/backend/agents/runtime/prompt-compiler/main/src/prompt-compiler.ts
+++ b/libs/backend/agents/runtime/prompt-compiler/main/src/prompt-compiler.ts
@@ -25,14 +25,15 @@ export const PROMPT_COMPILER_VERSION = "opencrane.prompt-compiler/2026-07-21.1";
  * record is immutable, the same snapshot always compiles to byte-identical output across restarts.
  *
  * @param snapshot - The immutable input snapshot whose `promptCompilerVersion` must equal this compiler's.
+ * @param attempt - Positive AgentRun attempt the input is sealed for; it is not the snapshot schema version.
  * @param repositories - Injected control-plane read ports; the compiler itself holds no database.
  * @returns The literal compiled input, digest-sealed and version-stamped.
  */
-export async function __CompileRunInput(snapshot: RunInputSnapshot, repositories: PromptCompilerRepositories): Promise<CompiledRunInput>
+export async function __CompileRunInput(snapshot: RunInputSnapshot, attempt: number, repositories: PromptCompilerRepositories): Promise<CompiledRunInput>
 {
 	return ___DoWithTrace("prompt_compiler.compile", { runId: snapshot.runId, snapshotDigest: snapshot.digest }, function _compile(): Promise<CompiledRunInput>
 	{
-		return _compileVerified(snapshot, repositories);
+		return _compileVerified(snapshot, attempt, repositories);
 	});
 }
 
@@ -44,13 +45,22 @@ export function __AppendCompiledTool(input: CompiledRunInput, tool: CompiledTool
 	return { ...unsealed, digest: _digest(unsealed) };
 }
 
+/** Verify that an untrusted persisted value is a complete, digest-sealed compiled runtime input. */
+export function __VerifyCompiledRunInput(value: unknown): CompiledRunInput | null
+{
+	if (!_isCompiledRunInput(value)) return null;
+	const input = value as CompiledRunInput;
+	const { digest, ...unsealed } = input;
+	return _digest(unsealed) === digest ? input : null;
+}
+
 /** Verify the snapshot's compiler version, then assemble and seal the compiled input. */
-async function _compileVerified(snapshot: RunInputSnapshot, repositories: PromptCompilerRepositories): Promise<CompiledRunInput>
+async function _compileVerified(snapshot: RunInputSnapshot, attempt: number, repositories: PromptCompilerRepositories): Promise<CompiledRunInput>
 {
 	// 1. Fail closed unless the snapshot was minted for exactly this compiler version.
-	if (snapshot.promptCompilerVersion !== PROMPT_COMPILER_VERSION)
+	if (snapshot.promptCompilerVersion !== PROMPT_COMPILER_VERSION || !Number.isSafeInteger(attempt) || attempt < 1)
 	{
-		throw new Error(`prompt compiler ${PROMPT_COMPILER_VERSION} cannot compile snapshot version ${snapshot.promptCompilerVersion}`);
+		throw new Error(`prompt compiler ${PROMPT_COMPILER_VERSION} requires its own snapshot version and a positive run attempt`);
 	}
 
 	// 2. Dereference every immutable record the literal input needs.
@@ -65,7 +75,7 @@ async function _compileVerified(snapshot: RunInputSnapshot, repositories: Prompt
 	// 3. Assemble instructions and budget deterministically, then seal the payload with its digest.
 	const instructions = _assembleInstructions(personaInstructions, memoryStatements, artifactSummaries, skillSummaries);
 	const budget = _resolveBudget(snapshot.budgetPolicy);
-	const unsealed = { promptCompilerVersion: PROMPT_COMPILER_VERSION, runId: snapshot.runId, attempt: _attempt(snapshot), instructions, messages, tools, model, budget };
+	const unsealed = { promptCompilerVersion: PROMPT_COMPILER_VERSION, runId: snapshot.runId, attempt, instructions, messages, tools, model, budget };
 	return { ...unsealed, digest: _digest(unsealed) };
 }
 
@@ -79,12 +89,6 @@ function _orderTools(tools: readonly CompiledToolDefinition[]): readonly Compile
 function _orderedFactIds(snapshot: RunInputSnapshot): readonly string[]
 {
 	return snapshot.memoryFacts.map(function _factId(reference): string { return reference.factId; }).sort();
-}
-
-/** Derive the positive attempt the snapshot compiles for, defaulting to the first attempt. */
-function _attempt(snapshot: RunInputSnapshot): number
-{
-	return Number.isSafeInteger(snapshot.snapshotVersion) && snapshot.snapshotVersion > 0 ? snapshot.snapshotVersion : 1;
 }
 
 /** Build the single instructions block from persona text and canonically ordered context sections. */
@@ -127,4 +131,66 @@ function _optionalCount(value: JsonValue | undefined): number | null
 function _digest(unsealed: Omit<CompiledRunInput, "digest">): `sha256:${string}`
 {
 	return `sha256:${createHash("sha256").update(___CanonicalizeJson(unsealed as unknown as JsonValue), "utf8").digest("hex")}`;
+}
+
+/** Return whether a value has every required compiled-input coordinate and nested wire shape. */
+function _isCompiledRunInput(value: unknown): value is CompiledRunInput
+{
+	if (!_isRecord(value) || typeof value["promptCompilerVersion"] !== "string" || typeof value["runId"] !== "string" || !Number.isSafeInteger(value["attempt"]) || (value["attempt"] as number) < 1 || typeof value["instructions"] !== "string" || typeof value["digest"] !== "string") return false;
+	return Array.isArray(value["messages"]) && value["messages"].every(_isCompiledMessage)
+		&& Array.isArray(value["tools"]) && value["tools"].every(_isCompiledTool)
+		&& _isCompiledModelRoute(value["model"])
+		&& _isCompiledBudget(value["budget"]);
+}
+
+/** Return whether a value is the exact literal shape accepted for one compiled conversation turn. */
+function _isCompiledMessage(value: unknown): boolean
+{
+	if (!_isRecord(value)) return false;
+	return (value["role"] === "system" || value["role"] === "user" || value["role"] === "assistant" || value["role"] === "tool") && typeof value["content"] === "string";
+}
+
+/** Return whether a value is one complete resolved tool definition with JSON-safe parameters. */
+function _isCompiledTool(value: unknown): boolean
+{
+	return _isRecord(value) && typeof value["name"] === "string" && typeof value["toolRevisionId"] === "string" && typeof value["description"] === "string" && typeof value["requiresApproval"] === "boolean" && _isJsonValue(value["parametersSchema"]);
+}
+
+/** Return whether a value is the credential-free resolved model route the runtime can consume. */
+function _isCompiledModelRoute(value: unknown): boolean
+{
+	return _isRecord(value) && typeof value["modelAlias"] === "string" && _isOptionalCount(value["maxOutputTokens"]);
+}
+
+/** Return whether a value carries every bounded aggregate budget field. */
+function _isCompiledBudget(value: unknown): boolean
+{
+	return _isRecord(value)
+		&& _isOptionalCount(value["maxModelTurns"])
+		&& _isOptionalCount(value["maxTotalTokens"])
+		&& _isOptionalCount(value["maxCostUsdMicros"])
+		&& _isOptionalCount(value["maxToolInvocations"])
+		&& _isOptionalCount(value["wallClockDeadlineEpochMs"]);
+}
+
+/** Return whether a value is a nullable non-negative safe-integer budget or output limit. */
+function _isOptionalCount(value: unknown): boolean
+{
+	return value === null || (typeof value === "number" && Number.isSafeInteger(value) && value >= 0);
+}
+
+/** Return whether a value is a plain record rather than an array or primitive. */
+function _isRecord(value: unknown): value is Record<string, unknown>
+{
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+/** Return whether a value can be persisted without executable or undefined JavaScript members. */
+function _isJsonValue(value: unknown): value is JsonValue
+{
+	if (value === null || typeof value === "string" || typeof value === "boolean") return true;
+	if (typeof value === "number") return Number.isFinite(value);
+	if (Array.isArray(value)) return value.every(_isJsonValue);
+	if (!_isRecord(value)) return false;
+	return Object.values(value).every(_isJsonValue);
 }


### PR DESCRIPTION
## Context

A runtime may reconnect after OpenCrane has minted its first command. That reconnect must receive exactly the same approved input without rebuilding persona, conversation, tools, or model routing from mutable source records. Rebuilding inside the locked dispatch transaction was both unnecessary load and a risk to deterministic delivery.

## What changes

- persist the digest-sealed `start_attempt` compiled input with its durable command row
- rebuild reconnect deliveries from that stored input, so input compilation runs once per minted start command
- verify the stored input's complete wire shape and canonical digest before delivery; invalid data fails closed and logs only safe command coordinates
- make compiled-input `attempt` come from the locked `AgentRun`, rather than the independent snapshot schema version

## Why it matters

This removes repeated prompt/persona/tool hydration from reconnect delivery while keeping Postgres command sequencing, fences, cancellation, and the existing runtime authority intact. It is the first bounded part of #350; durable idle wakeups and live load measurements remain subsequent work.

## Validation

- `npx nx test backend-agents-runtime-prompt-compiler` (14 tests)
- `npx nx lint backend-agents-runtime-prompt-compiler`
- `npx nx test backend-agents-execution-protocol` (61 tests)
- `npx nx lint backend-agents-execution-protocol`
- `npx nx lint opencrane`
- focused boundary ESLint, style check, and `git diff --check`

Full `npm run lint:boundaries` remains red on two pre-existing `execution-inputs` dependency violations outside this diff.