### PR TITLE
🐛 Repair GKE database-proof scheduling

### DIFF
--- a/apps/_infra/deploy-k8s/platform/README.md
+++ b/apps/_infra/deploy-k8s/platform/README.md
@@ -71,12 +71,11 @@ ingress Service reports the reserved address.
 The bootstrap also owns `opencrane-database-proof`, a GKE Autopilot ComputeClass used only by the
 short-lived PostgreSQL privilege-proof Job through `values/postgres-gke-autopilot.yaml`. Its explicit
 `ScaleUpAnyway` policy allows the proof to receive capacity when GKE system balloon Pods reserve all
-otherwise idle capacity. Its ten-GiB boot disk is the GKE minimum, sufficient for the Job's three
-one-GiB ephemeral-storage requests and small enough for the development SSD quota. It uses the
-two-vCPU, two-GiB `e2-small` machine type because GKE only permits an explicit boot disk with a
-machine type or family, not with a `podFamily`; this makes the node-based cost bounded to the
-short-lived proof Job. It does not change the Job's database grants, credentials, network path, or
-completion requirement.
+otherwise idle capacity. Its `general-purpose` pod family uses GKE's Autopilot container-optimized
+compute platform and pod-based billing; GKE manages the node shape and boot disk because explicit
+storage cannot be combined with this pod family. The Job retains its three one-GiB
+ephemeral-storage requests. The class does not change the Job's database grants, credentials,
+network path, or completion requirement.
 
 The pinned ingress-nginx release is accepted only for this single-silo development qualification.
 The upstream project is archived, so a supported ingress controller must replace it before a

--- a/apps/_infra/deploy-k8s/platform/bootstrap-prerequisites.sh
+++ b/apps/_infra/deploy-k8s/platform/bootstrap-prerequisites.sh
@@ -465,19 +465,17 @@ verify_prerequisites()
   wait_for_established_crds "${CERT_MANAGER_CLUSTER_RESOURCES[@]}"
   wait_for_established_crds "${CNPG_CLUSTER_RESOURCES[@]}"
   kubectl --context "$EXPECTED_CONTEXT" wait \
-    --for=condition=Health "computeclass/$DATABASE_PROOF_COMPUTE_CLASS" --timeout=2m
-  local scale_policy boot_disk_size machine_type
-  scale_policy="$(kubectl --context "$EXPECTED_CONTEXT" get "computeclass/$DATABASE_PROOF_COMPUTE_CLASS" \
-    --output=jsonpath='{.spec.whenUnsatisfiable}')"
-  [[ "$scale_policy" == "ScaleUpAnyway" ]] || fail \
-    "ComputeClass '$DATABASE_PROOF_COMPUTE_CLASS' has whenUnsatisfiable '$scale_policy', expected ScaleUpAnyway"
-  boot_disk_size="$(kubectl --context "$EXPECTED_CONTEXT" get "computeclass/$DATABASE_PROOF_COMPUTE_CLASS" \
-    --output=jsonpath='{.spec.priorities[0].storage.bootDiskSize}')"
-  [[ "$boot_disk_size" == "10" ]] || fail \
-    "ComputeClass '$DATABASE_PROOF_COMPUTE_CLASS' has bootDiskSize '$boot_disk_size', expected 10 GiB"
-  machine_type="$(kubectl --context "$EXPECTED_CONTEXT" get "computeclass/$DATABASE_PROOF_COMPUTE_CLASS" \
-    --output=jsonpath='{.spec.priorities[0].machineType}')"
-  [[ "$machine_type" == "e2-small" ]] || fail "ComputeClass '$DATABASE_PROOF_COMPUTE_CLASS' machineType '$machine_type', expected e2-small"
+    --for=condition=Health "computeclass/$DATABASE_PROOF_COMPUTE_CLASS" --timeout=2m || fail \
+    "ComputeClass '$DATABASE_PROOF_COMPUTE_CLASS' did not reach Health=True; inspect CrdMisconfigured"
+  local compute_class_json
+  compute_class_json="$(kubectl --context "$EXPECTED_CONTEXT" get \
+    "computeclass/$DATABASE_PROOF_COMPUTE_CLASS" --output=json)"
+  jq -e '(any(.status.conditions[]?; .type == "Health" and .status == "True"))
+    and (all(.status.conditions[]?; .type != "CrdMisconfigured" or .status != "True"))
+    and (.spec.autopilot.enabled == true) and (.spec.whenUnsatisfiable == "ScaleUpAnyway")
+    and (.spec.priorities == [{"podFamily":"general-purpose"}])' \
+    <<<"$compute_class_json" >/dev/null || fail \
+    "ComputeClass '$DATABASE_PROOF_COMPUTE_CLASS' does not match its healthy Autopilot database-proof contract"
   wait_for_ingress_address
 
   log "shared prerequisites are ready; ingress address: $INGRESS_ADDRESS_IP"

--- a/apps/_infra/deploy-k8s/platform/tests/bootstrap-prerequisites-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/bootstrap-prerequisites-contract.sh
@@ -69,12 +69,30 @@ case "$command_name" in
       if [[ "${MOCK_FOREIGN_COMPUTE_CLASS:-0}" != "1" && ! -e "$MOCK_MUTATED" ]]; then
         exit 1
       fi
+      if [[ "$*" == *"--output=json"* ]]; then
+        machine_type_json=""
+        [[ -z "${MOCK_COMPUTE_CLASS_MACHINE_TYPE:-}" ]] || \
+          machine_type_json=",\"machineType\":\"$MOCK_COMPUTE_CLASS_MACHINE_TYPE\""
+        storage_json=""
+        [[ "${MOCK_COMPUTE_CLASS_STORAGE_PRESENT:-0}" == "0" ]] || \
+          storage_json=',"storage":{"bootDiskType":"pd-balanced","bootDiskSize":10}'
+        extra_priority_json=""
+        [[ "${MOCK_COMPUTE_CLASS_PRIORITY_MARKERS:-x}" == "x" ]] || \
+          extra_priority_json=',{"podFamily":"general-purpose"}'
+        printf '{"spec":{"autopilot":{"enabled":%s},"whenUnsatisfiable":"%s","priorities":[{"podFamily":"%s"%s%s}%s]},"status":{"conditions":[{"type":"Health","status":"%s"},{"type":"CrdMisconfigured","status":"%s"}]}}\n' \
+          "${MOCK_COMPUTE_CLASS_AUTOPILOT_ENABLED:-true}" \
+          "${MOCK_COMPUTE_CLASS_SCALE_POLICY:-ScaleUpAnyway}" \
+          "${MOCK_COMPUTE_CLASS_POD_FAMILY:-general-purpose}" \
+          "$machine_type_json" \
+          "$storage_json" \
+          "$extra_priority_json" \
+          "${MOCK_COMPUTE_CLASS_HEALTH_STATUS:-True}" \
+          "${MOCK_COMPUTE_CLASS_MISCONFIGURED_STATUS:-False}"
+        exit
+      fi
       case "$*" in
         *"managed-by}"*) printf '%s' "${MOCK_COMPUTE_CLASS_MANAGED_BY:-foreign-manager}" ;;
         *"prerequisite-profile}"*) printf '%s' "${MOCK_COMPUTE_CLASS_PROFILE:-foreign-profile}" ;;
-        *"whenUnsatisfiable}"*) printf '%s' "${MOCK_COMPUTE_CLASS_SCALE_POLICY:-ScaleUpAnyway}" ;;
-        *"bootDiskSize}"*) printf '%s' "${MOCK_COMPUTE_CLASS_BOOT_DISK_SIZE:-10}" ;;
-        *"machineType}"*) printf '%s' "${MOCK_COMPUTE_CLASS_MACHINE_TYPE:-e2-small}" ;;
       esac
       exit
     fi
@@ -121,7 +139,8 @@ case "$command_name" in
       exit
     fi
     if [[ "$*" == *" wait --for=condition=Health computeclass/opencrane-database-proof"* ]]; then
-      [[ "${MOCK_COMPUTE_CLASS_HEALTH_FAIL:-0}" == "0" ]]
+      [[ "${MOCK_COMPUTE_CLASS_HEALTH_FAIL:-0}" == "0" \
+        && "${MOCK_COMPUTE_CLASS_HEALTH_STATUS:-True}" == "True" ]]
       exit
     fi
     if [[ "$*" == *" get ingressclass/nginx"* || "$*" == *" get crd/"* ]]; then
@@ -223,13 +242,34 @@ if run_case foreign-compute-class MOCK_FOREIGN_COMPUTE_CLASS=1; then
 fi
 ! grep -Fq 'helm upgrade' "$TEST_DIR/foreign-compute-class.calls"
 
-if run_case compute-class-disk-drift MOCK_COMPUTE_CLASS_BOOT_DISK_SIZE=20; then
-  echo 'ComputeClass boot-disk drift unexpectedly succeeded' >&2
+if run_case compute-class-storage-present MOCK_COMPUTE_CLASS_STORAGE_PRESENT=1; then
+  echo 'ComputeClass storage residue unexpectedly succeeded' >&2
   exit 1
 fi
 
-if run_case compute-class-machine-drift MOCK_COMPUTE_CLASS_MACHINE_TYPE=e2-medium; then
-  echo 'ComputeClass machine-type drift unexpectedly succeeded' >&2
+if run_case compute-class-pod-family-drift MOCK_COMPUTE_CLASS_POD_FAMILY=general-purpose-arm; then
+  echo 'ComputeClass pod-family drift unexpectedly succeeded' >&2
+  exit 1
+fi
+
+if run_case compute-class-extra-priority MOCK_COMPUTE_CLASS_PRIORITY_MARKERS=xx; then
+  echo 'ComputeClass extra priority unexpectedly succeeded' >&2
+  exit 1
+fi
+
+if run_case compute-class-machine-type-present MOCK_COMPUTE_CLASS_MACHINE_TYPE=e2-small; then
+  echo 'ComputeClass machineType residue unexpectedly succeeded' >&2
+  exit 1
+fi
+
+if run_case compute-class-health-failure MOCK_COMPUTE_CLASS_HEALTH_STATUS=False; then
+  echo 'unhealthy ComputeClass unexpectedly succeeded' >&2
+  exit 1
+fi
+
+if run_case compute-class-misconfigured \
+  MOCK_COMPUTE_CLASS_MISCONFIGURED_STATUS=True; then
+  echo 'misconfigured ComputeClass unexpectedly succeeded' >&2
   exit 1
 fi
 

--- a/apps/_infra/deploy-k8s/platform/values/prerequisites/gke-autopilot-dev/database-proof-compute-class.yaml
+++ b/apps/_infra/deploy-k8s/platform/values/prerequisites/gke-autopilot-dev/database-proof-compute-class.yaml
@@ -11,14 +11,8 @@ spec:
   autopilot:
     enabled: true
   priorities:
-    - machineType: e2-small
-      # The proof Job requests 3 GiB total ephemeral storage. Ten GiB is GKE's supported
-      # minimum boot disk and fits this short-lived node within the small dev SSD quota. A
-      # podFamily is intentionally not used: GKE permits boot-disk tuning only for a concrete
-      # machine type or family.
-      storage:
-        bootDiskType: pd-balanced
-        bootDiskSize: 10
+    - podFamily: general-purpose
+      # GKE manages the node shape and boot disk for this pod-based Autopilot family.
   # Unlike GKE's built-in autopilot ComputeClass, scale when the proof Job has no existing
   # placement. This class is selected only by that bounded, one-shot Job.
   whenUnsatisfiable: ScaleUpAnyway


### PR DESCRIPTION
## Summary

- replace the invalid E2 database-proof priority with GKE’s supported general-purpose Autopilot pod family
- fail prerequisite verification when the ComputeClass is unhealthy, misconfigured, or carries any unreviewed priority fields
- cover legacy machine, storage, extra-priority, unhealthy, and misconfigured drift
- align operator documentation with the provider-managed disk contract

## Review order

1. #587 — governed persona onboarding (merged)
2. #588 — governed first-chat onboarding (merged)
3. #594 — Linux first-chat Finishing baselines
4. #589 — component-owned Storybook fixtures and documentation
5. #590 — owner-supplied canvas-document visualisation
6. #591 — GKE database-proof scheduling repair

## Validation

- prerequisite bootstrap contract
- exact GKE 1.35.6 server-side dry-run (no mutation)
- Bash syntax and focused shell review
- agent style, Prisma boundary, module-growth, and diff checks

## Review

- first independent review blocked the mixed podFamily/storage manifest based on live admission evidence
- storage was removed and a second independent review passed with no findings
- post-rebase committed-range review passed with no findings

## Stack

- base: feat/canvas-document-contract / PR #590
- one linear prerequisite commit; deploy only after this PR’s exact change is applied through the app-owned bootstrap script
