### PR TITLE
⚡ Phase E: deliver child outcomes from terminal paths

### DIFF
--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -138,6 +138,9 @@ uncertainty fails closed.
   sibling allocations, and atomically persist the child run, snapshot, reservation, and dispatch.
 - `PrismaChildRunCompletionRepository` — append one terminal child outcome to its direct parent's
   conversation stream, or durably record why no parent stream can receive it.
+- `__DeliverChildRunCompletionInTransaction(transaction, command)` — use the same delivery fence
+  from a terminal-state transaction, so cancellation and dispatch failures cannot leave a child
+  closed without its parent notification.
 - `__DigestRunInputSnapshot(snapshot)` — compute the canonical SHA-256 identity of all frozen run
   inputs without digesting the self-referential `digest` field.
 - `PrismaRunAdmissionRepository` — serialise duplicate requests and atomically persist the initial

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -1,6 +1,6 @@
 export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-authority.js";
 export { __PrepareChildRunAdmission } from "./child-run-admission.js";
-export { PrismaChildRunCompletionRepository } from "./prisma-child-run-completion-repository.js";
+export { __DeliverChildRunCompletionInTransaction, PrismaChildRunCompletionRepository } from "./prisma-child-run-completion-repository.js";
 export { PrismaChildRunReservationRepository } from "./prisma-child-run-reservation-repository.js";
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";

--- a/libs/backend/agents/execution/runs/main/src/prisma-child-run-completion-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-child-run-completion-repository.ts
@@ -27,32 +27,7 @@ export class PrismaChildRunCompletionRepository implements ChildRunCompletionRep
 		{
 			return await this.prisma.$transaction(async function _deliver(transaction): Promise<ChildRunCompletionResult>
 			{
-				// 1. Lock immutable child evidence before deriving any cross-run notification.
-				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.childRunId}, 0))`);
-				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.childRunId} FOR UPDATE`);
-				const child = await transaction.agentRun.findUnique({ where: { id: command.childRunId } });
-				if (child === null) return { outcome: "ignored", reason: "child_not_found" };
-				if (!_isTerminal(child.state)) return { outcome: "ignored", reason: "child_not_terminal" };
-				if (child.parentRunId === null) return { outcome: "denied", reason: "not_child_run" };
-				const replay = await transaction.childRunCompletionDelivery.findUnique({ where: { childRunId: child.id } });
-				if (replay !== null) return _replay(child.parentRunId, replay);
-
-				// 2. Lock the direct parent stream before choosing its next sequence or terminal outcome.
-				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${child.parentRunId}, 0))`);
-				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${child.parentRunId} FOR UPDATE`);
-				await transaction.$queryRaw(Prisma.sql`SELECT "child_run_id" FROM "child_run_reservations" WHERE "child_run_id" = ${child.id} FOR UPDATE`);
-				const parent = await transaction.agentRun.findUnique({ where: { id: child.parentRunId } });
-				const reservation = await transaction.childRunReservation.findUnique({ where: { childRunId: child.id } });
-				if (parent === null || reservation === null || !_hasExactLineage(child, parent, reservation)) return { outcome: "denied", reason: "lineage_conflict" };
-				if (parent.threadId === null) return _recordSuppressed(transaction, child.id, parent.id, ChildRunCompletionDeliveryOutcome.NoParentStream);
-				const maximum = await transaction.conversationRunEvent.aggregate({ where: { runId: parent.id }, _max: { sequence: true } });
-				if (_hasTerminalEvent(await transaction.conversationRunEvent.findMany({ where: { runId: parent.id, type: { in: ["run.completed", "run.failed", "run.cancelled"] } }, select: { type: true } }))) return _recordSuppressed(transaction, child.id, parent.id, ChildRunCompletionDeliveryOutcome.ParentStreamTerminal);
-
-				// 3. Append the parent-visible event and ledger entry together, so a retry cannot create a second sequence.
-				const sequence = (maximum._max.sequence ?? 0) + 1;
-				await transaction.childRunCompletionDelivery.create({ data: { childRunId: child.id, parentRunId: parent.id, parentEventSequence: sequence, outcome: ChildRunCompletionDeliveryOutcome.Delivered } });
-				await transaction.conversationRunEvent.create({ data: { runId: parent.id, sequence, type: _eventType(child.state), payload: { childRunId: child.id, childAttempt: child.attempt, childState: _state(child.state), terminalReason: child.terminalReason, finishedAt: child.finishedAt?.toISOString() ?? null }, occurredAt: new Date() } });
-				return { outcome: "delivered", parentRunId: parent.id, parentEventSequence: sequence };
+				return __DeliverChildRunCompletionInTransaction(transaction, command);
 			});
 		}
 		catch (error)
@@ -61,6 +36,38 @@ export class PrismaChildRunCompletionRepository implements ChildRunCompletionRep
 			return { outcome: "denied", reason: "persistence_unavailable" };
 		}
 	}
+}
+
+/** Delivers a terminal child through an already-open authority transaction. */
+export async function __DeliverChildRunCompletionInTransaction(transaction: Prisma.TransactionClient, command: ChildRunCompletionCommand): Promise<ChildRunCompletionResult>
+{
+	if (command.childRunId.trim().length === 0) return { outcome: "denied", reason: "not_child_run" };
+	// 1. Lock immutable child evidence before deriving any cross-run notification.
+	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.childRunId}, 0))`);
+	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.childRunId} FOR UPDATE`);
+	const child = await transaction.agentRun.findUnique({ where: { id: command.childRunId } });
+	if (child === null) return { outcome: "ignored", reason: "child_not_found" };
+	if (!_isTerminal(child.state)) return { outcome: "ignored", reason: "child_not_terminal" };
+	if (child.parentRunId === null) return { outcome: "denied", reason: "not_child_run" };
+	const replay = await transaction.childRunCompletionDelivery.findUnique({ where: { childRunId: child.id } });
+	if (replay !== null) return _replay(child.parentRunId, replay);
+
+	// 2. Lock the direct parent stream before choosing its next sequence or terminal outcome.
+	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${child.parentRunId}, 0))`);
+	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${child.parentRunId} FOR UPDATE`);
+	await transaction.$queryRaw(Prisma.sql`SELECT "child_run_id" FROM "child_run_reservations" WHERE "child_run_id" = ${child.id} FOR UPDATE`);
+	const parent = await transaction.agentRun.findUnique({ where: { id: child.parentRunId } });
+	const reservation = await transaction.childRunReservation.findUnique({ where: { childRunId: child.id } });
+	if (parent === null || reservation === null || !_hasExactLineage(child, parent, reservation)) return { outcome: "denied", reason: "lineage_conflict" };
+	if (parent.threadId === null) return _recordSuppressed(transaction, child.id, parent.id, ChildRunCompletionDeliveryOutcome.NoParentStream);
+	const maximum = await transaction.conversationRunEvent.aggregate({ where: { runId: parent.id }, _max: { sequence: true } });
+	if (_hasTerminalEvent(await transaction.conversationRunEvent.findMany({ where: { runId: parent.id, type: { in: ["run.completed", "run.failed", "run.cancelled"] } }, select: { type: true } }))) return _recordSuppressed(transaction, child.id, parent.id, ChildRunCompletionDeliveryOutcome.ParentStreamTerminal);
+
+	// 3. Write the ledger before its matching parent event; the deferred database constraint makes the pair inseparable.
+	const sequence = (maximum._max.sequence ?? 0) + 1;
+	await transaction.childRunCompletionDelivery.create({ data: { childRunId: child.id, parentRunId: parent.id, parentEventSequence: sequence, outcome: ChildRunCompletionDeliveryOutcome.Delivered } });
+	await transaction.conversationRunEvent.create({ data: { runId: parent.id, sequence, type: _eventType(child.state), payload: { childRunId: child.id, childAttempt: child.attempt, childState: _state(child.state), terminalReason: child.terminalReason, finishedAt: child.finishedAt?.toISOString() ?? null }, occurredAt: new Date() } });
+	return { outcome: "delivered", parentRunId: parent.id, parentEventSequence: sequence };
 }
 
 /** Records a durable reason why the parent cannot receive a child completion event. */

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-cancellation-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-cancellation-repository.ts
@@ -4,6 +4,7 @@ import { AgentRunState, AgentRunTerminalReason, Prisma, RunOutboxEventKind, Work
 
 import { __CancelPendingRunApprovalAuthority } from "@opencrane/backend/server/iam/authorization";
 
+import { __DeliverChildRunCompletionInTransaction } from "./prisma-child-run-completion-repository.js";
 import type { ClaimNextRunWorkloadCleanupResult, ConfirmRunWorkloadCleanupCommand, ConfirmRunWorkloadCleanupResult, RequestRunCancellationCommand, RequestRunCancellationResult, RunCancellationRepository, RunCancellationRepositoryConfig, RunWorkloadCleanupProjection } from "./run-cancellation.types.js";
 
 /** Non-locking cleanup coordinates used only to establish canonical lock order. */
@@ -226,6 +227,7 @@ async function _FinalizeCancelledRun(transaction: Prisma.TransactionClient, run:
 {
 	const finalized = await transaction.agentRun.updateMany({ where: { id: run.id, attempt: run.attempt, state: AgentRunState.Cancelling }, data: { state: AgentRunState.Cancelled, terminalReason: AgentRunTerminalReason.UserCancelled, finishedAt: now } });
 	if (finalized.count !== 1) throw new Error("run cancellation lost its cleanup confirmation fence");
+	await __DeliverChildRunCompletionInTransaction(transaction, { childRunId: run.id });
 	if (run.threadId !== null)
 	{
 		const maximum = await transaction.conversationRunEvent.aggregate({ where: { runId: run.id }, _max: { sequence: true } });

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
@@ -5,6 +5,7 @@ import { AgentRunState, AgentRunTerminalReason, AgentServiceKind, AgentServiceSt
 import { AGENT_RUNTIME_PROJECTED_TOKEN_AUDIENCE, ___IsAgentRuntimeServiceAccountName, type AgentControllerRunAttemptAssignmentCommand, type AgentControllerRunAttemptClaimLease, type AgentControllerRunAttemptProjection, type AgentControllerRunWorkloadRegistrationCommand, type AgentControllerRunWorkloadReleaseProjection } from "@opencrane/contracts";
 import { ___DoWithTrace } from "@opencrane/observability";
 
+import { __DeliverChildRunCompletionInTransaction } from "./prisma-child-run-completion-repository.js";
 import type { AttemptModelKeyIssuer, ClaimNextRunAttemptResult, ClaimNextRunWorkloadReleaseResult, CommitRunAttemptAssignmentResult, PrunePublishedRunOutboxResult, RegisterRunWorkloadPodResult, RunDispatchRepository, RunDispatchRepositoryConfig, RunOutboxCandidateRow, RunWorkloadReleaseCandidateRow } from "./run-dispatch.types.js";
 
 /** Snapshot identity fields required at the dispatch authority boundary. */
@@ -467,6 +468,7 @@ async function _TerminalizeUndispatchableAttempt(transaction: Prisma.Transaction
 	const failedEvent = await transaction.outboxEvent.updateMany({ where: { id: event.id, claimedAt: event.claimedAt, deliveryCount: event.deliveryCount, publishedAt: null, failedAt: null }, data: { claimedAt, deliveryCount: event.deliveryCount + 1, failedAt: claimedAt, failureCode } });
 	const failedRun = await transaction.agentRun.updateMany({ where: { id: run.id, attempt: run.attempt, state: { in: [AgentRunState.Accepted, AgentRunState.Queued] } }, data: { state: AgentRunState.Failed, terminalReason, finishedAt: now } });
 	if (failedEvent.count !== 1 || failedRun.count !== 1) throw new Error("undispatchable run attempt lost its terminal failure fence");
+	await __DeliverChildRunCompletionInTransaction(transaction, { childRunId: run.id });
 
 	// 2. Conversation-bound runs require their contiguous canonical terminal event in this transaction.
 	if (run.threadId !== null)
@@ -703,6 +705,7 @@ async function _TerminalizePoisonedRelease(transaction: Prisma.TransactionClient
 	const claimedAt = new Date(Math.max(now.getTime(), (event.claimedAt?.getTime() ?? -1) + 1));
 	const failed = await transaction.outboxEvent.updateMany({ where: { id: event.id, claimedAt: event.claimedAt, deliveryCount: event.deliveryCount, publishedAt: null, failedAt: null }, data: { claimedAt, deliveryCount: event.deliveryCount + 1, failedAt: claimedAt, failureCode } });
 	if ((assignment !== null && revoked.count !== 1) || failedRun.count !== 1 || failed.count !== 1) throw new Error("poisoned run workload release lost its terminal failure fence");
+	await __DeliverChildRunCompletionInTransaction(transaction, { childRunId: run.id });
 
 	// 3. A committed assignment always receives exact physical cleanup authority; TTL cannot remove a suspended Job.
 	if (assignment !== null)


### PR DESCRIPTION
## Why

The child-completion ledger is only useful when every terminal path uses it. Cancellation and controller-side dispatch failures previously closed a child run without notifying its parent.

## What changed

- extract the delivery fence into one transaction-aware helper
- call it immediately after child terminal state transitions in cancellation, undispatchable-attempt, and poisoned-release paths
- keep parent notification and the child terminal event in the same database transaction
- document the transaction seam for future terminal paths

## Validation

- `backend-agents-execution-runs` lint and 66 focused tests
- style and whitespace gates

## Review

Independent review confirmed terminal ordering. It found duplicate delivery-fence logic; the adapter now delegates to the shared transaction helper and the reviewer confirmed the finding is resolved.