### PR TITLE
🧪 Restore the blocking develop smoke gate

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,7 @@ jobs:
       deployables: ${{ steps.affected.outputs.deployables }}
       has_deployables: ${{ steps.affected.outputs.has_deployables }}
       api_contract_changed: ${{ steps.affected.outputs.api_contract_changed }}
+      develop_smoke_required: ${{ steps.affected.outputs.develop_smoke_required }}
       guard_inputs_changed: ${{ steps.affected.outputs.guard_inputs_changed }}
     steps:
       - uses: actions/checkout@v6
@@ -202,15 +203,52 @@ jobs:
           npx nx run contracts:generate
           git diff --exit-code -- libs/contracts/src/generated/api.ts
 
+  develop_smoke:
+    name: k3d current-silo smoke test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    needs: [prepare, test]
+    # Every accepted develop commit proves the current deployment path. Pull requests pay for the
+    # live cluster only when they move that surface, so the smoke implementation proves itself.
+    if: >-
+      ${{
+        (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
+        (github.event_name == 'pull_request' && needs.prepare.outputs.develop_smoke_required == 'true')
+      }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install k3d
+        env:
+          K3D_VERSION: v5.8.3
+          K3D_LINUX_AMD64_SHA256: dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e
+        run: |
+          curl --location --fail --silent --show-error \
+            --output /tmp/k3d "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-amd64"
+          echo "${K3D_LINUX_AMD64_SHA256}  /tmp/k3d" | sha256sum --check
+          sudo install --mode 0755 /tmp/k3d /usr/local/bin/k3d
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v4.1.4
+
+      - name: Run the current-silo smoke
+        run: ./apps/_infra/deploy-k8s/platform/tests/develop-smoke.sh
+        env:
+          KEEP_CLUSTER: "0"
+          TIMEOUT_SECONDS: "300"
+
   build-and-push:
     name: Build and publish affected images
     runs-on: ubuntu-latest
-    needs: [prepare, test]
+    needs: [prepare, test, develop_smoke]
     if: >-
       ${{
         always() &&
         needs.prepare.outputs.has_deployables == 'true' &&
-        needs.test.result == 'success'
+        needs.test.result == 'success' &&
+        (needs.develop_smoke.result == 'success' || needs.develop_smoke.result == 'skipped')
       }}
     permissions:
       contents: read

--- a/apps/_infra/deploy-k8s/README.md
+++ b/apps/_infra/deploy-k8s/README.md
@@ -96,6 +96,11 @@ package imports it.
 - `npx nx run deploy-k8s:test` and `npx nx run deploy-k8s:helm-lint` build a disposable copy from
   the committed `Chart.lock`, linked to the current app-owned chart sources. They therefore validate
   the release contract without rewriting the tracked `charts/*.tgz` archives.
+- `npx nx run deploy-k8s:develop-smoke` creates a disposable k3d cluster, builds the five enabled
+  OpenCrane-owned workload images from the checkout, installs the current silo through `deploy.sh`,
+  and fails unless PostgreSQL isolation, every enabled Deployment, the self-signed Certificate, and
+  the TLS `/healthz` ingress are healthy. CI runs it for deployment-surface pull requests and every
+  push to `develop`; it never substitutes for backup/recovery or production-cluster qualification.
 
 ## Sub-docs (the deep detail)
 

--- a/apps/_infra/deploy-k8s/platform/README.md
+++ b/apps/_infra/deploy-k8s/platform/README.md
@@ -14,7 +14,14 @@ local source consumer.
 | `provision.sh` | Optional local, GKE, or VPS cluster provisioning invoked before deployment. |
 | `terraform/` | GKE, networking, DNS, Artifact Registry, Workload Identity, and optional chart installation. |
 | `values/` | Reusable environment and multi-instance deployment profiles. |
-| `tests/` | Rendered network, pooler, key-permission, post-deploy health, and skill-workload contract checks. |
+| `tests/` | Rendered contract checks plus the blocking disposable-k3d current-silo smoke used on `develop`. |
+
+`tests/develop-smoke.sh` exercises the real silo deploy entrypoint with images built from the checked
+out commit. It supplies only disposable OIDC and database credentials, installs pinned cert-manager,
+CloudNativePG, and the CI-only expandable hostpath CSI driver, then fails on any enabled workload,
+database-isolation, Certificate, or TLS `/healthz` failure. Set `KEEP_CLUSTER=1` for local diagnosis.
+It is intentionally a smoke gate: backup/restore and production storage, DNS, and transport remain
+separate live qualifications.
 
 Business logic does not belong here. Server-process infrastructure belongs in `libs/backend/_server`;
 backend capabilities belong in `libs/backend/server`; independently owned third-party workloads

--- a/apps/_infra/deploy-k8s/platform/tests/develop-smoke-postgres-values.yaml
+++ b/apps/_infra/deploy-k8s/platform/tests/develop-smoke-postgres-values.yaml
@@ -1,0 +1,3 @@
+# Keep the disposable database small; production storage defaults remain unchanged.
+storage:
+  size: 1Gi

--- a/apps/_infra/deploy-k8s/platform/tests/develop-smoke-values.yaml
+++ b/apps/_infra/deploy-k8s/platform/tests/develop-smoke-values.yaml
@@ -1,0 +1,43 @@
+# Disposable k3d overrides for develop-smoke.sh. OpenCrane-owned workloads use images built from
+# the checked-out commit; third-party planes stay on the pinned chart defaults.
+clustertenantManager:
+  image:
+    repository: opencrane/opencrane-server
+    tag: develop-smoke
+    pullPolicy: IfNotPresent
+  cognee:
+    persistence:
+      size: 1Gi
+
+controlPlaneSpa:
+  image:
+    repository: opencrane/opencrane-ui
+    tag: develop-smoke
+    pullPolicy: IfNotPresent
+
+channelProxy:
+  image:
+    repository: opencrane/channel-proxy
+    tag: develop-smoke
+    pullPolicy: IfNotPresent
+  ingressNamespace: kube-system
+
+memoryGateway:
+  image:
+    repository: opencrane/memory-gateway
+    tag: develop-smoke
+    pullPolicy: IfNotPresent
+
+artifactService:
+  image:
+    repository: opencrane/artifact-service
+    tag: develop-smoke
+    pullPolicy: IfNotPresent
+  persistence:
+    size: 1Gi
+
+ingress:
+  className: traefik
+
+networkPolicy:
+  ingressNamespace: kube-system

--- a/apps/_infra/deploy-k8s/platform/tests/develop-smoke.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/develop-smoke.sh
@@ -54,14 +54,17 @@ _diagnostics()
   kubectl get clusters,databases,poolers -A 2>/dev/null || true
   kubectl get certificates,issuers -A 2>/dev/null || true
   kubectl get events -A --sort-by=.lastTimestamp 2>/dev/null | tail -80 || true
+  local diagnostic_namespace
   local pod
-  while IFS= read -r pod; do
-    [[ -z "$pod" ]] && continue
-    echo "[develop-smoke] --- $NAMESPACE/$pod ---"
-    kubectl describe "$pod" -n "$NAMESPACE" 2>/dev/null | tail -40 || true
-    kubectl logs "$pod" -n "$NAMESPACE" --all-containers --tail=120 2>/dev/null || true
-    kubectl logs "$pod" -n "$NAMESPACE" --all-containers --previous --tail=120 2>/dev/null || true
-  done < <(kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null || true)
+  for diagnostic_namespace in "$NAMESPACE" "$ARTIFACT_NAMESPACE"; do
+    while IFS= read -r pod; do
+      [[ -z "$pod" ]] && continue
+      echo "[develop-smoke] --- $diagnostic_namespace/$pod ---"
+      kubectl describe "$pod" -n "$diagnostic_namespace" 2>/dev/null | tail -40 || true
+      kubectl logs "$pod" -n "$diagnostic_namespace" --all-containers --tail=120 2>/dev/null || true
+      kubectl logs "$pod" -n "$diagnostic_namespace" --all-containers --previous --tail=120 2>/dev/null || true
+    done < <(kubectl get pods -n "$diagnostic_namespace" -o name 2>/dev/null || true)
+  done
   echo "[develop-smoke] ===== end diagnostics ====="
 }
 

--- a/apps/_infra/deploy-k8s/platform/tests/develop-smoke.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/develop-smoke.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Blocking current-silo smoke for develop. This deliberately stays smaller than the retired
+# backup/recovery qualification: it proves the checked-out app images, production deploy entrypoint,
+# current umbrella chart, database authority boundary, TLS ingress, and every enabled Deployment.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+CLUSTER_NAME="${CLUSTER_NAME:-opencrane-develop-smoke}"
+NAMESPACE="${NAMESPACE:-opencrane-develop-smoke}"
+RELEASE_NAME="${RELEASE_NAME:-opencrane}"
+ARTIFACT_NAMESPACE="${RELEASE_NAME}-artifacts"
+BASE_DOMAIN="${BASE_DOMAIN:-develop-smoke.opencrane.test}"
+CLUSTER_TENANT="${CLUSTER_TENANT:-smoke}"
+CONTROL_PLANE_HOST="${CLUSTER_TENANT}.${BASE_DOMAIN}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-0}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-300}"
+K3S_IMAGE="${K3S_IMAGE:-rancher/k3s:v1.30.10-k3s1}"
+CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.15.1}"
+CNPG_CHART_VERSION="${CNPG_CHART_VERSION:-0.29.0}"
+KEY_DIR=""
+CSI_DIR=""
+
+POSTGRES_CREDENTIALS_SECRET="develop-smoke-opencrane-postgres"
+OBOT_POSTGRES_CREDENTIALS_SECRET="develop-smoke-obot-postgres"
+LITELLM_POSTGRES_CREDENTIALS_SECRET="develop-smoke-litellm-postgres"
+POSTGRES_ADMIN_CREDENTIALS_SECRET="develop-smoke-postgres-admin"
+
+_require_command()
+{
+  command -v "$1" >/dev/null 2>&1 || { echo "[develop-smoke] Missing required command: $1" >&2; exit 1; }
+}
+
+_retry()
+{
+  local attempts="$1"
+  shift
+  local attempt=1
+  until "$@"; do
+    if [[ "$attempt" -ge "$attempts" ]]; then
+      echo "[develop-smoke] Command failed after $attempts attempts: $*" >&2
+      return 1
+    fi
+    echo "[develop-smoke] Attempt $attempt/$attempts failed; retrying: $*"
+    sleep "$((attempt * 5))"
+    attempt=$((attempt + 1))
+  done
+}
+
+_diagnostics()
+{
+  echo "[develop-smoke] ===== failure diagnostics ====="
+  kubectl get pods,jobs,deployments -A -o wide 2>/dev/null || true
+  kubectl get clusters,databases,poolers -A 2>/dev/null || true
+  kubectl get certificates,issuers -A 2>/dev/null || true
+  kubectl get events -A --sort-by=.lastTimestamp 2>/dev/null | tail -80 || true
+  local pod
+  while IFS= read -r pod; do
+    [[ -z "$pod" ]] && continue
+    echo "[develop-smoke] --- $NAMESPACE/$pod ---"
+    kubectl describe "$pod" -n "$NAMESPACE" 2>/dev/null | tail -40 || true
+    kubectl logs "$pod" -n "$NAMESPACE" --all-containers --tail=120 2>/dev/null || true
+    kubectl logs "$pod" -n "$NAMESPACE" --all-containers --previous --tail=120 2>/dev/null || true
+  done < <(kubectl get pods -n "$NAMESPACE" -o name 2>/dev/null || true)
+  echo "[develop-smoke] ===== end diagnostics ====="
+}
+
+_cleanup()
+{
+  local exit_code=$?
+  if [[ "$exit_code" -ne 0 ]]; then
+    _diagnostics
+  fi
+  if [[ -n "$KEY_DIR" ]]; then
+    rm -rf -- "$KEY_DIR"
+  fi
+  if [[ -n "$CSI_DIR" ]]; then
+    rm -rf -- "$CSI_DIR"
+  fi
+  if [[ "$KEEP_CLUSTER" == "1" ]]; then
+    echo "[develop-smoke] KEEP_CLUSTER=1; leaving '$CLUSTER_NAME' running"
+  else
+    k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  fi
+  return "$exit_code"
+}
+
+_build_image()
+{
+  local image="$1"
+  local dockerfile="$2"
+  echo "[develop-smoke] Building $image"
+  _retry 3 docker build --file "$ROOT_DIR/$dockerfile" --tag "$image" "$ROOT_DIR"
+}
+
+_import_image()
+{
+  local image="$1"
+  echo "[develop-smoke] Importing $image"
+  _retry 3 k3d image import "$image" --cluster "$CLUSTER_NAME"
+}
+
+_create_database_credentials()
+{
+  local secret_name="$1"
+  local username="$2"
+  local password="$3"
+  kubectl create secret generic "$secret_name" \
+    --namespace "$NAMESPACE" \
+    --type kubernetes.io/basic-auth \
+    --from-literal=username="$username" \
+    --from-literal=password="$password" \
+    --dry-run=client -o yaml | kubectl apply -f -
+}
+
+_random_secret()
+{
+  openssl rand -hex 16
+}
+
+_install_expandable_test_storage()
+{
+  # The upstream hostpath CSI driver is explicitly a CI test driver. Unlike k3d's local-path
+  # provisioner, it includes the external resizer and actually implements volume expansion.
+  local snapshotter_commit="0f215370c7ca3eeef4ab7028824d3bc66e1f63bd"
+  local hostpath_commit="a785248f2709f55ed461e3da6c59d39152dace41"
+  local snapshotter_root="https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${snapshotter_commit}"
+
+  echo "[develop-smoke] Installing the pinned expandable hostpath CSI test driver"
+  kubectl apply -f "$snapshotter_root/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml"
+  kubectl apply -f "$snapshotter_root/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml"
+  kubectl apply -f "$snapshotter_root/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml"
+  kubectl apply -f "$snapshotter_root/deploy/kubernetes/snapshot-controller/rbac-snapshot-controller.yaml"
+  kubectl apply -f "$snapshotter_root/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml"
+
+  CSI_DIR="$(mktemp -d)"
+  git -C "$CSI_DIR" init --quiet
+  git -C "$CSI_DIR" remote add origin https://github.com/kubernetes-csi/csi-driver-host-path.git
+  _retry 3 git -C "$CSI_DIR" fetch --quiet --depth=1 origin "$hostpath_commit"
+  git -C "$CSI_DIR" checkout --quiet FETCH_HEAD
+  bash "$CSI_DIR/deploy/kubernetes-latest/deploy.sh"
+  kubectl apply -f "$CSI_DIR/examples/csi-storageclass.yaml"
+  kubectl rollout status deployment/snapshot-controller -n kube-system --timeout="${TIMEOUT_SECONDS}s"
+  kubectl rollout status statefulset/csi-hostpathplugin --timeout="${TIMEOUT_SECONDS}s"
+  if [[ "$(kubectl get storageclass csi-hostpath-sc -o jsonpath='{.allowVolumeExpansion}')" != "true" ]]; then
+    echo "[develop-smoke] csi-hostpath-sc does not declare volume expansion" >&2
+    return 1
+  fi
+
+  cat <<'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: develop-smoke-expansion
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: csi-hostpath-sc
+  resources:
+    requests:
+      storage: 64Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: develop-smoke-expansion
+spec:
+  restartPolicy: Never
+  containers:
+    - name: mount
+      image: registry.k8s.io/pause:3.10
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: develop-smoke-expansion
+EOF
+  kubectl wait --for=condition=Ready pod/develop-smoke-expansion --timeout="${TIMEOUT_SECONDS}s"
+  kubectl patch pvc develop-smoke-expansion --type=merge \
+    -p '{"spec":{"resources":{"requests":{"storage":"128Mi"}}}}'
+  kubectl wait --for=jsonpath='{.status.capacity.storage}'=128Mi \
+    pvc/develop-smoke-expansion --timeout="${TIMEOUT_SECONDS}s"
+  kubectl delete pod/develop-smoke-expansion pvc/develop-smoke-expansion --wait=true
+}
+
+_wait_for_job()
+{
+  local job_name="$1"
+  local deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+  while [[ $(date +%s) -lt "$deadline" ]]; do
+    if [[ "$(kubectl get job "$job_name" -n "$NAMESPACE" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)" == "1" ]]; then
+      return 0
+    fi
+    if [[ "$(kubectl get job "$job_name" -n "$NAMESPACE" -o jsonpath='{.status.failed}' 2>/dev/null || true)" == "1" ]]; then
+      kubectl logs "job/$job_name" -n "$NAMESPACE" --all-containers 2>/dev/null || true
+      return 1
+    fi
+    sleep 2
+  done
+  echo "[develop-smoke] Timed out waiting for job/$job_name" >&2
+  return 1
+}
+
+_assert_database_isolation()
+{
+  local job_name="develop-smoke-database-isolation"
+  cat <<EOF | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  namespace: ${NAMESPACE}
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: ${TIMEOUT_SECONDS}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: mcp-gateway
+    spec:
+      automountServiceAccountToken: false
+      restartPolicy: Never
+      containers:
+        - name: database-isolation
+          image: ghcr.io/cloudnative-pg/postgresql:17.5
+          command: ["/bin/sh", "-ceu"]
+          args:
+            - |
+              until psql -v ON_ERROR_STOP=1 -d obot -c 'SELECT 1' >/dev/null 2>&1; do sleep 2; done
+              if psql -v ON_ERROR_STOP=1 -d opencrane -c 'SELECT 1' >/dev/null 2>&1; then
+                echo "Obot authority unexpectedly connected to the OpenCrane database" >&2
+                exit 1
+              fi
+          env:
+            - name: PGHOST
+              value: ${RELEASE_NAME}-postgres-pooler
+            - name: PGUSER
+              valueFrom:
+                secretKeyRef:
+                  name: ${OBOT_POSTGRES_CREDENTIALS_SECRET}
+                  key: username
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ${OBOT_POSTGRES_CREDENTIALS_SECRET}
+                  key: password
+EOF
+  _wait_for_job "$job_name"
+}
+
+_assert_ingress_health()
+{
+  local health_url="https://${CONTROL_PLANE_HOST}:8443/healthz"
+  local deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+  local response=""
+  until response="$(curl --connect-timeout 2 --max-time 5 --fail --silent --show-error --insecure \
+    --resolve "${CONTROL_PLANE_HOST}:8443:127.0.0.1" "$health_url" 2>/dev/null)" \
+    && [[ "$response" == '{"status":"ok","db":true}' ]]; do
+    if [[ $(date +%s) -ge "$deadline" ]]; then
+      echo "[develop-smoke] Timed out waiting for database-backed health at $health_url; last response: $response" >&2
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+trap _cleanup EXIT
+
+for command in curl docker git helm k3d kubectl openssl; do _require_command "$command"; done
+docker info >/dev/null 2>&1 || { echo "[develop-smoke] Docker daemon is not reachable." >&2; exit 1; }
+
+_build_image opencrane/opencrane-server:develop-smoke apps/opencrane/deploy/Dockerfile
+_build_image opencrane/opencrane-ui:develop-smoke apps/opencrane-ui/deploy/Dockerfile
+_build_image opencrane/channel-proxy:develop-smoke apps/channel-proxy/deploy/Dockerfile
+_build_image opencrane/memory-gateway:develop-smoke apps/memory-gateway/deploy/Dockerfile
+_build_image opencrane/artifact-service:develop-smoke apps/artifact-service/deploy/Dockerfile
+
+echo "[develop-smoke] Creating disposable k3d cluster '$CLUSTER_NAME'"
+k3d cluster delete "$CLUSTER_NAME" >/dev/null 2>&1 || true
+k3d cluster create "$CLUSTER_NAME" --image "$K3S_IMAGE" --port "8443:443@loadbalancer" --wait
+
+_import_image opencrane/opencrane-server:develop-smoke
+_import_image opencrane/opencrane-ui:develop-smoke
+_import_image opencrane/channel-proxy:develop-smoke
+_import_image opencrane/memory-gateway:develop-smoke
+_import_image opencrane/artifact-service:develop-smoke
+
+echo "[develop-smoke] Installing external cluster prerequisites"
+_install_expandable_test_storage
+helm repo add jetstack https://charts.jetstack.io --force-update >/dev/null
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace --version "$CERT_MANAGER_VERSION" \
+  --wait --timeout "${TIMEOUT_SECONDS}s" --set crds.enabled=true
+helm repo add cnpg https://cloudnative-pg.github.io/charts --force-update >/dev/null
+helm upgrade --install cnpg cnpg/cloudnative-pg \
+  --namespace cnpg-system --create-namespace --version "$CNPG_CHART_VERSION" \
+  --wait --timeout "${TIMEOUT_SECONDS}s" --set-string monitoring.podMonitor.enabled=false
+
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+
+echo "[develop-smoke] Creating isolated database and fleet-verification inputs"
+_create_database_credentials "$POSTGRES_CREDENTIALS_SECRET" opencrane "$(_random_secret)"
+_create_database_credentials "$OBOT_POSTGRES_CREDENTIALS_SECRET" obot "$(_random_secret)"
+_create_database_credentials "$LITELLM_POSTGRES_CREDENTIALS_SECRET" litellm "$(_random_secret)"
+_create_database_credentials "$POSTGRES_ADMIN_CREDENTIALS_SECRET" opencrane_database_admin "$(_random_secret)"
+
+KEY_DIR="$(mktemp -d)"
+openssl genpkey -algorithm ED25519 -out "$KEY_DIR/private-key.pem"
+openssl pkey -in "$KEY_DIR/private-key.pem" -pubout -out "$KEY_DIR/public-key.pem"
+kubectl create secret generic opencrane-fleet-membership-verification \
+  --namespace "$NAMESPACE" \
+  --from-file=public-key.pem="$KEY_DIR/public-key.pem" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo "[develop-smoke] Installing the current silo through its app-owned deploy entrypoint"
+export OIDC_ISSUER_URL="https://issuer.opencrane.test"
+export OIDC_CLIENT_ID="develop-smoke"
+export OPENCRANE_OIDC_CLIENT_SECRET="$(_random_secret)"
+export OPENCRANE_OIDC_SESSION_SECRET="$(_random_secret)"
+export TIMEOUT_SECONDS
+"$ROOT_DIR/apps/_infra/deploy-k8s/deploy.sh" \
+  --base-domain "$BASE_DOMAIN" \
+  --cluster-tenant "$CLUSTER_TENANT" \
+  --namespace "$NAMESPACE" \
+  --release "$RELEASE_NAME" \
+  --image-tag develop-smoke \
+  --storage-class csi-hostpath-sc \
+  --postgres-credentials-secret "$POSTGRES_CREDENTIALS_SECRET" \
+  --obot-postgres-credentials-secret "$OBOT_POSTGRES_CREDENTIALS_SECRET" \
+  --litellm-postgres-credentials-secret "$LITELLM_POSTGRES_CREDENTIALS_SECRET" \
+  --postgres-admin-credentials-secret "$POSTGRES_ADMIN_CREDENTIALS_SECRET" \
+  --postgres-values "$ROOT_DIR/apps/_infra/deploy-k8s/platform/tests/develop-smoke-postgres-values.yaml" \
+  --values "$ROOT_DIR/apps/_infra/deploy-k8s/platform/tests/develop-smoke-values.yaml"
+
+echo "[develop-smoke] Waiting for every enabled workload and certificate"
+kubectl wait --for=condition=available deployment --all -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+kubectl wait --for=condition=available deployment --all -n "$ARTIFACT_NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+kubectl wait --for=condition=Ready certificate/opencrane-clustertenant-tls \
+  -n "$NAMESPACE" --timeout="${TIMEOUT_SECONDS}s"
+
+_assert_database_isolation
+_assert_ingress_health
+
+echo "[develop-smoke] PASS: current silo, database isolation, TLS ingress, and all enabled workloads are healthy"

--- a/apps/_infra/deploy-k8s/project.json
+++ b/apps/_infra/deploy-k8s/project.json
@@ -14,6 +14,10 @@
       "executor": "nx:run-commands",
       "options": { "command": "bash apps/_infra/deploy-k8s/platform/tests/helm-lint-current-sources.sh" }
     },
+    "develop-smoke": {
+      "executor": "nx:run-commands",
+      "options": { "command": "bash apps/_infra/deploy-k8s/platform/tests/develop-smoke.sh" }
+    },
     "dependency-status": {
       "executor": "nx:run-commands",
       "options": { "command": "helm dependency list apps/_infra/deploy-k8s" }

--- a/apps/artifact-service/package.json
+++ b/apps/artifact-service/package.json
@@ -5,6 +5,7 @@
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "dependencies": {
+    "@noble/hashes": "1.8.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.78.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",

--- a/apps/memory-gateway/package.json
+++ b/apps/memory-gateway/package.json
@@ -6,10 +6,13 @@
   "type": "module",
   "dependencies": {
     "@kubernetes/client-node": "^1.0.0",
+    "@noble/hashes": "1.8.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.78.0",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
     "@opentelemetry/sdk-node": "^0.220.0",
-    "pino": "^9.6.0"
+    "openapi-fetch": "^0.17.0",
+    "pino": "^9.6.0",
+    "zod": "^3.25.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
+        "@noble/hashes": "1.8.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.78.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
@@ -135,11 +136,14 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@kubernetes/client-node": "^1.0.0",
+        "@noble/hashes": "1.8.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.78.0",
         "@opentelemetry/exporter-trace-otlp-proto": "^0.220.0",
         "@opentelemetry/sdk-node": "^0.220.0",
-        "pino": "^9.6.0"
+        "openapi-fetch": "^0.17.0",
+        "pino": "^9.6.0",
+        "zod": "^3.25.0"
       }
     },
     "apps/opencrane": {

--- a/scripts/__tests__/affected-deployables.test.mjs
+++ b/scripts/__tests__/affected-deployables.test.mjs
@@ -3,13 +3,20 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { selectAffectedDeployables, selectApiContractChanged, selectGuardInputsChanged } from "../affected-deployables.core.mjs";
+import { selectAffectedDeployables, selectApiContractChanged, selectDevelopSmokeRequired, selectGuardInputsChanged } from "../affected-deployables.core.mjs";
 
 /** Reads the stable selector fixture. */
 function _Fixture()
 {
 	const path = fileURLToPath(new URL("./fixtures/affected-deployables/selection.json", import.meta.url));
 	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+/** Reads the publish workflow whose affected selector this suite protects. */
+function _Workflow()
+{
+	const path = fileURLToPath(new URL("../../.github/workflows/docker.yml", import.meta.url));
+	return readFileSync(path, "utf8");
 }
 
 test("selects sorted release descriptors owned by affected container apps", function _SelectsDescriptors()
@@ -35,4 +42,25 @@ test("uses all affected projects for contract verification and changed files for
 	assert.equal(selectGuardInputsChanged(fixture.changedFiles), true);
 	assert.equal(selectApiContractChanged(["skill-authoring"]), false);
 	assert.equal(selectGuardInputsChanged(["apps/skill-authoring/src/authoring_worker.py"]), false);
+});
+
+test("runs the develop smoke for deployment surfaces and not ordinary application sources", function _SelectsDevelopSmokeInputs()
+{
+	assert.equal(selectDevelopSmokeRequired(["apps/_infra/deploy-k8s/values.yaml"]), true);
+	assert.equal(selectDevelopSmokeRequired(["apps/opencrane/helm/templates/_deployment.tpl"]), true);
+	assert.equal(selectDevelopSmokeRequired(["apps/opencrane/deploy/Dockerfile"]), true);
+	assert.equal(selectDevelopSmokeRequired([".github/workflows/docker.yml"]), true);
+	assert.equal(selectDevelopSmokeRequired(["apps/opencrane/src/main.ts"]), false);
+	assert.equal(selectDevelopSmokeRequired(["website/guide.md"]), false);
+});
+
+test("keeps the blocking smoke on develop and ahead of image publication", function _ProtectsDevelopSmokeWiring()
+{
+	const workflow = _Workflow();
+	assert.match(workflow, /github\.ref == 'refs\/heads\/develop'/u);
+	assert.match(workflow, /run: \.\/apps\/_infra\/deploy-k8s\/platform\/tests\/develop-smoke\.sh/u);
+	assert.match(workflow, /needs: \[prepare, test, develop_smoke\]/u);
+	assert.match(workflow, /needs\.develop_smoke\.result == 'success'/u);
+	assert.match(workflow, /K3D_LINUX_AMD64_SHA256: [0-9a-f]{64}/u);
+	assert.match(workflow, /sha256sum --check/u);
 });

--- a/scripts/affected-deployables.core.mjs
+++ b/scripts/affected-deployables.core.mjs
@@ -44,3 +44,13 @@ export function selectGuardInputsChanged(changedFiles)
 			|| file === ".github/workflows/docker.yml";
 	});
 }
+
+/** Determines whether a pull request changed the live deployment surface exercised by k3d. */
+export function selectDevelopSmokeRequired(changedFiles)
+{
+	return changedFiles.some(function _DevelopSmokeInput(file) {
+		return file.startsWith("apps/_infra/deploy-k8s/")
+			|| (file.startsWith("apps/") && (file.includes("/helm/") || file.includes("/deploy/")))
+			|| file === ".github/workflows/docker.yml";
+	});
+}

--- a/scripts/affected-deployables.mjs
+++ b/scripts/affected-deployables.mjs
@@ -3,7 +3,7 @@
 import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
-import { selectAffectedDeployables, selectApiContractChanged, selectGuardInputsChanged } from "./affected-deployables.core.mjs";
+import { selectAffectedDeployables, selectApiContractChanged, selectDevelopSmokeRequired, selectGuardInputsChanged } from "./affected-deployables.core.mjs";
 
 /** Run a command and return trimmed stdout. */
 function _run(command, args)
@@ -51,6 +51,7 @@ const deployables = selectAffectedDeployables(affectedContainerProjects.map(func
 const changedFiles = _run("git", ["diff", "--name-only", base, head]).split("\n").filter(Boolean);
 
 const apiContractChanged = selectApiContractChanged(affectedProjects);
+const developSmokeRequired = selectDevelopSmokeRequired(changedFiles);
 const guardInputsChanged = selectGuardInputsChanged(changedFiles);
 
 _output("nx_base", base);
@@ -58,4 +59,5 @@ _output("nx_head", head);
 _output("deployables", JSON.stringify({ include: deployables }));
 _output("has_deployables", String(deployables.length > 0));
 _output("api_contract_changed", String(apiContractChanged));
+_output("develop_smoke_required", String(developSmokeRequired));
 _output("guard_inputs_changed", String(guardInputsChanged));


### PR DESCRIPTION
## Summary

- run a blocking current-silo k3d smoke on every `develop` push and on pull requests that change deployment surfaces
- build and import the five enabled OpenCrane-owned images from the checked-out commit, then install through the app-owned `deploy.sh` entrypoint
- prove real CSI expansion, the app-owned PostgreSQL baseline and cross-database isolation, all enabled workload rollouts, self-signed certificate readiness, and the database-backed TLS `/healthz` response
- make image publication depend on a successful smoke and pin the k3d binary with a repository-owned SHA-256

## PR relationship

This is an independent repair directly on `develop`. The live PR graph had no open pull requests before publication, and the branch starts at current `origin/develop` (`42578dc6`). No predecessor is stacked or absorbed.

## Validation

- independent correctness, security, maintainability, and residue review of the final overlay: PASS after fixing the remote-installer checksum finding
- affected-deployables selector and workflow wiring: 5 tests passing
- current Helm source and 9 deploy-k8s contract checks: PASS
- configuration documentation coverage: 4 tests passing; strict coverage reports 0 gaps
- module-growth: 13 tests passing, 0 errors, 0 candidates
- Prisma boundaries: 15 tests passing, 0 errors
- PR-stack integrity: 19 tests passing; live pre-PR graph check PASS with 0 open PRs
- shell syntax, workflow YAML parse, style gate, and `git diff --check`: PASS

The workstation has no reachable Docker daemon. This PR changes the deployment surface, so its new `k3d current-silo smoke test` check is the required live qualification and must be green before merge.