### PR TITLE
🐛 Fix onboarding chat conversation pin order

### DIFF
--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -655,6 +655,15 @@
       ],
       "reason": "custody route pre-checks the active same-silo integration before any credential can reach Obot; the read belongs in a declared integrations repository later",
       "expiresOn": "2026-12-31"
+    },
+    {
+      "path": "libs/backend/server/agents/onboarding/main/src/prisma-user-onboarding-repository.ts",
+      "owner": "user-onboarding",
+      "operations": [
+        "transaction"
+      ],
+      "reason": "bootstrap chat start must create the child conversation before the parent pin inside one atomic write; extract a dedicated onboarding UnitOfWork with the next onboarding persistence boundary change.",
+      "expiresOn": "2026-12-31"
     }
   ]
 }

--- a/libs/backend/server/agents/onboarding/main/src/__tests__/prisma-user-onboarding-repository.test.ts
+++ b/libs/backend/server/agents/onboarding/main/src/__tests__/prisma-user-onboarding-repository.test.ts
@@ -1,4 +1,4 @@
-import { Prisma, UserOnboardingBootstrapArchetype, UserOnboardingCompletionProvenance, UserOnboardingState } from "@prisma/client";
+import { Prisma, type PrismaClient, UserOnboardingBootstrapArchetype, UserOnboardingCompletionProvenance, UserOnboardingState } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
 import { PrismaUserOnboardingRepository } from "../prisma-user-onboarding-repository.js";
@@ -29,13 +29,13 @@ const _ROW: Prisma.UserOnboardingGetPayload<Record<string, never>> = {
 /** Build a repository over one explicitly mocked UserOnboarding delegate. */
 function _Repository(delegate: Record<string, unknown>): PrismaUserOnboardingRepository
 {
-	return new PrismaUserOnboardingRepository({ userOnboarding: delegate } as unknown as Prisma.TransactionClient);
+	return new PrismaUserOnboardingRepository({ userOnboarding: delegate } as unknown as Prisma.TransactionClient & Pick<PrismaClient, "$transaction">);
 }
 
 /** Build a repository over the exact chat delegates supplied by one adapter test. */
 function _ChatRepository(delegates: Record<string, unknown>): PrismaUserOnboardingRepository
 {
-	return new PrismaUserOnboardingRepository({ userOnboarding: {}, userOnboardingBootstrapAnswer: {}, userOnboardingBootstrapConversation: {}, ...delegates } as unknown as Prisma.TransactionClient);
+	return new PrismaUserOnboardingRepository({ userOnboarding: {}, userOnboardingBootstrapAnswer: {}, userOnboardingBootstrapConversation: {}, ...delegates } as unknown as Prisma.TransactionClient & Pick<PrismaClient, "$transaction">);
 }
 
 /** Build one exact bootstrap start command with immutable owner, persona, and content pins. */
@@ -141,12 +141,33 @@ describe("PrismaUserOnboardingRepository", function _PrismaUserOnboardingReposit
 		});
 	});
 
-	it("starts by atomically creating and pinning the exact nested conversation", async function _StartsConversation()
+	it("starts by creating the exact conversation before pinning it on the parent", async function _StartsConversation()
 	{
+		const calls: string[] = [];
+		const create = vi.fn(async function _Create()
+		{
+			calls.push("conversation.create");
+		});
 		const update = vi.fn().mockResolvedValue({});
-		const started = await _ChatRepository({ userOnboarding: { update } }).startConversation(_StartCommand());
+		const $transaction = vi.fn(async function _Transaction(work: (transaction: Prisma.TransactionClient) => Promise<void>, options: { readonly isolationLevel: Prisma.TransactionIsolationLevel }): Promise<void>
+		{
+			expect(options.isolationLevel).toBe(Prisma.TransactionIsolationLevel.Serializable);
+			await work({
+				userOnboarding: {
+					update: async function _Update(input: unknown)
+					{
+						calls.push("userOnboarding.update");
+						return update(input);
+					},
+				},
+				userOnboardingBootstrapConversation: { create },
+			} as unknown as Prisma.TransactionClient);
+		});
+		const started = await _ChatRepository({ $transaction }).startConversation(_StartCommand());
 
 		expect(started).toBe(true);
+		expect(calls).toEqual(["conversation.create", "userOnboarding.update"]);
+		expect(create).toHaveBeenCalledWith({ data: { id: "conversation-a", onboardingId: "onboarding-a", siloId: "silo-a", userId: "subject-a", personaRevisionId: "revision-a", personaDisplayName: "The Commander", personaArchetype: UserOnboardingBootstrapArchetype.Commander, contentRevisionId: "bootstrap-commander-v1", contentDigest: `sha256:${"a".repeat(64)}` } });
 		expect(update).toHaveBeenCalledWith({
 			where: { siloId_userId: { siloId: "silo-a", userId: "subject-a" }, state: UserOnboardingState.BootstrapChatPending, id: "onboarding-a", personaRevisionId: "revision-a", bootstrapConversationId: null },
 			data: {
@@ -154,7 +175,6 @@ describe("PrismaUserOnboardingRepository", function _PrismaUserOnboardingReposit
 				bootstrapConversationId: "conversation-a",
 				bootstrapContentRevisionId: "bootstrap-commander-v1",
 				bootstrapContentDigest: `sha256:${"a".repeat(64)}`,
-				ownedBootstrapConversation: { create: { id: "conversation-a", siloId: "silo-a", userId: "subject-a", personaRevisionId: "revision-a", personaDisplayName: "The Commander", personaArchetype: UserOnboardingBootstrapArchetype.Commander, contentRevisionId: "bootstrap-commander-v1", contentDigest: `sha256:${"a".repeat(64)}` } },
 			},
 		});
 	});
@@ -162,9 +182,17 @@ describe("PrismaUserOnboardingRepository", function _PrismaUserOnboardingReposit
 	it("returns a start conflict only for a failed compare-and-set update", async function _RejectsStartConflict()
 	{
 		const conflict = new Prisma.PrismaClientKnownRequestError("stale onboarding", { code: "P2025", clientVersion: "test" });
-		const update = vi.fn().mockRejectedValue(conflict);
+		const $transaction = vi.fn(async function _Transaction(): Promise<void> { throw conflict; });
 
-		await expect(_ChatRepository({ userOnboarding: { update } }).startConversation(_StartCommand())).resolves.toBe(false);
+		await expect(_ChatRepository({ $transaction }).startConversation(_StartCommand())).resolves.toBe(false);
+	});
+
+	it("returns a start conflict when a concurrent winner advances the parent before child insert", async function _RejectsConcurrentStartTrigger()
+	{
+		const conflict = new Prisma.PrismaClientUnknownRequestError("bootstrap conversation must bind the exact pending onboarding owner and persona", { clientVersion: "test" });
+		const $transaction = vi.fn(async function _Transaction(): Promise<void> { throw conflict; });
+
+		await expect(_ChatRepository({ $transaction }).startConversation(_StartCommand())).resolves.toBe(false);
 	});
 
 	it("appends only the exact next question through the answer delegate", async function _AppendsExactQuestion()

--- a/libs/backend/server/agents/onboarding/main/src/prisma-user-onboarding-repository.ts
+++ b/libs/backend/server/agents/onboarding/main/src/prisma-user-onboarding-repository.ts
@@ -6,6 +6,9 @@ import { UserOnboardingAnswerStatuses, UserOnboardingBootstrapArchetypes, UserOn
 import type { AppendUserOnboardingAnswerCommand, StartUserOnboardingChatCommand, UserOnboardingAnswerPersistenceResult, UserOnboardingBootstrapContentRevision, UserOnboardingBootstrapConversation, UserOnboardingChatRepository } from "./user-onboarding-chat.types.js";
 import type { ApprovedPersonaEvidence, UserOnboardingOwner, UserOnboardingRecord, UserOnboardingRepository } from "./user-onboarding.types.js";
 
+/** Trigger text emitted when a concurrent starter loses after another transaction advanced the parent. */
+const _BOOTSTRAP_CONVERSATION_PENDING_TRIGGER = "bootstrap conversation must bind the exact pending onboarding owner and persona";
+
 /** App-composed user-onboarding repository backed by the canonical product database. */
 export function _CreateUserOnboardingRepository(prisma: PrismaClient): UserOnboardingRepository & UserOnboardingChatRepository
 {
@@ -15,11 +18,11 @@ export function _CreateUserOnboardingRepository(prisma: PrismaClient): UserOnboa
 /** Prisma persistence adapter that can mutate only the UserOnboarding authority. */
 export class PrismaUserOnboardingRepository implements UserOnboardingRepository, UserOnboardingChatRepository
 {
-	/** Transaction-scoped canonical product database capability. */
-	private readonly prisma: Prisma.TransactionClient;
+	/** Canonical product database capability used directly or as a transaction opener. */
+	private readonly prisma: Prisma.TransactionClient & Pick<PrismaClient, "$transaction">;
 
 	/** Create an onboarding repository at the reviewed persistence boundary. */
-	constructor(prisma: Prisma.TransactionClient)
+	constructor(prisma: Prisma.TransactionClient & Pick<PrismaClient, "$transaction">)
 	{
 		this.prisma = prisma;
 	}
@@ -120,16 +123,22 @@ export class PrismaUserOnboardingRepository implements UserOnboardingRepository,
 	{
 		try
 		{
-			await this.prisma.userOnboarding.update({
-				where: { siloId_userId: { siloId: command.onboarding.siloId, userId: command.onboarding.subjectId }, state: UserOnboardingState.BootstrapChatPending, id: command.onboarding.id, personaRevisionId: command.persona.personaRevisionId, bootstrapConversationId: null },
-				data: {
-					state: UserOnboardingState.BootstrapChatInProgress,
-					bootstrapConversationId: command.conversationId,
-					bootstrapContentRevisionId: command.content.id,
-					bootstrapContentDigest: command.content.digest,
-					ownedBootstrapConversation: { create: { id: command.conversationId, siloId: command.onboarding.siloId, userId: command.onboarding.subjectId, personaRevisionId: command.persona.personaRevisionId, personaDisplayName: command.persona.displayName, personaArchetype: _PrismaArchetype(command.persona.archetype), contentRevisionId: command.content.id, contentDigest: command.content.digest } },
-				},
-			});
+			await this.prisma.$transaction(async function _StartTransaction(transaction: Prisma.TransactionClient)
+			{
+				// 1. Insert the child evidence while the parent is still pending so its trigger can verify the pending owner and persona.
+				await transaction.userOnboardingBootstrapConversation.create({ data: { id: command.conversationId, onboardingId: command.onboarding.id, siloId: command.onboarding.siloId, userId: command.onboarding.subjectId, personaRevisionId: command.persona.personaRevisionId, personaDisplayName: command.persona.displayName, personaArchetype: _PrismaArchetype(command.persona.archetype), contentRevisionId: command.content.id, contentDigest: command.content.digest } });
+
+				// 2. Pin the parent only after the child row exists, matching the lifecycle trigger's exact provenance check.
+				await transaction.userOnboarding.update({
+					where: { siloId_userId: { siloId: command.onboarding.siloId, userId: command.onboarding.subjectId }, state: UserOnboardingState.BootstrapChatPending, id: command.onboarding.id, personaRevisionId: command.persona.personaRevisionId, bootstrapConversationId: null },
+					data: {
+						state: UserOnboardingState.BootstrapChatInProgress,
+						bootstrapConversationId: command.conversationId,
+						bootstrapContentRevisionId: command.content.id,
+						bootstrapContentDigest: command.content.digest,
+					},
+				});
+			}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
 			return true;
 		}
 		catch (err)
@@ -279,5 +288,6 @@ function _ProjectConversation(conversation: Prisma.UserOnboardingBootstrapConver
 /** Recognise only expected compare-and-set or uniqueness races. */
 function _ExpectedConflict(err: unknown): boolean
 {
-	return err instanceof Prisma.PrismaClientKnownRequestError && (err.code === "P2002" || err.code === "P2025");
+	if (err instanceof Prisma.PrismaClientKnownRequestError) return err.code === "P2002" || err.code === "P2025";
+	return err instanceof Prisma.PrismaClientUnknownRequestError && err.message.includes(_BOOTSTRAP_CONVERSATION_PENDING_TRIGGER);
 }


### PR DESCRIPTION
## Summary

- create the onboarding bootstrap conversation row before pinning it on the parent onboarding record
- keep both writes inside one serializable Prisma transaction so the Postgres lifecycle trigger can see the child row and rollback remains atomic
- treat the expected concurrent duplicate-start trigger loser as a recoverable start conflict so retries resume the winning conversation instead of surfacing 503

## Cause

Prisma's nested update pinned the parent onboarding row before the child bootstrap conversation row was visible to the Postgres trigger.

## Validation

- npx nx run backend-server-user-onboarding:test
- npx tsc -p tsconfig.json --noEmit
- scripts/agent-style-check.sh
- npm run check:prisma-boundaries -- --diff upstream/develop
- npm run check:module-growth -- --diff upstream/develop
- npm run check:release-versioning -- --base upstream/develop
- git diff --check
- independent review pass: no correctness/security findings