### PR TITLE
♻️ Split production external-action runner responsibilities

### DIFF
--- a/libs/backend/agents/execution/protocol/README.md
+++ b/libs/backend/agents/execution/protocol/README.md
@@ -57,10 +57,12 @@ invocation receipt retains that bounded authority reason and the action boundary
 credential-free structured event; it never collapses a policy revocation into a transport failure.
 
 It intentionally owns no HTTP listener, Kubernetes resource, model driver, or provider credential.
-Its production composition factory binds external actions to integration custody, sandbox, and
-memory ports, the authorization-owned deferred approval transaction, and the canonical run terminal
-reporter. The app supplies only process persistence, fixed policy values, and logging, then hands
-the resulting authority to the stream transport. An integration action has the fixed
+Its production factory composes the external-action runner from the durable invocation, personal
+configuration, integration, approval, clock, and fail-closed transport adapters. The runner selects
+the user-only personal upgrade tool before reserving it; every other action is reserved before its
+transport can run, and a deferred approval is bound to that exact reservation. The app supplies only
+process persistence, fixed policy values, and logging, then hands the resulting authority to the
+stream transport. An integration action has the fixed
 `integration:<integrationId>:<toolName>` shape: its live custody reference and revision allow-list
 are rechecked at execution, so the runtime never sees either credential or mutable permission state.
 
@@ -74,8 +76,8 @@ are rechecked at execution, so the runtime never sees either credential or mutab
 - `_RuntimeSteeringOpenapiPaths` — contributes the steering contract to the server-owned API spec.
 
 Pure protocol decisions, Prisma adapters, executor construction, and their supporting types remain
-inside this package. Some support current production composition while others preserve domain-owned
-authority seams for later execution flows; none is an alternate entrypoint for sibling domains.
+inside this package. The production external-action runner and its composition helpers are
+package-private seams for the factory, not alternate entrypoints for sibling domains.
 
 ## Boundary
 

--- a/libs/backend/agents/execution/protocol/src/__tests__/production-external-action-runner.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/production-external-action-runner.test.ts
@@ -1,0 +1,150 @@
+import { UPGRADE_SESSION_TOOL, UPGRADE_SESSION_TOOL_REVISION } from "@opencrane/backend/agents/personal/configuration";
+import { __DigestCanonicalJson } from "@opencrane/backend/server/iam/authorization";
+import type { ToolInvocationIntent, ToolInvocationReceipt, ToolInvocationRepository, ToolInvocationReservationResult, ToolInvocationSuccessResult } from "@opencrane/backend/server/iam/authorization";
+import type { CompiledToolDefinition, RunInputSnapshot, RuntimeExternalActionCandidate } from "@opencrane/contracts";
+import type { Logger } from "@opencrane/observability";
+import { __UnavailableMemoryGatewayClient } from "@opencrane/server/_infra/memory-gateway-client";
+import { __UnavailableObotMcpInvocationAdapter } from "@opencrane/server/_infra/obot-custody";
+import { __UnavailableSandboxJobExecutor } from "@opencrane/server/_infra/sandbox-execution";
+import type { JsonValue } from "@opencrane/util";
+import { describe, expect, it, vi } from "vitest";
+
+import { _CreateProductionExternalActionRunnerWithDependencies } from "../production-external-action-runner.js";
+import type { ProductionExternalActionRunnerDependencies } from "../production-external-action-runner.types.js";
+
+/** Fixed server instant proving proposal and approval time never comes from the runtime. */
+const NOW = new Date("2026-08-01T08:00:00.000Z");
+
+/** In-memory invocation ledger sufficient to prove reserve-before-I/O runner sequencing. */
+class _InvocationRepository implements ToolInvocationRepository
+{
+	/** Intents observed in reservation order. */
+	readonly intents: ToolInvocationIntent[] = [];
+	/** Optional ordered-effect recorder used to prove reserve-before-approval sequencing. */
+	private readonly effects?: string[];
+	/** Most recently reserved intent used to produce a correctly bound receipt. */
+	private intent: ToolInvocationIntent | null = null;
+
+	/** Creates an in-memory ledger with an optional ordered-effect recorder. */
+	constructor(effects?: string[])
+	{
+		this.effects = effects;
+	}
+
+	/** Records one fresh reservation for the candidate. */
+	async reserve<TResult>(intent: ToolInvocationIntent): Promise<ToolInvocationReservationResult<TResult>>
+	{
+		this.effects?.push("reserve");
+		this.intents.push(intent);
+		this.intent = intent;
+		return { status: "reserved", reservationId: "reservation-1" };
+	}
+
+	/** Completes the current reservation with a receipt bound to its exact fingerprint. */
+	async markSucceeded<TResult>(_reservationId: string, result: TResult): Promise<ToolInvocationSuccessResult<TResult>>
+	{
+		if (this.intent === null) return { status: "conflict" };
+		const receipt: ToolInvocationReceipt<TResult> = { toolInvocationId: this.intent.toolInvocationId, requestFingerprint: this.intent.requestFingerprint, result };
+		return { status: "succeeded", receipt };
+	}
+
+	/** Records no failure in successful runner tests. */
+	async markFailed(_reservationId: string, _failureCode: string): Promise<{ status: "failed" }>
+	{
+		return { status: "failed" };
+	}
+}
+
+/** Build one immutable snapshot with only the authority facts the runner consumes. */
+function _snapshot(identityKind: "user" | "service" = "user"): RunInputSnapshot
+{
+	return {
+		runId: "run-1",
+		siloId: "silo-1",
+		agentServiceId: "service-1",
+		agentRevisionId: "revision-1",
+		capabilitySetDigest: "sha256:capabilities",
+		identitySnapshot: { kind: identityKind, executionSubjectId: identityKind === "user" ? "user-1" : "agent-service:service-1" },
+	} as unknown as RunInputSnapshot;
+}
+
+/** Build one upgrade-session candidate with its canonical arguments digest. */
+function _candidate(): RuntimeExternalActionCandidate
+{
+	const args: JsonValue = { kind: "persona_refresh" };
+	return { protocolVersion: "opencrane.agent-runtime/v1", runtimeInstanceId: "runtime-1", commandId: "command-1", candidateId: "candidate-1", runId: "run-1", attempt: 1, fence: 1, kind: "external_action", toolRevisionId: UPGRADE_SESSION_TOOL_REVISION, toolInvocationId: "invocation-1", argumentsDigest: __DigestCanonicalJson(args), arguments: args };
+}
+
+/** Build explicit test authorities while keeping every unrelated transport fail-closed. */
+function _dependencies(repository: ToolInvocationRepository = new _InvocationRepository()): ProductionExternalActionRunnerDependencies
+{
+	return {
+		invocations: repository,
+		personalConfiguration: { proposeUpgradeSession: vi.fn(async function _propose() { return { changeId: "change-1" }; }) },
+		transports: {
+			integrations: { resolveAssignment: vi.fn(async function _resolve() { throw new Error("integration transport was not expected"); }) },
+			obotMcpInvocation: new __UnavailableObotMcpInvocationAdapter(),
+			sandboxExecutor: new __UnavailableSandboxJobExecutor(),
+			memoryGateway: new __UnavailableMemoryGatewayClient(),
+		},
+		approvals: { open: vi.fn(async function _open() { return true; }) },
+		clock: { now(): Date { return NOW; } },
+		log: { warn: vi.fn() } as unknown as Logger,
+	};
+}
+
+describe("production external-action runner", function _suite()
+{
+	it("denies a managed identity before reserving the personal upgrade tool", async function _deniesManagedUpgrade()
+	{
+		const repository = new _InvocationRepository();
+		const dependencies = _dependencies(repository);
+		const runner = _CreateProductionExternalActionRunnerWithDependencies(dependencies);
+
+		await expect(runner.run(_candidate(), _snapshot("service"), [UPGRADE_SESSION_TOOL])).resolves.toEqual({ outcome: "denied" });
+		expect(repository.intents).toHaveLength(0);
+		expect(dependencies.personalConfiguration.proposeUpgradeSession).not.toHaveBeenCalled();
+	});
+
+	it("reserves and completes a user upgrade proposal with server-owned time", async function _completesUpgrade()
+	{
+		const repository = new _InvocationRepository();
+		const dependencies = _dependencies(repository);
+		const runner = _CreateProductionExternalActionRunnerWithDependencies(dependencies);
+
+		await expect(runner.run(_candidate(), _snapshot(), [UPGRADE_SESSION_TOOL])).resolves.toEqual({ outcome: "completed" });
+		expect(repository.intents).toHaveLength(1);
+		expect(dependencies.personalConfiguration.proposeUpgradeSession).toHaveBeenCalledWith(_candidate(), _snapshot(), NOW.toISOString());
+		expect(dependencies.approvals.open).not.toHaveBeenCalled();
+	});
+
+	it("opens approval only after reserving an approval-gated action", async function _opensDeferredApproval()
+	{
+		const effects: string[] = [];
+		const repository = new _InvocationRepository(effects);
+		const dependencies = _dependencies(repository);
+		dependencies.approvals.open = vi.fn(async function _open()
+		{
+			effects.push("open_approval");
+			return true;
+		});
+		const runner = _CreateProductionExternalActionRunnerWithDependencies(dependencies);
+		const approvalTool: CompiledToolDefinition = { ...UPGRADE_SESSION_TOOL, requiresApproval: true };
+
+		await expect(runner.run(_candidate(), _snapshot(), [approvalTool])).resolves.toEqual({ outcome: "completed" });
+		expect(repository.intents[0]?.approvalRequired).toBe(true);
+		expect(dependencies.personalConfiguration.proposeUpgradeSession).not.toHaveBeenCalled();
+		expect(effects).toEqual(["reserve", "open_approval"]);
+		expect(dependencies.approvals.open).toHaveBeenCalledWith({
+			runId: "run-1",
+			attempt: 1,
+			toolInvocationId: "invocation-1",
+			toolRevisionId: UPGRADE_SESSION_TOOL_REVISION,
+			argumentsDigest: _candidate().argumentsDigest,
+			capabilitySetDigest: "sha256:capabilities",
+			reservationId: "reservation-1",
+			now: NOW,
+			expiresAt: new Date("2026-08-02T08:00:00.000Z"),
+		});
+	});
+});

--- a/libs/backend/agents/execution/protocol/src/production-external-action-runner.composition.ts
+++ b/libs/backend/agents/execution/protocol/src/production-external-action-runner.composition.ts
@@ -1,0 +1,64 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { PrismaPersonalConfigurationChangeRepository } from "@opencrane/backend/agents/personal/configuration";
+import { PrismaIntegrationAuthorityRepository, __SystemIntegrationAuthorityClock } from "@opencrane/backend/server/gateways/integrations";
+import { PrismaToolInvocationRepository, __OpenDeferredToolApproval } from "@opencrane/backend/server/iam/authorization";
+import type { OpenDeferredToolApprovalCommand } from "@opencrane/backend/server/iam/authorization";
+import type { Logger } from "@opencrane/observability";
+import { __UnavailableMemoryGatewayClient } from "@opencrane/server/_infra/memory-gateway-client";
+import { __UnavailableObotMcpInvocationAdapter } from "@opencrane/server/_infra/obot-custody";
+import { __UnavailableSandboxJobExecutor } from "@opencrane/server/_infra/sandbox-execution";
+
+import type { RuntimeExternalActionRunner } from "./prisma-runtime-dispatch-authority.types.js";
+import { _CreateProductionExternalActionRunnerWithDependencies } from "./production-external-action-runner.js";
+import type { ProductionDeferredApprovalOpener, ProductionExternalActionClock } from "./production-external-action-runner.types.js";
+
+/** System clock used by the production composition. */
+class _ProductionExternalActionClock implements ProductionExternalActionClock
+{
+	/** Returns the current server wall-clock instant. */
+	now(): Date
+	{
+		return new Date();
+	}
+}
+
+/** Binds the functional deferred-approval authority to process-owned persistence and logging. */
+class _PrismaDeferredApprovalOpener implements ProductionDeferredApprovalOpener
+{
+	/** Canonical product-authority persistence client. */
+	private readonly prisma: PrismaClient;
+	/** Structured evidence sink for atomic approval-opening failures. */
+	private readonly log: Logger;
+
+	/** Creates an approval opener over process-owned dependencies. */
+	constructor(prisma: PrismaClient, log: Logger)
+	{
+		this.prisma = prisma;
+		this.log = log;
+	}
+
+	/** Opens one approval without exposing Prisma to the runner orchestration. */
+	async open(command: OpenDeferredToolApprovalCommand): Promise<boolean>
+	{
+		return __OpenDeferredToolApproval(this.prisma, command, this.log);
+	}
+}
+
+/** Compose the production external-action runner from durable authorities and fail-closed transports. */
+export function _CreateProductionExternalActionRunner(prisma: PrismaClient, log: Logger): RuntimeExternalActionRunner
+{
+	return _CreateProductionExternalActionRunnerWithDependencies({
+		invocations: new PrismaToolInvocationRepository(prisma),
+		personalConfiguration: new PrismaPersonalConfigurationChangeRepository(prisma),
+		transports: {
+			integrations: new PrismaIntegrationAuthorityRepository(prisma, new __SystemIntegrationAuthorityClock()),
+			obotMcpInvocation: new __UnavailableObotMcpInvocationAdapter(),
+			sandboxExecutor: new __UnavailableSandboxJobExecutor(),
+			memoryGateway: new __UnavailableMemoryGatewayClient(),
+		},
+		approvals: new _PrismaDeferredApprovalOpener(prisma, log),
+		clock: new _ProductionExternalActionClock(),
+		log,
+	});
+}

--- a/libs/backend/agents/execution/protocol/src/production-external-action-runner.ts
+++ b/libs/backend/agents/execution/protocol/src/production-external-action-runner.ts
@@ -1,0 +1,94 @@
+import { UPGRADE_SESSION_TOOL_REVISION } from "@opencrane/backend/agents/personal/configuration";
+import type { CompiledToolDefinition, RunInputSnapshot, RuntimeExternalActionCandidate } from "@opencrane/contracts";
+import type { JsonValue } from "@opencrane/util";
+
+import { __ExecuteExternalAction } from "./external-action-authority.js";
+import type { ExternalActionExecutor } from "./external-action-authority.types.js";
+import { __CreateExternalActionExecutor, __PersonalMemoryDatasetId } from "./external-action-executor.js";
+import type { RuntimeExternalActionRunner, RuntimeExternalActionRunnerResult } from "./prisma-runtime-dispatch-authority.types.js";
+import type { ProductionExternalActionRunnerDependencies } from "./production-external-action-runner.types.js";
+
+/** Bounded lifetime of a pending deferred-tool approval before it is no longer actionable. */
+const _DEFERRED_APPROVAL_TTL_MILLISECONDS = 24 * 60 * 60 * 1000;
+
+/** Build a production-equivalent runner over explicit authorities for focused orchestration tests. */
+export function _CreateProductionExternalActionRunnerWithDependencies(dependencies: ProductionExternalActionRunnerDependencies): RuntimeExternalActionRunner
+{
+	return {
+		async run(candidate, snapshot, compiledTools): Promise<RuntimeExternalActionRunnerResult>
+		{
+			return _runExternalAction(candidate, snapshot, compiledTools, dependencies);
+		},
+	};
+}
+
+/** Reserve, execute, and complete one candidate without letting transport state become authority. */
+async function _runExternalAction(candidate: RuntimeExternalActionCandidate, snapshot: RunInputSnapshot, compiledTools: readonly CompiledToolDefinition[], dependencies: ProductionExternalActionRunnerDependencies): Promise<RuntimeExternalActionRunnerResult>
+{
+	// 1. Select an executor only from the compiler-issued revision and admitted identity.
+	let executor: ExternalActionExecutor<JsonValue> | null;
+	try
+	{
+		executor = _createCandidateExecutor(candidate, snapshot, dependencies);
+	}
+	catch (error)
+	{
+		return { outcome: "retryable", error };
+	}
+	if (executor === null) return { outcome: "denied" };
+
+	// 2. Reserve before I/O; only proven terminal post-reservation outcomes become denials.
+	const approvalRequired = _approvalRequired(candidate, compiledTools);
+	const result = await __ExecuteExternalAction(dependencies.invocations, { candidate, snapshot, compiledTools, approvalRequired }, executor, dependencies.log);
+	if (result.outcome === "denied") return { outcome: "denied" };
+
+	// 3. Open approval only for the exact deferred reservation; every other success is complete.
+	if (result.outcome !== "deferred") return { outcome: "completed" };
+	return _openDeferredApproval(candidate, snapshot, result.reservationId, dependencies);
+}
+
+/** Select the first-party upgrade executor or the transport router admitted by the snapshot. */
+function _createCandidateExecutor(candidate: RuntimeExternalActionCandidate, snapshot: RunInputSnapshot, dependencies: ProductionExternalActionRunnerDependencies): ExternalActionExecutor<JsonValue> | null
+{
+	if (candidate.toolRevisionId === UPGRADE_SESSION_TOOL_REVISION)
+	{
+		if (snapshot.identitySnapshot.kind !== "user") return null;
+		return {
+			execute(): Promise<JsonValue>
+			{
+				return dependencies.personalConfiguration.proposeUpgradeSession(candidate, snapshot, dependencies.clock.now().toISOString());
+			},
+		};
+	}
+	return __CreateExternalActionExecutor(candidate, {
+		siloId: snapshot.siloId,
+		subjectId: snapshot.identitySnapshot.executionSubjectId,
+		cogneeDatasetId: __PersonalMemoryDatasetId(snapshot),
+		agentRevisionId: snapshot.agentRevisionId,
+		...dependencies.transports,
+	});
+}
+
+/** Derive approval policy only from the exact compiler-issued tool descriptor. */
+function _approvalRequired(candidate: RuntimeExternalActionCandidate, compiledTools: readonly CompiledToolDefinition[]): boolean
+{
+	return compiledTools.find(function _match(definition) { return definition.toolRevisionId === candidate.toolRevisionId; })?.requiresApproval ?? false;
+}
+
+/** Open the deferred approval with one trusted instant shared by creation and expiry. */
+async function _openDeferredApproval(candidate: RuntimeExternalActionCandidate, snapshot: RunInputSnapshot, reservationId: string, dependencies: ProductionExternalActionRunnerDependencies): Promise<RuntimeExternalActionRunnerResult>
+{
+	const now = dependencies.clock.now();
+	const opened = await dependencies.approvals.open({
+		runId: candidate.runId,
+		attempt: candidate.attempt,
+		toolInvocationId: candidate.toolInvocationId,
+		toolRevisionId: candidate.toolRevisionId,
+		argumentsDigest: candidate.argumentsDigest,
+		capabilitySetDigest: snapshot.capabilitySetDigest,
+		reservationId,
+		now,
+		expiresAt: new Date(now.getTime() + _DEFERRED_APPROVAL_TTL_MILLISECONDS),
+	});
+	return { outcome: opened ? "completed" : "denied" };
+}

--- a/libs/backend/agents/execution/protocol/src/production-external-action-runner.types.ts
+++ b/libs/backend/agents/execution/protocol/src/production-external-action-runner.types.ts
@@ -1,0 +1,39 @@
+import type { UpgradeSessionProposalRepository } from "@opencrane/backend/agents/personal/configuration";
+import type { OpenDeferredToolApprovalCommand, ToolInvocationRepository } from "@opencrane/backend/server/iam/authorization";
+import type { Logger } from "@opencrane/observability";
+
+import type { ExternalActionExecutorDependencies } from "./external-action-executor.types.js";
+
+/** External transports shared by every action while run-specific authority stays on the snapshot. */
+export type ProductionExternalActionTransports = Omit<ExternalActionExecutorDependencies, "siloId" | "subjectId" | "cogneeDatasetId" | "agentRevisionId">;
+
+/** Trusted wall clock used for upgrade proposals and deferred-approval expiry. */
+export interface ProductionExternalActionClock
+{
+	/** Returns the server instant for one policy decision. */
+	now(): Date;
+}
+
+/** Durable boundary that opens approval only for an already-reserved invocation. */
+export interface ProductionDeferredApprovalOpener
+{
+	/** Opens or idempotently resolves one exact deferred invocation reservation. */
+	open(command: OpenDeferredToolApprovalCommand): Promise<boolean>;
+}
+
+/** Authorities and transports required by the production external-action runner. */
+export interface ProductionExternalActionRunnerDependencies
+{
+	/** Durable reserve-before-I/O invocation authority. */
+	readonly invocations: ToolInvocationRepository;
+	/** Personal configuration authority behind the first-party upgrade-session tool. */
+	readonly personalConfiguration: UpgradeSessionProposalRepository;
+	/** Credential-free third-party and isolated execution transports. */
+	readonly transports: ProductionExternalActionTransports;
+	/** Approval authority used only after a deferred invocation reservation exists. */
+	readonly approvals: ProductionDeferredApprovalOpener;
+	/** Trusted server clock for proposal and approval lifetimes. */
+	readonly clock: ProductionExternalActionClock;
+	/** Structured evidence sink for bounded execution failures. */
+	readonly log: Logger;
+}

--- a/libs/backend/agents/execution/protocol/src/production-runtime-dispatch.ts
+++ b/libs/backend/agents/execution/protocol/src/production-runtime-dispatch.ts
@@ -2,23 +2,14 @@ import { AgentServiceKind, type Prisma, type PrismaClient } from "@prisma/client
 
 import { __AppendCompiledTool } from "@opencrane/backend/agents/execution/inputs";
 import { PrismaRuntimeTerminalReporter } from "@opencrane/backend/agents/execution/runs";
-import { __IsUpgradeSessionAvailable, PrismaPersonalConfigurationChangeRepository, UPGRADE_SESSION_TOOL, UPGRADE_SESSION_TOOL_REVISION } from "@opencrane/backend/agents/personal/configuration";
-import { PrismaIntegrationAuthorityRepository, __SystemIntegrationAuthorityClock } from "@opencrane/backend/server/gateways/integrations";
-import { PrismaToolInvocationRepository, __OpenDeferredToolApproval } from "@opencrane/backend/server/iam/authorization";
+import { __IsUpgradeSessionAvailable, UPGRADE_SESSION_TOOL } from "@opencrane/backend/agents/personal/configuration";
 import type { RunInputSnapshot } from "@opencrane/contracts";
-import { __UnavailableMemoryGatewayClient } from "@opencrane/server/_infra/memory-gateway-client";
-import { __UnavailableObotMcpInvocationAdapter } from "@opencrane/server/_infra/obot-custody";
-import { __UnavailableSandboxJobExecutor } from "@opencrane/server/_infra/sandbox-execution";
 import type { Logger } from "@opencrane/observability";
 
-import { __ExecuteExternalAction } from "./external-action-authority.js";
-import { __CreateExternalActionExecutor, __PersonalMemoryDatasetId } from "./external-action-executor.js";
 import { __CreatePrismaRunInputCompiler } from "./prisma-run-input-compiler.js";
 import { PrismaRuntimeDispatchAuthority } from "./prisma-runtime-dispatch-authority.js";
-import type { RunInputCompiler, RuntimeDispatchAuthorityConfig, RuntimeExternalActionRunner } from "./prisma-runtime-dispatch-authority.types.js";
-
-/** Bounded lifetime of a pending deferred-tool approval before it is no longer actionable. */
-const _DEFERRED_APPROVAL_TTL_MILLISECONDS = 24 * 60 * 60 * 1000;
+import type { RunInputCompiler, RuntimeDispatchAuthorityConfig } from "./prisma-runtime-dispatch-authority.types.js";
+import { _CreateProductionExternalActionRunner } from "./production-external-action-runner.composition.js";
 
 /** Compile ordinary grants, then append the sealed first-party upgrade intent to proven personal services. */
 function _CreateProductionRunInputCompiler(): RunInputCompiler
@@ -35,50 +26,6 @@ function _CreateProductionRunInputCompiler(): RunInputCompiler
 		// 3. Prove the service kind in the same compiler transaction and re-seal only that descriptor.
 		const service = await transaction.agentService.findFirst({ where: { id: snapshot.agentServiceId, siloId: snapshot.siloId, kind: AgentServiceKind.Personal }, select: { id: true } });
 		return service === null ? input : __AppendCompiledTool(input, UPGRADE_SESSION_TOOL);
-	};
-}
-
-/** Build the production external-action runner from its durable authorities and credential-free ports. */
-function _CreateProductionExternalActionRunner(prisma: PrismaClient, log: Logger): RuntimeExternalActionRunner
-{
-	const repository = new PrismaToolInvocationRepository(prisma);
-	const personalConfiguration = new PrismaPersonalConfigurationChangeRepository(prisma);
-	const integrations = new PrismaIntegrationAuthorityRepository(prisma, new __SystemIntegrationAuthorityClock());
-	const obotMcpInvocation = new __UnavailableObotMcpInvocationAdapter();
-	const sandboxExecutor = new __UnavailableSandboxJobExecutor();
-	const memoryGateway = new __UnavailableMemoryGatewayClient();
-	return {
-		async run(candidate, snapshot, compiledTools)
-		{
-			// 1. Derive approval and first-party policy only from the server-compiled tool descriptor.
-			const tool = compiledTools.find(function _match(definition) { return definition.toolRevisionId === candidate.toolRevisionId; });
-			const approvalRequired = tool?.requiresApproval ?? false;
-			let executor;
-			try
-			{
-				if (candidate.toolRevisionId === UPGRADE_SESSION_TOOL_REVISION && snapshot.identitySnapshot.kind !== "user") return { outcome: "denied" as const };
-				executor = candidate.toolRevisionId === UPGRADE_SESSION_TOOL_REVISION
-					? { execute: function _proposeUpgradeSession() { return personalConfiguration.proposeUpgradeSession(candidate, snapshot, new Date().toISOString()); } }
-					: __CreateExternalActionExecutor(candidate, { siloId: snapshot.siloId, subjectId: snapshot.identitySnapshot.executionSubjectId, cogneeDatasetId: __PersonalMemoryDatasetId(snapshot), agentRevisionId: snapshot.agentRevisionId, integrations, obotMcpInvocation, sandboxExecutor, memoryGateway });
-			}
-			catch (error)
-			{
-				return { outcome: "retryable" as const, error };
-			}
-
-			// 2. Reserve before I/O; only proven terminal post-reservation outcomes become denials.
-			const result = await __ExecuteExternalAction(repository, { candidate, snapshot, compiledTools, approvalRequired }, executor, log);
-			if (result.outcome === "denied") return { outcome: "denied" as const };
-
-			// 3. Atomically open approval for a deferred reservation or terminalise it without replay.
-			if (result.outcome === "deferred")
-			{
-				const now = new Date();
-				const deferred = await __OpenDeferredToolApproval(prisma, { runId: candidate.runId, attempt: candidate.attempt, toolInvocationId: candidate.toolInvocationId, toolRevisionId: candidate.toolRevisionId, argumentsDigest: candidate.argumentsDigest, capabilitySetDigest: snapshot.capabilitySetDigest, reservationId: result.reservationId, now, expiresAt: new Date(now.getTime() + _DEFERRED_APPROVAL_TTL_MILLISECONDS) }, log);
-				return { outcome: deferred ? "completed" as const : "denied" as const };
-			}
-			return { outcome: "completed" as const };
-		},
 	};
 }
 


### PR DESCRIPTION
## Why

The production runtime factory mixed dependency construction, identity policy, executor selection, reserve-before-I/O sequencing, result translation, server time, and deferred-approval creation in one nested function. That made the authority-critical path difficult to understand and test without Prisma and provider adapters.

## What changes

- keep production runtime dispatch as a small composition root
- move concrete Prisma and fail-closed transport construction into a package-private composition module
- move action orchestration into a dependency-injected runner with explicit authority, transport, approval, clock, and logging ports
- preserve user-only personal upgrades, reserve-before-I/O, server-owned timestamps, and exact deferred-approval binding
- retain the existing three-argument production factory and unavailable Obot, sandbox, and memory adapters
- add focused tests for pre-reservation denial, successful upgrade reservation, and reserve-before-approval ordering with the complete approval command
- document the internal ownership split without widening the public barrel

## Validation

- protocol TypeScript lint passed
- protocol tests passed: 70 of 70
- scoped module-growth check: 0 errors, 0 candidates
- scoped style check: 0 errors; 3 existing shared-discriminant warnings
- diff check passed
- independent review found no Critical, High, or Medium findings

## Scope

Six protocol package files only. No schema, API, migration, compatibility, transport configuration, or transcript behavior changes.