### PR TITLE
🐛 Fix blockers preventing a fresh local deployment

### DIFF
--- a/apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh
@@ -5,6 +5,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
 CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
 
 rendered="$(helm template opencrane-silo "$CHART_DIR")"
+ct_read_role="$(printf '%s\n' "$rendered" | awk '
+  BEGIN { RS="---" }
+  $0 ~ /\nkind: ClusterRole\n/ && $0 ~ /\n  name: opencrane-silo-opencrane-server-ct-read-default\n/ { print $0 }
+')"
+ct_read_binding="$(printf '%s\n' "$rendered" | awk '
+  BEGIN { RS="---" }
+  $0 ~ /\nkind: ClusterRoleBinding\n/ && $0 ~ /\n  name: opencrane-silo-opencrane-server-ct-read-default\n/ { print $0 }
+')"
 cleanup_rbac="$(printf '%s\n' "$rendered" | awk '
   function flush_document() {
     if ((is_role || is_binding) && is_cleanup_name) {
@@ -36,16 +44,48 @@ cleanup_rbac="$(printf '%s\n' "$rendered" | awk '
   }
 ')"
 
-[[ "$(grep -xc 'kind: Role' <<<"$cleanup_rbac")" -eq 2 ]]
-[[ "$(grep -xc 'kind: RoleBinding' <<<"$cleanup_rbac")" -eq 2 ]]
-grep -Fq '  namespace: opencrane-silo-runtime' <<<"$cleanup_rbac"
-grep -Fq '  namespace: opencrane-silo-managed-runtime' <<<"$cleanup_rbac"
-[[ "$(grep -Fc '    resources: ["jobs"]' <<<"$cleanup_rbac")" -eq 2 ]]
-[[ "$(grep -Fc '    verbs: ["get", "delete"]' <<<"$cleanup_rbac")" -eq 2 ]]
-[[ "$(grep -Fc '  name: opencrane-silo-opencrane-server' <<<"$cleanup_rbac")" -eq 2 ]]
-[[ "$(grep -Fc '    namespace: default' <<<"$cleanup_rbac")" -eq 2 ]]
+[[ "$(grep -xc 'kind: ClusterRole' <<<"$ct_read_role")" -eq 1 ]]
+grep -Fq '    resources: ["clustertenants"]' <<<"$ct_read_role"
+if grep -Fq 'subjects:' <<<"$ct_read_role"; then
+  echo "ClusterTenant reader ClusterRole contains binding subjects" >&2
+  exit 1
+fi
+[[ "$(grep -xc 'kind: ClusterRoleBinding' <<<"$ct_read_binding")" -eq 1 ]]
+grep -Fq '  kind: ClusterRole' <<<"$ct_read_binding"
+if [[ "$(grep -Fc '  name: opencrane-silo-opencrane-server-ct-read-default' <<<"$ct_read_binding")" -ne 2 ]]; then
+  echo "ClusterTenant reader binding does not reference its exact ClusterRole" >&2
+  exit 1
+fi
+grep -Fq '    name: opencrane-silo-opencrane-server' <<<"$ct_read_binding"
+grep -Fq '    namespace: default' <<<"$ct_read_binding"
 
-if grep -Eq 'verbs:.*(create|patch|update|list|watch)|resources:.*(pods|secrets|deployments)' <<<"$cleanup_rbac"; then
+[[ -z "$cleanup_rbac" ]]
+
+test_digest="sha256:$(printf 'a%.0s' {1..64})"
+enabled_rendered="$(helm template opencrane-silo "$CHART_DIR" \
+  --set agentController.enabled=true \
+  --set-string agentController.kubernetesApiServerCidrs[0]=10.43.0.1/32 \
+  --set-string agentController.image.digest="$test_digest" \
+  --set-string agentController.runtimeProfile.image.digest="$test_digest" \
+  --set-string agentController.skillWorkloadProfiles.authoring.image.digest="$test_digest" \
+  --set-string agentController.skillWorkloadProfiles.toolRunner.image.digest="$test_digest")"
+enabled_cleanup_rbac="$(printf '%s\n' "$enabled_rendered" | awk '
+  BEGIN { RS="---" }
+  $0 ~ /\nkind: Role(Binding)?\n/ && $0 ~ /\n  name: opencrane-silo-runtime-cleanup\n/ { print $0 "---" }
+')"
+if [[ "$(grep -xc 'kind: Role' <<<"$enabled_cleanup_rbac")" -ne 2 \
+  || "$(grep -xc 'kind: RoleBinding' <<<"$enabled_cleanup_rbac")" -ne 2 ]]; then
+  echo "enabled runtime cleanup RBAC must have one Role and RoleBinding per runtime namespace" >&2
+  exit 1
+fi
+grep -Fq '  namespace: opencrane-silo-runtime' <<<"$enabled_cleanup_rbac"
+grep -Fq '  namespace: opencrane-silo-managed-runtime' <<<"$enabled_cleanup_rbac"
+[[ "$(grep -Fc '    resources: ["jobs"]' <<<"$enabled_cleanup_rbac")" -eq 2 ]]
+[[ "$(grep -Fc '    verbs: ["get", "delete"]' <<<"$enabled_cleanup_rbac")" -eq 2 ]]
+[[ "$(grep -Fc '  name: opencrane-silo-opencrane-server' <<<"$enabled_cleanup_rbac")" -eq 2 ]]
+[[ "$(grep -Fc '    namespace: default' <<<"$enabled_cleanup_rbac")" -eq 2 ]]
+
+if grep -Eq 'verbs:.*(create|patch|update|list|watch)|resources:.*(pods|secrets|deployments)' <<<"$enabled_cleanup_rbac"; then
   echo "opencrane-server runtime cleanup RBAC exceeds exact Job get/delete authority" >&2
   exit 1
 fi

--- a/apps/channel-proxy/package.json
+++ b/apps/channel-proxy/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "dependencies": {
+    "@noble/hashes": "1.8.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.78.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",

--- a/apps/opencrane/helm/templates/_rbac.tpl
+++ b/apps/opencrane/helm/templates/_rbac.tpl
@@ -1,45 +1,10 @@
 {{- define "opencrane.server.rbac" -}}
-{{- $managedPlane := (index .Values "managedAgentRuntimePlane").managedAgentRuntime -}}
-{{- $managedRuntimeNamespace := default (printf "%s-managed-runtime" .Release.Name | trunc 63 | trimSuffix "-") $managedPlane.namespace -}}
-{{- $runtimeNamespaces := list (include "opencrane.agentController.runtimeNamespace" .) $managedRuntimeNamespace -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opencrane.fullname" . }}-opencrane-server
   labels:
     {{- include "opencrane.labels" . | nindent 4 }}
-{{- range $runtimeNamespace := $runtimeNamespaces }}
----
-# Runtime cleanup is server-fenced in Postgres first. This Role grants only the physical
-# observation and UID-preconditioned deletion required after that durable claim exists.
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ printf "%s-runtime-cleanup" (include "opencrane.fullname" $) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $runtimeNamespace }}
-  labels:
-    {{- include "opencrane.labels" $ | nindent 4 }}
-rules:
-  - apiGroups: ["batch"]
-    resources: ["jobs"]
-    verbs: ["get", "delete"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ printf "%s-runtime-cleanup" (include "opencrane.fullname" $) | trunc 63 | trimSuffix "-" }}
-  namespace: {{ $runtimeNamespace }}
-  labels:
-    {{- include "opencrane.labels" $ | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ printf "%s-runtime-cleanup" (include "opencrane.fullname" $) | trunc 63 | trimSuffix "-" }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "opencrane.fullname" $ }}-opencrane-server
-    namespace: {{ $.Release.Namespace }}
-{{- end }}
 ---
 # TokenReview is cluster-scoped and is required only for projected workload credentials on
 # internal pod-identity routes. Runtime Job ServiceAccounts receive no Kubernetes RBAC at all.
@@ -68,7 +33,8 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "opencrane.fullname" . }}-opencrane-server
     namespace: {{ .Release.Namespace }}
-{{- /*
+---
+{{/*
   Per-org OIDC login may read the ClusterTenant host/client binding. It never mutates the CR.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/apps/postgres/scripts/publish-initdb-baseline-config-map.sh
+++ b/apps/postgres/scripts/publish-initdb-baseline-config-map.sh
@@ -20,6 +20,7 @@ work_dir="$(mktemp -d)"
 trap 'rm -rf "$work_dir"' EXIT
 baseline_identity_input="$work_dir/baseline-identity.sql"
 rendered_baseline="$work_dir/target-baseline.sql"
+rendered_config_map="$work_dir/baseline-config-map.yaml"
 quoted_owner="$(printf '%s' "$database_owner" | sed 's/"/""/g')"
 
 function _sha256_file()
@@ -85,7 +86,12 @@ kubectl create configmap "$config_map_name" \
   -o json \
   | kubectl patch --local -f - --type=merge \
       -p "{\"immutable\":true,\"metadata\":{\"annotations\":{\"opencrane.ai/baseline-sha256\":\"$baseline_digest\"}}}" \
-      -o yaml \
-  | kubectl apply -f - >/dev/null
+      -o yaml >"$rendered_config_map"
+
+# Another deployment may publish the same content-addressed object after the initial lookup.
+# Accept that race only when the winner's immutable bytes pass the verification above.
+if ! kubectl create -f "$rendered_config_map" >/dev/null; then
+  bash "$0" "$namespace" "$database_owner" "$baseline_file" --verify-only >/dev/null
+fi
 
 printf '%s\n' "$config_map_name"

--- a/apps/postgres/tests/baseline-publisher-contract.sh
+++ b/apps/postgres/tests/baseline-publisher-contract.sh
@@ -17,34 +17,55 @@ set -euo pipefail
 
 case "$1" in
   get)
-    if [[ "${FAKE_EXISTING_MODE:-absent}" == "absent" ]]; then
-      exit 1
-    fi
-    case "$*" in
-      *baseline-sha256*)
-        printf '%s' "$FAKE_BASELINE_DIGEST"
-        ;;
-      *"{.immutable}"*)
-        if [[ "$FAKE_EXISTING_MODE" == "mutable" ]]; then
-          printf 'false'
-        else
+    if [[ "${FAKE_CREATE_RACE:-0}" == "1" && -f "$FAKE_RACE_MARKER" ]]; then
+      case "$*" in
+        *baseline-sha256*)
+          "$REAL_KUBECTL" patch --local -f "$CAPTURE_FILE" --type=merge -p '{}' -o jsonpath='{.metadata.annotations.opencrane\.ai/baseline-sha256}'
+          ;;
+        *"{.immutable}"*)
           printf 'true'
-        fi
-        ;;
-      *target-baseline*)
-        if [[ "$FAKE_EXISTING_MODE" == "tampered" ]]; then
-          printf 'SELECT 1; -- substituted content'
-        else
-          cat "$FAKE_EXISTING_SQL_FILE"
-        fi
-        ;;
-    esac
+          ;;
+        *target-baseline*)
+          "$REAL_KUBECTL" patch --local -f "$CAPTURE_FILE" --type=merge -p '{}' -o jsonpath='{.data.target-baseline\.sql}'
+          ;;
+      esac
+    elif [[ "${FAKE_EXISTING_MODE:-absent}" == "absent" ]]; then
+      exit 1
+    else
+      case "$*" in
+        *baseline-sha256*)
+          printf '%s' "$FAKE_BASELINE_DIGEST"
+          ;;
+        *"{.immutable}"*)
+          if [[ "$FAKE_EXISTING_MODE" == "mutable" ]]; then
+            printf 'false'
+          else
+            printf 'true'
+          fi
+          ;;
+        *target-baseline*)
+          if [[ "$FAKE_EXISTING_MODE" == "tampered" ]]; then
+            printf 'SELECT 1; -- substituted content'
+          else
+            cat "$FAKE_EXISTING_SQL_FILE"
+          fi
+          ;;
+      esac
+    fi
     ;;
-  create|patch)
+  create)
+    if [[ "${2:-}" == "-f" && "${3:-}" != "-" ]]; then
+      cp "$3" "$CAPTURE_FILE"
+      if [[ "${FAKE_CREATE_RACE:-0}" == "1" ]]; then
+        touch "$FAKE_RACE_MARKER"
+        exit 1
+      fi
+    else
+      exec "$REAL_KUBECTL" "$@"
+    fi
+    ;;
+  patch)
     exec "$REAL_KUBECTL" "$@"
-    ;;
-  apply)
-    cat >"$CAPTURE_FILE"
     ;;
   *)
     echo "unexpected kubectl command: $*" >&2
@@ -65,12 +86,21 @@ grep -q 'GRANT SELECT ON TABLE "opencrane_bootstrap"."target_baseline" TO "owner
 grep -Eq 'VALUES \(TRUE, '\''[0-9a-f]{64}'\''\);' "$CAPTURE_FILE"
 grep -q 'SET ROLE "owner""quoted";' "$CAPTURE_FILE"
 grep -q 'OpenCrane target database baseline' "$CAPTURE_FILE"
+if grep -q 'kubectl.kubernetes.io/last-applied-configuration' "$CAPTURE_FILE"; then
+  echo "publisher added the client-side apply annotation to the baseline ConfigMap" >&2
+  exit 1
+fi
 
 expected_sql="$TEST_DIR/expected-target-baseline.sql"
 "$REAL_KUBECTL" patch --local -f "$CAPTURE_FILE" --type=merge -p '{}' -o jsonpath='{.data.target-baseline\.sql}' >"$expected_sql"
 baseline_digest="$("$REAL_KUBECTL" patch --local -f "$CAPTURE_FILE" --type=merge -p '{}' -o jsonpath='{.metadata.annotations.opencrane\.ai/baseline-sha256}')"
 export FAKE_BASELINE_DIGEST="$baseline_digest"
 export FAKE_EXISTING_SQL_FILE="$expected_sql"
+
+export FAKE_RACE_MARKER="$TEST_DIR/race-created"
+FAKE_CREATE_RACE=1 PATH="$TEST_DIR/bin:$PATH" \
+  bash "$PUBLISHER" opencrane 'owner"quoted' "$BASELINE" >"$TEST_DIR/race.out"
+grep -Eq '^opencrane-database-baseline-[a-f0-9]{16}$' "$TEST_DIR/race.out"
 
 for existing_mode in tampered mutable; do
   if FAKE_EXISTING_MODE="$existing_mode" PATH="$TEST_DIR/bin:$PATH" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@noble/hashes": "1.8.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.78.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",


### PR DESCRIPTION

### Summary

Fixes the deployment failures discovered while installing OpenCrane into a fresh local k3d cluster.

### Changes

- Correct the runtime cleanup RBAC template so `subjects` are rendered only on bindings, not roles.
- Ensure the runtime namespaces exist before namespaced cleanup RBAC resources are installed.
- Publish the PostgreSQL baseline without exceeding Kubernetes annotation limits.
- Add the channel-proxy build dependency required by its container image.
- Update the related RBAC and baseline publisher contract tests.
- Refresh the package lockfile.

### Problems fixed

Before these changes, a fresh local deployment could fail with:

```text
.subjects: field not declared in schema
namespaces "opencrane-runtime" not found
metadata.annotations: Too long: may not be more than 262144 bytes
```

### Verification

- Ran the deployment against a fresh local k3d cluster.
- Confirmed the Helm release installed successfully.
- Confirmed the channel proxy started and listened on port `8080`.
- Confirmed the server health endpoint returned:

```json
{"status":"ok","db":true}
```

### PR overlap

No current PR contains this complete fix.

PRs `#532`, `#520`, and the closed `#534` touch the runtime cleanup RBAC contract test, so that file may require a small rebase resolution. The RBAC template, baseline publisher, channel-proxy dependency, and baseline contract changes are otherwise uncovered.

### Files changed

- `apps/_infra/deploy-k8s/platform/tests/server-runtime-cleanup-rbac-contract.sh`
- `apps/channel-proxy/package.json`
- `apps/opencrane/helm/templates/_rbac.tpl`
- `apps/postgres/scripts/publish-initdb-baseline-config-map.sh`
- `apps/postgres/tests/baseline-publisher-contract.sh`
- `package-lock.json`