### PR TITLE
✅ Phase F: expose an owner's pending approval inbox

### DIFF
--- a/apps/opencrane/src/app/deferred-tool-approval-wiring.ts
+++ b/apps/opencrane/src/app/deferred-tool-approval-wiring.ts
@@ -1,7 +1,7 @@
 import type { Request, Router } from "express";
 import type { PrismaClient } from "@prisma/client";
 
-import { __CreateDeferredToolApprovalRouter, PrismaDeferredToolApprovalDecisionRepository, type DeferredToolApprovalCaller } from "@opencrane/backend/server/iam/authorization";
+import { __CreateDeferredToolApprovalRouter, PrismaDeferredToolApprovalDecisionRepository, PrismaSelfDeferredToolApprovalListRepository, type DeferredToolApprovalCaller } from "@opencrane/backend/server/iam/authorization";
 import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
 // Side-effect import: loads the express-session SessionData.authUser augmentation.
 import "@opencrane/server/_infra/auth";
@@ -14,6 +14,7 @@ export function _CreateDeferredToolApprovalRouter(prisma: PrismaClient): Router
 	return __CreateDeferredToolApprovalRouter({
 		resolveCaller: _resolveCaller,
 		decisions: new PrismaDeferredToolApprovalDecisionRepository(prisma),
+		pendingApprovals: new PrismaSelfDeferredToolApprovalListRepository(prisma),
 		clock: { now(): Date { return new Date(); } },
 		logger: _log,
 	});

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -702,6 +702,18 @@ export const spec = {
           finishedAt: { type: "string", format: "date-time", nullable: true },
         },
       },
+      SelfDeferredToolApproval: {
+        type: "object",
+        required: ["approvalRequestId", "runId", "attempt", "toolRevisionId", "expiresAt", "createdAt"],
+        properties: {
+          approvalRequestId: { type: "string" },
+          runId: { type: "string" },
+          attempt: { type: "integer", minimum: 1 },
+          toolRevisionId: { type: "string" },
+          expiresAt: { type: "string", format: "date-time" },
+          createdAt: { type: "string", format: "date-time" },
+        },
+      },
       ZitadelCandidateKeyValidation: {
         type: "object",
         required: ["tokenExchangeOk", "instanceScopeOk", "keyId", "detail"],

--- a/libs/backend/server/iam/authorization/main/README.md
+++ b/libs/backend/server/iam/authorization/main/README.md
@@ -58,10 +58,10 @@ legitimate request — never hand out access it should not.
   effect exactly once (or returns the earlier result on an allowed idempotent retry).
 - `__CancelPendingRunApprovalAuthority` — closes only pending approvals for an exact run attempt on
   a caller-owned database transaction, clearing every late-resume token atomically with cancellation.
-- `__CreateDeferredToolApprovalRouter`, `PrismaDeferredToolApprovalDecisionRepository` — the
-  owner-only HTTP decision surface and its atomic persistence adapter. The router takes only an
-  approval id and an approve-or-deny choice; it derives the person and silo from the signed-in
-  browser session and mints the opaque resume marker inside the server.
+- `__CreateDeferredToolApprovalRouter`, `PrismaDeferredToolApprovalDecisionRepository`,
+  `PrismaSelfDeferredToolApprovalListRepository` — the owner-only pending approval inbox, decision
+  surface, and their persistence adapters. The router derives the person and silo from the signed-in
+  browser session; the list omits arguments, proof data, policy digests, and resume credentials.
 - `__DigestCanonicalJson` — a stable hash of a request used across the checks above.
 - `PrismaRuntimeAuthorityRepository`, `PrismaAuthorizationGrantRepository` — the database-backed
   stores for accepted proofs/receipts and for candidate grants.

--- a/libs/backend/server/iam/authorization/main/src/__tests__/deferred-tool-approval.router.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/__tests__/deferred-tool-approval.router.test.ts
@@ -12,6 +12,7 @@ function _dependencies(overrides: Partial<DeferredToolApprovalRouterDependencies
 	return {
 		resolveCaller: function _caller() { return { siloId: "silo-1", subjectId: "user-1" }; },
 		decisions: { decideAtomically: vi.fn().mockResolvedValue({ outcome: "approved", deferredToolResult: { approvalRequestId: "approval-1", decision: "approved" } }) },
+		pendingApprovals: { listPendingOwned: vi.fn().mockResolvedValue([]) },
 		clock: { now: function _now() { return new Date("2026-07-26T12:00:00.000Z"); } },
 		logger: { error: vi.fn() } as unknown as Logger,
 		...overrides,
@@ -34,6 +35,22 @@ describe("__CreateDeferredToolApprovalRouter", function _suite()
 		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).post("/api/v1/me/approvals/approval-1/decision").send({ decision: "approved" });
 		expect(response.status).toBe(401);
 		expect(response.body).toEqual({ error: "approval_authentication_required" });
+	});
+
+	it("requires session-derived ownership before listing approvals", async function _requiresCallerToList()
+	{
+		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).get("/api/v1/me/approvals/");
+		expect(response.status).toBe(401);
+		expect(response.body).toEqual({ error: "approval_authentication_required" });
+	});
+
+	it("lists only the pending approvals returned for the session-derived owner", async function _listsPending()
+	{
+		const dependencies = _dependencies({ pendingApprovals: { listPendingOwned: vi.fn().mockResolvedValue([{ approvalRequestId: "approval-1", runId: "run-1", attempt: 2, toolRevisionId: "tool-revision-1", expiresAt: "2026-07-26T13:00:00.000Z", createdAt: "2026-07-26T12:00:00.000Z" }]) } });
+		const response = await request(_app(dependencies)).get("/api/v1/me/approvals/");
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ approvals: [{ approvalRequestId: "approval-1", runId: "run-1", attempt: 2, toolRevisionId: "tool-revision-1", expiresAt: "2026-07-26T13:00:00.000Z", createdAt: "2026-07-26T12:00:00.000Z" }] });
+		expect(dependencies.pendingApprovals.listPendingOwned).toHaveBeenCalledWith("silo-1", "user-1", new Date("2026-07-26T12:00:00.000Z"));
 	});
 
 	it("passes only the server-derived owner and a server-minted resume marker to persistence", async function _approves()

--- a/libs/backend/server/iam/authorization/main/src/__tests__/prisma-self-deferred-tool-approval-list-repository.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/__tests__/prisma-self-deferred-tool-approval-list-repository.test.ts
@@ -1,0 +1,24 @@
+import { ApprovalRequestState, type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaSelfDeferredToolApprovalListRepository } from "../prisma-self-deferred-tool-approval-list-repository.js";
+
+/** Creates the selected persisted fields for one pending deferred tool approval. */
+function _approvalRow()
+{
+	return { id: "approval-1", runId: "run-1", attempt: 2, resourceId: "tool-revision-1", expiresAt: new Date("2026-07-26T13:00:00.000Z"), createdAt: new Date("2026-07-26T12:00:00.000Z") };
+}
+
+describe("Prisma self deferred tool approval list repository", function _suite()
+{
+	it("binds the pending inbox to the exact owner and silo without selecting sensitive approval data", async function _listsPendingOwned()
+	{
+		const findMany = vi.fn().mockResolvedValue([_approvalRow()]);
+		const prisma = { approvalRequest: { findMany } } as unknown as PrismaClient;
+		const repository = new PrismaSelfDeferredToolApprovalListRepository(prisma);
+
+		const now = new Date("2026-07-26T12:00:00.000Z");
+		await expect(repository.listPendingOwned("silo-1", "user-1", now)).resolves.toEqual([{ approvalRequestId: "approval-1", runId: "run-1", attempt: 2, toolRevisionId: "tool-revision-1", expiresAt: "2026-07-26T13:00:00.000Z", createdAt: "2026-07-26T12:00:00.000Z" }]);
+		expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { siloId: "silo-1", subjectId: "user-1", state: ApprovalRequestState.Pending, expiresAt: { gt: now }, toolInvocationRowId: { not: null } }, orderBy: [{ createdAt: "desc" }, { id: "desc" }], take: 50, select: { id: true, runId: true, attempt: true, resourceId: true, expiresAt: true, createdAt: true } }));
+	});
+});

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.ts
@@ -11,6 +11,22 @@ export function __CreateDeferredToolApprovalRouter(dependencies: DeferredToolApp
 {
 	const router = Router();
 
+	router.get("/", async function _list(request: Request, response: Response)
+	{
+		const caller = _requireCaller(request, response, dependencies);
+		if (caller === null) return;
+		try
+		{
+			const approvals = await dependencies.pendingApprovals.listPendingOwned(caller.siloId, caller.subjectId, dependencies.clock.now());
+			response.status(200).json({ approvals });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "deferred_tool_approval.list", siloId: caller.siloId }, "Deferred tool approval list failed");
+			_respond(response, 503, "approval_list_unavailable");
+		}
+	});
+
 	router.post("/:approvalRequestId/decision", async function _decide(request: Request, response: Response)
 	{
 		const caller = _requireCaller(request, response, dependencies);

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.types.ts
@@ -2,7 +2,7 @@ import type { Request } from "express";
 
 import type { Logger } from "@opencrane/observability";
 
-import type { DeferredToolApprovalDecisionRepository } from "./deferred-tool-approval.types.js";
+import type { DeferredToolApprovalDecisionRepository, SelfDeferredToolApprovalListRepository } from "./deferred-tool-approval.types.js";
 
 /** Authenticated browser caller resolved by the composing server, never from request input. */
 export interface DeferredToolApprovalCaller
@@ -27,6 +27,8 @@ export interface DeferredToolApprovalRouterDependencies
 	resolveCaller(request: Request): DeferredToolApprovalCaller | null;
 	/** Atomically records the decision after binding it to the durable approval owner. */
 	readonly decisions: DeferredToolApprovalDecisionRepository;
+	/** Lists only the pending approvals owned by the browser caller. */
+	readonly pendingApprovals: SelfDeferredToolApprovalListRepository;
 	/** Supplies trusted server timestamps. */
 	readonly clock: DeferredToolApprovalClock;
 	/** Records unexpected persistence failures without logging approval payloads or tokens. */

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.types.ts
@@ -69,3 +69,27 @@ export interface DeferredToolApprovalDecisionRepository
 	/** Decide one request only when its durable run coordinates still match the authenticated owner. */
 	decideAtomically(command: DecideDeferredToolRequestCommand): Promise<DecideDeferredToolRequestResult>;
 }
+
+/** Product-safe metadata for one still-actionable deferred tool approval. */
+export interface SelfDeferredToolApproval
+{
+	/** Opaque approval identifier used to submit a later decision. */
+	readonly approvalRequestId: string;
+	/** Logical personal run paused behind this decision. */
+	readonly runId: string;
+	/** Current attempt waiting for the decision. */
+	readonly attempt: number;
+	/** Immutable tool revision that the owner is being asked to allow. */
+	readonly toolRevisionId: string;
+	/** Server deadline after which the approval stops being actionable. */
+	readonly expiresAt: string;
+	/** Server time when the approval was opened. */
+	readonly createdAt: string;
+}
+
+/** Read-only persistence boundary for the signed-in owner's pending approvals inbox. */
+export interface SelfDeferredToolApprovalListRepository
+{
+	/** Lists at most fifty actionable tool approvals owned by one exact caller in one silo. */
+	listPendingOwned(siloId: string, subjectId: string, now: Date): Promise<readonly SelfDeferredToolApproval[]>;
+}

--- a/libs/backend/server/iam/authorization/main/src/index.ts
+++ b/libs/backend/server/iam/authorization/main/src/index.ts
@@ -7,8 +7,9 @@ export type { ActionReplayMode, CapabilityActionExecutor, CapabilityActionFailur
 export { __CancelPendingRunApprovalAuthority } from "./run-approval-cancellation.js";
 export type { CancelPendingRunApprovalAuthorityCommand, CancelPendingRunApprovalAuthorityResult } from "./run-approval-cancellation.types.js";
 export { __DecideDeferredToolRequest, __DeferToolRequest } from "./deferred-tool-approval.js";
-export type { DecideDeferredToolRequestCommand, DecideDeferredToolRequestResult, DeferredToolApprovalDecisionRepository, DeferredToolDecision, DeferToolRequestCommand, DeferToolRequestResult } from "./deferred-tool-approval.types.js";
+export type { DecideDeferredToolRequestCommand, DecideDeferredToolRequestResult, DeferredToolApprovalDecisionRepository, DeferredToolDecision, DeferToolRequestCommand, DeferToolRequestResult, SelfDeferredToolApproval, SelfDeferredToolApprovalListRepository } from "./deferred-tool-approval.types.js";
 export { PrismaDeferredToolApprovalDecisionRepository } from "./prisma-deferred-tool-approval-decision-repository.js";
+export { PrismaSelfDeferredToolApprovalListRepository } from "./prisma-self-deferred-tool-approval-list-repository.js";
 export { __CreateDeferredToolApprovalRouter } from "./deferred-tool-approval.router.js";
 export type { DeferredToolApprovalCaller, DeferredToolApprovalClock, DeferredToolApprovalRouterDependencies } from "./deferred-tool-approval.router.types.js";
 export { _AuthorizationOpenapiPaths } from "./openapi.js";

--- a/libs/backend/server/iam/authorization/main/src/openapi.ts
+++ b/libs/backend/server/iam/authorization/main/src/openapi.ts
@@ -1,5 +1,18 @@
 /** OpenAPI path fragment for owner-only deferred tool approvals. */
 export const _AuthorizationOpenapiPaths = {
+	"/me/approvals": {
+		get: {
+			operationId: "listMyPendingToolApprovals",
+			summary: "List the signed-in owner's pending tool approvals",
+			description: "The server derives the owner and silo from the browser session and host. It returns at most fifty actionable approvals and never returns arguments, proof data, policy digests, or resume credentials.",
+			tags: ["Approvals"],
+			responses: {
+				200: { description: "Pending owner-bound tool approvals.", content: { "application/json": { schema: { type: "object", required: ["approvals"], properties: { approvals: { type: "array", items: { $ref: "#/components/schemas/SelfDeferredToolApproval" } } } } } } },
+				401: { description: "No authenticated browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "The product authority could not read pending approvals.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
 	"/me/approvals/{approvalRequestId}/decision": {
 		post: {
 			operationId: "decideDeferredToolApproval",

--- a/libs/backend/server/iam/authorization/main/src/prisma-self-deferred-tool-approval-list-repository.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-self-deferred-tool-approval-list-repository.ts
@@ -1,0 +1,29 @@
+import { ApprovalRequestState, type PrismaClient } from "@prisma/client";
+
+import type { SelfDeferredToolApproval, SelfDeferredToolApprovalListRepository } from "./deferred-tool-approval.types.js";
+
+/** Prisma reader for the signed-in owner's bounded pending-tool-approval inbox. */
+export class PrismaSelfDeferredToolApprovalListRepository implements SelfDeferredToolApprovalListRepository
+{
+	/** Canonical product authority used for owner-bound approval reads. */
+	private readonly _prisma: PrismaClient;
+
+	/** Construct the pending-approval reader around the server-owned Prisma client. */
+	constructor(prisma: PrismaClient)
+	{
+		this._prisma = prisma;
+	}
+
+	/** List the latest fifty still-pending deferred tool approvals for one exact owner and silo. */
+	async listPendingOwned(siloId: string, subjectId: string, now: Date): Promise<readonly SelfDeferredToolApproval[]>
+	{
+		const approvals = await this._prisma.approvalRequest.findMany({ where: { siloId, subjectId, state: ApprovalRequestState.Pending, expiresAt: { gt: now }, toolInvocationRowId: { not: null } }, orderBy: [{ createdAt: "desc" }, { id: "desc" }], take: 50, select: { id: true, runId: true, attempt: true, resourceId: true, expiresAt: true, createdAt: true } });
+		return approvals.map(_toSelfDeferredToolApproval);
+	}
+}
+
+/** Map selected durable approval fields to the non-sensitive product inbox shape. */
+function _toSelfDeferredToolApproval(approval: { id: string; runId: string; attempt: number; resourceId: string; expiresAt: Date; createdAt: Date }): SelfDeferredToolApproval
+{
+	return { approvalRequestId: approval.id, runId: approval.runId, attempt: approval.attempt, toolRevisionId: approval.resourceId, expiresAt: approval.expiresAt.toISOString(), createdAt: approval.createdAt.toISOString() };
+}

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1065,6 +1065,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/approvals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the signed-in owner's pending tool approvals
+         * @description The server derives the owner and silo from the browser session and host. It returns at most fifty actionable approvals and never returns arguments, proof data, policy digests, or resume credentials.
+         */
+        get: operations["listMyPendingToolApprovals"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/me/approvals/{approvalRequestId}/decision": {
         parameters: {
             query?: never;
@@ -1845,6 +1865,16 @@ export interface components {
             acceptedAt: string;
             /** Format: date-time */
             finishedAt: string | null;
+        };
+        SelfDeferredToolApproval: {
+            approvalRequestId: string;
+            runId: string;
+            attempt: number;
+            toolRevisionId: string;
+            /** Format: date-time */
+            expiresAt: string;
+            /** Format: date-time */
+            createdAt: string;
         };
         ZitadelCandidateKeyValidation: {
             /** @description Whether the candidate key's jwt-bearer token exchange succeeded. */
@@ -5011,6 +5041,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TokenUsage"][];
+                };
+            };
+        };
+    };
+    listMyPendingToolApprovals: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pending owner-bound tool approvals. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        approvals: components["schemas"]["SelfDeferredToolApproval"][];
+                    };
+                };
+            };
+            /** @description No authenticated browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The product authority could not read pending approvals. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };


### PR DESCRIPTION
## What this adds

A signed-in person can now retrieve their actionable deferred tool approvals with `GET /api/v1/me/approvals`. Before this change the target API could decide an approval only when a client already knew its opaque ID; the product state layer had no way to build the approval inbox.

The endpoint returns at most fifty newest pending approvals. It includes only the decision identifier, run/attempt, tool revision, and timestamps. It does not return arguments, argument digests, policy or proof data, runtime identity, or resume credentials.

## Security boundary

The server derives the person from the browser session and silo from the request host. The persistence query binds both, requires the approval to be a deferred tool invocation, filters out rows whose deadline has passed using the trusted server clock, and uses deterministic newest-first ordering.

## Validation

- `npx nx run backend-server-authorization:test` — 63 tests passed
- `npx nx run backend-server-authorization:lint`
- `npx nx run opencrane:lint`
- `npx nx run backend-server-api-spec:lint` and `npx nx run contracts:lint`
- regenerated OpenAPI and typed API client
- `scripts/agent-style-check.sh` and `git diff --check`

## Review

Independent review found one Medium issue (expired rows could be listed as actionable). The implementation now injects the trusted clock and requires `expiresAt > now`; the reviewer independently confirmed the fix.