### PR TITLE
🛡️ Enforce Prisma repository and UnitOfWork ownership

### DIFF
--- a/.agents/skills/review/SKILL.md
+++ b/.agents/skills/review/SKILL.md
@@ -119,6 +119,10 @@ maintainability pass.
    - Treat `PRISMA-TRANSACTION-OWNER` and `PRISMA-DELEGATE-OWNER` as deterministic architecture
      failures: application services/materializers/use cases consume repository and UnitOfWork ports;
      repository adapters own model delegates and UnitOfWork implementations own `$transaction`.
+	 `PRISMA-RAW-QUERY-OWNER` reserves raw SQL for exact repository adapters, while
+	 `PRISMA-REPOSITORY-CONSTRUCTION` and `PRISMA-POLICY-*` require transaction-scoped repository
+	 wiring, constructor types, exact callback bindings, adapter names, source paths, and contract
+	 imports to match reviewed policy exactly.
      Exact temporary exemptions live only in `docs/agents/prisma-boundary-policy.json`; malformed,
      broad, ownerless, or expired exemptions fail closed.
    - For every language-neutral module-growth candidate, inventory configuration/identity,

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -28,6 +28,10 @@ fresh context — do not assume the author's intent was correct.
    including it. **Do not hunt for mechanical style issues beyond the script's output.**
    Module-growth output is a responsibility-inventory trigger, not a finding: review the
    cited module through the evidence-based maintainability checklist below.
+   Prisma-boundary errors are deterministic findings: repository adapter class/path/contract,
+  raw-query ownership, UnitOfWork transaction ownership, and transaction-scoped repository
+  construction (including the constructor type and exact callback binding) must match
+  `docs/agents/prisma-boundary-policy.json` exactly.
 4. **Grounding reads — only what the change touches:**
    - `.ts` changed → the style script covers mechanics; read `docs/agents/typescript.md`
      only if you need to confirm a convention the script flagged as WARN.

--- a/.codex/agents/review.toml
+++ b/.codex/agents/review.toml
@@ -18,6 +18,10 @@ fresh context — do not assume the author's intent was correct.
    including it. **Do not hunt for mechanical style issues beyond the script's output.**
    Module-growth output is a responsibility-inventory trigger, not a finding: review the
    cited module through the evidence-based maintainability checklist below.
+   Prisma-boundary errors are deterministic findings: repository adapter class/path/contract,
+   raw-query ownership, UnitOfWork transaction ownership, and transaction-scoped repository
+   construction (including the constructor type and exact callback binding) must match
+   `docs/agents/prisma-boundary-policy.json` exactly.
 4. **Grounding reads — only what the change touches:**
    - `.ts` changed → the script covers mechanics; read `docs/agents/typescript.md`
      only if you need to confirm a convention the script flagged as WARN.

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -3,42 +3,48 @@
   "owners": {
     "repositories": [
       {
+        "path": "libs/backend/agents/personal/configuration/main/src/materialization/prisma-personal-configuration-materialization.ts",
+        "adapter": "PrismaPersonalConfigurationMaterializationRepository",
         "contract": "PersonalConfigurationMaterializationRepository",
-        "importPath": "./personal-configuration-materialization-unit-of-work.types.js"
+        "contractImportPath": "./personal-configuration-materialization-unit-of-work.types.js",
+        "constructs": []
       },
       {
+        "path": "libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-model-selection.ts",
+        "adapter": "PrismaAgentRevisionModelSelectionRepository",
         "contract": "AgentRevisionModelSelectionRepository",
-        "importPath": "./agent-revision-model-selection.types.js"
+        "contractImportPath": "./agent-revision-model-selection.types.js",
+        "constructs": [
+          {
+            "adapter": "PrismaAgentRevisionWriterRepository",
+            "importPath": "./prisma-agent-revision-writer.js"
+          }
+        ]
       },
       {
+        "path": "libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-writer.ts",
+        "adapter": "PrismaAgentRevisionWriterRepository",
         "contract": "AgentRevisionWriterRepository",
-        "importPath": "./prisma-agent-revision-writer.types.js"
-      },
-      {
-        "contract": "PersonalConfigurationChangeDecisionRepository",
-        "importPath": "./personal-configuration-decision.types.js"
-      },
-      {
-        "contract": "PersonalConfigurationChangeViewRepository",
-        "importPath": "./personal-configuration-view.types.js"
-      },
-      {
-        "contract": "PersonalConfigurationProposalRepository",
-        "importPath": "./personal-configuration-proposal-unit-of-work.types.js"
-      },
-      {
-        "contract": "UpgradeSessionProposalRepository",
-        "importPath": "./upgrade-session.types.js"
+        "contractImportPath": "./prisma-agent-revision-writer.types.js",
+        "constructs": []
       }
     ],
     "unitsOfWork": [
       {
+        "path": "libs/backend/agents/personal/configuration/main/src/materialization/prisma-personal-configuration-materialization-unit-of-work.ts",
+        "adapter": "PrismaPersonalConfigurationMaterializationUnitOfWork",
         "contract": "PersonalConfigurationMaterializationUnitOfWork",
-        "importPath": "./personal-configuration-materialization-unit-of-work.types.js"
-      },
-      {
-        "contract": "PersonalConfigurationProposalUnitOfWork",
-        "importPath": "./personal-configuration-proposal-unit-of-work.types.js"
+        "contractImportPath": "./personal-configuration-materialization-unit-of-work.types.js",
+        "constructs": [
+          {
+            "adapter": "PrismaAgentRevisionModelSelectionRepository",
+            "importPath": "@opencrane/backend/server/agents/agent-services"
+          },
+          {
+            "adapter": "PrismaPersonalConfigurationMaterializationRepository",
+            "importPath": "./prisma-personal-configuration-materialization.js"
+          }
+        ]
       }
     ],
     "compositions": [

--- a/docs/agents/prisma.md
+++ b/docs/agents/prisma.md
@@ -34,6 +34,28 @@ clean target baseline remain, and every model/enum has exactly one owning domain
    digest in a protected database schema. Physical recovery restores that marker with the existing
    schema, never attaches fresh setup SQL, and must pass the digest-checking Postgres hook.
 
+## Runtime ORM ownership
+
+Production TypeScript reaches Prisma through reviewed capability boundaries, enforced by
+`npm run check:prisma-boundaries -- --diff <base-ref>`:
+
+1. Domain services, materializers, and use cases do not import Prisma or call model delegates.
+2. Only an exact repository adapter declared in
+   [`prisma-boundary-policy.json`](./prisma-boundary-policy.json) may call model delegates or raw
+   query methods. A declaration binds the repository contract import, adapter class, and source
+   path; renaming or moving any of them requires policy review.
+3. Only an exact declared UnitOfWork adapter may call `$transaction`.
+4. Passing a transaction client into another repository is also policy-owned. Every declared
+	repository constructor accepts `Prisma.TransactionClient`, and each declared construction must
+	receive the exact `$transaction` callback binding (or an owning repository's typed transaction
+	property), never the root `PrismaClient`. Stale declarations and substituted bindings fail.
+5. Composition roots may import `PrismaClient` only at exact listed paths. That permits dependency
+   wiring, never delegate, raw-query, or transaction ownership.
+
+The checker compares new findings with the base revision, so inherited violations remain visible
+through `--all` without blocking unrelated slices. Exact temporary exemptions require an owner,
+reason, allowed operation, and a real UTC calendar expiry; malformed or stale policy fails closed.
+
 ## Why this exists
 
 Per-domain schema files keep model ownership attributable while one reviewed target SQL describes

--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -99,6 +99,11 @@ Run `scripts/agent-style-check.sh`, `npm run check:prisma-boundaries -- --diff <
 `npm run check:module-growth` before delegating. The first checks TypeScript mechanics and invokes
 the same diff-scoped Prisma ownership floor; the explicit Prisma command is useful when reporting
 that gate separately; the final command produces language-neutral architecture candidates.
+The Prisma gate authorizes exact adapter class/path/contract tuples, raw-query ownership, transaction
+ownership, and transaction-scoped repository construction. A policy-only rename or stale
+construction declaration is therefore a failing change, not an implicit exemption. Construction
+also proves the target constructor and exact callback binding are transaction-scoped; a root client
+substitution fails even when the class and import still match policy.
 Mechanical errors are cheaper to fix before review, while module-growth warnings give the reviewer
 the exact files that need a responsibility inventory.
 

--- a/scripts/__tests__/fixtures/prisma-boundary/negative-computed-raw-service.ts.txt
+++ b/scripts/__tests__/fixtures/prisma-boundary/negative-computed-raw-service.ts.txt
@@ -1,0 +1,18 @@
+import type { PrismaClient } from "@prisma/client";
+
+export class ComputedRawService
+{
+	private readonly prisma: PrismaClient;
+
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	async execute(): Promise<unknown>
+	{
+		const { $executeRaw: executeRaw } = this.prisma;
+		void executeRaw;
+		return this.prisma["$queryRaw"]`SELECT 1`;
+	}
+}

--- a/scripts/__tests__/fixtures/prisma-boundary/negative-root-client-unit-of-work.ts.txt
+++ b/scripts/__tests__/fixtures/prisma-boundary/negative-root-client-unit-of-work.ts.txt
@@ -13,6 +13,6 @@ export class PrismaWidgetUnitOfWork implements WidgetUnitOfWork
 
 	async run(): Promise<unknown>
 	{
-		return this.prisma.$transaction(async function _Run(tx) { return new PrismaWidgetRepository(tx); });
+		return this.prisma.$transaction(async (tx) => { void tx; return new PrismaWidgetRepository(this.prisma); });
 	}
 }

--- a/scripts/__tests__/fixtures/prisma-boundary/negative-unit-of-work-raw-query.ts.txt
+++ b/scripts/__tests__/fixtures/prisma-boundary/negative-unit-of-work-raw-query.ts.txt
@@ -1,6 +1,5 @@
 import type { PrismaClient } from "@prisma/client";
 import type { WidgetUnitOfWork } from "./widget.types.js";
-import { PrismaWidgetRepository } from "./prisma-widget-repository.js";
 
 export class PrismaWidgetUnitOfWork implements WidgetUnitOfWork
 {
@@ -13,6 +12,9 @@ export class PrismaWidgetUnitOfWork implements WidgetUnitOfWork
 
 	async run(): Promise<unknown>
 	{
-		return this.prisma.$transaction(async function _Run(tx) { return new PrismaWidgetRepository(tx); });
+		return this.prisma.$transaction(async function _Run(transaction)
+		{
+			return transaction.$queryRaw`SELECT 1`;
+		});
 	}
 }

--- a/scripts/__tests__/fixtures/prisma-boundary/positive-raw-false-positives.ts.txt
+++ b/scripts/__tests__/fixtures/prisma-boundary/positive-raw-false-positives.ts.txt
@@ -1,0 +1,20 @@
+import type { PrismaClient } from "@prisma/client";
+
+export class RawQueryExamples
+{
+	private readonly prisma: PrismaClient;
+
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
+
+	execute(unrelated: { readonly $queryRaw: () => unknown }): unknown
+	{
+		// this.prisma.$queryRaw`comment only`;
+		const example = "this.prisma['$executeRaw'](string only)";
+		unrelated.$queryRaw();
+		unrelated["$queryRaw"]();
+		return example;
+	}
+}

--- a/scripts/__tests__/fixtures/prisma-boundary/positive-repository.ts.txt
+++ b/scripts/__tests__/fixtures/prisma-boundary/positive-repository.ts.txt
@@ -12,6 +12,7 @@ export class PrismaWidgetRepository implements WidgetRepository
 
 	async find(): Promise<unknown>
 	{
+		await this.transaction.$queryRaw`SELECT 1`;
 		return this.transaction.widget.findFirst({});
 	}
 }

--- a/scripts/__tests__/prisma-boundary-check.test.mjs
+++ b/scripts/__tests__/prisma-boundary-check.test.mjs
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { findingDelta, inspectPrismaBoundary, prismaModelDelegates, resolveExemptions, validatePolicy } from "../prisma-boundary/core.mjs";
+import { findingDelta, inspectPrismaBoundary, prismaModelDelegates, resolveExemptions, validateOwnerDeclarations, validatePolicy } from "../prisma-boundary/core.mjs";
 
 /** Fixture directory for deterministic ownership examples. */
 const _FIXTURES = fileURLToPath(new URL("./fixtures/prisma-boundary/", import.meta.url));
@@ -12,8 +12,8 @@ const _FIXTURES = fileURLToPath(new URL("./fixtures/prisma-boundary/", import.me
 const _ROOT = fileURLToPath(new URL("../../", import.meta.url));
 /** Authoritative owner contracts used by checker fixtures. */
 const _OWNERS = {
-	repositories: [{ contract: "WidgetRepository", importPath: "./widget.types.js" }],
-	unitsOfWork: [{ contract: "WidgetUnitOfWork", importPath: "./widget.types.js" }],
+	repositories: [{ path: "libs/widgets/prisma-widget-repository.ts", adapter: "PrismaWidgetRepository", contract: "WidgetRepository", contractImportPath: "./widget.types.js", constructs: [] }],
+	unitsOfWork: [{ path: "libs/widgets/prisma-widget-unit-of-work.ts", adapter: "PrismaWidgetUnitOfWork", contract: "WidgetUnitOfWork", contractImportPath: "./widget.types.js", constructs: [{ adapter: "PrismaWidgetRepository", importPath: "./prisma-widget-repository.js" }] }],
 	compositions: [],
 };
 
@@ -25,6 +25,7 @@ function _Fixture(name)
 
 test("allows imported repository and unit-of-work contract owners", function _AllowsOwners()
 {
+	assert.doesNotThrow(function _ValidPolicy() { validatePolicy({ version: 1, owners: _OWNERS, exemptions: [] }); });
 	assert.deepEqual(inspectPrismaBoundary("libs/widgets/prisma-widget-repository.ts", _Fixture("positive-repository"), ["widget"], _OWNERS), []);
 	assert.deepEqual(inspectPrismaBoundary("libs/widgets/prisma-widget-unit-of-work.ts", _Fixture("positive-unit-of-work"), ["widget"], _OWNERS), []);
 });
@@ -46,6 +47,55 @@ test("requires the exact authoritative contract import rather than a marker nami
 	assert.equal(findings.some(function _Delegate(finding) { return finding.rule === "PRISMA-DELEGATE-OWNER"; }), true);
 });
 
+test("requires the exact policy path and adapter name for Prisma ownership", function _RejectsRenamedOwner()
+{
+	const renamed = _Fixture("positive-repository").replaceAll("PrismaWidgetRepository", "PrismaRenamedRepository");
+	const renamedFindings = inspectPrismaBoundary("libs/widgets/prisma-widget-repository.ts", renamed, ["widget"], _OWNERS);
+	const movedFindings = inspectPrismaBoundary("libs/widgets/moved-prisma-widget-repository.ts", _Fixture("positive-repository"), ["widget"], _OWNERS);
+	assert.equal(renamedFindings.some(function _Delegate(finding) { return finding.rule === "PRISMA-DELEGATE-OWNER"; }), true);
+	assert.equal(movedFindings.some(function _Import(finding) { return finding.rule === "PRISMA-IMPORT-OWNER"; }), true);
+});
+
+test("allows raw queries only in exact policy-authorized repository adapters", function _RejectsUnitOfWorkRawQuery()
+{
+	const repository = inspectPrismaBoundary("libs/widgets/prisma-widget-repository.ts", _Fixture("positive-repository"), ["widget"], _OWNERS);
+	const unitOfWork = inspectPrismaBoundary("libs/widgets/prisma-widget-unit-of-work.ts", _Fixture("negative-unit-of-work-raw-query"), ["widget"], _OWNERS);
+	assert.equal(repository.some(function _Raw(finding) { return finding.rule === "PRISMA-RAW-QUERY-OWNER"; }), false);
+	assert.equal(unitOfWork.some(function _Raw(finding) { return finding.rule === "PRISMA-RAW-QUERY-OWNER"; }), true);
+});
+
+test("requires transaction-scoped repository construction to match the owning policy entry", function _RejectsUndeclaredConstruction()
+{
+	const undeclared = { ..._OWNERS, unitsOfWork: [{ ..._OWNERS.unitsOfWork[0], constructs: [] }] };
+	const findings = inspectPrismaBoundary("libs/widgets/prisma-widget-unit-of-work.ts", _Fixture("positive-unit-of-work"), ["widget"], undeclared);
+	const rootClient = inspectPrismaBoundary("libs/widgets/prisma-widget-unit-of-work.ts", _Fixture("negative-root-client-unit-of-work"), ["widget"], _OWNERS);
+	assert.equal(findings.some(function _Construction(finding) { return finding.rule === "PRISMA-REPOSITORY-CONSTRUCTION"; }), true);
+	assert.equal(rootClient.some(function _Construction(finding) { return finding.rule === "PRISMA-REPOSITORY-CONSTRUCTION"; }), true);
+});
+
+test("fails closed when live owner declarations drift from policy", function _RejectsStaleOwnerPolicy()
+{
+	const renamed = _Fixture("positive-repository").replaceAll("PrismaWidgetRepository", "PrismaRenamedRepository");
+	const missingConstruction = _Fixture("positive-unit-of-work").replace("return new PrismaWidgetRepository(tx);", "return tx;");
+	const rootClientConstructor = _Fixture("positive-repository")
+		.replace("import type { Prisma }", "import type { Prisma, PrismaClient }")
+		.replace("constructor(transaction: Prisma.TransactionClient)", "constructor(transaction: PrismaClient)");
+	const ownerFindings = validateOwnerDeclarations("libs/widgets/prisma-widget-repository.ts", renamed, _OWNERS);
+	const constructionFindings = validateOwnerDeclarations("libs/widgets/prisma-widget-unit-of-work.ts", missingConstruction, _OWNERS);
+	const constructorFindings = validateOwnerDeclarations("libs/widgets/prisma-widget-repository.ts", rootClientConstructor, _OWNERS);
+	assert.equal(ownerFindings.some(function _Owner(finding) { return finding.rule === "PRISMA-POLICY-OWNER"; }), true);
+	assert.equal(constructionFindings.some(function _Construction(finding) { return finding.rule === "PRISMA-POLICY-CONSTRUCTION"; }), true);
+	assert.equal(constructorFindings.some(function _Owner(finding) { return finding.rule === "PRISMA-POLICY-OWNER"; }), true);
+});
+
+test("detects computed raw-query access without matching prose or unrelated receivers", function _ScopesRawQueries()
+{
+	const bypass = inspectPrismaBoundary("libs/widgets/computed-service.ts", _Fixture("negative-computed-raw-service"), ["widget"], _OWNERS);
+	const examples = inspectPrismaBoundary("libs/widgets/examples.ts", _Fixture("positive-raw-false-positives"), ["widget"], _OWNERS);
+	assert.equal(bypass.filter(function _Raw(finding) { return finding.rule === "PRISMA-RAW-QUERY-OWNER"; }).length, 2);
+	assert.equal(examples.some(function _Raw(finding) { return finding.rule === "PRISMA-RAW-QUERY-OWNER"; }), false);
+});
+
 test("rejects aliased imports, delegate aliases, destructuring, and transaction aliases", function _RejectsAliases()
 {
 	const findings = inspectPrismaBoundary("libs/widgets/aliased-service.ts", _Fixture("negative-aliases"), ["gadget", "widget"], _OWNERS);
@@ -55,8 +105,8 @@ test("rejects aliased imports, delegate aliases, destructuring, and transaction 
 
 test("checks the complete changed file when an ownership declaration is removed", function _RejectsRemovedOwner()
 {
-	const base = inspectPrismaBoundary("libs/widgets/prisma-widget-store.ts", _Fixture("positive-repository"), ["widget"], _OWNERS);
-	const current = inspectPrismaBoundary("libs/widgets/prisma-widget-store.ts", _Fixture("negative-removed-owner"), ["widget"], _OWNERS);
+	const base = inspectPrismaBoundary("libs/widgets/prisma-widget-repository.ts", _Fixture("positive-repository"), ["widget"], _OWNERS);
+	const current = inspectPrismaBoundary("libs/widgets/prisma-widget-repository.ts", _Fixture("negative-removed-owner"), ["widget"], _OWNERS);
 	const introduced = findingDelta(base, current);
 	assert.equal(introduced.some(function _Delegate(finding) { return finding.rule === "PRISMA-DELEGATE-OWNER"; }), true);
 });
@@ -86,11 +136,12 @@ test("fails closed on broad, ownerless, stale, or malformed exemptions", functio
 		{ path: "libs/*/service.ts", operations: ["delegate"], owner: "team", reason: "A sufficiently detailed temporary reason.", expiresOn: "2026-09-01" },
 		{ path: "libs/service.ts", operations: ["unknown"], owner: "", reason: "short", expiresOn: "tomorrow" },
 		{ path: "libs/expired.ts", operations: ["transaction"], owner: "team", reason: "A sufficiently detailed temporary reason.", expiresOn: "2026-07-01" },
+		{ path: "libs/impossible-date.ts", operations: ["delegate"], owner: "team", reason: "A sufficiently detailed temporary reason.", expiresOn: "2026-02-30" },
 	], "2026-08-01");
 	assert.equal(resolved.active.size, 0);
-	assert.equal(resolved.errors.length, 3);
+	assert.equal(resolved.errors.length, 4);
 	assert.throws(function _InvalidPolicy() { validatePolicy({ version: 2, owners: { repositories: [], unitsOfWork: [], compositions: [] }, exemptions: [] }); }, /invalid Prisma-boundary policy schema/u);
-	assert.throws(function _BroadOwner() { validatePolicy({ version: 1, owners: { repositories: [{ contract: "WidgetRepository", importPath: "./*.types.js" }], unitsOfWork: [], compositions: [] }, exemptions: [] }); }, /invalid Prisma-boundary owner contract/u);
+	assert.throws(function _BroadOwner() { validatePolicy({ version: 1, owners: { repositories: [{ path: "libs/*/repository.ts", adapter: "PrismaWidgetRepository", contract: "WidgetRepository", contractImportPath: "./widget.types.js", constructs: [] }], unitsOfWork: [], compositions: [] }, exemptions: [] }); }, /invalid Prisma-boundary owner/u);
 });
 
 test("keeps review, style, package, and CI surfaces on the boundary check", function _VerifiesPipeline()
@@ -103,6 +154,8 @@ test("keeps review, style, package, and CI surfaces on the boundary check", func
 		"package.json",
 		".github/workflows/docker.yml",
 		".github/workflows/nightly.yml",
+		"docs/agents/prisma.md",
+		"docs/agents/workflow.md",
 	];
 	for (const path of surfaces)
 	{

--- a/scripts/prisma-boundary-check.mjs
+++ b/scripts/prisma-boundary-check.mjs
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
-import { findingDelta, inspectPrismaBoundary, isProductionTypeScript, prismaModelDelegates, resolveExemptions, validatePolicy } from "./prisma-boundary/core.mjs";
+import { findingDelta, inspectPrismaBoundary, isProductionTypeScript, prismaModelDelegates, resolveExemptions, validateOwnerDeclarations, validatePolicy } from "./prisma-boundary/core.mjs";
 
 /** Repository root for all path and Git operations. */
 const _ROOT = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
@@ -32,6 +32,32 @@ function _Main()
 	const scope = _Scope(process.argv.slice(2));
 	const files = scope.files;
 	let findings = 0;
+	const ownerPaths = [...new Set([...policy.owners.repositories, ...policy.owners.unitsOfWork].map(function _Path(entry) { return entry.path; }))];
+	for (const path of ownerPaths)
+	{
+		const absolutePath = join(_ROOT, path);
+		if (!existsSync(absolutePath))
+		{
+			console.error(`${path}:1\tERROR\tPRISMA-POLICY-OWNER\tpolicy owner path does not exist`);
+			findings += 1;
+			continue;
+		}
+		const source = readFileSync(absolutePath, "utf8");
+		for (const finding of validateOwnerDeclarations(path, source, policy.owners))
+		{
+			console.error(`${finding.path}:${finding.line}\tERROR\t${finding.rule}\t${finding.message}`);
+			findings += 1;
+		}
+	}
+	for (const path of policy.owners.compositions)
+	{
+		const absolutePath = join(_ROOT, path);
+		if (!existsSync(absolutePath) || !readFileSync(absolutePath, "utf8").includes('from "@prisma/client"'))
+		{
+			console.error(`${path}:1\tERROR\tPRISMA-POLICY-COMPOSITION\tcomposition path must exist and import @prisma/client`);
+			findings += 1;
+		}
+	}
 	for (const path of files)
 	{
 		if (!isProductionTypeScript(path) || !existsSync(join(_ROOT, path))) continue;

--- a/scripts/prisma-boundary/core.mjs
+++ b/scripts/prisma-boundary/core.mjs
@@ -1,2 +1,2 @@
-export { findingDelta, inspectPrismaBoundary, isProductionTypeScript, prismaModelDelegates } from "./inspection.mjs";
+export { findingDelta, inspectPrismaBoundary, isProductionTypeScript, prismaModelDelegates, validateOwnerDeclarations } from "./inspection.mjs";
 export { resolveExemptions, validatePolicy } from "./policy.mjs";

--- a/scripts/prisma-boundary/inspection.mjs
+++ b/scripts/prisma-boundary/inspection.mjs
@@ -1,5 +1,5 @@
-import { delegateMatches, transactionMatches } from "./prisma-bindings.mjs";
-import { classes, enclosingClass, importedBindings, ownerIdentity, ownsContract } from "./typescript-ownership.mjs";
+import { delegateMatches, rawQueryMatches, transactionMatches } from "./prisma-bindings.mjs";
+import { authorizedOwner, classes, enclosingClass, importedBindings, isTransactionScopedConstruction, ownerIdentity, repositoryAcceptsTransactionClient, repositoryConstructions } from "./typescript-ownership.mjs";
 
 /** Returns whether a path is hand-maintained production TypeScript. */
 export function isProductionTypeScript(path)
@@ -23,11 +23,11 @@ export function inspectPrismaBoundary(path, source, modelDelegates, owners, exem
 	const imports = importedBindings(source);
 	const findings = [];
 	const prismaImport = /^import[^;]+from\s+"@prisma\/client";/gmu.exec(source);
-	const authorizedOwner = classOwners.some(function _Authorized(candidate)
+	const hasAuthorizedOwner = classOwners.some(function _Authorized(candidate)
 	{
-		return ownsContract(candidate, imports, owners.repositories) || ownsContract(candidate, imports, owners.unitsOfWork);
+		return authorizedOwner(candidate, imports, owners.repositories, path) !== undefined || authorizedOwner(candidate, imports, owners.unitsOfWork, path) !== undefined;
 	});
-	if (prismaImport !== null && !authorizedOwner && !owners.compositions.includes(path))
+	if (prismaImport !== null && !hasAuthorizedOwner && !owners.compositions.includes(path))
 	{
 		findings.push(_Finding(path, source, prismaImport.index, "PRISMA-IMPORT-OWNER", "@prisma/client import outside an authoritative Repository, UnitOfWork, or exact composition owner", "module"));
 	}
@@ -35,18 +35,76 @@ export function inspectPrismaBoundary(path, source, modelDelegates, owners, exem
 	{
 		if (exemption.has("transaction")) continue;
 		const owner = enclosingClass(classOwners, match.index ?? 0);
-		if (!ownsContract(owner, imports, owners.unitsOfWork))
+		if (authorizedOwner(owner, imports, owners.unitsOfWork, path) === undefined)
 		{
-			findings.push(_Finding(path, source, match.index ?? 0, "PRISMA-TRANSACTION-OWNER", "direct $transaction call outside a class implementing an imported UnitOfWork contract", ownerIdentity(source, classOwners, match.index ?? 0)));
+			findings.push(_Finding(path, source, match.index ?? 0, "PRISMA-TRANSACTION-OWNER", "direct $transaction call outside an exact policy-authorized UnitOfWork adapter", ownerIdentity(source, classOwners, match.index ?? 0)));
+		}
+	}
+	for (const match of rawQueryMatches(source, imports))
+	{
+		if (exemption.has("raw-query")) continue;
+		const owner = enclosingClass(classOwners, match.index ?? 0);
+		if (authorizedOwner(owner, imports, owners.repositories, path) === undefined)
+		{
+			findings.push(_Finding(path, source, match.index ?? 0, "PRISMA-RAW-QUERY-OWNER", `direct ${match.method} access outside an exact policy-authorized Repository adapter`, ownerIdentity(source, classOwners, match.index ?? 0)));
 		}
 	}
 	for (const match of delegateMatches(source, modelDelegates, imports))
 	{
 		if (exemption.has("delegate")) continue;
 		const owner = enclosingClass(classOwners, match.index ?? 0);
-		if (!ownsContract(owner, imports, owners.repositories))
+		if (authorizedOwner(owner, imports, owners.repositories, path) === undefined)
 		{
-			findings.push(_Finding(path, source, match.index ?? 0, "PRISMA-DELEGATE-OWNER", `direct ${match.delegate}.${match.method} call outside a class implementing an authoritative Repository contract`, ownerIdentity(source, classOwners, match.index ?? 0)));
+			findings.push(_Finding(path, source, match.index ?? 0, "PRISMA-DELEGATE-OWNER", `direct ${match.delegate}.${match.method} call outside an exact policy-authorized Repository adapter`, ownerIdentity(source, classOwners, match.index ?? 0)));
+		}
+	}
+	for (const construction of owners.compositions.includes(path) ? [] : repositoryConstructions(source, classOwners, imports))
+	{
+		const policyOwner = authorizedOwner(construction.owner, imports, [...owners.repositories, ...owners.unitsOfWork], path);
+		const declared = policyOwner?.constructs.some(function _Declared(candidate)
+		{
+			return candidate.adapter === construction.adapter && candidate.importPath === construction.importPath;
+		});
+		if (!declared || !isTransactionScopedConstruction(source, construction, imports))
+		{
+			findings.push(_Finding(path, source, construction.index, "PRISMA-REPOSITORY-CONSTRUCTION", `${construction.adapter} construction must be declared and receive the exact Prisma transaction binding`, ownerIdentity(source, classOwners, construction.index)));
+		}
+	}
+	return findings;
+}
+
+/** Validates that policy-declared owners and construction lists still match the live tree. */
+export function validateOwnerDeclarations(path, source, owners)
+{
+	const findings = [];
+	const classOwners = classes(source);
+	const imports = importedBindings(source);
+	const constructions = repositoryConstructions(source, classOwners, imports);
+	for (const declaration of [...owners.repositories, ...owners.unitsOfWork].filter(function _Path(entry) { return entry.path === path; }))
+	{
+		const owner = classOwners.find(function _Adapter(candidate) { return candidate.name === declaration.adapter; });
+		if (authorizedOwner(owner, imports, [declaration], path) === undefined)
+		{
+			findings.push(_Finding(path, source, 0, "PRISMA-POLICY-OWNER", `policy owner ${declaration.adapter} no longer implements its exact declared contract import`, `class:${declaration.adapter}`));
+			continue;
+		}
+		if (owners.repositories.includes(declaration) && !repositoryAcceptsTransactionClient(source, owner, imports))
+		{
+			findings.push(_Finding(path, source, owner.start, "PRISMA-POLICY-OWNER", `repository owner ${declaration.adapter} constructor must accept Prisma.TransactionClient`, `class:${declaration.adapter}`));
+		}
+		const actual = constructions.filter(function _Owner(construction) { return construction.owner?.name === declaration.adapter; });
+		const actualKeys = actual.map(_ConstructionKey).sort();
+		const declaredKeys = declaration.constructs.map(_ConstructionKey).sort();
+		if (JSON.stringify(actualKeys) !== JSON.stringify(declaredKeys))
+		{
+			findings.push(_Finding(path, source, owner.start, "PRISMA-POLICY-CONSTRUCTION", `policy construction list for ${declaration.adapter} does not match its repository construction`, `class:${declaration.adapter}`));
+		}
+		for (const construction of actual)
+		{
+			if (!isTransactionScopedConstruction(source, construction, imports))
+			{
+				findings.push(_Finding(path, source, construction.index, "PRISMA-POLICY-CONSTRUCTION", `${construction.adapter} must receive the exact Prisma transaction binding`, `class:${declaration.adapter}`));
+			}
 		}
 	}
 	return findings;
@@ -89,4 +147,10 @@ export function findingDelta(baseFindings, currentFindings)
 function _Finding(path, source, offset, rule, message, owner)
 {
 	return { path, line: source.slice(0, offset).split("\n").length, rule, message, owner };
+}
+
+/** Returns the stable identity of one repository construction. */
+function _ConstructionKey(construction)
+{
+	return `${construction.adapter}\u0000${construction.importPath}`;
 }

--- a/scripts/prisma-boundary/policy.mjs
+++ b/scripts/prisma-boundary/policy.mjs
@@ -20,8 +20,8 @@ export function resolveExemptions(entries, today)
 			&& typeof entry?.reason === "string"
 			&& entry.reason.trim().length >= 20
 			&& operations.length > 0
-			&& operations.every(function _IsKnownOperation(operation) { return operation === "delegate" || operation === "transaction"; })
-			&& /^\d{4}-\d{2}-\d{2}$/u.test(expiry);
+			&& operations.every(function _IsKnownOperation(operation) { return operation === "delegate" || operation === "raw-query" || operation === "transaction"; })
+			&& _IsUtcCalendarDate(expiry);
 		if (!valid)
 		{
 			errors.push(`invalid exemption at index ${index}; require an exact .ts path, owner, 20-character reason, known operations, and ISO expiry`);
@@ -42,6 +42,14 @@ export function resolveExemptions(entries, today)
 	return { active, errors };
 }
 
+/** Returns whether a date is a real calendar day with a stable UTC round trip. */
+function _IsUtcCalendarDate(value)
+{
+	if (!/^\d{4}-\d{2}-\d{2}$/u.test(value)) return false;
+	const parsed = new Date(`${value}T00:00:00.000Z`);
+	return !Number.isNaN(parsed.valueOf()) && parsed.toISOString().slice(0, 10) === value;
+}
+
 /** Validates the top-level Prisma-boundary policy schema. */
 export function validatePolicy(policy)
 {
@@ -53,24 +61,62 @@ export function validatePolicy(policy)
 	{
 		throw new Error("invalid Prisma-boundary policy schema");
 	}
-	const entries = [...policy.owners.repositories, ...policy.owners.unitsOfWork];
+	const entries = [
+		...policy.owners.repositories.map(function _Repository(entry) { return { ...entry, expectedSuffix: "Repository" }; }),
+		...policy.owners.unitsOfWork.map(function _UnitOfWork(entry) { return { ...entry, expectedSuffix: "UnitOfWork" }; }),
+	];
 	const keys = new Set();
 	for (const entry of entries)
 	{
-		const valid = typeof entry?.contract === "string"
+		const valid = _IsExactTypeScriptPath(entry?.path)
+			&& typeof entry?.adapter === "string"
+			&& /^[A-Za-z_$][\w$]*$/u.test(entry.adapter)
+			&& entry.adapter.endsWith(entry.expectedSuffix)
+			&& typeof entry?.contract === "string"
 			&& /^[A-Za-z_$][\w$]*$/u.test(entry.contract)
-			&& typeof entry?.importPath === "string"
-			&& entry.importPath.length > 0
-			&& !/[?*\[\]{}]/u.test(entry.importPath);
-		const key = `${entry?.contract ?? ""}\u0000${entry?.importPath ?? ""}`;
-		if (!valid || keys.has(key)) throw new Error("invalid Prisma-boundary owner contract; require a unique exact contract name and import path");
+			&& entry.contract.endsWith(entry.expectedSuffix)
+			&& _IsExactImportPath(entry?.contractImportPath)
+			&& Array.isArray(entry?.constructs)
+			&& entry.constructs.every(_IsExactConstruction);
+		const key = `${entry?.path ?? ""}\u0000${entry?.adapter ?? ""}`;
+		if (!valid || keys.has(key)) throw new Error("invalid Prisma-boundary owner; require a unique exact path, adapter, contract import, and construction list");
 		keys.add(key);
+	}
+	const constructionKeys = new Set();
+	for (const entry of entries)
+	{
+		for (const construction of entry.constructs)
+		{
+			const key = `${entry.path}\u0000${entry.adapter}\u0000${construction.adapter}\u0000${construction.importPath}`;
+			if (constructionKeys.has(key)) throw new Error("duplicate Prisma-boundary construction declaration");
+			constructionKeys.add(key);
+		}
 	}
 	for (const path of policy.owners.compositions)
 	{
-		if (typeof path !== "string" || !path.endsWith(".ts") || path.startsWith("../") || /[?*\[\]{}]/u.test(path))
+		if (!_IsExactTypeScriptPath(path))
 		{
 			throw new Error("invalid Prisma-boundary composition path; require an exact repository-relative .ts path");
 		}
 	}
+}
+
+/** Returns whether an owner path is exact, repository-relative, and TypeScript. */
+function _IsExactTypeScriptPath(path)
+{
+	return typeof path === "string" && path.endsWith(".ts") && !path.startsWith("../") && !/[?*\[\]{}]/u.test(path);
+}
+
+/** Returns whether an import path is an exact module specifier. */
+function _IsExactImportPath(path)
+{
+	return typeof path === "string" && path.length > 0 && !/[?*\[\]{}]/u.test(path);
+}
+
+/** Returns whether one transaction-scoped repository construction is exact. */
+function _IsExactConstruction(construction)
+{
+	return typeof construction?.adapter === "string"
+		&& /^[A-Za-z_$][\w$]*Repository$/u.test(construction.adapter)
+		&& _IsExactImportPath(construction?.importPath);
 }

--- a/scripts/prisma-boundary/prisma-bindings.mjs
+++ b/scripts/prisma-boundary/prisma-bindings.mjs
@@ -28,6 +28,34 @@ export function transactionMatches(source, imports)
 	return matches;
 }
 
+/** Finds raw-query property access rooted only in imported Prisma client symbols. */
+export function rawQueryMatches(source, imports)
+{
+	const methodNames = ["$executeRaw", "$executeRawUnsafe", "$queryRaw", "$queryRawUnsafe"];
+	const matches = [];
+	const code = _CodeOnly(source);
+	for (const expression of _PrismaClientExpressions(source, imports))
+	{
+		const root = `(?<![\\w$.])${_EscapeRegex(expression)}(?![\\w$])`;
+		for (const method of methodNames)
+		{
+			const escapedMethod = _EscapeRegex(method);
+			const dot = new RegExp(`${root}\\s*\\.\\s*${escapedMethod}\\b`, "gu");
+			for (const match of code.matchAll(dot)) matches.push({ index: match.index, method });
+
+			const computed = new RegExp(`${root}\\s*\\[\\s*([\"'])${escapedMethod}\\1\\s*\\]`, "gu");
+			for (const match of source.matchAll(computed))
+			{
+				if (_ExpressionIsCode(code, match.index ?? 0, expression)) matches.push({ index: match.index, method });
+			}
+
+			const destructured = new RegExp(`\\bconst\\s*\\{[^}]*(?<![\\w$])${escapedMethod}(?![\\w$])[^}]*\\}\\s*=\\s*${root}`, "gu");
+			for (const match of code.matchAll(destructured)) matches.push({ index: match.index, method });
+		}
+	}
+	return _UniqueRawMatches(matches);
+}
+
 /** Finds direct model calls plus delegate aliases/destructures rooted in Prisma clients. */
 export function delegateMatches(source, modelDelegates, imports)
 {
@@ -70,9 +98,10 @@ function _AliasCalls(source, alias, delegate, after, escapedMethods)
 	return calls;
 }
 
-/** Resolves identifiers and class properties explicitly typed as imported Prisma clients. */
+/** Resolves identifiers and class properties explicitly rooted in imported Prisma client types. */
 function _PrismaClientExpressions(source, imports)
 {
+	const code = _CodeOnly(source);
 	const typeNames = [];
 	for (const [local, binding] of imports.entries())
 	{
@@ -83,17 +112,74 @@ function _PrismaClientExpressions(source, imports)
 	if (typeNames.length === 0) return [];
 	const expressions = new Set();
 	const declaration = new RegExp(`\\b([A-Za-z_$][\\w$]*)\\s*:\\s*(?:${typeNames.join("|")})\\b`, "gu");
-	for (const match of source.matchAll(declaration))
+	for (const match of code.matchAll(declaration))
 	{
 		expressions.add(match[1]);
-		const prefix = source.slice(Math.max(0, (match.index ?? 0) - 40), match.index ?? 0);
+		const prefix = code.slice(Math.max(0, (match.index ?? 0) - 40), match.index ?? 0);
 		if (/\b(?:private|protected|public)\s+(?:readonly\s+)?$/u.test(prefix)) expressions.add(`this.${match[1]}`);
 	}
-	for (const match of source.matchAll(/\bthis\.([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*)\s*;/gu))
+	for (const match of code.matchAll(/\bthis\.([A-Za-z_$][\w$]*)\s*=\s*([A-Za-z_$][\w$]*)\s*;/gu))
 	{
 		if (expressions.has(match[2])) expressions.add(`this.${match[1]}`);
 	}
+	for (const match of code.matchAll(/\.\$transaction\s*\(\s*async\s+(?:function\s+[A-Za-z_$][\w$]*\s*)?\(\s*([A-Za-z_$][\w$]*)/gu)) expressions.add(match[1]);
 	return [...expressions];
+}
+
+/** Returns source with comments and string contents blanked while preserving offsets. */
+function _CodeOnly(source)
+{
+	const characters = source.split("");
+	let quote = "";
+	let lineComment = false;
+	let blockComment = false;
+	for (let index = 0; index < characters.length; index += 1)
+	{
+		const character = source[index];
+		const next = source[index + 1];
+		if (lineComment)
+		{
+			if (character === "\n") lineComment = false;
+			else characters[index] = " ";
+			continue;
+		}
+		if (blockComment)
+		{
+			characters[index] = character === "\n" ? "\n" : " ";
+			if (character === "*" && next === "/") { characters[index + 1] = " "; blockComment = false; index += 1; }
+			continue;
+		}
+		if (quote)
+		{
+			characters[index] = character === "\n" ? "\n" : " ";
+			if (character === "\\") { if (index + 1 < characters.length) characters[index + 1] = " "; index += 1; continue; }
+			if (character === quote) quote = "";
+			continue;
+		}
+		if (character === "/" && next === "/") { characters[index] = " "; characters[index + 1] = " "; lineComment = true; index += 1; continue; }
+		if (character === "/" && next === "*") { characters[index] = " "; characters[index + 1] = " "; blockComment = true; index += 1; continue; }
+		if (character === "\"" || character === "'" || character === "`") { characters[index] = " "; quote = character; }
+	}
+	return characters.join("");
+}
+
+/** Returns whether a computed-access receiver is executable code at the matched offset. */
+function _ExpressionIsCode(code, index, expression)
+{
+	return code.slice(index, index + expression.length) === expression;
+}
+
+/** Removes duplicate raw-operation matches without hiding distinct source offsets. */
+function _UniqueRawMatches(matches)
+{
+	const seen = new Set();
+	return matches.filter(function _First(match)
+	{
+		const key = `${match.index ?? 0}\u0000${match.method}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
 }
 
 /** Escapes a literal for inclusion in a regular expression. */

--- a/scripts/prisma-boundary/typescript-ownership.mjs
+++ b/scripts/prisma-boundary/typescript-ownership.mjs
@@ -33,17 +33,67 @@ export function importedBindings(source)
 	return imports;
 }
 
-/** Returns whether the enclosing class implements an imported ownership contract. */
-export function ownsContract(owner, imports, allowedContracts)
+/** Returns the exact policy owner entry for one class, or undefined when it is unauthorized. */
+export function authorizedOwner(owner, imports, allowedContracts, path)
 {
-	return owner !== undefined && owner.contracts.some(function _Owns(contract)
+	if (owner === undefined) return undefined;
+	return allowedContracts.find(function _Allowed(allowed)
 	{
-		const binding = imports.get(contract);
-		return binding !== undefined && allowedContracts.some(function _Allowed(allowed)
+		if (allowed.path !== path || allowed.adapter !== owner.name) return false;
+		return owner.contracts.some(function _Owns(contract)
 		{
-			return allowed.contract === binding.imported && allowed.importPath === binding.importPath;
+			const binding = imports.get(contract);
+			return binding !== undefined && allowed.contract === binding.imported && allowed.contractImportPath === binding.importPath;
 		});
 	});
+}
+
+/** Finds repository constructions and resolves their exact import source. */
+export function repositoryConstructions(source, classCandidates, imports)
+{
+	const constructions = [];
+	const pattern = /\bnew\s+([A-Za-z_$][\w$]*Repository)\s*\(([^)]*)\)/gu;
+	for (const match of source.matchAll(pattern))
+	{
+		const owner = enclosingClass(classCandidates, match.index ?? 0);
+		const binding = imports.get(match[1]);
+		const sameFile = classCandidates.some(function _SameFile(candidate) { return candidate.name === match[1]; });
+		constructions.push({
+			adapter: match[1],
+			argument: match[2].trim(),
+			importPath: binding?.importPath ?? (sameFile ? "<same-file>" : "<unbound>"),
+			index: match.index ?? 0,
+			owner,
+		});
+	}
+	return constructions;
+}
+
+/** Returns whether a repository receives the exact transaction binding in scope. */
+export function isTransactionScopedConstruction(source, construction, imports)
+{
+	if (!/^(?:this\.)?[A-Za-z_$][\w$]*$/u.test(construction.argument)) return false;
+	if (construction.argument.startsWith("this."))
+	{
+		if (construction.owner === undefined) return false;
+		const property = construction.argument.slice("this.".length);
+		return _TransactionClientProperties(source, construction.owner, imports).has(property);
+	}
+	return _TransactionCallbackBindings(source).some(function _OwnsBinding(binding)
+	{
+		return binding.name === construction.argument && binding.start <= construction.index && construction.index <= binding.end;
+	});
+}
+
+/** Returns whether a repository constructor accepts an imported Prisma TransactionClient. */
+export function repositoryAcceptsTransactionClient(source, owner, imports)
+{
+	if (owner === undefined) return false;
+	const types = _TransactionClientTypes(imports);
+	if (types.length === 0) return false;
+	const body = source.slice(owner.start, owner.end + 1);
+	const pattern = new RegExp(`\\bconstructor\\s*\\(\\s*[A-Za-z_$][\\w$]*\\s*:\\s*(?:${types.join("|")})\\b`, "u");
+	return pattern.test(body);
 }
 
 /** Finds the smallest class body containing one source offset. */
@@ -104,4 +154,48 @@ function _MatchingBrace(source, open)
 		}
 	}
 	return source.length;
+}
+
+/** Finds transaction-client properties declared by one class. */
+function _TransactionClientProperties(source, owner, imports)
+{
+	const properties = new Set();
+	const types = _TransactionClientTypes(imports);
+	if (types.length === 0) return properties;
+	const body = source.slice(owner.start, owner.end + 1);
+	const pattern = new RegExp(`\\b([A-Za-z_$][\\w$]*)\\s*:\\s*(?:${types.join("|")})\\b`, "gu");
+	for (const match of body.matchAll(pattern)) properties.add(match[1]);
+	return properties;
+}
+
+/** Returns local type spellings that prove Prisma transaction-client authority. */
+function _TransactionClientTypes(imports)
+{
+	const types = [];
+	for (const [local, binding] of imports.entries())
+	{
+		if (binding.importPath !== "@prisma/client") continue;
+		if (binding.imported === "Prisma") types.push(`${_EscapeRegex(local)}\\.TransactionClient`);
+		if (binding.imported === "TransactionClient") types.push(_EscapeRegex(local));
+	}
+	return types;
+}
+
+/** Finds the exact callback parameter and body for each direct Prisma transaction. */
+function _TransactionCallbackBindings(source)
+{
+	const bindings = [];
+	const pattern = /\.\$transaction\s*\(\s*async\s+(?:function\s+[A-Za-z_$][\w$]*\s*)?\(\s*([A-Za-z_$][\w$]*)(?:\s*:[^,)]+)?\s*\)\s*(?::\s*[^={]+)?(?:=>\s*)?\{/gu;
+	for (const match of source.matchAll(pattern))
+	{
+		const open = (match.index ?? 0) + match[0].lastIndexOf("{");
+		bindings.push({ name: match[1], start: open, end: _MatchingBrace(source, open) });
+	}
+	return bindings;
+}
+
+/** Escapes a literal for inclusion in a regular expression. */
+function _EscapeRegex(value)
+{
+	return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
 }


### PR DESCRIPTION
## Product context

OpenCrane relies on repositories to own persistence details and UnitOfWork adapters to own atomic transaction boundaries. Naming those patterns is not enough: a materializer could still reach Prisma directly, a repository could receive the root client inside a transaction, or a raw query could bypass review.

## What changes

- bind every authorized Prisma adapter to its exact class and source path
- require repository constructors used inside a UnitOfWork to receive the exact transaction callback binding and accept Prisma.TransactionClient
- reserve transaction creation for policy-declared UnitOfWork adapters
- detect direct, computed, and destructured Prisma raw-query access while excluding comments, strings, and unrelated receivers
- fail closed when owners are renamed, moved, newly introduced, or drift from policy
- validate exemption scope, owner, expiry, and real calendar dates
- keep reviewer agents, style checks, package scripts, and CI on the same boundary gate
- add positive and adversarial fixtures for root-client substitution, computed raw access, false positives, and policy drift

## Product impact

Persistence changes now have one auditable path. Domain services and materializers cannot silently reacquire database ownership, and transactions cannot appear atomic while a repository actually writes through the root client.

## Validation

- Prisma-boundary regression suite: 15/15
- diff audit: 0 new violations
- full audit: 758 files, 844 inherited violations tracked behind the diff floor
- module-growth suite: 12/12
- style and diff checks passed
- initial independent review found three bypasses; all were fixed
- second Claude Code review: CONFIRMED_FIXED