### PR TITLE
🚚 Co-locate documented Storybook fixtures with tests

### DIFF
--- a/libs/frontend/elements/ui/.storybook/main.ts
+++ b/libs/frontend/elements/ui/.storybook/main.ts
@@ -5,8 +5,8 @@ const config: StorybookConfig =
 {
 	stories:
 	[
-		"../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-		"../../../features/onboarding/src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+		"../src/**/__tests__/*.stories.@(js|jsx|mjs|ts|tsx)",
+		"../../../features/onboarding/src/**/__tests__/*.stories.@(js|jsx|mjs|ts|tsx)"
 	],
 	addons:
 	[

--- a/libs/frontend/elements/ui/.storybook/tsconfig.json
+++ b/libs/frontend/elements/ui/.storybook/tsconfig.json
@@ -15,12 +15,12 @@
     "../**/*.spec.ts"
   ],
   "include": [
-    "../src/**/*.stories.ts",
-    "../src/**/*.stories.js",
-    "../src/**/*.stories.jsx",
-    "../src/**/*.stories.tsx",
-    "../src/**/*.stories.mdx",
-    "../../../features/onboarding/src/**/*.stories.ts",
+    "../src/**/__tests__/*.stories.ts",
+    "../src/**/__tests__/*.stories.js",
+    "../src/**/__tests__/*.stories.jsx",
+    "../src/**/__tests__/*.stories.tsx",
+    "../src/**/__tests__/*.stories.mdx",
+    "../../../features/onboarding/src/**/__tests__/*.stories.ts",
     "preview.ts"
   ]
 }

--- a/libs/frontend/elements/ui/README.md
+++ b/libs/frontend/elements/ui/README.md
@@ -24,6 +24,18 @@ detection as the application.
 **In this flow:** feature packages own orchestration; `OpenCranePreset` in
 [`core`](../../core/README.md) owns the PrimeNG theme mapping.
 
+## Story organisation
+
+Every catalogue story lives beside the contract it verifies, under that component's `__tests__/`
+directory. This keeps the visual, interaction, accessibility, and unit-test fixtures together and
+prevents a component implementation from accumulating a second, detached story tree.
+
+Each story must document three things in its Storybook description: the user-facing state it
+represents, the component contract it verifies, and the authority it deliberately does **not**
+own. `visual-test` stories additionally provide the stable screenshot baseline; `play` stories
+prove interactions against the component boundary rather than pretending to exercise a feature's
+network or persistence transition.
+
 ## Public surface
 
 The package's index file (barrel) re-exports the components directly:

--- a/libs/frontend/elements/ui/src/lib/components/avatar-circle/__tests__/avatar-circle.component.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/avatar-circle/__tests__/avatar-circle.component.stories.ts
@@ -1,14 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/angular";
 
-import { AvatarCircleComponent } from "./avatar-circle.component";
-import { AvatarSizes, AvatarTones } from "./avatar-circle.types";
+import { AvatarCircleComponent } from "../avatar-circle.component";
+import { AvatarSizes, AvatarTones } from "../avatar-circle.types";
 
 /** Storybook catalogue metadata for finite avatar states. */
 const meta: Meta<AvatarCircleComponent> =
 {
 	title: "Foundation/Avatar circle",
 	component: AvatarCircleComponent,
-	tags: ["autodocs"]
+	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "A labelled visual identity marker whose tone and size communicate context without carrying permissions or lifecycle state. The catalogue keeps every supported semantic treatment reviewable in one place."
+			}
+		}
+	}
 };
 
 export default meta;
@@ -19,6 +29,7 @@ type Story = StoryObj<AvatarCircleComponent>;
 /** Every supported semantic tone paired with representative sizes. */
 export const SemanticTonesAndSizes: Story =
 {
+	parameters: { docs: { description: { story: "The complete approved tone-and-size matrix, using representative initials and labels. It makes visual regressions across compact participant lists and prominent identity moments immediately comparable." } } },
 	tags: ["visual-test"],
 	render: function render()
 	{

--- a/libs/frontend/elements/ui/src/lib/components/choice-card-group/__tests__/choice-card-group.component.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/choice-card-group/__tests__/choice-card-group.component.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/angular";
 import { expect, userEvent, within } from "storybook/test";
 
-import { ChoiceCardGroupComponent } from "./choice-card-group.component";
-import { ChoiceCardLayouts, ChoiceCardOption } from "./choice-card-group.types";
+import { ChoiceCardGroupComponent } from "../choice-card-group.component";
+import { ChoiceCardLayouts, ChoiceCardOption } from "../choice-card-group.types";
 
 /** Stable persona-question options shared by the catalogue stories. */
 const _PERSONA_OPTIONS: readonly ChoiceCardOption[] =
@@ -19,6 +19,16 @@ const meta: Meta<ChoiceCardGroupComponent> =
 	title: "Foundation/Choice card group",
 	component: ChoiceCardGroupComponent,
 	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "An accessible, controlled radio-card group for one required decision. These fixtures distinguish the presentational selection contract from the feature that persists an answer."
+			}
+		}
+	},
 	args:
 	{
 		controlId: "working-style",
@@ -36,12 +46,14 @@ type Story = StoryObj<ChoiceCardGroupComponent>;
 /** Required question before the user has selected an answer. */
 export const Unselected: Story =
 {
+	parameters: { docs: { description: { story: "The required starting state before the owner selects an option. Use it to check that the question is legible and that no choice is implied by default." } } },
 	tags: ["visual-test"]
 };
 
 /** Selected card and its folded-corner treatment. */
 export const Selected: Story =
 {
+	parameters: { docs: { description: { story: "A selected answer after deliberate owner input. The folded-corner treatment must supplement, never replace, the radio's semantic checked state." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -52,6 +64,7 @@ export const Selected: Story =
 /** Invalid submission with an associated accessible error. */
 export const ValidationError: Story =
 {
+	parameters: { docs: { description: { story: "A submission attempt without an answer. It documents the accessible error relationship while keeping the selection authority with the parent form." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -62,6 +75,7 @@ export const ValidationError: Story =
 /** Whole-group disabled state while a durable answer is being saved. */
 export const Disabled: Story =
 {
+	parameters: { docs: { description: { story: "A previously chosen answer while its durable save is in flight. The UI may prevent a conflicting edit, but it must preserve the exact choice the owner made." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -73,6 +87,7 @@ export const Disabled: Story =
 /** Long and localised content constrained to a narrow container. */
 export const NarrowLongContent: Story =
 {
+	parameters: { docs: { description: { story: "A constrained viewport with longer Dutch copy. It guards readable wrapping and a stack layout without treating English-length labels as the design limit." } } },
 	tags: ["visual-test"],
 	render: function render(args)
 	{
@@ -96,6 +111,7 @@ export const NarrowLongContent: Story =
 /** User selection emits a stable value and updates the controlled state. */
 export const InteractionSelect: Story =
 {
+	parameters: { docs: { description: { story: "The controlled interaction contract: selecting a card emits its stable identifier and the parent feeds that state back. It intentionally does not simulate persistence or navigation." } } },
 	render: function render(args)
 	{
 		return {

--- a/libs/frontend/elements/ui/src/lib/components/collapsible-section/__tests__/collapsible-section.component.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/collapsible-section/__tests__/collapsible-section.component.stories.ts
@@ -1,15 +1,25 @@
 import type { Meta, StoryObj } from "@storybook/angular";
 import { expect, userEvent, within } from "storybook/test";
 
-import { CollapsibleSectionComponent } from "./collapsible-section.component";
-import { CollapsibleSectionVariants } from "./collapsible-section.types";
+import { CollapsibleSectionComponent } from "../collapsible-section.component";
+import { CollapsibleSectionVariants } from "../collapsible-section.types";
 
 /** Storybook catalogue metadata for expandable section states. */
 const meta: Meta<CollapsibleSectionComponent> =
 {
 	title: "Foundation/Collapsible section",
 	component: CollapsibleSectionComponent,
-	tags: ["autodocs"]
+	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "A disclosure control for context that may be read on demand. Its stories cover visual variants and the accessible button-to-region relationship, not the policy content projected inside it."
+			}
+		}
+	}
 };
 
 export default meta;
@@ -20,6 +30,7 @@ type Story = StoryObj<CollapsibleSectionComponent>;
 /** Expanded light-panel state with realistic projected content. */
 export const PanelExpanded: Story =
 {
+	parameters: { docs: { description: { story: "An open light-panel disclosure with realistic projected evidence. Use it to inspect the default reading state and the spacing inherited by content supplied by a feature." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -46,6 +57,7 @@ export const PanelExpanded: Story =
 /** Collapsed light-panel state. */
 export const PanelCollapsed: Story =
 {
+	parameters: { docs: { description: { story: "The compact, closed panel before an owner asks to inspect the detail. It confirms that the title remains discoverable while the controlled region is initially hidden." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -59,6 +71,7 @@ export const PanelCollapsed: Story =
 /** Dark-rail state retained for the context surface. */
 export const Rail: Story =
 {
+	parameters: { docs: { description: { story: "The dark-rail treatment used for secondary context. It documents contrast and projected-content legibility without creating a second disclosure implementation." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -85,6 +98,7 @@ export const Rail: Story =
 /** Keyboard interaction contract for the trigger and controlled region. */
 export const KeyboardToggle: Story =
 {
+	parameters: { docs: { description: { story: "The accessibility interaction contract for a closed panel. It proves the trigger reports expanded state and exposes a labelled region after the owner opens it." } } },
 	args:
 	{
 		sectionId: "keyboard-contract",

--- a/libs/frontend/elements/ui/src/lib/components/journey-progress/__tests__/journey-progress.component.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/journey-progress/__tests__/journey-progress.component.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/angular";
 
-import { JourneyProgressComponent } from "./journey-progress.component";
+import { JourneyProgressComponent } from "../journey-progress.component";
 
 /** Storybook catalogue metadata for finite journey progress. */
 const meta: Meta<JourneyProgressComponent> =
@@ -8,6 +8,16 @@ const meta: Meta<JourneyProgressComponent> =
 	title: "Foundation/Journey progress",
 	component: JourneyProgressComponent,
 	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "A read-only presentation of progress already admitted by an owning journey. It never calculates, advances, or authorizes a workflow position."
+			}
+		}
+	},
 	args:
 	{
 		label: "Persona sorting progress",
@@ -25,12 +35,14 @@ type Story = StoryObj<JourneyProgressComponent>;
 /** Active interview with durable progress already recorded. */
 export const InProgress: Story =
 {
+	parameters: { docs: { description: { story: "A mid-interview position whose completed count and status label have been supplied by the journey owner. It is the standard state for an resumable durable workflow." } } },
 	tags: ["visual-test"]
 };
 
 /** First position before the journey has accumulated much evidence. */
 export const Starting: Story =
 {
+	parameters: { docs: { description: { story: "The first question before any answer has been admitted. It documents the zero-progress treatment without implying that an empty local form is itself durable state." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -42,6 +54,7 @@ export const Starting: Story =
 /** Finite journey after every position has been completed. */
 export const Complete: Story =
 {
+	parameters: { docs: { description: { story: "The finite completed position after every required answer is saved. The display reports completion; the route still owns any next action such as review or approval." } } },
 	tags: ["visual-test"],
 	args:
 	{

--- a/libs/frontend/elements/ui/src/lib/components/journey-shell/__tests__/journey-shell.auth.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/journey-shell/__tests__/journey-shell.auth.stories.ts
@@ -4,8 +4,8 @@ import { ButtonModule } from "primeng/button";
 import { MessageModule } from "primeng/message";
 import { ProgressSpinnerModule } from "primeng/progressspinner";
 
-import { JourneyShellComponent } from "./journey-shell.component";
-import { JourneyShellLayouts } from "./journey-shell.types";
+import { JourneyShellComponent } from "../journey-shell.component";
+import { JourneyShellLayouts } from "../journey-shell.types";
 
 /** Storybook metadata for OIDC entry and recovery states. */
 const meta: Meta<JourneyShellComponent> =
@@ -13,6 +13,16 @@ const meta: Meta<JourneyShellComponent> =
 	title: "Foundation/Journey shell",
 	component: JourneyShellComponent,
 	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "The shared visual frame for the identity boundary. These fixtures demonstrate user-facing handoff and recovery states without treating the component as an authentication authority."
+			}
+		}
+	},
 	decorators: [moduleMetadata({ imports: [ButtonModule, MessageModule, ProgressSpinnerModule] })]
 };
 
@@ -24,6 +34,7 @@ type Story = StoryObj<JourneyShellComponent>;
 /** OIDC-only sign-in state with one primary identity-provider action. */
 export const SsoSignIn: Story =
 {
+	parameters: { docs: { description: { story: "The only supported sign-in entry: hand off to the organisation's identity provider. It makes the password boundary explicit and supplies one clear, non-local credential action." } } },
 	tags: ["visual-test"],
 	render: function render()
 	{
@@ -44,6 +55,7 @@ export const SsoSignIn: Story =
 /** Identity-provider handoff state with a bounded cancel action. */
 export const IdentityHandoff: Story =
 {
+	parameters: { docs: { description: { story: "The transitional state while the browser is handed to the identity provider. It communicates that the user will return here and offers a bounded cancel action without claiming an authentication outcome." } } },
 	tags: ["visual-test"],
 	render: function render()
 	{
@@ -65,6 +77,7 @@ export const IdentityHandoff: Story =
 /** Blocking authority error with one explicit recovery action. */
 export const Error: Story =
 {
+	parameters: { docs: { description: { story: "A blocking onboarding-read failure with one safe recovery action. The message explicitly says that saved survey, persona, and conversation data remain unchanged while the authority is unavailable." } } },
 	tags: ["visual-test"],
 	render: function render()
 	{

--- a/libs/frontend/elements/ui/src/lib/components/ledger-card/__tests__/ledger-card.component.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/ledger-card/__tests__/ledger-card.component.stories.ts
@@ -1,15 +1,25 @@
 import type { Meta, StoryObj } from "@storybook/angular";
 
 import { ScopeLevel } from "@opencrane/core";
-import { LedgerCardComponent } from "./ledger-card.component";
-import { LedgerCardKinds } from "./ledger-card.types";
+import { LedgerCardComponent } from "../ledger-card.component";
+import { LedgerCardKinds } from "../ledger-card.types";
 
 /** Storybook catalogue metadata for retained ledger states. */
 const meta: Meta<LedgerCardComponent> =
 {
 	title: "Foundation/Ledger card",
 	component: LedgerCardComponent,
-	tags: ["autodocs"]
+	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "A presentational record of a supplied observation, policy, or action. It preserves the provenance and scope a feature gives it, but never infers or changes that record's authority."
+			}
+		}
+	}
 };
 
 export default meta;
@@ -20,6 +30,7 @@ type Story = StoryObj<LedgerCardComponent>;
 /** Observation, policy, and action states with representative metadata. */
 export const KindsAndScopes: Story =
 {
+	parameters: { docs: { description: { story: "Observation, policy, and action cards shown with distinct owner-supplied scopes. This is the comparison fixture for semantic labels, references, and compact ledger density." } } },
 	tags: ["visual-test"],
 	render: function render()
 	{
@@ -39,6 +50,7 @@ export const KindsAndScopes: Story =
 /** Resolved action keeps its evidence legible while visually receding. */
 export const Resolved: Story =
 {
+	parameters: { docs: { description: { story: "A completed action that visually recedes while retaining its evidence reference. Resolution is displayed from the supplied record rather than inferred from styling or client-side behaviour." } } },
 	tags: ["visual-test"],
 	args:
 	{

--- a/libs/frontend/elements/ui/src/lib/components/persona-summary/__tests__/persona-summary.component.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/persona-summary/__tests__/persona-summary.component.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/angular";
 
-import { PersonaSummaryComponent } from "./persona-summary.component";
-import { PersonaArchetypeScore, PersonaArchetypeTones } from "./persona-summary.types";
+import { PersonaSummaryComponent } from "../persona-summary.component";
+import { PersonaArchetypeScore, PersonaArchetypeTones } from "../persona-summary.types";
 
 /** Stable complete score vector used by persona-summary stories. */
 const _SCORES: readonly PersonaArchetypeScore[] =
@@ -18,6 +18,16 @@ const meta: Meta<PersonaSummaryComponent> =
 	title: "Foundation/Persona summary",
 	component: PersonaSummaryComponent,
 	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "A reviewable presentation of a persona result and its supplied score vector. It makes the basis for an owner decision legible without turning a visual result into an active persona."
+			}
+		}
+	},
 	args:
 	{
 		componentId: "persona-summary",
@@ -38,12 +48,14 @@ type Story = StoryObj<PersonaSummaryComponent>;
 /** Typical reviewed persona with a complete four-colour vector. */
 export const Typical: Story =
 {
+	parameters: { docs: { description: { story: "The standard reviewed result with an explicit four-archetype vector. It is the baseline for the primary archetype, secondary influence, modifier, and complete evidence distribution." } } },
 	tags: ["visual-test"]
 };
 
 /** Narrow layout with long translated result content. */
 export const NarrowLongContent: Story =
 {
+	parameters: { docs: { description: { story: "Longer Dutch result content in the minimum supported reading width. It guards the review surface against clipped evidence or an unreadable score explanation in localized use." } } },
 	tags: ["visual-test"],
 	render: function render(args)
 	{

--- a/libs/frontend/elements/ui/src/lib/components/scope-chip/__tests__/scope-chip.component.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/scope-chip/__tests__/scope-chip.component.stories.ts
@@ -1,14 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/angular";
 
-import { ScopeChipComponent } from "./scope-chip.component";
-import { ScopeChipAppearances, ScopeChipTones } from "./scope-chip.types";
+import { ScopeChipComponent } from "../scope-chip.component";
+import { ScopeChipAppearances, ScopeChipTones } from "../scope-chip.types";
 
 /** Storybook catalogue metadata for finite chip states. */
 const meta: Meta<ScopeChipComponent> =
 {
 	title: "Foundation/Scope chip",
 	component: ScopeChipComponent,
-	tags: ["autodocs"]
+	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "A compact scope and status marker that makes the owner-provided meaning visible without granting access. Stories cover the semantic vocabulary and its permitted visual treatments."
+			}
+		}
+	}
 };
 
 export default meta;
@@ -19,6 +29,7 @@ type Story = StoryObj<ScopeChipComponent>;
 /** Every supported semantic tone in the default outlined treatment. */
 export const SemanticTones: Story =
 {
+	parameters: { docs: { description: { story: "The full semantic vocabulary in the default outlined treatment. Review it when adding a scope or status to ensure the colour remains an aid, not the only source of meaning." } } },
 	tags: ["visual-test"],
 	render: function render()
 	{
@@ -44,6 +55,7 @@ export const SemanticTones: Story =
 /** Outlined and soft treatments using one semantic meaning. */
 export const Appearances: Story =
 {
+	parameters: { docs: { description: { story: "Two approved treatments for the same personal scope. This documents that appearance changes emphasis only; it never changes the underlying scope or authority." } } },
 	tags: ["visual-test"],
 	render: function render()
 	{

--- a/libs/frontend/elements/ui/src/lib/components/section-heading/__tests__/section-heading.component.stories.ts
+++ b/libs/frontend/elements/ui/src/lib/components/section-heading/__tests__/section-heading.component.stories.ts
@@ -1,13 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/angular";
 
-import { SectionHeadingComponent } from "./section-heading.component";
+import { SectionHeadingComponent } from "../section-heading.component";
 
 /** Storybook catalogue metadata for retained section headings. */
 const meta: Meta<SectionHeadingComponent> =
 {
 	title: "Foundation/Section heading",
 	component: SectionHeadingComponent,
-	tags: ["autodocs"]
+	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "A structural heading with optional explanatory copy. It supplies hierarchy and context while leaving the surrounding route responsible for actions and data."
+			}
+		}
+	}
 };
 
 export default meta;
@@ -18,6 +28,7 @@ type Story = StoryObj<SectionHeadingComponent>;
 /** Typical heading with explanatory copy. */
 export const Typical: Story =
 {
+	parameters: { docs: { description: { story: "The ordinary two-line section introduction used before a constrained configuration decision. It is the baseline for typography, spacing, and readable supporting copy." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -29,6 +40,7 @@ export const Typical: Story =
 /** Long and localised text verifies wrapping without clipping. */
 export const LongLocalized: Story =
 {
+	parameters: { docs: { description: { story: "Longer Dutch content that exercises the supported wrapping behaviour. It protects translated UI from clipping, overlap, or a visually detached subtitle." } } },
 	tags: ["visual-test"],
 	args:
 	{

--- a/libs/frontend/features/onboarding/src/lib/__tests__/persona-onboarding-state.stories.ts
+++ b/libs/frontend/features/onboarding/src/lib/__tests__/persona-onboarding-state.stories.ts
@@ -4,11 +4,11 @@ import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { PersonaColours, PersonaModifiers, PersonaOnboardingSnapshot, PersonaOnboardingStates, PersonaResolutionKinds } from "@opencrane/state/onboarding";
 
-import { PersonaInterviewStateComponent } from "./states/interview/persona-interview-state.component";
-import { PersonaReadyStateComponent } from "./states/ready/persona-ready-state.component";
-import { PersonaResolutionStateComponent } from "./states/resolution/persona-resolution-state.component";
-import { PersonaResultEvidenceComponent } from "./states/result/persona-result-evidence.component";
-import { PersonaReviewStateComponent } from "./states/review/persona-review-state.component";
+import { PersonaInterviewStateComponent } from "../states/interview/persona-interview-state.component";
+import { PersonaReadyStateComponent } from "../states/ready/persona-ready-state.component";
+import { PersonaResolutionStateComponent } from "../states/resolution/persona-resolution-state.component";
+import { PersonaResultEvidenceComponent } from "../states/result/persona-result-evidence.component";
+import { PersonaReviewStateComponent } from "../states/review/persona-review-state.component";
 
 /** Frozen reviewed question used by the feature-state catalogue. */
 const _QUESTION = { id: "q1", category: "pace", prompt: "When the decision is consequential and the available evidence is incomplete, how should your agent help you move forward?", ordinal: 1, choices: [{ id: "recommend", label: "Lead with the strongest recommendation, then explain the uncertainty and the best alternative.", ordinal: 1 }, { id: "context", label: "Build the context first and wait for me to choose the direction.", ordinal: 2 }], selectedChoiceId: null } as const;

--- a/libs/frontend/features/onboarding/src/lib/chat/__tests__/persona-first-chat.component.stories.ts
+++ b/libs/frontend/features/onboarding/src/lib/chat/__tests__/persona-first-chat.component.stories.ts
@@ -3,8 +3,8 @@ import { expect, userEvent, within } from "storybook/test";
 
 import { PersonaArchetypeTones } from "@opencrane/elements/ui";
 
-import { PersonaFirstChatComponent } from "./persona-first-chat.component.js";
-import { type PersonaFirstChatIdentity, PersonaFirstChatMessageRoles, type PersonaFirstChatProvenance, type PersonaFirstChatQuestion, PersonaFirstChatStates, type PersonaFirstChatTranscriptMessage } from "./persona-first-chat.types.js";
+import { PersonaFirstChatComponent } from "../persona-first-chat.component.js";
+import { type PersonaFirstChatIdentity, PersonaFirstChatMessageRoles, type PersonaFirstChatProvenance, type PersonaFirstChatQuestion, PersonaFirstChatStates, type PersonaFirstChatTranscriptMessage } from "../persona-first-chat.types.js";
 
 /** Stable personal-agent identity shared by canonical Analyst stories. */
 const _ANALYST_IDENTITY: PersonaFirstChatIdentity =
@@ -58,6 +58,16 @@ const meta: Meta<PersonaFirstChatComponent> =
 	title: "Onboarding/Persona first chat",
 	component: PersonaFirstChatComponent,
 	tags: ["autodocs"],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "The feature presentation boundary for a reviewed first-chat calibration. It renders server-provided identity, provenance, transcript, and lifecycle state, then emits intent for the owning route to admit."
+			}
+		}
+	},
 	args:
 	{
 		identity: _ANALYST_IDENTITY,
@@ -105,12 +115,14 @@ type Story = StoryObj<PersonaFirstChatComponent>;
 /** First canonical question with keyboard and focus interaction coverage. */
 export const AwaitingCalibration: Story =
 {
+	parameters: { docs: { description: { story: "The initial reviewed calibration question after the agent's opening statement. It documents editable intent before any answer is sent, saved, or interpreted as a preference." } } },
 	tags: ["visual-test"]
 };
 
 /** Keyboard interaction keeps multiline intent distinct from answer submission. */
 export const InteractionKeyboardSubmit: Story =
 {
+	parameters: { docs: { description: { story: "The keyboard contract for a multiline answer: Shift+Enter remains text input and Enter emits the exact answer intent. The Storybook play test proves this component contract without performing a network transition." } } },
 	play: async function play({ canvasElement })
 	{
 		const canvas = within(canvasElement);
@@ -133,6 +145,7 @@ export const InteractionKeyboardSubmit: Story =
 /** Saved first answer followed by the second sequential Analyst question. */
 export const AnsweredProgression: Story =
 {
+	parameters: { docs: { description: { story: "A server-projected transcript after the first answer is saved and before the second is answered. It demonstrates that sequential position follows supplied durable evidence, not local draft state." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -149,6 +162,7 @@ export const AnsweredProgression: Story =
 /** Composer disabled while the exact current answer is being admitted. */
 export const Submitting: Story =
 {
+	parameters: { docs: { description: { story: "The exact current answer while admission is pending. Editing is disabled and an explicit status is announced, protecting against duplicate or conflicting local submissions." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -170,6 +184,7 @@ export const Submitting: Story =
 /** Saved progression retained while the authoritative projection reloads before question three. */
 export const ReconnectingResume: Story =
 {
+	parameters: { docs: { description: { story: "A reconnecting projection that retains two saved answers and identifies the next question. It assures the owner that transcript evidence is intact while editing waits for authoritative recovery." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -221,6 +236,7 @@ export const Finishing: Story =
 /** Long provenance, transcript, and question content at the supported narrow viewport. */
 export const NarrowLongContent: Story =
 {
+	parameters: { docs: { description: { story: "Long Dutch identity, provenance, transcript, and question content at the supported narrow viewport. It protects the audit trail and question meaning from truncation in localized or high-detail use." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -248,6 +264,7 @@ export const NarrowLongContent: Story =
 /** Authority-confirmed terminal state with no editable composer. */
 export const Completed: Story =
 {
+	parameters: { docs: { description: { story: "The terminal server-confirmed calibration state. The composer disappears, and the message distinguishes ordinary conversation evidence from an explicitly reviewed retained preference." } } },
 	tags: ["visual-test"],
 	args:
 	{
@@ -268,6 +285,7 @@ export const Completed: Story =
 /** Recoverable failure retains transcript and emits retry intent without local recovery logic. */
 export const Error: Story =
 {
+	parameters: { docs: { description: { story: "A recoverable authority failure that preserves the existing transcript and exposes retry intent. It never invents a recovery transition in the component itself." } } },
 	tags: ["visual-test"],
 	args:
 	{


### PR DESCRIPTION
## Summary

- Move all shared and onboarding Storybook fixtures into their owning component __tests__ directories.
- Restrict Storybook discovery and TypeScript inputs to those test-owned story locations.
- Document every catalogue state with its user outcome, component contract, and authority boundary.

## Validation

- Storybook build and browser interaction/accessibility suite passed.
- Style, module-growth, Prisma-boundary, and live stack-integrity checks passed.
- The review chain was revalidated after the merged foundation parent was retargeted to develop.

## Review order

1. #587 — governed persona onboarding (merged)
2. #588 — governed first-chat onboarding (merged)
3. #594 — Linux first-chat Finishing baselines
4. #589 — component-owned Storybook fixtures and documentation

## Scope

This PR contains only the incremental fixture relocation and documentation change.
