### PR TITLE
🔒 Fence runtime workload cleanup in the server

### DIFF
--- a/apps/agent-controller/helm/templates/_resources.tpl
+++ b/apps/agent-controller/helm/templates/_resources.tpl
@@ -159,6 +159,38 @@ roleRef:
   kind: Role
   name: {{ $controllerName }}
 ---
+# Cleanup is server-owned: the controller cannot delete or terminate active runtime Jobs.
+# The server performs UID-preconditioned deletion only after claiming the durable cleanup outbox row.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "opencrane.fullname" . }}-runtime-cleanup
+  namespace: {{ $runtimeNamespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opencrane-server
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "opencrane.fullname" . }}-runtime-cleanup
+  namespace: {{ $runtimeNamespace }}
+  labels:
+    {{- include "opencrane.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opencrane-server
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "opencrane.fullname" . }}-opencrane-server
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "opencrane.fullname" . }}-runtime-cleanup
+---
 {{- range $namespace := (list $authoringNamespace $toolRunnerNamespace) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/apps/agent-controller/tests/helm-contract.sh
+++ b/apps/agent-controller/tests/helm-contract.sh
@@ -10,6 +10,8 @@ MANIFEST="$(mktemp)"
 DISABLED="$(mktemp)"
 ROLE="$(mktemp)"
 BINDING="$(mktemp)"
+CLEANUP_ROLE="$(mktemp)"
+CLEANUP_BINDING="$(mktemp)"
 RUNTIME_NAMESPACE="$(mktemp)"
 RUNTIME_QUOTA="$(mktemp)"
 ADMISSION="$(mktemp)"
@@ -18,7 +20,7 @@ SERVER_POLICY="$(mktemp)"
 CONTROLLER_POLICY="$(mktemp)"
 RUNTIME_DENY="$(mktemp)"
 RUNTIME_EGRESS="$(mktemp)"
-trap 'rm -rf "$SOURCE_CHART_ROOT"; rm -f "$MANIFEST" "$DISABLED" "$ROLE" "$BINDING" "$RUNTIME_NAMESPACE" "$RUNTIME_QUOTA" "$ADMISSION" "$SKILL_URL_OVERRIDE" "$SERVER_POLICY" "$CONTROLLER_POLICY" "$RUNTIME_DENY" "$RUNTIME_EGRESS"' EXIT
+trap 'rm -rf "$SOURCE_CHART_ROOT"; rm -f "$MANIFEST" "$DISABLED" "$ROLE" "$BINDING" "$CLEANUP_ROLE" "$CLEANUP_BINDING" "$RUNTIME_NAMESPACE" "$RUNTIME_QUOTA" "$ADMISSION" "$SKILL_URL_OVERRIDE" "$SERVER_POLICY" "$CONTROLLER_POLICY" "$RUNTIME_DENY" "$RUNTIME_EGRESS"' EXIT
 
 # The umbrella vendors chart archives. Replace only the controller archive in a disposable copy so
 # this contract always renders the source template under test without refreshing remote dependencies.
@@ -46,6 +48,8 @@ render_enabled --set-string agentController.openCraneInternalUrl=http://override
 
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: Role\n/ && $0 ~ /\n  name: agent-controller\n/ { print $0 }' "$MANIFEST" > "$ROLE"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: RoleBinding\n/ && $0 ~ /\n  name: agent-controller\n/ { print $0 }' "$MANIFEST" > "$BINDING"
+awk 'BEGIN { RS="---" } $0 ~ /\nkind: Role\n/ && $0 ~ /\n  name: oc-opencrane-runtime-cleanup\n/ { print $0 }' "$MANIFEST" > "$CLEANUP_ROLE"
+awk 'BEGIN { RS="---" } $0 ~ /\nkind: RoleBinding\n/ && $0 ~ /\n  name: oc-opencrane-runtime-cleanup\n/ { print $0 }' "$MANIFEST" > "$CLEANUP_BINDING"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: Namespace\n/ && $0 ~ /\n  name: oc-opencrane-runtime\n/ { print $0 }' "$MANIFEST" > "$RUNTIME_NAMESPACE"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: ResourceQuota\n/ && $0 ~ /\n  name: oc-opencrane-agent-runtime\n/ { print $0 }' "$MANIFEST" > "$RUNTIME_QUOTA"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: ValidatingAdmissionPolicy\n/ { print $0 }' "$MANIFEST" > "$ADMISSION"
@@ -94,6 +98,19 @@ fi
 test -s "$BINDING"
 grep -Fq 'namespace: oc-opencrane-runtime' "$BINDING"
 grep -A4 -F 'kind: ServiceAccount' "$BINDING" | grep -Fq 'namespace: server-ns'
+
+# Only the OpenCrane server receives runtime Job deletion, through a separately named Role.
+test -s "$CLEANUP_ROLE"
+grep -Fq 'namespace: oc-opencrane-runtime' "$CLEANUP_ROLE"
+grep -Fq 'resources: ["jobs"]' "$CLEANUP_ROLE"
+grep -Fq 'verbs: ["get", "delete"]' "$CLEANUP_ROLE"
+if grep -Eq '"(create|list|patch|update|watch)"|resources: \["(pods|secrets)"\]' "$CLEANUP_ROLE"; then
+  echo "runtime cleanup Role exceeds server-owned Job observation/deletion authority" >&2
+  exit 1
+fi
+test -s "$CLEANUP_BINDING"
+grep -A4 -F 'kind: ServiceAccount' "$CLEANUP_BINDING" | grep -Fq 'name: oc-opencrane-opencrane-server'
+grep -A4 -F 'kind: ServiceAccount' "$CLEANUP_BINDING" | grep -Fq 'namespace: server-ns'
 
 # Governed skill namespaces are derived from their owning charts. Their controller Roles can create,
 # exact-adopt, and conditionally release Jobs, plus list the exact Job-owned Pod for registration.

--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -145,6 +145,12 @@ Cancellation is a nonterminal cleanup phase: active runs first enter `cancelling
 bootstrap or proof authority there, and become `cancelled` only after exact workload cleanup records
 the matching terminal event. Pending approvals close without resume authority even if their expiry
 sweeper has not yet run.
+
+The OpenCrane server, not the outbound agent controller, owns physical runtime cleanup. Its isolated
+runtime-namespace Role can observe and UID-precondition-delete Jobs only after a database-fenced
+cleanup claim. A deletion request is not completion: the server confirms only a later Kubernetes
+absence. An unassigned orphan requires two persisted absence observations separated by the full
+create horizon, so a delayed controller create cannot escape cleanup.
 Managed-agent definitions are likewise revisioned: a revision records its edit parent or restore
 source and change message, while scoped knowledge attachments remain immutable once published.
 

--- a/apps/opencrane/src/index.ts
+++ b/apps/opencrane/src/index.ts
@@ -23,7 +23,8 @@ import { _log as log } from "./app/log.js";
 import { _RegisterInternalRoutes, _RegisterRoutes } from "./app/routes.js";
 import { _CreateManagedRunAdmissionPort, _ReadRunAdmissionConcurrencyPolicy } from "./app/run-admission-wiring.js";
 import { _CreateScheduleTicker } from "./app/scheduler-wiring.js";
-import { PrismaRunCancellationRepository } from "@opencrane/backend/agents/execution/runs";
+import { PrismaRunCancellationRepository, type RunCancellationRepository, type RunWorkloadCleanupClaim } from "@opencrane/backend/agents/execution/runs";
+import { __AgentRuntimeAttemptResourceName } from "@opencrane/backend/agents/runtime/k8s-launcher";
 import { OpenClawTenantLifecycle } from "@opencrane/backend/feat-openclaw-tenant";
 
 // In-silo controllers (Stage 5). The silo runs every in-silo reconcile loop over its OWN
@@ -145,6 +146,79 @@ const coreApi = kc.makeApiClient(k8s.CoreV1Api);
 /** Kubernetes Authentication API client — used for tenant contract TokenReview validation. */
 const authApi = kc.makeApiClient(k8s.AuthenticationV1Api);
 
+/** Kubernetes Batch API client reserved for server-fenced runtime cleanup. */
+const batchApi = kc.makeApiClient(k8s.BatchV1Api);
+
+/** Return a Kubernetes HTTP status from the generated client's supported error shapes. */
+function _KubernetesStatus(err: unknown): number | undefined
+{
+	if (typeof err !== "object" || err === null) return undefined;
+	const record = err as Record<string, unknown>;
+	if (typeof record.statusCode === "number") return record.statusCode;
+	if (typeof record.code === "number") return record.code;
+	const body = typeof record.body === "object" && record.body !== null ? record.body as Record<string, unknown> : null;
+	return typeof body?.code === "number" ? body.code : undefined;
+}
+
+/** Verify that one Job is the sole deterministic Kubernetes projection of the fenced cleanup claim. */
+function _IsExactCleanupJob(job: k8s.V1Job, claim: RunWorkloadCleanupClaim): boolean
+{
+	const workload = claim.workload;
+	const name = __AgentRuntimeAttemptResourceName(workload.siloId, workload.runId, workload.attempt);
+	const annotations = job.metadata?.annotations;
+	const templateAnnotations = job.spec?.template.metadata?.annotations;
+	return job.metadata?.name === name && job.metadata.namespace === workload.namespace &&
+		annotations?.["opencrane.ai/run-id"] === workload.runId &&
+		annotations["opencrane.ai/run-attempt"] === String(workload.attempt) &&
+		annotations["opencrane.ai/agent-service-id"] === workload.agentServiceId &&
+		annotations["opencrane.ai/agent-revision-id"] === workload.agentRevisionId &&
+		annotations["opencrane.ai/silo-id"] === workload.siloId &&
+		templateAnnotations?.["opencrane.ai/bootstrap-reference"] === workload.bootstrapReference;
+}
+
+/** Claim and physically remove at most one server-fenced runtime Job without trusting controller input. */
+async function _ReconcileNextRuntimeWorkloadCleanup(repository: RunCancellationRepository, batch: k8s.BatchV1Api): Promise<void>
+{
+	// 1. Claim through Postgres first: only the server-held lease authorizes a Kubernetes mutation.
+	const claimed = await repository.claimNextWorkloadCleanupAtomically();
+	if (claimed.status === "none") return;
+	const claim = claimed.claim;
+	const name = __AgentRuntimeAttemptResourceName(claim.workload.siloId, claim.workload.runId, claim.workload.attempt);
+
+	// 2. Read the deterministic projection; only Kubernetes absence can finalize the durable cleanup.
+	let job: k8s.V1Job;
+	try
+	{
+		job = await batch.readNamespacedJob({ namespace: claim.workload.namespace, name });
+	}
+	catch (err)
+	{
+		if (_KubernetesStatus(err) !== 404) throw err;
+		if (claim.workload.mode === "unassigned_orphan" && claim.workload.orphanAbsenceObservedAt == null)
+		{
+			const deferred = await repository.deferUnassignedOrphanAbsenceAtomically(claim.lease.eventId, claim);
+			if (deferred !== "deferred") throw new Error("runtime orphan absence deferral conflicted");
+			log.info({ eventId: claim.lease.eventId, runId: claim.workload.runId, attempt: claim.workload.attempt }, "runtime orphan absence deferred for second observation");
+			return;
+		}
+		const confirmed = await repository.confirmWorkloadCleanupAtomically(claim.lease.eventId, { claimedAt: claim.lease.claimedAt, deliveryCount: claim.lease.deliveryCount, runId: claim.workload.runId, attempt: claim.workload.attempt, workloadUid: claim.workload.workloadUid, outcome: "absent" });
+		if (confirmed.status === "conflict") throw new Error(`runtime cleanup absence confirmation conflicted: ${confirmed.reason}`);
+		log.info({ eventId: claim.lease.eventId, runId: claim.workload.runId, attempt: claim.workload.attempt, outcome: confirmed.status }, "runtime workload cleanup confirmed absent");
+		return;
+	}
+
+	// 3. Bind the exact projection before delete and use Kubernetes' UID precondition against name reuse.
+	if (!_IsExactCleanupJob(job, claim)) throw new Error("refusing to clean a runtime Job outside the fenced cleanup projection");
+	if (claim.workload.workloadUid !== null && job.metadata?.uid !== claim.workload.workloadUid)
+	{
+		throw new Error("refusing to clean a runtime Job whose durable UID differs from the fenced assignment");
+	}
+	const workloadUid = job.metadata?.uid;
+	if (!workloadUid) throw new Error("runtime cleanup Job is missing its Kubernetes UID");
+	await batch.deleteNamespacedJob({ namespace: claim.workload.namespace, name, body: { preconditions: { uid: workloadUid } } });
+	log.info({ eventId: claim.lease.eventId, runId: claim.workload.runId, attempt: claim.workload.attempt, workloadUid }, "runtime workload cleanup requested");
+}
+
 /** One process-wide capacity boundary shared by run-now and scheduled managed admissions. */
 const managedRunAdmission = _CreateManagedRunAdmissionPort(prisma, _ReadRunAdmissionConcurrencyPolicy());
 
@@ -190,6 +264,9 @@ if (!runtimeRepairNamespace) throw new Error("AGENT_RUNTIME_NAMESPACE must be co
 const runtimeRepairRepository = new PrismaRunCancellationRepository(prisma, { namespace: runtimeRepairNamespace, claimLeaseMilliseconds: 30_000, orphanObservationMarginMilliseconds: 10_000 });
 const runtimeRepairHandle = setInterval(function _repair() { void runtimeRepairRepository.repairNextExpiredRunAtomically().catch(function _onError(err: unknown) { log.error({ err }, "runtime terminal repair failed"); }); }, 30_000);
 runtimeRepairHandle.unref();
+/** Server-owned cleanup loop consumes only database-fenced run workload cleanup claims. */
+const runtimeCleanupHandle = setInterval(function _cleanup() { void _ReconcileNextRuntimeWorkloadCleanup(runtimeRepairRepository, batchApi).catch(function _onError(err: unknown) { log.error({ err }, "runtime workload cleanup failed"); }); }, 5_000);
+runtimeCleanupHandle.unref();
 
 /** Frozen-blue OpenClaw tenant runtime composed behind its library lifecycle contract. */
 const openClawTenantLifecycle = new OpenClawTenantLifecycle({
@@ -219,8 +296,9 @@ async function _shutdown(signal: string): Promise<void>
   hardExit.unref();
 
   // Stop the schedule ticker and the in-silo controller before disconnecting their DB dependencies.
-  if (schedulerHandle !== null) clearInterval(schedulerHandle);
+	if (schedulerHandle !== null) clearInterval(schedulerHandle);
 	clearInterval(runtimeRepairHandle);
+	clearInterval(runtimeCleanupHandle);
   await openClawTenantLifecycle.stop();
 
   try

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -114,8 +114,10 @@ and fails any unpublished dispatch or release command. It then records both the 
 and any physical cleanup still required. A committed assignment yields an `assigned` cleanup claim
 with its immutable Kubernetes UID. If the controller may have created a suspended Job just before
 the database fence won, an `unassigned_orphan` claim becomes available only after the dispatch lease
-and request margin; the cleaner must reconstruct and exactly compare that suspended Job before it
-may adopt the API UID for deletion. If no controller claim ever left Postgres, the locked failed
+and request margin; the server-owned cleaner must reconstruct and exactly compare that suspended Job
+before it may adopt the API UID for deletion. Its first Kubernetes absence is persisted and deferred
+for one additional full create-observation horizon; only a second absence may finalize cancellation.
+If no controller claim ever left Postgres, the locked failed
 attempt event proves no Job can exist and cancellation can finish immediately. Only confirmed
 deletion or authoritative absence moves `Cancelling` to `Cancelled` and emits `run.cancelled`.
 

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-cancellation-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-cancellation-repository.test.ts
@@ -114,4 +114,18 @@ describe("PrismaRunCancellationRepository", function _DescribeCancellationReposi
 		await expect(repository.confirmWorkloadCleanupAtomically("cleanup-1", { claimedAt: "2026-07-20T00:01:00.000Z", deliveryCount: 1, runId: "run-1", attempt: 1, workloadUid: "job-uid-1", outcome: "deleted" })).resolves.toEqual({ status: "confirmed", runId: "run-1", attempt: 1, runFinalized: true });
 		expect(confirmTransaction.agentRun.updateMany).toHaveBeenCalledWith({ where: { id: "run-1", attempt: 1, state: AgentRunState.Cancelling }, data: expect.objectContaining({ state: AgentRunState.Cancelled }) });
 	});
+
+	it("persists a first orphan absence and rejects a stale deferral lease", async function _DefersOrphanAbsence()
+	{
+		const workload = { runId: "run-1", attempt: 1, siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", namespace: "silo-runtime", workloadProfile: "personal-small", bootstrapReference: "bootstrap-v1_exact", workloadUid: null, mode: "unassigned_orphan" as const, reason: "cancellation" as const, orphanAbsenceObservedAt: null };
+		const event = { id: "cleanup-1", runId: "run-1", attempt: 1, kind: RunOutboxEventKind.RunWorkloadCleanupRequested, payload: workload, availableAt: new Date("2026-07-20T00:00:00.000Z"), claimedAt: new Date("2026-07-20T00:01:00.000Z"), publishedAt: null, failedAt: null, deliveryCount: 1 };
+		const transaction = { $queryRaw: vi.fn(async function _Query(value: unknown) { return _SqlText(value).includes("clock_timestamp()::timestamp(3)") ? [{ now: new Date("2026-07-20T00:01:05.000Z") }] : []; }), outboxEvent: { findUnique: vi.fn().mockResolvedValue(event), updateMany: vi.fn().mockResolvedValue({ count: 1 }) } };
+		const prisma = { $transaction: vi.fn(async function _Transaction(callback: (client: never) => Promise<unknown>) { return callback(transaction as never); }) } as unknown as PrismaClient;
+		const repository = new PrismaRunCancellationRepository(prisma, { namespace: "silo-runtime", claimLeaseMilliseconds: 30_000, orphanObservationMarginMilliseconds: 10_000 });
+		const claim = { lease: { eventId: "cleanup-1", claimedAt: "2026-07-20T00:01:00.000Z", deliveryCount: 1, expiresAt: "2026-07-20T00:01:30.000Z" }, workload };
+
+		await expect(repository.deferUnassignedOrphanAbsenceAtomically("cleanup-1", claim)).resolves.toBe("deferred");
+		expect(transaction.outboxEvent.updateMany).toHaveBeenCalledWith({ where: expect.objectContaining({ id: "cleanup-1", deliveryCount: 1 }), data: expect.objectContaining({ availableAt: new Date("2026-07-20T00:01:15.000Z"), claimedAt: null, payload: expect.objectContaining({ orphanAbsenceObservedAt: "2026-07-20T00:01:05.000Z" }) }) });
+		await expect(repository.deferUnassignedOrphanAbsenceAtomically("cleanup-1", { ...claim, lease: { ...claim.lease, deliveryCount: 2 } })).resolves.toBe("conflict");
+	});
 });

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-cancellation-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-cancellation-repository.ts
@@ -5,7 +5,7 @@ import { AgentRunState, AgentRunTerminalReason, Prisma, RunOutboxEventKind, Work
 import { __CancelPendingRunApprovalAuthority } from "@opencrane/backend/server/iam/authorization";
 
 import { __DeliverChildRunCompletionInTransaction } from "./prisma-child-run-completion-repository.js";
-import type { ClaimNextRunWorkloadCleanupResult, ConfirmRunWorkloadCleanupCommand, ConfirmRunWorkloadCleanupResult, RepairExpiredRunResult, RequestRunCancellationCommand, RequestRunCancellationResult, RunCancellationRepository, RunCancellationRepositoryConfig, RunWorkloadCleanupProjection } from "./run-cancellation.types.js";
+import type { ClaimNextRunWorkloadCleanupResult, ConfirmRunWorkloadCleanupCommand, ConfirmRunWorkloadCleanupResult, RepairExpiredRunResult, RequestRunCancellationCommand, RequestRunCancellationResult, RunCancellationRepository, RunCancellationRepositoryConfig, RunWorkloadCleanupClaim, RunWorkloadCleanupProjection } from "./run-cancellation.types.js";
 
 /** Non-locking cleanup coordinates used only to establish canonical lock order. */
 interface CleanupCandidateRow
@@ -162,6 +162,26 @@ export class PrismaRunCancellationRepository implements RunCancellationRepositor
 		});
 	}
 
+	/** Persist the first orphan absence and force a second observation after the full create horizon. */
+	async deferUnassignedOrphanAbsenceAtomically(eventId: string, claim: RunWorkloadCleanupClaim): Promise<"deferred" | "conflict">
+	{
+		const config = this.config;
+		return this.prisma.$transaction(async function _defer(transaction: Prisma.TransactionClient): Promise<"deferred" | "conflict">
+		{
+			const event = await transaction.outboxEvent.findUnique({ where: { id: eventId } });
+			if (!event || event.runId !== claim.workload.runId || event.attempt !== claim.workload.attempt) return "conflict";
+			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${event.runId}, 0))`);
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "run_outbox_events" WHERE "id" = ${eventId} FOR UPDATE`);
+			const locked = await transaction.outboxEvent.findUnique({ where: { id: eventId } });
+			const now = (await transaction.$queryRaw<Array<{ now: Date }>>(Prisma.sql`SELECT clock_timestamp()::timestamp(3) AS "now"`))[0]?.now;
+			const workload = _ParseCleanupProjection(locked?.payload);
+			if (!locked || !now || !workload || workload.mode !== "unassigned_orphan" || workload.orphanAbsenceObservedAt !== null || locked.claimedAt?.getTime() !== Date.parse(claim.lease.claimedAt) || locked.deliveryCount !== claim.lease.deliveryCount || locked.publishedAt !== null || locked.failedAt !== null) return "conflict";
+			const payload = { ...workload, orphanAbsenceObservedAt: now.toISOString() };
+			const deferred = await transaction.outboxEvent.updateMany({ where: { id: eventId, claimedAt: locked.claimedAt, deliveryCount: locked.deliveryCount, publishedAt: null, failedAt: null }, data: { payload: payload as unknown as Prisma.InputJsonObject, availableAt: new Date(now.getTime() + config.orphanObservationMarginMilliseconds), claimedAt: null } });
+			return deferred.count === 1 ? "deferred" : "conflict";
+		});
+	}
+
 	/** Fail one registered attempt whose server-issued workload lease expired without a terminal report. */
 	async repairNextExpiredRunAtomically(): Promise<RepairExpiredRunResult>
 	{
@@ -216,7 +236,7 @@ function _BootstrapReference(eventId: string, run: Pick<AgentRun, "id" | "attemp
 /** Build the durable cleanup payload from run authority rather than caller input. */
 function _CleanupProjection(run: AgentRun, assignment: WorkloadAssignment | null, bootstrapReference: string, workloadProfile: string, namespace: string, reason: RunWorkloadCleanupProjection["reason"]): RunWorkloadCleanupProjection
 {
-	return { runId: run.id, attempt: run.attempt, siloId: run.siloId, agentServiceId: run.agentServiceId, agentRevisionId: run.agentRevisionId, namespace: assignment?.namespace ?? namespace, workloadProfile: assignment?.workloadProfile ?? workloadProfile, bootstrapReference, workloadUid: assignment?.workloadUid ?? null, mode: assignment === null ? "unassigned_orphan" : "assigned", reason };
+	return { runId: run.id, attempt: run.attempt, siloId: run.siloId, agentServiceId: run.agentServiceId, agentRevisionId: run.agentRevisionId, namespace: assignment?.namespace ?? namespace, workloadProfile: assignment?.workloadProfile ?? workloadProfile, bootstrapReference, workloadUid: assignment?.workloadUid ?? null, mode: assignment === null ? "unassigned_orphan" : "assigned", reason, orphanAbsenceObservedAt: null };
 }
 
 /** Parse one internally persisted cleanup payload without trusting arbitrary JSON. */
@@ -228,7 +248,8 @@ function _ParseCleanupProjection(value: Prisma.JsonValue | undefined): RunWorklo
 	if (item["workloadUid"] !== null && typeof item["workloadUid"] !== "string") return null;
 	if (item["mode"] !== "assigned" && item["mode"] !== "unassigned_orphan") return null;
 	if (item["reason"] !== "cancellation" && item["reason"] !== "dispatch_failure" && item["reason"] !== "runtime_lease_expired") return null;
-	return { runId: item["runId"], attempt: item["attempt"], siloId: item["siloId"], agentServiceId: item["agentServiceId"], agentRevisionId: item["agentRevisionId"], namespace: item["namespace"], workloadProfile: item["workloadProfile"], bootstrapReference: item["bootstrapReference"], workloadUid: item["workloadUid"], mode: item["mode"], reason: item["reason"] };
+	if (item["orphanAbsenceObservedAt"] !== undefined && item["orphanAbsenceObservedAt"] !== null && typeof item["orphanAbsenceObservedAt"] !== "string") return null;
+	return { runId: item["runId"], attempt: item["attempt"], siloId: item["siloId"], agentServiceId: item["agentServiceId"], agentRevisionId: item["agentRevisionId"], namespace: item["namespace"], workloadProfile: item["workloadProfile"], bootstrapReference: item["bootstrapReference"], workloadUid: item["workloadUid"], mode: item["mode"], reason: item["reason"], orphanAbsenceObservedAt: item["orphanAbsenceObservedAt"] ?? null };
 }
 
 /** Revalidate a cleanup event after canonical locks are held. */

--- a/libs/backend/agents/execution/runs/main/src/run-cancellation.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/run-cancellation.types.ts
@@ -56,6 +56,8 @@ export interface RunWorkloadCleanupProjection
 	readonly mode: RunWorkloadCleanupMode;
 	/** Why cleanup exists; cancellation finalises the run while failure only removes residue. */
 	readonly reason: "cancellation" | "dispatch_failure" | "runtime_lease_expired";
+	/** First authoritative orphan absence, retained until a second post-horizon observation confirms it. */
+	readonly orphanAbsenceObservedAt?: string | null;
 }
 
 /** Database claim generation fencing one cleanup worker delivery. */
@@ -120,6 +122,8 @@ export interface RunCancellationRepository
 	claimNextWorkloadCleanupAtomically(): Promise<ClaimNextRunWorkloadCleanupResult>;
 	/** Confirms exact deletion or authoritative absence and finalises Cancelling when applicable. */
 	confirmWorkloadCleanupAtomically(eventId: string, command: ConfirmRunWorkloadCleanupCommand): Promise<ConfirmRunWorkloadCleanupResult>;
+	/** Persist a first orphan absence and defer its required second observation horizon. */
+	deferUnassignedOrphanAbsenceAtomically(eventId: string, claim: RunWorkloadCleanupClaim): Promise<"deferred" | "conflict">;
 	/** Fence and terminalise one expired registered runtime attempt without trusting runtime output. */
 	repairNextExpiredRunAtomically(): Promise<RepairExpiredRunResult>;
 }

--- a/libs/backend/agents/runtime/k8s-launcher/README.md
+++ b/libs/backend/agents/runtime/k8s-launcher/README.md
@@ -38,6 +38,8 @@ after the deadline.
 
 - `__BuildSuspendedAgentRuntimeJob(assignment, profile)` — builds the suspended Job for one run
   attempt.
+- `__AgentRuntimeAttemptResourceName(siloId, runId, attempt)` — derives the same deterministic Job
+  name when a server-owned cleanup authority must locate a fenced attempt without receiving a profile.
 - `__DeriveAgentRuntimeReleaseDeadlineSeconds(assignmentExpiresAt, now, profileMaximum)` — converts
   absolute assignment authority into a conservative positive Kubernetes deadline.
 - `AgentRuntimeJobAssignment` — the durable run, attempt, revision, silo, namespace, and opaque

--- a/libs/backend/agents/runtime/k8s-launcher/src/__tests__/agent-runtime-job.test.ts
+++ b/libs/backend/agents/runtime/k8s-launcher/src/__tests__/agent-runtime-job.test.ts
@@ -1,7 +1,7 @@
 import { AGENT_RUNTIME_PROJECTED_TOKEN_AUDIENCE, MANAGED_AGENT_RUNTIME_PROJECTED_TOKEN_AUDIENCE } from "@opencrane/contracts";
 import { describe, expect, it } from "vitest";
 
-import { __BuildSuspendedAgentRuntimeJob, __DeriveAgentRuntimeReleaseDeadlineSeconds } from "../agent-runtime-job.js";
+import { __AgentRuntimeAttemptResourceName, __BuildSuspendedAgentRuntimeJob, __DeriveAgentRuntimeReleaseDeadlineSeconds } from "../agent-runtime-job.js";
 import type { AgentRuntimeJobAssignment, AgentRuntimeJobProfile } from "../agent-runtime-job.types.js";
 
 /** Create one valid immutable run-attempt assignment. */
@@ -39,6 +39,12 @@ function _Profile(): AgentRuntimeJobProfile
 
 describe("personal-runtime attempt Job", function _Suite()
 {
+	it("derives the same deterministic Job name without exposing a runtime profile", function _DerivesName()
+	{
+		const assignment = _Assignment();
+		expect(__AgentRuntimeAttemptResourceName(assignment.siloId, assignment.runId, assignment.attempt)).toBe(__BuildSuspendedAgentRuntimeJob(assignment, _Profile()).metadata?.name);
+	});
+
 	it("derives one stable resource identity per run attempt", function _DeterministicIdentity()
 	{
 		const first = __BuildSuspendedAgentRuntimeJob(_Assignment(), _Profile());

--- a/libs/backend/agents/runtime/k8s-launcher/src/agent-runtime-job.ts
+++ b/libs/backend/agents/runtime/k8s-launcher/src/agent-runtime-job.ts
@@ -168,6 +168,14 @@ function _AttemptResourceName(assignment: AgentRuntimeJobAssignment): string
 	return `agent-runtime-a${assignment.attempt}-${digest}`;
 }
 
+/** Derive the deterministic runtime Job name from its durable attempt identity. */
+export function __AgentRuntimeAttemptResourceName(siloId: string, runId: string, attempt: number): string
+{
+	const assignment = { siloId, runId, attempt, agentServiceId: "name-derivation", agentRevisionId: "name-derivation", namespace: "runtime", bootstrapReference: "name-derivation", litellmKeySecretName: "name-derivation" };
+	_AssertAssignment(assignment);
+	return _AttemptResourceName(assignment);
+}
+
 /** Build full authority annotations without forcing arbitrary identifiers into label grammar. */
 function _AuthorityAnnotations(assignment: AgentRuntimeJobAssignment): Record<string, string>
 {

--- a/libs/backend/agents/runtime/k8s-launcher/src/index.ts
+++ b/libs/backend/agents/runtime/k8s-launcher/src/index.ts
@@ -1,2 +1,2 @@
-export { __BuildSuspendedAgentRuntimeJob, __DeriveAgentRuntimeReleaseDeadlineSeconds } from "./agent-runtime-job.js";
+export { __AgentRuntimeAttemptResourceName, __BuildSuspendedAgentRuntimeJob, __DeriveAgentRuntimeReleaseDeadlineSeconds } from "./agent-runtime-job.js";
 export type { AgentRuntimeImagePullPolicy, AgentRuntimeJobAssignment, AgentRuntimeJobProfile } from "./agent-runtime-job.types.js";


### PR DESCRIPTION
## Summary

Runtime workload cleanup is now owned by the OpenCrane server rather than the outbound agent controller. The server claims the durable cleanup lease, verifies the deterministic Job projection, requests deletion with a Kubernetes UID precondition, and waits for a later Kubernetes absence before finalizing.

Unassigned-orphan cleanup requires two persisted absence observations separated by the full create horizon, preventing a delayed controller create from escaping cleanup.

## Security boundary

- agent-controller retains no Job delete authority
- a separately named runtime Role grants only the OpenCrane server jobs get and delete
- the server requires its database-fenced claim, exact Job projection, and Kubernetes UID precondition

## Validation

- runs suite: 69 passed
- opencrane lint
- agent-controller Helm contract
- runtime Job-builder suite
- style and diff checks

## Review

Independent review found no Critical or High issues. The orphan race and documentation findings were addressed before this PR.