### PR TITLE
🏗️ Phase E: govern child-run admissions

### DIFF
--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -58,6 +58,15 @@ polls) so a started attempt can never be lost between deciding and launching.
 Job, confirms the workload's full identity (who / where / which attempt) matches the expected authority exactly, uses the fixed
 `opencrane-agent-runtime` projected-token audience, and has not expired.
 
+`__PrepareChildRunAdmission` is the authority-only first step for an agent asking a parent run to
+start another agent. It inherits the silo, subject and run lineage exclusively from the already
+admitted parent; the child request cannot supply replacements. Before returning a prepared record it
+enforces server-owned depth, direct-child and remaining-budget limits, then calls the supplied
+delegation policy for the exact target service and immutable revision. It returns a plain denial for
+any failed check. A later persistence adapter must repeat the target check and reserve the budget in
+the same transaction that creates the child run: this pure package intentionally makes no durable
+reservation on its own.
+
 `PrismaRunDispatchRepository` is the database side of the controller handshake. It issues a short,
 server-owned claim lease over `RunAttemptRequested`, exposes only the coordinates needed to create a
 suspended Job, and commits the Job UID as a `PendingPod` assignment. At claim time it also mints the
@@ -116,6 +125,8 @@ uncertainty fails closed.
 
 - `__StartNextRunAttempt(repository, command)` — start the next attempt of a run via compare-and-swap.
 - `__ValidateRunWorkloadAssignment(assignment, expectation)` — confirm a workload is the one authorised for this attempt.
+- `__PrepareChildRunAdmission(parent, command, limits, targetAuthorization)` — prepare a bounded
+  child-run record after exact parent-to-target delegation has been rechecked.
 - `__DigestRunInputSnapshot(snapshot)` — compute the canonical SHA-256 identity of all frozen run
   inputs without digesting the self-referential `digest` field.
 - `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial
@@ -140,6 +151,11 @@ uncertainty fails closed.
 - `AgentRunAuthorityRepository` / `AgentRunAuthoritySnapshot` — the persistence port and its consistent read shape.
 - `StartNextRunAttemptCommand` / `StartNextRunAttemptResult`, `AtomicStartNextRunAttemptCommand` / `AtomicRunAttemptResult` — retry request/result and their atomic commit forms.
 - `RunWorkloadAssignment` / `RunWorkloadAssignmentExpectation` / `RunWorkloadAssignmentDecision` — the workload-identity check inputs and verdict.
+- `ChildRunParentAuthority` / `ChildRunAdmissionLimits` / `ChildRunBudget` — parent facts and
+  server limits used to control one recursive invocation.
+- `ChildRunTargetAuthorization` / `PrepareChildRunAdmissionCommand` /
+  `PrepareChildRunAdmissionResult` — the target-policy port and the prepared-or-denied child
+  admission vocabulary.
 
 ## Boundary
 
@@ -152,6 +168,12 @@ Kubernetes itself. It owns only durable admission, attempts, dispatch leases, as
 integrity, release delivery, first-Pod registration, cancellation fencing, and cleanup
 confirmation. Kubernetes inspection and mutation remain in dedicated runtime processes; this
 package only says which exact work may be removed.
+
+Child admission is not an alternate public run-start route. A caller must derive parent authority
+from the admitted parent run, use the target-authorization port backed by that parent's approved
+tool policy, and persist the prepared record through a transaction that rechecks and reserves it.
+This package neither trusts a child-supplied subject, silo or lineage nor creates a child run by
+itself.
 
 ## Dependency direction
 

--- a/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { __PrepareChildRunAdmission } from "../child-run-admission.js";
+import type { ChildRunTargetAuthorization } from "../child-run-admission.types.js";
+
+/** Parent facts whose remaining authority can be safely carved into child work. */
+const _PARENT = { runId: "parent-1", siloId: "silo-1", rootRunId: "root-1", depth: 1, executionSubjectId: "user-1", remainingTokens: 1_000, remainingCostUsdMicros: 5_000_000, admittedChildCount: 1 } as const;
+/** Server-owned recursive delegation bounds. */
+const _LIMITS = { maximumDepth: 3, maximumChildrenPerParent: 4 } as const;
+/** Target selected by a parent-authorized child-run tool policy. */
+const _COMMAND = { childRunId: "child-1", targetAgentServiceId: "service-child", targetAgentRevisionId: "revision-child", requestedBudget: { maxTokens: 200, maxCostUsdMicros: 1_000_000 } } as const;
+/** Policy double that permits the explicitly selected target. */
+const _AUTHORIZED_TARGET: ChildRunTargetAuthorization = { authorize: async function _authorizeTarget() { return { outcome: "authorized" }; } };
+/** Policy double that refuses the explicitly selected target. */
+const _DENIED_TARGET: ChildRunTargetAuthorization = { authorize: async function _denyTarget() { return { outcome: "denied" }; } };
+/** Policy double that cannot prove the target authorization. */
+const _UNAVAILABLE_TARGET: ChildRunTargetAuthorization = { authorize: async function _failTarget() { throw new Error("authority source unavailable"); } };
+
+describe("governed child run admission", function _describeChildRunAdmission()
+{
+	it("inherits lineage, silo, and subject only from parent authority while carving bounded budget", async function _preparesChild()
+	{
+		await expect(__PrepareChildRunAdmission(_PARENT, _COMMAND, _LIMITS, _AUTHORIZED_TARGET)).resolves.toEqual({ outcome: "prepared", value: { runId: "child-1", parentRunId: "parent-1", rootRunId: "root-1", siloId: "silo-1", executionSubjectId: "user-1", agentServiceId: "service-child", agentRevisionId: "revision-child", trigger: "managed_invocation", budget: { maxTokens: 200, maxCostUsdMicros: 1_000_000 } } });
+	});
+
+	it("denies a recursive fork at the configured depth cap", async function _deniesDepth()
+	{
+		await expect(__PrepareChildRunAdmission({ ..._PARENT, depth: 3 }, _COMMAND, _LIMITS, _AUTHORIZED_TARGET)).resolves.toEqual({ outcome: "denied", reason: "depth_exceeded" });
+	});
+
+	it("denies fan-out and budget reservations beyond the parent authority", async function _deniesFanoutAndBudget()
+	{
+		await expect(__PrepareChildRunAdmission({ ..._PARENT, admittedChildCount: 4 }, _COMMAND, _LIMITS, _AUTHORIZED_TARGET)).resolves.toEqual({ outcome: "denied", reason: "fanout_exceeded" });
+		await expect(__PrepareChildRunAdmission(_PARENT, { ..._COMMAND, requestedBudget: { maxTokens: 1_001, maxCostUsdMicros: 1_000_000 } }, _LIMITS, _AUTHORIZED_TARGET)).resolves.toEqual({ outcome: "denied", reason: "budget_exceeded" });
+	});
+
+	it("denies malformed, unauthorised, and unavailable delegation authority", async function _deniesInvalidAuthorityAndTarget()
+	{
+		await expect(__PrepareChildRunAdmission({ ..._PARENT, executionSubjectId: "" }, _COMMAND, _LIMITS, _AUTHORIZED_TARGET)).resolves.toEqual({ outcome: "denied", reason: "invalid_parent_authority" });
+		await expect(__PrepareChildRunAdmission(_PARENT, _COMMAND, _LIMITS, _DENIED_TARGET)).resolves.toEqual({ outcome: "denied", reason: "target_not_authorized" });
+		await expect(__PrepareChildRunAdmission(_PARENT, _COMMAND, _LIMITS, _UNAVAILABLE_TARGET)).resolves.toEqual({ outcome: "denied", reason: "target_authorization_unavailable" });
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
@@ -1,0 +1,46 @@
+import type { ChildRunAdmissionLimits, ChildRunParentAuthority, ChildRunTargetAuthorization, PrepareChildRunAdmissionCommand, PrepareChildRunAdmissionResult } from "./child-run-admission.types.js";
+
+/** Prepares a governed child run using only parent authority, fixed limits, and a carved budget. */
+export async function __PrepareChildRunAdmission(parent: ChildRunParentAuthority, command: PrepareChildRunAdmissionCommand, limits: ChildRunAdmissionLimits, targetAuthorization: ChildRunTargetAuthorization): Promise<PrepareChildRunAdmissionResult>
+{
+	// 1. Reject malformed parent authority separately, so callers cannot mistake it for a bad child request.
+	if (!_IsValidParent(parent)) return { outcome: "denied", reason: "invalid_parent_authority" };
+	if (!_IsValidCommand(command) || !_IsValidLimits(limits)) return { outcome: "denied", reason: "invalid_command" };
+
+	// 2. Enforce tree bounds here so no child can bypass the parent-brokered fan-out or recursive depth limits.
+	if (parent.depth >= limits.maximumDepth) return { outcome: "denied", reason: "depth_exceeded" };
+	if (parent.admittedChildCount >= limits.maximumChildrenPerParent) return { outcome: "denied", reason: "fanout_exceeded" };
+
+	// 3. Carve budget before persistence; a child may never reserve more than its parent still controls.
+	if (command.requestedBudget.maxTokens > parent.remainingTokens || command.requestedBudget.maxCostUsdMicros > parent.remainingCostUsdMicros) return { outcome: "denied", reason: "budget_exceeded" };
+
+	// 4. Recheck the exact target rather than trusting an agent-provided service or revision identifier.
+	try
+	{
+		if ((await targetAuthorization.authorize(parent, command)).outcome === "denied") return { outcome: "denied", reason: "target_not_authorized" };
+	}
+	catch
+	{
+		return { outcome: "denied", reason: "target_authorization_unavailable" };
+	}
+
+	return { outcome: "prepared", value: { runId: command.childRunId, parentRunId: parent.runId, rootRunId: parent.rootRunId, siloId: parent.siloId, executionSubjectId: parent.executionSubjectId, agentServiceId: command.targetAgentServiceId, agentRevisionId: command.targetAgentRevisionId, trigger: "managed_invocation", budget: command.requestedBudget } };
+}
+
+/** Returns whether parent facts are complete and safe for a child to inherit. */
+function _IsValidParent(parent: ChildRunParentAuthority): boolean
+{
+	return parent.runId.trim().length > 0 && parent.siloId.trim().length > 0 && parent.rootRunId.trim().length > 0 && parent.executionSubjectId.trim().length > 0 && Number.isSafeInteger(parent.depth) && parent.depth >= 0 && Number.isSafeInteger(parent.admittedChildCount) && parent.admittedChildCount >= 0 && Number.isSafeInteger(parent.remainingTokens) && parent.remainingTokens >= 0 && Number.isSafeInteger(parent.remainingCostUsdMicros) && parent.remainingCostUsdMicros >= 0;
+}
+
+/** Returns whether the requested child identity and budget are complete positive values. */
+function _IsValidCommand(command: PrepareChildRunAdmissionCommand): boolean
+{
+	return command.childRunId.trim().length > 0 && command.targetAgentServiceId.trim().length > 0 && command.targetAgentRevisionId.trim().length > 0 && Number.isSafeInteger(command.requestedBudget.maxTokens) && command.requestedBudget.maxTokens > 0 && Number.isSafeInteger(command.requestedBudget.maxCostUsdMicros) && command.requestedBudget.maxCostUsdMicros > 0;
+}
+
+/** Returns whether server-owned tree limits are finite non-negative values. */
+function _IsValidLimits(limits: ChildRunAdmissionLimits): boolean
+{
+	return Number.isSafeInteger(limits.maximumDepth) && limits.maximumDepth >= 0 && Number.isSafeInteger(limits.maximumChildrenPerParent) && limits.maximumChildrenPerParent >= 0;
+}

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
@@ -1,0 +1,92 @@
+/** Immutable budget carved from a parent run for one governed child. */
+export interface ChildRunBudget
+{
+	/** Maximum model tokens the child may consume. */
+	readonly maxTokens: number;
+	/** Maximum micro-USD the child may spend. */
+	readonly maxCostUsdMicros: number;
+}
+
+/** Parent authority facts already loaded at the child-run admission fence. */
+export interface ChildRunParentAuthority
+{
+	/** Parent logical run identifier. */
+	readonly runId: string;
+	/** Silo that owns the entire run tree. */
+	readonly siloId: string;
+	/** Root run identifier shared by every descendant. */
+	readonly rootRunId: string;
+	/** Parent depth below the root. */
+	readonly depth: number;
+	/** Subject whose authority the parent may broker to a child. */
+	readonly executionSubjectId: string;
+	/** Tokens still unreserved by the parent and its existing children. */
+	readonly remainingTokens: number;
+	/** Micro-USD still unreserved by the parent and its existing children. */
+	readonly remainingCostUsdMicros: number;
+	/** Number of children already admitted directly beneath this parent. */
+	readonly admittedChildCount: number;
+}
+
+/** Server-owned bounds applied to every parent fork. */
+export interface ChildRunAdmissionLimits
+{
+	/** Maximum child depth below a root run. */
+	readonly maximumDepth: number;
+	/** Maximum directly admitted children under one parent run. */
+	readonly maximumChildrenPerParent: number;
+}
+
+/** Request to prepare one child admission from parent-owned authority facts. */
+export interface PrepareChildRunAdmissionCommand
+{
+	/** New logical child run identifier. */
+	readonly childRunId: string;
+	/** Target service selected by the parent's already-authorized tool policy. */
+	readonly targetAgentServiceId: string;
+	/** Target immutable revision selected by the same policy. */
+	readonly targetAgentRevisionId: string;
+	/** Requested bounded child allocation. */
+	readonly requestedBudget: ChildRunBudget;
+}
+
+/** Rechecks whether a parent may delegate work to one exact service revision. */
+export interface ChildRunTargetAuthorization
+{
+	/**
+	 * Returns whether the already-authorized parent may invoke this exact child target.
+	 *
+	 * The persistence boundary must invoke this check again in the transaction that reserves the
+	 * child budget, so a policy change cannot race the durable admission.
+	 */
+	authorize(parent: ChildRunParentAuthority, command: PrepareChildRunAdmissionCommand): Promise<ChildRunTargetAuthorizationResult>;
+}
+
+/** Result returned by the policy that controls parent-to-child delegation. */
+export type ChildRunTargetAuthorizationResult = { readonly outcome: "authorized" } | { readonly outcome: "denied" };
+
+/** Parent-derived coordinates that the persistence/snapshot layer must preserve exactly. */
+export interface PreparedChildRunAdmission
+{
+	/** Child run identifier. */
+	readonly runId: string;
+	/** Parent run identifier; a child never starts as a root. */
+	readonly parentRunId: string;
+	/** Shared root run identifier for aggregate budget and audit. */
+	readonly rootRunId: string;
+	/** Silo inherited from the parent. */
+	readonly siloId: string;
+	/** Subject inherited from parent authority rather than the spawn-tool payload. */
+	readonly executionSubjectId: string;
+	/** Target service chosen by the parent-approved delegation policy. */
+	readonly agentServiceId: string;
+	/** Target revision chosen by the parent-approved delegation policy. */
+	readonly agentRevisionId: string;
+	/** Existing trigger representing an agent-originated managed invocation. */
+	readonly trigger: "managed_invocation";
+	/** Budget the persistence boundary must atomically reserve before creating this child. */
+	readonly budget: ChildRunBudget;
+}
+
+/** Stable result of evaluating one governed child-run admission. */
+export type PrepareChildRunAdmissionResult = { readonly outcome: "prepared"; readonly value: PreparedChildRunAdmission } | { readonly outcome: "denied"; readonly reason: "invalid_command" | "invalid_parent_authority" | "depth_exceeded" | "fanout_exceeded" | "budget_exceeded" | "target_not_authorized" | "target_authorization_unavailable" };

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -1,7 +1,9 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
+export { __PrepareChildRunAdmission } from "./child-run-admission.js";
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
+export type { ChildRunAdmissionLimits, ChildRunBudget, ChildRunParentAuthority, ChildRunTargetAuthorization, ChildRunTargetAuthorizationResult, PrepareChildRunAdmissionCommand, PrepareChildRunAdmissionResult, PreparedChildRunAdmission } from "./child-run-admission.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
 export { PrismaRunAdmissionRepository } from "./prisma-run-admission-repository.js";
 export { PrismaRunCancellationRepository } from "./prisma-run-cancellation-repository.js";


### PR DESCRIPTION
## Why

A managed agent may need another agent to perform bounded work. That must not create a second path around the parent run's identity, service policy, recursive limits, or budget.

## What changes

- add a pure child-run admission authority that inherits silo, subject, parent, and root lineage exclusively from the admitted parent
- enforce server-owned depth and direct-child caps plus both token and cost-budget bounds
- require a policy port to recheck the exact delegated service revision; unavailable policy fails closed
- document that the later persistence adapter must recheck delegation and atomically reserve the child budget with run creation

This is deliberately the authority foundation only: it does not create a new public run-start route or persist a child run yet.

## Validation

- `npx nx run backend-agents-execution-runs:lint`
- `npx nx run backend-agents-execution-runs:test` (61 tests)
- `npx nx affected -t lint test --base=HEAD~1 --parallel=4` (three projects; 120 tests)
- `bash scripts/agent-style-check.sh`
- `git diff --check`

Nx reported its cached rerun classification for the run-package test as flaky, although both direct and affected executions passed.

## Review

Independent review found no findings. Claude Code review was not run because its local CLI session remains unauthenticated.

## Stack

Base: #471 (`feat/phase-e-memory-tool-snapshot-scope-v2`).