### PR TITLE
🧪 Restore LiteLLM model-registration CI coverage

### DIFF
--- a/libs/backend/server/gateways/providers/main/src/__tests__/model-registry.test.ts
+++ b/libs/backend/server/gateways/providers/main/src/__tests__/model-registry.test.ts
@@ -129,7 +129,7 @@ describe("modelRegistryRouter", function _suite()
 
     const fetchSpy = vi.fn().mockResolvedValue({
       ok: true,
-      json: async function _json() { return { model_id: "deploy-abc123" }; },
+      text: async function _text() { return JSON.stringify({ model_id: "deploy-abc123" }); },
     });
     vi.stubGlobal("fetch", fetchSpy);
 


### PR DESCRIPTION
## Product context

When an operator registers a routable model, OpenCrane records the LiteLLM deployment identifier returned by the provider. CI must exercise that same response contract so a stale mock cannot hide a broken registration path.

## What changes

- align the successful LiteLLM test fixture with the production adapter's text-based JSON response handling

## Product impact

No production provider behaviour, API, configuration, or documentation changes. The repair restores coverage of the existing model-registration success path and prevents the test from falling through to its placeholder-ID fallback.

## Validation

- provider tests: 34 passed
- focused lint, style, module-growth, Prisma-boundary, schema, dependency, and diff checks
- independent review: PASS with no findings
