### PR TITLE
📝 Explain agent runtime authority and lifecycle code

### DIFF
--- a/apps/agent-runtime/src/attempts/execution.py
+++ b/apps/agent-runtime/src/attempts/execution.py
@@ -39,10 +39,14 @@ def execute_start_attempt(
     executor/transport failures become one ``run.failed`` terminal candidate unless cancellation has
     already suppressed local terminal delivery.
     """
+    # Coordinates are the runtime's capability fence for this command. Resolve them before reading
+    # payload data so unbound input can neither start model work nor elicit a candidate.
     coordinates = command_coordinates(command, runtime_instance_id)
     if coordinates is None:
         # Without accepted coordinates even an error candidate would be unauthorised and ambiguous.
         return
+    # The executor and terminal gate must share one signal. Otherwise cancellation could stop model
+    # iteration while a separately constructed gate still publishes completion.
     cancel_event = cancel_event or threading.Event()
     terminal_gate = terminal_gate or TerminalGate(cancel_event)
     payload = command.get("payload")
@@ -55,6 +59,8 @@ def execute_start_attempt(
             candidate(coordinates, "run.failed", {"reason": "missing_compiled_input"}),
         )
         return
+    # Announce the attempt before touching the model adapter. This keeps the candidate stream ordered
+    # even when model construction fails immediately after admission.
     post_candidate(
         candidate(
             coordinates,
@@ -63,13 +69,19 @@ def execute_start_attempt(
         ),
     )
     run_evidence(coordinates, "started")
+    # Checkpoint only after ``run.started``: local recovery state must never suggest that an attempt
+    # began before the server has seen the corresponding lifecycle candidate.
     _try_write_checkpoint(
         coordinates,
         payload if isinstance(payload, dict) else {},
         compiled_input,
         checkpoint_cipher,
     )
+    # A fresh start has no carried steering. The mutable list is intentionally attempt-local and is
+    # drained only by the model adapter at pre-request boundaries.
     steering_buffer: list[str] = []
+    # Projection is the protocol firewall: execution observes neutral events, while the projector
+    # alone binds them to canonical candidate kinds, command coordinates, and frozen tool grants.
     projector = RuntimeEventProjector(coordinates, compiled_input, post_candidate, record_pending_tool_call)
     with trace(
         "agent_runtime.start_attempt",
@@ -83,9 +95,13 @@ def execute_start_attempt(
                     # response cannot become a late candidate.
                     break
                 projector.emit(neutral_event)
+            # Do not close a partial message after cancellation. Leaving it open accurately records
+            # where local production stopped and avoids inventing a successful message boundary.
             if not cancel_event.is_set():
                 projector.complete_message()
             if projector.has_pending_tool_calls:
+                # A tool proposal pauses the model loop. Completion belongs after the control plane
+                # authorises and returns the saved result through a later resume command.
                 return
             if terminal_gate.post_completion(
                 post_candidate,
@@ -126,6 +142,8 @@ def execute_resume_attempt(
     tool results, and steering requests; recovers only coordinate-matching compiled context;
     then runs the same neutral-event and terminal pipeline as a fresh start.
     """
+    # A resume is not permission inferred from a run id. It is a separately fenced command, and all
+    # recovered local state remains subordinate to these newly accepted coordinates.
     coordinates = command_coordinates(command, runtime_instance_id)
     if coordinates is None:
         return
@@ -138,6 +156,8 @@ def execute_resume_attempt(
             candidate(coordinates, "run.failed", {"reason": "missing_resume_payload"}),
         )
         return
+    # Input generation prevents an otherwise matching run/attempt checkpoint from reviving context
+    # compiled before later steering or control-plane input was accepted.
     input_generation = payload.get("inputGeneration")
     tool_results = payload.get("toolResults")
     steering_requests = payload.get("steeringRequests")
@@ -163,6 +183,8 @@ def execute_resume_attempt(
             candidate(coordinates, "run.failed", {"reason": "invalid_resume_steering"}),
         )
         return
+    # Recover context before consuming pending calls, but treat missing local scratch as an empty,
+    # fail-closed grant set rather than asking the runtime to reconstruct authority.
     compiled_input = _recover_compiled_input(
         coordinates,
         input_generation,
@@ -170,6 +192,9 @@ def execute_resume_attempt(
     )
     # The control plane already executed or refused each call and persisted its terminal result.
     # The runtime only maps those exact results into the model framework.
+    # Resolution atomically consumes the pending calls named by this command. This must precede
+    # announcing ``run.resumed`` so an unknown, duplicated, or replayed result cannot masquerade as
+    # accepted continuation; other pending calls may remain for a later resume.
     resolved_tool_results = resolve_tool_results(
         coordinates,
         tool_results,
@@ -181,6 +206,9 @@ def execute_resume_attempt(
             candidate(coordinates, "run.failed", {"reason": "invalid_tool_results"}),
         )
         return
+    # At this point coordinates, resume structure, and the supplied pending-call identities have
+    # passed. Checkpoint recovery may still have produced empty context; only now is the accepted
+    # resume command visible in the candidate timeline.
     post_candidate(
         candidate(
             coordinates,
@@ -189,7 +217,11 @@ def execute_resume_attempt(
         ),
     )
     run_evidence(coordinates, "resumed", inputGeneration=input_generation)
+    # Preserve control-plane order while normalising only surrounding whitespace already validated
+    # above. The runtime does not merge, rank, or reinterpret steering content.
     steering_buffer = [item["text"].strip() for item in steering_requests]
+    # Construct a new projector for this command: message lifecycle and candidate identifiers are
+    # command-scoped, even though the model context continues the same durable run attempt.
     projector = RuntimeEventProjector(coordinates, compiled_input, post_candidate, record_pending_tool_call)
     with trace(
         "agent_runtime.resume_attempt",
@@ -207,9 +239,14 @@ def execute_resume_attempt(
                     # A resume is subject to the same late-output suppression as a fresh attempt.
                     break
                 projector.emit(neutral_event)
+            # Once cancellation is observed here, suppress the synthetic message end and subsequent
+            # local completion work. The terminal gate samples the signal again before posting, while
+            # the server remains authoritative for cancellation racing an already in-flight post.
             if not cancel_event.is_set():
                 projector.complete_message()
             if projector.has_pending_tool_calls:
+                # Additional tool calls create another control-plane round trip; a resume may pause
+                # repeatedly, and none of those intermediate pauses is a completed run.
                 return
             if terminal_gate.post_completion(
                 post_candidate,
@@ -251,6 +288,8 @@ def execute_cancel_attempt(
         # Set the shared event before recording evidence so the worker observes cancellation as soon
         # as possible and cannot race a late completion through the terminal gate.
         cancel_event.set()
+    # The reason is evidence only. It cannot alter cancellation semantics or select a different local
+    # worker, because command routing already paired this signal with the active attempt.
     payload = command.get("payload")
     reason = payload.get("reason") if isinstance(payload, dict) else None
     run_evidence(coordinates, "cancelled", reason=reason)
@@ -258,6 +297,8 @@ def execute_cancel_attempt(
 
 def _snapshot_input_generation(payload: dict[str, object]) -> object:
     """Read the accepted input generation, defaulting legacy/malformed absence to zero."""
+    # Generation is copied from the server snapshot rather than derived locally, preserving the
+    # control plane's ordering across accepted input changes.
     snapshot = payload.get("snapshot") if isinstance(payload, dict) else None
     if isinstance(snapshot, dict) and isinstance(snapshot.get("inputGeneration"), int):
         return snapshot["inputGeneration"]
@@ -275,6 +316,8 @@ def _try_write_checkpoint(
     Any local crypto or filesystem failure is reduced to safe evidence. The active model attempt
     continues because server authority and emitted candidates do not depend on local scratch.
     """
+    # Checkpoint failure is intentionally outside the model-loop failure path. Local scratch improves
+    # continuation only; it cannot veto execution of an otherwise admitted command.
     try:
         write_checkpoint(
             coordinates["runId"],
@@ -301,6 +344,8 @@ def _recover_compiled_input(
     An empty mapping is deliberately fail-closed: any subsequent tool call resolves as unknown
     rather than inheriting a stale or unverifiable grant set.
     """
+    # Decrypt and validate through the checkpoint owner rather than reading the file here. Keeping a
+    # single validation seam prevents resume code from accidentally accepting weaker coordinates.
     try:
         state = read_checkpoint(
             coordinates["runId"],
@@ -310,6 +355,8 @@ def _recover_compiled_input(
         )
     except Exception:  # noqa: BLE001 - checkpoints never crash resume
         return {}
+    # Return only the one state member execution understands. Other checkpoint fields, including any
+    # introduced by a future format, cannot silently become model input.
     if isinstance(state, dict) and isinstance(state.get("compiledInput"), dict):
         return state["compiledInput"]
     return {}

--- a/apps/agent-runtime/src/attempts/pending_tools.py
+++ b/apps/agent-runtime/src/attempts/pending_tools.py
@@ -14,7 +14,11 @@ import threading
 # Upper bound on simultaneously pending proposed calls; a run beyond this is already pathological.
 _MAX_PENDING_TOOL_CALLS = 256
 
+# The lock protects validation and consumption as one operation. The GIL is not an authority or an
+# atomicity contract, and stream dispatch may overlap worker completion on different threads.
 _LOCK = threading.Lock()
+# Keys include run and attempt so a provider-chosen call id cannot alias a call from another fenced
+# execution. Stored values are model-loop correlation data, never approval or execution receipts.
 _PENDING: dict[tuple[str, int, str], dict[str, object]] = {}
 
 
@@ -31,8 +35,12 @@ def record_pending_tool_call(
     invocation instead of this registry growing without limit.
     """
     with _LOCK:
+        # Capacity is checked while holding the same lock as insertion. Concurrent proposals cannot
+        # both observe free capacity and push the process registry past its defensive ceiling.
         if len(_PENDING) >= _MAX_PENDING_TOOL_CALLS:
             return
+        # Below the ceiling, re-recording the same composite identity replaces only ephemeral
+        # correlation data. Durable idempotency and action execution remain control-plane concerns.
         _PENDING[(run_id, attempt, tool_invocation_id)] = {"toolName": tool_name, "arguments": arguments}
 
 
@@ -47,9 +55,13 @@ def take_pending_tool_calls(
     partially consume state and make a later byte-identical redelivery impossible to validate.
     """
     with _LOCK:
+        # Build the full key set before any lookup or deletion. Batch validation must be all-or-none
+        # because resume commands can be redelivered after transport loss.
         keys = [(run_id, attempt, tool_invocation_id) for tool_invocation_id in tool_invocation_ids]
         if len(keys) != len(set(keys)) or any(key not in _PENDING for key in keys):
             return None
+        # Copy first, then delete while still locked. No concurrent resume can consume a subset between
+        # validation and removal, and a successful batch is available to the model exactly once.
         pending = {key[2]: _PENDING[key] for key in keys}
         for key in keys:
             del _PENDING[key]

--- a/apps/agent-runtime/src/attempts/terminal.py
+++ b/apps/agent-runtime/src/attempts/terminal.py
@@ -38,11 +38,15 @@ class TerminalGate:
             ``True`` after delivery returns successfully; otherwise ``False``.
         """
         with self._lock:
+            # The claim lock serializes terminal writers; cancellation is an independent signal
+            # sampled here and again by the delivery loop so it can stop a claimed retry path.
             if self._posted or self._cancel_event.is_set():
                 return False
             # From this point this exact candidate is the sole local terminal writer, even when its
             # first HTTP response is lost.
             self._posted = True
+        # Network retry happens outside the claim lock: no other caller can win after ``_posted``, and
+        # holding the lock during backoff would obscure that terminal ownership is already settled.
         while not self._cancel_event.is_set():
             try:
                 post_candidate(terminal_candidate)
@@ -73,5 +77,9 @@ class TerminalGate:
                     candidateId=terminal_candidate.get("candidateId"),
                     errorType=type(error).__name__,
                 )
+                # Event.wait makes backoff cancellation-responsive; a plain sleep could publish again
+                # after the stream has been dropped or the server has cancelled the attempt.
                 self._cancel_event.wait(TERMINAL_DELIVERY_RETRY_SECONDS)
+        # Cancellation can arrive between retries. Returning false records that local delivery did not
+        # complete, without claiming anything about the server's durable candidate state.
         return False

--- a/apps/agent-runtime/src/attempts/tool_results.py
+++ b/apps/agent-runtime/src/attempts/tool_results.py
@@ -15,6 +15,8 @@ def resolve_tool_results(
     post_candidate,
 ) -> dict[str, object] | None:
     """Validate and consume exact saved tool results, or reject the whole batch."""
+    # Keep validation output separate from registry state. Only after the complete wire batch has a
+    # recognised terminal shape may this function consume the corresponding pending calls.
     validated: list[tuple[str, object]] = []
     tool_invocation_ids: list[str] = []
     # Validate every result before touching the pending-call registry. This keeps malformed commands
@@ -25,6 +27,8 @@ def resolve_tool_results(
             return None
         tool_invocation_id = entry["toolInvocationId"]
         outcome = entry.get("outcome")
+        # Success requires an explicit result member, including when its value is null. Absence is not
+        # silently converted into a provider result because the server owns the terminal receipt.
         if outcome == "succeeded" and "result" in entry:
             validated.append((tool_invocation_id, entry["result"]))
         else:
@@ -32,9 +36,13 @@ def resolve_tool_results(
             if outcome != "failed" or not isinstance(failure_code, str) or not failure_code:
                 post_candidate(candidate(coordinates, "run.error", {"reason": "invalid_tool_result"}))
                 return None
+            # Feed only the stable failure code back to the model. Provider messages and execution
+            # detail remain behind the control-plane boundary and cannot leak into model context.
             validated.append((tool_invocation_id, {"error": failure_code}))
         tool_invocation_ids.append(tool_invocation_id)
 
+    # Pending-call identity is checked after structural validation and consumed atomically. This is
+    # the replay fence that rejects duplicate, foreign-attempt, and never-proposed results.
     pending = take_pending_tool_calls(
         str(coordinates["runId"]),
         int(coordinates["attempt"]),
@@ -44,6 +52,8 @@ def resolve_tool_results(
         post_candidate(candidate(coordinates, "run.error", {"reason": "unknown_tool_result"}))
         return None
 
+    # The model adapter receives only invocation-to-result mappings. Stored tool names and arguments
+    # are correlation evidence; replaying them here could be mistaken for authority to execute again.
     results: dict[str, object] = {}
     for tool_invocation_id, result in validated:
         results[tool_invocation_id] = result

--- a/apps/agent-runtime/src/bootstrap/exchange.py
+++ b/apps/agent-runtime/src/bootstrap/exchange.py
@@ -31,12 +31,18 @@ def perform_bootstrap(
         HTTPError: For a retryable server-side HTTP failure.
         OSError: For transport failures before a binding result is known.
     """
+    # These three values prove different things and are deliberately submitted together: the
+    # reference names the server-created admission, the workload token authenticates the caller at
+    # the HTTP boundary, and the public evidence records the key selected for this exact bootstrap.
+    # None of the fields in this body is sufficient to admit a runtime on its own.
     body = {
         "bootstrapReference": bootstrap_reference,
         "proofPublicJwk": proof_key["publicJwk"],
         "proofKeyThumbprint": proof_key["thumbprint"],
     }
     try:
+        # Bootstrap is the only endpoint allowed before the runtime has an authenticated command
+        # stream. Keep this call synchronous so no attempt work can race ahead of proof binding.
         status = post_json(f"{control_plane_url.rstrip('/')}/bootstrap", token, body, timeout=30)
     except HTTPError as error:
         # A 4xx is a decision, not an availability failure. Retrying it could turn a replayed or
@@ -44,6 +50,11 @@ def perform_bootstrap(
         if 400 <= error.code < 500:
             raise BootstrapDeniedError(f"bootstrap refused with status {error.code}") from error
         raise
+    # ``post_json`` normally raises for HTTP errors, but an injected/test transport may return an
+    # unexpected status directly. Treat that as a permanent refusal rather than silently opening a
+    # stream whose proof-key binding is unknown.
     if status < 200 or status >= 300:
         raise BootstrapDeniedError(f"bootstrap returned unexpected status {status}")
+    # Log only the public thumbprint. The projected token and opaque bootstrap reference remain out
+    # of observability fields because either could become useful replay material outside this Pod.
     log("bootstrap_bound", thumbprint=proof_key["thumbprint"])

--- a/apps/agent-runtime/src/bootstrap/proof.py
+++ b/apps/agent-runtime/src/bootstrap/proof.py
@@ -12,6 +12,8 @@ import json
 
 def base64url(raw: bytes) -> str:
     """Encode bytes as unpadded base64url, as required by JSON Web Key coordinates."""
+    # JWK thumbprints operate on the unpadded URL-safe representation. Retaining ``=`` padding would
+    # make the public document look equivalent to a reader but produce a different identity digest.
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
 
@@ -38,13 +40,20 @@ def generate_proof_key() -> dict[str, object]:
     coordinates are derived. The returned dictionary is intentionally shaped for
     ``bootstrap/exchange.py`` and contains no serialisable secret material.
     """
+    # Load the optional cryptographic dependency only at the identity boundary. Configuration and
+    # import-only tooling can inspect the runtime without generating or retaining key material.
     from cryptography.hazmat.primitives.asymmetric import ec
 
+    # Freshness matters more than durability here: this private key object names one process
+    # bootstrap and never leaves this function. Only its public coordinates and thumbprint survive
+    # for the exchange; no private key material reaches another Job, checkpoint, or server store.
     private_key = ec.generate_private_key(ec.SECP256R1())
     numbers = private_key.public_key().public_numbers()
     # P-256 coordinates are fixed-width 32-byte unsigned integers before base64url encoding.
     x_coordinate = base64url(numbers.x.to_bytes(32, "big"))
     y_coordinate = base64url(numbers.y.to_bytes(32, "big"))
+    # The exchange receives only the public half. Returning the private object would invite callers
+    # to serialize it or broaden proof-key custody beyond this deliberately narrow bootstrap seam.
     public_jwk = {"kty": "EC", "crv": "P-256", "x": x_coordinate, "y": y_coordinate}
     return {
         "publicJwk": public_jwk,

--- a/apps/agent-runtime/src/config.py
+++ b/apps/agent-runtime/src/config.py
@@ -19,8 +19,13 @@ def environment(name: str, default: str | None = None) -> str:
     Raises:
         RuntimeError: When neither a non-empty environment value nor a non-empty default exists.
     """
+    # This accessor deliberately distinguishes absence/empty from malformed-but-present values.
+    # Path, URL, and identifier shape validation stays with the component that owns that domain;
+    # central coercion here could make two security boundaries interpret one setting differently.
     value = os.environ.get(name, default)
     if not value:
+        # Mention only the public configuration key. Echoing the supplied value in an exception can
+        # leak secrets later when startup failures are collected by platform logging.
         raise RuntimeError(f"{name} must be configured")
     return value
 
@@ -35,9 +40,13 @@ def read_projected_token(token_path: str) -> str:
         OSError: When the projected file cannot be read.
         RuntimeError: When the file contains no token after its projected newline is stripped.
     """
+    # Open the projected path for each use instead of holding a file descriptor: Kubernetes may
+    # rotate a projected token by replacing the backing file rather than mutating the open inode.
     with open(token_path, "r", encoding="utf-8") as token_file:
         token = token_file.read().strip()
     if not token:
+        # Fail closed during an empty projection window. No fallback token source is permitted,
+        # because it could silently exchange one workload identity for another.
         raise RuntimeError("projected runtime token is empty")
     return token
 
@@ -52,9 +61,13 @@ def read_bootstrap_reference(bootstrap_path: str) -> str:
         OSError: When the projected file cannot be read.
         RuntimeError: When the file contains no reference.
     """
+    # Strip projection whitespace but otherwise keep the opaque value uninterpreted. The control
+    # plane owns its format; local parsing could change which one-use admission record is addressed.
     with open(bootstrap_path, "r", encoding="utf-8") as reference_file:
         reference = reference_file.read().strip()
     if not reference:
+        # An empty mount is not equivalent to "no bootstrap required". Every process must bind the
+        # exact workload admission before it is allowed to open the command stream.
         raise RuntimeError("projected bootstrap reference is empty")
     return reference
 
@@ -70,8 +83,13 @@ def read_attempt_litellm_key(key_path: str) -> str:
         OSError: When the mounted Secret cannot be read.
         RuntimeError: When the mounted Secret is empty.
     """
+    # Keep the credential read at the model-adapter boundary. Moving it into startup configuration
+    # would unnecessarily lengthen its in-memory lifetime and tempt callers to include it in broad
+    # configuration dumps or checkpoint state.
     with open(key_path, "r", encoding="utf-8") as key_file:
         key = key_file.read().strip()
     if not key:
+        # There is deliberately no provider-key or shared-key fallback. The attempt-scoped key is
+        # the budget and identity fence through which this runtime may reach LiteLLM.
         raise RuntimeError("attempt-scoped LiteLLM key is empty")
     return key

--- a/apps/agent-runtime/src/constants.py
+++ b/apps/agent-runtime/src/constants.py
@@ -7,6 +7,8 @@ the environment itself.
 """
 
 # Wire identity echoed on every stream open and candidate.
+# Changing this value is a protocol migration, not a cosmetic application-version change: the
+# control plane uses it to decide which request and candidate shapes it can interpret.
 PROTOCOL_VERSION = "opencrane.agent-runtime/v1"
 
 # Paths fixed by the Kubernetes Job projection contract. The supported path settings may override
@@ -17,10 +19,15 @@ DEFAULT_LITELLM_KEY_PATH = "/var/run/opencrane/litellm/key"
 DEFAULT_CHECKPOINT_DIR = "/tmp/opencrane/checkpoints"
 
 # The checkpoint version guards the local optimisation format; it is unrelated to the wire protocol.
+# Keep these versions separate so a replaceable local serialization can evolve without claiming a
+# new server contract, and a wire migration cannot accidentally bless an incompatible checkpoint.
 CHECKPOINT_VERSION = 1
 CHECKPOINT_FILENAME = "checkpoint.enc"
 
 # Resource and retry ceilings. These caps prevent an untrusted peer or unavailable control plane from
 # causing unbounded buffering or reconnect loops.
+# The frame bound rejects oversized lines before command decoding; transport buffering remains owned
+# by the HTTP client. The terminal delay is intentionally fixed: the candidate id remains unchanged
+# while only ambiguous delivery is retried, so application-level exponential work stays out of here.
 MAX_FRAME_BYTES = 65_536
 TERMINAL_DELIVERY_RETRY_SECONDS = 1.0

--- a/apps/agent-runtime/src/model_loop/checkpoints.py
+++ b/apps/agent-runtime/src/model_loop/checkpoints.py
@@ -30,6 +30,8 @@ def process_cipher() -> object:
     read/write seams, which keeps offline tests independent of the cryptography package.
     """
     global _PROCESS_CIPHER
+    # Lazy creation keeps importing this module side-effect free and delays optional crypto loading
+    # until checkpointing is actually used. The global remains process-local by design.
     if _PROCESS_CIPHER is None:
         from cryptography.fernet import Fernet
 
@@ -44,6 +46,8 @@ def checkpoint_path(checkpoint_dir: str | None) -> str:
     setting and finally the bounded scratch default. The fixed filename prevents accumulation of an
     unbounded local checkpoint history.
     """
+    # Injection is deliberately a directory, not an arbitrary final filename: production and tests
+    # both exercise the same single-slot replacement policy.
     directory = checkpoint_dir or environment(
         "OPENCRANE_RUNTIME_CHECKPOINT_DIR",
         DEFAULT_CHECKPOINT_DIR,
@@ -73,9 +77,13 @@ def write_checkpoint(
         OSError: When the scratch directory cannot be created, written, or replaced.
         Exception: When the injected or process cipher cannot encrypt the document.
     """
+    # Resolve cipher and path once so every subsequent operation in this write uses one key and one
+    # destination, even if environment or test fixtures change concurrently.
     cipher = cipher or process_cipher()
     path = checkpoint_path(checkpoint_dir)
     os.makedirs(os.path.dirname(path), exist_ok=True)
+    # Bind state inside the ciphertext rather than relying on the filename. One fixed file is reused
+    # across attempts, so only authenticated envelope coordinates can reject stale local bytes.
     document = {
         "checkpointVersion": CHECKPOINT_VERSION,
         "runId": run_id,
@@ -83,11 +91,15 @@ def write_checkpoint(
         "inputGeneration": input_generation,
         "state": state,
     }
+    # Canonical JSON is not an authority mechanism, but it keeps encrypted inputs deterministic before
+    # Fernet adds its nonce and avoids accidental formatting-dependent checkpoint drift.
     plaintext = json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8")
     token = cipher.encrypt(plaintext)
     # os.replace is atomic when source and destination share a filesystem; the temporary file is
     # deliberately created beside the destination to retain that guarantee.
     temporary = f"{path}.{uuid.uuid4().hex}.tmp"
+    # Never truncate the current checkpoint in place. A failed temporary write leaves the last complete
+    # encrypted document available, and replacement is the sole commit point.
     with open(temporary, "wb") as handle:
         handle.write(token)
     os.replace(temporary, path)
@@ -108,8 +120,12 @@ def read_checkpoint(
     coordinates all return ``None``. Those cases are ordinary loss of a local optimisation, not a run
     failure and never a reason to weaken validation.
     """
+    # Use the caller's expected coordinates as the read capability. The path alone conveys no right to
+    # resume and is intentionally insufficient to select checkpoint state.
     cipher = cipher or process_cipher()
     path = checkpoint_path(checkpoint_dir)
+    # Missing scratch is normal after eviction or process replacement. It must look identical to every
+    # other unavailable local optimisation and must not become a model-loop error.
     try:
         with open(path, "rb") as handle:
             token = handle.read()
@@ -121,6 +137,8 @@ def read_checkpoint(
         # Cipher and parser errors intentionally collapse to "no usable local state"; exposing their
         # details could leak file contents and would make the optimisation load-bearing.
         return None
+    # Version is checked before coordinates so an unknown schema can never be partially interpreted
+    # using assumptions from the current envelope.
     if not isinstance(document, dict) or document.get("checkpointVersion") != CHECKPOINT_VERSION:
         return None
     if (

--- a/apps/agent-runtime/src/model_loop/driver.py
+++ b/apps/agent-runtime/src/model_loop/driver.py
@@ -21,6 +21,8 @@ def absorb_steering(steering_buffer: list[str]) -> list[str]:
     only the entries observed in ``drained`` are removed. Callers must invoke this immediately before
     starting a model request, never while a request or tool call is in flight.
     """
+    # Snapshot before deletion rather than swapping the list object: producers retain the same shared
+    # buffer reference, and entries appended after the snapshot survive for the next request boundary.
     drained = steering_buffer[:]
     del steering_buffer[: len(drained)]
     return drained
@@ -33,6 +35,8 @@ def zero_retry_openai_settings() -> dict[str, int]:
     output validation retries belong to the Pydantic agent. Keeping all four names visible makes it
     difficult for a framework upgrade to reintroduce an unnoticed default retry path.
     """
+    # Keep each conceptual retry surface explicit even where the current SDK collapses two settings
+    # onto one transport knob. This is a review checklist against dependency-default drift.
     return {
         "model_request_retries": 0,
         "provider_http_retries": 0,
@@ -82,6 +86,8 @@ def build_zero_retry_agent(
     # would be misleading, so reject it before constructing the client.
     if settings["provider_http_retries"] != settings["model_request_retries"]:
         raise RuntimeError("provider HTTP and model-request retries must agree on the transport")
+    # The mounted attempt key and compiled alias are the only provider capabilities admitted here. No
+    # provider fallback, master key, or ambient client default may select a broader route.
     openai_client = async_openai(
         base_url=base_url,
         api_key=attempt_key,
@@ -114,9 +120,13 @@ def pydantic_ai_event_source(
 
     async def _collect() -> list[dict[str, object]]:
         """Collect one fresh framework run without leaking async objects across the adapter seam."""
+        # Buffer plain events until the async run closes; framework-owned nodes and contexts never
+        # escape into the synchronous attempt executor or checkpoint format.
         events: list[dict[str, object]] = []
         async with agent.iter(prompt(compiled_input)) as run:
             async for node in run:
+                # Avoid intentionally opening a node after observed cancellation. The in-stream check
+                # below still suppresses output if cancellation races this check-to-open boundary.
                 if cancel_event.is_set():
                     break
                 if Agent.is_model_request_node(node):
@@ -125,6 +135,8 @@ def pydantic_ai_event_source(
                     apply_steering_to_request(node, absorb_steering(steering_buffer))
                     async with node.stream(run.ctx) as request_stream:
                         async for event in request_stream:
+                            # Check inside the stream as well: node-level cancellation alone would still
+                            # allow buffered provider deltas to cross the runtime protocol seam.
                             if cancel_event.is_set():
                                 break
                             events.append(translate_framework_event(event))
@@ -167,17 +179,23 @@ def pydantic_ai_resume_source(
 
     async def _collect() -> list[dict[str, object]]:
         """Collect one authorised resume while keeping its framework state inside this adapter."""
+        # Resume uses a fresh framework runner but only the server-returned deferred results. The
+        # adapter never calls the external tool or recreates a result from pending-call metadata.
         events: list[dict[str, object]] = []
         async with agent.iter(
             prompt(compiled_input),
             deferred_tool_results=tool_results,
         ) as run:
             async for node in run:
+                # A resumed graph is no less cancellable than a fresh graph; do not enter another node
+                # after the shared attempt signal has been set.
                 if cancel_event.is_set():
                     break
                 if Agent.is_model_request_node(node):
                     # Resume steering follows the same pre-request rule as a fresh start. The optional
                     # framework dependency container is inspected defensively at this adapter seam.
+                    # Drain once per request node. Steering arriving after this point waits for the next
+                    # model boundary rather than mutating an in-flight prompt.
                     for steer in absorb_steering(steering_buffer):
                         deps = getattr(run.ctx, "deps", None)
                         if hasattr(deps, "steering"):
@@ -210,6 +228,8 @@ def prompt(compiled_input: dict[str, object]) -> str:
     context, or author instructions. Missing or malformed message collections produce an empty
     prompt and remain visible to the model executor rather than triggering an alternate source.
     """
+    # Consume only the literal, ordered server projection. The runtime performs no conversation lookup
+    # and cannot supplement this snapshot from local or provider state.
     messages = compiled_input.get("messages")
     if not isinstance(messages, list):
         return ""
@@ -228,6 +248,8 @@ def translate_framework_event(event: object) -> dict[str, object]:
     shapes become an empty text delta rather than leaking arbitrary framework objects across the
     protocol seam; the protocol normaliser decides what becomes a candidate.
     """
+    # Duck typing is contained here so framework upgrades cannot leak new object shapes directly into
+    # the wire protocol. Every admitted output is reconstructed as an owned primitive dictionary.
     delta = getattr(getattr(event, "delta", None), "content_delta", None)
     if isinstance(delta, str):
         return {"type": "output_text", "text": delta}
@@ -252,6 +274,8 @@ def apply_steering_to_request(model_request_node: object, steering: list[str]) -
     """
     if not steering:
         return
+    # Mutate only the recognised request-parts list. If the framework changes shape, dropping steering
+    # is safer than guessing at a new internal object and corrupting an in-flight request.
     parts = getattr(getattr(model_request_node, "request", None), "parts", None)
     if isinstance(parts, list):
         parts.extend({"content": text} for text in steering)
@@ -264,8 +288,12 @@ def _agent_for(compiled_input: dict[str, object]) -> object:
     and the attempt-scoped key is read at the point of use so no master or provider credential enters
     the runtime.
     """
+    # Configuration chooses only the in-cluster proxy endpoint and key mount. The immutable compiled
+    # snapshot remains the sole authority for the actual model alias and instructions.
     base_url = environment("OPENCRANE_RUNTIME_LITELLM_BASE_URL")
     key_path = environment("OPENCRANE_RUNTIME_LITELLM_KEY_PATH", DEFAULT_LITELLM_KEY_PATH)
+    # Read the secret at point of use so it is neither retained in process configuration nor exposed in
+    # candidate/checkpoint state. The key is scoped to this attempt, never a LiteLLM master key.
     attempt_key = read_attempt_litellm_key(key_path)
     model_route = compiled_input.get("model")
     model_alias = model_route.get("modelAlias") if isinstance(model_route, dict) else None

--- a/apps/agent-runtime/src/observability.py
+++ b/apps/agent-runtime/src/observability.py
@@ -17,6 +17,12 @@ def log(event: str, **fields: object) -> None:
     bounded outcomes only. This low-level helper cannot redact arbitrary nested payloads, so callers
     must never provide commands, model content, tool arguments, or credential material.
     """
+    # Build exactly one record so collectors cannot confuse continuation lines with separate events.
+    # Stable key ordering improves incident diffs without implying event ordering; causal order comes
+    # from runtime/run/attempt coordinates supplied by the caller.
+    #
+    # ``flush=True`` is operationally important in short-lived Jobs: termination may follow a denial
+    # or terminal outcome before Python's buffered stdout would otherwise be written.
     print(json.dumps({"component": "agent-runtime", "event": event, **fields}, sort_keys=True), flush=True)
 
 
@@ -29,6 +35,8 @@ def trace(operation: str, **attributes: object):
     Instrumentation failure due solely to an absent SDK therefore cannot change runtime behaviour.
     """
     try:
+        # Import at span creation rather than module import so telemetry remains optional and cannot
+        # prevent bootstrap in the minimal runtime image.
         from opentelemetry import trace as otel_trace
     except ImportError:
         # Observability is deliberately non-load-bearing for the execution protocol.
@@ -36,6 +44,9 @@ def trace(operation: str, **attributes: object):
         return
     tracer = otel_trace.get_tracer("agent-runtime")
     with tracer.start_as_current_span(operation) as span:
+        # Attributes are attached before yielding so nested work and exceptions are correlated with
+        # the admitted coordinates for the entire operation. Callers still own redaction: tracing
+        # backends are no safer a destination for content or credentials than logs.
         for key, value in attributes.items():
             span.set_attribute(key, value)
         yield span
@@ -48,6 +59,10 @@ def run_evidence(coordinates: dict[str, object], outcome: str, **fields: object)
     control-plane persistence. The coordinate projection keeps logs correlatable without copying the
     complete command or its payload.
     """
+    # Project an allowlisted set instead of spreading ``coordinates``. Commands carry additional
+    # content and authority evidence that must never be copied wholesale into an operator log.
+    # Missing values remain explicit ``null`` fields, which exposes incomplete correlation without
+    # fabricating identifiers or making observability a validation authority.
     log(
         "run_evidence",
         runId=coordinates.get("runId"),

--- a/apps/agent-runtime/src/protocol/candidates.py
+++ b/apps/agent-runtime/src/protocol/candidates.py
@@ -13,15 +13,21 @@ import uuid
 from ..constants import PROTOCOL_VERSION
 from ..observability import log
 
+# Bound the model-derived scalar fields owned here before transport. External-action arguments and
+# complete A2UI envelopes retain their separate validation and admission boundaries.
 MAX_TEXT_DELTA_LENGTH = 16_384
 MAX_COUNTER_VALUE = 2_147_483_647
 
+# A2UI is an allowlist of complete adapter-owned envelopes. Adding a framework event here is a
+# protocol decision: unknown UI events must remain invisible rather than acquiring guessed shapes.
 _A2UI_EVENT_TYPES = {
     "a2ui_rendering_begun": "a2ui.rendering.begun",
     "a2ui_surface_updated": "a2ui.surface.updated",
     "a2ui_data_model_updated": "a2ui.data_model.updated",
 }
 
+# Provider messages are intentionally absent. Only bounded class-like categories cross the process
+# boundary, so an exception cannot smuggle a URL, credential fragment, or prompt into durable state.
 _SAFE_ERROR_TYPES = {
     "AuthenticationError",
     "ConnectionError",
@@ -48,12 +54,16 @@ def command_coordinates(
     assignment = command.get("assignment")
     command_id = command.get("commandId")
     fence = command.get("fence")
+    # Validate the whole outer authority tuple before reading nested coordinates. Partial fallback
+    # would let a candidate inherit identity from local process state instead of the accepted command.
     if not isinstance(assignment, dict) or not isinstance(command_id, str) or not isinstance(fence, int):
         return None
     run_id = assignment.get("runId")
     attempt = assignment.get("attempt")
     if not isinstance(run_id, str) or not isinstance(attempt, int):
         return None
+    # Coordinates are copied rather than retaining the command mapping. Downstream candidate shaping
+    # therefore cannot accidentally echo compiled input or other command-only material.
     return {
         "protocolVersion": PROTOCOL_VERSION,
         "runtimeInstanceId": runtime_instance_id,
@@ -75,6 +85,8 @@ def candidate(
     after an ambiguous network loss; callers must never create a replacement for that replay because
     the stable ``candidateId`` is the control plane's idempotency coordinate.
     """
+    # Candidate identity belongs to the logical event, not an HTTP attempt. The transport may resend
+    # this returned object unchanged only where the server explicitly permits replay.
     return {
         **coordinates,
         "candidateId": str(uuid.uuid4()),
@@ -90,6 +102,8 @@ def arguments_digest(arguments: object) -> str:
     Sorted keys and compact separators remove presentation differences from JSON objects. The
     ``sha256:`` prefix makes the digest algorithm explicit in the wire value.
     """
+    # The server independently canonicalizes the parsed JSON value. Hashing the raw model string
+    # would make whitespace and object-member order security-significant even though JSON does not.
     canonical = json.dumps(arguments, sort_keys=True, separators=(",", ":"))
     return "sha256:" + hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
@@ -107,6 +121,8 @@ def external_action_candidate(
     invocation identifier, canonical argument digest, and parsed arguments so server authority can
     revalidate and either refuse, defer, or execute through its governed tool boundary.
     """
+    # This remains a proposal: including a revision id records which frozen grant was resolved, but
+    # does not transfer authorization or tool execution authority into the runtime.
     return {
         **coordinates,
         "candidateId": str(uuid.uuid4()),
@@ -127,6 +143,8 @@ def resolve_tool_revision(compiled_input: dict[str, object], tool_name: str) -> 
     tools = compiled_input.get("tools")
     if not isinstance(tools, list):
         return None
+    # Search only the command's frozen list. A similarly named tool in any mutable registry must not
+    # widen the authority of an already-admitted run.
     for tool in tools:
         if isinstance(tool, dict) and tool.get("name") == tool_name:
             revision = tool.get("toolRevisionId")
@@ -148,6 +166,8 @@ def tool_call_candidate(
     tool_name = neutral_event.get("toolName")
     tool_call_id = neutral_event.get("toolCallId")
     raw_arguments = neutral_event.get("arguments")
+    # Tool identity and arguments all originate in model output. Require the neutral adapter's exact
+    # string contract before doing any parsing or grant resolution.
     if (
         not isinstance(tool_name, str)
         or not isinstance(tool_call_id, str)
@@ -156,6 +176,8 @@ def tool_call_candidate(
         # Never include raw malformed fields in the error payload; they may contain model content.
         return candidate(coordinates, "run.error", {"reason": "malformed_tool_call"})
     try:
+        # Parsing establishes a deterministic JSON value for digesting; it is not schema validation
+        # and deliberately occurs before the server's authoritative admission checks.
         arguments = json.loads(raw_arguments)
     except json.JSONDecodeError:
         return candidate(
@@ -172,6 +194,8 @@ def tool_call_candidate(
             "tool.failed",
             {"reason": "unknown_tool", "toolInvocationId": tool_call_id},
         )
+    # Preserve the model's invocation id across proposal, durable execution, and resume matching.
+    # Generating a replacement id here would make a saved tool result impossible to bind safely.
     return external_action_candidate(
         coordinates,
         tool_revision_id,
@@ -194,6 +218,8 @@ def normalize_event(
     kind = neutral_event.get("type")
     if kind == "output_text":
         text = neutral_event.get("text")
+        # A malformed text payload becomes an empty bounded delta rather than serializing an
+        # arbitrary framework object. Message lifecycle ordering is added by the projector.
         return (
             "message.delta",
             {
@@ -202,6 +228,9 @@ def normalize_event(
             },
         )
     if kind == "usage":
+        # Usage is evidence reported by the model adapter, not local budget authority. Bound values
+        # accepted by Python's integer check and reduce invalid or negative counters to zero before
+        # the control plane records or evaluates them.
         return (
             "run.usage",
             {
@@ -210,6 +239,8 @@ def normalize_event(
             },
         )
     if kind == "error":
+        # Do not forward exception text. Even a familiar exception class can carry provider response
+        # bodies, request endpoints, or other secret-bearing context in its message.
         return (
             "run.error",
             {
@@ -231,9 +262,13 @@ def normalize_event(
 
 def _non_negative_int(value: object) -> int:
     """Coerce an untrusted framework usage counter to a safe non-negative integer."""
+    # Saturation preserves the signal that usage was large without allowing an unbounded framework
+    # integer to escape into the stable wire contract.
     return min(value, MAX_COUNTER_VALUE) if isinstance(value, int) and value >= 0 else 0
 
 
 def _safe_error_type(value: object) -> str:
     """Return a bounded class-like error label without provider messages or secret-bearing detail."""
+    # Collapse unknown labels to a stable category; echoing an arbitrary string would turn this
+    # allowlist into a provider-controlled logging channel.
     return value if isinstance(value, str) and value in _SAFE_ERROR_TYPES else "ModelLoopError"

--- a/apps/agent-runtime/src/protocol/event_projector.py
+++ b/apps/agent-runtime/src/protocol/event_projector.py
@@ -20,10 +20,14 @@ class RuntimeEventProjector:
         record_tool_call: Callable[[str, int, str, str, object], None],
     ) -> None:
         """Bind projection to immutable command coordinates and its frozen grant set."""
+        # This object is intentionally command-scoped. Reusing it across commands would carry message
+        # lifecycle or pending-tool state across fences and corrupt event ordering.
         self._coordinates = coordinates
         self._compiled_input = compiled_input
         self._post_candidate = post_candidate
         self._record_tool_call = record_tool_call
+        # Deriving the message id from the command makes replay deterministic while keeping separate
+        # command lifecycles distinct inside the same run attempt.
         self._message_id = f"assistant:{coordinates['commandId']}"
         self._message_started = False
         self._has_pending_tool_calls = False
@@ -35,12 +39,16 @@ class RuntimeEventProjector:
 
     def emit(self, neutral_event: dict[str, object]) -> None:
         """Emit the canonical candidate sequence for one neutral model event."""
+        # Tool calls have a multi-candidate lifecycle and must bypass the ordinary one-event mapping.
         if neutral_event.get("type") == "tool_call":
             self._emit_tool_call(neutral_event)
             return
         normalized = normalize_event(neutral_event, self._message_id)
         if normalized is None:
             return
+        # The first text delta opens the message before that delta is emitted. The flag is flipped
+        # only after the start candidate is posted, so a failed post cannot advance local lifecycle
+        # state beyond what may have reached server authority.
         if normalized[0] == "message.delta" and not self._message_started:
             self._post_candidate(
                 candidate(
@@ -54,6 +62,7 @@ class RuntimeEventProjector:
 
     def complete_message(self) -> None:
         """Close a started message once, while leaving an interrupted partial stream open."""
+        # No synthetic empty message is created when the model produces only usage, errors, or tools.
         if not self._message_started:
             return
         self._post_candidate(
@@ -63,6 +72,8 @@ class RuntimeEventProjector:
                 {"messageId": self._message_id},
             ),
         )
+        # Reset only after delivery succeeds. An ambiguous transport failure is handled at the stable
+        # candidate boundary rather than pretending the local lifecycle definitely completed.
         self._message_started = False
 
     def _emit_tool_call(self, neutral_event: dict[str, object]) -> None:
@@ -73,6 +84,8 @@ class RuntimeEventProjector:
             neutral_event,
         )
         if proposal.get("kind") == "external_action":
+            # ``tool.requested`` is ordered before the external-action proposal so the durable event
+            # history explains why authorization/execution was requested.
             self._has_pending_tool_calls = True
             self._post_candidate(
                 candidate(
@@ -84,6 +97,8 @@ class RuntimeEventProjector:
                     },
                 ),
             )
+            # Record the exact pending-call identity before posting the actionable proposal. A resume
+            # result is accepted only when it maps back to this run/attempt/invocation tuple.
             self._record_tool_call(
                 str(self._coordinates["runId"]),
                 int(self._coordinates["attempt"]),  # type: ignore[arg-type]
@@ -91,4 +106,6 @@ class RuntimeEventProjector:
                 str(neutral_event.get("toolName")),
                 proposal["arguments"],
             )
+        # Failed projections still emit their bounded error proposal, while valid proposals are sent
+        # only after their explanatory event and resume correlation state have been established.
         self._post_candidate(proposal)

--- a/apps/agent-runtime/src/runtime.py
+++ b/apps/agent-runtime/src/runtime.py
@@ -16,6 +16,9 @@ import uuid
 from collections.abc import Callable
 from urllib.error import HTTPError, URLError
 
+# These aliases mark the process-composition seam: the entrypoint chooses concrete implementations,
+# while ``run_forever`` receives callables so lifecycle policy can be tested without real identity,
+# network, or model infrastructure. Lower-level packages must not import this composition root.
 from .bootstrap.exchange import BootstrapDeniedError, perform_bootstrap as _perform_bootstrap
 from .bootstrap.proof import generate_proof_key
 from .config import (
@@ -53,6 +56,9 @@ def run_forever(
     """
     # Configuration is resolved before generating proof evidence. A missing mount or setting prevents
     # any identity claim or network work from starting.
+    #
+    # Keep this order deliberate. Resolve the endpoint, projected-file paths, and Pod coordinate
+    # before constructing process identity; actual mounted-file reads remain at their point of use.
     control_plane_url = environment("OPENCRANE_RUNTIME_STREAM_URL")
     token_path = environment("OPENCRANE_RUNTIME_TOKEN_PATH", DEFAULT_TOKEN_PATH)
     bootstrap_reference_path = environment(
@@ -60,8 +66,19 @@ def run_forever(
         DEFAULT_BOOTSTRAP_PATH,
     )
     pod_uid = environment("POD_UID")
+
+    # The instance id distinguishes this process lifetime from a replacement Pod or restarted
+    # process. It remains stable across transport reconnects, whereas the projected token below is
+    # intentionally reread because its credential lifetime is shorter than the process lifetime.
     runtime_instance_id = str(uuid.uuid4())
+
+    # Generate one proof key for the one-use binding attempt and retain the same public evidence
+    # across transient bootstrap failures. Regeneration during retries would make an ambiguous
+    # accepted response impossible to reconcile with the evidence held by this process.
     proof_key = generate_key()
+
+    # The bootstrap reference is workload-selection evidence, not a general credential. Reading it
+    # once preserves the identity being bound; only the rotating workload token is refreshed.
     bootstrap_reference = read_bootstrap_reference(bootstrap_reference_path)
     log("runtime_started", runtime_instance_id=runtime_instance_id)
 
@@ -70,6 +87,8 @@ def run_forever(
     attempts = 0
     while True:
         try:
+            # Token access stays inside the retry attempt so a kubelet rotation between attempts is
+            # observed without persisting credential material in process configuration or logs.
             perform_bootstrap(
                 control_plane_url,
                 read_projected_token(token_path),
@@ -78,6 +97,8 @@ def run_forever(
             )
             break
         except BootstrapDeniedError as error:
+            # A denial is an authority decision, not a connectivity condition. Retrying it would
+            # turn a one-use admission fence into an availability policy owned by this Pod.
             log(
                 "bootstrap_denied",
                 runtime_instance_id=runtime_instance_id,
@@ -87,6 +108,9 @@ def run_forever(
         except (HTTPError, URLError, OSError, RuntimeError) as error:
             # Log the exception type only. URLs, headers, or mounted-file details may contain
             # sensitive deployment information.
+            #
+            # These exception families include projected-file races as well as transient transport
+            # failures. Both are safe to retry because no command stream has been admitted yet.
             attempts += 1
             delay_seconds = retry_delay(attempts)
             log(
@@ -102,6 +126,9 @@ def run_forever(
     attempts = 0
     while True:
         try:
+            # ``open_stream`` owns command dispatch and active-attempt cancellation for the lifetime
+            # of this connection. It returns only after that connection's workers have been fenced,
+            # so reconnecting here cannot intentionally keep an old stream's executor alive.
             open_stream(
                 control_plane_url,
                 read_projected_token(token_path),
@@ -111,6 +138,9 @@ def run_forever(
             # EOF is not a successful terminal state: the Pod must keep its sole authority channel.
             # Back it off exactly like a transport exception so a peer returning immediate 200/EOF
             # cannot drive a hot reconnect loop.
+            #
+            # Do not reset ``attempts`` after a connection opens: repeated short-lived clean closes
+            # are still an outage pattern. A healthy stream normally remains inside ``open_stream``.
             attempts += 1
             delay_seconds = retry_delay(attempts)
             log(
@@ -121,6 +151,9 @@ def run_forever(
             )
             time.sleep(delay_seconds)
         except (HTTPError, URLError, OSError, RuntimeError) as error:
+            # Cancellation caused by Pod termination is intentionally outside this retry policy;
+            # SIGTERM ends the process. These recoverable failures describe only loss of the
+            # outbound authority channel, after which dispatch must stop until reconnection.
             attempts += 1
             delay_seconds = retry_delay(attempts)
             log(
@@ -135,6 +168,8 @@ def run_forever(
 if __name__ == "__main__":
     # SIGTERM remains the container orchestrator's termination path. KeyboardInterrupt is handled
     # only for an operator running the module interactively.
+    # Keep signal ownership out of ``run_forever`` so tests can exercise lifecycle policy without
+    # installing process-global handlers, and so Kubernetes receives normal termination semantics.
     try:
         run_forever()
     except KeyboardInterrupt:

--- a/apps/agent-runtime/src/transport/http.py
+++ b/apps/agent-runtime/src/transport/http.py
@@ -15,6 +15,8 @@ def post_json(url: str, token: str, body: dict[str, object], timeout: float) -> 
     Returns:
         The successful HTTP response status.
     """
+    # Materialize one immutable request body before opening the socket. A caller retry must construct
+    # its policy around the same logical document rather than streaming a partially encoded mapping.
     request = Request(
         url,
         data=json.dumps(body).encode("utf-8"),
@@ -25,6 +27,8 @@ def post_json(url: str, token: str, body: dict[str, object], timeout: float) -> 
         },
         method="POST",
     )
+    # Do not catch network or HTTP failures here. Bootstrap and candidate admission have different
+    # replay rules, so only the endpoint owner has enough context to classify an ambiguous outcome.
     with urlopen(request, timeout=timeout) as response:
         return response.status
 
@@ -39,11 +43,15 @@ def post_candidate(
 
     A transport error is ambiguous, so the runtime never repeats an external-action candidate.
     """
+    # ``candidate`` already carries its stable id and authority coordinates. This function performs
+    # exactly one attempt and never generates a replacement identity after a timeout or refusal.
     status = send_json(
         f"{control_plane_url.rstrip('/')}/candidates",
         token,
         candidate,
         30,
     )
+    # Injected transports may return a non-success status rather than raising ``HTTPError``. Preserve
+    # explicit refusal as a hard failure so upstream code cannot confuse it with ambiguous loss.
     if not 200 <= status < 300:
         raise RuntimeError(f"candidate admission returned unexpected status {status}")

--- a/apps/agent-runtime/src/transport/stream.py
+++ b/apps/agent-runtime/src/transport/stream.py
@@ -42,6 +42,8 @@ class _AttemptWorkerRegistry:
         """Register a fresh worker signal after cancelling any worker it supersedes."""
         fresh = threading.Event()
         with self._lock:
+            # Supersession is signalled before publishing the new current worker. This prevents a
+            # concurrent cancel command from targeting the stale worker while the replacement starts.
             if self._current is not None:
                 self._current.set()
             self._current = fresh
@@ -57,12 +59,16 @@ class _AttemptWorkerRegistry:
         """Forget a returned worker without disturbing a newer current worker."""
         with self._lock:
             self._signals.discard(signal)
+            # An older worker may finish after its replacement became current. Identity comparison
+            # keeps that late cleanup from clearing the replacement's cancellation handle.
             if self._current is signal:
                 self._current = None
 
     def cancel_all(self) -> None:
         """Signal every still-running worker when the authority stream is lost."""
         with self._lock:
+            # Snapshot under the lock, then signal outside it. ``Event.set`` is small today, but the
+            # registry lock must never become coupled to worker shutdown or callback behavior.
             signals = tuple(self._signals)
             self._current = None
         for signal in signals:
@@ -78,11 +84,15 @@ def _launch_attempt_worker(
     workers: _AttemptWorkerRegistry,
 ) -> None:
     """Launch one cancellation-bound start/resume handler and register its whole lifetime."""
+    # Every start/resume gets fresh local gates even when it supersedes work for the same run. The
+    # command fence, not a reusable process-global event, defines which output may still be emitted.
     cancel_event = workers.activate()
     terminal_gate = TerminalGate(cancel_event)
 
     def _post_candidate(candidate: dict[str, object]) -> None:
         """Post a stable candidate once; the server owns all durable preparation retries."""
+        # Capture this stream's URL and token in the worker closure. Candidates must never migrate to
+        # a later reconnected stream whose bootstrap or fence may differ.
         post_candidate(
             control_plane_url,
             token,
@@ -102,6 +112,8 @@ def _launch_attempt_worker(
         finally:
             workers.release(cancel_event)
 
+    # A daemon worker cannot keep an otherwise terminated runtime alive. The registry still signals
+    # normal teardown so cooperative model work stops before the process exits.
     worker = threading.Thread(target=_run, daemon=True)
     try:
         worker.start()
@@ -124,11 +136,15 @@ def iter_commands(response: object, cancelled: threading.Event) -> Iterator[obje
             break
         if len(raw_line) > MAX_FRAME_BYTES:
             raise RuntimeError("runtime stream frame exceeds the 64KiB boundary")
+        # Decode only after enforcing the byte bound. Replacement decoding is limited to the event
+        # name; command JSON remains strict UTF-8 through ``json.loads`` and fails closed if malformed.
         line = raw_line.rstrip(b"\n")
         if line.startswith(b"event: "):
             # SSE associates subsequent data lines with the most recently declared event name.
             current_event = line[len(b"event: ") :].decode("utf-8", "replace")
         elif line.startswith(b"data: ") and current_event == "command":
+            # The server contract uses one JSON value per data line. We do not concatenate arbitrary
+            # multi-line SSE payloads because that would weaken the per-frame size boundary.
             yield json.loads(line[len(b"data: ") :].decode("utf-8"))
         elif line == b"":
             # A blank line terminates the current SSE event; do not let its type bleed into the next
@@ -157,6 +173,8 @@ def open_stream(
     """
     # The open body binds this connection to both the process instance and the exact Kubernetes Pod
     # identity admitted by the server-side runtime stream.
+    # Opening the stream is itself an authenticated admission request, not a passive subscription.
+    # The server checks these coordinates alongside the projected bearer token before sending work.
     body = json.dumps(
         {
             "protocolVersion": PROTOCOL_VERSION,
@@ -174,6 +192,8 @@ def open_stream(
         },
         method="POST",
     )
+    # One loss signal covers both the reader and workers created by this response. A reconnect builds
+    # a new registry rather than allowing old workers to emit through a new authority channel.
     stream_lost = threading.Event()
     workers = _AttemptWorkerRegistry()
 
@@ -218,6 +238,8 @@ def open_stream(
                         cancel_event=workers.current(),
                     )
                 else:
+                    # Forward compatibility is fail-closed: an unknown command cannot acquire model,
+                    # cancellation, or candidate-emission behavior by falling through a default path.
                     continue
                 log(
                     "command_dispatched",


### PR DESCRIPTION
## Summary

- add 297 high-value inline comment lines across all 16 production Python modules in `apps/agent-runtime/src`
- explain command-coordinate authority, bootstrap proof binding, rotating-token custody, stream reconnection, and worker cancellation fences
- document candidate ordering, idempotent terminal replay, deferred tool-result correlation, checkpoint subordination, and zero-retry model boundaries
- clarify why logging, tracing, and protocol projection use allowlisted fields instead of copying commands, provider errors, arguments, or credentials
- keep executable Python unchanged: every modified file has an AST identical to the reviewed parent

## Ancestry

This PR is stacked directly on PR #611 (`feat/simplify-child-run-reservation`) at `686c0977`.

The delta is one documentation-only commit.

## Review order

1. #610
2. #611
3. #613

## Validation

- exact `ast.dump(..., include_attributes=False)` equality for all 16 modified Python files
- `npx nx lint agent-runtime`
- `npx nx test agent-runtime` (80 passed, 2 skipped)
- `scripts/agent-style-check.sh --diff 686c09776251af5bb020a9da852580b107fd108e`
- `npm run check:module-growth -- --diff 686c09776251af5bb020a9da852580b107fd108e`
- `npm run check:release-versioning -- --base 686c09776251af5bb020a9da852580b107fd108e`
- `npm run check:pr-stack-integrity -- --current-branch feat/document-agent-runtime-code`
- `git diff --check`

## Review

- module-growth architecture gate: PASS; the comment-only growth adds no new responsibility or boundary
- independent correctness/security/maintainability/residue review: PASS; no findings remain

## Versioning

This is documentation-only source commentary. It does not change the runtime protocol, application behavior, deployment contract, or `adaptedVersion`.
