### PR TITLE
🔒 Define fail-closed personal-memory gateway writes

### DIFF
--- a/libs/server/_infra/memory-gateway-client/README.md
+++ b/libs/server/_infra/memory-gateway-client/README.md
@@ -14,13 +14,14 @@ interface) that says *what* memory operations exist, with the real transport wir
 It sits between the personal-agent backend and the remote memory gateway:
 
 ```
- personal-agent backend  (recall / correct / forget on a subject's memory)
-          │  MemoryQueryCommand · MemoryCorrectionCommand · MemoryForgetCommand
+ personal-agent backend  (recall / record / correct / forget on a subject's memory)
+          │  MemoryQueryCommand · PersonalMemoryRecordCommand · MemoryCorrectionCommand · MemoryForgetCommand
           ▼
  ┌────────────────────────────────────┐
- │  memory-gateway-client  ◄── HERE    │  MemoryGatewayClient: query · correct · forget
+ │  memory-gateway-client  ◄── HERE    │  MemoryGatewayClient: query · record · correct · forget
  └────────────────────────────────────┘
-          │  MemoryQueryResult  (gateway-minted facts)
+          │  MemoryQueryResult (gateway-minted facts)
+          │  PersonalMemoryRecordResult (gateway id + sha256: digest / idempotency conflict)
           ▼
  remote memory gateway authority
 ```
@@ -28,8 +29,8 @@ It sits between the personal-agent backend and the remote memory gateway:
 **In this flow:** the personal-agent backend *(consumer)* · the remote memory gateway *(holds the
 facts, mints fact references)*
 
-It owns: the `MemoryGatewayClient` interface (`query` / `correct` / `forget` for a subject's personal
-memory, plus `recallScoped` / `injectScoped` for a shared knowledge SCOPE); the request/result
+It owns: the `MemoryGatewayClient` interface (`query` / `recordPersonalFact` / `correct` / `forget`
+for a subject's personal memory, plus `recallScoped` / `injectScoped` for a shared knowledge SCOPE); the request/result
 types, where recall returns only gateway-originated facts and a fact reference is only ever real if
 the gateway minted it; and a **fail-closed** default implementation,
 `__UnavailableMemoryGatewayClient`, which throws `MemoryGatewayUnavailableError` for every call. That
@@ -46,8 +47,15 @@ complete provenance.
 
 ## Public surface
 
-- `MemoryGatewayClient` — the runtime-neutral query/correct/forget + recallScoped/injectScoped contract.
+- `MemoryGatewayClient` — the runtime-neutral query/record/correct/forget + recallScoped/injectScoped contract.
 - `MemoryQueryCommand`, `MemoryQueryResult`, `MemoryFact`, `MemoryCorrectionCommand`, `MemoryForgetCommand` — the personal-memory I/O types.
+- `PersonalMemoryRecordCommand` / `PersonalMemoryRecordResult` — authenticated personal-memory retention:
+  the gateway receives the fact text and returns its own external id and SHA-256 digest only after
+  durable acceptance. The digest is always a lowercase `sha256:` content address; a reused key with
+  different content returns the explicit `idempotency_conflict` denial instead of silently reusing a
+  fact for the wrong statement.
+- `__AssertPersonalMemoryRecordResult` / `MemoryGatewayProtocolError` — response guard that every
+  concrete transport uses before exposing record evidence to the catalog boundary.
 - `MemoryProvenance`, `ScopedMemoryRecallCommand`, `ScopedMemoryRecallResult`, `ScopedMemoryFact`, `ScopedMemoryInjectionCommand` — the scoped read/write I/O types.
 - `__AssertMemoryProvenanceComplete`, `MemoryProvenanceIncompleteError` — the provenance guard and its error.
 - `__UnavailableMemoryGatewayClient`, `MemoryGatewayUnavailableError` — the fail-closed default and its error.
@@ -57,7 +65,9 @@ complete provenance.
 Consumed by the personal-agent backend. It defines the memory contract and a safe default; it does
 not talk to the gateway or Cognee itself yet — a concrete, authenticated client is wired when the
 gateway API contract is confirmed. It stores nothing and holds no fact beyond the single in-flight
-call.
+call. In particular, the record command uses the gateway-native dataset id, while the OpenCrane
+memory catalog's internal id stays at the catalog boundary. That prevents a caller from treating an
+OpenCrane row as proof that the gateway accepted the fact content.
 
 ## Dependency direction
 

--- a/libs/server/_infra/memory-gateway-client/src/__tests__/unavailable-memory-gateway-client.test.ts
+++ b/libs/server/_infra/memory-gateway-client/src/__tests__/unavailable-memory-gateway-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { __AssertMemoryProvenanceComplete, MemoryProvenanceIncompleteError } from "../memory-provenance.js";
+import { __AssertPersonalMemoryRecordResult, MemoryGatewayProtocolError } from "../personal-memory-record.js";
 import type { MemoryProvenance } from "../memory-gateway-client.types.js";
 import { __UnavailableMemoryGatewayClient, MemoryGatewayUnavailableError } from "../unavailable-memory-gateway-client.js";
 
@@ -16,6 +17,12 @@ describe("unavailable memory gateway client", function _suite()
 	{
 		const client = new __UnavailableMemoryGatewayClient();
 		await expect(client.query({ siloId: "silo-1", subjectId: "subject-1", query: "what do I know", maxResults: 5 })).rejects.toBeInstanceOf(MemoryGatewayUnavailableError);
+	});
+
+	it("fails closed rather than minting a personal-memory fact identifier", async function _recordPersonalFact()
+	{
+		const client = new __UnavailableMemoryGatewayClient();
+		await expect(client.recordPersonalFact({ siloId: "silo-1", subjectId: "user-1", cogneeDatasetId: "cognee-personal-user-1", content: "Use UK spelling", idempotencyKey: "interview-1:answer-1" })).rejects.toBeInstanceOf(MemoryGatewayUnavailableError);
 	});
 
 	it("fails closed rather than pretending a correction landed", async function _correct()
@@ -58,5 +65,21 @@ describe("memory provenance guard", function _provenanceSuite()
 		expect(() => __AssertMemoryProvenanceComplete(_provenance({ centralAgentId: "" }))).toThrow(MemoryProvenanceIncompleteError);
 		expect(() => __AssertMemoryProvenanceComplete(_provenance({ sourceRef: "  " }))).toThrow(MemoryProvenanceIncompleteError);
 		expect(() => __AssertMemoryProvenanceComplete(_provenance({ recordedAt: "not-a-date" }))).toThrow(MemoryProvenanceIncompleteError);
+	});
+});
+
+describe("personal-memory record response guard", function _recordResponseSuite()
+{
+	it("accepts canonical gateway evidence and the explicit idempotency collision", function _accepts()
+	{
+		expect(() => __AssertPersonalMemoryRecordResult({ outcome: "recorded", idempotent: false, cogneeExternalId: "gateway-fact-1", contentDigest: `sha256:${"a".repeat(64)}` })).not.toThrow();
+		expect(() => __AssertPersonalMemoryRecordResult({ outcome: "denied", reason: "idempotency_conflict" })).not.toThrow();
+	});
+
+	it("rejects noncanonical gateway digest evidence", function _rejects()
+	{
+		expect(() => __AssertPersonalMemoryRecordResult({ outcome: "recorded", idempotent: true, cogneeExternalId: "gateway-fact-1", contentDigest: "a".repeat(64) })).toThrow(MemoryGatewayProtocolError);
+		expect(() => __AssertPersonalMemoryRecordResult({ outcome: "unexpected", idempotent: true, cogneeExternalId: "gateway-fact-1", contentDigest: `sha256:${"a".repeat(64)}` })).toThrow(MemoryGatewayProtocolError);
+		expect(() => __AssertPersonalMemoryRecordResult({ outcome: "recorded", idempotent: false, cogneeExternalId: " ", contentDigest: `sha256:${"a".repeat(64)}` })).toThrow(MemoryGatewayProtocolError);
 	});
 });

--- a/libs/server/_infra/memory-gateway-client/src/index.ts
+++ b/libs/server/_infra/memory-gateway-client/src/index.ts
@@ -1,3 +1,4 @@
 export { __UnavailableMemoryGatewayClient, MemoryGatewayUnavailableError } from "./unavailable-memory-gateway-client.js";
 export { __AssertMemoryProvenanceComplete, MemoryProvenanceIncompleteError } from "./memory-provenance.js";
-export type { MemoryCorrectionCommand, MemoryFact, MemoryForgetCommand, MemoryGatewayClient, MemoryProvenance, MemoryQueryCommand, MemoryQueryResult, ScopedMemoryFact, ScopedMemoryInjectionCommand, ScopedMemoryRecallCommand, ScopedMemoryRecallResult } from "./memory-gateway-client.types.js";
+export { __AssertPersonalMemoryRecordResult, MemoryGatewayProtocolError } from "./personal-memory-record.js";
+export type { MemoryCorrectionCommand, MemoryFact, MemoryForgetCommand, MemoryGatewayClient, MemoryProvenance, MemoryQueryCommand, MemoryQueryResult, PersonalMemoryRecordCommand, PersonalMemoryRecordDenied, PersonalMemoryRecorded, PersonalMemoryRecordResult, ScopedMemoryFact, ScopedMemoryInjectionCommand, ScopedMemoryRecallCommand, ScopedMemoryRecallResult } from "./memory-gateway-client.types.js";

--- a/libs/server/_infra/memory-gateway-client/src/memory-gateway-client.types.ts
+++ b/libs/server/_infra/memory-gateway-client/src/memory-gateway-client.types.ts
@@ -27,6 +27,46 @@ export interface MemoryQueryResult
 	readonly facts: readonly MemoryFact[];
 }
 
+/** Request to durably retain one authenticated subject's personal-memory fact. */
+export interface PersonalMemoryRecordCommand
+{
+	/** Silo that owns the personal-memory dataset. */
+	readonly siloId: string;
+	/** Authenticated subject whose personal memory may receive this fact. */
+	readonly subjectId: string;
+	/** Gateway-native dataset identifier; OpenCrane's catalog id never crosses this boundary. */
+	readonly cogneeDatasetId: string;
+	/** Exact durable fact content, sent only to the remote memory gateway. */
+	readonly content: string;
+	/** Stable delivery key: it may be replayed only with byte-identical content in this subject and dataset. */
+	readonly idempotencyKey: string;
+}
+
+/** Gateway evidence returned only after a personal fact has durably been accepted. */
+export type PersonalMemoryRecordResult = PersonalMemoryRecorded | PersonalMemoryRecordDenied;
+
+/** Gateway evidence returned only after a personal fact has durably been accepted. */
+export interface PersonalMemoryRecorded
+{
+	/** Durable gateway acceptance outcome. */
+	readonly outcome: "recorded";
+	/** True when an identical earlier delivery already retained this exact content. */
+	readonly idempotent: boolean;
+	/** Stable fact identifier minted by the remote memory gateway. */
+	readonly cogneeExternalId: string;
+	/** Canonical lowercase sha256: content address computed over accepted durable content. */
+	readonly contentDigest: string;
+}
+
+/** Gateway denial that leaves no new durable personal-memory fact. */
+export interface PersonalMemoryRecordDenied
+{
+	/** Durable gateway denial outcome. */
+	readonly outcome: "denied";
+	/** Reused delivery key names content different from its already accepted request. */
+	readonly reason: "idempotency_conflict";
+}
+
 /** Request to correct the content of one stored fact. */
 export interface MemoryCorrectionCommand
 {
@@ -125,6 +165,8 @@ export interface MemoryGatewayClient
 {
 	/** Recalls facts for a subject and returns only gateway-originated results. */
 	query(command: MemoryQueryCommand): Promise<MemoryQueryResult>;
+	/** Retains one fact for the authenticated subject and returns gateway-minted evidence. */
+	recordPersonalFact(command: PersonalMemoryRecordCommand): Promise<PersonalMemoryRecordResult>;
 	/** Corrects one stored fact's content remotely. */
 	correct(command: MemoryCorrectionCommand): Promise<void>;
 	/** Forgets one stored fact remotely. */

--- a/libs/server/_infra/memory-gateway-client/src/personal-memory-record.ts
+++ b/libs/server/_infra/memory-gateway-client/src/personal-memory-record.ts
@@ -1,0 +1,26 @@
+import type { PersonalMemoryRecordResult } from "./memory-gateway-client.types.js";
+
+/** Typed failure emitted when a gateway response cannot prove a valid durable personal-memory write. */
+export class MemoryGatewayProtocolError extends Error
+{
+	/** Create an explicit protocol failure that callers must not reinterpret as an accepted fact. */
+	constructor(message: string)
+	{
+		super(message);
+		this.name = "MemoryGatewayProtocolError";
+	}
+}
+
+/** Validate untrusted gateway JSON and return only explicit collision or canonical write evidence. */
+export function __AssertPersonalMemoryRecordResult(value: unknown): PersonalMemoryRecordResult
+{
+	if (value === null || typeof value !== "object" || Array.isArray(value)) throw new MemoryGatewayProtocolError("Memory gateway returned a non-object personal-memory record response");
+	const result = value as Readonly<Record<string, unknown>>;
+	if (result["outcome"] === "denied")
+	{
+		if (result["reason"] === "idempotency_conflict") return { outcome: "denied", reason: "idempotency_conflict" };
+		throw new MemoryGatewayProtocolError("Memory gateway returned an unknown personal-memory record denial");
+	}
+	if (result["outcome"] !== "recorded" || typeof result["idempotent"] !== "boolean" || typeof result["cogneeExternalId"] !== "string" || typeof result["contentDigest"] !== "string" || !result["cogneeExternalId"].trim() || !/^sha256:[a-f0-9]{64}$/.test(result["contentDigest"])) throw new MemoryGatewayProtocolError("Memory gateway returned invalid personal-memory record evidence");
+	return { outcome: "recorded", idempotent: result["idempotent"], cogneeExternalId: result["cogneeExternalId"], contentDigest: result["contentDigest"] };
+}

--- a/libs/server/_infra/memory-gateway-client/src/unavailable-memory-gateway-client.ts
+++ b/libs/server/_infra/memory-gateway-client/src/unavailable-memory-gateway-client.ts
@@ -1,5 +1,5 @@
 import { __AssertMemoryProvenanceComplete } from "./memory-provenance.js";
-import type { MemoryCorrectionCommand, MemoryForgetCommand, MemoryGatewayClient, MemoryQueryCommand, MemoryQueryResult, ScopedMemoryInjectionCommand, ScopedMemoryRecallCommand, ScopedMemoryRecallResult } from "./memory-gateway-client.types.js";
+import type { MemoryCorrectionCommand, MemoryForgetCommand, MemoryGatewayClient, MemoryQueryCommand, MemoryQueryResult, PersonalMemoryRecordCommand, PersonalMemoryRecordResult, ScopedMemoryInjectionCommand, ScopedMemoryRecallCommand, ScopedMemoryRecallResult } from "./memory-gateway-client.types.js";
 
 /** Typed failure emitted when no authenticated memory-gateway transport is configured. */
 export class MemoryGatewayUnavailableError extends Error
@@ -17,6 +17,12 @@ export class __UnavailableMemoryGatewayClient implements MemoryGatewayClient
 {
 	/** Rejects recall rather than returning an empty or fabricated result. */
 	async query(_command: MemoryQueryCommand): Promise<MemoryQueryResult>
+	{
+		throw new MemoryGatewayUnavailableError();
+	}
+
+	/** Rejects personal-memory retention rather than inventing an external identifier or digest. */
+	async recordPersonalFact(_command: PersonalMemoryRecordCommand): Promise<PersonalMemoryRecordResult>
 	{
 		throw new MemoryGatewayUnavailableError();
 	}


### PR DESCRIPTION
## Why

The memory catalogue must only persist metadata after the durable memory authority accepts content. Before a concrete Cognee transport exists, the boundary needs an explicit typed contract that cannot mint fake success evidence.

## What changed

- adds a typed personal-memory record command and gateway-issued acceptance evidence;
- validates returned external ids and canonical `sha256:` digests before catalog code can trust them;
- defines explicit idempotency-collision behavior; and
- keeps the only configured adapter fail-closed: every record attempt throws rather than inventing an id or digest.

## Boundary

This PR does not add a Cognee HTTP client or expose a retention endpoint. A concrete transport remains blocked until its authenticated mutation semantics are verified against the pinned Cognee/plugin implementation.

## Validation

- `npx nx run server-infra-memory-gateway-client:test` — 10 tests passed
- `npx nx run server-infra-memory-gateway-client:lint`
- `scripts/agent-style-check.sh` and `git diff --check`

## Review

Claude Code is not authenticated on this PC, so no external Claude review was claimed or transmitted. This PR needs independent review before merge.