### PR TITLE
🧭 Phase F: expose owner-bound configuration proposals

### DIFF
--- a/apps/opencrane/src/app/personal-configuration-wiring.ts
+++ b/apps/opencrane/src/app/personal-configuration-wiring.ts
@@ -1,0 +1,24 @@
+import type { Request, Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { __CreatePersonalConfigurationRouter, PrismaPersonalConfigurationChangeRepository, type PersonalConfigurationCaller } from "@opencrane/backend/agents/personal/configuration";
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+import "@opencrane/server/_infra/auth";
+
+import { _log } from "./log.js";
+
+/** Compose the owner-only personal configuration proposal state API. */
+export function _CreatePersonalConfigurationRouter(prisma: PrismaClient): Router
+{
+	return __CreatePersonalConfigurationRouter({ resolveCaller: _resolveCaller, changes: new PrismaPersonalConfigurationChangeRepository(prisma), logger: _log });
+}
+
+/** Derive the proposal owner from the signed-in browser session and trusted host silo. */
+function _resolveCaller(request: Request): PersonalConfigurationCaller | null
+{
+	const authUser = request.session?.authUser;
+	if (!authUser) return null;
+	const userId = (typeof authUser.sub === "string" ? authUser.sub.trim() : "") || (typeof authUser.email === "string" ? authUser.email.trim().toLowerCase() : "");
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	return userId && siloId ? { userId, siloId } : null;
+}

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -40,6 +40,7 @@ import { _CreateDeferredToolApprovalRouter } from "./deferred-tool-approval-wiri
 import { _CreateSteeringIngestRouter } from "./steering-ingest-wiring.js";
 import { _CreateSelfConversationReplayRouter } from "./self-conversation-replay-wiring.js";
 import { _CreateSelfRunStatusRouter } from "./self-run-status-wiring.js";
+import { _CreatePersonalConfigurationRouter } from "./personal-configuration-wiring.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
@@ -379,6 +380,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/me/approvals", _CreateDeferredToolApprovalRouter(prisma));
 	app.use("/api/v1/me/runs", _CreateSteeringIngestRouter(prisma));
 	app.use("/api/v1/me/runs", _CreateSelfRunStatusRouter(prisma));
+	app.use("/api/v1/me/configuration", _CreatePersonalConfigurationRouter(prisma));
 	app.use("/api/v1/me/conversations", _CreateSelfConversationReplayRouter(prisma));
   app.use("/api/v1/mcp-servers", mcpServersRouter(prisma));
   app.use("/api/v1/mcp", mcpOperatorRouter(prisma));

--- a/libs/backend/agents/personal/configuration/main/README.md
+++ b/libs/backend/agents/personal/configuration/main/README.md
@@ -19,8 +19,9 @@ snapshot and only while the recorded active revisions still match.
 **In this flow:** [conversations](../../conversations/main/README.md) · [personas](../../personas/main/README.md) · [execution inputs](../../../execution/inputs/main/README.md)
 
 The invariant is that a proposal is durable provenance, not mutable session state. Missing or
-cross-owner source coordinates fail closed. This first foundation does not itself approve, apply,
-or expose a browser/API control. Its first-party `upgrade_session` descriptor is always callable in
+cross-owner source coordinates fail closed. This foundation does not itself apply a patch; its
+owner-only browser API can list durable proposal history, while a later decision route will use the
+existing atomic decision authority. Its first-party `upgrade_session` descriptor is always callable in
 a personal conversation, but its call records only a proposed change in this same journal; it never
 means the request is already user-approved or applied.
 
@@ -32,6 +33,9 @@ means the request is already user-approved or applied.
 - `ProposePersonalConfigurationChangeCommand` and `Result` describe the stable proposal boundary.
 - `__DecidePersonalConfigurationChange` records the owner's `Accepted` or `Rejected` decision but
   never applies a patch itself.
+- `__CreatePersonalConfigurationRouter` and `PrismaPersonalConfigurationChangeRepository` provide
+  the owner-only `GET /api/v1/me/configuration/changes` history. It lists at most fifty proposals
+  in the signed-in owner's selected silo and does not alter any current run snapshot.
 - `UPGRADE_SESSION_TOOL` / `__IsUpgradeSessionAvailable` describe the built-in, non-MCP tool the app
   adds only to personal conversation inputs.
 - `PersonalConfigurationPatch` is a closed union: `persona_refresh` requests the normal interview

--- a/libs/backend/agents/personal/configuration/main/src/__tests__/personal-configuration.router.test.ts
+++ b/libs/backend/agents/personal/configuration/main/src/__tests__/personal-configuration.router.test.ts
@@ -1,0 +1,33 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "@opencrane/observability";
+
+import { __CreatePersonalConfigurationRouter } from "../personal-configuration.router.js";
+import type { PersonalConfigurationChangeView } from "../personal-configuration.types.js";
+
+/** Builds the owner-only proposal route with a caller and observable read port. */
+function _app(caller: unknown, listOwned = vi.fn(async function _list(): Promise<readonly PersonalConfigurationChangeView[]> { return []; }))
+{
+	const app = express();
+	app.use(__CreatePersonalConfigurationRouter({ resolveCaller: function _caller() { return caller as never; }, changes: { listOwned }, logger: { error: vi.fn() } as unknown as Logger }));
+	return { app, listOwned };
+}
+
+describe("personal configuration router", function _suite()
+{
+	it("lists only proposal state read through the session-derived owner", async function _lists()
+	{
+		const { app, listOwned } = _app({ siloId: "silo-1", userId: "user-1" }, vi.fn(async function _list() { return [{ changeId: "change-1", requestedPatch: { kind: "persona_refresh" }, state: "proposed", sourceThreadId: "thread-1", sourceRunId: "run-1", proposedAt: "2026-07-26T12:00:00.000Z", decidedAt: null, rejectionReason: null }]; }));
+		const response = await request(app).get("/changes");
+		expect(response.status).toBe(200);
+		expect(response.body.changes).toHaveLength(1);
+		expect(listOwned).toHaveBeenCalledWith("silo-1", "user-1");
+	});
+
+	it("requires an authenticated owner", async function _requiresCaller()
+	{
+		const response = await request(_app(null).app).get("/changes");
+		expect(response.status).toBe(401);
+	});
+});

--- a/libs/backend/agents/personal/configuration/main/src/__tests__/prisma-personal-configuration-repository.test.ts
+++ b/libs/backend/agents/personal/configuration/main/src/__tests__/prisma-personal-configuration-repository.test.ts
@@ -51,4 +51,12 @@ describe("Prisma personal configuration repository", function _Suite()
 		const repository = new PrismaPersonalConfigurationChangeRepository({ personalConfigurationChange: { updateMany: vi.fn(async function _update() { return { count: 0 }; }), findFirst: vi.fn(async function _find() { return null; }) } } as never);
 		await expect(repository.decideAtomically({ siloId: "silo-1", userId: "user-1", changeId: "change-1", decision: "rejected", rejectionReason: "Keep current settings", decidedAt: "2026-07-23T00:00:00.000Z" })).resolves.toEqual({ status: "not_found_or_not_owner" });
 	});
+
+	it("lists only the selected owner's bounded newest-first proposal history", async function _ListsOwned()
+	{
+		const findMany = vi.fn(async function _find() { return [{ id: "change-1", requestedPatch: { kind: "model_alias", modelAlias: "careful-model" }, state: "Proposed", sourceThreadId: "thread-1", sourceRunId: "run-1", proposedAt: new Date("2026-07-23T00:00:00.000Z"), decidedAt: null, rejectionReason: null }]; });
+		const repository = new PrismaPersonalConfigurationChangeRepository({ personalConfigurationChange: { findMany } } as never);
+		await expect(repository.listOwned("silo-1", "user-1")).resolves.toEqual([{ changeId: "change-1", requestedPatch: { kind: "model_alias", modelAlias: "careful-model" }, state: "proposed", sourceThreadId: "thread-1", sourceRunId: "run-1", proposedAt: "2026-07-23T00:00:00.000Z", decidedAt: null, rejectionReason: null }]);
+		expect(findMany).toHaveBeenCalledWith({ where: { siloId: "silo-1", userId: "user-1" }, orderBy: [{ proposedAt: "desc" }, { id: "desc" }], take: 50, select: { id: true, requestedPatch: true, state: true, sourceThreadId: true, sourceRunId: true, proposedAt: true, decidedAt: true, rejectionReason: true } });
+	});
 });

--- a/libs/backend/agents/personal/configuration/main/src/index.ts
+++ b/libs/backend/agents/personal/configuration/main/src/index.ts
@@ -1,6 +1,9 @@
 export { __DecidePersonalConfigurationChange } from "./personal-configuration-decision.js";
 export { __ProposePersonalConfigurationChange } from "./personal-configuration.js";
 export { PrismaPersonalConfigurationChangeRepository } from "./prisma-personal-configuration-repository.js";
+export { __CreatePersonalConfigurationRouter } from "./personal-configuration.router.js";
+export type { PersonalConfigurationCaller, PersonalConfigurationRouterDependencies } from "./personal-configuration.router.types.js";
+export { _PersonalConfigurationOpenapiPaths } from "./openapi.js";
 export { __IsUpgradeSessionAvailable, UPGRADE_SESSION_TOOL, UPGRADE_SESSION_TOOL_REVISION } from "./upgrade-session.js";
-export type { DecidePersonalConfigurationChangeCommand, DecidePersonalConfigurationChangeResult, PersonalConfigurationChangeDecisionRepository, PersonalConfigurationChangeRepository, PersonalConfigurationPatch, ProposePersonalConfigurationChangeCommand, ProposePersonalConfigurationChangeResult } from "./personal-configuration.types.js";
+export type { DecidePersonalConfigurationChangeCommand, DecidePersonalConfigurationChangeResult, PersonalConfigurationChangeDecisionRepository, PersonalConfigurationChangeRepository, PersonalConfigurationChangeView, PersonalConfigurationChangeViewRepository, PersonalConfigurationPatch, ProposePersonalConfigurationChangeCommand, ProposePersonalConfigurationChangeResult } from "./personal-configuration.types.js";
 export type { UpgradeSessionProposalReceipt, UpgradeSessionProposalRepository } from "./upgrade-session.types.js";

--- a/libs/backend/agents/personal/configuration/main/src/openapi.ts
+++ b/libs/backend/agents/personal/configuration/main/src/openapi.ts
@@ -1,0 +1,16 @@
+/** OpenAPI path fragment for the signed-in owner's personal configuration proposal state. */
+export const _PersonalConfigurationOpenapiPaths = {
+	"/me/configuration/changes": {
+		get: {
+			operationId: "listMyPersonalConfigurationChanges",
+			summary: "List the signed-in owner's personal configuration proposals",
+			description: "The server derives the owner and silo from session and host. It returns at most fifty durable future-session proposals, never a mutable run snapshot.",
+			tags: ["Personal configuration"],
+			responses: {
+				200: { description: "Owner-bound configuration proposal history.", content: { "application/json": { schema: { type: "object", required: ["changes"], properties: { changes: { type: "array", items: { $ref: "#/components/schemas/PersonalConfigurationChange" } } } } } } },
+				401: { description: "No browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "Configuration proposal history could not be read.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
+};

--- a/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.ts
+++ b/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.ts
@@ -1,0 +1,25 @@
+import { Router, type Request, type Response } from "express";
+
+import type { PersonalConfigurationRouterDependencies } from "./personal-configuration.router.types.js";
+
+/** Create the browser-session-authenticated personal configuration proposal state router. */
+export function __CreatePersonalConfigurationRouter(dependencies: PersonalConfigurationRouterDependencies): Router
+{
+	const router = Router();
+	router.get("/changes", async function _list(request: Request, response: Response)
+	{
+		const caller = dependencies.resolveCaller(request);
+		if (caller === null) { response.status(401).json({ error: "configuration_authentication_required" }); return; }
+		try
+		{
+			const changes = await dependencies.changes.listOwned(caller.siloId, caller.userId);
+			response.status(200).json({ changes });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "personal_configuration.list", siloId: caller.siloId }, "Personal configuration list failed");
+			response.status(503).json({ error: "configuration_list_unavailable" });
+		}
+	});
+	return router;
+}

--- a/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.types.ts
+++ b/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.types.ts
@@ -1,0 +1,24 @@
+import type { Request } from "express";
+import type { Logger } from "@opencrane/observability";
+
+import type { PersonalConfigurationChangeViewRepository } from "./personal-configuration.types.js";
+
+/** Trusted browser identity for the owner-only configuration-proposal read surface. */
+export interface PersonalConfigurationCaller
+{
+	/** Selected silo derived from the trusted request host. */
+	readonly siloId: string;
+	/** Signed-in user who owns the returned proposal history. */
+	readonly userId: string;
+}
+
+/** Composition ports for the owner-only personal configuration state router. */
+export interface PersonalConfigurationRouterDependencies
+{
+	/** Resolves the browser caller without accepting owner coordinates from request input. */
+	resolveCaller(request: Request): PersonalConfigurationCaller | null;
+	/** Reads only durable proposals owned by the resolved caller. */
+	readonly changes: PersonalConfigurationChangeViewRepository;
+	/** Records unexpected persistence failures without logging patch contents. */
+	readonly logger: Logger;
+}

--- a/libs/backend/agents/personal/configuration/main/src/personal-configuration.types.ts
+++ b/libs/backend/agents/personal/configuration/main/src/personal-configuration.types.ts
@@ -68,3 +68,31 @@ export interface PersonalConfigurationChangeDecisionRepository
 	/** Atomically accepts or rejects one still-proposed change owned by this user. */
 	decideAtomically(command: DecidePersonalConfigurationChangeCommand): Promise<{ readonly status: "accepted" | "rejected" } | { readonly status: "not_found_or_not_owner" | "already_decided" | "persistence_unavailable" }>;
 }
+
+/** Product-safe owner view of one durable future-session configuration proposal. */
+export interface PersonalConfigurationChangeView
+{
+	/** Opaque durable proposal identifier. */
+	readonly changeId: string;
+	/** Closed patch requested for a later immutable run snapshot. */
+	readonly requestedPatch: PersonalConfigurationPatch;
+	/** Current durable proposal lifecycle state. */
+	readonly state: "proposed" | "accepted" | "applied" | "rejected" | "superseded";
+	/** Conversation source that prompted the proposal. */
+	readonly sourceThreadId: string;
+	/** Run source that recorded the proposal. */
+	readonly sourceRunId: string;
+	/** Server time the proposal was created. */
+	readonly proposedAt: string;
+	/** Server time it was decided, when applicable. */
+	readonly decidedAt: string | null;
+	/** Owner-provided reason for a rejection, when applicable. */
+	readonly rejectionReason: string | null;
+}
+
+/** Read-only persistence boundary for the signed-in owner's configuration-proposal state. */
+export interface PersonalConfigurationChangeViewRepository
+{
+	/** Lists at most fifty proposals belonging to the exact owner and selected silo. */
+	listOwned(siloId: string, userId: string): Promise<readonly PersonalConfigurationChangeView[]>;
+}

--- a/libs/backend/agents/personal/configuration/main/src/prisma-personal-configuration-repository.ts
+++ b/libs/backend/agents/personal/configuration/main/src/prisma-personal-configuration-repository.ts
@@ -4,11 +4,11 @@ import { ___CreateLogger, ___DoWithTrace, type Logger } from "@opencrane/observa
 
 import { __ProposePersonalConfigurationChange } from "./personal-configuration.js";
 import { _IsPersonalConfigurationPatch } from "./configuration-patch.js";
-import type { DecidePersonalConfigurationChangeCommand, PersonalConfigurationChangeDecisionRepository, PersonalConfigurationChangeRepository, ProposePersonalConfigurationChangeCommand } from "./personal-configuration.types.js";
+import type { DecidePersonalConfigurationChangeCommand, PersonalConfigurationChangeDecisionRepository, PersonalConfigurationChangeRepository, PersonalConfigurationChangeView, PersonalConfigurationChangeViewRepository, ProposePersonalConfigurationChangeCommand } from "./personal-configuration.types.js";
 import type { UpgradeSessionProposalReceipt, UpgradeSessionProposalRepository } from "./upgrade-session.types.js";
 
 /** Prisma adapter that proves a proposal's user, thread, run, profile, and service bindings atomically. */
-export class PrismaPersonalConfigurationChangeRepository implements PersonalConfigurationChangeDecisionRepository, PersonalConfigurationChangeRepository, UpgradeSessionProposalRepository
+export class PrismaPersonalConfigurationChangeRepository implements PersonalConfigurationChangeDecisionRepository, PersonalConfigurationChangeRepository, PersonalConfigurationChangeViewRepository, UpgradeSessionProposalRepository
 {
 	/** Canonical per-silo product database. */
 	private readonly prisma: PrismaClient;
@@ -20,6 +20,13 @@ export class PrismaPersonalConfigurationChangeRepository implements PersonalConf
 	{
 		this.prisma = prisma;
 		this.logger = logger;
+	}
+
+	/** List the latest fifty personal configuration proposals owned by one user in one silo. */
+	async listOwned(siloId: string, userId: string): Promise<readonly PersonalConfigurationChangeView[]>
+	{
+		const changes = await this.prisma.personalConfigurationChange.findMany({ where: { siloId, userId }, orderBy: [{ proposedAt: "desc" }, { id: "desc" }], take: 50, select: { id: true, requestedPatch: true, state: true, sourceThreadId: true, sourceRunId: true, proposedAt: true, decidedAt: true, rejectionReason: true } });
+		return changes.map(_toChangeView);
 	}
 
 	/** Insert one request only after every mutable provenance coordinate agrees in one transaction. */
@@ -88,6 +95,23 @@ export class PrismaPersonalConfigurationChangeRepository implements PersonalConf
 		if (result.outcome !== "proposed") throw new Error(`upgrade_session proposal denied: ${result.reason}`);
 		return { changeId: result.changeId };
 	}
+}
+
+/** Map a selected canonical proposal row into the closed owner-visible product shape. */
+function _toChangeView(change: { id: string; requestedPatch: Prisma.JsonValue; state: PersonalConfigurationChangeState; sourceThreadId: string; sourceRunId: string; proposedAt: Date; decidedAt: Date | null; rejectionReason: string | null }): PersonalConfigurationChangeView
+{
+	if (!_IsPersonalConfigurationPatch(change.requestedPatch)) throw new Error("personal configuration change has unsupported patch shape");
+	return { changeId: change.id, requestedPatch: change.requestedPatch, state: _state(change.state), sourceThreadId: change.sourceThreadId, sourceRunId: change.sourceRunId, proposedAt: change.proposedAt.toISOString(), decidedAt: change.decidedAt?.toISOString() ?? null, rejectionReason: change.rejectionReason };
+}
+
+/** Convert the database lifecycle enum to its stable product spelling. */
+function _state(state: PersonalConfigurationChangeState): PersonalConfigurationChangeView["state"]
+{
+	if (state === PersonalConfigurationChangeState.Proposed) return "proposed";
+	if (state === PersonalConfigurationChangeState.Accepted) return "accepted";
+	if (state === PersonalConfigurationChangeState.Applied) return "applied";
+	if (state === PersonalConfigurationChangeState.Rejected) return "rejected";
+	return "superseded";
 }
 
 /** Recognise the database's explicit business-fence rejection without exposing database details. */

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -33,6 +33,7 @@ import { _SelfRunStatusOpenapiPaths } from "@opencrane/backend/agents/execution/
 import { _PersonaOnboardingOpenapiPaths } from "@opencrane/backend/agents/personal/personas";
 import { _SelfConversationReplayOpenapiPaths } from "@opencrane/backend/server/agents/conversation-replay";
 import { _AgentServicesOpenapiPaths } from "@opencrane/backend/server/agents/agent-services";
+import { _PersonalConfigurationOpenapiPaths } from "@opencrane/backend/agents/personal/configuration";
 
 // ---------------------------------------------------------------------------
 // Reusable schema components
@@ -730,6 +731,20 @@ export const spec = {
           updatedAt: { type: "string", format: "date-time" },
         },
       },
+      PersonalConfigurationChange: {
+        type: "object",
+        required: ["changeId", "requestedPatch", "state", "sourceThreadId", "sourceRunId", "proposedAt", "decidedAt", "rejectionReason"],
+        properties: {
+          changeId: { type: "string" },
+          requestedPatch: { oneOf: [{ type: "object", required: ["kind"], additionalProperties: false, properties: { kind: { const: "persona_refresh" } } }, { type: "object", required: ["kind", "modelAlias"], additionalProperties: false, properties: { kind: { const: "model_alias" }, modelAlias: { type: "string", minLength: 1, maxLength: 200, pattern: ".*\\S.*" } } }] },
+          state: { type: "string", enum: ["proposed", "accepted", "applied", "rejected", "superseded"] },
+          sourceThreadId: { type: "string" },
+          sourceRunId: { type: "string" },
+          proposedAt: { type: "string", format: "date-time" },
+          decidedAt: { type: "string", format: "date-time", nullable: true },
+          rejectionReason: { type: "string", nullable: true },
+        },
+      },
       ZitadelCandidateKeyValidation: {
         type: "object",
         required: ["tokenExchangeOk", "instanceScopeOk", "keyId", "detail"],
@@ -820,6 +835,7 @@ export const spec = {
     ..._PersonaOnboardingOpenapiPaths,
     ..._SelfConversationReplayOpenapiPaths,
     ..._AgentServicesOpenapiPaths,
+    ..._PersonalConfigurationOpenapiPaths,
 
     // ------------------------------------------------------------------
     // Auth — OIDC browser flow and session introspection

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1222,6 +1222,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/configuration/changes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the signed-in owner's personal configuration proposals
+         * @description The server derives the owner and silo from session and host. It returns at most fifty durable future-session proposals, never a mutable run snapshot.
+         */
+        get: operations["listMyPersonalConfigurationChanges"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -1910,6 +1930,26 @@ export interface components {
             createdAt: string;
             /** Format: date-time */
             updatedAt: string;
+        };
+        PersonalConfigurationChange: {
+            changeId: string;
+            requestedPatch: {
+                /** @constant */
+                kind: "persona_refresh";
+            } | {
+                /** @constant */
+                kind: "model_alias";
+                modelAlias: string;
+            };
+            /** @enum {string} */
+            state: "proposed" | "accepted" | "applied" | "rejected" | "superseded";
+            sourceThreadId: string;
+            sourceRunId: string;
+            /** Format: date-time */
+            proposedAt: string;
+            /** Format: date-time */
+            decidedAt: string | null;
+            rejectionReason: string | null;
         };
         ZitadelCandidateKeyValidation: {
             /** @description Whether the candidate key's jwt-bearer token exchange succeeded. */
@@ -5509,6 +5549,46 @@ export interface operations {
             };
             /** @description The management authority could not read the catalogue. */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listMyPersonalConfigurationChanges: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Owner-bound configuration proposal history. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        changes: components["schemas"]["PersonalConfigurationChange"][];
+                    };
+                };
+            };
+            /** @description No browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Configuration proposal history could not be read. */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## What this adds

A signed-in person can now retrieve their durable, future-session personal configuration proposals through `GET /api/v1/me/configuration/changes`. This lets product state show requests such as a persona refresh or a chosen model alias without mutating an in-flight run.

## Boundary

The server derives the owner from the browser session and silo from the request host. The database query binds both, orders newest-first with an ID tie-breaker, and caps the history at fifty. It returns only the closed patch vocabulary, state, source thread/run, and decision timestamps; no snapshot, credential, tool, or revision content is exposed.

The OpenAPI union matches runtime validation exactly: closed variants only, and model aliases are 1–200 characters with at least one non-whitespace character.

## Validation

- `npx nx run backend-agents-personal-configuration:test` — 16 tests passed
- configuration package, server, API-spec, and contracts TypeScript checks
- regenerated OpenAPI and typed API client
- `scripts/agent-style-check.sh` and `git diff --check`

## Review

Independent review found one Medium contract mismatch around the closed patch shape. It was corrected and independently verified before this PR.