### PR TITLE
⬆️ Align Angular 21 maintenance dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,14 +15,14 @@
       "dependencies": {
         "@a2ui/angular": "0.10.2",
         "@a2ui/web_core": "0.10.3",
-        "@angular/animations": "^21.2.0",
-        "@angular/cdk": "^21.2.0",
-        "@angular/common": "^21.2.0",
-        "@angular/compiler": "^21.2.0",
-        "@angular/core": "^21.2.0",
-        "@angular/forms": "^21.2.0",
-        "@angular/platform-browser": "^21.2.0",
-        "@angular/router": "^21.2.0",
+        "@angular/animations": "^21.2.19",
+        "@angular/cdk": "^21.2.14",
+        "@angular/common": "^21.2.19",
+        "@angular/compiler": "^21.2.19",
+        "@angular/core": "^21.2.19",
+        "@angular/forms": "^21.2.19",
+        "@angular/platform-browser": "^21.2.19",
+        "@angular/router": "^21.2.19",
         "@kubernetes/client-node": "^1.0.0",
         "@noble/hashes": "1.8.0",
         "@opentelemetry/api": "^1.9.0",
@@ -49,9 +49,9 @@
         "zod": "^3.25.0"
       },
       "devDependencies": {
-        "@angular-devkit/build-angular": "^21.2.0",
-        "@angular/cli": "^21.2.0",
-        "@angular/compiler-cli": "^21.2.0",
+        "@angular-devkit/build-angular": "^21.2.19",
+        "@angular/cli": "^21.2.19",
+        "@angular/compiler-cli": "^21.2.19",
         "@nx/angular": "^23.0.2",
         "@nx/eslint-plugin": "^23.0.2",
         "@opentelemetry/sdk-trace-base": "^2.9.0",
@@ -703,9 +703,10 @@
       }
     },
     "node_modules/@angular/animations": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.18.tgz",
-      "integrity": "sha512-zN++Qb4Oz4x/5LYHuW9FItm7aHsV4HBz518GT25QusMvGymh+4io2TWhPYB0C9jx+g5q8GeQLd3c8r42yLrRxw==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-21.2.19.tgz",
+      "integrity": "sha512-qC0mviselvpKq2ID9bT+USnCsHKfwZAifkUr5A4h/WCzXvUvpVNWp/RPhGcKeOR+seg3EO5GtIZyblwiRlhzrA==",
+      "deprecated": "@angular/animations is deprecated. Use `animate.enter` and `animate.leave` instead. For more information see: https://v22.angular.dev/guide/animations.",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -714,7 +715,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.18"
+        "@angular/core": "21.2.19"
       }
     },
     "node_modules/@angular/build": {
@@ -879,9 +880,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.18.tgz",
-      "integrity": "sha512-gZugZ8gX/KkACIZ3/ekoImLu5z8a0Iu9O5b84kh8e+++VUjmkmd19IygBsq/8/fF3vKf0UcIKcx3P6A/gb2DJw==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-21.2.19.tgz",
+      "integrity": "sha512-Rvo/VXI0kUmfQT7+OeAjv526OJlf/WrLnJq1Tz84Jkyv9bs9SOMTCT6m4+boo8gxVNdrcxvGU3Q0o2jZzKceSg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -890,14 +891,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "21.2.18",
+        "@angular/core": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.18.tgz",
-      "integrity": "sha512-ccnDuKLuzIa0ayijR+alarsHNWIksuGV/lxGTZ0t6/0+B6J/RXupz6M2IO6ZHHEcg8r7pcrLCUBTyp3FoiRJrg==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-21.2.19.tgz",
+      "integrity": "sha512-vuF5i1t14ftJiHXVVLgDYLWkT99QuajphcUHy1VZaMX3FiqSGXRV62g+R2RMxL0OJ5C1ai8xTHKPx9n1lQFyFg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -907,9 +908,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.18.tgz",
-      "integrity": "sha512-L5zbIp7YfTTB4I4xT33FgEBanzhppNejzZX0HJOEqKDyDL2jXq+flt83lE0XVuRJ6/zrG+UKj0B+y/CK6Ro7Wg==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-21.2.19.tgz",
+      "integrity": "sha512-QxWqUvhTWgyYPPkfpupOUIEa3Y5cbzMilaFgRNpkvFy6teARw5Izsd7RxUbj3Tp3xJOi1MtumNmkxLxmv3iv7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -930,7 +931,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.18",
+        "@angular/compiler": "21.2.19",
         "typescript": ">=5.9 <6.1"
       },
       "peerDependenciesMeta": {
@@ -940,9 +941,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.18.tgz",
-      "integrity": "sha512-AG4bb6GU0+qp+vVBjc/IhSPjgcRX8QsCb8jzN8dDyhnjsyuuG/LlIiU0l6n65BI9SGKE9m6TfsJ1ObkkAiE5KQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-21.2.19.tgz",
+      "integrity": "sha512-PVoXD1kBexOJLkFzKx2zBY/0oZJXGru0eGn2hu0q5n3vkZlYsR1yRolfGenK1gZE48Qibiw/ttg/X/pAIPEZGg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -951,7 +952,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "21.2.18",
+        "@angular/compiler": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0 || ~0.16.0"
       },
@@ -965,9 +966,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.18.tgz",
-      "integrity": "sha512-TrRuiNjIzrrNtQgpJVH5gultQrvBlawa+tTzIpxBfIqLpkHrTPZLtYu118EUk6jhWzgRhKYUorInjJe+sSxC+w==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-21.2.19.tgz",
+      "integrity": "sha512-tEw8cz2UU6VSB+ReJN86k87nRdLRXGi+8SZhoRl2dFu2iReIO3S6kJAVTH7Y9kdrokqTPhWG+KNEzWgqhdjXOg==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -977,16 +978,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.18",
-        "@angular/core": "21.2.18",
-        "@angular/platform-browser": "21.2.18",
+        "@angular/common": "21.2.19",
+        "@angular/core": "21.2.19",
+        "@angular/platform-browser": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.18.tgz",
-      "integrity": "sha512-zltF+3HrlgtZbYg8U98LhG0dyGm1aHT3Px8//9wjqi/TUY8UlHsYKByL197QtVWDBjf/dekzXdz5c+iyVtanLQ==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-21.2.19.tgz",
+      "integrity": "sha512-YMguYVhdkV8tr9MvbN+VpMjbdmsYq6g12M9WPvAYM51BkL2iREbWeoXDGmfCw9G0it6+0pMdgrSPFFUFuOqpAQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -995,9 +996,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "21.2.18",
-        "@angular/common": "21.2.18",
-        "@angular/core": "21.2.18"
+        "@angular/animations": "21.2.19",
+        "@angular/common": "21.2.19",
+        "@angular/core": "21.2.19"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -1006,9 +1007,9 @@
       }
     },
     "node_modules/@angular/router": {
-      "version": "21.2.18",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.18.tgz",
-      "integrity": "sha512-Xix19uG1YthC8IslhWKSfPdhscVWREBGVJZW2OnRmLef8F7DvhF49S6vOywaBo+Uahe0egkmgWDNpEwxAzsgLw==",
+      "version": "21.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-21.2.19.tgz",
+      "integrity": "sha512-cKO/aq1xEMvgS29jFUc/Y3KsgEzHnwOw6sEL+UQZkZTmGD5YrYv8Yvj05GDMEUYbvDxBd5DixVVEbH38lyQKqA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -1017,9 +1018,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "21.2.18",
-        "@angular/core": "21.2.18",
-        "@angular/platform-browser": "21.2.18",
+        "@angular/common": "21.2.19",
+        "@angular/core": "21.2.19",
+        "@angular/platform-browser": "21.2.19",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -11437,35 +11438,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@vue/compiler-sfc/node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.39",
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
@@ -13864,35 +13836,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.5.13"
-      }
-    },
-    "node_modules/css-minimizer-webpack-plugin/node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/css-minimizer-webpack-plugin/node_modules/postcss-colormin": {
@@ -20853,9 +20796,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "dev": true,
       "funding": [
         {
@@ -20873,7 +20816,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "serve:opencrane-ui": "nx serve opencrane-ui"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^21.2.0",
-    "@angular/cli": "^21.2.0",
-    "@angular/compiler-cli": "^21.2.0",
+    "@angular-devkit/build-angular": "^21.2.19",
+    "@angular/cli": "^21.2.19",
+    "@angular/compiler-cli": "^21.2.19",
     "@nx/angular": "^23.0.2",
     "@nx/eslint-plugin": "^23.0.2",
     "@opentelemetry/sdk-trace-base": "^2.9.0",
@@ -68,14 +68,14 @@
   "dependencies": {
     "@a2ui/angular": "0.10.2",
     "@a2ui/web_core": "0.10.3",
-    "@angular/animations": "^21.2.0",
-    "@angular/cdk": "^21.2.0",
-    "@angular/common": "^21.2.0",
-    "@angular/compiler": "^21.2.0",
-    "@angular/core": "^21.2.0",
-    "@angular/forms": "^21.2.0",
-    "@angular/platform-browser": "^21.2.0",
-    "@angular/router": "^21.2.0",
+    "@angular/animations": "^21.2.19",
+    "@angular/cdk": "^21.2.14",
+    "@angular/common": "^21.2.19",
+    "@angular/compiler": "^21.2.19",
+    "@angular/core": "^21.2.19",
+    "@angular/forms": "^21.2.19",
+    "@angular/platform-browser": "^21.2.19",
+    "@angular/router": "^21.2.19",
     "@kubernetes/client-node": "^1.0.0",
     "@noble/hashes": "1.8.0",
     "@opentelemetry/api": "^1.9.0",
@@ -100,5 +100,8 @@
     "rxjs": "~7.8.2",
     "tslib": "^2.8.0",
     "zod": "^3.25.0"
+  },
+  "overrides": {
+    "postcss": "8.5.19"
   }
 }


### PR DESCRIPTION
## Review order

This PR belongs to one dependency stack. Review and merge it in this order:

1. #532 — browser-safe digest and deployment repair wave
2. #530 — runtime responsibility split
3. #548 — server-infrastructure relocation
4. #520 — authenticated private-memory transport
5. #563 — production Cognee recall
6. #564 — direct Obot invocation
7. #543 — consolidated server persistence authorities
8. #537 — consolidated persona lifecycle
9. #531 — personal-memory authority separation
10. #540 — trusted personal run admission
11. #547 — dead platform-policy removal and aggregate TypeScript cleanup
12. #552 — present-tense workload and agent boundary guards
13. #559 — Angular maintenance dependencies
14. #560 — AuthorizationGrant sharing authority
15. #561 — atomic MCP mutations
16. #562 — share-route rate limiting
17. #557 — ip-address dependency bump
18. #558 — fast-uri dependency bump

Each PR is based on its direct predecessor, so its GitHub diff contains only its incremental change. Review each diff once; do not compare sibling branches.

## Summary

- update Angular framework and compiler packages together to 21.2.19
- update the matching Angular build toolchain and CDK peer set
- update PostCSS to 8.5.19 with one lockfile resolution
- replace four overlapping dependency PRs with one coherent maintenance change

## Validation

- npm ci
- all 19 frontend test targets
- agent style, Prisma-boundary, and module-growth gates

## Current develop prerequisites

The affected-project CI reaches unrelated failures already represented by focused open PRs:

- #532 removes the browser-incompatible node:crypto import that breaks the UI build and frontend lint targets
- #533 repairs the provider model-registration test mock
- #552 updates the obsolete runtime-cleanup RBAC contract

This dependency update does not introduce or broaden those failures.

Supersedes #519, #554, #555, and #556.