### PR TITLE
🔒 Phase E: atomically admit governed child runs

### DIFF
--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -134,6 +134,8 @@ uncertainty fails closed.
 - `__ValidateRunWorkloadAssignment(assignment, expectation)` — confirm a workload is the one authorised for this attempt.
 - `__PrepareChildRunAdmission(parent, command, limits, targetAuthorization)` — prepare a bounded
   child-run record after exact parent-to-target delegation has been rechecked.
+- `PrismaChildRunReservationRepository` — lock the parent, recalculate capacity from immutable
+  sibling allocations, and atomically persist the child run, snapshot, reservation, and dispatch.
 - `__DigestRunInputSnapshot(snapshot)` — compute the canonical SHA-256 identity of all frozen run
   inputs without digesting the self-referential `digest` field.
 - `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial
@@ -183,6 +185,11 @@ from the admitted parent run, use the target-authorization port backed by that p
 tool policy, and persist the prepared record through a transaction that rechecks and reserves it.
 This package neither trusts a child-supplied subject, silo or lineage nor creates a child run by
 itself.
+
+The reservation repository is the sole durable child-admission boundary. It derives parent facts
+from locked database rows and the parent snapshot, rechecks the target policy, and records the
+derived depth with the child allocation. Replaying the same inherited-silo idempotency key returns
+only the exact sealed child; any coordinate mismatch fails closed.
 
 ## Dependency direction
 

--- a/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/child-run-admission.test.ts
@@ -20,7 +20,7 @@ describe("governed child run admission", function _describeChildRunAdmission()
 {
 	it("inherits lineage, silo, and subject only from parent authority while carving bounded budget", async function _preparesChild()
 	{
-		await expect(__PrepareChildRunAdmission(_PARENT, _COMMAND, _LIMITS, _AUTHORIZED_TARGET)).resolves.toEqual({ outcome: "prepared", value: { runId: "child-1", parentRunId: "parent-1", rootRunId: "root-1", siloId: "silo-1", executionSubjectId: "user-1", agentServiceId: "service-child", agentRevisionId: "revision-child", trigger: "managed_invocation", budget: { maxTokens: 200, maxCostUsdMicros: 1_000_000 } } });
+		await expect(__PrepareChildRunAdmission(_PARENT, _COMMAND, _LIMITS, _AUTHORIZED_TARGET)).resolves.toEqual({ outcome: "prepared", value: { depth: 2, runId: "child-1", parentRunId: "parent-1", rootRunId: "root-1", siloId: "silo-1", executionSubjectId: "user-1", agentServiceId: "service-child", agentRevisionId: "revision-child", trigger: "managed_invocation", budget: { maxTokens: 200, maxCostUsdMicros: 1_000_000 } } });
 	});
 
 	it("denies a recursive fork at the configured depth cap", async function _deniesDepth()

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-reservation-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-reservation-repository.test.ts
@@ -1,0 +1,32 @@
+import type { PrismaClient } from "@prisma/client";
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaChildRunReservationRepository } from "../prisma-child-run-reservation-repository.js";
+import { __DigestRunInputSnapshot } from "../run-input-snapshot-digest.js";
+
+/** Builds a digest-sealed snapshot with the smallest valid runtime input for a reservation test. */
+function _snapshot(runId: string, serviceId: string, revisionId: string): RunInputSnapshot
+{
+	const value = { runId, siloId: "silo-1", agentServiceId: serviceId, agentRevisionId: revisionId, snapshotVersion: 1, threadId: null, messageIds: [], personaRevisionId: null, preferenceFactIds: [], artifactRevisionIds: [], skillRevisionIds: [], memoryFacts: [], memoryQueryPolicy: { scope: "none" }, toolGrantIds: [], modelRoute: { alias: "test" }, budgetPolicy: { maxTokens: 1_000, maxCostUsdMicros: 5_000_000 }, identitySnapshot: { executionSubjectId: "user-1", organizationId: "org-1", fleetMembershipRevision: 1, fleetMembershipIssuer: "issuer", fleetMembershipIssuerKeyId: "key", fleetMembershipAssertionId: "assertion", fleetMembershipPayloadDigest: `sha256:${"a".repeat(64)}`, fleetMembershipTrustedUntil: "2026-07-30T00:00:00.000Z" }, capabilitySetDigest: `sha256:${"b".repeat(64)}`, effectiveContractDigest: `sha256:${"c".repeat(64)}`, promptCompilerVersion: "v1", compiledAt: "2026-07-26T00:00:00.000Z" } as const;
+	return { ...value, digest: __DigestRunInputSnapshot(value) };
+}
+
+describe("PrismaChildRunReservationRepository", function _describeReservationRepository()
+{
+	it("locks a running parent and atomically persists its bounded child authority", async function _persistsReservation()
+	{
+		const parent = _snapshot("parent-1", "parent-service", "parent-revision");
+		const childBase = _snapshot("child-1", "child-service", "child-revision");
+		const child = { ...childBase, budgetPolicy: { maxTokens: 100, maxCostUsdMicros: 500_000 } };
+		const childSnapshot = { ...child, digest: __DigestRunInputSnapshot(child) };
+		const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce({ id: "parent-1", state: "Running", siloId: "silo-1", rootRunId: "root-1", parentRunId: "root-1", inputSnapshotDigest: parent.digest }), create: vi.fn() }, runInputSnapshot: { findUnique: vi.fn().mockResolvedValue({ ...parent, compiledAt: new Date(parent.compiledAt) }), create: vi.fn() }, childRunReservation: { findUnique: vi.fn().mockResolvedValue({ depth: 1 }), aggregate: vi.fn().mockResolvedValue({ _count: { childRunId: 0 }, _sum: { maxTokens: null, maxCostUsdMicros: null } }), create: vi.fn() }, outboxEvent: { createMany: vi.fn() } };
+		const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+		const repository = new PrismaChildRunReservationRepository(prisma);
+		const result = await repository.reserve({ requestIdempotencyKey: "child-request", parentSnapshotDigest: parent.digest, prepared: { depth: 99, runId: "child-1", parentRunId: "parent-1", rootRunId: "root-1", siloId: "silo-1", executionSubjectId: "user-1", agentServiceId: "child-service", agentRevisionId: "child-revision", trigger: "managed_invocation", budget: { maxTokens: 100, maxCostUsdMicros: 500_000 } }, limits: { maximumDepth: 3, maximumChildrenPerParent: 2 }, targetAuthorization: { authorize: async function _authorize() { return { outcome: "authorized" }; } } }, { build: async function _build() { return { snapshot: childSnapshot, effectiveContractDigest: childSnapshot.effectiveContractDigest }; } });
+		expect(result).toEqual({ outcome: "reserved", snapshot: childSnapshot });
+		expect(transaction.agentRun.create).toHaveBeenCalledWith({ data: expect.objectContaining({ id: "child-1", parentRunId: "parent-1", trigger: "ManagedInvocation" }) });
+		expect(transaction.childRunReservation.create).toHaveBeenCalledWith({ data: expect.objectContaining({ childRunId: "child-1", depth: 2, maxTokens: 100, maxCostUsdMicros: 500_000n }) });
+		expect(transaction.outboxEvent.createMany).toHaveBeenCalledTimes(1);
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.ts
@@ -24,7 +24,7 @@ export async function __PrepareChildRunAdmission(parent: ChildRunParentAuthority
 		return { outcome: "denied", reason: "target_authorization_unavailable" };
 	}
 
-	return { outcome: "prepared", value: { runId: command.childRunId, parentRunId: parent.runId, rootRunId: parent.rootRunId, siloId: parent.siloId, executionSubjectId: parent.executionSubjectId, agentServiceId: command.targetAgentServiceId, agentRevisionId: command.targetAgentRevisionId, trigger: "managed_invocation", budget: command.requestedBudget } };
+	return { outcome: "prepared", value: { depth: parent.depth + 1, runId: command.childRunId, parentRunId: parent.runId, rootRunId: parent.rootRunId, siloId: parent.siloId, executionSubjectId: parent.executionSubjectId, agentServiceId: command.targetAgentServiceId, agentRevisionId: command.targetAgentRevisionId, trigger: "managed_invocation", budget: command.requestedBudget } };
 }
 
 /** Returns whether parent facts are complete and safe for a child to inherit. */

--- a/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-admission.types.ts
@@ -68,6 +68,8 @@ export type ChildRunTargetAuthorizationResult = { readonly outcome: "authorized"
 /** Parent-derived coordinates that the persistence/snapshot layer must preserve exactly. */
 export interface PreparedChildRunAdmission
 {
+	/** Depth inherited from the parent and fixed for this exact child. */
+	readonly depth: number;
 	/** Child run identifier. */
 	readonly runId: string;
 	/** Parent run identifier; a child never starts as a root. */

--- a/libs/backend/agents/execution/runs/main/src/child-run-reservation.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-reservation.types.ts
@@ -1,0 +1,44 @@
+import type { RunInputSnapshot } from "@opencrane/contracts";
+
+import type { ChildRunAdmissionLimits, ChildRunTargetAuthorization, PreparedChildRunAdmission } from "./child-run-admission.types.js";
+
+/** Complete parent-fenced request to durably admit one prepared child run. */
+export interface ChildRunReservationCommand
+{
+	/** Idempotency key scoped to the child run's inherited silo. */
+	readonly requestIdempotencyKey: string;
+	/** Exact immutable snapshot digest observed for the parent before this request. */
+	readonly parentSnapshotDigest: string;
+	/** Child coordinates prepared from parent authority rather than caller-supplied lineage. */
+	readonly prepared: PreparedChildRunAdmission;
+	/** Server-owned recursion limits rechecked while the parent is locked. */
+	readonly limits: ChildRunAdmissionLimits;
+	/** Exact delegation policy rechecked while the parent is locked. */
+	readonly targetAuthorization: ChildRunTargetAuthorization;
+}
+
+/** Callback that assembles the child snapshot only after parent authority is locked and rechecked. */
+export interface ChildRunReservationBuild
+{
+	/** Builds the immutable child runtime input from the parent-fenced prepared admission. */
+	build(prepared: PreparedChildRunAdmission): Promise<ChildRunReservationBuildResult>;
+}
+
+/** Result of assembling the immutable input needed to commit an admitted child. */
+export interface ChildRunReservationBuildResult
+{
+	/** Snapshot to persist with the child run and reservation. */
+	readonly snapshot: RunInputSnapshot;
+	/** Active revision whose contract was revalidated during child snapshot assembly. */
+	readonly effectiveContractDigest: string;
+}
+
+/** Durable result of atomically admitting or replaying one child run. */
+export type ChildRunReservationResult = { readonly outcome: "reserved" | "idempotent"; readonly snapshot: RunInputSnapshot } | { readonly outcome: "denied"; readonly reason: "invalid_command" | "invalid_parent_authority" | "parent_not_admittable" | "parent_snapshot_stale" | "depth_exceeded" | "budget_exceeded" | "fanout_exceeded" | "target_not_authorized" | "target_authorization_unavailable" | "authority_conflict" | "persistence_unavailable" };
+
+/** Persistence boundary that owns parent locking and all durable child-admission writes. */
+export interface ChildRunReservationRepository
+{
+	/** Rechecks parent authority and atomically writes a child run, snapshot, reservation, and outbox. */
+	reserve(command: ChildRunReservationCommand, build: ChildRunReservationBuild): Promise<ChildRunReservationResult>;
+}

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -1,9 +1,11 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
 export { __PrepareChildRunAdmission } from "./child-run-admission.js";
+export { PrismaChildRunReservationRepository } from "./prisma-child-run-reservation-repository.js";
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 export type { ChildRunAdmissionLimits, ChildRunBudget, ChildRunParentAuthority, ChildRunTargetAuthorization, ChildRunTargetAuthorizationResult, PrepareChildRunAdmissionCommand, PrepareChildRunAdmissionResult, PreparedChildRunAdmission } from "./child-run-admission.types.js";
+export type { ChildRunReservationBuild, ChildRunReservationBuildResult, ChildRunReservationCommand, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
 export { PrismaRunAdmissionRepository } from "./prisma-run-admission-repository.js";
 export { PrismaRunCancellationRepository } from "./prisma-run-cancellation-repository.js";

--- a/libs/backend/agents/execution/runs/main/src/prisma-child-run-reservation-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-child-run-reservation-repository.ts
@@ -1,0 +1,145 @@
+import { Prisma, RunOutboxEventKind, type PrismaClient } from "@prisma/client";
+
+import type { RunInputSnapshot } from "@opencrane/contracts";
+import { ___CreateLogger, type Logger } from "@opencrane/observability";
+import { ___CloneCanonicalJson } from "@opencrane/util";
+import type { JsonValue } from "@opencrane/util";
+
+import { __PrepareChildRunAdmission } from "./child-run-admission.js";
+import { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
+import type { ChildRunReservationBuild, ChildRunReservationCommand, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
+
+/** Atomically persists one child admission while its direct parent is locked. */
+export class PrismaChildRunReservationRepository implements ChildRunReservationRepository
+{
+	/** Canonical product-authority database client. */
+	private readonly prisma: PrismaClient;
+	/** Structured redacting log for fail-closed persistence faults. */
+	private readonly log: Logger;
+
+	/** Creates the transaction-owning child-run reservation repository. */
+	constructor(prisma: PrismaClient, log: Logger = ___CreateLogger("child-run-reservation"))
+	{
+		this.prisma = prisma;
+		this.log = log;
+	}
+
+	/** Rechecks and commits a child run, snapshot, immutable reservation, and initial outbox together. */
+	async reserve(command: ChildRunReservationCommand, build: ChildRunReservationBuild): Promise<ChildRunReservationResult>
+	{
+		if (!_isValidCommand(command)) return { outcome: "denied", reason: "invalid_command" };
+		try
+		{
+			return await this.prisma.$transaction(async function _reserve(transaction): Promise<ChildRunReservationResult>
+			{
+				// 1. Serialize one inherited-silo key before observing or creating a child.
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${command.prepared.siloId}\u0000${command.requestIdempotencyKey}`}, 0))`);
+				const existing = await transaction.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.prepared.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
+				if (existing !== null)
+				{
+					const reservation = await transaction.childRunReservation.findUnique({ where: { childRunId: existing.id } });
+					const existingSnapshot = await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: existing.id, digest: existing.inputSnapshotDigest } } });
+					if (reservation !== null && existingSnapshot !== null && existing.id === command.prepared.runId && existing.siloId === command.prepared.siloId && existing.agentServiceId === command.prepared.agentServiceId && existing.agentRevisionId === command.prepared.agentRevisionId && existing.parentRunId === command.prepared.parentRunId && existing.rootRunId === command.prepared.rootRunId && existing.trigger === "ManagedInvocation" && reservation.depth === command.prepared.depth && reservation.maxTokens === command.prepared.budget.maxTokens && reservation.maxCostUsdMicros === BigInt(command.prepared.budget.maxCostUsdMicros)) return { outcome: "idempotent", snapshot: _rowSnapshot(existingSnapshot) };
+					return { outcome: "denied", reason: "authority_conflict" };
+				}
+
+				// 2. Lock the parent before calculating capacity, preventing concurrent siblings from over-reserving it.
+				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.prepared.parentRunId} FOR UPDATE`);
+				const parent = await transaction.agentRun.findUnique({ where: { id: command.prepared.parentRunId } });
+				if (parent === null || parent.state !== "Running" || parent.siloId !== command.prepared.siloId || parent.rootRunId !== command.prepared.rootRunId || parent.inputSnapshotDigest !== command.parentSnapshotDigest) return { outcome: "denied", reason: "parent_not_admittable" };
+				const snapshot = await transaction.runInputSnapshot.findUnique({ where: { runId_digest: { runId: parent.id, digest: parent.inputSnapshotDigest } } });
+				if (snapshot === null || !_isParentSnapshot(snapshot, command)) return { outcome: "denied", reason: "parent_snapshot_stale" };
+				const parentReservation = parent.parentRunId === null ? null : await transaction.childRunReservation.findUnique({ where: { childRunId: parent.id } });
+				if (parent.parentRunId !== null && parentReservation === null) return { outcome: "denied", reason: "parent_not_admittable" };
+
+				// 3. Sum durable direct-child allocations and run target authorization again inside the parent fence.
+				const aggregate = await transaction.childRunReservation.aggregate({ where: { parentRunId: parent.id }, _count: { childRunId: true }, _sum: { maxTokens: true, maxCostUsdMicros: true } });
+				const parentAuthority = _parentAuthority(parent, snapshot, aggregate, parentReservation?.depth ?? 0);
+				if (parentAuthority === null) return { outcome: "denied", reason: "parent_snapshot_stale" };
+				const prepared = await __PrepareChildRunAdmission(parentAuthority, { childRunId: command.prepared.runId, targetAgentServiceId: command.prepared.agentServiceId, targetAgentRevisionId: command.prepared.agentRevisionId, requestedBudget: command.prepared.budget }, command.limits, command.targetAuthorization);
+				if (prepared.outcome === "denied") return prepared;
+
+				// 4. Build and persist only an exact child snapshot, allocation, and dispatch pair in this transaction.
+				const value = await build.build(prepared.value);
+				if (!_isChildSnapshot(value.snapshot, prepared.value, value.effectiveContractDigest)) return { outcome: "denied", reason: "authority_conflict" };
+				await _persist(transaction, command, value.snapshot, prepared.value);
+				return { outcome: "reserved", snapshot: value.snapshot };
+			});
+		}
+		catch (error)
+		{
+			this.log.error({ err: error, childRunId: command.prepared.runId, parentRunId: command.prepared.parentRunId, siloId: command.prepared.siloId, failureKind: "transaction_failed" }, "child run reservation persistence failed");
+			return { outcome: "denied", reason: "persistence_unavailable" };
+		}
+	}
+}
+
+/** Returns whether a request has the fixed non-empty authority coordinates needed for a reservation. */
+function _isValidCommand(command: ChildRunReservationCommand): boolean
+{
+	return command.requestIdempotencyKey.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(command.parentSnapshotDigest);
+}
+
+/** Returns a parent authority derived solely from locked rows and its frozen input snapshot. */
+function _parentAuthority(parent: { id: string; siloId: string; rootRunId: string }, snapshot: { identitySnapshot: Prisma.JsonValue; budgetPolicy: Prisma.JsonValue }, aggregate: { _count: { childRunId: number }; _sum: { maxTokens: number | null; maxCostUsdMicros: bigint | null } }, depth: number): { runId: string; siloId: string; rootRunId: string; depth: number; executionSubjectId: string; remainingTokens: number; remainingCostUsdMicros: number; admittedChildCount: number } | null
+{
+	const identity = snapshot.identitySnapshot as Record<string, unknown>;
+	const policy = snapshot.budgetPolicy as Record<string, unknown>;
+	const subject = identity["executionSubjectId"];
+	const tokens = policy["maxTokens"];
+	const cost = policy["maxCostUsdMicros"];
+	if (typeof subject !== "string" || subject.trim().length === 0 || !_positiveInteger(tokens) || !_positiveInteger(cost) || aggregate._sum.maxCostUsdMicros !== null && aggregate._sum.maxCostUsdMicros > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+	const usedTokens = aggregate._sum.maxTokens ?? 0;
+	const usedCost = Number(aggregate._sum.maxCostUsdMicros ?? 0n);
+	if (usedTokens < 0 || usedCost < 0) return null;
+	return { runId: parent.id, siloId: parent.siloId, rootRunId: parent.rootRunId, depth, executionSubjectId: subject, remainingTokens: tokens - usedTokens, remainingCostUsdMicros: cost - usedCost, admittedChildCount: aggregate._count.childRunId };
+}
+
+/** Returns whether the locked parent snapshot exactly binds the requested parent identity. */
+function _isParentSnapshot(snapshot: { runId: string; siloId: string; digest: string }, command: ChildRunReservationCommand): boolean
+{
+	return snapshot.runId === command.prepared.parentRunId && snapshot.siloId === command.prepared.siloId && snapshot.digest === command.parentSnapshotDigest;
+}
+
+/** Returns whether the assembled child snapshot retained only prepared run identity and allocation. */
+function _isChildSnapshot(snapshot: RunInputSnapshot, prepared: { runId: string; siloId: string; agentServiceId: string; agentRevisionId: string; executionSubjectId: string; budget: { maxTokens: number; maxCostUsdMicros: number } }, effectiveContractDigest: string): boolean
+{
+	const { digest: _digest, ...withoutDigest } = snapshot;
+	if (snapshot.runId !== prepared.runId || snapshot.siloId !== prepared.siloId || snapshot.agentServiceId !== prepared.agentServiceId || snapshot.agentRevisionId !== prepared.agentRevisionId || snapshot.effectiveContractDigest !== effectiveContractDigest || snapshot.identitySnapshot.executionSubjectId !== prepared.executionSubjectId || snapshot.digest !== __DigestRunInputSnapshot(withoutDigest)) return false;
+	const budget = snapshot.budgetPolicy as Record<string, unknown>;
+	return budget["maxTokens"] === prepared.budget.maxTokens && budget["maxCostUsdMicros"] === prepared.budget.maxCostUsdMicros;
+}
+
+/** Persists the four inseparable records that make a child eligible for dispatch. */
+async function _persist(transaction: Prisma.TransactionClient, command: ChildRunReservationCommand, snapshot: RunInputSnapshot, prepared: { depth: number; runId: string; parentRunId: string; rootRunId: string; siloId: string; agentServiceId: string; agentRevisionId: string; budget: { maxTokens: number; maxCostUsdMicros: number } }): Promise<void>
+{
+	const now = new Date(snapshot.compiledAt);
+	await transaction.agentRun.create({ data: { id: prepared.runId, siloId: prepared.siloId, agentServiceId: prepared.agentServiceId, agentRevisionId: prepared.agentRevisionId, threadId: snapshot.threadId, trigger: "ManagedInvocation", delegatedUserId: null, requestIdempotencyKey: command.requestIdempotencyKey, rootRunId: prepared.rootRunId, parentRunId: prepared.parentRunId, effectiveContractDigest: snapshot.effectiveContractDigest, inputSnapshotDigest: snapshot.digest, acceptedAt: now } });
+	await transaction.runInputSnapshot.create({ data: _snapshotData(snapshot) });
+	await transaction.childRunReservation.create({ data: { childRunId: prepared.runId, parentRunId: prepared.parentRunId, rootRunId: prepared.rootRunId, depth: prepared.depth, maxTokens: prepared.budget.maxTokens, maxCostUsdMicros: BigInt(prepared.budget.maxCostUsdMicros) } });
+	await transaction.outboxEvent.createMany({ data: [{ runId: prepared.runId, attempt: 1, sequence: 1, kind: RunOutboxEventKind.RunAccepted, idempotencyKey: `${prepared.runId}:accepted`, payload: { runId: prepared.runId, inputSnapshotDigest: snapshot.digest }, availableAt: now }, { runId: prepared.runId, attempt: 1, sequence: 2, kind: RunOutboxEventKind.RunAttemptRequested, idempotencyKey: `${prepared.runId}:attempt:1`, payload: { runId: prepared.runId, attempt: 1, inputSnapshotDigest: snapshot.digest }, availableAt: now }] });
+}
+
+/** Maps the immutable contract snapshot into the owned Prisma persistence shape. */
+function _snapshotData(snapshot: RunInputSnapshot): Prisma.RunInputSnapshotUncheckedCreateInput
+{
+	return { runId: snapshot.runId, snapshotVersion: snapshot.snapshotVersion, siloId: snapshot.siloId, agentServiceId: snapshot.agentServiceId, agentRevisionId: snapshot.agentRevisionId, effectiveContractDigest: snapshot.effectiveContractDigest, personaRevisionId: snapshot.personaRevisionId, threadId: snapshot.threadId, messageIds: [...snapshot.messageIds], preferenceFactIds: [...snapshot.preferenceFactIds], artifactRevisionIds: [...snapshot.artifactRevisionIds], memoryFacts: _json(snapshot.memoryFacts), identitySnapshot: _json(snapshot.identitySnapshot), modelRoute: _json(snapshot.modelRoute), toolGrantIds: [...snapshot.toolGrantIds], skillRevisionIds: [...snapshot.skillRevisionIds], memoryQueryPolicy: _json(snapshot.memoryQueryPolicy), budgetPolicy: _json(snapshot.budgetPolicy), capabilitySetDigest: snapshot.capabilitySetDigest, promptCompilerVersion: snapshot.promptCompilerVersion, digest: snapshot.digest, compiledAt: new Date(snapshot.compiledAt) };
+}
+
+/** Makes a JSON-safe deep copy before Prisma owns an immutable snapshot field. */
+function _json(value: unknown): Prisma.InputJsonValue
+{
+	return ___CloneCanonicalJson(value as JsonValue) as Prisma.InputJsonValue;
+}
+
+/** Maps a persisted immutable snapshot into the public runtime contract. */
+function _rowSnapshot(row: { runId: string; siloId: string; agentServiceId: string; agentRevisionId: string; snapshotVersion: number; threadId: string | null; messageIds: string[]; personaRevisionId: string | null; preferenceFactIds: string[]; artifactRevisionIds: string[]; skillRevisionIds: string[]; memoryFacts: Prisma.JsonValue; memoryQueryPolicy: Prisma.JsonValue; toolGrantIds: string[]; modelRoute: Prisma.JsonValue; budgetPolicy: Prisma.JsonValue; identitySnapshot: Prisma.JsonValue; capabilitySetDigest: string; effectiveContractDigest: string; promptCompilerVersion: string; digest: string; compiledAt: Date }): RunInputSnapshot
+{
+	return { runId: row.runId, siloId: row.siloId, agentServiceId: row.agentServiceId, agentRevisionId: row.agentRevisionId, snapshotVersion: row.snapshotVersion, threadId: row.threadId, messageIds: row.messageIds, personaRevisionId: row.personaRevisionId, preferenceFactIds: row.preferenceFactIds, artifactRevisionIds: row.artifactRevisionIds, skillRevisionIds: row.skillRevisionIds, memoryFacts: row.memoryFacts as unknown as RunInputSnapshot["memoryFacts"], memoryQueryPolicy: row.memoryQueryPolicy as RunInputSnapshot["memoryQueryPolicy"], toolGrantIds: row.toolGrantIds, modelRoute: row.modelRoute as RunInputSnapshot["modelRoute"], budgetPolicy: row.budgetPolicy as RunInputSnapshot["budgetPolicy"], identitySnapshot: row.identitySnapshot as unknown as RunInputSnapshot["identitySnapshot"], capabilitySetDigest: row.capabilitySetDigest, effectiveContractDigest: row.effectiveContractDigest, promptCompilerVersion: row.promptCompilerVersion, digest: row.digest, compiledAt: row.compiledAt.toISOString() };
+}
+
+/** Returns whether a JSON value is a positive safe-integer budget coordinate. */
+function _positiveInteger(value: unknown): value is number
+{
+	return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}


### PR DESCRIPTION
## Why

A child-run preparation and reservation record do not prevent concurrent or forged admissions by themselves. The durable boundary must derive authority from locked parent state and commit all child records together.

## What changes

- add the transaction-owning `PrismaChildRunReservationRepository`
- lock the parent, derive capacity from its frozen snapshot plus durable sibling allocations, and recheck target delegation
- atomically create the child run, sealed snapshot, immutable reservation, and dispatch outbox events
- derive nested depth from the locked parent reservation; a forged caller depth is ignored
- recover only an exact sealed child for an idempotent retry

## Validation

- run-domain lint
- run-domain test suite: 62 passing
- style and whitespace checks

## Review

Independent review found and verified fixes for nested depth, idempotent recovery, and forged precomputed depth. Claude Code review was not run because its local CLI session remains unauthenticated.

## Stack

Base: #473.