### PR TITLE
♻️ Clarify internal runtime composition by caller plane

### DIFF
--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -75,8 +75,8 @@ its resources to the lifecycle owner.
 - `src/app/public-app.ts` builds the browser-session-authenticated API.
 - `src/app/internal-app.ts` builds the workload-facing API on its separate socket.
 - `src/app/routes.ts` contains only named per-area route lists and the trivial mount loop.
-- `src/app/runtime-composition.ts` binds workload identity review, durable dispatch, and external-I/O
-  ports without choosing transport paths.
+- `src/app/runtime-composition.ts` binds controller, skill-workload, runtime, and optional-worker
+  authorities by caller plane without choosing transport paths.
 - `src/app/background-workers.ts` owns schedule ticks, expired-run repair, and fenced cleanup loops.
 - `src/app/lifecycle.ts` starts both listeners, stops producers first, drains requests, disconnects
   Prisma, and flushes telemetry.

--- a/apps/opencrane/src/app/__tests__/runtime-composition.test.ts
+++ b/apps/opencrane/src/app/__tests__/runtime-composition.test.ts
@@ -1,9 +1,22 @@
 import type { PrismaClient } from "@prisma/client";
 import type { AuthenticationV1Api } from "@kubernetes/client-node";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { _CreateInternalRuntimeComposition } from "../runtime-composition.js";
 import type { InternalRuntimeConfig } from "../config.types.js";
+
+/**
+ * Replace the artifact-service bridges because this composition test proves only the router-plane
+ * decision; broker tests own endpoint and mounted-key validation.
+ */
+vi.mock("../../infra/artifacts/artifact-upload.factory.js", function _MockArtifactUploadFactory()
+{
+	return {
+		_CreateArtifactPreprocessOutputBroker: function _CreateArtifactPreprocessOutputBroker() { return {}; },
+		_CreateArtifactPreprocessSourceBroker: function _CreateArtifactPreprocessSourceBroker() { return {}; },
+		_CreateSkillAuthoringArtifactReader: function _CreateSkillAuthoringArtifactReader() { return {}; },
+	};
+});
 
 /** Build the smallest valid workload-facing configuration used by composition tests. */
 function _RuntimeConfig(): InternalRuntimeConfig
@@ -47,5 +60,34 @@ describe("_CreateInternalRuntimeComposition", function _internalRuntimeCompositi
 		const config = { ..._RuntimeConfig(), artifactPreprocessorEnabled: true, artifactPreprocessorNamespace: "opencrane-server" };
 
 		expect(function _composeCrossedWorkerPlane() { _CreateInternalRuntimeComposition({} as PrismaClient, {} as AuthenticationV1Api, config); }).toThrow(/different from POD_NAMESPACE/);
+	});
+
+	it("composes both optional planes only after their concrete boundaries are configured", function _composesOptionalPlanes()
+	{
+		const config = {
+			..._RuntimeConfig(),
+			artifactPreprocessorEnabled: true,
+			artifactPreprocessorNamespace: "artifact-preprocessor",
+			channelReplayRouteId: "internal-channel-replay",
+		};
+
+		const composition = _CreateInternalRuntimeComposition({} as PrismaClient, {} as AuthenticationV1Api, config);
+
+		expect(composition.artifactPreprocessor).toEqual(expect.any(Function));
+		expect(composition.conversationReplay).toEqual(expect.any(Function));
+	});
+
+	it("refuses an enabled worker plane without a separate namespace", function _rejectsWorkerWithoutNamespace()
+	{
+		const config = { ..._RuntimeConfig(), artifactPreprocessorEnabled: true, artifactPreprocessorNamespace: undefined };
+
+		expect(function _composeWorkerWithoutNamespace() { _CreateInternalRuntimeComposition({} as PrismaClient, {} as AuthenticationV1Api, config); }).toThrow(/restricted workload namespace must be valid/);
+	});
+
+	it("refuses runtime planes that collapse into one identity namespace", function _rejectsCollapsedRuntimePlanes()
+	{
+		const config = { ..._RuntimeConfig(), managedRuntimeNamespace: "personal-runtime" };
+
+		expect(function _composeCollapsedRuntimePlanes() { _CreateInternalRuntimeComposition({} as PrismaClient, {} as AuthenticationV1Api, config); }).toThrow(/different from/);
 	});
 });

--- a/apps/opencrane/src/app/__tests__/runtime-composition.test.ts
+++ b/apps/opencrane/src/app/__tests__/runtime-composition.test.ts
@@ -1,0 +1,51 @@
+import type { PrismaClient } from "@prisma/client";
+import type { AuthenticationV1Api } from "@kubernetes/client-node";
+import { describe, expect, it } from "vitest";
+
+import { _CreateInternalRuntimeComposition } from "../runtime-composition.js";
+import type { InternalRuntimeConfig } from "../config.types.js";
+
+/** Build the smallest valid workload-facing configuration used by composition tests. */
+function _RuntimeConfig(): InternalRuntimeConfig
+{
+	return {
+		artifactPreprocessorEnabled: false,
+		artifactPreprocessorMaximumOutputBytes: 1_024,
+		artifactPreprocessorNamespace: undefined,
+		assignmentTtlMilliseconds: 60_000,
+		channelReplayRouteId: null,
+		claimLeaseMilliseconds: 30_000,
+		commandRecoveryMilliseconds: 15_000,
+		commandTtlMilliseconds: 60_000,
+		managedRuntimeNamespace: "managed-runtime",
+		outboxPruneBatchSize: 100,
+		personalRuntimeNamespace: "personal-runtime",
+		publishedOutboxRetentionMilliseconds: 86_400_000,
+		serverNamespace: "opencrane-server",
+	};
+}
+
+describe("_CreateInternalRuntimeComposition", function _internalRuntimeCompositionSuite()
+{
+	it("keeps disabled optional planes unmounted while composing every mandatory caller plane", function _composesRequiredPlanes()
+	{
+		const composition = _CreateInternalRuntimeComposition({} as PrismaClient, {} as AuthenticationV1Api, _RuntimeConfig());
+
+		expect(composition.agentControllerRunDispatch).toEqual(expect.any(Function));
+		expect(composition.skillWorkloadDispatch).toEqual(expect.any(Function));
+		expect(composition.skillWorkloadBootstrap).toEqual(expect.any(Function));
+		expect(composition.skillAuthoringInput).toEqual(expect.any(Function));
+		expect(composition.skillAuthoringCompletion).toEqual(expect.any(Function));
+		expect(composition.runtimeBootstrap).toEqual(expect.any(Function));
+		expect(composition.runtimeStream).toEqual(expect.any(Function));
+		expect(composition.artifactPreprocessor).toBeNull();
+		expect(composition.conversationReplay).toBeNull();
+	});
+
+	it("refuses an enabled worker plane that crosses into the trusted server namespace", function _rejectsCrossedWorkerPlane()
+	{
+		const config = { ..._RuntimeConfig(), artifactPreprocessorEnabled: true, artifactPreprocessorNamespace: "opencrane-server" };
+
+		expect(function _composeCrossedWorkerPlane() { _CreateInternalRuntimeComposition({} as PrismaClient, {} as AuthenticationV1Api, config); }).toThrow(/different from POD_NAMESPACE/);
+	});
+});

--- a/apps/opencrane/src/app/runtime-composition.ts
+++ b/apps/opencrane/src/app/runtime-composition.ts
@@ -15,7 +15,7 @@ import { _CreateAgentControllerTokenReviewer, _CreateArtifactPreprocessorTokenRe
 import { _CreateArtifactPreprocessOutputBroker, _CreateArtifactPreprocessSourceBroker, _CreateSkillAuthoringArtifactReader } from "../infra/artifacts/artifact-upload.factory.js";
 import type { InternalRuntimeConfig } from "./config.types.js";
 import { _log } from "./log.js";
-import type { InternalRuntimeComposition } from "./runtime-composition.types.js";
+import type { ControllerRuntimeComposition, InternalRuntimeComposition, OptionalRuntimeComposition, RuntimeProtocolComposition, SkillWorkloadRuntimeComposition } from "./runtime-composition.types.js";
 
 /**
  * Mint one attempt-scoped LiteLLM virtual key for a claimed run attempt.
@@ -45,14 +45,19 @@ async function _IssueAttemptModelKey(request: AttemptModelKeyMintRequest): Promi
  * @param tokenReviewer - Reviewer fixed to the sole agent-controller ServiceAccount.
  * @returns Controller dispatch routers with no runtime or worker routes.
  */
-function _CreateControllerRuntimeComposition(prisma: PrismaClient, config: InternalRuntimeConfig, namespaces: RuntimeIdentityNamespaces, tokenReviewer: ReturnType<typeof _CreateAgentControllerTokenReviewer>): Pick<InternalRuntimeComposition, "agentControllerRunDispatch" | "skillWorkloadDispatch">
+function _CreateControllerRuntimeComposition(prisma: PrismaClient, config: InternalRuntimeConfig, namespaces: RuntimeIdentityNamespaces, tokenReviewer: ReturnType<typeof _CreateAgentControllerTokenReviewer>): ControllerRuntimeComposition
 {
-	const { serverNamespace, personalRuntimeNamespace, managedRuntimeNamespace } = namespaces;
-	const runtimePlanes = { personalRuntimeNamespace, managedRuntimeNamespace };
-	const runDispatchRepository = new PrismaRunDispatchRepository(prisma, { ...runtimePlanes, claimLeaseMilliseconds: config.claimLeaseMilliseconds, assignmentTtlMilliseconds: config.assignmentTtlMilliseconds, publishedOutboxRetentionMilliseconds: config.publishedOutboxRetentionMilliseconds, outboxPruneBatchSize: config.outboxPruneBatchSize }, _IssueAttemptModelKey);
+	const runDispatchRepository = new PrismaRunDispatchRepository(prisma, {
+		personalRuntimeNamespace: namespaces.personalRuntimeNamespace,
+		managedRuntimeNamespace: namespaces.managedRuntimeNamespace,
+		claimLeaseMilliseconds: config.claimLeaseMilliseconds,
+		assignmentTtlMilliseconds: config.assignmentTtlMilliseconds,
+		publishedOutboxRetentionMilliseconds: config.publishedOutboxRetentionMilliseconds,
+		outboxPruneBatchSize: config.outboxPruneBatchSize,
+	}, _IssueAttemptModelKey);
 	return {
-		agentControllerRunDispatch: __CreateAgentControllerRunDispatchRouter({ tokenReviewer, namespace: serverNamespace, repository: runDispatchRepository, logger: _log }),
-		skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({ tokenReviewer, namespace: serverNamespace, repository: new PrismaSkillWorkloadClaimsRepository(prisma, config.claimLeaseMilliseconds), logger: _log }),
+		agentControllerRunDispatch: __CreateAgentControllerRunDispatchRouter({ tokenReviewer, namespace: namespaces.serverNamespace, repository: runDispatchRepository, logger: _log }),
+		skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({ tokenReviewer, namespace: namespaces.serverNamespace, repository: new PrismaSkillWorkloadClaimsRepository(prisma, config.claimLeaseMilliseconds), logger: _log }),
 	};
 }
 
@@ -66,7 +71,7 @@ function _CreateControllerRuntimeComposition(prisma: PrismaClient, config: Inter
  * @param tokenReviewer - Reviewer that exposes only a validated skill workload identity.
  * @returns Skill bootstrap, input, and completion routers.
  */
-function _CreateSkillWorkloadRuntimeComposition(prisma: PrismaClient, tokenReviewer: ReturnType<typeof _CreateSkillWorkloadTokenReviewer>): Pick<InternalRuntimeComposition, "skillWorkloadBootstrap" | "skillAuthoringInput" | "skillAuthoringCompletion">
+function _CreateSkillWorkloadRuntimeComposition(prisma: PrismaClient, tokenReviewer: ReturnType<typeof _CreateSkillWorkloadTokenReviewer>): SkillWorkloadRuntimeComposition
 {
 	return {
 		skillWorkloadBootstrap: __CreateSkillWorkloadBootstrapRouter({ tokenReviewer, repository: new PrismaSkillWorkloadBootstrapRepository(prisma), logger: _log }),
@@ -87,13 +92,17 @@ function _CreateSkillWorkloadRuntimeComposition(prisma: PrismaClient, tokenRevie
  * @param tokenReviewer - Reviewer constrained to the two runtime identity planes.
  * @returns Runtime bootstrap and stream routers.
  */
-function _CreateRuntimeProtocolComposition(prisma: PrismaClient, config: InternalRuntimeConfig, namespaces: RuntimeIdentityNamespaces, tokenReviewer: ReturnType<typeof _CreateRuntimeTokenReviewer>): Pick<InternalRuntimeComposition, "runtimeBootstrap" | "runtimeStream">
+function _CreateRuntimeProtocolComposition(prisma: PrismaClient, config: InternalRuntimeConfig, namespaces: RuntimeIdentityNamespaces, tokenReviewer: ReturnType<typeof _CreateRuntimeTokenReviewer>): RuntimeProtocolComposition
 {
-	const { personalRuntimeNamespace, managedRuntimeNamespace } = namespaces;
-	const runtimePlanes = { personalRuntimeNamespace, managedRuntimeNamespace };
-	const runtimeDispatchAuthority = __CreateProductionRuntimeDispatchAuthority(prisma, { ...runtimePlanes, commandTtlMilliseconds: config.commandTtlMilliseconds, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _log);
+	const runtimeDispatchAuthority = __CreateProductionRuntimeDispatchAuthority(prisma, {
+		personalRuntimeNamespace: namespaces.personalRuntimeNamespace,
+		managedRuntimeNamespace: namespaces.managedRuntimeNamespace,
+		commandTtlMilliseconds: config.commandTtlMilliseconds,
+		externalActionRetryLimit: 3,
+		externalActionRetryWindowMilliseconds: 30_000,
+	}, _log);
 	return {
-		runtimeBootstrap: __CreateRuntimeBootstrapRouter({ tokenReviewer, runtimeNamespaces: [personalRuntimeNamespace, managedRuntimeNamespace], repository: new PrismaRuntimeBootstrapExchange(prisma), clock: { nowEpochMs(): number { return Date.now(); } }, logger: _log }),
+		runtimeBootstrap: __CreateRuntimeBootstrapRouter({ tokenReviewer, runtimeNamespaces: [namespaces.personalRuntimeNamespace, namespaces.managedRuntimeNamespace], repository: new PrismaRuntimeBootstrapExchange(prisma), clock: { nowEpochMs: function _nowEpochMs() { return Date.now(); } }, logger: _log }),
 		runtimeStream: _RegisterInternalAgentRuntimeStream({ tokenReviewer, authority: runtimeDispatchAuthority, maxBodyBytes: 64 * 1024, heartbeatMilliseconds: 15_000, commandRecoveryMilliseconds: config.commandRecoveryMilliseconds }),
 	};
 }
@@ -110,7 +119,7 @@ function _CreateRuntimeProtocolComposition(prisma: PrismaClient, config: Interna
  * @param serverNamespace - Namespace containing the trusted server identity.
  * @returns Optional artifact-preprocessor and conversation-replay routers.
  */
-function _CreateOptionalRuntimeComposition(prisma: PrismaClient, authApi: k8s.AuthenticationV1Api, config: InternalRuntimeConfig, serverNamespace: string): Pick<InternalRuntimeComposition, "artifactPreprocessor" | "conversationReplay">
+function _CreateOptionalRuntimeComposition(prisma: PrismaClient, authApi: k8s.AuthenticationV1Api, config: InternalRuntimeConfig, serverNamespace: string): OptionalRuntimeComposition
 {
 	const artifactPreprocessorNamespace = config.artifactPreprocessorEnabled
 		? _ValidateIsolatedWorkloadNamespace(config.artifactPreprocessorNamespace, serverNamespace)
@@ -118,17 +127,10 @@ function _CreateOptionalRuntimeComposition(prisma: PrismaClient, authApi: k8s.Au
 	return {
 		conversationReplay: config.channelReplayRouteId === null
 			? null
-			: __CreateConversationReplayRouter({ contexts: new PrismaChannelTargetAuthorityRepository(prisma), repository: new PrismaConversationReplayRepository(prisma), expectedRouteId: config.channelReplayRouteId, nowEpochMs: function _now() { return Date.now(); } }),
+			: __CreateConversationReplayRouter({ contexts: new PrismaChannelTargetAuthorityRepository(prisma), repository: new PrismaConversationReplayRepository(prisma), expectedRouteId: config.channelReplayRouteId, nowEpochMs: function _nowEpochMs() { return Date.now(); } }),
 		artifactPreprocessor: artifactPreprocessorNamespace === null
 			? null
-			: __CreateArtifactPreprocessorRouter({
-				tokenReviewer: _CreateArtifactPreprocessorTokenReviewer(authApi, artifactPreprocessorNamespace),
-				namespace: artifactPreprocessorNamespace,
-				repository: new PrismaArtifactPreprocessRepository(prisma),
-				sourceBroker: _CreateArtifactPreprocessSourceBroker(prisma),
-				outputBroker: _CreateArtifactPreprocessOutputBroker(prisma, config.artifactPreprocessorMaximumOutputBytes),
-				logger: _log,
-			}),
+			: __CreateArtifactPreprocessorRouter({ tokenReviewer: _CreateArtifactPreprocessorTokenReviewer(authApi, artifactPreprocessorNamespace), namespace: artifactPreprocessorNamespace, repository: new PrismaArtifactPreprocessRepository(prisma), sourceBroker: _CreateArtifactPreprocessSourceBroker(prisma), outputBroker: _CreateArtifactPreprocessOutputBroker(prisma, config.artifactPreprocessorMaximumOutputBytes), logger: _log }),
 	};
 }
 

--- a/apps/opencrane/src/app/runtime-composition.ts
+++ b/apps/opencrane/src/app/runtime-composition.ts
@@ -10,7 +10,7 @@ import { PrismaRuntimeBootstrapExchange, __CreateRuntimeBootstrapRouter } from "
 import { __CreateConversationReplayRouter, PrismaConversationReplayRepository } from "@opencrane/backend/server/agents/conversation-replay";
 import { PrismaChannelTargetAuthorityRepository } from "@opencrane/backend/server/agents/channel-targets";
 import { PrismaArtifactPreprocessRepository, __CreateArtifactPreprocessorRouter } from "@opencrane/backend/server/agents/artifacts";
-import { _CreateAgentControllerTokenReviewer, _CreateArtifactPreprocessorTokenReviewer, _CreateRuntimeTokenReviewer, _CreateSkillWorkloadTokenReviewer, _ValidateIsolatedWorkloadNamespace, _ValidateRuntimeIdentityNamespaces } from "@opencrane/server/_infra/workload-identity";
+import { _CreateAgentControllerTokenReviewer, _CreateArtifactPreprocessorTokenReviewer, _CreateRuntimeTokenReviewer, _CreateSkillWorkloadTokenReviewer, _ValidateIsolatedWorkloadNamespace, _ValidateRuntimeIdentityNamespaces, type RuntimeIdentityNamespaces } from "@opencrane/server/_infra/workload-identity";
 
 import { _CreateArtifactPreprocessOutputBroker, _CreateArtifactPreprocessSourceBroker, _CreateSkillAuthoringArtifactReader } from "../infra/artifacts/artifact-upload.factory.js";
 import type { InternalRuntimeConfig } from "./config.types.js";
@@ -34,6 +34,105 @@ async function _IssueAttemptModelKey(request: AttemptModelKeyMintRequest): Promi
 }
 
 /**
+ * Bind the two controller-only dispatch routers to one reviewed controller identity.
+ *
+ * Both routers run in the trusted server namespace. Keeping their repositories together makes the
+ * shared claim lease explicit without giving either controller endpoint runtime-stream authority.
+ *
+ * @param prisma - Canonical product-authority database client.
+ * @param config - Frozen leases, assignment limits, and outbox-retention settings.
+ * @param namespaces - Validated server, personal-runtime, and managed-runtime identity planes.
+ * @param tokenReviewer - Reviewer fixed to the sole agent-controller ServiceAccount.
+ * @returns Controller dispatch routers with no runtime or worker routes.
+ */
+function _CreateControllerRuntimeComposition(prisma: PrismaClient, config: InternalRuntimeConfig, namespaces: RuntimeIdentityNamespaces, tokenReviewer: ReturnType<typeof _CreateAgentControllerTokenReviewer>): Pick<InternalRuntimeComposition, "agentControllerRunDispatch" | "skillWorkloadDispatch">
+{
+	const { serverNamespace, personalRuntimeNamespace, managedRuntimeNamespace } = namespaces;
+	const runtimePlanes = { personalRuntimeNamespace, managedRuntimeNamespace };
+	const runDispatchRepository = new PrismaRunDispatchRepository(prisma, { ...runtimePlanes, claimLeaseMilliseconds: config.claimLeaseMilliseconds, assignmentTtlMilliseconds: config.assignmentTtlMilliseconds, publishedOutboxRetentionMilliseconds: config.publishedOutboxRetentionMilliseconds, outboxPruneBatchSize: config.outboxPruneBatchSize }, _IssueAttemptModelKey);
+	return {
+		agentControllerRunDispatch: __CreateAgentControllerRunDispatchRouter({ tokenReviewer, namespace: serverNamespace, repository: runDispatchRepository, logger: _log }),
+		skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({ tokenReviewer, namespace: serverNamespace, repository: new PrismaSkillWorkloadClaimsRepository(prisma, config.claimLeaseMilliseconds), logger: _log }),
+	};
+}
+
+/**
+ * Bind the isolated skill workload exchange to its generic, durable-bootstrap reviewer.
+ *
+ * The reviewer validates a projected identity but leaves workload selection to the repositories,
+ * so the server does not turn a controller claim into a broader worker credential.
+ *
+ * @param prisma - Canonical product-authority database client.
+ * @param tokenReviewer - Reviewer that exposes only a validated skill workload identity.
+ * @returns Skill bootstrap, input, and completion routers.
+ */
+function _CreateSkillWorkloadRuntimeComposition(prisma: PrismaClient, tokenReviewer: ReturnType<typeof _CreateSkillWorkloadTokenReviewer>): Pick<InternalRuntimeComposition, "skillWorkloadBootstrap" | "skillAuthoringInput" | "skillAuthoringCompletion">
+{
+	return {
+		skillWorkloadBootstrap: __CreateSkillWorkloadBootstrapRouter({ tokenReviewer, repository: new PrismaSkillWorkloadBootstrapRepository(prisma), logger: _log }),
+		skillAuthoringInput: __CreateSkillAuthoringInputRouter({ tokenReviewer, repository: new PrismaSkillAuthoringInputRepository(prisma), artifactReader: _CreateSkillAuthoringArtifactReader(prisma), logger: _log }),
+		skillAuthoringCompletion: __CreateSkillAuthoringCompletionRouter({ tokenReviewer, repository: new PrismaSkillAuthoringCompletionRepository(prisma), logger: _log }),
+	};
+}
+
+/**
+ * Bind the personal and managed runtime protocol to one shared workload reviewer.
+ *
+ * Bootstrap and streaming must apply the same plane boundary. The durable dispatch authority stays
+ * here because it owns the server-side interpretation of runtime candidates, never the runtime Job.
+ *
+ * @param prisma - Canonical product-authority database client.
+ * @param config - Frozen command time-to-live and recovery settings.
+ * @param namespaces - Validated server, personal-runtime, and managed-runtime identity planes.
+ * @param tokenReviewer - Reviewer constrained to the two runtime identity planes.
+ * @returns Runtime bootstrap and stream routers.
+ */
+function _CreateRuntimeProtocolComposition(prisma: PrismaClient, config: InternalRuntimeConfig, namespaces: RuntimeIdentityNamespaces, tokenReviewer: ReturnType<typeof _CreateRuntimeTokenReviewer>): Pick<InternalRuntimeComposition, "runtimeBootstrap" | "runtimeStream">
+{
+	const { personalRuntimeNamespace, managedRuntimeNamespace } = namespaces;
+	const runtimePlanes = { personalRuntimeNamespace, managedRuntimeNamespace };
+	const runtimeDispatchAuthority = __CreateProductionRuntimeDispatchAuthority(prisma, { ...runtimePlanes, commandTtlMilliseconds: config.commandTtlMilliseconds, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _log);
+	return {
+		runtimeBootstrap: __CreateRuntimeBootstrapRouter({ tokenReviewer, runtimeNamespaces: [personalRuntimeNamespace, managedRuntimeNamespace], repository: new PrismaRuntimeBootstrapExchange(prisma), clock: { nowEpochMs(): number { return Date.now(); } }, logger: _log }),
+		runtimeStream: _RegisterInternalAgentRuntimeStream({ tokenReviewer, authority: runtimeDispatchAuthority, maxBodyBytes: 64 * 1024, heartbeatMilliseconds: 15_000, commandRecoveryMilliseconds: config.commandRecoveryMilliseconds }),
+	};
+}
+
+/**
+ * Bind optional worker and replay capabilities without changing the always-present runtime boundary.
+ *
+ * Each optional route validates its own deployment switch before a router exists. A missing switch
+ * therefore leaves the capability unreachable instead of mounting a partially configured endpoint.
+ *
+ * @param prisma - Canonical product-authority database client.
+ * @param authApi - Kubernetes TokenReview client for worker identity.
+ * @param config - Frozen worker and replay configuration.
+ * @param serverNamespace - Namespace containing the trusted server identity.
+ * @returns Optional artifact-preprocessor and conversation-replay routers.
+ */
+function _CreateOptionalRuntimeComposition(prisma: PrismaClient, authApi: k8s.AuthenticationV1Api, config: InternalRuntimeConfig, serverNamespace: string): Pick<InternalRuntimeComposition, "artifactPreprocessor" | "conversationReplay">
+{
+	const artifactPreprocessorNamespace = config.artifactPreprocessorEnabled
+		? _ValidateIsolatedWorkloadNamespace(config.artifactPreprocessorNamespace, serverNamespace)
+		: null;
+	return {
+		conversationReplay: config.channelReplayRouteId === null
+			? null
+			: __CreateConversationReplayRouter({ contexts: new PrismaChannelTargetAuthorityRepository(prisma), repository: new PrismaConversationReplayRepository(prisma), expectedRouteId: config.channelReplayRouteId, nowEpochMs: function _now() { return Date.now(); } }),
+		artifactPreprocessor: artifactPreprocessorNamespace === null
+			? null
+			: __CreateArtifactPreprocessorRouter({
+				tokenReviewer: _CreateArtifactPreprocessorTokenReviewer(authApi, artifactPreprocessorNamespace),
+				namespace: artifactPreprocessorNamespace,
+				repository: new PrismaArtifactPreprocessRepository(prisma),
+				sourceBroker: _CreateArtifactPreprocessSourceBroker(prisma),
+				outputBroker: _CreateArtifactPreprocessOutputBroker(prisma, config.artifactPreprocessorMaximumOutputBytes),
+				logger: _log,
+			}),
+	};
+}
+
+/**
  * Compose the workload-facing routers without deciding where they are mounted.
  *
  * Keeping path selection out of this module makes the trust split visible in `routes.ts`: the
@@ -47,44 +146,21 @@ async function _IssueAttemptModelKey(request: AttemptModelKeyMintRequest): Promi
  */
 export function _CreateInternalRuntimeComposition(prisma: PrismaClient, authApi: k8s.AuthenticationV1Api, config: InternalRuntimeConfig): InternalRuntimeComposition
 {
-	// 1. Freeze process configuration before constructing any authority so malformed trust
-	// coordinates fail startup rather than leaving a partially mounted internal API.
-	const { serverNamespace, personalRuntimeNamespace, managedRuntimeNamespace } = _ValidateRuntimeIdentityNamespaces(config);
-	const runtimePlanes = { personalRuntimeNamespace, managedRuntimeNamespace };
+	// 1. Validate all identity planes before constructing a router, so malformed coordinates fail
+	// startup rather than leaving a partially mounted internal API.
+	const namespaces = _ValidateRuntimeIdentityNamespaces(config);
 
-	// 2. Share the reviewed workload identity and durable dispatch authority across bootstrap and
-	// streaming so one runtime cannot be interpreted differently by neighbouring endpoints.
-	const controllerTokenReviewer = _CreateAgentControllerTokenReviewer(authApi, serverNamespace);
+	// 2. Create reviewers once and pass each only to its matching caller plane; neighbouring routes
+	// cannot silently reinterpret a controller, skill workload, or runtime identity.
+	const controllerTokenReviewer = _CreateAgentControllerTokenReviewer(authApi, namespaces.serverNamespace);
 	const skillWorkloadTokenReviewer = _CreateSkillWorkloadTokenReviewer(authApi);
-	const runtimeTokenReviewer = _CreateRuntimeTokenReviewer(authApi, runtimePlanes);
-	const runDispatchRepository = new PrismaRunDispatchRepository(prisma, { ...runtimePlanes, claimLeaseMilliseconds: config.claimLeaseMilliseconds, assignmentTtlMilliseconds: config.assignmentTtlMilliseconds, publishedOutboxRetentionMilliseconds: config.publishedOutboxRetentionMilliseconds, outboxPruneBatchSize: config.outboxPruneBatchSize }, _IssueAttemptModelKey);
-	const runtimeDispatchAuthority = __CreateProductionRuntimeDispatchAuthority(prisma, { ...runtimePlanes, commandTtlMilliseconds: config.commandTtlMilliseconds, externalActionRetryLimit: 3, externalActionRetryWindowMilliseconds: 30_000 }, _log);
+	const runtimeTokenReviewer = _CreateRuntimeTokenReviewer(authApi, namespaces);
 
-	// 3. Return named routers only; `routes.ts` remains the single readable map of internal paths.
-	const replayRouteId = config.channelReplayRouteId;
-	const artifactPreprocessorNamespace = config.artifactPreprocessorEnabled
-		? _ValidateIsolatedWorkloadNamespace(config.artifactPreprocessorNamespace, serverNamespace)
-		: null;
+	// 3. Compose only named routers; `routes.ts` remains the single readable map of internal paths.
 	return {
-		conversationReplay: replayRouteId === null
-			? null
-			: __CreateConversationReplayRouter({ contexts: new PrismaChannelTargetAuthorityRepository(prisma), repository: new PrismaConversationReplayRepository(prisma), expectedRouteId: replayRouteId, nowEpochMs: function _now() { return Date.now(); } }),
-		agentControllerRunDispatch: __CreateAgentControllerRunDispatchRouter({ tokenReviewer: controllerTokenReviewer, namespace: serverNamespace, repository: runDispatchRepository, logger: _log }),
-		skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({ tokenReviewer: controllerTokenReviewer, namespace: serverNamespace, repository: new PrismaSkillWorkloadClaimsRepository(prisma, config.claimLeaseMilliseconds), logger: _log }),
-		skillWorkloadBootstrap: __CreateSkillWorkloadBootstrapRouter({ tokenReviewer: skillWorkloadTokenReviewer, repository: new PrismaSkillWorkloadBootstrapRepository(prisma), logger: _log }),
-		skillAuthoringInput: __CreateSkillAuthoringInputRouter({ tokenReviewer: skillWorkloadTokenReviewer, repository: new PrismaSkillAuthoringInputRepository(prisma), artifactReader: _CreateSkillAuthoringArtifactReader(prisma), logger: _log }),
-		skillAuthoringCompletion: __CreateSkillAuthoringCompletionRouter({ tokenReviewer: skillWorkloadTokenReviewer, repository: new PrismaSkillAuthoringCompletionRepository(prisma), logger: _log }),
-		artifactPreprocessor: artifactPreprocessorNamespace === null
-			? null
-			: __CreateArtifactPreprocessorRouter({
-				tokenReviewer: _CreateArtifactPreprocessorTokenReviewer(authApi, artifactPreprocessorNamespace),
-				namespace: artifactPreprocessorNamespace,
-				repository: new PrismaArtifactPreprocessRepository(prisma),
-				sourceBroker: _CreateArtifactPreprocessSourceBroker(prisma),
-				outputBroker: _CreateArtifactPreprocessOutputBroker(prisma, config.artifactPreprocessorMaximumOutputBytes),
-				logger: _log,
-			}),
-		runtimeBootstrap: __CreateRuntimeBootstrapRouter({ tokenReviewer: runtimeTokenReviewer, runtimeNamespaces: [personalRuntimeNamespace, managedRuntimeNamespace], repository: new PrismaRuntimeBootstrapExchange(prisma), clock: { nowEpochMs(): number { return Date.now(); } }, logger: _log }),
-		runtimeStream: _RegisterInternalAgentRuntimeStream({ tokenReviewer: runtimeTokenReviewer, authority: runtimeDispatchAuthority, maxBodyBytes: 64 * 1024, heartbeatMilliseconds: 15_000, commandRecoveryMilliseconds: config.commandRecoveryMilliseconds }),
+		..._CreateControllerRuntimeComposition(prisma, config, namespaces, controllerTokenReviewer),
+		..._CreateSkillWorkloadRuntimeComposition(prisma, skillWorkloadTokenReviewer),
+		..._CreateRuntimeProtocolComposition(prisma, config, namespaces, runtimeTokenReviewer),
+		..._CreateOptionalRuntimeComposition(prisma, authApi, config, namespaces.serverNamespace),
 	};
 }

--- a/apps/opencrane/src/app/runtime-composition.ts
+++ b/apps/opencrane/src/app/runtime-composition.ts
@@ -191,7 +191,7 @@ function _CreateOptionalRuntimeComposition(prisma: PrismaClient, authApi: k8s.Au
  * @param prisma - Canonical product-authority database client.
  * @param authApi - Kubernetes TokenReview client for workload identity.
  * @param config - Frozen startup configuration shared with the internal body parser and workers.
- * @returns Routers sharing one runtime reviewer and dispatch authority.
+ * @returns Routers composed from controller, skill-workload, runtime, and optional-worker plane authorities.
  */
 export function _CreateInternalRuntimeComposition(prisma: PrismaClient, authApi: k8s.AuthenticationV1Api, config: InternalRuntimeConfig): InternalRuntimeComposition
 {

--- a/apps/opencrane/src/app/runtime-composition.ts
+++ b/apps/opencrane/src/app/runtime-composition.ts
@@ -56,8 +56,18 @@ function _CreateControllerRuntimeComposition(prisma: PrismaClient, config: Inter
 		outboxPruneBatchSize: config.outboxPruneBatchSize,
 	}, _IssueAttemptModelKey);
 	return {
-		agentControllerRunDispatch: __CreateAgentControllerRunDispatchRouter({ tokenReviewer, namespace: namespaces.serverNamespace, repository: runDispatchRepository, logger: _log }),
-		skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({ tokenReviewer, namespace: namespaces.serverNamespace, repository: new PrismaSkillWorkloadClaimsRepository(prisma, config.claimLeaseMilliseconds), logger: _log }),
+		agentControllerRunDispatch: __CreateAgentControllerRunDispatchRouter({
+			tokenReviewer,
+			namespace: namespaces.serverNamespace,
+			repository: runDispatchRepository,
+			logger: _log,
+		}),
+		skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({
+			tokenReviewer,
+			namespace: namespaces.serverNamespace,
+			repository: new PrismaSkillWorkloadClaimsRepository(prisma, config.claimLeaseMilliseconds),
+			logger: _log,
+		}),
 	};
 }
 
@@ -74,9 +84,22 @@ function _CreateControllerRuntimeComposition(prisma: PrismaClient, config: Inter
 function _CreateSkillWorkloadRuntimeComposition(prisma: PrismaClient, tokenReviewer: ReturnType<typeof _CreateSkillWorkloadTokenReviewer>): SkillWorkloadRuntimeComposition
 {
 	return {
-		skillWorkloadBootstrap: __CreateSkillWorkloadBootstrapRouter({ tokenReviewer, repository: new PrismaSkillWorkloadBootstrapRepository(prisma), logger: _log }),
-		skillAuthoringInput: __CreateSkillAuthoringInputRouter({ tokenReviewer, repository: new PrismaSkillAuthoringInputRepository(prisma), artifactReader: _CreateSkillAuthoringArtifactReader(prisma), logger: _log }),
-		skillAuthoringCompletion: __CreateSkillAuthoringCompletionRouter({ tokenReviewer, repository: new PrismaSkillAuthoringCompletionRepository(prisma), logger: _log }),
+		skillWorkloadBootstrap: __CreateSkillWorkloadBootstrapRouter({
+			tokenReviewer,
+			repository: new PrismaSkillWorkloadBootstrapRepository(prisma),
+			logger: _log,
+		}),
+		skillAuthoringInput: __CreateSkillAuthoringInputRouter({
+			tokenReviewer,
+			repository: new PrismaSkillAuthoringInputRepository(prisma),
+			artifactReader: _CreateSkillAuthoringArtifactReader(prisma),
+			logger: _log,
+		}),
+		skillAuthoringCompletion: __CreateSkillAuthoringCompletionRouter({
+			tokenReviewer,
+			repository: new PrismaSkillAuthoringCompletionRepository(prisma),
+			logger: _log,
+		}),
 	};
 }
 
@@ -102,8 +125,20 @@ function _CreateRuntimeProtocolComposition(prisma: PrismaClient, config: Interna
 		externalActionRetryWindowMilliseconds: 30_000,
 	}, _log);
 	return {
-		runtimeBootstrap: __CreateRuntimeBootstrapRouter({ tokenReviewer, runtimeNamespaces: [namespaces.personalRuntimeNamespace, namespaces.managedRuntimeNamespace], repository: new PrismaRuntimeBootstrapExchange(prisma), clock: { nowEpochMs: function _nowEpochMs() { return Date.now(); } }, logger: _log }),
-		runtimeStream: _RegisterInternalAgentRuntimeStream({ tokenReviewer, authority: runtimeDispatchAuthority, maxBodyBytes: 64 * 1024, heartbeatMilliseconds: 15_000, commandRecoveryMilliseconds: config.commandRecoveryMilliseconds }),
+		runtimeBootstrap: __CreateRuntimeBootstrapRouter({
+			tokenReviewer,
+			runtimeNamespaces: [namespaces.personalRuntimeNamespace, namespaces.managedRuntimeNamespace],
+			repository: new PrismaRuntimeBootstrapExchange(prisma),
+			clock: { nowEpochMs: function _nowEpochMs() { return Date.now(); } },
+			logger: _log,
+		}),
+		runtimeStream: _RegisterInternalAgentRuntimeStream({
+			tokenReviewer,
+			authority: runtimeDispatchAuthority,
+			maxBodyBytes: 64 * 1024,
+			heartbeatMilliseconds: 15_000,
+			commandRecoveryMilliseconds: config.commandRecoveryMilliseconds,
+		}),
 	};
 }
 
@@ -127,10 +162,22 @@ function _CreateOptionalRuntimeComposition(prisma: PrismaClient, authApi: k8s.Au
 	return {
 		conversationReplay: config.channelReplayRouteId === null
 			? null
-			: __CreateConversationReplayRouter({ contexts: new PrismaChannelTargetAuthorityRepository(prisma), repository: new PrismaConversationReplayRepository(prisma), expectedRouteId: config.channelReplayRouteId, nowEpochMs: function _nowEpochMs() { return Date.now(); } }),
+			: __CreateConversationReplayRouter({
+				contexts: new PrismaChannelTargetAuthorityRepository(prisma),
+				repository: new PrismaConversationReplayRepository(prisma),
+				expectedRouteId: config.channelReplayRouteId,
+				nowEpochMs: function _nowEpochMs() { return Date.now(); },
+			}),
 		artifactPreprocessor: artifactPreprocessorNamespace === null
 			? null
-			: __CreateArtifactPreprocessorRouter({ tokenReviewer: _CreateArtifactPreprocessorTokenReviewer(authApi, artifactPreprocessorNamespace), namespace: artifactPreprocessorNamespace, repository: new PrismaArtifactPreprocessRepository(prisma), sourceBroker: _CreateArtifactPreprocessSourceBroker(prisma), outputBroker: _CreateArtifactPreprocessOutputBroker(prisma, config.artifactPreprocessorMaximumOutputBytes), logger: _log }),
+			: __CreateArtifactPreprocessorRouter({
+				tokenReviewer: _CreateArtifactPreprocessorTokenReviewer(authApi, artifactPreprocessorNamespace),
+				namespace: artifactPreprocessorNamespace,
+				repository: new PrismaArtifactPreprocessRepository(prisma),
+				sourceBroker: _CreateArtifactPreprocessSourceBroker(prisma),
+				outputBroker: _CreateArtifactPreprocessOutputBroker(prisma, config.artifactPreprocessorMaximumOutputBytes),
+				logger: _log,
+			}),
 	};
 }
 

--- a/apps/opencrane/src/app/runtime-composition.types.ts
+++ b/apps/opencrane/src/app/runtime-composition.types.ts
@@ -29,10 +29,16 @@ export interface InternalRuntimeComposition
 }
 
 /** Controller-only composition slice. */
-export type ControllerRuntimeComposition = Pick<InternalRuntimeComposition, "agentControllerRunDispatch" | "skillWorkloadDispatch">;
+export type ControllerRuntimeComposition = Pick<
+	InternalRuntimeComposition,
+	"agentControllerRunDispatch" | "skillWorkloadDispatch"
+>;
 
 /** Isolated skill workload composition slice. */
-export type SkillWorkloadRuntimeComposition = Pick<InternalRuntimeComposition, "skillWorkloadBootstrap" | "skillAuthoringInput" | "skillAuthoringCompletion">;
+export type SkillWorkloadRuntimeComposition = Pick<
+	InternalRuntimeComposition,
+	"skillWorkloadBootstrap" | "skillAuthoringInput" | "skillAuthoringCompletion"
+>;
 
 /** Runtime protocol composition slice. */
 export type RuntimeProtocolComposition = Pick<InternalRuntimeComposition, "runtimeBootstrap" | "runtimeStream">;

--- a/apps/opencrane/src/app/runtime-composition.types.ts
+++ b/apps/opencrane/src/app/runtime-composition.types.ts
@@ -27,3 +27,15 @@ export interface InternalRuntimeComposition
 	/** Runtime server-sent-event stream and candidate-ingest router. */
 	readonly runtimeStream: Router;
 }
+
+/** Controller-only composition slice. */
+export type ControllerRuntimeComposition = Pick<InternalRuntimeComposition, "agentControllerRunDispatch" | "skillWorkloadDispatch">;
+
+/** Isolated skill workload composition slice. */
+export type SkillWorkloadRuntimeComposition = Pick<InternalRuntimeComposition, "skillWorkloadBootstrap" | "skillAuthoringInput" | "skillAuthoringCompletion">;
+
+/** Runtime protocol composition slice. */
+export type RuntimeProtocolComposition = Pick<InternalRuntimeComposition, "runtimeBootstrap" | "runtimeStream">;
+
+/** Optional workload and replay composition slice. */
+export type OptionalRuntimeComposition = Pick<InternalRuntimeComposition, "artifactPreprocessor" | "conversationReplay">;

--- a/docs/agents/app-source-allowlist.json
+++ b/docs/agents/app-source-allowlist.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "policy": "Implementation source under apps is closed by default across TypeScript, JavaScript, Python, Go, Rust, JVM, Vue, and Svelte files. Every retained file is exact; adding a file requires an ownership decision and this registry change.",
+  "policy": "Deployable implementation source under apps is closed by default across TypeScript, JavaScript, Python, Go, Rust, JVM, Vue, and Svelte files. Named test trees are excluded because they prove the composition without becoming part of it. Every retained implementation file is exact; adding one requires an ownership decision and this registry change.",
   "forbiddenPaths": [
     "apps/opencrane/src/gateways",
     "apps/opencrane/src/reconcilers",
@@ -12,8 +12,6 @@
   "allowedFiles": [
     { "path": "apps/opencrane/prisma.config.ts", "owner": "apps/opencrane", "classification": "prisma-composition" },
     { "path": "apps/opencrane/scripts/emit-openapi.mts", "owner": "apps/opencrane", "classification": "build-entrypoint" },
-    { "path": "apps/opencrane/src/__tests__/index.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
-    { "path": "apps/opencrane/src/app/__tests__/config.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/app/background-workers.ts", "owner": "apps/opencrane", "classification": "process-composition" },
     { "path": "apps/opencrane/src/app/background-workers.types.ts", "owner": "apps/opencrane", "classification": "process-composition" },
     { "path": "apps/opencrane/src/app/config.ts", "owner": "apps/opencrane", "classification": "app-config" },
@@ -34,7 +32,6 @@
     { "path": "apps/opencrane/src/index.ts", "owner": "apps/opencrane", "classification": "process-entrypoint" },
     { "path": "apps/opencrane/src/infra/db/db.ts", "owner": "apps/opencrane", "classification": "prisma-composition" },
     { "path": "apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts", "owner": "apps/opencrane", "classification": "route-composition" },
-    { "path": "apps/opencrane/src/infra/artifacts/__tests__/artifact-upload.factory.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/vitest.config.ts", "owner": "apps/opencrane", "classification": "test-config" },
 
     { "path": "apps/opencrane-ui/src/app/app.component.ts", "owner": "apps/opencrane-ui", "classification": "browser-composition" },
@@ -60,10 +57,8 @@
     { "path": "apps/artifact-service/src/instrument.ts", "owner": "apps/artifact-service", "classification": "process-instrumentation" },
     { "path": "apps/artifact-service/src/log.ts", "owner": "apps/artifact-service", "classification": "process-logging" },
     { "path": "apps/artifact-service/src/server.ts", "owner": "apps/artifact-service", "classification": "route-composition" },
-    { "path": "apps/artifact-service/src/__tests__/server.test.ts", "owner": "apps/artifact-service", "classification": "composition-test" },
     { "path": "apps/artifact-service/vitest.config.ts", "owner": "apps/artifact-service", "classification": "test-config" },
 
-    { "path": "apps/artifact-preprocessor/src/__tests__/config.test.ts", "owner": "apps/artifact-preprocessor", "classification": "composition-test" },
     { "path": "apps/artifact-preprocessor/src/config.ts", "owner": "apps/artifact-preprocessor", "classification": "app-config" },
     { "path": "apps/artifact-preprocessor/src/config.types.ts", "owner": "apps/artifact-preprocessor", "classification": "app-config" },
     { "path": "apps/artifact-preprocessor/src/index.ts", "owner": "apps/artifact-preprocessor", "classification": "process-entrypoint" },
@@ -71,7 +66,6 @@
     { "path": "apps/artifact-preprocessor/src/log.ts", "owner": "apps/artifact-preprocessor", "classification": "process-logging" },
     { "path": "apps/artifact-preprocessor/vitest.config.ts", "owner": "apps/artifact-preprocessor", "classification": "test-config" },
 
-    { "path": "apps/agent-controller/src/__tests__/config.test.ts", "owner": "apps/agent-controller", "classification": "composition-test" },
     { "path": "apps/agent-controller/src/config.ts", "owner": "apps/agent-controller", "classification": "app-config" },
     { "path": "apps/agent-controller/src/config.types.ts", "owner": "apps/agent-controller", "classification": "app-config" },
     { "path": "apps/agent-controller/src/index.ts", "owner": "apps/agent-controller", "classification": "process-entrypoint" },
@@ -80,7 +74,6 @@
     { "path": "apps/agent-controller/vitest.config.ts", "owner": "apps/agent-controller", "classification": "test-config" },
 
     { "path": "apps/skill-authoring/src/authoring_worker.py", "owner": "apps/skill-authoring", "classification": "process-entrypoint" },
-    { "path": "apps/skill-authoring/__tests__/test_authoring_worker.py", "owner": "apps/skill-authoring", "classification": "composition-test" },
 
     { "path": "apps/agent-runtime/src/attempts/execution.py", "owner": "apps/agent-runtime", "classification": "process-composition" },
     { "path": "apps/agent-runtime/src/attempts/terminal.py", "owner": "apps/agent-runtime", "classification": "process-composition" },
@@ -94,10 +87,7 @@
     { "path": "apps/agent-runtime/src/protocol/candidates.py", "owner": "apps/agent-runtime", "classification": "process-composition" },
     { "path": "apps/agent-runtime/src/runtime.py", "owner": "apps/agent-runtime", "classification": "process-entrypoint" },
     { "path": "apps/agent-runtime/src/transport/http.py", "owner": "apps/agent-runtime", "classification": "process-composition" },
-    { "path": "apps/agent-runtime/src/transport/stream.py", "owner": "apps/agent-runtime", "classification": "process-composition" },
-    { "path": "apps/agent-runtime/tests/test_conformance.py", "owner": "apps/agent-runtime", "classification": "composition-test" },
-    { "path": "apps/agent-runtime/tests/test_fault_matrix.py", "owner": "apps/agent-runtime", "classification": "composition-test" },
-    { "path": "apps/agent-runtime/tests/test_runtime.py", "owner": "apps/agent-runtime", "classification": "composition-test" }
+    { "path": "apps/agent-runtime/src/transport/stream.py", "owner": "apps/agent-runtime", "classification": "process-composition" }
   ],
   "requiredTaggedProjects": [
     "apps/_infra/cognee/project.json",

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -22,6 +22,7 @@
       }
     ],
     "compositions": [
+      "apps/opencrane/src/app/runtime-composition.ts",
       "libs/backend/agents/personal/configuration/main/src/prisma-personal-configuration.router.ts"
     ]
   },

--- a/scripts/phase-b-topology-negative-tests.sh
+++ b/scripts/phase-b-topology-negative-tests.sh
@@ -13,6 +13,7 @@ RUNTIME_COMMAND_PROBE="$ROOT/scripts/phase-b-runtime-command-guard-probe.sh"
 RUNTIME_DUPLICATE_PROBE="$ROOT/libs/server/_infra/http/src/phase-b-runtime-duplicate-guard-probe.ts"
 RUNTIME_NONPRODUCING_DUPLICATE_PROBE="$ROOT/libs/server/_infra/http/src/phase-b-runtime-nonproducing-duplicate-guard-probe.ts"
 APP_SOURCE_PROBE="$ROOT/apps/opencrane/src/phase-b-app-guard-probe.py"
+APP_TEST_SOURCE_PROBE="$ROOT/apps/opencrane/src/app/__tests__/phase-b-app-test-guard-probe.py"
 BUILD_SOURCE_PROBE="$ROOT/apps/opencrane/src/build/phase-b-build-source-guard-probe.py"
 GENERATED_DIST_PROBE="$ROOT/apps/opencrane/dist/phase-b-generated-guard-probe.js"
 GENERATED_CACHE_PROBE="$ROOT/apps/opencrane/node_modules/.cache/phase-b-generated-guard-probe.mjs"
@@ -22,6 +23,7 @@ cleanup()
   rm -f "$RENDER_PROBE" "$COMPUTED_KIND_PROBE" "$RUNTIME_PROBE" "$RUNTIME_COMMAND_PROBE"
   rm -f "$RUNTIME_DUPLICATE_PROBE" "$RUNTIME_NONPRODUCING_DUPLICATE_PROBE"
   rm -f "$APP_SOURCE_PROBE" "$BUILD_SOURCE_PROBE"
+  rm -f "$APP_TEST_SOURCE_PROBE"
   rm -f "$GENERATED_DIST_PROBE" "$GENERATED_CACHE_PROBE"
   rmdir "$(dirname "$BUILD_SOURCE_PROBE")" 2>/dev/null || true
   if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then rm -rf "$TMP_DIR"; fi
@@ -229,6 +231,12 @@ rm -f "$GENERATED_DIST_PROBE" "$GENERATED_CACHE_PROBE"
 printf '%s\n' 'def phase_b_guard_probe():' '    return "substantive app logic"' >"$APP_SOURCE_PROBE"
 expect_failure "unregistered implementation source under app root" "$GUARD"
 rm -f "$APP_SOURCE_PROBE"
+
+# Tests prove the app composition but do not become part of the deployable
+# implementation allowlist. Keep this fixture in the repository-wide test root.
+printf '%s\n' 'def phase_b_test_guard_probe():' '    return "test-only logic"' >"$APP_TEST_SOURCE_PROBE"
+"$GUARD" >/dev/null
+rm -f "$APP_TEST_SOURCE_PROBE"
 
 mkdir -p "$(dirname "$BUILD_SOURCE_PROBE")"
 printf '%s\n' 'def phase_b_build_source_probe():' '    return "tracked source, not generated output"' >"$BUILD_SOURCE_PROBE"

--- a/scripts/phase-b-topology.sh
+++ b/scripts/phase-b-topology.sh
@@ -22,6 +22,7 @@ const appSourceExtensions = new Set([
 const runtimeSourceExtensions = new Set([...appSourceExtensions, ".sh", ".yaml", ".yml"]);
 const typedSourceExtensions = new Set([".ts", ".tsx", ".mts", ".cts"]);
 const ignoredWalkDirectories = new Set(["node_modules", "dist", "coverage", ".nx", ".cache"]);
+const appTestDirectoryPattern = /(?:^|\/)(?:__tests__|tests)(?:\/|$)/;
 const workloadKinds = new Set(["Pod", "Deployment", "StatefulSet", "DaemonSet", "CronJob", "Job"]);
 const workloadClassifications = new Set(["delete", "survivor"]);
 const appSourceClassifications = new Set([
@@ -516,8 +517,6 @@ for (const entry of nonProducingRuntimeMatches.values())
   if (!entry.hit) fail(`non-producing runtime match was not discovered by the guard: ${entry.path}: ${entry.anchor}`);
 }
 info.push(`${runtimeConstructs.size} runtime and installer workload constructs are exactly registered`);
-
-
 const discoveredWorkloadTemplates = new Set();
 const nonWorkloadDynamicKinds = new Map();
 for (const entry of workloadRegistry.nonWorkloadDynamicKinds ?? [])
@@ -577,12 +576,12 @@ for (const path of coveredLocalTemplates)
   if (!discoveredWorkloadTemplates.has(path)) fail(`stale workload-template registration: ${path}`);
 }
 info.push(`${discoveredWorkloadTemplates.size} local workload templates are exactly registered`);
-
 const allowedSourceFiles = new Map();
 for (const entry of appSourceRegistry.allowedFiles ?? [])
 {
   const context = `app source '${entry.path ?? "<missing>"}'`;
   if (!entry.path || allowedSourceFiles.has(entry.path)) fail(`${context}: path is missing or duplicated`);
+  if (appTestDirectoryPattern.test(entry.path ?? "")) fail(`${context}: tests are not implementation source and must not be allowlisted`);
   allowedSourceFiles.set(entry.path, entry);
   if (!/^apps\/(?:_infra\/[^/]+|[^/_][^/]*)\//.test(entry.path ?? ""))
   {
@@ -610,6 +609,7 @@ walk(workspacePath("apps"), function inspectAppSource(path, stat) {
   const rel = relative(root, path).split(sep).join("/");
   if (stat.isSymbolicLink()) fail(`symlink under apps is forbidden: ${rel}`);
   if (!stat.isFile()) return;
+  if (appTestDirectoryPattern.test(rel)) return;
   if (appSourceExtensions.has(extname(rel))) discoveredAppSource.add(rel);
 });
 for (const path of discoveredAppSource)


### PR DESCRIPTION
## Product context

OpenCrane exposes workload-only endpoints to four distinct caller planes: the trusted controller, isolated skill workers, personal and managed runtime Jobs, and optional artifact/replay workers. The composition root needs to show those authority boundaries without turning router paths, shared libraries, or application code into a second policy layer.

## What changes

- split the internal runtime composer into controller, skill-workload, runtime-protocol, and optional-capability slices
- construct each TokenReview adapter once, then pass it only to its matching caller plane
- keep `routes.ts` as the sole path map and keep the composition root as wiring only
- retain existing repositories, policy values, broker ports, route order, and fail-closed namespace validation
- add composition coverage for mandatory routes, disabled/enabled optional routes, missing worker namespaces, and collapsed runtime namespaces
- teach the topology guard that `__tests__` trees prove a deployable but are not deployable implementation source
- record this exact app file as a Prisma composition owner; no repository, unit-of-work, or library public surface was widened
- correct the composition JSDoc so it names all four authority planes instead of implying one shared runtime reviewer

## Product impact

No API, persistence, wire-format, or deployment configuration changes. The same workload endpoints remain mounted, but a reviewer can now see which identity and authority are used for each caller plane.

## Validation

- OpenCrane server suite: 22 tests passed
- focused runtime-composition suite: 5 tests passed after the final documentation correction
- TypeScript no-emit and Prisma generation passed
- agent-style check: 0 errors, 0 warnings
- Prisma boundary, dependency-boundary, Phase A negative, Phase B topology, and topology-negative checks passed
- module-growth found one review candidate because 157 lines were added; the resulting 215-line composer is split into four caller-plane functions, has no limit violation, and received a maintainability review
- `git diff --check` passed

## Review status

- Claude final review: PASS after the one-line JSDoc residue correction
- no behaviour or public-surface changes were introduced by that correction.
