### PR TITLE
⚡ Phase E: persist fenced runtime terminal reports

### DIFF
--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -20,7 +20,7 @@ import { _CheckDbHealth, _OpenapiRouter } from "@opencrane/server/_infra/http";
 import { _CreateRuntimeTokenReviewer, _RegisterInternalAgentRuntimeStream } from "@opencrane/server/_infra/agent-runtime-stream";
 import { AGENT_CONTROLLER_PROJECTED_TOKEN_AUDIENCE, AGENT_CONTROLLER_SERVICE_ACCOUNT_NAME, type RunInputSnapshot } from "@opencrane/contracts";
 import { spec } from "@opencrane/backend/server/api-spec";
-import { PrismaRunDispatchRepository, __CreateAgentControllerRunDispatchRouter, type AgentControllerTokenReviewer, type AttemptModelKeyMintRequest, type MintedAttemptModelKey, type ReviewedAgentControllerIdentity } from "@opencrane/backend/agents/execution/runs";
+import { PrismaRunDispatchRepository, PrismaRuntimeTerminalReporter, __CreateAgentControllerRunDispatchRouter, type AgentControllerTokenReviewer, type AttemptModelKeyMintRequest, type MintedAttemptModelKey, type ReviewedAgentControllerIdentity } from "@opencrane/backend/agents/execution/runs";
 import { PrismaSkillAuthoringCompletionRepository, PrismaSkillAuthoringInputRepository, PrismaSkillWorkloadBootstrapRepository, PrismaSkillWorkloadClaimsRepository, __CreateSkillAuthoringCompletionRouter, __CreateSkillAuthoringInputRouter, __CreateSkillWorkloadBootstrapRouter, __CreateSkillWorkloadDispatchRouter, type SkillWorkloadBootstrapIdentity, type SkillWorkloadBootstrapTokenReviewer } from "@opencrane/backend/agents/skills/execution";
 import { __CreateExternalActionExecutor, __CreatePrismaRunInputCompiler, PrismaRuntimeDispatchAuthority, __ExecuteExternalAction, type RunInputCompiler, type RuntimeExternalActionRunner } from "@opencrane/backend/agents/execution/protocol";
 import { __IsUpgradeSessionAvailable, PrismaPersonalConfigurationChangeRepository, UPGRADE_SESSION_TOOL, UPGRADE_SESSION_TOOL_REVISION } from "@opencrane/backend/agents/personal/configuration";
@@ -308,7 +308,7 @@ export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, auth
 	const runDispatchRepository = new PrismaRunDispatchRepository(prisma, { namespace: runtimeNamespace, claimLeaseMilliseconds, assignmentTtlMilliseconds, publishedOutboxRetentionMilliseconds, outboxPruneBatchSize }, _IssueAttemptModelKey);
 	const skillWorkloadClaimsRepository = new PrismaSkillWorkloadClaimsRepository(prisma, claimLeaseMilliseconds);
 	const runtimeTokenReviewer = _CreateRuntimeTokenReviewer(authApi, runtimeNamespace);
-	const runtimeDispatchAuthority = new PrismaRuntimeDispatchAuthority(prisma, { namespace: runtimeNamespace, commandTtlMilliseconds, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _CreatePersonalRunInputCompiler(), _CreateExternalActionRunner(prisma));
+	const runtimeDispatchAuthority = new PrismaRuntimeDispatchAuthority(prisma, { namespace: runtimeNamespace, commandTtlMilliseconds, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _CreatePersonalRunInputCompiler(), _CreateExternalActionRunner(prisma), new PrismaRuntimeTerminalReporter());
 	const replayRouteId = _ReadChannelReplayRouteId();
 	if (replayRouteId !== null)
 	{

--- a/libs/backend/agents/execution/protocol/README.md
+++ b/libs/backend/agents/execution/protocol/README.md
@@ -19,6 +19,9 @@ loads and locks the live workload assignment for a connected runtime Pod, mints 
 pure authority accepts, and durably advances the monotonic command sequence and the accepted
 candidate ids so a transport reconnect can neither reorder nor duplicate work. Its compiler adapter
 hydrates the immutable snapshot through the same locked Prisma transaction before dispatch.
+For the two workload-reportable terminal results, the app injects the canonical run authority into
+that transaction: `run.completed` and `run.failed` become one durable run outcome, stream event, and
+child-to-parent notification. A runtime cannot cancel itself; cancellation remains server-owned.
 
 ```
  OpenCrane run authority + immutable snapshot
@@ -69,6 +72,8 @@ authorities to accept or reject.
   neither runtime tool arguments nor a subject id can choose a dataset.
 - `RuntimeStreamWorkloadIdentity` / `RuntimeCandidateDispatchResult` / `RuntimeDispatchAuthorityConfig`
   — the identity handed in by the transport, the candidate result, and the fixed dispatch policy.
+- `RuntimeTerminalReporter` — the composition-root port that persists permitted terminal results
+  through the run authority without making this protocol package own run state.
 - `RuntimeAttemptAuthority` — exact durable facts, including current run state, that the owning run
   authority must supply at the final acceptance fence.
 - `RuntimeAdmissionRunState` — run lifecycle values understood by the admission fence, including the
@@ -91,7 +96,8 @@ attempt — the lease fence, the bound runtime instance, the next command sequen
 candidate ids) and `RuntimeDispatchedCommand` (one row per minted command, whose ids are exactly the
 attempt's accepted command set). Their clean-database schema lives in the OpenCrane-owned target
 baseline. It reads the assignment, run, and immutable snapshot rows owned by the execution-run and
-conversation domains but never writes those authorities.
+conversation domains. Terminal state remains written by the injected execution-run authority, never
+by this transport/protocol package directly.
 
 ## Dependency direction
 

--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { AGENT_RUNTIME_PROTOCOL_V1, type CompiledRunInput, type RuntimeCandidate, type RuntimeCommandEnvelope } from "@opencrane/contracts";
 
 import { PrismaRuntimeDispatchAuthority } from "../prisma-runtime-dispatch-authority.js";
-import type { RunInputCompiler, RuntimeExternalActionRunner, RuntimeStreamWorkloadIdentity } from "../prisma-runtime-dispatch-authority.types.js";
+import type { RunInputCompiler, RuntimeExternalActionRunner, RuntimeStreamWorkloadIdentity, RuntimeTerminalReporter } from "../prisma-runtime-dispatch-authority.types.js";
 import type { RuntimeProtocolClock } from "../runtime-protocol-authority.types.js";
 
 /** Fixed reviewed identity for the registered runtime Pod under test. */
@@ -87,6 +87,8 @@ interface FakeOptions
 	readonly externalActionRunner?: RuntimeExternalActionRunner;
 	/** Optional structured logger injected to assert handled dispatch failures remain observable. */
 	readonly logger?: Logger;
+	/** Optional terminal lifecycle bridge supplied by the composition root. */
+	readonly terminalReporter?: RuntimeTerminalReporter;
 	/** Optional trusted clock for retry-window expiry assertions. */
 	readonly clock?: RuntimeProtocolClock;
 	/** Approved deferred-tool results available for a resume frame. */
@@ -94,7 +96,7 @@ interface FakeOptions
 }
 
 /** Minimal in-memory Prisma double covering only the reads and writes the adapter performs. */
-function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; streams: FakeStreamRow[]; commands: FakeCommandRow[]; retries: FakeExternalActionRetryRow[]; approvals: { id: string; deferredToolResult: unknown; resumeTokenHash: string | null }[] }
+function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; queryRaw: ReturnType<typeof vi.fn>; streams: FakeStreamRow[]; commands: FakeCommandRow[]; retries: FakeExternalActionRetryRow[]; approvals: { id: string; deferredToolResult: unknown; resumeTokenHash: string | null }[] }
 {
 	const streams: FakeStreamRow[] = [];
 	const commands: FakeCommandRow[] = [];
@@ -103,6 +105,7 @@ function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; streams: Fak
 	const assignment = { runId: "run-1", attempt: 1, agentServiceId: "svc-1", agentRevisionId: "rev-1", siloId: "silo-1", subjectId: "user-1", audience: "opencrane-agent-runtime", serviceAccountName: _identity.serviceAccountName, namespace: _identity.namespace, workloadKind: "Job", workloadUid: "wl-1", workloadProfile: "profile", podUid: options.podUid === undefined ? "pod-1" : options.podUid, state: options.assignmentState ?? "Registered", expiresAt: new Date("2026-07-20T00:05:00.000Z"), createdAt: new Date("2026-07-20T00:00:00.000Z") };
 	const run = { id: "run-1", attempt: 1, agentServiceId: "svc-1", agentRevisionId: "rev-1", siloId: "silo-1", state: options.runState, inputSnapshotDigest: "sha256:snap" };
 	const snapshot = { runId: "run-1", siloId: "silo-1", agentServiceId: "svc-1", agentRevisionId: "rev-1", snapshotVersion: 1, threadId: null, messageIds: [], personaRevisionId: null, preferenceFactIds: [], artifactRevisionIds: [], skillRevisionIds: [], memoryFacts: [], memoryQueryPolicy: {}, toolGrantIds: [], modelRoute: {}, budgetPolicy: {}, identitySnapshot: { executionSubjectId: "user-1", organizationId: "org-1", fleetMembershipRevision: 3 }, capabilitySetDigest: "sha256:cap", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "v1", digest: "sha256:snap", compiledAt: new Date("2026-07-20T00:00:00.000Z") };
+	const queryRaw = vi.fn().mockResolvedValue([]);
 
 	/** Return whether a stream row satisfies the guard fields present in a where clause. */
 	function _streamMatches(row: FakeStreamRow, where: Record<string, unknown>): boolean
@@ -115,7 +118,7 @@ function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; streams: Fak
 
 	const client = {
 		async $transaction(run_: (tx: unknown) => Promise<unknown>) { return run_(client); },
-		async $queryRaw() { return []; },
+		$queryRaw: queryRaw,
 		workloadAssignment: {
 			async findUnique(args: { where: { namespace_podUid?: { namespace: string; podUid: string } } })
 			{
@@ -176,7 +179,7 @@ function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; streams: Fak
 			},
 		},
 	};
-	return { prisma: client as unknown as PrismaClient, streams, commands, retries, approvals };
+	return { prisma: client as unknown as PrismaClient, queryRaw, streams, commands, retries, approvals };
 }
 
 /** Deterministic fake compiler: same snapshot digest always yields byte-identical compiled input. */
@@ -189,7 +192,7 @@ const _compileRunInput: RunInputCompiler = async function _compile(snapshot): Pr
 function _authority(options: FakeOptions)
 {
 	const fake = _fakePrisma(options);
-	return { authority: new PrismaRuntimeDispatchAuthority(fake.prisma, { namespace: "runtime-ns", commandTtlMilliseconds: 60_000, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _compileRunInput, options.externalActionRunner, options.clock ?? _clock, options.logger), ...fake };
+	return { authority: new PrismaRuntimeDispatchAuthority(fake.prisma, { namespace: "runtime-ns", commandTtlMilliseconds: 60_000, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _compileRunInput, options.externalActionRunner, options.terminalReporter, options.clock ?? _clock, options.logger), ...fake };
 }
 
 /** Build a runtime event candidate bound to a dispatched command. */
@@ -211,6 +214,16 @@ describe("PrismaRuntimeDispatchAuthority", function _describeDispatchAuthority()
 		expect(context.commands).toHaveLength(1);
 		expect(context.streams[0]?.nextCommandSequence).toBe(2);
 		expect(command?.kind === "start_attempt" ? command.payload.compiledInput.digest : null).toBe("sha256:sha256:snap");
+	});
+
+	it("takes the per-run advisory lock before its row lock, matching cancellation", async function _ordersRunLocks()
+	{
+		const context = _authority({ runState: "Running" });
+
+		await context.authority.__NextCommand(_identity, _open, 0);
+		const queries = context.queryRaw.mock.calls.map(function _sql(call) { return ((call[0] as { strings?: readonly string[] }).strings ?? []).join(" "); });
+		expect(queries[0]).toContain("pg_advisory_xact_lock");
+		expect(queries[1]).toContain('FROM "agent_runs"');
 	});
 
 	it("idempotently redelivers the same start command to a reconnecting instance", async function _redelivers()
@@ -305,6 +318,26 @@ describe("PrismaRuntimeDispatchAuthority", function _describeDispatchAuthority()
 
 		expect(result.accepted).toBe(true);
 		expect(ran).toBe(1);
+	});
+
+	it("persists only a fenced runtime completion through the injected run authority", async function _reportsTerminalCompletion()
+	{
+		const reporter = { reportInTransaction: vi.fn().mockResolvedValue({ outcome: "reported" }) };
+		const context = _authority({ runState: "Running", terminalReporter: reporter });
+		const start = await context.authority.__NextCommand(_identity, _open, 0);
+		const candidate: RuntimeCandidate = { protocolVersion: AGENT_RUNTIME_PROTOCOL_V1, runtimeInstanceId: "instance-1", commandId: start?.commandId ?? "command-1", candidateId: "candidate-complete", runId: "run-1", attempt: 1, fence: 1, kind: "event", eventType: "run.completed", payload: { ignored: "runtime payload never becomes durable terminal evidence" } };
+
+		await expect(context.authority.__AdmitCandidate(_identity, candidate)).resolves.toEqual({ accepted: true });
+		expect(reporter.reportInTransaction).toHaveBeenCalledWith(expect.anything(), { runId: "run-1", attempt: 1, eventType: "run.completed" });
+	});
+
+	it("keeps cancellation server-owned even for an authenticated runtime", async function _deniesRuntimeCancellation()
+	{
+		const context = _authority({ runState: "Running", terminalReporter: { reportInTransaction: vi.fn() } });
+		const start = await context.authority.__NextCommand(_identity, _open, 0);
+		const candidate: RuntimeCandidate = { protocolVersion: AGENT_RUNTIME_PROTOCOL_V1, runtimeInstanceId: "instance-1", commandId: start?.commandId ?? "command-1", candidateId: "candidate-cancel", runId: "run-1", attempt: 1, fence: 1, kind: "event", eventType: "run.cancelled", payload: {} };
+
+		await expect(context.authority.__AdmitCandidate(_identity, candidate)).resolves.toEqual({ accepted: false, reason: "runtime_cancellation_not_authoritative" });
 	});
 
 	it("retries only an explicit pre-reservation runner failure within its durable server budget", async function _surfacesExternalActionFailure()

--- a/libs/backend/agents/execution/protocol/src/index.ts
+++ b/libs/backend/agents/execution/protocol/src/index.ts
@@ -2,7 +2,7 @@ export { __AdmitRuntimeCandidate, __AdmitRuntimeCommand } from "./runtime-protoc
 export type { RuntimeAdmissionRunState, RuntimeAttemptAuthority, RuntimeCandidateAdmission, RuntimeCandidateAdmissionInput, RuntimeCommandAdmission, RuntimeCommandAdmissionInput, RuntimeProtocolClock } from "./runtime-protocol-authority.types.js";
 export { PrismaRuntimeDispatchAuthority } from "./prisma-runtime-dispatch-authority.js";
 export { __CreatePrismaRunInputCompiler } from "./prisma-run-input-compiler.js";
-export type { RunInputCompiler, RuntimeCandidateDispatchResult, RuntimeDispatchAuthorityConfig, RuntimeExternalActionRunner, RuntimeExternalActionRunnerResult, RuntimeStreamWorkloadIdentity } from "./prisma-runtime-dispatch-authority.types.js";
+export type { RunInputCompiler, RuntimeCandidateDispatchResult, RuntimeDispatchAuthorityConfig, RuntimeExternalActionRunner, RuntimeExternalActionRunnerResult, RuntimeStreamWorkloadIdentity, RuntimeTerminalReporter } from "./prisma-runtime-dispatch-authority.types.js";
 export { __ExecuteExternalAction } from "./external-action-authority.js";
 export type { ExecuteExternalActionCommand, ExecuteExternalActionResult, ExternalActionExecutor, ExternalActionFailureReason } from "./external-action-authority.types.js";
 export { __CreateExternalActionExecutor } from "./external-action-executor.js";

--- a/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
@@ -2,13 +2,13 @@ import { createHash } from "node:crypto";
 
 import { AgentRunState as PrismaAgentRunState, AgentRunTerminalReason, ApprovalRequestState, Prisma, RuntimeCommandKind, WorkloadAssignmentState, type PrismaClient } from "@prisma/client";
 
-import { AGENT_RUNTIME_PROTOCOL_V1, type CancelAttemptCommand, type CompiledRunInput, type ResumeAttemptCommand, type RunInputSnapshot, type RunInputSnapshotIdentity, type RuntimeAssignment, type RuntimeCandidate, type RuntimeCommand, type RuntimeCommandEnvelope, type RuntimeExternalActionCandidate, type RuntimeStreamOpen } from "@opencrane/contracts";
+import { AGENT_RUNTIME_PROTOCOL_V1, type CancelAttemptCommand, type CompiledRunInput, type ResumeAttemptCommand, type RunInputSnapshot, type RunInputSnapshotIdentity, type RuntimeAssignment, type RuntimeCandidate, type RuntimeCommand, type RuntimeCommandEnvelope, type RuntimeEventCandidate, type RuntimeExternalActionCandidate, type RuntimeStreamOpen } from "@opencrane/contracts";
 import type { JsonValue } from "@opencrane/util";
 import { ___CreateLogger, ___DoWithTrace, type Logger } from "@opencrane/observability";
 
 import { __AdmitRuntimeCandidate, __AdmitRuntimeCommand } from "./runtime-protocol-authority.js";
 import type { RuntimeAdmissionRunState, RuntimeAttemptAuthority, RuntimeProtocolClock } from "./runtime-protocol-authority.types.js";
-import type { RunInputCompiler, RuntimeCandidateDispatchResult, RuntimeDispatchAuthorityConfig, RuntimeExternalActionRunner, RuntimeStreamWorkloadIdentity } from "./prisma-runtime-dispatch-authority.types.js";
+import type { RunInputCompiler, RuntimeCandidateDispatchResult, RuntimeDispatchAuthorityConfig, RuntimeExternalActionRunner, RuntimeStreamWorkloadIdentity, RuntimeTerminalReporter } from "./prisma-runtime-dispatch-authority.types.js";
 
 /** Fixed retry delay returned before an admitted action has a durable invocation receipt. */
 const _EXTERNAL_ACTION_DISPATCH_RETRY_AFTER_MILLISECONDS = 1_000;
@@ -98,9 +98,11 @@ export class PrismaRuntimeDispatchAuthority
 	private readonly externalActionRunner: RuntimeExternalActionRunner | null;
 	/** Structured logger for dispatch failures that must be retried by the runtime. */
 	private readonly log: Logger;
+	/** Optional composition-root bridge to the canonical terminal run authority. */
+	private readonly terminalReporter: RuntimeTerminalReporter | null;
 
 	/** Creates a dispatch adapter over canonical Postgres with a bounded command lifetime. */
-	constructor(prisma: PrismaClient, config: RuntimeDispatchAuthorityConfig, compileRunInput: RunInputCompiler, externalActionRunner?: RuntimeExternalActionRunner, clock?: RuntimeProtocolClock, log: Logger = ___CreateLogger("runtime-dispatch"))
+	constructor(prisma: PrismaClient, config: RuntimeDispatchAuthorityConfig, compileRunInput: RunInputCompiler, externalActionRunner?: RuntimeExternalActionRunner, terminalReporter?: RuntimeTerminalReporter, clock?: RuntimeProtocolClock, log: Logger = ___CreateLogger("runtime-dispatch"))
 	{
 		if (!_configIsValid(config)) throw new Error("runtime dispatch authority requires a bounded namespace and command lifetime");
 		this.prisma = prisma;
@@ -109,6 +111,7 @@ export class PrismaRuntimeDispatchAuthority
 		this.externalActionRunner = externalActionRunner ?? null;
 		this.clock = clock ?? { nowEpochMs(): number { return Date.now(); } };
 		this.log = log;
+		this.terminalReporter = terminalReporter ?? null;
 	}
 
 	/** Returns the next server-issued command after the supplied sequence, or null while idle. */
@@ -134,10 +137,11 @@ export class PrismaRuntimeDispatchAuthority
 		const clock = this.clock;
 		const compileRunInput = this.compileRunInput;
 		const externalActionRunner = this.externalActionRunner;
+		const terminalReporter = this.terminalReporter;
 		const log = this.log;
 		return ___DoWithTrace("runtime_dispatch.candidate.admit", { namespace: identity.namespace }, async function _traceAdmit(): Promise<RuntimeCandidateDispatchResult>
 		{
-			const admission = await _admitCandidate(prisma, clock, identity, candidate);
+			const admission = await _admitCandidate(prisma, clock, identity, candidate, terminalReporter);
 			// After the fence-checked admission commits, dispatch accepted external actions outside the
 			// admission transaction. Only an explicit runner result that proves no ToolInvocation exists can
 			// use the server-owned retry budget; every post-reservation outcome stays terminal and fail closed.
@@ -239,8 +243,11 @@ async function _nextCommand(prisma: PrismaClient, config: RuntimeDispatchAuthori
 }
 
 /** Admit one runtime candidate and durably record its id when the pure authority accepts it. */
-async function _admitCandidate(prisma: PrismaClient, clock: RuntimeProtocolClock, identity: RuntimeStreamWorkloadIdentity, candidate: RuntimeCandidate): Promise<RuntimeCandidateDispatchResult>
+async function _admitCandidate(prisma: PrismaClient, clock: RuntimeProtocolClock, identity: RuntimeStreamWorkloadIdentity, candidate: RuntimeCandidate, terminalReporter: RuntimeTerminalReporter | null): Promise<RuntimeCandidateDispatchResult>
 {
+	const terminal = _terminalRuntimeEvent(candidate);
+	if (candidate.kind === "event" && candidate.eventType === "run.cancelled") return { accepted: false, reason: "runtime_cancellation_not_authoritative" };
+	if (terminal !== null && terminalReporter === null) return { accepted: false, reason: "terminal_reporter_unavailable" };
 	return prisma.$transaction(async function _admit(transaction: Prisma.TransactionClient): Promise<RuntimeCandidateDispatchResult>
 	{
 		// 1. Load and lock the live assignment, run, and snapshot for the reviewed Pod.
@@ -255,12 +262,26 @@ async function _admitCandidate(prisma: PrismaClient, clock: RuntimeProtocolClock
 		const admission = __AdmitRuntimeCandidate({ authority, candidate, clock });
 		if (admission.outcome === "idempotent") return { accepted: true };
 		if (admission.outcome === "denied") return { accepted: false, reason: admission.reason };
+		if (terminal !== null && terminalReporter !== null)
+		{
+			const report = await terminalReporter.reportInTransaction(transaction, { runId: context.runId, attempt: context.attempt, eventType: terminal });
+			if (report.outcome === "denied") return { accepted: false, reason: report.reason ?? "terminal_report_denied" };
+		}
 
 		// 3. Append the accepted candidate id monotonically under the held stream lock.
 		const appended = await transaction.runtimeCommandStream.updateMany({ where: { runId: context.runId, attempt: context.attempt, nextCommandSequence: stream.nextCommandSequence }, data: { acceptedCandidateIds: { push: candidate.candidateId } } });
 		if (appended.count !== 1) throw new Error("runtime dispatch lost its candidate acceptance fence");
 		return { accepted: true };
 	});
+}
+
+/** Return a terminal event type only for workload outcomes the server lets a runtime report. */
+function _terminalRuntimeEvent(candidate: RuntimeCandidate): "run.completed" | "run.failed" | null
+{
+	if (candidate.kind !== "event") return null;
+	const event = candidate as RuntimeEventCandidate;
+	if (event.eventType === "run.completed" || event.eventType === "run.failed") return event.eventType;
+	return null;
 }
 
 /** Reserve and dispatch one admitted external-action candidate through the composition-root runner. */
@@ -321,7 +342,14 @@ async function _releaseStream(prisma: PrismaClient, identity: RuntimeStreamWorkl
 /** Load and lock the assignment, run, and snapshot for the reviewed namespace and Pod UID. */
 async function _loadContext(transaction: Prisma.TransactionClient, identity: RuntimeStreamWorkloadIdentity): Promise<RuntimeDispatchContext | null>
 {
-	// 1. Establish the assignment lock by its unique namespace/Pod key before reading dependents.
+	// 1. Discover the run without holding the assignment. All terminal/cancellation authorities lock
+	// the run before its assignment, so this prevents a runtime report from deadlocking with a cancel.
+	const discovered = await transaction.workloadAssignment.findUnique({ where: { namespace_podUid: { namespace: identity.namespace, podUid: identity.podUid } } });
+	if (discovered === null) return null;
+	// The cancellation and terminal-report authorities use this advisory-before-row order too. It
+	// serialises every writer for one run without creating an advisory/row lock inversion.
+	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${discovered.runId}, 0))`);
+	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${discovered.runId} FOR UPDATE`);
 	await transaction.$queryRaw(Prisma.sql`SELECT "run_id" FROM "workload_assignments" WHERE "namespace" = ${identity.namespace} AND "pod_uid" = ${identity.podUid} FOR UPDATE`);
 	const assignment = await transaction.workloadAssignment.findUnique({ where: { namespace_podUid: { namespace: identity.namespace, podUid: identity.podUid } } });
 	if (assignment === null || assignment.podUid === null || assignment.state !== WorkloadAssignmentState.Registered || assignment.serviceAccountName !== identity.serviceAccountName) return null;

--- a/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.types.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.types.ts
@@ -65,6 +65,13 @@ export interface RuntimeExternalActionRunner
 	run(candidate: RuntimeExternalActionCandidate, snapshot: RunInputSnapshot, compiledTools: readonly CompiledToolDefinition[]): Promise<RuntimeExternalActionRunnerResult>;
 }
 
+/** Terminal lifecycle persistence supplied by the composition root without reversing library dependencies. */
+export interface RuntimeTerminalReporter
+{
+	/** Persist an already-fenced runtime completion or failure in the current authority transaction. */
+	reportInTransaction(transaction: Prisma.TransactionClient, command: { readonly runId: string; readonly attempt: number; readonly eventType: "run.completed" | "run.failed" }): Promise<{ readonly outcome: "reported" | "denied"; readonly reason?: string }>;
+}
+
 /** Stable result returned after a candidate reaches the authoritative run boundary. */
 export interface RuntimeCandidateDispatchResult
 {

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -119,6 +119,12 @@ may adopt the API UID for deletion. If no controller claim ever left Postgres, t
 attempt event proves no Job can exist and cancellation can finish immediately. Only confirmed
 deletion or authoritative absence moves `Cancelling` to `Cancelled` and emits `run.cancelled`.
 
+`PrismaRuntimeTerminalReporter` is the matching completion boundary for an authenticated runtime
+Pod. It accepts only a protocol-fenced `run.completed` or `run.failed` report for the currently
+running attempt, serialises terminal writers on the run, and commits the lifecycle state, canonical
+conversation event, and any child-to-parent completion delivery together. Runtime Pods have no
+`run.cancelled` authority: cancellation continues to flow through the server-owned cleanup process.
+
 Poisoned or expired release authority uses the same generic cleanup event after failing the run, so
 physical residue is not confused with user cancellation and a suspended Job is never left for an
 inapplicable terminal TTL to discover.

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-runtime-terminal-reporter.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-runtime-terminal-reporter.test.ts
@@ -1,0 +1,43 @@
+import { AgentRunState, AgentRunTerminalReason } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaRuntimeTerminalReporter } from "../prisma-runtime-terminal-reporter.js";
+
+/** Builds the minimum direct run row needed by the terminal reporting authority. */
+function _run(overrides: Record<string, unknown> = {})
+{
+	return { id: "run-1", attempt: 1, state: AgentRunState.Running, threadId: "thread-1", parentRunId: null, ...overrides };
+}
+
+/** Builds one transaction double that exposes only terminal reporter dependencies. */
+function _transaction(run: ReturnType<typeof _run> | null, updateCount = 1)
+{
+	return {
+		$queryRaw: vi.fn().mockResolvedValue([]),
+		agentRun: { findUnique: vi.fn().mockResolvedValue(run), updateMany: vi.fn().mockResolvedValue({ count: updateCount }) },
+		conversationRunEvent: { aggregate: vi.fn().mockResolvedValue({ _max: { sequence: 4 } }), create: vi.fn().mockResolvedValue({}) },
+	};
+}
+
+describe("PrismaRuntimeTerminalReporter", function _describeReporter()
+{
+	it("commits a fenced runtime success and its canonical stream event together", async function _reportsCompletion()
+	{
+		const transaction = _transaction(_run());
+		const reporter = new PrismaRuntimeTerminalReporter();
+
+		await expect(reporter.reportInTransaction(transaction as never, { runId: "run-1", attempt: 1, eventType: "run.completed" })).resolves.toEqual({ outcome: "reported" });
+		expect(transaction.agentRun.updateMany).toHaveBeenCalledWith({ where: { id: "run-1", attempt: 1, state: AgentRunState.Running }, data: expect.objectContaining({ state: AgentRunState.Completed, terminalReason: AgentRunTerminalReason.Success }) });
+		expect(transaction.conversationRunEvent.create).toHaveBeenCalledWith({ data: expect.objectContaining({ runId: "run-1", sequence: 5, type: "run.completed", payload: { terminalReason: "success" } }) });
+	});
+
+	it("refuses a report after cancellation or another terminal writer won", async function _deniesStaleReport()
+	{
+		const transaction = _transaction(_run({ state: AgentRunState.Cancelling }));
+		const reporter = new PrismaRuntimeTerminalReporter();
+
+		await expect(reporter.reportInTransaction(transaction as never, { runId: "run-1", attempt: 1, eventType: "run.failed" })).resolves.toEqual({ outcome: "denied", reason: "run_not_running" });
+		expect(transaction.agentRun.updateMany).not.toHaveBeenCalled();
+		expect(transaction.conversationRunEvent.create).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -2,12 +2,14 @@ export { __StartNextRunAttempt, __ValidateRunWorkloadAssignment } from "./run-au
 export { __PrepareChildRunAdmission } from "./child-run-admission.js";
 export { __DeliverChildRunCompletionInTransaction, PrismaChildRunCompletionRepository } from "./prisma-child-run-completion-repository.js";
 export { PrismaChildRunReservationRepository } from "./prisma-child-run-reservation-repository.js";
+export { PrismaRuntimeTerminalReporter } from "./prisma-runtime-terminal-reporter.js";
 export { __DigestRunInputSnapshot } from "./run-input-snapshot-digest.js";
 export type { AgentRunAuthorityRepository, AgentRunAuthoritySnapshot, AtomicRunAttemptResult, AtomicStartNextRunAttemptCommand, RunWorkloadAssignment, RunWorkloadAssignmentDecision, RunWorkloadAssignmentExpectation, StartNextRunAttemptCommand, StartNextRunAttemptResult } from "./run-authority.types.js";
 export type { InitialRunAuthority, RunAdmissionBuild, RunAdmissionBuildResult, RunAdmissionClock, RunAdmissionCommand, RunAdmissionRepository, RunAdmissionResult, RunAdmissionTransaction } from "./run-admission.types.js";
 export type { ChildRunAdmissionLimits, ChildRunBudget, ChildRunParentAuthority, ChildRunTargetAuthorization, ChildRunTargetAuthorizationResult, PrepareChildRunAdmissionCommand, PrepareChildRunAdmissionResult, PreparedChildRunAdmission } from "./child-run-admission.types.js";
 export type { ChildRunCompletionCommand, ChildRunCompletionRepository, ChildRunCompletionResult } from "./child-run-completion.types.js";
 export type { ChildRunReservationBuild, ChildRunReservationBuildResult, ChildRunReservationCommand, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types.js";
+export type { RuntimeTerminalEventType, RuntimeTerminalReportCommand, RuntimeTerminalReporter, RuntimeTerminalReportResult } from "./runtime-terminal-reporter.types.js";
 export { PrismaAgentRunAuthorityRepository } from "./prisma-run-authority.js";
 export { PrismaRunAdmissionRepository } from "./prisma-run-admission-repository.js";
 export { PrismaRunCancellationRepository } from "./prisma-run-cancellation-repository.js";

--- a/libs/backend/agents/execution/runs/main/src/prisma-runtime-terminal-reporter.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-runtime-terminal-reporter.ts
@@ -1,0 +1,41 @@
+import { AgentRunState, AgentRunTerminalReason, Prisma } from "@prisma/client";
+
+import { __DeliverChildRunCompletionInTransaction } from "./prisma-child-run-completion-repository.js";
+import type { RuntimeTerminalEventType, RuntimeTerminalReportCommand, RuntimeTerminalReporter, RuntimeTerminalReportResult } from "./runtime-terminal-reporter.types.js";
+
+/** Prisma authority that turns a fenced runtime result into the sole terminal run outcome. */
+export class PrismaRuntimeTerminalReporter implements RuntimeTerminalReporter
+{
+	/** Persist one terminal report with its own stream event and child-to-parent hand-off. */
+	async reportInTransaction(transaction: Prisma.TransactionClient, command: RuntimeTerminalReportCommand): Promise<RuntimeTerminalReportResult>
+	{
+		// Serialise all terminal writers for this run before choosing the next stream sequence.
+		await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.runId}, 0))`);
+		await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.runId} FOR UPDATE`);
+		const run = await transaction.agentRun.findUnique({ where: { id: command.runId } });
+		if (run === null || run.attempt !== command.attempt || run.state !== AgentRunState.Running) return { outcome: "denied", reason: "run_not_running" };
+
+		const terminal = _terminal(command.eventType);
+		const now = new Date();
+		const updated = await transaction.agentRun.updateMany({ where: { id: run.id, attempt: run.attempt, state: AgentRunState.Running }, data: { state: terminal.state, terminalReason: terminal.reason, finishedAt: now } });
+		if (updated.count !== 1) return { outcome: "denied", reason: "run_not_running" };
+
+		if (run.threadId !== null)
+		{
+			const maximum = await transaction.conversationRunEvent.aggregate({ where: { runId: run.id }, _max: { sequence: true } });
+			await transaction.conversationRunEvent.create({ data: { runId: run.id, sequence: (maximum._max.sequence ?? 0) + 1, type: command.eventType, payload: { terminalReason: terminal.payloadReason }, occurredAt: now } });
+		}
+
+		// A terminal child must notify its parent in this same transaction; the delivery helper records a
+		// durable suppression instead when the parent stream is intentionally unavailable.
+		if (run.parentRunId !== null) await __DeliverChildRunCompletionInTransaction(transaction, { childRunId: run.id });
+		return { outcome: "reported" };
+	}
+}
+
+/** Map the only workload-reportable terminal types to canonical durable lifecycle values. */
+function _terminal(eventType: RuntimeTerminalEventType): { readonly state: "Completed" | "Failed"; readonly reason: AgentRunTerminalReason; readonly payloadReason: "success" | "runtime_failure" }
+{
+	if (eventType === "run.completed") return { state: AgentRunState.Completed, reason: AgentRunTerminalReason.Success, payloadReason: "success" };
+	return { state: AgentRunState.Failed, reason: AgentRunTerminalReason.RuntimeFailure, payloadReason: "runtime_failure" };
+}

--- a/libs/backend/agents/execution/runs/main/src/runtime-terminal-reporter.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/runtime-terminal-reporter.types.ts
@@ -1,0 +1,27 @@
+import type { Prisma } from "@prisma/client";
+
+/** Terminal runtime event types that an authenticated workload may propose. */
+export type RuntimeTerminalEventType = "run.completed" | "run.failed";
+
+/** Immutable, already-fenced runtime terminal report handed to the run authority. */
+export interface RuntimeTerminalReportCommand
+{
+	/** Exact run whose authenticated workload proposed the terminal result. */
+	readonly runId: string;
+	/** Exact attempt bound to the authenticated workload assignment. */
+	readonly attempt: number;
+	/** Only success or runtime-failure may be proposed by the workload. */
+	readonly eventType: RuntimeTerminalEventType;
+}
+
+/** Result of turning one admitted terminal runtime report into durable run evidence. */
+export type RuntimeTerminalReportResult =
+	| { readonly outcome: "reported" }
+	| { readonly outcome: "denied"; readonly reason: "run_not_running" };
+
+/** Transaction-scoped port from the protocol fence to the canonical run authority. */
+export interface RuntimeTerminalReporter
+{
+	/** Persist one terminal report inside the caller's assignment-and-stream transaction. */
+	reportInTransaction(transaction: Prisma.TransactionClient, command: RuntimeTerminalReportCommand): Promise<RuntimeTerminalReportResult>;
+}


### PR DESCRIPTION
## Why

An assigned runtime Pod could authenticate to the command stream and propose an event, but a successful or failed execution was not yet converted into the authoritative run lifecycle. This left terminal state, the user-visible event stream, and child-to-parent completion disconnected.

## What changes

- admit only fenced `run.completed` and `run.failed` reports through the authenticated runtime stream
- keep `run.cancelled` server-owned; runtimes cannot self-cancel
- add the execution-runs terminal reporter, which atomically writes the terminal state, canonical event, and child completion hand-off
- inject that authority at the OpenCrane composition root without reversing protocol-to-runs dependencies
- align runtime, terminal, and cancellation lock order: advisory run lock before the row lock

## Validation

- `npx nx run backend-agents-execution-protocol:lint`
- `npx nx run backend-agents-execution-runs:lint`
- `npx nx run opencrane:lint`
- `npx nx run backend-agents-execution-protocol:test` — 54 passed
- `npx nx run backend-agents-execution-runs:test` — 68 passed
- `scripts/agent-style-check.sh` and `git diff --check`

## Independent review

The independent review found a potential runtime-versus-cancellation advisory/row lock inversion. This PR fixes it and adds an ordering test; the follow-up review found no Critical or High findings.

## Stack

Base: `feat/phase-e-child-run-terminal-wiring-v2` (PR #476). This is the next dependent runtime-completion slice.