### PR TITLE
🐛 Preserve checkpoint authority on runtime resume

### DIFF
--- a/apps/agent-runtime/src/attempts/execution.py
+++ b/apps/agent-runtime/src/attempts/execution.py
@@ -177,9 +177,7 @@ def execute_resume_attempt(
     ):
         try:
             for neutral_event in resume_event_source(
-                coordinates["runId"],
-                coordinates["attempt"],
-                input_generation,
+                compiled_input,
                 deferred_tool_results,
                 cancel_event,
                 steering_buffer,

--- a/apps/agent-runtime/src/model_loop/driver.py
+++ b/apps/agent-runtime/src/model_loop/driver.py
@@ -12,7 +12,6 @@ from collections.abc import Callable, Iterator
 
 from ..config import environment, read_attempt_litellm_key
 from ..constants import DEFAULT_LITELLM_KEY_PATH
-from .checkpoints import read_checkpoint
 
 
 def absorb_steering(steering_buffer: list[str]) -> list[str]:
@@ -150,27 +149,20 @@ def pydantic_ai_event_source(
 
 
 def pydantic_ai_resume_source(
-    run_id: str,
-    attempt: int,
-    input_generation: object,
+    compiled_input: dict[str, object],
     deferred_tool_results: object,
     cancel_event: threading.Event,
     steering_buffer: list[str],
-    *,
-    checkpoint_cipher: object | None = None,
 ) -> Iterator[dict[str, object]]:
-    """Resume only from agreeing local context and control-plane-authorised tool results.
+    """Resume from attempt-owned compiled context and control-plane-authorised tool results.
 
-    The server supplies the run coordinates, input generation, and deferred results. The checkpoint
-    contributes only the compiled input needed by the framework adapter. If the local state is absent
-    or disagrees, this function raises instead of inventing context or weakening the grant set.
+    The attempts layer supplies the one coordinate-checked compiled input recovery and owns every
+    checkpoint/cipher decision. This persistence-free adapter only translates that exact immutable
+    context into a bounded framework resume, so it cannot reread a checkpoint with a different
+    process cipher or silently select stale tool grants.
     """
     from pydantic_ai import Agent
 
-    state = read_checkpoint(run_id, attempt, input_generation, cipher=checkpoint_cipher)
-    compiled_input = state.get("compiledInput") if isinstance(state, dict) else None
-    if not isinstance(compiled_input, dict):
-        raise RuntimeError("no agreeing local checkpoint to resume from")
     agent = _agent_for(compiled_input)
 
     async def _collect() -> list[dict[str, object]]:

--- a/apps/agent-runtime/tests/test_conformance.py
+++ b/apps/agent-runtime/tests/test_conformance.py
@@ -202,9 +202,8 @@ class ConformanceApprovalResumeTests(unittest.TestCase):
 
         captured: dict = {}
 
-        def _resume_source(run_id, attempt, input_generation, deferred, _cancel, _steering):
+        def _resume_source(_compiled_input, deferred, _cancel, _steering):
             captured["deferred"] = deferred
-            captured["inputGeneration"] = input_generation
             return iter([{"type": "output_text", "text": "done"}, {"type": "usage", "inputTokens": 1, "outputTokens": 1}])
 
         resume_emitted: list[dict] = []

--- a/apps/agent-runtime/tests/test_runtime.py
+++ b/apps/agent-runtime/tests/test_runtime.py
@@ -536,17 +536,14 @@ class RuntimeResumeCancelTests(unittest.TestCase):
         emitted: list[dict] = []
         captured: dict = {}
 
-        def _resume_source(run_id, attempt, input_generation, deferred_tool_results, _cancel, _steer):
-            captured["runId"] = run_id
-            captured["attempt"] = attempt
-            captured["inputGeneration"] = input_generation
+        def _resume_source(compiled_input, deferred_tool_results, _cancel, _steer):
+            captured["compiledInput"] = compiled_input
             captured["deferred"] = deferred_tool_results
             return iter([{"type": "output_text", "text": "resumed"}, {"type": "usage", "inputTokens": 1, "outputTokens": 2}])
 
         _execute_resume_attempt(_resume_command(), "instance-1", emitted.append, resume_event_source=_resume_source)
         self.assertEqual(captured["deferred"], {"t1": {"ok": True}})
-        self.assertEqual(captured["inputGeneration"], 7)
-        self.assertEqual((captured["runId"], captured["attempt"]), ("r1", 1))
+        self.assertEqual(captured["compiledInput"], {})
         event_types = [candidate["eventType"] for candidate in emitted]
         self.assertEqual(event_types, ["run.resumed", "run.output_text", "run.usage", "run.completed"])
         self.assertEqual(emitted[0]["payload"], {"inputGeneration": 7})
@@ -557,12 +554,34 @@ class RuntimeResumeCancelTests(unittest.TestCase):
         command["payload"]["steeringRequests"] = [{"text": "Prioritise the current decision."}]
         captured: dict = {}
 
-        def _resume_source(_run_id, _attempt, _generation, _deferred, _cancel, steering_buffer):
+        def _resume_source(_compiled_input, _deferred, _cancel, steering_buffer):
             captured["steering"] = steering_buffer[:]
             return iter([])
 
         _execute_resume_attempt(command, "instance-1", lambda _candidate: None, resume_event_source=_resume_source)
         self.assertEqual(captured["steering"], ["Prioritise the current decision."])
+
+    def test_resume_passes_the_injected_cipher_recovery_to_the_driver(self) -> None:
+        """The model driver receives the exact coordinate-checked checkpoint, never a second cipher read."""
+        emitted: list[dict] = []
+        captured: dict = {}
+        cipher = _ReversingCipher()
+        compiled_input = _compiled_input()
+
+        def _resume_source(recovered_input, _deferred, _cancel, _steering):
+            captured["compiledInput"] = recovered_input
+            return iter([])
+
+        with tempfile.TemporaryDirectory() as directory:
+            os.environ["OPENCRANE_RUNTIME_CHECKPOINT_DIR"] = directory
+            try:
+                _write_checkpoint("r1", 1, 7, {"compiledInput": compiled_input}, cipher=cipher, checkpoint_dir=directory)
+                _execute_resume_attempt(_resume_command(), "instance-1", emitted.append, resume_event_source=_resume_source, checkpoint_cipher=cipher)
+            finally:
+                os.environ.pop("OPENCRANE_RUNTIME_CHECKPOINT_DIR", None)
+
+        self.assertEqual(captured["compiledInput"], compiled_input)
+        self.assertEqual([candidate["eventType"] for candidate in emitted], ["run.resumed", "run.completed"])
 
     def test_missing_resume_payload_is_a_terminal_failure(self) -> None:
         """A resume command without a payload surfaces `run.failed`, never a silent ack."""


### PR DESCRIPTION
## Summary

- keep coordinate-checked checkpoint recovery in the attempt layer
- pass that exact recovered compiled input to the persistence-free Pydantic resume adapter
- cover an injected-cipher checkpoint resume so model context and tool grants use one recovered object

## Validation

- npx nx run agent-runtime:test (78 tests, 2 skipped)
- npx nx run agent-runtime:lint
- npm run check:module-growth -- --diff origin/feat/sql-trigger-authority-hardening
- git diff --check
- independent review: clean

## Module-growth review of PR #506

The merged PR #515 gate reviewed all 26 candidates. It confirmed this fixed resume authority defect and identified two separate medium-priority hard-limit refactors: split the runtime protocol dispatch authority (701 lines) and run dispatch repository (850 lines). They are deliberately not folded into this focused behavior fix because each needs a transaction-preserving authority split.