### PR TITLE
🐛 stabilize CI promotion and stack snapshots

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,6 +43,7 @@ jobs:
     outputs:
       nx_base: ${{ steps.affected.outputs.nx_base }}
       nx_head: ${{ steps.affected.outputs.nx_head }}
+      guard_base: ${{ steps.guard-base.outputs.guard_base }}
       deployables: ${{ steps.affected.outputs.deployables }}
       has_deployables: ${{ steps.affected.outputs.has_deployables }}
       api_contract_changed: ${{ steps.affected.outputs.api_contract_changed }}
@@ -73,6 +74,17 @@ jobs:
         uses: nrwl/nx-set-shas@v5
         with:
           main-branch-name: ${{ github.base_ref || github.ref_name }}
+
+      # The full main...develop range still drives builds, smoke selection, and publication. Diff-
+      # scoped policy guards may trust the source only after this exact develop SHA passed its push
+      # workflow; ordinary branches, adjusted merge trees, and unvalidated promotions stay on the
+      # full last-successful base.
+      - name: Select the validated policy comparison base
+        id: guard-base
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PULL_REQUEST_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node scripts/promotion-guard-base.mjs
 
       - name: Prove app-owned deployable selection
         run: npm run test:affected-deployables
@@ -105,6 +117,7 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/opencrane
       NX_BASE: ${{ needs.prepare.outputs.nx_base }}
       NX_HEAD: ${{ needs.prepare.outputs.nx_head }}
+      GUARD_BASE: ${{ needs.prepare.outputs.guard_base }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -168,13 +181,13 @@ jobs:
         run: npm run test:agent-domain-boundary
 
       - name: Enforce mechanical TypeScript agent style
-        run: scripts/agent-style-check.sh --diff "$NX_BASE"
+        run: scripts/agent-style-check.sh --diff "$GUARD_BASE"
 
       - name: Prove the inline-conditional classifier
         run: npm run test:agent-style
 
       - name: Enforce language-neutral production module growth
-        run: npm run check:module-growth -- --diff "$NX_BASE"
+        run: npm run check:module-growth -- --diff "$GUARD_BASE"
 
       - name: Prove the module-growth classifier
         run: npm run test:module-growth
@@ -189,7 +202,7 @@ jobs:
         run: scripts/config-docs-coverage.sh --strict
 
       - name: Enforce Prisma repository and unit-of-work ownership
-        run: npm run check:prisma-boundaries -- --diff "$NX_BASE"
+        run: npm run check:prisma-boundaries -- --diff "$GUARD_BASE"
 
       - name: Prove the Prisma-boundary classifier
         run: npm run test:prisma-boundaries

--- a/scripts/__tests__/affected-deployables.test.mjs
+++ b/scripts/__tests__/affected-deployables.test.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import test from "node:test";
 
 import { selectAffectedDeployables, selectApiContractChanged, selectDevelopSmokeRequired, selectForcedContainerProjects, selectGuardInputsChanged } from "../affected-deployables.core.mjs";
+import { hasSuccessfulDevelopValidation, selectGuardComparisonBase, selectPromotionSource } from "../promotion-guard-base.core.mjs";
 
 /** Reads the stable selector fixture. */
 function _Fixture()
@@ -74,4 +75,94 @@ test("keeps the blocking smoke on develop and ahead of image publication", funct
 	assert.match(workflow, /needs\.develop_smoke\.result == 'success'/u);
 	assert.match(workflow, /K3D_LINUX_AMD64_SHA256: [0-9a-f]{64}/u);
 	assert.match(workflow, /sha256sum --check/u);
+});
+
+test("trusts only an exact develop-to-main promotion source", function _SelectsPromotionSource()
+{
+	const pullRequest = selectPromotionSource({
+		eventName: "pull_request",
+		baseRef: "main",
+		headRef: "develop",
+		pullRequestHeadSha: "develop-head",
+		pushParentShas: [],
+	});
+	assert.equal(pullRequest, "develop-head");
+	assert.equal(selectPromotionSource({
+		eventName: "pull_request",
+		baseRef: "main",
+		headRef: "feat/untrusted",
+		pullRequestHeadSha: "feature-head",
+		pushParentShas: [],
+	}), null);
+
+	const push = selectPromotionSource({
+		eventName: "push",
+		ref: "refs/heads/main",
+		pushParentShas: ["old-main", "develop-head"],
+		pushSourceInDevelop: true,
+		pushHeadTree: "release-tree",
+		pushSourceTree: "release-tree",
+	});
+	assert.equal(push, "develop-head");
+	assert.equal(selectPromotionSource({
+		eventName: "push",
+		ref: "refs/heads/main",
+		pushParentShas: ["old-main", "feature-head"],
+		pushSourceInDevelop: false,
+		pushHeadTree: "release-tree",
+		pushSourceTree: "release-tree",
+	}), null);
+	assert.equal(selectPromotionSource({
+		eventName: "push",
+		ref: "refs/heads/main",
+		pushParentShas: ["old-main", "develop-head"],
+		pushSourceInDevelop: true,
+		pushHeadTree: "merge-adjusted-tree",
+		pushSourceTree: "release-tree",
+	}), null);
+});
+
+test("requires a successful exact-SHA develop push before narrowing policy guards", function _RequiresValidatedPromotion()
+{
+	const sourceSha = "develop-head";
+	const successfulRun = {
+		path: ".github/workflows/docker.yml",
+		head_branch: "develop",
+		head_sha: sourceSha,
+		event: "push",
+		status: "completed",
+		conclusion: "success",
+	};
+	assert.equal(hasSuccessfulDevelopValidation([successfulRun], sourceSha), true);
+	assert.equal(selectGuardComparisonBase({
+		nxBase: "old-main",
+		promotionSourceSha: sourceSha,
+		validationRuns: [successfulRun],
+	}), sourceSha);
+	assert.equal(selectGuardComparisonBase({
+		nxBase: "ordinary-base",
+		promotionSourceSha: null,
+		validationRuns: [],
+	}), "ordinary-base");
+	assert.throws(function _PendingSource() {
+		selectGuardComparisonBase({
+			nxBase: "old-main",
+			promotionSourceSha: sourceSha,
+			validationRuns: [{ ...successfulRun, conclusion: null, status: "pending" }],
+		});
+	}, /PROMOTION_SOURCE_UNVALIDATED/u);
+	assert.equal(hasSuccessfulDevelopValidation([{ ...successfulRun, event: "pull_request" }], sourceSha), false);
+	assert.equal(hasSuccessfulDevelopValidation([{ ...successfulRun, head_sha: "other-head" }], sourceSha), false);
+});
+
+test("uses the validated promotion base only for diff-scoped policy guards", function _ProtectsPromotionWiring()
+{
+	const workflow = _Workflow();
+	assert.match(workflow, /guard_base: \$\{\{ steps\.guard-base\.outputs\.guard_base \}\}/u);
+	assert.match(workflow, /run: node scripts\/promotion-guard-base\.mjs/u);
+	assert.match(workflow, /GUARD_BASE: \$\{\{ needs\.prepare\.outputs\.guard_base \}\}/u);
+	assert.match(workflow, /agent-style-check\.sh --diff "\$GUARD_BASE"/u);
+	assert.match(workflow, /check:module-growth -- --diff "\$GUARD_BASE"/u);
+	assert.match(workflow, /check:prisma-boundaries -- --diff "\$GUARD_BASE"/u);
+	assert.match(workflow, /npx nx affected -t build test lint/u);
 });

--- a/scripts/__tests__/pr-stack-integrity.test.mjs
+++ b/scripts/__tests__/pr-stack-integrity.test.mjs
@@ -7,7 +7,7 @@ import test from "node:test";
 import { validationResult } from "../pr-stack-integrity/evidence.mjs";
 import { createGitHubAdapter } from "../pr-stack-integrity/github.mjs";
 import { createGitAdapter } from "../pr-stack-integrity/git.mjs";
-import { inspectLiveStack } from "../pr-stack-integrity/inspection.mjs";
+import { inspectLiveStack, inspectStableStack } from "../pr-stack-integrity/inspection.mjs";
 import { evaluateStack } from "../pr-stack-integrity/policy.mjs";
 import { createCommandRunner } from "../pr-stack-integrity/process.mjs";
 import { publishResult, renderMarkdown } from "../pr-stack-integrity/report.mjs";
@@ -221,6 +221,50 @@ test("fails when a live base ref changes during inspection", function _BaseDrift
 			},
 		});
 	}, /BASE_REF_DRIFT/u);
+});
+
+test("retries a transient merge-time base-ref drift with a fresh full inspection", function _TransientBaseDrift()
+{
+	const pullRequests = [_PullRequest(1, "feat/one", "a", "develop", "d")];
+	let fetches = 0;
+	const inspection = inspectStableStack({
+		repository: "example/opencrane",
+		event: { number: 99, action: "closed", headSha: "merged" },
+		github: { openPullRequests() { return pullRequests; } },
+		git: {
+			fetchAndVerify()
+			{
+				fetches += 1;
+				return new Map([["develop", fetches === 1 ? "before" : "after"]]);
+			},
+			remoteBaseHeads() { return new Map([["develop", "after"]]); },
+			evidence() { return { ancestry: new Set(), diffDigests: new Map(), patchIds: new Map() }; },
+		},
+	});
+	assert.equal(fetches, 2);
+	assert.equal(inspection.baseHeads.get("develop"), "after");
+});
+
+test("fails closed after bounded repeated base-ref drift", function _RepeatedBaseDrift()
+{
+	const pullRequests = [_PullRequest(1, "feat/one", "a", "develop", "d")];
+	let fetches = 0;
+	assert.throws(function _Inspect() {
+		inspectStableStack({
+			repository: "example/opencrane",
+			event: { number: 1, action: "edited", headSha: "a" },
+			github: { openPullRequests() { return pullRequests; } },
+			git: {
+				fetchAndVerify()
+				{
+					fetches += 1;
+					return new Map([["develop", "before"]]);
+				},
+				remoteBaseHeads() { return new Map([["develop", "after"]]); },
+			},
+		});
+	}, /BASE_REF_DRIFT/u);
+	assert.equal(fetches, 3);
 });
 
 test("fails when the graph changes while Git evidence is computed", function _FinalSnapshotDrift()

--- a/scripts/pr-stack-integrity/cli.mjs
+++ b/scripts/pr-stack-integrity/cli.mjs
@@ -1,7 +1,7 @@
 import { digestEvidence, validationResult } from "./evidence.mjs";
 import { createGitHubAdapter } from "./github.mjs";
 import { createGitAdapter } from "./git.mjs";
-import { inspectLiveStack } from "./inspection.mjs";
+import { inspectStableStack } from "./inspection.mjs";
 import { evaluateStack } from "./policy.mjs";
 import { createCommandRunner } from "./process.mjs";
 import { publishResult } from "./report.mjs";
@@ -57,7 +57,7 @@ export function runCli(arguments_, dependencies = {})
 	try
 	{
 		repository ??= github.repositoryName();
-		const inspection = inspectLiveStack({
+		const inspection = inspectStableStack({
 			repository,
 			currentBranch: _Option(arguments_, "--current-branch"),
 			event,

--- a/scripts/pr-stack-integrity/inspection.mjs
+++ b/scripts/pr-stack-integrity/inspection.mjs
@@ -4,6 +4,14 @@ function _Entries(heads)
 	return Array.from(heads).sort(function _ByRef(left, right) { return left[0].localeCompare(right[0]); });
 }
 
+const _RetryableInspectionFailure = /^(?:SNAPSHOT_DRIFT|BASE_REF_DRIFT|FINAL_SNAPSHOT_DRIFT|FINAL_BASE_REF_DRIFT):/u;
+
+/** Return whether a fresh full inspection can resolve this failure. */
+function _IsRetryable(error)
+{
+	return error instanceof Error && _RetryableInspectionFailure.test(error.message);
+}
+
 /** Inspect a race-free live PR graph through injected GitHub and Git adapters. */
 export function inspectLiveStack(input)
 {
@@ -55,4 +63,26 @@ export function inspectLiveStack(input)
 			headSha: input.event?.headSha,
 		} : undefined,
 	};
+}
+
+/** Retry a transient snapshot race while preserving a bounded fail-closed result. */
+export function inspectStableStack(input, maximumAttempts = 3)
+{
+	let attempts = 0;
+	while (attempts < maximumAttempts)
+	{
+		attempts += 1;
+		try
+		{
+			return inspectLiveStack(input);
+		}
+		catch (error)
+		{
+			if (!_IsRetryable(error) || attempts >= maximumAttempts)
+			{
+				throw error;
+			}
+		}
+	}
+	throw new Error("INSPECTION_ATTEMPTS_INVALID: at least one inspection attempt is required.");
 }

--- a/scripts/promotion-guard-base.core.mjs
+++ b/scripts/promotion-guard-base.core.mjs
@@ -1,0 +1,52 @@
+/** Return the exact source SHA when this event is a verifiable develop-to-main promotion. */
+export function selectPromotionSource(input)
+{
+	if (input.eventName === "pull_request")
+	{
+		if (input.baseRef !== "main" || input.headRef !== "develop")
+		{
+			return null;
+		}
+		if (!input.pullRequestHeadSha)
+		{
+			throw new Error("PROMOTION_HEAD_MISSING: a develop-to-main pull request must expose its source SHA.");
+		}
+		return input.pullRequestHeadSha;
+	}
+	if (input.eventName !== "push" || input.ref !== "refs/heads/main")
+	{
+		return null;
+	}
+	if (input.pushParentShas.length !== 2 || !input.pushSourceInDevelop || input.pushHeadTree !== input.pushSourceTree)
+	{
+		return null;
+	}
+	return input.pushParentShas[1];
+}
+
+/** Return whether the exact source SHA completed the authoritative develop push workflow. */
+export function hasSuccessfulDevelopValidation(runs, sourceSha)
+{
+	return runs.some(function _Successful(run) {
+		return run.path === ".github/workflows/docker.yml"
+			&& run.head_branch === "develop"
+			&& run.head_sha === sourceSha
+			&& run.event === "push"
+			&& run.status === "completed"
+			&& run.conclusion === "success";
+	});
+}
+
+/** Select the diff-policy base without trusting an unvalidated promotion source. */
+export function selectGuardComparisonBase(input)
+{
+	if (!input.promotionSourceSha)
+	{
+		return input.nxBase;
+	}
+	if (!hasSuccessfulDevelopValidation(input.validationRuns, input.promotionSourceSha))
+	{
+		throw new Error(`PROMOTION_SOURCE_UNVALIDATED: develop ${input.promotionSourceSha} has no successful push validation.`);
+	}
+	return input.promotionSourceSha;
+}

--- a/scripts/promotion-guard-base.mjs
+++ b/scripts/promotion-guard-base.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+import { selectGuardComparisonBase, selectPromotionSource } from "./promotion-guard-base.core.mjs";
+
+/** Run a bounded command and return trimmed stdout. */
+function _Run(command, arguments_)
+{
+	return execFileSync(command, arguments_, { encoding: "utf8", timeout: 30_000 }).trim();
+}
+
+/** Return whether a bounded command completed successfully. */
+function _Succeeds(command, arguments_)
+{
+	return spawnSync(command, arguments_, { encoding: "utf8", timeout: 30_000 }).status === 0;
+}
+
+/** Write one GitHub Actions output or a local diagnostic. */
+function _Output(name, value)
+{
+	if (process.env.GITHUB_OUTPUT)
+	{
+		appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
+		return;
+	}
+	process.stdout.write(`${name}=${value}\n`);
+}
+
+/** Resolve merge facts required to recognize an unchanged develop promotion on main. */
+function _PushFacts(eventName, ref, headSha)
+{
+	if (eventName !== "push" || ref !== "refs/heads/main")
+	{
+		return { parentShas: [], sourceInDevelop: false, headTree: "", sourceTree: "" };
+	}
+	_Run("git", ["fetch", "--quiet", "--no-tags", "origin", "+refs/heads/develop:refs/remotes/origin/develop"]);
+	const revision = _Run("git", ["rev-list", "--parents", "-n", "1", headSha]).split(/\s+/u);
+	const parentShas = revision.slice(1);
+	const sourceSha = parentShas[1];
+	if (!sourceSha)
+	{
+		return { parentShas, sourceInDevelop: false, headTree: "", sourceTree: "" };
+	}
+	return {
+		parentShas,
+		sourceInDevelop: _Succeeds("git", ["merge-base", "--is-ancestor", sourceSha, "refs/remotes/origin/develop"]),
+		headTree: _Run("git", ["rev-parse", `${headSha}^{tree}`]),
+		sourceTree: _Run("git", ["rev-parse", `${sourceSha}^{tree}`]),
+	};
+}
+
+/** Read exact-SHA develop validation runs from GitHub. */
+function _ValidationRuns(repository, sourceSha)
+{
+	if (!sourceSha)
+	{
+		return [];
+	}
+	const query = new URLSearchParams({ branch: "develop", event: "push", head_sha: sourceSha, per_page: "100" });
+	const response = _Run("gh", ["api", `repos/${repository}/actions/workflows/docker.yml/runs?${query.toString()}`]);
+	return JSON.parse(response).workflow_runs ?? [];
+}
+
+const nxBase = process.env.NX_BASE;
+const nxHead = process.env.NX_HEAD;
+if (!nxBase || !nxHead)
+{
+	throw new Error("NX_BASE and NX_HEAD must be set before selecting the policy comparison base.");
+}
+
+const eventName = process.env.GITHUB_EVENT_NAME ?? "local";
+const ref = process.env.GITHUB_REF ?? "";
+const push = _PushFacts(eventName, ref, nxHead);
+const promotionSourceSha = selectPromotionSource({
+	eventName,
+	ref,
+	baseRef: process.env.GITHUB_BASE_REF ?? "",
+	headRef: process.env.GITHUB_HEAD_REF ?? "",
+	pullRequestHeadSha: process.env.PULL_REQUEST_HEAD_SHA ?? "",
+	pushParentShas: push.parentShas,
+	pushSourceInDevelop: push.sourceInDevelop,
+	pushHeadTree: push.headTree,
+	pushSourceTree: push.sourceTree,
+});
+const guardBase = selectGuardComparisonBase({
+	nxBase,
+	promotionSourceSha,
+	validationRuns: _ValidationRuns(process.env.GITHUB_REPOSITORY ?? "", promotionSourceSha),
+});
+
+_Output("guard_base", guardBase);


### PR DESCRIPTION
## Summary

- retry transient PR-stack snapshot and base-ref drift with a fresh bounded inspection while preserving fail-closed behavior
- let develop-to-main promotions narrow diff-only policy guards only after the exact develop SHA has a successful push workflow
- keep affected builds, smoke selection, API checks, and image publication on the full NX base

## Failure evidence

- PR #575 close-event run 31201917717 failed on a transient BASE_REF_DRIFT and passed once the graph stabilized
- release PR #581 and main push run 31202999909 reclassified the historical main-to-develop promotion as 538 new policy violations

## Validation

- npm run test:affected-deployables (9/9)
- npm run test:pr-stack-integrity (21/21)
- scripts/agent-style-check.sh --diff origin/develop
- npm run check:module-growth -- --diff origin/develop
- npm run check:prisma-boundaries -- --diff origin/develop
- live PR-stack integrity checkpoint
- workflow YAML parse and git diff check
- independent review: clean

## Review order

1. #582

## Independence

PRs #579 and #580 are independent dependency updates.