### PR TITLE
📚 Phase F: expose the silo-managed agent catalogue

### DIFF
--- a/libs/backend/server/agents/agent-services/main/README.md
+++ b/libs/backend/server/agents/agent-services/main/README.md
@@ -49,8 +49,8 @@ leaves a half-published service. Anything missing or stale is refused with a pla
 
 ## Public surface
 
-- `__CreateAgentServicesRouter` — the authoritative management router (create / revise / compare /
-  publish / restore / enable / pause / run-now / history / retire); the UI and parity client are
+- `__CreateAgentServicesRouter` — the authoritative management router (catalogue / create / revise /
+  compare / publish / restore / enable / pause / run-now / history / retire); the UI and parity client are
   clients of it. Composed with `AgentServicesRouterDependencies`, `ManagementCaller`, `ManagementClock`.
 - Lifecycle use cases: `__CreateManagedAgentService`, `__ReviseAgentRevision`, `__RestoreAgentRevision`,
   `__ChangeAgentServiceState`, `__CompareAgentRevisions`, `__ReadAgentServiceHistory`, `__AdmitManagedRunNow`.

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/agent-revision-lifecycle.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/agent-revision-lifecycle.test.ts
@@ -17,6 +17,11 @@ class _Repository implements AgentRevisionLifecycleRepository
 	readonly revisions: AgentRevision[] = [];
 	private counter = 0;
 
+	async listManagedServices(siloId: string): Promise<readonly AgentService[]>
+	{
+		return [...this.services.values()].filter(service => service.siloId === siloId && service.kind === "managed").sort(function _newestFirst(left, right) { return right.updatedAt.localeCompare(left.updatedAt) || right.id.localeCompare(left.id); });
+	}
+
 	async getService(id: string, siloId: string): Promise<AgentService | null>
 	{
 		const service = this.services.get(id) ?? null;

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/agent-services-catalog.router.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/agent-services-catalog.router.test.ts
@@ -1,0 +1,44 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "@opencrane/observability";
+
+import { __CreateAgentServicesRouter } from "../agent-revision.router.js";
+import type { AgentServicesRouterDependencies } from "../agent-revision.router.types.js";
+
+/** Builds router dependencies with a caller and an observable catalogue repository port. */
+function _dependencies(overrides: Partial<AgentServicesRouterDependencies> = {}): AgentServicesRouterDependencies
+{
+	return {
+		lifecycle: { listManagedServices: vi.fn().mockResolvedValue([]) },
+		resolveCaller: function _caller() { return { siloId: "silo-1", subjectId: "user-1", isOrgAdmin: false }; },
+		logger: { error: vi.fn() } as unknown as Logger,
+		...overrides,
+	} as unknown as AgentServicesRouterDependencies;
+}
+
+/** Mounts the router below its public agent-services prefix. */
+function _app(dependencies: AgentServicesRouterDependencies)
+{
+	const app = express();
+	app.use("/api/v1/agent-services", __CreateAgentServicesRouter(dependencies));
+	return app;
+}
+
+describe("managed agent services catalogue router", function _suite()
+{
+	it("lists only the management catalogue for the session-derived silo", async function _lists()
+	{
+		const listManagedServices = vi.fn().mockResolvedValue([{ id: "service-1", siloId: "silo-1", kind: "managed", name: "Research", state: "active", activeRevisionId: "revision-1", workloadProfile: "managed", createdAt: "2026-07-26T12:00:00.000Z", updatedAt: "2026-07-26T12:00:00.000Z" }]);
+		const response = await request(_app(_dependencies({ lifecycle: { listManagedServices } } as unknown as Partial<AgentServicesRouterDependencies>))).get("/api/v1/agent-services/");
+		expect(response.status).toBe(200);
+		expect(response.body.services).toHaveLength(1);
+		expect(listManagedServices).toHaveBeenCalledWith("silo-1");
+	});
+
+	it("requires a signed-in caller before catalogue discovery", async function _requiresCaller()
+	{
+		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).get("/api/v1/agent-services/");
+		expect(response.status).toBe(401);
+	});
+});

--- a/libs/backend/server/agents/agent-services/main/src/__tests__/prisma-agent-services-catalog.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/__tests__/prisma-agent-services-catalog.test.ts
@@ -1,0 +1,23 @@
+import { AgentServiceKind, type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaAgentRevisionLifecycleRepository } from "../prisma-agent-revision-lifecycle.js";
+
+/** Creates the persisted fields mapped into one management catalogue service summary. */
+function _serviceRow()
+{
+	return { id: "service-1", siloId: "silo-1", kind: AgentServiceKind.Managed, name: "Research", state: "Active", activeRevisionId: "revision-1", workloadProfile: "managed", createdAt: new Date("2026-07-26T12:00:00.000Z"), updatedAt: new Date("2026-07-26T13:00:00.000Z") };
+}
+
+describe("Prisma managed agent services catalogue", function _suite()
+{
+	it("reads only managed services from the exact silo in a bounded deterministic order", async function _listsManagedSiloServices()
+	{
+		const findMany = vi.fn().mockResolvedValue([_serviceRow()]);
+		const prisma = { agentService: { findMany } } as unknown as PrismaClient;
+		const repository = new PrismaAgentRevisionLifecycleRepository(prisma);
+
+		await expect(repository.listManagedServices("silo-1")).resolves.toEqual([{ id: "service-1", siloId: "silo-1", kind: "managed", name: "Research", state: "active", activeRevisionId: "revision-1", workloadProfile: "managed", createdAt: "2026-07-26T12:00:00.000Z", updatedAt: "2026-07-26T13:00:00.000Z" }]);
+		expect(findMany).toHaveBeenCalledWith({ where: { siloId: "silo-1", kind: AgentServiceKind.Managed }, orderBy: [{ updatedAt: "desc" }, { id: "desc" }], take: 200 });
+	});
+});

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
@@ -163,6 +163,8 @@ export interface AgentServiceHistory
 /** Concurrency-capable persistence boundary for the managed-agent definition plane. */
 export interface AgentRevisionLifecycleRepository
 {
+	/** Lists managed service identities in the caller's silo, newest first, for catalogue discovery. */
+	listManagedServices(siloId: SiloId): Promise<readonly AgentService[]>;
 	/** Loads one stable service identity scoped to the caller's silo, or null when absent. */
 	getService(agentServiceId: AgentServiceId, siloId: SiloId): Promise<AgentService | null>;
 	/** Loads one immutable revision whose parent service is in the caller's silo, or null. */

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
@@ -165,6 +165,17 @@ export function __CreateAgentServicesRouter(dependencies: AgentServicesRouterDep
 		return caller;
 	}
 
+	router.get("/", async function _list(req: Request, res: Response)
+	{
+		try
+		{
+			const caller = _requireCaller(req, res);
+			if (caller === null) return;
+			res.status(200).json({ services: await lifecycle.listManagedServices(caller.siloId) });
+		}
+		catch (error) { _fail(res, error, "list"); }
+	});
+
 	router.post("/", async function _create(req: Request, res: Response)
 	{
 		try

--- a/libs/backend/server/agents/agent-services/main/src/index.ts
+++ b/libs/backend/server/agents/agent-services/main/src/index.ts
@@ -7,6 +7,7 @@ export type { AgentRevisionContent, AgentRevisionLifecycleDenial, AgentRevisionL
 export { PrismaAgentRevisionLifecycleRepository } from "./prisma-agent-revision-lifecycle.js";
 export { __CreateAgentServicesRouter } from "./agent-revision.router.js";
 export type { AgentServicesRouterDependencies, ManagementCaller, ManagementClock } from "./agent-revision.router.types.js";
+export { _AgentServicesOpenapiPaths } from "./openapi.js";
 export { __IntersectScopeAttachments, __ResolveEffectiveScopeAttachments, __ValidateAttachAuthority } from "./scope-attachment-authority.js";
 export type { AttachAuthorityResult, EffectiveScopeGrant, ScopeAttachmentIntersection, ScopeGrantResolver } from "./scope-attachment-authority.types.js";
 export { PrismaScopeGrantResolver } from "./prisma-scope-grant-resolver.js";

--- a/libs/backend/server/agents/agent-services/main/src/openapi.ts
+++ b/libs/backend/server/agents/agent-services/main/src/openapi.ts
@@ -1,0 +1,16 @@
+/** OpenAPI path fragments owned by the managed-agent catalogue and management authority. */
+export const _AgentServicesOpenapiPaths = {
+	"/agent-services": {
+		get: {
+			operationId: "listManagedAgentServices",
+			summary: "List managed agent services in the signed-in caller's silo",
+			description: "The server derives the silo from the browser session and request host. It returns at most two hundred managed-service summaries, ordered by most recently updated first.",
+			tags: ["Agent services"],
+			responses: {
+				200: { description: "Managed agent services in the selected silo.", content: { "application/json": { schema: { type: "object", required: ["services"], properties: { services: { type: "array", items: { $ref: "#/components/schemas/AgentService" } } } } } } },
+				401: { description: "No authenticated browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				500: { description: "The management authority could not read the catalogue.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
+};

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-lifecycle.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-lifecycle.ts
@@ -1,6 +1,6 @@
 import { AgentRevisionState, AgentServiceKind, AgentServiceState, GrantScope, GrantSubjectType, Prisma, type PrismaClient } from "@prisma/client";
 
-import type { GrantScope as DomainGrantScope, GrantSubjectType as DomainGrantSubjectType } from "@opencrane/models/agents";
+import type { AgentService, GrantScope as DomainGrantScope, GrantSubjectType as DomainGrantSubjectType } from "@opencrane/models/agents";
 
 import { __DigestCanonicalJson } from "@opencrane/backend/server/iam/authorization";
 import type { JsonValue } from "@opencrane/util";
@@ -129,6 +129,13 @@ export class PrismaAgentRevisionLifecycleRepository implements AgentRevisionLife
 	constructor(prisma: PrismaClient)
 	{
 		this.prisma = prisma;
+	}
+
+	/** List the newest two hundred managed service identities from one exact silo. */
+	async listManagedServices(siloId: string): Promise<readonly AgentService[]>
+	{
+		const rows = await this.prisma.agentService.findMany({ where: { siloId, kind: AgentServiceKind.Managed }, orderBy: [{ updatedAt: "desc" }, { id: "desc" }], take: 200 });
+		return rows.map(_mapService);
 	}
 
 	/** Loads one stable service identity scoped to the caller's silo. */

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -32,6 +32,7 @@ import { _RuntimeSteeringOpenapiPaths } from "@opencrane/backend/agents/executio
 import { _SelfRunStatusOpenapiPaths } from "@opencrane/backend/agents/execution/runs";
 import { _PersonaOnboardingOpenapiPaths } from "@opencrane/backend/agents/personal/personas";
 import { _SelfConversationReplayOpenapiPaths } from "@opencrane/backend/server/agents/conversation-replay";
+import { _AgentServicesOpenapiPaths } from "@opencrane/backend/server/agents/agent-services";
 
 // ---------------------------------------------------------------------------
 // Reusable schema components
@@ -714,6 +715,21 @@ export const spec = {
           createdAt: { type: "string", format: "date-time" },
         },
       },
+      AgentService: {
+        type: "object",
+        required: ["id", "siloId", "kind", "name", "state", "activeRevisionId", "workloadProfile", "createdAt", "updatedAt"],
+        properties: {
+          id: { type: "string" },
+          siloId: { type: "string" },
+          kind: { type: "string", enum: ["managed"] },
+          name: { type: "string" },
+          state: { type: "string", enum: ["draft", "active", "paused", "retired"] },
+          activeRevisionId: { type: "string", nullable: true },
+          workloadProfile: { type: "string" },
+          createdAt: { type: "string", format: "date-time" },
+          updatedAt: { type: "string", format: "date-time" },
+        },
+      },
       ZitadelCandidateKeyValidation: {
         type: "object",
         required: ["tokenExchangeOk", "instanceScopeOk", "keyId", "detail"],
@@ -803,6 +819,7 @@ export const spec = {
     ..._SelfRunStatusOpenapiPaths,
     ..._PersonaOnboardingOpenapiPaths,
     ..._SelfConversationReplayOpenapiPaths,
+    ..._AgentServicesOpenapiPaths,
 
     // ------------------------------------------------------------------
     // Auth — OIDC browser flow and session introspection

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1202,6 +1202,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/agent-services": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List managed agent services in the signed-in caller's silo
+         * @description The server derives the silo from the browser session and request host. It returns at most two hundred managed-service summaries, ordered by most recently updated first.
+         */
+        get: operations["listManagedAgentServices"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -1875,6 +1895,21 @@ export interface components {
             expiresAt: string;
             /** Format: date-time */
             createdAt: string;
+        };
+        AgentService: {
+            id: string;
+            siloId: string;
+            /** @enum {string} */
+            kind: "managed";
+            name: string;
+            /** @enum {string} */
+            state: "draft" | "active" | "paused" | "retired";
+            activeRevisionId: string | null;
+            workloadProfile: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
         };
         ZitadelCandidateKeyValidation: {
             /** @description Whether the candidate key's jwt-bearer token exchange succeeded. */
@@ -5434,6 +5469,46 @@ export interface operations {
             };
             /** @description Canonical history could not be read. */
             503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listManagedAgentServices: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Managed agent services in the selected silo. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        services: components["schemas"]["AgentService"][];
+                    };
+                };
+            };
+            /** @description No authenticated browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The management authority could not read the catalogue. */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## What this adds

The target management API now supports `GET /api/v1/agent-services`, allowing an authenticated user to discover managed-agent services in the selected silo before opening an existing service’s history, revisions, schedules, or lifecycle actions.

It returns stable service summaries only: identity, name, lifecycle state, active revision, workload profile, and timestamps. Personal services are deliberately excluded; they are part of the personal-agent product flow, not the managed-agent catalogue.

## Boundary

The server derives the silo from the signed-in browser session and request host. The repository filters to that exact silo and `Managed` kind, orders by update time with an ID tie-breaker, and caps the result at 200. No caller-supplied silo, kind, pagination override, or ownership coordinate is accepted.

## Validation

- `npx nx run backend-server-agent-services:test` — 31 tests passed
- `npx nx run backend-server-agent-services:lint`
- `npx nx run opencrane:lint`
- `npx nx run backend-server-api-spec:lint`
- regenerated OpenAPI and typed API client, then `contracts:lint`
- `scripts/agent-style-check.sh` and `git diff --check`

## Review

Independent review found no Critical, High, or Medium findings. It confirmed caller/host silo binding, managed-only query filtering, deterministic bounded ordering, route composition, generated contract, and README update.