### PR TITLE
🧭 Phase F: expose resumable persona onboarding status

### DIFF
--- a/apps/opencrane/src/app/persona-onboarding-wiring.ts
+++ b/apps/opencrane/src/app/persona-onboarding-wiring.ts
@@ -1,7 +1,7 @@
 import type { Request, Router } from "express";
 import type { PrismaClient } from "@prisma/client";
 
-import { __CreatePersonaOnboardingRouter, PrismaPersonaAuthorityRepository, PrismaPersonaDraftRepository, PrismaPersonaInterviewRepository, PrismaPersonaOnboardingRepository, type PersonaOnboardingCaller } from "@opencrane/backend/agents/personal/personas";
+import { __CreatePersonaOnboardingRouter, PrismaPersonaAuthorityRepository, PrismaPersonaDraftRepository, PrismaPersonaInterviewRepository, PrismaPersonaOnboardingRepository, PrismaPersonaOnboardingStatusRepository, type PersonaOnboardingCaller } from "@opencrane/backend/agents/personal/personas";
 import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
 // Side-effect import: loads the express-session SessionData.authUser augmentation.
 import "@opencrane/server/_infra/auth";
@@ -21,6 +21,7 @@ export function _CreatePersonaOnboardingRouter(prisma: PrismaClient): Router
 		approval: new PrismaPersonaAuthorityRepository(prisma),
 		clock: { now(): Date { return new Date(); } },
 		logger: _log,
+		status: new PrismaPersonaOnboardingStatusRepository(prisma),
 	});
 }
 

--- a/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding.router.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/persona-onboarding.router.test.ts
@@ -18,6 +18,7 @@ function _dependencies(overrides: Partial<PersonaOnboardingRouterDependencies> =
 		approval: { getApprovalSnapshot: vi.fn(), approveAndActivateAtomically: vi.fn() },
 		clock: { now: function _now() { return new Date("2026-07-26T12:00:00.000Z"); } },
 		logger: { error: vi.fn() } as unknown as Logger,
+		status: { readStatus: vi.fn().mockResolvedValue({ state: "interview", interviewId: null, answeredQuestionCount: 0, questionCount: 8, personaRevisionId: null }) },
 		...overrides,
 	};
 }
@@ -33,6 +34,14 @@ function _app(dependencies: PersonaOnboardingRouterDependencies)
 
 describe("__CreatePersonaOnboardingRouter", function _describe()
 {
+	it("returns only durable resumable onboarding metadata for the authenticated owner", async function _status()
+	{
+		const dependencies = _dependencies();
+		const response = await request(_app(dependencies)).get("/api/v1/me/persona/");
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ state: "interview", interviewId: null, answeredQuestionCount: 0, questionCount: 8, personaRevisionId: null });
+		expect(dependencies.status.readStatus).toHaveBeenCalledWith("silo-1", "user-1");
+	});
 	it("requires session-derived caller identity before it reveals an onboarding flow", async function _requiresCaller()
 	{
 		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).post("/api/v1/me/persona/interview").send({});

--- a/libs/backend/agents/personal/personas/main/src/__tests__/prisma-persona-onboarding-status-repository.test.ts
+++ b/libs/backend/agents/personal/personas/main/src/__tests__/prisma-persona-onboarding-status-repository.test.ts
@@ -1,0 +1,25 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaPersonaOnboardingStatusRepository } from "../prisma-persona-onboarding-status-repository.js";
+
+/** Build a status-reader Prisma double with an old active revision and a newer retake interview. */
+function _prisma(interviewState: string): PrismaClient
+{
+	return { personaProfile: { findUnique: vi.fn().mockResolvedValue({ id: "profile-1", activeRevisionId: "old-approved", interviews: [{ id: "retake-1", answers: [{ id: "answer-1" }], questionSet: { questions: [{ id: "role" }, { id: "tone" }] }, state: interviewState }] }) }, personaRevision: { findFirst: vi.fn().mockResolvedValue(null) } } as unknown as PrismaClient;
+}
+
+describe("PrismaPersonaOnboardingStatusRepository", function _suite()
+{
+	it("prioritizes an in-progress retake over an older active approved revision", async function _retake()
+	{
+		const repository = new PrismaPersonaOnboardingStatusRepository(_prisma("InProgress"));
+		await expect(repository.readStatus("silo-1", "user-1")).resolves.toEqual({ state: "interview", interviewId: "retake-1", answeredQuestionCount: 1, questionCount: 2, personaRevisionId: null });
+	});
+
+	it("keeps a completed retake resumable until it has a new draft", async function _completedRetake()
+	{
+		const repository = new PrismaPersonaOnboardingStatusRepository(_prisma("Completed"));
+		await expect(repository.readStatus("silo-1", "user-1")).resolves.toEqual({ state: "interview", interviewId: "retake-1", answeredQuestionCount: 1, questionCount: 2, personaRevisionId: null });
+	});
+});

--- a/libs/backend/agents/personal/personas/main/src/index.ts
+++ b/libs/backend/agents/personal/personas/main/src/index.ts
@@ -11,5 +11,8 @@ export { __EnsurePersonaOnboarding } from "./persona-onboarding-authority.js";
 export { PERSONA_ONBOARDING_QUESTION_SET_ID, PERSONA_ONBOARDING_QUESTION_SET_VERSION, PERSONA_ONBOARDING_TEMPLATE_ANSWERS } from "./persona-onboarding-catalogue.js";
 export type { EnsurePersonaOnboardingCommand, EnsurePersonaOnboardingResult, PersonaOnboardingQuestionSet, PersonaOnboardingRepository } from "./persona-onboarding-authority.types.js";
 export { PrismaPersonaOnboardingRepository } from "./prisma-persona-onboarding-repository.js";
+export { PrismaPersonaOnboardingStatusRepository } from "./prisma-persona-onboarding-status-repository.js";
+export { _PersonaOnboardingOpenapiPaths } from "./openapi.js";
 export { __CreatePersonaOnboardingRouter } from "./persona-onboarding.router.js";
 export type { PersonaOnboardingCaller, PersonaOnboardingClock, PersonaOnboardingRouterDependencies } from "./persona-onboarding.router.types.js";
+export type { PersonaOnboardingStatus, PersonaOnboardingStatusRepository } from "./persona-onboarding-status.types.js";

--- a/libs/backend/agents/personal/personas/main/src/openapi.ts
+++ b/libs/backend/agents/personal/personas/main/src/openapi.ts
@@ -1,0 +1,15 @@
+/** OpenAPI fragment for resumable owner-only persona onboarding state. */
+export const _PersonaOnboardingOpenapiPaths = {
+	"/me/persona": {
+		get: {
+			operationId: "getMyPersonaOnboarding",
+			summary: "Return the signed-in owner's resumable persona onboarding state",
+			tags: ["Persona"],
+			responses: {
+				200: { description: "Durable onboarding progress without compiled persona instructions.", content: { "application/json": { schema: { type: "object", required: ["state", "interviewId", "answeredQuestionCount", "questionCount", "personaRevisionId"], properties: { state: { type: "string", enum: ["interview", "review", "ready"] }, interviewId: { type: "string", nullable: true }, answeredQuestionCount: { type: "integer", minimum: 0 }, questionCount: { type: "integer", minimum: 0 }, personaRevisionId: { type: "string", nullable: true } } } } } },
+				401: { description: "No browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "Onboarding status could not be read.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
+};

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding-status.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding-status.types.ts
@@ -1,0 +1,21 @@
+/** Owner-visible resumable state of the required personal persona onboarding flow. */
+export interface PersonaOnboardingStatus
+{
+	/** Whether an approved persona currently makes a personal session eligible. */
+	readonly state: "interview" | "review" | "ready";
+	/** Current interview identifier, or null before the interview is started. */
+	readonly interviewId: string | null;
+	/** Number of answers durably captured for the current interview. */
+	readonly answeredQuestionCount: number;
+	/** Total reviewed questions required for the current interview. */
+	readonly questionCount: number;
+	/** Current draft or approved revision identifier, when one exists. */
+	readonly personaRevisionId: string | null;
+}
+
+/** Read-only persistence port for one authenticated owner's onboarding status. */
+export interface PersonaOnboardingStatusRepository
+{
+	/** Reads the latest durable onboarding facts for the exact silo and user. */
+	readStatus(siloId: string, userId: string): Promise<PersonaOnboardingStatus>;
+}

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.ts
@@ -11,6 +11,20 @@ import type { PersonaOnboardingCaller, PersonaOnboardingRouterDependencies } fro
 export function __CreatePersonaOnboardingRouter(dependencies: PersonaOnboardingRouterDependencies): Router
 {
 	const router = Router();
+	router.get("/", async function _status(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		if (caller === null) return;
+		try
+		{
+			response.status(200).json(await dependencies.status.readStatus(caller.siloId, caller.userId));
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "persona_onboarding.status", siloId: caller.siloId }, "Persona onboarding status read failed");
+			_respond(response, 503, "persona_onboarding_unavailable");
+		}
+	});
 
 	router.post("/interview", async function _start(request: Request, response: Response)
 	{

--- a/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.types.ts
+++ b/libs/backend/agents/personal/personas/main/src/persona-onboarding.router.types.ts
@@ -5,6 +5,7 @@ import type { PersonaInterviewQuestionReader, PersonaInterviewRepository } from 
 import type { PersonaOnboardingRepository } from "./persona-onboarding-authority.types.js";
 import type { PersonaAuthorityRepository } from "./persona-authority.types.js";
 import type { PersonaDraftFromInterviewRepository } from "./persona-draft-authority.types.js";
+import type { PersonaOnboardingStatusRepository } from "./persona-onboarding-status.types.js";
 
 /** Authenticated browser identity resolved by the composing server, never from request input. */
 export interface PersonaOnboardingCaller
@@ -41,4 +42,6 @@ export interface PersonaOnboardingRouterDependencies
 	clock: PersonaOnboardingClock;
 	/** Records unexpected authority failures without including owner answers. */
 	logger: Logger;
+	/** Reads the resumable onboarding state without exposing compiled persona instructions. */
+	status: PersonaOnboardingStatusRepository;
 }

--- a/libs/backend/agents/personal/personas/main/src/prisma-persona-onboarding-status-repository.ts
+++ b/libs/backend/agents/personal/personas/main/src/prisma-persona-onboarding-status-repository.ts
@@ -1,0 +1,33 @@
+import { PersonaRevisionState, type PrismaClient } from "@prisma/client";
+
+import type { PersonaOnboardingStatus, PersonaOnboardingStatusRepository } from "./persona-onboarding-status.types.js";
+
+/** Prisma read adapter for the exact owner's resumable onboarding state. */
+export class PrismaPersonaOnboardingStatusRepository implements PersonaOnboardingStatusRepository
+{
+	/** Canonical product database client. */
+	private readonly _prisma: PrismaClient;
+
+	/** Construct the status reader over the app-owned Prisma client. */
+	constructor(prisma: PrismaClient)
+	{
+		this._prisma = prisma;
+	}
+
+	/** Read the latest interview and revision without exposing compiled persona instructions. */
+	async readStatus(siloId: string, userId: string): Promise<PersonaOnboardingStatus>
+	{
+		const profile = await this._prisma.personaProfile.findUnique({ where: { siloId_userId: { siloId, userId } }, include: { interviews: { orderBy: { startedAt: "desc" }, take: 1, include: { answers: { select: { id: true }, }, questionSet: { include: { questions: { select: { id: true } } } } }, } } });
+		if (profile === null) return { state: "interview", interviewId: null, answeredQuestionCount: 0, questionCount: 0, personaRevisionId: null };
+		const interview = profile.interviews[0] ?? null;
+		if (interview !== null)
+		{
+			const revision = await this._prisma.personaRevision.findFirst({ where: { personaProfileId: profile.id, interviewId: interview.id }, orderBy: { revision: "desc" }, select: { id: true, state: true } });
+			if (revision?.state === PersonaRevisionState.Draft) return { state: "review", interviewId: interview.id, answeredQuestionCount: interview.answers.length, questionCount: interview.questionSet.questions.length, personaRevisionId: revision.id };
+			return { state: "interview", interviewId: interview.id, answeredQuestionCount: interview.answers.length, questionCount: interview.questionSet.questions.length, personaRevisionId: null };
+		}
+		return profile.activeRevisionId === null
+			? { state: "interview", interviewId: null, answeredQuestionCount: 0, questionCount: 0, personaRevisionId: null }
+			: { state: "ready", interviewId: null, answeredQuestionCount: 0, questionCount: 0, personaRevisionId: profile.activeRevisionId };
+	}
+}

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -30,6 +30,7 @@ import { _MetricsOpenapiPaths } from "@opencrane/backend/server/reporting/metric
 import { _AuthorizationOpenapiPaths } from "@opencrane/backend/server/iam/authorization";
 import { _RuntimeSteeringOpenapiPaths } from "@opencrane/backend/agents/execution/protocol";
 import { _SelfRunStatusOpenapiPaths } from "@opencrane/backend/agents/execution/runs";
+import { _PersonaOnboardingOpenapiPaths } from "@opencrane/backend/agents/personal/personas";
 import { _SelfConversationReplayOpenapiPaths } from "@opencrane/backend/server/agents/conversation-replay";
 
 // ---------------------------------------------------------------------------
@@ -775,6 +776,7 @@ export const spec = {
     ..._AuthorizationOpenapiPaths,
     ..._RuntimeSteeringOpenapiPaths,
     ..._SelfRunStatusOpenapiPaths,
+    ..._PersonaOnboardingOpenapiPaths,
     ..._SelfConversationReplayOpenapiPaths,
 
     // ------------------------------------------------------------------

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1125,6 +1125,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/persona": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Return the signed-in owner's resumable persona onboarding state */
+        get: operations["getMyPersonaOnboarding"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/me/conversations/{threadId}/events": {
         parameters: {
             query?: never;
@@ -5184,6 +5201,51 @@ export interface operations {
                 };
             };
             /** @description Run status could not be read. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getMyPersonaOnboarding: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Durable onboarding progress without compiled persona instructions. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @enum {string} */
+                        state: "interview" | "review" | "ready";
+                        interviewId: string | null;
+                        answeredQuestionCount: number;
+                        questionCount: number;
+                        personaRevisionId: string | null;
+                    };
+                };
+            };
+            /** @description No browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Onboarding status could not be read. */
             503: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

Adds the authenticated read model a client needs to resume the required persona interview and review flow after reload. The response contains only durable progress metadata; it never exposes compiled SOUL instructions.

## Safety

- session and host derive the exact owner/silo
- a newer retake always takes precedence over an older active persona
- absent onboarding is a clean interview state

## Validation

- 25 persona tests passed
- persona/API-spec/contracts type checks passed
- independent review found and verified the retake precedence correction

## Stack

Base: #485. Next dependent Phase F product API slice.