### PR TITLE
📝 Correct Cognee memory capability contract

### DIFF
--- a/libs/backend/feat-openclaw-tenant/main/src/reconcilers/tenants/deploy/2-config-map.ts
+++ b/libs/backend/feat-openclaw-tenant/main/src/reconcilers/tenants/deploy/2-config-map.ts
@@ -314,7 +314,8 @@ export function _BuildConfigMap(config: OpenClawTenantOperatorConfig, tenant: Te
   //    slot and disable the built-in `memory-core`. OpenClaw registers the memory capability ONLY for
   //    the slot owner, so the built-in's embedding index — which self-disables with "index metadata is
   //    missing" on a provider/model mismatch and would otherwise shadow this — never surfaces. The
-  //    plugin auto-recalls scope-labeled context per turn and exposes the `cognee_memories` tool.
+  //    plugin auto-recalls scope-labeled context per turn and captures workspace notes; it exposes
+  //    no agent-callable memory tool.
   //    Multi-scope is operator-configured: company (org-wide) / user (per IdP subject) / agent (per tenant).
   if (config.cogneeEndpoint)
   {


### PR DESCRIPTION
## Summary

Corrects the frozen OpenClaw Cognee configuration comment to match the rendered agent contract: the pinned plugin automatically recalls context and captures workspace notes, but registers no agent-callable memory tool.

## Why

The previous comment promised a cognee_memories tool that does not exist. Keeping the configuration comment accurate prevents later work from treating an assumed remote mutation/tool surface as real.

## Validation

- backend-feat-openclaw-tenant lint
- agent style check
- diff check