### PR TITLE
🔐 Phase E: bind personal memory to verified run identity

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -169,7 +169,7 @@ export default [
             { sourceTag: "scope:policies", onlyDependOnLibsWithTags: ["scope:grants", "scope:k8s-api", "scope:policies", "scope:projection", "scope:shared"] },
             { sourceTag: "scope:personal-personas", onlyDependOnLibsWithTags: ["scope:personal-personas", "scope:shared"] },
             { sourceTag: "scope:projection", onlyDependOnLibsWithTags: ["scope:cluster-tenants", "scope:k8s-api", "scope:projection", "scope:shared"] },
-            { sourceTag: "scope:execution-inputs", onlyDependOnLibsWithTags: ["scope:agents", "scope:artifacts", "scope:membership", "scope:execution-runs", "scope:execution-inputs", "scope:shared"] },
+            { sourceTag: "scope:execution-inputs", onlyDependOnLibsWithTags: ["scope:agents", "scope:artifacts", "scope:membership", "scope:execution-runs", "scope:execution-inputs", "scope:personal-memory", "scope:shared"] },
             { sourceTag: "scope:providers", onlyDependOnLibsWithTags: ["scope:auth", "scope:cluster-tenants", "scope:model-routing", "scope:providers", "scope:shared"] },
             { sourceTag: "scope:retrieval", onlyDependOnLibsWithTags: ["scope:retrieval", "scope:shared"] },
             { sourceTag: "scope:execution-runs", onlyDependOnLibsWithTags: ["scope:agents", "scope:authorization", "scope:execution-runs", "scope:shared"] },

--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -51,6 +51,8 @@ caller input.
 - `FleetMembershipIdentityEnvelopeSource` — the identity port implementation: accepts only a
   cryptographically verified fleet-membership assertion (never caller-supplied claims) and a
   same-transaction capability-set digest.
+- `PersonalMemoryScopeSource` — selects a personal memory dataset from that verified identity's
+  silo, organization, and subject. It cannot receive a dataset identifier from the runtime caller.
 - `PrismaSkillRevisionEligibilitySource` — locks the AgentRevision's skill assignments
   at admission and refuses an invented, foreign, revoked, or unpublished revision with
   `skill_unavailable`.
@@ -74,8 +76,10 @@ non-canonical digest, or any single source refusal denies the run.
 ## Dependency direction
 
 Tagged `scope:execution-inputs`: it may depend only on `scope:agents`, `scope:artifacts`,
-`scope:membership`, `scope:execution-runs`, `scope:execution-inputs`, and `scope:shared` — never on
-apps or unrelated domains.
+`scope:membership`, `scope:personal-memory`, `scope:execution-runs`, `scope:execution-inputs`, and
+`scope:shared` — never on apps or unrelated domains. The personal-memory dependency is one-way:
+the assembler consumes its dataset-selection authority; the memory domain never depends on runtime
+assembly.
 
 ## See also
 

--- a/libs/backend/agents/execution/inputs/main/src/__tests__/personal-memory-scope-source.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/__tests__/personal-memory-scope-source.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PersonalMemoryScopeSource } from "../personal-memory-scope-source.js";
+
+describe("PersonalMemoryScopeSource", function _describePersonalMemoryScopeSource()
+{
+	it("selects the dataset from the verified organization and subject instead of caller input", async function _selectsVerifiedDataset()
+	{
+		const datasets = { findActivePersonalDataset: vi.fn().mockResolvedValue({ datasetId: "dataset-1", cogneeDatasetId: "cognee-personal-1" }) };
+		const source = new PersonalMemoryScopeSource(datasets);
+
+		await expect(source.load({ siloId: "silo-1" } as never, { agentKind: "personal" } as never, { organizationId: "org-1", executionSubjectId: "user-1" } as never, {} as never)).resolves.toEqual({ outcome: "loaded", value: { memoryQueryPolicy: { scope: "personal", datasetId: "dataset-1", cogneeDatasetId: "cognee-personal-1" }, memoryFacts: [] } });
+		expect(datasets.findActivePersonalDataset).toHaveBeenCalledWith({ siloId: "silo-1", organizationId: "org-1", subjectId: "user-1" });
+	});
+
+	it("refuses a managed run before personal dataset lookup", async function _deniesManagedRun()
+	{
+		const datasets = { findActivePersonalDataset: vi.fn() };
+		const source = new PersonalMemoryScopeSource(datasets);
+
+		await expect(source.load({ siloId: "silo-1" } as never, { agentKind: "managed" } as never, { organizationId: "org-1", executionSubjectId: "user-1" } as never, {} as never)).resolves.toEqual({ outcome: "denied", reason: "memory_scope_unavailable" });
+		expect(datasets.findActivePersonalDataset).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/execution/inputs/main/src/index.ts
+++ b/libs/backend/agents/execution/inputs/main/src/index.ts
@@ -1,4 +1,5 @@
 export { __AssembleRunInputSnapshot } from "./session-assembly.js";
 export { FleetMembershipIdentityEnvelopeSource } from "./fleet-membership-identity-envelope-source.js";
+export { PersonalMemoryScopeSource } from "./personal-memory-scope-source.js";
 export { PrismaSkillRevisionEligibilitySource } from "./prisma-skill-revision-eligibility-source.js";
 export type { ApprovedPersonaInput, ApprovedPersonaSource, AssembleRunInputSnapshotResult, BudgetPolicyInput, BudgetPolicySource, CapabilitySetDigestSource, IdentityEnvelopeInput, IdentityEnvelopeSource, MemoryScopeInput, MemoryScopeSource, PreferenceFactInput, PreferenceFactSource, RunAuthoritySource, SessionAssemblyAuthorities, SessionAssemblyCommand, SessionAssemblyLoad, SessionAssemblyRefusalReason, SkillRevisionEligibilitySource, ThreadContextInput, ThreadContextSource, ToolPolicyInput, ToolPolicySource } from "./session-assembly.types.js";

--- a/libs/backend/agents/execution/inputs/main/src/personal-memory-scope-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/personal-memory-scope-source.ts
@@ -1,0 +1,32 @@
+import { __ResolvePersonalMemoryDataset } from "@opencrane/backend/agents/personal/memory";
+import type { PersonalMemoryDatasetRepository } from "@opencrane/backend/agents/personal/memory";
+import type { InitialRunAuthority, RunAdmissionTransaction } from "@opencrane/backend/agents/execution/runs";
+
+import type { IdentityEnvelopeInput, MemoryScopeInput, MemoryScopeSource, SessionAssemblyCommand, SessionAssemblyLoad } from "./session-assembly.types.js";
+
+/** Memory-scope source that selects a personal Cognee dataset only from verified run identity. */
+export class PersonalMemoryScopeSource implements MemoryScopeSource
+{
+	/** Product-database authority for exact personal dataset selection. */
+	private readonly datasets: PersonalMemoryDatasetRepository;
+
+	/** Creates the source over the injected personal-memory dataset authority. */
+	constructor(datasets: PersonalMemoryDatasetRepository)
+	{
+		this.datasets = datasets;
+	}
+
+	/** Freezes the verified personal dataset as recall policy without accepting a caller-selected dataset. */
+	async load(command: SessionAssemblyCommand, run: InitialRunAuthority, identity: IdentityEnvelopeInput, _transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<MemoryScopeInput>>
+	{
+		// 1. Personal datasets cannot enter a managed-service snapshot, even if a delegated user has signed membership.
+		if (run.agentKind !== "personal") return { outcome: "denied", reason: "memory_scope_unavailable" };
+
+		// 2. Resolve the sole personal dataset from identity already verified at the admission fence.
+		const resolved = await __ResolvePersonalMemoryDataset(this.datasets, { siloId: command.siloId, organizationId: identity.organizationId, subjectId: identity.executionSubjectId });
+		if (resolved.outcome === "denied") return resolved;
+
+		// 3. Freeze only catalog and gateway coordinates; retrieval itself remains a later runtime-gateway action.
+		return { outcome: "loaded", value: { memoryQueryPolicy: { scope: "personal", datasetId: resolved.dataset.datasetId, cogneeDatasetId: resolved.dataset.cogneeDatasetId }, memoryFacts: [] } };
+	}
+}

--- a/libs/backend/agents/execution/inputs/main/src/session-assembly.ts
+++ b/libs/backend/agents/execution/inputs/main/src/session-assembly.ts
@@ -32,20 +32,25 @@ export async function __AssembleRunInputSnapshot(command: SessionAssemblyCommand
 		const run = await authorities.runAuthority.load(command, transaction);
 		if (run.outcome === "denied") return run;
 
-		// 4. A personal run requires an approved persona; a managed run must not carry one.
+		// 4. Verify signed identity before any identity-scoped input can select data from another organization.
+		const identity = await authorities.identityEnvelope.load(command, run.value, transaction);
+		if (identity.outcome === "denied") return identity;
+		if (!_IsIdentityFresh(identity.value, transaction.admittedAt)) return { outcome: "denied", reason: "membership_stale" } as const;
+
+		// 5. A personal run requires an approved persona; a managed run must not carry one.
 		const persona = await authorities.approvedPersona.load(command, run.value, transaction);
 		if (persona.outcome === "denied") return persona;
 		if ((run.value.agentKind === "personal") !== (persona.value.personaRevisionId !== null)) return { outcome: "denied", reason: "persona_unavailable" } as const;
 
-		// 5. Freeze the transcript, rejecting messages that leaked into a non-conversational run.
+		// 6. Freeze the transcript, rejecting messages that leaked into a non-conversational run.
 		const thread = await authorities.threadContext.load(command, run.value, transaction);
 		if (thread.outcome === "denied") return thread;
 		if (command.threadId === null && thread.value.messageIds.length > 0) return { outcome: "denied", reason: "thread_unavailable" } as const;
 
-		// 6. Freeze preferences, memory, tools, budgets, and signed identity in the same final transaction.
+		// 7. Freeze preferences, identity-scoped memory, tools, and budgets in the same final transaction.
 		const preferences = await authorities.preferenceFacts.load(command, run.value, transaction);
 		if (preferences.outcome === "denied") return preferences;
-		const memory = await authorities.memoryScope.load(command, run.value, transaction);
+		const memory = await authorities.memoryScope.load(command, run.value, identity.value, transaction);
 		if (memory.outcome === "denied") return memory;
 		const tools = await authorities.toolPolicy.load(command, run.value, transaction);
 		if (tools.outcome === "denied") return tools;
@@ -53,11 +58,7 @@ export async function __AssembleRunInputSnapshot(command: SessionAssemblyCommand
 		if (skills.outcome === "denied") return skills;
 		const budget = await authorities.budgetPolicy.load(command, run.value, transaction);
 		if (budget.outcome === "denied") return budget;
-		const identity = await authorities.identityEnvelope.load(command, run.value, transaction);
-		if (identity.outcome === "denied") return identity;
-		if (!_IsIdentityFresh(identity.value, transaction.admittedAt)) return { outcome: "denied", reason: "membership_stale" } as const;
-
-		// 7. Compile the immutable snapshot only after all source authority is revalidated at the durable fence.
+		// 8. Compile the immutable snapshot only after all source authority is revalidated at the durable fence.
 		return { outcome: "ready", value: { authority: run.value, snapshot: _compileSnapshot(command, transaction.admittedAt, run.value, persona.value, thread.value, preferences.value, memory.value, tools.value, budget.value.budgetPolicy, identity.value) } } as const;
 	});
 	if (admitted.outcome === "denied") return { outcome: "denied", reason: _publicReason(admitted.reason) };

--- a/libs/backend/agents/execution/inputs/main/src/session-assembly.types.ts
+++ b/libs/backend/agents/execution/inputs/main/src/session-assembly.types.ts
@@ -124,8 +124,8 @@ export interface PreferenceFactSource
 /** Reads authorised memory scope and pinned fact references. */
 export interface MemoryScopeSource
 {
-	/** Loads the exact memory scope allowed for this run. */
-	load(command: SessionAssemblyCommand, run: InitialRunAuthority, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<MemoryScopeInput>>;
+	/** Loads the exact memory scope allowed for this run from fresh verified identity. */
+	load(command: SessionAssemblyCommand, run: InitialRunAuthority, identity: IdentityEnvelopeInput, transaction: RunAdmissionTransaction): Promise<SessionAssemblyLoad<MemoryScopeInput>>;
 }
 
 /** Reads revision assignments intersected with the caller's effective grants. */


### PR DESCRIPTION
## Why

A resolved personal dataset is safe only when session assembly derives it from signed identity before any identity-scoped input is selected. Shared assembly must also never place a user personal dataset in a managed-agent run.

## What changed

- load fresh fleet-membership identity before memory scope assembly
- pass verified identity to every memory-scope source
- add `PersonalMemoryScopeSource`, which resolves the personal dataset from the signed silo, organization, and subject
- deny managed-agent runs before any personal-dataset lookup
- establish the one-way NX dependency from execution-input assembly to the personal-memory authority

## Validation

- `npx nx affected -t lint test --base=HEAD~1 --parallel=4`
- `npm run lint:boundaries`
- `bash scripts/agent-style-check.sh`
- `git diff --check`

## Review

- independent review caught the managed-run personal-memory exposure; it was fixed and independently verified
- Claude Code review was not run because the local CLI session remains unauthenticated

## Stack

Base: #469 (`feat/phase-e-personal-memory-scope-v2`).