### PR TITLE
📝 Functionality-first rewrite of README, CHANGELOG, and website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,25 +43,24 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   workspaces are mounted non-authoritative scratch; and future application updates must return ready
   target Pods in strictly less than five minutes while remounting existing canonical volumes.
 
-- **Platform developers can now work on one functional domain in isolation, with module boundaries
-  enforced by lint.** Each of 20 functional domains (tenants, policies, grants, skills, model-routing,
-  providers, awareness, spend, groups, MCP, sessions, company-docs, audit, access-tokens, metrics,
-  connections, cluster-tenants, retrieval, contract, projection) is now an NX package at
-  `libs/domain/<domain>/main`, owning its routes, services, types, tests, and Prisma schema slice.
-  A module-boundary lint rule (`npm run lint:boundaries`) enforces that imports flow domain → domain + shared
-  only — no cross-domain hard coupling. The stepping stone for multi-tenant customisation and Wave 5
-  plugin ownership.
+- **Platform developers can now work on one functional capability in isolation, with module
+  boundaries enforced by lint.** The server's capabilities are split into scope-tagged NX libraries
+  grouped by area under `libs/backend/server/` (`agents`, `gateways`, `iam`, `knowledge`,
+  `reporting`, `tenancy`) and the surrounding `libs/backend` seams, each owning its routes, services,
+  types, tests, and Prisma schema slice. A module-boundary lint rule (`npm run lint:boundaries`)
+  enforces that imports flow capability → allowed dependency + shared only — no cross-capability hard
+  coupling. The stepping stone for multi-tenant customisation and plugin ownership.
 
-- **The workspace now builds, tests, and lints with NX caching — `npm run build/test/lint` runs once per
-  input change across all 20 domains.** NX derives the project graph from project metadata and source
-  imports, so a new package or dependency edge updates cache invalidation without manual
-  configuration. The developer experience remains `npm run build && npm test` and the
-  CI cost drops as unchanged domains are skipped.
+- **The workspace now builds, tests, and lints with NX caching — `npm run build/test/lint` runs once
+  per input change across every capability library.** NX derives the project graph from project
+  metadata and source imports, so a new package or dependency edge updates cache invalidation without
+  manual configuration. The developer experience remains `npm run build && npm test`, and CI cost
+  drops as unchanged capabilities are skipped.
 
-- **Adding a new domain package requires no Dockerfile or CI edits — the image builds the app's
+- **Adding a new capability library requires no Dockerfile or CI edits — the image builds the app's
   dependency closure automatically.** The Dockerfile copies `libs` wholesale and runs the
   OpenCrane server's npm workspace build, which lets Nx build the required dependency graph; each
-  new domain is included on the next build without touching the build definition. The `npm ci` →
+  new library is included on the next build without touching the build definition. The `npm ci` →
   `docker build` → app-start pipeline stays identical.
 
 - **Operators can create a silo database directly from one reviewed target definition.** Per-domain
@@ -90,6 +89,48 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   on the pod template, so any config change — including a newly registered BYOK default model —
   triggers a rolling restart automatically. Before this, a BYOK key registration had no effect
   until the pod was manually recycled.
+
+- **Approved agent tool calls now execute directly against Obot, with no server in the data
+  path.** Each run attempt is issued a short-lived Obot API key scoped to exactly that attempt's
+  MCP server ids (minted at dispatch, revoked with the attempt); the runtime pairs it with the
+  tool's Obot MCP server id to call Obot's connection proxy directly, so the underlying
+  integration credential never leaves Obot and never transits OpenCrane. The recorded tool-call
+  receipt carries only a content digest, never the tool payload.
+
+- **Personal-agent runs can recall organisation and personal memory through a locked-down memory
+  gateway.** A dedicated `memory-gateway` app is the only process allowed to reach the silo's
+  Cognee instance: it TokenReviews the server's identity and accepts only a single bounded
+  `CHUNKS` search against one caller-authorised dataset, rejecting anything else before it reaches
+  Cognee. Admission-time recall freezes the selected fact references (an id and content digest,
+  never raw text) into the run's input, and the compiler re-resolves and digest-verifies every
+  reference before it is compiled into the run, so a redelivered run stays byte-identical or fails
+  closed rather than silently drifting. Mid-run recall, writes, and correction remain unavailable
+  pending a durable write lifecycle.
+
+- **Skill authoring and tenant-authored tool execution now run as fully isolated, hardened
+  Kubernetes Jobs.** The agent controller — the only process allowed to create these workloads —
+  projects a suspended, non-privileged, read-only-root-filesystem Job with no embedded source
+  code, bundle bytes, arguments, or credentials; a database-fenced release then permits exactly
+  one conditional unsuspend, and a fail-closed admission policy accepts only that exact pinned Job
+  shape from the controller's identity. Each Job receives its identity through a short-lived,
+  audience-bound projected token and an opaque bootstrap reference in separate read-only files —
+  never inline — so an authoring or tool-runner workload cannot escalate past what it was granted.
+
+- **Every artifact and skill now has a stable, content-addressed, versioned identity, and users
+  can browse their own uploads.** Artifact bytes are stored once, addressed by their SHA-256
+  content hash, and finalised into an immutable revision only after a signed, single-use
+  promotion receipt is verified — a replayed or forged receipt is rejected. Skills carry the same
+  stable-identity/immutable-revision shape, exposed read-only at `GET /api/v1/skills`. Users can
+  list their own non-deleted assets at `GET /api/v1/me/assets`; an uploaded PDF is automatically
+  converted to text by an isolated worker so its content becomes searchable, with the derived text
+  kept as an immutable, lineage-linked revision.
+
+- **API clients now get structured, per-field validation errors instead of an opaque 400.** An
+  invalid request body returns bounded `{ location, path, message }` issues (capped at 20 issues,
+  16 path segments deep, generic messages that never echo the rejected value) generated from the
+  same Zod schema that validates the request — surfaced through `@opencrane/contracts`'s typed
+  error envelope and a browser API-error helper, so a form can map each issue straight to the
+  field that caused it.
 
 ### Changed
 
@@ -154,6 +195,12 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   from the DB and pod-token resolution could fail for tenants that had not gone through a
   post-split reconcile cycle.
 
+- **Listing or resolving a share can no longer widen what a row exposes, or guess at an
+  unrecognised scope.** Share reads now select only the fields declared in the public sharing
+  contract rather than the full underlying row, and mapping a stored scope value that doesn't
+  match one of the four supported kinds (org, department, project, personal) now fails closed
+  instead of silently defaulting to `personal`.
+
 ### Security
 
 - **Tenant pods can no longer self-install or self-update their agent runtime.** Runtime code is
@@ -169,6 +216,13 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   `allowUsers` pin on the gateway restricts it to the tenant owner's email. Device auth is
   redundant in this topology; the flag makes that explicit rather than leaving it as a silent
   gap.
+
+- **Application code can no longer run raw SQL against the database, anywhere, under any
+  exemption.** `$queryRaw`, `$queryRawUnsafe`, `$executeRaw`, and `$executeRawUnsafe` are now
+  forbidden in production TypeScript — including inside a previously-declared repository adapter —
+  and no temporary policy exemption can reopen them. The invariants those queries used to enforce
+  (skill-workload fencing, artifact-preprocessing claims) now live as reviewed, database-owned
+  functions and triggers in the schema baseline, reached only through typed Prisma delegates.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -49,37 +49,38 @@ frozen snapshot of its input, and removes it when the attempt finishes. The run 
 back as an ordered stream of events but holds no authority of its own, so an assistant survives
 restarts, scaling, and a closed browser tab without ever becoming the source of truth.
 
-```mermaid
-flowchart TB
-    emp["Employees"]
-    trig["Schedules &amp; triggers"]
-
-    subgraph org["Your organisation — one isolated boundary"]
-        direction TB
-
-        pa["Personal assistants<br/>private to one employee"]
-        ma["Managed agents<br/>bounded, scoped work"]
-
-        cp["OpenCrane control plane<br/>identity · conversations · runs<br/>approvals · budgets · access · audit"]
-
-        run(["Isolated run<br/>short-lived · one attempt · no standing authority"])
-
-        subgraph shared["Shared organisation services"]
-            direction LR
-            models["Models"]
-            tools["Tools"]
-            mem["Memory &amp;<br/>knowledge"]
-            files["Files &amp;<br/>artifacts"]
-        end
-    end
-
-    emp --> pa
-    trig --> ma
-    pa --> cp
-    ma --> cp
-    cp -- "starts a governed run" --> run
-    run -- "ordered events" --> cp
-    run --> shared
+```text
+        Employees                                              Schedules & triggers
+            │                                                           │
+            │                                                           │
+╔═══ YOUR ORGANISATION — one isolated boundary ═════════════════════════════════════════════════════╗
+║           │                                                           │                           ║
+║           │                                                           │                           ║
+║           ▼                                                           ▼                           ║
+║   ┌─────────────────────────┐  ┌─────────────────────────┐   ┌───────────────────────────────┐    ║
+║   │ Personal assistant      │  │ identity adjusted       │   │ Managed agent                 │    ║
+║   │ private to one          │╌╌│ to the employee         │   │ bounded, scoped work          │    ║
+║   │ employee                │  │ (per-person sidecar)    │   │ own scoped identity           │    ║
+║   └─────────────────────────┘  └─────────────────────────┘   └───────────────────────────────┘    ║
+║                │                                                             │                    ║
+║                └─────────────────┬───────────────────────────────────────────┘                    ║
+║                                  ▼                                                                ║
+║           ┌─────────────────────────────────────────────┐    ┌─────────────────────────────────┐  ║
+║           │           OpenCrane control plane           │    │ Shared organisation services    │  ║
+║           │       identity · conversations · runs       │    │ maintained centrally,           │  ║
+║           │     approvals · budgets · access · audit    │    │ outside the agents              │  ║
+║           └─────────────────────────────────────────────┘    │                                 │  ║
+║              starts a          │   ▲  ordered                │  • Models                       │  ║
+║             governed run       │   │   events                │  • Tools                        │  ║
+║                                ▼   │                         │  • Memory & knowledge           │  ║
+║           ┌─────────────────────────────────────────────┐    │  • Files & artifacts            │  ║
+║           │                 Isolated run                │uses│                                 │  ║
+║           │         short-lived · one attempt ·         │───▶│                                 │  ║
+║           │            no standing authority            │    │                                 │  ║
+║           └─────────────────────────────────────────────┘    └─────────────────────────────────┘  ║
+║                                                                                                   ║
+║                                                                                                   ║
+╚═══════════════════════════════════════════════════════════════════════════════════════════════════╝
 ```
 
 The control plane governs the parts that must be consistent across every agent:

--- a/README.md
+++ b/README.md
@@ -3,101 +3,109 @@
 ## The vision
 
 AI assistants become far more valuable when they understand how people work, can use company tools,
-and can carry knowledge across conversations. At organisation scale, that also creates a difficult
-governance problem: every assistant needs the right identity, context, permissions, budget, and
-approval boundaries without exposing one person's work to another.
+and can carry knowledge across conversations. At organisation scale, that creates a governance
+problem: every assistant needs the right identity, context, permissions, budget, and approval
+boundaries — without exposing one person's work to another.
 
-OpenCrane is a self-hosted control plane for organisational AI. It gives employees durable personal
-assistants and lets organisations create shared agents for scheduled or triggered work, while the
-organisation remains in control of its data, skills, tools, models, and audit history.
+OpenCrane is a self-hosted control plane for organisational AI. It gives every employee a durable
+personal assistant, lets the organisation run shared agents for scheduled and triggered work, and
+keeps the organisation in control of its data, knowledge, skills, tools, models, and audit history.
 
 ## Why OpenCrane
 
 Vendor-hosted assistants are convenient, but they place proprietary workflows, conversations, and
-company knowledge inside another company's platform. They can also tie an organisation's skills and
-operating model to one model provider.
+company knowledge inside another company's platform, and they tie an organisation's operating model
+to one model provider.
 
 OpenCrane keeps the organisational layer on infrastructure you control:
 
-- employee conversations, files, personas, and memory remain private to their authorised users;
-- company knowledge, integrations, skills, and agent definitions remain organisation-owned;
+- employee conversations, files, personas, and memory stay private to their authorised user;
+- company knowledge, integrations, skills, and agent definitions stay organisation-owned;
 - model providers and credentials can change without rebuilding the assistant product;
 - budgets, approvals, access decisions, and activity are governed in one place; and
-- each organisation runs within its own isolated boundary.
+- each organisation runs inside its own isolated boundary.
 
-## Meet OpenCrane
+## Two kinds of agent
 
-OpenCrane gives every employee a durable assistant rather than a long-running personal server.
-Conversations, messages, run inputs, events, approvals, and files are recorded by the control plane.
-When work needs to run, OpenCrane starts an isolated, short-lived Job for that attempt and removes it
-when the attempt finishes.
+Everything in OpenCrane is built around one distinction.
 
-The same foundation supports personal and managed agents:
+- **Personal assistants** work for a single employee. An assistant can see and use only that
+  person's approved context, tools, skills, files, and memory. Its work is private to them, and it
+  builds up an understanding of how that employee works over time.
+- **Managed agents** do bounded work for the organisation, a department, a team, or a project — on a
+  schedule or in response to a trigger. Each managed agent runs under its own narrowly scoped
+  identity, and can never quietly inherit the person who created it, the employee who started it, or
+  anyone's private memory or personal tools.
 
-- **Personal assistants** work for one employee and can use only that person's approved context,
-  tools, skills, and files.
-- **Managed agents** perform bounded organisation, department, team, or project work on a schedule or
-  trigger, under their own narrowly scoped identity.
-- **Durable conversations** keep an ordered history that can be replayed after a reconnect without
-  making the browser or runtime the source of truth.
-- **Governed actions** pause for approval when required and record the exact action and outcome.
-- **Versioned assets and skills** preserve which input or capability a run used, even after a newer
-  version is published.
-- **Organisation memory** makes permitted company knowledge available without granting broad access
-  to private employee data.
+Both kinds share the same foundation: durable conversations, governed actions, versioned skills and
+files, and permitted access to organisation knowledge.
 
 ## How it works
 
-Each organisation is represented by a **ClusterTenant**, the organisation-level isolation boundary.
-Its OpenCrane installation combines:
+Each organisation is one isolated boundary. Inside it, a control plane holds the durable record of
+everything — who the agents are, what they may do, and everything they have done. When an agent
+needs to act, OpenCrane starts a short-lived, isolated run for that single attempt, gives it one
+frozen snapshot of its input, and removes it when the attempt finishes. The run reports its progress
+back as an ordered stream of events but holds no authority of its own, so an assistant survives
+restarts, scaling, and a closed browser tab without ever becoming the source of truth.
 
-- a control plane that owns identity, agent definitions, conversations, runs, approvals, access,
-  budgets, audit, and schedules;
-- one isolated Job for each agent run attempt;
-- a channel proxy that authenticates inbound browser and channel traffic before it reaches runtime
-  authority; and
-- shared organisation services for models, tools, memory, artifacts, and telemetry.
+```mermaid
+flowchart TB
+    emp["Employees"]
+    trig["Schedules &amp; triggers"]
 
-The runtime receives one frozen input snapshot, reports ordered events back to OpenCrane, and has no
-durable authority of its own. An employee's assistant therefore survives worker replacement and
-scaling without turning a Pod or browser session into the product record.
+    subgraph org["Your organisation — one isolated boundary"]
+        direction TB
+
+        pa["Personal assistants<br/>private to one employee"]
+        ma["Managed agents<br/>bounded, scoped work"]
+
+        cp["OpenCrane control plane<br/>identity · conversations · runs<br/>approvals · budgets · access · audit"]
+
+        run(["Isolated run<br/>short-lived · one attempt · no standing authority"])
+
+        subgraph shared["Shared organisation services"]
+            direction LR
+            models["Models"]
+            tools["Tools"]
+            mem["Memory &amp;<br/>knowledge"]
+            files["Files &amp;<br/>artifacts"]
+        end
+    end
+
+    emp --> pa
+    trig --> ma
+    pa --> cp
+    ma --> cp
+    cp -- "starts a governed run" --> run
+    run -- "ordered events" --> cp
+    run --> shared
+```
+
+The control plane governs the parts that must be consistent across every agent:
+
+- **Durable conversations** keep an ordered history that replays after a reconnect, instead of
+  trusting the browser or the runtime to remember.
+- **Governed actions** pause for approval when a step needs it, and record the exact action taken and
+  its outcome.
+- **Versioned skills and files** preserve which capability or input a run actually used, even after a
+  newer version is published.
+- **Organisation memory** makes permitted company knowledge available to an agent without granting it
+  broad access to any employee's private data.
+- **Budgets and audit** track spend and activity in one place, per agent and per organisation.
 
 See the illustrated [architecture overview](https://opencrane.ai/advanced/architecture) for the
-reader-facing system view.
-
-## Components
-
-| Path | What it is |
-| --- | --- |
-| [`apps/opencrane/`](apps/opencrane/) | The authenticated REST API and control-plane composition root. |
-| [`apps/opencrane-ui/`](apps/opencrane-ui/) | The organisation administration and employee web interface. |
-| [`apps/channel-proxy/`](apps/channel-proxy/) | The inbound channel trust boundary. |
-| [`apps/agent-controller/`](apps/agent-controller/) | The controller that assigns and releases isolated runtime Jobs. |
-| [`apps/agent-runtime/`](apps/agent-runtime/) | The outbound-only process that performs one run attempt. |
-| [`apps/managed-agent-runtime/`](apps/managed-agent-runtime/) | The isolated runtime plane for scheduled and triggered managed agents. |
-| [`apps/artifact-service/`](apps/artifact-service/) | The service that receives and promotes governed artifact bytes. |
-| [`apps/artifact-preprocessor/`](apps/artifact-preprocessor/) | The bounded document-extraction worker. |
-| [`apps/skill-authoring/`](apps/skill-authoring/) | The isolated Job plane for candidate skill authoring. |
-| [`apps/tool-runner/`](apps/tool-runner/) | The isolated Job plane for governed tool execution. |
-| [`apps/_infra/`](apps/_infra/) | Deployment wrappers for PostgreSQL, Cognee, LiteLLM, Obot, and the Kubernetes release. |
-| [`libs/backend/`](libs/backend/) | Server, agent, artifact, channel, and runtime capabilities. |
-| [`libs/frontend/`](libs/frontend/) | Reusable web features, elements, platform services, and state adapters. |
-| [`libs/contracts/`](libs/contracts/) | Shared API contracts and the generated TypeScript client. |
-| [`website/`](website/) | The VitePress documentation site published at opencrane.ai. |
+full reader-facing system view.
 
 ## Documentation
 
-The full documentation is at [opencrane.ai](https://opencrane.ai), including:
+The complete documentation is at [opencrane.ai](https://opencrane.ai), including:
 
 - [getting started](https://opencrane.ai/guide/getting-started);
 - the [architecture overview](https://opencrane.ai/advanced/architecture);
 - the [deployment guide](https://opencrane.ai/guide/deploy-cluster);
 - the [MCP integration guide](https://opencrane.ai/integrators/mcp-gateway); and
 - the [API overview](https://opencrane.ai/reference/api-overview).
-
-Repository contributors should start with [`AGENTS.md`](AGENTS.md). Capability history lives in
-[`CHANGELOG.md`](CHANGELOG.md), while completed implementation history and design context live in
-[`plan-done.md`](plan-done.md).
 
 ## Quick start
 
@@ -119,9 +127,9 @@ npm run test
 
 ### Deploy an organisation
 
-The deployment entrypoint installs one isolated organisation boundary. Before running it, create
-the PostgreSQL credential Secrets named in the command and configure the organisation's OpenID
-Connect (OIDC) identity provider.
+The deployment entrypoint installs one isolated organisation boundary. Before running it, create the
+PostgreSQL credential Secrets named in the command and configure the organisation's OpenID Connect
+(OIDC) identity provider.
 
 ```bash
 export OIDC_ISSUER_URL="https://identity.example.com"
@@ -136,12 +144,22 @@ apps/_infra/deploy-k8s/deploy.sh \
   --litellm-postgres-credentials-secret opencrane-litellm-postgres-bootstrap
 ```
 
-This installs the isolated `acme` ClusterTenant organisation boundary and serves its UI and REST API at
+This installs the isolated `acme` organisation boundary and serves its UI and REST API at
 `https://acme.opencrane.example`. The API is rooted at `/api/v1`; the generated OpenAPI document and
 interactive reference are linked from the [API documentation](https://opencrane.ai/reference/api).
 
 For deployment profiles, required Secrets, and local cluster setup, follow the
 [cluster deployment guide](https://opencrane.ai/guide/deploy-cluster).
+
+## Repository layout
+
+For a two-minute orientation: application deployables live under [`apps/`](apps/), reusable
+capabilities under [`libs/`](libs/), shared API contracts under [`libs/contracts/`](libs/contracts/),
+and the documentation site under [`website/`](website/).
+
+Repository contributors should start with [`AGENTS.md`](AGENTS.md). Capability history lives in
+[`CHANGELOG.md`](CHANGELOG.md), while completed implementation history and design context live in
+[`plan-done.md`](plan-done.md).
 
 ## Licence
 

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -32,7 +32,8 @@ export default defineConfig({
       {
         text: 'Guides',
         items: [
-          { text: 'Create an agent', link: '/guide/first-agent' },
+          { text: 'Set up your personal assistant', link: '/guide/persona' },
+          { text: 'Create a managed agent', link: '/guide/first-agent' },
           { text: 'Organize your company', link: '/guide/organize' },
           { text: 'Agent skills', link: '/guide/skills' },
           { text: 'Agent delegation (child runs)', link: '/guide/child-runs' },
@@ -73,13 +74,14 @@ export default defineConfig({
             ],
           },
           { text: '2. Set up your domain', link: '/guide/dns' },
-          { text: '3. Create your first agent', link: '/guide/first-agent' },
+          { text: '3. Set up your personal assistant', link: '/guide/persona' },
         ],
       },
       {
         text: 'Guides',
         items: [
-          { text: 'Create an agent', link: '/guide/first-agent' },
+          { text: 'Set up your personal assistant', link: '/guide/persona' },
+          { text: 'Create a managed agent', link: '/guide/first-agent' },
           { text: 'Organize your company', link: '/guide/organize' },
           { text: 'Agent skills', link: '/guide/skills' },
           { text: 'Agent delegation (child runs)', link: '/guide/child-runs' },

--- a/website/advanced/architecture.md
+++ b/website/advanced/architecture.md
@@ -47,16 +47,51 @@ Thread
 Retries advance the attempt counter on the same logical run. Child runs are separate
 `AgentRun` records with a durable parent reservation and bounded inherited budget.
 
+## Personal and managed are separate authorities, not a flag
+
+The architecture treats *personal* and *managed* as two distinct admission and identity paths that
+happen to share the same runtime and execution machinery, not as one code path with a boolean on
+it:
+
+- **Personal admission** derives its `AgentService` from the caller's own participant-owned
+  thread and verifies exactly one signed personal membership assertion — the caller can only ever
+  admit a run as themselves.
+- **Managed admission** derives the canonical `agent-service:<id>` principal, verifies its current
+  Ed25519-signed fleet membership, and intersects the active revision's exact knowledge and tool
+  attachments with effective grants — it never resolves a human caller's identity at all.
+
+A personal run always carries an approved `PersonaRevision`; a managed run never does — its
+published revision is already its complete instruction set. Both share one run-admission capacity
+gate, one execution/runtime substrate, and one audit trail, so "what ran and under what authority"
+is answered the same way regardless of which path admitted it.
+
 ## Isolation
 
 One `ClusterTenant` represents one customer organisation. Its trusted server and runtime
 namespaces are distinct. There is no Kubernetes user resource and no standing per-user runtime.
-Personal work is bound through the admitted run's subject and immutable evidence.
+Personal work is bound through the admitted run's subject and immutable evidence; managed work is
+bound through its own service identity and signed fleet membership — neither can borrow the
+other's authority.
 
 ## Shared services
 
-Model routing, MCP custody, skill publication, artifacts and memory are control-plane services.
-They expose narrow, authenticated boundaries and do not become alternate run or policy authorities.
+Model routing (via LiteLLM), MCP tool custody (via Obot), skill publication, content-addressed
+artifacts and organisation memory (via the memory gateway, backed by Cognee) are control-plane
+services. They expose narrow, authenticated boundaries and do not become alternate run or policy
+authorities — a personal or managed run only ever reaches them through the frozen, admitted
+snapshot for that run.
+
+## Module structure
+
+Server-side capabilities are organised as focused, independently buildable libraries rather than
+one large backend package — tenancy, IAM (identity, membership, grants, groups, policies,
+authorization, audit), knowledge, gateways (MCP, model routing, providers, integrations), agent
+definitions and scheduling, personal configuration/memory/personas, execution (admission, inputs,
+runs), skills and artifacts each own their routes, types and Prisma schema slice. An
+`@nx/enforce-module-boundaries` lint rule keeps imports flowing in one direction — a capability may
+depend on its own scope, `scope:shared`, and explicitly approved peers, never a silent cross-domain
+shortcut. See [`docs/agents/monorepo.md`](https://github.com/elewa-git/opencrane/blob/main/docs/agents/monorepo.md)
+for the full placement and dependency rules.
 
 → [Governed agent runtime](/integrators/agent-runtime) ·
 [Organisation boundary](/operators/organisation-boundary) ·

--- a/website/guide/audit.md
+++ b/website/guide/audit.md
@@ -1,7 +1,8 @@
 # Review activity
 
-OpenCrane records **governance decisions and durable run evidence** so operators can explain
-who requested work, which revision ran, what was authorised and how it ended.
+Every run — your personal assistant's or a managed agent's — leaves a full trail: who or what
+triggered it, exactly what it was allowed to use, every action it took along the way, and how it
+ended. You can always answer "what did this agent do, and who let it" without guessing.
 
 ## What to inspect
 

--- a/website/guide/budgets.md
+++ b/website/guide/budgets.md
@@ -1,7 +1,9 @@
 # Manage cost
 
-OpenCrane applies **budget policy at run admission and model-key issuance**. A runtime
-attempt receives only a short-lived model key bounded to its allowed model and spend.
+Set a spending ceiling once, and OpenCrane enforces it at the moment a run starts — not after the
+fact. Every run, whether it's your personal assistant answering a question or a managed agent
+processing a nightly batch, is checked against budget before it's allowed to call a model, and it
+receives a spending credential that simply cannot exceed what was approved.
 
 ## Set limits
 

--- a/website/guide/deploy-cluster.md
+++ b/website/guide/deploy-cluster.md
@@ -50,4 +50,4 @@ Keep provider-specific identity and storage configuration outside the runtime au
 
 ## Next
 
-→ [Set up your domain](/guide/dns) → [Create your first agent](/guide/first-agent)
+→ [Set up your domain](/guide/dns) → [Set up your personal assistant](/guide/persona)

--- a/website/guide/deploy-local.md
+++ b/website/guide/deploy-local.md
@@ -43,4 +43,4 @@ untrusted runtime Jobs beside the trusted server.
 
 ## Next
 
-→ [Set up your domain](/guide/dns) → [Create your first agent](/guide/first-agent)
+→ [Set up your domain](/guide/dns) → [Set up your personal assistant](/guide/persona)

--- a/website/guide/dns.md
+++ b/website/guide/dns.md
@@ -33,4 +33,4 @@ For operator details, see [DNS configuration](/operators/dns-config).
 
 ## Next
 
-→ [Create your first agent](/guide/first-agent)
+→ [Set up your personal assistant](/guide/persona)

--- a/website/guide/first-agent.md
+++ b/website/guide/first-agent.md
@@ -1,43 +1,62 @@
-# Create your first agent
+# Create a managed agent
 
-An **agent service** is the governed definition OpenCrane uses to admit managed work.
-The current product surface is the authenticated management API.
+A **managed agent** is a shared, narrowly scoped worker — the agent that triages incoming tickets,
+compiles a weekly report, or runs a nightly data job for a team. Unlike your
+[personal assistant](/guide/persona), it isn't built through an interview and it never inherits
+anyone's personal access: its published configuration *is* its complete instruction set, and it
+runs under its own identity from the moment it's admitted.
 
-## Create and publish the service
+::: tip When to reach for a managed agent instead of your personal assistant
+Reach for a managed agent when the work should keep running whether or not you're around
+(a schedule, an inbound trigger), when several people should be able to trust the same
+behaviour, or when the task needs its own bounded, auditable identity rather than yours. For
+everything else — day-to-day work for one person — your personal assistant is the right tool.
+:::
 
-Use `POST /api/v1/agent-services` as an organisation administrator. Supply the name,
-workload profile, change message and revision content defined by the deployed OpenAPI contract.
-The response contains the new service and its first immutable revision.
+## Define the agent
 
-Review that revision, then publish it with
-`POST /api/v1/agent-services/{serviceId}/publish`. Publishing uses an expected active-revision
-fence so a concurrent change cannot be overwritten silently. Enable the published service
-through its state action before requesting work.
+Creating and publishing a managed agent is currently an administrator task through the management
+API — supply a name, the workload profile it should run under, and the content of its first
+revision (its instructions, model choice, budget, and which skills and integrations it may use).
+OpenCrane keeps that first revision as a draft until you publish it.
 
 ::: info
-The OpenCrane UI does not yet expose agent-service management. Retrieve request and response
-schemas through the [API reference](/reference/api) and use an authenticated client.
+The OpenCrane UI does not yet expose managed-agent management end to end. Retrieve the exact
+request and response shapes from the [API reference](/reference/api) and use an authenticated
+client.
 :::
+
+Review the draft revision, then publish it. Publishing only succeeds if the revision you reviewed
+is still the one about to go live — a concurrent edit can't silently overwrite what you approved.
+Enable the published agent before requesting work from it.
+
+## Give it what it needs — and nothing else
+
+A freshly created managed agent has no capabilities. Before it can do useful work, decide:
+
+- Which [skills](/guide/skills) it needs.
+- Which [tools](/guide/tools) it may call.
+- What [organisational knowledge](/guide/knowledge) it may read.
+- What [access rules](/guide/permissions) and [budget](/guide/budgets) apply to it.
+- Whether it runs on a schedule or only when triggered.
 
 ## Start a run
 
-Call `POST /api/v1/agent-services/{serviceId}/run-now` with a unique
-`requestIdempotencyKey`. OpenCrane returns `202` for a newly accepted run or the existing run
-for an exact replay.
+Once published and enabled, the agent can be run on demand or on its configured schedule. Every
+run:
 
-The control plane then:
+1. re-checks the agent's current grants, budget and membership before doing anything;
+2. **freezes** exactly which skills, tools, knowledge and model this attempt may use — the running
+   agent cannot widen that set itself;
+3. executes in a fresh, disposable container assigned to that one attempt; and
+4. records its events, any actions it took, and how it ended.
 
-1. verifies the caller, organisation membership, grants and budget;
-2. freezes accepted inputs in a `RunInputSnapshot`;
-3. assigns one bounded Kubernetes `Job` for the run attempt; and
-4. persists events and action decisions as the run progresses.
-
-The runtime cannot select a different user, revision, tool set or organisation. A retry
-increments the attempt on the same logical run and receives a fresh workload identity.
+A retry advances the same logical run rather than starting a disconnected one, and it always gets
+a fresh identity for that attempt — it never reuses a stale one.
 
 ::: tip
-A run is the durable unit to inspect, cancel and audit. Kubernetes Pods are replaceable
-execution details and are never the product record.
+A run is the durable thing to inspect, cancel and audit — not the container that executed it. See
+[Review activity](/guide/audit).
 :::
 
 ## What to configure next
@@ -47,3 +66,7 @@ execution details and are never the product record.
 - [Add organisational knowledge](/guide/knowledge).
 - [Control access](/guide/permissions).
 - [Set budget limits](/guide/budgets).
+
+> See also: [Set up your personal assistant](/guide/persona) (the other kind of agent) ·
+> [Organize your company](/guide/organize) (deciding a managed agent's scope) ·
+> [Agent delegation (child runs)](/guide/child-runs) (having one agent hand work to another)

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -24,5 +24,7 @@ For TypeScript integrations, use the generated client described in the
 ## Then
 
 1. **[Set up your domain](/guide/dns)** — point DNS at OpenCrane and turn on HTTPS.
-2. **[Create your first agent](/guide/first-agent)**.
-3. Start a governed run through the agent-services API and inspect its durable status.
+2. **[Set up your personal assistant](/guide/persona)** — the interview every person completes
+   before their assistant can run.
+3. **[Create a managed agent](/guide/first-agent)** for shared, scheduled or triggered work, once
+   you're ready to go beyond your own assistant.

--- a/website/guide/how-it-works.md
+++ b/website/guide/how-it-works.md
@@ -1,63 +1,91 @@
 # How OpenCrane works
 
-OpenCrane separates **durable control** from **replaceable execution**. The control plane
-decides what may run; bounded runtime Jobs perform only the admitted work.
+Every time an agent does something in OpenCrane — answers you, drafts a document, calls a tool —
+that work happens as a **run**: a tracked, disposable unit of execution that OpenCrane admits,
+watches and records from start to finish. This page is a short tour of what that means in
+practice, for both kinds of agent.
 
-## The big picture
+## Personal and managed runs, side by side
+
+| | Your personal assistant | A managed agent |
+|---|---|---|
+| Who it acts as | You | Its own service identity |
+| What it can see | Only what's been granted to *you* | Only what its published revision was configured with |
+| How it starts | You talking to it | A schedule, a trigger, or another authorised caller |
+| Persona | Built through your [interview](/guide/persona) | None — its published configuration *is* its complete instruction set |
+| Typical use | Drafting, research, day-to-day work for one person | Triaging tickets, nightly reports, org-wide or team-wide jobs |
+
+Both kinds go through the same admission and execution machinery below — that's what makes every
+run auditable the same way, no matter who or what started it.
+
+## What happens when work starts
 
 ```text
-person or schedule
+you, or a schedule/trigger
        │
        ▼
-OpenCrane control plane
-       │  admit and freeze
+OpenCrane checks who's asking and what they're allowed to do
+       │
        ▼
-AgentRun + RunInputSnapshot
-       │  assign one attempt
+OpenCrane freezes exactly what this run may use — before anything executes
+       │
        ▼
-bounded runtime Job ──► ordered events and governed actions
+a fresh, disposable Kubernetes Job carries out the work
+       │
+       ▼
+you see the ordered events, any actions taken, and the final outcome
 ```
+
+1. OpenCrane authenticates the caller and resolves the organisation.
+2. It checks membership, grants, model access and budget.
+3. It **freezes** the accepted inputs — which tools, skills, knowledge and model this exact run may
+   use — before any container starts. Nothing can widen its own access mid-run.
+4. A fresh, bounded Job carries out the work and streams results back.
+5. Every tool call OpenCrane executes on the agent's behalf is recorded, and any that needs a human
+   decision pauses for [approval](/guide/audit).
+6. The run reaches a final outcome. The Job that executed it can disappear — the durable record of
+   what ran, what it used and what happened does not.
+
+::: tip Why "disposable execution, durable record" matters
+The container is a detail; it can crash, get rescheduled, or simply finish and vanish. What you
+audit, retry or investigate later is the run record — never a Pod name.
+:::
 
 ## The words you'll see
 
-### Agent service
+### Agent (personal or managed)
 
-A governed agent definition. Its immutable revisions bind the persona, model posture,
-skills and other configuration used by a run. → [Create one](/guide/first-agent)
+The thing that does the work. A personal assistant is yours alone; a managed agent is a shared,
+narrowly scoped worker your organisation configures. See
+[the distinction](/guide/introduction#two-kinds-of-agent-and-why-the-difference-matters).
 
-### Agent run
+### Run
 
-The durable record of one invocation. It carries its state, attempt number, frozen input
-digest, lineage, cost and terminal reason. A retry creates another attempt on the same run.
+One tracked execution of an agent — a single conversation turn, a scheduled job, a triggered task.
+A run keeps its state, how many attempts it's had, exactly what it was allowed to use, and how it
+ended. Retrying creates another attempt on the same run rather than a disconnected new one.
 
 ### Skill
 
-A reusable, versioned capability published through the skill catalogue.
+A reusable ability you give an agent — drafting a follow-up, reviewing a document, summarising a
+ticket — published as a versioned, reviewed artifact rather than a loose snippet.
 → [Manage skills](/guide/skills)
 
 ### Tool
 
-An external action exposed through MCP or another governed executor. The runtime proposes
-the action; the control plane authorises and records it. → [Manage tools](/guide/tools)
+An action an agent can ask OpenCrane to take in another system. The agent proposes it; OpenCrane
+authorises, executes and records it. → [Manage tools](/guide/tools)
 
 ### Organisational knowledge
 
-Information retrieved from organisation-scoped and personal memory datasets, with provenance
-and access policy applied by the control plane. → [Connect knowledge](/guide/knowledge)
+Facts and documents an agent can recall — personal notes for your assistant, shared knowledge for
+a managed agent — always filtered through who's allowed to see what.
+→ [Connect knowledge](/guide/knowledge)
 
-### ClusterTenant
+### Organisation (silo)
 
-The customer organisation and isolation boundary. It is not an individual assistant or user.
+Your company's isolated slice of OpenCrane. Every agent, run, grant and piece of knowledge lives
+inside your organisation's boundary and never crosses into another customer's.
 → [Organisation boundary](/operators/organisation-boundary)
-
-## What happens when work starts
-
-1. OpenCrane authenticates the caller and resolves the organisation.
-2. It checks membership, grants, model posture and budget.
-3. It freezes accepted evidence into a `RunInputSnapshot`.
-4. The controller creates and releases the exact runtime Job for that attempt.
-5. The runtime streams normalised candidates back to OpenCrane.
-6. OpenCrane persists events before delivery and keeps tool execution under its own authority.
-7. A terminal outcome closes the run; the Job can disappear without losing the record.
 
 Ready? → [Install OpenCrane](/guide/getting-started)

--- a/website/guide/introduction.md
+++ b/website/guide/introduction.md
@@ -1,29 +1,52 @@
 # What is OpenCrane?
 
-OpenCrane is a **self-hosted control plane for governed AI agents**. It gives each
-organisation one place to define agents, control their capabilities and inspect every run.
+OpenCrane is a **self-hosted platform for AI agents your organisation actually controls.** You
+run it on your own Kubernetes cluster, so your conversations, documents and credentials never
+leave infrastructure you operate. Every agent starts with no access at all — you decide exactly
+what it can see, use and do, and every action it takes is recorded.
 
-Instead of trusting a long-lived assistant process, OpenCrane admits work as durable
-`AgentRun` records. Each attempt executes in a bounded Kubernetes `Job`, while identity,
-inputs, approvals, tool calls, cost and events remain under control-plane authority.
+## Two kinds of agent, and why the difference matters
+
+OpenCrane draws one hard line through everything it does: the line between **personal** and
+**managed**.
+
+- **Your personal assistant** belongs to you. It only ever uses the tools, files and knowledge
+  you've been granted, it only ever acts as you, and no one else's assistant can read your
+  conversations or your files. → [Set up your personal assistant](/guide/persona)
+- **A managed agent** is a shared worker your organisation configures — think "the agent that
+  triages support tickets" or "the agent that compiles the weekly sales digest." It runs bounded
+  work on a schedule or a trigger, under its own narrow identity, and it never inherits anyone's
+  personal access. → [Create a managed agent](/guide/first-agent)
+
+Neither kind can quietly become the other. A managed agent can never read your personal
+conversation, memory or files; it only ever sees what it was explicitly configured to see. Your
+personal assistant can hand a task to a managed agent, but the managed agent still runs under its
+own, smaller identity — see [Agent delegation](/guide/child-runs).
 
 ## Why teams choose OpenCrane
 
-- **Private by design** — data and execution remain on infrastructure you operate.
-- **Deny by default** — agents use only explicitly granted tools, skills, knowledge and models.
-- **Auditable runs** — each run freezes its revision and accepted input evidence.
-- **Replaceable execution** — runtime Jobs hold no durable product authority.
-- **Organisation isolation** — every request and workload stays inside a `ClusterTenant` silo.
+- **Private by design** — your data and every agent run stay on infrastructure you operate.
+- **Nothing by default** — an agent (personal or managed) starts with zero tools, skills,
+  knowledge or model access until you grant it.
+- **Every run is a record** — what ran, under what identity, with what inputs and what it did is
+  kept, not just the final answer.
+- **Execution is disposable, decisions aren't** — the container that ran your request can be
+  thrown away; the record of what it was allowed to do and what happened cannot be quietly changed
+  after the fact.
+- **One boundary per organisation** — your organisation's agents, data and identities are isolated
+  from every other organisation on the same OpenCrane installation.
 
 ## What you'll do here
 
 1. [Install OpenCrane](/guide/getting-started).
-2. [Set up your organisation domain](/guide/dns).
-3. [Create an agent service](/guide/first-agent).
-4. Add [skills](/guide/skills), [tools](/guide/tools) and
+2. [Set up your organisation's domain](/guide/dns).
+3. [Set up your personal assistant](/guide/persona) — or
+   [create a managed agent](/guide/first-agent) for shared, scheduled work.
+4. Give it [skills](/guide/skills), [tools](/guide/tools) and
    [organisational knowledge](/guide/knowledge).
 5. Apply [access rules](/guide/permissions) and [budgets](/guide/budgets).
 
 ::: tip
-Start with [How OpenCrane works](/guide/how-it-works) for a short tour of the run lifecycle.
+Read [How OpenCrane works](/guide/how-it-works) next for a short tour of what happens every time an
+agent runs.
 :::

--- a/website/guide/knowledge.md
+++ b/website/guide/knowledge.md
@@ -1,7 +1,15 @@
 # Connect organisational knowledge
 
-OpenCrane uses **Cognee-backed datasets** for durable memory and keeps access, provenance
-and dataset identity under control-plane governance.
+Give agents something worth remembering. OpenCrane keeps a durable memory store (backed by
+Cognee) behind its own access control, so what an agent can recall always matches what its owner
+is allowed to see — never a raw, ungoverned document dump.
+
+::: tip Personal memory vs shared knowledge
+Your [personal assistant](/guide/persona) recalls from **your own** personal dataset — no one
+else's assistant can read it, and it can't read anyone else's. A managed agent recalls only from
+the **shared** organisation, department or project knowledge it was explicitly configured with.
+Neither kind can wander into the other's memory.
+:::
 
 ## Register sources and datasets
 

--- a/website/guide/model-routing.md
+++ b/website/guide/model-routing.md
@@ -1,7 +1,10 @@
 # Model routing
 
-**Model routing** registers the models an organisation may use and resolves the default
-model posture that a run freezes at admission.
+Instead of wiring each agent to one hard-coded model, register the models your organisation is
+allowed to use, and let OpenCrane resolve which one a given run actually calls. Every model call
+goes through **LiteLLM**, a self-hosted proxy that fronts your chosen providers, so a raw provider
+API key never reaches a runtime container — agents only ever hold a short-lived key scoped to one
+model and one spending limit.
 
 ## Register models
 

--- a/website/guide/organize.md
+++ b/website/guide/organize.md
@@ -23,6 +23,13 @@ shared and with whom.
 That keeps things flexible — your org structure lives in the labels you choose, not
 in a rigid hierarchy you have to maintain.
 
+::: tip Personal scope is your assistant's scope
+*Personal* isn't just the narrowest option on the list — it's the scope your
+[personal assistant](/guide/persona) always operates in. A managed agent, by contrast, is created
+at *project*, *department* or *org* scope on purpose, because it's meant to be shared. See
+[the personal/managed distinction](/guide/introduction#two-kinds-of-agent-and-why-the-difference-matters).
+:::
+
 ## How scopes show up
 
 The same four scopes appear everywhere you share or restrict something:

--- a/website/guide/permissions.md
+++ b/website/guide/permissions.md
@@ -1,7 +1,10 @@
 # Control who can access what
 
-OpenCrane resolves **current organisation membership and explicit grants** before it admits
-work. Agent services start with no capabilities.
+Every agent — personal or managed — starts with **nothing**: no skills, no tools, no knowledge,
+no model. Before OpenCrane admits any run, it checks that the person and, separately, the agent
+itself both currently have the access being used. Granting access to a person doesn't
+automatically hand it to their assistant, and configuring an agent with a capability doesn't
+automatically extend it to everyone who can talk to that agent — both sides have to line up.
 
 ## Grant a capability
 

--- a/website/guide/persona.md
+++ b/website/guide/persona.md
@@ -1,0 +1,77 @@
+# Set up your personal assistant
+
+Your **personal assistant** is the one agent in OpenCrane that belongs to you alone — it only
+ever sees the context, tools and files you've been granted, and only ever acts as you. Before it
+can have its first conversation with you, it needs to know who it's working for. OpenCrane builds
+that through a short interview, and nothing it produces goes live until you've reviewed and
+approved it.
+
+::: tip Personal vs managed, in one line
+A **personal assistant** is your assistant — it learns your persona and only acts within your own
+access. A **managed agent** is a shared worker your organisation configures to do bounded work on
+a schedule or trigger, under its own narrow identity. Managed agents never go through this
+interview — see [Create a managed agent](/guide/first-agent).
+:::
+
+## What onboarding gives you
+
+- **A short, guided interview** instead of a blank prompt box. A reviewed set of questions asks
+  about how you work and how you'd like your assistant to behave.
+- **A draft persona you can inspect before it does anything.** OpenCrane turns your answers into
+  three to five explicit insights and picks a base personality template — never a black box.
+- **A hard approval gate.** Your assistant cannot start its first real conversation until you've
+  looked at the draft and approved it. There's no "it started acting weird, who approved that?" —
+  you did, explicitly, or it didn't happen.
+- **A record of why, not just what.** Every insight in your persona traces back to the exact
+  interview answer that produced it, so the persona is never just a guess about you.
+
+## Walk through the interview
+
+1. **Start the interview.** Sign in and start (or resume) your onboarding interview. If you've
+   started one already, OpenCrane resumes it — your answers are kept from your first attempt, so
+   retrying a submission never discards what you've already told it.
+2. **Answer each question once.** Every answer is tied to the exact question you answered, so
+   there's a clear trail from "you said X" to "the persona does Y."
+3. **Complete it.** OpenCrane accepts completion only once every question in the interview has an
+   answer.
+4. **Review the draft.** From your completed interview, OpenCrane derives a small set of insights
+   (three to five) and selects a base personality template — the same underlying idea as a
+   `SOUL.md` file, but reviewed and versioned rather than a file you edit by hand. Nothing here is
+   invented outside your answers.
+5. **Approve it.** Approving activates that exact draft as your one active persona. Until you do,
+   your personal assistant has no persona to run with and cannot take its first run.
+
+::: info What "approve" actually locks in
+Approval checks that the interview is genuinely complete, that there are between three and five
+insights, and that the selected template still matches what your answers produced. If anything
+has drifted — a stale draft, a mismatched template — OpenCrane refuses the approval rather than
+activating something that no longer matches what you reviewed.
+:::
+
+## Updating your persona later
+
+Life and working habits change, so a persona isn't locked in forever. Requesting a refresh starts
+a **new** interview rather than editing the old one in place — your previous interview stays on
+record as evidence of what you approved and when. Approving the new draft atomically swaps it in
+as your one active persona; if that swap fails partway through, your previous persona keeps
+running rather than being left half-updated.
+
+::: warning No editable persona file
+OpenCrane deliberately has no mutable "edit your SOUL file and restart" path. A persona becomes
+active only by going through interview → draft → your explicit approval. This is what keeps
+"why does my assistant think that about me" always answerable.
+:::
+
+## Why managed agents skip this
+
+A managed agent's published revision — its prompt, model, skills and integrations — is its
+complete instruction set from the moment it's published. There is no personal context to onboard,
+because a managed agent isn't supposed to have one: it does bounded, named work for a team or
+project, not a relationship with one person. See
+[Create a managed agent](/guide/first-agent) and
+[Organize your company](/guide/organize) for how that scope is decided instead.
+
+> See also: [How OpenCrane works](/guide/how-it-works) (the run lifecycle your assistant uses once
+> approved) · [Organizational knowledge](/guide/knowledge) (what your assistant can recall) ·
+> [Agent delegation (child runs)](/guide/child-runs) (when your assistant hands work to a
+> specialist or a managed agent)

--- a/website/guide/skills.md
+++ b/website/guide/skills.md
@@ -6,8 +6,11 @@ signed artifact**, not an executable snippet appended to someone's workspace: it
 across a team or the whole organisation without trusting mutable runtime-local files.
 
 ::: info Foundation in progress
-The ArtifactStore-backed publication authority is implemented, but the end-user catalogue,
-authoring, and sharing API and UI are not mounted yet.
+`GET /api/v1/skills` serves a live, read-only catalogue of your organisation's skills (name,
+description, lifecycle state) — enough to see what exists. Authoring a new skill from a
+conversation, reviewing and publishing one, and sharing it across scopes are not exposed as
+end-user product surfaces yet; the isolated authoring-job and publication authority described
+below already exist underneath.
 :::
 
 ## What a skill contains
@@ -43,7 +46,7 @@ Skills move from draft to shared ability through a governed pipeline:
    already in review.
 
 The implementation of the publication authority lives in
-[`libs/backend/server/agents/skills/main`](https://github.com/elewa-git/opencrane/blob/own-personal-ai-agent-setup/libs/backend/server/agents/skills/main).
+[`libs/backend/server/agents/skills/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/server/agents/skills/main).
 The public product workflow builds on that authority.
 
 Sharing follows the platform's scope model — personal, project, department, organisation — and
@@ -90,10 +93,10 @@ upgrade a checklist into a code-executing specialist.
 
 ## What comes next
 
-The product surface still needs catalogue browsing, isolated authoring jobs mounted end-to-end,
-review and publication workflows, and governed sharing across personal, project, department and
-organisation scopes. Until those surfaces are mounted, there is no supported end-user
-skill-publishing workflow.
+The product surface still needs the conversational "turn this into a skill" tool, review and
+publication workflows exposed to end users, and governed sharing across personal, project,
+department and organisation scopes. Until those surfaces are mounted, there is no supported
+end-user skill-publishing workflow — only the read-only catalogue above.
 
 > See also: [Agent delegation (child runs)](/guide/child-runs) ·
 > [Control access](/guide/permissions) · [Architecture](/advanced/architecture)

--- a/website/guide/tools.md
+++ b/website/guide/tools.md
@@ -1,7 +1,14 @@
 # Manage tools with MCP
 
-A **tool** lets an agent request an action in another system. OpenCrane uses MCP for tool
-registration while keeping credentials, approvals and invocation receipts outside the runtime.
+A **tool** lets an agent reach into another system — send a message, update a record, search a
+calendar. OpenCrane uses the Model Context Protocol (MCP) to register those integrations, and
+keeps the credentials, the approval decision and the record of every call outside the runtime
+that executes it: a compromised or misbehaving agent run can't walk off with a live integration
+credential.
+
+Both kinds of agent use the same tool machinery — your personal assistant can only use the tools
+granted to *you*; a managed agent can only use the tools its published revision was configured
+with.
 
 ## Register a tool
 

--- a/website/index.md
+++ b/website/index.md
@@ -1,25 +1,33 @@
 # Governed AI agents on your infrastructure
 
-OpenCrane is a **self-hosted Kubernetes control plane** for defining agents, admitting
-their work and keeping identity, tools, approvals, cost and evidence under your authority.
+OpenCrane is a **self-hosted platform for AI agents**, running on your own Kubernetes cluster, that
+keeps identity, tools, approvals, cost and evidence under your authority — not a vendor's.
 
-## Durable control, bounded execution
+## Personal assistants and managed agents
+
+- **Your personal assistant** works for you alone — only your granted tools, files and knowledge,
+  only acting as you. → [Set up your personal assistant](/guide/persona)
+- **A managed agent** is a shared worker your organisation configures for bounded, scheduled or
+  triggered work, under its own narrow identity — never inheriting anyone's personal access.
+  → [Create a managed agent](/guide/first-agent)
+
+## Disposable execution, durable record
 
 ```text
-define an agent
+define an agent (personal or managed)
       │
       ▼
-admit an AgentRun
+admit a run — freeze exactly what it may use
       │
       ▼
-execute one bounded Job attempt
+execute in one disposable, bounded Job
       │
       ▼
-inspect ordered events, actions and outcome
+inspect the ordered events, actions and outcome
 ```
 
-OpenCrane keeps the durable run record in the control plane. Runtime Jobs are isolated,
-short-lived execution details with no direct tool credentials or persistent user volume.
+The container that runs your agent's work can be replaced or disappear; the record of what it was
+allowed to use and what it did stays with OpenCrane.
 
 ## Build useful agents
 
@@ -33,4 +41,4 @@ short-lived execution details with no direct tool credentials or persistent user
 
 → [See how OpenCrane works](/guide/how-it-works) ·
 [Install OpenCrane](/guide/getting-started) ·
-[Create your first agent](/guide/first-agent)
+[Set up your personal assistant](/guide/persona)

--- a/website/integrators/agent-runtime.md
+++ b/website/integrators/agent-runtime.md
@@ -7,6 +7,17 @@ The control plane remains authoritative for identity, inputs, events, approvals 
 > [MCP gateway](/integrators/mcp-gateway) (tool custody), and
 > [Identity and runtime authentication](/security/identity) (workload proof).
 
+## One runtime, two admission authorities
+
+Personal and managed runs share every mechanism below, but never share an admission path.
+Personal admission derives its `AgentService` from the caller's own thread and verifies one signed
+personal membership assertion; managed admission derives the `agent-service:<id>` principal,
+verifies its current Ed25519-signed fleet membership, and intersects the active revision's exact
+knowledge/tool attachments with effective grants. A personal run's frozen input always names an
+approved `PersonaRevision`; a managed run's never does, because its published revision is already
+complete. Neither path can produce the other's identity or inherit its grants — see
+[Architecture](/advanced/architecture#personal-and-managed-are-separate-authorities-not-a-flag).
+
 ## Runtime sequence
 
 ```text
@@ -53,6 +64,6 @@ second policy, credential or transcript authority.
 
 ## Source
 
-- [`apps/agent-runtime`](https://github.com/italanta/opencrane/blob/main/apps/agent-runtime/README.md)
-- [`apps/agent-controller`](https://github.com/italanta/opencrane/blob/main/apps/agent-controller/README.md)
-- [`apps/opencrane/prisma/schema/runs.prisma`](https://github.com/italanta/opencrane/blob/main/apps/opencrane/prisma/schema/runs.prisma)
+- [`apps/agent-runtime`](https://github.com/elewa-git/opencrane/blob/main/apps/agent-runtime/README.md)
+- [`apps/agent-controller`](https://github.com/elewa-git/opencrane/blob/main/apps/agent-controller/README.md)
+- [`apps/opencrane/prisma/schema/runs.prisma`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/prisma/schema/runs.prisma)

--- a/website/integrators/mcp-gateway.md
+++ b/website/integrators/mcp-gateway.md
@@ -91,5 +91,5 @@ digest-only receipts stay server-side; a model response cannot widen its own rea
 - An unknown or duplicate `tool.completed` report is refused; receipts are digest-only.
 - A late result from a cancelled or replaced attempt is not accepted.
 
-Source: [`libs/backend/_server/obot-custody`](https://github.com/italanta/opencrane/blob/main/libs/backend/_server/obot-custody/README.md)
-and [`libs/backend/agents/execution/protocol`](https://github.com/italanta/opencrane/blob/main/libs/backend/agents/execution/protocol/README.md).
+Source: [`libs/backend/_server/obot-custody`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/_server/obot-custody/README.md)
+and [`libs/backend/agents/execution/protocol`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/execution/protocol/README.md).

--- a/website/integrators/retrieval-memory.md
+++ b/website/integrators/retrieval-memory.md
@@ -71,6 +71,6 @@ governed external actions subject to the same approval, receipt and audit bounda
 - An unavailable memory transport does not fabricate a result.
 - Runtime-local scratch is never promoted to durable memory implicitly.
 
-Source: [`libs/backend/agents/memory/main`](https://github.com/italanta/opencrane/blob/main/libs/backend/agents/memory/main/README.md),
-[`libs/backend/agents/personal/memory/main`](https://github.com/italanta/opencrane/blob/main/libs/backend/agents/personal/memory/main/README.md),
-and [`libs/backend/_server/memory-gateway-client`](https://github.com/italanta/opencrane/blob/main/libs/backend/_server/memory-gateway-client/README.md).
+Source: [`libs/backend/agents/memory/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/memory/main/README.md),
+[`libs/backend/agents/personal/memory/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/personal/memory/main/README.md),
+and [`libs/backend/_server/memory-gateway-client`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/_server/memory-gateway-client/README.md).

--- a/website/integrators/silo-iam.md
+++ b/website/integrators/silo-iam.md
@@ -58,5 +58,5 @@ Membership authority is checked before a run is admitted and uncertainty fails c
 Direct shares and group grants change future authorisation decisions. They do not rewrite
 snapshots or events belonging to already accepted runs.
 
-Source: [`libs/backend/server/iam/authorization/main`](https://github.com/italanta/opencrane/blob/main/libs/backend/server/iam/authorization/main/README.md)
-and [`libs/backend/agents/execution/inputs/main`](https://github.com/italanta/opencrane/blob/main/libs/backend/agents/execution/inputs/main/README.md).
+Source: [`libs/backend/server/iam/authorization/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/server/iam/authorization/main/README.md)
+and [`libs/backend/agents/execution/inputs/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/execution/inputs/main/README.md).

--- a/website/operators/dns-config.md
+++ b/website/operators/dns-config.md
@@ -50,5 +50,5 @@ kubectl get ingress,certificate -n <server-namespace>
 Then verify the certificate chain and that `/api/v1/openapi.json` is served by the expected
 silo. Internal `/api/internal` routes must not be exposed by the Ingress.
 
-Source: [`apps/opencrane/helm/templates/_ingress.tpl`](https://github.com/italanta/opencrane/blob/main/apps/opencrane/helm/templates/_ingress.tpl)
-and [`apps/opencrane/helm/templates/_certificate.tpl`](https://github.com/italanta/opencrane/blob/main/apps/opencrane/helm/templates/_certificate.tpl).
+Source: [`apps/opencrane/helm/templates/_ingress.tpl`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/helm/templates/_ingress.tpl)
+and [`apps/opencrane/helm/templates/_certificate.tpl`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/helm/templates/_certificate.tpl).

--- a/website/operators/hosting.md
+++ b/website/operators/hosting.md
@@ -75,5 +75,5 @@ validates that all three namespaces are distinct and refuses to start on a colla
 | Run authority | PostgreSQL-backed OpenCrane server |
 | Cluster-wide controllers | External prerequisites, not installed as silo business workloads |
 
-Source: [`apps/_infra/deploy-k8s`](https://github.com/italanta/opencrane/blob/main/apps/_infra/deploy-k8s/README.md)
-and [`apps/agent-controller`](https://github.com/italanta/opencrane/blob/main/apps/agent-controller/README.md).
+Source: [`apps/_infra/deploy-k8s`](https://github.com/elewa-git/opencrane/blob/main/apps/_infra/deploy-k8s/README.md)
+and [`apps/agent-controller`](https://github.com/elewa-git/opencrane/blob/main/apps/agent-controller/README.md).

--- a/website/operators/networking.md
+++ b/website/operators/networking.md
@@ -60,5 +60,5 @@ boundary. Both must pass.
 4. Verify runtime Jobs have no Service, Ingress, role binding or persistent volume.
 5. Verify only the ingress controller can reach the public API port.
 
-Source: [`apps/opencrane/helm/templates/_networkpolicy.tpl`](https://github.com/italanta/opencrane/blob/main/apps/opencrane/helm/templates/_networkpolicy.tpl)
-and [`libs/backend/agents/runtime/k8s-launcher`](https://github.com/italanta/opencrane/blob/main/libs/backend/agents/runtime/k8s-launcher/README.md).
+Source: [`apps/opencrane/helm/templates/_networkpolicy.tpl`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/helm/templates/_networkpolicy.tpl)
+and [`libs/backend/agents/runtime/k8s-launcher`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/runtime/k8s-launcher/README.md).

--- a/website/operators/organisation-boundary.md
+++ b/website/operators/organisation-boundary.md
@@ -39,5 +39,5 @@ Confirm that the release, public host and runtime profiles all resolve to the sa
 Then verify that the personal and managed runtime namespaces are separate from the server
 namespace and from each other.
 
-Source: [`libs/backend/server/tenancy/cluster-tenants/main`](https://github.com/italanta/opencrane/blob/main/libs/backend/server/tenancy/cluster-tenants/main/README.md)
-and [`apps/opencrane/src/app/routes.ts`](https://github.com/italanta/opencrane/blob/main/apps/opencrane/src/app/routes.ts).
+Source: [`libs/backend/server/tenancy/cluster-tenants/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/server/tenancy/cluster-tenants/main/README.md)
+and [`apps/opencrane/src/app/routes.ts`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/src/app/routes.ts).

--- a/website/operators/runbook.md
+++ b/website/operators/runbook.md
@@ -88,5 +88,5 @@ Restart trusted long-lived deployments with the app-owned deploy script or a nor
 upgrade. Runtime Jobs are bounded attempts; do not convert them into Deployments or preserve
 their local scratch between attempts.
 
-Source: [`libs/backend/agents/execution/runs/main`](https://github.com/italanta/opencrane/blob/main/libs/backend/agents/execution/runs/main/README.md)
-and [`apps/opencrane/src/index.ts`](https://github.com/italanta/opencrane/blob/main/apps/opencrane/src/index.ts).
+Source: [`libs/backend/agents/execution/runs/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/execution/runs/main/README.md)
+and [`apps/opencrane/src/index.ts`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/src/index.ts).

--- a/website/reference/api-overview.md
+++ b/website/reference/api-overview.md
@@ -31,7 +31,7 @@ The current composition includes:
 
 | Prefix | Purpose |
 |---|---|
-| `/agent-services` | Agent service, revision and run admission |
+| `/agent-services` | Managed agent definition, revision, publication, schedules and run admission |
 | `/me/runs` | Current user's run status, steering and cancellation surfaces |
 | `/me/conversations` | Authorised conversation replay |
 | `/me/approvals` | Deferred action approval decisions |

--- a/website/security/identity.md
+++ b/website/security/identity.md
@@ -12,6 +12,13 @@ Management UI calls use the same-origin session cookie.
 Current organisation membership is checked before a run is admitted. Accepted membership,
 delegated subject and scope evidence are frozen into the run input snapshot.
 
+A **personal** run always resolves to that one authenticated person — it can never be admitted as
+someone else, and it can never pick up a group's or another user's grants. A **managed** agent
+never resolves to a human at all: it runs as its own `agent-service:<id>` principal, verified
+against a separately signed fleet-membership assertion, with no path back to the administrator who
+published or triggered it. See
+[the personal/managed distinction](/guide/introduction#two-kinds-of-agent-and-why-the-difference-matters).
+
 ## Workload identity
 
 ```text
@@ -54,5 +61,5 @@ Session revocation stops new human requests. Run cancellation is a durable state
 OpenCrane fences the exact attempt, sends a positive cancel command when possible and authorises
 cleanup of only the assigned Job. Late candidates are rejected.
 
-Source: [`libs/backend/server/iam/authorization/main`](https://github.com/italanta/opencrane/blob/main/libs/backend/server/iam/authorization/main/README.md)
-and [`apps/opencrane/prisma/schema/runs.prisma`](https://github.com/italanta/opencrane/blob/main/apps/opencrane/prisma/schema/runs.prisma).
+Source: [`libs/backend/server/iam/authorization/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/server/iam/authorization/main/README.md)
+and [`apps/opencrane/prisma/schema/runs.prisma`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/prisma/schema/runs.prisma).


### PR DESCRIPTION
Rewrites the reader-facing documentation surfaces functionality-first and syncs them with everything shipped since tag `0.6.2`.

## README
- Full rewrite that leads with **what OpenCrane does and why**, not the tech.
- The **personal vs managed agent** distinction is now the spine of the doc.
- Adds a **mermaid architecture diagram** (verified rendering under GitHub's strict security level) — employees → personal assistants, schedules/triggers → managed agents, both governed by the control plane, each spawning a short-lived isolated run against shared org services. Deliberately does not name the individual apps.
- Drops the 14-row app-by-app Components table for a two-line repo-orientation pointer.

## CHANGELOG
- Seven new capability entries since 0.6.2 (Obot direct invocation, Cognee production recall, skill Kubernetes launcher, versioned skills/artifacts read routes, typed Zod validation errors, share-authorization row-projection tightening, Prisma raw-query removal), each grounded in a merged PR.
- **Corrects a stale factual claim:** the old "20 functional domains at `libs/domain/<domain>/main`" bullet — that path no longer exists. Rewritten to the current ~55 scope-tagged capability libraries under `libs/backend/server/{agents,gateways,iam,knowledge,reporting,tenancy}`.

## Website (opencrane.ai)
- Functionality-first pass across the guide/operator/integrator/reference pages, carrying the personal-vs-managed split through.
- New **persona onboarding guide** (`guide/persona.md`) wired into nav + sidebar; "Create an agent" → "Create a managed agent".
- Accuracy fixes: corrected a stale skills-catalogue claim and fixed ~10 dead `italanta` → `elewa-git` source links.
- Site build passes with no dead-link errors.

## Not touched
- Internal `docs/` (ADRs, design contracts, agent rules) — a decision archive whose design docs already describe what shipped; verified the one likely-drift line (runtime is Python/Pydantic). Left intact rather than rewriting decision history.