### PR TITLE
🐛 Preserve deployment recovery under Bash 5

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -302,6 +302,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      # The production deploy wrapper resolves and schema-validates the database transition before
+      # it mutates the cluster. The smoke job is a fresh checkout, so restore the same exact
+      # lockfile-bound runtime dependencies that the prepare and test jobs use.
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}
+
+      - name: Install deploy validation dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
       - name: Install k3d
         env:
           K3D_VERSION: v5.8.3

--- a/apps/_infra/deploy-k8s/platform/database-migration-orchestrator.sh
+++ b/apps/_infra/deploy-k8s/platform/database-migration-orchestrator.sh
@@ -76,63 +76,70 @@ install_postgres_release()
   build_postgres_release_args "$migration_enabled" "$privileges_enabled"
 
   log "Reconciling PostgreSQL server while preserving bootstrap origin '$POSTGRES_BOOTSTRAP_BASELINE_CONFIG_MAP'…"
-  set +e
-  helm "${POSTGRES_ARGS[@]}"
-  command_status=$?
-  set -e
+  if helm "${POSTGRES_ARGS[@]}"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "PostgreSQL Helm reconciliation failed."
     return "$command_status"
   fi
-  set +e
-  kubectl wait --for=condition=Ready "cluster/${POSTGRES_RELEASE}" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
-  command_status=$?
-  set -e
+  if kubectl wait --for=condition=Ready "cluster/${POSTGRES_RELEASE}" -n "$NAMESPACE" --timeout="${TIMEOUT}s"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "PostgreSQL Cluster did not become Ready."
     return "$command_status"
   fi
-  set +e
-  kubectl wait --for=create "deployment/${POSTGRES_RELEASE}-pooler" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
-  command_status=$?
-  set -e
+  if kubectl wait --for=create "deployment/${POSTGRES_RELEASE}-pooler" -n "$NAMESPACE" --timeout="${TIMEOUT}s"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "PostgreSQL pooler Deployment was not created."
     return "$command_status"
   fi
-  set +e
-  kubectl wait --for=condition=available "deployment/${POSTGRES_RELEASE}-pooler" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
-  command_status=$?
-  set -e
+  if kubectl wait --for=condition=available "deployment/${POSTGRES_RELEASE}-pooler" -n "$NAMESPACE" --timeout="${TIMEOUT}s"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "PostgreSQL pooler Deployment did not become Available."
     return "$command_status"
   fi
   for database_resource in "${POSTGRES_RELEASE}-obot" "${POSTGRES_RELEASE}-litellm"; do
-    set +e
-    kubectl wait --for=jsonpath='{.status.applied}'=true "database/${database_resource}" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
-    command_status=$?
-    set -e
+    if kubectl wait --for=jsonpath='{.status.applied}'=true "database/${database_resource}" -n "$NAMESPACE" --timeout="${TIMEOUT}s"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Database resource '$database_resource' was not applied."
       return "$command_status"
     fi
   done
   if [[ "$migration_enabled" == "true" ]]; then
-    set +e
-    kubectl wait --for=condition=complete "job/${POSTGRES_RELEASE}-database-migration" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
-    command_status=$?
-    set -e
+    if kubectl wait --for=condition=complete "job/${POSTGRES_RELEASE}-database-migration" -n "$NAMESPACE" --timeout="${TIMEOUT}s"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Database migration Job did not complete."
       return "$command_status"
     fi
   fi
   if [[ "$privileges_enabled" == "true" ]]; then
-    set +e
-    kubectl wait --for=condition=complete "job/${POSTGRES_RELEASE}-database-privileges" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
-    command_status=$?
-    set -e
+    if kubectl wait --for=condition=complete "job/${POSTGRES_RELEASE}-database-privileges" -n "$NAMESPACE" --timeout="${TIMEOUT}s"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Database privilege Job did not complete."
       return "$command_status"
@@ -143,10 +150,11 @@ install_postgres_release()
 classify_database_convergence_state()
 {
   local classification_status classification_output
-  set +e
-  classification_output="$(set -e; classify_live_database_convergence)"
-  classification_status=$?
-  set -e
+  if classification_output="$(classify_live_database_convergence)"; then
+    classification_status=0
+  else
+    classification_status=$?
+  fi
   if (( classification_status != 0 )); then
     err "Unable to read unambiguous live database convergence evidence."
     return "$classification_status"
@@ -162,12 +170,13 @@ publish_database_migration_config_map()
 {
   local publisher_status
   local published_config_map
-  set +e
-  published_config_map="$(bash "$POSTGRES_MIGRATION_PUBLISHER" \
+  if published_config_map="$(bash "$POSTGRES_MIGRATION_PUBLISHER" \
     "$NAMESPACE" "$DATABASE_PREVIOUS_MIGRATION_ID" "$DATABASE_MIGRATION_SQL_FILE" \
-    "$DATABASE_PREVIOUS_MIGRATION_SQL_SHA256")"
-  publisher_status=$?
-  set -e
+    "$DATABASE_PREVIOUS_MIGRATION_SQL_SHA256")"; then
+    publisher_status=0
+  else
+    publisher_status=$?
+  fi
   if (( publisher_status != 0 )); then
     err "Unable to publish the exact reviewed database migration SQL."
     return "$publisher_status"
@@ -186,15 +195,17 @@ adopt_matching_existing_database_fence()
   local listed_releases
   local release_values
   local release_status
-  set +e
-  release_status="$(helm status "$RELEASE" -n "$NAMESPACE" -o json)"
-  command_status=$?
-  set -e
-  if (( command_status != 0 )); then
-    set +e
-    listed_releases="$(helm list --namespace "$NAMESPACE" --filter "^${RELEASE}$" --output json)"
+  if release_status="$(helm status "$RELEASE" -n "$NAMESPACE" -o json)"; then
+    command_status=0
+  else
     command_status=$?
-    set -e
+  fi
+  if (( command_status != 0 )); then
+    if listed_releases="$(helm list --namespace "$NAMESPACE" --filter "^${RELEASE}$" --output json)"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to determine whether a persisted database migration fence exists."
       return "$command_status"
@@ -205,10 +216,11 @@ adopt_matching_existing_database_fence()
     fi
     return 0
   fi
-  set +e
-  release_values="$(helm get values "$RELEASE" -n "$NAMESPACE" -o json)"
-  command_status=$?
-  set -e
+  if release_values="$(helm get values "$RELEASE" -n "$NAMESPACE" -o json)"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "Unable to read a possible persisted database migration fence."
     return "$command_status"
@@ -253,18 +265,20 @@ run_database_release_transition()
   fi
 
   if [[ "$POSTGRES_CLUSTER_EXISTS" == "1" ]]; then
-    set +e
-    classify_database_convergence_state
-    classification_status=$?
-    set -e
+    if classify_database_convergence_state; then
+      classification_status=0
+    else
+      classification_status=$?
+    fi
     if (( classification_status != 0 )); then
       return "$classification_status"
     fi
-    set +e
-    convergence_outcome="$(resolve_database_convergence_outcome live_transition \
-      "$DATABASE_LIVE_CONVERGENCE_STATE")"
-    policy_status=$?
-    set -e
+    if convergence_outcome="$(resolve_database_convergence_outcome live_transition \
+      "$DATABASE_LIVE_CONVERGENCE_STATE")"; then
+      policy_status=0
+    else
+      policy_status=$?
+    fi
     if (( policy_status != 0 )); then
       err "Database convergence policy rejected the live transition state."
       return "$policy_status"
@@ -296,19 +310,21 @@ run_database_release_transition()
     log "Restoring the previous-version database before its bounded migration…"
     run_guarded_post_fence_stage install_postgres_release false false || return $?
     POSTGRES_CLUSTER_EXISTS="1"
-    set +e
-    classify_database_convergence_state
-    classification_status=$?
-    set -e
+    if classify_database_convergence_state; then
+      classification_status=0
+    else
+      classification_status=$?
+    fi
     if (( classification_status != 0 )); then
       recover_failed_database_transition "$classification_status"
       return $?
     fi
-    set +e
-    convergence_outcome="$(resolve_database_convergence_outcome recovered_transition \
-      "$DATABASE_LIVE_CONVERGENCE_STATE")"
-    policy_status=$?
-    set -e
+    if convergence_outcome="$(resolve_database_convergence_outcome recovered_transition \
+      "$DATABASE_LIVE_CONVERGENCE_STATE")"; then
+      policy_status=0
+    else
+      policy_status=$?
+    fi
     if (( policy_status != 0 )); then
       err "Database convergence policy rejected the recovered transition state."
       return "$policy_status"
@@ -332,16 +348,18 @@ run_database_release_transition()
         ;;
     esac
   fi
-  set +e
-  backup_evidence="$(bash "$POSTGRES_MIGRATION_BACKUP" \
-    "$NAMESPACE" "$POSTGRES_RELEASE" "$TIMEOUT")"
-  backup_status=$?
-  set -e
-  if (( backup_status != 0 )); then
-    set +e
-    recover_failed_database_transition "$backup_status"
+  if backup_evidence="$(bash "$POSTGRES_MIGRATION_BACKUP" \
+    "$NAMESPACE" "$POSTGRES_RELEASE" "$TIMEOUT")"; then
+    backup_status=0
+  else
     backup_status=$?
-    set -e
+  fi
+  if (( backup_status != 0 )); then
+    if recover_failed_database_transition "$backup_status"; then
+      backup_status=0
+    else
+      backup_status=$?
+    fi
     return "$backup_status"
   fi
   log "CNPG recovery evidence completed before migration: $backup_evidence"

--- a/apps/_infra/deploy-k8s/platform/database-migration-recovery.sh
+++ b/apps/_infra/deploy-k8s/platform/database-migration-recovery.sh
@@ -9,10 +9,11 @@ capture_recovery_command_output()
   local command_output
   local command_status
   shift
-  set +e
-  command_output="$("$@")"
-  command_status=$?
-  set -e
+  if command_output="$("$@")"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   printf -v "$output_name" '%s' "$command_output"
   return "$command_status"
 }
@@ -22,10 +23,11 @@ capture_pre_fence_main_release_revision()
   local listed_releases
   local release_status
   local status_result
-  set +e
-  release_status="$(helm status "$RELEASE" -n "$NAMESPACE" -o json)"
-  status_result=$?
-  set -e
+  if release_status="$(helm status "$RELEASE" -n "$NAMESPACE" -o json)"; then
+    status_result=0
+  else
+    status_result=$?
+  fi
   if (( status_result != 0 )); then
     if ! listed_releases="$(helm list --namespace "$NAMESPACE" --filter "^${RELEASE}$" --output json)"; then
       err "Unable to determine whether an OpenCrane Helm release exists before migration."
@@ -106,8 +108,7 @@ fence_existing_opencrane_server()
     return 1
   fi
   log "Fencing the existing OpenCrane server through its Helm release before database mutation…"
-  set +e
-  helm upgrade "$RELEASE" "$CHART_DIR" \
+  if helm upgrade "$RELEASE" "$CHART_DIR" \
     --namespace "$NAMESPACE" \
     --force-conflicts \
     --reuse-values \
@@ -117,18 +118,21 @@ fence_existing_opencrane_server()
     --set-string migrationFence.fromReleaseVersion="$FROM_RELEASE_VERSION" \
     --set-string migrationFence.toReleaseVersion="$RELEASE_VERSION" \
     --wait \
-    --timeout "${TIMEOUT}s"
-  command_status=$?
-  set -e
+    --timeout "${TIMEOUT}s"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "OpenCrane server Helm fence failed."
     return "$command_status"
   fi
-  set +e
-  capture_recovery_command_output server_deployment_inventory kubectl get deployment "$server_deployment" \
-    -n "$NAMESPACE" --ignore-not-found -o name
-  command_status=$?
-  set -e
+  if capture_recovery_command_output server_deployment_inventory kubectl get deployment "$server_deployment" \
+    -n "$NAMESPACE" --ignore-not-found -o name; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "Unable to read the fenced OpenCrane server deployment."
     return "$command_status"
@@ -137,11 +141,12 @@ fence_existing_opencrane_server()
     err "Helm release '$RELEASE' exists but its server deployment is absent after fencing."
     return 1
   fi
-  set +e
-  capture_recovery_command_output deployment_uid kubectl get deployment "$server_deployment" \
-    -n "$NAMESPACE" -o jsonpath='{.metadata.uid}'
-  command_status=$?
-  set -e
+  if capture_recovery_command_output deployment_uid kubectl get deployment "$server_deployment" \
+    -n "$NAMESPACE" -o jsonpath='{.metadata.uid}'; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "Unable to read the fenced OpenCrane server Deployment UID."
     return "$command_status"
@@ -149,78 +154,86 @@ fence_existing_opencrane_server()
   [[ -n "$deployment_uid" ]] || { err "Fenced OpenCrane server deployment has no readable UID."; return 1; }
   fence_deadline="$(( $(date +%s) + TIMEOUT ))"
   while true; do
-    set +e
-    capture_recovery_command_output desired_replicas kubectl get deployment "$server_deployment" \
-      -n "$NAMESPACE" -o jsonpath='{.spec.replicas}'
-    command_status=$?
-    set -e
+    if capture_recovery_command_output desired_replicas kubectl get deployment "$server_deployment" \
+      -n "$NAMESPACE" -o jsonpath='{.spec.replicas}'; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to read the fenced OpenCrane server desired replicas."
       return "$command_status"
     fi
-    set +e
-    capture_recovery_command_output live_replicas kubectl get deployment "$server_deployment" \
-      -n "$NAMESPACE" -o jsonpath='{.status.replicas}'
-    command_status=$?
-    set -e
+    if capture_recovery_command_output live_replicas kubectl get deployment "$server_deployment" \
+      -n "$NAMESPACE" -o jsonpath='{.status.replicas}'; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to read the fenced OpenCrane server live replicas."
       return "$command_status"
     fi
-    set +e
-    capture_recovery_command_output server_pod_inventory kubectl get pods -n "$NAMESPACE" \
-      --selector "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=opencrane-server" -o json
-    command_status=$?
-    set -e
+    if capture_recovery_command_output server_pod_inventory kubectl get pods -n "$NAMESPACE" \
+      --selector "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=opencrane-server" -o json; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to inventory OpenCrane server pods after fencing."
       return "$command_status"
     fi
-    set +e
-    capture_recovery_command_output server_replica_set_inventory kubectl get replicasets -n "$NAMESPACE" \
-      --selector "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=opencrane-server" -o json
-    command_status=$?
-    set -e
+    if capture_recovery_command_output server_replica_set_inventory kubectl get replicasets -n "$NAMESPACE" \
+      --selector "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=opencrane-server" -o json; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to inventory OpenCrane server replica sets after fencing."
       return "$command_status"
     fi
-    set +e
-    capture_recovery_command_output server_job_inventory kubectl get jobs -n "$NAMESPACE" \
-      --selector "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=opencrane-server" -o json
-    command_status=$?
-    set -e
+    if capture_recovery_command_output server_job_inventory kubectl get jobs -n "$NAMESPACE" \
+      --selector "app.kubernetes.io/instance=${RELEASE},app.kubernetes.io/component=opencrane-server" -o json; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to inventory OpenCrane server jobs after fencing."
       return "$command_status"
     fi
-    set +e
-    jq -e --arg deployment_uid "$deployment_uid" '
+    if jq -e --arg deployment_uid "$deployment_uid" '
       .items | all(
         (.spec.replicas // 0) == 0
         and any(.metadata.ownerReferences[]?; .kind == "Deployment" and .uid == $deployment_uid)
       )
-    ' <<<"$server_replica_set_inventory" >/dev/null
-    command_status=$?
-    set -e
+    ' <<<"$server_replica_set_inventory" >/dev/null; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "A server replica set is foreign-owned or remains scaled above zero after fencing."
       return "$command_status"
     fi
-    set +e
-    active_pod_count="$(jq -er '[.items[] | select(.status.phase == "Pending" or .status.phase == "Running" or .status.phase == "Unknown")] | length' \
-      <<<"$server_pod_inventory")"
-    command_status=$?
-    set -e
+    if active_pod_count="$(jq -er '[.items[] | select(.status.phase == "Pending" or .status.phase == "Running" or .status.phase == "Unknown")] | length' \
+      <<<"$server_pod_inventory")"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to classify OpenCrane server pod activity after fencing."
       return "$command_status"
     fi
-    set +e
-    nonterminal_job_count="$(jq -er '[.items[] | select(all(.status.conditions[]?; .type != "Complete" and .type != "Failed"))] | length' \
-      <<<"$server_job_inventory")"
-    command_status=$?
-    set -e
+    if nonterminal_job_count="$(jq -er '[.items[] | select(all(.status.conditions[]?; .type != "Complete" and .type != "Failed"))] | length' \
+      <<<"$server_job_inventory")"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to classify OpenCrane server Job activity after fencing."
       return "$command_status"
@@ -241,11 +254,12 @@ database_migration_job_is_terminal_or_absent()
 {
   local command_status
   local migration_job
-  set +e
-  capture_recovery_command_output migration_job kubectl get job "${POSTGRES_RELEASE}-database-migration" \
-    -n "$NAMESPACE" --ignore-not-found -o json
-  command_status=$?
-  set -e
+  if capture_recovery_command_output migration_job kubectl get job "${POSTGRES_RELEASE}-database-migration" \
+    -n "$NAMESPACE" --ignore-not-found -o json; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "Unable to determine whether the database migration Job is still active."
     return "$command_status"
@@ -271,27 +285,30 @@ recover_failed_database_transition()
   local classification_status
   local convergence_outcome
   local policy_status
-  set +e
-  database_migration_job_is_terminal_or_absent
-  job_status=$?
-  set -e
+  if database_migration_job_is_terminal_or_absent; then
+    job_status=0
+  else
+    job_status=$?
+  fi
   if (( job_status != 0 )); then
     return "$original_status"
   fi
 
-  set +e
-  classify_database_convergence_state
-  classification_status=$?
-  set -e
+  if classify_database_convergence_state; then
+    classification_status=0
+  else
+    classification_status=$?
+  fi
   if (( classification_status != 0 )); then
     err "Database state could not be reclassified after failure; the server fence remains active."
     return "$original_status"
   fi
-  set +e
-  convergence_outcome="$(resolve_database_convergence_outcome failed_transition \
-    "$DATABASE_LIVE_CONVERGENCE_STATE")"
-  policy_status=$?
-  set -e
+  if convergence_outcome="$(resolve_database_convergence_outcome failed_transition \
+    "$DATABASE_LIVE_CONVERGENCE_STATE")"; then
+    policy_status=0
+  else
+    policy_status=$?
+  fi
   if (( policy_status != 0 )); then
     err "Database convergence policy rejected the post-failure state; the server fence remains active."
     return "$original_status"
@@ -326,10 +343,11 @@ recover_failed_database_transition()
 run_guarded_post_fence_stage()
 {
   local stage_status
-  set +e
-  "$@"
-  stage_status=$?
-  set -e
+  if "$@"; then
+    stage_status=0
+  else
+    stage_status=$?
+  fi
   if (( stage_status == 0 )); then
     return 0
   fi

--- a/apps/_infra/deploy-k8s/platform/database-release-finalization.sh
+++ b/apps/_infra/deploy-k8s/platform/database-release-finalization.sh
@@ -7,10 +7,11 @@ capture_fenced_main_release_revision()
 {
   local fenced_release_status
   local status_result
-  set +e
-  fenced_release_status="$(helm status "$RELEASE" -n "$NAMESPACE" -o json)"
-  status_result=$?
-  set -e
+  if fenced_release_status="$(helm status "$RELEASE" -n "$NAMESPACE" -o json)"; then
+    status_result=0
+  else
+    status_result=$?
+  fi
   if (( status_result != 0 )); then
     err "Unable to read the fenced OpenCrane Helm release before final application transition."
     return "$status_result"
@@ -27,14 +28,15 @@ restore_fenced_release_after_finalization_failure()
   local original_status="$1"
   local rollback_status
   err "Final OpenCrane application transition failed; restoring the exact fenced release revision."
-  set +e
-  helm rollback "$RELEASE" "$DATABASE_FENCED_RELEASE_REVISION" \
+  if helm rollback "$RELEASE" "$DATABASE_FENCED_RELEASE_REVISION" \
     --namespace "$NAMESPACE" \
     --wait \
     --timeout "${TIMEOUT}s" \
-    --force-conflicts
-  rollback_status=$?
-  set -e
+    --force-conflicts; then
+    rollback_status=0
+  else
+    rollback_status=$?
+  fi
   if (( rollback_status != 0 )); then
     err "Rollback to fenced Helm revision '$DATABASE_FENCED_RELEASE_REVISION' failed; manual fence verification is required."
   fi
@@ -44,10 +46,11 @@ restore_fenced_release_after_finalization_failure()
 run_fenced_finalization_stage()
 {
   local stage_status
-  set +e
-  (set -e; "$@")
-  stage_status=$?
-  set -e
+  if "$@"; then
+    stage_status=0
+  else
+    stage_status=$?
+  fi
   if (( stage_status == 0 )); then
     return 0
   fi
@@ -60,7 +63,7 @@ run_opencrane_finalization_stage()
     run_fenced_finalization_stage "$@"
     return
   fi
-  (set -e; "$@")
+  "$@"
 }
 
 restart_database_consumers_for_finalization()
@@ -72,19 +75,21 @@ restart_database_consumers_for_finalization()
   local deployment_resource
   shift 2
   for deployment in "$@"; do
-    set +e
-    deployment_resource="$(kubectl get "deployment/$deployment" -n "$namespace" --ignore-not-found -o name)"
-    command_status=$?
-    set -e
+    if deployment_resource="$(kubectl get "deployment/$deployment" -n "$namespace" --ignore-not-found -o name)"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to inventory database consumer Deployment '$deployment' before restart."
       return "$command_status"
     fi
     if [[ -n "$deployment_resource" ]]; then
-      set +e
-      kubectl rollout restart "deployment/$deployment" -n "$namespace"
-      command_status=$?
-      set -e
+      if kubectl rollout restart "deployment/$deployment" -n "$namespace"; then
+        command_status=0
+      else
+        command_status=$?
+      fi
       if (( command_status != 0 )); then
         err "Unable to restart database consumer Deployment '$deployment'."
         return "$command_status"
@@ -92,19 +97,21 @@ restart_database_consumers_for_finalization()
     fi
   done
   for deployment in "$@"; do
-    set +e
-    deployment_resource="$(kubectl get "deployment/$deployment" -n "$namespace" --ignore-not-found -o name)"
-    command_status=$?
-    set -e
+    if deployment_resource="$(kubectl get "deployment/$deployment" -n "$namespace" --ignore-not-found -o name)"; then
+      command_status=0
+    else
+      command_status=$?
+    fi
     if (( command_status != 0 )); then
       err "Unable to inventory database consumer Deployment '$deployment' after restart."
       return "$command_status"
     fi
     if [[ -n "$deployment_resource" ]]; then
-      set +e
-      kubectl rollout status "deployment/$deployment" -n "$namespace" --timeout="${timeout}s"
-      command_status=$?
-      set -e
+      if kubectl rollout status "deployment/$deployment" -n "$namespace" --timeout="${timeout}s"; then
+        command_status=0
+      else
+        command_status=$?
+      fi
       if (( command_status != 0 )); then
         err "Database consumer Deployment '$deployment' did not complete its restart."
         return "$command_status"
@@ -118,10 +125,11 @@ wait_for_final_deployment_if_present()
   local deployment="$1"
   local command_status
   local deployment_resource
-  set +e
-  deployment_resource="$(kubectl get "deployment/$deployment" -n "$NAMESPACE" --ignore-not-found -o name)"
-  command_status=$?
-  set -e
+  if deployment_resource="$(kubectl get "deployment/$deployment" -n "$NAMESPACE" --ignore-not-found -o name)"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "Unable to inventory final Deployment '$deployment'."
     return "$command_status"
@@ -129,10 +137,11 @@ wait_for_final_deployment_if_present()
   if [[ -z "$deployment_resource" ]]; then
     return 0
   fi
-  set +e
-  kubectl rollout status "deployment/$deployment" -n "$NAMESPACE" --timeout="${TIMEOUT}s"
-  command_status=$?
-  set -e
+  if kubectl rollout status "deployment/$deployment" -n "$NAMESPACE" --timeout="${TIMEOUT}s"; then
+    command_status=0
+  else
+    command_status=$?
+  fi
   if (( command_status != 0 )); then
     err "Final Deployment '$deployment' did not complete its rollout."
     return "$command_status"

--- a/apps/_infra/deploy-k8s/platform/tests/database-migration-deploy-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/database-migration-deploy-contract.sh
@@ -53,6 +53,11 @@ grep -q 'install_postgres_release false false' "$ORCHESTRATOR"
 grep -q 'install_postgres_release true true' "$ORCHESTRATOR"
 grep -q -- '--set "migration.enabled=$migration_enabled"' "$ORCHESTRATOR"
 grep -q -- '--set "privileges.enabled=$privileges_enabled"' "$ORCHESTRATOR"
+if rg -n '^[[:space:]]*set[[:space:]]+[-+]e([[:space:];]|$)' \
+  "$ORCHESTRATOR" "$RECOVERY" "$FINALIZATION"; then
+  echo "database transition modules must not mutate their caller's errexit option" >&2
+  exit 1
+fi
 
 # The deploy timeout is the single operator-owned budget. Both Helm hook Jobs inherit it, while
 # Helm receives the Job deadline grace plus a final status-propagation margin. This prevents
@@ -418,7 +423,6 @@ done
 
 STATE_CALLS="$TEST_DIR/unreadable.calls"
 export STATE_CALLS
-set +e
 (
   source "$RECOVERY"
   source "$ORCHESTRATOR"
@@ -429,12 +433,17 @@ set +e
   fence_existing_opencrane_server() { printf '%s\n' fence >>"$STATE_CALLS"; }
   log() { :; }
   err() { :; }
-  run_database_release_transition
+  [[ "$-" == *e* ]]
+  if run_database_release_transition; then
+    echo "unreadable live convergence evidence unexpectedly succeeded" >&2
+    exit 1
+  else
+    unreadable_status=$?
+  fi
+  [[ "$-" == *e* ]]
+  [[ "$unreadable_status" == "19" ]]
+  [[ ! -s "$STATE_CALLS" ]]
 )
-unreadable_status=$?
-set -e
-[[ "$unreadable_status" == "19" ]]
-[[ ! -s "$STATE_CALLS" ]]
 
 # Exercise the successful live-source branch through its public orchestration function. This proves
 # classification -> exact SQL publication -> revision capture -> fence -> backup -> migration.
@@ -566,7 +575,6 @@ done
 # Unreadable recovery evidence leaves the fence active and does not mask the original status.
 RECOVERY_CALLS="$TEST_DIR/recovery-unreadable.calls"
 export RECOVERY_CALLS
-set +e
 (
   source "$RECOVERY"
   source "$ORCHESTRATOR"
@@ -575,12 +583,17 @@ set +e
   helm() { printf 'helm %s\n' "$*" >>"$RECOVERY_CALLS"; }
   log() { :; }
   err() { :; }
-  recover_failed_database_transition 23
+  [[ "$-" == *e* ]]
+  if recover_failed_database_transition 23; then
+    echo "unreadable recovery evidence unexpectedly succeeded" >&2
+    exit 1
+  else
+    recovery_status=$?
+  fi
+  [[ "$-" == *e* ]]
+  [[ "$recovery_status" == "23" ]]
+  [[ ! -s "$RECOVERY_CALLS" ]]
 )
-recovery_status=$?
-set -e
-[[ "$recovery_status" == "23" ]]
-[[ ! -s "$RECOVERY_CALLS" ]]
 
 # Active and non-active-but-nonterminal migration Jobs both block reclassification and rollback.
 for job_state in active unknown; do

--- a/scripts/__tests__/affected-deployables.test.mjs
+++ b/scripts/__tests__/affected-deployables.test.mjs
@@ -69,12 +69,17 @@ test("runs the develop smoke for deployment surfaces and not ordinary applicatio
 test("keeps the blocking smoke on develop and ahead of image publication", function _ProtectsDevelopSmokeWiring()
 {
 	const workflow = _Workflow();
+	const smokeJob = workflow.match(/\n  develop_smoke:[\s\S]*?\n  build-and-push:/u);
+	assert.ok(smokeJob, "develop smoke job must remain independently inspectable");
 	assert.match(workflow, /github\.ref == 'refs\/heads\/develop'/u);
 	assert.match(workflow, /run: \.\/apps\/_infra\/deploy-k8s\/platform\/tests\/develop-smoke\.sh/u);
 	assert.match(workflow, /needs: \[prepare, test, develop_smoke\]/u);
 	assert.match(workflow, /needs\.develop_smoke\.result == 'success'/u);
 	assert.match(workflow, /K3D_LINUX_AMD64_SHA256: [0-9a-f]{64}/u);
 	assert.match(workflow, /sha256sum --check/u);
+	assert.match(smokeJob[0], /uses: actions\/setup-node@v6/u);
+	assert.match(smokeJob[0], /key: node-modules-\$\{\{ runner\.os \}\}-node24-\$\{\{ hashFiles\('package-lock\.json'\) \}\}/u);
+	assert.match(smokeJob[0], /name: Install deploy validation dependencies[\s\S]*?run: npm ci/u);
 });
 
 test("trusts only an exact develop-to-main promotion source", function _SelectsPromotionSource()


### PR DESCRIPTION
## Summary

- remove direct errexit option mutation from database transition, recovery, and finalization modules
- capture every command status with explicit conditional control flow
- preserve exact classifier, migration, rollback, and finalization statuses without leaking shell options into callers
- enforce zero direct set +/-e mutations and retain exact 19, 23, and 41 regression coverage

## Why this follows #605

PR #605 merged while its Linux CI failure was being diagnosed. Its diagnostic identified the unreadable-recovery assertion: nested status capture re-enabled errexit under Bash 5, so recovery exited before it could preserve the original stage status.

This focused follow-up contains only the reviewed correction. It is based on the current develop tip after #599, #605, and #579.

## Validation

- full deploy-k8s contract suite
- all PostgreSQL contracts
- release-versioning check and 38 release-versioning tests
- monorepo boundaries and module-growth checks
- PR-stack integrity PASS
- architecture gate PASS
- reaper gate PASS
- independent review PASS

The GitHub Linux runner is the exact Bash 5 qualification gate.