### PR TITLE
🧠 Persist personal-memory catalogue facts

### DIFF
--- a/libs/backend/agents/personal/memory/main/README.md
+++ b/libs/backend/agents/personal/memory/main/README.md
@@ -39,13 +39,21 @@ the rest of the system a fact was recorded) commit together in one transaction, 
 never claim a fact Cognee does not have. Repeat deliveries are treated as success (idempotent) via the
 idempotency key, while a retired dataset or a conflicting correction fails closed.
 
+For an explicit statement, the command also carries the authenticated statement author's id. The
+catalog requires that id to match both `recordedBy` and the provenance's `sourceUserId`; it therefore
+cannot turn one user's statement into a preference for another user's run. A successor fact emits
+`memory.fact_corrected` rather than `memory.fact_recorded`, so consumers can distinguish a correction
+from a first learned preference.
+
 ## Public surface
 
 - `__RecordMemoryFact(repository, command)` — the single use case: validate provenance, then record catalog metadata atomically.
 - `RecordMemoryFactCommand` / `RecordMemoryFactResult` — the request and the stable allow/deny outcome.
 - `MemoryFactSource` — the one-of-three provenance reference (artifact revision · message · explicit statement).
 - `AtomicRecordMemoryFactResult` — the raw persistence outcome the repository returns.
-- `MemoryCatalogRepository` — the persistence port a caller must implement (or inject).
+- `MemoryCatalogRepository` — the persistence port a caller may inject.
+- `PrismaMemoryCatalogRepository` — the production adapter: checks the dataset, writes immutable
+  metadata, and creates the `memory.fact_recorded` outbox intent in one transaction.
 
 ## Boundary
 
@@ -61,7 +69,11 @@ revision as a source), `scope:personal-memory`, and `scope:shared` — never on 
 ## Data & persistence
 
 Persists catalog metadata and a Cognee-outbox intent in one transaction through the injected
-repository. Postgres-level behaviour is exercised by the `test:sql` target (`tests/memory-authority.sql`).
+repository. The shipped `PrismaMemoryCatalogRepository` is that canonical product-database adapter;
+it deliberately accepts only metadata returned after Cognee has durably accepted the content. It does
+not create a personal dataset, call Cognee, or dispatch the outbox. Those are separate boundaries so a
+network failure can never make Postgres claim content that Cognee did not accept. Postgres-level
+behaviour is exercised by the `test:sql` target (`tests/memory-authority.sql`).
 
 ## See also
 

--- a/libs/backend/agents/personal/memory/main/src/__tests__/memory-catalog.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/__tests__/memory-catalog.test.ts
@@ -7,7 +7,7 @@ describe("memory catalog", function ()
 	it("records provenance metadata without accepting fact content", async function ()
 	{
 		const recordFactAtomically = vi.fn().mockResolvedValue({ status: "recorded" });
-		const result = await __RecordMemoryFact({ recordFactAtomically }, { datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", contentDigest: `sha256:${"a".repeat(64)}`, consentState: "explicit", sensitivity: "ordinary", provenance: { questionId: "q1" }, source: { artifactRevisionId: null, messageId: "message-1", explicitUserStatement: false }, supersedesFactId: null, recordedBy: "user-1", idempotencyKey: "fact-1" });
+		const result = await __RecordMemoryFact({ recordFactAtomically }, { datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", contentDigest: `sha256:${"a".repeat(64)}`, consentState: "explicit", sensitivity: "ordinary", provenance: { questionId: "q1" }, source: { artifactRevisionId: null, messageId: "message-1", explicitUserStatement: false, explicitUserId: null }, supersedesFactId: null, recordedBy: "user-1", idempotencyKey: "fact-1" });
 		expect(result).toEqual({ outcome: "recorded", idempotent: false });
 		expect(recordFactAtomically).toHaveBeenCalledOnce();
 	});
@@ -15,7 +15,31 @@ describe("memory catalog", function ()
 	it("rejects ambiguous provenance", async function ()
 	{
 		const recordFactAtomically = vi.fn();
-		const result = await __RecordMemoryFact({ recordFactAtomically }, { datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", contentDigest: `sha256:${"a".repeat(64)}`, consentState: "explicit", sensitivity: "ordinary", provenance: {}, source: { artifactRevisionId: "artifact-revision-1", messageId: "message-1", explicitUserStatement: false }, supersedesFactId: null, recordedBy: "user-1", idempotencyKey: "fact-1" });
+		const result = await __RecordMemoryFact({ recordFactAtomically }, { datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", contentDigest: `sha256:${"a".repeat(64)}`, consentState: "explicit", sensitivity: "ordinary", provenance: {}, source: { artifactRevisionId: "artifact-revision-1", messageId: "message-1", explicitUserStatement: false, explicitUserId: null }, supersedesFactId: null, recordedBy: "user-1", idempotencyKey: "fact-1" });
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(recordFactAtomically).not.toHaveBeenCalled();
+	});
+
+	it("requires the explicit-user provenance marker for an explicit statement", async function ()
+	{
+		const recordFactAtomically = vi.fn();
+		const result = await __RecordMemoryFact({ recordFactAtomically }, { datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", contentDigest: `sha256:${"a".repeat(64)}`, consentState: "explicit", sensitivity: "ordinary", provenance: { sourceKind: "explicit-user-fact" }, source: { artifactRevisionId: null, messageId: null, explicitUserStatement: true, explicitUserId: "user-1" }, supersedesFactId: null, recordedBy: "user-1", idempotencyKey: "fact-1" });
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(recordFactAtomically).not.toHaveBeenCalled();
+	});
+
+	it("rejects a database-ambiguous explicit marker beside an artifact source", async function ()
+	{
+		const recordFactAtomically = vi.fn();
+		const result = await __RecordMemoryFact({ recordFactAtomically }, { datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", contentDigest: `sha256:${"a".repeat(64)}`, consentState: "explicit", sensitivity: "ordinary", provenance: { user_statement: true }, source: { artifactRevisionId: "artifact-revision-1", messageId: null, explicitUserStatement: false, explicitUserId: null }, supersedesFactId: null, recordedBy: "user-1", idempotencyKey: "fact-1" });
+		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(recordFactAtomically).not.toHaveBeenCalled();
+	});
+
+	it("rejects an explicit statement whose provenance names a different user", async function ()
+	{
+		const recordFactAtomically = vi.fn();
+		const result = await __RecordMemoryFact({ recordFactAtomically }, { datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", contentDigest: `sha256:${"a".repeat(64)}`, consentState: "explicit", sensitivity: "ordinary", provenance: { user_statement: true, sourceKind: "explicit-user-fact", sourceUserId: "user-2" }, source: { artifactRevisionId: null, messageId: null, explicitUserStatement: true, explicitUserId: "user-1" }, supersedesFactId: null, recordedBy: "user-1", idempotencyKey: "fact-1" });
 		expect(result).toEqual({ outcome: "denied", reason: "invalid_command" });
 		expect(recordFactAtomically).not.toHaveBeenCalled();
 	});

--- a/libs/backend/agents/personal/memory/main/src/__tests__/prisma-memory-catalog-repository.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/__tests__/prisma-memory-catalog-repository.test.ts
@@ -1,0 +1,109 @@
+import { MemoryDatasetState, MemoryOutboxEventKind, Prisma } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaMemoryCatalogRepository } from "../prisma-memory-catalog-repository.js";
+
+/** Build a valid, content-free catalog persistence command. */
+function _command()
+{
+	return { datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", contentDigest: `sha256:${"a".repeat(64)}`, consentState: "explicit" as const, sensitivity: "ordinary", provenance: { user_statement: true, sourceKind: "explicit-user-fact", sourceUserId: "user-1" }, source: { artifactRevisionId: null, messageId: null, explicitUserStatement: true, explicitUserId: "user-1" }, supersedesFactId: null, recordedBy: "user-1", idempotencyKey: "fact-1" };
+}
+
+/** Build a Prisma transaction fake that exposes the memory catalog's entire atomic boundary. */
+function _transaction()
+{
+	return {
+		$queryRaw: vi.fn(),
+		memoryOutboxEvent: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({}) },
+		memoryDataset: { findUnique: vi.fn().mockResolvedValue({ state: MemoryDatasetState.Active }) },
+		memoryFactCatalog: { create: vi.fn().mockResolvedValue({ id: "fact-1" }) },
+	};
+}
+
+/** Create a repository with a transaction fake for deterministic persistence-boundary tests. */
+function _repository(transaction: ReturnType<typeof _transaction>, idempotencyDelivery: unknown = null): PrismaMemoryCatalogRepository
+{
+	const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }), memoryOutboxEvent: { findUnique: vi.fn().mockResolvedValue(idempotencyDelivery) } } as never;
+	return new PrismaMemoryCatalogRepository(prisma);
+}
+
+describe("Prisma memory catalog repository", function _suite()
+{
+	it("commits immutable catalog metadata and the recorded-fact outbox intent together", async function _records()
+	{
+		const transaction = _transaction();
+		await expect(_repository(transaction).recordFactAtomically(_command())).resolves.toEqual({ status: "recorded" });
+		expect(transaction.memoryFactCatalog.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ datasetId: "dataset-1", cogneeExternalId: "cognee-fact-1", sourceArtifactRevisionId: null, sourceMessageId: null }) }));
+		expect(transaction.memoryOutboxEvent.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ datasetId: "dataset-1", factId: "fact-1", kind: MemoryOutboxEventKind.FactRecorded, idempotencyKey: "fact-1" }) }));
+	});
+
+	it("denies an unavailable dataset without creating catalog or outbox rows", async function _datasetMissing()
+	{
+		const transaction = _transaction();
+		transaction.memoryDataset.findUnique.mockResolvedValue(null);
+		await expect(_repository(transaction).recordFactAtomically(_command())).resolves.toEqual({ status: "dataset_not_found" });
+		expect(transaction.memoryFactCatalog.create).not.toHaveBeenCalled();
+		expect(transaction.memoryOutboxEvent.create).not.toHaveBeenCalled();
+	});
+
+	it("denies a retired dataset without creating catalog or outbox rows", async function _datasetRetired()
+	{
+		const transaction = _transaction();
+		transaction.memoryDataset.findUnique.mockResolvedValue({ state: MemoryDatasetState.Retired });
+		await expect(_repository(transaction).recordFactAtomically(_command())).resolves.toEqual({ status: "dataset_retired" });
+		expect(transaction.memoryFactCatalog.create).not.toHaveBeenCalled();
+	});
+
+	it("accepts only an exact prior fact for a repeated idempotency key", async function _idempotent()
+	{
+		const transaction = _transaction();
+		const command = _command();
+		transaction.memoryOutboxEvent.findUnique.mockResolvedValue({ datasetId: command.datasetId, kind: MemoryOutboxEventKind.FactRecorded, fact: { cogneeExternalId: command.cogneeExternalId, contentDigest: command.contentDigest, consentState: "Explicit", sensitivity: command.sensitivity, provenance: { sourceUserId: "user-1", sourceKind: "explicit-user-fact", user_statement: true }, sourceArtifactRevisionId: null, sourceMessageId: null, supersedesFactId: null, recordedBy: command.recordedBy } });
+		await expect(_repository(transaction).recordFactAtomically(command)).resolves.toEqual({ status: "idempotent" });
+		expect(transaction.memoryDataset.findUnique).not.toHaveBeenCalled();
+		expect(transaction.memoryFactCatalog.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects a changed fact behind a reused idempotency key", async function _conflictingIdempotencyKey()
+	{
+		const transaction = _transaction();
+		const command = _command();
+		transaction.memoryOutboxEvent.findUnique.mockResolvedValue({ datasetId: command.datasetId, kind: MemoryOutboxEventKind.FactRecorded, fact: { cogneeExternalId: "other-cognee-fact", contentDigest: command.contentDigest, consentState: "Explicit", sensitivity: command.sensitivity, provenance: command.provenance, sourceArtifactRevisionId: null, sourceMessageId: null, supersedesFactId: null, recordedBy: command.recordedBy } });
+		await expect(_repository(transaction).recordFactAtomically(command)).resolves.toEqual({ status: "conflict" });
+		expect(transaction.memoryFactCatalog.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects an explicit fact whose author differs from its provenance owner before a transaction", async function _wrongExplicitOwner()
+	{
+		const transaction = _transaction();
+		const command = { ..._command(), provenance: { user_statement: true, sourceKind: "explicit-user-fact", sourceUserId: "user-2" } };
+		await expect(_repository(transaction).recordFactAtomically(command)).resolves.toEqual({ status: "invalid_command" });
+		expect(transaction.memoryOutboxEvent.findUnique).not.toHaveBeenCalled();
+	});
+
+	it("recovers an exact concurrent idempotency delivery after a unique-key race", async function _concurrentIdempotency()
+	{
+		const transaction = _transaction();
+		const command = _command();
+		const delivery = { datasetId: command.datasetId, kind: MemoryOutboxEventKind.FactRecorded, fact: { cogneeExternalId: command.cogneeExternalId, contentDigest: command.contentDigest, consentState: "Explicit", sensitivity: command.sensitivity, provenance: command.provenance, sourceArtifactRevisionId: null, sourceMessageId: null, supersedesFactId: null, recordedBy: command.recordedBy } };
+		const prisma = { $transaction: vi.fn().mockRejectedValue(new Prisma.PrismaClientKnownRequestError("unique key race", { code: "P2002", clientVersion: "test" })), memoryOutboxEvent: { findUnique: vi.fn().mockResolvedValue(delivery) } } as never;
+		const repository = new PrismaMemoryCatalogRepository(prisma);
+		await expect(repository.recordFactAtomically(command)).resolves.toEqual({ status: "idempotent" });
+	});
+
+	it("recovers an exact concurrent idempotency delivery after a transaction serialization race", async function _serializationRace()
+	{
+		const command = _command();
+		const delivery = { datasetId: command.datasetId, kind: MemoryOutboxEventKind.FactRecorded, fact: { cogneeExternalId: command.cogneeExternalId, contentDigest: command.contentDigest, consentState: "Explicit", sensitivity: command.sensitivity, provenance: command.provenance, sourceArtifactRevisionId: null, sourceMessageId: null, supersedesFactId: null, recordedBy: command.recordedBy } };
+		const prisma = { $transaction: vi.fn().mockRejectedValue(new Prisma.PrismaClientKnownRequestError("serialization race", { code: "P2034", clientVersion: "test" })), memoryOutboxEvent: { findUnique: vi.fn().mockResolvedValue(delivery) } } as never;
+		await expect(new PrismaMemoryCatalogRepository(prisma).recordFactAtomically(command)).resolves.toEqual({ status: "idempotent" });
+	});
+
+	it("emits a correction event rather than a first-recording event for a successor fact", async function _correction()
+	{
+		const transaction = _transaction();
+		const command = { ..._command(), supersedesFactId: "fact-previous" };
+		await expect(_repository(transaction).recordFactAtomically(command)).resolves.toEqual({ status: "recorded" });
+		expect(transaction.memoryOutboxEvent.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ kind: MemoryOutboxEventKind.FactCorrected, payload: expect.objectContaining({ supersedesFactId: "fact-previous" }) }) }));
+	});
+});

--- a/libs/backend/agents/personal/memory/main/src/index.ts
+++ b/libs/backend/agents/personal/memory/main/src/index.ts
@@ -1,2 +1,3 @@
-export { __RecordMemoryFact } from "./memory-catalog.js";
+export { __IsValidMemoryFactCommand, __RecordMemoryFact } from "./memory-catalog.js";
+export { PrismaMemoryCatalogRepository } from "./prisma-memory-catalog-repository.js";
 export type { AtomicRecordMemoryFactResult, MemoryCatalogRepository, MemoryFactSource, RecordMemoryFactCommand, RecordMemoryFactResult } from "./memory-catalog.types.js";

--- a/libs/backend/agents/personal/memory/main/src/memory-catalog.ts
+++ b/libs/backend/agents/personal/memory/main/src/memory-catalog.ts
@@ -6,8 +6,7 @@ import type { MemoryCatalogRepository, RecordMemoryFactCommand, RecordMemoryFact
 export async function __RecordMemoryFact(repository: MemoryCatalogRepository, command: RecordMemoryFactCommand): Promise<RecordMemoryFactResult>
 {
 	// 1. Require one explainable source and a content digest, never raw fact content.
-	const sourceCount = Number(command.source.artifactRevisionId !== null) + Number(command.source.messageId !== null) + Number(command.source.explicitUserStatement);
-	if (!command.datasetId.trim() || !command.cogneeExternalId.trim() || !___IsSha256ContentAddress(command.contentDigest) || !command.sensitivity.trim() || !command.recordedBy.trim() || !command.idempotencyKey.trim() || sourceCount !== 1)
+	if (!__IsValidMemoryFactCommand(command))
 	{
 		return { outcome: "denied", reason: "invalid_command" };
 	}
@@ -19,4 +18,18 @@ export async function __RecordMemoryFact(repository: MemoryCatalogRepository, co
 	if (result.status === "recorded") return { outcome: "recorded", idempotent: false };
 	if (result.status === "idempotent") return { outcome: "recorded", idempotent: true };
 	return { outcome: "denied", reason: result.status };
+}
+
+/** Validate source cardinality and bind an explicit statement to its authenticated author. */
+export function __IsValidMemoryFactCommand(command: RecordMemoryFactCommand): boolean
+{
+	const sourceCount = Number(command.source.artifactRevisionId !== null) + Number(command.source.messageId !== null) + Number(command.source.explicitUserStatement);
+	if (!command.datasetId.trim() || !command.cogneeExternalId.trim() || !___IsSha256ContentAddress(command.contentDigest) || !command.sensitivity.trim() || !command.recordedBy.trim() || !command.idempotencyKey.trim() || sourceCount !== 1) return false;
+	if (!command.source.explicitUserStatement) return command.source.explicitUserId === null && command.provenance["user_statement"] !== true;
+	return command.source.explicitUserId !== null
+		&& command.source.explicitUserId.trim().length > 0
+		&& command.provenance["user_statement"] === true
+		&& command.provenance["sourceKind"] === "explicit-user-fact"
+		&& command.provenance["sourceUserId"] === command.source.explicitUserId
+		&& command.recordedBy === command.source.explicitUserId;
 }

--- a/libs/backend/agents/personal/memory/main/src/memory-catalog.types.ts
+++ b/libs/backend/agents/personal/memory/main/src/memory-catalog.types.ts
@@ -7,6 +7,8 @@ export interface MemoryFactSource
 	readonly messageId: string | null;
 	/** True only for an explicit user statement with no artifact or message coordinate. */
 	readonly explicitUserStatement: boolean;
+	/** Authenticated user who made the explicit statement, otherwise null. */
+	readonly explicitUserId: string | null;
 }
 
 /** Catalog metadata recorded after Cognee accepts durable fact content. */
@@ -35,7 +37,7 @@ export interface RecordMemoryFactCommand
 }
 
 /** Atomic memory catalog persistence result. */
-export type AtomicRecordMemoryFactResult = { readonly status: "recorded" } | { readonly status: "idempotent" } | { readonly status: "dataset_not_found" } | { readonly status: "dataset_retired" } | { readonly status: "correction_conflict" } | { readonly status: "conflict" };
+export type AtomicRecordMemoryFactResult = { readonly status: "recorded" } | { readonly status: "idempotent" } | { readonly status: "invalid_command" } | { readonly status: "dataset_not_found" } | { readonly status: "dataset_retired" } | { readonly status: "correction_conflict" } | { readonly status: "conflict" };
 
 /** Persistence boundary committing catalog provenance and Cognee outbox intent together. */
 export interface MemoryCatalogRepository

--- a/libs/backend/agents/personal/memory/main/src/prisma-memory-catalog-repository.ts
+++ b/libs/backend/agents/personal/memory/main/src/prisma-memory-catalog-repository.ts
@@ -1,0 +1,101 @@
+import { MemoryDatasetState, MemoryOutboxEventKind, Prisma, type PrismaClient } from "@prisma/client";
+
+import { __IsValidMemoryFactCommand } from "./memory-catalog.js";
+
+import type { AtomicRecordMemoryFactResult, MemoryCatalogRepository, RecordMemoryFactCommand } from "./memory-catalog.types.js";
+
+/** Prisma persistence authority for immutable memory-fact catalog records and their outbox intents. */
+export class PrismaMemoryCatalogRepository implements MemoryCatalogRepository
+{
+	/** Canonical per-silo product database. */
+	private readonly prisma: PrismaClient;
+
+	/** Create the catalog persistence authority over the canonical product database. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Atomically record gateway-confirmed metadata and the downstream fact-recorded intent. */
+	async recordFactAtomically(command: RecordMemoryFactCommand): Promise<AtomicRecordMemoryFactResult>
+	{
+		if (!__IsValidMemoryFactCommand(command)) return { status: "invalid_command" };
+
+		try
+		{
+			return await this.prisma.$transaction(async function _record(transaction)
+			{
+				// 1. Reuse only an identical prior delivery so an idempotency key cannot authorize changed evidence.
+				const existing = await transaction.memoryOutboxEvent.findUnique({ where: { idempotencyKey: command.idempotencyKey }, include: { fact: true } });
+				if (existing !== null) return _MatchesExistingDelivery(existing, command) ? { status: "idempotent" } as const : { status: "conflict" } as const;
+
+				// 2. Lock then reject unavailable catalog targets; the baseline trigger repeats this fence at commit.
+				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "memory_datasets" WHERE "id" = ${command.datasetId} FOR UPDATE`);
+				const dataset = await transaction.memoryDataset.findUnique({ where: { id: command.datasetId }, select: { state: true } });
+				if (dataset === null) return { status: "dataset_not_found" } as const;
+				if (dataset.state === MemoryDatasetState.Retired) return { status: "dataset_retired" } as const;
+
+				// 3. Commit immutable metadata and its delivery intent together, leaving durable content exclusively in Cognee.
+				const fact = await transaction.memoryFactCatalog.create({ data: { datasetId: command.datasetId, cogneeExternalId: command.cogneeExternalId, contentDigest: command.contentDigest, consentState: command.consentState === "explicit" ? "Explicit" : "Confirmed", sensitivity: command.sensitivity, provenance: command.provenance as Prisma.InputJsonValue, sourceArtifactRevisionId: command.source.artifactRevisionId, sourceMessageId: command.source.messageId, supersedesFactId: command.supersedesFactId, recordedBy: command.recordedBy }, select: { id: true } });
+				await transaction.memoryOutboxEvent.create({ data: { datasetId: command.datasetId, factId: fact.id, kind: _OutboxKind(command), idempotencyKey: command.idempotencyKey, payload: _OutboxPayload(command) } });
+				return { status: "recorded" } as const;
+			});
+		}
+		catch (error)
+		{
+			if (error instanceof Prisma.PrismaClientKnownRequestError && _IsCorrectionConflict(error)) return { status: "correction_conflict" };
+			if (error instanceof Prisma.PrismaClientKnownRequestError && (error.code === "P2002" || error.code === "P2034")) return this._ResolveConcurrentIdempotency(command);
+			throw error;
+		}
+	}
+
+	/** Re-read a unique-key race after transaction rollback and accept only the exact committed delivery. */
+	private async _ResolveConcurrentIdempotency(command: RecordMemoryFactCommand): Promise<AtomicRecordMemoryFactResult>
+	{
+		const existing = await this.prisma.memoryOutboxEvent.findUnique({ where: { idempotencyKey: command.idempotencyKey }, include: { fact: true } });
+		return existing !== null && _MatchesExistingDelivery(existing, command) ? { status: "idempotent" } : { status: "conflict" };
+	}
+}
+
+/** Return whether Postgres rejected a correction because its predecessor is no longer eligible. */
+function _IsCorrectionConflict(error: Prisma.PrismaClientKnownRequestError): boolean
+{
+	return error.code === "P0001" && error.message.includes("memory correction must supersede an active fact");
+}
+
+/** Return whether an already-committed idempotency key represents the exact same immutable fact. */
+function _MatchesExistingDelivery(existing: { readonly datasetId: string; readonly kind: MemoryOutboxEventKind; readonly fact: { readonly cogneeExternalId: string; readonly contentDigest: string; readonly consentState: "Explicit" | "Confirmed"; readonly sensitivity: string; readonly provenance: unknown; readonly sourceArtifactRevisionId: string | null; readonly sourceMessageId: string | null; readonly supersedesFactId: string | null; readonly recordedBy: string } }, command: RecordMemoryFactCommand): boolean
+{
+	return existing.kind === _OutboxKind(command)
+		&& existing.datasetId === command.datasetId
+		&& existing.fact.cogneeExternalId === command.cogneeExternalId
+		&& existing.fact.contentDigest === command.contentDigest
+		&& existing.fact.consentState === (command.consentState === "explicit" ? "Explicit" : "Confirmed")
+		&& existing.fact.sensitivity === command.sensitivity
+		&& _CanonicalJson(existing.fact.provenance) === _CanonicalJson(command.provenance)
+		&& existing.fact.sourceArtifactRevisionId === command.source.artifactRevisionId
+		&& existing.fact.sourceMessageId === command.source.messageId
+		&& existing.fact.supersedesFactId === command.supersedesFactId
+		&& existing.fact.recordedBy === command.recordedBy;
+}
+
+/** Select the one event that tells consumers whether a fact is newly recorded or replaces another. */
+function _OutboxKind(command: RecordMemoryFactCommand): MemoryOutboxEventKind
+{
+	return command.supersedesFactId === null ? MemoryOutboxEventKind.FactRecorded : MemoryOutboxEventKind.FactCorrected;
+}
+
+/** Build the content-free delivery payload used by downstream catalog consumers. */
+function _OutboxPayload(command: RecordMemoryFactCommand): Prisma.InputJsonValue
+{
+	return { cogneeExternalId: command.cogneeExternalId, contentDigest: command.contentDigest, consentState: command.consentState, sensitivity: command.sensitivity, provenance: command.provenance as unknown as Prisma.InputJsonValue, source: command.source as unknown as Prisma.InputJsonValue, supersedesFactId: command.supersedesFactId, recordedBy: command.recordedBy } as Prisma.InputJsonObject;
+}
+
+/** Serialize JSON deterministically so equivalent provenance objects remain idempotent across key order. */
+function _CanonicalJson(value: unknown): string
+{
+	if (value === null || typeof value !== "object") return JSON.stringify(value);
+	if (Array.isArray(value)) return `[${value.map(function _item(item) { return _CanonicalJson(item); }).join(",")}]`;
+	const record = value as Readonly<Record<string, unknown>>;
+	return `{${Object.keys(record).sort().map(function _property(key) { return `${JSON.stringify(key)}:${_CanonicalJson(record[key])}`; }).join(",")}}`;
+}


### PR DESCRIPTION
## Why

Personal memory needs a durable metadata catalogue without moving long-term content into agent-tenant storage. Cognee remains the durable recall system; Postgres records only the evidence required to govern what Cognee already accepted.

## What changed

- adds the canonical Prisma catalogue repository for dataset-scoped memory fact metadata;
- records a content digest, Cognee external id, provenance, consent, and idempotency key—but never raw memory content;
- binds explicit-user facts to their authenticated author; and
- commits an outbox intent with the catalogue record, while distinguishing a successor fact from an initial record.

## Boundary

This does not claim correction or forgetting changed Cognee recall. Those operations require a verified, authenticated Cognee mutation API and a delivery worker; neither is invented here.

## Validation

- `npx nx run backend-agents-personal-memory:test` — 14 tests passed
- `npx nx run backend-agents-personal-memory:lint`
- `scripts/agent-style-check.sh` and `git diff --check`

## Review

Claude Code is not authenticated on this PC, so no external Claude review was claimed or transmitted. This PR needs independent review before merge.