### PR TITLE
🐛 Tighten share authorization row boundaries

### DIFF
--- a/libs/backend/server/iam/authorization/main/README.md
+++ b/libs/backend/server/iam/authorization/main/README.md
@@ -70,6 +70,8 @@ legitimate request — never hand out access it should not.
   canonical JSON hash, preserving one SHA-256 implementation across server and browser consumers.
 - `PrismaRuntimeAuthorityRepository`, `PrismaAuthorizationGrantRepository` — the database-backed
   stores for accepted proofs/receipts and for candidate grants.
+- `ShareAuthorizationScopeKinds` — the four domain scope categories that sharing accepts; the
+  Prisma adapter translates them explicitly and rejects any unsupported stored category.
 - Contract types: `ResolveEffectiveAccessCommand`/`Result`, `AuthorizationGrantRepository`,
   `AuthorizationMembershipAuthority`, `CapabilityActionExecutor`, and their siblings.
 
@@ -103,7 +105,9 @@ owns the narrow catalog-seeding and share-grant persistence seam used by the sha
 every grant lookup, list and revocation to one `siloId`, so
 a principal can never discover or revoke a delegation held by another ClusterTenant. The catalog
 revision is seeded idempotently; the stored digest, rather than a caller-supplied value, binds later
-grant evaluation to the canonical capability list.
+grant evaluation to the canonical capability list. Share reads select only the fields in the public
+repository contract and map the generated Prisma scope enum into the narrower sharing vocabulary;
+an unsupported stored scope fails closed rather than being cast into the domain result.
 
 Owns `AuthorizationGrant`, `CapabilityCatalogRevision`, `ApprovalRequest`, and
 `ActionExecutionReceipt` in `apps/opencrane/prisma/schema/authorization.prisma`.

--- a/libs/backend/server/iam/authorization/main/src/__tests__/prisma-share-authorization-repository.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/__tests__/prisma-share-authorization-repository.test.ts
@@ -1,40 +1,38 @@
-import { Prisma, type PrismaClient } from "@prisma/client";
+import { AuthorizationScopeKind, Prisma, type PrismaClient } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
 import { PrismaShareAuthorizationRepository } from "../prisma-share-authorization-repository.js";
+import { ShareAuthorizationScopeKinds } from "../share-authorization-repository.types.js";
 
-/** Creates one complete share row for adapter mapping assertions. */
-function _shareRow(): Record<string, unknown>
+/** Creates one selected share row plus persistence-only fields for projection assertions. */
+function _shareRow(scopeKind: AuthorizationScopeKind = AuthorizationScopeKind.Personal)
 {
 	return {
 		id: "grant-1",
-		siloId: "silo-1",
 		subjectId: "user-2",
-		scopeKind: "Personal",
-		organizationId: "silo-1",
-		catalogId: "opencrane-core",
-		catalogRevision: 1,
-		catalogDigest: "sha256:catalog",
-		capabilityId: "mcp-server:use",
+		scopeKind,
 		resourceKind: "mcp-server",
 		resourceId: "server-1",
+		priority: 0,
+		revokedAt: null,
 		createdBy: "user-1",
 		createdAt: new Date("2026-08-01T00:00:00.000Z"),
 	};
 }
 
 /** Builds a narrow Prisma stub owned by this adapter's tests. */
-function _prisma(): PrismaClient
+function _prisma()
 {
-	return {
+	const prisma = {
 		capabilityCatalogRevision: { upsert: vi.fn(async function _upsert(input: { create: { digest: string } }) { return { digest: input.create.digest }; }) },
 		authorizationGrant: {
-			findFirst: vi.fn(async function _findFirst() { return _shareRow(); }),
+			findFirst: vi.fn(async function _findFirst(): Promise<ReturnType<typeof _shareRow> | null> { return _shareRow(); }),
 			create: vi.fn(async function _create() { return _shareRow(); }),
-			findMany: vi.fn(async function _findMany() { return [_shareRow()]; }),
+			findMany: vi.fn(async function _findMany(): Promise<ReturnType<typeof _shareRow>[]> { return [_shareRow()]; }),
 			deleteMany: vi.fn(async function _deleteMany() { return { count: 1 }; }),
 		},
-	} as unknown as PrismaClient;
+	};
+	return { ...prisma, client: prisma as unknown as PrismaClient };
 }
 
 describe("PrismaShareAuthorizationRepository", function _suite()
@@ -42,7 +40,7 @@ describe("PrismaShareAuthorizationRepository", function _suite()
 	it("uses the catalog composite key and preserves the stored digest", async function _catalog()
 	{
 		const prisma = _prisma();
-		const repository = new PrismaShareAuthorizationRepository(prisma);
+		const repository = new PrismaShareAuthorizationRepository(prisma.client);
 
 		const digest = await repository.ensureCatalogRevision({ catalogId: "opencrane-core", revision: 1, digest: "sha256:catalog", capabilities: [{ id: "mcp-server:use", actions: ["use"] }], createdBy: "system:shares-bootstrap" });
 
@@ -53,8 +51,8 @@ describe("PrismaShareAuthorizationRepository", function _suite()
 	it("fails closed when an existing catalog revision has a different digest", async function _conflictingCatalog()
 	{
 		const prisma = _prisma();
-		vi.mocked(prisma.capabilityCatalogRevision.upsert).mockResolvedValueOnce({ digest: "sha256:conflict" } as never);
-		const repository = new PrismaShareAuthorizationRepository(prisma);
+		vi.mocked(prisma.capabilityCatalogRevision.upsert).mockResolvedValueOnce({ digest: "sha256:conflict" });
+		const repository = new PrismaShareAuthorizationRepository(prisma.client);
 
 		await expect(repository.ensureCatalogRevision({ catalogId: "opencrane-core", revision: 1, digest: "sha256:catalog", capabilities: [{ id: "mcp-server:use", actions: ["use"] }], createdBy: "system:shares-bootstrap" })).rejects.toThrow("share capability catalog revision digest conflicts");
 	});
@@ -62,7 +60,7 @@ describe("PrismaShareAuthorizationRepository", function _suite()
 	it("filters share listings and revocations by silo, sharer, catalog and capability", async function _silo()
 	{
 		const prisma = _prisma();
-		const repository = new PrismaShareAuthorizationRepository(prisma);
+		const repository = new PrismaShareAuthorizationRepository(prisma.client);
 
 		await repository.listActiveShares("silo-1", "user-1", "opencrane-core", "mcp-server:use");
 		await repository.revokeOwnedShare("silo-1", "user-1", "grant-1");
@@ -71,12 +69,44 @@ describe("PrismaShareAuthorizationRepository", function _suite()
 		expect(vi.mocked(prisma.authorizationGrant.deleteMany)).toHaveBeenCalledWith({ where: { id: "grant-1", siloId: "silo-1", createdBy: "user-1" } });
 	});
 
+	it("selects only contract fields and maps the stored Prisma scope into the share domain", async function _projection()
+	{
+		const prisma = _prisma();
+		const repository = new PrismaShareAuthorizationRepository(prisma.client);
+
+		const shares = await repository.listActiveShares("silo-1", "user-1", "opencrane-core", "mcp-server:use");
+
+		expect(vi.mocked(prisma.authorizationGrant.findMany)).toHaveBeenCalledWith(expect.objectContaining({
+			select: {
+				id: true,
+				subjectId: true,
+				scopeKind: true,
+				resourceKind: true,
+				resourceId: true,
+				createdBy: true,
+				createdAt: true,
+			},
+		}));
+		expect(shares[0]).toMatchObject({ id: "grant-1", scopeKind: ShareAuthorizationScopeKinds.Personal });
+		expect(shares[0]).not.toHaveProperty("priority");
+		expect(shares[0]).not.toHaveProperty("revokedAt");
+	});
+
+	it("fails closed when a stored grant uses a scope unsupported by sharing", async function _scope()
+	{
+		const prisma = _prisma();
+		vi.mocked(prisma.authorizationGrant.findMany).mockResolvedValueOnce([_shareRow(AuthorizationScopeKind.Team)]);
+		const repository = new PrismaShareAuthorizationRepository(prisma.client);
+
+		await expect(repository.listActiveShares("silo-1", "user-1", "opencrane-core", "mcp-server:use")).rejects.toThrow("authorization grant scope Team is not supported by sharing");
+	});
+
 	it("uses the durable authority key, not the sharer, to find an idempotent share", async function _idempotency()
 	{
 		const prisma = _prisma();
-		const repository = new PrismaShareAuthorizationRepository(prisma);
+		const repository = new PrismaShareAuthorizationRepository(prisma.client);
 
-		const result = await repository.createOrFindExactShare({ siloId: "silo-1", subjectId: "user-2", scopeKind: "Personal", organizationId: "silo-1", catalogId: "opencrane-core", catalogRevision: 1, catalogDigest: "sha256:catalog", capabilityId: "mcp-server:use", resourceKind: "mcp-server", resourceId: "server-1", priority: 0, createdBy: "user-1" });
+		const result = await repository.createOrFindExactShare({ siloId: "silo-1", subjectId: "user-2", scopeKind: ShareAuthorizationScopeKinds.Personal, organizationId: "silo-1", catalogId: "opencrane-core", catalogRevision: 1, catalogDigest: "sha256:catalog", capabilityId: "mcp-server:use", resourceKind: "mcp-server", resourceId: "server-1", priority: 0, createdBy: "user-1" });
 
 		expect(result.created).toBe(false);
 		expect(vi.mocked(prisma.authorizationGrant.findFirst)).toHaveBeenCalledWith(expect.objectContaining({ where: expect.not.objectContaining({ createdBy: expect.anything() }) }));
@@ -85,11 +115,11 @@ describe("PrismaShareAuthorizationRepository", function _suite()
 	it("returns the winning concurrent insert after the durable unique constraint rejects this create", async function _concurrent()
 	{
 		const prisma = _prisma();
-		vi.mocked(prisma.authorizationGrant.findFirst).mockResolvedValueOnce(null as never).mockResolvedValueOnce(_shareRow() as never);
+		vi.mocked(prisma.authorizationGrant.findFirst).mockResolvedValueOnce(null).mockResolvedValueOnce(_shareRow());
 		vi.mocked(prisma.authorizationGrant.create).mockRejectedValueOnce(new Prisma.PrismaClientKnownRequestError("duplicate authority", { code: "P2002", clientVersion: "6.19.3" }));
-		const repository = new PrismaShareAuthorizationRepository(prisma);
+		const repository = new PrismaShareAuthorizationRepository(prisma.client);
 
-		const result = await repository.createOrFindExactShare({ siloId: "silo-1", subjectId: "user-2", scopeKind: "Personal", organizationId: "silo-1", catalogId: "opencrane-core", catalogRevision: 1, catalogDigest: "sha256:catalog", capabilityId: "mcp-server:use", resourceKind: "mcp-server", resourceId: "server-1", priority: 0, createdBy: "user-1" });
+		const result = await repository.createOrFindExactShare({ siloId: "silo-1", subjectId: "user-2", scopeKind: ShareAuthorizationScopeKinds.Personal, organizationId: "silo-1", catalogId: "opencrane-core", catalogRevision: 1, catalogDigest: "sha256:catalog", capabilityId: "mcp-server:use", resourceKind: "mcp-server", resourceId: "server-1", priority: 0, createdBy: "user-1" });
 
 		expect(result).toMatchObject({ created: false, share: { id: "grant-1" } });
 		expect(vi.mocked(prisma.authorizationGrant.findFirst)).toHaveBeenCalledTimes(2);

--- a/libs/backend/server/iam/authorization/main/src/index.ts
+++ b/libs/backend/server/iam/authorization/main/src/index.ts
@@ -22,6 +22,7 @@ export { PrismaRuntimeAuthorityRepository } from "./prisma-runtime-authority.js"
 export { PrismaAuthorizationGrantRepository } from "./prisma-authorization-grants.js";
 export { PrismaShareAuthorizationRepository } from "./prisma-share-authorization-repository.js";
 export { PrismaShareAuthorizationUnitOfWork } from "./prisma-share-authorization-unit-of-work.js";
+export { ShareAuthorizationScopeKinds } from "./share-authorization-repository.types.js";
 export type { CreateOrFindShareAuthorizationGrantResult, CreateShareAuthorizationGrant, ShareAuthorizationGrant, ShareAuthorizationRepository, ShareCapabilityCatalogRevision } from "./share-authorization-repository.types.js";
 export type { ShareAuthorizationTransaction, ShareAuthorizationUnitOfWork } from "./share-authorization-unit-of-work.types.js";
 export { __CreateRuntimeBootstrapRouter } from "./runtime-bootstrap.router.js";

--- a/libs/backend/server/iam/authorization/main/src/prisma-share-authorization-repository.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-share-authorization-repository.ts
@@ -1,20 +1,49 @@
-import { Prisma } from "@prisma/client";
+import { AuthorizationScopeKind, Prisma } from "@prisma/client";
 
-import type { CreateOrFindShareAuthorizationGrantResult, CreateShareAuthorizationGrant, ShareAuthorizationGrant, ShareAuthorizationRepository, ShareCapabilityCatalogRevision } from "./share-authorization-repository.types.js";
+import { ShareAuthorizationScopeKinds, type CreateOrFindShareAuthorizationGrantResult, type CreateShareAuthorizationGrant, type ShareAuthorizationGrant, type ShareAuthorizationRepository, type ShareCapabilityCatalogRevision } from "./share-authorization-repository.types.js";
 
-/** Maps the authorization-owned Prisma row into the share-specific persistence contract. */
-function _share(row: { id: string; siloId: string; subjectId: string; scopeKind: string; organizationId: string; catalogId: string; catalogRevision: number; catalogDigest: string; capabilityId: string; resourceKind: string; resourceId: string; createdBy: string; createdAt: Date }): ShareAuthorizationGrant
+/** Exact persistence fields that the sharing contract may expose. */
+const _SHARE_SELECT = {
+	id: true,
+	subjectId: true,
+	scopeKind: true,
+	resourceKind: true,
+	resourceId: true,
+	createdBy: true,
+	createdAt: true,
+} as const satisfies Prisma.AuthorizationGrantSelect;
+
+/** Prisma-generated result for the exact share projection. */
+type ShareAuthorizationGrantRow = Prisma.AuthorizationGrantGetPayload<{ select: typeof _SHARE_SELECT }>;
+
+/** Prisma scope value written for each supported sharing scope. */
+const _PRISMA_SCOPE_BY_SHARE: Record<ShareAuthorizationScopeKinds, AuthorizationScopeKind> = {
+	[ShareAuthorizationScopeKinds.Organization]: AuthorizationScopeKind.Organization,
+	[ShareAuthorizationScopeKinds.Department]: AuthorizationScopeKind.Department,
+	[ShareAuthorizationScopeKinds.Project]: AuthorizationScopeKind.Project,
+	[ShareAuthorizationScopeKinds.Personal]: AuthorizationScopeKind.Personal,
+};
+
+/** Maps a stored Prisma scope into the narrower share-domain vocabulary. */
+function _shareScopeKind(kind: AuthorizationScopeKind): ShareAuthorizationScopeKinds
+{
+	switch (kind)
+	{
+		case AuthorizationScopeKind.Organization: return ShareAuthorizationScopeKinds.Organization;
+		case AuthorizationScopeKind.Department: return ShareAuthorizationScopeKinds.Department;
+		case AuthorizationScopeKind.Project: return ShareAuthorizationScopeKinds.Project;
+		case AuthorizationScopeKind.Personal: return ShareAuthorizationScopeKinds.Personal;
+		default: throw new Error(`authorization grant scope ${kind} is not supported by sharing`);
+	}
+}
+
+/** Maps the selected authorization-owned Prisma row into the share-specific contract. */
+function _share(row: ShareAuthorizationGrantRow): ShareAuthorizationGrant
 {
 	return {
 		id: row.id,
-		siloId: row.siloId,
 		subjectId: row.subjectId,
-		scopeKind: row.scopeKind,
-		organizationId: row.organizationId,
-		catalogId: row.catalogId,
-		catalogRevision: row.catalogRevision,
-		catalogDigest: row.catalogDigest,
-		capabilityId: row.capabilityId,
+		scopeKind: _shareScopeKind(row.scopeKind),
 		resourceKind: row.resourceKind,
 		resourceId: row.resourceId,
 		createdBy: row.createdBy,
@@ -67,7 +96,7 @@ export class PrismaShareAuthorizationRepository implements ShareAuthorizationRep
 				data: {
 					siloId: input.siloId,
 					subjectId: input.subjectId,
-					scopeKind: input.scopeKind as never,
+					scopeKind: _PRISMA_SCOPE_BY_SHARE[input.scopeKind],
 					organizationId: input.organizationId,
 					scopeResourceId: null,
 					catalogId: input.catalogId,
@@ -80,6 +109,7 @@ export class PrismaShareAuthorizationRepository implements ShareAuthorizationRep
 					priority: input.priority,
 					createdBy: input.createdBy,
 				},
+				select: _SHARE_SELECT,
 			});
 			return { share: _share(created), created: true };
 		}
@@ -103,7 +133,7 @@ export class PrismaShareAuthorizationRepository implements ShareAuthorizationRep
 			where: {
 				siloId: input.siloId,
 				subjectId: input.subjectId,
-				scopeKind: input.scopeKind as never,
+				scopeKind: _PRISMA_SCOPE_BY_SHARE[input.scopeKind],
 				organizationId: input.organizationId,
 				scopeResourceId: null,
 				catalogId: input.catalogId,
@@ -114,6 +144,7 @@ export class PrismaShareAuthorizationRepository implements ShareAuthorizationRep
 				effect: "Allow",
 				priority: input.priority,
 			},
+			select: _SHARE_SELECT,
 		});
 		return row === null ? null : _share(row);
 	}
@@ -124,6 +155,7 @@ export class PrismaShareAuthorizationRepository implements ShareAuthorizationRep
 		const rows = await this._prisma.authorizationGrant.findMany({
 			where: { siloId, createdBy, catalogId, capabilityId, revokedAt: null },
 			orderBy: { createdAt: "desc" },
+			select: _SHARE_SELECT,
 		});
 		return rows.map(function _mapShare(row)
 		{

--- a/libs/backend/server/iam/authorization/main/src/share-authorization-repository.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/share-authorization-repository.types.ts
@@ -1,5 +1,24 @@
 import type { JsonValue } from "@opencrane/util";
 
+/**
+ * Stable authorization scope categories supported by the sharing capability.
+ *
+ * These domain values cross the grants-to-authorization package boundary. The Prisma adapter maps
+ * them explicitly to its generated persistence enum rather than leaking database spellings into
+ * callers.
+ */
+export enum ShareAuthorizationScopeKinds
+{
+	/** Applies the share across one organization. */
+	Organization = "organization",
+	/** Applies the share within one department. */
+	Department = "department",
+	/** Applies the share within one independent project. */
+	Project = "project",
+	/** Applies the share to one personal-agent scope. */
+	Personal = "personal",
+}
+
 /** A persisted capability-catalog revision used to bind a share to its evaluated capability. */
 export interface ShareCapabilityCatalogRevision
 {
@@ -20,22 +39,10 @@ export interface ShareAuthorizationGrant
 {
 	/** Stable authorization-grant identifier. */
 	readonly id: string;
-	/** Silo that contains the sharer, recipient, and governed resource. */
-	readonly siloId: string;
 	/** Recipient identity, which may be an opaque user or a group identifier. */
 	readonly subjectId: string;
-	/** Independent authorization scope kind serialized by the Prisma schema. */
-	readonly scopeKind: string;
-	/** Organization dimension of the independent authorization scope. */
-	readonly organizationId: string;
-	/** Capability catalog identifier that supplied the granted capability. */
-	readonly catalogId: string;
-	/** Immutable capability catalog revision used by the grant. */
-	readonly catalogRevision: number;
-	/** Digest that binds the grant to the exact catalog revision contents. */
-	readonly catalogDigest: string;
-	/** Capability granted to the recipient. */
-	readonly capabilityId: string;
+	/** Independent authorization scope category supported by sharing. */
+	readonly scopeKind: ShareAuthorizationScopeKinds;
 	/** Stable resource family, for example `mcp-server`. */
 	readonly resourceKind: string;
 	/** Exact resource instance granted to the recipient. */
@@ -53,8 +60,8 @@ export interface CreateShareAuthorizationGrant
 	readonly siloId: string;
 	/** Recipient that will receive the grant. */
 	readonly subjectId: string;
-	/** Prisma-backed independent scope kind. */
-	readonly scopeKind: string;
+	/** Independent authorization scope category supported by sharing. */
+	readonly scopeKind: ShareAuthorizationScopeKinds;
 	/** Organization dimension required by every share scope. */
 	readonly organizationId: string;
 	/** Catalog that owns the share capability. */

--- a/libs/backend/server/iam/grants/main/src/routes/shares.ts
+++ b/libs/backend/server/iam/grants/main/src/routes/shares.ts
@@ -1,10 +1,8 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
-import type { AuthorizationScopeKind, PrismaClient } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
 
-import { __DecideAuthorization, AuthorizationDecisionOutcomes } from "@opencrane/models/authorization";
-import type { AuthorizationRequest, AuthorizationScope } from "@opencrane/models/authorization";
-import { __DigestCanonicalJson, PrismaShareAuthorizationUnitOfWork } from "@opencrane/backend/server/iam/authorization";
-import type { ShareAuthorizationGrant, ShareAuthorizationRepository } from "@opencrane/backend/server/iam/authorization";
+import { __DecideAuthorization, AuthorizationDecisionOutcomes, type AuthorizationRequest, type AuthorizationScope } from "@opencrane/models/authorization";
+import { __DigestCanonicalJson, PrismaShareAuthorizationUnitOfWork, ShareAuthorizationScopeKinds, type ShareAuthorizationGrant, type ShareAuthorizationRepository } from "@opencrane/backend/server/iam/authorization";
 import { _ResolveRequestPrincipal } from "@opencrane/backend/_server/auth";
 import type { JsonValue } from "@opencrane/util";
 import { _log } from "../log.js";
@@ -16,7 +14,7 @@ import "@opencrane/backend/_server/auth";
 const _PAYLOAD_TYPES: readonly SharePayloadType[] = ["mcp-server"];
 /** Recipient kinds a share may target. */
 const _RECIPIENT_TYPES: readonly ShareRecipientType[] = ["user", "group"];
-/** Visibility scopes a share may carry (mirrors AuthorizationScopeKind; defaults to personal). */
+/** Visibility scopes that the public sharing API accepts. */
 const _SCOPES: readonly ShareScope[] = ["org", "department", "project", "personal"];
 
 /** Well-known catalog for platform-owned share capabilities. */
@@ -30,13 +28,21 @@ const _SHARES_RESOURCE_KIND = "mcp-server";
 /** Priority for share-originated grants (user-to-user delegation, lowest tier). */
 const _SHARES_GRANT_PRIORITY = 0;
 
-/** Map the API scope string to the Prisma AuthorizationScopeKind enum. */
-const _PRISMA_SCOPE_BY_API: Record<ShareScope, AuthorizationScopeKind> =
+/** Map each public API scope into the authorization-owned sharing vocabulary. */
+const _SHARE_SCOPE_BY_API: Record<ShareScope, ShareAuthorizationScopeKinds> =
 {
-	org: "Organization" as AuthorizationScopeKind,
-	department: "Department" as AuthorizationScopeKind,
-	project: "Project" as AuthorizationScopeKind,
-	personal: "Personal" as AuthorizationScopeKind,
+	org: ShareAuthorizationScopeKinds.Organization,
+	department: ShareAuthorizationScopeKinds.Department,
+	project: ShareAuthorizationScopeKinds.Project,
+	personal: ShareAuthorizationScopeKinds.Personal,
+};
+
+/** Map authorization-owned sharing scopes back into the public API vocabulary. */
+const _API_SCOPE_BY_SHARE: Record<ShareAuthorizationScopeKinds, ShareScope> = {
+	[ShareAuthorizationScopeKinds.Organization]: "org",
+	[ShareAuthorizationScopeKinds.Department]: "department",
+	[ShareAuthorizationScopeKinds.Project]: "project",
+	[ShareAuthorizationScopeKinds.Personal]: "personal",
 };
 
 /** Map the API scope string to the domain AuthorizationScope used for grant evaluation. */
@@ -88,23 +94,10 @@ function _ToShare(row: ShareAuthorizationGrant)
 		payloadId: row.resourceId,
 		recipientType: "user" as ShareRecipientType,
 		recipientId: row.subjectId,
-		scope: _ApiScopeFromPrisma(row.scopeKind),
+		scope: _API_SCOPE_BY_SHARE[row.scopeKind],
 		sharedBy: row.createdBy,
 		createdAt: row.createdAt.toISOString(),
 	};
-}
-
-/** Reverse-map a Prisma AuthorizationScopeKind to the API scope string. */
-function _ApiScopeFromPrisma(kind: string): ShareScope
-{
-	switch (kind)
-	{
-		case "Organization": return "org";
-		case "Department": return "department";
-		case "Project": return "project";
-		case "Personal": return "personal";
-		default: return "personal";
-	}
 }
 
 /**
@@ -207,7 +200,7 @@ export function sharesRouter(prisma: PrismaClient): Router
 				const persisted = await shareRepository.createOrFindExactShare({
 				siloId,
 				subjectId: recipientId,
-				scopeKind: _PRISMA_SCOPE_BY_API[scope],
+				scopeKind: _SHARE_SCOPE_BY_API[scope],
 				organizationId,
 				catalogId: _SHARES_CATALOG_ID,
 				catalogRevision: _SHARES_CATALOG_REVISION,


### PR DESCRIPTION
## Review order

The predecessor stack is now integrated into `develop`:

1. #560 — AuthorizationGrant sharing authority
2. #561 — atomic MCP mutations
3. #562 — share-route rate limiting
4. #557 — ip-address dependency update
5. #570 — integrates the reviewed stack into `develop`
6. #571 — this share authorization row boundary repair

This PR is rebased onto the live `develop` head after confirming the #560, #561, #562, and #557 heads are ancestral there. Its GitHub diff contains only this repair. The earlier #558 was closed without merge; its fast-uri commit subsequently landed through #570.

## Outcome

Share persistence no longer relies on an anonymous duplicate row shape or `as never` scope casts. The authorization package exposes one explicit share-scope vocabulary, translates it to and from Prisma at the adapter boundary, and fails closed when a stored grant uses a scope that sharing does not support.

## What changed

- select only the seven fields that the share result contract exposes
- derive the adapter row type from the named Prisma select
- replace arbitrary scope strings and casts with `ShareAuthorizationScopeKinds` plus explicit Prisma mappings
- remove unread coordinates from the returned share contract
- remove the route fallback that silently treated unknown stored scopes as personal
- add projection and unsupported-scope regression coverage; update the authorization package README

## Validation

- authorization: 80 tests; grants: 15 tests
- TypeScript lint for both packages
- affected lint/test run: 13 projects and 27 tasks green, including the OpenCrane app
- post-rebase focused lint/test rerun green
- Prisma boundary, agent style, module growth, ESLint, and diff checks green

## Live CI status

- stack integrity and all CodeQL jobs pass
- the affected-build job reaches the shared PostgreSQL authority gate, then fails outside this diff in `backend-agents-skills-execution:test:sql`; a single rerun also hit that suite plus `backend-server-artifacts:test:sql`
- PR #570's integration run fails the same shared skills-execution suite at a different assertion, confirming baseline SQL-test instability rather than a share-row regression

## Review

- post-implementation reaper: PASS after removing unread result fields and anonymous test-fixture casts
- final independent review: no Critical, High, Medium, or Low findings
