### PR TITLE
🐛 Fix post-release database migration CI

### DIFF
--- a/apps/opencrane/prisma/migrations/tests/normalize-schema-dump.mjs
+++ b/apps/opencrane/prisma/migrations/tests/normalize-schema-dump.mjs
@@ -1,0 +1,140 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function _CompareEntries(left, right)
+{
+	if (left < right) return -1;
+	if (left > right) return 1;
+	return 0;
+}
+
+function _SplitTableEntries(body)
+{
+	const entries = [];
+	let current = "";
+	let depth = 0;
+	let quote = null;
+
+	for (let index = 0; index < body.length; index += 1)
+	{
+		const character = body[index];
+		const next = body[index + 1];
+		current += character;
+
+		if (quote === "single" || quote === "escape-single")
+		{
+			if (quote === "escape-single" && character === "\\" && next !== undefined)
+			{
+				current += next;
+				index += 1;
+			}
+			else if (character === "'" && next === "'")
+			{
+				current += next;
+				index += 1;
+			}
+			else if (character === "'") quote = null;
+			continue;
+		}
+		if (quote?.startsWith("$") === true)
+		{
+			if (body.startsWith(quote, index))
+			{
+				current += quote.slice(1);
+				index += quote.length - 1;
+				quote = null;
+			}
+			continue;
+		}
+		if (quote === "double")
+		{
+			if (character === '"' && next === '"')
+			{
+				current += next;
+				index += 1;
+			}
+			else if (character === '"') quote = null;
+			continue;
+		}
+		if (character === "'")
+		{
+			const prefix = body[index - 1];
+			const beforePrefix = body[index - 2];
+			const escapePrefix = (prefix === "E" || prefix === "e")
+				&& (beforePrefix === undefined || !/[A-Za-z0-9_$]/u.test(beforePrefix));
+			quote = escapePrefix ? "escape-single" : "single";
+			continue;
+		}
+		if (character === '"')
+		{
+			quote = "double";
+			continue;
+		}
+		if (character === "$")
+		{
+			const dollarQuote = body.slice(index).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/u)?.[0];
+			if (dollarQuote)
+			{
+				current += dollarQuote.slice(1);
+				index += dollarQuote.length - 1;
+				quote = dollarQuote;
+				continue;
+			}
+		}
+		if (character === "(") depth += 1;
+		else if (character === ")") depth -= 1;
+		else if (character === "," && depth === 0)
+		{
+			entries.push(current.slice(0, -1).trim());
+			current = "";
+		}
+	}
+
+	if (quote !== null || depth !== 0) throw new Error("unbalanced CREATE TABLE definition in schema dump");
+	if (current.trim()) entries.push(current.trim());
+	return entries;
+}
+
+/** Sort CREATE TABLE clauses so semantically irrelevant PostgreSQL column order does not hide real drift. */
+export function normalizeSchemaDump(dump)
+{
+	const lines = dump.split("\n");
+	const normalized = [];
+
+	for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1)
+	{
+		const line = lines[lineIndex];
+		if (!/^CREATE TABLE .+ \($/u.test(line))
+		{
+			normalized.push(line);
+			continue;
+		}
+
+		const body = [];
+		normalized.push(line);
+		lineIndex += 1;
+		while (lineIndex < lines.length && lines[lineIndex] !== ");")
+		{
+			body.push(lines[lineIndex]);
+			lineIndex += 1;
+		}
+		if (lineIndex >= lines.length) throw new Error(`unterminated CREATE TABLE block: ${line}`);
+
+		const entries = _SplitTableEntries(body.join("\n")).sort(_CompareEntries);
+		for (const [entryIndex, entry] of entries.entries())
+		{
+			const suffix = entryIndex === entries.length - 1 ? "" : ",";
+			normalized.push(`    ${entry}${suffix}`);
+		}
+		normalized.push(");");
+	}
+
+	return normalized.join("\n");
+}
+
+const modulePath = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === modulePath)
+{
+	process.stdout.write(normalizeSchemaDump(readFileSync(0, "utf8")));
+}

--- a/apps/opencrane/prisma/migrations/tests/verify-contract.mjs
+++ b/apps/opencrane/prisma/migrations/tests/verify-contract.mjs
@@ -1,7 +1,9 @@
+import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { normalizeSchemaDump } from "./normalize-schema-dump.mjs";
 
 const migrationRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const transitionRoot = join(migrationRoot, "0.7.0-to-0.8.0");
@@ -15,6 +17,28 @@ function requireContract(condition, message)
 {
 	if (!condition) throw new Error(message);
 }
+
+const reorderedTable = String.raw`CREATE TABLE public.example (
+    "second" text NOT NULL,
+    "first" text DEFAULT $value$a,b$value$ NOT NULL,
+    "regular_backslash" text DEFAULT '\'::text,
+    "escaped_quote" text DEFAULT E'one\'two,three'::text,
+    CONSTRAINT example_check CHECK (("second" <> ','::text))
+);
+`;
+const canonicalTable = String.raw`CREATE TABLE public.example (
+    CONSTRAINT example_check CHECK (("second" <> ','::text)),
+    "escaped_quote" text DEFAULT E'one\'two,three'::text,
+    "first" text DEFAULT $value$a,b$value$ NOT NULL,
+    "regular_backslash" text DEFAULT '\'::text,
+    "second" text NOT NULL
+);
+`;
+assert.equal(normalizeSchemaDump(reorderedTable), normalizeSchemaDump(canonicalTable));
+assert.notEqual(
+	normalizeSchemaDump(reorderedTable),
+	normalizeSchemaDump(canonicalTable.replace("DEFAULT $value$a,b$value$", "DEFAULT $value$a,c$value$")),
+);
 
 requireContract(manifest.fromSchemaVersion === "0.7.0", "migration source version must remain exact");
 requireContract(manifest.toSchemaVersion === "0.8.0", "migration target version must remain exact");

--- a/apps/opencrane/prisma/migrations/tests/verify-postgres.sh
+++ b/apps/opencrane/prisma/migrations/tests/verify-postgres.sh
@@ -68,7 +68,9 @@ for database in migrated fresh; do
 	docker exec "$CONTAINER" pg_dump --username postgres --dbname "$database" \
 		--schema-only --no-owner --no-privileges \
 		--exclude-schema opencrane_bootstrap --exclude-schema opencrane_migrations \
-		| sed -E '/^\\(un)?restrict /d' >"$WORK_DIR/$database-schema.sql"
+		| sed -E '/^\\(un)?restrict /d' \
+		| node "$ROOT/apps/opencrane/prisma/migrations/tests/normalize-schema-dump.mjs" \
+		>"$WORK_DIR/$database-schema.sql"
 done
 diff --unified "$WORK_DIR/fresh-schema.sql" "$WORK_DIR/migrated-schema.sql"
 

--- a/scripts/__tests__/release-versioning-check.test.mjs
+++ b/scripts/__tests__/release-versioning-check.test.mjs
@@ -438,6 +438,25 @@ test("allows a newly introduced historical adoption manifest", async () =>
 	assert.deepEqual(await validateWorkspace(fixture.root, [file], fixture.graph, [], [file]), []);
 });
 
+test("accepts an unchanged adoption manifest from the cumulative release-train diff", async () =>
+{
+	const fixture = _Fixture({
+		repositoryVersion: "0.8.0",
+		previousRepositoryVersion: "0.7.0",
+		adaptedVersion: "0.8.0",
+	});
+	_WriteDatabaseMigration(fixture.root, "0.7.0", "0.8.0");
+	assert.deepEqual(await validateWorkspace(
+		fixture.root,
+		["releases/0.7.0.json"],
+		fixture.graph,
+		[],
+		[],
+		null,
+		[],
+	), []);
+});
+
 test("rejects an unrelated newly introduced historical manifest", async () =>
 {
 	const fixture = _Fixture({

--- a/scripts/release-versioning-check.mjs
+++ b/scripts/release-versioning-check.mjs
@@ -90,6 +90,7 @@ const releaseManifest = JSON.parse(readFileSync(join(repositoryRoot, "releases",
 const versionBase = releaseManifest.previousRepositoryVersion;
 if (versionBase) _GitFiles(["rev-parse", "--verify", `${versionBase}^{commit}`]);
 const releaseTag = _ExistingReleaseTag(rootVersion);
+const directChangedFiles = _ChangedFiles([base, releaseTag].filter(Boolean));
 const changedFiles = _ChangedFiles([...new Set([base, versionBase, releaseTag].filter(Boolean))]);
 const newFiles = changedFiles.filter((file) => _BaseText(base, file) === null);
 const errors = await validateWorkspace(
@@ -99,6 +100,7 @@ const errors = await validateWorkspace(
 	_StampOnlyFiles(repositoryRoot, versionBase ?? base, changedFiles),
 	newFiles,
 	releaseTag,
+	directChangedFiles,
 );
 if (errors.length > 0)
 {

--- a/scripts/release-versioning/core.mjs
+++ b/scripts/release-versioning/core.mjs
@@ -201,6 +201,7 @@ export async function validateWorkspace(
 	suppliedStampOnlyFiles = [],
 	suppliedNewFiles = [],
 	releasedVersionTag = null,
+	suppliedDirectChangedFiles = changedFiles,
 )
 {
 	const rootVersion = readJson(join(repositoryRoot, "package.json")).version;
@@ -213,6 +214,7 @@ export async function validateWorkspace(
 	errors.push(...validateReleaseManifest(manifest));
 	const stampOnlyFiles = new Set(suppliedStampOnlyFiles);
 	const newFiles = new Set(suppliedNewFiles);
+	const directChangedFiles = new Set(suppliedDirectChangedFiles);
 	if (releasedVersionTag)
 	{
 		const compositionChanged = changedFiles.some((file) =>
@@ -227,6 +229,7 @@ export async function validateWorkspace(
 	{
 		const changedManifestVersion = /^releases\/(?<version>\d+\.\d+\.\d+)\.json$/u.exec(file)?.groups?.version;
 		if (!changedManifestVersion || changedManifestVersion === rootVersion) continue;
+		if (!directChangedFiles.has(file)) continue;
 		if (!newFiles.has(file))
 		{
 			errors.push(`release manifest '${changedManifestVersion}' is immutable; create '${rootVersion}' instead`);


### PR DESCRIPTION
## Summary

- normalize only top-level `CREATE TABLE` clause ordering before comparing fresh and migrated PostgreSQL schemas, while preserving every definition and all remaining dump content
- cover standard strings, PostgreSQL escape strings, dollar quoting, nested commas, reordered clauses, and real definition drift
- separate direct PR changes from the cumulative release-train diff so an unchanged adoption manifest remains valid after the 0.8 release has landed, while direct rewrites still fail

## Context

PR #595 is merged into `develop` and carried the complete #596 head. #596 was therefore closed as superseded. This PR contains the only work that was not yet merged and targets `develop` directly.

## Validation

- database migration contract: PASS
- release-versioning tests: 38/38 PASS
- release-versioning check against `origin/develop`: PASS
- Bash syntax and diff checks: PASS
- independent focused review: PASS, no findings

The Docker-backed PostgreSQL convergence job is intentionally left to CI because no local Docker daemon is available.
