### PR TITLE
♻️ Unify JSON trust-boundary validation

### DIFF
--- a/apps/agent-controller/src/__tests__/config.test.ts
+++ b/apps/agent-controller/src/__tests__/config.test.ts
@@ -81,4 +81,10 @@ describe("agent-controller process config", function _Suite()
 		expect(function _TooFrequent() { _ReadConfig({ ..._Environment(), AGENT_CONTROLLER_OUTBOX_PRUNE_INTERVAL_MS: "59999" }); }).toThrow(/OUTBOX_PRUNE_INTERVAL/);
 		expect(function _TooSlow() { _ReadConfig({ ..._Environment(), AGENT_CONTROLLER_OUTBOX_PRUNE_INTERVAL_MS: "86400001" }); }).toThrow(/OUTBOX_PRUNE_INTERVAL/);
 	});
+
+	it("identifies the exact JSON configuration source whose syntax is invalid", function _RejectsInvalidJson()
+	{
+		expect(function _InvalidRuntimeProfiles() { _ReadConfig({ ..._Environment(), AGENT_CONTROLLER_PROFILES_JSON: "{" }); }).toThrow(/AGENT_CONTROLLER_PROFILES_JSON must contain valid JSON/);
+		expect(function _InvalidSkillProfiles() { _ReadConfig({ ..._Environment(), AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON: "{" }); }).toThrow(/AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON must contain valid JSON/);
+	});
 });

--- a/apps/agent-controller/src/config.ts
+++ b/apps/agent-controller/src/config.ts
@@ -2,6 +2,7 @@ import { isAbsolute } from "node:path";
 
 import { __ValidateAgentControllerRuntimeProfiles } from "@opencrane/backend/agents/runtime/controller";
 import { __ValidateSkillWorkloadControllerProfiles } from "@opencrane/backend/agents/skills/controller";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import type { AgentControllerProcessConfig } from "./config.types.js";
 
@@ -25,32 +26,6 @@ function _Integer(environment: NodeJS.ProcessEnv, name: string, fallback: number
 	return value;
 }
 
-/** Parse JSON while converting syntax errors into a stable configuration failure. */
-function _Json(value: string): unknown
-{
-	try
-	{
-		return JSON.parse(value) as unknown;
-	}
-	catch
-	{
-		throw new Error("AGENT_CONTROLLER_PROFILES_JSON must contain valid JSON");
-	}
-}
-
-/** Parse skill profile JSON while keeping its configuration failure distinct from runtime profiles. */
-function _SkillProfilesJson(value: string): unknown
-{
-	try
-	{
-		return JSON.parse(value) as unknown;
-	}
-	catch
-	{
-		throw new Error("AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON must contain valid JSON");
-	}
-}
-
 /** Read and fail-closed validate the complete agent-controller process configuration. */
 export function _ReadConfig(environment: NodeJS.ProcessEnv = process.env): AgentControllerProcessConfig
 {
@@ -62,8 +37,8 @@ export function _ReadConfig(environment: NodeJS.ProcessEnv = process.env): Agent
 	}
 
 	// 2. Validate every immutable profile and its dedicated runtime namespace at startup.
-	const profiles = __ValidateAgentControllerRuntimeProfiles(_Json(_Required(environment, "AGENT_CONTROLLER_PROFILES_JSON")));
-	const skillWorkloadProfiles = __ValidateSkillWorkloadControllerProfiles(_SkillProfilesJson(_Required(environment, "AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON")));
+	const profiles = ___ParseAndValidateJson(_Required(environment, "AGENT_CONTROLLER_PROFILES_JSON"), "AGENT_CONTROLLER_PROFILES_JSON", __ValidateAgentControllerRuntimeProfiles);
+	const skillWorkloadProfiles = ___ParseAndValidateJson(_Required(environment, "AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON"), "AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON", __ValidateSkillWorkloadControllerProfiles);
 	return {
 		openCraneInternalUrl: _Required(environment, "OPENCRANE_INTERNAL_URL"),
 		controllerTokenPath,

--- a/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
+++ b/apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts
@@ -46,6 +46,8 @@ describe("artifact upload app composition", function _suite()
 		await expect(port.promote("signed-lease", _bytes())).rejects.toThrow("promotion failed with 403");
 		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({}), { status: 201 })));
 		await expect(port.promote("signed-lease", _bytes())).rejects.toThrow("returned no receipt");
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("{", { status: 201 })));
+		await expect(port.promote("signed-lease", _bytes())).rejects.toThrow(/artifact service promotion response must contain valid JSON/);
 	});
 
 	it("uses the fixed read endpoint and dedicated read-lease header", async function _ReadsPinnedArtifact()

--- a/apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts
+++ b/apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts
@@ -9,6 +9,7 @@ import { __CompleteArtifactPreprocessJob, __IssueArtifactPreprocessOutputLease, 
 import type { ArtifactPreprocessOutputBroker, ArtifactPreprocessSourceBroker, ArtifactUploadResult, VerifiedArtifactUploadCommand } from "@opencrane/backend/server/agents/artifacts";
 import type { SkillAuthoringArtifactReader, SkillAuthoringInputRecord } from "@opencrane/backend/agents/skills/execution";
 import { ___DoWithTrace } from "@opencrane/observability";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 /** Build the app-owned bridge from a proof-authorized command to the private artifact service. */
 export function _CreateArtifactUploadGateway(prisma: PrismaClient, environment: NodeJS.ProcessEnv = process.env): { upload(command: VerifiedArtifactUploadCommand): Promise<ArtifactUploadResult> }
@@ -37,11 +38,16 @@ export function _CreateArtifactServicePromotionPort(serviceUrl: string): { promo
 		{
 			const response = await fetch(`${serviceUrl}/v1/artifacts/promote`, { method: "POST", headers: { "x-opencrane-artifact-lease": lease }, body: Readable.toWeb(Readable.from(bytes)) as unknown as BodyInit, duplex: "half" } as RequestInit);
 			if (!response.ok) throw new Error(`artifact service promotion failed with ${response.status}`);
-			const body = await response.json() as { receipt?: unknown };
-			if (typeof body.receipt !== "string") throw new Error("artifact service promotion returned no receipt");
-			return { receipt: body.receipt };
+			return ___ParseAndValidateJson(await response.text(), "artifact service promotion response", _PromotionReceipt);
 		},
 	};
+}
+
+/** Validate the exact receipt returned after artifact promotion. */
+function _PromotionReceipt(value: unknown): { readonly receipt: string }
+{
+	if (typeof value !== "object" || value === null || Array.isArray(value) || !("receipt" in value) || typeof value.receipt !== "string" || value.receipt.length === 0) throw new Error("artifact service promotion returned no receipt");
+	return { receipt: value.receipt };
 }
 
 /** Build the server-only HTTP client that retrieves bytes covered by one immutable read lease. */

--- a/libs/backend/agents/runtime/controller/src/__tests__/http-agent-controller-authority.test.ts
+++ b/libs/backend/agents/runtime/controller/src/__tests__/http-agent-controller-authority.test.ts
@@ -34,6 +34,21 @@ function _Registration(): AgentControllerRunWorkloadRegistrationCommand
 	return { claimedAt: "2026-07-20T00:02:00.000Z", deliveryCount: 2, runId: "run-1", attempt: 1, siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", namespace: "silo-a-runtime", serviceAccountName: "agent-runtime-default", workloadUid: "job-uid", workloadProfile: "personal-default", bootstrapReference: "bootstrap-ref-1", podUid: "pod-uid" };
 }
 
+/** Return a chunked response that crosses the controller allocation ceiling. */
+function _OversizedChunkedResponse(maximumBytes: number): Response
+{
+	let chunk = 0;
+	return new Response(new ReadableStream<Uint8Array>({
+		pull(controller)
+		{
+			if (chunk === 0) controller.enqueue(new Uint8Array(maximumBytes));
+			else if (chunk === 1) controller.enqueue(new Uint8Array(1));
+			else controller.close();
+			chunk += 1;
+		},
+	}));
+}
+
 describe("agent-controller OpenCrane HTTP authority", function _Suite()
 {
 	it("claims and commits over the exact projected-token-authenticated routes", async function _CallsAuthority()
@@ -84,6 +99,8 @@ describe("agent-controller OpenCrane HTTP authority", function _Suite()
 
 		const malformed = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: "http://opencrane-server.silo-a.svc.cluster.local:3001", tokenPath: "/token", requestTimeoutMilliseconds: 5_000, fetch: async function _malformed() { return new Response(JSON.stringify({ lease: {}, attempt: {} }), { status: 200 }); }, readToken: async function _token() { return "token"; } });
 		await expect(malformed.__Claim(new AbortController().signal)).rejects.toThrow(/malformed controller claim/);
+		const invalidJson = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: "http://opencrane-server.silo-a.svc.cluster.local:3001", tokenPath: "/token", requestTimeoutMilliseconds: 5_000, fetch: async function _invalidJson() { return new Response("{", { status: 200 }); }, readToken: async function _token() { return "token"; } });
+		await expect(invalidJson.__Claim(new AbortController().signal)).rejects.toThrow(/OpenCrane controller response must contain valid JSON/);
 		const malformedRelease = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: "http://opencrane-server.silo-a.svc.cluster.local:3001", tokenPath: "/token", requestTimeoutMilliseconds: 5_000, fetch: async function _malformedRelease() { return new Response(JSON.stringify({ ..._ReleaseBody(), workload: { ..._ReleaseBody().workload, assignmentExpiresAt: "2026-07-20T01:00:00Z" } }), { status: 200 }); }, readToken: async function _token() { return "token"; } });
 		await expect(malformedRelease.__ClaimWorkloadRelease(new AbortController().signal)).rejects.toThrow(/malformed workload-release claim/);
 
@@ -92,5 +109,12 @@ describe("agent-controller OpenCrane HTTP authority", function _Suite()
 
 		const mismatchedPod = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: "http://opencrane-server.silo-a.svc.cluster.local:3001", tokenPath: "/token", requestTimeoutMilliseconds: 5_000, fetch: async function _mismatchedPod() { return new Response(JSON.stringify({ outcome: "registered", runId: "run-1", attempt: 1, workloadUid: "job-uid", podUid: "foreign-pod" }), { status: 200 }); }, readToken: async function _token() { return "token"; } });
 		await expect(mismatchedPod.__RegisterFirstPod("event-1", _Registration(), new AbortController().signal)).rejects.toThrow(/mismatched first-Pod/);
+	});
+
+	it("stops a chunked response as soon as it crosses the allocation ceiling", async function _BoundsChunkedResponse()
+	{
+		const authority = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: "http://opencrane-server.silo-a.svc.cluster.local:3001", tokenPath: "/token", requestTimeoutMilliseconds: 5_000, fetch: async function _oversized() { return _OversizedChunkedResponse(64 * 1024); }, readToken: async function _token() { return "token"; } });
+
+		await expect(authority.__Claim(new AbortController().signal)).rejects.toThrow(/exceeded the 64 KiB boundary/);
 	});
 });

--- a/libs/backend/agents/runtime/controller/src/http-agent-controller-authority.ts
+++ b/libs/backend/agents/runtime/controller/src/http-agent-controller-authority.ts
@@ -3,6 +3,7 @@ import { isAbsolute } from "node:path";
 
 import { ___DoWithTrace } from "@opencrane/observability";
 import type { AgentControllerRunAttemptAssignmentCommand, AgentControllerRunAttemptAssignmentResult, AgentControllerRunAttemptClaim, AgentControllerRunAttemptClaimLease, AgentControllerRunWorkloadRegistrationCommand, AgentControllerRunWorkloadRegistrationResult, AgentControllerRunWorkloadReleaseClaim } from "@opencrane/contracts";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import type { AgentControllerAuthority, AgentControllerFetch, AgentControllerHttpAuthorityOptions, AgentControllerTokenReader } from "./agent-controller.types.js";
 
@@ -44,21 +45,52 @@ function _AsObject(value: unknown): Record<string, unknown> | null
 	return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
 }
 
-/** Parse and bound one JSON response without trusting its content type alone. */
-async function _ReadJson(response: Response): Promise<unknown>
+/**
+ * Read one bounded controller response and return only the validator-owned domain value.
+ *
+ * @param response - Internal controller response whose body remains untrusted.
+ * @param validate - Domain validator that binds the decoded payload to its expected contract.
+ * @param validatorArguments - Request coordinates used to reject mismatched authority responses.
+ * @returns The validated response value.
+ */
+async function _ReadAndValidateJson<T, TArguments extends readonly unknown[]>(response: Response, validate: (candidate: unknown, ...arguments_: TArguments) => T, ...validatorArguments: TArguments): Promise<T>
 {
-	const text = await response.text();
-	if (Buffer.byteLength(text, "utf8") > _MAX_RESPONSE_BYTES)
+	// 1. Stream the body through the allocation ceiling before retaining or parsing it.
+	const text = await _ReadBoundedText(response);
+
+	// 2. Parse and validate in one boundary operation so no untyped payload escapes this adapter.
+	return ___ParseAndValidateJson(text, "OpenCrane controller response", validate, ...validatorArguments);
+}
+
+/** Read one controller response without allocating beyond its fixed protocol ceiling. */
+async function _ReadBoundedText(response: Response): Promise<string>
+{
+	const declaredLength = response.headers.get("content-length");
+	if (declaredLength !== null)
 	{
-		throw new Error("OpenCrane controller response exceeded the 64 KiB boundary");
+		const parsedLength = Number(declaredLength);
+		if (!Number.isSafeInteger(parsedLength) || parsedLength < 0 || parsedLength > _MAX_RESPONSE_BYTES)
+		{
+			await response.body?.cancel();
+			throw new Error("OpenCrane controller response exceeded the 64 KiB boundary");
+		}
 	}
-	try
+	if (response.body === null) throw new Error("OpenCrane controller returned no response body");
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let byteLength = 0;
+	while (true)
 	{
-		return JSON.parse(text) as unknown;
-	}
-	catch
-	{
-		throw new Error("OpenCrane controller response was not valid JSON");
+		const result = await reader.read();
+		if (result.done) return Buffer.concat(chunks, byteLength).toString("utf8");
+		byteLength += result.value.byteLength;
+		if (byteLength > _MAX_RESPONSE_BYTES)
+		{
+			await reader.cancel();
+			throw new Error("OpenCrane controller response exceeded the 64 KiB boundary");
+		}
+		chunks.push(result.value);
 	}
 }
 
@@ -218,7 +250,7 @@ export function __CreateHttpAgentControllerAuthority(options: AgentControllerHtt
 				const response = await fetchRequest(new URL(_CLAIM_PATH, baseUrl), { method: "POST", headers: _Headers(token), body: "{}", signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status === 204) return null;
 				if (response.status !== 200) throw new Error(`OpenCrane controller claim failed with HTTP ${response.status}`);
-				return _ParseClaim(await _ReadJson(response));
+				return _ReadAndValidateJson(response, _ParseClaim);
 			});
 		},
 		async __CommitAssignment(eventId: string, command: AgentControllerRunAttemptAssignmentCommand, signal: AbortSignal): Promise<AgentControllerRunAttemptAssignmentResult>
@@ -230,7 +262,7 @@ export function __CreateHttpAgentControllerAuthority(options: AgentControllerHtt
 				const path = `/api/internal/agent-controller/run-attempts/${encodeURIComponent(eventId)}/assignment`;
 				const response = await fetchRequest(new URL(path, baseUrl), { method: "PUT", headers: _Headers(token), body: JSON.stringify(command), signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status !== 200) throw new Error(`OpenCrane controller assignment failed with HTTP ${response.status}`);
-				return _ParseAssignmentResult(await _ReadJson(response), command);
+				return _ReadAndValidateJson(response, _ParseAssignmentResult, command);
 			});
 		},
 		async __ClaimWorkloadRelease(signal: AbortSignal): Promise<AgentControllerRunWorkloadReleaseClaim | null>
@@ -241,7 +273,7 @@ export function __CreateHttpAgentControllerAuthority(options: AgentControllerHtt
 				const response = await fetchRequest(new URL(_RELEASE_CLAIM_PATH, baseUrl), { method: "POST", headers: _Headers(token), body: "{}", signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status === 204) return null;
 				if (response.status !== 200) throw new Error(`OpenCrane workload-release claim failed with HTTP ${response.status}`);
-				return _ParseWorkloadReleaseClaim(await _ReadJson(response));
+				return _ReadAndValidateJson(response, _ParseWorkloadReleaseClaim);
 			});
 		},
 		async __RegisterFirstPod(eventId: string, command: AgentControllerRunWorkloadRegistrationCommand, signal: AbortSignal): Promise<AgentControllerRunWorkloadRegistrationResult>
@@ -253,7 +285,7 @@ export function __CreateHttpAgentControllerAuthority(options: AgentControllerHtt
 				const path = `/api/internal/agent-controller/workload-releases/${encodeURIComponent(eventId)}/registration`;
 				const response = await fetchRequest(new URL(path, baseUrl), { method: "PUT", headers: _Headers(token), body: JSON.stringify(command), signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status !== 200) throw new Error(`OpenCrane first-Pod registration failed with HTTP ${response.status}`);
-				return _ParseRegistrationResult(await _ReadJson(response), command);
+				return _ReadAndValidateJson(response, _ParseRegistrationResult, command);
 			});
 		},
 		async __PrunePublishedOutbox(signal: AbortSignal): Promise<number>
@@ -263,7 +295,7 @@ export function __CreateHttpAgentControllerAuthority(options: AgentControllerHtt
 				const token = await readToken();
 				const response = await fetchRequest(new URL(_OUTBOX_PRUNE_PATH, baseUrl), { method: "POST", headers: _Headers(token), body: "{}", signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status !== 200) throw new Error(`OpenCrane outbox prune failed with HTTP ${response.status}`);
-				return _ParsePrunedCount(await _ReadJson(response));
+				return _ReadAndValidateJson(response, _ParsePrunedCount);
 			});
 		},
 	};

--- a/libs/backend/agents/skills/controller/src/__tests__/http-skill-workload-authority.test.ts
+++ b/libs/backend/agents/skills/controller/src/__tests__/http-skill-workload-authority.test.ts
@@ -14,6 +14,21 @@ function _Claim()
 	return { workloadId: "workload-1", siloId: "silo-a", kind: "authoring", skillRevisionId: "revision-1", claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, expiresAt: "2026-07-24T00:00:30.000Z" };
 }
 
+/** Return a chunked response that crosses the skill-workload allocation ceiling. */
+function _OversizedChunkedResponse(maximumBytes: number): Response
+{
+	let chunk = 0;
+	return new Response(new ReadableStream<Uint8Array>({
+		pull(controller)
+		{
+			if (chunk === 0) controller.enqueue(new Uint8Array(maximumBytes));
+			else if (chunk === 1) controller.enqueue(new Uint8Array(1));
+			else controller.close();
+			chunk += 1;
+		},
+	}));
+}
+
 describe("HTTP governed skill workload authority", function _DescribeAuthority()
 {
 	it("claims only an exact bounded database-issued workload response", async function _Claims()
@@ -40,5 +55,19 @@ describe("HTTP governed skill workload authority", function _DescribeAuthority()
 		const authority = __CreateHttpSkillWorkloadControllerAuthority(_Options(fetch));
 
 		await expect(authority.__CommitAssignment("workload-1", { claimedAt: "2026-07-24T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1", bootstrapReference: `skill-bootstrap-v1_${"a".repeat(64)}`, namespace: "opencrane-tools" }, new AbortController().signal)).rejects.toThrow(/mismatched/);
+	});
+
+	it("identifies invalid authority JSON before claim validation", async function _RejectsInvalidJson()
+	{
+		const authority = __CreateHttpSkillWorkloadControllerAuthority(_Options(vi.fn().mockResolvedValue(new Response("{", { status: 200 }))));
+
+		await expect(authority.__Claim(new AbortController().signal)).rejects.toThrow(/OpenCrane skill workload response must contain valid JSON/);
+	});
+
+	it("stops a chunked response as soon as it crosses the allocation ceiling", async function _BoundsChunkedResponse()
+	{
+		const authority = __CreateHttpSkillWorkloadControllerAuthority(_Options(vi.fn().mockResolvedValue(_OversizedChunkedResponse(16 * 1024))));
+
+		await expect(authority.__Claim(new AbortController().signal)).rejects.toThrow(/exceeded the 16 KiB boundary/);
 	});
 });

--- a/libs/backend/agents/skills/controller/src/__tests__/skill-workload-controller.test.ts
+++ b/libs/backend/agents/skills/controller/src/__tests__/skill-workload-controller.test.ts
@@ -84,6 +84,9 @@ describe("governed skill workload controller", function _DescribeController()
 	it("rejects incomplete or class-mismatched deployment profiles before polling", function _RejectsProfiles()
 	{
 		expect(function _MissingRunner() { __ValidateSkillWorkloadControllerProfiles({ authoring: _Profiles().authoring }); }).toThrow(/exactly authoring and tool-runner/);
+		expect(function _NullAuthoring() { __ValidateSkillWorkloadControllerProfiles({ ..._Profiles(), authoring: null }); }).toThrow(/authoring profile must be one complete bounded object/);
+		expect(function _MissingResources() { const { resources: _resources, ...authoring } = _Profiles().authoring; __ValidateSkillWorkloadControllerProfiles({ ..._Profiles(), authoring }); }).toThrow(/authoring profile must be one complete bounded object/);
+		expect(function _ExtendedResource() { const authoring = _Profiles().authoring; __ValidateSkillWorkloadControllerProfiles({ ..._Profiles(), authoring: { ...authoring, resources: { requests: { ...authoring.resources.requests, "example.com/fpga": "8" }, limits: { ...authoring.resources.limits, "example.com/fpga": "8" } } } }); }).toThrow(/authoring profile must be one complete bounded object/);
 		expect(function _WrongKind() { __ValidateSkillWorkloadControllerProfiles({ ..._Profiles(), authoring: { ..._Profiles().authoring, kind: "tool-runner" } }); }).toThrow(/wrong workload class/);
 	});
 

--- a/libs/backend/agents/skills/controller/src/http-skill-workload-authority.ts
+++ b/libs/backend/agents/skills/controller/src/http-skill-workload-authority.ts
@@ -3,6 +3,7 @@ import { isAbsolute } from "node:path";
 
 import { ___DoWithTrace } from "@opencrane/observability";
 import type { AgentControllerSkillWorkloadAssignmentCommand, AgentControllerSkillWorkloadClaim } from "@opencrane/contracts";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import type { SkillWorkloadControllerAuthority, SkillWorkloadControllerFetch, SkillWorkloadControllerHttpAuthorityOptions, SkillWorkloadControllerPodRegistrationCommand, SkillWorkloadControllerReleaseClaim, SkillWorkloadControllerReleaseCommand, SkillWorkloadControllerTokenReader } from "./skill-workload-controller.types.js";
 
@@ -38,18 +39,52 @@ function _AsObject(value: unknown): Record<string, unknown> | null
 	return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
 }
 
-/** Read one bounded JSON response without trusting its content type alone. */
-async function _ReadJson(response: Response): Promise<unknown>
+/**
+ * Read one bounded skill-workload response and return only its validator-owned domain value.
+ *
+ * @param response - Internal authority response whose body remains untrusted.
+ * @param validate - Domain validator that binds the decoded payload to its expected contract.
+ * @param validatorArguments - Request coordinates used to reject mismatched authority responses.
+ * @returns The validated response value.
+ */
+async function _ReadAndValidateJson<T, TArguments extends readonly unknown[]>(response: Response, validate: (candidate: unknown, ...arguments_: TArguments) => T, ...validatorArguments: TArguments): Promise<T>
 {
-	const text = await response.text();
-	if (Buffer.byteLength(text, "utf8") > _MAX_RESPONSE_BYTES) throw new Error("OpenCrane skill workload response exceeded the 16 KiB boundary");
-	try
+	// 1. Stream the body through the allocation ceiling before retaining or parsing it.
+	const text = await _ReadBoundedText(response);
+
+	// 2. Parse and validate together so no untyped authority response leaves this adapter.
+	return ___ParseAndValidateJson(text, "OpenCrane skill workload response", validate, ...validatorArguments);
+}
+
+/** Read one skill-workload response without allocating beyond its fixed protocol ceiling. */
+async function _ReadBoundedText(response: Response): Promise<string>
+{
+	const declaredLength = response.headers.get("content-length");
+	if (declaredLength !== null)
 	{
-		return JSON.parse(text) as unknown;
+		const parsedLength = Number(declaredLength);
+		if (!Number.isSafeInteger(parsedLength) || parsedLength < 0 || parsedLength > _MAX_RESPONSE_BYTES)
+		{
+			await response.body?.cancel();
+			throw new Error("OpenCrane skill workload response exceeded the 16 KiB boundary");
+		}
 	}
-	catch
+	if (response.body === null) throw new Error("OpenCrane skill workload authority returned no response body");
+
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let byteLength = 0;
+	while (true)
 	{
-		throw new Error("OpenCrane skill workload response was not valid JSON");
+		const result = await reader.read();
+		if (result.done) return Buffer.concat(chunks, byteLength).toString("utf8");
+		byteLength += result.value.byteLength;
+		if (byteLength > _MAX_RESPONSE_BYTES)
+		{
+			await reader.cancel();
+			throw new Error("OpenCrane skill workload response exceeded the 16 KiB boundary");
+		}
+		chunks.push(result.value);
 	}
 }
 
@@ -140,7 +175,7 @@ export function __CreateHttpSkillWorkloadControllerAuthority(options: SkillWorkl
 				const response = await fetchRequest(new URL(_CLAIM_PATH, baseUrl), { method: "POST", headers: _Headers(await readToken()), body: "{}", signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status === 204) return null;
 				if (response.status !== 200) throw new Error(`OpenCrane skill workload claim failed with HTTP ${response.status}`);
-				return _ParseClaim(await _ReadJson(response));
+				return _ReadAndValidateJson(response, _ParseClaim);
 			});
 		},
 		async __CommitAssignment(workloadId: string, command: AgentControllerSkillWorkloadAssignmentCommand, signal: AbortSignal): Promise<"assigned" | "idempotent" | "conflict">
@@ -152,7 +187,7 @@ export function __CreateHttpSkillWorkloadControllerAuthority(options: SkillWorkl
 				const response = await fetchRequest(new URL(path, baseUrl), { method: "PUT", headers: _Headers(await readToken()), body: JSON.stringify(command), signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status === 409) return "conflict";
 				if (response.status !== 200) throw new Error(`OpenCrane skill workload assignment failed with HTTP ${response.status}`);
-				return _ParseAssignment(await _ReadJson(response), workloadId, command);
+				return _ReadAndValidateJson(response, _ParseAssignment, workloadId, command);
 			});
 		},
 		async __ClaimRelease(signal: AbortSignal): Promise<SkillWorkloadControllerReleaseClaim | null>
@@ -162,7 +197,7 @@ export function __CreateHttpSkillWorkloadControllerAuthority(options: SkillWorkl
 				const response = await fetchRequest(new URL("/api/internal/agent-controller/skill-workloads:release-claim", baseUrl), { method: "POST", headers: _Headers(await readToken()), body: "{}", signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status === 204) return null;
 				if (response.status !== 200) throw new Error(`OpenCrane skill workload release claim failed with HTTP ${response.status}`);
-				return _ParseReleaseClaim(await _ReadJson(response));
+				return _ReadAndValidateJson(response, _ParseReleaseClaim);
 			});
 		},
 		async __CommitRelease(workloadId: string, command: SkillWorkloadControllerReleaseCommand, signal: AbortSignal): Promise<"released" | "idempotent" | "conflict">
@@ -173,7 +208,7 @@ export function __CreateHttpSkillWorkloadControllerAuthority(options: SkillWorkl
 				const response = await fetchRequest(new URL(`/api/internal/agent-controller/skill-workloads/${encodeURIComponent(workloadId)}/release`, baseUrl), { method: "PUT", headers: _Headers(await readToken()), body: JSON.stringify(command), signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status === 409) return "conflict";
 				if (response.status !== 200) throw new Error(`OpenCrane skill workload release failed with HTTP ${response.status}`);
-				const outcome = _ParseReleaseResult(await _ReadJson(response), workloadId, command);
+				const outcome = await _ReadAndValidateJson(response, _ParseReleaseResult, workloadId, command);
 				if (outcome === "registered") throw new Error("OpenCrane returned a Pod-registration outcome for a Job release");
 				return outcome;
 			});
@@ -186,7 +221,7 @@ export function __CreateHttpSkillWorkloadControllerAuthority(options: SkillWorkl
 				const response = await fetchRequest(new URL(`/api/internal/agent-controller/skill-workloads/${encodeURIComponent(workloadId)}/pod-registration`, baseUrl), { method: "PUT", headers: _Headers(await readToken()), body: JSON.stringify(command), signal: _RequestSignal(signal, options.requestTimeoutMilliseconds) });
 				if (response.status === 409) return "conflict";
 				if (response.status !== 200) throw new Error(`OpenCrane skill workload Pod registration failed with HTTP ${response.status}`);
-				const outcome = _ParseReleaseResult(await _ReadJson(response), workloadId, command, command.podUid);
+				const outcome = await _ReadAndValidateJson(response, _ParseReleaseResult, workloadId, command, command.podUid);
 				if (outcome === "released") throw new Error("OpenCrane returned a Job-release outcome for Pod registration");
 				return outcome;
 			});

--- a/libs/backend/agents/skills/controller/src/skill-workload-controller.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-controller.ts
@@ -35,6 +35,37 @@ function _RequirePodUid(uid: string | undefined): string
 	return uid;
 }
 
+/** Return whether a boundary value is one non-array object with inspectable properties. */
+function _IsRecord(value: unknown): value is Readonly<Record<string, unknown>> { return typeof value === "object" && value !== null && !Array.isArray(value); }
+
+/** Return whether an object contains exactly the expected own-property names. */
+function _HasOnlyKeys(value: Readonly<Record<string, unknown>>, expected: readonly string[]): boolean { return Object.keys(value).length === expected.length && expected.every(function _HasKey(key): boolean { return Object.prototype.hasOwnProperty.call(value, key); }); }
+
+/** Canonicalize one CPU-and-memory resource map without forwarding extended Kubernetes resources. */
+function _ResourceMap(value: unknown): Readonly<Record<"cpu" | "memory", string>> | null
+{
+	if (!_IsRecord(value) || !_HasOnlyKeys(value, ["cpu", "memory"]) || typeof value["cpu"] !== "string" || typeof value["memory"] !== "string") return null;
+	return { cpu: value["cpu"], memory: value["memory"] };
+}
+
+/** Validate and canonicalize one untrusted deployment profile for the hardened Job builder. */
+function _SkillWorkloadJobProfile(value: unknown): SkillWorkloadJobProfile | null
+{
+	// 1. Require the fixed workload discriminant before class-specific validation can run.
+	if (!_IsRecord(value) || !_HasOnlyKeys(value, ["kind", "image", "imagePullPolicy", "serverNamespace", "namespace", "serviceAccountName", "capabilityTokenAudience", "bootstrapUrl", "capabilityTokenPath", "bootstrapReferencePath", "scratchSize", "activeDeadlineSeconds", "ttlSecondsAfterFinished", "resources"]) || (value["kind"] !== "authoring" && value["kind"] !== "tool-runner")) return null;
+
+	// 2. Require every scalar field so the canonical builder never receives an assertion-created value.
+	if (typeof value["image"] !== "string" || (value["imagePullPolicy"] !== "Always" && value["imagePullPolicy"] !== "IfNotPresent" && value["imagePullPolicy"] !== "Never") || typeof value["serverNamespace"] !== "string" || typeof value["namespace"] !== "string" || typeof value["serviceAccountName"] !== "string" || typeof value["capabilityTokenAudience"] !== "string" || typeof value["bootstrapUrl"] !== "string" || typeof value["capabilityTokenPath"] !== "string" || typeof value["bootstrapReferencePath"] !== "string" || typeof value["scratchSize"] !== "string" || typeof value["activeDeadlineSeconds"] !== "number" || typeof value["ttlSecondsAfterFinished"] !== "number") return null;
+
+	// 3. Rebuild exact resource and profile objects so no unreviewed field can reach Kubernetes.
+	const resources = value["resources"];
+	if (!_IsRecord(resources) || !_HasOnlyKeys(resources, ["requests", "limits"])) return null;
+	const requests = _ResourceMap(resources["requests"]);
+	const limits = _ResourceMap(resources["limits"]);
+	if (requests === null || limits === null) return null;
+	return { kind: value["kind"], image: value["image"], imagePullPolicy: value["imagePullPolicy"], serverNamespace: value["serverNamespace"], namespace: value["namespace"], serviceAccountName: value["serviceAccountName"], capabilityTokenAudience: value["capabilityTokenAudience"], bootstrapUrl: value["bootstrapUrl"], capabilityTokenPath: value["capabilityTokenPath"], bootstrapReferencePath: value["bootstrapReferencePath"], scratchSize: value["scratchSize"], activeDeadlineSeconds: value["activeDeadlineSeconds"], ttlSecondsAfterFinished: value["ttlSecondsAfterFinished"], resources: { requests, limits } };
+}
+
 /** Validate both fixed deployment profiles through the canonical hardened Job builder. */
 export function __ValidateSkillWorkloadControllerProfiles(value: unknown): SkillWorkloadControllerProfiles
 {
@@ -50,7 +81,11 @@ export function __ValidateSkillWorkloadControllerProfiles(value: unknown): Skill
 	const profiles: Record<"authoring" | "tool-runner", SkillWorkloadJobProfile> = {} as Record<"authoring" | "tool-runner", SkillWorkloadJobProfile>;
 	for (const kind of ["authoring", "tool-runner"] as const)
 	{
-		const profile = structuredClone(candidate[kind]) as SkillWorkloadJobProfile;
+		const profile = _SkillWorkloadJobProfile(candidate[kind]);
+		if (profile === null)
+		{
+			throw new Error(`skill workload controller ${kind} profile must be one complete bounded object`);
+		}
 		if (profile.kind !== kind)
 		{
 			throw new Error(`skill workload controller ${kind} profile has the wrong workload class`);

--- a/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
+++ b/libs/backend/artifacts/authorization/main/src/artifact-lease.ts
@@ -1,6 +1,6 @@
 import { createPrivateKey, createPublicKey, sign, verify } from "node:crypto";
 
-import { ___CanonicalizeJson } from "@opencrane/util";
+import { ___CanonicalizeJson, ___ParseAndValidateJson } from "@opencrane/util";
 
 import { __IsSafeArtifactMediaType } from "./artifact-media-type.js";
 import type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "./artifact-lease.types.js";
@@ -77,12 +77,18 @@ function _verify(compact: string, publicKeyPem: string): Record<string, unknown>
 	if (parts.length !== 3 || parts.some(part => !/^[A-Za-z0-9_-]+$/u.test(part))) return null;
 	try
 	{
-		const header = JSON.parse(Buffer.from(parts[0], "base64url").toString("utf8")) as Record<string, unknown>;
+		const header = ___ParseAndValidateJson(Buffer.from(parts[0], "base64url").toString("utf8"), "artifact JWS protected header", _ObjectPayload);
 		if (header.alg !== "EdDSA" || header.typ !== "JWT" || !verify(null, Buffer.from(`${parts[0]}.${parts[1]}`), createPublicKey(publicKeyPem), Buffer.from(parts[2], "base64url"))) return null;
-		const payload = JSON.parse(Buffer.from(parts[1], "base64url").toString("utf8")) as unknown;
-		return typeof payload === "object" && payload !== null && !Array.isArray(payload) ? payload as Record<string, unknown> : null;
+		return ___ParseAndValidateJson(Buffer.from(parts[1], "base64url").toString("utf8"), "artifact JWS payload", _ObjectPayload);
 	}
 	catch { return null; }
+}
+
+/** Require one decoded JWS component to be a non-array object. */
+function _ObjectPayload(value: unknown): Record<string, unknown>
+{
+	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("artifact JWS component must be an object");
+	return value as Record<string, unknown>;
 }
 
 function _leaseFromPayload(value: Record<string, unknown>): ArtifactWriteLeaseClaims | null

--- a/libs/backend/artifacts/preprocessor/main/src/__tests__/remote.test.ts
+++ b/libs/backend/artifacts/preprocessor/main/src/__tests__/remote.test.ts
@@ -47,6 +47,23 @@ describe("artifact preprocessor remote adapter", function _suite()
 		}
 	});
 
+	it("rejects invalid claim JSON before it can become protocol state", async function _RejectsInvalidClaimJson()
+	{
+		const scratch = await mkdtemp(join(tmpdir(), "artifact-preprocessor-remote-"));
+		const tokenPath = join(scratch, "token");
+		await writeFile(tokenPath, "projected-token");
+		vi.stubGlobal("fetch", vi.fn(async function _Fetch() { return new Response("{", { status: 200, headers: { "content-length": "1" } }); }));
+		try
+		{
+			const remote = _CreateArtifactPreprocessorRemote({ openCraneInternalUrl: "http://opencrane", tokenPath, requestTimeoutMilliseconds: 1_000 });
+			await expect(remote.claim(new AbortController().signal)).rejects.toThrow(/artifact preprocess authority response must contain valid JSON/);
+		}
+		finally
+		{
+			await rm(scratch, { recursive: true, force: true });
+		}
+	});
+
 	it("cancels an anomalous claim response before clearing its deadline", async function _cancelRejectedResponse()
 	{
 		const scratch = await mkdtemp(join(tmpdir(), "artifact-preprocessor-remote-"));

--- a/libs/backend/artifacts/preprocessor/main/src/remote.ts
+++ b/libs/backend/artifacts/preprocessor/main/src/remote.ts
@@ -5,6 +5,7 @@ import { pipeline } from "node:stream/promises";
 
 import type { ArtifactPreprocessorClaimCommand, ArtifactPreprocessorFailureCommand, ArtifactPreprocessorJobClaim } from "@opencrane/contracts";
 import { ___DoWithTrace } from "@opencrane/observability";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import type { ArtifactPreprocessorRemote, ArtifactPreprocessorRemoteConfig } from "./preprocessor.types.js";
 
@@ -33,7 +34,7 @@ async function _Claim(config: ArtifactPreprocessorRemoteConfig, signal: AbortSig
 			const response = await fetch(`${config.openCraneInternalUrl}/api/internal/artifact-preprocessor/jobs:claim`, { method: "POST", headers: { authorization: await _Authorization(config), "content-type": "application/json" }, body: "{}", signal: requestSignal });
 			if (response.status === 204) return null;
 			if (!response.ok) return _RejectResponse(response, `artifact preprocess claim failed with HTTP ${response.status}`);
-			return _ClaimFromUnknown(await _ReadBoundedJson(response, _MAXIMUM_CLAIM_RESPONSE_BYTES));
+			return _ReadBoundedAndValidateJson(response, _MAXIMUM_CLAIM_RESPONSE_BYTES, _ClaimFromUnknown);
 		}
 		finally
 		{
@@ -173,8 +174,16 @@ function _ClaimFromUnknown(value: unknown): ArtifactPreprocessorJobClaim
 	return claim as unknown as ArtifactPreprocessorJobClaim;
 }
 
-/** Read a small JSON authority response without accepting an unbounded body. */
-async function _ReadBoundedJson(response: Response, maximumBytes: number): Promise<unknown>
+/**
+ * Read a bounded authority response and return only the validator-owned protocol value.
+ *
+ * @param response - Authority response whose body remains untrusted.
+ * @param maximumBytes - Hard allocation ceiling enforced before and during streaming.
+ * @param validate - Protocol validator applied immediately after syntax decoding.
+ * @param validatorArguments - Additional request coordinates required by the validator.
+ * @returns The validated protocol value.
+ */
+async function _ReadBoundedAndValidateJson<T, TArguments extends readonly unknown[]>(response: Response, maximumBytes: number, validate: (candidate: unknown, ...arguments_: TArguments) => T, ...validatorArguments: TArguments): Promise<T>
 {
 	// 1. Reject an impossible declared size before allocating any response storage.
 	const declaredLength = response.headers.get("content-length");
@@ -195,15 +204,8 @@ async function _ReadBoundedJson(response: Response, maximumBytes: number): Promi
 		chunks.push(chunk);
 	}
 
-	// 3. Parse only the now-bounded bytes into the protocol's exact structural validator.
-	try
-	{
-		return JSON.parse(Buffer.concat(chunks, byteLength).toString("utf8")) as unknown;
-	}
-	catch
-	{
-		throw new Error("artifact preprocess authority returned invalid JSON");
-	}
+	// 3. Parse only the now-bounded bytes and immediately apply the exact protocol validator.
+	return ___ParseAndValidateJson(Buffer.concat(chunks, byteLength).toString("utf8"), "artifact preprocess authority response", validate, ...validatorArguments);
 }
 
 /** Require an object to carry exactly the fixed protocol keys. */

--- a/libs/backend/channel-proxy/main/src/__tests__/channel-proxy.test.ts
+++ b/libs/backend/channel-proxy/main/src/__tests__/channel-proxy.test.ts
@@ -145,6 +145,18 @@ describe("channel proxy public boundary", () =>
 		expect(response.status).toBe(400);
 		expect(resolve).not.toHaveBeenCalled();
 	});
+
+	it("rejects malformed and non-object command JSON before target resolution", async function _RejectsInvalidCommandJson()
+	{
+		const resolve = vi.fn(async function _Resolve() { return _Target(); });
+		const dependencies = _Dependencies(resolve, vi.fn() as unknown as typeof fetch);
+		const malformed = await __ForwardCommand(_Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: "{" }), dependencies);
+		const array = await __ForwardCommand(_Request("/v1/commands", { method: "POST", headers: { "content-type": "application/json" }, body: "[]" }), dependencies);
+
+		expect(malformed.status).toBe(400);
+		expect(array.status).toBe(400);
+		expect(resolve).not.toHaveBeenCalled();
+	});
 });
 
 describe("channel proxy SSE relay", () =>

--- a/libs/backend/channel-proxy/main/src/__tests__/target-resolver.test.ts
+++ b/libs/backend/channel-proxy/main/src/__tests__/target-resolver.test.ts
@@ -50,4 +50,14 @@ describe("OpenCrane channel target resolver", () =>
 		const resolver = new __OpenCraneTargetResolver({ baseUrl: "http://opencrane.default.svc.cluster.local:8081", fetch: transport, readFile: async function _readFile() { return "token"; } });
 		await expect(resolver.resolve({ action: "command.forward", threadId: "thread-1", requestIdempotencyKey: "delivery-1", session: { cookie: "session=opaque", trustedHost: "acme.example.com" } }, new AbortController().signal)).rejects.toThrow("expired");
 	});
+
+	it("rejects invalid JSON and structurally untrusted resolver output", async function _RejectsInvalidResponses()
+	{
+		const request = { action: "command.forward" as const, threadId: "thread-1", requestIdempotencyKey: "delivery-1", session: { cookie: "session=opaque", trustedHost: "acme.example.com" } };
+		const invalidJson = new __OpenCraneTargetResolver({ baseUrl: "http://opencrane.default.svc.cluster.local:8081", fetch: vi.fn().mockResolvedValue(new Response("{", { status: 200 })) as unknown as typeof fetch, readFile: async function _ReadFile() { return "token"; } });
+		await expect(invalidJson.resolve(request, new AbortController().signal)).rejects.toThrow(/channel target response must contain valid JSON/);
+
+		const invalidShape = new __OpenCraneTargetResolver({ baseUrl: "http://opencrane.default.svc.cluster.local:8081", fetch: vi.fn().mockResolvedValue(Response.json([])) as unknown as typeof fetch, readFile: async function _ReadFile() { return "token"; } });
+		await expect(invalidShape.resolve(request, new AbortController().signal)).rejects.toThrow(/not an object/);
+	});
 });

--- a/libs/backend/channel-proxy/main/src/forwarding.ts
+++ b/libs/backend/channel-proxy/main/src/forwarding.ts
@@ -1,4 +1,5 @@
 import { ___DoWithTrace } from "@opencrane/observability";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import type { AuthorizedChannelTarget, ChannelProxyDependencies, DelegatedSession } from "./channel-proxy.types.js";
 import { __HasForgedIdentityHeaders, __ValidateOrigin } from "./origin-policy.js";
@@ -99,19 +100,20 @@ export async function __ForwardCommand(request: Request, dependencies: ChannelPr
 /** Parses only the command coordinates required before the proxy asks OpenCrane to authorize a route. */
 function _CommandCoordinates(body: Uint8Array, requestIdempotencyKey: string | null): { readonly threadId: string; readonly requestIdempotencyKey: string } | null
 {
-	// 1. Parse the bounded JSON body so the route authority never receives a body-only thread assertion.
-	let value: unknown;
 	try
 	{
-		value = JSON.parse(new TextDecoder().decode(body)) as unknown;
+		return ___ParseAndValidateJson(new TextDecoder().decode(body), "channel command body", _CommandCoordinatesFromUnknown, requestIdempotencyKey);
 	}
 	catch
 	{
 		return null;
 	}
-	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+}
 
-	// 2. Require opaque coordinates before resolution so a retry cannot create an unaddressable run.
+/** Validate the command coordinates required before asking OpenCrane to authorize a route. */
+function _CommandCoordinatesFromUnknown(value: unknown, requestIdempotencyKey: string | null): { readonly threadId: string; readonly requestIdempotencyKey: string } | null
+{
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
 	const record = value as Record<string, unknown>;
 	if (typeof record.threadId !== "string" || !_OpaqueIdentifierAllowed(record.threadId) || !requestIdempotencyKey || !_OpaqueIdentifierAllowed(requestIdempotencyKey)) return null;
 	return { threadId: record.threadId, requestIdempotencyKey };

--- a/libs/backend/channel-proxy/main/src/target-resolver.ts
+++ b/libs/backend/channel-proxy/main/src/target-resolver.ts
@@ -1,5 +1,7 @@
 import { readFile } from "node:fs/promises";
 
+import { ___ParseAndValidateJson } from "@opencrane/util";
+
 import type { AuthorizedChannelTarget, ChannelTargetResolver, OpenCraneResolverOptions, TargetResolutionRequest } from "./channel-proxy.types.js";
 
 /** Default path of the audience-bound channel-proxy workload token. */
@@ -65,8 +67,7 @@ export class __OpenCraneTargetResolver implements ChannelTargetResolver
 				throw new Error(`channel target resolution denied with status ${response.status}`);
 			}
 
-			const value: unknown = await response.json();
-			return _ParseTarget(value);
+			return ___ParseAndValidateJson(await response.text(), "channel target response", _ParseTarget);
 		}
 		finally
 		{
@@ -78,7 +79,7 @@ export class __OpenCraneTargetResolver implements ChannelTargetResolver
 /** Parse the narrow resolver response without trusting structural casts. */
 function _ParseTarget(value: unknown): AuthorizedChannelTarget
 {
-	if (!value || typeof value !== "object")
+	if (!value || typeof value !== "object" || Array.isArray(value))
 	{
 		throw new Error("channel target response is not an object");
 	}

--- a/libs/backend/server/agents/conversation-replay/main/src/__tests__/replay-cursor.test.ts
+++ b/libs/backend/server/agents/conversation-replay/main/src/__tests__/replay-cursor.test.ts
@@ -16,6 +16,7 @@ describe("conversation replay cursor", function _Suite()
 		expect(__DecodeConversationReplayCursor({ cursor: "e.tampered" })).toBeNull();
 		expect(__DecodeConversationReplayCursor("wrong")).toBeNull();
 		expect(__DecodeConversationReplayCursor("e.eyJydW5JZCI6InJ1bi0xIn0")).toBeNull();
+		expect(__DecodeConversationReplayCursor(`e.${Buffer.from("[]").toString("base64url")}`)).toBeNull();
 		expect(__DecodeConversationReplayCursor(__EncodeConversationReplayCursor({ acceptedAt: "2026-07-23T10:00:00.000Z", runId: "run-1", sequence: 0 }))).toBeNull();
 	});
 });

--- a/libs/backend/server/agents/conversation-replay/main/src/replay-cursor.ts
+++ b/libs/backend/server/agents/conversation-replay/main/src/replay-cursor.ts
@@ -1,3 +1,5 @@
+import { ___ParseAndValidateJson } from "@opencrane/util";
+
 import type { ConversationReplayCursor } from "./replay-cursor.types.js";
 
 /** Encode one opaque cursor without exposing a database predicate to the caller. */
@@ -13,11 +15,16 @@ export function __DecodeConversationReplayCursor(value: unknown): ConversationRe
 	if (!value.startsWith("e.") || value.length > 512) return null;
 	try
 	{
-		const candidate = JSON.parse(Buffer.from(value.slice(2), "base64url").toString("utf8")) as unknown;
-		if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
-		const record = candidate as Record<string, unknown>;
-		if (typeof record.acceptedAt !== "string" || Number.isNaN(Date.parse(record.acceptedAt)) || typeof record.runId !== "string" || !record.runId || typeof record.sequence !== "number" || !Number.isSafeInteger(record.sequence) || record.sequence < 1) return null;
-		return { acceptedAt: record.acceptedAt, runId: record.runId, sequence: record.sequence };
+		return ___ParseAndValidateJson(Buffer.from(value.slice(2), "base64url").toString("utf8"), "conversation replay cursor", _ReplayCursorFromUnknown);
 	}
 	catch { return null; }
+}
+
+/** Validate exact replay coordinates before they can reach a database query. */
+function _ReplayCursorFromUnknown(candidate: unknown): ConversationReplayCursor | null
+{
+	if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) return null;
+	const record = candidate as Record<string, unknown>;
+	if (typeof record.acceptedAt !== "string" || Number.isNaN(Date.parse(record.acceptedAt)) || typeof record.runId !== "string" || !record.runId || typeof record.sequence !== "number" || !Number.isSafeInteger(record.sequence) || record.sequence < 1) return null;
+	return { acceptedAt: record.acceptedAt, runId: record.runId, sequence: record.sequence };
 }

--- a/libs/backend/server/gateways/model-routing/main/src/__tests__/attempt-litellm-key.test.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/__tests__/attempt-litellm-key.test.ts
@@ -15,7 +15,7 @@ function _fetchMock(response: { ok: boolean; status: number; body: unknown })
 	{
 		_captured.url = url;
 		_captured.init = init;
-		return { ok: response.ok, status: response.status, json: async function _json() { return response.body; } } as unknown as Response;
+		return new Response(JSON.stringify(response.body), { status: response.status });
 	});
 }
 
@@ -79,5 +79,12 @@ describe("_IssueAttemptLiteLlmKey", function _describeIssuer()
 		vi.stubGlobal("fetch", _fetchMock({ ok: true, status: 200, body: {} }));
 
 		await expect(_IssueAttemptLiteLlmKey({ keyAlias: "attempt-run1-1", modelAlias: "silo-default", maxBudgetUsd: 2, expirySeconds: 3600 })).rejects.toThrow(/returned no key/);
+	});
+
+	it("identifies invalid JSON before it can become an attempt key", async function _RejectsInvalidJson()
+	{
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("{", { status: 200 })));
+
+		await expect(_IssueAttemptLiteLlmKey({ keyAlias: "attempt-run1-1", modelAlias: "silo-default", maxBudgetUsd: 2, expirySeconds: 3600 })).rejects.toThrow(/LiteLLM attempt key response must contain valid JSON/);
 	});
 });

--- a/libs/backend/server/gateways/model-routing/main/src/__tests__/litellm-model-registration.test.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/__tests__/litellm-model-registration.test.ts
@@ -1,0 +1,48 @@
+import { ModelRoutingScope } from "@opencrane/contracts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { _RegisterLiteLlmModel } from "../core/litellm-model-registration.js";
+
+/** Environment keys restored after each live-registration boundary test. */
+const _SAVED_ENVIRONMENT: Record<string, string | undefined> = {};
+
+/** Stable registration input used to prove malformed responses cannot escape as model ids. */
+const _INPUT = { publicModelName: "openai/test", upstreamModel: "openai/test", scope: ModelRoutingScope.Global };
+
+describe("LiteLLM model registration response", function _Suite()
+{
+	beforeEach(function _Configure()
+	{
+		for (const key of ["LITELLM_ENDPOINT", "LITELLM_MASTER_KEY"]) _SAVED_ENVIRONMENT[key] = process.env[key];
+		process.env.LITELLM_ENDPOINT = "http://litellm.svc";
+		process.env.LITELLM_MASTER_KEY = "sk-master";
+	});
+
+	afterEach(function _Restore()
+	{
+		vi.unstubAllGlobals();
+		for (const key of ["LITELLM_ENDPOINT", "LITELLM_MASTER_KEY"])
+		{
+			if (_SAVED_ENVIRONMENT[key] === undefined) delete process.env[key];
+			else process.env[key] = _SAVED_ENVIRONMENT[key];
+		}
+	});
+
+	it("accepts only a non-empty string deployment id", async function _ValidatesId()
+	{
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({ model_info: { id: "deployment-1" } }), { status: 200 })));
+
+		await expect(_RegisterLiteLlmModel(_INPUT)).resolves.toBe("deployment-1");
+	});
+
+	it("uses a string placeholder for wrong-type or invalid JSON responses", async function _FallsBack()
+	{
+		const fetchMock = vi.fn()
+			.mockResolvedValueOnce(new Response(JSON.stringify({ model_id: 42 }), { status: 200 }))
+			.mockResolvedValueOnce(new Response("{", { status: 200 }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(_RegisterLiteLlmModel(_INPUT)).resolves.toBe("placeholder:global-openai-test");
+		await expect(_RegisterLiteLlmModel(_INPUT)).resolves.toBe("placeholder:global-openai-test");
+	});
+});

--- a/libs/backend/server/gateways/model-routing/main/src/__tests__/model-routing-metrics.test.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/__tests__/model-routing-metrics.test.ts
@@ -117,6 +117,28 @@ describe("modelRoutingMetricsRouter", function _suite()
     expect(forwarded.filters[0].column).toBe("metadata.clusterTenant");
   });
 
+  it("replaces non-object caller queries with a tenant-scoped object", async function _RejectsNonObjectQuery()
+  {
+    process.env.LANGFUSE_HOST = "https://lf.internal";
+    process.env.LANGFUSE_PUBLIC_KEY = "pk";
+    process.env.LANGFUSE_SECRET_KEY = "sk";
+
+    const fetchMock = vi.fn(async function _Fetch(_input: string) { return { ok: true, status: 200, json: async function _Json() { return {}; } } as unknown as Response; });
+    vi.stubGlobal("fetch", fetchMock);
+    const app = _buildApp(_mockPrisma("acme"), _authUser({ sub: "user-acme", email: "user@acme.test" }));
+
+    for (const query of ["[]", "null", "7", "{"])
+    {
+      await request(app).get("/api/v1/model-routing/metrics").query({ query });
+    }
+
+    for (const call of fetchMock.mock.calls)
+    {
+      const forwarded = JSON.parse(new URL(String(call[0])).searchParams.get("query")!);
+      expect(forwarded).toEqual({ filters: [{ column: "metadata.clusterTenant", operator: "=", value: "acme", type: "string" }] });
+    }
+  });
+
   it("returns 403 for a non-operator with no resolved ClusterTenant (fail-closed, no upstream call)", async function _failClosed()
   {
     process.env.LANGFUSE_HOST = "https://lf.internal";
@@ -157,5 +179,18 @@ describe("modelRoutingMetricsRouter", function _suite()
 
     const res = await request(_buildApp(_mockPrisma())).get("/api/v1/model-routing/metrics");
     expect(res.status).toBe(502);
+  });
+
+  it("returns the documented 502 envelope when the upstream body is invalid JSON", async function _InvalidUpstreamJson()
+  {
+    process.env.LANGFUSE_HOST = "https://lf.internal";
+    process.env.LANGFUSE_PUBLIC_KEY = "pk";
+    process.env.LANGFUSE_SECRET_KEY = "sk";
+
+    vi.stubGlobal("fetch", vi.fn(async function _Fetch() { return { ok: true, status: 200, json: async function _Json() { throw new SyntaxError("invalid JSON"); } } as unknown as Response; }));
+
+    const res = await request(_buildApp(_mockPrisma())).get("/api/v1/model-routing/metrics");
+    expect(res.status).toBe(502);
+    expect(res.body).toEqual({ status: "upstream_error", error: "Metrics backend returned invalid JSON." });
   });
 });

--- a/libs/backend/server/gateways/model-routing/main/src/core/attempt-litellm-key.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/attempt-litellm-key.ts
@@ -1,4 +1,5 @@
 import { ___DoWithTrace } from "@opencrane/observability";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import { _log } from "../log.js";
 import type { AttemptLiteLlmKey, AttemptLiteLlmKeyRequest } from "./attempt-litellm-key.types.js";
@@ -73,12 +74,15 @@ async function _mintLive(endpoint: string, masterKey: string, input: AttemptLite
     throw new Error(`litellm attempt key mint returned status ${response.status}`);
   }
 
-  const body = await response.json() as { key?: unknown };
-  if (typeof body.key !== "string" || body.key.length === 0)
-  {
-    throw new Error("litellm attempt key mint returned no key");
-  }
+  const key = ___ParseAndValidateJson(await response.text(), "LiteLLM attempt key response", _MintedKey);
 
   _log.info({ keyAlias: input.keyAlias, modelAlias: input.modelAlias }, "litellm attempt key minted");
-  return { key: body.key, keyAlias: input.keyAlias, modelAlias: input.modelAlias, expirySeconds: input.expirySeconds };
+  return { key, keyAlias: input.keyAlias, modelAlias: input.modelAlias, expirySeconds: input.expirySeconds };
+}
+
+/** Validate the non-empty virtual key returned by LiteLLM. */
+function _MintedKey(value: unknown): string
+{
+  if (typeof value !== "object" || value === null || Array.isArray(value) || !("key" in value) || typeof value.key !== "string" || value.key.length === 0) throw new Error("litellm attempt key mint returned no key");
+  return value.key;
 }

--- a/libs/backend/server/gateways/model-routing/main/src/core/litellm-model-registration.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/litellm-model-registration.ts
@@ -1,4 +1,5 @@
 import { ___DoWithTrace } from "@opencrane/observability";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import { _log } from "../log.js";
 import type { LiteLlmModelRegistration } from "./litellm-model-registration.types.js";
@@ -93,8 +94,7 @@ async function _registerLive(endpoint: string, masterKey: string, input: LiteLlm
       return _placeholderModelId(input);
     }
 
-    const payload = await response.json() as { model_id?: string; id?: string; model_info?: { id?: string } };
-    const litellmModelId = payload.model_id ?? payload.id ?? payload.model_info?.id ?? _placeholderModelId(input);
+    const litellmModelId = ___ParseAndValidateJson(await response.text(), "LiteLLM model registration response", _RegisteredModelId, input);
     _log.info({ publicModelName: input.publicModelName, litellmModelId }, "litellm model registered");
     return litellmModelId;
   }
@@ -104,6 +104,21 @@ async function _registerLive(endpoint: string, masterKey: string, input: LiteLlm
     _log.warn({ publicModelName: input.publicModelName, err }, "litellm model registration errored; using placeholder id");
     return _placeholderModelId(input);
   }
+}
+
+/** Select one non-empty LiteLLM deployment id or use the deterministic local placeholder. */
+function _RegisteredModelId(value: unknown, input: LiteLlmModelRegistration): string
+{
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return _placeholderModelId(input);
+  const payload = value as Record<string, unknown>;
+  if (typeof payload["model_id"] === "string" && payload["model_id"].length > 0) return payload["model_id"];
+  if (typeof payload["id"] === "string" && payload["id"].length > 0) return payload["id"];
+  if (typeof payload["model_info"] === "object" && payload["model_info"] !== null && !Array.isArray(payload["model_info"]))
+  {
+    const nestedId = (payload["model_info"] as Record<string, unknown>)["id"];
+    if (typeof nestedId === "string" && nestedId.length > 0) return nestedId;
+  }
+  return _placeholderModelId(input);
 }
 
 /**

--- a/libs/backend/server/gateways/model-routing/main/src/core/provision-byok-key.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/provision-byok-key.ts
@@ -5,6 +5,7 @@ import type { Logger } from "pino";
 import type { PrismaClient, ProviderCredential as PrismaProviderCredential } from "@prisma/client";
 
 import { ModelRoutingScope } from "@opencrane/contracts";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 import { _DeleteLiteLlmCredential, _UpsertLiteLlmCredential } from "./litellm-credential-registration.js";
 import { _RegisterLiteLlmModel } from "./litellm-model-registration.js";
 import { _BYOK_PROVIDER_CATALOG } from "./byok-default-models.js";
@@ -415,11 +416,28 @@ async function _litellmRegisteredModelNames(endpoint: string, masterKey: string)
     {
       return new Set();
     }
-    const info = await response.json() as { data?: Array<{ model_name?: string }> };
-    return new Set((info.data ?? []).map(function _name(m) { return m.model_name ?? ""; }).filter(Boolean));
+    return ___ParseAndValidateJson(await response.text(), "LiteLLM model inventory response", _RegisteredModelNames);
   }
   catch
   {
     return new Set();
   }
+}
+
+/** Validate and collect the registered model names returned by LiteLLM. */
+function _RegisteredModelNames(value: unknown): Set<string>
+{
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("LiteLLM model inventory must be an object");
+  const data = (value as Record<string, unknown>)["data"];
+  if (data === undefined) return new Set();
+  if (!Array.isArray(data)) throw new Error("LiteLLM model inventory data must be an array");
+  const names = data.map(function _Name(entry): string
+  {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) throw new Error("LiteLLM model inventory entry must be an object");
+    const modelName = (entry as Record<string, unknown>)["model_name"];
+    if (modelName === undefined) return "";
+    if (typeof modelName !== "string") throw new Error("LiteLLM model inventory name must be a string");
+    return modelName;
+  });
+  return new Set(names.filter(Boolean));
 }

--- a/libs/backend/server/gateways/model-routing/main/src/routes/model-routing-metrics.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/routes/model-routing-metrics.ts
@@ -3,6 +3,7 @@ import type { PrismaClient } from "@prisma/client";
 
 // Side-effect import: loads the express-session SessionData.authUser augmentation.
 import "@opencrane/server/_infra/auth";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 import type { LangfuseConfig, MetricsCallerScope } from "./model-routing-metrics.types.js";
 import { _ResolveCallerClusterTenant as _resolveCallerClusterTenant } from "@opencrane/backend/server/tenancy/cluster-tenants";
 
@@ -112,13 +113,20 @@ function _buildUpstreamUrl(config: LangfuseConfig, req: Request, scope: MetricsC
   const raw = url.searchParams.get("query");
   if (raw)
   {
-    try { parsed = JSON.parse(raw) as Record<string, unknown>; }
+    try { parsed = ___ParseAndValidateJson(raw, "Langfuse metrics query", _MetricsQueryObject); }
     catch { parsed = {}; }
   }
   const existing = Array.isArray(parsed.filters) ? (parsed.filters as unknown[]) : [];
   parsed.filters = [...existing, tenantFilter];
   url.searchParams.set("query", JSON.stringify(parsed));
   return url;
+}
+
+/** Require a caller-provided Langfuse query to be a JSON object before adding tenant scope. */
+function _MetricsQueryObject(value: unknown): Record<string, unknown>
+{
+  if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("Langfuse metrics query must be an object");
+  return value as Record<string, unknown>;
 }
 
 /**
@@ -185,9 +193,17 @@ export function modelRoutingMetricsRouter(prisma: PrismaClient): Router
         return;
       }
 
-      // 7. Pass the upstream JSON through verbatim (loosely-typed passthrough).
-      const body = await upstream.json();
-      res.json(body);
+      // 7. Pass valid upstream JSON through verbatim. Invalid JSON is still an upstream failure,
+      //    so preserve this route's documented 502 envelope instead of leaking a generic 500.
+      try
+      {
+        const body = await upstream.json();
+        res.json(body);
+      }
+      catch
+      {
+        res.status(502).json({ status: "upstream_error", error: "Metrics backend returned invalid JSON." });
+      }
     }
     catch (err) { next(err); }
   });

--- a/libs/backend/server/iam/authorization/main/src/__tests__/capability-proof.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/__tests__/capability-proof.test.ts
@@ -174,9 +174,11 @@ describe("ES256 capability proof", function _suite()
 	{
 		const validParts = _signProof(HEADER, CLAIMS).split(".");
 		const malformedJson = Buffer.from("{", "utf8").toString("base64url");
+		const arrayJson = Buffer.from("[]", "utf8").toString("base64url");
 
 		expect(__VerifyCapabilityProof("one.two", EXPECTATION)).toEqual({ valid: false, reason: "malformed_compact_proof" });
 		expect(__VerifyCapabilityProof(`${malformedJson}.${validParts[1]}.${validParts[2]}`, EXPECTATION)).toEqual({ valid: false, reason: "malformed_header" });
+		expect(__VerifyCapabilityProof(`${arrayJson}.${validParts[1]}.${validParts[2]}`, EXPECTATION)).toEqual({ valid: false, reason: "malformed_header" });
 		expect(__VerifyCapabilityProof(_signProof({ typ: "JWT", alg: "ES256", jwk: PUBLIC_JWK as unknown as JsonValue }, CLAIMS), EXPECTATION)).toEqual({ valid: false, reason: "malformed_header" });
 		expect(__VerifyCapabilityProof(_signProof({ typ: "dpop+jwt", alg: "none", jwk: PUBLIC_JWK as unknown as JsonValue }, CLAIMS), EXPECTATION)).toEqual({ valid: false, reason: "malformed_header" });
 	});

--- a/libs/backend/server/iam/authorization/main/src/capability-proof.ts
+++ b/libs/backend/server/iam/authorization/main/src/capability-proof.ts
@@ -3,7 +3,7 @@ import { TextDecoder } from "node:util";
 
 import type { CapabilityProofClaims, CapabilityProofExpectation, CapabilityProofFailureReason, CapabilityProofVerification, CapabilityReference, Es256PublicJwk, InvalidCapabilityProof } from "@opencrane/models/authorization";
 import { __AuthorizationResourcesEqual, __IsAuthorizationResourceLocator } from "@opencrane/models/authorization";
-import { ___CanonicalizeJson } from "@opencrane/util";
+import { ___CanonicalizeJson, ___ParseAndValidateJson } from "@opencrane/util";
 import type { JsonValue } from "@opencrane/util";
 
 /** Maximum compact proof size accepted before parsing. */
@@ -51,13 +51,18 @@ function _parseProtectedObject(encodedValue: string): Record<string, unknown> | 
 	if (decoded === null) return null;
 	try
 	{
-		const parsed = JSON.parse(UTF8_DECODER.decode(decoded)) as unknown;
-		return _isRecord(parsed) ? parsed : null;
+		return ___ParseAndValidateJson(UTF8_DECODER.decode(decoded), "protected capability proof object", _recordOrNull);
 	}
 	catch
 	{
 		return null;
 	}
+}
+
+/** Return an untrusted decoded value only when it is a non-array object. */
+function _recordOrNull(value: unknown): Record<string, unknown> | null
+{
+	return _isRecord(value) ? value : null;
 }
 
 /** Verifies that an unknown value is a non-empty string. */

--- a/libs/frontend/state/conversation/ag-ui/src/__tests__/ag-ui-stream.test.ts
+++ b/libs/frontend/state/conversation/ag-ui/src/__tests__/ag-ui-stream.test.ts
@@ -42,6 +42,8 @@ describe("AG-UI stream state", function _Suite()
 	{
 		expect(__DecodeAgUiSseRecord("id: event-1\nevent: ag-ui\ndata: {bad}\n\n")).toBeNull();
 		expect(__DecodeAgUiSseRecord("id: event-1\nevent: ag-ui\ndata: {\"type\":\"RUN_STARTED\"}\n\n")).toBeNull();
+		expect(__DecodeAgUiSseRecord("id: event-1\nevent: ag-ui\ndata: null\n\n")).toBeNull();
+		expect(__DecodeAgUiSseRecord("id: event-1\nevent: ag-ui\ndata: []\n\n")).toBeNull();
 		expect(__DecodeAgUiSseRecord("id: event-1\nevent: other\ndata: {}\n\n")).toBeNull();
 	});
 

--- a/libs/frontend/state/conversation/ag-ui/src/ag-ui-stream.ts
+++ b/libs/frontend/state/conversation/ag-ui/src/ag-ui-stream.ts
@@ -1,4 +1,5 @@
 import type { AgUiProjectionEvent } from "@opencrane/contracts";
+import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import type { AgUiStreamRecord, AgUiStreamState } from "./ag-ui-stream.types.js";
 
@@ -23,10 +24,17 @@ export function __DecodeAgUiSseRecord(frame: string): AgUiStreamRecord | null
 	if (!id || event !== "ag-ui" || !serialized || /[\r\n]/.test(id)) return null;
 	try
 	{
-		const data = JSON.parse(serialized) as unknown;
-		return _IsProjectionEvent(data) ? { id, event: "ag-ui", data } : null;
+		const data = ___ParseAndValidateJson(serialized, "AG-UI SSE data", _ProjectionEvent);
+		return { id, event: "ag-ui", data };
 	}
 	catch { return null; }
+}
+
+/** Return one supported projection event or reject the decoded transport value. */
+function _ProjectionEvent(value: unknown): AgUiProjectionEvent
+{
+	if (!_IsProjectionEvent(value)) throw new Error("AG-UI SSE data must contain a supported projection event");
+	return value;
 }
 
 /** Fold one replay record, refusing duplicate cursors without inferring order from opaque identifiers. */

--- a/libs/frontend/state/onboarding/README.md
+++ b/libs/frontend/state/onboarding/README.md
@@ -27,7 +27,8 @@ signup completes.
 ## Public surface
 
 - `WelcomeOnboardingService` — the first-run completed flag as a signal (`completed`, `markComplete`, `reset`).
-- `OnboardingCacheService` — save/restore/clear the funnel step + selection across the OIDC redirect.
+- `OnboardingCacheService` — save/restore/clear the funnel step + selection across the OIDC redirect;
+  restored browser data is rebuilt only after its step, plan, and account fields pass domain validation.
 - `welcome-onboarding.util` — the pure completion-decision helper.
 - `onboarding.types` — the funnel step, account, selection, and payment/provision state types.
 

--- a/libs/frontend/state/onboarding/src/lib/__tests__/onboarding-cache.service.spec.ts
+++ b/libs/frontend/state/onboarding/src/lib/__tests__/onboarding-cache.service.spec.ts
@@ -76,6 +76,24 @@ describe("OnboardingCacheService", () =>
 		expect(service.restoreState()).toBeNull();
 	});
 
+	it("rejects structurally present but invalid cached domain values", () =>
+	{
+		const { service, mockGateway } = _setup();
+		const account = { displayName: "Acme", adminEmail: "a@b.com", baseDomain: "a.com", name: "acme" };
+		const invalidStates = [
+			{ step: "Account", selection: { planId: "pro", account } },
+			{ step: OnboardingStep.Account, selection: null },
+			{ step: OnboardingStep.Account, selection: { planId: 7, account } },
+			{ step: OnboardingStep.Account, selection: { planId: "pro", account: { ...account, adminEmail: false } } },
+		];
+
+		for (const invalidState of invalidStates)
+		{
+			mockGateway.__seed(STATE_KEY, JSON.stringify(invalidState));
+			expect(service.restoreState()).toBeNull();
+		}
+	});
+
 	it("successfully parses and returns a valid saved state", () =>
 	{
 		const { service, mockGateway } = _setup();

--- a/libs/frontend/state/onboarding/src/lib/onboarding-cache.service.ts
+++ b/libs/frontend/state/onboarding/src/lib/onboarding-cache.service.ts
@@ -1,8 +1,10 @@
 import { Inject, Injectable } from "@angular/core";
 
-import { OnboardingSelection, OnboardingStep } from "./onboarding.types";
-
 import { SESSION_STORAGE_GATEWAY, StorageGateway } from "@opencrane/state/utils/storage";
+import { ___ParseAndValidateJson } from "@opencrane/util";
+
+import { OnboardingStep } from "./onboarding.types";
+import type { OnboardingSelection } from "./onboarding.types";
 
 /**
  * Headless state service for persisting the self-serve onboarding flow.
@@ -38,12 +40,7 @@ export class OnboardingCacheService
 
 		try
 		{
-			const parsed = JSON.parse(raw) as { step: OnboardingStep; selection: OnboardingSelection };
-			if (typeof parsed === "object" && parsed !== null && "step" in parsed && "selection" in parsed)
-			{
-				return parsed;
-			}
-			return null;
+			return ___ParseAndValidateJson(raw, "onboarding session state", _OnboardingState);
 		}
 		catch
 		{
@@ -57,4 +54,36 @@ export class OnboardingCacheService
 	{
 		this._storage.removeItem(this._STATE_KEY);
 	}
+}
+
+/** Validate and rebuild the cached onboarding state instead of trusting browser storage. */
+function _OnboardingState(value: unknown): { step: OnboardingStep; selection: OnboardingSelection }
+{
+	if (typeof value !== "object" || value === null || Array.isArray(value)) throw new Error("onboarding session state must be an object");
+	const state = value as Record<string, unknown>;
+	if (!_IsOnboardingStep(state["step"])) throw new Error("onboarding session state contains an invalid step");
+	if (typeof state["selection"] !== "object" || state["selection"] === null || Array.isArray(state["selection"])) throw new Error("onboarding session state contains an invalid selection");
+	const selection = state["selection"] as Record<string, unknown>;
+	if (typeof selection["planId"] !== "string" && selection["planId"] !== null) throw new Error("onboarding session state contains an invalid plan");
+	if (typeof selection["account"] !== "object" || selection["account"] === null || Array.isArray(selection["account"])) throw new Error("onboarding session state contains an invalid account");
+	const account = selection["account"] as Record<string, unknown>;
+	if (typeof account["displayName"] !== "string" || typeof account["adminEmail"] !== "string" || typeof account["baseDomain"] !== "string" || typeof account["name"] !== "string") throw new Error("onboarding session state contains invalid account fields");
+	return {
+		step: state["step"],
+		selection: {
+			planId: selection["planId"],
+			account: { displayName: account["displayName"], adminEmail: account["adminEmail"], baseDomain: account["baseDomain"], name: account["name"] },
+		},
+	};
+}
+
+/** Return whether one persisted numeric value is an actual onboarding step. */
+function _IsOnboardingStep(value: unknown): value is OnboardingStep
+{
+	return value === OnboardingStep.Plan
+		|| value === OnboardingStep.Account
+		|| value === OnboardingStep.SignUp
+		|| value === OnboardingStep.Payment
+		|| value === OnboardingStep.Provision
+		|| value === OnboardingStep.Status;
 }

--- a/libs/util/README.md
+++ b/libs/util/README.md
@@ -16,7 +16,10 @@ It owns four things:
   behaviour is used everywhere rather than re-implemented.
 - **JSON trust-boundary parsing** — `___ParseAndValidateJson` parses raw JSON as `unknown`, then
   immediately delegates to a caller-owned validator that produces the generic result type. Optional
-  validator arguments carry contextual constraints without one-off parsing wrappers.
+  validator arguments carry contextual constraints without one-off parsing wrappers. Configuration
+  readers and HTTP adapters use this same parser after enforcing any transport-specific byte limit;
+  tolerant JSONL/rendering heuristics remain local because malformed fragments are part of their
+  best-effort protocol rather than an exceptional domain boundary.
 - **Canonical JSON and digest grammar** — `___CanonicalizeJson` serialises a JSON value to the one
   canonical string
   form defined by RFC 8785 (JSON Canonicalization Scheme): object keys sorted, whitespace and number

--- a/libs/util/README.md
+++ b/libs/util/README.md
@@ -9,11 +9,14 @@ across domain packages. "Pure" means every function returns a value computed onl
 arguments — no database, no network, no clock, no global state — so the results are identical every
 time and safe to call anywhere.
 
-It owns three things:
+It owns four things:
 
 - **Collection helpers** — `___SortBy` (stable sort by an optional key), `___SomeArray` and
   `___SomeRecord` (typed "does any element/value match?" checks). Small, but shared so the same
   behaviour is used everywhere rather than re-implemented.
+- **JSON trust-boundary parsing** — `___ParseAndValidateJson` parses raw JSON as `unknown`, then
+  immediately delegates to a caller-owned validator that produces the generic result type. Optional
+  validator arguments carry contextual constraints without one-off parsing wrappers.
 - **Canonical JSON and digest grammar** — `___CanonicalizeJson` serialises a JSON value to the one
   canonical string
   form defined by RFC 8785 (JSON Canonicalization Scheme): object keys sorted, whitespace and number
@@ -34,6 +37,7 @@ platform-wide API. Invariant: purity and determinism — no hidden inputs, same 
 ## Public surface
 
 - `___SortBy`, `___SomeArray`, `___SomeRecord` — collection helpers.
+- `___ParseAndValidateJson` — parse untrusted JSON and return only the caller-validated generic type.
 - `___CanonicalizeJson` — RFC 8785 canonical JSON serialisation.
 - `___CloneCanonicalJson` — detached deep copy through the canonical JSON representation.
 - `___IsSha256Digest` — strict validator for the platform's lowercase SHA-256 digest grammar.

--- a/libs/util/src/__tests__/json.test.ts
+++ b/libs/util/src/__tests__/json.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { ___ParseAndValidateJson } from "../json.js";
+
+/** Validate one object field while proving the generic return type. */
+function _Count(candidate: unknown, minimum: number): number
+{
+	if (typeof candidate !== "object" || candidate === null || Array.isArray(candidate) || !("count" in candidate) || typeof candidate.count !== "number" || candidate.count < minimum)
+	{
+		throw new Error("count is below its required minimum");
+	}
+	return candidate.count;
+}
+
+describe("JSON boundary utility", function _Suite()
+{
+	it("parses unknown JSON and returns the validator-owned generic type", function _ParsesAndValidates()
+	{
+		const count: number = ___ParseAndValidateJson("{\"count\":3}", "COUNT_JSON", _Count, 2);
+
+		expect(count).toBe(3);
+	});
+
+	it("labels syntax failures without swallowing domain validation failures", function _SeparatesFailures()
+	{
+		expect(function _InvalidJson() { ___ParseAndValidateJson("{", "COUNT_JSON", _Count, 2); }).toThrow(/COUNT_JSON must contain valid JSON/);
+		expect(function _InvalidCount() { ___ParseAndValidateJson("{\"count\":1}", "COUNT_JSON", _Count, 2); }).toThrow(/count is below its required minimum/);
+	});
+});

--- a/libs/util/src/index.ts
+++ b/libs/util/src/index.ts
@@ -3,5 +3,6 @@
  */
 export * from "./collections.js";
 export * from "./digest.js";
+export * from "./json.js";
 export * from "./json-canonicalization.js";
 export * from "./json-canonicalization.types.js";

--- a/libs/util/src/json.ts
+++ b/libs/util/src/json.ts
@@ -1,0 +1,26 @@
+/**
+ * Parse one JSON string and immediately validate its untrusted result into a caller-owned type.
+ *
+ * JSON syntax parsing deliberately produces `unknown`; only the injected validator can turn that
+ * boundary value into `T`. Additional validator arguments let callers pass contextual constraints
+ * without creating one-off parsing wrappers.
+ *
+ * @param value - Raw JSON text from an untrusted configuration or transport boundary.
+ * @param sourceName - Stable source label included in syntax-error diagnostics.
+ * @param validate - Domain validator that either returns `T` or throws a domain-specific error.
+ * @param validatorArguments - Additional contextual constraints passed unchanged to the validator.
+ * @returns The fully validated caller-owned value.
+ */
+export function ___ParseAndValidateJson<T, TArguments extends readonly unknown[]>(value: string, sourceName: string, validate: (candidate: unknown, ...arguments_: TArguments) => T, ...validatorArguments: TArguments): T
+{
+	let candidate: unknown;
+	try
+	{
+		candidate = JSON.parse(value) as unknown;
+	}
+	catch (cause)
+	{
+		throw new Error(`${sourceName} must contain valid JSON`, { cause });
+	}
+	return validate(candidate, ...validatorArguments);
+}


### PR DESCRIPTION
## Why

OpenCrane accepted JSON at many trust boundaries through local `try`/`catch` blocks, `response.json()`, and structural casts. That duplicated syntax handling and sometimes let values carry TypeScript types without runtime proof.

The repository-wide sweep found concrete failure modes: an array-shaped Langfuse query could lose its injected tenant filter, a numeric LiteLLM model identifier could escape a function declared to return a string, and malformed onboarding cache state could be restored as valid state.

This change establishes one rule: strict JSON becomes a domain type only after the owning validator accepts and, where needed, canonicalizes it.

## What changes

- add one generic parse-and-validate utility with inferred return types and contextual validator arguments
- route strict configuration, authority HTTP, replay cursor, channel command, JWS, SSE, browser-storage, and typed upstream-response boundaries through it
- retain adapter-owned byte limits for controller and artifact-preprocessor responses
- rebuild accepted skill profiles and onboarding state from validated fields instead of asserting input objects
- require non-empty string credentials, receipts, and LiteLLM model identifiers at runtime
- reject non-object metrics queries before tenant-filter injection and map malformed upstream metrics JSON to the documented `502`
- preserve security ordering: artifact payload JSON is not parsed until after signature verification
- document why tolerant JSONL/render parsing and schema-free passthroughs remain local

## Deliberate boundaries

- A2UI JSONL and conversation-render parsers intentionally tolerate malformed fragments and therefore do not use the strict helper.
- The generic frontend API client and Langfuse metrics response remain schema-free transports; the metrics route now handles invalid upstream JSON explicitly.
- Response and stream reading stays in the owning adapter so size ceilings and I/O behavior do not leak into the pure utility.

## Validation

- lint/typecheck across all 13 affected projects
- 284 focused tests across utilities, apps, backend authorities, gateways, artifacts, channel proxy, and frontend state
- repository style gate and `git diff --check`
- exhaustive backend/frontend parser audits
- independent correctness/security review and post-refactor reaper pass

## Integration

This PR intentionally targets `feat/sql-trigger-authority-hardening` (#506), because several affected controller packages are introduced there. #506 targets `develop`; keeping the dependency explicit avoids repeating that branch's unrelated changes in this review.
