### PR TITLE
🔌 Phase F: wire governed skills into frontend state

### DIFF
--- a/docs/agents/app-specific.md
+++ b/docs/agents/app-specific.md
@@ -83,7 +83,7 @@ implementation, or second durable event store.
 Angular libraries feeding `apps/opencrane-ui`, ported in from WeOwnAI (#152): `core`, `platform`
 (FORK — also live in the WeOwnAI repo, kept in sync deliberately), `elements/{ui,a2ui}`,
 `features/{welcome,customer-admin,tools,workspace,settings,conversation,context,notifications,metrics}`,
-and `state/{core,gateways,conversation/*,settings/adapter,mcp/adapter,provider-key/adapter,tenant/adapter,onboarding,utils/storage}`.
+and `state/{core,gateways,conversation/*,assets/adapter,skills/adapter,settings/adapter,mcp/adapter,provider-key/adapter,tenant/adapter,onboarding,utils/storage}`.
 Project names are `frontend-<lib>` (`scope:web` tag, may only depend on `scope:web`/`scope:shared`);
 aliases are `@opencrane/*` in `tsconfig.json`, resolved via `tsconfig.frontend.json` (Angular's
 module/decorator settings layered over the shared `tsconfig.json` — never edit the base config's

--- a/libs/frontend/README.md
+++ b/libs/frontend/README.md
@@ -13,6 +13,8 @@ directory hierarchy in the SPA.
 | --- | --- | --- |
 | Managed personal agents | `features/conversation`, `state/conversation/*`, `state/onboarding` | personal agents and `server/agents` |
 | Gateway governance | `features/tools`, `state/mcp/adapter`, `state/provider-key/adapter` | `server/gateways` |
+| Governed skill catalogue | `state/skills/adapter` | `server/agents/skills` |
+| Personal asset catalogue | `state/assets/adapter` | server-side artifact authority |
 | Tenancy and administration | `features/customer-admin`, `state/tenant/adapter`, `state/settings/adapter` | `server/tenancy`, `server/iam` |
 | Reporting | `features/metrics` | `server/reporting` |
 | Shared browser composition | `core`, `platform`, `elements/*`, `state/core`, `state/gateways` | cross-cutting |

--- a/libs/frontend/state/README.md
+++ b/libs/frontend/state/README.md
@@ -18,10 +18,12 @@ owns the client-side stores and caches that hold fetched data.
 | [`conversation/cache`](./conversation/cache/README.md) | IndexedDB conversation cache. |
 | [`conversation/render`](./conversation/render/README.md) | Vendored render view-models. |
 | [`conversation/ag-ui`](./conversation/ag-ui/README.md) | Safe projected-event browser state. |
+| [`assets/adapter`](./assets/adapter/README.md) | Live owner-bound personal-asset catalogue gateway. |
 | [`mcp/adapter`](./mcp/adapter/README.md) | Live MCP gateway. |
 | [`onboarding`](./onboarding/README.md) | Shared onboarding persistence. |
 | [`provider-key/adapter`](./provider-key/adapter/README.md) | Live BYOK provider-key gateway. |
 | [`settings/adapter`](./settings/adapter/README.md) | Live settings gateway. |
+| [`skills/adapter`](./skills/adapter/README.md) | Live governed-skill catalogue gateway. |
 | [`tenant/adapter`](./tenant/adapter/README.md) | Live tenant gateway and store. |
 | [`utils/storage`](./utils/storage/README.md) | Safe browser-storage seam. |
 
@@ -31,8 +33,9 @@ owns the client-side stores and caches that hold fetched data.
       ▼
     core  ── defines ports, holds stores ──  gateways (wires ports → adapters)
       │
-      ├─ conversation/{adapter,cache,render}   mcp/adapter   provider-key/adapter
-      ├─ settings/adapter   tenant/adapter   onboarding   utils/storage
+      ├─ conversation/{adapter,cache,render}   assets/adapter   skills/adapter
+      ├─ mcp/adapter   provider-key/adapter   settings/adapter   tenant/adapter
+      └─ onboarding   utils/storage
       ▼ HTTP
    backend API
 ```

--- a/libs/frontend/state/gateways/README.md
+++ b/libs/frontend/state/gateways/README.md
@@ -22,12 +22,14 @@ into its config, binding every swappable data gateway to its live adapter in one
  USER_TENANT_GATEWAY  → OpenCraneUserTenantGateway
  MCP_GATEWAY          → OpenCraneMcpGateway
  PROVIDER_KEY_GATEWAY → OpenCraneProviderKeyGateway
+ PERSONAL_ASSETS_GATEWAY → OpenCranePersonalAssetsGateway
+ SKILL_CATALOGUE_GATEWAY → OpenCraneSkillCatalogueGateway
         │  features inject the port, never the class
         ▼
  features/* (UI screens)
 ```
 
-**In this flow:** [conversation/adapter](../conversation/adapter/README.md) · [settings/adapter](../settings/adapter/README.md) · [tenant/adapter](../tenant/adapter/README.md) · [mcp/adapter](../mcp/adapter/README.md) · [provider-key/adapter](../provider-key/adapter/README.md) · [core](../core/README.md)
+**In this flow:** [conversation/adapter](../conversation/adapter/README.md) · [settings/adapter](../settings/adapter/README.md) · [tenant/adapter](../tenant/adapter/README.md) · [mcp/adapter](../mcp/adapter/README.md) · [provider-key/adapter](../provider-key/adapter/README.md) · [assets/adapter](../assets/adapter/README.md) · [skills/adapter](../skills/adapter/README.md) · [core](../core/README.md)
 
 It also owns `ActiveTenantStore`, which resolves *which pod a data fetch should target* by reconciling
 `SessionStore.currentTenant` with the active `GATEWAY_MODE`, and the `GATEWAY_MODE` token itself
@@ -57,4 +59,4 @@ packages — here the `state/*/adapter` libs, `state/core`, and Angular — neve
 ## See also
 
 - Parent index: [state](../README.md)
-- Siblings: [core](../core/README.md) · [tenant/adapter](../tenant/adapter/README.md) · [settings/adapter](../settings/adapter/README.md)
+- Siblings: [core](../core/README.md) · [assets/adapter](../assets/adapter/README.md) · [skills/adapter](../skills/adapter/README.md) · [tenant/adapter](../tenant/adapter/README.md) · [settings/adapter](../settings/adapter/README.md)

--- a/libs/frontend/state/gateways/src/lib/__test__/mock-skill-catalogue-gateway.ts
+++ b/libs/frontend/state/gateways/src/lib/__test__/mock-skill-catalogue-gateway.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@angular/core";
+
+import type { GovernedSkill, SkillCatalogueGateway } from "@opencrane/state/skills/adapter";
+
+/** In-memory governed-skill gateway for UI-state tests. */
+@Injectable()
+export class MockSkillCatalogueGateway implements SkillCatalogueGateway
+{
+	/** Configurable host-silo governed-skill fixture. */
+	public skills: readonly GovernedSkill[] = [];
+
+	/** @inheritdoc */
+	public async list(): Promise<readonly GovernedSkill[]>
+	{
+		return this.skills;
+	}
+}

--- a/libs/frontend/state/gateways/src/lib/__test__/test-gateways.provider.ts
+++ b/libs/frontend/state/gateways/src/lib/__test__/test-gateways.provider.ts
@@ -6,6 +6,7 @@ import { USER_TENANT_GATEWAY } from "@opencrane/state/tenant/adapter";
 import { MCP_GATEWAY } from "@opencrane/state/mcp/adapter";
 import { PROVIDER_KEY_GATEWAY } from "@opencrane/state/provider-key/adapter";
 import { PERSONAL_ASSETS_GATEWAY } from "@opencrane/state/assets/adapter";
+import { SKILL_CATALOGUE_GATEWAY } from "@opencrane/state/skills/adapter";
 
 import { GATEWAY_MODE } from "../gateway-mode.types";
 import { MockConversationGateway } from "./mock-conversation-gateway";
@@ -14,6 +15,7 @@ import { MockProviderKeyGateway } from "./mock-provider-key-gateway";
 import { MockSettingsGateway } from "./mock-settings-gateway";
 import { MockUserTenantGateway } from "./mock-tenant-gateway";
 import { MockPersonalAssetsGateway } from "./mock-personal-assets-gateway";
+import { MockSkillCatalogueGateway } from "./mock-skill-catalogue-gateway";
 
 export { MockConversationGateway } from "./mock-conversation-gateway";
 export { MockMcpGateway } from "./mock-mcp-gateway";
@@ -21,6 +23,7 @@ export { MockProviderKeyGateway } from "./mock-provider-key-gateway";
 export { MockSettingsGateway } from "./mock-settings-gateway";
 export { MockUserTenantGateway } from "./mock-tenant-gateway";
 export { MockPersonalAssetsGateway } from "./mock-personal-assets-gateway";
+export { MockSkillCatalogueGateway } from "./mock-skill-catalogue-gateway";
 
 /**
  * Binds every swappable gateway to its in-memory fixture implementation.
@@ -35,6 +38,7 @@ export function provideTestGateways(): Provider[]
 		{ provide: USER_TENANT_GATEWAY, useClass: MockUserTenantGateway },
 		{ provide: MCP_GATEWAY, useClass: MockMcpGateway },
 		{ provide: PROVIDER_KEY_GATEWAY, useClass: MockProviderKeyGateway },
-		{ provide: PERSONAL_ASSETS_GATEWAY, useClass: MockPersonalAssetsGateway }
+		{ provide: PERSONAL_ASSETS_GATEWAY, useClass: MockPersonalAssetsGateway },
+		{ provide: SKILL_CATALOGUE_GATEWAY, useClass: MockSkillCatalogueGateway }
 	];
 }

--- a/libs/frontend/state/gateways/src/lib/__tests__/gateways.provider.spec.ts
+++ b/libs/frontend/state/gateways/src/lib/__tests__/gateways.provider.spec.ts
@@ -7,6 +7,7 @@ import { OpenCraneSettingsGateway, SETTINGS_GATEWAY } from "@opencrane/state/set
 import { OpenCraneUserTenantGateway, USER_TENANT_GATEWAY } from "@opencrane/state/tenant/adapter";
 import { MCP_GATEWAY, OpenCraneMcpGateway } from "@opencrane/state/mcp/adapter";
 import { OpenCranePersonalAssetsGateway, PERSONAL_ASSETS_GATEWAY } from "@opencrane/state/assets/adapter";
+import { OpenCraneSkillCatalogueGateway, SKILL_CATALOGUE_GATEWAY } from "@opencrane/state/skills/adapter";
 
 import { GATEWAY_MODE } from "../gateway-mode.types";
 import { provideControlPlaneGateways } from "../control-plane-gateways.provider";
@@ -16,6 +17,7 @@ import {
 	MockSettingsGateway,
 	MockUserTenantGateway,
 	MockPersonalAssetsGateway,
+	MockSkillCatalogueGateway,
 	provideTestGateways
 } from "../__test__/test-gateways.provider";
 
@@ -64,6 +66,7 @@ describe("provideControlPlaneGateways", () =>
 		expect(classFor(providers, USER_TENANT_GATEWAY)).toBe(OpenCraneUserTenantGateway);
 		expect(classFor(providers, MCP_GATEWAY)).toBe(OpenCraneMcpGateway);
 		expect(classFor(providers, PERSONAL_ASSETS_GATEWAY)).toBe(OpenCranePersonalAssetsGateway);
+		expect(classFor(providers, SKILL_CATALOGUE_GATEWAY)).toBe(OpenCraneSkillCatalogueGateway);
 		expect(valueFor(providers, GATEWAY_MODE)).toBe("live");
 	});
 });
@@ -79,6 +82,7 @@ describe("provideTestGateways", () =>
 		expect(classFor(providers, USER_TENANT_GATEWAY)).toBe(MockUserTenantGateway);
 		expect(classFor(providers, MCP_GATEWAY)).toBe(MockMcpGateway);
 		expect(classFor(providers, PERSONAL_ASSETS_GATEWAY)).toBe(MockPersonalAssetsGateway);
+		expect(classFor(providers, SKILL_CATALOGUE_GATEWAY)).toBe(MockSkillCatalogueGateway);
 		expect(valueFor(providers, GATEWAY_MODE)).toBe("mock");
 	});
 });

--- a/libs/frontend/state/gateways/src/lib/control-plane-gateways.provider.ts
+++ b/libs/frontend/state/gateways/src/lib/control-plane-gateways.provider.ts
@@ -7,6 +7,7 @@ import { OpenCraneUserTenantGateway, USER_TENANT_GATEWAY } from "@opencrane/stat
 import { MCP_GATEWAY, OpenCraneMcpGateway } from "@opencrane/state/mcp/adapter";
 import { OpenCraneProviderKeyGateway, PROVIDER_KEY_GATEWAY } from "@opencrane/state/provider-key/adapter";
 import { OpenCranePersonalAssetsGateway, PERSONAL_ASSETS_GATEWAY } from "@opencrane/state/assets/adapter";
+import { OpenCraneSkillCatalogueGateway, SKILL_CATALOGUE_GATEWAY } from "@opencrane/state/skills/adapter";
 
 import { GATEWAY_MODE } from "./gateway-mode.types";
 
@@ -29,6 +30,7 @@ export function provideControlPlaneGateways(): Provider[]
 		{ provide: USER_TENANT_GATEWAY, useClass: OpenCraneUserTenantGateway },
 		{ provide: MCP_GATEWAY, useClass: OpenCraneMcpGateway },
 		{ provide: PROVIDER_KEY_GATEWAY, useClass: OpenCraneProviderKeyGateway },
-		{ provide: PERSONAL_ASSETS_GATEWAY, useClass: OpenCranePersonalAssetsGateway }
+		{ provide: PERSONAL_ASSETS_GATEWAY, useClass: OpenCranePersonalAssetsGateway },
+		{ provide: SKILL_CATALOGUE_GATEWAY, useClass: OpenCraneSkillCatalogueGateway }
 	];
 }

--- a/libs/frontend/state/skills/README.md
+++ b/libs/frontend/state/skills/README.md
@@ -1,0 +1,31 @@
+# Skills state
+
+> [frontend](../../README.md) › [state](../README.md) › skills
+
+This group contains the browser-state adapter for the governed skill catalogue. A **governed skill** is a reusable, reviewed automation instruction; the browser can see its safe catalogue metadata but cannot inspect its source, revision evidence, or execution details.
+
+## Map
+
+| Package | What it owns |
+| --- | --- |
+| [adapter](./adapter/README.md) | The read-only Angular port and live Control Plane adapter for the host-silo skill catalogue. |
+
+```
+ opencrane-ui feature
+          │ injects a read-only port
+          ▼
+ skills/adapter  ◄── HERE
+          │ fetches safe catalogue metadata
+          ▼
+ Control Plane API → governed skill authority
+```
+
+## Dependency rule for this group
+
+Packages here carry `scope:web` and `type:state`. They may depend on frontend core and shared contracts, but never on UI features, backend domains, or an application. The server, not the browser, chooses the current silo and filters what a session may see.
+
+## See also
+
+- Parent index: [state](../README.md)
+- Child package: [adapter](./adapter/README.md)
+- Sibling: [gateways](../gateways/README.md)

--- a/libs/frontend/state/skills/adapter/README.md
+++ b/libs/frontend/state/skills/adapter/README.md
@@ -1,0 +1,47 @@
+# @opencrane/state/skills/adapter — governed skill catalogue gateway
+
+> [frontend](../../../README.md) › [state](../../README.md) › [skills](../README.md) › adapter
+
+## What it owns
+
+This package is part of the frontend state layer: the small layer between an Angular screen and the Control Plane HTTP API. It exposes the host-silo's **governed skill catalogue** as a narrow, read-only gateway. A governed skill is a reusable automation instruction that has a server-owned lifecycle and revision history.
+
+A feature injects `SKILL_CATALOGUE_GATEWAY`, requests the safe summaries it needs, and renders them. Before this adapter runs, Angular has already established the browser's cookie session. After it runs, a feature receives only catalogue metadata; server authorities keep source, review evidence, worker details, and all mutations private.
+
+```
+ signed-in browser session
+          │ feature asks for catalogue entries
+          ▼
+ ┌─────────────────────────────────────┐
+ │ skills/adapter  ◄── HERE              │
+ │ port token + live HTTP implementation │
+ └─────────────────────────────────────┘
+          │ GET /skills (no silo or owner supplied)
+          ▼
+ Control Plane API → governed skill authority
+```
+
+**In this flow:** [gateways](../../gateways/README.md) binds the live implementation; the server-side governed-skill authority decides the caller's host silo and permitted projection.
+
+Invariant: this package can only list browser-safe summaries. It must never add a client-controlled silo coordinate or become a route to skill source, evidence, execution, or mutation.
+
+## Public surface
+
+- `GovernedSkill` — browser-safe catalogue metadata for one governed skill.
+- `SkillCatalogueGateway` — the read-only port a feature depends on.
+- `SKILL_CATALOGUE_GATEWAY` — Angular injection token for that port.
+- `OpenCraneSkillCatalogueGateway` — live cookie-session implementation using the Control Plane API.
+
+## Boundary
+
+Consumed by frontend features through the injection token and composed by [state/gateways](../../gateways/README.md). On an API error it fails closed by rejecting the request; it does not invent a cache, retry policy, or fallback data. It owns no UI, server-side authorization, or skill lifecycle transition.
+
+## Dependency direction
+
+Tagged `scope:web` and `type:state`: it may import frontend core and browser-safe shared contracts, but never an application, UI feature, backend domain, or deployment package. The adapter depends downward on the public API; features depend upward on this port.
+
+## See also
+
+- Parent index: [skills](../README.md)
+- Composition root: [gateways](../../gateways/README.md)
+- Sibling adapter: [assets/adapter](../../assets/adapter/README.md)

--- a/libs/frontend/state/skills/adapter/project.json
+++ b/libs/frontend/state/skills/adapter/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "frontend-skills-adapter",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/frontend/state/skills/adapter/src",
+  "tags": [
+    "scope:web",
+    "layer:frontend",
+    "type:lib",
+    "type:state"
+  ],
+  "targets": {
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc -p tsconfig.lint.json",
+        "cwd": "libs/frontend/state/skills/adapter"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "vitest run --passWithNoTests",
+        "cwd": "libs/frontend/state/skills/adapter"
+      }
+    }
+  }
+}

--- a/libs/frontend/state/skills/adapter/src/index.ts
+++ b/libs/frontend/state/skills/adapter/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./lib/skill-catalogue-gateway.types";
+export * from "./lib/opencrane-skill-catalogue-gateway";

--- a/libs/frontend/state/skills/adapter/src/lib/__tests__/opencrane-skill-catalogue-gateway.spec.ts
+++ b/libs/frontend/state/skills/adapter/src/lib/__tests__/opencrane-skill-catalogue-gateway.spec.ts
@@ -1,0 +1,61 @@
+import { Injector, runInInjectionContext } from "@angular/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { ControlPlaneApiService } from "@opencrane/core";
+
+import { OpenCraneSkillCatalogueGateway } from "../opencrane-skill-catalogue-gateway";
+
+/** Builds the adapter with a deterministic Control Plane HTTP response. */
+function _make(response: unknown): OpenCraneSkillCatalogueGateway
+{
+	const api = {
+		client: {
+			GET: vi.fn().mockResolvedValue(response)
+		}
+	} as unknown as ControlPlaneApiService;
+	const injector = Injector.create({ providers: [{ provide: ControlPlaneApiService, useValue: api }] });
+
+	return runInInjectionContext(injector, function _create(): OpenCraneSkillCatalogueGateway
+	{
+		return new OpenCraneSkillCatalogueGateway();
+	});
+}
+
+describe("OpenCraneSkillCatalogueGateway", () =>
+{
+	it("returns only the generated safe catalogue response", async () =>
+	{
+		const gateway = _make({
+			data: {
+				skills: [{
+					id: "skill-1",
+					name: "Research brief",
+					description: "Produces a source-grounded brief.",
+					state: "active",
+					currentRevisionId: "revision-1",
+					currentRevisionState: "published",
+					createdAt: "2026-07-26T08:00:00.000Z",
+					updatedAt: "2026-07-26T08:00:00.000Z"
+				}]
+			},
+			error: undefined
+		});
+
+		await expect(gateway.list()).resolves.toEqual([{
+			id: "skill-1",
+			name: "Research brief",
+			description: "Produces a source-grounded brief.",
+			state: "active",
+			currentRevisionId: "revision-1",
+			currentRevisionState: "published",
+			createdAt: "2026-07-26T08:00:00.000Z",
+			updatedAt: "2026-07-26T08:00:00.000Z"
+		}]);
+	});
+
+	it("fails closed when the Control Plane omits data or returns an error", async () =>
+	{
+		await expect(_make({ data: undefined, error: undefined }).list()).rejects.toThrow("failed to list governed skills");
+		await expect(_make({ data: undefined, error: { message: "denied" } }).list()).rejects.toThrow("failed to list governed skills");
+	});
+});

--- a/libs/frontend/state/skills/adapter/src/lib/opencrane-skill-catalogue-gateway.ts
+++ b/libs/frontend/state/skills/adapter/src/lib/opencrane-skill-catalogue-gateway.ts
@@ -1,0 +1,21 @@
+import { Injectable, inject } from "@angular/core";
+
+import { ControlPlaneApiService } from "@opencrane/core";
+
+import type { GovernedSkill, SkillCatalogueGateway } from "./skill-catalogue-gateway.types";
+
+/** Live read-only gateway for the host-silo governed skill catalogue. */
+@Injectable()
+export class OpenCraneSkillCatalogueGateway implements SkillCatalogueGateway
+{
+	/** Shared cookie-session Control Plane client. */
+	private readonly _api = inject(ControlPlaneApiService);
+
+	/** @inheritdoc */
+	public async list(): Promise<readonly GovernedSkill[]>
+	{
+		const { data, error } = await this._api.client.GET("/skills");
+		if (error || !data) throw new Error("failed to list governed skills");
+		return data.skills;
+	}
+}

--- a/libs/frontend/state/skills/adapter/src/lib/skill-catalogue-gateway.types.ts
+++ b/libs/frontend/state/skills/adapter/src/lib/skill-catalogue-gateway.types.ts
@@ -1,0 +1,32 @@
+import { InjectionToken } from "@angular/core";
+
+/** Browser-safe summary of a governed skill. */
+export interface GovernedSkill
+{
+	/** Stable skill identifier. */
+	readonly id: string;
+	/** Skill display name. */
+	readonly name: string;
+	/** Browser-safe description. */
+	readonly description: string;
+	/** Current logical lifecycle. */
+	readonly state: "active" | "retired";
+	/** Selected revision identifier. */
+	readonly currentRevisionId: string | null;
+	/** Selected revision lifecycle. */
+	readonly currentRevisionState: "draft" | "review" | "published" | "rejected" | "revoked" | null;
+	/** Creation time. */
+	readonly createdAt: string;
+	/** Update time. */
+	readonly updatedAt: string;
+}
+
+/** Read-only port for the host-silo governed skill catalogue. */
+export interface SkillCatalogueGateway
+{
+	/** Lists safe governed skills from the host-selected silo. */
+	list(): Promise<readonly GovernedSkill[]>;
+}
+
+/** DI token for the governed skill catalogue. */
+export const SKILL_CATALOGUE_GATEWAY: InjectionToken<SkillCatalogueGateway> = new InjectionToken<SkillCatalogueGateway>("OC_SKILL_CATALOGUE_GATEWAY");

--- a/libs/frontend/state/skills/adapter/tsconfig.json
+++ b/libs/frontend/state/skills/adapter/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../../../tsconfig.frontend.json",
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/libs/frontend/state/skills/adapter/tsconfig.lib.json
+++ b/libs/frontend/state/skills/adapter/tsconfig.lib.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../dist/out-tsc",
+    "types": [],
+    "composite": true,
+    "tsBuildInfoFile": "../../../../../dist/out-tsc/libs/frontend/state/skills/adapter/tsconfig.lib.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts"
+  ],
+  "references": [
+    {
+      "path": "../../../core"
+    }
+  ]
+}

--- a/libs/frontend/state/skills/adapter/tsconfig.lint.json
+++ b/libs/frontend/state/skills/adapter/tsconfig.lint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": false,
+    "disableSourceOfProjectReferenceRedirect": true,
+    "incremental": false,
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "**/*.spec.ts"
+  ],
+  "references": []
+}

--- a/libs/frontend/state/skills/adapter/vitest.config.ts
+++ b/libs/frontend/state/skills/adapter/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../vitest.cache.js";
+
+/** Vitest configuration for the browser-state adapter package. */
+export default defineConfig({
+	cacheDir: _PackageCacheDir(import.meta.url),
+	plugins: [tsconfigPaths({ projects: ["../../../../../tsconfig.vitest.json"] })],
+	test: {
+		globals: true,
+		environment: "node",
+		setupFiles: ["../../../vitest.frontend.setup.ts"],
+		passWithNoTests: true
+	}
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -269,6 +269,7 @@
         "./libs/frontend/state/provider-key/adapter/src/index.ts"
       ],
 		"@opencrane/state/assets/adapter": ["./libs/frontend/state/assets/adapter/src/index.ts"],
+		"@opencrane/state/skills/adapter": ["./libs/frontend/state/skills/adapter/src/index.ts"],
       "@opencrane/state/tenant/adapter": [
         "./libs/frontend/state/tenant/adapter/src/index.ts"
       ],


### PR DESCRIPTION
## Why

The Control Plane can already list governed skills safely, but browser features had no state-layer port for consuming that catalogue. This change adds the missing state boundary without introducing a user interface.

## What changes

- add a read-only Angular gateway for browser-safe governed-skill summaries
- bind the live gateway through the shared Control Plane composition root
- provide the matching in-memory test gateway
- document the package boundary and where the server retains authority

## Functional flow

A signed-in browser feature asks the injected skill-catalogue port for entries. The live adapter calls GET /api/v1/skills through the cookie-session client. The server derives the silo from the request host and session; the browser supplies no silo or owner coordinate.

## Safety boundary

This surface exposes names, descriptions and lifecycle metadata only. It cannot mutate skills or access bundles, artifact coordinates, review evidence, signatures, worker details or execution controls.

## Validation

- frontend-skills-adapter lint: pass
- frontend-skills-adapter tests: 2 pass
- frontend-gateways lint: pass
- frontend-gateways tests: 42 pass
- agent TypeScript style check: pass
- git diff check: pass
- full boundary lint: inherited eight API-spec boundary failures from the parent stack; these are repaired on the new combined trunk in #495 and are unrelated to this state-only diff

## Review

- required architecture post-diff gate: PASS
- independent correctness/security review: no critical, high or medium findings
- one documentation-taxonomy low finding was fixed and reverified

## Stack

Dependent on the personal-assets state branch. The later reconciliation work will replay this Phase F follow-on onto #495 after the divergent Phase D/E lanes are settled.