### PR TITLE
📋 Phase F: list an owner's recent personal runs

### DIFF
--- a/libs/backend/agents/execution/runs/main/README.md
+++ b/libs/backend/agents/execution/runs/main/README.md
@@ -168,8 +168,9 @@ uncertainty fails closed.
 - `__CreateAgentControllerRunDispatchRouter` — projected-token-authenticated internal assignment and
   release API for the fixed `agent-controller` ServiceAccount.
 - `__CreateSelfRunStatusRouter` / `PrismaSelfRunStatusRepository` — authenticated product read of
-  one personal run's lifecycle, attempt, immutable revision, and timestamps. The app derives the
-  subject and silo from session and host; foreign or absent runs share the same non-disclosing 404.
+  one personal run or the owner's latest fifty runs, including lifecycle, attempt, immutable
+  revision, and timestamps. The app derives the subject and silo from session and host; foreign or
+  absent single runs share the same non-disclosing 404.
 - `RunDispatchRepository` / `AgentControllerTokenReviewer` — persistence and TokenReview ports used by that internal API.
 - `ClaimNextRunWorkloadReleaseResult` / `RegisterRunWorkloadPodResult` — release-claim and first-Pod
   registration outcomes used across the internal adapter boundary.

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-self-run-status-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-self-run-status-repository.test.ts
@@ -1,0 +1,23 @@
+import type { PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaSelfRunStatusRepository } from "../prisma-self-run-status-repository.js";
+
+/** Creates the selected persisted fields for one owner-visible run. */
+function _runRow()
+{
+	return { id: "run-1", attempt: 2, state: "WaitingForApproval", threadId: "thread-1", agentRevisionId: "revision-1", acceptedAt: new Date("2026-07-26T12:00:00.000Z"), finishedAt: null };
+}
+
+describe("Prisma self run status repository", function _suite()
+{
+	it("binds the recent list to the exact owner and silo, with a bounded newest-first window", async function _listsOwnedRuns()
+	{
+		const findMany = vi.fn().mockResolvedValue([_runRow()]);
+		const prisma = { agentRun: { findMany } } as unknown as PrismaClient;
+		const repository = new PrismaSelfRunStatusRepository(prisma);
+
+		await expect(repository.listOwned("silo-1", "user-1")).resolves.toEqual([{ runId: "run-1", attempt: 2, state: "waiting_for_approval", threadId: "thread-1", agentRevisionId: "revision-1", acceptedAt: "2026-07-26T12:00:00.000Z", finishedAt: null }]);
+		expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { siloId: "silo-1", delegatedUserId: "user-1" }, orderBy: [{ acceptedAt: "desc" }, { id: "desc" }], take: 50 }));
+	});
+});

--- a/libs/backend/agents/execution/runs/main/src/__tests__/self-run-status.router.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/self-run-status.router.test.ts
@@ -8,13 +8,15 @@ import type { SelfRunStatus } from "../self-run-status.router.types.js";
 
 /** Read signature exposed by the owner-bound run-status repository. */
 type ReadOwned = (runId: string, siloId: string, subjectId: string) => Promise<SelfRunStatus | null>;
+/** List signature exposed by the owner-bound run-status repository. */
+type ListOwned = (siloId: string, subjectId: string) => Promise<readonly SelfRunStatus[]>;
 
 /** Build the self-only run route with session identity and persistence seams. */
-function _app(caller: unknown, readOwned: Mock<ReadOwned> = vi.fn<ReadOwned>(async function _read() { return null; }))
+function _app(caller: unknown, readOwned: Mock<ReadOwned> = vi.fn<ReadOwned>(async function _read() { return null; }), listOwned: Mock<ListOwned> = vi.fn<ListOwned>(async function _list() { return []; }))
 {
 	const app = express();
-	app.use(__CreateSelfRunStatusRouter({ resolveCaller: function _caller() { return caller as never; }, repository: { readOwned }, logger: { error: vi.fn() } as unknown as Logger }));
-	return { app, readOwned };
+	app.use(__CreateSelfRunStatusRouter({ resolveCaller: function _caller() { return caller as never; }, repository: { listOwned, readOwned }, logger: { error: vi.fn() } as unknown as Logger }));
+	return { app, listOwned, readOwned };
 }
 
 describe("self run status router", function _suite()
@@ -29,6 +31,16 @@ describe("self run status router", function _suite()
 		expect(readOwned).toHaveBeenCalledWith("run-1", "silo-1", "user-1");
 	});
 
+	it("lists only the caller's recent runs through the owner-bound repository", async function _listsOwnedRuns()
+	{
+		const status = { runId: "run-1", attempt: 2, state: "running", threadId: "thread-1", agentRevisionId: "revision-1", acceptedAt: "2026-07-26T12:00:00.000Z", finishedAt: null };
+		const { app, listOwned } = _app({ siloId: "silo-1", subjectId: "user-1" }, undefined, vi.fn(async function _list() { return [status]; }));
+		const response = await request(app).get("/");
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ runs: [status] });
+		expect(listOwned).toHaveBeenCalledWith("silo-1", "user-1");
+	});
+
 	it("does not disclose absent or another owner's run", async function _hidesForeignRun()
 	{
 		const { app } = _app({ siloId: "silo-1", subjectId: "user-1" });
@@ -40,6 +52,12 @@ describe("self run status router", function _suite()
 	it("requires a session-derived caller", async function _requiresCaller()
 	{
 		const response = await request(_app(null).app).get("/run-1");
+		expect(response.status).toBe(401);
+	});
+
+	it("requires a session-derived caller before listing runs", async function _requiresCallerToList()
+	{
+		const response = await request(_app(null).app).get("/");
 		expect(response.status).toBe(401);
 	});
 });

--- a/libs/backend/agents/execution/runs/main/src/openapi.ts
+++ b/libs/backend/agents/execution/runs/main/src/openapi.ts
@@ -1,5 +1,18 @@
 /** OpenAPI path fragment for authenticated owner-visible run status. */
 export const _SelfRunStatusOpenapiPaths = {
+	"/me/runs": {
+		get: {
+			operationId: "listMyRuns",
+			summary: "List a signed-in owner's fifty most recent personal runs",
+			description: "The server derives the owner and silo from session and host, then returns at most fifty canonical lifecycle summaries ordered newest first.",
+			tags: ["Runs"],
+			responses: {
+				200: { description: "Recent canonical lifecycle views for the owned runs.", content: { "application/json": { schema: { type: "object", required: ["runs"], properties: { runs: { type: "array", items: { $ref: "#/components/schemas/SelfRunStatus" } } } } } } },
+				401: { description: "No browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "Run status could not be read.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
 	"/me/runs/{runId}": {
 		get: {
 			operationId: "getMyRunStatus",
@@ -8,7 +21,7 @@ export const _SelfRunStatusOpenapiPaths = {
 			tags: ["Runs"],
 			parameters: [{ name: "runId", in: "path", required: true, schema: { type: "string" }, description: "Opaque run identifier." }],
 			responses: {
-				200: { description: "Current canonical lifecycle view for the owned run.", content: { "application/json": { schema: { type: "object", required: ["runId", "attempt", "state", "threadId", "agentRevisionId", "acceptedAt", "finishedAt"], properties: { runId: { type: "string" }, attempt: { type: "integer", minimum: 1 }, state: { type: "string", enum: ["accepted", "queued", "assigned", "running", "waiting_for_approval", "cancelling", "completed", "failed", "cancelled"] }, threadId: { type: "string", nullable: true }, agentRevisionId: { type: "string" }, acceptedAt: { type: "string", format: "date-time" }, finishedAt: { type: "string", format: "date-time", nullable: true } } } } } },
+				200: { description: "Current canonical lifecycle view for the owned run.", content: { "application/json": { schema: { $ref: "#/components/schemas/SelfRunStatus" } } } },
 				400: { description: "The run identifier is malformed.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
 				401: { description: "No browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
 				404: { description: "The run is absent or not owned by the caller.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },

--- a/libs/backend/agents/execution/runs/main/src/prisma-self-run-status-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-self-run-status-repository.ts
@@ -14,12 +14,25 @@ export class PrismaSelfRunStatusRepository implements SelfRunStatusRepository
 		this._prisma = prisma;
 	}
 
+	/** List the latest fifty personal runs owned by one session subject in one silo. */
+	async listOwned(siloId: string, subjectId: string): Promise<readonly SelfRunStatus[]>
+	{
+		const runs = await this._prisma.agentRun.findMany({ where: { siloId, delegatedUserId: subjectId }, orderBy: [{ acceptedAt: "desc" }, { id: "desc" }], take: 50, select: { id: true, attempt: true, state: true, threadId: true, agentRevisionId: true, acceptedAt: true, finishedAt: true } });
+		return runs.map(_toSelfRunStatus);
+	}
+
 	/** Read only the exact run owned by the session subject in the selected silo. */
 	async readOwned(runId: string, siloId: string, subjectId: string): Promise<SelfRunStatus | null>
 	{
 		const run = await this._prisma.agentRun.findFirst({ where: { id: runId, siloId, delegatedUserId: subjectId }, select: { id: true, attempt: true, state: true, threadId: true, agentRevisionId: true, acceptedAt: true, finishedAt: true } });
-		return run === null ? null : { runId: run.id, attempt: run.attempt, state: _state(run.state.toString()), threadId: run.threadId, agentRevisionId: run.agentRevisionId, acceptedAt: run.acceptedAt.toISOString(), finishedAt: run.finishedAt?.toISOString() ?? null };
+		return run === null ? null : _toSelfRunStatus(run);
 	}
+}
+
+/** Convert the selected canonical Prisma fields into the stable product status shape. */
+function _toSelfRunStatus(run: { id: string; attempt: number; state: { toString(): string }; threadId: string | null; agentRevisionId: string; acceptedAt: Date; finishedAt: Date | null }): SelfRunStatus
+{
+	return { runId: run.id, attempt: run.attempt, state: _state(run.state.toString()), threadId: run.threadId, agentRevisionId: run.agentRevisionId, acceptedAt: run.acceptedAt.toISOString(), finishedAt: run.finishedAt?.toISOString() ?? null };
 }
 
 /** Map Prisma's PascalCase lifecycle enum to the product API's stable lowercase spelling. */

--- a/libs/backend/agents/execution/runs/main/src/self-run-status.router.ts
+++ b/libs/backend/agents/execution/runs/main/src/self-run-status.router.ts
@@ -6,6 +6,21 @@ import type { SelfRunStatusRouterDependencies } from "./self-run-status.router.t
 export function __CreateSelfRunStatusRouter(dependencies: SelfRunStatusRouterDependencies): Router
 {
 	const router = Router();
+	router.get("/", async function _list(request: Request, response: Response)
+	{
+		const caller = dependencies.resolveCaller(request);
+		if (caller === null) { response.status(401).json({ error: "run_authentication_required" }); return; }
+		try
+		{
+			const runs = await dependencies.repository.listOwned(caller.siloId, caller.subjectId);
+			response.status(200).json({ runs });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "run_status.self_list", siloId: caller.siloId }, "Self run list read failed");
+			response.status(503).json({ error: "run_status_unavailable" });
+		}
+	});
 	router.get("/:runId", async function _status(request: Request, response: Response)
 	{
 		const caller = dependencies.resolveCaller(request);

--- a/libs/backend/agents/execution/runs/main/src/self-run-status.router.types.ts
+++ b/libs/backend/agents/execution/runs/main/src/self-run-status.router.types.ts
@@ -32,6 +32,8 @@ export interface SelfRunStatus
 /** Read-only owner-bound persistence port for one run status. */
 export interface SelfRunStatusRepository
 {
+	/** Lists the caller's most recent personal runs in one exact selected silo. */
+	listOwned(siloId: string, subjectId: string): Promise<readonly SelfRunStatus[]>;
 	/** Returns the run only when it belongs to the exact authenticated subject in the silo. */
 	readOwned(runId: string, siloId: string, subjectId: string): Promise<SelfRunStatus | null>;
 }

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -689,6 +689,19 @@ export const spec = {
       Budget: BudgetSchema,
       ThirdPartySource: ThirdPartySourceSchema,
       TokenUsage: TokenUsageSchema,
+      SelfRunStatus: {
+        type: "object",
+        required: ["runId", "attempt", "state", "threadId", "agentRevisionId", "acceptedAt", "finishedAt"],
+        properties: {
+          runId: { type: "string" },
+          attempt: { type: "integer", minimum: 1 },
+          state: { type: "string", enum: ["accepted", "queued", "assigned", "running", "waiting_for_approval", "cancelling", "completed", "failed", "cancelled"] },
+          threadId: { type: "string", nullable: true },
+          agentRevisionId: { type: "string" },
+          acceptedAt: { type: "string", format: "date-time" },
+          finishedAt: { type: "string", format: "date-time", nullable: true },
+        },
+      },
       ZitadelCandidateKeyValidation: {
         type: "object",
         required: ["tokenExchangeOk", "instanceScopeOk", "keyId", "detail"],

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1105,6 +1105,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List a signed-in owner's fifty most recent personal runs
+         * @description The server derives the owner and silo from session and host, then returns at most fifty canonical lifecycle summaries ordered newest first.
+         */
+        get: operations["listMyRuns"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/me/runs/{runId}": {
         parameters: {
             query?: never;
@@ -1813,6 +1833,18 @@ export interface components {
             totalCostUsd?: number;
             /** Format: date-time */
             recordedAt?: string;
+        };
+        SelfRunStatus: {
+            runId: string;
+            attempt: number;
+            /** @enum {string} */
+            state: "accepted" | "queued" | "assigned" | "running" | "waiting_for_approval" | "cancelling" | "completed" | "failed" | "cancelled";
+            threadId: string | null;
+            agentRevisionId: string;
+            /** Format: date-time */
+            acceptedAt: string;
+            /** Format: date-time */
+            finishedAt: string | null;
         };
         ZitadelCandidateKeyValidation: {
             /** @description Whether the candidate key's jwt-bearer token exchange succeeded. */
@@ -5141,6 +5173,46 @@ export interface operations {
             };
         };
     };
+    listMyRuns: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Recent canonical lifecycle views for the owned runs. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        runs: components["schemas"]["SelfRunStatus"][];
+                    };
+                };
+            };
+            /** @description No browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Run status could not be read. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getMyRunStatus: {
         parameters: {
             query?: never;
@@ -5159,18 +5231,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        runId: string;
-                        attempt: number;
-                        /** @enum {string} */
-                        state: "accepted" | "queued" | "assigned" | "running" | "waiting_for_approval" | "cancelling" | "completed" | "failed" | "cancelled";
-                        threadId: string | null;
-                        agentRevisionId: string;
-                        /** Format: date-time */
-                        acceptedAt: string;
-                        /** Format: date-time */
-                        finishedAt: string | null;
-                    };
+                    "application/json": components["schemas"]["SelfRunStatus"];
                 };
             };
             /** @description The run identifier is malformed. */


### PR DESCRIPTION
## What this adds

A signed-in person can now retrieve the fifty most recent runs for their personal agent with `GET /api/v1/me/runs`. This gives the product state layer a small, canonical activity feed without creating a second run store or exposing another person’s history.

The server derives both the user identity and selected silo from the browser session and request host. The Prisma query binds both values, orders results deterministically, and returns only the product-safe lifecycle fields already used by the single-run status endpoint.

## Boundary

This is deliberately not a budget or spend endpoint: the existing LiteLLM spend package is an operator control surface, not a personal-agent budget authority.

## Validation

- `npx nx run backend-agents-execution-runs:test` — 75 tests passed
- `npx nx run backend-agents-execution-runs:lint`
- `npx nx run backend-server-api-spec:lint`
- regenerated OpenAPI and `contracts:generate`, then `contracts:lint`
- `scripts/agent-style-check.sh` and `git diff --check`

## Review

Independent review found no Critical, High, or Medium findings. It confirmed the exact owner/silo filter, deterministic bounded ordering, route composition, generated contract, and README update.