### PR TITLE
🧪 Validate current Helm chart sources in CI

### DIFF
--- a/apps/_infra/deploy-k8s/README.md
+++ b/apps/_infra/deploy-k8s/README.md
@@ -93,8 +93,9 @@ package imports it.
 - `opencrane-tool-runner.toolRunner` — the separate, default-deny tenant-tool namespace and aggregate
   Job quota; it contains no standing worker.
 - Reusable environment/multi-instance profiles live under `values/` and `platform/values/`.
-- `npx nx run deploy-k8s:test` renders the silo chart and verifies that the non-root server can read
-  projected ArtifactStore keys through its declared uid/gid and `fsGroup` contract.
+- `npx nx run deploy-k8s:test` and `npx nx run deploy-k8s:helm-lint` build a disposable copy from
+  the committed `Chart.lock`, linked to the current app-owned chart sources. They therefore validate
+  the release contract without rewriting the tracked `charts/*.tgz` archives.
 
 ## Sub-docs (the deep detail)
 

--- a/apps/_infra/deploy-k8s/platform/current-chart-sources.sh
+++ b/apps/_infra/deploy-k8s/platform/current-chart-sources.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Builds the umbrella's file dependencies in a disposable chart tree. Contract
+# checks must render the same current app-owned sources as deploy.sh, but must
+# never leave timestamp-only archive churn in the checkout.
+
+_CURRENT_CHART_SOURCES_FIXTURE=""
+_CURRENT_CHART_SOURCES_TOKEN=""
+_CURRENT_CHART_SOURCES_DIR=""
+
+current_chart_sources_root()
+{
+  cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd
+}
+
+prepare_current_chart_sources()
+{
+  if [[ -n "$_CURRENT_CHART_SOURCES_FIXTURE" ]]; then
+    printf 'Current chart sources are already prepared by this shell.\n' >&2
+    return 1
+  fi
+
+  local root fixture_apps temp_parent fixture_name marker
+  root="$(current_chart_sources_root)"
+  temp_parent="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
+  _CURRENT_CHART_SOURCES_FIXTURE="$(mktemp -d "$temp_parent/opencrane-deploy-k8s-chart.XXXXXX")"
+  fixture_name="$(basename "$_CURRENT_CHART_SOURCES_FIXTURE")"
+  if [[ "$(dirname "$_CURRENT_CHART_SOURCES_FIXTURE")" != "$temp_parent" \
+    || ! "$fixture_name" =~ ^opencrane-deploy-k8s-chart\.[[:alnum:]]{6}$ ]]; then
+    printf 'mktemp returned an invalid chart fixture path: %s\n' "$_CURRENT_CHART_SOURCES_FIXTURE" >&2
+    _CURRENT_CHART_SOURCES_FIXTURE=""
+    return 1
+  fi
+
+  _CURRENT_CHART_SOURCES_TOKEN="$fixture_name:$$:$RANDOM$RANDOM"
+  marker="$_CURRENT_CHART_SOURCES_FIXTURE/.opencrane-chart-fixture-owner"
+  printf '%s\n' "$_CURRENT_CHART_SOURCES_TOKEN" >"$marker"
+  fixture_apps="$_CURRENT_CHART_SOURCES_FIXTURE/apps"
+  _CURRENT_CHART_SOURCES_DIR="$fixture_apps/_infra/deploy-k8s"
+
+  if ! (
+    mkdir -p "$fixture_apps/_infra"
+    cp -R "$root/apps/_infra/deploy-k8s" "$_CURRENT_CHART_SOURCES_DIR"
+
+    # Keep the dependency layout identical to Chart.yaml while linking every
+    # app-owned source directory. New local dependencies then need no fixture
+    # maintenance and Helm still verifies the committed Chart.lock digest.
+    for app_dir in "$root/apps"/*; do
+      [[ "$(basename "$app_dir")" == "_infra" ]] && continue
+      ln -s "$app_dir" "$fixture_apps/$(basename "$app_dir")"
+    done
+    for infra_dir in "$root/apps/_infra"/*; do
+      [[ "$(basename "$infra_dir")" == "deploy-k8s" ]] && continue
+      ln -s "$infra_dir" "$fixture_apps/_infra/$(basename "$infra_dir")"
+    done
+
+    helm dependency build --skip-refresh "$_CURRENT_CHART_SOURCES_DIR" >/dev/null
+  ); then
+    cleanup_current_chart_sources
+    return 1
+  fi
+}
+
+current_chart_sources_dir()
+{
+  if [[ -z "$_CURRENT_CHART_SOURCES_DIR" ]]; then
+    printf 'Current chart sources have not been prepared.\n' >&2
+    return 1
+  fi
+  printf '%s\n' "$_CURRENT_CHART_SOURCES_DIR"
+}
+
+cleanup_current_chart_sources()
+{
+  local fixture marker marker_token temp_parent fixture_name
+  fixture="$_CURRENT_CHART_SOURCES_FIXTURE"
+  if [[ -z "$fixture" ]]; then
+    return
+  fi
+
+  temp_parent="$(cd "${TMPDIR:-/tmp}" && pwd -P)"
+  fixture_name="$(basename "$fixture")"
+  marker="$fixture/.opencrane-chart-fixture-owner"
+  marker_token=""
+  if [[ -f "$marker" ]]; then
+    IFS= read -r marker_token <"$marker"
+  fi
+  if [[ "$(dirname "$fixture")" != "$temp_parent" \
+    || ! "$fixture_name" =~ ^opencrane-deploy-k8s-chart\.[[:alnum:]]{6}$ \
+    || "$marker_token" != "$_CURRENT_CHART_SOURCES_TOKEN" ]]; then
+    printf 'Refusing to remove an unowned chart fixture: %s\n' "$fixture" >&2
+    return 1
+  fi
+
+  _CURRENT_CHART_SOURCES_FIXTURE=""
+  _CURRENT_CHART_SOURCES_TOKEN=""
+  _CURRENT_CHART_SOURCES_DIR=""
+  rm -rf -- "$fixture"
+}

--- a/apps/_infra/deploy-k8s/platform/tests/current-chart-sources-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/current-chart-sources-contract.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+HELPER="$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+AMBIENT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/opencrane-ambient-chart.XXXXXX")"
+AMBIENT_FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/opencrane-ambient-fixture.XXXXXX")"
+CALLS="$(mktemp)"
+FAILURE_CHART="$(mktemp)"
+REAL_HELM="$(command -v helm)"
+trap 'rm -rf -- "$AMBIENT_DIR" "$AMBIENT_FIXTURE"; rm -f "$CALLS" "$FAILURE_CHART"' EXIT
+
+touch "$AMBIENT_FIXTURE/must-survive"
+export OPENCRANE_DEPLOY_K8S_CHART_DIR="$AMBIENT_DIR"
+export OPENCRANE_DEPLOY_K8S_CHART_FIXTURE="$AMBIENT_FIXTURE"
+source "$HELPER"
+
+helm()
+{
+  printf '%s\n' "$*" >>"$CALLS"
+  "$REAL_HELM" "$@"
+}
+
+prepare_current_chart_sources
+prepared_chart="$(current_chart_sources_dir)"
+[[ "$prepared_chart" != "$AMBIENT_DIR" ]]
+grep -Fq 'dependency build --skip-refresh' "$CALLS"
+[[ -L "$prepared_chart/../../opencrane" ]]
+cleanup_current_chart_sources
+[[ -f "$AMBIENT_FIXTURE/must-survive" ]]
+
+helm()
+{
+  printf '%s\n' "$4" >"$FAILURE_CHART"
+  return 42
+}
+
+if prepare_current_chart_sources; then
+  printf 'Expected dependency build failure.\n' >&2
+  exit 1
+fi
+failed_chart="$(<"$FAILURE_CHART")"
+failed_fixture="${failed_chart%/apps/_infra/deploy-k8s}"
+[[ "$failed_fixture" != "$failed_chart" ]]
+if [[ -e "$failed_fixture" ]]; then
+  printf 'Failed dependency build left its fixture behind: %s\n' "$failed_fixture" >&2
+  exit 1
+fi
+[[ -f "$AMBIENT_FIXTURE/must-survive" ]]
+
+echo "current chart sources contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/tests/helm-lint-current-sources.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/helm-lint-current-sources.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
+
+helm lint "$CHART_DIR"

--- a/apps/_infra/deploy-k8s/platform/tests/platform-network-policy-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/platform-network-policy-contract.sh
@@ -6,9 +6,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
 OUTPUT="$(mktemp)"
 MULTI_OUTPUT="$(mktemp)"
-trap 'rm -f "$OUTPUT" "$MULTI_OUTPUT"' EXIT
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
 
-helm template opencrane-silo "$ROOT_DIR/apps/_infra/deploy-k8s" \
+prepare_current_chart_sources
+trap 'cleanup_current_chart_sources; rm -f "$OUTPUT" "$MULTI_OUTPUT"' EXIT
+CHART_DIR="$(current_chart_sources_dir)"
+
+helm template opencrane-silo "$CHART_DIR" \
   --set networkPolicy.mainNetworkDefaultDeny.enabled=true \
   --set-string networkPolicy.postgresPoolerName=opencrane-postgres-restored-pooler >"$OUTPUT"
 
@@ -29,7 +33,7 @@ if grep -Fq 'cnpg.io/cluster' <<<"$PLATFORM_POLICY"; then
   exit 1
 fi
 
-helm template oc-acme "$ROOT_DIR/apps/_infra/deploy-k8s" \
+helm template oc-acme "$CHART_DIR" \
   --namespace oc-acme \
   --values "$ROOT_DIR/apps/_infra/deploy-k8s/platform/values/multi-instance/oc-acme.yaml" \
   >"$MULTI_OUTPUT"

--- a/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+
+for contract in \
+  current-chart-sources-contract.sh \
+  server-key-permissions-contract.sh \
+  server-runtime-cleanup-rbac-contract.sh \
+  server-network-policy-contract.sh \
+  platform-network-policy-contract.sh \
+  skill-workload-contract.sh; do
+  bash "$ROOT_DIR/apps/_infra/deploy-k8s/platform/tests/$contract"
+done

--- a/apps/_infra/deploy-k8s/platform/tests/server-key-permissions-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/server-key-permissions-contract.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR")"
 server_manifest="$(printf '%s\n' "$rendered" | awk '

--- a/apps/_infra/deploy-k8s/platform/tests/server-network-policy-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/server-network-policy-contract.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR" \
   --set-string networkPolicy.postgresPoolerName=opencrane-postgres-restored-pooler)"

--- a/apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR")"
 cleanup_rbac="$(printf '%s\n' "$rendered" | awk '

--- a/apps/_infra/deploy-k8s/platform/tests/skill-workload-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/skill-workload-contract.sh
@@ -2,7 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR" \
   --set-string opencrane-skill-authoring.skillAuthoring.namespace=authoring-contract \

--- a/apps/_infra/deploy-k8s/project.json
+++ b/apps/_infra/deploy-k8s/project.json
@@ -7,19 +7,12 @@
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "commands": [
-          "bash apps/_infra/deploy-k8s/platform/tests/server-key-permissions-contract.sh",
-            "bash apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh",
-          "bash apps/_infra/deploy-k8s/platform/tests/server-network-policy-contract.sh",
-          "bash apps/_infra/deploy-k8s/platform/tests/platform-network-policy-contract.sh",
-          "bash apps/_infra/deploy-k8s/platform/tests/skill-workload-contract.sh"
-        ],
-        "parallel": false
+        "command": "bash apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh"
       }
     },
     "helm-lint": {
       "executor": "nx:run-commands",
-      "options": { "command": "helm lint apps/_infra/deploy-k8s" }
+      "options": { "command": "bash apps/_infra/deploy-k8s/platform/tests/helm-lint-current-sources.sh" }
     },
     "dependency-status": {
       "executor": "nx:run-commands",

--- a/scripts/phase-b-render-profiles.mjs
+++ b/scripts/phase-b-render-profiles.mjs
@@ -1,0 +1,90 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+const [, , root, workloadRegistryPath, chartPath] = process.argv;
+const errors = [];
+const renderedWorkloadKindPattern = /^kind:\s*(Pod|Deployment|StatefulSet|DaemonSet|CronJob|Job)\s*$/m;
+const workloadRegistry = JSON.parse(readFileSync(workloadRegistryPath, "utf8"));
+const renderedPodClasses = new Set(
+  (workloadRegistry.workloads ?? [])
+    .map(function renderedPodClass(workload) { return workload.renderedPodClass; })
+    .filter(Boolean),
+);
+const renderedAcrossProfiles = new Set();
+
+function fail(message)
+{
+  errors.push(message);
+}
+
+for (const profile of workloadRegistry.renderProfiles ?? [])
+{
+  const context = `render profile '${profile.id ?? "<missing>"}'`;
+  if (!profile.id) fail(`${context}: id is required`);
+  const args = [
+    "template",
+    "opencrane",
+    chartPath,
+    "--namespace",
+    "opencrane-system",
+  ];
+  for (const value of profile.setValues ?? []) args.push("--set", value);
+  let manifest = "";
+  try
+  {
+    manifest = execFileSync("helm", args, { cwd: root, encoding: "utf8" });
+  }
+  catch (err)
+  {
+    fail(`${context}: Helm render failed: ${err.message}`);
+    continue;
+  }
+
+  const actual = new Set();
+  for (const document of manifest.split(/^---\s*$/m))
+  {
+    const kind = renderedWorkloadKindPattern.exec(document)?.[1];
+    if (!kind) continue;
+    const metadataStart = document.search(/^metadata:\s*$/m);
+    const name = metadataStart === -1
+      ? undefined
+      : /^  name:\s*([^\s]+)\s*$/m.exec(document.slice(metadataStart))?.[1];
+    if (!name)
+    {
+      fail(`${context}: rendered ${kind} has no exact metadata.name`);
+      continue;
+    }
+    const podClass = `${kind}/${name}`;
+    if (actual.has(podClass)) fail(`${context}: duplicate rendered pod class ${podClass}`);
+    actual.add(podClass);
+    renderedAcrossProfiles.add(podClass);
+    if (!renderedPodClasses.has(podClass)) fail(`${context}: unregistered rendered pod class ${podClass}`);
+  }
+
+  const expected = new Set(profile.expectedRenderedPodClasses ?? []);
+  if (expected.size !== (profile.expectedRenderedPodClasses ?? []).length)
+  {
+    fail(`${context}: expectedRenderedPodClasses contains a duplicate`);
+  }
+  for (const podClass of expected)
+  {
+    if (!actual.has(podClass)) fail(`${context}: expected pod class did not render: ${podClass}`);
+    if (!renderedPodClasses.has(podClass)) fail(`${context}: expected pod class has no workload owner: ${podClass}`);
+  }
+  for (const podClass of actual)
+  {
+    if (!expected.has(podClass)) fail(`${context}: render output is not pinned: ${podClass}`);
+  }
+}
+for (const podClass of renderedPodClasses)
+{
+  if (!renderedAcrossProfiles.has(podClass)) fail(`registered rendered pod class is absent from every profile: ${podClass}`);
+}
+
+if (errors.length > 0)
+{
+  for (const error of errors) process.stderr.write(`${error}\n`);
+  process.exit(1);
+}
+
+process.stdout.write(`${(workloadRegistry.renderProfiles ?? []).length} Helm profiles match their exact pod-class inventories\n`);

--- a/scripts/phase-b-render-profiles.sh
+++ b/scripts/phase-b-render-profiles.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$1"
+WORKLOAD_REGISTRY="$2"
+source "$ROOT/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+
+prepare_current_chart_sources
+trap cleanup_current_chart_sources EXIT
+CHART_DIR="$(current_chart_sources_dir)"
+
+node "$ROOT/scripts/phase-b-render-profiles.mjs" \
+  "$ROOT" \
+  "$WORKLOAD_REGISTRY" \
+  "$CHART_DIR"

--- a/scripts/phase-b-topology.sh
+++ b/scripts/phase-b-topology.sh
@@ -45,7 +45,6 @@ const appSourceClassifications = new Set([
   "test-config",
 ]);
 const workloadKindPattern = /^\s*kind:\s*(Pod|Deployment|StatefulSet|DaemonSet|CronJob|Job)\s*$/m;
-const renderedWorkloadKindPattern = /^kind:\s*(Pod|Deployment|StatefulSet|DaemonSet|CronJob|Job)\s*$/m;
 const runtimeWorkloadLinePattern = /^(?:\s*kind:\s*["']?(?:Pod|Deployment|StatefulSet|DaemonSet|CronJob|Job|Cluster)["']?,?\s*|.*\bkubectl\s+(?:run|create\s+(?:job|cronjob|deployment))\b.*|.*\bupgrade\s+--install\b.*|.*\.createNamespaced(?:Pod|Job|Deployment|StatefulSet|DaemonSet)\b.*)$/;
 
 function fail(message)
@@ -281,74 +280,19 @@ for (const forbidden of workloadRegistry.forbiddenPaths ?? [])
   if (existsSync(workspacePath(forbidden))) fail(`retired embedded workload path returned: ${forbidden}`);
 }
 
-const renderedAcrossProfiles = new Set();
-for (const profile of workloadRegistry.renderProfiles ?? [])
+try
 {
-  const context = `render profile '${profile.id ?? "<missing>"}'`;
-  if (!profile.id) fail(`${context}: id is required`);
-  const args = [
-    "template",
-    "opencrane",
-    workspacePath("apps/_infra/deploy-k8s"),
-    "--namespace",
-    "opencrane-system",
-  ];
-  for (const value of profile.setValues ?? []) args.push("--set", value);
-  let manifest = "";
-  try
-  {
-    manifest = execFileSync("helm", args, { cwd: root, encoding: "utf8" });
-  }
-  catch (err)
-  {
-    fail(`${context}: Helm render failed: ${err.message}`);
-    continue;
-  }
-
-  const actual = new Set();
-  for (const document of manifest.split(/^---\s*$/m))
-  {
-    const kind = renderedWorkloadKindPattern.exec(document)?.[1];
-    if (!kind) continue;
-    const metadataStart = document.search(/^metadata:\s*$/m);
-    const name = metadataStart === -1
-      ? undefined
-      : /^  name:\s*([^\s]+)\s*$/m.exec(document.slice(metadataStart))?.[1];
-    if (!name)
-    {
-      fail(`${context}: rendered ${kind} has no exact metadata.name`);
-      continue;
-    }
-    const podClass = `${kind}/${name}`;
-    if (actual.has(podClass)) fail(`${context}: duplicate rendered pod class ${podClass}`);
-    actual.add(podClass);
-    renderedAcrossProfiles.add(podClass);
-    if (!renderedPodClasses.has(podClass))
-    {
-      fail(`${context}: unregistered rendered pod class ${podClass}`);
-    }
-  }
-
-  const expected = new Set(profile.expectedRenderedPodClasses ?? []);
-  if (expected.size !== (profile.expectedRenderedPodClasses ?? []).length)
-  {
-    fail(`${context}: expectedRenderedPodClasses contains a duplicate`);
-  }
-  for (const podClass of expected)
-  {
-    if (!actual.has(podClass)) fail(`${context}: expected pod class did not render: ${podClass}`);
-    if (!renderedPodClasses.has(podClass)) fail(`${context}: expected pod class has no workload owner: ${podClass}`);
-  }
-  for (const podClass of actual)
-  {
-    if (!expected.has(podClass)) fail(`${context}: render output is not pinned: ${podClass}`);
-  }
+  const renderInfo = execFileSync(
+    "bash",
+    [resolve(root, "scripts/phase-b-render-profiles.sh"), root, workloadRegistryPath],
+    { cwd: root, encoding: "utf8" },
+  ).trim();
+  info.push(renderInfo);
 }
-for (const podClass of renderedPodClasses.keys())
+catch (err)
 {
-  if (!renderedAcrossProfiles.has(podClass)) fail(`registered rendered pod class is absent from every profile: ${podClass}`);
+  fail(`Helm profile rendering failed: ${err.stderr?.trim() || err.message}`);
 }
-info.push(`${(workloadRegistry.renderProfiles ?? []).length} Helm profiles match their exact pod-class inventories`);
 
 const runtimeConstructs = new Map();
 for (const entry of workloadRegistry.runtimeConstructs ?? [])


### PR DESCRIPTION
## Product context

The deployment chart is an umbrella over app-owned Helm sources. CI was rendering committed dependency archives that could lag behind those sources, while the real deployment path rebuilds dependencies from `Chart.lock`. That let source changes pass or fail against a different chart than operators would install and created noisy timestamp-only archive churn.

## What changes

- build current local-file Helm dependencies in a disposable chart fixture for contract tests, Helm lint, and topology rendering
- preserve the committed `Chart.lock` as the reproducibility authority without rewriting tracked `charts/*.tgz` archives
- share one focused current-source preparation helper across the validation paths
- extract profile rendering from the already-large topology guard
- fail closed against ambient environment overrides and delete only invocation-owned, marker-proven temporary fixtures
- clean owned fixtures when dependency building fails and cover cleanup/bypass cases with regressions
- document the validation contract in the deployment package README

## Product impact

No rendered production workload, deployment value, IAM rule, or release workflow changes. CI now validates the same current app-owned chart sources that `deploy.sh` packages, so chart drift is caught without changing generated archives in developer worktrees.

## Validation

- deploy-k8s Helm contract suite and Helm lint
- both topology render profiles and 17 mutation-based rejection paths
- ambient-variable bypass, arbitrary-path cleanup, and dependency-build failure regressions
- style, Prisma-boundary, module-growth, and diff checks
- independent architecture/security re-review: PASS after the unsafe cleanup path was fixed
