### PR TITLE
🔒 Reconcile one canonical artifact-read authority

### DIFF
--- a/apps/artifact-service/README.md
+++ b/apps/artifact-service/README.md
@@ -51,14 +51,16 @@ can only refuse a legitimate upload; it can never store bytes that were not cove
 `Entrypoint: src/index.ts` (`_Main`) — reads config, prepares the mounted CAS root (mode `0700`), opens
 the listener, and binds bounded `SIGTERM`/`SIGINT` shutdown that drains requests and flushes telemetry.
 
-HTTP endpoints: `POST /v1/artifacts/promote` writes bounded bytes; `GET /v1/artifacts/content/:sha256`
-streams only the exact canonical bytes named by a separately signed immutable-read lease; and `/livez`
+HTTP endpoints: `POST /v1/artifacts/promote` writes bounded bytes; `GET /v1/artifacts/read` streams only
+the exact canonical bytes named by the `X-Opencrane-Artifact-Read-Lease` immutable-read lease, after its
+stored length matches the signed length; and `/livez`
 · `/readyz` probes. Any other path or method is `404`.
 
 ## Boundary
 
 Stateless apart from the mounted CAS volume. It does **not** issue leases (the server does), list
-artifacts, or accept a caller-selected content address: a read path must equal the signed lease. It
+artifacts, or accept a caller-selected content address: reads have no address in the request and use
+only the address inside the signed lease. It
 does not accept raw secrets as environment variables — signing keys are
 mounted PEM files, not env values. Verification and signing are delegated to the artifacts libraries;
 this process is only the HTTP adapter and byte pump around them.
@@ -77,7 +79,7 @@ key file is not PEM.
 |---|---|---|
 | `PORT` | Listener port | `8080` |
 | `ARTIFACT_ROOT` | Absolute mounted CAS directory | `/var/lib/opencrane/artifacts` |
-| `ARTIFACT_LEASE_PUBLIC_KEY_PATH` | Mounted PEM public key used to verify write leases | *(required)* |
+| `ARTIFACT_LEASE_PUBLIC_KEY_PATH` | Mounted PEM public key used to verify distinct write and immutable-read leases | *(required)* |
 | `ARTIFACT_RECEIPT_PRIVATE_KEY_PATH` | Mounted PEM private key used to sign receipts | *(required)* |
 | `ARTIFACT_MAX_UPLOAD_DURATION_MILLISECONDS` | Hard cap on a single upload's duration | `300000` |
 

--- a/apps/artifact-service/src/__tests__/server.test.ts
+++ b/apps/artifact-service/src/__tests__/server.test.ts
@@ -80,18 +80,42 @@ describe("artifact-service promotion endpoint", function _suite()
 			const writeLease = __SignArtifactWriteLease({ leaseId: "write-1", siloId: "silo-1", artifactId: "artifact-1", action: "artifact.write", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60, expectedContentAddress: digest, expectedByteLength: bytes.byteLength, mediaType: "text/plain" }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
 			await fetch(`http://127.0.0.1:${port}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": writeLease }, body: bytes });
 			const readLease = __SignArtifactReadLease({ leaseId: "read-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: digest, byteLength: bytes.byteLength, mediaType: "text/plain", action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60 }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
-			const response = await fetch(`http://127.0.0.1:${port}/v1/artifacts/content/${digest.slice("sha256:".length)}`, { headers: { "x-opencrane-artifact-lease": readLease } });
+			const response = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read`, { headers: { "x-opencrane-artifact-read-lease": readLease } });
 
 			expect(response.status).toBe(200);
 			expect(response.headers.get("content-length")).toBe(String(bytes.byteLength));
 			expect(response.headers.get("cache-control")).toBe("no-store");
+			expect(response.headers.get("x-content-type-options")).toBe("nosniff");
 			expect(await response.text()).toBe("opencrane");
-			expect((await fetch(`http://127.0.0.1:${port}/v1/artifacts/content/${"b".repeat(64)}`, { headers: { "x-opencrane-artifact-lease": readLease } })).status).toBe(403);
+			expect((await fetch(`http://127.0.0.1:${port}/v1/artifacts/read`, { headers: { "x-opencrane-artifact-lease": readLease } })).status).toBe(403);
+			expect((await fetch(`http://127.0.0.1:${port}/v1/artifacts/content/${digest.slice("sha256:".length)}`, { headers: { "x-opencrane-artifact-read-lease": readLease } })).status).toBe(404);
 		}
 		finally
 		{
 			await rm(root, { recursive: true, force: true });
 		}
+	});
+
+	it("denies missing and byte-mismatched objects before reading or sending a success response", async function _readPreflight()
+	{
+		const read = vi.fn(async function _read() { return null; });
+		let storedByteLength: number | null = 8;
+		const store = { stage: vi.fn(), promote: vi.fn(), byteLength: vi.fn(async function _byteLength() { return storedByteLength; }), read, purge: vi.fn() } as never;
+		const server = _CreateServer({ port: 0, artifactRoot: "/tmp/artifact-service", maxUploadDurationMilliseconds: 300_000, leasePublicKeyPem: _leasePublicKey, receiptPrivateKeyPem: _receiptPrivateKey }, store);
+		_servers.push(server);
+		await new Promise<void>(function _listen(resolve) { server.listen(0, "127.0.0.1", function _ready() { resolve(); }); });
+		const port = (server.address() as { port: number }).port;
+		const readLease = __SignArtifactReadLease({ leaseId: "read-2", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 9, mediaType: "text/plain", action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60 }, _leasePrivateKey, Math.floor(Date.now() / 1_000));
+		const mismatch = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read`, { headers: { "x-opencrane-artifact-read-lease": readLease } });
+		storedByteLength = null;
+		const missing = await fetch(`http://127.0.0.1:${port}/v1/artifacts/read`, { headers: { "x-opencrane-artifact-read-lease": readLease } });
+
+		expect(mismatch.status).toBe(403);
+		expect(missing.status).toBe(403);
+		expect(mismatch.headers.get("cache-control")).toBe("no-store");
+		expect(missing.headers.get("cache-control")).toBe("no-store");
+		expect(await mismatch.text()).toBe(await missing.text());
+		expect(read).not.toHaveBeenCalled();
 	});
 
 	it("cuts off a client that drips bytes beyond the independent lease-bound deadline", async function _absoluteDeadline()

--- a/apps/artifact-service/src/server.ts
+++ b/apps/artifact-service/src/server.ts
@@ -21,7 +21,7 @@ export async function _PrepareArtifactStore(config: ArtifactServiceProcessConfig
 	});
 }
 
-/** Create the private server, which accepts only OpenCrane-signed, bounded write leases. */
+/** Create the private server for bounded promotion writes and lease-pinned immutable reads. */
 export function _CreateServer(config: ArtifactServiceProcessConfig, store: ArtifactStore): Server
 {
 	return createServer(function _handle(request, response)
@@ -46,9 +46,9 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 				}
 				return;
 			}
-			if (path.startsWith("/v1/artifacts/content/") && request.method === "GET")
+			if (path === "/v1/artifacts/read" && request.method === "GET")
 			{
-				await _ReadCanonicalArtifact(request, response, store, config.leasePublicKeyPem, path.slice("/v1/artifacts/content/".length));
+				await _ReadCanonicalArtifact(request, response, store, config.leasePublicKeyPem);
 				return;
 			}
 			response.writeHead(404, { "content-type": "application/json" });
@@ -61,36 +61,50 @@ export function _CreateServer(config: ArtifactServiceProcessConfig, store: Artif
 	});
 }
 
-/** Verify one exact immutable read lease, then stream only its pinned canonical bytes. */
-async function _ReadCanonicalArtifact(request: IncomingMessage, response: ServerResponse, store: ArtifactStore, leasePublicKeyPem: string, digest: string): Promise<void>
+/** Verifies one exact immutable read lease, preflights its bytes, then streams only its pinned address. */
+async function _ReadCanonicalArtifact(request: IncomingMessage, response: ServerResponse, store: ArtifactStore, leasePublicKeyPem: string): Promise<void>
 {
-	// 1. Verify the private-server lease before trusting the requested content coordinate.
-	const compactLease = request.headers["x-opencrane-artifact-lease"];
+	// 1. Read the dedicated header because write authority must never open the read endpoint.
+	const compactLease = request.headers["x-opencrane-artifact-read-lease"];
 	const lease = typeof compactLease === "string" ? __VerifyArtifactReadLease(compactLease, leasePublicKeyPem, Math.floor(Date.now() / 1_000)) : null;
-	const contentAddress = `sha256:${digest}`;
-	if (lease === null || !/^[a-f0-9]{64}$/u.test(digest) || lease.contentAddress !== contentAddress)
+	if (lease === null)
 	{
-		response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
-		response.end(JSON.stringify({ error: "artifact_read_denied" }));
+		_WriteArtifactReadDenied(response);
 		return;
 	}
 
-	// 2. Read only the lease-pinned address; a missing object must never widen the read scope.
+	// 2. Preflight the stored length before opening a stream so missing and mismatched bytes fail identically.
+	const storedByteLength = await store.byteLength(lease.contentAddress);
+	if (storedByteLength === null || storedByteLength !== lease.byteLength)
+	{
+		_WriteArtifactReadDenied(response);
+		return;
+	}
+
+	// 3. Read only the lease-pinned address after its size matches; there is no caller-selected coordinate.
 	const stream = await store.read(lease.contentAddress);
 	if (stream === null)
 	{
-		response.writeHead(404, { "content-type": "application/json", "cache-control": "no-store" });
-		response.end(JSON.stringify({ error: "artifact_not_found" }));
+		_WriteArtifactReadDenied(response);
 		return;
 	}
 
-	// 3. Send signed metadata, never request-controlled headers or inferred catalog details.
-	response.writeHead(200, { "content-type": lease.mediaType, "content-length": String(lease.byteLength), "cache-control": "no-store" });
+	// 4. Send only lease-signed metadata after all preflight gates passed, preventing a partial successful response.
+	// X-Content-Type-Options: proprietary response header that asks clients not to MIME-sniff signed bytes.
+	// @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Content-Type-Options
+	response.writeHead(200, { "content-type": lease.mediaType, "content-length": String(lease.byteLength), "cache-control": "no-store", "x-content-type-options": "nosniff" });
 	for await (const chunk of stream)
 	{
 		if (!response.write(chunk) && !await _WaitForWritableResponse(response)) return;
 	}
 	response.end();
+}
+
+/** Returns the same non-cacheable denial for an invalid lease, missing object, or size mismatch. */
+function _WriteArtifactReadDenied(response: ServerResponse): void
+{
+	response.writeHead(403, { "content-type": "application/json", "cache-control": "no-store" });
+	response.end(JSON.stringify({ error: "artifact_read_denied" }));
 }
 
 /** Wait for downstream backpressure to drain, but stop reading when the private client disconnects. */

--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -88,6 +88,12 @@ ServiceAccount, Job, Pod, run, and revision; the projected bootstrap reference a
 name alone are never sufficient. Governed skill workers can reach the internal listener only to
 acknowledge their one-use bootstrap reference: their default-deny namespaces receive an additive
 egress rule for this listener and DNS, and the response contains no workload identity or capability.
+For a skill-authoring input, the worker-facing route first proves the exact workload, Pod, bootstrap,
+draft skill revision, and published source artifact. App composition then asks the server artifact
+authority to reload only those catalogue coordinates and mint a five-minute-maximum read lease from
+mounted key material. The server consumes that lease against the private artifact-service and relays
+the bytes; the worker receives neither the lease, the content address, the ArtifactStore endpoint,
+nor disk access.
 The runtime stream mints the full `start_attempt`, `resume_attempt`, and `cancel_attempt` command
 lifecycle and admits candidates, so a verified Pod runs its bounded model/tool loop, proposes
 external actions through the reserve-before-dispatch tool-invocation authority, pauses for deferred

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -325,7 +325,7 @@ export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, auth
 	app.use("/api/internal/agent-controller", __CreateAgentControllerRunDispatchRouter({ tokenReviewer: _CreateAgentControllerTokenReviewer(authApi, serverNamespace), namespace: serverNamespace, repository: runDispatchRepository, logger: _log }));
 	app.use("/api/internal/agent-controller", __CreateSkillWorkloadDispatchRouter({ tokenReviewer: _CreateAgentControllerTokenReviewer(authApi, serverNamespace), namespace: serverNamespace, repository: skillWorkloadClaimsRepository, logger: _log }));
 	app.use("/api/internal/agent-runtime", __CreateSkillWorkloadBootstrapRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillWorkloadBootstrapRepository(prisma), logger: _log }));
-	app.use("/api/internal/agent-runtime", __CreateSkillAuthoringInputRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillAuthoringInputRepository(prisma), artifactReader: _CreateSkillAuthoringArtifactReader(), logger: _log }));
+	app.use("/api/internal/agent-runtime", __CreateSkillAuthoringInputRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillAuthoringInputRepository(prisma), artifactReader: _CreateSkillAuthoringArtifactReader(prisma), logger: _log }));
 	app.use("/api/internal/agent-runtime", __CreateSkillAuthoringCompletionRouter({ tokenReviewer: _CreateSkillWorkloadTokenReviewer(authApi), repository: new PrismaSkillAuthoringCompletionRepository(prisma), logger: _log }));
   // NetworkPolicy-only (no auth/TokenReview): the operator fetches a tenant's
   // allowed model set + effective default at reconcile. Best-effort — never 404/500.

--- a/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
+++ b/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { __VerifyArtifactReadLease } from "@opencrane/backend/artifacts/authorization";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { _CreateArtifactServicePromotionPort, _CreateArtifactServiceReadPort, _CreateArtifactUploadGateway, _CreateSkillAuthoringArtifactReader } from "../artifact-upload.factory.js";
@@ -46,28 +47,54 @@ describe("artifact upload app composition", function _suite()
 		await expect(port.promote("signed-lease", _bytes())).rejects.toThrow("returned no receipt");
 	});
 
-	it("uses a signed server lease only for the exact canonical read path", async function _readsPinnedArtifact()
+	it("uses the fixed read endpoint and dedicated read-lease header", async function _ReadsPinnedArtifact()
 	{
 		const fetchMock = vi.fn().mockResolvedValue(new Response("artifact", { status: 200 }));
 		vi.stubGlobal("fetch", fetchMock);
 		const port = _CreateArtifactServiceReadPort(_serviceUrl);
-		const address = `sha256:${"a".repeat(64)}`;
 
-		await expect(port.read("signed-read-lease", address)).resolves.toBeInstanceOf(Response);
-		expect(fetchMock).toHaveBeenCalledWith(`${_serviceUrl}/v1/artifacts/content/${"a".repeat(64)}`, { redirect: "error", headers: { "x-opencrane-artifact-lease": "signed-read-lease" } });
-		await expect(port.read("signed-read-lease", "../../etc/passwd")).rejects.toThrow("canonical content address");
+		await expect(port.read("signed-read-lease")).resolves.toBeInstanceOf(Response);
+		expect(fetchMock).toHaveBeenCalledWith(`${_serviceUrl}/v1/artifacts/read`, { redirect: "error", headers: { "x-opencrane-artifact-read-lease": "signed-read-lease" } });
 	});
 
-	it("refuses artifact bytes whose transport metadata does not match the fenced revision", async function _rejectsMismatchedMetadata()
+	it("reloads published catalogue facts instead of signing caller-supplied byte metadata", async function _ReloadsCatalogueFacts()
 	{
 		const directory = mkdtempSync(join(tmpdir(), "opencrane-artifact-read-"));
 		const keyPath = join(directory, "lease.pem");
-		const key = generateKeyPairSync("ed25519").privateKey.export({ type: "pkcs8", format: "pem" }).toString();
-		writeFileSync(keyPath, key, "utf8");
+		const keys = generateKeyPairSync("ed25519");
+		const privateKey = keys.privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+		const publicKey = keys.publicKey.export({ type: "spki", format: "pem" }).toString();
+		writeFileSync(keyPath, privateKey, "utf8");
 		try
 		{
+			const findFirst = vi.fn().mockResolvedValue({ id: "revision-1", artifactId: "artifact-1", contentAddress: `sha256:${"b".repeat(64)}`, byteLength: 8n, mediaType: "text/plain; charset=utf-8", artifact: { siloId: "silo-1" } });
+			const fetchMock = vi.fn().mockResolvedValue(new Response("artifact", { status: 200, headers: { "content-length": "8", "content-type": "text/plain; charset=utf-8" } }));
+			vi.stubGlobal("fetch", fetchMock);
+			const reader = _CreateSkillAuthoringArtifactReader({ artifactRevision: { findFirst } } as never, { ARTIFACT_SERVICE_URL: _serviceUrl, ARTIFACT_LEASE_PRIVATE_KEY_PATH: keyPath });
+			await expect(reader.read({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 9, mediaType: "application/gzip" })).resolves.toBeInstanceOf(ReadableStream);
+
+			const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+			const compactLease = (request.headers as Record<string, string>)["x-opencrane-artifact-read-lease"] ?? "";
+			expect(__VerifyArtifactReadLease(compactLease, publicKey, Math.floor(Date.now() / 1_000))).toMatchObject({ contentAddress: `sha256:${"b".repeat(64)}`, byteLength: 8, mediaType: "text/plain; charset=utf-8" });
+			expect(findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "revision-1", artifactId: "artifact-1", state: "Published", artifact: { siloId: "silo-1", state: "Active" } } }));
+		}
+		finally
+		{
+			rmSync(directory, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses artifact bytes whose transport metadata does not match the reloaded revision", async function _RejectsMismatchedMetadata()
+	{
+		const directory = mkdtempSync(join(tmpdir(), "opencrane-artifact-read-"));
+		const keyPath = join(directory, "lease.pem");
+		const privateKey = generateKeyPairSync("ed25519").privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+		writeFileSync(keyPath, privateKey, "utf8");
+		try
+		{
+			const artifactRevision = { findFirst: vi.fn().mockResolvedValue({ id: "revision-1", artifactId: "artifact-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 9n, mediaType: "application/gzip", artifact: { siloId: "silo-1" } }) };
 			vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("artifact", { status: 200, headers: { "content-length": "8", "content-type": "text/plain" } })));
-			const reader = _CreateSkillAuthoringArtifactReader({ ARTIFACT_SERVICE_URL: _serviceUrl, ARTIFACT_LEASE_PRIVATE_KEY_PATH: keyPath });
+			const reader = _CreateSkillAuthoringArtifactReader({ artifactRevision } as never, { ARTIFACT_SERVICE_URL: _serviceUrl, ARTIFACT_LEASE_PRIVATE_KEY_PATH: keyPath });
 			await expect(reader.read({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 9, mediaType: "application/gzip" })).rejects.toThrow("metadata did not match");
 		}
 		finally

--- a/apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts
+++ b/apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts
@@ -1,13 +1,14 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { Readable } from "node:stream";
 
 import type { PrismaClient } from "@prisma/client";
 
 import { __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt } from "@opencrane/backend/artifacts/authorization";
-import { __UploadArtifact, PrismaArtifactAuthorityRepository } from "@opencrane/backend/server/agents/artifacts";
+import { __IssueArtifactReadLease, __UploadArtifact, PrismaArtifactAuthorityRepository } from "@opencrane/backend/server/agents/artifacts";
 import type { ArtifactUploadResult, VerifiedArtifactUploadCommand } from "@opencrane/backend/server/agents/artifacts";
 import type { SkillAuthoringArtifactReader, SkillAuthoringInputRecord } from "@opencrane/backend/agents/skills/execution";
+import { ___DoWithTrace } from "@opencrane/observability";
 
 /** Build the app-owned bridge from a proof-authorized command to the private artifact service. */
 export function _CreateArtifactUploadGateway(prisma: PrismaClient, environment: NodeJS.ProcessEnv = process.env): { upload(command: VerifiedArtifactUploadCommand): Promise<ArtifactUploadResult> }
@@ -44,15 +45,17 @@ export function _CreateArtifactServicePromotionPort(serviceUrl: string): { promo
 }
 
 /** Build the server-only HTTP client that retrieves bytes covered by one immutable read lease. */
-export function _CreateArtifactServiceReadPort(serviceUrl: string): { read(lease: string, contentAddress: string): Promise<Response> }
+export function _CreateArtifactServiceReadPort(serviceUrl: string): { read(lease: string): Promise<Response> }
 {
 	return {
-		async read(lease: string, contentAddress: string): Promise<Response>
+		async read(lease: string): Promise<Response>
 		{
-			if (!/^sha256:[a-f0-9]{64}$/u.test(contentAddress)) throw new Error("artifact read requires a canonical content address");
-			const response = await fetch(`${serviceUrl}/v1/artifacts/content/${contentAddress.slice("sha256:".length)}`, { redirect: "error", headers: { "x-opencrane-artifact-lease": lease } });
-			if (!response.ok || response.body === null) throw new Error(`artifact service read failed with ${response.status}`);
-			return response;
+			return ___DoWithTrace("artifact.read.fetch", { service: "artifact-service" }, async function _FetchArtifact(): Promise<Response>
+			{
+				const response = await fetch(`${serviceUrl}/v1/artifacts/read`, { redirect: "error", headers: { "x-opencrane-artifact-read-lease": lease } });
+				if (!response.ok || response.body === null) throw new Error(`artifact service read failed with ${response.status}`);
+				return response;
+			});
 		},
 	};
 }
@@ -65,18 +68,23 @@ export function _CreateArtifactReadLeaseSigner(environment: NodeJS.ProcessEnv = 
 }
 
 /** Build the only server-side bridge from a fenced authoring input to verified ArtifactStore bytes. */
-export function _CreateSkillAuthoringArtifactReader(environment: NodeJS.ProcessEnv = process.env): SkillAuthoringArtifactReader
+export function _CreateSkillAuthoringArtifactReader(prisma: PrismaClient, environment: NodeJS.ProcessEnv = process.env): SkillAuthoringArtifactReader
 {
+	const repository = new PrismaArtifactAuthorityRepository(prisma);
 	return {
 		async read(input: SkillAuthoringInputRecord): Promise<ReadableStream<Uint8Array>>
 		{
-			const serviceUrl = _InternalServiceUrl(environment.ARTIFACT_SERVICE_URL ?? "");
-			const signLease = _CreateArtifactReadLeaseSigner(environment);
-			const readPort = _CreateArtifactServiceReadPort(serviceUrl);
-			const lease = signLease({ leaseId: randomUUID(), siloId: input.siloId, artifactId: input.artifactId, artifactRevisionId: input.artifactRevisionId, contentAddress: input.contentAddress, byteLength: input.byteLength, mediaType: input.mediaType, action: "artifact.read", expiresAtEpochSeconds: Math.floor(Date.now() / 1_000) + 60 });
-			const response = await readPort.read(lease, input.contentAddress);
-			if (response.headers.get("content-length") !== String(input.byteLength) || response.headers.get("content-type") !== input.mediaType) throw new Error("artifact service read metadata did not match the fenced revision");
-			return response.body as ReadableStream<Uint8Array>;
+			return ___DoWithTrace("skill-authoring.artifact-read", { siloId: input.siloId, artifactId: input.artifactId, artifactRevisionId: input.artifactRevisionId }, async function _ReadArtifact(): Promise<ReadableStream<Uint8Array>>
+			{
+				const serviceUrl = _InternalServiceUrl(environment.ARTIFACT_SERVICE_URL ?? "");
+				const signLease = _CreateArtifactReadLeaseSigner(environment);
+				const readPort = _CreateArtifactServiceReadPort(serviceUrl);
+				const issued = await __IssueArtifactReadLease(repository, { sign: signLease }, { siloId: input.siloId, artifactId: input.artifactId, artifactRevisionId: input.artifactRevisionId }, Math.floor(Date.now() / 1_000));
+				if (issued.outcome !== "issued") throw new Error("artifact read lease denied");
+				const response = await readPort.read(issued.compactLease);
+				if (response.headers.get("content-length") !== String(issued.claims.byteLength) || response.headers.get("content-type") !== issued.claims.mediaType) throw new Error("artifact service read metadata did not match the published revision");
+				return response.body as ReadableStream<Uint8Array>;
+			});
 		},
 	};
 }

--- a/docs/adr/0008-target-agent-contracts-and-workload-identity.md
+++ b/docs/adr/0008-target-agent-contracts-and-workload-identity.md
@@ -1,6 +1,7 @@
 # ADR 0008: Target agent contracts and workload identity
 
-**Status:** Accepted
+**Status:** Accepted; artifact-read and prompt-compiler placement clarified by
+[ADR 0011](0011-single-run-input-and-artifact-read-authorities.md)
 **Origin:** [#245](https://github.com/elewa-git/opencrane/issues/245)
 
 ## Context
@@ -98,7 +99,7 @@ omitted from the network column for brevity.
 | `apps/_infra/litellm` | Model gateway | `litellm` | none | approved model providers and its mounted store |
 | `apps/_infra/obot` | Integration gateway | `obot` | none | approved external integrations and its mounted store |
 | `apps/postgres` | OpenCrane CNPG database Pods | CNPG-generated `<cluster-name>` instance identity | CNPG-generated instance-manager Role only | in-silo database replication and approved backup destination |
-| `apps/skill-authoring` | Skill authoring Job | `skill-authoring` | none | artifact-service, LiteLLM |
+| `apps/skill-authoring` | Skill authoring Job | `skill-authoring` | none | OpenCrane internal byte broker, LiteLLM |
 | `apps/tool-runner` | Sandboxed non-Obot tool Job | per-job projected `tool-runner` identity | none | only capability-declared destinations |
 | `apps/silo-provisioner` | Fresh target-store initialization Job | `silo-provisioner` | none | target Postgres and app-owned mounted stores |
 

--- a/docs/adr/0011-single-run-input-and-artifact-read-authorities.md
+++ b/docs/adr/0011-single-run-input-and-artifact-read-authorities.md
@@ -1,0 +1,73 @@
+# ADR 0011 — Single run-input and artifact-read authorities
+
+- **Status:** Accepted 2026-07-26
+- **Date:** 2026-07-26
+- **Task:** Phase D/E lane reconciliation (`#400`–`#402`)
+- **Supersedes / superseded by:** clarifies the `artifact.read` capability and workload boundary in
+  [ADR 0008](0008-target-agent-contracts-and-workload-identity.md); no ADR is superseded
+- **Related:** [ADR 0005](0005-opencrane-owned-agent-runtime.md) ·
+  [ADR 0008](0008-target-agent-contracts-and-workload-identity.md) ·
+  [ADR 0010](0010-language-neutral-agent-runtime.md)
+
+## Context
+
+Phase D and Phase E were implemented through several dependent branches. Their later branches built
+working runtime input compilation and skill-authoring artifact delivery, while an earlier artifact
+lane separately introduced a generic catalogue-to-lease issuer and an addressless ArtifactStore read
+contract. Replaying every branch would create parallel prompt compilers, multiple places that turn
+catalogue facts into leases, and two private byte-read protocols.
+
+The product is a clean build. There is no compatibility reason to preserve both shapes. The
+reconciliation therefore needs one owner for each decision and a narrow composition path from
+workload admission to immutable bytes.
+
+## Decision
+
+- Deterministic input compilation has one implementation under
+  `libs/backend/agents/execution/inputs/main`. It hydrates an immutable `RunInputSnapshot` through
+  injected read ports. Runtime workloads consume compiled input and never reimplement prompt,
+  persona, memory, tool, model, or budget assembly.
+- `libs/backend/artifacts/authorization/main` owns the storage-neutral read-lease claim, Ed25519
+  signing and verification rules, distinct token type and verification contract, and the hard
+  lifetime limit. Read and write leases share the private artifact-service audience but cannot be
+  substituted because each verifier requires its exact token type and claims.
+  A read lease expires no later than 300 seconds after issuance.
+- `libs/backend/server/agents/artifacts/main` is the only catalogue-to-lease authority. Given
+  already-authorized silo, artifact, and revision coordinates, it reloads an active artifact's
+  exact published revision and signs only the returned content address, byte length, and media type.
+  It exposes no HTTP route and performs no byte I/O.
+- `apps/opencrane` owns composition: mounted private-key access, the app-only signing adapter, the
+  private artifact-service client, and the worker-facing byte broker. A workload-specific repository
+  remains responsible for proving the exact Pod, assignment, bootstrap, and product revision before
+  it supplies coordinates to the generic artifact issuer.
+- `apps/artifact-service` owns the fixed private `GET /v1/artifacts/read` endpoint. The signed lease
+  is the sole source of the content address. The service preflights the mounted object's exact length
+  before sending a successful response and streams only the lease-bound bytes and media type.
+- Untrusted workers receive bytes only through their server broker. They never receive the read
+  lease, ArtifactStore URL, content address, mounted disk, or a list/read-by-address capability.
+
+## Alternatives considered
+
+- **Keep the later read-by-address route because it compares the URL digest with the lease.**
+  Rejected. The address is redundant input, creates a second probing surface, and weakens the rule
+  that the signed lease is the only read request.
+- **Let each workload domain sign its own catalogue projection.** Rejected. Workload admission is
+  intentionally domain-specific, but immutable artifact facts and lease construction need one
+  catalogue authority so every consumer receives the same active/published/silo checks.
+- **Replace the workload-specific selector with the generic artifact lookup.** Rejected. The generic
+  lookup cannot prove Pod identity, bootstrap consumption, assignment state, or the product record
+  that authorized the artifact. Both checks are required in sequence and own different decisions.
+- **Replay a second prompt compiler near the runtime protocol.** Rejected. It would make delivery a
+  second semantic authority and allow compilation to drift from run admission.
+
+## Consequences
+
+- A new artifact consumer must first prove its domain-specific admission, then call the shared
+  catalogue issuer; it cannot mint a lease from caller-supplied byte metadata.
+- Artifact-service can change its storage adapter without changing product or workload authorities,
+  provided the adapter preserves exact byte-length preflight and immutable-address reads.
+- The read lease is deliberately reusable only within its short expiry. One-time admission stays in
+  the workload bootstrap/exchange authority; the lease is a service credential and never crosses
+  into the workload.
+- Tests must keep the fixed endpoint, separate read header, five-minute maximum, active/published
+  catalogue filters, byte-length preflight, and absence of worker-visible leases intact.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ is not itself published.
 | [0007](0007-direct-target-refactor.md) | Direct target refactor without an estate migration | Accepted |
 | [0008](0008-target-agent-contracts-and-workload-identity.md) | Target agent contracts and workload identity | Accepted |
 | [0010](0010-language-neutral-agent-runtime.md) | Language-neutral agent runtime (Pydantic AI first qualification) | Accepted |
+| [0011](0011-single-run-input-and-artifact-read-authorities.md) | Single run-input and artifact-read authorities | Accepted |
 
 ## Writing a new ADR
 

--- a/libs/backend/agents/skills/execution/main/src/__tests__/skill-authoring-input.router.test.ts
+++ b/libs/backend/agents/skills/execution/main/src/__tests__/skill-authoring-input.router.test.ts
@@ -33,7 +33,7 @@ describe("skill authoring input router", function _DescribeAuthoringInput()
 		expect(response.status).toBe(200);
 		expect(response.headers["content-type"]).toBe("application/gzip");
 		expect(response.headers["content-length"]).toBe("13");
-		expect(response.headers["x-opencrane-content-address"]).toBe(_INPUT.contentAddress);
+		expect(response.headers["x-opencrane-content-address"]).toBeUndefined();
 		expect(response.body.toString()).toBe("skill archive");
 		expect(dependencies.tokenReviewer.__Review).toHaveBeenCalledWith("projected-token", "opencrane-skill-authoring");
 		expect(dependencies.repository.loadForWorker).toHaveBeenCalledWith("workload-1", { namespace: "opencrane-skill-authoring", serviceAccountName: "skill-authoring-default", podUid: "pod-uid-1" });

--- a/libs/backend/agents/skills/execution/main/src/skill-authoring-input.router.ts
+++ b/libs/backend/agents/skills/execution/main/src/skill-authoring-input.router.ts
@@ -49,7 +49,7 @@ export function __CreateSkillAuthoringInputRouter(dependencies: SkillAuthoringIn
 			const bytes = await dependencies.artifactReader.read(input);
 			const reader = bytes.getReader();
 			const first = await reader.read();
-			response.status(200).set({ "content-type": input.mediaType, "content-length": String(input.byteLength), "x-opencrane-content-address": input.contentAddress, "cache-control": "no-store" });
+			response.status(200).set({ "content-type": input.mediaType, "content-length": String(input.byteLength), "cache-control": "no-store" });
 			const stream = Readable.from(_ReadBytes(reader, first));
 			/** Terminate a half-written protected response without serialising its broker failure. */
 			function _AbortStream(err: Error): void

--- a/libs/backend/artifacts/authorization/main/README.md
+++ b/libs/backend/artifacts/authorization/main/README.md
@@ -35,8 +35,9 @@ The two tokens use **separate keys and audiences** on purpose: a lease is addres
 `artifact-service` and a receipt back to `opencrane`, so one can never be replayed as the other.
 An **immutable read lease** is a separate permission slip for one exact artifact revision, content
 address, length, and media type. It cannot be used to upload, list, or select another artifact.
-Verification is strict — wrong type, wrong audience, bad signature, or a lease outside its ±5-minute
-issue window returns `null`. Invariant: a genuine, unexpired, correctly-typed token is the only thing
+Verification is strict — wrong type, wrong audience, bad signature, unsafe media type, an expiry more
+than five minutes after issuance, a future issue time, or an issue time more than five minutes ago
+returns `null`. Invariant: a genuine, unexpired, correctly-typed token is the only thing
 that opens each gate; anything else fails closed, so a forged slip can never authorise a write and a
 forged receipt can never finalise a catalog entry.
 
@@ -45,6 +46,8 @@ forged receipt can never finalise a catalog entry.
 - `__SignArtifactWriteLease(claims, privateKeyPem, now)` / `__VerifyArtifactWriteLease(compact, publicKeyPem, now)` — mint and check the pre-upload permission slip.
 - `__SignArtifactReadLease(claims, privateKeyPem, now)` / `__VerifyArtifactReadLease(compact, publicKeyPem, now)` — mint and check a pinned immutable-read permission slip.
 - `__SignArtifactPromotionReceipt(claims, privateKeyPem)` / `__VerifyArtifactPromotionReceipt(compact, publicKeyPem)` — mint and check the post-upload proof.
+- `__IsSafeArtifactMediaType(value)` — apply the shared response-safe media-type grammar used by
+  write leases, read leases, receipts, and catalogue read issuance.
 - `ArtifactWriteLeaseClaims` / `ArtifactReadLeaseClaims` / `ArtifactPromotionReceiptClaims` — the exact fields carried by each token.
 
 ## Boundary

--- a/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
+++ b/libs/backend/artifacts/authorization/main/src/__tests__/artifact-lease.test.ts
@@ -1,4 +1,4 @@
-import { generateKeyPairSync } from "node:crypto";
+import { createPrivateKey, generateKeyPairSync, sign } from "node:crypto";
 
 import { describe, expect, it } from "vitest";
 
@@ -10,6 +10,15 @@ const _leasePrivateKey = _leaseKeys.privateKey.export({ type: "pkcs8", format: "
 const _leasePublicKey = _leaseKeys.publicKey.export({ type: "spki", format: "pem" }).toString();
 const _receiptPrivateKey = _receiptKeys.privateKey.export({ type: "pkcs8", format: "pem" }).toString();
 const _receiptPublicKey = _receiptKeys.publicKey.export({ type: "spki", format: "pem" }).toString();
+
+/** Signs an adversarial payload without the production claim validator to exercise verification. */
+function _SignUncheckedReadLease(payload: Record<string, unknown>): string
+{
+	const header = Buffer.from(JSON.stringify({ alg: "EdDSA", typ: "JWT" })).toString("base64url");
+	const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	const signingInput = `${header}.${body}`;
+	return `${signingInput}.${sign(null, Buffer.from(signingInput), createPrivateKey(_leasePrivateKey)).toString("base64url")}`;
+}
 
 describe("ArtifactStore signed internal protocol", function _suite()
 {
@@ -34,10 +43,25 @@ describe("ArtifactStore signed internal protocol", function _suite()
 
 	it("keeps one immutable read lease distinct from upload authority", function _readLeaseRoundTrip()
 	{
-		const compact = __SignArtifactReadLease({ leaseId: "read-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "application/gzip", action: "artifact.read", expiresAtEpochSeconds: 1_750_000_060 }, _leasePrivateKey, 1_750_000_000);
-		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_001)).toMatchObject({ leaseId: "read-1", action: "artifact.read" });
-		expect(__VerifyArtifactWriteLease(compact, _leasePublicKey, 1_750_000_001)).toBeNull();
-		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, 1_750_000_061)).toBeNull();
+		const now = 1_750_000_000;
+		const compact = __SignArtifactReadLease({ leaseId: "read-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "application/gzip", action: "artifact.read", expiresAtEpochSeconds: now + 300 }, _leasePrivateKey, now);
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, now)).toMatchObject({ leaseId: "read-1", action: "artifact.read" });
+		expect(__VerifyArtifactWriteLease(compact, _leasePublicKey, now)).toBeNull();
+		expect(__VerifyArtifactReadLease(compact, _receiptPublicKey, now)).toBeNull();
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, now - 1)).toBeNull();
+		expect(__VerifyArtifactReadLease(compact, _leasePublicKey, now + 300)).toBeNull();
+	});
+
+	it("rejects read leases longer than five minutes or with unsafe response media types", function _boundedReadLease()
+	{
+		const now = 1_750_000_000;
+		const base = { leaseId: "read-1", siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "text/plain", action: "artifact.read" as const };
+		expect(function _tooLongReadLease(): string { return __SignArtifactReadLease({ ...base, expiresAtEpochSeconds: now + 301 }, _leasePrivateKey, now); }).toThrow(/invalid artifact read lease claims/);
+		expect(function _unsafeMediaType(): string { return __SignArtifactReadLease({ ...base, mediaType: "text/plain\r\nX-Injected: yes", expiresAtEpochSeconds: now + 60 }, _leasePrivateKey, now); }).toThrow(/invalid artifact read lease claims/);
+		const parameterized = __SignArtifactReadLease({ ...base, mediaType: "text/plain; charset=utf-8", expiresAtEpochSeconds: now + 60 }, _leasePrivateKey, now);
+		expect(__VerifyArtifactReadLease(parameterized, _leasePublicKey, now)).toMatchObject({ mediaType: "text/plain; charset=utf-8" });
+		const overlongSignedPayload = _SignUncheckedReadLease({ typ: "opencrane.artifact-read-lease", aud: "artifact-service", iat: now, ...base, expiresAtEpochSeconds: now + 301 });
+		expect(__VerifyArtifactReadLease(overlongSignedPayload, _leasePublicKey, now)).toBeNull();
 	});
 
 	it("keeps service promotion receipts distinct from write-lease authority", function _receiptRoundTrip()

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
@@ -2,6 +2,7 @@ import { createPrivateKey, createPublicKey, sign, verify } from "node:crypto";
 
 import { ___CanonicalizeJson } from "@opencrane/util";
 
+import { __IsSafeArtifactMediaType } from "./artifact-media-type.js";
 import type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
 
 const _LEASE_AUDIENCE = "artifact-service";
@@ -39,9 +40,9 @@ export function __VerifyArtifactReadLease(compact: string, publicKeyPem: string,
 {
 	const payload = _verify(compact, publicKeyPem);
 	const issuedAt = payload?.iat;
-	if (payload === null || payload.typ !== _READ_LEASE_TYPE || payload.aud !== _LEASE_AUDIENCE || typeof issuedAt !== "number" || !Number.isSafeInteger(issuedAt) || issuedAt < nowEpochSeconds - 300 || issuedAt > nowEpochSeconds + 300) return null;
+	if (payload === null || payload.typ !== _READ_LEASE_TYPE || payload.aud !== _LEASE_AUDIENCE || typeof issuedAt !== "number" || !Number.isSafeInteger(issuedAt) || issuedAt < nowEpochSeconds - 300 || issuedAt > nowEpochSeconds) return null;
 	const claims = _readLeaseFromPayload(payload);
-	return claims !== null && _isReadLease(claims, nowEpochSeconds) ? claims : null;
+	return claims !== null && _isReadLease(claims, issuedAt) && claims.expiresAtEpochSeconds > nowEpochSeconds ? claims : null;
 }
 
 /** Sign promotion facts with the service's distinct Ed25519 receipt key. */
@@ -102,16 +103,16 @@ function _receiptFromPayload(value: Record<string, unknown>): ArtifactPromotionR
 
 function _isLease(value: ArtifactWriteLeaseClaims, now: number): boolean
 {
-	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && (value.expectedContentAddress === null || /^sha256:[0-9a-f]{64}$/u.test(value.expectedContentAddress)) && (value.expectedByteLength === null || (Number.isSafeInteger(value.expectedByteLength) && value.expectedByteLength >= 0)) && value.mediaType.includes("/");
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.action === "artifact.write" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && (value.expectedContentAddress === null || /^sha256:[0-9a-f]{64}$/u.test(value.expectedContentAddress)) && (value.expectedByteLength === null || (Number.isSafeInteger(value.expectedByteLength) && value.expectedByteLength >= 0)) && __IsSafeArtifactMediaType(value.mediaType);
 }
 
 /** Validate every immutable coordinate before an artifact read lease can be signed or accepted. */
 function _isReadLease(value: ArtifactReadLeaseClaims, now: number): boolean
 {
-	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.artifactRevisionId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && value.mediaType.includes("/") && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now;
+	return value.leaseId.trim().length > 0 && value.siloId.trim().length > 0 && value.artifactId.trim().length > 0 && value.artifactRevisionId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && __IsSafeArtifactMediaType(value.mediaType) && value.action === "artifact.read" && Number.isSafeInteger(value.expiresAtEpochSeconds) && value.expiresAtEpochSeconds > now && value.expiresAtEpochSeconds <= now + 300;
 }
 
 function _isReceipt(value: ArtifactPromotionReceiptClaims): boolean
 {
-	return value.leaseId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && value.mediaType.includes("/") && Number.isSafeInteger(value.issuedAtEpochSeconds) && value.issuedAtEpochSeconds >= 0;
+	return value.leaseId.trim().length > 0 && /^sha256:[0-9a-f]{64}$/u.test(value.contentAddress) && Number.isSafeInteger(value.byteLength) && value.byteLength >= 0 && __IsSafeArtifactMediaType(value.mediaType) && Number.isSafeInteger(value.issuedAtEpochSeconds) && value.issuedAtEpochSeconds >= 0;
 }

--- a/libs/backend/artifacts/authorization/main/src/artifact-media-type.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-media-type.ts
@@ -1,0 +1,11 @@
+/** HTTP token characters accepted in artifact media types and unquoted parameter values. */
+const _TOKEN = "[!#$%&'*+.^_`|~0-9A-Za-z-]+";
+
+/** Safe media-type grammar shared by artifact leases, receipts, and catalogue read issuance. */
+const _MEDIA_TYPE = new RegExp(`^${_TOKEN}/${_TOKEN}(?:[\\t ]*;[\\t ]*${_TOKEN}=${_TOKEN})*$`, "u");
+
+/** Accept a bounded response-safe media type, including token-valued parameters such as charset. */
+export function __IsSafeArtifactMediaType(value: string): boolean
+{
+	return value.length <= 255 && _MEDIA_TYPE.test(value);
+}

--- a/libs/backend/artifacts/authorization/main/src/index.ts
+++ b/libs/backend/artifacts/authorization/main/src/index.ts
@@ -1,2 +1,3 @@
 export { __SignArtifactPromotionReceipt, __SignArtifactReadLease, __SignArtifactWriteLease, __VerifyArtifactPromotionReceipt, __VerifyArtifactReadLease, __VerifyArtifactWriteLease } from "./artifact-lease.js";
+export { __IsSafeArtifactMediaType } from "./artifact-media-type.js";
 export type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";

--- a/libs/backend/artifacts/filesystem/main/README.md
+++ b/libs/backend/artifacts/filesystem/main/README.md
@@ -22,7 +22,7 @@ else. It owns the durability and integrity of the write, and the safety of every
  └─────────────────────────────────────────────────────────┘
           │  canonical immutable object (created: true/false)
           ▼
- read(address) streams it back · purge(address) removes it
+ byteLength(address) proves a regular file's size · read(address) streams it back · purge(address) removes it
 ```
 
 **In this flow:** [store](../../store/main/README.md) *(defines the `ArtifactStore` port and validates every command)* ·
@@ -43,7 +43,7 @@ in to read or overwrite a file outside the mounted volume, and stored bytes alwa
 
 ## Public surface
 
-- `__FilesystemArtifactStore` — the POSIX `ArtifactStore` adapter (`stage` · `promote` · `read` · `purge`).
+- `__FilesystemArtifactStore` — the POSIX `ArtifactStore` adapter (`stage` · `promote` · `byteLength` · `read` · `purge`). `byteLength` uses metadata only and returns `null` for an absent or non-regular canonical path. `read` eagerly opens and validates a regular file handle before returning its stream, so a concurrent unlink cannot invalidate an admitted read.
 - `FilesystemArtifactStoreOptions` — construction options (the absolute `rootPath` of the mounted volume).
 
 ## Boundary

--- a/libs/backend/artifacts/filesystem/main/src/__tests__/filesystem-artifact-store.test.ts
+++ b/libs/backend/artifacts/filesystem/main/src/__tests__/filesystem-artifact-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -114,6 +114,47 @@ describe("filesystem ArtifactStore", function _suite()
 			await expect(store.read("../../etc/passwd")).rejects.toThrow(/invalid ArtifactStore content address/);
 			expect(await store.purge(promotion.contentAddress)).toEqual({ purged: true });
 			expect(await store.purge(promotion.contentAddress)).toEqual({ purged: false });
+		}
+		finally
+		{
+			await rm(rootPath, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps an eagerly opened canonical file readable across a concurrent purge", async function _eagerReadHandle()
+	{
+		const rootPath = await mkdtemp(join(tmpdir(), "opencrane-artifact-store-"));
+		try
+		{
+			const store = new __FilesystemArtifactStore({ rootPath });
+			const staged = await store.stage({ lease: _lease("lease-1"), bytes: _bytes("artifact"), expectedContentAddress: null, expectedByteLength: null, mediaType: "text/plain" });
+			const promotion = await store.promote(staged);
+			const stream = await store.read(promotion.contentAddress);
+			expect(stream).not.toBeNull();
+
+			expect(await store.purge(promotion.contentAddress)).toEqual({ purged: true });
+			expect(stream === null ? null : (await _collect(stream)).toString("utf8")).toBe("artifact");
+		}
+		finally
+		{
+			await rm(rootPath, { recursive: true, force: true });
+		}
+	});
+
+	it("reports only regular canonical-object lengths and treats absent or non-file paths as unavailable", async function _canonicalByteLength()
+	{
+		const rootPath = await mkdtemp(join(tmpdir(), "opencrane-artifact-store-"));
+		try
+		{
+			const store = new __FilesystemArtifactStore({ rootPath });
+			const staged = await store.stage({ lease: _lease("lease-1"), bytes: _bytes("artifact"), expectedContentAddress: null, expectedByteLength: null, mediaType: "text/plain" });
+			const promotion = await store.promote(staged);
+			const nonFileAddress = `sha256:${"b".repeat(64)}`;
+			await mkdir(join(rootPath, "sha256", "bb", "b".repeat(64)), { recursive: true });
+
+			expect(await store.byteLength(promotion.contentAddress)).toBe(8);
+			expect(await store.byteLength(`sha256:${"a".repeat(64)}`)).toBeNull();
+			expect(await store.byteLength(nonFileAddress)).toBeNull();
 		}
 		finally
 		{

--- a/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
+++ b/libs/backend/artifacts/filesystem/main/src/filesystem-artifact-store.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
-import { createReadStream } from "node:fs";
-import { link, lstat, mkdir, open, stat, unlink } from "node:fs/promises";
+import { link, lstat, mkdir, open, unlink } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import { join } from "node:path";
 
@@ -116,8 +115,8 @@ export class __FilesystemArtifactStore implements ArtifactStore
 		return { leaseId: staged.leaseId, contentAddress: staged.contentAddress, byteLength: staged.byteLength, mediaType: staged.mediaType, created };
 	}
 
-	/** Opens immutable bytes only by a strict canonical address, never a caller-provided path. */
-	async read(contentAddress: string): Promise<ArtifactByteStream | null>
+	/** Returns one regular canonical file's byte length without opening a stream. */
+	async byteLength(contentAddress: string): Promise<number | null>
 	{
 		if (!___IsSha256ContentAddress(contentAddress))
 		{
@@ -125,11 +124,38 @@ export class __FilesystemArtifactStore implements ArtifactStore
 		}
 		try
 		{
-			await stat(this._contentPath(contentAddress));
-			return createReadStream(this._contentPath(contentAddress));
+			const canonicalFile = await lstat(this._contentPath(contentAddress));
+			return canonicalFile.isFile() ? canonicalFile.size : null;
 		}
 		catch (error)
 		{
+			if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
+			throw error;
+		}
+	}
+
+	/** Opens immutable bytes only by a strict canonical address, never a caller-provided path. */
+	async read(contentAddress: string): Promise<ArtifactByteStream | null>
+	{
+		if (!___IsSha256ContentAddress(contentAddress))
+		{
+			throw new Error("invalid ArtifactStore content address");
+		}
+		let canonicalFile: FileHandle | null = null;
+		try
+		{
+			canonicalFile = await open(this._contentPath(contentAddress), "r");
+			const openedFile = await canonicalFile.stat();
+			if (!openedFile.isFile())
+			{
+				await canonicalFile.close();
+				return null;
+			}
+			return canonicalFile.createReadStream();
+		}
+		catch (error)
+		{
+			await canonicalFile?.close().catch(function _ignoreAlreadyClosedFile() {});
 			if (error instanceof Error && "code" in error && error.code === "ENOENT") return null;
 			throw error;
 		}

--- a/libs/backend/artifacts/store/main/README.md
+++ b/libs/backend/artifacts/store/main/README.md
@@ -42,7 +42,7 @@ boundary, and a receipt is impossible unless the exact authorised object became 
 
 - `__PromoteArtifactUpload(store, leaseVerifier, byteSource, config)` — the end-to-end promotion protocol (verify → stage → promote → receipt).
 - `__ValidateVerifiedArtifactWriteLease`, `__ValidateStageArtifactCommand`, `__ValidateStagedArtifact`, `__ValidateArtifactStorePromotion` — the fail-closed input guards.
-- `ArtifactStore` — the storage port an adapter implements (`stage` · `promote` · `read` · `purge`).
+- `ArtifactStore` — the storage port an adapter implements (`stage` · `promote` · `byteLength` · `read` · `purge`); `byteLength` lets readers prove the signed size before opening bytes.
 - `ArtifactPromotionLeaseVerifier` / `ArtifactPromotionReceiptSigner` — the injected signing/verification seams.
 - `StageArtifactCommand`, `StagedArtifact`, `ArtifactStorePromotion`, `PromoteArtifactUploadResult`, `BoundedArtifactUploadByteSource`, and the related claim/config types.
 

--- a/libs/backend/artifacts/store/main/src/__tests__/artifact-promotion.test.ts
+++ b/libs/backend/artifacts/store/main/src/__tests__/artifact-promotion.test.ts
@@ -65,6 +65,7 @@ function _store(): TestStore
 				promoteCount += 1;
 				return { ...staged, created: true };
 			},
+			async byteLength() { return null; },
 			async read() { return null; },
 			async purge() { return { purged: false }; },
 		},

--- a/libs/backend/artifacts/store/main/src/artifact-store.types.ts
+++ b/libs/backend/artifacts/store/main/src/artifact-store.types.ts
@@ -145,6 +145,8 @@ export interface ArtifactStore
 	stage(command: StageArtifactCommand): Promise<StagedArtifact>;
 	/** Atomically promotes staged bytes to their immutable content address. */
 	promote(staged: StagedArtifact): Promise<ArtifactStorePromotion>;
+	/** Returns the size of one regular canonical object, or null when it is absent or not a regular file. */
+	byteLength(contentAddress: string): Promise<number | null>;
 	/** Reads canonical bytes by an already-authorized immutable content address. */
 	read(contentAddress: string): Promise<ArtifactByteStream | null>;
 	/** Removes bytes only after the OpenCrane authority proved no active lease or reference remains. */

--- a/libs/backend/server/agents/artifacts/main/README.md
+++ b/libs/backend/server/agents/artifacts/main/README.md
@@ -30,23 +30,43 @@ genuine and has not already been used.
  skills / agent revisions reference the exact ArtifactRevision by content address
 ```
 
+For internal reads, an upstream authority first decides *which* revision a workload may use. This
+package then reloads that exact revision through the active artifact and published-revision
+relations before minting a short-lived lease from catalogue-owned facts:
+
+```
+ workload-specific admission  ──►  silo + artifact + revision coordinates
+                                          │
+                                          ▼
+                        reload active published catalogue facts
+                                          │ exact digest · bytes · media type
+                                          ▼
+                         five-minute-maximum signed read lease
+```
+
 **In this flow:** [skills](../../skills/main/README.md) · [agent-services](../../agent-services/main/README.md) *(both pin artifacts)*
 
 Invariant: this domain never touches artifact bytes — no upload, no download, no hashing of content
 here. It commits revision metadata, the current-revision pointer, the lease consumption, and the
 outbox event in one transaction, keyed by an idempotency key so a retried finalize returns the same
 result instead of creating a duplicate. A stale, replayed, or already-consumed receipt fails closed.
+Read leases contain only facts reloaded from the catalogue; caller-provided digests, byte counts,
+media types, storage paths, and URLs never become read authority.
 
 ## Public surface
 
 - `__FinalizeArtifactRevision` — commit promoted bytes into a visible, immutable revision.
+- `__IssueArtifactReadLease` — reload an active artifact's exact published revision and issue one
+  internal read lease that expires after at most five minutes.
 - `__UploadArtifact` — orchestrate the full verified upload (lease → promote → finalize).
 - `PrismaArtifactAuthorityRepository` — the Postgres-backed persistence adapter.
 - `__CreatePersonalArtifactCatalogueRouter` — serves `GET /api/v1/me/assets`, a bounded list of
   non-deleted asset metadata owned by the signed-in caller in the trusted host silo.
 - Types: `ArtifactAuthorityRepository`, `ArtifactStorePromotionReceipt`, `FinalizeArtifactRevisionCommand`,
-  and the upload ports (`ArtifactServicePromotionPort`, `ArtifactUploadCryptoPort`,
-  `ArtifactUploadLeaseRepository`, `VerifiedArtifactUploadCommand`, `ArtifactUploadResult`).
+  the read-lease ports (`ArtifactReadLeaseRepository`, `ArtifactReadLeaseSigner`,
+  `IssueArtifactReadLeaseCommand`), and the upload ports (`ArtifactServicePromotionPort`,
+  `ArtifactUploadCryptoPort`, `ArtifactUploadLeaseRepository`, `VerifiedArtifactUploadCommand`,
+  `ArtifactUploadResult`).
 
 ## Boundary
 
@@ -54,6 +74,12 @@ The application layer wires the byte-store client, the crypto port, and the Pris
 use cases. Proof verification and replay reservation happen upstream — this package trusts that a
 `VerifiedArtifactUploadCommand` is already authorized, and its job is to keep metadata consistent
 with what the byte store actually promoted.
+
+Read-lease issuance is internal and has no router. It does not decide which workload may name an
+artifact; the caller must already have passed its workload-specific admission authority. The issuer
+then independently reloads the exact active/published catalogue facts and delegates signing to an
+app-owned port backed by mounted key material. The lease and ArtifactStore endpoint never reach the
+workload.
 
 The personal catalogue is discovery only. It returns kind, lifecycle, current-revision media type,
 size, indexing state, and timestamps. It never returns bytes, a content address, provenance,

--- a/libs/backend/server/agents/artifacts/main/src/__tests__/artifact-read-lease.test.ts
+++ b/libs/backend/server/agents/artifacts/main/src/__tests__/artifact-read-lease.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __IssueArtifactReadLease } from "../artifact-read-lease.js";
+import type { PublishedArtifactReadTarget } from "../artifact-read-lease.types.js";
+
+/** Build one exact active published revision returned by the server-owned repository. */
+function _Target(overrides: Partial<PublishedArtifactReadTarget> = {}): PublishedArtifactReadTarget
+{
+	return { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "text/plain", ...overrides };
+}
+
+describe("ArtifactStore read lease issuer", function _Suite()
+{
+	it("issues only server-loaded active published facts with a five-minute lifetime", async function _Issues()
+	{
+		const signer = { sign: vi.fn().mockReturnValue("compact-read-lease") };
+		const repository = { loadPublishedReadTarget: vi.fn().mockResolvedValue(_Target({ mediaType: "text/plain; charset=utf-8" })) };
+		const result = await __IssueArtifactReadLease(repository, signer, { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" }, 1_750_000_000);
+
+		expect(result).toMatchObject({ outcome: "issued", compactLease: "compact-read-lease", claims: { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: _Target().contentAddress, byteLength: 12, mediaType: "text/plain; charset=utf-8", expiresAtEpochSeconds: 1_750_000_300 } });
+		expect(signer.sign).toHaveBeenCalledWith(expect.objectContaining({ action: "artifact.read" }));
+	});
+
+	it("rejects malformed coordinates before querying or signing", async function _RejectsMalformedCommand()
+	{
+		const repository = { loadPublishedReadTarget: vi.fn() };
+		const signer = { sign: vi.fn() };
+
+		await expect(__IssueArtifactReadLease(repository, signer, { siloId: "../silo", artifactId: "artifact-1", artifactRevisionId: "revision-1" }, 1_750_000_000)).resolves.toEqual({ outcome: "denied", reason: "invalid_command" });
+		expect(repository.loadPublishedReadTarget).not.toHaveBeenCalled();
+		expect(signer.sign).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["a different revision", _Target({ artifactRevisionId: "revision-2" })],
+		["an unsafe byte length", _Target({ byteLength: Number.MAX_SAFE_INTEGER + 1 })],
+		["a header-unsafe media type", _Target({ mediaType: "text/plain\r\nx-injected: yes" })],
+		["an invalid content address", _Target({ contentAddress: "sha256:not-a-digest" })],
+	])("fails closed for %s returned by the repository", async function _RejectsTarget(_name, target)
+	{
+		const signer = { sign: vi.fn() };
+		const result = await __IssueArtifactReadLease({ loadPublishedReadTarget: vi.fn().mockResolvedValue(target) }, signer, { siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" }, 1_750_000_000);
+
+		expect(result).toEqual({ outcome: "denied", reason: "revision_not_readable" });
+		expect(signer.sign).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/agents/artifacts/main/src/__tests__/prisma-artifact-authority.test.ts
+++ b/libs/backend/server/agents/artifacts/main/src/__tests__/prisma-artifact-authority.test.ts
@@ -9,6 +9,25 @@ function _command()
 
 describe("Prisma artifact authority", function _suite()
 {
+	it("loads only an exact published revision owned by an active artifact in the requested silo", async function _LoadsReadTarget()
+	{
+		const artifactRevision = { findFirst: vi.fn().mockResolvedValue({ id: "revision-1", artifactId: "artifact-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12n, mediaType: "text/plain", artifact: { siloId: "silo-1" } }) };
+		const repository = new PrismaArtifactAuthorityRepository({ artifactRevision } as never);
+
+		await expect(repository.loadPublishedReadTarget({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" })).resolves.toEqual({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: 12, mediaType: "text/plain" });
+		expect(artifactRevision.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+			where: { id: "revision-1", artifactId: "artifact-1", state: "Published", artifact: { siloId: "silo-1", state: "Active" } },
+			select: expect.objectContaining({ contentAddress: true, byteLength: true, mediaType: true }),
+		}));
+	});
+
+	it.each([null, { id: "revision-1", artifactId: "artifact-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: -1n, mediaType: "text/plain", artifact: { siloId: "silo-1" } }, { id: "revision-1", artifactId: "artifact-1", contentAddress: `sha256:${"a".repeat(64)}`, byteLength: BigInt(Number.MAX_SAFE_INTEGER) + 1n, mediaType: "text/plain", artifact: { siloId: "silo-1" } }])("fails closed for an absent or unsafe published revision projection", async function _RejectsUnsafeReadTarget(row)
+	{
+		const repository = new PrismaArtifactAuthorityRepository({ artifactRevision: { findFirst: vi.fn().mockResolvedValue(row) } } as never);
+
+		await expect(repository.loadPublishedReadTarget({ siloId: "silo-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" })).resolves.toBeNull();
+	});
+
 	it("commits promotion receipt, immutable revision, current pointer, outbox, and final lease state together", async function _finalize()
 	{
 		const transaction = {

--- a/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.ts
@@ -1,0 +1,52 @@
+import { randomUUID } from "node:crypto";
+
+import { __IsSafeArtifactMediaType } from "@opencrane/backend/artifacts/authorization";
+
+import type { ArtifactReadLeaseRepository, ArtifactReadLeaseSigner, IssueArtifactReadLeaseCommand, IssueArtifactReadLeaseResult, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
+
+/** Maximum lifetime for a service-verified internal artifact read lease. */
+const _READ_LEASE_SECONDS = 300;
+
+/** Issue one exact short-lived read lease from independently loaded active catalogue facts. */
+export async function __IssueArtifactReadLease(repository: ArtifactReadLeaseRepository, signer: ArtifactReadLeaseSigner, command: IssueArtifactReadLeaseCommand, nowEpochSeconds: number): Promise<IssueArtifactReadLeaseResult>
+{
+	if (!_IsCommand(command) || !Number.isSafeInteger(nowEpochSeconds) || nowEpochSeconds < 0)
+	{
+		return { outcome: "denied", reason: "invalid_command" };
+	}
+
+	// 1. Reload the exact revision under its silo; no caller byte metadata becomes lease content.
+	const target = await repository.loadPublishedReadTarget(command);
+	if (!_MatchesCommand(target, command))
+	{
+		return { outcome: "denied", reason: "revision_not_readable" };
+	}
+
+	// 2. Bind one opaque, bounded lease to the immutable facts returned by the catalogue authority.
+	const claims = { leaseId: randomUUID(), siloId: target.siloId, artifactId: target.artifactId, artifactRevisionId: target.artifactRevisionId, contentAddress: target.contentAddress, byteLength: target.byteLength, mediaType: target.mediaType, action: "artifact.read" as const, expiresAtEpochSeconds: nowEpochSeconds + _READ_LEASE_SECONDS };
+
+	// 3. Only app composition owns the mounted signing key and may serialize the reviewed claims.
+	return { outcome: "issued", compactLease: signer.sign(claims), claims };
+}
+
+/** Reject malformed durable coordinates before they can probe the catalogue repository. */
+function _IsCommand(value: IssueArtifactReadLeaseCommand): boolean
+{
+	return [value.siloId, value.artifactId, value.artifactRevisionId].every(function _IsIdentifier(part): boolean
+	{
+		return /^[A-Za-z0-9_-]{1,128}$/u.test(part);
+	});
+}
+
+/** Prove the repository returned the requested immutable coordinates and safe exact byte facts. */
+function _MatchesCommand(target: PublishedArtifactReadTarget | null, command: IssueArtifactReadLeaseCommand): target is PublishedArtifactReadTarget
+{
+	return target !== null
+		&& target.siloId === command.siloId
+		&& target.artifactId === command.artifactId
+		&& target.artifactRevisionId === command.artifactRevisionId
+		&& /^sha256:[a-f0-9]{64}$/u.test(target.contentAddress)
+		&& Number.isSafeInteger(target.byteLength)
+		&& target.byteLength >= 0
+		&& __IsSafeArtifactMediaType(target.mediaType);
+}

--- a/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.types.ts
@@ -1,0 +1,48 @@
+import type { ArtifactReadLeaseClaims } from "@opencrane/backend/artifacts/authorization";
+
+/** Server-owned coordinates for one exact published revision that may be read internally. */
+export interface IssueArtifactReadLeaseCommand
+{
+	/** Silo whose artifact authority must contain the requested revision. */
+	readonly siloId: string;
+	/** Logical artifact that owns the revision. */
+	readonly artifactId: string;
+	/** Immutable published revision that owns the canonical bytes. */
+	readonly artifactRevisionId: string;
+}
+
+/** Immutable catalogue facts loaded only after active-silo and published-revision checks. */
+export interface PublishedArtifactReadTarget
+{
+	/** Silo independently loaded from the active artifact record. */
+	readonly siloId: string;
+	/** Logical artifact independently loaded from the revision relation. */
+	readonly artifactId: string;
+	/** Exact immutable revision independently loaded from the catalogue. */
+	readonly artifactRevisionId: string;
+	/** Canonical SHA-256 object address approved by that revision. */
+	readonly contentAddress: string;
+	/** Exact canonical byte count approved by that revision. */
+	readonly byteLength: number;
+	/** Catalogue-approved media type for the immutable bytes. */
+	readonly mediaType: string;
+}
+
+/** Persistence boundary exposing no artifact path, list, or caller-supplied byte metadata. */
+export interface ArtifactReadLeaseRepository
+{
+	/** Loads one active artifact's exact published revision, or null for every other state. */
+	loadPublishedReadTarget(command: IssueArtifactReadLeaseCommand): Promise<PublishedArtifactReadTarget | null>;
+}
+
+/** Narrow signing port owned by server composition and backed by mounted key material. */
+export interface ArtifactReadLeaseSigner
+{
+	/** Signs only validated server-owned artifact-read claims. */
+	sign(claims: ArtifactReadLeaseClaims): string;
+}
+
+/** Stable outcome of one server-internal read-lease issuance attempt. */
+export type IssueArtifactReadLeaseResult =
+	| { readonly outcome: "issued"; readonly compactLease: string; readonly claims: ArtifactReadLeaseClaims }
+	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "revision_not_readable" };

--- a/libs/backend/server/agents/artifacts/main/src/index.ts
+++ b/libs/backend/server/agents/artifacts/main/src/index.ts
@@ -1,8 +1,10 @@
 export { __FinalizeArtifactRevision } from "./artifact-finalization.js";
+export { __IssueArtifactReadLease } from "./artifact-read-lease.js";
 export { PrismaArtifactAuthorityRepository } from "./prisma-artifact-authority.js";
 export { __UploadArtifact } from "./artifact-upload.js";
 export { __CreatePersonalArtifactCatalogueRouter } from "./personal-artifact-catalogue.router.js";
 export { _PersonalArtifactsOpenapiPaths } from "./openapi.js";
 export type { ArtifactAuthorityRepository, ArtifactStorePromotionReceipt, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand, FinalizeArtifactRevisionResult, PersonalArtifactCatalogueRepository, PersonalArtifactEntry } from "./artifact-finalization.types.js";
+export type { ArtifactReadLeaseRepository, ArtifactReadLeaseSigner, IssueArtifactReadLeaseCommand, IssueArtifactReadLeaseResult, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
 export type { PersonalArtifactCaller, PersonalArtifactCatalogueRouterDependencies } from "./personal-artifact-catalogue.router.types.js";
 export type { ArtifactServicePromotionPort, ArtifactUploadCryptoPort, ArtifactUploadLeaseRepository, ArtifactUploadResult, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
@@ -1,12 +1,13 @@
 import { randomUUID } from "node:crypto";
 
-import { ArtifactIndexState, ArtifactKind, ArtifactState, ArtifactUploadLeaseState, Prisma, type PrismaClient } from "@prisma/client";
+import { ArtifactIndexState, ArtifactKind, ArtifactRevisionState, ArtifactState, ArtifactUploadLeaseState, Prisma, type PrismaClient } from "@prisma/client";
 
+import type { ArtifactReadLeaseRepository, IssueArtifactReadLeaseCommand, PublishedArtifactReadTarget } from "./artifact-read-lease.types.js";
 import type { ArtifactAuthorityRepository, AtomicFinalizeArtifactResult, FinalizeArtifactRevisionCommand, PersonalArtifactCatalogueRepository, PersonalArtifactEntry } from "./artifact-finalization.types.js";
 import type { ArtifactUploadLeaseRepository, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";
 
 /** Postgres authority for receipt consumption, immutable revision publication, and outbox creation. */
-export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactUploadLeaseRepository, PersonalArtifactCatalogueRepository
+export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactReadLeaseRepository, ArtifactUploadLeaseRepository, PersonalArtifactCatalogueRepository
 {
 	/** Canonical OpenCrane catalog database client. */
 	private readonly prisma: PrismaClient;
@@ -15,6 +16,17 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 	constructor(prisma: PrismaClient)
 	{
 		this.prisma = prisma;
+	}
+
+	/** Loads only an active artifact's exact published revision as a storage-neutral read target. */
+	async loadPublishedReadTarget(command: IssueArtifactReadLeaseCommand): Promise<PublishedArtifactReadTarget | null>
+	{
+		const revision = await this.prisma.artifactRevision.findFirst({
+			where: { id: command.artifactRevisionId, artifactId: command.artifactId, state: ArtifactRevisionState.Published, artifact: { siloId: command.siloId, state: ArtifactState.Active } },
+			select: { id: true, artifactId: true, contentAddress: true, byteLength: true, mediaType: true, artifact: { select: { siloId: true } } },
+		});
+		if (revision === null || revision.byteLength < 0n || revision.byteLength > BigInt(Number.MAX_SAFE_INTEGER)) return null;
+		return { siloId: revision.artifact.siloId, artifactId: revision.artifactId, artifactRevisionId: revision.id, contentAddress: revision.contentAddress, byteLength: Number(revision.byteLength), mediaType: revision.mediaType };
 	}
 
 	/** List only safe metadata from non-deleted assets owned in the exact trusted silo. */


### PR DESCRIPTION
## Why this exists

Phase D and Phase E produced two useful but overlapping artifact-read lanes. This PR reconciles them into one authority chain instead of preserving both protocols in the clean-build product.

The result is a narrow trust boundary: a skill-authoring workload proves its exact Pod and assignment, OpenCrane reloads the active published artifact revision from the catalogue, and only then signs a short-lived read lease. The worker receives bytes only, never a storage address, service URL, mounted disk, or reusable lease.

## What changes

- add one shared catalogue-to-read-lease issuer under the server artifact domain
- make OpenCrane the sole composition owner for the private signing key and artifact-service client
- replace caller-selected content routes with fixed GET /v1/artifacts/read
- enforce exact active, published, and silo catalogue facts and bounded five-minute leases
- share response-safe media-type validation across catalogue issuance, signatures, and receipts
- preflight stored length and eagerly open the canonical file before a successful response
- remove the worker-visible content-address header
- record the single-authority decision in ADR 0011 and update affected package documentation

## Trust flow

1. The workload-specific repository proves Pod, assignment, bootstrap, and product revision.
2. The shared catalogue issuer reloads the exact active published artifact revision.
3. OpenCrane signs a short-lived lease from those database facts.
4. Artifact service verifies the lease, checks length, eagerly opens the file, and streams bytes.
5. The worker receives only the artifact body.

## Validation

- npx nx affected build, test, and lint: 8 affected projects green
- focused lint and test gate: 110 tests green across authorization, filesystem, catalogue, worker broker, artifact service, and OpenCrane
- monorepo boundary lint passed
- agent style check: 0 errors, 0 warnings
- git diff check passed
- Phase A, B, and D negative guards passed before review

## Review

- required structural architecture review: PASS
- rewrite and reaper review: no stale production protocol or duplicate authority remains
- independent correctness and security review found two medium issues; both were fixed and the same reviewer returned PASS

## Scope

Backend and state composition only. No UI work.