### PR TITLE
🐛 make agent revision digest browser-safe

### DIFF
--- a/libs/backend/agents/personal/configuration/main/src/__tests__/prisma-personal-configuration-materialization.test.ts
+++ b/libs/backend/agents/personal/configuration/main/src/__tests__/prisma-personal-configuration-materialization.test.ts
@@ -197,7 +197,7 @@ describe("Prisma-backed personal configuration materialization", function _Mater
 						subjectId: "user-1",
 					}],
 				},
-				digest: __DigestAgentRevisionContent("service-1", 2, expectedContent),
+				digest: await __DigestAgentRevisionContent("service-1", 2, expectedContent),
 			}),
 		}));
 		expect(transaction.agentRevision.update).toHaveBeenCalledWith({

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-writer.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-writer.ts
@@ -85,7 +85,7 @@ export function _AgentRevisionContentFromRow(row: AgentRevisionWithAssignments):
  * in the agent-service authority prevents another package from independently reproducing revision
  * persistence rules while still allowing an existing transaction to remain atomic.
  */
-function _RevisionCreateData(command: CreateAgentRevisionWithinTransactionCommand): Prisma.AgentRevisionCreateInput
+async function _RevisionCreateData(command: CreateAgentRevisionWithinTransactionCommand): Promise<Prisma.AgentRevisionCreateInput>
 {
 	return {
 		agentService: { connect: { id: command.agentServiceId } },
@@ -98,7 +98,7 @@ function _RevisionCreateData(command: CreateAgentRevisionWithinTransactionComman
 			: { connect: { id: command.sourceRevisionId } },
 		changeMessage: command.changeMessage,
 		state: AgentRevisionState.Draft,
-		digest: __DigestAgentRevisionContent(
+		digest: await __DigestAgentRevisionContent(
 			command.agentServiceId,
 			command.revision,
 			command.content,
@@ -159,7 +159,7 @@ export class PrismaAgentRevisionWriterRepository implements AgentRevisionWriterR
 	async createDraft(command: CreateAgentRevisionWithinTransactionCommand)
 	{
 		return this.transaction.agentRevision.create({
-			data: _RevisionCreateData(command),
+			data: await _RevisionCreateData(command),
 			include: _AGENT_REVISION_INCLUDE,
 		});
 	}

--- a/libs/models/agents/main/src/__tests__/agent-revision-content.test.ts
+++ b/libs/models/agents/main/src/__tests__/agent-revision-content.test.ts
@@ -24,10 +24,10 @@ function _Content(overrides: Partial<AgentRevisionContent> = {}): AgentRevisionC
 
 describe("agent revision content digest", function _AgentRevisionContentDigestSuite()
 {
-	it("is stable for the same numbered executable content", function _StableDigest()
+	it("is stable for the same numbered executable content", async function _StableDigest()
 	{
-		const first = __DigestAgentRevisionContent("service-1", 2, _Content());
-		const second = __DigestAgentRevisionContent("service-1", 2, _Content());
+		const first = await __DigestAgentRevisionContent("service-1", 2, _Content());
+		const second = await __DigestAgentRevisionContent("service-1", 2, _Content());
 
 		expect(second).toBe(first);
 		expect(first).toBe("sha256:41510297d3c19cbfe27a9ad17480844770606934c14aa556a1eda3ae22ec5fcc");
@@ -41,10 +41,10 @@ describe("agent revision content digest", function _AgentRevisionContentDigestSu
 		["skills", { skills: [{ skillId: "skill-2", revisionId: "skill-revision-2" }] }],
 		["integrations", { integrationAssignments: [{ integrationId: "integration-2", custodyReferenceId: "custody-2", allowedTools: ["mail.read"] }] }],
 		["scope attachments", { scopeAttachments: [{ scope: "team", subjectType: "group", subjectId: "team-1" }] }],
-	] satisfies readonly (readonly [string, Partial<AgentRevisionContent>])[])("changes when %s change", function _ExecutableFieldChangesDigest(_field, overrides)
+	] satisfies readonly (readonly [string, Partial<AgentRevisionContent>])[])("changes when %s change", async function _ExecutableFieldChangesDigest(_field, overrides)
 	{
-		const original = __DigestAgentRevisionContent("service-1", 2, _Content());
-		const changed = __DigestAgentRevisionContent("service-1", 2, _Content(overrides));
+		const original = await __DigestAgentRevisionContent("service-1", 2, _Content());
+		const changed = await __DigestAgentRevisionContent("service-1", 2, _Content(overrides));
 
 		expect(changed).not.toBe(original);
 	});

--- a/libs/models/agents/main/src/agent-revision-content.ts
+++ b/libs/models/agents/main/src/agent-revision-content.ts
@@ -1,8 +1,15 @@
-import { createHash } from "node:crypto";
-
 import { ___CanonicalizeJson, type CanonicalJsonSha256Digest, type JsonValue } from "@opencrane/util";
 
 import type { AgentRevisionContent } from "./agent-revision.types.js";
+
+async function _Sha256Hex(input: string): Promise<string>
+{
+	const hashBuffer = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+	return Array.from(new Uint8Array(hashBuffer), function _ToHexByte(byte)
+	{
+		return byte.toString(16).padStart(2, "0");
+	}).join("");
+}
 
 /**
  * Computes the canonical digest for one numbered agent revision.
@@ -16,7 +23,7 @@ import type { AgentRevisionContent } from "./agent-revision.types.js";
  * @param content - Complete immutable executable content persisted on the revision.
  * @returns Canonical SHA-256 digest covering the service, number, and executable content.
  */
-export function __DigestAgentRevisionContent(agentServiceId: string, revision: number, content: AgentRevisionContent): CanonicalJsonSha256Digest
+export async function __DigestAgentRevisionContent(agentServiceId: string, revision: number, content: AgentRevisionContent): Promise<CanonicalJsonSha256Digest>
 {
 	const canonical: JsonValue = {
 		agentServiceId,
@@ -51,5 +58,5 @@ export function __DigestAgentRevisionContent(agentServiceId: string, revision: n
 		}),
 	};
 
-	return `sha256:${createHash("sha256").update(___CanonicalizeJson(canonical), "utf8").digest("hex")}`;
+	return `sha256:${await _Sha256Hex(___CanonicalizeJson(canonical))}`;
 }


### PR DESCRIPTION
## Summary

Fixes the Angular build failure caused by the shared agent revision digest helper importing Node-only `node:crypto`.

The digest now uses browser-safe Web Crypto while preserving the canonical SHA-256 digest format used by backend revision writers.

## Changes

- Replaced `node:crypto` usage in `__DigestAgentRevisionContent` with `globalThis.crypto.subtle.digest`.
- Made the digest helper async and updated current call sites/tests to await it.
- Kept the digest in `@opencrane/models/agents`, matching the package’s documented ownership of pure canonical revision invariants.
- Removed leftover unused digest helper code.

## Validation

- `scripts/agent-style-check.sh`
- `npx nx run models-agents:lint`
- `npx nx run models-agents:test`
- `npm run build:opencrane-ui`

## Notes

No backend API, database, routing, or contract changes.