### PR TITLE
🔐 Phase E: bind memory recall to its snapshot dataset

### DIFF
--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -196,7 +196,7 @@ function _CreateExternalActionRunner(prisma: PrismaClient): RuntimeExternalActio
 			{
 				executor = candidate.toolRevisionId === UPGRADE_SESSION_TOOL_REVISION
 					? { execute: function _proposeUpgradeSession() { return personalConfiguration.proposeUpgradeSession(candidate, snapshot, new Date().toISOString()); } }
-					: __CreateExternalActionExecutor(candidate, { siloId: snapshot.siloId, subjectId: snapshot.identitySnapshot.executionSubjectId, obotCustody, sandboxExecutor, memoryGateway });
+					: __CreateExternalActionExecutor(candidate, { siloId: snapshot.siloId, subjectId: snapshot.identitySnapshot.executionSubjectId, cogneeDatasetId: _PersonalMemoryDatasetId(snapshot), obotCustody, sandboxExecutor, memoryGateway });
 			}
 			catch (error)
 			{
@@ -213,6 +213,17 @@ function _CreateExternalActionRunner(prisma: PrismaClient): RuntimeExternalActio
 			return { outcome: "completed" as const };
 		},
 	};
+}
+
+/** Returns the personal Cognee dataset frozen in a snapshot, or null for every other scope. */
+function _PersonalMemoryDatasetId(snapshot: RunInputSnapshot): string | null
+{
+	const policy = snapshot.memoryQueryPolicy;
+	if (policy === null || typeof policy !== "object" || Array.isArray(policy)) return null;
+	const record = policy as Readonly<Record<string, unknown>>;
+	if (record["scope"] !== "personal") return null;
+	const candidate = record["cogneeDatasetId"];
+	return typeof candidate === "string" && candidate.trim().length > 0 ? candidate : null;
 }
 
 /** Compile normal grants, then add the sealed first-party upgrade intent only to personal sessions. */

--- a/libs/backend/agents/execution/protocol/README.md
+++ b/libs/backend/agents/execution/protocol/README.md
@@ -64,7 +64,9 @@ authorities to accept or reject.
 - `__CreatePrismaRunInputCompiler` — binds the deterministic prompt compiler to the control-plane
   Prisma reads used by the dispatch transaction.
 - `__CreateExternalActionExecutor` — routes one admitted action to the injected MCP custody,
-  sandbox, or memory port and fails closed for unsupported revisions.
+  sandbox, or memory port and fails closed for unsupported revisions. Memory recall additionally
+  requires a `scope: personal` policy and Cognee dataset identifier frozen in the admitted snapshot;
+  neither runtime tool arguments nor a subject id can choose a dataset.
 - `RuntimeStreamWorkloadIdentity` / `RuntimeCandidateDispatchResult` / `RuntimeDispatchAuthorityConfig`
   — the identity handed in by the transport, the candidate result, and the fixed dispatch policy.
 - `RuntimeAttemptAuthority` — exact durable facts, including current run state, that the owning run

--- a/libs/backend/agents/execution/protocol/src/__tests__/external-action-executor.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/external-action-executor.test.ts
@@ -4,7 +4,7 @@ import { __UnavailableSandboxJobExecutor } from "@opencrane/server/_infra/sandbo
 import { __UnavailableMemoryGatewayClient } from "@opencrane/server/_infra/memory-gateway-client";
 import { describe, expect, it } from "vitest";
 
-import { __CreateExternalActionExecutor, UnsupportedExternalActionError } from "../external-action-executor.js";
+import { __CreateExternalActionExecutor, MemoryScopeUnavailableError, UnsupportedExternalActionError } from "../external-action-executor.js";
 
 /** Build a candidate for the given tool revision prefix. */
 function _candidate(toolRevisionId: string): RuntimeExternalActionCandidate
@@ -13,7 +13,7 @@ function _candidate(toolRevisionId: string): RuntimeExternalActionCandidate
 }
 
 /** The composition root wires only fail-closed transports until a real one is verified. */
-const DEPENDENCIES = { siloId: "silo-1", subjectId: "user-1", obotCustody: new __UnavailableObotCustodyAdapter(), sandboxExecutor: new __UnavailableSandboxJobExecutor(), memoryGateway: new __UnavailableMemoryGatewayClient() };
+const DEPENDENCIES = { siloId: "silo-1", subjectId: "user-1", cogneeDatasetId: "cognee-personal-1", obotCustody: new __UnavailableObotCustodyAdapter(), sandboxExecutor: new __UnavailableSandboxJobExecutor(), memoryGateway: new __UnavailableMemoryGatewayClient() };
 
 describe("composition-root external action executor", function _suite()
 {
@@ -33,6 +33,12 @@ describe("composition-root external action executor", function _suite()
 	{
 		const executor = __CreateExternalActionExecutor(_candidate("memory:recall"), DEPENDENCIES);
 		await expect(executor.execute()).rejects.toThrow(/Memory gateway is unavailable/);
+	});
+
+	it("refuses a memory tool call when the admitted snapshot did not select a personal dataset", async function _deniesMissingMemoryScope()
+	{
+		const executor = __CreateExternalActionExecutor(_candidate("memory:recall"), { ...DEPENDENCIES, cogneeDatasetId: null });
+		await expect(executor.execute()).rejects.toBeInstanceOf(MemoryScopeUnavailableError);
 	});
 
 	it("refuses a tool revision that names no wired transport kind", async function _unsupported()

--- a/libs/backend/agents/execution/protocol/src/external-action-executor.ts
+++ b/libs/backend/agents/execution/protocol/src/external-action-executor.ts
@@ -14,6 +14,17 @@ export class UnsupportedExternalActionError extends Error
 	}
 }
 
+/** Typed failure emitted when an admitted snapshot did not authorize a personal memory dataset. */
+export class MemoryScopeUnavailableError extends Error
+{
+	/** Creates a failure that cannot fall back to subject-selected memory. */
+	constructor()
+	{
+		super("personal memory scope is unavailable for this run snapshot");
+		this.name = "MemoryScopeUnavailableError";
+	}
+}
+
 /** Read a string field from a candidate's canonical argument object, or null when absent. */
 function _stringArgument(candidate: RuntimeExternalActionCandidate, key: string): string | null
 {
@@ -57,8 +68,9 @@ export function __CreateExternalActionExecutor(candidate: RuntimeExternalActionC
 			}
 			if (toolRevisionId.startsWith("memory:"))
 			{
+				if (dependencies.cogneeDatasetId === null) throw new MemoryScopeUnavailableError();
 				const query = _stringArgument(candidate, "query") ?? "";
-				const result = await dependencies.memoryGateway.query({ siloId: dependencies.siloId, subjectId: dependencies.subjectId, query, maxResults: 20 });
+				const result = await dependencies.memoryGateway.query({ siloId: dependencies.siloId, cogneeDatasetId: dependencies.cogneeDatasetId, subjectId: dependencies.subjectId, query, maxResults: 20 });
 				return result.facts.map(function _fact(fact) { return { factId: fact.factId, content: fact.content }; });
 			}
 			throw new UnsupportedExternalActionError(toolRevisionId);

--- a/libs/backend/agents/execution/protocol/src/external-action-executor.types.ts
+++ b/libs/backend/agents/execution/protocol/src/external-action-executor.types.ts
@@ -9,6 +9,8 @@ export interface ExternalActionExecutorDependencies
 	readonly siloId: string;
 	/** Subject on whose behalf the action runs. */
 	readonly subjectId: string;
+	/** Gateway dataset frozen in the admitted snapshot, or null when this run cannot recall personal memory. */
+	readonly cogneeDatasetId: string | null;
 	/** Obot credential-custody transport backing MCP tool calls (fail-closed until verified). */
 	readonly obotCustody: ObotCustodyPort;
 	/** Sandbox Job transport backing sandboxed tool calls (fail-closed until verified). */

--- a/libs/server/_infra/memory-gateway-client/README.md
+++ b/libs/server/_infra/memory-gateway-client/README.md
@@ -5,7 +5,9 @@
 ## What it owns
 
 This library owns the **boundary for a subject's personal memory** — recalling, correcting, and
-forgetting stored facts through the memory gateway instead of calling Cognee directly. The *memory
+forgetting stored facts through the memory gateway instead of calling Cognee directly. A recall also
+names the gateway-native dataset that OpenCrane froze in the admitted run snapshot; a subject id is
+never enough to select a dataset. The *memory
 gateway* is the green-side authority that fronts org/personal memory; routing every read and write
 through this port is what lets the platform stop reaching into Cognee from scattered call sites (see
 the org-memory wiring notes). This package is a **port** — a runtime-neutral contract (a TypeScript
@@ -14,7 +16,7 @@ interface) that says *what* memory operations exist, with the real transport wir
 It sits between the personal-agent backend and the remote memory gateway:
 
 ```
- personal-agent backend  (recall / record / correct / forget on a subject's memory)
+ personal-agent backend  (recall / record / correct / forget in an admitted personal dataset)
           │  MemoryQueryCommand · PersonalMemoryRecordCommand · MemoryCorrectionCommand · MemoryForgetCommand
           ▼
  ┌────────────────────────────────────┐
@@ -65,9 +67,11 @@ complete provenance.
 Consumed by the personal-agent backend. It defines the memory contract and a safe default; it does
 not talk to the gateway or Cognee itself yet — a concrete, authenticated client is wired when the
 gateway API contract is confirmed. It stores nothing and holds no fact beyond the single in-flight
-call. In particular, the record command uses the gateway-native dataset id, while the OpenCrane
-memory catalog's internal id stays at the catalog boundary. That prevents a caller from treating an
-OpenCrane row as proof that the gateway accepted the fact content.
+call. In particular, record and query commands use the gateway-native dataset id, while the OpenCrane
+memory catalog's internal id stays at the catalog boundary. A runtime supplies that query id only
+from its immutable personal-memory policy; no tool argument or subject id may select another
+dataset. That prevents a caller from treating an OpenCrane row as proof that the gateway accepted
+the fact content.
 
 ## Dependency direction
 

--- a/libs/server/_infra/memory-gateway-client/src/__tests__/unavailable-memory-gateway-client.test.ts
+++ b/libs/server/_infra/memory-gateway-client/src/__tests__/unavailable-memory-gateway-client.test.ts
@@ -16,7 +16,7 @@ describe("unavailable memory gateway client", function _suite()
 	it("fails closed instead of returning an empty recall", async function _query()
 	{
 		const client = new __UnavailableMemoryGatewayClient();
-		await expect(client.query({ siloId: "silo-1", subjectId: "subject-1", query: "what do I know", maxResults: 5 })).rejects.toBeInstanceOf(MemoryGatewayUnavailableError);
+		await expect(client.query({ siloId: "silo-1", cogneeDatasetId: "cognee-personal-1", subjectId: "subject-1", query: "what do I know", maxResults: 5 })).rejects.toBeInstanceOf(MemoryGatewayUnavailableError);
 	});
 
 	it("fails closed rather than minting a personal-memory fact identifier", async function _recordPersonalFact()

--- a/libs/server/_infra/memory-gateway-client/src/memory-gateway-client.types.ts
+++ b/libs/server/_infra/memory-gateway-client/src/memory-gateway-client.types.ts
@@ -12,6 +12,8 @@ export interface MemoryQueryCommand
 {
 	/** Silo that owns the memory scope. */
 	readonly siloId: string;
+	/** Gateway-native personal dataset identifier frozen in the admitted run snapshot. */
+	readonly cogneeDatasetId: string;
 	/** Subject whose personal memory is being queried. */
 	readonly subjectId: string;
 	/** Free-text recall query. */


### PR DESCRIPTION
## Why

A memory tool must not infer its dataset from a subject identifier at execution time. The admitted immutable snapshot is the authority that selected the personal Cognee dataset.

## What changed

- require every personal-memory gateway query to name a Cognee dataset id
- extract that id only from a snapshot policy explicitly marked `scope: personal`
- deny memory-tool execution before gateway I/O if the snapshot has no valid personal dataset
- preserve the subject only as correlation identity; it no longer chooses the recalled dataset

## Validation

- `npx nx affected -t lint test --base=HEAD~1 --parallel=4`
- `npm run lint:boundaries`
- `bash scripts/agent-style-check.sh`
- `git diff --check`

## Review

- independent review completed with no findings; it also verified the personal-scope hardening
- Claude Code review was not run because the local CLI session remains unauthenticated

## Stack

Base: #470 (`feat/phase-e-personal-memory-assembly-v2`).