### PR TITLE
📚 Phase F: discover governed skills safely

### DIFF
--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -41,6 +41,7 @@ import { _CreateSteeringIngestRouter } from "./steering-ingest-wiring.js";
 import { _CreateSelfConversationReplayRouter } from "./self-conversation-replay-wiring.js";
 import { _CreateSelfRunStatusRouter } from "./self-run-status-wiring.js";
 import { _CreatePersonalConfigurationRouter } from "./personal-configuration-wiring.js";
+import { _CreateSkillCatalogueRouter } from "./skill-catalogue-wiring.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
@@ -376,6 +377,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/token-usage", tokenUsageRouter(prisma));
   app.use("/api/v1/groups", groupsRouter(prisma));
   app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma, runAdmission));
+  app.use("/api/v1/skills", _CreateSkillCatalogueRouter(prisma));
   app.use("/api/v1/me/persona", _CreatePersonaOnboardingRouter(prisma));
   app.use("/api/v1/me/approvals", _CreateDeferredToolApprovalRouter(prisma));
 	app.use("/api/v1/me/runs", _CreateSteeringIngestRouter(prisma));

--- a/apps/opencrane/src/app/skill-catalogue-wiring.ts
+++ b/apps/opencrane/src/app/skill-catalogue-wiring.ts
@@ -1,0 +1,22 @@
+import type { Request, Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { __CreateSkillCatalogueRouter, PrismaSkillAuthorityRepository, type SkillCatalogueCaller } from "@opencrane/backend/server/agents/skills";
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+import "@opencrane/server/_infra/auth";
+
+import { _log } from "./log.js";
+
+/** Compose the authenticated, browser-safe governed skill catalogue API. */
+export function _CreateSkillCatalogueRouter(prisma: PrismaClient): Router
+{
+	return __CreateSkillCatalogueRouter({ resolveCaller: _resolveCaller, catalogue: new PrismaSkillAuthorityRepository(prisma), logger: _log });
+}
+
+/** Derive only the exact catalogue silo from the signed-in browser session and trusted host. */
+function _resolveCaller(request: Request): SkillCatalogueCaller | null
+{
+	if (!request.session?.authUser) return null;
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	return siloId ? { siloId } : null;
+}

--- a/libs/backend/server/agents/skills/main/README.md
+++ b/libs/backend/server/agents/skills/main/README.md
@@ -12,10 +12,9 @@ authority that publishes a reviewed skill revision.
 
 It is the final step of the authoring flow. A bundle is authored, uploaded as an artifact, then
 tested, scanned, and signed by an isolated job; this package publishes the revision only when that
-server-owned review evidence and the artifact reference still line up. The later product API is
-deliberately not composed yet: it needs the authoritative fleet-to-silo membership projection to
-prove the administrator belongs to the host-derived ClusterTenant, rather than trusting a global
-session flag.
+server-owned review evidence and the artifact reference still line up. Its read-only catalogue API
+is composed by the OpenCrane app: an authenticated browser session and request host select the
+silo, and callers see only safe skill metadata.
 
 ```
  authored skill bundle  ──►  ArtifactRevision (exact content address)
@@ -50,6 +49,10 @@ or invalidates inputs already accepted for a run.
 - `__RevokeSkillRevision` — the future-only withdrawal use case for an exact published revision.
 - `PrismaSkillAuthorityRepository.revokeAtomically` — shares the publication lock order, changes
   `published → revoked`, and conditionally clears the live current-revision pointer.
+- `__CreateSkillCatalogueRouter` — serves `GET /api/v1/skills`, a bounded catalogue of skill name,
+  description, lifecycle, and current-revision state in the trusted host silo.
+- `SkillCatalogueRepository` and `SkillCatalogueEntry` — the narrow read boundary and safe summary
+  shape used by the browser catalogue.
 - Types: `SkillAuthorityRepository` (the persistence boundary), `PublishSkillRevisionCommand`,
   `PublishSkillRevisionResult`, `SkillPublicationEvidence`, `SkillPublicationSnapshot`, and the
   atomic result `AtomicPublishSkillRevisionResult`.
@@ -62,6 +65,11 @@ records that a reviewed revision is now published, consistently with the artifac
 It is not an OCI/package registry, has no internal bundle-download route, and does not configure or
 communicate with the retired `feat-skill-registry` workload. It does not re-evaluate or cancel
 already accepted runs; their immutable snapshots remain the audit record.
+
+The catalogue deliberately excludes artifact content addresses, bundle bytes, manifests,
+requirements, test and scan evidence, signatures, signer keys, reviewer identities, and all
+authoring or tool-runner workload coordinates. It is a discovery surface, not a skill authoring,
+publication, download, or execution API.
 
 ## Dependency direction
 

--- a/libs/backend/server/agents/skills/main/src/__tests__/prisma-skill-catalogue.test.ts
+++ b/libs/backend/server/agents/skills/main/src/__tests__/prisma-skill-catalogue.test.ts
@@ -1,0 +1,22 @@
+import { SkillRevisionState, SkillState, type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaSkillAuthorityRepository } from "../prisma-skill-authority.js";
+
+/** Builds one persisted row containing only the catalogue fields safe for browser delivery. */
+function _skillRow()
+{
+	return { id: "skill-1", name: "Research", description: "Summarises trusted sources.", state: SkillState.Active, currentRevisionId: "revision-1", currentRevision: { state: SkillRevisionState.Published }, createdAt: new Date("2026-07-26T12:00:00.000Z"), updatedAt: new Date("2026-07-26T13:00:00.000Z") };
+}
+
+describe("Prisma skill catalogue", function _suite()
+{
+	it("reads only the host-derived silo in a bounded deterministic order", async function _listsSiloCatalogue()
+	{
+		const findMany = vi.fn().mockResolvedValue([_skillRow()]);
+		const prisma = { skill: { findMany } } as unknown as PrismaClient;
+
+		await expect(new PrismaSkillAuthorityRepository(prisma).listCatalogue("silo-1")).resolves.toEqual([{ id: "skill-1", name: "Research", description: "Summarises trusted sources.", state: "active", currentRevisionId: "revision-1", currentRevisionState: "published", createdAt: "2026-07-26T12:00:00.000Z", updatedAt: "2026-07-26T13:00:00.000Z" }]);
+		expect(findMany).toHaveBeenCalledWith({ where: { siloId: "silo-1" }, select: { id: true, name: true, description: true, state: true, currentRevisionId: true, currentRevision: { select: { state: true } }, createdAt: true, updatedAt: true }, orderBy: [{ updatedAt: "desc" }, { id: "desc" }], take: 200 });
+	});
+});

--- a/libs/backend/server/agents/skills/main/src/__tests__/skill-catalogue.router.test.ts
+++ b/libs/backend/server/agents/skills/main/src/__tests__/skill-catalogue.router.test.ts
@@ -1,0 +1,41 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "@opencrane/observability";
+
+import { __CreateSkillCatalogueRouter } from "../skill-catalogue.router.js";
+import type { SkillCatalogueRouterDependencies } from "../skill-catalogue.router.types.js";
+
+/** Builds router dependencies with a caller and observable silo-bound catalogue port. */
+function _dependencies(overrides: Partial<SkillCatalogueRouterDependencies> = {}): SkillCatalogueRouterDependencies
+{
+	return { resolveCaller: function _caller() { return { siloId: "silo-1" }; }, catalogue: { listCatalogue: vi.fn().mockResolvedValue([]) }, logger: { error: vi.fn() } as unknown as Logger, ...overrides };
+}
+
+/** Mounts the router beneath its public skill catalogue prefix. */
+function _app(dependencies: SkillCatalogueRouterDependencies)
+{
+	const app = express();
+	app.use("/api/v1/skills", __CreateSkillCatalogueRouter(dependencies));
+	return app;
+}
+
+describe("skill catalogue router", function _suite()
+{
+	it("lists only the session-derived silo catalogue", async function _lists()
+	{
+		const listCatalogue = vi.fn().mockResolvedValue([{ id: "skill-1" }]);
+		const response = await request(_app(_dependencies({ catalogue: { listCatalogue } }))).get("/api/v1/skills/");
+
+		expect(response.status).toBe(200);
+		expect(response.body.skills).toEqual([{ id: "skill-1" }]);
+		expect(listCatalogue).toHaveBeenCalledWith("silo-1");
+	});
+
+	it("requires an authenticated caller before catalogue discovery", async function _requiresCaller()
+	{
+		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).get("/api/v1/skills/");
+
+		expect(response.status).toBe(401);
+	});
+});

--- a/libs/backend/server/agents/skills/main/src/index.ts
+++ b/libs/backend/server/agents/skills/main/src/index.ts
@@ -1,4 +1,7 @@
 export { __PublishSkillRevision } from "./skill-publication.js";
 export { __RevokeSkillRevision } from "./skill-revocation.js";
 export { PrismaSkillAuthorityRepository } from "./prisma-skill-authority.js";
-export type { AtomicPublishSkillRevisionResult, AtomicRevokeSkillRevisionResult, PublishSkillRevisionCommand, PublishSkillRevisionResult, RevokeSkillRevisionCommand, RevokeSkillRevisionResult, SkillAuthorityRepository, SkillPublicationEvidence, SkillPublicationSnapshot, SkillRevocationRepository } from "./skill-publication.types.js";
+export { __CreateSkillCatalogueRouter } from "./skill-catalogue.router.js";
+export { _SkillCatalogueOpenapiPaths } from "./openapi.js";
+export type { AtomicPublishSkillRevisionResult, AtomicRevokeSkillRevisionResult, PublishSkillRevisionCommand, PublishSkillRevisionResult, RevokeSkillRevisionCommand, RevokeSkillRevisionResult, SkillAuthorityRepository, SkillCatalogueEntry, SkillCatalogueRepository, SkillPublicationEvidence, SkillPublicationSnapshot, SkillRevocationRepository } from "./skill-publication.types.js";
+export type { SkillCatalogueCaller, SkillCatalogueRouterDependencies } from "./skill-catalogue.router.types.js";

--- a/libs/backend/server/agents/skills/main/src/openapi.ts
+++ b/libs/backend/server/agents/skills/main/src/openapi.ts
@@ -1,0 +1,45 @@
+/** OpenAPI path fragment for the browser-safe silo-scoped skill catalogue. */
+export const _SkillCatalogueOpenapiPaths = {
+	"/skills": {
+		get: {
+			operationId: "listSkills",
+			summary: "List governed skills in the signed-in caller's silo",
+			description: "The server derives the silo from the browser session and request host. It returns at most two hundred catalogue summaries, never skill bundles, artifact addresses, manifests, review evidence, signatures, or workload coordinates.",
+			tags: ["Skills"],
+			responses: {
+				200: {
+					description: "Browser-safe governed skill catalogue.",
+					content: {
+						"application/json": {
+							schema: {
+								type: "object",
+								required: ["skills"],
+								properties: {
+									skills: {
+										type: "array",
+										items: {
+											type: "object",
+											required: ["id", "name", "description", "state", "currentRevisionId", "currentRevisionState", "createdAt", "updatedAt"],
+											properties: {
+												id: { type: "string" },
+												name: { type: "string" },
+												description: { type: "string" },
+												state: { type: "string", enum: ["active", "retired"] },
+												currentRevisionId: { type: ["string", "null"] },
+												currentRevisionState: { type: ["string", "null"], enum: ["draft", "review", "published", "rejected", "revoked", null] },
+												createdAt: { type: "string", format: "date-time" },
+												updatedAt: { type: "string", format: "date-time" },
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				401: { description: "No authenticated browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "The skill catalogue could not be read.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
+};

--- a/libs/backend/server/agents/skills/main/src/prisma-skill-authority.ts
+++ b/libs/backend/server/agents/skills/main/src/prisma-skill-authority.ts
@@ -2,10 +2,10 @@ import { Prisma, SkillRevisionState, SkillState, type PrismaClient } from "@pris
 
 import { ___DoWithTrace } from "@opencrane/observability";
 
-import type { AtomicPublishSkillRevisionResult, AtomicRevokeSkillRevisionResult, PublishSkillRevisionCommand, RevokeSkillRevisionCommand, SkillAuthorityRepository, SkillPublicationSnapshot, SkillRevocationRepository } from "./skill-publication.types.js";
+import type { AtomicPublishSkillRevisionResult, AtomicRevokeSkillRevisionResult, PublishSkillRevisionCommand, RevokeSkillRevisionCommand, SkillAuthorityRepository, SkillCatalogueEntry, SkillCatalogueRepository, SkillPublicationSnapshot, SkillRevocationRepository } from "./skill-publication.types.js";
 
 /** Postgres authority that publishes one reviewed SkillRevision and advances its logical pointer. */
-export class PrismaSkillAuthorityRepository implements SkillAuthorityRepository, SkillRevocationRepository
+export class PrismaSkillAuthorityRepository implements SkillAuthorityRepository, SkillCatalogueRepository, SkillRevocationRepository
 {
 	/** Canonical OpenCrane catalog database client. */
 	private readonly prisma: PrismaClient;
@@ -27,6 +27,16 @@ export class PrismaSkillAuthorityRepository implements SkillAuthorityRepository,
 			const artifact = await self.prisma.artifactRevision.findFirst({ where: { id: command.artifactRevisionId, contentAddress: command.artifactContentAddress, artifact: { siloId: command.siloId } }, select: { state: true } });
 			if (artifact === null) return null;
 			return { skillState: revision.skill.state === SkillState.Active ? "active" : "retired", currentRevisionId: revision.skill.currentRevisionId, state: _ToPublicationState(revision.state), artifactPublished: artifact.state === "Published", artifactContentAddress: revision.artifactContentAddress, evidence: _Evidence(revision) };
+		});
+	}
+
+	/** List only browser-safe catalogue metadata from the exact host-derived silo. */
+	async listCatalogue(siloId: string): Promise<readonly SkillCatalogueEntry[]>
+	{
+		const skills = await this.prisma.skill.findMany({ where: { siloId }, select: { id: true, name: true, description: true, state: true, currentRevisionId: true, currentRevision: { select: { state: true } }, createdAt: true, updatedAt: true }, orderBy: [{ updatedAt: "desc" }, { id: "desc" }], take: 200 });
+		return skills.map(function _toCatalogueEntry(skill): SkillCatalogueEntry
+		{
+			return { id: skill.id, name: skill.name, description: skill.description, state: skill.state === SkillState.Active ? "active" : "retired", currentRevisionId: skill.currentRevisionId, currentRevisionState: skill.currentRevision === null ? null : _ToPublicationState(skill.currentRevision.state), createdAt: skill.createdAt.toISOString(), updatedAt: skill.updatedAt.toISOString() };
 		});
 	}
 
@@ -100,39 +110,6 @@ export class PrismaSkillAuthorityRepository implements SkillAuthorityRepository,
 		}
 	}
 
-	/** Lock and revoke one scoped published revision without changing already admitted run snapshots. */
-	async revokeAtomically(command: RevokeSkillRevisionCommand): Promise<AtomicRevokeSkillRevisionResult>
-	{
-		const self = this;
-		try
-		{
-			return await ___DoWithTrace("skills.revision.revoke", { siloId: command.siloId, skillId: command.skillId, skillRevisionId: command.skillRevisionId }, async function _traceRevocation(): Promise<AtomicRevokeSkillRevisionResult>
-			{
-				return await self.prisma.$transaction(async function _revoke(transaction: Prisma.TransactionClient): Promise<AtomicRevokeSkillRevisionResult>
-				{
-					// 1. Lock the logical skill before its revision so publication and revocation share one lock order.
-					await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "skills" WHERE "id" = ${command.skillId} AND "silo_id" = ${command.siloId} FOR UPDATE`);
-					await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "skill_revisions" WHERE "id" = ${command.skillRevisionId} AND "skill_id" = ${command.skillId} FOR UPDATE`);
-
-					// 2. Recheck the trusted silo and lifecycle state while those locks prevent a stale transition.
-					const revision = await transaction.skillRevision.findFirst({ where: { id: command.skillRevisionId, skillId: command.skillId, skill: { siloId: command.siloId } }, select: { id: true, state: true } });
-					if (revision === null) return { status: "not_found" };
-					if (revision.state !== SkillRevisionState.Published) return { status: "not_published" };
-
-					// 3. Transition exactly once and remove the pointer only if it still targets this withdrawn revision.
-					const revoked = await transaction.skillRevision.updateMany({ where: { id: command.skillRevisionId, skillId: command.skillId, state: SkillRevisionState.Published }, data: { state: SkillRevisionState.Revoked, revokedAt: new Date(command.revokedAt) } });
-					if (revoked.count !== 1) return { status: "conflict" };
-					const skill = await transaction.skill.updateMany({ where: { id: command.skillId, siloId: command.siloId, currentRevisionId: command.skillRevisionId }, data: { currentRevisionId: null } });
-					return skill.count <= 1 ? { status: "revoked" } : { status: "conflict" };
-				});
-			});
-		}
-		catch (error)
-		{
-			if (error instanceof Prisma.PrismaClientKnownRequestError && (error.code === "P2002" || error.code === "P2034")) return { status: "conflict" };
-			throw error;
-		}
-	}
 }
 
 /** Forces rollback when the final pointer compare-and-swap loses after the revision lifecycle write. */

--- a/libs/backend/server/agents/skills/main/src/skill-catalogue.router.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-catalogue.router.ts
@@ -1,0 +1,25 @@
+import { Router, type Request, type Response } from "express";
+
+import type { SkillCatalogueRouterDependencies } from "./skill-catalogue.router.types.js";
+
+/** Create the browser-session-authenticated, read-only skill catalogue router. */
+export function __CreateSkillCatalogueRouter(dependencies: SkillCatalogueRouterDependencies): Router
+{
+	const router = Router();
+	router.get("/", async function _list(request: Request, response: Response)
+	{
+		const caller = dependencies.resolveCaller(request);
+		if (caller === null) { response.status(401).json({ error: "skill_catalogue_authentication_required" }); return; }
+		try
+		{
+			const skills = await dependencies.catalogue.listCatalogue(caller.siloId);
+			response.status(200).json({ skills });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "skills.catalogue.list", siloId: caller.siloId }, "Skill catalogue list failed");
+			response.status(503).json({ error: "skill_catalogue_unavailable" });
+		}
+	});
+	return router;
+}

--- a/libs/backend/server/agents/skills/main/src/skill-catalogue.router.types.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-catalogue.router.types.ts
@@ -1,0 +1,23 @@
+import type { Request } from "express";
+
+import type { Logger } from "@opencrane/observability";
+
+import type { SkillCatalogueRepository } from "./skill-publication.types.js";
+
+/** Trusted browser identity used only to select a skill catalogue silo. */
+export interface SkillCatalogueCaller
+{
+	/** Silo derived from the authenticated request host. */
+	readonly siloId: string;
+}
+
+/** Composition ports for the read-only skill catalogue router. */
+export interface SkillCatalogueRouterDependencies
+{
+	/** Resolves the authenticated browser caller and trusted host silo. */
+	resolveCaller(request: Request): SkillCatalogueCaller | null;
+	/** Reads the bounded catalogue from the resolved silo only. */
+	readonly catalogue: SkillCatalogueRepository;
+	/** Records unexpected catalogue persistence failures without logging skill content. */
+	readonly logger: Logger;
+}

--- a/libs/backend/server/agents/skills/main/src/skill-publication.types.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-publication.types.ts
@@ -82,6 +82,34 @@ export interface SkillRevocationRepository
 	revokeAtomically(command: RevokeSkillRevisionCommand): Promise<AtomicRevokeSkillRevisionResult>;
 }
 
+/** A browser-safe summary of one governed skill in the caller's silo. */
+export interface SkillCatalogueEntry
+{
+	/** Stable skill identifier. */
+	readonly id: string;
+	/** Human-readable skill name. */
+	readonly name: string;
+	/** Human-readable summary supplied while authoring the skill. */
+	readonly description: string;
+	/** Current lifecycle state of the logical skill. */
+	readonly state: "active" | "retired";
+	/** Identifier of the revision selected for new admissions, when any. */
+	readonly currentRevisionId: string | null;
+	/** Lifecycle state of the selected revision, when any. */
+	readonly currentRevisionState: "draft" | "review" | "published" | "rejected" | "revoked" | null;
+	/** Creation instant in ISO-8601 form. */
+	readonly createdAt: string;
+	/** Most recent metadata or current-pointer update instant in ISO-8601 form. */
+	readonly updatedAt: string;
+}
+
+/** Reads the browser-safe skill catalogue within an already trusted silo boundary. */
+export interface SkillCatalogueRepository
+{
+	/** Returns a bounded, deterministic list of skill summaries from one silo. */
+	listCatalogue(siloId: string): Promise<readonly SkillCatalogueEntry[]>;
+}
+
 /** Stable result of attempting to revoke one skill revision. */
 export type RevokeSkillRevisionResult = { readonly outcome: "revoked" } | { readonly outcome: "denied"; readonly reason: "invalid_command" | "not_found" | "not_published" | "conflict" };
 

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -34,6 +34,7 @@ import { _PersonaOnboardingOpenapiPaths } from "@opencrane/backend/agents/person
 import { _SelfConversationReplayOpenapiPaths } from "@opencrane/backend/server/agents/conversation-replay";
 import { _AgentServicesOpenapiPaths } from "@opencrane/backend/server/agents/agent-services";
 import { _PersonalConfigurationOpenapiPaths } from "@opencrane/backend/agents/personal/configuration";
+import { _SkillCatalogueOpenapiPaths } from "@opencrane/backend/server/agents/skills";
 
 // ---------------------------------------------------------------------------
 // Reusable schema components
@@ -836,6 +837,7 @@ export const spec = {
     ..._SelfConversationReplayOpenapiPaths,
     ..._AgentServicesOpenapiPaths,
     ..._PersonalConfigurationOpenapiPaths,
+    ..._SkillCatalogueOpenapiPaths,
 
     // ------------------------------------------------------------------
     // Auth — OIDC browser flow and session introspection

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1262,6 +1262,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/skills": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List governed skills in the signed-in caller's silo
+         * @description The server derives the silo from the browser session and request host. It returns at most two hundred catalogue summaries, never skill bundles, artifact addresses, manifests, review evidence, signatures, or workload coordinates.
+         */
+        get: operations["listSkills"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -5681,6 +5701,59 @@ export interface operations {
                 };
             };
             /** @description Configuration proposal history could not be read. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listSkills: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Browser-safe governed skill catalogue. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        skills: {
+                            id: string;
+                            name: string;
+                            description: string;
+                            /** @enum {string} */
+                            state: "active" | "retired";
+                            currentRevisionId: string | null;
+                            /** @enum {string|null} */
+                            currentRevisionState: "draft" | "review" | "published" | "rejected" | "revoked" | null;
+                            /** Format: date-time */
+                            createdAt: string;
+                            /** Format: date-time */
+                            updatedAt: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description No authenticated browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The skill catalogue could not be read. */
             503: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

This adds the first browser-facing governed-skill discovery surface: an authenticated user can see the skills available in their current ClusterTenant without receiving executable bundles or internal review/worker data.

- exposes GET /api/v1/skills with the silo derived exclusively from the signed-in browser session and request host
- returns bounded, deterministic safe summaries: name, description, lifecycle, and current-revision state
- keeps artifact addresses and bytes, manifests, requirements, scan/test evidence, signatures, identities, and workload coordinates private
- removes a duplicate skill-revocation method, retaining the single atomic implementation
- updates the domain README, OpenAPI source, and generated client contract

## Validation

- npx nx run backend-server-skills:test — 18 tests passed
- npx nx run backend-server-skills:lint
- npx nx run opencrane:lint
- npx nx run backend-server-api-spec:lint
- OpenAPI emission, contracts generation, and contracts lint
- scripts/agent-style-check.sh — 0 errors, 0 warnings
- git diff --check

## Review

Independent review found no Critical, High, or Medium findings. It confirmed exact host-silo scoping, the absence of sensitive skill fields from the query and response, contract alignment, and the single surviving revocation implementation.