### PR TITLE
✨ Phase E: deliver governed child outcomes exactly once

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -176,6 +176,9 @@ CREATE TYPE "WorkloadKind" AS ENUM ('job', 'deployment');
 CREATE TYPE "RunOutboxEventKind" AS ENUM ('run.accepted', 'run.attempt_requested', 'run.workload_release_requested', 'run.workload_cleanup_requested', 'run.cancellation_requested', 'run.resume_requested');
 
 -- CreateEnum
+CREATE TYPE "ChildRunCompletionDeliveryOutcome" AS ENUM ('delivered', 'no_parent_stream', 'parent_stream_terminal');
+
+-- CreateEnum
 CREATE TYPE "RuntimeCommandKind" AS ENUM ('start_attempt', 'resume_attempt', 'cancel_attempt');
 
 -- CreateEnum
@@ -1366,6 +1369,17 @@ CREATE TABLE "child_run_reservations" (
 );
 
 -- CreateTable
+CREATE TABLE "child_run_completion_deliveries" (
+    "child_run_id" TEXT NOT NULL,
+    "parent_run_id" TEXT NOT NULL,
+    "parent_event_sequence" INTEGER,
+    "outcome" "ChildRunCompletionDeliveryOutcome" NOT NULL,
+    "delivered_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "child_run_completion_deliveries_pkey" PRIMARY KEY ("child_run_id")
+);
+
+-- CreateTable
 CREATE TABLE "workload_assignments" (
     "run_id" TEXT NOT NULL,
     "attempt" INTEGER NOT NULL,
@@ -2215,6 +2229,9 @@ CREATE INDEX "child_run_reservations_parent_run_id_idx" ON "child_run_reservatio
 CREATE INDEX "child_run_reservations_root_run_id_idx" ON "child_run_reservations"("root_run_id");
 
 -- CreateIndex
+CREATE INDEX "child_run_completion_deliveries_parent_run_id_idx" ON "child_run_completion_deliveries"("parent_run_id");
+
+-- CreateIndex
 CREATE INDEX "workload_assignments_silo_id_subject_id_idx" ON "workload_assignments"("silo_id", "subject_id");
 
 -- CreateIndex
@@ -2576,6 +2593,12 @@ ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_pare
 
 -- AddForeignKey
 ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_child_run_id_fkey" FOREIGN KEY ("child_run_id") REFERENCES "agent_runs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "child_run_completion_deliveries" ADD CONSTRAINT "child_run_completion_deliveries_child_run_id_fkey" FOREIGN KEY ("child_run_id") REFERENCES "agent_runs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "child_run_completion_deliveries" ADD CONSTRAINT "child_run_completion_deliveries_parent_run_id_fkey" FOREIGN KEY ("parent_run_id") REFERENCES "agent_runs"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_run_id_input_digest_thread_id_silo_id__fkey" FOREIGN KEY ("run_id", "input_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest") REFERENCES "agent_runs"("id", "input_snapshot_digest", "thread_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -3642,7 +3665,61 @@ BEGIN
     ELSIF NEW."type" NOT IN ('run.completed', 'run.failed', 'run.cancelled') AND run_state IN ('completed', 'failed', 'cancelled') THEN
         RAISE EXCEPTION 'terminal AgentRun accepts only its matching terminal event';
     END IF;
+    IF NEW."type" IN ('child.run.completed', 'child.run.failed', 'child.run.cancelled') AND NOT EXISTS (
+        SELECT 1
+        FROM "child_run_completion_deliveries" delivery
+        JOIN "agent_runs" child ON child."id" = delivery."child_run_id"
+        WHERE delivery."child_run_id" = NEW."payload"->>'childRunId'
+          AND delivery."parent_run_id" = NEW."run_id"
+          AND delivery."parent_event_sequence" = NEW."sequence"
+          AND delivery."outcome" = 'delivered'
+          AND ((NEW."type" = 'child.run.completed' AND child."state" = 'completed') OR (NEW."type" = 'child.run.failed' AND child."state" = 'failed') OR (NEW."type" = 'child.run.cancelled' AND child."state" = 'cancelled'))
+    ) THEN
+        RAISE EXCEPTION 'child RunEvent requires child completion delivery authority';
+    END IF;
     RETURN NEW;
+END;
+$$;
+CREATE FUNCTION "enforce_child_run_completion_delivery"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    child_parent_run_id TEXT;
+    child_root_run_id TEXT;
+    child_silo_id TEXT;
+    child_state "AgentRunState";
+    reservation_parent_run_id TEXT;
+    reservation_root_run_id TEXT;
+    parent_silo_id TEXT;
+    parent_root_run_id TEXT;
+    parent_thread_id TEXT;
+    expected_event_type TEXT;
+BEGIN
+    IF TG_OP <> 'INSERT' THEN RAISE EXCEPTION 'child completion deliveries are append-only'; END IF;
+    SELECT "parent_run_id", "root_run_id", "silo_id", "state" INTO child_parent_run_id, child_root_run_id, child_silo_id, child_state FROM "agent_runs" WHERE "id" = NEW."child_run_id" FOR UPDATE;
+    IF child_parent_run_id IS NULL OR child_state NOT IN ('completed', 'failed', 'cancelled') THEN RAISE EXCEPTION 'child completion delivery requires terminal child authority'; END IF;
+    SELECT "parent_run_id", "root_run_id" INTO reservation_parent_run_id, reservation_root_run_id FROM "child_run_reservations" WHERE "child_run_id" = NEW."child_run_id" FOR UPDATE;
+    SELECT "silo_id", "root_run_id", "thread_id" INTO parent_silo_id, parent_root_run_id, parent_thread_id FROM "agent_runs" WHERE "id" = NEW."parent_run_id" FOR UPDATE;
+    IF reservation_parent_run_id IS NULL OR parent_silo_id IS NULL OR NEW."parent_run_id" <> child_parent_run_id OR reservation_parent_run_id <> child_parent_run_id OR reservation_root_run_id <> child_root_run_id OR parent_silo_id <> child_silo_id OR parent_root_run_id <> child_root_run_id THEN RAISE EXCEPTION 'child completion delivery lineage mismatch'; END IF;
+    IF NEW."outcome" = 'delivered' THEN
+        expected_event_type := CASE child_state WHEN 'completed' THEN 'child.run.completed' WHEN 'failed' THEN 'child.run.failed' ELSE 'child.run.cancelled' END;
+        IF parent_thread_id IS NULL OR NEW."parent_event_sequence" IS NULL THEN RAISE EXCEPTION 'delivered child completion requires a parent conversation stream and event sequence'; END IF;
+    ELSIF NEW."outcome" = 'no_parent_stream' THEN
+        IF parent_thread_id IS NOT NULL OR NEW."parent_event_sequence" IS NOT NULL THEN RAISE EXCEPTION 'no_parent_stream outcome requires no parent conversation stream'; END IF;
+    ELSE
+        IF NEW."parent_event_sequence" IS NOT NULL OR NOT EXISTS (SELECT 1 FROM "conversation_run_events" WHERE "run_id" = NEW."parent_run_id" AND "type" IN ('run.completed', 'run.failed', 'run.cancelled')) THEN RAISE EXCEPTION 'parent_stream_terminal outcome requires terminal parent stream'; END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE FUNCTION "enforce_child_run_completion_delivery_event"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    child_state "AgentRunState";
+    expected_event_type TEXT;
+BEGIN
+    IF NEW."outcome" <> 'delivered' THEN RETURN NULL; END IF;
+    SELECT "state" INTO child_state FROM "agent_runs" WHERE "id" = NEW."child_run_id";
+    expected_event_type := CASE child_state WHEN 'completed' THEN 'child.run.completed' WHEN 'failed' THEN 'child.run.failed' ELSE 'child.run.cancelled' END;
+    IF NOT EXISTS (SELECT 1 FROM "conversation_run_events" WHERE "run_id" = NEW."parent_run_id" AND "sequence" = NEW."parent_event_sequence" AND "type" = expected_event_type AND "payload"->>'childRunId' = NEW."child_run_id") THEN RAISE EXCEPTION 'delivered child completion requires exact parent event'; END IF;
+    RETURN NULL;
 END;
 $$;
 CREATE FUNCTION "reject_conversation_immutable_mutation"() RETURNS trigger LANGUAGE plpgsql AS $$
@@ -4465,7 +4542,8 @@ ALTER TABLE "conversation_run_events" ADD CONSTRAINT "conversation_run_events_ty
         'run.accepted', 'run.started', 'message.started', 'message.delta', 'message.completed',
         'tool.requested', 'tool.approval_required', 'tool.started', 'tool.progress', 'tool.completed',
         'context.compaction_started', 'context.compaction_completed', 'run.usage',
-        'run.completed', 'run.failed', 'run.cancelled'
+        'run.completed', 'run.failed', 'run.cancelled',
+        'child.run.completed', 'child.run.failed', 'child.run.cancelled'
     ));
 ALTER TABLE "conversation_run_events" ADD CONSTRAINT "conversation_run_events_payload_check" CHECK (jsonb_typeof("payload") = 'object');
 ALTER TABLE "conversation_context_revisions" ADD CONSTRAINT "conversation_context_revisions_revision_check" CHECK ("revision" > 0);
@@ -4634,6 +4712,8 @@ CREATE TRIGGER "run_outbox_events_accepted_attempt" BEFORE INSERT OR UPDATE OF "
 CREATE TRIGGER "run_input_snapshots_immutable" BEFORE UPDATE OR DELETE ON "run_input_snapshots" FOR EACH ROW EXECUTE FUNCTION "reject_run_input_snapshot_mutation"();
 CREATE TRIGGER "child_run_reservations_authority" BEFORE INSERT ON "child_run_reservations" FOR EACH ROW EXECUTE FUNCTION "enforce_child_run_reservation"();
 CREATE TRIGGER "child_run_reservations_immutable" BEFORE UPDATE OR DELETE ON "child_run_reservations" FOR EACH ROW EXECUTE FUNCTION "reject_child_run_reservation_mutation"();
+CREATE TRIGGER "child_run_completion_deliveries_authority" BEFORE INSERT OR UPDATE OR DELETE ON "child_run_completion_deliveries" FOR EACH ROW EXECUTE FUNCTION "enforce_child_run_completion_delivery"();
+CREATE CONSTRAINT TRIGGER "child_run_completion_deliveries_exact_parent_event" AFTER INSERT ON "child_run_completion_deliveries" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION "enforce_child_run_completion_delivery_event"();
 CREATE TRIGGER "agent_runs_initial_state"
     BEFORE INSERT ON "agent_runs"
     FOR EACH ROW EXECUTE FUNCTION "enforce_initial_agent_run_state"();

--- a/apps/opencrane/prisma/schema/runs.prisma
+++ b/apps/opencrane/prisma/schema/runs.prisma
@@ -45,6 +45,13 @@ enum RunOutboxEventKind {
   RunResumeRequested          @map("run.resume_requested")
 }
 
+/// Immutable outcome of attempting to append one terminal child's result to its parent stream.
+enum ChildRunCompletionDeliveryOutcome {
+  Delivered            @map("delivered")
+  NoParentStream       @map("no_parent_stream")
+  ParentStreamTerminal @map("parent_stream_terminal")
+}
+
 /// One logical run authority. Retries atomically increment `attempt`; there is no AgentRunAttempt.
 model AgentRun {
   id                       String                   @id @default(cuid())
@@ -78,6 +85,8 @@ model AgentRun {
   outboxEvents             OutboxEvent[]
   spawnedChildReservations ChildRunReservation[]    @relation("ChildRunReservationParent")
   childReservation         ChildRunReservation?     @relation("ChildRunReservationChild")
+  childCompletionDelivery  ChildRunCompletionDelivery? @relation("ChildRunCompletionDeliveryChild")
+  receivedChildCompletions ChildRunCompletionDelivery[] @relation("ChildRunCompletionDeliveryParent")
 
   @@unique([siloId, requestIdempotencyKey])
   @@unique([id, agentServiceId, agentRevisionId])
@@ -89,6 +98,20 @@ model AgentRun {
   @@index([threadId, acceptedAt])
   @@index([rootRunId])
   @@map("agent_runs")
+}
+
+/// Append-only proof that a terminal child was delivered to its direct parent's stream or deliberately suppressed.
+model ChildRunCompletionDelivery {
+  childRunId          String                            @id @map("child_run_id")
+  parentRunId         String                            @map("parent_run_id")
+  parentEventSequence Int?                              @map("parent_event_sequence")
+  outcome             ChildRunCompletionDeliveryOutcome
+  deliveredAt         DateTime                          @default(now()) @map("delivered_at")
+  childRun            AgentRun                          @relation("ChildRunCompletionDeliveryChild", fields: [childRunId], references: [id], onDelete: Restrict)
+  parentRun           AgentRun                          @relation("ChildRunCompletionDeliveryParent", fields: [parentRunId], references: [id], onDelete: Restrict)
+
+  @@index([parentRunId])
+  @@map("child_run_completion_deliveries")
 }
 
 /// Immutable token and cost allocation made by a parent for one governed child run.

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -136,6 +136,8 @@ uncertainty fails closed.
   child-run record after exact parent-to-target delegation has been rechecked.
 - `PrismaChildRunReservationRepository` — lock the parent, recalculate capacity from immutable
   sibling allocations, and atomically persist the child run, snapshot, reservation, and dispatch.
+- `PrismaChildRunCompletionRepository` — append one terminal child outcome to its direct parent's
+  conversation stream, or durably record why no parent stream can receive it.
 - `__DigestRunInputSnapshot(snapshot)` — compute the canonical SHA-256 identity of all frozen run
   inputs without digesting the self-referential `digest` field.
 - `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial
@@ -190,6 +192,12 @@ The reservation repository is the sole durable child-admission boundary. It deri
 from locked database rows and the parent snapshot, rechecks the target policy, and records the
 derived depth with the child allocation. Replaying the same inherited-silo idempotency key returns
 only the exact sealed child; any coordinate mismatch fails closed.
+
+Completion delivery is a separate, child-keyed ledger rather than an in-memory callback. It locks
+the terminal child, its reservation, and the parent event stream before adding a single
+`child.run.*` event. A duplicate report returns the existing ledger result. A parent without a
+conversation stream, or a parent that has already terminalised, is recorded as a deliberate
+suppressed outcome instead of silently losing the result or violating the event-stream fence.
 
 ## Dependency direction
 

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-completion-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-completion-repository.test.ts
@@ -1,0 +1,61 @@
+import { AgentRunState, ChildRunCompletionDeliveryOutcome, type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaChildRunCompletionRepository } from "../prisma-child-run-completion-repository.js";
+
+/** Builds one terminal child that inherits the exact direct-parent lineage. */
+function _child(overrides: Record<string, unknown> = {})
+{
+	return { id: "child-1", parentRunId: "parent-1", rootRunId: "root-1", siloId: "silo-1", attempt: 1, state: AgentRunState.Completed, terminalReason: "Success", finishedAt: new Date("2026-07-26T00:00:00.000Z"), ...overrides };
+}
+
+/** Builds a live conversation-bound parent able to receive a child result event. */
+function _parent(overrides: Record<string, unknown> = {})
+{
+	return { id: "parent-1", rootRunId: "root-1", siloId: "silo-1", threadId: "thread-1", ...overrides };
+}
+
+/** Builds a transaction-backed repository with independently controlled authority rows. */
+function _repository(child: Record<string, unknown> | null, parent: Record<string, unknown> | null, reservation: Record<string, unknown> | null, delivery: Record<string, unknown> | null = null, terminalEvents: Array<{ type: string }> = [])
+{
+	const transaction = { $queryRaw: vi.fn().mockResolvedValue([]), agentRun: { findUnique: vi.fn().mockResolvedValueOnce(child).mockResolvedValueOnce(parent) }, childRunCompletionDelivery: { findUnique: vi.fn().mockResolvedValue(delivery), create: vi.fn() }, childRunReservation: { findUnique: vi.fn().mockResolvedValue(reservation) }, conversationRunEvent: { aggregate: vi.fn().mockResolvedValue({ _max: { sequence: 4 } }), findMany: vi.fn().mockResolvedValue(terminalEvents), create: vi.fn() } };
+	const prisma = { $transaction: vi.fn(async function _transaction(callback: (client: typeof transaction) => Promise<unknown>) { return callback(transaction); }) } as unknown as PrismaClient;
+	return { repository: new PrismaChildRunCompletionRepository(prisma), transaction };
+}
+
+describe("PrismaChildRunCompletionRepository", function _describeCompletionDelivery()
+{
+	it("appends the terminal child result and immutable receipt in one transaction", async function _delivers()
+	{
+		const { repository, transaction } = _repository(_child(), _parent(), { childRunId: "child-1", parentRunId: "parent-1", rootRunId: "root-1" });
+
+		await expect(repository.deliverAtomically({ childRunId: "child-1" })).resolves.toEqual({ outcome: "delivered", parentRunId: "parent-1", parentEventSequence: 5 });
+		expect(transaction.childRunCompletionDelivery.create).toHaveBeenCalledWith({ data: { childRunId: "child-1", parentRunId: "parent-1", parentEventSequence: 5, outcome: ChildRunCompletionDeliveryOutcome.Delivered } });
+		expect(transaction.childRunCompletionDelivery.create.mock.invocationCallOrder[0]).toBeLessThan(transaction.conversationRunEvent.create.mock.invocationCallOrder[0]!);
+		expect(transaction.conversationRunEvent.create).toHaveBeenCalledWith({ data: expect.objectContaining({ runId: "parent-1", sequence: 5, type: "child.run.completed", payload: expect.objectContaining({ childRunId: "child-1", childState: "completed" }) }) });
+	});
+
+	it("returns the existing receipt instead of appending the child twice", async function _deduplicates()
+	{
+		const { repository, transaction } = _repository(_child(), _parent(), { childRunId: "child-1", parentRunId: "parent-1", rootRunId: "root-1" }, { outcome: ChildRunCompletionDeliveryOutcome.Delivered, parentEventSequence: 5 });
+
+		await expect(repository.deliverAtomically({ childRunId: "child-1" })).resolves.toEqual({ outcome: "idempotent", parentRunId: "parent-1", parentEventSequence: 5, delivery: "delivered" });
+		expect(transaction.conversationRunEvent.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects a forged reservation before it can append to another root stream", async function _rejectsForgedLineage()
+	{
+		const { repository, transaction } = _repository(_child(), _parent(), { childRunId: "child-1", parentRunId: "parent-1", rootRunId: "other-root" });
+
+		await expect(repository.deliverAtomically({ childRunId: "child-1" })).resolves.toEqual({ outcome: "denied", reason: "lineage_conflict" });
+		expect(transaction.conversationRunEvent.create).not.toHaveBeenCalled();
+	});
+
+	it("durably suppresses delivery when the parent has no conversation stream", async function _recordsNoParentStream()
+	{
+		const { repository, transaction } = _repository(_child(), _parent({ threadId: null }), { childRunId: "child-1", parentRunId: "parent-1", rootRunId: "root-1" });
+
+		await expect(repository.deliverAtomically({ childRunId: "child-1" })).resolves.toEqual({ outcome: "suppressed", parentRunId: "parent-1", reason: "no_parent_stream" });
+		expect(transaction.childRunCompletionDelivery.create).toHaveBeenCalledWith({ data: { childRunId: "child-1", parentRunId: "parent-1", parentEventSequence: null, outcome: ChildRunCompletionDeliveryOutcome.NoParentStream } });
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/child-run-completion.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/child-run-completion.types.ts
@@ -1,0 +1,21 @@
+/** Request to append one terminal child result to its direct parent's event stream. */
+export interface ChildRunCompletionCommand
+{
+	/** Terminal child run whose outcome is being delivered. */
+	readonly childRunId: string;
+}
+
+/** Stable result of recording or replaying a child completion delivery. */
+export type ChildRunCompletionResult =
+	| { readonly outcome: "delivered"; readonly parentRunId: string; readonly parentEventSequence: number }
+	| { readonly outcome: "suppressed"; readonly parentRunId: string; readonly reason: "no_parent_stream" | "parent_stream_terminal" }
+	| { readonly outcome: "idempotent"; readonly parentRunId: string; readonly parentEventSequence: number | null; readonly delivery: "delivered" | "no_parent_stream" | "parent_stream_terminal" }
+	| { readonly outcome: "ignored"; readonly reason: "child_not_found" | "child_not_terminal" }
+	| { readonly outcome: "denied"; readonly reason: "not_child_run" | "lineage_conflict" | "persistence_unavailable" };
+
+/** Persistence boundary that owns the idempotent child-to-parent completion hand-off. */
+export interface ChildRunCompletionRepository
+{
+	/** Appends one parent event or records why a parent stream cannot receive it. */
+	deliverAtomically(command: ChildRunCompletionCommand): Promise<ChildRunCompletionResult>;
+}

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -1,10 +1,12 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
 export { __PrepareChildRunAdmission } from "./child-run-admission.js";
+export { PrismaChildRunCompletionRepository } from "./prisma-child-run-completion-repository.js";
 export { PrismaChildRunReservationRepository } from "./prisma-child-run-reservation-repository.js";
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 export type { ChildRunAdmissionLimits, ChildRunBudget, ChildRunParentAuthority, ChildRunTargetAuthorization, ChildRunTargetAuthorizationResult, PrepareChildRunAdmissionCommand, PrepareChildRunAdmissionResult, PreparedChildRunAdmission } from "./child-run-admission.types.js";
+export type { ChildRunCompletionCommand, ChildRunCompletionRepository, ChildRunCompletionResult } from "./child-run-completion.types.js";
 export type { ChildRunReservationBuild, ChildRunReservationBuildResult, ChildRunReservationCommand, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
 export { PrismaRunAdmissionRepository } from "./prisma-run-admission-repository.js";

--- a/libs/backend/agents/execution/runs/main/src/prisma-child-run-completion-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-child-run-completion-repository.ts
@@ -1,0 +1,111 @@
+import { AgentRunState, ChildRunCompletionDeliveryOutcome, Prisma, type PrismaClient } from "@prisma/client";
+
+import { ___CreateLogger, type Logger } from "@opencrane/observability";
+
+import type { ChildRunCompletionCommand, ChildRunCompletionRepository, ChildRunCompletionResult } from "./child-run-completion.types.js";
+
+/** Atomically records one terminal child result in its parent conversation stream. */
+export class PrismaChildRunCompletionRepository implements ChildRunCompletionRepository
+{
+	/** Canonical product-authority database client. */
+	private readonly prisma: PrismaClient;
+	/** Structured redacting log for fail-closed persistence faults. */
+	private readonly log: Logger;
+
+	/** Creates the transaction-owning completion-delivery repository. */
+	constructor(prisma: PrismaClient, log: Logger = ___CreateLogger("child-run-completion"))
+	{
+		this.prisma = prisma;
+		this.log = log;
+	}
+
+	/** Delivers a terminal child exactly once, with a durable suppressed outcome when the parent stream is unavailable. */
+	async deliverAtomically(command: ChildRunCompletionCommand): Promise<ChildRunCompletionResult>
+	{
+		if (command.childRunId.trim().length === 0) return { outcome: "denied", reason: "not_child_run" };
+		try
+		{
+			return await this.prisma.$transaction(async function _deliver(transaction): Promise<ChildRunCompletionResult>
+			{
+				// 1. Lock immutable child evidence before deriving any cross-run notification.
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.childRunId}, 0))`);
+				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.childRunId} FOR UPDATE`);
+				const child = await transaction.agentRun.findUnique({ where: { id: command.childRunId } });
+				if (child === null) return { outcome: "ignored", reason: "child_not_found" };
+				if (!_isTerminal(child.state)) return { outcome: "ignored", reason: "child_not_terminal" };
+				if (child.parentRunId === null) return { outcome: "denied", reason: "not_child_run" };
+				const replay = await transaction.childRunCompletionDelivery.findUnique({ where: { childRunId: child.id } });
+				if (replay !== null) return _replay(child.parentRunId, replay);
+
+				// 2. Lock the direct parent stream before choosing its next sequence or terminal outcome.
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${child.parentRunId}, 0))`);
+				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${child.parentRunId} FOR UPDATE`);
+				await transaction.$queryRaw(Prisma.sql`SELECT "child_run_id" FROM "child_run_reservations" WHERE "child_run_id" = ${child.id} FOR UPDATE`);
+				const parent = await transaction.agentRun.findUnique({ where: { id: child.parentRunId } });
+				const reservation = await transaction.childRunReservation.findUnique({ where: { childRunId: child.id } });
+				if (parent === null || reservation === null || !_hasExactLineage(child, parent, reservation)) return { outcome: "denied", reason: "lineage_conflict" };
+				if (parent.threadId === null) return _recordSuppressed(transaction, child.id, parent.id, ChildRunCompletionDeliveryOutcome.NoParentStream);
+				const maximum = await transaction.conversationRunEvent.aggregate({ where: { runId: parent.id }, _max: { sequence: true } });
+				if (_hasTerminalEvent(await transaction.conversationRunEvent.findMany({ where: { runId: parent.id, type: { in: ["run.completed", "run.failed", "run.cancelled"] } }, select: { type: true } }))) return _recordSuppressed(transaction, child.id, parent.id, ChildRunCompletionDeliveryOutcome.ParentStreamTerminal);
+
+				// 3. Append the parent-visible event and ledger entry together, so a retry cannot create a second sequence.
+				const sequence = (maximum._max.sequence ?? 0) + 1;
+				await transaction.childRunCompletionDelivery.create({ data: { childRunId: child.id, parentRunId: parent.id, parentEventSequence: sequence, outcome: ChildRunCompletionDeliveryOutcome.Delivered } });
+				await transaction.conversationRunEvent.create({ data: { runId: parent.id, sequence, type: _eventType(child.state), payload: { childRunId: child.id, childAttempt: child.attempt, childState: _state(child.state), terminalReason: child.terminalReason, finishedAt: child.finishedAt?.toISOString() ?? null }, occurredAt: new Date() } });
+				return { outcome: "delivered", parentRunId: parent.id, parentEventSequence: sequence };
+			});
+		}
+		catch (error)
+		{
+			this.log.error({ err: error, childRunId: command.childRunId, failureKind: "transaction_failed" }, "child run completion delivery failed");
+			return { outcome: "denied", reason: "persistence_unavailable" };
+		}
+	}
+}
+
+/** Records a durable reason why the parent cannot receive a child completion event. */
+async function _recordSuppressed(transaction: Prisma.TransactionClient, childRunId: string, parentRunId: string, outcome: ChildRunCompletionDeliveryOutcome): Promise<ChildRunCompletionResult>
+{
+	await transaction.childRunCompletionDelivery.create({ data: { childRunId, parentRunId, parentEventSequence: null, outcome } });
+	return { outcome: "suppressed", parentRunId, reason: outcome === ChildRunCompletionDeliveryOutcome.NoParentStream ? "no_parent_stream" : "parent_stream_terminal" };
+}
+
+/** Maps a persisted delivery ledger row into the same replay outcome across all callers. */
+function _replay(parentRunId: string, delivery: { outcome: ChildRunCompletionDeliveryOutcome; parentEventSequence: number | null }): ChildRunCompletionResult
+{
+	return { outcome: "idempotent", parentRunId, parentEventSequence: delivery.parentEventSequence, delivery: delivery.outcome === ChildRunCompletionDeliveryOutcome.Delivered ? "delivered" : delivery.outcome === ChildRunCompletionDeliveryOutcome.NoParentStream ? "no_parent_stream" : "parent_stream_terminal" };
+}
+
+/** Returns whether a run state has immutable terminal outcome evidence. */
+function _isTerminal(state: AgentRunState): boolean
+{
+	return state === AgentRunState.Completed || state === AgentRunState.Failed || state === AgentRunState.Cancelled;
+}
+
+/** Verifies that the reservation, child, and parent form one exact inherited-silo lineage. */
+function _hasExactLineage(child: { id: string; siloId: string; parentRunId: string | null; rootRunId: string }, parent: { id: string; siloId: string; rootRunId: string }, reservation: { childRunId: string; parentRunId: string; rootRunId: string }): boolean
+{
+	return child.parentRunId === parent.id && child.siloId === parent.siloId && child.rootRunId === parent.rootRunId && reservation.childRunId === child.id && reservation.parentRunId === parent.id && reservation.rootRunId === parent.rootRunId;
+}
+
+/** Returns whether the parent stream has already accepted its sole terminal event. */
+function _hasTerminalEvent(events: Array<{ type: string }>): boolean
+{
+	return events.length > 0;
+}
+
+/** Maps a child terminal state to its parent-stream event type. */
+function _eventType(state: AgentRunState): "child.run.completed" | "child.run.failed" | "child.run.cancelled"
+{
+	if (state === AgentRunState.Completed) return "child.run.completed";
+	if (state === AgentRunState.Failed) return "child.run.failed";
+	return "child.run.cancelled";
+}
+
+/** Maps only terminal Prisma run states to the delivery payload vocabulary. */
+function _state(state: AgentRunState): "completed" | "failed" | "cancelled"
+{
+	if (state === AgentRunState.Completed) return "completed";
+	if (state === AgentRunState.Failed) return "failed";
+	return "cancelled";
+}

--- a/libs/backend/agents/personal/conversations/main/tests/conversation-authority.sql
+++ b/libs/backend/agents/personal/conversations/main/tests/conversation-authority.sql
@@ -34,6 +34,7 @@ SELECT pg_temp.expect_failure('run must bind its exact conversation thread', $st
 INSERT INTO "conversation_run_events" ("run_id", "sequence", "type", "payload") VALUES ('conversation-run', 1, 'run.accepted', '{}');
 
 SELECT pg_temp.expect_failure('event sequence cannot skip', $statement$INSERT INTO "conversation_run_events" ("run_id", "sequence", "type", "payload") VALUES ('conversation-run', 3, 'run.started', '{}')$statement$, 'must be contiguous');
+SELECT pg_temp.expect_failure('child completion event requires delivery authority', $statement$INSERT INTO "conversation_run_events" ("run_id", "sequence", "type", "payload") VALUES ('conversation-run', 2, 'child.run.completed', '{"childRunId":"forged-child"}')$statement$, 'requires child completion delivery authority');
 SELECT pg_temp.expect_failure('terminal event requires matching run authority', $statement$INSERT INTO "conversation_run_events" ("run_id", "sequence", "type", "payload") VALUES ('conversation-run', 2, 'run.completed', '{}')$statement$, 'requires Completed AgentRun authority');
 UPDATE "agent_runs" SET "state"='failed', "finished_at"=clock_timestamp(), "terminal_reason"='runtime_failure' WHERE "id"='conversation-run';
 INSERT INTO "conversation_run_events" ("run_id", "sequence", "type", "payload") VALUES ('conversation-run', 2, 'run.failed', '{}');


### PR DESCRIPTION
## Why

A governed child run must be able to report its terminal outcome to the parent without relying on an in-memory callback or silently duplicating the report after a retry. This PR gives the parent conversation stream one durable, auditable child-result entry.

## What changed

- add an immutable, child-keyed completion-delivery ledger
- atomically validate terminal child and reservation lineage, then append exactly one `child.run.*` parent event
- record deliberate suppression when a parent has no stream or its stream is already terminal
- fence direct `child.run.*` inserts at the database boundary; a deferred constraint prevents a ledger without its matching event
- document the new run-lifecycle boundary and cover delivery, replay, lineage forgery, no-parent-stream, and direct-insert fencing

## Validation

- Prisma generate and schema validation
- `backend-agents-execution-runs` lint and 66 focused tests
- `backend-agents-personal-conversations` focused tests
- `nx affected -t lint,test --base=own-personal-ai-agent-setup --head=HEAD`
- style and whitespace gates

## Review

Independent review found an initial direct-insert bypass. The final ledger-first/deferred-constraint design was re-reviewed and the finding was refuted.