### PR TITLE
🔧 Verify public server health after deployment

### DIFF
--- a/apps/_infra/deploy-k8s/platform/README.md
+++ b/apps/_infra/deploy-k8s/platform/README.md
@@ -9,12 +9,12 @@ local source consumer.
 | Path | Responsibility |
 |---|---|
 | `Chart.yaml`, `templates/` | Helm library chart providing labels, names, RBAC, endpoint, database, identity, and observability helpers to the parent release. It renders no workload by itself. |
-| `k8s-deploy.sh` | Provider-neutral install and upgrade engine used by the release wrapper. |
+| `k8s-deploy.sh` | Provider-neutral install and upgrade engine used by the release wrapper. Its optional `--verify` check reports pod readiness, DNS resolution, and public server/database health without changing deployment success. |
 | `configure-oidc.sh` | Surgical OIDC configuration for an existing installation. |
 | `provision.sh` | Optional local, GKE, or VPS cluster provisioning invoked before deployment. |
 | `terraform/` | GKE, networking, DNS, Artifact Registry, Workload Identity, and optional chart installation. |
 | `values/` | Reusable environment and multi-instance deployment profiles. |
-| `tests/` | Rendered network, pooler, key-permission, and skill-workload contract checks. |
+| `tests/` | Rendered network, pooler, key-permission, post-deploy health, and skill-workload contract checks. |
 
 Business logic does not belong here. Server-process infrastructure belongs in `libs/server/_infra`;
 backend capabilities belong in `libs/backend/server`; independently owned third-party workloads

--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -21,7 +21,7 @@
 #                            [--oidc-session-secret SECRET]
 #                            [--platform-operator-seed-email EMAIL]
 #                            [--platform-operator-groups CSV]
-#                            [--preflight] [--multi-ct]
+#                            [--preflight] [--multi-ct] [--verify] [--verify-insecure]
 #                            --postgres-credentials-secret NAME
 #                            [--postgres-owner OWNER]
 #                            --obot-postgres-credentials-secret NAME [--obot-postgres-owner OWNER]
@@ -78,6 +78,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+POST_DEPLOY_VERIFY="$SCRIPT_DIR/post-deploy-verify.sh"
+if [[ ! -f "$POST_DEPLOY_VERIFY" ]]; then
+  echo "[k8s-deploy] Post-deploy verifier is missing at '$POST_DEPLOY_VERIFY'." >&2
+  exit 1
+fi
+source "$POST_DEPLOY_VERIFY"
 # The Helm chart no longer sits beside this engine — it is per-role and lives in the calling
 # app (the fleet chart, now in the WeOwnAI repo per elewa-git/opencrane#150; apps/_infra/deploy-k8s
 # = the silo chart, still here). Each app's deploy.sh wrapper exports OPENCRANE_CHART_DIR to its
@@ -176,9 +182,12 @@ PREFLIGHT="${OPENCRANE_PREFLIGHT:-0}"
 # Also via OPENCRANE_MULTI_CT=1.
 MULTI_CT="${OPENCRANE_MULTI_CT:-0}"
 
-# --verify runs an advisory post-deploy check (pods Running and host resolution). Never fails
-# the install. Also via OPENCRANE_VERIFY=1.
+# --verify runs an advisory post-deploy check (pods Running, host resolution, and the public
+# /healthz endpoint). Never fails the install. Also via OPENCRANE_VERIFY=1.
 VERIFY="${OPENCRANE_VERIFY:-0}"
+# --verify-insecure permits only the advisory HTTP check to accept a self-signed certificate.
+# It has no effect unless --verify is enabled. Also via OPENCRANE_VERIFY_INSECURE=1.
+VERIFY_INSECURE="${OPENCRANE_VERIFY_INSECURE:-0}"
 
 POSTGRES_RELEASE=""
 TIMEOUT="${TIMEOUT_SECONDS:-300}"
@@ -205,6 +214,7 @@ while [[ $# -gt 0 ]]; do
     --preflight)        PREFLIGHT="1"; shift ;;
     --multi-ct)         MULTI_CT="1"; shift ;;
     --verify)           VERIFY="1"; shift ;;
+    --verify-insecure)  VERIFY_INSECURE="1"; shift ;;
     --postgres-credentials-secret) POSTGRES_CREDENTIALS_SECRET="$2"; shift 2 ;;
     --postgres-owner) POSTGRES_OWNER="$2"; shift 2 ;;
     --obot-postgres-credentials-secret) OBOT_POSTGRES_CREDENTIALS_SECRET="$2"; shift 2 ;;
@@ -782,51 +792,6 @@ for _comp in fleet-manager clustertenant-manager; do
   fi
 done
 
-# Read the ACTUAL opencrane-ui host(s) off the deployed ingress(es). Never assume platform.<base>:
-# the fleet may serve the apex (controlPlaneHost=<base>), a silo serves <org>.<base>, and only the
-# unset default is platform.<base>. Ask the cluster what was rendered; fall back to platform.<base>
-# when no ingress exposes a host (e.g. ingress disabled) so callers still get a sensible hint.
-_control_plane_hosts() {
-  local hosts
-  hosts="$(kubectl get ingress -n "$NAMESPACE" \
-    -o jsonpath='{range .items[*]}{range .spec.rules[*]}{.host}{"\n"}{end}{end}' 2>/dev/null \
-    | grep -v '^$' | sort -u)"
-  if [[ -n "$hosts" ]]; then
-    echo "$hosts"
-  elif [[ -n "$BASE_DOMAIN" ]]; then
-    echo "platform.$BASE_DOMAIN"
-  fi
-}
-
-# 5. Post-deploy verify (opt-in, --verify). Advisory only — surfaces the failure modes that
-# leave an install unreachable (pods not Running or host not resolving).
-_post_deploy_verify() {
-  [[ "$VERIFY" == "1" ]] || return 0
-  log "Post-deploy verify (advisory — does not fail the install):"
-
-  # 1. Core pods Running — a CrashLoop/ImagePullBackOff that helm --wait didn't catch.
-  local notready
-  notready="$(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null | grep -c . || true)"
-  if [[ "$notready" == "0" ]]; then
-    log "  ✓ all pods Running/Succeeded in $NAMESPACE"
-  else
-    warn "  ✗ $notready pod(s) not Running in $NAMESPACE — kubectl get pods -n $NAMESPACE"
-  fi
-
-  # 2. Control-plane host(s) resolve to the ingress — the end of the chain a user hits first.
-  #    Read the rendered host(s) off the ingress so the apex / org host is checked, not platform.<base>.
-  if command -v dig >/dev/null 2>&1; then
-    local host resolved
-    for host in $(_control_plane_hosts); do
-      resolved="$(dig +short "$host" 2>/dev/null | tail -1)"
-      if [[ -n "$resolved" ]]; then
-        log "  ✓ $host resolves to $resolved"
-      else
-        warn "  ✗ $host does not resolve yet (DNS propagation lag or a missing record)."
-      fi
-    done
-  fi
-}
 _post_deploy_verify
 
 log "Done. OpenCrane is installed in namespace '$NAMESPACE'."

--- a/apps/_infra/deploy-k8s/platform/post-deploy-verify.sh
+++ b/apps/_infra/deploy-k8s/platform/post-deploy-verify.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Advisory checks run by k8s-deploy.sh after Helm reports a completed release.
+
+# Read actual UI hosts from the deployed ingresses. The fleet may serve the apex, while a silo
+# serves an organisation host, so verification must not assume platform.<base-domain>.
+_control_plane_hosts() {
+  local hosts
+  hosts="$(kubectl get ingress -n "$NAMESPACE" \
+    -o jsonpath='{range .items[*]}{range .spec.rules[*]}{.host}{"\n"}{end}{end}' 2>/dev/null \
+    | grep -v '^$' | sort -u)"
+  if [[ -n "$hosts" ]]; then
+    echo "$hosts"
+  elif [[ -n "$BASE_DOMAIN" ]]; then
+    echo "platform.$BASE_DOMAIN"
+  fi
+}
+
+_verify_health_url() {
+  local health_url="$1"
+  if [[ "$VERIFY_INSECURE" == "1" ]]; then
+    curl --silent --show-error --fail --connect-timeout 5 --max-time 10 \
+      --insecure "$health_url" >/dev/null
+  else
+    curl --silent --show-error --fail --connect-timeout 5 --max-time 10 \
+      "$health_url" >/dev/null
+  fi
+}
+
+# Verification stays advisory: every failed diagnostic becomes a warning, never a failed release.
+_post_deploy_verify() {
+  [[ "$VERIFY" == "1" ]] || return 0
+  log "Post-deploy verify (advisory — does not fail the install):"
+
+  local notready
+  notready="$(kubectl get pods -n "$NAMESPACE" --field-selector=status.phase!=Running,status.phase!=Succeeded -o name 2>/dev/null | grep -c . || true)"
+  if [[ "$notready" == "0" ]]; then
+    log "  ✓ all pods Running/Succeeded in $NAMESPACE"
+  else
+    warn "  ✗ $notready pod(s) not Running in $NAMESPACE — kubectl get pods -n $NAMESPACE"
+  fi
+
+  local host resolved
+  if command -v dig >/dev/null 2>&1; then
+    for host in $(_control_plane_hosts); do
+      resolved="$(dig +short "$host" 2>/dev/null | tail -1)"
+      if [[ -n "$resolved" ]]; then
+        log "  ✓ $host resolves to $resolved"
+      else
+        warn "  ✗ $host does not resolve yet (DNS propagation lag or a missing record)."
+      fi
+    done
+  fi
+
+  # /healthz is public by design and fails when the server cannot reach its durable database.
+  if command -v curl >/dev/null 2>&1; then
+    local health_url
+    for host in $(_control_plane_hosts); do
+      health_url="https://${host}/healthz"
+      if _verify_health_url "$health_url"; then
+        log "  ✓ $health_url is healthy"
+      else
+        warn "  ✗ $health_url is unavailable or unhealthy"
+      fi
+    done
+  else
+    warn "  ! curl is unavailable — skipping the HTTP health check."
+  fi
+}

--- a/apps/_infra/deploy-k8s/platform/tests/post-deploy-health-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/post-deploy-health-contract.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+DEPLOY_SCRIPT="$ROOT_DIR/apps/_infra/deploy-k8s/platform/k8s-deploy.sh"
+VERIFY_SCRIPT="$ROOT_DIR/apps/_infra/deploy-k8s/platform/post-deploy-verify.sh"
+CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+CHART_FIXTURE="$(mktemp -d)"
+trap 'rm -rf "$CHART_FIXTURE"' EXIT
+
+grep -Fq 'source "$POST_DEPLOY_VERIFY"' "$DEPLOY_SCRIPT"
+source "$VERIFY_SCRIPT"
+
+# Render against the current app-owned server chart, not the potentially stale committed archive.
+cp -R "$CHART_DIR/." "$CHART_FIXTURE"
+helm package "$ROOT_DIR/apps/opencrane/helm" --destination "$CHART_FIXTURE/charts" >/dev/null
+rendered_ingress="$(helm template opencrane-silo "$CHART_FIXTURE" \
+  --show-only templates/app-rollups.yaml)"
+health_route="$(awk '
+  /          - path: \/healthz/ { capture = 1 }
+  capture { print }
+  capture && /                  number:/ { exit }
+' <<<"$rendered_ingress")"
+grep -Fq '          - path: /healthz' <<<"$health_route"
+grep -Fq '            pathType: Exact' <<<"$health_route"
+grep -Fq '                name: opencrane-silo-opencrane-server' <<<"$health_route"
+grep -Fq '                  number: 8080' <<<"$health_route"
+
+_run_verify() {
+  local curl_outcome="$1"
+  local insecure="$2"
+  local missing_curl="${3:-0}"
+  local curl_args_file
+  curl_args_file="$(mktemp)"
+
+  VERIFY=1
+  VERIFY_INSECURE="$insecure"
+  NAMESPACE=opencrane-acme
+  log() { printf '%s\n' "$*"; }
+  warn() { printf '%s\n' "$*"; }
+  kubectl() { return 0; }
+  dig() { printf '127.0.0.1\n'; }
+  _control_plane_hosts() { printf 'acme.opencrane.local\n'; }
+  curl() {
+    printf '%s\n' "$@" >"$curl_args_file"
+    [[ "$curl_outcome" == "healthy" ]]
+  }
+  command() {
+    if [[ "$missing_curl" == "1" && "${1:-}" == "-v" && "${2:-}" == "curl" ]]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+
+  _post_deploy_verify
+  cat "$curl_args_file"
+  rm -f "$curl_args_file"
+}
+
+healthy_output="$(_run_verify healthy 0)"
+grep -Fq 'https://acme.opencrane.local/healthz is healthy' <<<"$healthy_output"
+grep -Fq -- '--connect-timeout' <<<"$healthy_output"
+grep -Fq -- '--max-time' <<<"$healthy_output"
+if grep -Fq -- '--insecure' <<<"$healthy_output"; then
+  echo "post-deploy health check disables TLS verification by default" >&2
+  exit 1
+fi
+
+insecure_output="$(_run_verify healthy 1)"
+grep -Fq -- '--insecure' <<<"$insecure_output"
+
+unhealthy_output="$(_run_verify unhealthy 0)"
+grep -Fq 'https://acme.opencrane.local/healthz is unavailable or unhealthy' <<<"$unhealthy_output"
+
+missing_curl_output="$(_run_verify healthy 0 1)"
+grep -Fq 'curl is unavailable — skipping the HTTP health check.' <<<"$missing_curl_output"
+
+echo "post-deploy health contract: PASS"

--- a/apps/_infra/deploy-k8s/project.json
+++ b/apps/_infra/deploy-k8s/project.json
@@ -12,6 +12,7 @@
             "bash apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh",
           "bash apps/_infra/deploy-k8s/platform/tests/server-network-policy-contract.sh",
           "bash apps/_infra/deploy-k8s/platform/tests/platform-network-policy-contract.sh",
+          "bash apps/_infra/deploy-k8s/platform/tests/post-deploy-health-contract.sh",
           "bash apps/_infra/deploy-k8s/platform/tests/skill-workload-contract.sh"
         ],
         "parallel": false

--- a/apps/opencrane/HELM.md
+++ b/apps/opencrane/HELM.md
@@ -1,3 +1,3 @@
 # Server Helm ownership
 
-The OpenCrane server application owns its Deployment, identity and RBAC, Services, edge ingress and certificate, and ingress NetworkPolicy as named Helm templates under `helm/`. The silo umbrella composes these resources with its parent release context.
+The OpenCrane server application owns its Deployment, identity and RBAC, Services, edge ingress and certificate, and ingress NetworkPolicy as named Helm templates under `helm/`. The edge ingress sends exact `/healthz` requests to the public server listener before its SPA catch-all, so deployment verification observes server and database health. The silo umbrella composes these resources with its parent release context.

--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -95,7 +95,7 @@ transport, and external-service seams belong under
 [`libs/server/_infra`](../../libs/server/_infra/README.md). Libraries never import this app.
 
 The public and workload-facing APIs share a process but not an exposure boundary. Public ingress
-routes only to `:8080`. The `:8081` Service is restricted by Kubernetes NetworkPolicy, and endpoints
+routes `/api` and the database-aware `/healthz` endpoint only to `:8080`. The `:8081` Service is restricted by Kubernetes NetworkPolicy, and endpoints
 that grant workload authority additionally review the caller's projected Kubernetes identity and
 bind it to durable assignment evidence.
 

--- a/apps/opencrane/helm/templates/_ingress.tpl
+++ b/apps/opencrane/helm/templates/_ingress.tpl
@@ -32,12 +32,19 @@ spec:
     - host: {{ $host | quote }}
       http:
         paths:
-          # Same-origin hosting: the OpenCrane API under /api, the bounded channel HTTP/SSE
-          # endpoints under /v1, and the org-admin SPA under /. One origin gives the channel
+          # Same-origin hosting: server health at /healthz, the OpenCrane API under /api, the
+          # bounded channel HTTP/SSE endpoints under /v1, and the org-admin SPA under /. One origin gives the channel
           # proxy first-party session cookies without CORS. Helm OWNS these rules,
           # so the frontend layer never has to kubectl-patch the Ingress out-of-band (that
           # patch fought `helm upgrade` via an SSA field-manager conflict and reverted on
           # every reconcile — see docs/optimalisation-plan.md §5).
+          - path: /healthz
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "opencrane.fullname" . }}-opencrane-server
+                port:
+                  number: {{ .Values.clustertenantManager.service.port }}
           - path: /api
             pathType: Prefix
             backend:

--- a/website/guide/deploy-local.md
+++ b/website/guide/deploy-local.md
@@ -31,6 +31,11 @@ The chart installs trusted services and distinct restricted namespaces for perso
 managed and worker Jobs. A single-node cluster does not collapse those boundaries. Create the
 three PostgreSQL bootstrap Secrets in the target namespace first, using distinct credentials.
 
+Add `--verify` when you want an advisory check of pod readiness, hostname resolution, and the public
+server/database health endpoint after installation. For a local self-signed certificate, use
+`--verify --verify-insecure`; omit `--verify-insecure` whenever the certificate is trusted. These
+checks report diagnostics without turning a completed installation into a failed release.
+
 ::: warning
 Single-node does not mean single namespace. OpenCrane refuses a deployment that places
 untrusted runtime Jobs beside the trusted server.


### PR DESCRIPTION
## What this fixes

The optional post-deployment verification checked pod status and DNS resolution, but it did not confirm that the OpenCrane server and its database were healthy.

The server already exposed a database-aware `/healthz` endpoint. However, the public ingress did not route that path to the server, so requests fell through to the UI container’s basic health response.

## What changes

- Route exact public `/healthz` requests to the OpenCrane server.
- Extend `--verify` to request the database-aware health endpoint.
- Keep verification advisory so diagnostics never roll back a completed deployment.
- Keep TLS certificate validation enabled by default.
- Add optional `--verify-insecure` support for local self-signed certificates.
- Extract post-deployment verification into a focused deployment helper.
- Add a contract test covering:
  - rendered `/healthz` ingress routing;
  - healthy and unhealthy responses;
  - strict TLS defaults;
  - explicit self-signed certificate support;
  - missing `curl`;
  - bounded request timeouts.
- Document the optional verification flags without changing the primary deployment command.

## Safety

`--verify` remains optional. Existing deployment commands behave exactly as before.

`--verify-insecure` affects only the advisory health request and must be explicitly supplied. It does not change ingress, browser, or workload TLS behavior.

## Validation

- Post-deployment health contract: passed
- Shell syntax checks: passed
- Helm lint: passed
- Module-growth check: passed
- Prisma and style checks: passed
- VitePress documentation build: passed
- Diff and whitespace checks: passed
- Independent review: passed with no remaining findings

