### PR TITLE
⚡ Phase E: align runtime terminal emission

### DIFF
--- a/apps/agent-runtime/README.md
+++ b/apps/agent-runtime/README.md
@@ -17,8 +17,8 @@ command as a bounded Pydantic AI model/tool loop over the per-silo LiteLLM proxy
 candidates as the attempt runs. A model tool call is surfaced as a bounded `external_action`
 candidate for the control plane to authorize — the runtime never executes the tool itself. It also
 handles `resume_attempt` (feeding control-plane-authorized deferred tool results back into the paused
-loop) and `cancel_attempt` (a positive signal that kills the active task and acknowledges the
-server-chosen reason), absorbs steering only at pre-model-request boundaries, and writes an encrypted,
+loop) and `cancel_attempt` (a positive signal that kills the active task while the server retains the
+canonical cancellation outcome), absorbs steering only at pre-model-request boundaries, and writes an encrypted,
 version-tagged, replaceable local checkpoint subordinate to canonical server state.
 
 ```text
@@ -59,7 +59,7 @@ and whose `argumentsDigest` is a deterministic `sha256:<hex>` the control plane 
 AI types, ids, and checkpoints never cross that seam. Resume injects only control-plane-authorized
 deferred tool results; cancel is a positive signal that suppresses any late candidate; steering is
 absorbed only at the safe pre-model-request boundary. Any executor failure surfaces as a real
-`run.error` candidate rather than a silent acknowledgement, and a dropped stream bounds further
+`run.failed` terminal report rather than a silent acknowledgement, and a dropped stream bounds further
 candidate emission. The one exception is the control plane's explicit bounded retry response before
 an external action has a durable invocation receipt: the runtime resubmits that exact candidate id
 until the server accepts it, exhausts its durable retry budget, or the active attempt/stream is

--- a/apps/agent-runtime/src/runtime.py
+++ b/apps/agent-runtime/src/runtime.py
@@ -16,7 +16,7 @@ positive signal that kills the active task and acknowledges the server-chosen re
 absorbed only at pre-model-request boundaries, and an encrypted, version-tagged, replaceable local
 checkpoint is written to the per-attempt scratch as a resume optimisation subordinate to canonical
 server state. Because the loop is configured with zero implicit retries, any executor failure
-surfaces as a real ``run.error`` candidate rather than a silent acknowledgement.
+surfaces as a real ``run.failed`` terminal report rather than a silent acknowledgement.
 
 Phase E slice 4 lands the offline conformance harness and fault-injection matrix that exercise this
 shell against independently authored neutral-event fixtures and a LiteLLM-compatible test double; both
@@ -51,6 +51,7 @@ _CHECKPOINT_VERSION = 1
 _CHECKPOINT_FILENAME = "checkpoint.enc"
 _MAX_FRAME_BYTES = 65_536
 _MAX_CANDIDATE_RETRY_DELAY_SECONDS = 30.0
+_TERMINAL_DELIVERY_RETRY_SECONDS = 1.0
 
 # Process-lifetime symmetric cipher for local checkpoints. It is generated in memory at first use and
 # never written, logged, or exported; a restarted process cannot read a prior process's checkpoint,
@@ -727,11 +728,9 @@ def _recover_compiled_input(coordinates: dict[str, object], input_generation: ob
 class _TerminalGate:
     """Guards the exactly-once terminal candidate for one attempt across the reader and worker threads.
 
-    A run posts exactly one of ``run.completed`` / ``run.error`` / ``run.cancelled``. The completion
-    path runs on the attempt worker thread while the positive-cancel path runs on the stream-reader
-    thread, so the decision to post and the post itself are made atomically under one lock: a
-    completion is skipped if cancellation has been signalled or a terminal already posted, and a
-    cancellation is skipped if a terminal already posted. Late output can never reopen a terminal run.
+    A run posts exactly one of ``run.completed`` / ``run.failed`` from its attempt worker. The
+    server-owned cancel path only signals the shared cancellation event, so no runtime cancellation
+    candidate can race or reopen the server's canonical terminal state.
     """
 
     def __init__(self, cancel_event: threading.Event) -> None:
@@ -741,23 +740,21 @@ class _TerminalGate:
         self._posted = False
 
     def post_completion(self, post_candidate: Callable[[dict[str, object]], None], candidate: dict[str, object]) -> bool:
-        """Post a completion or error terminal only if no terminal posted and no cancel is signalled."""
+        """Retain and deliver one stable terminal candidate until it reaches the control plane or cancels."""
         with self._lock:
             if self._posted or self._cancel_event.is_set():
                 return False
             self._posted = True
-        post_candidate(candidate)
-        return True
-
-    def post_cancellation(self, post_candidate: Callable[[dict[str, object]], None], candidate: dict[str, object]) -> bool:
-        """Post the cancellation terminal only if no terminal has already been posted."""
-        with self._lock:
-            if self._posted:
-                return False
-            self._posted = True
-        post_candidate(candidate)
-        return True
-
+        while not self._cancel_event.is_set():
+            try:
+                post_candidate(candidate)
+                return True
+            except (HTTPError, URLError, OSError, RuntimeError, ValueError) as error:
+                # Keep the exact candidate id and terminal payload. A lost response may already have
+                # committed it; replay is idempotent at the server fence, never a second terminal.
+                _log("terminal_candidate_retry", runId=candidate.get("runId"), attempt=candidate.get("attempt"), candidateId=candidate.get("candidateId"), errorType=type(error).__name__)
+                self._cancel_event.wait(_TERMINAL_DELIVERY_RETRY_SECONDS)
+        return False
 
 def _execute_start_attempt(command: dict[str, object], runtime_instance_id: str, post_candidate: Callable[[dict[str, object]], None], event_source: Callable[..., Iterable[dict[str, object]]] = _pydantic_ai_event_source, cancel_event: threading.Event | None = None, checkpoint_cipher: object | None = None, terminal_gate: "_TerminalGate | None" = None) -> None:
     """Execute one ``start_attempt`` command as a bounded model loop, reporting candidates.
@@ -768,7 +765,7 @@ def _execute_start_attempt(command: dict[str, object], runtime_instance_id: str,
     ``run.completed``. Cancellation is a positive signal — once ``cancel_event`` is set no further
     candidate (not even ``run.completed`` or a late ``run.error``) is emitted, so late runtime output
     after cancel is suppressed. Because the loop performs zero implicit retries, any failure surfaces
-    as a single ``run.error`` candidate, never a silent acknowledgement.
+    as a single ``run.failed`` terminal report, never a silent acknowledgement.
     """
     coordinates = _command_coordinates(command, runtime_instance_id)
     if coordinates is None:
@@ -780,7 +777,7 @@ def _execute_start_attempt(command: dict[str, object], runtime_instance_id: str,
     payload = command.get("payload")
     compiled_input = payload.get("compiledInput") if isinstance(payload, dict) else None
     if not isinstance(compiled_input, dict):
-        post_candidate(_candidate(coordinates, "run.error", {"reason": "missing_compiled_input"}))
+        terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.failed", {"reason": "missing_compiled_input"}))
         return
     post_candidate(_candidate(coordinates, "run.started", {"promptCompilerVersion": compiled_input.get("promptCompilerVersion")}))
     _run_evidence(coordinates, "started")
@@ -795,7 +792,7 @@ def _execute_start_attempt(command: dict[str, object], runtime_instance_id: str,
             if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.completed", {})):
                 _run_evidence(coordinates, "completed")
         except (HTTPError, URLError, OSError, RuntimeError, ValueError) as error:
-            if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.error", {"reason": "executor_failed", "errorType": type(error).__name__})):
+            if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.failed", {"reason": "executor_failed", "errorType": type(error).__name__})):
                 _run_evidence(coordinates, "error", reason="executor_failed", errorType=type(error).__name__)
 
 
@@ -817,7 +814,7 @@ def _execute_resume_attempt(command: dict[str, object], runtime_instance_id: str
         terminal_gate = _TerminalGate(cancel_event)
     payload = command.get("payload")
     if not isinstance(payload, dict):
-        post_candidate(_candidate(coordinates, "run.error", {"reason": "missing_resume_payload"}))
+        terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.failed", {"reason": "missing_resume_payload"}))
         return
     input_generation = payload.get("inputGeneration")
     deferred_tool_results = payload.get("deferredToolResults")
@@ -834,7 +831,7 @@ def _execute_resume_attempt(command: dict[str, object], runtime_instance_id: str
             if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.completed", {})):
                 _run_evidence(coordinates, "completed")
         except (HTTPError, URLError, OSError, RuntimeError, ValueError) as error:
-            if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.error", {"reason": "executor_failed", "errorType": type(error).__name__})):
+            if terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.failed", {"reason": "executor_failed", "errorType": type(error).__name__})):
                 _run_evidence(coordinates, "error", reason="executor_failed", errorType=type(error).__name__)
 
 
@@ -842,10 +839,9 @@ def _execute_cancel_attempt(command: dict[str, object], runtime_instance_id: str
     """Handle a positive-signal cancel: kill the active attempt and acknowledge the server's reason.
 
     Cancellation is a POSITIVE signal: on receipt the runtime sets the shared ``cancel_event`` so the
-    running model/tool task stops promptly and emits no further candidate. The runtime never chooses a
-    terminal state — it echoes the server-chosen reason from the ``CancelAttemptCommand`` payload as a
-    bounded ``run.cancelled`` event candidate, posted through the shared terminal gate so it and the
-    worker thread's completion can never both reach a terminal (exactly one terminal candidate posts).
+    running model/tool task stops promptly and emits no further candidate. The runtime does not
+    acknowledge cancellation with a terminal candidate: the server already owns that lifecycle
+    transition and its cleanup evidence.
     """
     coordinates = _command_coordinates(command, runtime_instance_id)
     if coordinates is None:
@@ -855,13 +851,7 @@ def _execute_cancel_attempt(command: dict[str, object], runtime_instance_id: str
         cancel_event.set()
     payload = command.get("payload")
     reason = payload.get("reason") if isinstance(payload, dict) else None
-    candidate = _candidate(coordinates, "run.cancelled", {"reason": reason})
-    if terminal_gate is not None:
-        if terminal_gate.post_cancellation(post_candidate, candidate):
-            _run_evidence(coordinates, "cancelled", reason=reason)
-    else:
-        post_candidate(candidate)
-        _run_evidence(coordinates, "cancelled", reason=reason)
+    _run_evidence(coordinates, "cancelled", reason=reason)
 
 
 def _iter_commands(response: object, cancelled: threading.Event) -> object:

--- a/apps/agent-runtime/tests/test_conformance.py
+++ b/apps/agent-runtime/tests/test_conformance.py
@@ -239,10 +239,10 @@ class ConformanceCancellationTests(unittest.TestCase):
 
 
 class ConformanceProviderFaultTests(unittest.TestCase):
-    """A provider/executor fault surfaces exactly one ``run.error`` with zero implicit retries."""
+    """A provider/executor fault surfaces exactly one ``run.failed`` with zero implicit retries."""
 
-    def test_provider_fault_surfaces_single_run_error(self) -> None:
-        """An executor exception yields started then one ``run.error``, never a silent success."""
+    def test_provider_fault_surfaces_single_run_failure(self) -> None:
+        """An executor exception yields started then one authoritative ``run.failed`` report."""
 
         def _boom(_compiled, _cancel, _steering):
             raise RuntimeError("litellm proxy unreachable")
@@ -250,7 +250,7 @@ class ConformanceProviderFaultTests(unittest.TestCase):
 
         emitted: list[dict] = []
         _execute_start_attempt(_start_command(), "instance-conf", emitted.append, event_source=_boom)
-        self.assertEqual(_event_types(emitted), ["run.started", "run.error"])
+        self.assertEqual(_event_types(emitted), ["run.started", "run.failed"])
         self.assertEqual(emitted[1]["payload"], {"reason": "executor_failed", "errorType": "RuntimeError"})
 
     def test_every_retry_path_is_pinned_to_zero(self) -> None:
@@ -265,12 +265,12 @@ class ConformanceCompactionAndBudgetTests(unittest.TestCase):
         """Unknown or negative usage counters default to zero so budget accounting cannot go negative."""
         self.assertEqual(_normalize_event({"type": "usage", "inputTokens": None, "outputTokens": -3}), ("run.usage", {"inputTokens": 0, "outputTokens": 0}))
 
-    def test_budget_exhausted_cancel_reason_is_echoed_verbatim(self) -> None:
-        """A server budget cancel reason is echoed, never re-authored by the runtime."""
+    def test_budget_exhausted_cancel_reason_stays_server_owned(self) -> None:
+        """A server budget cancel signal stops work without creating a second terminal candidate."""
         cancel_command = {"kind": "cancel_attempt", "commandId": "cmd-cancel", "fence": 3, "assignment": {"runId": "run-conf", "attempt": 1}, "payload": {"reason": "budget_exhausted"}}
         emitted: list[dict] = []
         runtime._execute_cancel_attempt(cancel_command, "instance-conf", emitted.append, cancel_event=threading.Event())
-        self.assertEqual(emitted[0]["payload"], {"reason": "budget_exhausted"})
+        self.assertEqual(emitted, [])
 
     def test_unknown_framework_event_is_dropped_not_compacted_into_output(self) -> None:
         """An unrecognized framework event is dropped (never accumulated) and logged for observability."""

--- a/apps/agent-runtime/tests/test_fault_matrix.py
+++ b/apps/agent-runtime/tests/test_fault_matrix.py
@@ -118,8 +118,8 @@ class FaultTerminalGateTests(unittest.TestCase):
         terminals = [candidate["eventType"] for candidate in emitted if candidate["eventType"] in ("run.completed", "run.error", "run.cancelled")]
         self.assertEqual(terminals, ["run.completed"])
 
-    def test_cancel_in_the_check_then_act_window_posts_exactly_one_terminal(self) -> None:
-        """A cancel firing between loop end and completion post yields exactly one cancelled terminal."""
+    def test_cancel_in_the_check_then_act_window_posts_no_runtime_terminal(self) -> None:
+        """A cancel firing between loop end and completion post leaves terminal state server-owned."""
         emitted: list[dict] = []
         cancel_event = threading.Event()
         gate = _TerminalGate(cancel_event)
@@ -130,7 +130,7 @@ class FaultTerminalGateTests(unittest.TestCase):
 
         _execute_start_attempt(_start_command(), "instance-fault", emitted.append, event_source=_source, cancel_event=cancel_event, terminal_gate=gate)
         terminals = [candidate["eventType"] for candidate in emitted if candidate["eventType"] in ("run.completed", "run.error", "run.cancelled")]
-        self.assertEqual(terminals, ["run.cancelled"])
+        self.assertEqual(terminals, [])
 
 
 class FaultStreamLossTests(unittest.TestCase):

--- a/apps/agent-runtime/tests/test_runtime.py
+++ b/apps/agent-runtime/tests/test_runtime.py
@@ -459,17 +459,17 @@ class RuntimeExecutorTests(unittest.TestCase):
         self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.started", "run.output_text"])
         self.assertEqual(emitted[1]["payload"]["text"], "before")
 
-    def test_missing_compiled_input_is_a_real_error(self) -> None:
-        """A start command without compiled input surfaces a ``run.error``, never a silent ack."""
+    def test_missing_compiled_input_is_a_terminal_failure(self) -> None:
+        """A start command without compiled input surfaces `run.failed`, never a silent ack."""
         emitted: list[dict] = []
         command = _start_command()
         command["payload"] = {}
         _execute_start_attempt(command, "instance-1", emitted.append, event_source=lambda _compiled, _cancel, _steer: iter([]))
-        self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.error"])
+        self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.failed"])
         self.assertEqual(emitted[0]["payload"]["reason"], "missing_compiled_input")
 
-    def test_event_source_failure_surfaces_run_error(self) -> None:
-        """An executor failure with zero retries produces started then a single ``run.error``."""
+    def test_event_source_failure_surfaces_run_failed(self) -> None:
+        """An executor failure with zero retries produces started then a single `run.failed`."""
         emitted: list[dict] = []
 
         def _boom(_compiled: dict, _cancel: threading.Event, _steer: list):
@@ -477,7 +477,7 @@ class RuntimeExecutorTests(unittest.TestCase):
             yield  # pragma: no cover - generator marker
 
         _execute_start_attempt(_start_command(), "instance-1", emitted.append, event_source=_boom)
-        self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.started", "run.error"])
+        self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.started", "run.failed"])
         self.assertEqual(emitted[1]["payload"], {"reason": "executor_failed", "errorType": "RuntimeError"})
 
     def test_malformed_command_emits_no_candidate(self) -> None:
@@ -519,24 +519,22 @@ class RuntimeResumeCancelTests(unittest.TestCase):
         self.assertEqual(event_types, ["run.resumed", "run.output_text", "run.usage", "run.completed"])
         self.assertEqual(emitted[0]["payload"], {"inputGeneration": 7})
 
-    def test_missing_resume_payload_is_a_real_error(self) -> None:
-        """A resume command without a payload surfaces a ``run.error``, never a silent ack."""
+    def test_missing_resume_payload_is_a_terminal_failure(self) -> None:
+        """A resume command without a payload surfaces `run.failed`, never a silent ack."""
         emitted: list[dict] = []
         command = _resume_command()
         command["payload"] = None
         _execute_resume_attempt(command, "instance-1", emitted.append, resume_event_source=lambda *args: iter([]))
-        self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.error"])
+        self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.failed"])
         self.assertEqual(emitted[0]["payload"]["reason"], "missing_resume_payload")
 
-    def test_cancel_signals_the_active_task_and_acknowledges_the_server_reason(self) -> None:
-        """Cancel sets the shared cancel event and emits a ``run.cancelled`` echoing the server reason."""
+    def test_cancel_signals_the_active_task_without_a_runtime_terminal(self) -> None:
+        """Cancel sets the shared event while the server retains the cancellation terminal outcome."""
         emitted: list[dict] = []
         cancel_event = threading.Event()
         _execute_cancel_attempt(_cancel_command(), "instance-1", emitted.append, cancel_event=cancel_event)
         self.assertTrue(cancel_event.is_set())
-        self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.cancelled"])
-        self.assertEqual(emitted[0]["kind"], "event")
-        self.assertEqual(emitted[0]["payload"], {"reason": "budget_exhausted"})
+        self.assertEqual(emitted, [])
 
     def test_cancel_before_the_active_task_emits_no_candidate_without_coordinates(self) -> None:
         """A cancel frame lacking coordinates yields no candidate and no crash when no task is active."""
@@ -557,7 +555,7 @@ class RuntimeResumeCancelTests(unittest.TestCase):
 
         _execute_start_attempt(_start_command(), "instance-1", emitted.append, event_source=_source, cancel_event=cancel_event, terminal_gate=gate)
         terminals = [candidate["eventType"] for candidate in emitted if candidate["eventType"] in ("run.completed", "run.error", "run.cancelled")]
-        self.assertEqual(terminals, ["run.cancelled"])
+        self.assertEqual(terminals, [])
 
     def test_completion_then_late_cancel_keeps_the_single_terminal(self) -> None:
         """When completion wins the race, a late cancel is a no-op and does not add a second terminal."""
@@ -568,6 +566,26 @@ class RuntimeResumeCancelTests(unittest.TestCase):
         _execute_cancel_attempt(_cancel_command(), "instance-1", emitted.append, cancel_event=cancel_event, terminal_gate=gate)
         terminals = [candidate["eventType"] for candidate in emitted if candidate["eventType"] in ("run.completed", "run.error", "run.cancelled")]
         self.assertEqual(terminals, ["run.completed"])
+
+    def test_failed_completion_delivery_retries_the_same_terminal_candidate(self) -> None:
+        """A lost terminal response retries the exact same candidate rather than inventing a failure."""
+        cancel_event = threading.Event()
+        gate = runtime._TerminalGate(cancel_event)
+        delivered: list[dict] = []
+        attempts = 0
+
+        def _reject_completion(candidate: dict) -> None:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("stream reset")
+            delivered.append(candidate)
+
+        coordinates = _command_coordinates(_start_command(), "instance-1")
+        assert coordinates is not None
+        self.assertTrue(gate.post_completion(_reject_completion, _candidate(coordinates, "run.completed", {})))
+        self.assertEqual(attempts, 2)
+        self.assertEqual([candidate["eventType"] for candidate in delivered], ["run.completed"])
 
 
 class RuntimePydanticAiDriverTests(unittest.TestCase):


### PR DESCRIPTION
## Why

The server now makes fenced runtime terminal reports authoritative. The Job runtime still emitted `run.error` for execution failures and `run.cancelled` after a server cancellation, leaving failures non-terminal and creating a competing cancellation writer.

## What changes

- emit `run.failed` for terminal start/resume/executor failures
- keep cancellation server-owned: cancel signals local work but emits no terminal candidate
- reopen the local delivery gate if a completion post fails, allowing the failure path to report `run.failed`
- update conformance/fault tests and runtime documentation

## Validation

- `python3 -m unittest discover -s tests -p test_*.py` — 72 passed, 2 intentional live-driver skips
- `git diff --check`

## Review

Independent review found the terminal-gate delivery-fence issue; this PR reopens the gate after a failed post and adds coverage.

## Stack

Base: #477.