### PR TITLE
📊 Phase F: expose owner-bound personal run status

### DIFF
--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -39,6 +39,7 @@ import { _CreatePersonaOnboardingRouter } from "./persona-onboarding-wiring.js";
 import { _CreateDeferredToolApprovalRouter } from "./deferred-tool-approval-wiring.js";
 import { _CreateSteeringIngestRouter } from "./steering-ingest-wiring.js";
 import { _CreateSelfConversationReplayRouter } from "./self-conversation-replay-wiring.js";
+import { _CreateSelfRunStatusRouter } from "./self-run-status-wiring.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
@@ -377,6 +378,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/me/persona", _CreatePersonaOnboardingRouter(prisma));
   app.use("/api/v1/me/approvals", _CreateDeferredToolApprovalRouter(prisma));
 	app.use("/api/v1/me/runs", _CreateSteeringIngestRouter(prisma));
+	app.use("/api/v1/me/runs", _CreateSelfRunStatusRouter(prisma));
 	app.use("/api/v1/me/conversations", _CreateSelfConversationReplayRouter(prisma));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));

--- a/apps/opencrane/src/app/self-run-status-wiring.ts
+++ b/apps/opencrane/src/app/self-run-status-wiring.ts
@@ -1,0 +1,24 @@
+import type { Request, Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { __CreateSelfRunStatusRouter, PrismaSelfRunStatusRepository, type SelfRunStatusCaller } from "@opencrane/backend/agents/execution/runs";
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+import "@opencrane/server/_infra/auth";
+
+import { _log } from "./log.js";
+
+/** Build the app-composed self-only personal run status API. */
+export function _CreateSelfRunStatusRouter(prisma: PrismaClient): Router
+{
+	return __CreateSelfRunStatusRouter({ resolveCaller: _resolveCaller, repository: new PrismaSelfRunStatusRepository(prisma), logger: _log });
+}
+
+/** Derive the run owner from the session and host-selected silo. */
+function _resolveCaller(request: Request): SelfRunStatusCaller | null
+{
+	const authUser = request.session?.authUser;
+	if (!authUser) return null;
+	const subjectId = (typeof authUser.sub === "string" ? authUser.sub.trim() : "") || (typeof authUser.email === "string" ? authUser.email.trim().toLowerCase() : "");
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	return subjectId && siloId ? { subjectId, siloId } : null;
+}

--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -167,6 +167,9 @@ uncertainty fails closed.
   lifecycle, lease, server-derived Job projection, and physical-evidence outcomes.
 - `__CreateAgentControllerRunDispatchRouter` — projected-token-authenticated internal assignment and
   release API for the fixed `agent-controller` ServiceAccount.
+- `__CreateSelfRunStatusRouter` / `PrismaSelfRunStatusRepository` — authenticated product read of
+  one personal run's lifecycle, attempt, immutable revision, and timestamps. The app derives the
+  subject and silo from session and host; foreign or absent runs share the same non-disclosing 404.
 - `RunDispatchRepository` / `AgentControllerTokenReviewer` — persistence and TokenReview ports used by that internal API.
 - `ClaimNextRunWorkloadReleaseResult` / `RegisterRunWorkloadPodResult` — release-claim and first-Pod
   registration outcomes used across the internal adapter boundary.

--- a/libs/backend/agents/execution/runs/main/src/__tests__/self-run-status.router.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/self-run-status.router.test.ts
@@ -1,0 +1,45 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi, type Mock } from "vitest";
+import type { Logger } from "@opencrane/observability";
+
+import { __CreateSelfRunStatusRouter } from "../self-run-status.router.js";
+import type { SelfRunStatus } from "../self-run-status.router.types.js";
+
+/** Read signature exposed by the owner-bound run-status repository. */
+type ReadOwned = (runId: string, siloId: string, subjectId: string) => Promise<SelfRunStatus | null>;
+
+/** Build the self-only run route with session identity and persistence seams. */
+function _app(caller: unknown, readOwned: Mock<ReadOwned> = vi.fn<ReadOwned>(async function _read() { return null; }))
+{
+	const app = express();
+	app.use(__CreateSelfRunStatusRouter({ resolveCaller: function _caller() { return caller as never; }, repository: { readOwned }, logger: { error: vi.fn() } as unknown as Logger }));
+	return { app, readOwned };
+}
+
+describe("self run status router", function _suite()
+{
+	it("reads only with session-derived owner coordinates", async function _readsOwnedRun()
+	{
+		const status = { runId: "run-1", attempt: 2, state: "running", threadId: "thread-1", agentRevisionId: "revision-1", acceptedAt: "2026-07-26T12:00:00.000Z", finishedAt: null };
+		const { app, readOwned } = _app({ siloId: "silo-1", subjectId: "user-1" }, vi.fn(async function _read() { return status; }));
+		const response = await request(app).get("/run-1");
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual(status);
+		expect(readOwned).toHaveBeenCalledWith("run-1", "silo-1", "user-1");
+	});
+
+	it("does not disclose absent or another owner's run", async function _hidesForeignRun()
+	{
+		const { app } = _app({ siloId: "silo-1", subjectId: "user-1" });
+		const response = await request(app).get("/run-foreign");
+		expect(response.status).toBe(404);
+		expect(response.body).toEqual({ error: "run_not_found" });
+	});
+
+	it("requires a session-derived caller", async function _requiresCaller()
+	{
+		const response = await request(_app(null).app).get("/run-1");
+		expect(response.status).toBe(401);
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/index.ts
+++ b/libs/backend/agents/execution/runs/main/src/index.ts
@@ -15,7 +15,11 @@ export { PrismaRunAdmissionRepository } from "./prisma-run-admission-repository.
 export { PrismaRunCancellationRepository } from "./prisma-run-cancellation-repository.js";
 export { PrismaRunDispatchRepository } from "./prisma-run-dispatch-repository.js";
 export { __CreateAgentControllerRunDispatchRouter } from "./run-dispatch.router.js";
+export { __CreateSelfRunStatusRouter } from "./self-run-status.router.js";
+export { PrismaSelfRunStatusRepository } from "./prisma-self-run-status-repository.js";
+export { _SelfRunStatusOpenapiPaths } from "./openapi.js";
 export type { AgentControllerRunDispatchRouterDependencies, AgentControllerTokenReviewer, AttemptModelKeyIssuer, AttemptModelKeyMintRequest, ClaimNextRunAttemptResult, ClaimNextRunWorkloadReleaseResult, CommitRunAttemptAssignmentResult, MintedAttemptModelKey, RegisterRunWorkloadPodResult, ReviewedAgentControllerIdentity, RunDispatchRepository, RunDispatchRepositoryConfig } from "./run-dispatch.types.js";
+export type { SelfRunStatus, SelfRunStatusCaller, SelfRunStatusRepository, SelfRunStatusRouterDependencies } from "./self-run-status.router.types.js";
 export type { ClaimNextRunWorkloadCleanupResult, ConfirmRunWorkloadCleanupCommand, ConfirmRunWorkloadCleanupResult, RepairExpiredRunResult, RequestRunCancellationCommand, RequestRunCancellationResult, RunCancellationRepository, RunCancellationRepositoryConfig, RunWorkloadCleanupClaim, RunWorkloadCleanupClaimLease, RunWorkloadCleanupMode, RunWorkloadCleanupProjection } from "./run-cancellation.types.js";
 export { RunAdmissionConcurrencyGate } from "./run-admission-concurrency.js";
 export type { RunAdmissionConcurrencyPolicy, RunAdmissionConcurrencyResult } from "./run-admission-concurrency.types.js";

--- a/libs/backend/agents/execution/runs/main/src/openapi.ts
+++ b/libs/backend/agents/execution/runs/main/src/openapi.ts
@@ -1,0 +1,19 @@
+/** OpenAPI path fragment for authenticated owner-visible run status. */
+export const _SelfRunStatusOpenapiPaths = {
+	"/me/runs/{runId}": {
+		get: {
+			operationId: "getMyRunStatus",
+			summary: "Return one signed-in owner's personal run status",
+			description: "The server derives the owner and silo from session and host. It never accepts owner coordinates from the request.",
+			tags: ["Runs"],
+			parameters: [{ name: "runId", in: "path", required: true, schema: { type: "string" }, description: "Opaque run identifier." }],
+			responses: {
+				200: { description: "Current canonical lifecycle view for the owned run.", content: { "application/json": { schema: { type: "object", required: ["runId", "attempt", "state", "threadId", "agentRevisionId", "acceptedAt", "finishedAt"], properties: { runId: { type: "string" }, attempt: { type: "integer", minimum: 1 }, state: { type: "string", enum: ["accepted", "queued", "assigned", "running", "waiting_for_approval", "cancelling", "completed", "failed", "cancelled"] }, threadId: { type: "string", nullable: true }, agentRevisionId: { type: "string" }, acceptedAt: { type: "string", format: "date-time" }, finishedAt: { type: "string", format: "date-time", nullable: true } } } } } },
+				400: { description: "The run identifier is malformed.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				401: { description: "No browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				404: { description: "The run is absent or not owned by the caller.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "Run status could not be read.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
+};

--- a/libs/backend/agents/execution/runs/main/src/prisma-self-run-status-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-self-run-status-repository.ts
@@ -1,0 +1,30 @@
+import type { PrismaClient } from "@prisma/client";
+
+import type { SelfRunStatus, SelfRunStatusRepository } from "./self-run-status.router.types.js";
+
+/** Prisma read adapter for the product owner's immutable run-status view. */
+export class PrismaSelfRunStatusRepository implements SelfRunStatusRepository
+{
+	/** Canonical product database client. */
+	private readonly _prisma: PrismaClient;
+
+	/** Construct the owner-bound status reader around the app-owned Prisma client. */
+	constructor(prisma: PrismaClient)
+	{
+		this._prisma = prisma;
+	}
+
+	/** Read only the exact run owned by the session subject in the selected silo. */
+	async readOwned(runId: string, siloId: string, subjectId: string): Promise<SelfRunStatus | null>
+	{
+		const run = await this._prisma.agentRun.findFirst({ where: { id: runId, siloId, delegatedUserId: subjectId }, select: { id: true, attempt: true, state: true, threadId: true, agentRevisionId: true, acceptedAt: true, finishedAt: true } });
+		return run === null ? null : { runId: run.id, attempt: run.attempt, state: _state(run.state.toString()), threadId: run.threadId, agentRevisionId: run.agentRevisionId, acceptedAt: run.acceptedAt.toISOString(), finishedAt: run.finishedAt?.toISOString() ?? null };
+	}
+}
+
+/** Map Prisma's PascalCase lifecycle enum to the product API's stable lowercase spelling. */
+function _state(value: string): string
+{
+	if (value === "WaitingForApproval") return "waiting_for_approval";
+	return value.replace(/([a-z])([A-Z])/gu, "$1_$2").toLowerCase();
+}

--- a/libs/backend/agents/execution/runs/main/src/self-run-status.router.ts
+++ b/libs/backend/agents/execution/runs/main/src/self-run-status.router.ts
@@ -1,0 +1,28 @@
+import { Router, type Request, type Response } from "express";
+
+import type { SelfRunStatusRouterDependencies } from "./self-run-status.router.types.js";
+
+/** Create the session-authenticated endpoint for a personal run's current status. */
+export function __CreateSelfRunStatusRouter(dependencies: SelfRunStatusRouterDependencies): Router
+{
+	const router = Router();
+	router.get("/:runId", async function _status(request: Request, response: Response)
+	{
+		const caller = dependencies.resolveCaller(request);
+		const runId = request.params["runId"];
+		if (caller === null) { response.status(401).json({ error: "run_authentication_required" }); return; }
+		if (typeof runId !== "string" || !runId.trim()) { response.status(400).json({ error: "invalid_run_identifier" }); return; }
+		try
+		{
+			const run = await dependencies.repository.readOwned(runId, caller.siloId, caller.subjectId);
+			if (run === null) { response.status(404).json({ error: "run_not_found" }); return; }
+			response.status(200).json(run);
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "run_status.self", siloId: caller.siloId }, "Self run status read failed");
+			response.status(503).json({ error: "run_status_unavailable" });
+		}
+	});
+	return router;
+}

--- a/libs/backend/agents/execution/runs/main/src/self-run-status.router.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/self-run-status.router.types.ts
@@ -1,0 +1,48 @@
+import type { Request } from "express";
+import type { Logger } from "@opencrane/observability";
+
+/** Session-derived owner identity for the self-only run status surface. */
+export interface SelfRunStatusCaller
+{
+	/** Canonical silo selected from the trusted request host. */
+	readonly siloId: string;
+	/** Stable authenticated subject who owns the personal run. */
+	readonly subjectId: string;
+}
+
+/** Persisted run fields safe to show to its owner. */
+export interface SelfRunStatus
+{
+	/** Opaque canonical run identifier. */
+	readonly runId: string;
+	/** Current server-owned attempt number. */
+	readonly attempt: number;
+	/** Product lifecycle state. */
+	readonly state: string;
+	/** Linked conversation thread when the run began from one. */
+	readonly threadId: string | null;
+	/** Immutable revision selected when the run was accepted. */
+	readonly agentRevisionId: string;
+	/** Server acceptance time. */
+	readonly acceptedAt: string;
+	/** Terminal completion time, when finished. */
+	readonly finishedAt: string | null;
+}
+
+/** Read-only owner-bound persistence port for one run status. */
+export interface SelfRunStatusRepository
+{
+	/** Returns the run only when it belongs to the exact authenticated subject in the silo. */
+	readOwned(runId: string, siloId: string, subjectId: string): Promise<SelfRunStatus | null>;
+}
+
+/** Composition ports for the authenticated self-run status route. */
+export interface SelfRunStatusRouterDependencies
+{
+	/** Resolves server-derived browser identity. */
+	resolveCaller(request: Request): SelfRunStatusCaller | null;
+	/** Reads only the caller-owned run. */
+	repository: SelfRunStatusRepository;
+	/** Records unexpected read failures without run data. */
+	logger: Logger;
+}

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -29,6 +29,7 @@ import { _AuditOpenapiPaths } from "@opencrane/backend/server/iam/audit";
 import { _MetricsOpenapiPaths } from "@opencrane/backend/server/reporting/metrics";
 import { _AuthorizationOpenapiPaths } from "@opencrane/backend/server/iam/authorization";
 import { _RuntimeSteeringOpenapiPaths } from "@opencrane/backend/agents/execution/protocol";
+import { _SelfRunStatusOpenapiPaths } from "@opencrane/backend/agents/execution/runs";
 import { _SelfConversationReplayOpenapiPaths } from "@opencrane/backend/server/agents/conversation-replay";
 
 // ---------------------------------------------------------------------------
@@ -773,6 +774,7 @@ export const spec = {
     ..._MetricsOpenapiPaths,
     ..._AuthorizationOpenapiPaths,
     ..._RuntimeSteeringOpenapiPaths,
+    ..._SelfRunStatusOpenapiPaths,
     ..._SelfConversationReplayOpenapiPaths,
 
     // ------------------------------------------------------------------

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1105,6 +1105,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/runs/{runId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Return one signed-in owner's personal run status
+         * @description The server derives the owner and silo from session and host. It never accepts owner coordinates from the request.
+         */
+        get: operations["getMyRunStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/me/conversations/{threadId}/events": {
         parameters: {
             query?: never;
@@ -5094,6 +5114,76 @@ export interface operations {
                 };
             };
             /** @description The product authority could not persist the instruction. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getMyRunStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Opaque run identifier. */
+                runId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current canonical lifecycle view for the owned run. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        runId: string;
+                        attempt: number;
+                        /** @enum {string} */
+                        state: "accepted" | "queued" | "assigned" | "running" | "waiting_for_approval" | "cancelling" | "completed" | "failed" | "cancelled";
+                        threadId: string | null;
+                        agentRevisionId: string;
+                        /** Format: date-time */
+                        acceptedAt: string;
+                        /** Format: date-time */
+                        finishedAt: string | null;
+                    };
+                };
+            };
+            /** @description The run identifier is malformed. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The run is absent or not owned by the caller. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Run status could not be read. */
             503: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

Adds a session- and host-derived product API for a person to read the canonical lifecycle status of their own personal run. It exposes no user-supplied ownership coordinates and gives absent and foreign runs the same response.

## Validation

- 72 execution-run tests passed
- execution-runs and generated-contract type checks passed
- independent review found no Critical or High findings; lifecycle state is a typed OpenAPI enum

## Stack

Base: #484. This is the next Phase F product API slice.