### PR TITLE
🐛 Repair browser-safe digest validation wave

### DIFF
--- a/apps/_infra/deploy-k8s/README.md
+++ b/apps/_infra/deploy-k8s/README.md
@@ -93,8 +93,9 @@ package imports it.
 - `opencrane-tool-runner.toolRunner` — the separate, default-deny tenant-tool namespace and aggregate
   Job quota; it contains no standing worker.
 - Reusable environment/multi-instance profiles live under `values/` and `platform/values/`.
-- `npx nx run deploy-k8s:test` renders the silo chart and verifies that the non-root server can read
-  projected ArtifactStore keys through its declared uid/gid and `fsGroup` contract.
+- `npx nx run deploy-k8s:test` and `npx nx run deploy-k8s:helm-lint` build a disposable copy from
+  the committed `Chart.lock`, linked to the current app-owned chart sources. They therefore validate
+  the release contract without rewriting the tracked `charts/*.tgz` archives.
 
 ## Sub-docs (the deep detail)
 

--- a/apps/_infra/deploy-k8s/platform/README.md
+++ b/apps/_infra/deploy-k8s/platform/README.md
@@ -9,12 +9,12 @@ local source consumer.
 | Path | Responsibility |
 |---|---|
 | `Chart.yaml`, `templates/` | Helm library chart providing labels, names, RBAC, endpoint, database, identity, and observability helpers to the parent release. It renders no workload by itself. |
-| `k8s-deploy.sh` | Provider-neutral install and upgrade engine used by the release wrapper. |
+| `k8s-deploy.sh` | Provider-neutral install and upgrade engine used by the release wrapper. Its optional `--verify` check reports pod readiness, DNS resolution, and public server/database health without changing deployment success. |
 | `configure-oidc.sh` | Surgical OIDC configuration for an existing installation. |
 | `provision.sh` | Optional local, GKE, or VPS cluster provisioning invoked before deployment. |
 | `terraform/` | GKE, networking, DNS, Artifact Registry, Workload Identity, and optional chart installation. |
 | `values/` | Reusable environment and multi-instance deployment profiles. |
-| `tests/` | Rendered network, pooler, key-permission, and skill-workload contract checks. |
+| `tests/` | Rendered network, pooler, key-permission, post-deploy health, and skill-workload contract checks. |
 
 Business logic does not belong here. Server-process infrastructure belongs in `libs/server/_infra`;
 backend capabilities belong in `libs/backend/server`; independently owned third-party workloads

--- a/apps/_infra/deploy-k8s/platform/current-chart-sources.sh
+++ b/apps/_infra/deploy-k8s/platform/current-chart-sources.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Builds the umbrella's file dependencies in a disposable chart tree. Contract
+# checks must render the same current app-owned sources as deploy.sh, but must
+# never leave timestamp-only archive churn in the checkout.
+
+_CURRENT_CHART_SOURCES_FIXTURE=""
+_CURRENT_CHART_SOURCES_TOKEN=""
+_CURRENT_CHART_SOURCES_DIR=""
+
+current_chart_sources_root()
+{
+  cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd
+}
+
+prepare_current_chart_sources()
+{
+  if [[ -n "$_CURRENT_CHART_SOURCES_FIXTURE" ]]; then
+    printf 'Current chart sources are already prepared by this shell.\n' >&2
+    return 1
+  fi
+
+  local root fixture_apps temp_parent fixture_name marker
+  root="$(current_chart_sources_root)"
+  temp_parent="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
+  _CURRENT_CHART_SOURCES_FIXTURE="$(mktemp -d "$temp_parent/opencrane-deploy-k8s-chart.XXXXXX")"
+  fixture_name="$(basename "$_CURRENT_CHART_SOURCES_FIXTURE")"
+  if [[ "$(dirname "$_CURRENT_CHART_SOURCES_FIXTURE")" != "$temp_parent" \
+    || ! "$fixture_name" =~ ^opencrane-deploy-k8s-chart\.[[:alnum:]]{6}$ ]]; then
+    printf 'mktemp returned an invalid chart fixture path: %s\n' "$_CURRENT_CHART_SOURCES_FIXTURE" >&2
+    _CURRENT_CHART_SOURCES_FIXTURE=""
+    return 1
+  fi
+
+  _CURRENT_CHART_SOURCES_TOKEN="$fixture_name:$$:$RANDOM$RANDOM"
+  marker="$_CURRENT_CHART_SOURCES_FIXTURE/.opencrane-chart-fixture-owner"
+  printf '%s\n' "$_CURRENT_CHART_SOURCES_TOKEN" >"$marker"
+  fixture_apps="$_CURRENT_CHART_SOURCES_FIXTURE/apps"
+  _CURRENT_CHART_SOURCES_DIR="$fixture_apps/_infra/deploy-k8s"
+
+  if ! (
+    mkdir -p "$fixture_apps/_infra"
+    cp -R "$root/apps/_infra/deploy-k8s" "$_CURRENT_CHART_SOURCES_DIR"
+
+    # Keep the dependency layout identical to Chart.yaml while linking every
+    # app-owned source directory. New local dependencies then need no fixture
+    # maintenance and Helm still verifies the committed Chart.lock digest.
+    for app_dir in "$root/apps"/*; do
+      [[ "$(basename "$app_dir")" == "_infra" ]] && continue
+      ln -s "$app_dir" "$fixture_apps/$(basename "$app_dir")"
+    done
+    for infra_dir in "$root/apps/_infra"/*; do
+      [[ "$(basename "$infra_dir")" == "deploy-k8s" ]] && continue
+      ln -s "$infra_dir" "$fixture_apps/_infra/$(basename "$infra_dir")"
+    done
+
+    helm dependency build --skip-refresh "$_CURRENT_CHART_SOURCES_DIR" >/dev/null
+  ); then
+    cleanup_current_chart_sources
+    return 1
+  fi
+}
+
+current_chart_sources_dir()
+{
+  if [[ -z "$_CURRENT_CHART_SOURCES_DIR" ]]; then
+    printf 'Current chart sources have not been prepared.\n' >&2
+    return 1
+  fi
+  printf '%s\n' "$_CURRENT_CHART_SOURCES_DIR"
+}
+
+cleanup_current_chart_sources()
+{
+  local fixture marker marker_token temp_parent fixture_name
+  fixture="$_CURRENT_CHART_SOURCES_FIXTURE"
+  if [[ -z "$fixture" ]]; then
+    return
+  fi
+
+  temp_parent="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
+  fixture_name="$(basename "$fixture")"
+  marker="$fixture/.opencrane-chart-fixture-owner"
+  marker_token=""
+  if [[ -f "$marker" ]]; then
+    IFS= read -r marker_token <"$marker"
+  fi
+  if [[ "$(dirname "$fixture")" != "$temp_parent" \
+    || ! "$fixture_name" =~ ^opencrane-deploy-k8s-chart\.[[:alnum:]]{6}$ \
+    || "$marker_token" != "$_CURRENT_CHART_SOURCES_TOKEN" ]]; then
+    printf 'Refusing to remove an unowned chart fixture: %s\n' "$fixture" >&2
+    return 1
+  fi
+
+  _CURRENT_CHART_SOURCES_FIXTURE=""
+  _CURRENT_CHART_SOURCES_TOKEN=""
+  _CURRENT_CHART_SOURCES_DIR=""
+  rm -rf -- "$fixture"
+}

--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -21,7 +21,7 @@
 #                            [--oidc-session-secret SECRET]
 #                            [--platform-operator-seed-email EMAIL]
 #                            [--platform-operator-groups CSV]
-#                            [--preflight] [--multi-ct]
+#                            [--preflight] [--multi-ct] [--verify] [--verify-insecure]
 #                            --postgres-credentials-secret NAME
 #                            [--postgres-owner OWNER]
 #                            --obot-postgres-credentials-secret NAME [--obot-postgres-owner OWNER]
@@ -78,6 +78,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POST_DEPLOY_VERIFY="$SCRIPT_DIR/post-deploy-verify.sh"
+if [[ ! -f "$POST_DEPLOY_VERIFY" ]]; then
+  echo "[k8s-deploy] Post-deploy verifier is missing at '$POST_DEPLOY_VERIFY'." >&2
+  exit 1
+fi
+source "$POST_DEPLOY_VERIFY"
 # The Helm chart no longer sits beside this engine — it is per-role and lives in the calling
 # app (the fleet chart, now in the WeOwnAI repo per elewa-git/opencrane#150; apps/_infra/deploy-k8s
 # = the silo chart, still here). Each app's deploy.sh wrapper exports OPENCRANE_CHART_DIR to its
@@ -176,9 +182,12 @@ PREFLIGHT="${OPENCRANE_PREFLIGHT:-0}"
 # Also via OPENCRANE_MULTI_CT=1.
 MULTI_CT="${OPENCRANE_MULTI_CT:-0}"
 
-# --verify runs an advisory post-deploy check (pods Running and host resolution). Never fails
-# the install. Also via OPENCRANE_VERIFY=1.
+# --verify runs an advisory post-deploy check (pods Running, host resolution, and the public
+# /healthz endpoint). Never fails the install. Also via OPENCRANE_VERIFY=1.
 VERIFY="${OPENCRANE_VERIFY:-0}"
+# --verify-insecure permits only the advisory HTTP check to accept a self-signed certificate.
+# It has no effect unless --verify is enabled. Also via OPENCRANE_VERIFY_INSECURE=1.
+VERIFY_INSECURE="${OPENCRANE_VERIFY_INSECURE:-0}"
 
 POSTGRES_RELEASE=""
 TIMEOUT="${TIMEOUT_SECONDS:-300}"
@@ -205,6 +214,7 @@ while [[ $# -gt 0 ]]; do
     --preflight)        PREFLIGHT="1"; shift ;;
     --multi-ct)         MULTI_CT="1"; shift ;;
     --verify)           VERIFY="1"; shift ;;
+    --verify-insecure)  VERIFY_INSECURE="1"; shift ;;
     --postgres-credentials-secret) POSTGRES_CREDENTIALS_SECRET="$2"; shift 2 ;;
     --postgres-owner) POSTGRES_OWNER="$2"; shift 2 ;;
     --obot-postgres-credentials-secret) OBOT_POSTGRES_CREDENTIALS_SECRET="$2"; shift 2 ;;
@@ -782,51 +792,6 @@ for _comp in fleet-manager clustertenant-manager; do
   fi
 done
 
-# Read the ACTUAL opencrane-ui host(s) off the deployed ingress(es). Never assume platform.<base>:
-# the fleet may serve the apex (controlPlaneHost=<base>), a silo serves <org>.<base>, and only the
-# unset default is platform.<base>. Ask the cluster what was rendered; fall back to platform.<base>
-# when no ingress exposes a host (e.g. ingress disabled) so callers still get a sensible hint.
-_control_plane_hosts() {
-  local hosts
-  hosts="$(kubectl get ingress -n "$NAMESPACE" \
-    -o jsonpath='{range .items[*]}{range .spec.rules[*]}{.host}{"\n"}{end}{end}' 2>/dev/null \
-    | grep -v '^$' | sort -u)"
-  if [[ -n "$hosts" ]]; then
-    echo "$hosts"
-  elif [[ -n "$BASE_DOMAIN" ]]; then
-    echo "platform.$BASE_DOMAIN"
-  fi
-}
-
-# 5. Post-deploy verify (opt-in, --verify). Advisory only — surfaces the failure modes that
-# leave an install unreachable (pods not Running or host not resolving).
-_post_deploy_verify() {
-  [[ "$VERIFY" == "1" ]] || return 0
-  log "Post-deploy verify (advisory — does not fail the install):"
-
-  # 1. Core pods Running — a CrashLoop/ImagePullBackOff that helm --wait didn't catch.
-  local notready
-  notready="$(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null | grep -c . || true)"
-  if [[ "$notready" == "0" ]]; then
-    log "  ✓ all pods Running/Succeeded in $NAMESPACE"
-  else
-    warn "  ✗ $notready pod(s) not Running in $NAMESPACE — kubectl get pods -n $NAMESPACE"
-  fi
-
-  # 2. Control-plane host(s) resolve to the ingress — the end of the chain a user hits first.
-  #    Read the rendered host(s) off the ingress so the apex / org host is checked, not platform.<base>.
-  if command -v dig >/dev/null 2>&1; then
-    local host resolved
-    for host in $(_control_plane_hosts); do
-      resolved="$(dig +short "$host" 2>/dev/null | tail -1)"
-      if [[ -n "$resolved" ]]; then
-        log "  ✓ $host resolves to $resolved"
-      else
-        warn "  ✗ $host does not resolve yet (DNS propagation lag or a missing record)."
-      fi
-    done
-  fi
-}
 _post_deploy_verify
 
 log "Done. OpenCrane is installed in namespace '$NAMESPACE'."

--- a/apps/_infra/deploy-k8s/platform/post-deploy-verify.sh
+++ b/apps/_infra/deploy-k8s/platform/post-deploy-verify.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Advisory checks run by k8s-deploy.sh after Helm reports a completed release.
+
+# Read actual UI hosts from the deployed ingresses. The fleet may serve the apex, while a silo
+# serves an organisation host, so verification must not assume platform.<base-domain>.
+_control_plane_hosts() {
+  local hosts
+  hosts="$(kubectl get ingress -n "$NAMESPACE" \
+    -o jsonpath='{range .items[*]}{range .spec.rules[*]}{.host}{"\n"}{end}{end}' 2>/dev/null \
+    | grep -v '^$' | sort -u)"
+  if [[ -n "$hosts" ]]; then
+    echo "$hosts"
+  elif [[ -n "$BASE_DOMAIN" ]]; then
+    echo "platform.$BASE_DOMAIN"
+  fi
+}
+
+_verify_health_url() {
+  local health_url="$1"
+  if [[ "$VERIFY_INSECURE" == "1" ]]; then
+    curl --silent --show-error --fail --connect-timeout 5 --max-time 10 \
+      --insecure "$health_url" >/dev/null
+  else
+    curl --silent --show-error --fail --connect-timeout 5 --max-time 10 \
+      "$health_url" >/dev/null
+  fi
+}
+
+# Verification stays advisory: every failed diagnostic becomes a warning, never a failed release.
+_post_deploy_verify() {
+  [[ "$VERIFY" == "1" ]] || return 0
+  log "Post-deploy verify (advisory — does not fail the install):"
+
+  local notready
+  notready="$(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null | grep -c . || true)"
+  if [[ "$notready" == "0" ]]; then
+    log "  ✓ all pods Running/Succeeded in $NAMESPACE"
+  else
+    warn "  ✗ $notready pod(s) not Running in $NAMESPACE — kubectl get pods -n $NAMESPACE"
+  fi
+
+  local host resolved
+  if command -v dig >/dev/null 2>&1; then
+    for host in $(_control_plane_hosts); do
+      resolved="$(dig +short "$host" 2>/dev/null | tail -1)"
+      if [[ -n "$resolved" ]]; then
+        log "  ✓ $host resolves to $resolved"
+      else
+        warn "  ✗ $host does not resolve yet (DNS propagation lag or a missing record)."
+      fi
+    done
+  fi
+
+  # /healthz is public by design and fails when the server cannot reach its durable database.
+  if command -v curl >/dev/null 2>&1; then
+    local health_url
+    for host in $(_control_plane_hosts); do
+      health_url="https://${host}/healthz"
+      if _verify_health_url "$health_url"; then
+        log "  ✓ $health_url is healthy"
+      else
+        warn "  ✗ $health_url is unavailable or unhealthy"
+      fi
+    done
+  else
+    warn "  ! curl is unavailable — skipping the HTTP health check."
+  fi
+}

--- a/apps/_infra/deploy-k8s/platform/tests/current-chart-sources-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/current-chart-sources-contract.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+HELPER="$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+AMBIENT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/opencrane-ambient-chart.XXXXXX")"
+AMBIENT_FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/opencrane-ambient-fixture.XXXXXX")"
+CALLS="$(mktemp)"
+FAILURE_CHART="$(mktemp)"
+REAL_HELM="$(command -v helm)"
+trap 'rm -rf -- "$AMBIENT_DIR" "$AMBIENT_FIXTURE"; rm -f "$CALLS" "$FAILURE_CHART"' EXIT
+
+touch "$AMBIENT_FIXTURE/must-survive"
+export OPENCRANE_DEPLOY_K8S_CHART_DIR="$AMBIENT_DIR"
+export OPENCRANE_DEPLOY_K8S_CHART_FIXTURE="$AMBIENT_FIXTURE"
+source "$HELPER"
+
+helm()
+{
+  printf '%s\n' "$*" >>"$CALLS"
+  "$REAL_HELM" "$@"
+}
+
+prepare_current_chart_sources
+prepared_chart="$(current_chart_sources_dir)"
+[[ "$prepared_chart" != "$AMBIENT_DIR" ]]
+grep -Fq 'dependency build --skip-refresh' "$CALLS"
+[[ -L "$prepared_chart/../../opencrane" ]]
+cleanup_current_chart_sources
+[[ -f "$AMBIENT_FIXTURE/must-survive" ]]
+
+helm()
+{
+  printf '%s\n' "$4" >"$FAILURE_CHART"
+  return 42
+}
+
+if prepare_current_chart_sources; then
+  printf 'Expected dependency build failure.\n' >&2
+  exit 1
+fi
+failed_chart="$(<"$FAILURE_CHART")"
+failed_fixture="${failed_chart%/apps/_infra/deploy-k8s}"
+[[ "$failed_fixture" != "$failed_chart" ]]
+if [[ -e "$failed_fixture" ]]; then
+  printf 'Failed dependency build left its fixture behind: %s\n' "$failed_fixture" >&2
+  exit 1
+fi
+[[ -f "$AMBIENT_FIXTURE/must-survive" ]]
+
+echo "current chart sources contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/tests/helm-lint-current-sources.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/helm-lint-current-sources.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
+
+helm lint "$CHART_DIR"

--- a/apps/_infra/deploy-k8s/platform/tests/platform-network-policy-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/platform-network-policy-contract.sh
@@ -6,9 +6,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
 OUTPUT="$(mktemp)"
 MULTI_OUTPUT="$(mktemp)"
-trap 'rm -f "$OUTPUT" "$MULTI_OUTPUT"' EXIT
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
 
-helm template opencrane-silo "$ROOT_DIR/apps/_infra/deploy-k8s" \
+prepare_current_chart_sources
+trap 'cleanup_current_chart_sources; rm -f "$OUTPUT" "$MULTI_OUTPUT"' EXIT
+CHART_DIR="$(current_chart_sources_dir)"
+
+helm template opencrane-silo "$CHART_DIR" \
   --set networkPolicy.mainNetworkDefaultDeny.enabled=true \
   --set-string networkPolicy.postgresPoolerName=opencrane-postgres-restored-pooler >"$OUTPUT"
 
@@ -29,7 +33,7 @@ if grep -Fq 'cnpg.io/cluster' <<<"$PLATFORM_POLICY"; then
   exit 1
 fi
 
-helm template oc-acme "$ROOT_DIR/apps/_infra/deploy-k8s" \
+helm template oc-acme "$CHART_DIR" \
   --namespace oc-acme \
   --values "$ROOT_DIR/apps/_infra/deploy-k8s/platform/values/multi-instance/oc-acme.yaml" \
   >"$MULTI_OUTPUT"

--- a/apps/_infra/deploy-k8s/platform/tests/post-deploy-health-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/post-deploy-health-contract.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+DEPLOY_SCRIPT="$ROOT_DIR/apps/_infra/deploy-k8s/platform/k8s-deploy.sh"
+VERIFY_SCRIPT="$ROOT_DIR/apps/_infra/deploy-k8s/platform/post-deploy-verify.sh"
+CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+CHART_FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$CHART_FIXTURE"' EXIT
+
+grep -Fq 'source "$POST_DEPLOY_VERIFY"' "$DEPLOY_SCRIPT"
+source "$VERIFY_SCRIPT"
+
+# Render against the current app-owned server chart, not the potentially stale committed archive.
+cp -R "$CHART_DIR/." "$CHART_FIXTURE"
+helm package "$ROOT_DIR/apps/opencrane/helm" --destination "$CHART_FIXTURE/charts" >/dev/null
+rendered_ingress="$(helm template opencrane-silo "$CHART_FIXTURE" \
+  --show-only templates/app-rollups.yaml)"
+health_route="$(awk '
+  /          - path: \/healthz/ { capture = 1 }
+  capture { print }
+  capture && /                  number:/ { exit }
+' <<<"$rendered_ingress")"
+grep -Fq '          - path: /healthz' <<<"$health_route"
+grep -Fq '            pathType: Exact' <<<"$health_route"
+grep -Fq '                name: opencrane-silo-opencrane-server' <<<"$health_route"
+grep -Fq '                  number: 8080' <<<"$health_route"
+
+_run_verify() {
+  local curl_outcome="$1"
+  local insecure="$2"
+  local missing_curl="${3:-0}"
+  local curl_args_file
+  curl_args_file="$(mktemp)"
+
+  VERIFY=1
+  VERIFY_INSECURE="$insecure"
+  NAMESPACE=opencrane-acme
+  log() { printf '%s\n' "$*"; }
+  warn() { printf '%s\n' "$*"; }
+  kubectl() { return 0; }
+  dig() { printf '127.0.0.1\n'; }
+  _control_plane_hosts() { printf 'acme.opencrane.local\n'; }
+  curl() {
+    printf '%s\n' "$@" >"$curl_args_file"
+    [[ "$curl_outcome" == "healthy" ]]
+  }
+  command() {
+    if [[ "$missing_curl" == "1" && "${1:-}" == "-v" && "${2:-}" == "curl" ]]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+
+  _post_deploy_verify
+  cat "$curl_args_file"
+  rm -f "$curl_args_file"
+}
+
+healthy_output="$(_run_verify healthy 0)"
+grep -Fq 'https://acme.opencrane.local/healthz is healthy' <<<"$healthy_output"
+grep -Fq -- '--connect-timeout' <<<"$healthy_output"
+grep -Fq -- '--max-time' <<<"$healthy_output"
+if grep -Fq -- '--insecure' <<<"$healthy_output"; then
+  echo "post-deploy health check disables TLS verification by default" >&2
+  exit 1
+fi
+
+insecure_output="$(_run_verify healthy 1)"
+grep -Fq -- '--insecure' <<<"$insecure_output"
+
+unhealthy_output="$(_run_verify unhealthy 0)"
+grep -Fq 'https://acme.opencrane.local/healthz is unavailable or unhealthy' <<<"$unhealthy_output"
+
+missing_curl_output="$(_run_verify healthy 0 1)"
+grep -Fq 'curl is unavailable — skipping the HTTP health check.' <<<"$missing_curl_output"
+
+echo "post-deploy health contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+
+for contract in \
+  current-chart-sources-contract.sh \
+  server-key-permissions-contract.sh \
+  server-runtime-cleanup-rbac-contract.sh \
+  server-network-policy-contract.sh \
+  platform-network-policy-contract.sh \
+  skill-workload-contract.sh; do
+  bash "$ROOT_DIR/apps/_infra/deploy-k8s/platform/tests/$contract"
+done

--- a/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
@@ -9,6 +9,7 @@ for contract in \
   server-runtime-cleanup-rbac-contract.sh \
   server-network-policy-contract.sh \
   platform-network-policy-contract.sh \
+  post-deploy-health-contract.sh \
   skill-workload-contract.sh; do
   bash "$ROOT_DIR/apps/_infra/deploy-k8s/platform/tests/$contract"
 done

--- a/apps/_infra/deploy-k8s/platform/tests/server-key-permissions-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/server-key-permissions-contract.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR")"
 server_manifest="$(printf '%s\n' "$rendered" | awk '

--- a/apps/_infra/deploy-k8s/platform/tests/server-network-policy-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/server-network-policy-contract.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR" \
   --set-string networkPolicy.postgresPoolerName=opencrane-postgres-restored-pooler)"

--- a/apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh
@@ -9,6 +9,14 @@ trap cleanup_current_chart_sources EXIT
 CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR")"
+ct_read_role="$(printf '%s\n' "$rendered" | awk '
+  BEGIN { RS="---" }
+  $0 ~ /\nkind: ClusterRole\n/ && $0 ~ /\n  name: opencrane-silo-opencrane-server-ct-read-default\n/ { print $0 }
+')"
+ct_read_binding="$(printf '%s\n' "$rendered" | awk '
+  BEGIN { RS="---" }
+  $0 ~ /\nkind: ClusterRoleBinding\n/ && $0 ~ /\n  name: opencrane-silo-opencrane-server-ct-read-default\n/ { print $0 }
+')"
 cleanup_rbac="$(printf '%s\n' "$rendered" | awk '
   function flush_document() {
     if ((is_role || is_binding) && is_cleanup_name) {
@@ -40,16 +48,48 @@ cleanup_rbac="$(printf '%s\n' "$rendered" | awk '
   }
 ')"
 
-[[ "$(grep -xc 'kind: Role' <<<"$cleanup_rbac")" -eq 2 ]]
-[[ "$(grep -xc 'kind: RoleBinding' <<<"$cleanup_rbac")" -eq 2 ]]
-grep -Fq '  namespace: opencrane-silo-runtime' <<<"$cleanup_rbac"
-grep -Fq '  namespace: opencrane-silo-managed-runtime' <<<"$cleanup_rbac"
-[[ "$(grep -Fc '    resources: ["jobs"]' <<<"$cleanup_rbac")" -eq 2 ]]
-[[ "$(grep -Fc '    verbs: ["get", "delete"]' <<<"$cleanup_rbac")" -eq 2 ]]
-[[ "$(grep -Fc '  name: opencrane-silo-opencrane-server' <<<"$cleanup_rbac")" -eq 2 ]]
-[[ "$(grep -Fc '    namespace: default' <<<"$cleanup_rbac")" -eq 2 ]]
+[[ "$(grep -xc 'kind: ClusterRole' <<<"$ct_read_role")" -eq 1 ]]
+grep -Fq '    resources: ["clustertenants"]' <<<"$ct_read_role"
+if grep -Fq 'subjects:' <<<"$ct_read_role"; then
+  echo "ClusterTenant reader ClusterRole contains binding subjects" >&2
+  exit 1
+fi
+[[ "$(grep -xc 'kind: ClusterRoleBinding' <<<"$ct_read_binding")" -eq 1 ]]
+grep -Fq '  kind: ClusterRole' <<<"$ct_read_binding"
+if [[ "$(grep -Fc '  name: opencrane-silo-opencrane-server-ct-read-default' <<<"$ct_read_binding")" -ne 2 ]]; then
+  echo "ClusterTenant reader binding does not reference its exact ClusterRole" >&2
+  exit 1
+fi
+grep -Fq '    name: opencrane-silo-opencrane-server' <<<"$ct_read_binding"
+grep -Fq '    namespace: default' <<<"$ct_read_binding"
 
-if grep -Eq 'verbs:.*(create|patch|update|list|watch)|resources:.*(pods|secrets|deployments)' <<<"$cleanup_rbac"; then
+[[ -z "$cleanup_rbac" ]]
+
+test_digest="sha256:$(printf 'a%.0s' {1..64})"
+enabled_rendered="$(helm template opencrane-silo "$CHART_DIR" \
+  --set agentController.enabled=true \
+  --set-string agentController.kubernetesApiServerCidrs[0]=10.43.0.1/32 \
+  --set-string agentController.image.digest="$test_digest" \
+  --set-string agentController.runtimeProfile.image.digest="$test_digest" \
+  --set-string agentController.skillWorkloadProfiles.authoring.image.digest="$test_digest" \
+  --set-string agentController.skillWorkloadProfiles.toolRunner.image.digest="$test_digest")"
+enabled_cleanup_rbac="$(printf '%s\n' "$enabled_rendered" | awk '
+  BEGIN { RS="---" }
+  $0 ~ /\nkind: Role(Binding)?\n/ && $0 ~ /\n  name: opencrane-silo-runtime-cleanup\n/ { print $0 "---" }
+')"
+if [[ "$(grep -xc 'kind: Role' <<<"$enabled_cleanup_rbac")" -ne 2 \
+  || "$(grep -xc 'kind: RoleBinding' <<<"$enabled_cleanup_rbac")" -ne 2 ]]; then
+  echo "enabled runtime cleanup RBAC must have one Role and RoleBinding per runtime namespace" >&2
+  exit 1
+fi
+grep -Fq '  namespace: opencrane-silo-runtime' <<<"$enabled_cleanup_rbac"
+grep -Fq '  namespace: opencrane-silo-managed-runtime' <<<"$enabled_cleanup_rbac"
+[[ "$(grep -Fc '    resources: ["jobs"]' <<<"$enabled_cleanup_rbac")" -eq 2 ]]
+[[ "$(grep -Fc '    verbs: ["get", "delete"]' <<<"$enabled_cleanup_rbac")" -eq 2 ]]
+[[ "$(grep -Fc '  name: opencrane-silo-opencrane-server' <<<"$enabled_cleanup_rbac")" -eq 2 ]]
+[[ "$(grep -Fc '    namespace: default' <<<"$enabled_cleanup_rbac")" -eq 2 ]]
+
+if grep -Eq 'verbs:.*(create|patch|update|list|watch)|resources:.*(pods|secrets|deployments)' <<<"$enabled_cleanup_rbac"; then
   echo "opencrane-server runtime cleanup RBAC exceeds exact Job get/delete authority" >&2
   exit 1
 fi

--- a/apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR")"
 cleanup_rbac="$(printf '%s\n' "$rendered" | awk '

--- a/apps/_infra/deploy-k8s/platform/tests/skill-workload-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/skill-workload-contract.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR" \
   --set-string opencrane-skill-authoring.skillAuthoring.namespace=authoring-contract \

--- a/apps/_infra/deploy-k8s/project.json
+++ b/apps/_infra/deploy-k8s/project.json
@@ -7,19 +7,12 @@
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": [
-          "bash apps/_infra/deploy-k8s/platform/tests/server-key-permissions-contract.sh",
-            "bash apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh",
-          "bash apps/_infra/deploy-k8s/platform/tests/server-network-policy-contract.sh",
-          "bash apps/_infra/deploy-k8s/platform/tests/platform-network-policy-contract.sh",
-          "bash apps/_infra/deploy-k8s/platform/tests/skill-workload-contract.sh"
-        ],
-        "parallel": false
+        "command": "bash apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh"
       }
     },
     "helm-lint": {
       "executor": "nx:run-commands",
-      "options": { "command": "helm lint apps/_infra/deploy-k8s" }
+      "options": { "command": "bash apps/_infra/deploy-k8s/platform/tests/helm-lint-current-sources.sh" }
     },
     "dependency-status": {
       "executor": "nx:run-commands",

--- a/apps/agent-controller/tests/helm-contract.sh
+++ b/apps/agent-controller/tests/helm-contract.sh
@@ -68,7 +68,7 @@ grep -Fq 'opencrane.ai/runtime-release:' "$RUNTIME_NAMESPACE"
 grep -Fq 'pod-security.kubernetes.io/enforce: restricted' "$RUNTIME_NAMESPACE"
 grep -Fq 'pod-security.kubernetes.io/enforce-version: latest' "$RUNTIME_NAMESPACE"
 grep -Fq 'name: agent-runtime-default' "$MANIFEST"
-grep -A4 -F 'name: agent-runtime-default' "$MANIFEST" | grep -Fq 'namespace: oc-opencrane-runtime'
+grep -A4 -F 'name: agent-runtime-default' "$MANIFEST" | grep -F 'namespace: oc-opencrane-runtime' >/dev/null
 test -s "$RUNTIME_QUOTA"
 grep -Fq 'pods: "20"' "$RUNTIME_QUOTA"
 grep -Fq 'count/jobs.batch: "20"' "$RUNTIME_QUOTA"
@@ -87,11 +87,11 @@ grep -Fq 'verbs: ["list"]' "$ROLE"
 # Attempt-key Secrets are create-only in the runtime namespace: the exact resource+verb must appear,
 # and the secrets rule must grant nothing beyond create.
 grep -Fq 'resources: ["secrets"]' "$ROLE"
-if ! grep -A1 'resources: \["secrets"\]' "$ROLE" | grep -Fq 'verbs: ["create"]'; then
+if ! grep -A1 'resources: \["secrets"\]' "$ROLE" | grep -F 'verbs: ["create"]' >/dev/null; then
   echo "agent-controller secrets rule must be create-only" >&2
   exit 1
 fi
-if grep -A1 'resources: \["secrets"\]' "$ROLE" | grep -Eq '"(get|list|patch|delete|update|watch)"'; then
+if grep -A1 'resources: \["secrets"\]' "$ROLE" | grep -E '"(get|list|patch|delete|update|watch)"' >/dev/null; then
   echo "agent-controller secrets rule exceeds create-only" >&2
   exit 1
 fi
@@ -101,14 +101,14 @@ if grep -Eq 'networkpolicies|serviceaccounts|deployments|configmaps|"(delete|upd
 fi
 test -s "$BINDING"
 grep -Fq 'namespace: oc-opencrane-runtime' "$BINDING"
-grep -A4 -F 'kind: ServiceAccount' "$BINDING" | grep -Fq 'namespace: server-ns'
+grep -A4 -F 'kind: ServiceAccount' "$BINDING" | grep -F 'namespace: server-ns' >/dev/null
 # The same controller KSA has an independently namespaced least-privilege RoleBinding for managed
 # runtime attempts; it receives no cluster role and no permission outside the two exact namespaces.
-grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -Fq 'name: agent-controller'
-grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -Fq 'resources: ["jobs"]'
-grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -Fq 'resources: ["pods"]'
-grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -Fq 'resources: ["secrets"]'
-grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -Fq 'namespace: server-ns'
+grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -F 'name: agent-controller' >/dev/null
+grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -F 'resources: ["jobs"]' >/dev/null
+grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -F 'resources: ["pods"]' >/dev/null
+grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -F 'resources: ["secrets"]' >/dev/null
+grep -A28 -F 'namespace: oc-opencrane-managed-runtime' "$MANIFEST" | grep -F 'namespace: server-ns' >/dev/null
 
 # Only the OpenCrane server receives runtime Job deletion, through a separately named Role.
 test -s "$CLEANUP_ROLE"
@@ -120,28 +120,28 @@ if grep -Eq '"(create|list|patch|update|watch)"|resources: \["(pods|secrets)"\]'
   exit 1
 fi
 test -s "$CLEANUP_BINDING"
-grep -A4 -F 'kind: ServiceAccount' "$CLEANUP_BINDING" | grep -Fq 'name: oc-opencrane-opencrane-server'
-grep -A4 -F 'kind: ServiceAccount' "$CLEANUP_BINDING" | grep -Fq 'namespace: server-ns'
+grep -A4 -F 'kind: ServiceAccount' "$CLEANUP_BINDING" | grep -F 'name: oc-opencrane-opencrane-server' >/dev/null
+grep -A4 -F 'kind: ServiceAccount' "$CLEANUP_BINDING" | grep -F 'namespace: server-ns' >/dev/null
 
 # Governed skill namespaces are derived from their owning charts. Their controller Roles can create,
 # exact-adopt, and conditionally release Jobs, plus list the exact Job-owned Pod for registration.
-grep -A16 -F 'namespace: opencrane-skill-authoring' "$MANIFEST" | grep -Fq 'name: agent-controller-skill-workloads'
-grep -A16 -F 'namespace: opencrane-tools' "$MANIFEST" | grep -Fq 'name: agent-controller-skill-workloads'
-grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -Fq 'verbs: ["get", "create", "patch"]'
-grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -Fq 'resources: ["pods"]'
-grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -Fq 'verbs: ["list"]'
-if grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -Eq '"(delete|update|watch)"'; then
+grep -A16 -F 'namespace: opencrane-skill-authoring' "$MANIFEST" | grep -F 'name: agent-controller-skill-workloads' >/dev/null
+grep -A16 -F 'namespace: opencrane-tools' "$MANIFEST" | grep -F 'name: agent-controller-skill-workloads' >/dev/null
+grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -F 'verbs: ["get", "create", "patch"]' >/dev/null
+grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -F 'resources: ["pods"]' >/dev/null
+grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -F 'verbs: ["list"]' >/dev/null
+if grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -E '"(delete|update|watch)"' >/dev/null; then
   echo "skill workload Roles exceed fenced Job release and Pod discovery authority" >&2
   exit 1
 fi
 
 # The controller receives both profile-owned namespaces in one immutable map; it never gets a
 # process-wide runtime namespace that could let one profile borrow another's RoleBinding.
-grep -A1 -F 'name: AGENT_CONTROLLER_PROFILES_JSON' "$MANIFEST" | grep -Fq '\"namespace\":\"oc-opencrane-runtime\"'
-grep -A1 -F 'name: AGENT_CONTROLLER_PROFILES_JSON' "$MANIFEST" | grep -Fq '\"namespace\":\"oc-opencrane-managed-runtime\"'
-grep -A1 -F 'name: AGENT_CONTROLLER_PROFILES_JSON' "$MANIFEST" | grep -Fq '\"identityProfile\":\"managed\"'
-grep -A1 -F 'name: AGENT_CONTROLLER_PROFILES_JSON' "$MANIFEST" | grep -Fq '\"serviceAccountName\":\"managed-agent-runtime-default\"'
-grep -B8 -A8 -F 'name: oc-opencrane-agent-controller' "$MANIFEST" | grep -Fq 'namespace: server-ns'
+grep -A1 -F 'name: AGENT_CONTROLLER_PROFILES_JSON' "$MANIFEST" | grep -F '\"namespace\":\"oc-opencrane-runtime\"' >/dev/null
+grep -A1 -F 'name: AGENT_CONTROLLER_PROFILES_JSON' "$MANIFEST" | grep -F '\"namespace\":\"oc-opencrane-managed-runtime\"' >/dev/null
+grep -A1 -F 'name: AGENT_CONTROLLER_PROFILES_JSON' "$MANIFEST" | grep -F '\"identityProfile\":\"managed\"' >/dev/null
+grep -A1 -F 'name: AGENT_CONTROLLER_PROFILES_JSON' "$MANIFEST" | grep -F '\"serviceAccountName\":\"managed-agent-runtime-default\"' >/dev/null
+grep -B8 -A8 -F 'name: oc-opencrane-agent-controller' "$MANIFEST" | grep -F 'namespace: server-ns' >/dev/null
 
 # Helm, not the controller, owns the namespace-wide network boundary.
 test -s "$CONTROLLER_POLICY"
@@ -157,7 +157,7 @@ if grep -Fq 'ingress:' "$RUNTIME_EGRESS"; then
   echo "runtime egress policy redundantly owns ingress" >&2
   exit 1
 fi
-grep -A20 -F 'name: oc-opencrane-agent-runtime-egress' "$MANIFEST" | grep -Fq 'namespace: oc-opencrane-runtime'
+grep -A20 -F 'name: oc-opencrane-agent-runtime-egress' "$MANIFEST" | grep -F 'namespace: oc-opencrane-runtime' >/dev/null
 grep -Fq 'opencrane.ai/runtime-release:' "$MANIFEST"
 grep -Fq 'kubernetes.io/metadata.name: server-ns' "$MANIFEST"
 grep -Fq 'kubernetes.io/metadata.name: kube-system' "$MANIFEST"
@@ -165,16 +165,16 @@ grep -Fq 'app.kubernetes.io/component: litellm' "$RUNTIME_EGRESS"
 grep -Fq 'port: 4000' "$RUNTIME_EGRESS"
 test -s "$SERVER_POLICY"
 grep -Fq 'cidr: "10.43.0.1/32"' "$SERVER_POLICY"
-grep -A3 -F 'cidr: "10.43.0.1/32"' "$SERVER_POLICY" | grep -Fq 'port: 443'
+grep -A3 -F 'cidr: "10.43.0.1/32"' "$SERVER_POLICY" | grep -F 'port: 443' >/dev/null
 grep -Fq 'cidr: "172.18.0.2/32"' "$SERVER_POLICY"
-grep -A3 -F 'cidr: "172.18.0.2/32"' "$SERVER_POLICY" | grep -Fq 'port: 6443'
+grep -A3 -F 'cidr: "172.18.0.2/32"' "$SERVER_POLICY" | grep -F 'port: 6443' >/dev/null
 grep -Fq 'cidr: "172.18.0.2/32"' "$CONTROLLER_POLICY"
-grep -A3 -F 'cidr: "172.18.0.2/32"' "$CONTROLLER_POLICY" | grep -Fq 'port: 6443'
+grep -A3 -F 'cidr: "172.18.0.2/32"' "$CONTROLLER_POLICY" | grep -F 'port: 6443' >/dev/null
 
 # Admission is fail closed, scoped by the release-unique namespace label, and grants no rights.
 test -s "$ADMISSION"
 grep -Fq 'failurePolicy: Fail' "$ADMISSION"
-grep -A2 -F '  matchConstraints:' "$ADMISSION" | grep -Fq '    matchPolicy: Exact'
+grep -A2 -F '  matchConstraints:' "$ADMISSION" | grep -F '    matchPolicy: Exact' >/dev/null
 grep -Fq 'operations: ["CREATE", "UPDATE"]' "$ADMISSION"
 grep -Fq 'resources: ["jobs"]' "$ADMISSION"
 grep -Fq 'request.userInfo.username == "system:serviceaccount:server-ns:agent-controller"' "$ADMISSION"
@@ -205,8 +205,8 @@ grep -Fq "object.spec.template.spec.containers[0].env[2].name == 'OPENCRANE_SKIL
 grep -Fq "object.spec.template.spec.volumes[1].name == 'bootstrap-reference'" "$ADMISSION"
 grep -Fq "object.spec.template.spec.volumes[1].downwardAPI.items[0].fieldRef.fieldPath == \"metadata.annotations['opencrane.ai/capability-reference']\"" "$ADMISSION"
 grep -Fq "object.spec.template.spec.volumes[2].name == 'scratch'" "$ADMISSION"
-grep -A1 -F 'name: AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON' "$SKILL_URL_OVERRIDE" | grep -Fq 'http://oc-opencrane-opencrane-server.server-ns.svc.cluster.local:8081/api/internal/agent-runtime'
-if grep -A1 -F 'name: AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON' "$SKILL_URL_OVERRIDE" | grep -Fq 'http://override.example:8081'; then
+grep -A1 -F 'name: AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON' "$SKILL_URL_OVERRIDE" | grep -F 'http://oc-opencrane-opencrane-server.server-ns.svc.cluster.local:8081/api/internal/agent-runtime' >/dev/null
+if grep -A1 -F 'name: AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON' "$SKILL_URL_OVERRIDE" | grep -F 'http://override.example:8081' >/dev/null; then
   echo "governed worker bootstrap must not inherit the mutable runtime endpoint override" >&2
   exit 1
 fi
@@ -272,9 +272,9 @@ grep -Fq 'validationActions: [Deny]' "$MANIFEST"
 # Disabled renders no controller-owned namespace, RBAC, network policy, profile map, or
 # cluster-scoped admission residue.
 grep -Fq 'cidr: "10.43.0.1/32"' "$DISABLED"
-grep -A3 -F 'cidr: "10.43.0.1/32"' "$DISABLED" | grep -Fq 'port: 443'
+grep -A3 -F 'cidr: "10.43.0.1/32"' "$DISABLED" | grep -F 'port: 443' >/dev/null
 grep -Fq 'cidr: "172.18.0.2/32"' "$DISABLED"
-grep -A3 -F 'cidr: "172.18.0.2/32"' "$DISABLED" | grep -Fq 'port: 6443'
+grep -A3 -F 'cidr: "172.18.0.2/32"' "$DISABLED" | grep -F 'port: 6443' >/dev/null
 if grep -Eq 'kind: ValidatingAdmissionPolicy|name: oc-opencrane-runtime|name: oc-opencrane-managed-runtime|name: oc-opencrane-agent-runtime|opencrane.ai/runtime-release|AGENT_CONTROLLER_PROFILES_JSON' "$DISABLED"; then
   echo "disabled agent-controller rendered runtime authority" >&2
   exit 1

--- a/apps/channel-proxy/package.json
+++ b/apps/channel-proxy/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "dependencies": {
+    "@noble/hashes": "1.8.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.78.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",

--- a/apps/opencrane/HELM.md
+++ b/apps/opencrane/HELM.md
@@ -1,3 +1,3 @@
 # Server Helm ownership
 
-The OpenCrane server application owns its Deployment, identity and RBAC, Services, edge ingress and certificate, and ingress NetworkPolicy as named Helm templates under `helm/`. The silo umbrella composes these resources with its parent release context.
+The OpenCrane server application owns its Deployment, identity and RBAC, Services, edge ingress and certificate, and ingress NetworkPolicy as named Helm templates under `helm/`. The edge ingress sends exact `/healthz` requests to the public server listener before its SPA catch-all, so deployment verification observes server and database health. The silo umbrella composes these resources with its parent release context.

--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -95,7 +95,7 @@ transport, and external-service seams belong under
 [`libs/server/_infra`](../../libs/server/_infra/README.md). Libraries never import this app.
 
 The public and workload-facing APIs share a process but not an exposure boundary. Public ingress
-routes only to `:8080`. The `:8081` Service is restricted by Kubernetes NetworkPolicy, and endpoints
+routes `/api` and the database-aware `/healthz` endpoint only to `:8080`. The `:8081` Service is restricted by Kubernetes NetworkPolicy, and endpoints
 that grant workload authority additionally review the caller's projected Kubernetes identity and
 bind it to durable assignment evidence.
 

--- a/apps/opencrane/helm/templates/_ingress.tpl
+++ b/apps/opencrane/helm/templates/_ingress.tpl
@@ -32,12 +32,19 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          # Same-origin hosting: the OpenCrane API under /api, the bounded channel HTTP/SSE
-          # endpoints under /v1, and the org-admin SPA under /. One origin gives the channel
+          # Same-origin hosting: server health at /healthz, the OpenCrane API under /api, the
+          # bounded channel HTTP/SSE endpoints under /v1, and the org-admin SPA under /. One origin gives the channel
           # proxy first-party session cookies without CORS. Helm OWNS these rules,
           # so the frontend layer never has to kubectl-patch the Ingress out-of-band (that
           # patch fought `helm upgrade` via an SSA field-manager conflict and reverted on
           # every reconcile — see docs/optimalisation-plan.md §5).
+          - path: /healthz
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "opencrane.fullname" . }}-opencrane-server
+                port:
+                  number: {{ .Values.clustertenantManager.service.port }}
           - path: /api
             pathType: Prefix
             backend:

--- a/apps/opencrane/helm/templates/_rbac.tpl
+++ b/apps/opencrane/helm/templates/_rbac.tpl
@@ -1,45 +1,10 @@
 {{- define "opencrane.server.rbac" -}}
-{{- $managedPlane := (index .Values "managedAgentRuntimePlane").managedAgentRuntime -}}
-{{- $managedRuntimeNamespace := default (printf "%s-managed-runtime" .Release.Name | trunc 63 | trimSuffix "-") $managedPlane.namespace -}}
-{{- $runtimeNamespaces := list (include "opencrane.agentController.runtimeNamespace" .) $managedRuntimeNamespace -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opencrane.fullname" . }}-opencrane-server
   labels:
     {{- include "opencrane.labels" . | nindent 4 }}
-{{- range $runtimeNamespace := $runtimeNamespaces }}
----
-# Runtime cleanup is server-fenced in Postgres first. This Role grants only the physical
-# observation and UID-preconditioned deletion required after that durable claim exists.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ printf "%s-runtime-cleanup" (include "opencrane.fullname" $) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $runtimeNamespace }}
-  labels:
-    {{- include "opencrane.labels" $ | nindent 4 }}
-rules:
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["get", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ printf "%s-runtime-cleanup" (include "opencrane.fullname" $) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $runtimeNamespace }}
-  labels:
-    {{- include "opencrane.labels" $ | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ printf "%s-runtime-cleanup" (include "opencrane.fullname" $) | trunc 63 | trimSuffix "-" }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "opencrane.fullname" $ }}-opencrane-server
-    namespace: {{ $.Release.Namespace }}
-{{- end }}
 ---
 # TokenReview is cluster-scoped and is required only for projected workload credentials on
 # internal pod-identity routes. Runtime Job ServiceAccounts receive no Kubernetes RBAC at all.
@@ -68,7 +33,8 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "opencrane.fullname" . }}-opencrane-server
     namespace: {{ .Release.Namespace }}
-{{- /*
+---
+{{/*
   Per-org OIDC login may read the ClusterTenant host/client binding. It never mutates the CR.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/apps/postgres/scripts/publish-initdb-baseline-config-map.sh
+++ b/apps/postgres/scripts/publish-initdb-baseline-config-map.sh
@@ -20,6 +20,7 @@ work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT
 baseline_identity_input="$work_dir/baseline-identity.sql"
 rendered_baseline="$work_dir/target-baseline.sql"
+rendered_config_map="$work_dir/baseline-config-map.yaml"
 quoted_owner="$(printf '%s' "$database_owner" | sed 's/"/""/g')"
 
 function _sha256_file()
@@ -85,7 +86,12 @@ kubectl create configmap "$config_map_name" \
   -o json \
   | kubectl patch --local -f - --type=merge \
       -p "{\"immutable\":true,\"metadata\":{\"annotations\":{\"opencrane.ai/baseline-sha256\":\"$baseline_digest\"}}}" \
-      -o yaml \
-  | kubectl apply -f - >/dev/null
+      -o yaml >"$rendered_config_map"
+
+# Another deployment may publish the same content-addressed object after the initial lookup.
+# Accept that race only when the winner's immutable bytes pass the verification above.
+if ! kubectl create -f "$rendered_config_map" >/dev/null; then
+  bash "$0" "$namespace" "$database_owner" "$baseline_file" --verify-only >/dev/null
+fi
 
 printf '%s\n' "$config_map_name"

--- a/apps/postgres/tests/baseline-publisher-contract.sh
+++ b/apps/postgres/tests/baseline-publisher-contract.sh
@@ -17,34 +17,55 @@ set -euo pipefail
 
 case "$1" in
   get)
-    if [[ "${FAKE_EXISTING_MODE:-absent}" == "absent" ]]; then
-      exit 1
-    fi
-    case "$*" in
-      *baseline-sha256*)
-        printf '%s' "$FAKE_BASELINE_DIGEST"
-        ;;
-      *"{.immutable}"*)
-        if [[ "$FAKE_EXISTING_MODE" == "mutable" ]]; then
-          printf 'false'
-        else
+    if [[ "${FAKE_CREATE_RACE:-0}" == "1" && -f "$FAKE_RACE_MARKER" ]]; then
+      case "$*" in
+        *baseline-sha256*)
+          "$REAL_KUBECTL" patch --local -f "$CAPTURE_FILE" --type=merge -p '{}' -o jsonpath='{.metadata.annotations.opencrane\.ai/baseline-sha256}'
+          ;;
+        *"{.immutable}"*)
           printf 'true'
-        fi
-        ;;
-      *target-baseline*)
-        if [[ "$FAKE_EXISTING_MODE" == "tampered" ]]; then
-          printf 'SELECT 1; -- substituted content'
-        else
-          cat "$FAKE_EXISTING_SQL_FILE"
-        fi
-        ;;
-    esac
+          ;;
+        *target-baseline*)
+          "$REAL_KUBECTL" patch --local -f "$CAPTURE_FILE" --type=merge -p '{}' -o jsonpath='{.data.target-baseline\.sql}'
+          ;;
+      esac
+    elif [[ "${FAKE_EXISTING_MODE:-absent}" == "absent" ]]; then
+      exit 1
+    else
+      case "$*" in
+        *baseline-sha256*)
+          printf '%s' "$FAKE_BASELINE_DIGEST"
+          ;;
+        *"{.immutable}"*)
+          if [[ "$FAKE_EXISTING_MODE" == "mutable" ]]; then
+            printf 'false'
+          else
+            printf 'true'
+          fi
+          ;;
+        *target-baseline*)
+          if [[ "$FAKE_EXISTING_MODE" == "tampered" ]]; then
+            printf 'SELECT 1; -- substituted content'
+          else
+            cat "$FAKE_EXISTING_SQL_FILE"
+          fi
+          ;;
+      esac
+    fi
     ;;
-  create|patch)
+  create)
+    if [[ "${2:-}" == "-f" && "${3:-}" != "-" ]]; then
+      cp "$3" "$CAPTURE_FILE"
+      if [[ "${FAKE_CREATE_RACE:-0}" == "1" ]]; then
+        touch "$FAKE_RACE_MARKER"
+        exit 1
+      fi
+    else
+      exec "$REAL_KUBECTL" "$@"
+    fi
+    ;;
+  patch)
     exec "$REAL_KUBECTL" "$@"
-    ;;
-  apply)
-    cat >"$CAPTURE_FILE"
     ;;
   *)
     echo "unexpected kubectl command: $*" >&2
@@ -65,12 +86,21 @@ grep -q 'GRANT SELECT ON TABLE "opencrane_bootstrap"."target_baseline" TO "owner
 grep -Eq 'VALUES \(TRUE, '\''[0-9a-f]{64}'\''\);' "$CAPTURE_FILE"
 grep -q 'SET ROLE "owner""quoted";' "$CAPTURE_FILE"
 grep -q 'OpenCrane target database baseline' "$CAPTURE_FILE"
+if grep -q 'kubectl.kubernetes.io/last-applied-configuration' "$CAPTURE_FILE"; then
+  echo "publisher added the client-side apply annotation to the baseline ConfigMap" >&2
+  exit 1
+fi
 
 expected_sql="$TEST_DIR/expected-target-baseline.sql"
 "$REAL_KUBECTL" patch --local -f "$CAPTURE_FILE" --type=merge -p '{}' -o jsonpath='{.data.target-baseline\.sql}' >"$expected_sql"
 baseline_digest="$("$REAL_KUBECTL" patch --local -f "$CAPTURE_FILE" --type=merge -p '{}' -o jsonpath='{.metadata.annotations.opencrane\.ai/baseline-sha256}')"
 export FAKE_BASELINE_DIGEST="$baseline_digest"
 export FAKE_EXISTING_SQL_FILE="$expected_sql"
+
+export FAKE_RACE_MARKER="$TEST_DIR/race-created"
+FAKE_CREATE_RACE=1 PATH="$TEST_DIR/bin:$PATH" \
+  bash "$PUBLISHER" opencrane 'owner"quoted' "$BASELINE" >"$TEST_DIR/race.out"
+grep -Eq '^opencrane-database-baseline-[a-f0-9]{16}$' "$TEST_DIR/race.out"
 
 for existing_mode in tampered mutable; do
   if FAKE_EXISTING_MODE="$existing_mode" PATH="$TEST_DIR/bin:$PATH" \

--- a/libs/backend/agents/execution/inputs/main/src/prompt-compiler.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prompt-compiler.ts
@@ -1,10 +1,7 @@
-import { createHash } from "node:crypto";
-
 import { PROMPT_COMPILER_VERSION } from "@opencrane/contracts";
 import type { CompiledBudget, CompiledRunInput, CompiledToolDefinition, RunInputSnapshot } from "@opencrane/contracts";
-import { ___CanonicalizeJson } from "@opencrane/util";
-import type { JsonValue } from "@opencrane/util";
 import { ___DoWithTrace } from "@opencrane/observability";
+import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 
 import type { PromptCompilerRepositories } from "./prompt-compiler.types.js";
 
@@ -119,5 +116,5 @@ function _optionalCount(value: JsonValue | undefined): number | null
 /** Seal the compiled payload with a SHA-256 digest over its canonical serialization. */
 function _digest(unsealed: Omit<CompiledRunInput, "digest">): `sha256:${string}`
 {
-	return `sha256:${createHash("sha256").update(___CanonicalizeJson(unsealed as unknown as JsonValue), "utf8").digest("hex")}`;
+	return ___DigestCanonicalJson(unsealed as unknown as JsonValue);
 }

--- a/libs/backend/agents/personal/configuration/main/src/proposal/personal-configuration-proposal.ts
+++ b/libs/backend/agents/personal/configuration/main/src/proposal/personal-configuration-proposal.ts
@@ -1,6 +1,4 @@
-import { createHash } from "node:crypto";
-
-import { ___CanonicalizeJson, type JsonValue } from "@opencrane/util";
+import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 
 import { _IsPersonalConfigurationPatch } from "./personal-configuration-patch.js";
 import { PersonalConfigurationProposalCodes, type PersonalConfigurationChangeRepository, type ProposePersonalConfigurationChangeCommand, type ProposePersonalConfigurationChangeResult } from "./personal-configuration-proposal.types.js";
@@ -31,7 +29,7 @@ function _DigestPatch(value: Readonly<Record<string, unknown>>): string | null
 {
 	try
 	{
-		return `sha256:${createHash("sha256").update(___CanonicalizeJson(value as JsonValue), "utf8").digest("hex")}`;
+		return ___DigestCanonicalJson(value as JsonValue);
 	}
 	catch
 	{

--- a/libs/backend/server/gateways/providers/main/src/__tests__/model-registry.test.ts
+++ b/libs/backend/server/gateways/providers/main/src/__tests__/model-registry.test.ts
@@ -129,7 +129,7 @@ describe("modelRegistryRouter", function _suite()
 
     const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
-      json: async function _json() { return { model_id: "deploy-abc123" }; },
+      text: async function _text() { return JSON.stringify({ model_id: "deploy-abc123" }); },
     });
     vi.stubGlobal("fetch", fetchSpy);
 

--- a/libs/backend/server/iam/authorization/main/README.md
+++ b/libs/backend/server/iam/authorization/main/README.md
@@ -66,7 +66,8 @@ legitimate request — never hand out access it should not.
   authenticated request principal into the approval caller and owns the adapters and clock.
 - `__OpenDeferredToolApproval` — atomically links a reserved external action to its approval, then
   recovers an ambiguous commit or terminalises the reservation so it cannot be replayed.
-- `__DigestCanonicalJson` — a stable hash of a request used across the checks above.
+- `__DigestCanonicalJson` — an authorization-domain wrapper over the shared environment-neutral
+  canonical JSON hash, preserving one SHA-256 implementation across server and browser consumers.
 - `PrismaRuntimeAuthorityRepository`, `PrismaAuthorizationGrantRepository` — the database-backed
   stores for accepted proofs/receipts and for candidate grants.
 - Contract types: `ResolveEffectiveAccessCommand`/`Result`, `AuthorizationGrantRepository`,

--- a/libs/backend/server/iam/authorization/main/src/canonical-json-digest.ts
+++ b/libs/backend/server/iam/authorization/main/src/canonical-json-digest.ts
@@ -1,15 +1,12 @@
-import { createHash } from "node:crypto";
-
 import type { CanonicalJsonSha256Digest } from "@opencrane/models/authorization";
-import { ___CanonicalizeJson } from "@opencrane/util";
-import type { JsonValue } from "@opencrane/util";
+import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 
 /**
- * Digests RFC 8785 canonical JSON as UTF-8 bytes with backend-owned SHA-256.
+ * Gives authorization callers a domain-named wrapper over the shared canonical JSON digest.
  * @param value - JSON value whose exact canonical content is being bound.
  * @returns Digest encoded as `sha256:` followed by 64 lowercase hexadecimal characters.
  */
 export function __DigestCanonicalJson(value: JsonValue): CanonicalJsonSha256Digest
 {
-	return `sha256:${createHash("sha256").update(___CanonicalizeJson(value), "utf8").digest("hex")}`;
+	return ___DigestCanonicalJson(value);
 }

--- a/libs/models/agents/main/src/__tests__/agent-revision-content.browser.test.ts
+++ b/libs/models/agents/main/src/__tests__/agent-revision-content.browser.test.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from "node:url";
+
+import { build } from "esbuild";
+import { describe, expect, it } from "vitest";
+
+describe("agent revision content browser bundle", function _BrowserAgentRevisionContentBundleSuite()
+{
+	it("bundles the public digest implementation for the browser without Node built-ins", async function _BundlesForBrowser()
+	{
+		const result = await build({
+			entryPoints: [fileURLToPath(new URL("../agent-revision-content.ts", import.meta.url))],
+			bundle: true,
+			format: "esm",
+			platform: "browser",
+			write: false,
+			logLevel: "silent",
+		});
+
+		expect(result.outputFiles).toHaveLength(1);
+		expect(result.outputFiles[0]?.text).not.toContain("node:crypto");
+	});
+});

--- a/libs/models/agents/main/src/agent-revision-content.ts
+++ b/libs/models/agents/main/src/agent-revision-content.ts
@@ -1,6 +1,4 @@
-import { createHash } from "node:crypto";
-
-import { ___CanonicalizeJson, type CanonicalJsonSha256Digest, type JsonValue } from "@opencrane/util";
+import { ___DigestCanonicalJson, type CanonicalJsonSha256Digest, type JsonValue } from "@opencrane/util";
 
 import type { AgentRevisionContent } from "./agent-revision.types.js";
 
@@ -51,5 +49,5 @@ export function __DigestAgentRevisionContent(agentServiceId: string, revision: n
 		}),
 	};
 
-	return `sha256:${createHash("sha256").update(___CanonicalizeJson(canonical), "utf8").digest("hex")}`;
+	return ___DigestCanonicalJson(canonical);
 }

--- a/libs/util/README.md
+++ b/libs/util/README.md
@@ -1,10 +1,10 @@
-# @opencrane/util — dependency-free pure helpers
+# @opencrane/util — environment-neutral pure helpers
 
 > [OpenCrane](../../README.md) › util
 
 ## What it owns
 
-The smallest shared library in the platform: a handful of **pure, dependency-free helpers** used
+The smallest shared library in the platform: a handful of **pure, environment-neutral helpers** used
 across domain packages. "Pure" means every function returns a value computed only from its
 arguments — no database, no network, no clock, no global state — so the results are identical every
 time and safe to call anywhere.
@@ -24,7 +24,9 @@ It owns four things:
   canonical string
   form defined by RFC 8785 (JSON Canonicalization Scheme): object keys sorted, whitespace and number
   formatting fixed. Two values that are equal produce byte-identical text, which is what makes a
-  stable hash possible. `___CloneCanonicalJson` round-trips through that form to produce a detached,
+  stable hash possible. `___DigestCanonicalJson` hashes those bytes with SHA-256 using the same
+  synchronous implementation in Node and browser bundles, so callers get one `sha256:<hex>` result
+  without importing a runtime-specific crypto module. `___CloneCanonicalJson` round-trips through that form to produce a detached,
   JSON-equivalent value; callers must canonicalise again when deterministic bytes or key order matter.
   The type `CanonicalJsonSha256Digest` is the template-literal string type
   `` `sha256:${string}` `` — an explicitly encoded digest, so a hash of canonical bytes is never
@@ -42,15 +44,16 @@ platform-wide API. Invariant: purity and determinism — no hidden inputs, same 
 - `___SortBy`, `___SomeArray`, `___SomeRecord` — collection helpers.
 - `___ParseAndValidateJson` — parse untrusted JSON and return only the caller-validated generic type.
 - `___CanonicalizeJson` — RFC 8785 canonical JSON serialisation.
+- `___DigestCanonicalJson` — browser- and Node-safe SHA-256 digest of canonical JSON.
 - `___CloneCanonicalJson` — detached deep copy through the canonical JSON representation.
 - `___IsSha256Digest` — strict validator for the platform's lowercase SHA-256 digest grammar.
 - `JsonValue`, `JsonPrimitive`, `CanonicalJsonSha256Digest` — JSON and digest types.
 
 ## Boundary
 
-Pure and dependency-free: it may not import any other package, and it does no I/O. It validates
-digest spelling but does not decide what a digest means; hashing canonical bytes and persistence
-remain with the owning domain.
+Pure and environment-neutral: it imports no OpenCrane package and does no I/O. It owns the one
+shared implementation of canonical JSON hashing, but does not decide what a digest means or persist
+it; those authority decisions remain with the owning domain.
 
 ## Dependency direction
 

--- a/libs/util/src/canonical-json-digest.ts
+++ b/libs/util/src/canonical-json-digest.ts
@@ -1,0 +1,23 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+import { bytesToHex } from "@noble/hashes/utils.js";
+
+import { ___CanonicalizeJson } from "./json-canonicalization.js";
+import type { CanonicalJsonSha256Digest, JsonValue } from "./json-canonicalization.types.js";
+
+/**
+ * Hashes RFC 8785 canonical JSON with SHA-256 and returns the platform's canonical digest spelling.
+ *
+ * This intentionally uses one synchronous, environment-neutral implementation rather than Node's
+ * `crypto` module or the browser's asynchronous Web Crypto API. Callers can therefore bind the same
+ * canonical bytes in Node and browser bundles without changing the digest contract or choosing a
+ * runtime-specific algorithm.
+ *
+ * @param value - JSON value whose canonical UTF-8 representation is hashed.
+ * @returns Lowercase `sha256:<hex>` digest of the RFC 8785 canonical JSON representation.
+ * @see https://www.rfc-editor.org/rfc/rfc8785
+ * @see https://csrc.nist.gov/pubs/fips/180-4/upd1/final
+ */
+export function ___DigestCanonicalJson(value: JsonValue): CanonicalJsonSha256Digest
+{
+	return `sha256:${bytesToHex(sha256(___CanonicalizeJson(value)))}`;
+}

--- a/libs/util/src/index.ts
+++ b/libs/util/src/index.ts
@@ -2,6 +2,7 @@
  * @opencrane/util — public barrel.
  */
 export * from "./collections.js";
+export * from "./canonical-json-digest.js";
 export * from "./digest.js";
 export * from "./json.js";
 export * from "./json-canonicalization.js";

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@angular/platform-browser": "^21.2.0",
         "@angular/router": "^21.2.0",
         "@kubernetes/client-node": "^1.0.0",
+        "@noble/hashes": "1.8.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.78.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
@@ -5680,7 +5681,6 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@noble/hashes": "1.8.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.78.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@angular/platform-browser": "^21.2.0",
     "@angular/router": "^21.2.0",
     "@kubernetes/client-node": "^1.0.0",
+    "@noble/hashes": "1.8.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.78.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",

--- a/scripts/phase-b-render-profiles.mjs
+++ b/scripts/phase-b-render-profiles.mjs
@@ -1,0 +1,90 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const [, , root, workloadRegistryPath, chartPath] = process.argv;
+const errors = [];
+const renderedWorkloadKindPattern = /^kind:\s*(Pod|Deployment|StatefulSet|DaemonSet|CronJob|Job)\s*$/m;
+const workloadRegistry = JSON.parse(readFileSync(workloadRegistryPath, "utf8"));
+const renderedPodClasses = new Set(
+  (workloadRegistry.workloads ?? [])
+    .map(function renderedPodClass(workload) { return workload.renderedPodClass; })
+    .filter(Boolean),
+);
+const renderedAcrossProfiles = new Set();
+
+function fail(message)
+{
+  errors.push(message);
+}
+
+for (const profile of workloadRegistry.renderProfiles ?? [])
+{
+  const context = `render profile '${profile.id ?? "<missing>"}'`;
+  if (!profile.id) fail(`${context}: id is required`);
+  const args = [
+    "template",
+    "opencrane",
+    chartPath,
+    "--namespace",
+    "opencrane-system",
+  ];
+  for (const value of profile.setValues ?? []) args.push("--set", value);
+  let manifest = "";
+  try
+  {
+    manifest = execFileSync("helm", args, { cwd: root, encoding: "utf8" });
+  }
+  catch (err)
+  {
+    fail(`${context}: Helm render failed: ${err.message}`);
+    continue;
+  }
+
+  const actual = new Set();
+  for (const document of manifest.split(/^---\s*$/m))
+  {
+    const kind = renderedWorkloadKindPattern.exec(document)?.[1];
+    if (!kind) continue;
+    const metadataStart = document.search(/^metadata:\s*$/m);
+    const name = metadataStart === -1
+      ? undefined
+      : /^  name:\s*([^\s]+)\s*$/m.exec(document.slice(metadataStart))?.[1];
+    if (!name)
+    {
+      fail(`${context}: rendered ${kind} has no exact metadata.name`);
+      continue;
+    }
+    const podClass = `${kind}/${name}`;
+    if (actual.has(podClass)) fail(`${context}: duplicate rendered pod class ${podClass}`);
+    actual.add(podClass);
+    renderedAcrossProfiles.add(podClass);
+    if (!renderedPodClasses.has(podClass)) fail(`${context}: unregistered rendered pod class ${podClass}`);
+  }
+
+  const expected = new Set(profile.expectedRenderedPodClasses ?? []);
+  if (expected.size !== (profile.expectedRenderedPodClasses ?? []).length)
+  {
+    fail(`${context}: expectedRenderedPodClasses contains a duplicate`);
+  }
+  for (const podClass of expected)
+  {
+    if (!actual.has(podClass)) fail(`${context}: expected pod class did not render: ${podClass}`);
+    if (!renderedPodClasses.has(podClass)) fail(`${context}: expected pod class has no workload owner: ${podClass}`);
+  }
+  for (const podClass of actual)
+  {
+    if (!expected.has(podClass)) fail(`${context}: render output is not pinned: ${podClass}`);
+  }
+}
+for (const podClass of renderedPodClasses)
+{
+  if (!renderedAcrossProfiles.has(podClass)) fail(`registered rendered pod class is absent from every profile: ${podClass}`);
+}
+
+if (errors.length > 0)
+{
+  for (const error of errors) process.stderr.write(`${error}\n`);
+  process.exit(1);
+}
+
+process.stdout.write(`${(workloadRegistry.renderProfiles ?? []).length} Helm profiles match their exact pod-class inventories\n`);

--- a/scripts/phase-b-render-profiles.sh
+++ b/scripts/phase-b-render-profiles.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$1"
+WORKLOAD_REGISTRY="$2"
+source "$ROOT/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
+
+node "$ROOT/scripts/phase-b-render-profiles.mjs" \
+  "$ROOT" \
+  "$WORKLOAD_REGISTRY" \
+  "$CHART_DIR"

--- a/scripts/phase-b-topology.sh
+++ b/scripts/phase-b-topology.sh
@@ -47,7 +47,6 @@ const appSourceClassifications = new Set([
   "test-config",
 ]);
 const workloadKindPattern = /^\s*kind:\s*(Pod|Deployment|StatefulSet|DaemonSet|CronJob|Job)\s*$/m;
-const renderedWorkloadKindPattern = /^kind:\s*(Pod|Deployment|StatefulSet|DaemonSet|CronJob|Job)\s*$/m;
 const runtimeWorkloadLinePattern = /^(?:\s*kind:\s*["']?(?:Pod|Deployment|StatefulSet|DaemonSet|CronJob|Job|Cluster)["']?,?\s*|.*\bkubectl\s+(?:run|create\s+(?:job|cronjob|deployment))\b.*|.*\bupgrade\s+--install\b.*|.*\.createNamespaced(?:Pod|Job|Deployment|StatefulSet|DaemonSet)\b.*)$/;
 
 function fail(message)
@@ -283,74 +282,19 @@ for (const forbidden of workloadRegistry.forbiddenPaths ?? [])
   if (existsSync(workspacePath(forbidden))) fail(`retired embedded workload path returned: ${forbidden}`);
 }
 
-const renderedAcrossProfiles = new Set();
-for (const profile of workloadRegistry.renderProfiles ?? [])
+try
 {
-  const context = `render profile '${profile.id ?? "<missing>"}'`;
-  if (!profile.id) fail(`${context}: id is required`);
-  const args = [
-    "template",
-    "opencrane",
-    workspacePath("apps/_infra/deploy-k8s"),
-    "--namespace",
-    "opencrane-system",
-  ];
-  for (const value of profile.setValues ?? []) args.push("--set", value);
-  let manifest = "";
-  try
-  {
-    manifest = execFileSync("helm", args, { cwd: root, encoding: "utf8" });
-  }
-  catch (err)
-  {
-    fail(`${context}: Helm render failed: ${err.message}`);
-    continue;
-  }
-
-  const actual = new Set();
-  for (const document of manifest.split(/^---\s*$/m))
-  {
-    const kind = renderedWorkloadKindPattern.exec(document)?.[1];
-    if (!kind) continue;
-    const metadataStart = document.search(/^metadata:\s*$/m);
-    const name = metadataStart === -1
-      ? undefined
-      : /^  name:\s*([^\s]+)\s*$/m.exec(document.slice(metadataStart))?.[1];
-    if (!name)
-    {
-      fail(`${context}: rendered ${kind} has no exact metadata.name`);
-      continue;
-    }
-    const podClass = `${kind}/${name}`;
-    if (actual.has(podClass)) fail(`${context}: duplicate rendered pod class ${podClass}`);
-    actual.add(podClass);
-    renderedAcrossProfiles.add(podClass);
-    if (!renderedPodClasses.has(podClass))
-    {
-      fail(`${context}: unregistered rendered pod class ${podClass}`);
-    }
-  }
-
-  const expected = new Set(profile.expectedRenderedPodClasses ?? []);
-  if (expected.size !== (profile.expectedRenderedPodClasses ?? []).length)
-  {
-    fail(`${context}: expectedRenderedPodClasses contains a duplicate`);
-  }
-  for (const podClass of expected)
-  {
-    if (!actual.has(podClass)) fail(`${context}: expected pod class did not render: ${podClass}`);
-    if (!renderedPodClasses.has(podClass)) fail(`${context}: expected pod class has no workload owner: ${podClass}`);
-  }
-  for (const podClass of actual)
-  {
-    if (!expected.has(podClass)) fail(`${context}: render output is not pinned: ${podClass}`);
-  }
+  const renderInfo = execFileSync(
+    "bash",
+    [resolve(root, "scripts/phase-b-render-profiles.sh"), root, workloadRegistryPath],
+    { cwd: root, encoding: "utf8" },
+  ).trim();
+  info.push(renderInfo);
 }
-for (const podClass of renderedPodClasses.keys())
+catch (err)
 {
-  if (!renderedAcrossProfiles.has(podClass)) fail(`registered rendered pod class is absent from every profile: ${podClass}`);
+  fail(`Helm profile rendering failed: ${err.stderr?.trim() || err.message}`);
 }
-info.push(`${(workloadRegistry.renderProfiles ?? []).length} Helm profiles match their exact pod-class inventories`);
 
 const runtimeConstructs = new Map();
 for (const entry of workloadRegistry.runtimeConstructs ?? [])

--- a/website/guide/deploy-local.md
+++ b/website/guide/deploy-local.md
@@ -31,6 +31,11 @@ The chart installs trusted services and distinct restricted namespaces for perso
 managed and worker Jobs. A single-node cluster does not collapse those boundaries. Create the
 three PostgreSQL bootstrap Secrets in the target namespace first, using distinct credentials.
 
+Add `--verify` when you want an advisory check of pod readiness, hostname resolution, and the public
+server/database health endpoint after installation. For a local self-signed certificate, use
+`--verify --verify-insecure`; omit `--verify-insecure` whenever the certificate is trusted. These
+checks report diagnostics without turning a completed installation into a failed release.
+
 ::: warning
 Single-node does not mean single namespace. OpenCrane refuses a deployment that places
 untrusted runtime Jobs beside the trusted server.


### PR DESCRIPTION
## Review order

This PR belongs to one dependency stack. Review and merge it in this order:

1. #532 — browser-safe digest and deployment repair wave
2. #530 — runtime responsibility split
3. #548 — server-infrastructure relocation
4. #520 — authenticated private-memory transport
5. #563 — production Cognee recall
6. #564 — direct Obot invocation
7. #543 — consolidated server persistence authorities
8. #537 — consolidated persona lifecycle
9. #531 — personal-memory authority separation
10. #540 — trusted personal run admission
11. #547 — dead platform-policy removal and aggregate TypeScript cleanup
12. #552 — present-tense workload and agent boundary guards
13. #559 — Angular maintenance dependencies
14. #560 — AuthorizationGrant sharing authority
15. #561 — atomic MCP mutations
16. #562 — share-route rate limiting
17. #557 — ip-address dependency bump
18. #558 — fast-uri dependency bump

Each PR is based on its direct predecessor, so its GitHub diff contains only its incremental change. Review each diff once; do not compare sibling branches.

## Why this change

The browser-safe digest fix exposed two independent stale CI assumptions in the affected graph: a LiteLLM registration fixture lacked the response body consumed by production code, and the deployment contract test still referenced superseded chart paths. Keeping those as separate repair PRs made the same validation wave require three reviews.

## What changed

- move canonical JSON SHA-256 hashing to the environment-neutral shared utility backed by the pinned noble hashes package
- preserve the synchronous `sha256:<hex>` contract across agent revisions, authorization, prompt compilation, and personal configuration
- add a browser-platform bundle regression that rejects Node built-ins
- update the LiteLLM registration fixture to model the response consumed by the provider
- validate the current app-owned Helm chart sources and current runtime cleanup, network policy, and skill workload contracts


## Validation

- five affected digest projects: 190 tests and lint passed
- browser-platform esbuild regression and opencrane-ui production build passed
- backend server provider tests: 34 passing
- current deploy-k8s chart, permissions, cleanup RBAC, network-policy, and skill-workload contracts pass
- agent-controller Helm contract is Linux `pipefail` safe and passes locally
- style, Prisma-boundary, module-growth, and whitespace gates pass
- independent cumulative review and final Helm repair review: PASS
