### PR TITLE
🔧 Repair conversation CI prerequisites

### DIFF
--- a/libs/frontend/state/conversation/ag-ui/src/__tests__/ag-ui-client-conformance.test.ts
+++ b/libs/frontend/state/conversation/ag-ui/src/__tests__/ag-ui-client-conformance.test.ts
@@ -72,7 +72,7 @@ describe("pinned AG-UI client conformance", function _PinnedClientConformance()
 
 	it("preserves one open approval across reconnect and forwards approve-with-edits exactly", async function _ApprovalResume()
 	{
-		const interrupt = { id: "approval-1", reason: "tool_approval", message: "Review the exact query", toolCallId: "tool-1", responseSchema: { type: "object", required: ["query"], properties: { query: { type: "string" } } }, expiresAt: "2026-08-12T00:00:00.000Z" };
+		const interrupt = { id: "approval-1", reason: "tool_approval", message: "Review the exact query", toolCallId: "tool-1", responseSchema: { type: "object", required: ["query"], properties: { query: { type: "string" } } }, expiresAt: "2099-08-12T00:00:00.000Z" };
 		const agent = new _ProjectedEventAgent([
 			[_Started("run-approval"), { type: EventType.RUN_FINISHED, threadId: "conversation-1", runId: "run-approval", outcome: { type: "interrupt", interrupts: [interrupt] } }],
 			[_Started("run-resume"), _Succeeded("run-resume")]


### PR DESCRIPTION
## Summary

- keep the pinned AG-UI approval-resume fixture active beyond its original calendar date
- refresh the checked-in current Helm dependency archives so they match their already-merged source charts
- unblock every downstream conversation PR from inherited date-dependent and package-drift failures

## Validation

- frontend-conversation-ag-ui lint
- frontend-conversation-ag-ui tests: 22 passed
- release-versioning check
- git diff check

## Review order

1. #618

## Related

Test and packaging prerequisites only; no product behavior is added.