### PR TITLE
🧭 Materialize accepted persona refresh proposals

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -1141,6 +1141,7 @@ CREATE TABLE "persona_interviews" (
     "id" TEXT NOT NULL,
     "persona_profile_id" TEXT NOT NULL,
     "user_id" TEXT NOT NULL,
+    "refresh_configuration_change_id" TEXT,
     "question_set_id" TEXT NOT NULL,
     "question_set_version" INTEGER NOT NULL,
     "state" "PersonaInterviewState" NOT NULL DEFAULT 'in_progress',
@@ -2108,6 +2109,9 @@ CREATE UNIQUE INDEX "persona_interviews_id_persona_profile_id_user_id_question_s
 CREATE INDEX "persona_interview_answers_question_set_id_question_set_vers_idx" ON "persona_interview_answers"("question_set_id", "question_set_version", "question_id");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "persona_interviews_refresh_configuration_change_id_key" ON "persona_interviews"("refresh_configuration_change_id");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "persona_interview_answers_interview_id_question_id_key" ON "persona_interview_answers"("interview_id", "question_id");
 
 -- CreateIndex
@@ -2517,6 +2521,9 @@ ALTER TABLE "persona_interviews" ADD CONSTRAINT "persona_interviews_persona_prof
 
 -- AddForeignKey
 ALTER TABLE "persona_interviews" ADD CONSTRAINT "persona_interviews_question_set_id_question_set_version_fkey" FOREIGN KEY ("question_set_id", "question_set_version") REFERENCES "persona_question_sets"("question_set_id", "version") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "persona_interviews" ADD CONSTRAINT "persona_interviews_refresh_configuration_change_id_fkey" FOREIGN KEY ("refresh_configuration_change_id") REFERENCES "personal_configuration_changes"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "persona_interview_answers" ADD CONSTRAINT "persona_interview_answers_interview_id_fkey" FOREIGN KEY ("interview_id") REFERENCES "persona_interviews"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -3697,14 +3704,27 @@ END;
 $$;
 CREATE FUNCTION "enforce_persona_interview_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
 DECLARE expected_answers INTEGER; actual_answers INTEGER; question_set_state "PersonaQuestionSetState";
+        refresh_state "PersonalConfigurationChangeState"; refresh_user TEXT; refresh_profile TEXT; refresh_patch JSONB;
 BEGIN
     IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'PersonaInterview rows cannot be deleted'; END IF;
     IF TG_OP = 'INSERT' THEN
         SELECT "state" INTO question_set_state FROM "persona_question_sets"
           WHERE "question_set_id" = NEW."question_set_id" AND "version" = NEW."question_set_version" FOR UPDATE;
         IF question_set_state IS DISTINCT FROM 'reviewed' THEN RAISE EXCEPTION 'PersonaInterview requires a Reviewed question set'; END IF;
+        IF NEW."refresh_configuration_change_id" IS NOT NULL THEN
+            SELECT "state", "user_id", "persona_profile_id", "requested_patch"
+              INTO refresh_state, refresh_user, refresh_profile, refresh_patch
+              FROM "personal_configuration_changes" WHERE "id" = NEW."refresh_configuration_change_id" FOR UPDATE;
+            IF refresh_state IS DISTINCT FROM 'accepted' OR refresh_user IS DISTINCT FROM NEW."user_id"
+               OR refresh_profile IS DISTINCT FROM NEW."persona_profile_id" OR refresh_patch IS DISTINCT FROM '{"kind":"persona_refresh"}'::jsonb THEN
+                RAISE EXCEPTION 'PersonaInterview refresh must bind one accepted owner persona_refresh proposal';
+            END IF;
+        END IF;
     END IF;
     IF TG_OP = 'UPDATE' AND OLD."state" IN ('completed', 'retaken') THEN RAISE EXCEPTION 'completed PersonaInterview evidence is immutable'; END IF;
+    IF TG_OP = 'UPDATE' AND NEW."refresh_configuration_change_id" IS DISTINCT FROM OLD."refresh_configuration_change_id" THEN
+        RAISE EXCEPTION 'PersonaInterview refresh provenance is immutable';
+    END IF;
     IF NEW."state" = 'completed' THEN
         SELECT count(*) INTO expected_answers FROM "persona_questions" WHERE "question_set_id" = NEW."question_set_id" AND "question_set_version" = NEW."question_set_version";
         SELECT count(*) INTO actual_answers FROM "persona_interview_answers" WHERE "interview_id" = NEW."id";
@@ -3857,6 +3877,7 @@ $$;
 CREATE FUNCTION "enforce_personal_configuration_change_lifecycle"() RETURNS trigger LANGUAGE plpgsql AS $$
 DECLARE profile_silo TEXT; profile_user TEXT; active_persona TEXT; thread_silo TEXT; thread_service TEXT;
         run_silo TEXT; run_thread TEXT; run_service TEXT; run_user TEXT; service_silo TEXT; service_kind "AgentServiceKind"; active_agent TEXT;
+        refresh_change TEXT; applied_revision_profile TEXT;
 BEGIN
     IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'PersonalConfigurationChange rows cannot be deleted'; END IF;
     IF TG_OP = 'INSERT' THEN
@@ -3896,10 +3917,22 @@ BEGIN
     IF OLD."state" <> 'proposed' AND (NEW."decided_at" IS DISTINCT FROM OLD."decided_at" OR NEW."decided_by" IS DISTINCT FROM OLD."decided_by" OR NEW."rejection_reason" IS DISTINCT FROM OLD."rejection_reason") THEN
         RAISE EXCEPTION 'PersonalConfigurationChange decision evidence is immutable';
     END IF;
-    IF NOT (OLD."state" = 'proposed' AND NEW."state" IN ('accepted', 'rejected')) THEN
-        RAISE EXCEPTION 'PersonalConfigurationChange has an invalid lifecycle transition';
+    IF OLD."state" = 'proposed' AND NEW."state" IN ('accepted', 'rejected') THEN RETURN NEW; END IF;
+    IF OLD."state" = 'accepted' AND NEW."state" = 'applied' THEN
+        IF NEW."requested_patch" IS DISTINCT FROM '{"kind":"persona_refresh"}'::jsonb
+           OR NEW."applied_persona_revision_id" IS NULL OR NEW."applied_agent_revision_id" IS NOT NULL THEN
+            RAISE EXCEPTION 'only accepted persona_refresh changes may apply an approved persona revision';
+        END IF;
+        SELECT revision."persona_profile_id", interview."refresh_configuration_change_id"
+          INTO applied_revision_profile, refresh_change
+          FROM "persona_revisions" revision JOIN "persona_interviews" interview ON interview."id" = revision."interview_id"
+          WHERE revision."id" = NEW."applied_persona_revision_id" AND revision."state" = 'approved' FOR UPDATE OF revision, interview;
+        IF applied_revision_profile IS DISTINCT FROM NEW."persona_profile_id" OR refresh_change IS DISTINCT FROM NEW."id" THEN
+            RAISE EXCEPTION 'applied persona refresh must use its exact approved interview-derived revision';
+        END IF;
+        RETURN NEW;
     END IF;
-    RETURN NEW;
+    RAISE EXCEPTION 'PersonalConfigurationChange has an invalid lifecycle transition';
 END;
 $$;
 CREATE FUNCTION "enforce_artifact_revision_silo_provenance"() RETURNS trigger LANGUAGE plpgsql AS $$
@@ -4627,7 +4660,7 @@ CREATE TRIGGER "persona_question_sets_closed_lifecycle" BEFORE INSERT OR UPDATE 
     FOR EACH ROW EXECUTE FUNCTION "enforce_persona_question_set_lifecycle"();
 CREATE TRIGGER "persona_questions_draft_only" BEFORE INSERT OR UPDATE OR DELETE ON "persona_questions"
     FOR EACH ROW EXECUTE FUNCTION "enforce_persona_question_mutation"();
-CREATE TRIGGER "persona_interviews_closed_lifecycle" BEFORE UPDATE OR DELETE ON "persona_interviews" FOR EACH ROW EXECUTE FUNCTION "enforce_persona_interview_lifecycle"();
+CREATE TRIGGER "persona_interviews_closed_lifecycle" BEFORE INSERT OR UPDATE OR DELETE ON "persona_interviews" FOR EACH ROW EXECUTE FUNCTION "enforce_persona_interview_lifecycle"();
 CREATE TRIGGER "persona_interview_answers_exact_question_set" BEFORE INSERT ON "persona_interview_answers" FOR EACH ROW EXECUTE FUNCTION "enforce_persona_answer_provenance"();
 CREATE TRIGGER "persona_insights_exact_provenance" BEFORE INSERT ON "persona_insights" FOR EACH ROW EXECUTE FUNCTION "enforce_persona_insight_provenance"();
 CREATE TRIGGER "persona_revisions_closed_lifecycle" BEFORE INSERT OR UPDATE OR DELETE ON "persona_revisions" FOR EACH ROW EXECUTE FUNCTION "enforce_persona_revision_lifecycle"();

--- a/apps/opencrane/prisma/schema/personal-configuration.prisma
+++ b/apps/opencrane/prisma/schema/personal-configuration.prisma
@@ -27,6 +27,7 @@ model PersonalConfigurationChange {
   decidedAt                DateTime?                        @map("decided_at")
   decidedBy                String?                          @map("decided_by")
   rejectionReason          String?                          @map("rejection_reason")
+  refreshInterview         PersonaInterview?                @relation("PersonaRefreshConfiguration")
 
   @@index([siloId, userId, proposedAt])
   @@index([sourceRunId])

--- a/apps/opencrane/prisma/schema/personas.prisma
+++ b/apps/opencrane/prisma/schema/personas.prisma
@@ -88,18 +88,20 @@ model PersonaProfile {
 }
 
 model PersonaInterview {
-  id                 String                @id @default(cuid())
-  personaProfileId   String                @map("persona_profile_id")
-  userId             String                @map("user_id")
-  questionSetId      String                @map("question_set_id")
-  questionSetVersion Int                   @map("question_set_version")
-  state              PersonaInterviewState @default(InProgress)
-  startedAt          DateTime              @default(now()) @map("started_at")
-  completedAt        DateTime?             @map("completed_at")
-  profile            PersonaProfile        @relation(fields: [personaProfileId, userId], references: [id, userId], onDelete: Restrict)
-  questionSet        PersonaQuestionSet    @relation(fields: [questionSetId, questionSetVersion], references: [id, version], onDelete: Restrict)
-  answers            PersonaInterviewAnswer[]
-  revisions          PersonaRevision[]
+  id                           String                       @id @default(cuid())
+  personaProfileId             String                       @map("persona_profile_id")
+  userId                       String                       @map("user_id")
+  refreshConfigurationChangeId String?                      @unique @map("refresh_configuration_change_id")
+  questionSetId                String                       @map("question_set_id")
+  questionSetVersion           Int                          @map("question_set_version")
+  state                        PersonaInterviewState        @default(InProgress)
+  startedAt                    DateTime                     @default(now()) @map("started_at")
+  completedAt                  DateTime?                    @map("completed_at")
+  profile                      PersonaProfile               @relation(fields: [personaProfileId, userId], references: [id, userId], onDelete: Restrict)
+  questionSet                  PersonaQuestionSet           @relation(fields: [questionSetId, questionSetVersion], references: [id, version], onDelete: Restrict)
+  answers                      PersonaInterviewAnswer[]
+  revisions                    PersonaRevision[]
+  refreshConfigurationChange   PersonalConfigurationChange? @relation("PersonaRefreshConfiguration", fields: [refreshConfigurationChangeId], references: [id], onDelete: Restrict)
 
   @@unique([id, personaProfileId, userId, questionSetId, questionSetVersion])
   @@index([personaProfileId, state])

--- a/libs/backend/agents/personal/configuration/main/README.md
+++ b/libs/backend/agents/personal/configuration/main/README.md
@@ -8,7 +8,9 @@ This package records a person's request to change how their agent behaves. It bi
 the user, conversation, run, current persona revision, and current agent revision. A run input
 snapshot is immutable, so the package never changes work already in progress. An owner may first
 mark a request `Accepted`; a later materialisation authority may mark it `Applied` only while assembling a new
-snapshot and only while the recorded active revisions still match.
+snapshot and only while the recorded active revisions still match. A `persona_refresh` proposal is
+materialised by a new, proposal-bound onboarding interview; approving that interview's derived
+persona revision applies that exact proposal atomically.
 
 ```
  conversation request ─► configuration proposal ◄── HERE ─► later approved revision
@@ -42,10 +44,10 @@ change in this same journal; it never means the request is already user-approved
 
 ## Boundary
 
-The package does not mutate `RunInputSnapshot`, perform persona synthesis, apply an accepted patch,
-or invoke an MCP tool. Its narrow self-only API records an owner's accept/reject decision; the app
-composes its Prisma adapter and `ToolInvocation` ledger, while runtime transport and UI remain
-separate owners.
+The package does not mutate `RunInputSnapshot`, perform persona synthesis, or invoke an MCP tool.
+Its narrow self-only API records an owner's accept/reject decision; the persona authority alone can
+apply the linked `persona_refresh` proposal while approving the resulting revision. The app composes
+its Prisma adapter and `ToolInvocation` ledger, while runtime transport and UI remain separate owners.
 
 ## Dependency direction
 

--- a/libs/backend/agents/personal/configuration/main/tests/personal-configuration-authority.sql
+++ b/libs/backend/agents/personal/configuration/main/tests/personal-configuration-authority.sql
@@ -32,4 +32,16 @@ SELECT pg_temp.expect_failure('accepted proposal cannot return to proposed', $st
 SELECT pg_temp.expect_failure('unknown patch fields are rejected', $statement$INSERT INTO "personal_configuration_changes" ("id", "silo_id", "user_id", "persona_profile_id", "agent_service_id", "source_thread_id", "source_run_id", "requested_patch", "requested_patch_digest") VALUES ('change-extra', 'silo-1', 'user-1', 'profile-1', 'service-1', 'thread-1', 'run-1', '{"kind":"model_alias","modelAlias":"careful","budget":1}', 'sha256:' || repeat('e',64))$statement$, 'personal_configuration_changes_valid_check');
 SELECT pg_temp.expect_failure('whitespace model alias is rejected', $statement$INSERT INTO "personal_configuration_changes" ("id", "silo_id", "user_id", "persona_profile_id", "agent_service_id", "source_thread_id", "source_run_id", "requested_patch", "requested_patch_digest") VALUES ('change-whitespace', 'silo-1', 'user-1', 'profile-1', 'service-1', 'thread-1', 'run-1', '{"kind":"model_alias","modelAlias":"\t"}', 'sha256:' || repeat('f',64))$statement$, 'personal_configuration_changes_valid_check');
 
+INSERT INTO "persona_question_sets" ("question_set_id", "version") VALUES ('refresh-onboarding', 1);
+INSERT INTO "persona_questions" ("question_set_id", "question_set_version", "question_id", "category", "prompt", "ordinal") VALUES
+('refresh-onboarding',1,'q1','relationship_role','Role?',1), ('refresh-onboarding',1,'q2','tone_language','Tone?',2),
+('refresh-onboarding',1,'q3','answer_structure','Structure?',3), ('refresh-onboarding',1,'q4','challenge_support','Challenge?',4),
+('refresh-onboarding',1,'q5','initiative','Initiative?',5), ('refresh-onboarding',1,'q6','approval_risk','Risk?',6),
+('refresh-onboarding',1,'q7','working_habits','Habits?',7), ('refresh-onboarding',1,'q8','memory_boundaries','Memory?',8);
+UPDATE "persona_question_sets" SET "state"='reviewed', "reviewed_by"='reviewer-1', "reviewed_at"=clock_timestamp() WHERE "question_set_id"='refresh-onboarding' AND "version"=1;
+SELECT pg_temp.expect_failure('refresh interview rejects a non-refresh proposal', $statement$INSERT INTO "persona_interviews" ("id", "persona_profile_id", "user_id", "refresh_configuration_change_id", "question_set_id", "question_set_version") VALUES ('invalid-refresh-interview','profile-1','user-1','change-1','refresh-onboarding',1)$statement$, 'PersonaInterview refresh must bind one accepted owner persona_refresh proposal');
+INSERT INTO "personal_configuration_changes" ("id", "silo_id", "user_id", "persona_profile_id", "agent_service_id", "source_thread_id", "source_run_id", "requested_patch", "requested_patch_digest") VALUES ('refresh-change-1', 'silo-1', 'user-1', 'profile-1', 'service-1', 'thread-1', 'run-1', '{"kind":"persona_refresh"}', 'sha256:' || repeat('a',64));
+UPDATE "personal_configuration_changes" SET "state"='accepted', "decided_at"=clock_timestamp(), "decided_by"='user-1' WHERE "id"='refresh-change-1';
+INSERT INTO "persona_interviews" ("id", "persona_profile_id", "user_id", "refresh_configuration_change_id", "question_set_id", "question_set_version") VALUES ('refresh-interview','profile-1','user-1','refresh-change-1','refresh-onboarding',1);
+
 ROLLBACK;

--- a/libs/backend/agents/personal/personas/main/README.md
+++ b/libs/backend/agents/personal/personas/main/README.md
@@ -6,7 +6,9 @@
 
 This package is part of the **personal-agent product**. A **persona** is the saved personality and
 instructions an agent runs with — who it is and how it should behave. A user builds one through an
-onboarding interview, producing a **draft**. This package owns the full durable lifecycle: it starts
+onboarding interview, producing a **draft**. An accepted persona-refresh proposal starts the same
+interview with its proposal identity permanently recorded; approving the resulting revision applies
+that exact proposal. This package owns the full durable lifecycle: it starts
 an interview from a reviewed question set, captures each answer once, freezes the completed evidence,
 derives a draft from selected-template evidence, and then approves a fully evidenced draft into the
 single live persona.
@@ -80,8 +82,9 @@ whole provisioning transaction.
 - `PERSONA_ONBOARDING_QUESTION_SET_ID`, `PERSONA_ONBOARDING_QUESTION_SET_VERSION`,
   `PERSONA_ONBOARDING_QUESTIONS`, and `PERSONA_ONBOARDING_SOUL_TEMPLATES` — the reviewed catalogue
   source: eight key questions and three role-selected SOUL.md starting templates.
-- `__CreatePersonaOnboardingRouter` — the API-first self-persona surface. It starts an interview,
-  records one answer, and completes it using only session-and-host-derived ownership.
+- `__CreatePersonaOnboardingRouter` — the API-first self-persona surface. It starts ordinary or
+  proposal-bound refresh interviews, records one answer, and completes them using only
+  session-and-host-derived ownership.
 
 ## Boundary
 

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-interview-authority.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-interview-authority.test.ts
@@ -19,7 +19,7 @@ function _repository(overrides: Partial<PersonaInterviewRepository> = {}): Perso
 /** Creates the valid exact reviewed-question-set request used by lifecycle tests. */
 function _startCommand()
 {
-	return { siloId: "silo-1", userId: "user-1", personaProfileId: "profile-1", questionSetId: "onboarding", questionSetVersion: 1, startedAt: "2026-07-23T09:00:00.000Z" } as const;
+	return { siloId: "silo-1", userId: "user-1", personaProfileId: "profile-1", refreshConfigurationChangeId: null, questionSetId: "onboarding", questionSetVersion: 1, startedAt: "2026-07-23T09:00:00.000Z" } as const;
 }
 
 /** Wraps one fake transactional client in the narrow Prisma interface this authority needs. */

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding.router.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding.router.test.ts
@@ -49,6 +49,14 @@ describe("__CreatePersonaOnboardingRouter", function _describe()
 		expect(dependencies.interviews.startAtomically).toHaveBeenCalledWith(expect.objectContaining({ siloId: "silo-1", userId: "user-1", personaProfileId: "profile-1", questionSetId: "personal-onboarding", questionSetVersion: 1 }));
 	});
 
+	it("starts a refresh interview only from the route-bound accepted proposal identity", async function _startsRefresh()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).post("/api/v1/me/persona/refreshes/change-1/interview").send({});
+		expect(response.status).toBe(200);
+		expect(dependencies.interviews.startAtomically).toHaveBeenCalledWith(expect.objectContaining({ personaProfileId: "profile-1", refreshConfigurationChangeId: "change-1" }));
+	});
+
 	it("rejects a role value that cannot select one reviewed SOUL template", async function _rejectsUnsupportedRole()
 	{
 		const dependencies = _dependencies();

--- a/libs/backend/agents/personal/personas/main/src/__tests__/prisma-persona-authority-repository.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/prisma-persona-authority-repository.test.ts
@@ -53,6 +53,21 @@ describe("PrismaPersonaAuthorityRepository", function _describePrismaPersonaAuth
 		expect(updateRevision).not.toHaveBeenCalled();
 	});
 
+	it("applies only the accepted refresh proposal bound to the approved revision interview", async function _appliesBoundRefresh()
+	{
+		const updateChange = vi.fn().mockResolvedValue({ count: 1 });
+		const queryRaw = vi.fn().mockResolvedValueOnce([{ id: "profile-1" }]).mockResolvedValueOnce([{ id: "revision-1", interviewId: "interview-1" }]);
+		const prisma = _Prisma({
+			personaInterview: { findUnique: vi.fn().mockResolvedValue({ refreshConfigurationChangeId: "change-1" }) },
+			personalConfigurationChange: { updateMany: updateChange },
+			$queryRaw: queryRaw,
+		});
+		const repository = new PrismaPersonaAuthorityRepository(prisma);
+
+		await expect(repository.approveAndActivateAtomically({ personaProfileId: "profile-1", personaRevisionId: "revision-1", userId: "user-1", approvedAt: "2026-07-23T12:00:00.000Z", expectedRevisionState: "draft", expectedInterviewState: "completed", expectedInsightCount: 3 })).resolves.toEqual({ status: "approved" });
+		expect(updateChange).toHaveBeenCalledWith({ where: expect.objectContaining({ id: "change-1", userId: "user-1", personaProfileId: "profile-1" }), data: expect.objectContaining({ appliedPersonaRevisionId: "revision-1" }) });
+	});
+
 	it("does not approve when the draft evidence changed after its preflight snapshot", async function _rejectsChangedEvidence()
 	{
 		const updateRevision = vi.fn();

--- a/libs/backend/agents/personal/personas/main/src/persona-interview-authority.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-interview-authority.ts
@@ -27,7 +27,7 @@ export async function __CompletePersonaInterview(repository: PersonaInterviewRep
 /** Return whether every start coordinate and instant is safely present. */
 function _validStart(command: StartPersonaInterviewCommand): boolean
 {
-	return _validIdentifier(command.siloId) && _validIdentifier(command.userId) && _validIdentifier(command.personaProfileId) && _validIdentifier(command.questionSetId) && Number.isSafeInteger(command.questionSetVersion) && command.questionSetVersion > 0 && _validInstant(command.startedAt);
+	return _validIdentifier(command.siloId) && _validIdentifier(command.userId) && _validIdentifier(command.personaProfileId) && _validIdentifier(command.questionSetId) && (command.refreshConfigurationChangeId === null || _validIdentifier(command.refreshConfigurationChangeId)) && Number.isSafeInteger(command.questionSetVersion) && command.questionSetVersion > 0 && _validInstant(command.startedAt);
 }
 
 /** Return whether one answer remains bounded enough for durable interview evidence. */

--- a/libs/backend/agents/personal/personas/main/src/persona-interview-authority.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-interview-authority.types.ts
@@ -11,6 +11,8 @@ export interface StartPersonaInterviewCommand
 	readonly questionSetId: string;
 	/** Exact reviewed question-set version. */
 	readonly questionSetVersion: number;
+	/** Accepted personal refresh proposal this interview materialises, or null for ordinary onboarding. */
+	readonly refreshConfigurationChangeId: string | null;
 	/** Trusted start instant. */
 	readonly startedAt: string;
 }
@@ -48,7 +50,7 @@ export interface CompletePersonaInterviewCommand
 /** Stable outcome from starting a reviewed persona interview. */
 export type StartPersonaInterviewResult =
 	| { readonly outcome: "started" | "already_in_progress"; readonly interviewId: string }
-	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found_or_wrong_owner" | "question_set_unavailable" | "persistence_unavailable" };
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found_or_wrong_owner" | "question_set_unavailable" | "refresh_change_unavailable" | "refresh_interview_conflict" | "persistence_unavailable" };
 
 /** Stable outcome from recording one interview answer. */
 export type RecordPersonaInterviewAnswerResult =
@@ -64,7 +66,7 @@ export type CompletePersonaInterviewResult =
 export interface PersonaInterviewRepository
 {
 	/** Starts one reviewed interview or returns the owner's existing in-progress interview. */
-	startAtomically(command: StartPersonaInterviewCommand): Promise<{ readonly status: "started" | "already_in_progress"; readonly interviewId: string } | { readonly status: "not_found_or_wrong_owner" | "question_set_unavailable" | "persistence_unavailable" }>;
+	startAtomically(command: StartPersonaInterviewCommand): Promise<{ readonly status: "started" | "already_in_progress"; readonly interviewId: string } | { readonly status: "not_found_or_wrong_owner" | "question_set_unavailable" | "refresh_change_unavailable" | "refresh_interview_conflict" | "persistence_unavailable" }>;
 	/** Appends one answer only while the owner interview remains in progress. */
 	recordAnswerAtomically(command: RecordPersonaInterviewAnswerCommand): Promise<{ readonly status: "recorded"; readonly answerId: string } | { readonly status: "not_found_or_wrong_owner" | "not_in_progress" | "question_unavailable" | "already_answered" | "persistence_unavailable" }>;
 	/** Completes a fully answered owner interview once and freezes its evidence. */

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.ts
@@ -20,7 +20,7 @@ export function __CreatePersonaOnboardingRouter(dependencies: PersonaOnboardingR
 		{
 			const ready = await _ensure(caller, dependencies);
 			if (ready === null) { _respond(response, 503, "persona_onboarding_unavailable"); return; }
-			const result = await __StartPersonaInterview(dependencies.interviews, { siloId: caller.siloId, userId: caller.userId, personaProfileId: ready.personaProfileId, questionSetId: ready.questionSet.id, questionSetVersion: ready.questionSet.version, startedAt: dependencies.clock.now().toISOString() });
+			const result = await __StartPersonaInterview(dependencies.interviews, { siloId: caller.siloId, userId: caller.userId, personaProfileId: ready.personaProfileId, refreshConfigurationChangeId: null, questionSetId: ready.questionSet.id, questionSetVersion: ready.questionSet.version, startedAt: dependencies.clock.now().toISOString() });
 			if (result.outcome === "denied") { _respond(response, _interviewDenialStatus(result.reason), result.reason); return; }
 			const questions = await dependencies.questions.getQuestions(result.interviewId, ready.personaProfileId, caller.userId);
 			if (questions === null || questions.length === 0) { _respond(response, 503, "persona_onboarding_unavailable"); return; }
@@ -29,6 +29,29 @@ export function __CreatePersonaOnboardingRouter(dependencies: PersonaOnboardingR
 		catch (err)
 		{
 			dependencies.logger.error({ err, operation: "persona_onboarding.start", siloId: caller.siloId }, "Persona onboarding interview start failed");
+			_respond(response, 503, "persona_onboarding_unavailable");
+		}
+	});
+
+	router.post("/refreshes/:configurationChangeId/interview", async function _startRefresh(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		const configurationChangeId = request.params["configurationChangeId"];
+		if (caller === null) return;
+		if (typeof configurationChangeId !== "string" || !_isEmptyObject(request.body)) { _respond(response, 400, "invalid_persona_refresh"); return; }
+		try
+		{
+			const ready = await _ensure(caller, dependencies);
+			if (ready === null) { _respond(response, 503, "persona_onboarding_unavailable"); return; }
+			const result = await __StartPersonaInterview(dependencies.interviews, { siloId: caller.siloId, userId: caller.userId, personaProfileId: ready.personaProfileId, refreshConfigurationChangeId: configurationChangeId, questionSetId: ready.questionSet.id, questionSetVersion: ready.questionSet.version, startedAt: dependencies.clock.now().toISOString() });
+			if (result.outcome === "denied") { _respond(response, _interviewDenialStatus(result.reason), result.reason); return; }
+			const questions = await dependencies.questions.getQuestions(result.interviewId, ready.personaProfileId, caller.userId);
+			if (questions === null || questions.length === 0) { _respond(response, 503, "persona_onboarding_unavailable"); return; }
+			response.status(200).json({ interviewId: result.interviewId, state: "in_progress", questions });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "persona_onboarding.start_refresh", siloId: caller.siloId }, "Persona refresh interview start failed");
 			_respond(response, 503, "persona_onboarding_unavailable");
 		}
 	});
@@ -131,7 +154,7 @@ function _answerValue(body: unknown, questionId: unknown, questions: readonly { 
 /** Map interview lifecycle denials to a bounded HTTP status without leaking another owner's state. */
 function _interviewDenialStatus(reason: string): number
 {
-	return reason === "persistence_unavailable" ? 503 : reason === "question_set_unavailable" ? 422 : reason === "not_found_or_wrong_owner" ? 404 : reason === "already_answered" || reason === "not_in_progress" || reason === "incomplete_answers" ? 409 : 400;
+	return reason === "persistence_unavailable" ? 503 : reason === "question_set_unavailable" ? 422 : reason === "not_found_or_wrong_owner" || reason === "refresh_change_unavailable" ? 404 : reason === "already_answered" || reason === "not_in_progress" || reason === "incomplete_answers" || reason === "refresh_interview_conflict" ? 409 : 400;
 }
 
 /** Require an empty object for a state transition with no caller-owned coordinates. */

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-authority-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-authority-repository.ts
@@ -1,4 +1,4 @@
-import { PersonaInterviewState, PersonaRevisionState, Prisma, type PrismaClient } from "@prisma/client";
+import { PersonalConfigurationChangeState, PersonaInterviewState, PersonaRevisionState, Prisma, type PrismaClient } from "@prisma/client";
 
 import type { ApprovePersonaCommand, AtomicApprovePersonaCommand, AtomicApprovePersonaResult, PersonaApprovalSnapshot, PersonaAuthorityRepository } from "./persona-authority.types.js";
 
@@ -58,7 +58,7 @@ export class PrismaPersonaAuthorityRepository implements PersonaAuthorityReposit
 				if (profiles.length !== 1) return { status: "not_found" } as const;
 
 				// 2. Lock the draft revision before inspecting its evidence, matching the lock used by the insight-provenance trigger.
-				const revisions = await transaction.$queryRaw<readonly { readonly id: string }[]>(Prisma.sql`SELECT "id" FROM "persona_revisions" WHERE "id" = ${command.personaRevisionId} AND "persona_profile_id" = ${command.personaProfileId} AND "state" = 'draft' FOR UPDATE`);
+				const revisions = await transaction.$queryRaw<readonly { readonly id: string; readonly interviewId: string }[]>(Prisma.sql`SELECT "id", "interview_id" AS "interviewId" FROM "persona_revisions" WHERE "id" = ${command.personaRevisionId} AND "persona_profile_id" = ${command.personaProfileId} AND "state" = 'draft' FOR UPDATE`);
 				if (revisions.length !== 1) return { status: "conflict" } as const;
 
 				// 3. Rebind the exact evidence count accepted at preflight; a valid extra insight still changes the reviewed draft.
@@ -77,7 +77,18 @@ export class PrismaPersonaAuthorityRepository implements PersonaAuthorityReposit
 					where: { id: command.personaProfileId, userId: command.userId },
 					data: { activeRevisionId: command.personaRevisionId },
 				});
-				return profile.count === 1 ? { status: "approved" } as const : { status: "conflict" } as const;
+				if (profile.count !== 1) return { status: "conflict" } as const;
+
+				// 6. Apply only the refresh proposal that the completed interview carries; unrelated accepted proposals remain pending.
+				const interviewId = revisions[0]?.interviewId;
+				if (typeof interviewId !== "string") return { status: "approved" } as const;
+				const interview = await transaction.personaInterview.findUnique({ where: { id: interviewId }, select: { refreshConfigurationChangeId: true } });
+				if (interview?.refreshConfigurationChangeId === null || interview === null) return { status: "approved" } as const;
+				const change = await transaction.personalConfigurationChange.updateMany({
+					where: { id: interview.refreshConfigurationChangeId, userId: command.userId, personaProfileId: command.personaProfileId, state: PersonalConfigurationChangeState.Accepted, requestedPatch: { equals: { kind: "persona_refresh" } } },
+					data: { state: PersonalConfigurationChangeState.Applied, appliedPersonaRevisionId: command.personaRevisionId },
+				});
+				return change.count === 1 ? { status: "approved" } as const : { status: "conflict" } as const;
 			});
 		}
 		catch (error)

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-interview-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-interview-repository.ts
@@ -1,4 +1,4 @@
-import { PersonaInterviewState, PersonaQuestionSetState, Prisma, type PrismaClient } from "@prisma/client";
+import { PersonalConfigurationChangeState, PersonaInterviewState, PersonaQuestionSetState, Prisma, type PrismaClient } from "@prisma/client";
 
 import type { CompletePersonaInterviewCommand, PersonaInterviewQuestionReader, PersonaInterviewRepository, RecordPersonaInterviewAnswerCommand, StartPersonaInterviewCommand } from "./persona-interview-authority.types.js";
 
@@ -23,7 +23,7 @@ export class PrismaPersonaInterviewRepository implements PersonaInterviewReposit
 	}
 
 	/** Start one reviewed interview while serialising all in-progress attempts for the same profile. */
-	async startAtomically(command: StartPersonaInterviewCommand): Promise<{ readonly status: "started" | "already_in_progress"; readonly interviewId: string } | { readonly status: "not_found_or_wrong_owner" | "question_set_unavailable" | "persistence_unavailable" }>
+	async startAtomically(command: StartPersonaInterviewCommand): Promise<{ readonly status: "started" | "already_in_progress"; readonly interviewId: string } | { readonly status: "not_found_or_wrong_owner" | "question_set_unavailable" | "refresh_change_unavailable" | "refresh_interview_conflict" | "persistence_unavailable" }>
 	{
 		try
 		{
@@ -33,14 +33,21 @@ export class PrismaPersonaInterviewRepository implements PersonaInterviewReposit
 				const profiles = await transaction.$queryRaw<readonly { readonly id: string }[]>(Prisma.sql`SELECT "id" FROM "persona_profiles" WHERE "id" = ${command.personaProfileId} AND "silo_id" = ${command.siloId} AND "user_id" = ${command.userId} FOR UPDATE`);
 				if (profiles.length !== 1) return { status: "not_found_or_wrong_owner" } as const;
 
-				// 2. Reuse a still-active interview; starting again must not discard unreviewed user answers.
-				const existing = await transaction.personaInterview.findFirst({ where: { personaProfileId: command.personaProfileId, userId: command.userId, state: PersonaInterviewState.InProgress }, select: { id: true } });
-				if (existing !== null) return { status: "already_in_progress", interviewId: existing.id } as const;
+				// 2. Claim only an accepted owner-bound persona-refresh proposal before any interview exists.
+				if (command.refreshConfigurationChangeId !== null)
+				{
+					const refresh = await transaction.personalConfigurationChange.findFirst({ where: { id: command.refreshConfigurationChangeId, siloId: command.siloId, userId: command.userId, personaProfileId: command.personaProfileId, state: PersonalConfigurationChangeState.Accepted, requestedPatch: { equals: { kind: "persona_refresh" } } }, select: { id: true } });
+					if (refresh === null) return { status: "refresh_change_unavailable" } as const;
+				}
 
-				// 3. Accept only an exact reviewed question-set revision before recording the interview attempt.
+				// 3. Reuse a still-active interview; a different refresh may not hijack unreviewed answers.
+				const existing = await transaction.personaInterview.findFirst({ where: { personaProfileId: command.personaProfileId, userId: command.userId, state: PersonaInterviewState.InProgress }, select: { id: true } });
+				if (existing !== null) return command.refreshConfigurationChangeId === null ? { status: "already_in_progress", interviewId: existing.id } as const : { status: "refresh_interview_conflict" } as const;
+
+				// 4. Accept only an exact reviewed question-set revision before recording the interview attempt.
 				const questionSet = await transaction.personaQuestionSet.findUnique({ where: { id_version: { id: command.questionSetId, version: command.questionSetVersion } }, select: { state: true } });
 				if (questionSet?.state !== PersonaQuestionSetState.Reviewed) return { status: "question_set_unavailable" } as const;
-				const interview = await transaction.personaInterview.create({ data: { personaProfileId: command.personaProfileId, userId: command.userId, questionSetId: command.questionSetId, questionSetVersion: command.questionSetVersion, startedAt: new Date(command.startedAt) }, select: { id: true } });
+				const interview = await transaction.personaInterview.create({ data: { personaProfileId: command.personaProfileId, userId: command.userId, refreshConfigurationChangeId: command.refreshConfigurationChangeId, questionSetId: command.questionSetId, questionSetVersion: command.questionSetVersion, startedAt: new Date(command.startedAt) }, select: { id: true } });
 				return { status: "started", interviewId: interview.id } as const;
 			});
 		}


### PR DESCRIPTION
## What this enables

When a person accepts a request to refresh their agent persona, that decision now has a complete, durable route to a new live persona. The person completes the normal interview again; the approved revision that results becomes the only evidence allowed to apply that refresh. No in-flight run is changed.

## How it stays safe

- The refresh interview is bound to one accepted `persona_refresh` proposal, owned by the authenticated user and profile.
- A proposal can be linked to only one interview, and the link cannot be changed later.
- Approval applies only the proposal carried by that interview; other accepted requests remain pending.
- PostgreSQL repeats the ownership, proposal-kind, lifecycle, and exact-revision checks, so direct database writes fail closed too.

## Documentation

Updated the personal configuration and persona package READMEs to explain the proposal-to-interview-to-approved-revision flow.

## Validation

- `npx nx test backend-agents-personal-personas` — 24 passing tests
- `npx nx lint backend-agents-personal-personas`
- `npx nx test backend-agents-personal-configuration` — 18 passing tests
- `npx nx lint backend-agents-personal-configuration`
- `DATABASE_URL=... npx prisma validate --schema apps/opencrane/prisma/schema`
- `scripts/agent-style-check.sh` and `git diff --check`
- Added live-Postgres SQL authority coverage for rejected and valid proposal-bound interview creation; it remains a CI/live-database gate on this workstation.

## Review

Independent review caught and verified the database-trigger INSERT fence; the correction and SQL coverage are included in this PR.