### PR TITLE
🧱 Phase E: persist governed child-run reservations

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -1353,6 +1353,19 @@ CREATE TABLE "run_input_snapshots" (
 );
 
 -- CreateTable
+CREATE TABLE "child_run_reservations" (
+    "child_run_id" TEXT NOT NULL,
+    "parent_run_id" TEXT NOT NULL,
+    "root_run_id" TEXT NOT NULL,
+    "depth" INTEGER NOT NULL,
+    "max_tokens" INTEGER NOT NULL,
+    "max_cost_usd_micros" BIGINT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "child_run_reservations_pkey" PRIMARY KEY ("child_run_id")
+);
+
+-- CreateTable
 CREATE TABLE "workload_assignments" (
     "run_id" TEXT NOT NULL,
     "attempt" INTEGER NOT NULL,
@@ -2196,6 +2209,12 @@ CREATE UNIQUE INDEX "run_input_snapshots_run_id_input_digest_key" ON "run_input_
 CREATE UNIQUE INDEX "run_input_snapshot_run_identity_key" ON "run_input_snapshots"("run_id", "input_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest");
 
 -- CreateIndex
+CREATE INDEX "child_run_reservations_parent_run_id_idx" ON "child_run_reservations"("parent_run_id");
+
+-- CreateIndex
+CREATE INDEX "child_run_reservations_root_run_id_idx" ON "child_run_reservations"("root_run_id");
+
+-- CreateIndex
 CREATE INDEX "workload_assignments_silo_id_subject_id_idx" ON "workload_assignments"("silo_id", "subject_id");
 
 -- CreateIndex
@@ -2553,6 +2572,12 @@ ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_agent_service_id_agent_revis
 ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_agent_service_id_silo_id_fkey" FOREIGN KEY ("agent_service_id", "silo_id") REFERENCES "agent_services"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
+ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_parent_run_id_fkey" FOREIGN KEY ("parent_run_id") REFERENCES "agent_runs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_child_run_id_fkey" FOREIGN KEY ("child_run_id") REFERENCES "agent_runs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_run_id_input_digest_thread_id_silo_id__fkey" FOREIGN KEY ("run_id", "input_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest") REFERENCES "agent_runs"("id", "input_snapshot_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
@@ -2862,6 +2887,50 @@ $$;
 CREATE FUNCTION "reject_run_input_snapshot_mutation"() RETURNS trigger LANGUAGE plpgsql AS $$
 BEGIN
     RAISE EXCEPTION 'RunInputSnapshot rows are immutable';
+END;
+$$;
+CREATE FUNCTION "enforce_child_run_reservation"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    child "agent_runs"%ROWTYPE;
+    parent "agent_runs"%ROWTYPE;
+    root "agent_runs"%ROWTYPE;
+    parent_depth INTEGER;
+BEGIN
+    SELECT * INTO child FROM "agent_runs" WHERE "id" = NEW."child_run_id" FOR KEY SHARE;
+    SELECT * INTO parent FROM "agent_runs" WHERE "id" = NEW."parent_run_id" FOR UPDATE;
+    SELECT * INTO root FROM "agent_runs" WHERE "id" = NEW."root_run_id" FOR KEY SHARE;
+
+    IF child."id" IS NULL OR parent."id" IS NULL OR root."id" IS NULL
+        OR child."state" IS DISTINCT FROM 'accepted'::"AgentRunState"
+        OR child."attempt" <> 1
+        OR child."trigger" IS DISTINCT FROM 'managed_invocation'::"AgentRunTrigger"
+        OR child."parent_run_id" IS DISTINCT FROM NEW."parent_run_id"
+        OR child."root_run_id" IS DISTINCT FROM NEW."root_run_id"
+        OR parent."root_run_id" IS DISTINCT FROM NEW."root_run_id"
+        OR root."id" IS DISTINCT FROM root."root_run_id"
+        OR root."parent_run_id" IS NOT NULL
+        OR child."silo_id" IS DISTINCT FROM parent."silo_id"
+        OR parent."silo_id" IS DISTINCT FROM root."silo_id"
+        OR NEW."child_run_id" = NEW."parent_run_id" THEN
+        RAISE EXCEPTION 'ChildRunReservation must bind one same-silo child to its exact parent and root';
+    END IF;
+
+    IF parent."parent_run_id" IS NULL THEN
+        IF parent."id" IS DISTINCT FROM NEW."root_run_id" OR NEW."depth" <> 1 THEN
+            RAISE EXCEPTION 'a direct child reservation must have the canonical root parent and depth 1';
+        END IF;
+    ELSE
+        SELECT "depth" INTO parent_depth FROM "child_run_reservations" WHERE "child_run_id" = parent."id" FOR KEY SHARE;
+        IF parent_depth IS NULL OR NEW."depth" <> parent_depth + 1 THEN
+            RAISE EXCEPTION 'a nested child reservation must continue its parent reservation depth';
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE FUNCTION "reject_child_run_reservation_mutation"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'ChildRunReservation rows are immutable';
 END;
 $$;
 CREATE FUNCTION "enforce_initial_agent_run_state"() RETURNS trigger LANGUAGE plpgsql AS $$
@@ -4259,6 +4328,11 @@ ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_nonempty_c
         btrim("effective_contract_digest") <> '' AND btrim("prompt_compiler_version") <> '' AND btrim("input_digest") <> '' AND
         "effective_contract_digest" ~ '^sha256:[0-9a-f]{64}$' AND "input_digest" ~ '^sha256:[0-9a-f]{64}$'
     );
+ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_positive_limits" CHECK (
+    "depth" > 0
+    AND "max_tokens" > 0
+    AND "max_cost_usd_micros" > 0
+);
 ALTER TABLE "workload_assignments" ADD CONSTRAINT "workload_assignments_attempt_check" CHECK ("attempt" > 0);
 ALTER TABLE "workload_assignments" ADD CONSTRAINT "workload_assignments_nonempty_check" CHECK (
         btrim("agent_service_id") <> '' AND btrim("agent_revision_id") <> '' AND btrim("silo_id") <> '' AND
@@ -4558,6 +4632,8 @@ CREATE TRIGGER "agent_revision_scope_attachments_immutable"
 CREATE TRIGGER "workload_assignments_current_attempt" BEFORE INSERT OR UPDATE OF "run_id", "attempt" ON "workload_assignments" FOR EACH ROW EXECUTE FUNCTION "enforce_current_workload_assignment_attempt"();
 CREATE TRIGGER "run_outbox_events_accepted_attempt" BEFORE INSERT OR UPDATE OF "run_id", "attempt" ON "run_outbox_events" FOR EACH ROW EXECUTE FUNCTION "enforce_accepted_outbox_attempt"();
 CREATE TRIGGER "run_input_snapshots_immutable" BEFORE UPDATE OR DELETE ON "run_input_snapshots" FOR EACH ROW EXECUTE FUNCTION "reject_run_input_snapshot_mutation"();
+CREATE TRIGGER "child_run_reservations_authority" BEFORE INSERT ON "child_run_reservations" FOR EACH ROW EXECUTE FUNCTION "enforce_child_run_reservation"();
+CREATE TRIGGER "child_run_reservations_immutable" BEFORE UPDATE OR DELETE ON "child_run_reservations" FOR EACH ROW EXECUTE FUNCTION "reject_child_run_reservation_mutation"();
 CREATE TRIGGER "agent_runs_initial_state"
     BEFORE INSERT ON "agent_runs"
     FOR EACH ROW EXECUTE FUNCTION "enforce_initial_agent_run_state"();

--- a/apps/opencrane/prisma/schema/runs.prisma
+++ b/apps/opencrane/prisma/schema/runs.prisma
@@ -47,35 +47,37 @@ enum RunOutboxEventKind {
 
 /// One logical run authority. Retries atomically increment `attempt`; there is no AgentRunAttempt.
 model AgentRun {
-  id                      String                   @id @default(cuid())
-  siloId                  String                   @map("silo_id")
-  agentServiceId          String                   @map("agent_service_id")
-  agentRevisionId         String                   @map("agent_revision_id")
-  threadId                String?                  @map("thread_id")
-  trigger                 AgentRunTrigger
-  delegatedUserId         String?                  @map("delegated_user_id")
-  requestIdempotencyKey   String                   @map("request_idempotency_key")
-  rootRunId               String                   @map("root_run_id")
-  parentRunId             String?                  @map("parent_run_id")
-  attempt                 Int                      @default(1)
-  state                   AgentRunState            @default(Accepted)
-  effectiveContractDigest String                   @map("effective_contract_digest")
-  inputSnapshotDigest     String                   @map("input_snapshot_digest")
-  acceptedAt              DateTime                 @default(now()) @map("accepted_at")
-  startedAt               DateTime?                @map("started_at")
-  finishedAt              DateTime?                @map("finished_at")
-  terminalReason          AgentRunTerminalReason?  @map("terminal_reason")
-  costAmount              Decimal?                 @map("cost_amount") @db.Decimal(18, 6)
-  costCurrency            String?                  @map("cost_currency")
-  revision                AgentRevision            @relation(fields: [agentServiceId, agentRevisionId], references: [agentServiceId, id], onDelete: Restrict)
-  service                 AgentService             @relation(fields: [agentServiceId, siloId], references: [id, siloId], onDelete: Restrict)
-  inputSnapshot           RunInputSnapshot?
-  workloadAssignments     WorkloadAssignment[]
-  proofKeys               RunProofKey[]
-  approvalRequests        ApprovalRequest[]
-  executionReceipts       ActionExecutionReceipt[]
-  toolInvocations         ToolInvocation[]
-  outboxEvents            OutboxEvent[]
+  id                       String                   @id @default(cuid())
+  siloId                   String                   @map("silo_id")
+  agentServiceId           String                   @map("agent_service_id")
+  agentRevisionId          String                   @map("agent_revision_id")
+  threadId                 String?                  @map("thread_id")
+  trigger                  AgentRunTrigger
+  delegatedUserId          String?                  @map("delegated_user_id")
+  requestIdempotencyKey    String                   @map("request_idempotency_key")
+  rootRunId                String                   @map("root_run_id")
+  parentRunId              String?                  @map("parent_run_id")
+  attempt                  Int                      @default(1)
+  state                    AgentRunState            @default(Accepted)
+  effectiveContractDigest  String                   @map("effective_contract_digest")
+  inputSnapshotDigest      String                   @map("input_snapshot_digest")
+  acceptedAt               DateTime                 @default(now()) @map("accepted_at")
+  startedAt                DateTime?                @map("started_at")
+  finishedAt               DateTime?                @map("finished_at")
+  terminalReason           AgentRunTerminalReason?  @map("terminal_reason")
+  costAmount               Decimal?                 @map("cost_amount") @db.Decimal(18, 6)
+  costCurrency             String?                  @map("cost_currency")
+  revision                 AgentRevision            @relation(fields: [agentServiceId, agentRevisionId], references: [agentServiceId, id], onDelete: Restrict)
+  service                  AgentService             @relation(fields: [agentServiceId, siloId], references: [id, siloId], onDelete: Restrict)
+  inputSnapshot            RunInputSnapshot?
+  workloadAssignments      WorkloadAssignment[]
+  proofKeys                RunProofKey[]
+  approvalRequests         ApprovalRequest[]
+  executionReceipts        ActionExecutionReceipt[]
+  toolInvocations          ToolInvocation[]
+  outboxEvents             OutboxEvent[]
+  spawnedChildReservations ChildRunReservation[]    @relation("ChildRunReservationParent")
+  childReservation         ChildRunReservation?     @relation("ChildRunReservationChild")
 
   @@unique([siloId, requestIdempotencyKey])
   @@unique([id, agentServiceId, agentRevisionId])
@@ -89,30 +91,51 @@ model AgentRun {
   @@map("agent_runs")
 }
 
+/// Immutable token and cost allocation made by a parent for one governed child run.
+///
+/// This row is committed with its accepted child run. It makes the parent/root lineage and the
+/// budget carved from the parent auditable, while allowing a parent-locked transaction to count
+/// durable allocations rather than trust a caller-provided remaining budget.
+model ChildRunReservation {
+  childRunId       String   @id @map("child_run_id")
+  parentRunId      String   @map("parent_run_id")
+  rootRunId        String   @map("root_run_id")
+  depth            Int
+  maxTokens        Int      @map("max_tokens")
+  maxCostUsdMicros BigInt   @map("max_cost_usd_micros")
+  createdAt        DateTime @default(now()) @map("created_at")
+  parentRun        AgentRun @relation("ChildRunReservationParent", fields: [parentRunId], references: [id], onDelete: Restrict)
+  childRun         AgentRun @relation("ChildRunReservationChild", fields: [childRunId], references: [id], onDelete: Restrict)
+
+  @@index([parentRunId])
+  @@index([rootRunId])
+  @@map("child_run_reservations")
+}
+
 model RunInputSnapshot {
-  id                      String   @id @default(cuid())
-  runId                   String   @unique @map("run_id")
-  snapshotVersion         Int      @map("snapshot_version")
-  siloId                  String   @map("silo_id")
-  agentServiceId          String   @map("agent_service_id")
-  agentRevisionId         String   @map("agent_revision_id")
-  effectiveContractDigest String   @map("effective_contract_digest")
-  personaRevisionId       String?  @map("persona_revision_id")
-  threadId                String?  @map("thread_id")
-  messageIds              String[] @default([]) @map("message_ids")
-  preferenceFactIds       String[] @default([]) @map("preference_fact_ids")
-  artifactRevisionIds     String[] @default([]) @map("artifact_revision_ids")
-  memoryFacts             Json     @map("memory_facts")
-  identitySnapshot        Json     @map("identity_snapshot")
-  modelRoute              Json     @map("model_route")
-  toolGrantIds            String[] @default([]) @map("tool_grant_ids")
-  skillRevisionIds        String[] @default([]) @map("skill_revision_ids")
-  memoryQueryPolicy       Json     @map("memory_query_policy")
-  budgetPolicy            Json     @map("budget_policy")
-  capabilitySetDigest     String   @map("capability_set_digest")
-  promptCompilerVersion   String   @map("prompt_compiler_version")
-  digest                  String   @unique @map("input_digest")
-  compiledAt              DateTime @default(now()) @map("created_at")
+  id                      String    @id @default(cuid())
+  runId                   String    @unique @map("run_id")
+  snapshotVersion         Int       @map("snapshot_version")
+  siloId                  String    @map("silo_id")
+  agentServiceId          String    @map("agent_service_id")
+  agentRevisionId         String    @map("agent_revision_id")
+  effectiveContractDigest String    @map("effective_contract_digest")
+  personaRevisionId       String?   @map("persona_revision_id")
+  threadId                String?   @map("thread_id")
+  messageIds              String[]  @default([]) @map("message_ids")
+  preferenceFactIds       String[]  @default([]) @map("preference_fact_ids")
+  artifactRevisionIds     String[]  @default([]) @map("artifact_revision_ids")
+  memoryFacts             Json      @map("memory_facts")
+  identitySnapshot        Json      @map("identity_snapshot")
+  modelRoute              Json      @map("model_route")
+  toolGrantIds            String[]  @default([]) @map("tool_grant_ids")
+  skillRevisionIds        String[]  @default([]) @map("skill_revision_ids")
+  memoryQueryPolicy       Json      @map("memory_query_policy")
+  budgetPolicy            Json      @map("budget_policy")
+  capabilitySetDigest     String    @map("capability_set_digest")
+  promptCompilerVersion   String    @map("prompt_compiler_version")
+  digest                  String    @unique @map("input_digest")
+  compiledAt              DateTime  @default(now()) @map("created_at")
   run                     AgentRun? @relation(fields: [runId, digest, threadId, siloId, agentServiceId, agentRevisionId, effectiveContractDigest], references: [id, inputSnapshotDigest, threadId, siloId, agentServiceId, agentRevisionId, effectiveContractDigest], onDelete: Restrict)
 
   @@unique([runId, digest])

--- a/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
+++ b/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
@@ -93,4 +93,72 @@ BEGIN
 END;
 $$;
 
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "thread_id", "trigger", "request_idempotency_key", "root_run_id", "parent_run_id", "effective_contract_digest", "input_snapshot_digest")
+VALUES ('snapshot-scheduled-child', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-scheduled-child-request', 'snapshot-run', 'snapshot-run', 'sha256:' || repeat('b', 64), 'sha256:' || repeat('c', 64));
+INSERT INTO "run_input_snapshots" ("run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "thread_id", "memory_facts", "identity_snapshot", "model_route", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-scheduled-child', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('b', 64), NULL, '[]', '{}', '{}', '{}', '{}', 'sha256:' || repeat('d', 64), 'prompt-v1', 'sha256:' || repeat('c', 64));
+DO $$
+DECLARE
+    actual_message TEXT;
+BEGIN
+    BEGIN
+        INSERT INTO "child_run_reservations" ("child_run_id", "parent_run_id", "root_run_id", "depth", "max_tokens", "max_cost_usd_micros")
+        VALUES ('snapshot-scheduled-child', 'snapshot-run', 'snapshot-run', 1, 100, 1000000);
+    EXCEPTION WHEN raise_exception THEN
+        GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+        IF strpos(actual_message, 'ChildRunReservation must bind one same-silo child to its exact parent and root') = 0 THEN RAISE EXCEPTION 'FAIL: expected non-child trigger rejection, got %', actual_message; END IF;
+        RAISE NOTICE 'PASS: a scheduled run cannot receive a child reservation';
+        RETURN;
+    END;
+    RAISE EXCEPTION 'FAIL: a scheduled run unexpectedly received a child reservation';
+END;
+$$;
+
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "thread_id", "trigger", "request_idempotency_key", "root_run_id", "parent_run_id", "effective_contract_digest", "input_snapshot_digest")
+VALUES ('snapshot-child-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'managed_invocation', 'snapshot-child-request', 'snapshot-run', 'snapshot-run', 'sha256:' || repeat('9', 64), 'sha256:' || repeat('0', 64));
+INSERT INTO "run_input_snapshots" ("run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "thread_id", "memory_facts", "identity_snapshot", "model_route", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-child-run', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('9', 64), NULL, '[]', '{}', '{}', '{}', '{}', 'sha256:' || repeat('a', 64), 'prompt-v1', 'sha256:' || repeat('0', 64));
+INSERT INTO "child_run_reservations" ("child_run_id", "parent_run_id", "root_run_id", "depth", "max_tokens", "max_cost_usd_micros")
+VALUES ('snapshot-child-run', 'snapshot-run', 'snapshot-run', 1, 100, 1000000);
+SET CONSTRAINTS ALL IMMEDIATE;
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM "child_run_reservations" WHERE "child_run_id" = 'snapshot-child-run' AND "parent_run_id" = 'snapshot-run' AND "root_run_id" = 'snapshot-run') THEN
+        RAISE EXCEPTION 'FAIL: child reservation did not retain exact lineage';
+    END IF;
+    RAISE NOTICE 'PASS: a child reservation binds exact durable lineage and token/cost limits';
+END;
+$$;
+DO $$
+DECLARE
+    actual_message TEXT;
+BEGIN
+    BEGIN
+        INSERT INTO "child_run_reservations" ("child_run_id", "parent_run_id", "root_run_id", "depth", "max_tokens", "max_cost_usd_micros")
+        VALUES ('snapshot-scheduled-run', 'snapshot-run', 'snapshot-run', 1, 100, 1000000);
+    EXCEPTION WHEN raise_exception THEN
+        GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+        IF strpos(actual_message, 'ChildRunReservation must bind one same-silo child to its exact parent and root') = 0 THEN RAISE EXCEPTION 'FAIL: expected lineage rejection, got %', actual_message; END IF;
+        RAISE NOTICE 'PASS: a reservation cannot assign a root run to another parent';
+        RETURN;
+    END;
+    RAISE EXCEPTION 'FAIL: a reservation unexpectedly rewrote root lineage';
+END;
+$$;
+DO $$
+DECLARE
+    actual_message TEXT;
+BEGIN
+    BEGIN
+        UPDATE "child_run_reservations" SET "max_tokens" = 101 WHERE "child_run_id" = 'snapshot-child-run';
+    EXCEPTION WHEN raise_exception THEN
+        GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
+        IF strpos(actual_message, 'ChildRunReservation rows are immutable') = 0 THEN RAISE EXCEPTION 'FAIL: expected immutable reservation rejection, got %', actual_message; END IF;
+        RAISE NOTICE 'PASS: a child reservation is immutable after durable admission';
+        RETURN;
+    END;
+    RAISE EXCEPTION 'FAIL: a child reservation unexpectedly mutated';
+END;
+$$;
+
 ROLLBACK;

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -67,6 +67,13 @@ any failed check. A later persistence adapter must repeat the target check and r
 the same transaction that creates the child run: this pure package intentionally makes no durable
 reservation on its own.
 
+`ChildRunReservation` is the durable companion record for that later transaction. It fixes a
+child's exact parent/root lineage, depth, token allocation, and micro-USD cost allocation. The
+database accepts it only for an accepted first attempt whose existing `AgentRun` already has that
+same lineage and silo, locks the parent while checking it, and rejects every subsequent change.
+The later transaction will calculate remaining capacity from these append-only records rather than
+from a mutable counter or a value supplied by the requesting agent.
+
 `PrismaRunDispatchRepository` is the database side of the controller handshake. It issues a short,
 server-owned claim lease over `RunAttemptRequested`, exposes only the coordinates needed to create a
 suspended Job, and commits the Job UID as a `PendingPod` assignment. At claim time it also mints the
@@ -156,6 +163,8 @@ uncertainty fails closed.
 - `ChildRunTargetAuthorization` / `PrepareChildRunAdmissionCommand` /
   `PrepareChildRunAdmissionResult` — the target-policy port and the prepared-or-denied child
   admission vocabulary.
+- `ChildRunReservation` — the Prisma-owned durable allocation that binds one admitted child to its
+  parent, root, depth, token ceiling, and cost ceiling.
 
 ## Boundary
 


### PR DESCRIPTION
## Why

Preparing a child run is not enough: concurrent children must not rely on an in-memory counter or a caller-provided remaining budget. Each accepted child needs a durable allocation that proves its lineage and can later be summed under the parent lock.

## What changes

- add the run-owned `ChildRunReservation` target-schema model, one-to-one with an accepted child run
- persist immutable parent/root lineage, depth, token allocation, and micro-USD cost allocation
- make PostgreSQL lock the direct parent and reject cross-silo, false-root, non-child-trigger, invalid-depth, or mutable reservations
- add SQL authority coverage for valid lineage, scheduled-run rejection, root-lineage rejection, and immutability

This is the durable foundation only. The next transaction slice will calculate available budget from these append-only allocations and create the child run plus reservation atomically.

## Validation

- Prisma client generation
- Prisma schema validation
- `npx nx affected -t lint test --base=HEAD~1 --parallel=4` (three projects; 120 tests)
- `bash scripts/agent-style-check.sh`
- `git diff --check`

The live PostgreSQL authority suite remains intentionally unrun on this machine because `psql` is unavailable; its SQL fixture is wired for the live gate.

## Review

Independent review identified a missing managed-invocation check in the database trigger. It is fixed and independently confirmed. Claude Code review was not run because its local CLI session remains unauthenticated.

## Stack

Base: #472 (`feat/phase-e-child-run-trigger-v2`).