### PR TITLE
🛡️ Rate-limit share authority requests

### DIFF
--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -77,7 +77,8 @@ its resources to the lifecycle owner.
 - The neutral [membership](../../libs/backend/server/iam/membership/main/README.md) package owns
   common mounted-key fleet-membership verifier configuration used by both admission paths.
 - `src/app/internal-app.ts` builds the workload-facing API on its separate socket.
-- `src/app/routes.ts` contains only named per-area route lists and the trivial mount loop.
+- `src/app/routes.ts` contains named per-area route lists and app-owned transport composition. The
+  sharing authority is mounted behind the shared per-IP limiter before identity or database work.
 - `src/app/runtime-composition.ts` binds controller, skill-workload, runtime, and optional-worker
   authorities by caller plane without choosing transport paths.
 - `src/infra/artifacts/*` is one app-only artifact-broker composition slice. It binds the server's

--- a/apps/opencrane/src/__tests__/shares-rate-limit.test.ts
+++ b/apps/opencrane/src/__tests__/shares-rate-limit.test.ts
@@ -1,0 +1,42 @@
+import type { PrismaClient } from "@prisma/client";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import type { RateLimitOptions } from "@opencrane/server/_infra/http";
+import { _CreateRateLimitedSharesRouter } from "../app/routes.js";
+
+/** Builds the application-owned shares composition without bypassing its HTTP abuse boundary. */
+function _app(rateLimit: RateLimitOptions): express.Express
+{
+	const app = express();
+	app.set("trust proxy", 1);
+	app.use(express.json());
+	app.use("/api/v1/shares", _CreateRateLimitedSharesRouter({} as PrismaClient, { rateLimit }));
+	return app;
+}
+
+describe("_CreateRateLimitedSharesRouter", function _suite()
+{
+	it("returns 429 before a repeat reaches the unauthenticated shares handler", async function _limits()
+	{
+		const app = _app({ max: 1, windowMs: 1_000 });
+		expect((await request(app).get("/api/v1/shares").set("X-Forwarded-For", "203.0.113.10")).status).toBe(401);
+
+		const blocked = await request(app).get("/api/v1/shares").set("X-Forwarded-For", "203.0.113.10");
+		expect(blocked.status).toBe(429);
+		expect(blocked.headers["ratelimit-limit"]).toBe("1");
+	});
+
+	it("isolates forwarded clients and resets a client budget after its bounded window", async function _isolatesAndResets()
+	{
+		const app = _app({ max: 1, windowMs: 100 });
+		expect((await request(app).get("/api/v1/shares").set("X-Forwarded-For", "203.0.113.11")).status).toBe(401);
+		expect((await request(app).get("/api/v1/shares").set("X-Forwarded-For", "203.0.113.11")).status).toBe(429);
+		expect((await request(app).get("/api/v1/shares").set("X-Forwarded-For", "203.0.113.12")).status).toBe(401);
+
+		await new Promise<void>(function _waitForWindow(resolve) { setTimeout(resolve, 125); });
+
+		expect((await request(app).get("/api/v1/shares").set("X-Forwarded-For", "203.0.113.11")).status).toBe(401);
+	});
+});

--- a/apps/opencrane/src/__tests__/shares-rate-limit.test.ts
+++ b/apps/opencrane/src/__tests__/shares-rate-limit.test.ts
@@ -3,7 +3,7 @@ import express from "express";
 import request from "supertest";
 import { describe, expect, it } from "vitest";
 
-import type { RateLimitOptions } from "@opencrane/server/_infra/http";
+import type { RateLimitOptions } from "@opencrane/backend/_server/http";
 import { _CreateRateLimitedSharesRouter } from "../app/routes.js";
 
 /** Builds the application-owned shares composition without bypassing its HTTP abuse boundary. */

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -1,4 +1,4 @@
-import type { Express, Router } from "express";
+import { Router, type Express } from "express";
 import type { PrismaClient } from "@prisma/client";
 import type * as k8s from "@kubernetes/client-node";
 
@@ -24,13 +24,13 @@ import { __CreatePersonalRunAdmissionRouter, type PersonalRunAdmissionPort } fro
 import { _CreateSkillCatalogueRouter } from "@opencrane/backend/server/agents/skills";
 import { _CreateSteeringIngestRouter } from "@opencrane/backend/agents/execution/protocol";
 import { _ResolveRequestPrincipal } from "@opencrane/backend/_server/auth";
-import { _CheckDbHealth, _OpenapiRouter } from "@opencrane/backend/_server/http";
+import { _CheckDbHealth, _OpenapiRouter, _RateLimit } from "@opencrane/backend/_server/http";
 import type { MemoryGatewayClient } from "@opencrane/backend/_server/memory-gateway-client";
 
 import type { InternalRuntimeConfig } from "./config.types.js";
 import { _log } from "./log.js";
 import { _CreateInternalRuntimeComposition } from "./runtime-composition.js";
-import type { RouteMount } from "./routes.types.js";
+import type { RouteMount, SharesRouteOptions } from "./routes.types.js";
 
 /**
  * Register the authenticated product API from functional route lists.
@@ -49,7 +49,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, coreApi: k8s
 	const identityAndAccessRoutes: readonly RouteMount[] = [
 		{ method: "use", path: "/api/v1/audit", handler: auditRouter(prisma) },
 		{ method: "use", path: "/api/v1/groups", handler: groupsRouter(prisma) },
-		{ method: "use", path: "/api/v1/shares", handler: sharesRouter(prisma) },
+		{ method: "use", path: "/api/v1/shares", handler: _CreateRateLimitedSharesRouter(prisma) },
 		{ method: "use", path: "/api/v1/resource-shares", handler: resourceSharesRouter(prisma) },
 	];
 	const agentRoutes: readonly RouteMount[] = [
@@ -96,6 +96,23 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, coreApi: k8s
 		infrastructureRoutes,
 	]);
 	return app;
+}
+
+/**
+ * Composes the share authority behind the shared per-IP limiter before identity or database work.
+ *
+ * The grants domain stays transport-agnostic; the OpenCrane app owns HTTP abuse protection.
+ *
+ * @param prisma - Canonical product-authority database client.
+ * @param options - Optional bounded limiter tuning for an isolated application test.
+ * @returns The protected sharing router.
+ */
+export function _CreateRateLimitedSharesRouter(prisma: PrismaClient, options?: SharesRouteOptions): Router
+{
+	const router = Router();
+	router.use(_RateLimit(options?.rateLimit));
+	router.use(sharesRouter(prisma));
+	return router;
 }
 
 /**

--- a/apps/opencrane/src/app/routes.types.ts
+++ b/apps/opencrane/src/app/routes.types.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler, Router } from "express";
 
-import type { RateLimitOptions } from "@opencrane/server/_infra/http";
+import type { RateLimitOptions } from "@opencrane/backend/_server/http";
 
 /** One Express mount shown in the app's route catalogue. */
 export interface RouteMount

--- a/apps/opencrane/src/app/routes.types.ts
+++ b/apps/opencrane/src/app/routes.types.ts
@@ -1,5 +1,7 @@
 import type { RequestHandler, Router } from "express";
 
+import type { RateLimitOptions } from "@opencrane/server/_infra/http";
+
 /** One Express mount shown in the app's route catalogue. */
 export interface RouteMount
 {
@@ -9,4 +11,11 @@ export interface RouteMount
 	readonly path: string;
 	/** Capability router or terminal request handler mounted at the path. */
 	readonly handler: Router | RequestHandler;
+}
+
+/** Optional bounded limiter tuning for the rate-limited shares composition, primarily in tests. */
+export interface SharesRouteOptions
+{
+	/** Shared HTTP limiter options applied before the shares router. */
+	readonly rateLimit?: RateLimitOptions;
 }

--- a/docs/agents/app-source-allowlist.json
+++ b/docs/agents/app-source-allowlist.json
@@ -30,6 +30,7 @@
     { "path": "apps/opencrane/src/app/runtime-composition.types.ts", "owner": "apps/opencrane", "classification": "route-composition" },
     { "path": "apps/opencrane/prisma/bootstrap/verify-persona-source-seeds.mjs", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/prisma/bootstrap/verify-authority-baseline.mjs", "owner": "apps/opencrane", "classification": "composition-test" },
+    { "path": "apps/opencrane/src/__tests__/shares-rate-limit.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/index.ts", "owner": "apps/opencrane", "classification": "process-entrypoint" },
     { "path": "apps/opencrane/src/infra/db/db.ts", "owner": "apps/opencrane", "classification": "prisma-composition" },
     { "path": "apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts", "owner": "apps/opencrane", "classification": "route-composition" },

--- a/docs/agents/app-source-allowlist.json
+++ b/docs/agents/app-source-allowlist.json
@@ -30,7 +30,6 @@
     { "path": "apps/opencrane/src/app/runtime-composition.types.ts", "owner": "apps/opencrane", "classification": "route-composition" },
     { "path": "apps/opencrane/prisma/bootstrap/verify-persona-source-seeds.mjs", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/prisma/bootstrap/verify-authority-baseline.mjs", "owner": "apps/opencrane", "classification": "composition-test" },
-    { "path": "apps/opencrane/src/__tests__/shares-rate-limit.test.ts", "owner": "apps/opencrane", "classification": "composition-test" },
     { "path": "apps/opencrane/src/index.ts", "owner": "apps/opencrane", "classification": "process-entrypoint" },
     { "path": "apps/opencrane/src/infra/db/db.ts", "owner": "apps/opencrane", "classification": "prisma-composition" },
     { "path": "apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts", "owner": "apps/opencrane", "classification": "route-composition" },


### PR DESCRIPTION
## Review order

This PR belongs to one dependency stack. Review and merge it in this order:

1. #532 — browser-safe digest and deployment repair wave
2. #530 — runtime responsibility split
3. #548 — server-infrastructure relocation
4. #520 — authenticated private-memory transport
5. #563 — production Cognee recall
6. #564 — direct Obot invocation
7. #543 — consolidated server persistence authorities
8. #537 — consolidated persona lifecycle
9. #531 — personal-memory authority separation
10. #540 — trusted personal run admission
11. #547 — dead platform-policy removal and aggregate TypeScript cleanup
12. #552 — present-tense workload and agent boundary guards
13. #559 — Angular maintenance dependencies
14. #560 — AuthorizationGrant sharing authority
15. #561 — atomic MCP mutations
16. #562 — share-route rate limiting
17. #557 — ip-address dependency bump
18. #558 — fast-uri dependency bump

Each PR is based on its direct predecessor, so its GitHub diff contains only its incremental change. Review each diff once; do not compare sibling branches.

## What this enables

The OpenCrane app now composes the sharing router behind the shared per-IP limiter before identity lookup, authorization, or database work. This keeps HTTP abuse protection in the app composition root instead of the grants domain.

## Review boundary

- named, typed shares-route composition
- 429 enforcement, forwarded-client isolation, and bounded-window reset tests
- no AuthorizationGrant persistence or MCP mutation changes

## Validation

- app: 25 tests
- app TypeScript lint
- agent style, Prisma boundary, module-growth, and ESLint boundary gates

Replaces the HTTP abuse-protection portion of #536.