### PR TITLE
🧭 Phase F: accept owner steering at fenced runtime resumes

### DIFF
--- a/apps/agent-runtime/src/runtime.py
+++ b/apps/agent-runtime/src/runtime.py
@@ -818,10 +818,14 @@ def _execute_resume_attempt(command: dict[str, object], runtime_instance_id: str
         return
     input_generation = payload.get("inputGeneration")
     deferred_tool_results = payload.get("deferredToolResults")
+    steering_requests = payload.get("steeringRequests")
+    if not isinstance(steering_requests, list) or any(not isinstance(item, dict) or not isinstance(item.get("text"), str) or not item["text"].strip() for item in steering_requests):
+        terminal_gate.post_completion(post_candidate, _candidate(coordinates, "run.failed", {"reason": "invalid_resume_steering"}))
+        return
     compiled_input = _recover_compiled_input(coordinates, input_generation, checkpoint_cipher)
     post_candidate(_candidate(coordinates, "run.resumed", {"inputGeneration": input_generation}))
     _run_evidence(coordinates, "resumed", inputGeneration=input_generation)
-    steering_buffer: list[str] = []
+    steering_buffer = [item["text"].strip() for item in steering_requests]
     with _trace("agent_runtime.resume_attempt", runId=coordinates["runId"], attempt=coordinates["attempt"]):
         try:
             for neutral_event in resume_event_source(coordinates["runId"], coordinates["attempt"], input_generation, deferred_tool_results, cancel_event, steering_buffer):

--- a/apps/agent-runtime/tests/test_conformance.py
+++ b/apps/agent-runtime/tests/test_conformance.py
@@ -84,7 +84,7 @@ def _resume_command(deferred: dict) -> dict:
         "commandId": "cmd-resume",
         "fence": 3,
         "assignment": {"runId": "run-conf", "attempt": 1},
-        "payload": {"inputGeneration": 10, "deferredToolResults": deferred},
+        "payload": {"inputGeneration": 10, "deferredToolResults": deferred, "steeringRequests": []},
     }
 
 

--- a/apps/agent-runtime/tests/test_runtime.py
+++ b/apps/agent-runtime/tests/test_runtime.py
@@ -74,7 +74,7 @@ def _resume_command() -> dict:
         "commandId": "c2",
         "fence": 2,
         "assignment": {"runId": "r1", "attempt": 1},
-        "payload": {"inputGeneration": 7, "deferredToolResults": {"t1": {"ok": True}}},
+        "payload": {"inputGeneration": 7, "deferredToolResults": {"t1": {"ok": True}}, "steeringRequests": []},
     }
 
 
@@ -518,6 +518,19 @@ class RuntimeResumeCancelTests(unittest.TestCase):
         event_types = [candidate["eventType"] for candidate in emitted]
         self.assertEqual(event_types, ["run.resumed", "run.output_text", "run.usage", "run.completed"])
         self.assertEqual(emitted[0]["payload"], {"inputGeneration": 7})
+
+    def test_resume_seeds_queued_steering_before_the_next_safe_boundary(self) -> None:
+        """Resume passes validated owner steering to the executor's pre-model buffer."""
+        command = _resume_command()
+        command["payload"]["steeringRequests"] = [{"text": "Prioritise the current decision."}]
+        captured: dict = {}
+
+        def _resume_source(_run_id, _attempt, _generation, _deferred, _cancel, steering_buffer):
+            captured["steering"] = steering_buffer[:]
+            return iter([])
+
+        _execute_resume_attempt(command, "instance-1", lambda _candidate: None, resume_event_source=_resume_source)
+        self.assertEqual(captured["steering"], ["Prioritise the current decision."])
 
     def test_missing_resume_payload_is_a_terminal_failure(self) -> None:
         """A resume command without a payload surfaces `run.failed`, never a silent ack."""

--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -185,6 +185,9 @@ CREATE TYPE "RuntimeCommandKind" AS ENUM ('start_attempt', 'resume_attempt', 'ca
 CREATE TYPE "RuntimeSteeringDisposition" AS ENUM ('absorbed', 'deferred');
 
 -- CreateEnum
+CREATE TYPE "RuntimeSteeringRequestState" AS ENUM ('pending', 'consumed', 'superseded');
+
+-- CreateEnum
 CREATE TYPE "SkillState" AS ENUM ('active', 'retired');
 
 -- CreateEnum
@@ -1509,6 +1512,22 @@ CREATE TABLE "runtime_steering_boundaries" (
 );
 
 -- CreateTable
+CREATE TABLE "runtime_steering_requests" (
+    "id" TEXT NOT NULL,
+    "run_id" TEXT NOT NULL,
+    "attempt" INTEGER NOT NULL,
+    "silo_id" TEXT NOT NULL,
+    "subject_id" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "digest" TEXT NOT NULL,
+    "state" "RuntimeSteeringRequestState" NOT NULL DEFAULT 'pending',
+    "submitted_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "consumed_at" TIMESTAMP(3),
+
+    CONSTRAINT "runtime_steering_requests_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "runtime_dispatched_commands" (
     "id" TEXT NOT NULL,
     "run_id" TEXT NOT NULL,
@@ -1689,6 +1708,12 @@ CREATE UNIQUE INDEX "runtime_steering_boundaries_run_id_attempt_to_input_generat
 
 -- CreateIndex
 CREATE INDEX "runtime_steering_boundaries_run_id_attempt_idx" ON "runtime_steering_boundaries"("run_id", "attempt");
+
+-- CreateIndex
+CREATE INDEX "runtime_steering_requests_run_id_attempt_state_submitted_at_idx" ON "runtime_steering_requests"("run_id", "attempt", "state", "submitted_at");
+
+-- CreateIndex
+CREATE INDEX "runtime_steering_requests_silo_id_subject_id_submitted_at_idx" ON "runtime_steering_requests"("silo_id", "subject_id", "submitted_at");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "runtime_dispatched_commands_command_id_key" ON "runtime_dispatched_commands"("command_id");

--- a/apps/opencrane/prisma/schema/runtime.prisma
+++ b/apps/opencrane/prisma/schema/runtime.prisma
@@ -15,6 +15,15 @@ enum RuntimeSteeringDisposition {
   Deferred @map("deferred")
 }
 
+/// Lifecycle of one owner-submitted steering instruction. A request becomes consumable only after
+/// the server has bound it to the current run attempt; the runtime may mark it consumed only while
+/// claiming its fenced safe boundary.
+enum RuntimeSteeringRequestState {
+  Pending  @map("pending")
+  Consumed @map("consumed")
+  Superseded @map("superseded")
+}
+
 /// Per-attempt durable authority for the runtime command stream. It owns the monotonic command
 /// sequence, the server-owned lease fence, the runtime instance bound to the current stream, and
 /// the accepted candidate ids. It is created lazily the first time a registered runtime Pod polls
@@ -76,6 +85,26 @@ model RuntimeSteeringBoundary {
   @@unique([runId, attempt, toInputGeneration])
   @@index([runId, attempt])
   @@map("runtime_steering_boundaries")
+}
+
+/// Durable owner-authored instruction for a running attempt. The public API stores it here before
+/// the runtime observes it, so a disconnect cannot lose a user instruction and the request body is
+/// never trusted as a direct mutation of the stream input generation.
+model RuntimeSteeringRequest {
+  id          String                      @id @default(cuid())
+  runId       String                      @map("run_id")
+  attempt     Int
+  siloId      String                      @map("silo_id")
+  subjectId   String                      @map("subject_id")
+  content     Json
+  digest      String
+  state       RuntimeSteeringRequestState @default(Pending)
+  submittedAt DateTime                    @default(now()) @map("submitted_at")
+  consumedAt  DateTime?                   @map("consumed_at")
+
+  @@index([runId, attempt, state, submittedAt])
+  @@index([siloId, subjectId, submittedAt])
+  @@map("runtime_steering_requests")
 }
 
 /// One durably minted command dispatched to the runtime. The rows for an attempt are exactly the

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -37,6 +37,7 @@ import { _CreateAgentServicesRouter } from "./agent-services-wiring.js";
 import { _CreateSkillAuthoringArtifactReader } from "../infra/artifacts/artifact-upload.factory.js";
 import { _CreatePersonaOnboardingRouter } from "./persona-onboarding-wiring.js";
 import { _CreateDeferredToolApprovalRouter } from "./deferred-tool-approval-wiring.js";
+import { _CreateSteeringIngestRouter } from "./steering-ingest-wiring.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
@@ -374,6 +375,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma, runAdmission));
   app.use("/api/v1/me/persona", _CreatePersonaOnboardingRouter(prisma));
   app.use("/api/v1/me/approvals", _CreateDeferredToolApprovalRouter(prisma));
+  app.use("/api/v1/me/runs", _CreateSteeringIngestRouter(prisma));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));
   app.use("/api/v1/shares", sharesRouter(prisma));

--- a/apps/opencrane/src/app/steering-ingest-wiring.ts
+++ b/apps/opencrane/src/app/steering-ingest-wiring.ts
@@ -1,0 +1,30 @@
+import type { Request, Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { __CreateSteeringIngestRouter, PrismaSteeringRequestRepository, type SteeringIngestCaller } from "@opencrane/backend/agents/execution/protocol";
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+// Side-effect import: loads the express-session SessionData.authUser augmentation.
+import "@opencrane/server/_infra/auth";
+
+import { _log } from "./log.js";
+
+/** Builds the app-composed self-only runtime steering ingest API. */
+export function _CreateSteeringIngestRouter(prisma: PrismaClient): Router
+{
+	return __CreateSteeringIngestRouter({
+		resolveCaller: _resolveCaller,
+		requests: new PrismaSteeringRequestRepository(prisma),
+		clock: { now(): Date { return new Date(); } },
+		logger: _log,
+	});
+}
+
+/** Resolve the self-only steering owner from session identity and the request host's silo. */
+function _resolveCaller(request: Request): SteeringIngestCaller | null
+{
+	const authUser = request.session?.authUser;
+	if (!authUser) return null;
+	const subjectId = (typeof authUser.sub === "string" ? authUser.sub.trim() : "") || (typeof authUser.email === "string" ? authUser.email.trim().toLowerCase() : "");
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	return subjectId && siloId ? { subjectId, siloId } : null;
+}

--- a/libs/backend/agents/execution/protocol/README.md
+++ b/libs/backend/agents/execution/protocol/README.md
@@ -80,6 +80,9 @@ authorities to accept or reject.
   non-terminal-but-closed `cancelling` state.
 - `RuntimeCommandAdmission*` / `RuntimeCandidateAdmission*` — typed allow, idempotent, or fail-closed
   decisions and their input ports.
+- `__CreateSteeringIngestRouter`, `PrismaSteeringRequestRepository` — the self-only product surface
+  and durable queue for a user's instruction to a live run. It records the instruction against the
+  current owner-bound attempt but never changes input generation from the HTTP request.
 
 ## Boundary
 
@@ -98,6 +101,13 @@ attempt's accepted command set). Their clean-database schema lives in the OpenCr
 baseline. It reads the assignment, run, and immutable snapshot rows owned by the execution-run and
 conversation domains. Terminal state remains written by the injected execution-run authority, never
 by this transport/protocol package directly.
+
+`RuntimeSteeringRequest` holds each owner-authored instruction before the runtime observes it. A
+request can be accepted only before the attempt's single fenced resume command is minted; that command
+consumes every pending request and seeds the runtime's pre-model buffer. This prevents a second
+executor loop from running concurrently for the same attempt. Its queue is deliberately separate from
+`RuntimeSteeringBoundary`, which remains the sole authority that can advance input generation. A lost
+browser connection therefore cannot drop an instruction or force a model turn to change mid-flight.
 
 ## Dependency direction
 

--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
@@ -93,15 +93,18 @@ interface FakeOptions
 	readonly clock?: RuntimeProtocolClock;
 	/** Approved deferred-tool results available for a resume frame. */
 	readonly approvedDeferredResults?: readonly unknown[];
+	/** Owner steering requests waiting for the next fenced resume command. */
+	readonly pendingSteeringRequests?: readonly unknown[];
 }
 
 /** Minimal in-memory Prisma double covering only the reads and writes the adapter performs. */
-function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; queryRaw: ReturnType<typeof vi.fn>; streams: FakeStreamRow[]; commands: FakeCommandRow[]; retries: FakeExternalActionRetryRow[]; approvals: { id: string; deferredToolResult: unknown; resumeTokenHash: string | null }[] }
+function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; queryRaw: ReturnType<typeof vi.fn>; streams: FakeStreamRow[]; commands: FakeCommandRow[]; retries: FakeExternalActionRetryRow[]; approvals: { id: string; deferredToolResult: unknown; resumeTokenHash: string | null }[]; steeringRequests: { id: string; content: unknown; state: string }[] }
 {
 	const streams: FakeStreamRow[] = [];
 	const commands: FakeCommandRow[] = [];
 	const retries: FakeExternalActionRetryRow[] = [];
 	const approvals: { id: string; deferredToolResult: unknown; resumeTokenHash: string | null }[] = [...(options.approvedDeferredResults ?? [])].map(function _row(result, index) { return { id: `approval-${index}`, deferredToolResult: result, resumeTokenHash: `hash-${index}` }; });
+	const steeringRequests: { id: string; content: unknown; state: string }[] = [...(options.pendingSteeringRequests ?? [])].map(function _row(content, index) { return { id: `steering-${index}`, content, state: "Pending" }; });
 	const assignment = { runId: "run-1", attempt: 1, agentServiceId: "svc-1", agentRevisionId: "rev-1", siloId: "silo-1", subjectId: "user-1", audience: "opencrane-agent-runtime", serviceAccountName: _identity.serviceAccountName, namespace: _identity.namespace, workloadKind: "Job", workloadUid: "wl-1", workloadProfile: "profile", podUid: options.podUid === undefined ? "pod-1" : options.podUid, state: options.assignmentState ?? "Registered", expiresAt: new Date("2026-07-20T00:05:00.000Z"), createdAt: new Date("2026-07-20T00:00:00.000Z") };
 	const run = { id: "run-1", attempt: 1, agentServiceId: "svc-1", agentRevisionId: "rev-1", siloId: "silo-1", state: options.runState, inputSnapshotDigest: "sha256:snap" };
 	const snapshot = { runId: "run-1", siloId: "silo-1", agentServiceId: "svc-1", agentRevisionId: "rev-1", snapshotVersion: 1, threadId: null, messageIds: [], personaRevisionId: null, preferenceFactIds: [], artifactRevisionIds: [], skillRevisionIds: [], memoryFacts: [], memoryQueryPolicy: {}, toolGrantIds: [], modelRoute: {}, budgetPolicy: {}, identitySnapshot: { executionSubjectId: "user-1", organizationId: "org-1", fleetMembershipRevision: 3 }, capabilitySetDigest: "sha256:cap", effectiveContractDigest: "sha256:contract", promptCompilerVersion: "v1", digest: "sha256:snap", compiledAt: new Date("2026-07-20T00:00:00.000Z") };
@@ -178,8 +181,17 @@ function _fakePrisma(options: FakeOptions): { prisma: PrismaClient; queryRaw: Re
 				return { count };
 			},
 		},
+		runtimeSteeringRequest: {
+			async findMany() { return steeringRequests.filter(row => row.state === "Pending"); },
+			async updateMany(args: { where: { id: { in: string[] }; state: string }; data: { state: string; consumedAt: Date } })
+			{
+				let count = 0;
+				for (const row of steeringRequests.filter(candidate => args.where.id.in.includes(candidate.id) && candidate.state === args.where.state)) { row.state = args.data.state; count += 1; }
+				return { count };
+			},
+		},
 	};
-	return { prisma: client as unknown as PrismaClient, queryRaw, streams, commands, retries, approvals };
+	return { prisma: client as unknown as PrismaClient, queryRaw, streams, commands, retries, approvals, steeringRequests };
 }
 
 /** Deterministic fake compiler: same snapshot digest always yields byte-identical compiled input. */
@@ -280,6 +292,19 @@ describe("PrismaRuntimeDispatchAuthority", function _describeDispatchAuthority()
 		expect(start?.kind).toBe("start_attempt");
 		expect(resume?.kind).toBe("resume_attempt");
 		expect(resume?.kind === "resume_attempt" ? resume.payload.deferredToolResults : null).toEqual([{ ok: true }]);
+	});
+
+	it("mints one fenced resume carrying pending steering and consumes it only after persistence", async function _mintsSteeringResume()
+	{
+		const context = _authority({ runState: "Running", pendingSteeringRequests: [{ text: "Focus on risks." }] });
+		const authority = context.authority;
+		await authority.__NextCommand(_identity, _open, 0);
+		const resume = await authority.__NextCommand(_identity, _open, 1);
+		expect(resume?.kind).toBe("resume_attempt");
+		if (resume?.kind !== "resume_attempt") throw new Error("expected resume command");
+		expect(resume.payload.steeringRequests).toEqual([{ text: "Focus on risks." }]);
+		expect(context.steeringRequests[0]?.state).toBe("Consumed");
+		expect(await authority.__NextCommand(_identity, _open, 2)).toBeNull();
 	});
 
 	it("consumes the single-use resume token so no duplicate resume is minted", async function _singleUseResume()

--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-steering-request-repository.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-steering-request-repository.test.ts
@@ -1,0 +1,28 @@
+import { AgentRunState, type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaSteeringRequestRepository } from "../prisma-steering-request-repository.js";
+
+/** Build the smallest transaction double used by the owner-bound steering queue. */
+function _prisma(priorResume: boolean): { client: PrismaClient; create: ReturnType<typeof vi.fn> }
+{
+	const create = vi.fn();
+	const transaction = {
+		$queryRaw: vi.fn().mockResolvedValue([]),
+		agentRun: { findFirst: vi.fn().mockResolvedValue({ attempt: 3, state: AgentRunState.Running }) },
+		runtimeDispatchedCommand: { findFirst: vi.fn().mockResolvedValue(priorResume ? { id: "resume-1" } : null) },
+		runtimeSteeringRequest: { create },
+	};
+	return { client: { $transaction: vi.fn().mockImplementation(async function _transaction(callback) { return callback(transaction); }) } as unknown as PrismaClient, create };
+}
+
+describe("PrismaSteeringRequestRepository", function _suite()
+{
+	it("refuses a later request once the attempt has minted its sole resume", async function _refusesLaterRequest()
+	{
+		const context = _prisma(true);
+		const repository = new PrismaSteeringRequestRepository(context.client);
+		await expect(repository.submitAtomically({ runId: "run-1", siloId: "silo-1", subjectId: "user-1", content: { text: "Focus." }, digest: "sha256:test", submittedAt: new Date("2026-07-26T12:00:00.000Z") })).resolves.toEqual({ outcome: "run_not_steerable" });
+		expect(context.create).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/agents/execution/protocol/src/__tests__/steering-ingest.router.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/steering-ingest.router.test.ts
@@ -1,0 +1,69 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "@opencrane/observability";
+
+import { __CreateSteeringIngestRouter } from "../steering-ingest.router.js";
+import type { SteeringIngestRouterDependencies } from "../steering-ingest.router.types.js";
+
+/** Build one owner-authenticated router with observable steering persistence. */
+function _dependencies(overrides: Partial<SteeringIngestRouterDependencies> = {}): SteeringIngestRouterDependencies
+{
+	return {
+		resolveCaller: function _caller() { return { siloId: "silo-1", subjectId: "user-1" }; },
+		requests: { submitAtomically: vi.fn().mockResolvedValue({ outcome: "queued", steeringRequestId: "steer-1", attempt: 2 }) },
+		clock: { now: function _now() { return new Date("2026-07-26T12:00:00.000Z"); } },
+		logger: { error: vi.fn() } as unknown as Logger,
+		...overrides,
+	};
+}
+
+/** Mount the route below the public self-run prefix. */
+function _app(dependencies: SteeringIngestRouterDependencies)
+{
+	const app = express();
+	app.use(express.json());
+	app.use("/api/v1/me/runs", __CreateSteeringIngestRouter(dependencies));
+	return app;
+}
+
+describe("__CreateSteeringIngestRouter", function _suite()
+{
+	it("requires session-derived ownership before queueing steering", async function _requiresCaller()
+	{
+		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).post("/api/v1/me/runs/run-1/steering").send({ text: "Focus on the risks." });
+		expect(response.status).toBe(401);
+		expect(response.body).toEqual({ error: "steering_authentication_required" });
+	});
+
+	it("queues only the accepted text and server-derived owner coordinates", async function _queues()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).post("/api/v1/me/runs/run-1/steering").send({ text: "  Focus on the risks.  " });
+		expect(response.status).toBe(202);
+		expect(response.body).toEqual({ steeringRequestId: "steer-1", attempt: 2, state: "pending" });
+		expect(dependencies.requests.submitAtomically).toHaveBeenCalledWith(expect.objectContaining({ runId: "run-1", siloId: "silo-1", subjectId: "user-1", content: { text: "Focus on the risks." }, digest: expect.stringMatching(/^sha256:/) }));
+	});
+
+	it("rejects a body that tries to add caller-controlled runtime coordinates", async function _rejectsCoordinates()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).post("/api/v1/me/runs/run-1/steering").send({ text: "Focus.", attempt: 99 });
+		expect(response.status).toBe(400);
+		expect(dependencies.requests.submitAtomically).not.toHaveBeenCalled();
+	});
+
+	it("does not disclose an absent or non-owned run", async function _hidesRun()
+	{
+		const response = await request(_app(_dependencies({ requests: { submitAtomically: vi.fn().mockResolvedValue({ outcome: "not_found_or_not_owner" }) } }))).post("/api/v1/me/runs/run-1/steering").send({ text: "Focus." });
+		expect(response.status).toBe(404);
+		expect(response.body).toEqual({ error: "run_not_found" });
+	});
+
+	it("refuses steering after the attempt's sole resume command is already minted", async function _refusesSecondResume()
+	{
+		const response = await request(_app(_dependencies({ requests: { submitAtomically: vi.fn().mockResolvedValue({ outcome: "run_not_steerable" }) } }))).post("/api/v1/me/runs/run-1/steering").send({ text: "Focus." });
+		expect(response.status).toBe(409);
+		expect(response.body).toEqual({ error: "run_not_steerable" });
+	});
+});

--- a/libs/backend/agents/execution/protocol/src/index.ts
+++ b/libs/backend/agents/execution/protocol/src/index.ts
@@ -9,3 +9,8 @@ export { __CreateExternalActionExecutor } from "./external-action-executor.js";
 export { __AdmitModelTerminal, __ClaimSteeringBoundary } from "./steering-authority.js";
 export type { AdmitModelTerminalCommand, AdmitModelTerminalResult, ClaimSteeringBoundaryCommand, ClaimSteeringBoundaryResult, PendingSteering, SteeringBoundaryClaim, SteeringBoundaryClaimResult, SteeringBoundaryRepository, SteeringDisposition } from "./steering-authority.types.js";
 export { PrismaSteeringBoundaryRepository } from "./prisma-steering-boundary-repository.js";
+export { PrismaSteeringRequestRepository } from "./prisma-steering-request-repository.js";
+export type { SteeringRequestRepository, SubmitSteeringRequestCommand, SubmitSteeringRequestResult } from "./steering-request.types.js";
+export { __CreateSteeringIngestRouter } from "./steering-ingest.router.js";
+export type { SteeringIngestCaller, SteeringIngestClock, SteeringIngestRouterDependencies } from "./steering-ingest.router.types.js";
+export { _RuntimeSteeringOpenapiPaths } from "./openapi.js";

--- a/libs/backend/agents/execution/protocol/src/openapi.ts
+++ b/libs/backend/agents/execution/protocol/src/openapi.ts
@@ -1,0 +1,21 @@
+/** OpenAPI path fragment for owner-only runtime steering ingestion. */
+export const _RuntimeSteeringOpenapiPaths = {
+	"/me/runs/{runId}/steering": {
+		post: {
+			operationId: "submitRuntimeSteering",
+			summary: "Queue one signed-in owner's instruction for a running agent",
+			description: "The server derives the owner, silo, and current attempt. The instruction is queued durably and is consumed only at the runtime's fenced safe boundary.",
+			tags: ["Runs"],
+			parameters: [{ name: "runId", in: "path", required: true, schema: { type: "string" }, description: "Opaque run identifier." }],
+			requestBody: { required: true, content: { "application/json": { schema: { type: "object", required: ["text"], additionalProperties: false, properties: { text: { type: "string", minLength: 1, maxLength: 4000 } } } } } },
+			responses: {
+				202: { description: "Steering request queued for the current run attempt.", content: { "application/json": { schema: { type: "object", required: ["steeringRequestId", "attempt", "state"], properties: { steeringRequestId: { type: "string" }, attempt: { type: "integer", minimum: 1 }, state: { type: "string", enum: ["pending"] } } } } } },
+				400: { description: "The body is not one bounded text instruction.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				401: { description: "No authenticated browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				404: { description: "The run is absent or not owned by the caller.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				409: { description: "The owned run has no steerable live attempt.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "The product authority could not persist the instruction.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
+};

--- a/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
@@ -238,6 +238,7 @@ async function _nextCommand(prisma: PrismaClient, config: RuntimeDispatchAuthori
 		if (advanced.count !== 1) throw new Error("runtime dispatch lost its command sequence fence");
 		// Consume the single-use resume tokens so a duplicate resume can never re-dispatch the results.
 		if (kind === RuntimeCommandKind.ResumeAttempt && extras.resumeApprovalIds.length > 0) await transaction.approvalRequest.updateMany({ where: { id: { in: [...extras.resumeApprovalIds] } }, data: { resumeTokenHash: null } });
+		if (kind === RuntimeCommandKind.ResumeAttempt && extras.resumeSteeringRequestIds.length > 0) await transaction.runtimeSteeringRequest.updateMany({ where: { id: { in: [...extras.resumeSteeringRequestIds] }, state: "Pending" }, data: { state: "Consumed", consumedAt: new Date(nowEpochMs) } });
 		return envelope;
 	});
 }
@@ -456,6 +457,8 @@ interface CommandExtras
 	readonly resume: ResumeAttemptCommand | null;
 	/** Approval rows whose single-use resume tokens this resume frame consumes when minted. */
 	readonly resumeApprovalIds: readonly string[];
+	/** Steering rows consumed only after their enclosing resume command is persisted. */
+	readonly resumeSteeringRequestIds: readonly string[];
 	/** Server-defined stop reason carried by a `cancel_attempt` frame. */
 	readonly cancelReason: CancelAttemptCommand["reason"];
 }
@@ -506,12 +509,12 @@ async function _mintCommandExtras(transaction: Prisma.TransactionClient, context
 	if (kind === RuntimeCommandKind.StartAttempt)
 	{
 		const compiledInput = await compileRunInput(context.snapshot, transaction);
-		return { compiledInput, resume: null, resumeApprovalIds: [], cancelReason: "cancelled" };
+		return { compiledInput, resume: null, resumeApprovalIds: [], resumeSteeringRequestIds: [], cancelReason: "cancelled" };
 	}
-	if (kind === RuntimeCommandKind.CancelAttempt) return { compiledInput: null, resume: null, resumeApprovalIds: [], cancelReason: _cancelReason(context.terminalReason) };
+	if (kind === RuntimeCommandKind.CancelAttempt) return { compiledInput: null, resume: null, resumeApprovalIds: [], resumeSteeringRequestIds: [], cancelReason: _cancelReason(context.terminalReason) };
 	const loaded = await _loadResume(transaction, context, inputGeneration);
 	if (loaded === null) return null;
-	return { compiledInput: null, resume: loaded.resume, resumeApprovalIds: loaded.approvalIds, cancelReason: "cancelled" };
+	return { compiledInput: null, resume: loaded.resume, resumeApprovalIds: loaded.approvalIds, resumeSteeringRequestIds: loaded.steeringRequestIds, cancelReason: "cancelled" };
 }
 
 /** Rebuild the body data for a stored command on redelivery, reading a resume payload from its row. */
@@ -520,12 +523,12 @@ async function _storedCommandExtras(transaction: Prisma.TransactionClient, conte
 	if (row.kind === RuntimeCommandKind.StartAttempt)
 	{
 		const compiledInput = await compileRunInput(context.snapshot, transaction);
-		return { compiledInput, resume: null, resumeApprovalIds: [], cancelReason: "cancelled" };
+		return { compiledInput, resume: null, resumeApprovalIds: [], resumeSteeringRequestIds: [], cancelReason: "cancelled" };
 	}
-	if (row.kind === RuntimeCommandKind.CancelAttempt) return { compiledInput: null, resume: null, resumeApprovalIds: [], cancelReason: _cancelReason(context.terminalReason) };
+	if (row.kind === RuntimeCommandKind.CancelAttempt) return { compiledInput: null, resume: null, resumeApprovalIds: [], resumeSteeringRequestIds: [], cancelReason: _cancelReason(context.terminalReason) };
 	const resume = _resumeFromPayload(row.payload);
 	if (resume === null) return null;
-	return { compiledInput: null, resume, resumeApprovalIds: [], cancelReason: "cancelled" };
+	return { compiledInput: null, resume, resumeApprovalIds: [], resumeSteeringRequestIds: [], cancelReason: "cancelled" };
 }
 
 /** Parse a persisted resume payload back into the exact frame it was minted from. */
@@ -533,8 +536,8 @@ function _resumeFromPayload(payload: Prisma.JsonValue | null): ResumeAttemptComm
 {
 	if (payload === null || typeof payload !== "object" || Array.isArray(payload)) return null;
 	const record = payload as { readonly [key: string]: JsonValue };
-	if (typeof record["inputGeneration"] !== "number" || !("deferredToolResults" in record)) return null;
-	return { inputGeneration: record["inputGeneration"], deferredToolResults: record["deferredToolResults"] };
+	if (typeof record["inputGeneration"] !== "number" || !("deferredToolResults" in record) || !("steeringRequests" in record)) return null;
+	return { inputGeneration: record["inputGeneration"], deferredToolResults: record["deferredToolResults"], steeringRequests: record["steeringRequests"] };
 }
 
 /** Map a durable run terminal reason to the server-defined cancellation reason the runtime receives. */
@@ -554,12 +557,14 @@ function _cancelReason(terminalReason: AgentRunTerminalReason | null): CancelAtt
  * mint. Once consumed, a duplicate resume finds nothing and is a no-op rather than a re-execution.
  * Returns null when no unconsumed approved result exists.
  */
-async function _loadResume(transaction: Prisma.TransactionClient, context: RuntimeDispatchContext, inputGeneration: number): Promise<{ resume: ResumeAttemptCommand; approvalIds: string[] } | null>
+async function _loadResume(transaction: Prisma.TransactionClient, context: RuntimeDispatchContext, inputGeneration: number): Promise<{ resume: ResumeAttemptCommand; approvalIds: string[]; steeringRequestIds: string[] } | null>
 {
 	const approvals = await transaction.approvalRequest.findMany({ where: { runId: context.runId, attempt: context.attempt, state: ApprovalRequestState.Approved, toolInvocationRowId: { not: null }, resumeTokenHash: { not: null } }, orderBy: { id: "asc" } });
-	if (approvals.length === 0) return null;
+	const steering = await transaction.runtimeSteeringRequest.findMany({ where: { runId: context.runId, attempt: context.attempt, state: "Pending" }, orderBy: { submittedAt: "asc" } });
+	if (approvals.length === 0 && steering.length === 0) return null;
 	const deferredToolResults = approvals.map(function _result(row): JsonValue { return row.deferredToolResult as JsonValue; });
-	return { resume: { inputGeneration, deferredToolResults }, approvalIds: approvals.map(function _id(row) { return row.id; }) };
+	const steeringRequests = steering.map(function _content(row): JsonValue { return row.content as JsonValue; });
+	return { resume: { inputGeneration, deferredToolResults, steeringRequests }, approvalIds: approvals.map(function _id(row) { return row.id; }), steeringRequestIds: steering.map(function _id(row) { return row.id; }) };
 }
 
 /** Map the durable snapshot row into the immutable wire snapshot the runtime receives. */
@@ -606,7 +611,8 @@ function _commandId(context: RuntimeDispatchContext, sequence: number): string
  * additive to — never a replacement for — the fence bump and stream loss that already bound a
  * cancelled attempt, so cancellation still holds if the runtime never receives the frame.
  * `resume_attempt` is minted while the run is running once at least one approved deferred-tool result
- * is ready and no resume has yet been dispatched, feeding the authorized results back into the loop.
+ * or queued steering request is ready and no resume has yet been dispatched. The sole-resume fence
+ * prevents a second executor loop from running concurrently for the same attempt.
  */
 async function _decideKind(transaction: Prisma.TransactionClient, context: RuntimeDispatchContext, commands: readonly DispatchedCommandRow[]): Promise<RuntimeCommandKind | null>
 {
@@ -614,8 +620,9 @@ async function _decideKind(transaction: Prisma.TransactionClient, context: Runti
 	const hasStart = commands.some(function _isStart(row) { return row.kind === RuntimeCommandKind.StartAttempt; });
 	if (runState === "cancelling") return commands.some(function _isCancel(row) { return row.kind === RuntimeCommandKind.CancelAttempt; }) ? null : RuntimeCommandKind.CancelAttempt;
 	if ((runState === "assigned" || runState === "running") && !hasStart) return RuntimeCommandKind.StartAttempt;
-	if (runState === "running" && hasStart && !commands.some(function _isResume(row) { return row.kind === RuntimeCommandKind.ResumeAttempt; }))
+	if (runState === "running" && hasStart)
 	{
+		if (commands.some(function _isResume(row) { return row.kind === RuntimeCommandKind.ResumeAttempt; })) return null;
 		const loaded = await _loadResume(transaction, context, 0);
 		if (loaded !== null) return RuntimeCommandKind.ResumeAttempt;
 	}

--- a/libs/backend/agents/execution/protocol/src/prisma-steering-request-repository.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-steering-request-repository.ts
@@ -1,0 +1,34 @@
+import { AgentRunState, Prisma, RuntimeCommandKind, type PrismaClient } from "@prisma/client";
+
+import type { SubmitSteeringRequestCommand, SubmitSteeringRequestResult, SteeringRequestRepository } from "./steering-request.types.js";
+
+/** Prisma-backed owner-bound queue for steering that a runtime consumes only at a safe boundary. */
+export class PrismaSteeringRequestRepository implements SteeringRequestRepository
+{
+	/** Canonical OpenCrane product-authority database client. */
+	private readonly _prisma: PrismaClient;
+
+	/** Construct the queue repository around the server-owned Prisma client. */
+	constructor(prisma: PrismaClient)
+	{
+		this._prisma = prisma;
+	}
+
+	/** Queue one instruction after proving the current run belongs to the caller in this silo. */
+	async submitAtomically(command: SubmitSteeringRequestCommand): Promise<SubmitSteeringRequestResult>
+	{
+		return this._prisma.$transaction(async function _submit(transaction): Promise<SubmitSteeringRequestResult>
+		{
+			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.runId}, 0))`);
+			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.runId} FOR UPDATE`);
+			const run = await transaction.agentRun.findFirst({ where: { id: command.runId, siloId: command.siloId, delegatedUserId: command.subjectId }, select: { attempt: true, state: true } });
+			if (run === null) return { outcome: "not_found_or_not_owner" };
+			if (run.state !== AgentRunState.Assigned && run.state !== AgentRunState.Running && run.state !== AgentRunState.WaitingForApproval) return { outcome: "run_not_steerable" };
+			const priorResume = await transaction.runtimeDispatchedCommand.findFirst({ where: { runId: command.runId, attempt: run.attempt, kind: RuntimeCommandKind.ResumeAttempt }, select: { id: true } });
+			if (priorResume !== null) return { outcome: "run_not_steerable" };
+			const content = command.content === null ? Prisma.JsonNull : command.content as Prisma.InputJsonValue;
+			const created = await transaction.runtimeSteeringRequest.create({ data: { runId: command.runId, attempt: run.attempt, siloId: command.siloId, subjectId: command.subjectId, content, digest: command.digest, submittedAt: command.submittedAt } });
+			return { outcome: "queued", steeringRequestId: created.id, attempt: run.attempt };
+		});
+	}
+}

--- a/libs/backend/agents/execution/protocol/src/steering-ingest.router.ts
+++ b/libs/backend/agents/execution/protocol/src/steering-ingest.router.ts
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto";
+
+import { Router, type Request, type Response } from "express";
+
+import type { SteeringIngestCaller, SteeringIngestRouterDependencies } from "./steering-ingest.router.types.js";
+
+/** Largest accepted steering instruction, keeping it safe for durable event and prompt handling. */
+const _MAX_STEERING_CHARACTERS = 4_000;
+
+/** Create the browser-session-authenticated, self-only runtime steering ingest router. */
+export function __CreateSteeringIngestRouter(dependencies: SteeringIngestRouterDependencies): Router
+{
+	const router = Router();
+
+	router.post("/:runId/steering", async function _submit(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		const runId = request.params["runId"];
+		const text = _text(request.body);
+		if (caller === null) return;
+		if (typeof runId !== "string" || !runId.trim() || text === null) { _respond(response, 400, "invalid_steering_request"); return; }
+
+		try
+		{
+			const content = { text };
+			const result = await dependencies.requests.submitAtomically({ runId, siloId: caller.siloId, subjectId: caller.subjectId, content, digest: _digest(content), submittedAt: dependencies.clock.now() });
+			if (result.outcome === "queued") { response.status(202).json({ steeringRequestId: result.steeringRequestId, attempt: result.attempt, state: "pending" }); return; }
+			if (result.outcome === "run_not_steerable") { _respond(response, 409, "run_not_steerable"); return; }
+			_respond(response, 404, "run_not_found");
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "runtime_steering.submit", siloId: caller.siloId }, "Runtime steering submission failed");
+			_respond(response, 503, "steering_unavailable");
+		}
+	});
+
+	return router;
+}
+
+/** Resolve one session-derived caller or write a non-disclosing authentication denial. */
+function _requireCaller(request: Request, response: Response, dependencies: SteeringIngestRouterDependencies): SteeringIngestCaller | null
+{
+	const caller = dependencies.resolveCaller(request);
+	if (caller === null) _respond(response, 401, "steering_authentication_required");
+	return caller;
+}
+
+/** Accept one exact bounded text body rather than caller-chosen runtime coordinates or payloads. */
+function _text(body: unknown): string | null
+{
+	if (body === null || typeof body !== "object" || Array.isArray(body) || Object.keys(body).length !== 1) return null;
+	const text = (body as Record<string, unknown>)["text"];
+	if (typeof text !== "string") return null;
+	const trimmed = text.trim();
+	return trimmed && trimmed.length <= _MAX_STEERING_CHARACTERS ? trimmed : null;
+}
+
+/** Digest the accepted canonical instruction without retaining a browser-supplied identifier. */
+function _digest(content: { readonly text: string }): string
+{
+	return `sha256:${createHash("sha256").update(JSON.stringify(content), "utf8").digest("hex")}`;
+}
+
+/** Write one bounded JSON problem response. */
+function _respond(response: Response, status: number, error: string): void
+{
+	response.status(status).json({ error });
+}

--- a/libs/backend/agents/execution/protocol/src/steering-ingest.router.types.ts
+++ b/libs/backend/agents/execution/protocol/src/steering-ingest.router.types.ts
@@ -1,0 +1,34 @@
+import type { Request } from "express";
+
+import type { Logger } from "@opencrane/observability";
+
+import type { SteeringRequestRepository } from "./steering-request.types.js";
+
+/** Authenticated browser caller resolved by the composing server rather than request input. */
+export interface SteeringIngestCaller
+{
+	/** Silo resolved from the authenticated request host. */
+	readonly siloId: string;
+	/** Stable identity-provider subject allowed to steer only their own run. */
+	readonly subjectId: string;
+}
+
+/** Trusted clock injected so steering ingest is deterministic in route tests. */
+export interface SteeringIngestClock
+{
+	/** Return the server's current trusted instant. */
+	now(): Date;
+}
+
+/** Composition ports for the owner-only steering ingest API. */
+export interface SteeringIngestRouterDependencies
+{
+	/** Resolve browser session identity and host silo, or null when unauthenticated. */
+	resolveCaller(request: Request): SteeringIngestCaller | null;
+	/** Queue steering only after proving the current run belongs to that caller. */
+	readonly requests: SteeringRequestRepository;
+	/** Supply a trusted persistence instant. */
+	readonly clock: SteeringIngestClock;
+	/** Record unexpected failures without logging the owner's instruction text. */
+	readonly logger: Logger;
+}

--- a/libs/backend/agents/execution/protocol/src/steering-request.types.ts
+++ b/libs/backend/agents/execution/protocol/src/steering-request.types.ts
@@ -1,0 +1,31 @@
+import type { JsonValue } from "@opencrane/util";
+
+/** Server-derived request to queue one owner's instruction for the current run attempt. */
+export interface SubmitSteeringRequestCommand
+{
+	/** Logical run selected by the public path. */
+	readonly runId: string;
+	/** Silo resolved from the authenticated request host. */
+	readonly siloId: string;
+	/** Stable authenticated subject that must own the run. */
+	readonly subjectId: string;
+	/** Bounded JSON instruction accepted from the owner. */
+	readonly content: JsonValue;
+	/** Server-computed canonical digest of the accepted instruction. */
+	readonly digest: string;
+	/** Trusted submission instant. */
+	readonly submittedAt: Date;
+}
+
+/** Stable result of attempting to queue steering for the live run attempt. */
+export type SubmitSteeringRequestResult =
+	| { readonly outcome: "queued"; readonly steeringRequestId: string; readonly attempt: number }
+	| { readonly outcome: "not_found_or_not_owner" }
+	| { readonly outcome: "run_not_steerable" };
+
+/** Atomic product-authority boundary for owner-submitted runtime steering. */
+export interface SteeringRequestRepository
+{
+/** Queue a request only for the authenticated owner's current attempt before its sole resume command. */
+	submitAtomically(command: SubmitSteeringRequestCommand): Promise<SubmitSteeringRequestResult>;
+}

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -28,6 +28,7 @@ import { _SpendOpenapiPaths } from "@opencrane/backend/server/reporting/spend";
 import { _AuditOpenapiPaths } from "@opencrane/backend/server/iam/audit";
 import { _MetricsOpenapiPaths } from "@opencrane/backend/server/reporting/metrics";
 import { _AuthorizationOpenapiPaths } from "@opencrane/backend/server/iam/authorization";
+import { _RuntimeSteeringOpenapiPaths } from "@opencrane/backend/agents/execution/protocol";
 
 // ---------------------------------------------------------------------------
 // Reusable schema components
@@ -770,6 +771,7 @@ export const spec = {
     ..._AuditOpenapiPaths,
     ..._MetricsOpenapiPaths,
     ..._AuthorizationOpenapiPaths,
+    ..._RuntimeSteeringOpenapiPaths,
 
     // ------------------------------------------------------------------
     // Auth — OIDC browser flow and session introspection

--- a/libs/contracts/src/agent-runtime-protocol.types.ts
+++ b/libs/contracts/src/agent-runtime-protocol.types.ts
@@ -98,13 +98,15 @@ export interface StartAttemptCommand
 	readonly compiledInput: CompiledRunInput;
 }
 
-/** Resumes a paused attempt only with control-plane-authorized deferred results. */
+/** Resumes an attempt only with control-plane-authorized deferred results and steering. */
 export interface ResumeAttemptCommand
 {
 	/** Monotonic input generation that must still be current at resume. */
 	readonly inputGeneration: number;
 	/** Opaque canonical result payloads for previously deferred actions. */
 	readonly deferredToolResults: JsonValue;
+	/** Owner-authored steering consumed at this server-fenced command boundary. */
+	readonly steeringRequests: JsonValue;
 }
 
 /** Stops one attempt without allowing the runtime to choose a terminal state. */

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1085,6 +1085,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/runs/{runId}/steering": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Queue one signed-in owner's instruction for a running agent
+         * @description The server derives the owner, silo, and current attempt. The instruction is queued durably and is consumed only at the runtime's fenced safe boundary.
+         */
+        post: operations["submitRuntimeSteering"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -4975,6 +4995,85 @@ export interface operations {
                 };
             };
             /** @description The product authority could not persist the decision. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    submitRuntimeSteering: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque run identifier. */
+                runId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    text: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Steering request queued for the current run attempt. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        steeringRequestId: string;
+                        attempt: number;
+                        /** @enum {string} */
+                        state: "pending";
+                    };
+                };
+            };
+            /** @description The body is not one bounded text instruction. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The run is absent or not owned by the caller. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The owned run has no steerable live attempt. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The product authority could not persist the instruction. */
             503: {
                 headers: {
                     [name: string]: unknown;

--- a/plan.md
+++ b/plan.md
@@ -118,14 +118,13 @@ positive `cancel_attempt` stop signal (with exactly-once terminal reporting unde
 surfaces model tool calls as external-action candidates validated against the immutable snapshot and
 reserved before dispatch through an injected tool-invocation authority. A tool grant flagged
 `requiresApproval` defers: the reserved invocation opens a pending `ApprovalRequest`, so the
-pause is reachable end to end. The deferred-tool DECIDE authority and single-use resume feed
-(`resumeTokenHash`-consumed) are built and unit-covered, and steering is absorbed only at safe
-pre-model boundaries with an exactly-once ordered claim that advances a fenced input generation. The
+pause is reachable end to end. The owner-bound approval-DECISION and steering-INGEST APIs are built:
+an owner may decide only their own pending tool approval or queue bounded text only to their own live
+run. The deferred-tool DECIDE authority and steering queue feed a fenced, single-use resume command;
+the runtime absorbs the queued steering only at safe pre-model boundaries. The
 runtime also writes encrypted, version-tagged, replaceable LOCAL checkpoints subordinate to canonical
 state (no server-side checkpoint model). The MCP, memory, and sandbox execution transports are ports
-with fail-closed stubs wired only in the composition root. NOT yet built: the human
-approval-DECISION HTTP endpoint and the steering-INGEST HTTP surface are the operator/product plane in
-Phase F (#224), so approval and steering are not end-to-end live. The offline conformance harness and
+with fail-closed stubs wired only in the composition root. The offline conformance harness and
 fault-injection matrix ARE built and CI-runnable (runtime protocol/reliability, attempt-scoped
 credential rejection, observability evidence); still gated on
 [#337](https://github.com/italanta/opencrane/issues/337) are the live-LiteLLM conformance leg,


### PR DESCRIPTION
## Why

A person needs a safe way to redirect their own agent while it is waiting to continue. This change makes that intent a durable, owner-bound product action rather than an untrusted change to a live prompt.

## What changes

- adds the authenticated self-run steering endpoint and generated API contract
- stores bounded steering text against the caller-owned run attempt before delivery
- releases queued text only in the attempt's single fenced resume command, then seeds the runtime's existing safe pre-model buffer
- rejects later requests after that resume exists, preventing concurrent executor loops or undeliverable accepted requests
- records the clean-green database baseline and documents the delivery boundary

## Validation

- agent-runtime test: 73 passed, 2 skipped
- execution-protocol test: 61 passed
- execution-protocol, server, API-spec, and contracts type checks
- Prisma schema validation, style check, and diff check
- independent review rechecked locking, payload delivery, and resume concurrency; no Critical or High findings remain

## Stack

Base: #482 (owner-bound tool-approval decisions). This PR is the next dependent Phase F API/state slice.