### PR TITLE
♻️ Hide conversation replay Prisma adapter

### DIFF
--- a/apps/opencrane/src/app/runtime-composition.ts
+++ b/apps/opencrane/src/app/runtime-composition.ts
@@ -7,7 +7,7 @@ import { PrismaRunDispatchRepository, __CreateAgentControllerRunDispatchRouter, 
 import { PrismaSkillAuthoringCompletionRepository, PrismaSkillAuthoringInputRepository, PrismaSkillWorkloadBootstrapRepository, PrismaSkillWorkloadClaimsRepository, __CreateSkillAuthoringCompletionRouter, __CreateSkillAuthoringInputRouter, __CreateSkillWorkloadBootstrapRouter, __CreateSkillWorkloadDispatchRouter } from "@opencrane/backend/agents/skills/execution";
 import { __CreateProductionRuntimeDispatchAuthority } from "@opencrane/backend/agents/execution/protocol";
 import { PrismaRuntimeBootstrapExchange, __CreateRuntimeBootstrapRouter } from "@opencrane/backend/server/iam/authorization";
-import { __CreateConversationReplayRouter, PrismaConversationReplayRepository } from "@opencrane/backend/server/agents/conversation-replay";
+import { _CreateConversationReplayRepository, __CreateConversationReplayRouter } from "@opencrane/backend/server/agents/conversation-replay";
 import { PrismaChannelTargetAuthorityRepository } from "@opencrane/backend/server/agents/channel-targets";
 import { PrismaArtifactPreprocessRepository, __CreateArtifactPreprocessorRouter } from "@opencrane/backend/server/agents/artifacts";
 import { _CreateAgentControllerTokenReviewer, _CreateArtifactPreprocessorTokenReviewer, _CreateRuntimeTokenReviewer, _CreateSkillWorkloadTokenReviewer, _ValidateIsolatedWorkloadNamespace, _ValidateRuntimeIdentityNamespaces } from "@opencrane/server/_infra/workload-identity";
@@ -68,7 +68,7 @@ export function _CreateInternalRuntimeComposition(prisma: PrismaClient, authApi:
 	return {
 		conversationReplay: replayRouteId === null
 			? null
-			: __CreateConversationReplayRouter({ contexts: new PrismaChannelTargetAuthorityRepository(prisma), repository: new PrismaConversationReplayRepository(prisma), expectedRouteId: replayRouteId, nowEpochMs: function _now() { return Date.now(); } }),
+			: __CreateConversationReplayRouter({ contexts: new PrismaChannelTargetAuthorityRepository(prisma), repository: _CreateConversationReplayRepository(prisma), expectedRouteId: replayRouteId, nowEpochMs: function _now() { return Date.now(); } }),
 		agentControllerRunDispatch: __CreateAgentControllerRunDispatchRouter({ tokenReviewer: controllerTokenReviewer, namespace: serverNamespace, repository: runDispatchRepository, logger: _log }),
 		skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({ tokenReviewer: controllerTokenReviewer, namespace: serverNamespace, repository: new PrismaSkillWorkloadClaimsRepository(prisma, config.claimLeaseMilliseconds), logger: _log }),
 		skillWorkloadBootstrap: __CreateSkillWorkloadBootstrapRouter({ tokenReviewer: skillWorkloadTokenReviewer, repository: new PrismaSkillWorkloadBootstrapRepository(prisma), logger: _log }),

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -13,6 +13,10 @@
       {
         "contract": "AgentRevisionWriterRepository",
         "importPath": "./prisma-agent-revision-writer.types.js"
+      },
+      {
+        "contract": "ConversationReplayRepository",
+        "importPath": "./replay-reader.types.js"
       }
     ],
     "unitsOfWork": [

--- a/libs/backend/server/agents/conversation-replay/main/README.md
+++ b/libs/backend/server/agents/conversation-replay/main/README.md
@@ -45,7 +45,9 @@ endpoint as the current `events.read` channel route. Without both facts, no repl
   opaque resume position.
 - `__ReadConversationReplay` applies server-owned bounds and display-safe redaction to repository
   rows.
-- `PrismaConversationReplayRepository` reads canonical rows after participant and cursor checks.
+- `_CreateConversationReplayRepository` is the named app-composition factory for the read-only
+  participant-and-cursor-checked repository. It opens no transaction because replay has no durable
+  write or cross-query atomicity requirement.
 - `__CreateConversationReplayRouter` consumes the one-use context and writes the AG-UI SSE snapshot.
 - `__CreateSelfConversationReplayRouter` exposes the same redacted snapshot to the authenticated
   participant at `GET /api/v1/me/conversations/:threadId/events`; it derives the subject and silo
@@ -56,7 +58,9 @@ endpoint as the current `events.read` channel route. Without both facts, no repl
 ## Boundary
 
 The channel route caller supplies a consumed channel-context authority and exact controller-selected
-route identifier. The self route caller supplies only a server-derived session/host identity. This
+route identifier. The self route caller supplies only a server-derived session/host identity. The
+app composition creates the private Prisma repository once; callers receive the replay port, never a
+Prisma adapter. This
 package does not authenticate a browser, resolve a channel target, create a run, register an
 endpoint, or persist new conversation events. It fails closed before a canonical read whenever the
 context, cursor, thread, silo, or participant binding is wrong.

--- a/libs/backend/server/agents/conversation-replay/main/src/__tests__/prisma-conversation-replay-repository.test.ts
+++ b/libs/backend/server/agents/conversation-replay/main/src/__tests__/prisma-conversation-replay-repository.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { PrismaConversationReplayRepository } from "../prisma-conversation-replay-repository.js";
+import { _CreateConversationReplayRepository } from "../prisma-conversation-replay-repository.js";
 
 describe("Prisma conversation replay repository", function _Suite()
 {
@@ -13,7 +13,7 @@ describe("Prisma conversation replay repository", function _Suite()
 			agentRun: { findFirst: async function _cursorRun() { return { id: "run-1" }; }, findMany: agentRunFindMany },
 			conversationRunEvent: { findUnique: async function _cursorEvent() { return { runId: "run-1" }; }, findMany },
 		};
-		const repository = new PrismaConversationReplayRepository(prisma as never);
+		const repository = _CreateConversationReplayRepository(prisma as never);
 		const rows = await repository.read({ threadId: "thread-1", siloId: "silo-1", subjectId: "user-1", cursor: { acceptedAt: "2026-07-23T10:00:00.000Z", runId: "run-1", sequence: 2 }, limit: 10 });
 		expect(rows).toHaveLength(1);
 		expect(agentRunFindMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ OR: expect.arrayContaining([expect.objectContaining({ acceptedAt: new Date("2026-07-23T10:00:00.000Z"), id: { gte: "run-1" } })]) }) }));
@@ -27,7 +27,7 @@ describe("Prisma conversation replay repository", function _Suite()
 			agentRun: { findFirst: async function _cursorRun() { return null; }, findMany },
 			conversationRunEvent: { findUnique: async function _cursorEvent() { return null; }, findMany: async function _events() { return []; } },
 		};
-		const rows = await new PrismaConversationReplayRepository(prisma as never).read({ threadId: "thread-1", siloId: "silo-1", subjectId: "user-1", cursor: { acceptedAt: "2026-07-23T10:00:00.000Z", runId: "foreign-run", sequence: 1 }, limit: 10 });
+		const rows = await _CreateConversationReplayRepository(prisma as never).read({ threadId: "thread-1", siloId: "silo-1", subjectId: "user-1", cursor: { acceptedAt: "2026-07-23T10:00:00.000Z", runId: "foreign-run", sequence: 1 }, limit: 10 });
 		expect(rows).toEqual([]);
 		expect(findMany).not.toHaveBeenCalled();
 	});

--- a/libs/backend/server/agents/conversation-replay/main/src/index.ts
+++ b/libs/backend/server/agents/conversation-replay/main/src/index.ts
@@ -1,7 +1,7 @@
 export { __DecodeConversationReplayCursor, __EncodeConversationReplayCursor } from "./replay-cursor.js";
 export { __ProjectConversationReplayEvent } from "./replay-projection.js";
 export { __ReadConversationReplay } from "./conversation-replay.js";
-export { PrismaConversationReplayRepository } from "./prisma-conversation-replay-repository.js";
+export { _CreateConversationReplayRepository } from "./prisma-conversation-replay-repository.js";
 export { __CreateConversationReplayRouter } from "./conversation-replay.router.js";
 export { __CreateSelfConversationReplayRouter } from "./self-conversation-replay.router.js";
 export { _CreateSelfConversationReplayRouter } from "./prisma-self-conversation-replay.router.js";

--- a/libs/backend/server/agents/conversation-replay/main/src/prisma-conversation-replay-repository.ts
+++ b/libs/backend/server/agents/conversation-replay/main/src/prisma-conversation-replay-repository.ts
@@ -5,8 +5,14 @@ import type { ConversationReplayCursor } from "./replay-cursor.types.js";
 import type { ConversationReplayRepository, ReadConversationReplayCommand } from "./replay-reader.types.js";
 import type { ConversationReplayEventRow } from "./replay-projection.types.js";
 
-/** Prisma adapter that reads only a consumed context's participant-bound canonical thread events. */
-export class PrismaConversationReplayRepository implements ConversationReplayRepository
+/** App-composed read repository that accepts a Prisma client only at this persistence edge. */
+export function _CreateConversationReplayRepository(prisma: PrismaClient): ConversationReplayRepository
+{
+	return new _PrismaConversationReplayRepository(prisma);
+}
+
+/** Private Prisma adapter that reads only a consumed context's participant-bound canonical thread events. */
+class _PrismaConversationReplayRepository implements ConversationReplayRepository
 {
 	/** Canonical product database. */
 	private readonly prisma: PrismaClient;

--- a/libs/backend/server/agents/conversation-replay/main/src/prisma-self-conversation-replay.router.ts
+++ b/libs/backend/server/agents/conversation-replay/main/src/prisma-self-conversation-replay.router.ts
@@ -4,7 +4,7 @@ import type { Logger } from "pino";
 
 import { _ResolveRequestPrincipal } from "@opencrane/server/_infra/auth";
 
-import { PrismaConversationReplayRepository } from "./prisma-conversation-replay-repository.js";
+import { _CreateConversationReplayRepository } from "./prisma-conversation-replay-repository.js";
 import { __CreateSelfConversationReplayRouter } from "./self-conversation-replay.router.js";
 import type { SelfConversationReplayCaller } from "./self-conversation-replay.router.types.js";
 
@@ -25,7 +25,7 @@ export function _CreateSelfConversationReplayRouter(prisma: PrismaClient, logger
 {
 	return __CreateSelfConversationReplayRouter({
 		resolveCaller: _resolveCaller,
-		repository: new PrismaConversationReplayRepository(prisma),
+		repository: _CreateConversationReplayRepository(prisma),
 		logger,
 	});
 }


### PR DESCRIPTION
## Summary

- retain the live signed-in and controller-selected conversation replay routes
- keep participant, silo, thread, cursor, and AG-UI redaction behaviour unchanged
- replace public Prisma repository construction with a named read-only composition factory
- document that replay has no durable write or cross-query atomicity requirement, so it intentionally has no Unit of Work
- register the capability repository with the Prisma-boundary gate

## Validation

- backend-server-conversation-replay lint and 14/14 focused tests
- opencrane app lint
- style, module-growth, Prisma-boundary, and diff checks

## Review

- architecture/reaper tracing confirmed replay is live and no caller or route is obsolete
- local Claude review was attempted but this workstation is signed out; its non-sensitive result is stored only under the ignored .agent-reviews directory