### PR TITLE
🗂️ Phase F: discover personal assets safely

### DIFF
--- a/apps/opencrane/src/app/personal-artifact-catalogue-wiring.ts
+++ b/apps/opencrane/src/app/personal-artifact-catalogue-wiring.ts
@@ -1,0 +1,24 @@
+import type { Request, Router } from "express";
+import type { PrismaClient } from "@prisma/client";
+
+import { __CreatePersonalArtifactCatalogueRouter, PrismaArtifactAuthorityRepository, type PersonalArtifactCaller } from "@opencrane/backend/server/agents/artifacts";
+import { _ClusterTenantFromHost, _RequestHost } from "@opencrane/server/_infra/auth";
+import "@opencrane/server/_infra/auth";
+
+import { _log } from "./log.js";
+
+/** Compose the authenticated, owner-only personal asset catalogue API. */
+export function _CreatePersonalArtifactCatalogueRouter(prisma: PrismaClient): Router
+{
+	return __CreatePersonalArtifactCatalogueRouter({ resolveCaller: _resolveCaller, catalogue: new PrismaArtifactAuthorityRepository(prisma), logger: _log });
+}
+
+/** Derive the owner and silo only from the signed-in browser session and trusted request host. */
+function _resolveCaller(request: Request): PersonalArtifactCaller | null
+{
+	const authUser = request.session?.authUser;
+	if (!authUser) return null;
+	const ownerPrincipalId = (typeof authUser.sub === "string" ? authUser.sub.trim() : "") || (typeof authUser.email === "string" ? authUser.email.trim().toLowerCase() : "");
+	const siloId = _ClusterTenantFromHost(_RequestHost(request)) ?? "";
+	return ownerPrincipalId && siloId ? { ownerPrincipalId, siloId } : null;
+}

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -42,6 +42,7 @@ import { _CreateSelfConversationReplayRouter } from "./self-conversation-replay-
 import { _CreateSelfRunStatusRouter } from "./self-run-status-wiring.js";
 import { _CreatePersonalConfigurationRouter } from "./personal-configuration-wiring.js";
 import { _CreateSkillCatalogueRouter } from "./skill-catalogue-wiring.js";
+import { _CreatePersonalArtifactCatalogueRouter } from "./personal-artifact-catalogue-wiring.js";
 import type { ManagedRunAdmissionPort } from "@opencrane/backend/server/agents/agent-services";
 import { _log } from "./log.js";
 
@@ -378,6 +379,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, customApi: k
   app.use("/api/v1/groups", groupsRouter(prisma));
   app.use("/api/v1/agent-services", _CreateAgentServicesRouter(prisma, runAdmission));
   app.use("/api/v1/skills", _CreateSkillCatalogueRouter(prisma));
+  app.use("/api/v1/me/assets", _CreatePersonalArtifactCatalogueRouter(prisma));
   app.use("/api/v1/me/persona", _CreatePersonaOnboardingRouter(prisma));
   app.use("/api/v1/me/approvals", _CreateDeferredToolApprovalRouter(prisma));
 	app.use("/api/v1/me/runs", _CreateSteeringIngestRouter(prisma));

--- a/libs/backend/server/agents/artifacts/main/README.md
+++ b/libs/backend/server/agents/artifacts/main/README.md
@@ -42,6 +42,8 @@ result instead of creating a duplicate. A stale, replayed, or already-consumed r
 - `__FinalizeArtifactRevision` — commit promoted bytes into a visible, immutable revision.
 - `__UploadArtifact` — orchestrate the full verified upload (lease → promote → finalize).
 - `PrismaArtifactAuthorityRepository` — the Postgres-backed persistence adapter.
+- `__CreatePersonalArtifactCatalogueRouter` — serves `GET /api/v1/me/assets`, a bounded list of
+  non-deleted asset metadata owned by the signed-in caller in the trusted host silo.
 - Types: `ArtifactAuthorityRepository`, `ArtifactStorePromotionReceipt`, `FinalizeArtifactRevisionCommand`,
   and the upload ports (`ArtifactServicePromotionPort`, `ArtifactUploadCryptoPort`,
   `ArtifactUploadLeaseRepository`, `VerifiedArtifactUploadCommand`, `ArtifactUploadResult`).
@@ -52,6 +54,11 @@ The application layer wires the byte-store client, the crypto port, and the Pris
 use cases. Proof verification and replay reservation happen upstream — this package trusts that a
 `VerifiedArtifactUploadCommand` is already authorized, and its job is to keep metadata consistent
 with what the byte store actually promoted.
+
+The personal catalogue is discovery only. It returns kind, lifecycle, current-revision media type,
+size, indexing state, and timestamps. It never returns bytes, a content address, provenance,
+leases, promotion receipts, or outbox records, and it cannot upload, download, mutate, or delete an
+asset.
 
 ## Dependency direction
 

--- a/libs/backend/server/agents/artifacts/main/src/__tests__/personal-artifact-catalogue.router.test.ts
+++ b/libs/backend/server/agents/artifacts/main/src/__tests__/personal-artifact-catalogue.router.test.ts
@@ -1,0 +1,40 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import type { Logger } from "@opencrane/observability";
+
+import { __CreatePersonalArtifactCatalogueRouter } from "../personal-artifact-catalogue.router.js";
+import type { PersonalArtifactCatalogueRouterDependencies } from "../personal-artifact-catalogue.router.types.js";
+
+/** Builds owner-scoped catalogue dependencies for router tests. */
+function _dependencies(overrides: Partial<PersonalArtifactCatalogueRouterDependencies> = {}): PersonalArtifactCatalogueRouterDependencies
+{
+	return { resolveCaller: function _caller() { return { siloId: "silo-1", ownerPrincipalId: "user-1" }; }, catalogue: { listOwnedCatalogue: vi.fn().mockResolvedValue([]) }, logger: { error: vi.fn() } as unknown as Logger, ...overrides };
+}
+
+/** Mounts the router below its public personal-assets prefix. */
+function _app(dependencies: PersonalArtifactCatalogueRouterDependencies)
+{
+	const app = express();
+	app.use("/api/v1/me/assets", __CreatePersonalArtifactCatalogueRouter(dependencies));
+	return app;
+}
+
+describe("personal asset catalogue router", function _suite()
+{
+	it("lists only the session-derived owner in the host-derived silo", async function _lists()
+	{
+		const listOwnedCatalogue = vi.fn().mockResolvedValue([{ id: "asset-1" }]);
+		const response = await request(_app(_dependencies({ catalogue: { listOwnedCatalogue } }))).get("/api/v1/me/assets/");
+
+		expect(response.status).toBe(200);
+		expect(response.body.assets).toEqual([{ id: "asset-1" }]);
+		expect(listOwnedCatalogue).toHaveBeenCalledWith("silo-1", "user-1");
+	});
+
+	it("requires an authenticated owner before asset discovery", async function _requiresCaller()
+	{
+		const response = await request(_app(_dependencies({ resolveCaller: function _none() { return null; } }))).get("/api/v1/me/assets/");
+		expect(response.status).toBe(401);
+	});
+});

--- a/libs/backend/server/agents/artifacts/main/src/__tests__/personal-artifact-catalogue.test.ts
+++ b/libs/backend/server/agents/artifacts/main/src/__tests__/personal-artifact-catalogue.test.ts
@@ -1,0 +1,22 @@
+import { ArtifactIndexState, ArtifactKind, ArtifactState, type PrismaClient } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaArtifactAuthorityRepository } from "../prisma-artifact-authority.js";
+
+/** Builds one persisted asset row containing only browser-safe metadata. */
+function _artifactRow()
+{
+	return { id: "asset-1", kind: ArtifactKind.Document, state: ArtifactState.Active, currentRevisionId: "revision-1", currentRevision: { mediaType: "text/plain", byteLength: 12n, indexState: ArtifactIndexState.Indexed }, createdAt: new Date("2026-07-26T12:00:00.000Z"), updatedAt: new Date("2026-07-26T13:00:00.000Z") };
+}
+
+describe("Prisma personal asset catalogue", function _suite()
+{
+	it("reads non-deleted assets only from the exact owner and silo in bounded order", async function _listsOwnedAssets()
+	{
+		const findMany = vi.fn().mockResolvedValue([_artifactRow()]);
+		const prisma = { artifact: { findMany } } as unknown as PrismaClient;
+
+		await expect(new PrismaArtifactAuthorityRepository(prisma).listOwnedCatalogue("silo-1", "user-1")).resolves.toEqual([{ id: "asset-1", kind: "document", state: "active", currentRevisionId: "revision-1", mediaType: "text/plain", byteLength: "12", indexState: "indexed", createdAt: "2026-07-26T12:00:00.000Z", updatedAt: "2026-07-26T13:00:00.000Z" }]);
+		expect(findMany).toHaveBeenCalledWith({ where: { siloId: "silo-1", ownerPrincipalId: "user-1", state: { not: ArtifactState.Deleted } }, select: { id: true, kind: true, state: true, currentRevisionId: true, currentRevision: { select: { mediaType: true, byteLength: true, indexState: true } }, createdAt: true, updatedAt: true }, orderBy: [{ updatedAt: "desc" }, { id: "desc" }], take: 50 });
+	});
+});

--- a/libs/backend/server/agents/artifacts/main/src/artifact-finalization.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-finalization.types.ts
@@ -42,6 +42,36 @@ export interface ArtifactAuthorityRepository
 	finalizeRevisionAtomically(command: FinalizeArtifactRevisionCommand): Promise<AtomicFinalizeArtifactResult>;
 }
 
+/** Browser-safe metadata for one asset owned by the signed-in user. */
+export interface PersonalArtifactEntry
+{
+	/** Stable logical asset identifier. */
+	readonly id: string;
+	/** High-level purpose of the asset. */
+	readonly kind: "document" | "generated" | "skill" | "upload";
+	/** Current lifecycle state, excluding terminally deleted assets. */
+	readonly state: "active" | "deletion_pending";
+	/** Current revision identifier when a revision has been finalized. */
+	readonly currentRevisionId: string | null;
+	/** Browser-safe media type of the current revision when one exists. */
+	readonly mediaType: string | null;
+	/** Exact decimal byte count of the current revision when one exists. */
+	readonly byteLength: string | null;
+	/** Search/index lifecycle state of the current revision when one exists. */
+	readonly indexState: "pending" | "indexed" | "failed" | "removal_pending" | "removed" | null;
+	/** Creation instant in ISO-8601 form. */
+	readonly createdAt: string;
+	/** Most recent metadata or current-pointer update instant in ISO-8601 form. */
+	readonly updatedAt: string;
+}
+
+/** Reads browser-safe personal asset metadata from an exact owner and silo boundary. */
+export interface PersonalArtifactCatalogueRepository
+{
+	/** Returns a bounded deterministic list of non-deleted assets owned by one user in one silo. */
+	listOwnedCatalogue(siloId: string, ownerPrincipalId: string): Promise<readonly PersonalArtifactEntry[]>;
+}
+
 /** Stable result of ArtifactRevision finalization. */
 export type FinalizeArtifactRevisionResult =
 	| { readonly outcome: "finalized"; readonly idempotent: boolean }

--- a/libs/backend/server/agents/artifacts/main/src/index.ts
+++ b/libs/backend/server/agents/artifacts/main/src/index.ts
@@ -1,5 +1,8 @@
 export { __FinalizeArtifactRevision } from "./artifact-finalization.js";
 export { PrismaArtifactAuthorityRepository } from "./prisma-artifact-authority.js";
 export { __UploadArtifact } from "./artifact-upload.js";
-export type { ArtifactAuthorityRepository, ArtifactStorePromotionReceipt, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand, FinalizeArtifactRevisionResult } from "./artifact-finalization.types.js";
+export { __CreatePersonalArtifactCatalogueRouter } from "./personal-artifact-catalogue.router.js";
+export { _PersonalArtifactsOpenapiPaths } from "./openapi.js";
+export type { ArtifactAuthorityRepository, ArtifactStorePromotionReceipt, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand, FinalizeArtifactRevisionResult, PersonalArtifactCatalogueRepository, PersonalArtifactEntry } from "./artifact-finalization.types.js";
+export type { PersonalArtifactCaller, PersonalArtifactCatalogueRouterDependencies } from "./personal-artifact-catalogue.router.types.js";
 export type { ArtifactServicePromotionPort, ArtifactUploadCryptoPort, ArtifactUploadLeaseRepository, ArtifactUploadResult, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";

--- a/libs/backend/server/agents/artifacts/main/src/openapi.ts
+++ b/libs/backend/server/agents/artifacts/main/src/openapi.ts
@@ -1,0 +1,16 @@
+/** OpenAPI path fragment for the owner-only personal asset catalogue. */
+export const _PersonalArtifactsOpenapiPaths = {
+	"/me/assets": {
+		get: {
+			operationId: "listMyAssets",
+			summary: "List the signed-in owner's assets",
+			description: "The server derives the owner and silo from the browser session and request host. It returns at most fifty non-deleted asset metadata records, never bytes, content addresses, provenance, leases, receipts, or outbox data.",
+			tags: ["Personal assets"],
+			responses: {
+				200: { description: "Owner-bound personal asset metadata.", content: { "application/json": { schema: { type: "object", required: ["assets"], properties: { assets: { type: "array", items: { type: "object", required: ["id", "kind", "state", "currentRevisionId", "mediaType", "byteLength", "indexState", "createdAt", "updatedAt"], properties: { id: { type: "string" }, kind: { type: "string", enum: ["document", "generated", "skill", "upload"] }, state: { type: "string", enum: ["active", "deletion_pending"] }, currentRevisionId: { type: ["string", "null"] }, mediaType: { type: ["string", "null"] }, byteLength: { type: ["string", "null"], pattern: "^(0|[1-9][0-9]*)$" }, indexState: { type: ["string", "null"], enum: ["pending", "indexed", "failed", "removal_pending", "removed", null] }, createdAt: { type: "string", format: "date-time" }, updatedAt: { type: "string", format: "date-time" } } } } } } } } },
+				401: { description: "No browser session owns the request.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+				503: { description: "Personal asset metadata could not be read.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+			},
+		},
+	},
+};

--- a/libs/backend/server/agents/artifacts/main/src/personal-artifact-catalogue.router.ts
+++ b/libs/backend/server/agents/artifacts/main/src/personal-artifact-catalogue.router.ts
@@ -1,0 +1,25 @@
+import { Router, type Request, type Response } from "express";
+
+import type { PersonalArtifactCatalogueRouterDependencies } from "./personal-artifact-catalogue.router.types.js";
+
+/** Create the browser-session-authenticated, owner-only personal asset catalogue router. */
+export function __CreatePersonalArtifactCatalogueRouter(dependencies: PersonalArtifactCatalogueRouterDependencies): Router
+{
+	const router = Router();
+	router.get("/", async function _list(request: Request, response: Response)
+	{
+		const caller = dependencies.resolveCaller(request);
+		if (caller === null) { response.status(401).json({ error: "personal_artifact_authentication_required" }); return; }
+		try
+		{
+			const assets = await dependencies.catalogue.listOwnedCatalogue(caller.siloId, caller.ownerPrincipalId);
+			response.status(200).json({ assets });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "personal_artifacts.list", siloId: caller.siloId }, "Personal asset catalogue list failed");
+			response.status(503).json({ error: "personal_artifact_catalogue_unavailable" });
+		}
+	});
+	return router;
+}

--- a/libs/backend/server/agents/artifacts/main/src/personal-artifact-catalogue.router.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/personal-artifact-catalogue.router.types.ts
@@ -1,0 +1,25 @@
+import type { Request } from "express";
+
+import type { Logger } from "@opencrane/observability";
+
+import type { PersonalArtifactCatalogueRepository } from "./artifact-finalization.types.js";
+
+/** Trusted browser identity used only to select personal assets. */
+export interface PersonalArtifactCaller
+{
+	/** Silo derived from the trusted request host. */
+	readonly siloId: string;
+	/** Signed-in owner whose assets may be listed. */
+	readonly ownerPrincipalId: string;
+}
+
+/** Composition ports for the owner-only personal asset catalogue. */
+export interface PersonalArtifactCatalogueRouterDependencies
+{
+	/** Resolves an authenticated browser caller and trusted host silo. */
+	resolveCaller(request: Request): PersonalArtifactCaller | null;
+	/** Reads only browser-safe metadata owned by the resolved caller. */
+	readonly catalogue: PersonalArtifactCatalogueRepository;
+	/** Records unexpected persistence failures without logging artifact metadata. */
+	readonly logger: Logger;
+}

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
@@ -1,12 +1,12 @@
 import { randomUUID } from "node:crypto";
 
-import { ArtifactUploadLeaseState, Prisma, type PrismaClient } from "@prisma/client";
+import { ArtifactIndexState, ArtifactKind, ArtifactState, ArtifactUploadLeaseState, Prisma, type PrismaClient } from "@prisma/client";
 
-import type { ArtifactAuthorityRepository, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand } from "./artifact-finalization.types.js";
+import type { ArtifactAuthorityRepository, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand, PersonalArtifactCatalogueRepository, PersonalArtifactEntry } from "./artifact-finalization.types.js";
 import type { ArtifactUploadLeaseRepository, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";
 
 /** Postgres authority for receipt consumption, immutable revision publication, and outbox creation. */
-export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactUploadLeaseRepository
+export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactUploadLeaseRepository, PersonalArtifactCatalogueRepository
 {
 	/** Canonical OpenCrane catalog database client. */
 	private readonly prisma: PrismaClient;
@@ -15,6 +15,16 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 	constructor(prisma: PrismaClient)
 	{
 		this.prisma = prisma;
+	}
+
+	/** List only safe metadata from non-deleted assets owned in the exact trusted silo. */
+	async listOwnedCatalogue(siloId: string, ownerPrincipalId: string): Promise<readonly PersonalArtifactEntry[]>
+	{
+		const artifacts = await this.prisma.artifact.findMany({ where: { siloId, ownerPrincipalId, state: { not: ArtifactState.Deleted } }, select: { id: true, kind: true, state: true, currentRevisionId: true, currentRevision: { select: { mediaType: true, byteLength: true, indexState: true } }, createdAt: true, updatedAt: true }, orderBy: [{ updatedAt: "desc" }, { id: "desc" }], take: 50 });
+		return artifacts.map(function _toPersonalEntry(artifact): PersonalArtifactEntry
+		{
+			return { id: artifact.id, kind: _ToKind(artifact.kind), state: artifact.state === ArtifactState.Active ? "active" : "deletion_pending", currentRevisionId: artifact.currentRevisionId, mediaType: artifact.currentRevision?.mediaType ?? null, byteLength: artifact.currentRevision === null ? null : artifact.currentRevision.byteLength.toString(), indexState: artifact.currentRevision === null ? null : _ToIndexState(artifact.currentRevision.indexState), createdAt: artifact.createdAt.toISOString(), updatedAt: artifact.updatedAt.toISOString() };
+		});
 	}
 
 	/** Creates or returns the one durable, proof-bound lease for one exact capability JTI. */
@@ -91,5 +101,30 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 			if (error instanceof Prisma.PrismaClientKnownRequestError && (error.code === "P2002" || error.code === "P2034")) return { status: "conflict" };
 			throw error;
 		}
+	}
+}
+
+/** Converts generated artifact-kind values into the stable browser vocabulary. */
+function _ToKind(kind: ArtifactKind): PersonalArtifactEntry["kind"]
+{
+	switch (kind)
+	{
+		case ArtifactKind.Document: return "document";
+		case ArtifactKind.Generated: return "generated";
+		case ArtifactKind.Skill: return "skill";
+		case ArtifactKind.Upload: return "upload";
+	}
+}
+
+/** Converts generated index values into the stable browser vocabulary. */
+function _ToIndexState(state: ArtifactIndexState): NonNullable<PersonalArtifactEntry["indexState"]>
+{
+	switch (state)
+	{
+		case ArtifactIndexState.Pending: return "pending";
+		case ArtifactIndexState.Indexed: return "indexed";
+		case ArtifactIndexState.Failed: return "failed";
+		case ArtifactIndexState.RemovalPending: return "removal_pending";
+		case ArtifactIndexState.Removed: return "removed";
 	}
 }

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -35,6 +35,7 @@ import { _SelfConversationReplayOpenapiPaths } from "@opencrane/backend/server/a
 import { _AgentServicesOpenapiPaths } from "@opencrane/backend/server/agents/agent-services";
 import { _PersonalConfigurationOpenapiPaths } from "@opencrane/backend/agents/personal/configuration";
 import { _SkillCatalogueOpenapiPaths } from "@opencrane/backend/server/agents/skills";
+import { _PersonalArtifactsOpenapiPaths } from "@opencrane/backend/server/agents/artifacts";
 
 // ---------------------------------------------------------------------------
 // Reusable schema components
@@ -838,6 +839,7 @@ export const spec = {
     ..._AgentServicesOpenapiPaths,
     ..._PersonalConfigurationOpenapiPaths,
     ..._SkillCatalogueOpenapiPaths,
+    ..._PersonalArtifactsOpenapiPaths,
 
     // ------------------------------------------------------------------
     // Auth — OIDC browser flow and session introspection

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1282,6 +1282,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/assets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List the signed-in owner's assets
+         * @description The server derives the owner and silo from the browser session and request host. It returns at most fifty non-deleted asset metadata records, never bytes, content addresses, provenance, leases, receipts, or outbox data.
+         */
+        get: operations["listMyAssets"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/me": {
         parameters: {
             query?: never;
@@ -5754,6 +5774,61 @@ export interface operations {
                 };
             };
             /** @description The skill catalogue could not be read. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listMyAssets: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Owner-bound personal asset metadata. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        assets: {
+                            id: string;
+                            /** @enum {string} */
+                            kind: "document" | "generated" | "skill" | "upload";
+                            /** @enum {string} */
+                            state: "active" | "deletion_pending";
+                            currentRevisionId: string | null;
+                            mediaType: string | null;
+                            byteLength: string | null;
+                            /** @enum {string|null} */
+                            indexState: "pending" | "indexed" | "failed" | "removal_pending" | "removed" | null;
+                            /** Format: date-time */
+                            createdAt: string;
+                            /** Format: date-time */
+                            updatedAt: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description No browser session owns the request. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Personal asset metadata could not be read. */
             503: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
## Summary

This adds the personal asset discovery surface. A signed-in person can see the metadata for assets they own in the current ClusterTenant, without gaining a file-download, upload, or mutation capability.

- exposes GET /api/v1/me/assets with owner and silo derived only from browser session and request host
- returns at most fifty non-deleted asset summaries in deterministic order
- keeps file bytes, content addresses, provenance, leases, promotion receipts, and outbox records private
- represents asset sizes as exact decimal strings, avoiding loss of precision for large files
- updates the artifact README, OpenAPI source, and generated client contract

## Validation

- npx nx run backend-server-artifacts:test — 10 tests passed
- npx nx run backend-server-artifacts:lint
- npx nx run opencrane:lint
- npx nx run backend-server-api-spec:lint
- contracts generation and contracts lint
- scripts/agent-style-check.sh — 0 errors, 0 warnings
- git diff --check

## Review

Independent review found and verified the fix for exact large-file byte sizes. It also confirmed exact owner and host-silo scoping, lifecycle handling, sensitive-field redaction, ordering, and API contract alignment.