### PR TITLE
📝 Explain governed skill Job safety invariants

### DIFF
--- a/libs/backend/agents/skills/k8s-launcher/README.md
+++ b/libs/backend/agents/skills/k8s-launcher/README.md
@@ -30,7 +30,7 @@ filesystem, bounded temporary scratch space, no auto-mounted service-account tok
 code, artifact bytes, arguments, or credentials embedded in the manifest. The controller releases it
 only after it has durably committed the exact Kubernetes identity. The Job receives an audience-bound
 projected token and an opaque bootstrap reference in separate read-only files; the worker can use them
-only to acknowledge its own bootstrap endpoint. Authoring Jobs require at least
+only to acknowledge the deployment-selected cluster-local bootstrap endpoint. Authoring Jobs require at least
 64 MiB of scratch: a future validator uses that space for a bounded archive, an extracted tree, and
 fixed offline checks without borrowing persistent storage.
 
@@ -44,9 +44,10 @@ fixed offline checks without borrowing persistent storage.
 
 The agent controller consumes this builder. It does not make a tool executable, contact the
 ArtifactStore, or provide a worker transport; those require the later durable claim/result protocol.
-Malformed identity, image, lifetime, namespace, resource, or bootstrap-reference inputs fail before
-Kubernetes sees a manifest. The reference must use the fixed opaque grammar, so durable workload
-identifiers are never copied into the Job annotation or environment.
+Malformed identity, image, lifetime, namespace, resource, bootstrap-endpoint, or bootstrap-reference
+inputs fail before Kubernetes sees a manifest. The reference must use the fixed opaque grammar, so readable durable
+workload identifiers are not repeated in the worker's bootstrap input or environment. Job annotations retain only
+bounded job and silo trace coordinates alongside that opaque reference.
 
 ## Dependency direction
 

--- a/libs/backend/agents/skills/k8s-launcher/src/index.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/index.ts
@@ -1,2 +1,3 @@
 export { __BuildGovernedSkillWorkloadJob } from "./skill-workload-job.js";
+export { SkillWorkloadKinds } from "./skill-workload-job.types.js";
 export type { SkillWorkloadImagePullPolicy, SkillWorkloadJobAssignment, SkillWorkloadJobProfile, SkillWorkloadKind } from "./skill-workload-job.types.js";

--- a/libs/backend/agents/skills/k8s-launcher/src/skill-authoring-workload-job.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/skill-authoring-workload-job.ts
@@ -3,11 +3,20 @@ import type { V1Job } from "@kubernetes/client-node";
 import { __BuildSkillWorkloadJobSpec, __SkillWorkloadJobName } from "./skill-workload-job.js";
 import type { SkillWorkloadJobAssignment, SkillWorkloadJobProfile } from "./skill-workload-job.types.js";
 
-/** Build the actual Job envelope owned by the skill-authoring deployable. */
+/**
+ * Builds the skill-authoring Job envelope around the shared hardened pod policy.
+ *
+ * This small class-specific seam keeps the authoring image's workload identity visible to the
+ * controller and workload registry. It deliberately owns metadata only; all security posture,
+ * token projection, suspension, retries, and cleanup remain centralized in the shared spec.
+ */
 export function __BuildSkillAuthoringWorkloadJob(assignment: SkillWorkloadJobAssignment, profile: SkillWorkloadJobProfile): V1Job
 {
+	// 1. Derive an opaque selector-safe resource name so the Job name does not reveal durable authority ids.
 	const name = __SkillWorkloadJobName(assignment, profile);
+	// 2. Retain only bounded trace coordinates and the opaque exchange reference; never project source or credentials.
 	const annotations = { "opencrane.ai/silo-id": assignment.siloId, "opencrane.ai/job-id": assignment.jobId, "opencrane.ai/capability-reference": assignment.capabilityReference };
+	// 3. Delegate the Pod security policy to the one shared builder so both workload classes stay equally constrained.
 	return {
 		apiVersion: "batch/v1",
 		kind: "Job",

--- a/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type { V1Job } from "@kubernetes/client-node";
 
 import { __BuildSkillAuthoringWorkloadJob } from "./skill-authoring-workload-job.js";
+import { SkillWorkloadKinds } from "./skill-workload-job.types.js";
 import type { SkillWorkloadJobAssignment, SkillWorkloadJobProfile } from "./skill-workload-job.types.js";
 import { __BuildToolRunnerWorkloadJob } from "./tool-runner-workload-job.js";
 
@@ -31,7 +32,13 @@ const _CAPABILITY_TOKEN_PATH = "/var/run/opencrane/tokens/capability.token";
 /** Fixed read-only downward-API bootstrap reference path. */
 const _BOOTSTRAP_REFERENCE_PATH = "/var/run/opencrane/bootstrap/reference";
 
-/** Validate the one deployment-owned same-silo bootstrap endpoint. */
+/**
+ * Accepts only a deployment-owned cluster-local bootstrap endpoint with the worker protocol path.
+ *
+ * The URL is not worker input: it is a constrained profile value. This validator enforces only a
+ * syntactically valid uncredentialed cluster-local host and exact worker path; NetworkPolicy and
+ * the receiving bootstrap route separately bind that destination to the expected service identity.
+ */
 function _IsBootstrapUrl(value: string): boolean
 {
 	try
@@ -46,13 +53,18 @@ function _IsBootstrapUrl(value: string): boolean
 	}
 }
 
-/** Validate an opaque identifier before it is projected into Kubernetes metadata. */
+/**
+ * Accepts a bounded printable coordinate before it is projected into Kubernetes metadata.
+ *
+ * This is a size and control-character guard, not authorization. The opaque-reference grammar is
+ * checked separately because an annotation must remain traceable without becoming a capability.
+ */
 function _IsBoundedCoordinate(value: string): boolean
 {
 	return value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/.test(value);
 }
 
-/** Parse a positive binary Kubernetes quantity into bytes. */
+/** Parses a strictly positive binary Kubernetes quantity into bytes without accepting ambiguous units. */
 function _ParseBinaryBytes(value: string): bigint | null
 {
 	const match = /^([1-9][0-9]*)(Ki|Mi|Gi)$/.exec(value);
@@ -61,7 +73,7 @@ function _ParseBinaryBytes(value: string): bigint | null
 	return BigInt(match[1]) * (1024n ** exponent);
 }
 
-/** Parse a positive Kubernetes CPU quantity into millicores. */
+/** Parses a strictly positive CPU quantity into millicores so requests and limits can be compared safely. */
 function _ParseCpuMillis(value: string): number | null
 {
 	const milli = /^([1-9][0-9]*)m$/.exec(value);
@@ -70,23 +82,39 @@ function _ParseCpuMillis(value: string): number | null
 	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
-/** Validate deployment-owned limits before a controller can submit the worker Job. */
+/**
+ * Validates the deployment-owned Job policy before a controller can submit the worker manifest.
+ *
+ * Each condition is fail-closed. A Job needs a distinct class identity, a short-lived
+ * exact-audience token, one constrained bootstrap endpoint, bounded ephemeral resources, and no
+ * retry or retained scratch. Accepting a partial profile would silently widen worker authority.
+ */
 function _AssertProfile(profile: SkillWorkloadJobProfile): void
 {
-	const expectedServiceAccountName = profile.kind === "authoring" ? "skill-authoring-default" : "tool-runner-default";
-	const expectedAudience = profile.kind === "authoring" ? "opencrane-skill-authoring" : "opencrane-tool-runner";
+	// 1. Derive the only identity and audience accepted for this workload class, never from Job input.
+	const expectedServiceAccountName = profile.kind === SkillWorkloadKinds.Authoring ? "skill-authoring-default" : "tool-runner-default";
+	const expectedAudience = profile.kind === SkillWorkloadKinds.Authoring ? "opencrane-skill-authoring" : "opencrane-tool-runner";
+
+	// 2. Normalize deployment quantities before comparing resource envelopes and class-specific minima.
 	const scratchBytes = _ParseBinaryBytes(profile.scratchSize);
 	const requestedCpu = _ParseCpuMillis(String(profile.resources.requests?.cpu ?? ""));
 	const limitedCpu = _ParseCpuMillis(String(profile.resources.limits?.cpu ?? ""));
 	const requestedMemory = _ParseBinaryBytes(String(profile.resources.requests?.memory ?? ""));
 	const limitedMemory = _ParseBinaryBytes(String(profile.resources.limits?.memory ?? ""));
-	if (!/^[a-z0-9][a-z0-9._:/-]*@sha256:[a-f0-9]{64}$/.test(profile.image) || !["Always", "IfNotPresent", "Never"].includes(profile.imagePullPolicy) || profile.serviceAccountName !== expectedServiceAccountName || profile.capabilityTokenAudience !== expectedAudience || !_IsBootstrapUrl(profile.bootstrapUrl) || profile.capabilityTokenPath !== _CAPABILITY_TOKEN_PATH || profile.bootstrapReferencePath !== _BOOTSTRAP_REFERENCE_PATH || profile.namespace.length > 63 || !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(profile.namespace) || profile.namespace === profile.serverNamespace || !scratchBytes || scratchBytes > _MAX_SCRATCH_BYTES || (profile.kind === "authoring" && scratchBytes < _MIN_AUTHORING_SCRATCH_BYTES) || !Number.isSafeInteger(profile.activeDeadlineSeconds) || profile.activeDeadlineSeconds < 1 || profile.activeDeadlineSeconds > _MAX_ACTIVE_DEADLINE_SECONDS || profile.ttlSecondsAfterFinished !== 0 || !requestedCpu || !limitedCpu || requestedCpu > limitedCpu || limitedCpu > _MAX_CPU_MILLICORES || !requestedMemory || !limitedMemory || requestedMemory > limitedMemory || limitedMemory > _MAX_MEMORY_BYTES || (profile.kind === "authoring" && (requestedMemory < _MIN_AUTHORING_MEMORY_BYTES || limitedMemory < _MIN_AUTHORING_MEMORY_LIMIT_BYTES)))
+	// 3. Reject the whole profile on any widening: Kubernetes must never receive a partially safe manifest.
+	if (!/^[a-z0-9][a-z0-9._:/-]*@sha256:[a-f0-9]{64}$/.test(profile.image) || !["Always", "IfNotPresent", "Never"].includes(profile.imagePullPolicy) || profile.serviceAccountName !== expectedServiceAccountName || profile.capabilityTokenAudience !== expectedAudience || !_IsBootstrapUrl(profile.bootstrapUrl) || profile.capabilityTokenPath !== _CAPABILITY_TOKEN_PATH || profile.bootstrapReferencePath !== _BOOTSTRAP_REFERENCE_PATH || profile.namespace.length > 63 || !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(profile.namespace) || profile.namespace === profile.serverNamespace || !scratchBytes || scratchBytes > _MAX_SCRATCH_BYTES || (profile.kind === SkillWorkloadKinds.Authoring && scratchBytes < _MIN_AUTHORING_SCRATCH_BYTES) || !Number.isSafeInteger(profile.activeDeadlineSeconds) || profile.activeDeadlineSeconds < 1 || profile.activeDeadlineSeconds > _MAX_ACTIVE_DEADLINE_SECONDS || profile.ttlSecondsAfterFinished !== 0 || !requestedCpu || !limitedCpu || requestedCpu > limitedCpu || limitedCpu > _MAX_CPU_MILLICORES || !requestedMemory || !limitedMemory || requestedMemory > limitedMemory || limitedMemory > _MAX_MEMORY_BYTES || (profile.kind === SkillWorkloadKinds.Authoring && (requestedMemory < _MIN_AUTHORING_MEMORY_BYTES || limitedMemory < _MIN_AUTHORING_MEMORY_LIMIT_BYTES)))
 	{
 		throw new Error("governed skill Job profile requires one fixed bootstrap endpoint, fixed audience and paths, class-bounded identity, immutable image, bounded resources, scratch, and lifetime");
 	}
 }
 
-/** Validate controller-supplied durable coordinates before they become labels or annotations. */
+/**
+ * Validates controller-supplied durable coordinates before they become Job metadata.
+ *
+ * Assignment data selects one already-reserved attempt, but cannot select another namespace or
+ * expose a readable durable identifier through the bootstrap exchange reference. Those violations stop
+ * projection before a Kubernetes object exists, rather than relying on later route rejection.
+ */
 function _AssertAssignment(assignment: SkillWorkloadJobAssignment, profile: SkillWorkloadJobProfile): void
 {
 	if (![assignment.jobId, assignment.siloId, assignment.namespace, assignment.capabilityReference].every(function _isValid(value): boolean { return _IsBoundedCoordinate(value); }) || !/^skill-bootstrap-v1_[a-f0-9]{64}$/.test(assignment.capabilityReference) || assignment.namespace !== profile.namespace)
@@ -95,14 +123,26 @@ function _AssertAssignment(assignment: SkillWorkloadJobAssignment, profile: Skil
 	}
 }
 
-/** Derive a selector-safe, collision-resistant one-shot Job name without leaking authority ids. */
+/**
+ * Derives a selector-safe collision-resistant one-shot Job name without leaking authority ids.
+ *
+ * The hash includes class, silo, and attempt so equivalent ids in a different tenant or workload
+ * class never share a Kubernetes name. It is naming only; the internal route still binds identity
+ * and durable assignment before it accepts a bootstrap acknowledgement.
+ */
 export function __SkillWorkloadJobName(assignment: SkillWorkloadJobAssignment, profile: SkillWorkloadJobProfile): string
 {
 	const digest = createHash("sha256").update(`${profile.kind}\u0000${assignment.siloId}\u0000${assignment.jobId}`).digest("hex").slice(0, 24);
-	return `${profile.kind === "authoring" ? "skill-author" : "tool-run"}-${digest}`;
+	return `${profile.kind === SkillWorkloadKinds.Authoring ? "skill-author" : "tool-run"}-${digest}`;
 }
 
-/** Build one deterministic, unprivileged Job carrying only an opaque exchanged capability reference. */
+/**
+ * Builds one deterministic unprivileged Job carrying only an opaque capability exchange reference.
+ *
+ * The controller must persist the chosen Kubernetes identity before unsuspending this manifest.
+ * Until then, `suspend: true` prevents execution; after terminal state, retry and TTL policy ensure
+ * that the attempt cannot silently continue or preserve its temporary filesystem.
+ */
 export function __BuildGovernedSkillWorkloadJob(assignment: SkillWorkloadJobAssignment, profile: SkillWorkloadJobProfile): V1Job
 {
 	// 1. Refuse unbounded identity, image, storage, or lifetime inputs before Kubernetes can see them.
@@ -110,13 +150,21 @@ export function __BuildGovernedSkillWorkloadJob(assignment: SkillWorkloadJobAssi
 	_AssertAssignment(assignment, profile);
 
 	// 2. Select one app-owned Job class so the workload registry can inspect distinct construction anchors.
-	return profile.kind === "authoring" ? __BuildSkillAuthoringWorkloadJob(assignment, profile) : __BuildToolRunnerWorkloadJob(assignment, profile);
+	return profile.kind === SkillWorkloadKinds.Authoring ? __BuildSkillAuthoringWorkloadJob(assignment, profile) : __BuildToolRunnerWorkloadJob(assignment, profile);
 }
 
-/** Build the shared hardened Job spec after an app-specific function constructed the Job envelope. */
+/**
+ * Builds the hardened shared Job spec after a class-specific function constructs the envelope.
+ *
+ * The profile and assignment have already been validated. This function must not add a second
+ * execution path or encode untrusted source, arguments, artifacts, or credentials in the manifest:
+ * workers obtain an exact short-lived capability only by presenting their projected token and the
+ * separate opaque reference to the verified bootstrap route.
+ */
 export function __BuildSkillWorkloadJobSpec(profile: SkillWorkloadJobProfile, component: "skill-authoring" | "tool-runner", name: string, annotations: Readonly<Record<string, string>>): NonNullable<V1Job["spec"]>
 {
 	return {
+		// 1. Lifecycle invariant: controller persistence releases the Job; it never retries and immediately removes scratch.
 		suspend: true,
 		backoffLimit: 0,
 		completions: 1,
@@ -126,13 +174,16 @@ export function __BuildSkillWorkloadJobSpec(profile: SkillWorkloadJobProfile, co
 		template: {
 			metadata: { labels: { "app.kubernetes.io/component": component, "opencrane.ai/skill-workload": name }, annotations },
 			spec: {
+				// 2. Identity invariant: default credentials and cluster service discovery stay unavailable to the worker.
 				serviceAccountName: profile.serviceAccountName,
 				automountServiceAccountToken: false,
 				enableServiceLinks: false,
 				restartPolicy: "Never",
 				terminationGracePeriodSeconds: 0,
 				securityContext: { runAsNonRoot: true, runAsUser: 65532, runAsGroup: 65532, fsGroup: 65532, seccompProfile: { type: "RuntimeDefault" } },
+				// 3. Container invariant: an immutable image runs non-privileged with a read-only root and bounded writable scratch.
 				containers: [{ name: component, image: profile.image, imagePullPolicy: profile.imagePullPolicy, securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: ["ALL"] }, readOnlyRootFilesystem: true }, env: [{ name: "OPENCRANE_SKILL_BOOTSTRAP_URL", value: profile.bootstrapUrl }, { name: "OPENCRANE_SKILL_TOKEN_PATH", value: profile.capabilityTokenPath }, { name: "OPENCRANE_SKILL_BOOTSTRAP_REFERENCE_PATH", value: profile.bootstrapReferencePath }], resources: structuredClone(profile.resources), volumeMounts: [{ name: "capability-token", mountPath: "/var/run/opencrane/tokens", readOnly: true }, { name: "bootstrap-reference", mountPath: "/var/run/opencrane/bootstrap", readOnly: true }, { name: "scratch", mountPath: "/tmp" }] }],
+				// 4. Bootstrap invariant: the audience-bound token and opaque reference are separate read-only inputs.
 				volumes: [{ name: "capability-token", projected: { defaultMode: 0o440, sources: [{ serviceAccountToken: { path: "capability.token", audience: profile.capabilityTokenAudience, expirationSeconds: 600 } }] } }, { name: "bootstrap-reference", downwardAPI: { defaultMode: 0o440, items: [{ path: "reference", fieldRef: { fieldPath: "metadata.annotations['opencrane.ai/capability-reference']" } }] } }, { name: "scratch", emptyDir: { sizeLimit: profile.scratchSize } }],
 			},
 		},

--- a/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.types.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/skill-workload-job.types.ts
@@ -1,53 +1,85 @@
 import type { V1ResourceRequirements } from "@kubernetes/client-node";
 
-/** The two isolated Python workload classes owned by the governed-skill plane. */
-export type SkillWorkloadKind = "authoring" | "tool-runner";
+/**
+ * Stable serialized workload-class values owned by the governed-skill plane.
+ *
+ * This discriminant selects a deliberately separate deployment identity, token audience, image,
+ * and component label. It is not an instruction from the worker and therefore cannot be changed
+ * by a durable job coordinate or bootstrap reference.
+ */
+export enum SkillWorkloadKinds
+{
+	/** Offline authoring and validation worker with its larger fixed extraction resource floor. */
+	Authoring = "authoring",
+	/** Tenant-authored tool execution worker with its distinct ServiceAccount and token audience. */
+	ToolRunner = "tool-runner",
+}
 
-/** Kubernetes image pull behaviour accepted for a governed skill workload. */
+/** The two serialized workload classes accepted by a deployment-owned Job profile. */
+export type SkillWorkloadKind = `${SkillWorkloadKinds}`;
+
+/**
+ * Kubernetes image pull behaviour accepted for a governed skill workload.
+ *
+ * The image itself is always digest-pinned; this only controls whether Kubernetes reuses an
+ * already-verified local copy of that immutable image.
+ */
 export type SkillWorkloadImagePullPolicy = "Always" | "IfNotPresent" | "Never";
 
-/** Deployment-owned limits applied to one isolated governed-skill Job class. */
+/**
+ * Deployment-owned policy projected into every isolated Job of one workload class.
+ *
+ * The controller supplies a profile from trusted deployment configuration. The builder validates
+ * it again because a manifest is a security boundary: a malformed profile must never broaden the
+ * worker's identity, network destination, lifetime, or resource envelope.
+ */
 export interface SkillWorkloadJobProfile
 {
-	/** Fixed workload class selecting the identity grammar and component label. */
+	/** Fixed class that selects its distinct identity grammar, token audience, and component label. */
 	readonly kind: SkillWorkloadKind;
-	/** Immutable digest-pinned Python worker image. */
+	/** Immutable digest-pinned Python worker image; mutable tags are rejected before projection. */
 	readonly image: string;
-	/** Kubernetes image pull policy for the immutable worker image. */
+	/** Kubernetes pull behaviour for the immutable worker image, not a mechanism to select an image. */
 	readonly imagePullPolicy: SkillWorkloadImagePullPolicy;
-	/** OpenCrane server namespace, which must differ from the isolated Job namespace. */
+	/** OpenCrane server namespace, required to differ from the isolated Job namespace. */
 	readonly serverNamespace: string;
-	/** Exact deployment-owned namespace for this workload class. */
+	/** Exact deployment-owned namespace for this Job class; assignment input may only repeat it. */
 	readonly namespace: string;
-	/** Bounded, zero-RBAC ServiceAccount for this exact Job class. */
+	/** Expected ServiceAccount name for this Job class, never a controller or server identity; its RBAC is chart-owned. */
 	readonly serviceAccountName: string;
-	/** Audience for the sole projected capability token mounted into the Job. */
+	/** Audience of the sole short-lived projected token mounted into the Job. */
 	readonly capabilityTokenAudience: string;
-	/** Fixed same-silo internal route where the worker may acknowledge its bootstrap. */
+	/** Fixed cluster-local internal endpoint where the worker may acknowledge its bootstrap and nothing else. */
 	readonly bootstrapUrl: string;
-	/** Fixed read-only projected-token path used by the worker client. */
+	/** Fixed read-only path of the projected token; it prevents a worker argument from selecting a token. */
 	readonly capabilityTokenPath: string;
-	/** Fixed read-only downward-API reference path used by the worker client. */
+	/** Fixed read-only path of the opaque downward-API reference; it is not a capability or secret. */
 	readonly bootstrapReferencePath: string;
-	/** Bounded non-authoritative scratch volume quantity. */
+	/** Bounded ephemeral non-authoritative scratch volume quantity; it is never durable tenant storage. */
 	readonly scratchSize: string;
-	/** Maximum wall-clock lifetime of the one-shot Job. */
+	/** Maximum wall-clock lifetime of the one-shot Job, after which Kubernetes terminates it. */
 	readonly activeDeadlineSeconds: number;
-	/** Terminal cleanup delay, which must be zero for untrusted scratch. */
+	/** Terminal cleanup delay, which must remain zero so Kubernetes may clean up untrusted scratch after it observes completion. */
 	readonly ttlSecondsAfterFinished: number;
-	/** CPU and memory requests and limits for the Job container. */
+	/** CPU and memory requests and limits; requests cannot exceed limits and both remain class-bounded. */
 	readonly resources: V1ResourceRequirements;
 }
 
-/** Durable coordinates that become one deterministic governed-skill Kubernetes Job. */
+/**
+ * Durable controller coordinates that become one deterministic governed-skill Kubernetes Job.
+ *
+ * These values identify the already-authorized assignment. They do not authorize the Job: the
+ * internal bootstrap route still verifies the projected token, class, namespace, and durable
+ * assignment before it accepts any worker request.
+ */
 export interface SkillWorkloadJobAssignment
 {
-	/** Stable opaque authority id for this one Job attempt. */
+	/** Stable controller-owned id for this one Job attempt; hashed before it becomes a resource name. */
 	readonly jobId: string;
-	/** ClusterTenant silo containing every durable authority fact. */
+	/** ClusterTenant silo containing every durable authority fact; retained as bounded trace metadata. */
 	readonly siloId: string;
-	/** Dedicated namespace selected by the controller for this job class. */
+	/** Dedicated namespace selected by the controller; it must exactly match the deployment profile. */
 	readonly namespace: string;
-	/** Opaque, non-secret reference that the worker exchanges for its exact capability. */
+	/** Opaque non-secret reference exchanged for the exact capability; it cannot expose a readable workload id. */
 	readonly capabilityReference: string;
 }

--- a/libs/backend/agents/skills/k8s-launcher/src/tool-runner-workload-job.ts
+++ b/libs/backend/agents/skills/k8s-launcher/src/tool-runner-workload-job.ts
@@ -3,11 +3,20 @@ import type { V1Job } from "@kubernetes/client-node";
 import { __BuildSkillWorkloadJobSpec, __SkillWorkloadJobName } from "./skill-workload-job.js";
 import type { SkillWorkloadJobAssignment, SkillWorkloadJobProfile } from "./skill-workload-job.types.js";
 
-/** Build the actual Job envelope owned by the tool-runner deployable. */
+/**
+ * Builds the tool-runner Job envelope around the shared hardened pod policy.
+ *
+ * This class-specific seam makes the tool runner's identity and registry label explicit without
+ * giving it a separate security policy. The returned manifest intentionally contains only bounded
+ * trace metadata plus an opaque exchange reference, never tool arguments, credentials, or bytes.
+ */
 export function __BuildToolRunnerWorkloadJob(assignment: SkillWorkloadJobAssignment, profile: SkillWorkloadJobProfile): V1Job
 {
+	// 1. Derive an opaque selector-safe resource name so the Job name does not reveal durable authority ids.
 	const name = __SkillWorkloadJobName(assignment, profile);
+	// 2. Retain only bounded trace coordinates and the opaque exchange reference; never project source or credentials.
 	const annotations = { "opencrane.ai/silo-id": assignment.siloId, "opencrane.ai/job-id": assignment.jobId, "opencrane.ai/capability-reference": assignment.capabilityReference };
+	// 3. Delegate the Pod security policy to the one shared builder so both workload classes stay equally constrained.
 	return {
 		apiVersion: "batch/v1",
 		kind: "Job",


### PR DESCRIPTION
## Review relationship

Intentionally independent from the main stack: this PR documents and tightens the skill-workload launcher without depending on its authority or package changes. A cumulative merge simulation after stack tip #562 passed without conflicts.

## Context

The governed skill Kubernetes Job builder is a high-trust projection boundary: its manifest determines worker identity, token visibility, lifecycle, and resource limits. Its code previously expressed those rules but did not adequately explain why they must remain fixed.

## What changed

- document profile and assignment validation as fail-closed policy, including class identity, resource floors, and opaque metadata
- add numbered code-local invariants for Job lifecycle, suspension, no-retry cleanup, pod security, and the separate token/reference mounts
- make documentation precise about grammar-only bootstrap URL validation, asynchronous TTL cleanup, and bounded trace annotations
- replace owned raw workload-kind branching with the documented SkillWorkloadKinds vocabulary while preserving serialized literal-string callers

## Deliberately unchanged

This does not change Kubernetes Job behavior, service binding, RBAC, NetworkPolicy, or bootstrap routing. Those constraints remain owned by deployment configuration and the receiving internal route.

## Validation

- npx nx run backend-agents-skills-k8s-launcher:test — 4/4 passed
- npx nx run backend-agents-skills-k8s-launcher:lint
- scripts/agent-style-check.sh — 0 errors, 0 warnings
- npm run check:prisma-boundaries -- --diff origin/develop
- npm run check:module-growth -- --diff origin/develop
- git diff --check

## Review

Independent review: PASS. Local Claude Code review was attempted but Claude is signed out; the record is in ignored .agent-reviews/.
