### PR TITLE
✅ Phase F: let owners decide deferred tool approvals

### DIFF
--- a/apps/opencrane/src/app/deferred-tool-approval-wiring.ts
+++ b/apps/opencrane/src/app/deferred-tool-approval-wiring.ts
@@ -1,0 +1,30 @@
+import type { Request, Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { __CreateDeferredToolApprovalRouter, PrismaDeferredToolApprovalDecisionRepository, type DeferredToolApprovalCaller } from "@opencrane/backend/server/iam/authorization";
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+// Side-effect import: loads the express-session SessionData.authUser augmentation.
+import "@opencrane/server/_infra/auth";
+
+import { _log } from "./log.js";
+
+/** Builds the app-composed self-only deferred-tool approval decision API. */
+export function _CreateDeferredToolApprovalRouter(prisma: PrismaClient): Router
+{
+	return __CreateDeferredToolApprovalRouter({
+		resolveCaller: _resolveCaller,
+		decisions: new PrismaDeferredToolApprovalDecisionRepository(prisma),
+		clock: { now(): Date { return new Date(); } },
+		logger: _log,
+	});
+}
+
+/** Resolves the self-only approval owner from session identity and the request host's silo. */
+function _resolveCaller(request: Request): DeferredToolApprovalCaller | null
+{
+	const authUser = request.session?.authUser;
+	if (!authUser) return null;
+	const subjectId = (typeof authUser.sub === "string" ? authUser.sub.trim() : "") || (typeof authUser.email === "string" ? authUser.email.trim().toLowerCase() : "");
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	return subjectId && siloId ? { subjectId, siloId } : null;
+}

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -36,6 +36,7 @@ import { ___DoWithTrace } from "@opencrane/observability";
 import { _CreateAgentServicesRouter } from "./agent-services-wiring.js";
 import { _CreateSkillAuthoringArtifactReader } from "../infra/artifacts/artifact-upload.factory.js";
 import { _CreatePersonaOnboardingRouter } from "./persona-onboarding-wiring.js";
+import { _CreateDeferredToolApprovalRouter } from "./deferred-tool-approval-wiring.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
@@ -372,6 +373,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/groups", groupsRouter(prisma));
   app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma, runAdmission));
   app.use("/api/v1/me/persona", _CreatePersonaOnboardingRouter(prisma));
+  app.use("/api/v1/me/approvals", _CreateDeferredToolApprovalRouter(prisma));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));
   app.use("/api/v1/shares", sharesRouter(prisma));

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -27,6 +27,7 @@ import { _ModelRoutingOpenapiPaths } from "@opencrane/backend/server/gateways/mo
 import { _SpendOpenapiPaths } from "@opencrane/backend/server/reporting/spend";
 import { _AuditOpenapiPaths } from "@opencrane/backend/server/iam/audit";
 import { _MetricsOpenapiPaths } from "@opencrane/backend/server/reporting/metrics";
+import { _AuthorizationOpenapiPaths } from "@opencrane/backend/server/iam/authorization";
 
 // ---------------------------------------------------------------------------
 // Reusable schema components
@@ -768,6 +769,7 @@ export const spec = {
     ..._SpendOpenapiPaths,
     ..._AuditOpenapiPaths,
     ..._MetricsOpenapiPaths,
+    ..._AuthorizationOpenapiPaths,
 
     // ------------------------------------------------------------------
     // Auth — OIDC browser flow and session introspection

--- a/libs/backend/server/iam/authorization/main/README.md
+++ b/libs/backend/server/iam/authorization/main/README.md
@@ -58,6 +58,10 @@ legitimate request — never hand out access it should not.
   effect exactly once (or returns the earlier result on an allowed idempotent retry).
 - `__CancelPendingRunApprovalAuthority` — closes only pending approvals for an exact run attempt on
   a caller-owned database transaction, clearing every late-resume token atomically with cancellation.
+- `__CreateDeferredToolApprovalRouter`, `PrismaDeferredToolApprovalDecisionRepository` — the
+  owner-only HTTP decision surface and its atomic persistence adapter. The router takes only an
+  approval id and an approve-or-deny choice; it derives the person and silo from the signed-in
+  browser session and mints the opaque resume marker inside the server.
 - `__DigestCanonicalJson` — a stable hash of a request used across the checks above.
 - `PrismaRuntimeAuthorityRepository`, `PrismaAuthorizationGrantRepository` — the database-backed
   stores for accepted proofs/receipts and for candidate grants.
@@ -72,6 +76,11 @@ throughout: an invalid command, denied or stale membership, a proof that does no
 replayed id all return a denial, never an allow. The personal-runs domain owns run cancellation but
 must delegate approval-row cancellation through this package's transaction-level port; it never
 writes authorization tables directly.
+
+For a deferred tool action, the API is deliberately narrower than the database record: the browser
+cannot name a run, choose an executor result, or provide a resume token. It may only approve or deny
+the pending action attached to its own subject in its own silo. An expired request is terminalised
+before any decision is recorded, and a successful approval wakes the existing runtime command path.
 
 ## Dependency direction
 

--- a/libs/backend/server/iam/authorization/main/src/__tests__/deferred-tool-approval.router.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/__tests__/deferred-tool-approval.router.test.ts
@@ -1,0 +1,65 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "@opencrane/observability";
+
+import { __CreateDeferredToolApprovalRouter } from "../deferred-tool-approval.router.js";
+import type { DeferredToolApprovalRouterDependencies } from "../deferred-tool-approval.router.types.js";
+
+/** Build router ports with one authenticated owner and observable decision persistence. */
+function _dependencies(overrides: Partial<DeferredToolApprovalRouterDependencies> = {}): DeferredToolApprovalRouterDependencies
+{
+	return {
+		resolveCaller: function _caller() { return { siloId: "silo-1", subjectId: "user-1" }; },
+		decisions: { decideAtomically: vi.fn().mockResolvedValue({ outcome: "approved", deferredToolResult: { approvalRequestId: "approval-1", decision: "approved" } }) },
+		clock: { now: function _now() { return new Date("2026-07-26T12:00:00.000Z"); } },
+		logger: { error: vi.fn() } as unknown as Logger,
+		...overrides,
+	};
+}
+
+/** Mount the router below its public self-approval prefix. */
+function _app(dependencies: DeferredToolApprovalRouterDependencies)
+{
+	const app = express();
+	app.use(express.json());
+	app.use("/api/v1/me/approvals", __CreateDeferredToolApprovalRouter(dependencies));
+	return app;
+}
+
+describe("__CreateDeferredToolApprovalRouter", function _suite()
+{
+	it("requires session-derived ownership before deciding an approval", async function _requiresCaller()
+	{
+		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).post("/api/v1/me/approvals/approval-1/decision").send({ decision: "approved" });
+		expect(response.status).toBe(401);
+		expect(response.body).toEqual({ error: "approval_authentication_required" });
+	});
+
+	it("passes only the server-derived owner and a server-minted resume marker to persistence", async function _approves()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).post("/api/v1/me/approvals/approval-1/decision").send({ decision: "approved", subjectId: "forged", deferredToolResult: { forged: true } });
+		expect(response.status).toBe(400);
+		expect(dependencies.decisions.decideAtomically).not.toHaveBeenCalled();
+
+		const accepted = await request(_app(dependencies)).post("/api/v1/me/approvals/approval-1/decision").send({ decision: "approved" });
+		expect(accepted.status).toBe(200);
+		expect(accepted.body).toEqual({ approvalRequestId: "approval-1", state: "approved" });
+		expect(dependencies.decisions.decideAtomically).toHaveBeenCalledWith(expect.objectContaining({ approvalRequestId: "approval-1", siloId: "silo-1", subjectId: "user-1", decidedBy: "user-1", decision: "approved", deferredToolResult: { approvalRequestId: "approval-1", decision: "approved" }, resumeTokenHash: expect.stringMatching(/^sha256:/) }));
+	});
+
+	it("returns the durable terminal decision on an idempotent retry", async function _replays()
+	{
+		const response = await request(_app(_dependencies({ decisions: { decideAtomically: vi.fn().mockResolvedValue({ outcome: "already_decided", decision: "denied" }) } }))).post("/api/v1/me/approvals/approval-1/decision").send({ decision: "denied" });
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ approvalRequestId: "approval-1", state: "denied" });
+	});
+
+	it("makes an expired approval actionable by nobody", async function _expires()
+	{
+		const response = await request(_app(_dependencies({ decisions: { decideAtomically: vi.fn().mockResolvedValue({ outcome: "expired" }) } }))).post("/api/v1/me/approvals/approval-1/decision").send({ decision: "approved" });
+		expect(response.status).toBe(409);
+		expect(response.body).toEqual({ error: "approval_expired" });
+	});
+});

--- a/libs/backend/server/iam/authorization/main/src/__tests__/deferred-tool-approval.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/__tests__/deferred-tool-approval.test.ts
@@ -14,7 +14,7 @@ function _transaction(row: unknown, updatedCount: number): { transaction: Prisma
 /** A pending deferred-tool approval bound to a tool invocation row. */
 function _pending(): unknown
 {
-	return { id: "approval-1", runId: "run-1", attempt: 2, toolInvocationRowId: "tool-1", state: ApprovalRequestState.Pending };
+	return { id: "approval-1", runId: "run-1", attempt: 2, siloId: "silo-1", subjectId: "user-1", toolInvocationRowId: "tool-1", state: ApprovalRequestState.Pending, expiresAt: new Date("2026-07-22T09:00:00.000Z") };
 }
 
 const NOW = new Date("2026-07-21T09:00:00.000Z");
@@ -24,22 +24,22 @@ describe("deferred tool approval authority", function _suite()
 	it("approves and records the authorized deferred result and resume-token hash", async function _approve()
 	{
 		const { transaction, updateMany } = _transaction(_pending(), 1);
-		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", runId: "run-1", attempt: 2, decision: "approved", decidedBy: "reviewer-1", now: NOW, resumeTokenHash: "hash-1", deferredToolResult: { ok: true } });
+		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", siloId: "silo-1", subjectId: "user-1", decision: "approved", decidedBy: "user-1", now: NOW, resumeTokenHash: "hash-1", deferredToolResult: { ok: true } });
 		expect(result).toEqual({ outcome: "approved", deferredToolResult: { ok: true } });
-		expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "approval-1", state: ApprovalRequestState.Pending }, data: expect.objectContaining({ state: ApprovalRequestState.Approved, resumeTokenHash: "hash-1" }) }));
+		expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ id: "approval-1", state: ApprovalRequestState.Pending, expiresAt: { gt: NOW } }), data: expect.objectContaining({ state: ApprovalRequestState.Approved, resumeTokenHash: "hash-1" }) }));
 	});
 
 	it("denies by closing the pending request without a result", async function _deny()
 	{
 		const { transaction } = _transaction(_pending(), 1);
-		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", runId: "run-1", attempt: 2, decision: "denied", decidedBy: "reviewer-1", now: NOW });
+		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", siloId: "silo-1", subjectId: "user-1", decision: "denied", decidedBy: "user-1", now: NOW });
 		expect(result).toEqual({ outcome: "denied" });
 	});
 
 	it("replays an identical decision idempotently", async function _idempotent()
 	{
 		const { transaction, updateMany } = _transaction({ ..._pending() as object, state: ApprovalRequestState.Approved }, 0);
-		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", runId: "run-1", attempt: 2, decision: "approved", decidedBy: "reviewer-1", now: NOW });
+		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", siloId: "silo-1", subjectId: "user-1", decision: "approved", decidedBy: "user-1", now: NOW });
 		expect(result).toEqual({ outcome: "already_decided", decision: "approved" });
 		expect(updateMany).not.toHaveBeenCalled();
 	});
@@ -47,15 +47,34 @@ describe("deferred tool approval authority", function _suite()
 	it("conflicts when re-decided the other way", async function _conflict()
 	{
 		const { transaction } = _transaction({ ..._pending() as object, state: ApprovalRequestState.Approved }, 0);
-		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", runId: "run-1", attempt: 2, decision: "denied", decidedBy: "reviewer-1", now: NOW });
+		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", siloId: "silo-1", subjectId: "user-1", decision: "denied", decidedBy: "user-1", now: NOW });
 		expect(result).toEqual({ outcome: "conflict" });
 	});
 
 	it("conflicts on a row that is not a deferred-tool approval", async function _notTool()
 	{
 		const { transaction } = _transaction({ ..._pending() as object, toolInvocationRowId: null }, 0);
-		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", runId: "run-1", attempt: 2, decision: "approved", decidedBy: "reviewer-1", now: NOW });
+		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", siloId: "silo-1", subjectId: "user-1", decision: "approved", decidedBy: "user-1", now: NOW });
 		expect(result).toEqual({ outcome: "conflict" });
+	});
+
+	it("expires a pending approval before it can be decided", async function _expires()
+	{
+		const { transaction, updateMany } = _transaction({ ..._pending() as object, expiresAt: new Date("2026-07-20T09:00:00.000Z") }, 1);
+		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", siloId: "silo-1", subjectId: "user-1", decision: "approved", decidedBy: "user-1", now: NOW });
+		expect(result).toEqual({ outcome: "expired" });
+		expect(updateMany).toHaveBeenCalledWith(expect.objectContaining({
+			where: expect.objectContaining({ state: ApprovalRequestState.Pending, expiresAt: { lte: NOW } }),
+			data: expect.objectContaining({ state: ApprovalRequestState.Expired, resumeTokenHash: null }),
+		}));
+	});
+
+	it("does not let a different subject decide an otherwise valid approval", async function _wrongOwner()
+	{
+		const { transaction, updateMany } = _transaction(_pending(), 1);
+		const result = await __DecideDeferredToolRequest(transaction, { approvalRequestId: "approval-1", siloId: "silo-1", subjectId: "user-2", decision: "approved", decidedBy: "user-2", now: NOW });
+		expect(result).toEqual({ outcome: "conflict" });
+		expect(updateMany).not.toHaveBeenCalled();
 	});
 });
 

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.ts
@@ -1,0 +1,81 @@
+import { randomUUID } from "node:crypto";
+
+import { Router, type Request, type Response } from "express";
+
+import { __DigestCanonicalJson } from "./canonical-json-digest.js";
+import type { DeferredToolDecision } from "./deferred-tool-approval.types.js";
+import type { DeferredToolApprovalCaller, DeferredToolApprovalRouterDependencies } from "./deferred-tool-approval.router.types.js";
+
+/** Create the browser-session-authenticated, self-only deferred-tool approval router. */
+export function __CreateDeferredToolApprovalRouter(dependencies: DeferredToolApprovalRouterDependencies): Router
+{
+	const router = Router();
+
+	router.post("/:approvalRequestId/decision", async function _decide(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		const approvalRequestId = request.params["approvalRequestId"];
+		const decision = _decision(request.body);
+		if (caller === null) return;
+		if (typeof approvalRequestId !== "string" || !_isNonEmptyString(approvalRequestId) || decision === null) { _respond(response, 400, "invalid_approval_decision"); return; }
+
+		try
+		{
+			const result = await dependencies.decisions.decideAtomically({
+				approvalRequestId,
+				siloId: caller.siloId,
+				subjectId: caller.subjectId,
+				decision,
+				decidedBy: caller.subjectId,
+				now: dependencies.clock.now(),
+				resumeTokenHash: decision === "approved" ? _resumeTokenHash(approvalRequestId) : undefined,
+				deferredToolResult: decision === "approved" ? { approvalRequestId, decision: "approved" } : undefined,
+			});
+			if (result.outcome === "approved" || (result.outcome === "already_decided" && result.decision === "approved")) { response.status(200).json({ approvalRequestId, state: "approved" }); return; }
+			if (result.outcome === "denied" || (result.outcome === "already_decided" && result.decision === "denied")) { response.status(200).json({ approvalRequestId, state: "denied" }); return; }
+			if (result.outcome === "expired") { _respond(response, 409, "approval_expired"); return; }
+			_respond(response, 404, "approval_not_found");
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "deferred_tool_approval.decide", siloId: caller.siloId }, "Deferred tool approval decision failed");
+			_respond(response, 503, "approval_decision_unavailable");
+		}
+	});
+
+	return router;
+}
+
+/** Resolve one session-derived caller or write a non-disclosing authentication denial. */
+function _requireCaller(request: Request, response: Response, dependencies: DeferredToolApprovalRouterDependencies): DeferredToolApprovalCaller | null
+{
+	const caller = dependencies.resolveCaller(request);
+	if (caller === null) _respond(response, 401, "approval_authentication_required");
+	return caller;
+}
+
+/** Accept only the exact body shape used by the approval-decision contract. */
+function _decision(body: unknown): DeferredToolDecision | null
+{
+	if (body === null || typeof body !== "object" || Array.isArray(body) || Object.keys(body).length !== 1) return null;
+	const decision = (body as Record<string, unknown>)["decision"];
+	return decision === "approved" || decision === "denied" ? decision : null;
+}
+
+/** Return whether one path or header coordinate contains a non-empty identifier. */
+function _isNonEmptyString(value: string): boolean
+{
+	return value.trim().length > 0;
+}
+
+/** Mint a one-use opaque resume marker without returning its secret material to the browser. */
+function _resumeTokenHash(approvalRequestId: string): string
+{
+	return __DigestCanonicalJson({ approvalRequestId, nonce: randomUUID() });
+}
+
+/** Write one bounded JSON problem response. */
+function _respond(response: Response, status: number, error: string): void
+{
+	response.status(status).json({ error });
+}

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.types.ts
@@ -1,0 +1,34 @@
+import type { Request } from "express";
+
+import type { Logger } from "@opencrane/observability";
+
+import type { DeferredToolApprovalDecisionRepository } from "./deferred-tool-approval.types.js";
+
+/** Authenticated browser caller resolved by the composing server, never from request input. */
+export interface DeferredToolApprovalCaller
+{
+	/** Silo resolved from the authenticated request host. */
+	readonly siloId: string;
+	/** Stable identity-provider subject who owns the pending runtime action. */
+	readonly subjectId: string;
+}
+
+/** Trusted clock injected for deterministic approval-decision tests. */
+export interface DeferredToolApprovalClock
+{
+	/** Return the server's current decision time. */
+	now(): Date;
+}
+
+/** Composition ports for the self-only deferred-tool approval decision API. */
+export interface DeferredToolApprovalRouterDependencies
+{
+	/** Resolves session and host identity, or null when no authenticated caller exists. */
+	resolveCaller(request: Request): DeferredToolApprovalCaller | null;
+	/** Atomically records the decision after binding it to the durable approval owner. */
+	readonly decisions: DeferredToolApprovalDecisionRepository;
+	/** Supplies trusted server timestamps. */
+	readonly clock: DeferredToolApprovalClock;
+	/** Records unexpected persistence failures without logging approval payloads or tokens. */
+	readonly logger: Logger;
+}

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.ts
@@ -89,10 +89,9 @@ function _decisionOf(state: ApprovalRequestState): DeferredToolDecision | null
  * cancelled/expired out from under the reviewer) returns `conflict` rather than mutating a terminal
  * approval. The caller commits this in the same transaction that transitions the owning run state.
  *
- * Scope: this decision authority is built and unit-covered here. The human-facing approval-DECISION
- * HTTP endpoint that calls it is an operator/product surface delivered in Phase F (#224); until then
- * the pause is reachable (a sensitive tool defers and opens a pending approval) but the decision is
- * not yet driven by an external route.
+ * The browser-facing Phase F decision route supplies only an authenticated owner, a silo, and the
+ * terminal choice. This authority rechecks that ownership against the durable row and mints no
+ * browser-controlled result or resume credential, so a caller cannot redirect a pending action.
  *
  * @param transaction - Prisma transaction already holding the owning run's approval fence.
  * @param command - Exact pending request, reviewer decision, and trusted instant.
@@ -102,27 +101,35 @@ export async function __DecideDeferredToolRequest(transaction: Prisma.Transactio
 {
 	// 1. Lock and reload the exact approval row bound to the run attempt before any state change.
 	const approval = await transaction.approvalRequest.findUnique({ where: { id: command.approvalRequestId } });
-	if (approval === null || approval.runId !== command.runId || approval.attempt !== command.attempt || approval.toolInvocationRowId === null) return { outcome: "conflict" };
+	if (approval === null || approval.siloId !== command.siloId || approval.subjectId !== command.subjectId || approval.toolInvocationRowId === null) return { outcome: "conflict" };
 
 	// 2. A previously decided request replays idempotently or conflicts on a differing outcome.
 	const priorDecision = _decisionOf(approval.state);
 	if (priorDecision !== null) return priorDecision === command.decision ? { outcome: "already_decided", decision: priorDecision } : { outcome: "conflict" };
 	if (approval.state !== ApprovalRequestState.Pending) return { outcome: "conflict" };
+	if (approval.expiresAt.getTime() <= command.now.getTime())
+	{
+		const expired = await transaction.approvalRequest.updateMany({
+			where: { id: command.approvalRequestId, state: ApprovalRequestState.Pending, expiresAt: { lte: command.now } },
+			data: { state: ApprovalRequestState.Expired, decidedAt: command.now, decidedBy: null, resumeTokenHash: null },
+		});
+		return expired.count === 1 ? { outcome: "expired" } : { outcome: "conflict" };
+	}
 
 	// 3. Deny by closing the pending row; no result and no resume token are recorded.
 	if (command.decision === "denied")
 	{
 		const denied = await transaction.approvalRequest.updateMany({
-			where: { id: command.approvalRequestId, state: ApprovalRequestState.Pending },
+			where: { id: command.approvalRequestId, state: ApprovalRequestState.Pending, expiresAt: { gt: command.now } },
 			data: { state: ApprovalRequestState.Denied, decidedAt: command.now, decidedBy: command.decidedBy },
 		});
-		return denied.count === 1 ? { outcome: "denied" } : { outcome: "conflict" };
+		return denied.count === 1 ? { outcome: "denied" } : _conflictOrExpire(transaction, command);
 	}
 
 	// 4. Approve atomically, recording the authorized deferred result and single-use resume-token hash.
 	const deferredToolResult: JsonValue = command.deferredToolResult ?? null;
 	const approved = await transaction.approvalRequest.updateMany({
-		where: { id: command.approvalRequestId, state: ApprovalRequestState.Pending },
+		where: { id: command.approvalRequestId, state: ApprovalRequestState.Pending, expiresAt: { gt: command.now } },
 		data: {
 			state: ApprovalRequestState.Approved,
 			decidedAt: command.now,
@@ -131,5 +138,17 @@ export async function __DecideDeferredToolRequest(transaction: Prisma.Transactio
 			deferredToolResult: deferredToolResult as unknown as Prisma.InputJsonValue,
 		},
 	});
-	return approved.count === 1 ? { outcome: "approved", deferredToolResult } : { outcome: "conflict" };
+	return approved.count === 1 ? { outcome: "approved", deferredToolResult } : _conflictOrExpire(transaction, command);
+}
+
+/** Terminalise a just-expired owner-bound request after a decision compare-and-set loses its fence. */
+async function _conflictOrExpire(transaction: Prisma.TransactionClient, command: DecideDeferredToolRequestCommand): Promise<DecideDeferredToolRequestResult>
+{
+	const approval = await transaction.approvalRequest.findUnique({ where: { id: command.approvalRequestId } });
+	if (approval === null || approval.siloId !== command.siloId || approval.subjectId !== command.subjectId || approval.state !== ApprovalRequestState.Pending || approval.expiresAt.getTime() > command.now.getTime()) return { outcome: "conflict" };
+	const expired = await transaction.approvalRequest.updateMany({
+		where: { id: command.approvalRequestId, state: ApprovalRequestState.Pending, expiresAt: { lte: command.now } },
+		data: { state: ApprovalRequestState.Expired, decidedAt: command.now, decidedBy: null, resumeTokenHash: null },
+	});
+	return expired.count === 1 ? { outcome: "expired" } : { outcome: "conflict" };
 }

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.types.ts
@@ -8,10 +8,10 @@ export interface DecideDeferredToolRequestCommand
 {
 	/** Approval row that gates the deferred tool invocation. */
 	readonly approvalRequestId: string;
-	/** Logical run the deferred request belongs to. */
-	readonly runId: string;
-	/** Current positive attempt the deferred request belongs to. */
-	readonly attempt: number;
+	/** Silo the authenticated reviewer is operating within. */
+	readonly siloId: string;
+	/** Authenticated subject that owns the approval-bound runtime action. */
+	readonly subjectId: string;
 	/** Reviewer's terminal decision. */
 	readonly decision: DeferredToolDecision;
 	/** Subject who recorded the decision. */
@@ -59,5 +59,13 @@ export type DeferToolRequestResult =
 export type DecideDeferredToolRequestResult =
 	| { readonly outcome: "approved"; readonly deferredToolResult: JsonValue }
 	| { readonly outcome: "denied" }
+	| { readonly outcome: "expired" }
 	| { readonly outcome: "already_decided"; readonly decision: DeferredToolDecision }
 	| { readonly outcome: "conflict" };
+
+/** Atomic persistence boundary for a session-authorized deferred-tool decision. */
+export interface DeferredToolApprovalDecisionRepository
+{
+	/** Decide one request only when its durable run coordinates still match the authenticated owner. */
+	decideAtomically(command: DecideDeferredToolRequestCommand): Promise<DecideDeferredToolRequestResult>;
+}

--- a/libs/backend/server/iam/authorization/main/src/index.ts
+++ b/libs/backend/server/iam/authorization/main/src/index.ts
@@ -7,7 +7,11 @@ export type { ActionReplayMode, CapabilityActionExecutor, CapabilityActionFailur
 export { __CancelPendingRunApprovalAuthority } from "./run-approval-cancellation.js";
 export type { CancelPendingRunApprovalAuthorityCommand, CancelPendingRunApprovalAuthorityResult } from "./run-approval-cancellation.types.js";
 export { __DecideDeferredToolRequest, __DeferToolRequest } from "./deferred-tool-approval.js";
-export type { DecideDeferredToolRequestCommand, DecideDeferredToolRequestResult, DeferredToolDecision, DeferToolRequestCommand, DeferToolRequestResult } from "./deferred-tool-approval.types.js";
+export type { DecideDeferredToolRequestCommand, DecideDeferredToolRequestResult, DeferredToolApprovalDecisionRepository, DeferredToolDecision, DeferToolRequestCommand, DeferToolRequestResult } from "./deferred-tool-approval.types.js";
+export { PrismaDeferredToolApprovalDecisionRepository } from "./prisma-deferred-tool-approval-decision-repository.js";
+export { __CreateDeferredToolApprovalRouter } from "./deferred-tool-approval.router.js";
+export type { DeferredToolApprovalCaller, DeferredToolApprovalClock, DeferredToolApprovalRouterDependencies } from "./deferred-tool-approval.router.types.js";
+export { _AuthorizationOpenapiPaths } from "./openapi.js";
 export { PrismaToolInvocationRepository } from "./prisma-tool-invocation-repository.js";
 export type { ToolInvocationFailureResult, ToolInvocationIntent, ToolInvocationReceipt, ToolInvocationRepository, ToolInvocationReservationResult, ToolInvocationSuccessResult } from "./tool-invocation.types.js";
 export { PrismaRuntimeAuthorityRepository } from "./prisma-runtime-authority.js";

--- a/libs/backend/server/iam/authorization/main/src/openapi.ts
+++ b/libs/backend/server/iam/authorization/main/src/openapi.ts
@@ -1,0 +1,21 @@
+/** OpenAPI path fragment for owner-only deferred tool approvals. */
+export const _AuthorizationOpenapiPaths = {
+	"/me/approvals/{approvalRequestId}/decision": {
+		post: {
+			operationId: "decideDeferredToolApproval",
+			summary: "Approve or deny one pending tool action owned by the signed-in user",
+			description: "The server derives the owner and silo from the browser session. The body can contain only the terminal decision; it cannot choose another run, subject, tool result, or resume credential.",
+			tags: ["Approvals"],
+			parameters: [{ name: "approvalRequestId", in: "path", required: true, schema: { type: "string" }, description: "Opaque identifier for the pending approval." }],
+			requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["decision"], additionalProperties: false, properties: { decision: { type: "string", enum: ["approved", "denied"] } } } } } },
+			responses: {
+				200: { description: "Decision recorded or identical terminal decision replayed.", content: { "application/json": { schema: { type: "object", required: ["approvalRequestId", "state"], properties: { approvalRequestId: { type: "string" }, state: { type: "string", enum: ["approved", "denied"] } } } } } },
+				400: { description: "The request body is not the exact decision shape.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				401: { description: "No authenticated browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				404: { description: "The approval is absent, terminal in another way, or not owned by the caller.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				409: { description: "The approval expired before the decision.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "The product authority could not persist the decision.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
+};

--- a/libs/backend/server/iam/authorization/main/src/prisma-deferred-tool-approval-decision-repository.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-deferred-tool-approval-decision-repository.ts
@@ -1,0 +1,26 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { __DecideDeferredToolRequest } from "./deferred-tool-approval.js";
+import type { DecideDeferredToolRequestCommand, DecideDeferredToolRequestResult, DeferredToolApprovalDecisionRepository } from "./deferred-tool-approval.types.js";
+
+/** Prisma-backed atomic persistence for session-authorized deferred-tool decisions. */
+export class PrismaDeferredToolApprovalDecisionRepository implements DeferredToolApprovalDecisionRepository
+{
+	/** Canonical product authority used to group the decision read and compare-and-set. */
+	private readonly _prisma: PrismaClient;
+
+	/** Construct the repository around the server's canonical product-authority client. */
+	constructor(prisma: PrismaClient)
+	{
+		this._prisma = prisma;
+	}
+
+	/** Decide one owner-bound request inside one database transaction. */
+	async decideAtomically(command: DecideDeferredToolRequestCommand): Promise<DecideDeferredToolRequestResult>
+	{
+		return this._prisma.$transaction(async function _decide(transaction): Promise<DecideDeferredToolRequestResult>
+		{
+			return __DecideDeferredToolRequest(transaction, command);
+		});
+	}
+}

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1065,6 +1065,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/approvals/{approvalRequestId}/decision": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve or deny one pending tool action owned by the signed-in user
+         * @description The server derives the owner and silo from the browser session. The body can contain only the terminal decision; it cannot choose another run, subject, tool result, or resume credential.
+         */
+        post: operations["decideDeferredToolApproval"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -4882,6 +4902,85 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenUsage"][];
+                };
+            };
+        };
+    };
+    decideDeferredToolApproval: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque identifier for the pending approval. */
+                approvalRequestId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    decision: "approved" | "denied";
+                };
+            };
+        };
+        responses: {
+            /** @description Decision recorded or identical terminal decision replayed. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        approvalRequestId: string;
+                        /** @enum {string} */
+                        state: "approved" | "denied";
+                    };
+                };
+            };
+            /** @description The request body is not the exact decision shape. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The approval is absent, terminal in another way, or not owned by the caller. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The approval expired before the decision. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The product authority could not persist the decision. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };


### PR DESCRIPTION
## Context\n\nA sensitive tool could already defer safely and persist an approval request, but there was no product API for its owner to record a decision. This left the runtime pause reachable but not actionable.\n\n## What changes\n\n- adds the self-only endpoint POST /api/v1/me/approvals/{approvalRequestId}/decision\n- derives the subject and silo from the authenticated browser session and host, never from request input\n- accepts only approve or deny; run coordinates, tool results, and resume markers remain server-owned\n- fences both terminal writes against expiry and converts a lost expiry race into the durable expired state\n- wakes the existing runtime resume path only after a durable approval\n- publishes the endpoint in OpenAPI and regenerates the typed client\n\n## Validation\n\n- nx lint: backend-server-api-spec, backend-server-authorization, opencrane, contracts\n- nx test: backend-server-authorization (60 tests)\n- agent style check and diff check\n- independent review found and verified the expiry race fix; no Critical or High finding remains\n\n## Dependency\n\nBase: #481 (Cognee contract clarification).