### PR TITLE
🔐 Phase E: resolve personal memory from signed identity

### DIFF
--- a/libs/backend/agents/personal/memory/main/README.md
+++ b/libs/backend/agents/personal/memory/main/README.md
@@ -54,12 +54,18 @@ from a first learned preference.
 - `MemoryCatalogRepository` — the persistence port a caller may inject.
 - `PrismaMemoryCatalogRepository` — the production adapter: checks the dataset, writes immutable
   metadata, and creates the `memory.fact_recorded` outbox intent in one transaction.
+- `__ResolvePersonalMemoryDataset(repository, command)` — selects the one active personal dataset
+  from a signed run's silo, organization, and subject. It takes no caller-supplied dataset id.
+- `PrismaPersonalMemoryDatasetRepository` — the production lookup adapter for that exact personal
+  dataset tuple.
 
 ## Boundary
 
 Consumed by the personal-agent memory-writing path. It never stores durable fact content — that stays
-in Cognee — and it never accepts a fact without an explainable source. Storage is injected through
-`MemoryCatalogRepository`, keeping the use case pure.
+in Cognee — and it never accepts a fact without an explainable source. Its dataset resolver binds
+personal memory to the run's verified `(silo, organization, subject)` tuple; no browser or runtime
+caller can select a different user's dataset by id. Storage is injected through small repository ports,
+keeping both use cases pure.
 
 ## Dependency direction
 

--- a/libs/backend/agents/personal/memory/main/src/__tests__/personal-memory-dataset.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/__tests__/personal-memory-dataset.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __ResolvePersonalMemoryDataset } from "../personal-memory-dataset.js";
+
+/** Builds a repository fake exposing the exact proof-bound lookup seam. */
+function _Repository(dataset: { readonly datasetId: string; readonly cogneeDatasetId: string } | null)
+{
+	return { findActivePersonalDataset: vi.fn().mockResolvedValue(dataset) };
+}
+
+describe("personal memory dataset authority", function _describePersonalMemoryDataset()
+{
+	it("resolves the active dataset only from signed silo, organization, and subject coordinates", async function _resolvesExactScope()
+	{
+		const repository = _Repository({ datasetId: "dataset-1", cogneeDatasetId: "cognee-personal-1" });
+
+		await expect(__ResolvePersonalMemoryDataset(repository, { siloId: "silo-1", organizationId: "org-1", subjectId: "user-1" })).resolves.toEqual({ outcome: "resolved", dataset: { datasetId: "dataset-1", cogneeDatasetId: "cognee-personal-1" } });
+		expect(repository.findActivePersonalDataset).toHaveBeenCalledWith({ siloId: "silo-1", organizationId: "org-1", subjectId: "user-1" });
+	});
+
+	it("fails closed without a matching active personal dataset", async function _deniesMissingScope()
+	{
+		await expect(__ResolvePersonalMemoryDataset(_Repository(null), { siloId: "silo-1", organizationId: "org-1", subjectId: "user-1" })).resolves.toEqual({ outcome: "denied", reason: "memory_scope_unavailable" });
+	});
+
+	it("rejects incomplete identity before any dataset lookup", async function _deniesIncompleteIdentity()
+	{
+		const repository = _Repository({ datasetId: "dataset-1", cogneeDatasetId: "cognee-personal-1" });
+
+		await expect(__ResolvePersonalMemoryDataset(repository, { siloId: "silo-1", organizationId: " ", subjectId: "user-1" })).resolves.toEqual({ outcome: "denied", reason: "memory_scope_unavailable" });
+		expect(repository.findActivePersonalDataset).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/personal/memory/main/src/__tests__/prisma-personal-memory-dataset-repository.test.ts
+++ b/libs/backend/agents/personal/memory/main/src/__tests__/prisma-personal-memory-dataset-repository.test.ts
@@ -1,0 +1,27 @@
+import { AuthorizationScopeKind, MemoryDatasetState } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaPersonalMemoryDatasetRepository } from "../prisma-personal-memory-dataset-repository.js";
+
+/** Builds the smallest Prisma fake that exposes personal-dataset resolution. */
+function _Prisma(dataset: { readonly id: string; readonly cogneeDatasetId: string } | null)
+{
+	return { memoryDataset: { findFirst: vi.fn().mockResolvedValue(dataset) } };
+}
+
+describe("Prisma personal memory dataset repository", function _describePrismaPersonalMemoryDataset()
+{
+	it("queries only the active personal dataset matching the full signed identity tuple", async function _queriesExactIdentity()
+	{
+		const prisma = _Prisma({ id: "dataset-1", cogneeDatasetId: "cognee-personal-1" });
+		const repository = new PrismaPersonalMemoryDatasetRepository(prisma as never);
+
+		await expect(repository.findActivePersonalDataset({ siloId: "silo-1", organizationId: "org-1", subjectId: "user-1" })).resolves.toEqual({ datasetId: "dataset-1", cogneeDatasetId: "cognee-personal-1" });
+		expect(prisma.memoryDataset.findFirst).toHaveBeenCalledWith({ where: { siloId: "silo-1", organizationId: "org-1", scopeKind: AuthorizationScopeKind.Personal, scopeResourceId: "user-1", state: MemoryDatasetState.Active }, select: { id: true, cogneeDatasetId: true } });
+	});
+
+	it("returns no dataset when the exact active personal scope is absent", async function _returnsMissingScope()
+	{
+		await expect(new PrismaPersonalMemoryDatasetRepository(_Prisma(null) as never).findActivePersonalDataset({ siloId: "silo-1", organizationId: "org-1", subjectId: "user-1" })).resolves.toBeNull();
+	});
+});

--- a/libs/backend/agents/personal/memory/main/src/index.ts
+++ b/libs/backend/agents/personal/memory/main/src/index.ts
@@ -1,3 +1,6 @@
 export { __IsValidMemoryFactCommand, __RecordMemoryFact } from "./memory-catalog.js";
+export { __ResolvePersonalMemoryDataset } from "./personal-memory-dataset.js";
 export { PrismaMemoryCatalogRepository } from "./prisma-memory-catalog-repository.js";
+export { PrismaPersonalMemoryDatasetRepository } from "./prisma-personal-memory-dataset-repository.js";
 export type { AtomicRecordMemoryFactResult, MemoryCatalogRepository, MemoryFactSource, RecordMemoryFactCommand, RecordMemoryFactResult } from "./memory-catalog.types.js";
+export type { PersonalMemoryDataset, PersonalMemoryDatasetRepository, ResolvePersonalMemoryDatasetCommand, ResolvePersonalMemoryDatasetResult } from "./personal-memory-dataset.types.js";

--- a/libs/backend/agents/personal/memory/main/src/personal-memory-dataset.ts
+++ b/libs/backend/agents/personal/memory/main/src/personal-memory-dataset.ts
@@ -1,0 +1,22 @@
+import type { PersonalMemoryDatasetRepository, ResolvePersonalMemoryDatasetCommand, ResolvePersonalMemoryDatasetResult } from "./personal-memory-dataset.types.js";
+
+/** Resolves personal memory from signed identity coordinates and never from a caller-provided dataset identifier. */
+export async function __ResolvePersonalMemoryDataset(repository: PersonalMemoryDatasetRepository, command: ResolvePersonalMemoryDatasetCommand): Promise<ResolvePersonalMemoryDatasetResult>
+{
+	// 1. Reject incomplete identity before a lookup could accidentally widen personal-memory scope.
+	if (!_IsValidPersonalMemoryDatasetCommand(command)) return { outcome: "denied", reason: "memory_scope_unavailable" };
+
+	// 2. Resolve only the exact active personal scope selected by the verified silo, organization, and subject.
+	const dataset = await repository.findActivePersonalDataset(command);
+	if (dataset === null) return { outcome: "denied", reason: "memory_scope_unavailable" };
+
+	// 3. Refuse malformed persistence output so no invalid gateway dataset coordinate reaches later runtime composition.
+	if (!dataset.datasetId.trim() || !dataset.cogneeDatasetId.trim()) return { outcome: "denied", reason: "memory_scope_unavailable" };
+	return { outcome: "resolved", dataset };
+}
+
+/** Returns whether every proof-bound personal-memory coordinate is present. */
+function _IsValidPersonalMemoryDatasetCommand(command: ResolvePersonalMemoryDatasetCommand): boolean
+{
+	return command.siloId.trim().length > 0 && command.organizationId.trim().length > 0 && command.subjectId.trim().length > 0;
+}

--- a/libs/backend/agents/personal/memory/main/src/personal-memory-dataset.types.ts
+++ b/libs/backend/agents/personal/memory/main/src/personal-memory-dataset.types.ts
@@ -1,0 +1,29 @@
+/** Proof-bound coordinates used to resolve one personal memory dataset. */
+export interface ResolvePersonalMemoryDatasetCommand
+{
+	/** Silo in which the personal dataset must exist. */
+	readonly siloId: string;
+	/** Organization from the verified fleet-membership assertion. */
+	readonly organizationId: string;
+	/** Subject whose personal dataset is being resolved. */
+	readonly subjectId: string;
+}
+
+/** Active personal dataset selected from proof-bound identity rather than caller-supplied dataset input. */
+export interface PersonalMemoryDataset
+{
+	/** OpenCrane catalog identifier used for durable fact provenance. */
+	readonly datasetId: string;
+	/** Cognee identifier used only by the memory-gateway boundary. */
+	readonly cogneeDatasetId: string;
+}
+
+/** Persistence boundary for resolving the one active personal dataset under exact identity coordinates. */
+export interface PersonalMemoryDatasetRepository
+{
+	/** Finds the active personal dataset for the exact silo, organization, and subject, or none. */
+	findActivePersonalDataset(command: ResolvePersonalMemoryDatasetCommand): Promise<PersonalMemoryDataset | null>;
+}
+
+/** Stable outcome from resolving personal memory without accepting a caller-selected dataset. */
+export type ResolvePersonalMemoryDatasetResult = { readonly outcome: "resolved"; readonly dataset: PersonalMemoryDataset } | { readonly outcome: "denied"; readonly reason: "memory_scope_unavailable" };

--- a/libs/backend/agents/personal/memory/main/src/prisma-personal-memory-dataset-repository.ts
+++ b/libs/backend/agents/personal/memory/main/src/prisma-personal-memory-dataset-repository.ts
@@ -1,0 +1,32 @@
+import { AuthorizationScopeKind, MemoryDatasetState, type PrismaClient } from "@prisma/client";
+
+import type { PersonalMemoryDataset, PersonalMemoryDatasetRepository, ResolvePersonalMemoryDatasetCommand } from "./personal-memory-dataset.types.js";
+
+/** Prisma authority that resolves only an active personal dataset under proof-bound identity coordinates. */
+export class PrismaPersonalMemoryDatasetRepository implements PersonalMemoryDatasetRepository
+{
+	/** Canonical per-silo product database. */
+	private readonly prisma: PrismaClient;
+
+	/** Creates the repository over the canonical product database. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	/** Returns the one active personal dataset matching the exact signed identity tuple. */
+	async findActivePersonalDataset(command: ResolvePersonalMemoryDatasetCommand): Promise<PersonalMemoryDataset | null>
+	{
+		const dataset = await this.prisma.memoryDataset.findFirst({
+			where: {
+				siloId: command.siloId,
+				organizationId: command.organizationId,
+				scopeKind: AuthorizationScopeKind.Personal,
+				scopeResourceId: command.subjectId,
+				state: MemoryDatasetState.Active,
+			},
+			select: { id: true, cogneeDatasetId: true },
+		});
+		return dataset === null ? null : { datasetId: dataset.id, cogneeDatasetId: dataset.cogneeDatasetId };
+	}
+}


### PR DESCRIPTION
## Why

Personal memory is private to a user inside an organization. A runtime must therefore select its dataset from verified identity, not from a browser or runtime-supplied dataset identifier.

## What changed

- add a small personal-memory dataset authority that accepts only `(silo, organization, subject)` coordinates
- resolve only an active `Personal` dataset whose full tuple matches those coordinates
- return both the catalog id and gateway-native Cognee dataset id only after that exact lookup
- document the authorization boundary for newcomers

## Enables

The next session-assembly slice can consume a dataset selected from the signed organization already frozen in the run identity, without adding a caller-controlled cross-organization dataset route.

## Validation

- `npx nx affected -t lint test --base=HEAD~1 --parallel=4`
- `bash scripts/agent-style-check.sh`
- `git diff HEAD~1 --check`

## Review

- independent security/correctness review completed with no findings
- Claude Code review was not run because the local CLI session remains unauthenticated

## Stack

Base: #468 (`feat/phase-e-org-scoped-memory-v2`).