### PR TITLE
🧭 Phase E: let owners decide personal configuration changes

### DIFF
--- a/apps/opencrane/src/app/persona-onboarding-wiring.ts
+++ b/apps/opencrane/src/app/persona-onboarding-wiring.ts
@@ -1,19 +1,17 @@
-import type { Request, Router } from "express";
+import type { Router } from "express";
 import type { PrismaClient } from "@prisma/client";
 
-import { __CreatePersonaOnboardingRouter, PrismaPersonaAuthorityRepository, PrismaPersonaDraftRepository, PrismaPersonaInterviewRepository, PrismaPersonaOnboardingRepository, type PersonaOnboardingCaller } from "@opencrane/backend/agents/personal/personas";
-import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
-// Side-effect import: loads the express-session SessionData.authUser augmentation.
-import "@opencrane/server/_infra/auth";
+import { __CreatePersonaOnboardingRouter, PrismaPersonaAuthorityRepository, PrismaPersonaDraftRepository, PrismaPersonaInterviewRepository, PrismaPersonaOnboardingRepository } from "@opencrane/backend/agents/personal/personas";
 
 import { _log } from "./log.js";
+import { _ResolvePersonalSelfCaller } from "./personal-self-caller.js";
 
 /** Builds the app-composed self-only persona onboarding API. */
 export function _CreatePersonaOnboardingRouter(prisma: PrismaClient): Router
 {
 	const interviews = new PrismaPersonaInterviewRepository(prisma);
 	return __CreatePersonaOnboardingRouter({
-		resolveCaller: _resolveCaller,
+		resolveCaller: _ResolvePersonalSelfCaller,
 		onboarding: new PrismaPersonaOnboardingRepository(prisma, _log),
 		interviews,
 		questions: interviews,
@@ -22,14 +20,4 @@ export function _CreatePersonaOnboardingRouter(prisma: PrismaClient): Router
 		clock: { now(): Date { return new Date(); } },
 		logger: _log,
 	});
-}
-
-/** Resolves the self-only persona owner from session identity and the request host's silo. */
-function _resolveCaller(request: Request): PersonaOnboardingCaller | null
-{
-	const authUser = request.session?.authUser;
-	if (!authUser) return null;
-	const userId = (typeof authUser.sub === "string" ? authUser.sub.trim() : "") || (typeof authUser.email === "string" ? authUser.email.trim().toLowerCase() : "");
-	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
-	return userId && siloId ? { userId, siloId } : null;
 }

--- a/apps/opencrane/src/app/personal-configuration-wiring.ts
+++ b/apps/opencrane/src/app/personal-configuration-wiring.ts
@@ -1,0 +1,18 @@
+import type { PrismaClient } from "@prisma/client";
+import type { Router } from "express";
+
+import { __CreatePersonalConfigurationRouter, PrismaPersonalConfigurationChangeRepository } from "@opencrane/backend/agents/personal/configuration";
+
+import { _log } from "./log.js";
+import { _ResolvePersonalSelfCaller } from "./personal-self-caller.js";
+
+/** Build the app-composed self-only personal-configuration decision API. */
+export function _CreatePersonalConfigurationRouter(prisma: PrismaClient): Router
+{
+	return __CreatePersonalConfigurationRouter({
+		resolveCaller: _ResolvePersonalSelfCaller,
+		changes: new PrismaPersonalConfigurationChangeRepository(prisma, _log),
+		clock: { now(): Date { return new Date(); } },
+		logger: _log,
+	});
+}

--- a/apps/opencrane/src/app/personal-self-caller.ts
+++ b/apps/opencrane/src/app/personal-self-caller.ts
@@ -1,0 +1,15 @@
+import type { Request } from "express";
+
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+// Side-effect import: loads the express-session SessionData.authUser augmentation.
+import "@opencrane/server/_infra/auth";
+
+/** Resolve the authenticated subject and tenant-host silo shared by self-only personal APIs. */
+export function _ResolvePersonalSelfCaller(request: Request): { readonly siloId: string; readonly userId: string } | null
+{
+	const authUser = request.session?.authUser;
+	if (!authUser) return null;
+	const userId = (typeof authUser.sub === "string" ? authUser.sub.trim() : "") || (typeof authUser.email === "string" ? authUser.email.trim().toLowerCase() : "");
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	return userId && siloId ? { userId, siloId } : null;
+}

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -34,6 +34,7 @@ import { __CreateArtifactPreprocessorRouter, PrismaArtifactPreprocessRepository,
 import { ___DoWithTrace } from "@opencrane/observability";
 
 import { _CreateAgentServicesRouter } from "./agent-services-wiring.js";
+import { _CreatePersonalConfigurationRouter } from "./personal-configuration-wiring.js";
 import { _CreatePersonaOnboardingRouter } from "./persona-onboarding-wiring.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
@@ -359,6 +360,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/token-usage", tokenUsageRouter(prisma));
   app.use("/api/v1/groups", groupsRouter(prisma));
   app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma, runAdmission));
+  app.use("/api/v1/me/personal-configuration", _CreatePersonalConfigurationRouter(prisma));
   app.use("/api/v1/me/persona", _CreatePersonaOnboardingRouter(prisma));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));

--- a/libs/backend/agents/personal/configuration/main/README.md
+++ b/libs/backend/agents/personal/configuration/main/README.md
@@ -19,10 +19,10 @@ snapshot and only while the recorded active revisions still match.
 **In this flow:** [conversations](../../conversations/main/README.md) · [personas](../../personas/main/README.md) · [execution inputs](../../../execution/inputs/main/README.md)
 
 The invariant is that a proposal is durable provenance, not mutable session state. Missing or
-cross-owner source coordinates fail closed. This first foundation does not itself approve, apply,
-or expose a browser/API control. Its first-party `upgrade_session` descriptor is always callable in
-a personal conversation, but its call records only a proposed change in this same journal; it never
-means the request is already user-approved or applied.
+cross-owner source coordinates fail closed. The self-only decision API may accept or reject that
+proposal, but never applies it or changes an in-flight run. Its first-party `upgrade_session`
+descriptor is always callable in a personal conversation, but its call records only a proposed
+change in this same journal; it never means the request is already user-approved or applied.
 
 ## Public surface
 
@@ -32,6 +32,8 @@ means the request is already user-approved or applied.
 - `ProposePersonalConfigurationChangeCommand` and `Result` describe the stable proposal boundary.
 - `__DecidePersonalConfigurationChange` records the owner's `Accepted` or `Rejected` decision but
   never applies a patch itself.
+- `__CreatePersonalConfigurationRouter` exposes that decision only to the authenticated proposal
+  owner; browser input cannot choose a user, silo, timestamp, or lifecycle state beyond accept/reject.
 - `UPGRADE_SESSION_TOOL` / `__IsUpgradeSessionAvailable` describe the built-in, non-MCP tool the app
   adds only to personal conversation inputs.
 - `PersonalConfigurationPatch` is a closed union: `persona_refresh` requests the normal interview
@@ -40,9 +42,10 @@ means the request is already user-approved or applied.
 
 ## Boundary
 
-The package does not mutate `RunInputSnapshot`, perform persona synthesis, apply a user decision,
-or invoke an MCP tool. The app composes its Prisma adapter and `ToolInvocation` ledger; runtime
-transport and UI remain separate owners.
+The package does not mutate `RunInputSnapshot`, perform persona synthesis, apply an accepted patch,
+or invoke an MCP tool. Its narrow self-only API records an owner's accept/reject decision; the app
+composes its Prisma adapter and `ToolInvocation` ledger, while runtime transport and UI remain
+separate owners.
 
 ## Dependency direction
 

--- a/libs/backend/agents/personal/configuration/main/src/__tests__/personal-configuration.router.test.ts
+++ b/libs/backend/agents/personal/configuration/main/src/__tests__/personal-configuration.router.test.ts
@@ -1,0 +1,77 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Logger } from "@opencrane/observability";
+
+import { __CreatePersonalConfigurationRouter } from "../personal-configuration.router.js";
+import type { PersonalConfigurationRouterDependencies } from "../personal-configuration.router.types.js";
+
+/** Build one self-only decision router with observable authority ports. */
+function _dependencies(overrides: Partial<PersonalConfigurationRouterDependencies> = {}): PersonalConfigurationRouterDependencies
+{
+	return {
+		resolveCaller: function _caller() { return { siloId: "silo-1", userId: "user-1" }; },
+		changes: { decideAtomically: vi.fn().mockResolvedValue({ status: "accepted" }) },
+		clock: { now: function _now() { return new Date("2026-07-26T12:00:00.000Z"); } },
+		logger: { error: vi.fn() } as unknown as Logger,
+		...overrides,
+	};
+}
+
+/** Mount the router below the public self-only personal-configuration prefix. */
+function _app(dependencies: PersonalConfigurationRouterDependencies)
+{
+	const app = express();
+	app.use(express.json());
+	app.use("/api/v1/me/personal-configuration", __CreatePersonalConfigurationRouter(dependencies));
+	return app;
+}
+
+describe("__CreatePersonalConfigurationRouter", function _describeRouter()
+{
+	it("requires a session-derived owner before revealing a proposal decision path", async function _requiresCaller()
+	{
+		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).post("/api/v1/me/personal-configuration/changes/change-1/decision").send({ decision: "accepted" });
+
+		expect(response.status).toBe(401);
+		expect(response.body).toEqual({ error: "personal_configuration_authentication_required" });
+	});
+
+	it("rejects extra browser coordinates before it calls the owner decision authority", async function _rejectsExtraCoordinates()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).post("/api/v1/me/personal-configuration/changes/change-1/decision").send({ decision: "accepted", userId: "forged" });
+
+		expect(response.status).toBe(400);
+		expect(dependencies.changes.decideAtomically).not.toHaveBeenCalled();
+	});
+
+	it("records a session-owned accept decision with the server timestamp", async function _accepts()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).post("/api/v1/me/personal-configuration/changes/change-1/decision").send({ decision: "accepted" });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ changeId: "change-1", state: "accepted" });
+		expect(dependencies.changes.decideAtomically).toHaveBeenCalledWith({ siloId: "silo-1", userId: "user-1", changeId: "change-1", decision: "accepted", rejectionReason: null, decidedAt: "2026-07-26T12:00:00.000Z" });
+	});
+
+	it("records a rejected decision with its bounded owner explanation", async function _rejects()
+	{
+		const dependencies = _dependencies({ changes: { decideAtomically: vi.fn().mockResolvedValue({ status: "rejected" }) } });
+		const response = await request(_app(dependencies)).post("/api/v1/me/personal-configuration/changes/change-1/decision").send({ decision: "rejected", rejectionReason: "Keep the current setup." });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ changeId: "change-1", state: "rejected" });
+		expect(dependencies.changes.decideAtomically).toHaveBeenCalledWith({ siloId: "silo-1", userId: "user-1", changeId: "change-1", decision: "rejected", rejectionReason: "Keep the current setup.", decidedAt: "2026-07-26T12:00:00.000Z" });
+	});
+
+	it("does not disclose another owner's proposal when the authority refuses it", async function _hidesOtherOwner()
+	{
+		const response = await request(_app(_dependencies({ changes: { decideAtomically: vi.fn().mockResolvedValue({ status: "not_found_or_not_owner" }) } }))).post("/api/v1/me/personal-configuration/changes/change-other/decision").send({ decision: "accepted" });
+
+		expect(response.status).toBe(404);
+		expect(response.body).toEqual({ error: "not_found_or_not_owner" });
+	});
+});

--- a/libs/backend/agents/personal/configuration/main/src/index.ts
+++ b/libs/backend/agents/personal/configuration/main/src/index.ts
@@ -1,6 +1,8 @@
 export { __DecidePersonalConfigurationChange } from "./personal-configuration-decision.js";
+export { __CreatePersonalConfigurationRouter } from "./personal-configuration.router.js";
 export { __ProposePersonalConfigurationChange } from "./personal-configuration.js";
 export { PrismaPersonalConfigurationChangeRepository } from "./prisma-personal-configuration-repository.js";
 export { __IsUpgradeSessionAvailable, UPGRADE_SESSION_TOOL, UPGRADE_SESSION_TOOL_REVISION } from "./upgrade-session.js";
 export type { DecidePersonalConfigurationChangeCommand, DecidePersonalConfigurationChangeResult, PersonalConfigurationChangeDecisionRepository, PersonalConfigurationChangeRepository, PersonalConfigurationPatch, ProposePersonalConfigurationChangeCommand, ProposePersonalConfigurationChangeResult } from "./personal-configuration.types.js";
+export type { PersonalConfigurationCaller, PersonalConfigurationClock, PersonalConfigurationRouterDependencies } from "./personal-configuration.router.types.js";
 export type { UpgradeSessionProposalReceipt, UpgradeSessionProposalRepository } from "./upgrade-session.types.js";

--- a/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.ts
+++ b/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.ts
@@ -1,0 +1,76 @@
+import { Router, type Request, type Response } from "express";
+
+import { __DecidePersonalConfigurationChange } from "./personal-configuration-decision.js";
+import type { PersonalConfigurationCaller, PersonalConfigurationRouterDependencies } from "./personal-configuration.router.types.js";
+
+/** Create the session-authenticated self-only decision API for future personal configuration changes. */
+export function __CreatePersonalConfigurationRouter(dependencies: PersonalConfigurationRouterDependencies): Router
+{
+	const router = Router();
+
+	router.post("/changes/:changeId/decision", async function _decide(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		const changeId = request.params["changeId"];
+		if (caller === null) return;
+		if (typeof changeId !== "string" || !_isDecisionBody(request.body))
+		{
+			_respond(response, 400, "invalid_personal_configuration_decision");
+			return;
+		}
+
+		try
+		{
+			// 1. Bind the state transition to the session-derived owner and silo, never body coordinates.
+			const result = await __DecidePersonalConfigurationChange(dependencies.changes, { siloId: caller.siloId, userId: caller.userId, changeId, decision: request.body.decision, rejectionReason: request.body.decision === "rejected" ? request.body.rejectionReason : null, decidedAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied")
+			{
+				_respond(response, _denialStatus(result.reason), result.reason);
+				return;
+			}
+
+			// 2. Return only the new state; a separate reviewed flow materializes a later immutable snapshot.
+			response.status(200).json({ changeId, state: result.outcome });
+		}
+		catch (err)
+		{
+			// 3. Keep persistence details out of the self-service response while retaining safe diagnosis data.
+			dependencies.logger.error({ err, operation: "personal_configuration.decision", siloId: caller.siloId, changeId }, "Personal configuration decision failed");
+			_respond(response, 503, "personal_configuration_unavailable");
+		}
+	});
+
+	return router;
+}
+
+/** Resolve the session-derived caller or write the shared non-disclosing authentication denial. */
+function _requireCaller(request: Request, response: Response, dependencies: PersonalConfigurationRouterDependencies): PersonalConfigurationCaller | null
+{
+	const caller = dependencies.resolveCaller(request);
+	if (caller === null) _respond(response, 401, "personal_configuration_authentication_required");
+	return caller;
+}
+
+/** Parse precisely the two supported owner decisions without accepting caller-selected lifecycle fields. */
+function _isDecisionBody(value: unknown): value is { readonly decision: "accepted"; readonly rejectionReason?: never } | { readonly decision: "rejected"; readonly rejectionReason: string }
+{
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+	const body = value as Record<string, unknown>;
+	if (body["decision"] === "accepted") return Object.keys(body).length === 1;
+	return body["decision"] === "rejected" && Object.keys(body).length === 2 && typeof body["rejectionReason"] === "string" && body["rejectionReason"].trim().length > 0;
+}
+
+/** Map a fail-closed authority denial to a bounded public HTTP status. */
+function _denialStatus(reason: string): number
+{
+	if (reason === "persistence_unavailable") return 503;
+	if (reason === "not_found_or_not_owner") return 404;
+	if (reason === "already_decided") return 409;
+	return 400;
+}
+
+/** Write one compact machine-readable problem response. */
+function _respond(response: Response, status: number, error: string): void
+{
+	response.status(status).json({ error });
+}

--- a/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.types.ts
+++ b/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.types.ts
@@ -1,0 +1,33 @@
+import type { Request } from "express";
+import type { Logger } from "@opencrane/observability";
+
+import type { PersonalConfigurationChangeDecisionRepository } from "./personal-configuration.types.js";
+
+/** Authenticated owner identity resolved by the server rather than the browser request body. */
+export interface PersonalConfigurationCaller
+{
+	/** Silo selected from the authenticated request host. */
+	readonly siloId: string;
+	/** Stable subject who alone may decide their own configuration proposal. */
+	readonly userId: string;
+}
+
+/** Trusted clock injected by the app to make decision timestamps deterministic in tests. */
+export interface PersonalConfigurationClock
+{
+	/** Return the current server-controlled instant. */
+	now(): Date;
+}
+
+/** Composition ports for the self-only personal-configuration decision surface. */
+export interface PersonalConfigurationRouterDependencies
+{
+	/** Resolves the authenticated session and host identity, or null for an anonymous request. */
+	resolveCaller(request: Request): PersonalConfigurationCaller | null;
+	/** Owns the compare-and-set proposal decision lifecycle. */
+	changes: PersonalConfigurationChangeDecisionRepository;
+	/** Supplies trusted decision timestamps. */
+	clock: PersonalConfigurationClock;
+	/** Records unexpected persistence failures without request content. */
+	logger: Logger;
+}


### PR DESCRIPTION
## Context

A personal agent can propose a change through its always-granted `upgrade_session` tool, but until now that proposal had no authenticated owner-decision surface. The durable journal correctly kept the proposal separate from an in-flight run, yet a user could not accept or reject it through OpenCrane.

## What changes

- add a self-only endpoint for accepting or rejecting a personal configuration proposal
- derive user and silo exclusively from the authenticated session and tenant host
- reject forged body coordinates and return non-disclosing ownership denials
- share the app-level personal caller resolver with persona onboarding

## Boundary

This is state/API wiring only—no UI. An accepted proposal still cannot mutate the current `RunInputSnapshot` or an active run. Persona refresh remains a normal interview and approved-persona flow; later snapshots observe the approved revision.

## Validation

- `npx nx test backend-agents-personal-configuration` (18 tests)
- `npx nx lint backend-agents-personal-configuration`
- `npx nx lint opencrane`
- focused ESLint boundary check, style check, and `git diff --check`

## Review

- independent review completed with no remaining findings.