### PR TITLE
✅ Phase F: decide owner-bound configuration proposals

### DIFF
--- a/apps/opencrane/src/app/personal-configuration-wiring.ts
+++ b/apps/opencrane/src/app/personal-configuration-wiring.ts
@@ -10,7 +10,8 @@ import { _log } from "./log.js";
 /** Compose the owner-only personal configuration proposal state API. */
 export function _CreatePersonalConfigurationRouter(prisma: PrismaClient): Router
 {
-	return __CreatePersonalConfigurationRouter({ resolveCaller: _resolveCaller, changes: new PrismaPersonalConfigurationChangeRepository(prisma), logger: _log });
+	const changes = new PrismaPersonalConfigurationChangeRepository(prisma);
+	return __CreatePersonalConfigurationRouter({ resolveCaller: _resolveCaller, changes, decisions: changes, clock: { now(): Date { return new Date(); } }, logger: _log });
 }
 
 /** Derive the proposal owner from the signed-in browser session and trusted host silo. */

--- a/libs/backend/agents/personal/configuration/main/README.md
+++ b/libs/backend/agents/personal/configuration/main/README.md
@@ -20,8 +20,8 @@ snapshot and only while the recorded active revisions still match.
 
 The invariant is that a proposal is durable provenance, not mutable session state. Missing or
 cross-owner source coordinates fail closed. This foundation does not itself apply a patch; its
-owner-only browser API can list durable proposal history, while a later decision route will use the
-existing atomic decision authority. Its first-party `upgrade_session` descriptor is always callable in
+owner-only browser API lists durable proposal history and records an explicit accept-or-reject
+decision through the existing atomic authority. Its first-party `upgrade_session` descriptor is always callable in
 a personal conversation, but its call records only a proposed change in this same journal; it never
 means the request is already user-approved or applied.
 
@@ -34,8 +34,9 @@ means the request is already user-approved or applied.
 - `__DecidePersonalConfigurationChange` records the owner's `Accepted` or `Rejected` decision but
   never applies a patch itself.
 - `__CreatePersonalConfigurationRouter` and `PrismaPersonalConfigurationChangeRepository` provide
-  the owner-only `GET /api/v1/me/configuration/changes` history. It lists at most fifty proposals
-  in the signed-in owner's selected silo and does not alter any current run snapshot.
+  the owner-only configuration API: `GET /api/v1/me/configuration/changes` lists at most fifty
+  proposals in the signed-in owner's selected silo, and `POST /api/v1/me/configuration/changes/:changeId/decision`
+  records their accept-or-reject consent. Neither endpoint alters any current run snapshot.
 - `UPGRADE_SESSION_TOOL` / `__IsUpgradeSessionAvailable` describe the built-in, non-MCP tool the app
   adds only to personal conversation inputs.
 - `PersonalConfigurationPatch` is a closed union: `persona_refresh` requests the normal interview

--- a/libs/backend/agents/personal/configuration/main/src/__tests__/personal-configuration.router.test.ts
+++ b/libs/backend/agents/personal/configuration/main/src/__tests__/personal-configuration.router.test.ts
@@ -10,8 +10,10 @@ import type { PersonalConfigurationChangeView } from "../personal-configuration.
 function _app(caller: unknown, listOwned = vi.fn(async function _list(): Promise<readonly PersonalConfigurationChangeView[]> { return []; }))
 {
 	const app = express();
-	app.use(__CreatePersonalConfigurationRouter({ resolveCaller: function _caller() { return caller as never; }, changes: { listOwned }, logger: { error: vi.fn() } as unknown as Logger }));
-	return { app, listOwned };
+	const decideAtomically = vi.fn(async function _decide() { return { status: "accepted" } as const; });
+	app.use(express.json());
+	app.use(__CreatePersonalConfigurationRouter({ resolveCaller: function _caller() { return caller as never; }, changes: { listOwned }, decisions: { decideAtomically }, clock: { now: function _now() { return new Date("2026-07-26T12:00:00.000Z"); } }, logger: { error: vi.fn() } as unknown as Logger }));
+	return { app, decideAtomically, listOwned };
 }
 
 describe("personal configuration router", function _suite()
@@ -29,5 +31,14 @@ describe("personal configuration router", function _suite()
 	{
 		const response = await request(_app(null).app).get("/changes");
 		expect(response.status).toBe(401);
+	});
+
+	it("decides using only the session-derived owner and trusted server time", async function _decides()
+	{
+		const { app, decideAtomically } = _app({ siloId: "silo-1", userId: "user-1" });
+		const response = await request(app).post("/changes/change-1/decision").send({ decision: "accepted" });
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ changeId: "change-1", state: "accepted" });
+		expect(decideAtomically).toHaveBeenCalledWith({ siloId: "silo-1", userId: "user-1", changeId: "change-1", decision: "accepted", rejectionReason: null, decidedAt: "2026-07-26T12:00:00.000Z" });
 	});
 });

--- a/libs/backend/agents/personal/configuration/main/src/openapi.ts
+++ b/libs/backend/agents/personal/configuration/main/src/openapi.ts
@@ -1,5 +1,22 @@
 /** OpenAPI path fragment for the signed-in owner's personal configuration proposal state. */
 export const _PersonalConfigurationOpenapiPaths = {
+	"/me/configuration/changes/{changeId}/decision": {
+		post: {
+			operationId: "decideMyPersonalConfigurationChange",
+			summary: "Accept or reject one signed-in owner's configuration proposal",
+			description: "The server derives the owner, silo, and decision time. A decision records consent only; it never applies a patch to an existing run snapshot.",
+			tags: ["Personal configuration"],
+			parameters: [{ name: "changeId", in: "path", required: true, schema: { type: "string" } }],
+			requestBody: { required: true, content: { "application/json": { schema: { oneOf: [{ type: "object", required: ["decision"], additionalProperties: false, properties: { decision: { const: "accepted" } } }, { type: "object", required: ["decision", "rejectionReason"], additionalProperties: false, properties: { decision: { const: "rejected" }, rejectionReason: { type: "string", minLength: 1, maxLength: 200, pattern: ".*\\S.*" } } }] } } } },
+			responses: {
+				200: { description: "Owner decision recorded.", content: { "application/json": { schema: { type: "object", required: ["changeId", "state"], properties: { changeId: { type: "string" }, state: { type: "string", enum: ["accepted", "rejected"] } } } } } },
+				400: { description: "Decision body is not the exact accepted or rejected shape.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				401: { description: "No browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				404: { description: "Proposal is absent, terminal, or not owned by the caller.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "Decision could not be persisted.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
 	"/me/configuration/changes": {
 		get: {
 			operationId: "listMyPersonalConfigurationChanges",

--- a/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.ts
+++ b/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from "express";
 
+import { __DecidePersonalConfigurationChange } from "./personal-configuration-decision.js";
 import type { PersonalConfigurationRouterDependencies } from "./personal-configuration.router.types.js";
 
 /** Create the browser-session-authenticated personal configuration proposal state router. */
@@ -21,5 +22,36 @@ export function __CreatePersonalConfigurationRouter(dependencies: PersonalConfig
 			response.status(503).json({ error: "configuration_list_unavailable" });
 		}
 	});
+	router.post("/changes/:changeId/decision", async function _decide(request: Request, response: Response)
+	{
+		const caller = dependencies.resolveCaller(request);
+		const changeId = request.params["changeId"];
+		const decision = _decision(request.body);
+		if (caller === null) { response.status(401).json({ error: "configuration_authentication_required" }); return; }
+		if (typeof changeId !== "string" || changeId.trim().length === 0 || decision === null) { response.status(400).json({ error: "invalid_configuration_decision" }); return; }
+		try
+		{
+			const result = await __DecidePersonalConfigurationChange(dependencies.decisions, { siloId: caller.siloId, userId: caller.userId, changeId, decision: decision.decision, rejectionReason: decision.rejectionReason, decidedAt: dependencies.clock.now().toISOString() });
+			if (result.outcome !== "denied") { response.status(200).json({ changeId, state: result.outcome }); return; }
+			if (result.reason === "not_found_or_not_owner" || result.reason === "already_decided") { response.status(404).json({ error: "configuration_change_not_found" }); return; }
+			if (result.reason === "persistence_unavailable") { response.status(503).json({ error: "configuration_decision_unavailable" }); return; }
+			response.status(400).json({ error: "invalid_configuration_decision" });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "personal_configuration.decide", siloId: caller.siloId }, "Personal configuration decision failed");
+			response.status(503).json({ error: "configuration_decision_unavailable" });
+		}
+	});
 	return router;
+}
+
+/** Accept only the closed decision payload; callers cannot supply ownership or application fields. */
+function _decision(body: unknown): { readonly decision: "accepted" | "rejected"; readonly rejectionReason: string | null } | null
+{
+	if (body === null || typeof body !== "object" || Array.isArray(body)) return null;
+	const values = body as Record<string, unknown>;
+	if (values.decision === "accepted" && Object.keys(values).length === 1) return { decision: "accepted", rejectionReason: null };
+	if (values.decision === "rejected" && typeof values.rejectionReason === "string" && Object.keys(values).length === 2) return { decision: "rejected", rejectionReason: values.rejectionReason };
+	return null;
 }

--- a/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.types.ts
+++ b/libs/backend/agents/personal/configuration/main/src/personal-configuration.router.types.ts
@@ -1,7 +1,7 @@
 import type { Request } from "express";
 import type { Logger } from "@opencrane/observability";
 
-import type { PersonalConfigurationChangeViewRepository } from "./personal-configuration.types.js";
+import type { PersonalConfigurationChangeDecisionRepository, PersonalConfigurationChangeViewRepository } from "./personal-configuration.types.js";
 
 /** Trusted browser identity for the owner-only configuration-proposal read surface. */
 export interface PersonalConfigurationCaller
@@ -19,6 +19,10 @@ export interface PersonalConfigurationRouterDependencies
 	resolveCaller(request: Request): PersonalConfigurationCaller | null;
 	/** Reads only durable proposals owned by the resolved caller. */
 	readonly changes: PersonalConfigurationChangeViewRepository;
+	/** Atomically records an owner decision without applying the proposed patch. */
+	readonly decisions: PersonalConfigurationChangeDecisionRepository;
+	/** Supplies trusted decision timestamps. */
+	readonly clock: { now(): Date };
 	/** Records unexpected persistence failures without logging patch contents. */
 	readonly logger: Logger;
 }

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1222,6 +1222,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/configuration/changes/{changeId}/decision": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Accept or reject one signed-in owner's configuration proposal
+         * @description The server derives the owner, silo, and decision time. A decision records consent only; it never applies a patch to an existing run snapshot.
+         */
+        post: operations["decideMyPersonalConfigurationChange"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/me/configuration/changes": {
         parameters: {
             query?: never;
@@ -5549,6 +5569,79 @@ export interface operations {
             };
             /** @description The management authority could not read the catalogue. */
             500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    decideMyPersonalConfigurationChange: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                changeId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @constant */
+                    decision: "accepted";
+                } | {
+                    /** @constant */
+                    decision: "rejected";
+                    rejectionReason: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Owner decision recorded. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        changeId: string;
+                        /** @enum {string} */
+                        state: "accepted" | "rejected";
+                    };
+                };
+            };
+            /** @description Decision body is not the exact accepted or rejected shape. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Proposal is absent, terminal, or not owned by the caller. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Decision could not be persisted. */
+            503: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## What this adds

A signed-in owner can now accept or reject a listed personal configuration proposal through `POST /api/v1/me/configuration/changes/:changeId/decision`. The decision records explicit consent for a future session only; it never changes an active run, persona, or agent revision.

## Security boundary

The server derives user, silo, and decision timestamp from the browser session and request host. Clients can submit only the exact accepted shape or a rejected shape with a bounded nonblank reason. The persistence authority atomically binds the decision to the durable owner and maps foreign, absent, and already-terminal proposals to the same non-disclosing 404.

## Validation

- `backend-agents-personal-configuration:test` — 17 tests passed
- configuration, server, API-spec, and contracts TypeScript checks
- regenerated OpenAPI and typed API client
- `scripts/agent-style-check.sh` and `git diff --check`

## Review

Independent review found one Medium README drift. The README now documents both owner-only endpoints and the consent-only/no-current-snapshot-mutation boundary; the reviewer independently verified the fix.