### PR TITLE
📝 Rewrite server-lib comments in plain English with heavy export JSDoc

### DIFF
--- a/libs/backend/server/agents/agent-services/main/src/agent-publication.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-publication.types.ts
@@ -15,7 +15,14 @@ export interface PublishAgentRevisionCommand
 	readonly publishedAt: string;
 }
 
-/** Atomic publication request after the domain has validated service and revision ownership. */
+/**
+ * The publish request handed to the database once {@link __PublishAgentRevision} has confirmed the
+ * service exists, is not retired, and owns a publishable draft.
+ *
+ * It carries two "as I last saw it" values — `expectedServiceState` and `expectedActiveRevisionId`.
+ * The database re-checks both under a lock and refuses the write if either moved, which is what
+ * stops two administrators from overwriting each other.
+ */
 export interface AtomicAgentRevisionPublication
 {
 	/** Stable service receiving the published revision. */
@@ -30,23 +37,80 @@ export interface AtomicAgentRevisionPublication
 	readonly publishedAt: string;
 }
 
-/** Result returned by the repository's publication compare-and-swap. */
+/**
+ * Outcome of the database step that publishes a revision and repoints the service at it.
+ *
+ * The two writes happen inside one transaction that first locks the service row, so the update only
+ * lands if the service is still on the exact revision the caller said it had observed. That check is
+ * the compare-and-swap: compare the stored active revision against the expected one, swap only on a
+ * match.
+ *
+ * A publisher that loses the race gets `conflict` with `currentActiveRevisionId` — the revision the
+ * winner just activated (null if the service has no active revision). Nothing was written for the
+ * loser: its draft is still a draft and is still publishable. The fix is to re-read the service and
+ * publish again with the new active revision as `expectedActiveRevisionId`, after checking that the
+ * winner's revision has not made the change unnecessary.
+ */
 export type AtomicAgentRevisionPublicationResult =
 	| { readonly status: "published"; readonly service: AgentService; readonly revision: AgentRevision }
 	| { readonly status: "conflict"; readonly currentActiveRevisionId: AgentRevisionId | null };
 
-/** Concurrency-capable persistence boundary for agent-service publication. */
+/**
+ * Reads and publishes agent-service revisions.
+ *
+ * Both read methods are silo-scoped and return `null` for anything outside the caller's silo, so a
+ * caller cannot tell a foreign service from a missing one. `publishRevisionAtomically` is the only
+ * write, and it is built as one locked transaction so two administrators publishing at the same
+ * moment cannot both succeed.
+ *
+ * Implemented by: `PrismaAgentServicePublicationRepository` in `prisma-agent-publication.ts`.
+ * Called by: {@link __PublishAgentRevision} in `agent-publication.ts`; a caller-attributed instance
+ * is built per request by `_publicationFor` in `prisma-agent-services.router.ts` so the audit row
+ * names the real administrator.
+ */
 export interface AgentServicePublicationRepository
 {
 	/** Loads one stable service identity scoped to the caller's silo, or null. */
 	getService(agentServiceId: AgentServiceId, siloId: SiloId): Promise<AgentService | null>;
 	/** Loads one immutable revision whose parent service is in the caller's silo, or null. */
 	getRevision(agentRevisionId: AgentRevisionId, siloId: SiloId): Promise<AgentRevision | null>;
-	/** Atomically publishes the draft and activates it only when the expected active revision still matches. */
+	/**
+	 * Marks the draft published and points the service at it, in one transaction.
+	 *
+	 * The implementation locks the service row, then the revision row, always in that order, so
+	 * concurrent publishes queue instead of deadlocking. It then re-checks the service state, the
+	 * active revision, the revision's parent service, and that the revision is still a draft. Any
+	 * mismatch aborts with `conflict` and writes nothing. An audit row is appended before commit, so a
+	 * failed audit write rolls the whole publication back.
+	 *
+	 * @param publication - The service, the draft, and the two values that must still match: the
+	 *   observed service state and the observed active revision.
+	 * @returns `published` with the updated service and revision, or `conflict` with the active
+	 *   revision as it is now.
+	 * @throws Whatever the database layer throws when the transaction itself fails. The router turns
+	 *   that into a 500; it is not a `conflict`.
+	 */
 	publishRevisionAtomically(publication: AtomicAgentRevisionPublication): Promise<AtomicAgentRevisionPublicationResult>;
 }
 
-/** Stable reason that publication did not change authority state. */
+/**
+ * Why a publish attempt changed nothing.
+ *
+ * The strings are stable because the router upper-cases them into the response `code`.
+ * - `invalid_command` (400): an id was empty or `publishedAt` was not a parseable date.
+ * - `service_not_found` (404): no such service in the caller's silo (a foreign-silo service also
+ *   reads as not-found, so it cannot be probed).
+ * - `service_retired` (409): the service is retired and accepts no more publications.
+ * - `revision_not_found` (404): no such revision in the caller's silo.
+ * - `revision_service_mismatch` (409): that revision belongs to a different service in this silo.
+ * - `revision_not_draft` (409): the revision was already published (or rejected/retired). Publish is
+ *   a one-way step per revision; make a new draft instead.
+ * - `invalid_revision` (422): the stored revision fails its own checks — a non-positive budget
+ *   ceiling, a malformed tool definition, or a digest that no longer matches its content. This means
+ *   the row was tampered with or written by an older, incompatible writer; do not retry, investigate.
+ * - `publication_conflict` (409): another publisher won the race. See
+ *   {@link PublishAgentRevisionResult} for what to do next.
+ */
 export type PublishAgentRevisionFailureReason =
 	| "invalid_command"
 	| "service_not_found"
@@ -57,7 +121,10 @@ export type PublishAgentRevisionFailureReason =
 	| "invalid_revision"
 	| "publication_conflict";
 
-/** Result of publishing one immutable agent revision. */
+/**
+ * Outcome of a publish request. `currentActiveRevisionId` is present only when `reason` is
+ * `publication_conflict`, and then it is the revision the winning publisher activated.
+ */
 export type PublishAgentRevisionResult =
 	| { readonly outcome: "published"; readonly service: AgentService; readonly revision: AgentRevision }
 	| { readonly outcome: "denied"; readonly reason: PublishAgentRevisionFailureReason; readonly currentActiveRevisionId?: AgentRevisionId | null };

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-content.parser.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-content.parser.ts
@@ -8,7 +8,7 @@ function _isNonEmptyString(value: unknown): value is string
 	return typeof value === "string" && value.trim().length > 0;
 }
 
-/** Returns whether a string is safe as one segment of the runtime integration tool revision. */
+/** Returns whether a string can be used in a colon-joined runtime tool name: non-empty and containing no `:`. A colon inside a segment would let two different integrations produce the same joined name. */
 function _isToolRevisionSegment(value: unknown): value is string
 {
 	return _isNonEmptyString(value) && !value.includes(":");
@@ -61,7 +61,7 @@ function _parseIntegrations(raw: unknown): AgentRevisionContent["integrationAssi
 	return assignments.some(assignment => assignment === null) ? null : (assignments as AgentRevisionContent["integrationAssignments"]);
 }
 
-/** Parses the optional revision-scoped scope-attachment array against the canonical vocabulary. */
+/** Parses the optional scope-attachment array, accepting only the five known scope names and the three known subject types. Absent means no attachments; malformed means the whole request is rejected. */
 function _parseScopeAttachments(raw: unknown): AgentRevisionContent["scopeAttachments"] | null
 {
 	if (raw === undefined) return [];
@@ -77,7 +77,22 @@ function _parseScopeAttachments(raw: unknown): AgentRevisionContent["scopeAttach
 	return attachments.some(attachment => attachment === null) ? null : (attachments as AgentRevisionContent["scopeAttachments"]);
 }
 
-/** Parses and validates immutable executable content from the reviewed administrator payload. */
+/**
+ * Turns an untrusted request body into agent revision content, or returns null.
+ *
+ * This is the only door between JSON off the wire and anything the runtime will execute, so it
+ * accepts nothing it cannot fully check and never fills in a default for a malformed field. It
+ * rejects a body whose `promptPolicyVersion` is not the compiler version this build ships, so a
+ * revision authored against a different prompt compiler cannot be stored and later mis-compiled.
+ *
+ * Called by: the create and revise handlers in `agent-revision.router.ts`, both of which answer 400
+ * `VALIDATION_ERROR` on null.
+ *
+ * @param raw - `req.body.content`, entirely untrusted.
+ * @returns Content safe to hand to {@link __CreateManagedAgentService} / {@link __ReviseAgentRevision},
+ *   or null when anything is missing, malformed, or of the wrong type. Null carries no detail on
+ *   purpose — the response must not tell a caller which internal check tripped.
+ */
 export function _ParseAgentRevisionContent(raw: unknown): AgentRevisionContent | null
 {
 	// 1. Bound the top-level JSON object before inspecting any executable field.
@@ -85,18 +100,18 @@ export function _ParseAgentRevisionContent(raw: unknown): AgentRevisionContent |
 	const body = raw as Record<string, unknown>;
 	const budget = body.budget as Record<string, unknown> | undefined;
 
-	// 2. Require the deployed compiler pin and complete primitive revision coordinates.
+	// 2. Require the prompt-compiler version this build ships, plus a model id and all three budget numbers.
 	if (body.promptPolicyVersion !== PROMPT_COMPILER_VERSION || !_isNonEmptyString(body.modelDefinitionId) || budget === undefined || typeof budget !== "object") return null;
 	if (typeof budget.maxTurns !== "number" || typeof budget.maxTokens !== "number" || typeof budget.maxDurationMs !== "number") return null;
 	const personaRevisionId = body.personaRevisionId === undefined || body.personaRevisionId === null ? null : body.personaRevisionId;
 	if (personaRevisionId !== null && !_isNonEmptyString(personaRevisionId)) return null;
 
-	// 3. Parse every nested authority with no fallback for malformed assignments or schemas.
+	// 3. Parse the nested arrays. One malformed entry rejects the whole body — never a partial list.
 	const skills = _parseSkills(body.skills);
 	const integrationAssignments = _parseIntegrations(body.integrationAssignments);
 	const scopeAttachments = _parseScopeAttachments(body.scopeAttachments);
 	if (skills === null || integrationAssignments === null || scopeAttachments === null) return null;
 
-	// 4. Return only the canonical domain shape consumed by revision validation and persistence.
+	// 4. Rebuild the value field by field, so nothing extra from the request body is carried through.
 	return { promptPolicyVersion: body.promptPolicyVersion, personaRevisionId, modelDefinitionId: body.modelDefinitionId, budget: { maxTurns: budget.maxTurns, maxTokens: budget.maxTokens, maxDurationMs: budget.maxDurationMs }, skills, integrationAssignments, scopeAttachments };
 }

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-lifecycle.types.ts
@@ -7,7 +7,7 @@ export interface CreateManagedAgentServiceCommand
 	readonly siloId: SiloId;
 	/** Human-readable service name. */
 	readonly name: string;
-	/** Named workload profile projecting runtime policy. */
+	/** Runtime profile name the agent controller turns into a Kubernetes Job (image, limits, identity). Must be `MANAGED_AGENT_RUNTIME_PROFILE_NAME` — the only profile the controller can resolve. */
 	readonly workloadProfile: string;
 	/** Author of the first revision. */
 	readonly authoredBy: string;
@@ -17,7 +17,7 @@ export interface CreateManagedAgentServiceCommand
 	readonly content: AgentRevisionContent;
 }
 
-/** Command that appends one new draft revision editing the expected head. */
+/** Request to add a new draft revision on top of the newest one. Carries the revision the author edited so a concurrent append is rejected rather than overwritten. */
 export interface ReviseAgentRevisionCommand
 {
 	/** Silo the caller is operating within; a service in another silo must not resolve. */
@@ -51,7 +51,7 @@ export interface RestoreAgentRevisionCommand
 	readonly changeMessage: string;
 }
 
-/** Lifecycle action changing a stable AgentService state. */
+/** The three state changes a service supports: `enable` → active, `pause` → paused, `retire` → retired. Retiring also clears the active revision and cannot be undone. */
 export type AgentServiceLifecycleAction = "enable" | "pause" | "retire";
 
 /** Command that changes a stable AgentService state with optimistic concurrency. */
@@ -67,23 +67,37 @@ export interface ChangeAgentServiceStateCommand
 	readonly action: AgentServiceLifecycleAction;
 }
 
-/** Why a managed run was admitted: an explicit run-now, or a due schedule slot. */
+/**
+ * Who asked for the run: `managed_invocation` for a person pressing run-now, `schedule` for a cron
+ * slot coming due. Recorded on the run row so history can tell the two apart.
+ */
 export type ManagedRunTrigger = "managed_invocation" | "schedule";
 
 /**
- * Stable outcomes produced by the managed run-admission boundary.
+ * What happened when a run-now or scheduled-slot request was recorded.
  *
- * These values are returned to browser and scheduler callers and remain serialized as shown. They
- * describe whether this authority created a run, resolved an existing idempotent run, or denied the
- * command; they do not grant permission independently of the admission checks.
+ * The strings are stable because both the browser and the scheduler compare against them.
+ * `Accepted` and `Idempotent` are both successes and both carry a run id — the difference is only
+ * whether this call created the row. Treating `Idempotent` as a failure is the usual mistake: it
+ * means the same `requestIdempotencyKey` already produced a run, which is exactly what a retried
+ * POST or two schedulers racing on the same cron slot should produce. The router answers 202 for
+ * `Accepted` and 200 for `Idempotent`.
+ *
+ * These values report an outcome; they do not themselves authorise anything. The admission checks in
+ * {@link __AdmitManagedRunNow} and the run-input assembler decide that.
+ *
+ * Called by: `libs/backend/agents/execution/admission/main/src/managed-run-admission.ts` produces
+ * them; `libs/backend/server/agents/scheduling/main/src/schedule-tick.ts` and the run-now handler in
+ * `agent-revision.router.ts` branch on them.
+ * @see {@link ManagedRunAdmissionResult} for the payload attached to each outcome.
  */
 export enum ManagedRunAdmissionOutcomes
 {
-	/** A new durable AgentRun was accepted through the shared admission authority. */
+	/** This call created the run row. The router answers 202 with the new run id. */
 	Accepted = "accepted",
-	/** The supplied idempotency key resolved to the already accepted durable AgentRun. */
+	/** This key already created a run; the same run id comes back. Success, not a duplicate error. */
 	Idempotent = "idempotent",
-	/** The admission command was refused with one stable lifecycle reason. */
+	/** No run was created; `reason` carries one {@link AgentRevisionLifecycleDenial} value. */
 	Denied = "denied",
 }
 
@@ -112,7 +126,58 @@ export interface ManagedRunNowCommand
 	readonly scheduledSlot: string | null;
 }
 
-/** Stable reason a lifecycle command was refused before touching authority state. */
+/**
+ * Why a managed-agent lifecycle or run command was refused.
+ *
+ * These strings are stable: the router upper-cases the value into the response `code`, and
+ * {@link https://www.rfc-editor.org/rfc/rfc6648 RFC 6648} style renaming would break clients. Two
+ * groups produce them. The definition-plane use cases in `agent-revision-lifecycle.ts` produce the
+ * first nine; the rest come back through {@link ManagedRunAdmissionPort} from the run-input
+ * assembler (`SessionAssemblyRefusalReason` in
+ * libs/backend/agents/execution/inputs/main/src/session-assembly-result.types.ts) and the capacity
+ * gate (`RunAdmissionConcurrencyDenialReasons` in
+ * libs/backend/agents/execution/runs/main/src/run-admission-concurrency.types.ts).
+ *
+ * What the caller must change, per value:
+ * - `invalid_command` (400): a required field was empty, or the date was not parseable. Fix the body.
+ * - `service_not_found` (404): no service with that id exists in the caller's silo. A service in
+ *   another silo also reads as not-found on purpose, so nobody can probe for foreign services.
+ * - `service_retired` (409): the service is retired. Nothing can be appended to it again.
+ * - `revision_not_found` (404): no revision with that id exists in the caller's silo.
+ * - `revision_service_mismatch` (409): the revision exists in this silo but belongs to a different
+ *   service. Pass a revision of the service in the URL.
+ * - `model_definition_unavailable` (422): `content.modelDefinitionId` is neither a Global model nor
+ *   one owned by this silo. Pick a model the silo can actually route to.
+ * - `transition_not_allowed` (409): the requested enable/pause/retire is illegal from the state the
+ *   caller claims to have observed. Re-read the service and retry from its real state.
+ * - `service_not_runnable` (409): the service is not Managed, is not Active, or has no published
+ *   active revision. Publish a revision first, then enable the service.
+ * - `run_not_admittable` (409): the run's active published revision could not be re-read at
+ *   admission time. Re-read the service; its active revision probably moved.
+ * - `revision_unavailable`, `persona_unavailable`, `conversation_unavailable`,
+ *   `memory_unavailable`, `tool_policy_unavailable`, `skill_unavailable`, `budget_unavailable`,
+ *   `identity_unavailable` (409): one input the run needs could not be assembled. These are
+ *   configuration problems, not transient ones — fix the revision, do not retry the same request.
+ * - `memory_scope_unavailable` (409): a scope attachment on the revision is not backed by a real
+ *   grant, or a managed service attached a `personal` scope (never allowed). Remove the attachment
+ *   or grant the scope.
+ * - `membership_stale` (503): the signed fleet-membership evidence for the agent principal is
+ *   missing or older than the configured limit. Retry after the issuer republishes.
+ * - `persistence_unavailable` (503): a database write failed with no safe outcome to report. Retry.
+ * - `authority_conflict` (409): a row with the same idempotency key belongs to a different silo,
+ *   service, or revision. Use a fresh key.
+ * - `admission_concurrency_limited` (503 with `Retry-After: 1`): the admission queue is full. Retry.
+ *
+ * `membership_stale`, `admission_concurrency_limited`, `persistence_unavailable`, and
+ * `authority_conflict` are the four the scheduler treats as worth retrying (`_RETRYABLE_DENIALS` in
+ * libs/backend/server/agents/scheduling/main/src/schedule-tick.ts); every other value makes the
+ * scheduler record the slot and move on, so a broken revision cannot wedge a schedule forever.
+ *
+ * Called by: `_denialStatus` and `_runDenialStatus` in `agent-revision.router.ts` map these to HTTP
+ * status codes; `_RETRYABLE_DENIALS` in libs/backend/server/agents/scheduling/main/src/schedule-tick.ts
+ * decides retry-versus-drop.
+ * @see {@link ManagedRunAdmissionResult} for how a denial is returned to a run-now caller.
+ */
 export type AgentRevisionLifecycleDenial =
 	| "invalid_command"
 	| "service_not_found"
@@ -137,24 +202,36 @@ export type AgentRevisionLifecycleDenial =
 	| "authority_conflict"
 	| "admission_concurrency_limited";
 
-/** Result of creating a managed service. */
+/** Outcome of creating a managed service: the new service plus its first draft revision, or a refusal with a {@link AgentRevisionLifecycleDenial} reason. */
 export type CreateManagedAgentServiceResult =
 	| { readonly outcome: "created"; readonly service: AgentService; readonly revision: AgentRevision }
 	| { readonly outcome: "denied"; readonly reason: AgentRevisionLifecycleDenial };
 
-/** Result of appending a revision through revise or restore. */
+/**
+ * Outcome of appending a revision through revise or restore.
+ *
+ * `conflict` means another author appended first: `currentHeadRevisionId` is the newest revision now
+ * stored (null if the service somehow has none). The caller must re-read that revision, re-apply its
+ * edit on top of it, and send the request again with that id as `expectedParentRevisionId`. Nothing
+ * was written, so retrying with the old id will just conflict again. The router maps this to 409.
+ */
 export type AppendAgentRevisionResult =
 	| { readonly outcome: "revised"; readonly revision: AgentRevision }
 	| { readonly outcome: "conflict"; readonly currentHeadRevisionId: AgentRevisionId | null }
 	| { readonly outcome: "denied"; readonly reason: AgentRevisionLifecycleDenial };
 
-/** Result of a stable-service state change. */
+/**
+ * Outcome of an enable, pause, or retire request.
+ *
+ * `conflict` means the service was not in the state the caller claimed to have observed;
+ * `currentState` is what it is now, and nothing was changed. Retry from that state.
+ */
 export type ChangeAgentServiceStateResult =
 	| { readonly outcome: "changed"; readonly service: AgentService }
 	| { readonly outcome: "conflict"; readonly currentState: AgentServiceState }
 	| { readonly outcome: "denied"; readonly reason: AgentRevisionLifecycleDenial };
 
-/** Result of comparing two revisions of the same service. */
+/** Outcome of comparing two revisions: both revisions plus their differences, or a refusal (both revisions must exist in the caller's silo and belong to the same service). */
 export type CompareAgentRevisionsResult =
 	| { readonly outcome: "compared"; readonly base: AgentRevision; readonly target: AgentRevision; readonly diff: AgentRevisionDiff }
 	| { readonly outcome: "denied"; readonly reason: AgentRevisionLifecycleDenial };
@@ -168,34 +245,67 @@ export interface AgentServiceHistory
 	readonly runs: readonly AgentRun[];
 }
 
-/** Concurrency-capable persistence boundary for the managed-agent definition plane. */
+/**
+ * Stores and reads managed-agent definitions: services, their revision lineage, and run history.
+ *
+ * Every method is silo-scoped. A service or revision belonging to another silo reads as `null`, not
+ * as a permission error, so a caller cannot use this to discover that a foreign service exists.
+ *
+ * Revisions are append-only. `reviseRevision` and `restoreRevision` add a new draft rather than
+ * editing an existing one, and each takes the revision the author was looking at
+ * (`expectedParentRevisionId`); if someone else appended first, the call returns a conflict with the
+ * current newest revision instead of silently overwriting the other author's work.
+ *
+ * Implemented by: `PrismaAgentRevisionLifecycleRepository` in `prisma-agent-revision-lifecycle.ts`.
+ * Called by: the seven `__*` use cases in `agent-revision-lifecycle.ts`; wired in
+ * `prisma-agent-services.router.ts`.
+ */
 export interface AgentRevisionLifecycleRepository
 {
-	/** Lists managed service identities in the caller's silo, newest first, for catalogue discovery. */
+	/** Lists managed services in the caller's silo, most recently updated first, capped at 200 rows. */
 	listManagedServices(siloId: SiloId): Promise<readonly AgentService[]>;
 	/** Loads one stable service identity scoped to the caller's silo, or null when absent. */
 	getService(agentServiceId: AgentServiceId, siloId: SiloId): Promise<AgentService | null>;
 	/** Loads one immutable revision whose parent service is in the caller's silo, or null. */
 	getRevision(agentRevisionId: AgentRevisionId, siloId: SiloId): Promise<AgentRevision | null>;
-	/** Creates a managed service and its first draft revision atomically. */
+	/** Creates the service and its first draft revision in one transaction, so a service can never exist with no revision. */
 	createManagedService(command: CreateManagedAgentServiceCommand, createdAt: string): Promise<CreateManagedAgentServiceResult>;
-	/** Appends a new draft revision editing the expected head atomically, silo-scoped. */
+	/** Adds a draft revision on top of the newest one, in one transaction; returns a conflict if another author appended first. */
 	reviseRevision(command: ReviseAgentRevisionCommand, createdAt: string): Promise<AppendAgentRevisionResult>;
 	/** Clones an older revision into a new draft revision atomically, silo-scoped. */
 	restoreRevision(command: RestoreAgentRevisionCommand, createdAt: string): Promise<AppendAgentRevisionResult>;
-	/** Changes a stable service state under optimistic concurrency atomically, silo-scoped. */
+	/** Changes the service state only if it still matches `expectedState`; otherwise returns a conflict with the current state. */
 	changeServiceState(command: ChangeAgentServiceStateCommand, changedAt: string): Promise<ChangeAgentServiceStateResult>;
 	/** Reads the silo-scoped revision lineage and durable run history for one service. */
 	readHistory(agentServiceId: AgentServiceId, siloId: SiloId, runLimit: number): Promise<AgentServiceHistory>;
 }
 
-/** Result of admitting one managed run-now request. */
+/**
+ * Outcome of one run-now or scheduled-slot request.
+ *
+ * `Accepted` and `Idempotent` both carry `runId` and both mean a run exists. Only `Denied` carries a
+ * `reason`, and {@link AgentRevisionLifecycleDenial} says which reasons are worth retrying.
+ */
 export type ManagedRunAdmissionResult =
 	| { readonly outcome: ManagedRunAdmissionOutcomes.Accepted; readonly runId: string }
 	| { readonly outcome: ManagedRunAdmissionOutcomes.Idempotent; readonly runId: string }
 	| { readonly outcome: ManagedRunAdmissionOutcomes.Denied; readonly reason: AgentRevisionLifecycleDenial };
 
-/** App-owned boundary that records a managed run admission on the shared run substrate. */
+/**
+ * Records one managed-agent run in the database, without starting it.
+ *
+ * This package decides *whether* a run may be admitted (is the service managed, active, and does it
+ * have a published revision) but deliberately does not own the run tables, so it calls out through
+ * this one method. The implementation writes an AgentRun row, compiles its frozen input snapshot,
+ * and stops. Nothing here creates a Kubernetes Job or executes agent logic — a separate dispatcher
+ * picks the row up later.
+ *
+ * Implemented by: `_CreateManagedRunAdmissionPortWithGate` and `__CreateManagedRunAdmissionPort` in
+ * libs/backend/agents/execution/admission/main/src/managed-run-admission{,.composition}.ts.
+ * Called by: {@link __AdmitManagedRunNow} in `agent-revision-lifecycle.ts` (the HTTP run-now path),
+ * and `__RunScheduleTick` in libs/backend/server/agents/scheduling/main/src/schedule-tick.ts (the
+ * cron path).
+ */
 export interface ManagedRunAdmissionPort
 {
 	/**

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision-model-selection.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision-model-selection.types.ts
@@ -1,4 +1,10 @@
-/** Intent to clone one active personal revision with a newly selected model definition. */
+/**
+ * Request to copy a personal agent's active revision with only its model changed.
+ *
+ * The `expected*` fields are what the owner was looking at when they accepted the change. They are
+ * re-checked before any write, so a request that has gone stale is refused rather than applied to a
+ * revision the owner never reviewed.
+ */
 export interface MaterializeAgentRevisionModelSelectionCommand
 {
 	/** Silo that owns both the personal service and selected model definition. */
@@ -7,9 +13,9 @@ export interface MaterializeAgentRevisionModelSelectionCommand
 	readonly agentServiceId: string;
 	/** Active revision accepted when the owner reviewed the model proposal. */
 	readonly expectedSourceRevisionId: string;
-	/** Persona revision accepted with the proposal and preserved in the clone. */
+	/** Persona the owner saw alongside the model choice, or null. Refused as `StaleSource` if the source revision now carries a different one, so a model choice cannot be applied to a personality the owner never reviewed. */
 	readonly expectedPersonaRevisionId: string | null;
-	/** Normalized owner-visible alias resolved without accepting a provider identifier. */
+	/** The model's public name (a `ModelDefinition.publicModelName`), not a provider model id. Callers must not send a provider identifier; a silo-scoped definition wins over a global one with the same name. NEEDS-HUMAN: add the LiteLLM model-registration doc URI — these names are what the control plane registers with LiteLLM. */
 	readonly modelAlias: string;
 	/** Human-readable explanation recorded on the immutable revision. */
 	readonly changeMessage: string;
@@ -20,10 +26,15 @@ export interface MaterializeAgentRevisionModelSelectionCommand
 }
 
 /**
- * Stable results from agent-services' model-selection strategy.
+ * Outcome of a model swap on a personal agent.
  *
- * Personal configuration consumes these values across a package boundary, so agent-services owns
- * the vocabulary and preserves the strings while callers compile against one shared contract.
+ * The strings are stable because another package (personal configuration) branches on them.
+ * `StaleSource` and `ModelUnavailable` need different handling: `StaleSource` means the world moved
+ * under a proposal the owner had already accepted, so the owner has to look again; `ModelUnavailable`
+ * means the request itself named a model this silo cannot route to.
+ *
+ * Called by: `personal-configuration-materializer.ts` in
+ * libs/backend/agents/personal/configuration/main/src/materialization/.
  */
 export enum AgentRevisionModelSelectionMaterializationCodes
 {
@@ -31,7 +42,7 @@ export enum AgentRevisionModelSelectionMaterializationCodes
 	Materialized = "materialized",
 	/** No registered model definition matches the owner-visible alias in the silo. */
 	ModelUnavailable = "model_unavailable",
-	/** The service or source revision changed after the proposal was accepted. */
+	/** The service moved off the approved revision, its persona changed, or a newer revision was added since the owner accepted. Nothing was written; re-read and propose again. */
 	StaleSource = "stale_source",
 }
 
@@ -41,9 +52,39 @@ export type MaterializeAgentRevisionModelSelectionResult =
 	| { readonly status: AgentRevisionModelSelectionMaterializationCodes.ModelUnavailable }
 	| { readonly status: AgentRevisionModelSelectionMaterializationCodes.StaleSource };
 
-/** Agent-service strategy port used inside an owning unit-of-work transaction. */
+/**
+ * Swaps the model on a personal agent's active revision, inside a transaction someone else owns.
+ *
+ * Personal configuration owns the transaction because it also has to move its own proposal journal
+ * in the same commit; it must not reproduce revision lineage rules, so it calls in here. This port
+ * appends and activates a revision but never commits — the caller does, and a later failure on the
+ * caller's side rolls these writes back with it.
+ *
+ * Implemented by: `PrismaAgentRevisionModelSelectionRepository` in
+ * `prisma-agent-revision-model-selection.ts`.
+ * Called by:
+ * libs/backend/agents/personal/configuration/main/src/materialization/prisma-personal-configuration-materialization-unit-of-work.ts
+ * (construction) and `personal-configuration-materializer.ts` (invocation).
+ */
 export interface AgentRevisionModelSelectionRepository
 {
-	/** Revalidates the accepted source and atomically prepares the selected-model revision. */
+	/**
+	 * Re-checks the revision the owner approved, then appends and activates its model-swapped copy.
+	 *
+	 * Four checks run before any write, so a stale request is always safe to retry: the service must
+	 * still be an active personal service in the silo and still be on `expectedSourceRevisionId`; that
+	 * revision must still be published and still carry `expectedPersonaRevisionId` (so a model choice
+	 * cannot land on a personality the owner never saw); it must still be the newest revision in the
+	 * lineage; and only then is `modelAlias` resolved. The new revision copies the source's content
+	 * with just the model changed.
+	 *
+	 * @param command - Service, the revision and persona the owner approved, the chosen model alias, and
+	 *   the author and time to record.
+	 * @returns `Materialized` with the new revision id, `StaleSource` if any of the first three checks
+	 *   failed (nothing written — re-read and re-propose), or `ModelUnavailable` if no model in this silo
+	 *   answers to that alias.
+	 * @throws Whatever Prisma throws inside the caller's transaction, including a serialization failure.
+	 *   The caller's transaction is then rolled back and nothing is activated.
+	 */
 	materialize(command: MaterializeAgentRevisionModelSelectionCommand): Promise<MaterializeAgentRevisionModelSelectionResult>;
 }

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision.router.ts
@@ -78,8 +78,12 @@ function _publishDenialStatus(reason: PublishAgentRevisionFailureReason): number
  * administrators cannot silently overwrite each other. run-now records an admission on the shared
  * run substrate and never dispatches or executes anything.
  *
- * @param dependencies - Composition-root persistence, admission, caller, clock, and logging ports.
- * @returns The configured Express router.
+ * Called by: `_CreateAgentServicesRouter` in `prisma-agent-services.router.ts`, which supplies the
+ * Prisma-backed dependencies and is mounted at `/api/v1/agent-services` by
+ * apps/opencrane/src/app/routes.ts.
+ *
+ * @param dependencies - Persistence, admission, caller resolution, clock, and logging.
+ * @returns An Express router with no prefix of its own; the caller decides where it mounts.
  */
 export function __CreateAgentServicesRouter(dependencies: AgentServicesRouterDependencies): Router
 {
@@ -87,8 +91,10 @@ export function __CreateAgentServicesRouter(dependencies: AgentServicesRouterDep
 	const { lifecycle, publicationFor, runAdmission, schedules, scopeGrantResolver, resolveCaller, clock, logger } = dependencies;
 
 	/**
-	 * Enforce that the caller administers every scope they attach, before the revision is persisted.
-	 * Returns true when the request may proceed; otherwise it has already sent a fail-closed response.
+	 * Check the caller holds every scope the new revision attaches, before anything is stored.
+	 *
+	 * @returns True to carry on. On false it has already sent 403 `FORBIDDEN_SCOPE_ATTACHMENT` listing
+	 *   the offending attachments, so the caller must return immediately and not touch the response.
 	 */
 	async function _authoriseAttachments(caller: ManagementCaller, content: AgentRevisionContent, res: Response): Promise<boolean>
 	{
@@ -97,7 +103,7 @@ export function __CreateAgentServicesRouter(dependencies: AgentServicesRouterDep
 		return true;
 	}
 
-	/** Resolves an org-admin caller, or sends the fail-closed 401/403 envelope. */
+	/** Returns the caller only if authenticated AND an org admin. On null it has already sent 401 or 403, so the handler must return at once. */
 	function _requireAdmin(req: Request, res: Response): ManagementCaller | null
 	{
 		const caller = resolveCaller(req);
@@ -323,7 +329,7 @@ export function __CreateAgentServicesRouter(dependencies: AgentServicesRouterDep
 		});
 	}
 
-	/** Emits the shared append (revise/restore) result envelope. */
+	/** Sends the response for revise and restore, which return the same shape: 201 with the new revision, 409 with the current newest revision id, or the denial's own status. */
 	function _sendAppend(res: Response, result: Awaited<ReturnType<typeof __ReviseAgentRevision>>): void
 	{
 		if (result.outcome === "conflict") { res.status(409).json({ error: "A newer revision exists; rebase on the current head.", code: "REVISION_CONFLICT", currentHeadRevisionId: result.currentHeadRevisionId }); return; }

--- a/libs/backend/server/agents/agent-services/main/src/agent-revision.router.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-revision.router.types.ts
@@ -7,7 +7,13 @@ import type { AgentRevisionLifecycleRepository, ManagedRunAdmissionPort } from "
 import type { AgentScheduleRepository } from "./agent-schedule.types.js";
 import type { ScopeGrantResolver } from "./scope-attachment-authority.types.js";
 
-/** Authenticated management caller resolved by the app from the browser session. */
+/**
+ * Who is making a management request, worked out by the app from the browser session and request
+ * host — never from the request body.
+ *
+ * The router trusts this completely: `siloId` scopes every query, and `isOrgAdmin` is the only gate
+ * on every mutation. Anything that builds one of these is deciding authorisation.
+ */
 export interface ManagementCaller
 {
 	/** Stable IdP subject of the caller. */
@@ -18,7 +24,7 @@ export interface ManagementCaller
 	readonly isOrgAdmin: boolean;
 }
 
-/** Server-owned clock injected for deterministic management-time instants. */
+/** Supplies the timestamps written to `createdAt`, `publishedAt`, and `updatedAt`. It is injected only so tests can fix time; a caller-supplied timestamp must never reach these fields. */
 export interface ManagementClock
 {
 	/** Returns the trusted wall-clock instant for a management action. */
@@ -28,13 +34,13 @@ export interface ManagementClock
 /** Composition-root dependencies for the managed-agent management router. */
 export interface AgentServicesRouterDependencies
 {
-	/** Atomic definition-plane persistence boundary. */
+	/** Stores and reads services, revisions, and run history — see {@link AgentRevisionLifecycleRepository}. */
 	readonly lifecycle: AgentRevisionLifecycleRepository;
-	/** Builds a caller-attributed publication boundary so the publish audit records the real actor. */
+	/** Returns a publication repository bound to this caller, so the audit row it appends names the administrator who published rather than the process. */
 	publicationFor(caller: ManagementCaller): AgentServicePublicationRepository;
 	/** App-owned managed run admission boundary used by run-now. */
 	readonly runAdmission: ManagedRunAdmissionPort;
-	/** Silo-scoped schedule persistence boundary backing the schedule-management surface. */
+	/** Stores the recurring schedules behind the `/schedules` endpoints — see {@link AgentScheduleRepository}. */
 	readonly schedules: AgentScheduleRepository;
 	/**
 	 * Grant-compiler-backed resolver used to validate, at attach time, that a caller administers every

--- a/libs/backend/server/agents/agent-services/main/src/agent-schedule.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/agent-schedule.types.ts
@@ -1,18 +1,51 @@
 import type { AgentServiceId, SiloId } from "@opencrane/models/agents";
 
-/** Stable overlap policies shared by schedule APIs, persistence, and tick evaluation. */
+/**
+ * What to do when a scheduled run comes due while an earlier one is still going.
+ *
+ * The strings are stable: the HTTP body, the Postgres enum, and the scheduler all use these exact
+ * values. {@link AgentScheduleOverlapPolicies.Skip} is the safe default for anything that writes;
+ * {@link AgentScheduleOverlapPolicies.Allow} lets runs pile up. The two behave identically while
+ * nothing is in flight, which is why the difference only shows up under load or after an outage.
+ *
+ * Called by: `__RunScheduleTick` in
+ * libs/backend/server/agents/scheduling/main/src/schedule-tick.ts decides per-slot behaviour from
+ * this value; `prisma-schedule-tick-repositories.ts` and `prisma-agent-schedule.ts` map it to and
+ * from the Prisma enum.
+ */
 export enum AgentScheduleOverlapPolicies
 {
-	/** Admit at most one due slot when no earlier scheduled run remains active. */
+	/**
+	 * Never run two scheduled runs at once.
+	 *
+	 * At each tick the scheduler first asks whether any earlier scheduled run of this service is still
+	 * running. If one is, every slot that came due is dropped and the cursor jumps to the newest of
+	 * them, so they never fire late. If none is, exactly one run starts — the oldest due slot — and
+	 * the rest of a catch-up backlog is left for later ticks. Pick this for a job that would corrupt
+	 * its own output if two copies ran together.
+	 */
 	Skip = "skip",
-	/** Admit every due slot through the shared idempotent run-admission authority. */
+	/**
+	 * Let scheduled runs overlap.
+	 *
+	 * Every slot that came due starts a run, even if an earlier scheduled run is still going. After an
+	 * outage this means the whole catch-up backlog fires at once, up to the tick's slot limit. Each
+	 * slot still gets one run and one only, because the idempotency key is derived from the slot
+	 * instant — but there is no cap on how many of them run concurrently. Pick this only for jobs that
+	 * are safe to run in parallel with themselves.
+	 */
 	Allow = "allow",
 }
 
-/** Serialized overlap-policy values derived from the canonical schedule vocabulary. */
+/** The overlap-policy values as plain strings (`"skip" | "allow"`), for JSON bodies and stored rows that hold the value without importing the enum. */
 export type AgentScheduleOverlapPolicy = `${AgentScheduleOverlapPolicies}`;
 
-/** A stored recurring schedule for one managed AgentService. */
+/**
+ * One stored recurring schedule for a managed agent service. A service may have several.
+ *
+ * This is the row the HTTP surface returns and the scheduler reads. It holds no run state beyond
+ * `lastScheduledAt`, which is the cursor marking how far evaluation has got.
+ */
 export interface AgentServiceScheduleRecord
 {
 	/** Stable schedule identifier. */
@@ -21,17 +54,24 @@ export interface AgentServiceScheduleRecord
 	readonly siloId: SiloId;
 	/** Managed service whose active revision each due slot admits. */
 	readonly agentServiceId: AgentServiceId;
-	/** Standard 5-field cron expression evaluated in `timezone`. */
+	/** Five-field cron expression (minute hour day-of-month month day-of-week), read in `timezone` rather than UTC. */
 	readonly cron: string;
 	/** IANA timezone the cron expression is evaluated in. */
 	readonly timezone: string;
-	/** Behaviour when a prior scheduled run is still active. */
+	/** What to do when a slot comes due while an earlier scheduled run is still going — see {@link AgentScheduleOverlapPolicies}. */
 	readonly overlapPolicy: AgentScheduleOverlapPolicy;
 	/** Whether evaluation is active; `false` suspends the schedule without deleting it. */
 	readonly enabled: boolean;
-	/** Bounded catch-up horizon in seconds. */
+	/**
+	 * How far back the scheduler will reach for slots it missed, in seconds.
+	 *
+	 * After downtime the scheduler replays only the slots inside this window, oldest first; anything
+	 * older is dropped and never runs. `0` means never catch up — only fire slots due right now.
+	 * Accepted range is 0 to 604800 (7 days), checked in `__CreateAgentSchedule` /
+	 * `__UpdateAgentSchedule`; anything else is refused as `invalid_command`.
+	 */
 	readonly catchupWindowSeconds: number;
-	/** Newest slot already admitted, or null when the schedule has never fired. */
+	/** Cursor: the newest slot already dealt with. The next tick only considers slots after this instant, so advancing it is what stops a slot from firing twice. Null before the schedule first fires. */
 	readonly lastScheduledAt: string | null;
 	/** ISO-8601 creation instant. */
 	readonly createdAt: string;
@@ -54,7 +94,14 @@ export interface CreateAgentScheduleCommand
 	readonly overlapPolicy: AgentScheduleOverlapPolicy;
 	/** Whether the schedule is enabled at creation. */
 	readonly enabled: boolean;
-	/** Bounded catch-up horizon in seconds. */
+	/**
+	 * How far back the scheduler will reach for slots it missed, in seconds.
+	 *
+	 * After downtime the scheduler replays only the slots inside this window, oldest first; anything
+	 * older is dropped and never runs. `0` means never catch up — only fire slots due right now.
+	 * Accepted range is 0 to 604800 (7 days), checked in `__CreateAgentSchedule` /
+	 * `__UpdateAgentSchedule`; anything else is refused as `invalid_command`.
+	 */
 	readonly catchupWindowSeconds: number;
 }
 
@@ -79,7 +126,18 @@ export interface UpdateAgentScheduleCommand
 	readonly catchupWindowSeconds: number;
 }
 
-/** Stable reason a schedule command was refused. */
+/**
+ * Why a schedule create, update, or delete was refused. The router upper-cases the value into the
+ * response `code`.
+ * - `invalid_command` (400): an id was empty, `catchupWindowSeconds` was outside 0–604800, or the
+ *   timestamp did not parse.
+ * - `invalid_cron` (400): not five whitespace-separated fields, or a field is malformed.
+ * - `invalid_timezone` (400): not a timezone name `Intl.DateTimeFormat` can resolve.
+ * - `service_not_found` (404): no such service in the caller's silo.
+ * - `service_not_managed` (409): the service exists but is a personal agent; only managed services
+ *   can be scheduled.
+ * - `schedule_not_found` (404): no schedule with that id on that service in that silo.
+ */
 export type AgentScheduleDenial =
 	| "invalid_command"
 	| "invalid_cron"
@@ -98,7 +156,20 @@ export type AgentScheduleDeletionResult =
 	| { readonly outcome: "deleted" }
 	| { readonly outcome: "denied"; readonly reason: AgentScheduleDenial };
 
-/** Silo-scoped persistence boundary for the schedule plane. */
+/**
+ * Stores the recurring schedules attached to managed agent services.
+ *
+ * Every method is scoped to one silo, and creation additionally requires the target service to exist
+ * in that silo and be a managed service. A service in another silo is refused as
+ * `service_not_found`, indistinguishable from one that does not exist, so a caller cannot probe for
+ * foreign services. This port only stores rows; the scheduler in
+ * libs/backend/server/agents/scheduling reads them and decides when runs happen.
+ *
+ * Implemented by: `PrismaAgentScheduleRepository` in `prisma-agent-schedule.ts`.
+ * Called by: {@link __CreateAgentSchedule} and {@link __UpdateAgentSchedule} in `agent-schedule.ts`;
+ * `deleteSchedule` and `listSchedules` are called straight from the schedule handlers in
+ * `agent-revision.router.ts`.
+ */
 export interface AgentScheduleRepository
 {
 	/** Creates one schedule for a managed service in the caller's silo. */

--- a/libs/backend/server/agents/agent-services/main/src/managed-execution-evidence.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/managed-execution-evidence.types.ts
@@ -3,7 +3,7 @@ import type { Prisma } from "@prisma/client";
 import type { ServiceRunInputSnapshotIdentity } from "@opencrane/contracts";
 import type { FleetMembershipSignatureVerifier } from "@opencrane/backend/server/iam/membership";
 
-/** Stable coordinates used to resolve a managed service's execution evidence. */
+/** Names the exact run to check: which silo, which managed service, and which revision the caller believes is its published active revision. */
 export interface ManagedExecutionEvidenceCommand
 {
 	/** Silo containing the service, revision, membership, and grants. */
@@ -14,7 +14,14 @@ export interface ManagedExecutionEvidenceCommand
 	readonly agentRevisionId: string;
 }
 
-/** Transaction fence supplied by the run-input assembler. */
+/**
+ * The caller's open database transaction plus the admission time, passed in so evidence is read
+ * inside the same transaction that writes the run.
+ *
+ * Sharing one transaction is the point: the service, the revision, the membership high-water mark,
+ * the grants, and the run row are all read or written under it, so nothing can change underneath
+ * between the check and the write.
+ */
 export interface ManagedExecutionEvidenceTransaction
 {
 	/** Shared Prisma transaction used for every authority read and membership acceptance write. */
@@ -23,34 +30,90 @@ export interface ManagedExecutionEvidenceTransaction
 	readonly admittedAtEpochMs: number;
 }
 
-/** Frozen identity and capability evidence for one managed-service run. */
+/**
+ * What one managed run is allowed to be and do, fixed at admission time.
+ *
+ * Both fields are copied onto the run's input snapshot and never recomputed later, so a run keeps the
+ * access it was admitted with even if grants or membership change mid-run.
+ */
 export interface ManagedExecutionEvidence
 {
-	/** Tagged service identity containing signed membership and exact effective scope attachments. */
+	/** The agent's own identity for this run: its `agent-service:<id>` principal, its organisation, the signed fleet-membership evidence, and the scope attachments that survived the grant check. Never the human who triggered the run. */
 	readonly identity: ServiceRunInputSnapshotIdentity;
-	/** Digest of the complete managed-service capability-bearing revision evidence. */
+	/**
+	 * One SHA-256 hash fingerprinting everything this run is allowed to do.
+	 *
+	 * It is computed over the silo, the service, the revision id and the revision's own content digest,
+	 * the agent's principal, its organisation, the fleet-membership revision and payload digest, the
+	 * scope attachments that survived the grant check, the model definition, the budget ceilings, the
+	 * assigned skill revisions, and each integration's custody reference plus its reviewed tool
+	 * definitions. Anything that widens what the agent can reach is inside; nothing about the human who
+	 * pressed the button is.
+	 *
+	 * It is stored on the run's input snapshot and copied onto the runtime assignment handed to the pod,
+	 * so a later reader can prove the pod is running the capability set that was approved. That only
+	 * works if the hash is reproducible, which is why every list is sorted before hashing
+	 * (`_CanonicalAttachments`, `_CanonicalSkillAssignments`, `_CanonicalIntegrationAssignments` in
+	 * `prisma-managed-execution-evidence.ts`): RFC 8785 sorts object keys for us but keeps array order
+	 * exactly as given. If the sort were unstable — or omitted, leaving Postgres row order to decide —
+	 * two runs of the identical revision would hash differently, comparisons against the stored digest
+	 * would fail for no real reason, and the digest would stop being usable as evidence.
+	 *
+	 * @see https://www.rfc-editor.org/rfc/rfc8785 — the canonical-JSON rules the hash relies on, and
+	 *   the reason array order must be fixed by the caller rather than by the serializer.
+	 */
 	readonly capabilitySetDigest: string;
 }
 
-/** Fail-closed result from resolving managed execution evidence. */
+/**
+ * Outcome of one evidence load. `denied` never means "partially allowed" — no run is admitted.
+ * - `run_not_admittable`: the service is not a managed, active service in this silo, or the revision
+ *   named is not its published active revision. The service's active revision has probably moved;
+ *   re-read it.
+ * - `membership_stale`: the agent principal has no signed fleet membership in the trusted issuer's
+ *   newest revision, has assertions spanning more than one organisation, or the newest signature is
+ *   older than `maximumStalenessMs`. Transient — retry after the issuer republishes.
+ * - `memory_scope_unavailable`: the revision declares a `personal` scope (never allowed for a managed
+ *   service), or declares a scope the agent's principal does not actually hold. Fix the revision or
+ *   grant the scope; retrying will not help.
+ * - `identity_unavailable`, `tool_policy_unavailable`: reserved for identity and tool-policy failures
+ *   in the same union used by the wider run-admission path; the current implementation does not
+ *   return them. NEEDS-HUMAN — confirm whether they should stay in this narrower union.
+ */
 export type ManagedExecutionEvidenceResult =
 	| { readonly outcome: "loaded"; readonly value: ManagedExecutionEvidence }
 	| { readonly outcome: "denied"; readonly reason: "run_not_admittable" | "membership_stale" | "identity_unavailable" | "tool_policy_unavailable" | "memory_scope_unavailable" };
 
-/** Boundary consumed by run-input assembly without moving service authority into the app. */
+/**
+ * Answers "may this managed service run right now, and with exactly what access?".
+ *
+ * Run-input assembly lives in another package but must not re-implement these rules, so it calls in
+ * here. One call re-reads the service and its published active revision, verifies the agent's signed
+ * fleet membership, intersects the revision's declared scope attachments against the grants actually
+ * held, and hashes the result into a capability digest. It fails closed: any missing or stale piece
+ * returns a denial rather than a partial answer.
+ *
+ * Implemented by: `PrismaManagedExecutionEvidenceAuthority` in
+ * `prisma-managed-execution-evidence.ts`; built for the process by
+ * `_CreateManagedExecutionEvidenceAuthority` and composed in apps/opencrane/src/index.ts.
+ * Called by: `ManagedExecutionIdentityEnvelopeSource` in
+ * libs/backend/agents/execution/inputs/main/src/managed-execution-identity-envelope-source.ts, and
+ * passed through `__CreateManagedRunAdmissionPort` in
+ * libs/backend/agents/execution/admission/main/src/managed-run-admission.composition.ts.
+ */
 export interface ManagedExecutionEvidenceAuthority
 {
 	/** Resolves evidence through the caller's already-open admission transaction. */
 	load(command: ManagedExecutionEvidenceCommand, transaction: ManagedExecutionEvidenceTransaction): Promise<ManagedExecutionEvidenceResult>;
 }
 
-/** Configuration for the production managed-service evidence authority. */
+/** Deployment-chosen membership trust settings for {@link ManagedExecutionEvidenceAuthority}: which issuer to trust, how stale its evidence may be, and the key material to verify it with. Fixed once at composition; not per request. */
 export interface ManagedExecutionEvidenceConfig
 {
-	/** Fleet issuer trusted for service-principal membership. */
+	/** The only issuer whose signed membership is accepted for agent principals. Must be non-empty; the constructor throws otherwise. */
 	readonly trustedIssuerId: string;
-	/** Maximum accepted age of the newest signed membership revision. */
+	/** How old, in milliseconds, the newest signed membership evidence may be before a run is denied with `membership_stale`. Must be a positive safe integer; the constructor throws otherwise. */
 	readonly maximumStalenessMs: number;
-	/** Cryptographic verifier backed by the exact mounted fleet key ring. */
+	/** Checks the signature on membership evidence against the issuer keys mounted into this process. Built by `_CreateFleetMembershipEvidenceConfig` from the environment. */
 	readonly verifier: FleetMembershipSignatureVerifier;
 }

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-publication.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-publication.ts
@@ -7,7 +7,16 @@ import type { AgentServicePublicationRepository, AtomicAgentRevisionPublication,
 import { _mapRevision, _mapService, _serviceState } from "./prisma-agent-mappers.js";
 import type { AgentPublicationAuditEvidencePort } from "./prisma-agent-publication.types.js";
 
-/** Prisma-backed publication adapter that commits revision, active pointer, and audit atomically. */
+/**
+ * Publishes agent revisions in Postgres, writing the revision, the service's active revision, and the
+ * audit row in one transaction.
+ *
+ * All three land together or none does, so there is no window where a service points at a revision
+ * with no audit trail, and a failed audit write cancels the publication.
+ *
+ * Called by: `_publicationFor` in `prisma-agent-services.router.ts` builds one per request so the
+ * audit row names the administrator publishing.
+ */
 export class PrismaAgentServicePublicationRepository implements AgentServicePublicationRepository
 {
 	/** OpenCrane product-authority database client. */

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-publication.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-publication.types.ts
@@ -3,7 +3,18 @@ import type { AgentRevision, AgentService } from "@opencrane/models/agents";
 import type { AuditDecisionRecord } from "@opencrane/backend/server/iam/audit";
 import type { AtomicAgentRevisionPublication } from "./agent-publication.types.js";
 
-/** Builds exact audit evidence for one publication while its transaction is active. */
+/**
+ * Builds the audit row for one publication, while the publication transaction is still open.
+ *
+ * It is a port so the repository never has to know who the caller is: the request layer supplies an
+ * implementation already bound to the authenticated administrator, and the audit row names that
+ * person rather than the process. The row is appended before commit, so a failed audit write rolls
+ * the publication back.
+ *
+ * Implemented by: `_buildPublicationAuditEvidence` in `prisma-agent-services.router.ts`.
+ * Called by: `PrismaAgentServicePublicationRepository.publishRevisionAtomically` in
+ * `prisma-agent-publication.ts`.
+ */
 export interface AgentPublicationAuditEvidencePort
 {
 	/**

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-lifecycle.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-lifecycle.ts
@@ -23,12 +23,20 @@ async function _isModelDefinitionAvailable(transaction: Prisma.TransactionClient
 }
 
 /**
- * Prisma-backed authority for the managed-agent definition plane.
+ * Stores managed-agent services and revisions in Postgres.
  *
- * Every mutation runs inside one transaction that locks the parent service first, so concurrent
- * edits either observe the same head revision or fail closed. Revisions are immutable: revise and
- * restore append a new draft rather than mutating an existing one, and restore records both the
- * lineage parent and the cloned source revision without touching history.
+ * Every write runs in one transaction that takes a row lock on the parent service first, so two
+ * concurrent edits queue rather than race: the second one sees the first one's revision and returns
+ * a conflict instead of overwriting it.
+ *
+ * Revisions are never edited or deleted. Revise adds a new draft; restore adds a new draft that
+ * copies an older revision's content and records both its lineage parent and the revision it was
+ * copied from, so the history stays complete.
+ *
+ * Called by: constructed in `prisma-agent-services.router.ts` and passed to the router as
+ * `lifecycle`.
+ * NEEDS-HUMAN: the row lock is PostgreSQL `SELECT … FOR UPDATE`; add the doc URI for the Postgres
+ * major version this deployment pins.
  */
 export class PrismaAgentRevisionLifecycleRepository implements AgentRevisionLifecycleRepository
 {
@@ -180,7 +188,14 @@ type _HeadGuard =
 	| { readonly outcome: "ok"; readonly siloId: string; readonly head: { id: string; revision: number } }
 	| { readonly outcome: "blocked"; readonly result: AppendAgentRevisionResult };
 
-/** Locks the silo-scoped service, then confirms the observed parent still matches the head revision. */
+/**
+ * Locks the service row, then checks the caller is editing the newest revision.
+ *
+ * Returns `blocked` for three cases the caller must not proceed past: the service is missing (or in
+ * another silo — indistinguishable on purpose), the service is retired, or the newest stored revision
+ * is not the one the caller said they edited. The last case returns the current newest revision id so
+ * the caller can re-apply its edit on top of it.
+ */
 async function _lockAndReadHead(transaction: Prisma.TransactionClient, agentServiceId: string, siloId: string, expectedParentRevisionId: string | null): Promise<_HeadGuard>
 {
 	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${agentServiceId} AND "silo_id" = ${siloId} FOR UPDATE`);

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-model-selection.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-model-selection.ts
@@ -8,11 +8,13 @@ import { _AGENT_REVISION_INCLUDE, _AgentRevisionContentFromRow, PrismaAgentRevis
 /**
  * Prisma strategy for model-selection changes inside an owning unit of work.
  *
- * The caller provides a Serializable transaction. This strategy proves that the personal revision
- * the owner reviewed is still active, changes only its registered model definition, then prepares
- * and activates the next immutable revision. The surrounding personal-configuration Unit of Work
- * retains transaction ownership so its proposal journal transition can commit or roll back with
- * these writes.
+ * The caller opens the transaction at Serializable isolation and keeps ownership of it. This class
+ * re-checks that the revision the owner reviewed is still the active one, copies it with only the
+ * model changed, then publishes and activates the copy — all without committing. The caller commits,
+ * so its own proposal-journal update either lands with these writes or rolls back with them.
+ *
+ * Called by:
+ * libs/backend/agents/personal/configuration/main/src/materialization/prisma-personal-configuration-materialization-unit-of-work.ts.
  */
 export class PrismaAgentRevisionModelSelectionRepository implements AgentRevisionModelSelectionRepository
 {
@@ -71,16 +73,18 @@ export class PrismaAgentRevisionModelSelectionRepository implements AgentRevisio
 			return { status: AgentRevisionModelSelectionMaterializationCodes.StaleSource };
 		}
 
-		// 4. Resolve the owner-visible alias only after every source fence has passed.
-		// Tenant definitions take precedence, and no provider identifier crosses the browser boundary.
+		// 4. Only now look up the model, after all three staleness checks have passed.
+		// A silo's own model wins over a global one with the same public name, and the provider's model
+		// id stays server-side — the owner only ever names the public alias.
 		const modelDefinitionId = await this._ResolveModelDefinitionId(command.siloId, command.modelAlias);
 		if (modelDefinitionId === null)
 		{
 			return { status: AgentRevisionModelSelectionMaterializationCodes.ModelUnavailable };
 		}
 
-		// 5. Reconstruct one canonical content value and append the next immutable draft.
-		// Agent-services alone chooses revision lineage and represents that content in Prisma.
+		// 5. Copy the source revision's content with only the model changed, and append it as a new draft.
+		// Revision numbering and the Prisma mapping stay in this package so no other package can
+		// reproduce them and drift.
 		const content: AgentRevisionContent = {
 			..._AgentRevisionContentFromRow(source),
 			modelDefinitionId,
@@ -97,8 +101,9 @@ export class PrismaAgentRevisionModelSelectionRepository implements AgentRevisio
 			createdAt: command.materializedAt,
 		});
 
-		// 6. Publish before activation, while remaining inside the caller-owned transaction.
-		// The caller's later journal CAS can still roll both lifecycle writes back atomically.
+		// 6. Mark the draft published, then point the service at it — both still inside the caller's
+		// transaction and uncommitted. If the caller's own check later fails, both writes roll back
+		// together, so the service can never end up active on an unpublished revision.
 		await this.transaction.agentRevision.update({
 			where: { id: draft.id },
 			data: {

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-writer.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-writer.ts
@@ -80,11 +80,12 @@ export function _AgentRevisionContentFromRow(row: AgentRevisionWithAssignments):
 }
 
 /**
- * Builds the sole Prisma create representation of immutable agent-revision content.
+ * Builds the one Prisma create input used for every new agent revision.
  *
- * The digest and nested assignment writes derive from the same domain value. Keeping this mapping
- * in the agent-service authority prevents another package from independently reproducing revision
- * persistence rules while still allowing an existing transaction to remain atomic.
+ * The stored digest and the nested skill, integration, and scope rows all come from the same content
+ * value, so the digest always describes exactly what was written. Every writer goes through here —
+ * the lifecycle repository and the model-selection strategy both call it — so no second place can
+ * drift on how a revision is stored, while each keeps its own transaction.
  */
 function _RevisionCreateData(command: CreateAgentRevisionWithinTransactionCommand): Prisma.AgentRevisionCreateInput
 {
@@ -144,7 +145,15 @@ function _RevisionCreateData(command: CreateAgentRevisionWithinTransactionComman
 	};
 }
 
-/** Prisma repository for the canonical immutable revision persistence mapping. */
+/**
+ * Writes new agent revisions through the one shared Prisma mapping.
+ *
+ * It takes a transaction rather than a client, so the calling repository keeps ownership of the
+ * commit and can roll this write back with its own.
+ *
+ * Called by: `prisma-agent-revision-lifecycle.ts` (create, revise, restore) and
+ * `prisma-agent-revision-model-selection.ts` (model swap).
+ */
 export class PrismaAgentRevisionWriterRepository implements AgentRevisionWriterRepository
 {
 	/** Transaction-scoped ORM client supplied by the owning repository or unit of work. */

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-writer.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-revision-writer.types.ts
@@ -23,7 +23,14 @@ export interface CreateAgentRevisionWithinTransactionCommand
 	readonly createdAt: Date;
 }
 
-/** Canonical agent-revision persistence mapping used by transaction-owning repositories. */
+/**
+ * Writes one new agent revision inside a transaction the caller owns.
+ *
+ * `Row` is left generic so a caller can get back whatever include shape it needs without this
+ * package depending on the caller's query.
+ *
+ * Implemented by: `PrismaAgentRevisionWriterRepository` in `prisma-agent-revision-writer.ts`.
+ */
 export interface AgentRevisionWriterRepository<Row = unknown>
 {
 	/** Creates one draft revision and every immutable assignment inside the current transaction. */

--- a/libs/backend/server/agents/agent-services/main/src/prisma-agent-services.router.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-agent-services.router.ts
@@ -66,11 +66,19 @@ function _publicationFor(prisma: PrismaClient, caller: ManagementCaller): AgentS
 }
 
 /**
- * Composes the Prisma-backed managed-agent management router.
- * @param prisma - Canonical product-authority client.
- * @param runAdmission - Shared, capacity-bounded managed run admission boundary.
- * @param logger - Process logger supplied by the app composition root.
- * @returns The configured agent-services router.
+ * Builds the managed-agent management router with its Prisma-backed dependencies.
+ *
+ * Every repository here is silo-scoped at query level and the caller's silo comes from the session,
+ * so nothing needs a silo from the request body. Note the publication repository is built per
+ * request, not once, so each publish audit row names the administrator who made it.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at `/api/v1/agent-services`.
+ *
+ * @param prisma - The OpenCrane Prisma client.
+ * @param runAdmission - Run-recording port, shared with the scheduler so both go through one
+ *   capacity limit.
+ * @param logger - Process logger from the app's composition root.
+ * @returns The router, ready to mount.
  */
 export function _CreateAgentServicesRouter(prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, logger: Logger): Router
 {

--- a/libs/backend/server/agents/agent-services/main/src/prisma-managed-execution-evidence.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-managed-execution-evidence.ts
@@ -12,31 +12,74 @@ import { __ResolveEffectiveScopeAttachments } from "./scope-attachment-authority
 import { PrismaScopeGrantResolver } from "./prisma-scope-grant-resolver.js";
 import type { ManagedExecutionEvidenceAuthority, ManagedExecutionEvidenceCommand, ManagedExecutionEvidenceConfig, ManagedExecutionEvidenceResult, ManagedExecutionEvidenceTransaction } from "./managed-execution-evidence.types.js";
 
-/** Canonical principal exercised by one managed AgentService. */
+/**
+ * Builds the principal name a managed agent acts as: `agent-service:<id>`.
+ *
+ * A managed agent has no human behind it, so grants, membership, and audit rows are all recorded
+ * against this derived name rather than a user id. Everything that has to agree on that name calls
+ * this function instead of formatting the string itself, so the prefix can never drift between the
+ * writer and the reader.
+ *
+ * Called by: {@link PrismaManagedExecutionEvidenceAuthority.load} in this file, and
+ * `ManagedExecutionIdentityEnvelopeSource` in
+ * libs/backend/agents/execution/inputs/main/src/managed-execution-identity-envelope-source.ts, which
+ * checks the snapshot's execution subject against it before trusting a run.
+ *
+ * @param agentServiceId - The managed service's id.
+ * @returns The principal name used for grants, membership lookups, and audit rows.
+ */
 export function __ManagedAgentServicePrincipal(agentServiceId: string): string
 {
 	return `agent-service:${agentServiceId}`;
 }
 
 /**
- * Resolves signed membership and effective revision capabilities for one managed service.
+ * Checks a managed service's membership and access against Postgres, inside the caller's transaction.
  *
- * The service, revision, membership high-water mark, grants, and final snapshot all share the
- * caller's admission transaction. The human requester is deliberately absent from this authority.
+ * Reading the service, the revision, the newest signed membership, and the grants under one
+ * transaction is what stops any of them changing between the check and the run being written.
+ *
+ * A managed agent acts as itself, not on behalf of whoever pressed run-now, so nothing about the
+ * human requester reaches this class — the access it grants must be the agent's own.
+ *
+ * Called by: `ManagedExecutionIdentityEnvelopeSource` in
+ * libs/backend/agents/execution/inputs/main/src/managed-execution-identity-envelope-source.ts;
+ * constructed by `_CreateManagedExecutionEvidenceAuthority` in
+ * `prisma-managed-execution-evidence.factory.ts`.
  */
 export class PrismaManagedExecutionEvidenceAuthority implements ManagedExecutionEvidenceAuthority
 {
 	/** Trusted membership configuration fixed by app composition. */
 	private readonly config: ManagedExecutionEvidenceConfig;
 
-	/** Creates the production evidence authority. */
+	/**
+	 * @param config - Trusted issuer, staleness limit, and signature verifier, fixed at composition.
+	 * @throws Error when the issuer id is blank or the staleness limit is not a positive safe integer.
+	 *   Failing here rather than per request means a misconfigured deployment cannot silently accept
+	 *   membership evidence of any age.
+	 */
 	constructor(config: ManagedExecutionEvidenceConfig)
 	{
 		if (config.trustedIssuerId.trim().length === 0 || !Number.isSafeInteger(config.maximumStalenessMs) || config.maximumStalenessMs <= 0) throw new Error("managed execution evidence requires a trusted issuer and positive staleness bound");
 		this.config = config;
 	}
 
-	/** Loads exact current service, membership, attachment, and assignment evidence. */
+	/**
+	 * Re-reads everything a managed run's access depends on, inside the caller's transaction.
+	 *
+	 * In order: the revision must still be the published active revision of an active managed service
+	 * in this silo; the agent's principal must have exactly one organisation's signed membership in the
+	 * issuer's newest revision, and that signature must verify and be within the staleness limit; the
+	 * revision must declare no `personal` scope; and every declared scope must be backed by a real
+	 * grant. Only then are the identity and capability digest built.
+	 *
+	 * @param command - Silo, service, and the revision the caller believes is active.
+	 * @param transaction - The caller's open transaction and the admission time.
+	 * @returns `loaded` with the run's identity and its capability digest, or `denied` — see
+	 *   {@link ManagedExecutionEvidenceResult} for what each reason means and whether to retry.
+	 * @throws Whatever the database or the signature verifier throws. A throw is not a denial; the
+	 *   caller's transaction rolls back and no run is admitted.
+	 */
 	async load(command: ManagedExecutionEvidenceCommand, transaction: ManagedExecutionEvidenceTransaction): Promise<ManagedExecutionEvidenceResult>
 	{
 		const revision = await transaction.prisma.agentRevision.findFirst({
@@ -117,11 +160,17 @@ export class PrismaManagedExecutionEvidenceAuthority implements ManagedExecution
 }
 
 /**
- * Selects the lowest stable assertion identifier inside one organization.
+ * Picks one signed membership assertion for the agent principal, or refuses.
  *
- * Multiple same-organization membership scopes are valid. This choice freezes one exact signed
- * membership assertion as identity evidence; executable knowledge scope remains the separate
- * intersection of revision attachments and effective grants.
+ * An agent may legitimately hold several membership scopes within one organisation, so the
+ * lowest-sorting assertion id is chosen to make the choice repeatable. If the assertions span more
+ * than one organisation, this returns null and the run is denied: there would be no single
+ * organisation to record on the run.
+ *
+ * Choosing an assertion only fixes *who* the agent is. What it may reach is decided separately, by
+ * intersecting the revision's scope attachments against the grants actually held.
+ *
+ * @returns The chosen assertion, or null when the principal has no membership or spans organisations.
  */
 async function _SelectMembershipAssertion(prisma: Prisma.TransactionClient, trustedIssuerId: string, siloId: string, subjectId: string): Promise<{ assertionId: string; scopeKind: FleetMembershipScopeKind; organizationId: string; scopeResourceId: string | null } | null>
 {
@@ -135,7 +184,7 @@ async function _SelectMembershipAssertion(prisma: Prisma.TransactionClient, trus
 	return assertions[0] ?? null;
 }
 
-/** Returns the organization coordinate for ambiguity detection. */
+/** Reads one assertion's organisation id, so the caller can check that all of them agree. */
 function _OrganizationId(assertion: { organizationId: string }): string
 {
 	return assertion.organizationId;
@@ -169,7 +218,13 @@ function _IsPersonalAttachment(value: RevisionScopeAttachment): boolean
 	return value.scope === "personal";
 }
 
-/** Compares canonical ASCII coordinates without locale- or ICU-dependent collation. */
+/**
+ * Compares two strings by raw code unit, not by locale.
+ *
+ * `String.prototype.localeCompare` and the default `Array.sort` comparator can order the same two
+ * strings differently on different builds or locales. Sorting is what makes the capability digest
+ * reproducible, so the comparison has to be one that never varies.
+ */
 function _CompareCanonicalCoordinate(left: string, right: string): number
 {
 	if (left < right) return -1;
@@ -177,7 +232,15 @@ function _CompareCanonicalCoordinate(left: string, right: string): number
 	return 0;
 }
 
-/** Canonicalizes effective attachments before persistence and digesting. */
+/**
+ * Copies the authorised attachments and sorts them by scope, then subject type, then subject id.
+ *
+ * The sort is not cosmetic. RFC 8785 fixes object key order but leaves array order alone, so if this
+ * list arrived in whatever order Postgres returned it, the same revision would produce a different
+ * digest on different reads.
+ * @see https://www.rfc-editor.org/rfc/rfc8785 — why array order must be fixed here rather than by
+ *   the JSON serializer.
+ */
 function _CanonicalAttachments(values: readonly RevisionScopeAttachment[]): readonly ManagedRunInputScopeAttachment[]
 {
 	return [...values]
@@ -185,13 +248,13 @@ function _CanonicalAttachments(values: readonly RevisionScopeAttachment[]): read
 		.sort(function _ByTriple(left, right): number { return _CompareCanonicalCoordinate(`${left.scope}\u0000${left.subjectType}\u0000${left.subjectId}`, `${right.scope}\u0000${right.subjectType}\u0000${right.subjectId}`); });
 }
 
-/** Canonicalizes revision skill coordinates for capability digesting. */
+/** Sorts the assigned skill revisions by skill id, then revision id, so the capability digest does not depend on database row order. */
 function _CanonicalSkillAssignments(values: readonly { skillId: string; skillRevisionId: string }[]): JsonValue
 {
 	return [...values].sort(function _BySkill(left, right): number { return _CompareCanonicalCoordinate(`${left.skillId}\u0000${left.skillRevisionId}`, `${right.skillId}\u0000${right.skillRevisionId}`); }) as JsonValue;
 }
 
-/** Canonicalizes integration custody and exact tool allowances for capability digesting. */
+/** Rebuilds each integration assignment with only the fields that affect access — custody reference and reviewed tool definitions — and sorts both the tools by name and the integrations by id, so the capability digest does not depend on database row order. */
 function _CanonicalIntegrationAssignments(values: readonly { integrationId: string; custodyReferenceId: string; toolDefinitions: Prisma.JsonValue }[]): JsonValue
 {
 	return [...values]

--- a/libs/backend/server/agents/agent-services/main/src/prisma-scope-grant-resolver.ts
+++ b/libs/backend/server/agents/agent-services/main/src/prisma-scope-grant-resolver.ts
@@ -3,10 +3,18 @@ import type { Prisma, PrismaClient } from "@prisma/client";
 import type { EffectiveScopeGrant, ScopeGrantResolver } from "./scope-attachment-authority.types.js";
 
 /**
- * Stub scope-grant resolver.
+ * Not implemented yet — always returns no grants.
  *
- * Returns an empty effective-grant set. The grant-compiler that previously backed this resolver
- * has been reaped; a follow-up wires RbacAuthority as the production source of scope grants.
+ * The grant compiler that used to back this was removed and RbacAuthority has not been wired in. The
+ * consequence is not neutral: with no grants, every declared scope attachment is rejected, so
+ * authoring a revision with any attachment is refused with 403 `FORBIDDEN_SCOPE_ATTACHMENT`, and
+ * admitting a managed run whose revision has any attachment is denied `memory_scope_unavailable`.
+ * Revisions with no attachments are unaffected. Failing closed like this is the right direction for
+ * a missing authorisation source, but it is a stub, not the finished behaviour.
+ *
+ * Called by: injected as `scopeGrantResolver` in `prisma-agent-services.router.ts`, and constructed
+ * inline by `PrismaManagedExecutionEvidenceAuthority.load` in
+ * `prisma-managed-execution-evidence.ts`.
  */
 export class PrismaScopeGrantResolver implements ScopeGrantResolver
 {
@@ -22,7 +30,7 @@ export class PrismaScopeGrantResolver implements ScopeGrantResolver
 		this.prisma = prisma;
 	}
 
-	/** Compiles the allow-only effective knowledge-scope grants for the principal set. */
+	/** Always returns an empty list; see the note on the class. The `prisma` field and `principalIds` are unused until a real grant source is wired in. */
 	async resolveEffectiveScopeGrants(principalIds: readonly string[]): Promise<readonly EffectiveScopeGrant[]>
 	{
 		void principalIds;

--- a/libs/backend/server/agents/agent-services/main/src/scope-attachment-authority.ts
+++ b/libs/backend/server/agents/agent-services/main/src/scope-attachment-authority.ts
@@ -9,16 +9,19 @@ function _tripleKey(triple: { scope: string; subjectType: string; subjectId: str
 }
 
 /**
- * Intersect declared scope attachments against a set of effective allow grants.
+ * Splits requested attachments into those backed by a real grant and those not.
  *
- * Pure: an attachment survives only when its exact `{ scope, subjectType, subjectId }` triple is
- * present among the effective grants. Because the grant set is allow-only, the intersection can
- * never grant access the principal does not already hold — a stored attachment is a filter over real
- * access, never a widening.
+ * No database, no clock: an attachment survives only when its exact `{ scope, subjectType,
+ * subjectId }` triple appears in the grant list. Since that list holds allow entries only, the
+ * result can never contain access the principals do not already hold — an attachment narrows what
+ * they can reach, it never widens it.
  *
- * @param attachments - Declared revision-scope attachments.
- * @param effectiveGrants - Allow-only effective knowledge-scope grants.
- * @returns The authorised (backed) and rejected (unbacked) attachment partition.
+ * Called by: {@link __ResolveEffectiveScopeAttachments} in this file, which is the only production
+ * entry point; tests call this directly with fixed grant lists.
+ *
+ * @param attachments - The attachments a revision declares.
+ * @param effectiveGrants - Allow-only grants the principals hold.
+ * @returns `authorized` (backed) and `rejected` (unbacked), preserving input order in both.
  */
 export function __IntersectScopeAttachments(attachments: readonly RevisionScopeAttachment[], effectiveGrants: readonly EffectiveScopeGrant[]): ScopeAttachmentIntersection
 {
@@ -41,10 +44,14 @@ export function __IntersectScopeAttachments(attachments: readonly RevisionScopeA
  * — a project-scoped agent gets its project attachment and nothing for a peer project, personal,
  * department, or org scope it was never granted.
  *
- * @param resolver - Effective-grant resolver.
- * @param principalIds - The agent's execution principals.
- * @param attachments - Declared revision-scope attachments.
- * @returns The authorised/rejected intersection.
+ * Called by: {@link __ValidateAttachAuthority} in this file, and
+ * `PrismaManagedExecutionEvidenceAuthority.load` in `prisma-managed-execution-evidence.ts`, which
+ * denies the run outright if anything is rejected.
+ *
+ * @param resolver - Grant lookup. Not called at all when `attachments` is empty.
+ * @param principalIds - The principals the agent runs as.
+ * @param attachments - The attachments the revision declares.
+ * @returns `authorized` (given to the runtime) and `rejected` (dropped).
  */
 export async function __ResolveEffectiveScopeAttachments(resolver: ScopeGrantResolver, principalIds: readonly string[], attachments: readonly RevisionScopeAttachment[]): Promise<ScopeAttachmentIntersection>
 {

--- a/libs/backend/server/agents/agent-services/main/src/scope-attachment-authority.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/scope-attachment-authority.types.ts
@@ -1,26 +1,40 @@
 import type { GrantScope, GrantSubjectType, RevisionScopeAttachment } from "@opencrane/models/agents";
 
 /**
- * One effective knowledge-scope grant a principal set actually holds, compiled from the canonical
- * grant table. The triple is the same `{ scope, subjectType, subjectId }` vocabulary an attachment
- * declares, so an attachment is authorised exactly when it appears here with allow access.
+ * One knowledge scope a set of principals really holds.
+ *
+ * It uses the same three fields as a declared attachment — `scope`, `subjectType`, `subjectId` — on
+ * purpose: matching is a plain exact match on all three, with no widening or inheritance. An
+ * attachment is authorised when, and only when, the identical triple appears in this list.
  */
 export interface EffectiveScopeGrant
 {
-	/** Canonical containment scope the effective grant covers. */
+	/** Scope level of the grant: `org`, `department`, `team`, `project`, or `personal`. */
 	readonly scope: GrantScope;
-	/** Canonical principal type the effective grant covers. */
+	/** Whether `subjectId` names a `group` or a `user`. */
 	readonly subjectType: GrantSubjectType;
 	/** Identifier of the scoped knowledge target the effective grant covers. */
 	readonly subjectId: string;
 }
 
 /**
- * Boundary that compiles the effective knowledge-scope grants for a principal set.
+ * Lists the knowledge scopes a set of principals actually holds.
  *
- * The production adapter is backed by the IAM grant compiler; a test supplies a fake so the pure
- * intersection can be exercised without a database. It returns only ALLOW grants (deny/absent scopes
- * simply do not appear), so intersecting against it can never widen access.
+ * The list is ALLOW-only: a scope that was denied, or was never granted, simply is not in it. There
+ * is no deny entry to misread, so filtering a set of requested attachments against this list can only
+ * ever remove entries — it can never hand out access a principal does not already have. Every caller
+ * in this file depends on that property.
+ *
+ * WARNING: the production implementation `PrismaScopeGrantResolver` currently returns an empty list
+ * (its grant compiler was removed and RbacAuthority is not wired up yet). With an empty list every
+ * declared attachment is rejected, so authoring a revision with any scope attachment is refused with
+ * 403 and a managed run with any attachment is denied `memory_scope_unavailable`. Tests pass a fake
+ * resolver, which is why the intersection logic is still exercised.
+ *
+ * Implemented by: `PrismaScopeGrantResolver` in `prisma-scope-grant-resolver.ts`.
+ * Called by: {@link __ResolveEffectiveScopeAttachments} and {@link __ValidateAttachAuthority} in
+ * `scope-attachment-authority.ts`; injected as `scopeGrantResolver` by
+ * `prisma-agent-services.router.ts` and constructed inline by `prisma-managed-execution-evidence.ts`.
  */
 export interface ScopeGrantResolver
 {
@@ -37,7 +51,13 @@ export interface ScopeAttachmentIntersection
 	readonly rejected: readonly RevisionScopeAttachment[];
 }
 
-/** Result of validating that a caller may attach every declared scope at authoring time. */
+/**
+ * Outcome of the authoring-time check that a caller holds every scope they are attaching.
+ *
+ * `unauthorized` lists the exact attachments with no backing grant, so the router can tell the
+ * administrator which ones to remove or get granted. It is all-or-nothing: nothing is persisted, not
+ * even the attachments that did pass.
+ */
 export type AttachAuthorityResult =
 	| { readonly outcome: "authorized" }
 	| { readonly outcome: "unauthorized"; readonly unauthorized: readonly RevisionScopeAttachment[] };

--- a/libs/backend/server/agents/artifacts/main/src/artifact-authority.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-authority.ts
@@ -2,10 +2,27 @@ import type { ArtifactAuthorityRepository } from "./artifact-finalization.types.
 import { _ArtifactPublicationConflictError, type ArtifactPublicationUnitOfWork } from "./artifact-unit-of-work.types.js";
 import type { ArtifactUploadLeaseRepository, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";
 
-/** Coordinates short, independent durable transactions around an external byte-store promotion. */
+/**
+ * Runs each publication step in its own transaction, so none is held open while bytes are in flight.
+ *
+ * An upload is two short transactions with an external call between them: reserve the write
+ * lease, promote the bytes through the artifact service, commit the revision. Holding one
+ * transaction across the promotion would keep a serializable transaction open for the whole
+ * upload, so each step gets its own instead. The gap is safe because the lease row carries the
+ * expected hash, size, and media type, and the commit re-checks the receipt against it.
+ *
+ * If the second transaction fails, the bytes are already stored with no revision pointing at
+ * them. Nothing here deletes them; the caller reports the failure and artifact-service cleanup
+ * removes unreferenced bytes.
+ *
+ * Both methods turn {@link _ArtifactPublicationConflictError} into a `conflict` status, so the
+ * application layer never sees a database-specific exception.
+ *
+ * Called by: `_CreateArtifactUploadAuthority` in prisma-artifact-authority.composition.ts.
+ */
 export class _ArtifactUploadAuthority implements ArtifactAuthorityRepository, ArtifactUploadLeaseRepository
 {
-	/** Opaque boundary that alone owns database transaction creation. */
+	/** The only thing here allowed to open a transaction; this class asks it to run work rather than starting one itself. */
 	private readonly unitOfWork: ArtifactPublicationUnitOfWork;
 
 	/** Creates the transaction-owning facade used by upload and finalization workflows. */
@@ -14,7 +31,15 @@ export class _ArtifactUploadAuthority implements ArtifactAuthorityRepository, Ar
 		this.unitOfWork = unitOfWork;
 	}
 
-	/** Reserves one exact proof-bound write lease before the external promotion begins. */
+	/**
+	 * Reserves the write lease - the first transaction, before any bytes move.
+	 *
+	 * @param command - Upload facts without the finalization-only fields.
+	 * @returns `issued` with the claims to sign, or `artifact_not_found`/`conflict`. A `conflict`
+	 *   here also covers a database collision that exhausted its retries; either way nothing was
+	 *   written and no bytes exist yet.
+	 * @throws Any database error that is not a recognised rolled-back collision.
+	 */
 	async issueLeaseAtomically(command: Omit<VerifiedArtifactUploadCommand, "bytes" | "createdBy" | "revision" | "artifactRevisionId" | "provenance" | "idempotencyKey">): ReturnType<ArtifactUploadLeaseRepository["issueLeaseAtomically"]>
 	{
 		try
@@ -31,7 +56,15 @@ export class _ArtifactUploadAuthority implements ArtifactAuthorityRepository, Ar
 		}
 	}
 
-	/** Commits the verified receipt, immutable revision, and outbox in one isolated transaction. */
+	/**
+	 * Commits the revision - the second transaction, after the bytes are stored.
+	 *
+	 * @param command - Validated revision metadata plus the verified promotion receipt.
+	 * @returns One of the statuses in {@link AtomicFinalizeArtifactResult}; a retry collision that
+	 *   exhausted its attempts arrives as `conflict`. Any non-success value means the promoted
+	 *   bytes are now unreferenced.
+	 * @throws Any database error that is not a recognised rolled-back collision.
+	 */
 	async finalizeRevisionAtomically(command: Parameters<ArtifactAuthorityRepository["finalizeRevisionAtomically"]>[0]): ReturnType<ArtifactAuthorityRepository["finalizeRevisionAtomically"]>
 	{
 		try

--- a/libs/backend/server/agents/artifacts/main/src/artifact-finalization.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-finalization.ts
@@ -2,10 +2,25 @@ import { ___IsSha256ContentAddress } from "@opencrane/models/artifacts";
 
 import type { ArtifactAuthorityRepository, FinalizeArtifactRevisionCommand, FinalizeArtifactRevisionResult } from "./artifact-finalization.types.js";
 
-/** Finalizes ArtifactStore-promoted bytes into canonical metadata and an outbox event. */
+/**
+ * Make already-stored bytes visible: write the revision row and its publication event.
+ *
+ * The second of the two upload transactions. Everything is checked before the database is
+ * touched, then the revision, the artifact's current-revision pointer, the receipt consumption,
+ * and the outbox event all commit together. No bytes are read or written here.
+ *
+ * Called by: `__UploadArtifact` in artifact-upload.ts. Exported from the package barrel, but no
+ * caller outside this package uses it directly.
+ *
+ * @param repository - The persistence port that owns the transaction.
+ * @param command - Revision metadata plus the verified promotion receipt.
+ * @returns `finalized` with `idempotent: false` on the first commit and `idempotent: true` when
+ *   the same idempotency key already produced this exact revision, so a retry after a lost
+ *   response is safe. A `denied` result names which check failed and means nothing was written.
+ */
 export async function __FinalizeArtifactRevision(repository: ArtifactAuthorityRepository, command: FinalizeArtifactRevisionCommand): Promise<FinalizeArtifactRevisionResult>
 {
-	// 1. Validate storage-neutral metadata and authenticated receipt coordinates before persistence.
+	// 1. Check every field, including the receipt's hash, size, and media type, before touching the database.
 	const validPromotion = command.promotion.leaseId.trim()
 		&& ___IsSha256ContentAddress(command.promotion.contentAddress)
 		&& Number.isSafeInteger(command.promotion.byteLength)
@@ -17,10 +32,10 @@ export async function __FinalizeArtifactRevision(repository: ArtifactAuthorityRe
 		return { outcome: "denied", reason: "invalid_command" };
 	}
 
-	// 2. Commit only metadata, current pointer, receipt consumption, and outbox; bytes stay behind ArtifactStore.
+	// 2. Commit the revision row, the current-revision pointer, the spent receipt, and the outbox event. No bytes move here.
 	const result = await repository.finalizeRevisionAtomically(command);
 
-	// 3. Expose idempotent success while keeping stale or replayed receipts fail closed.
+	// 3. Report a repeat of the same commit as success, but refuse a receipt that was already spent or no longer matches its lease.
 	if (result.status === "finalized") return { outcome: "finalized", idempotent: false };
 	if (result.status === "idempotent") return { outcome: "finalized", idempotent: true };
 	return { outcome: "denied", reason: result.status };

--- a/libs/backend/server/agents/artifacts/main/src/artifact-finalization.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-finalization.types.ts
@@ -1,4 +1,25 @@
-/** ArtifactStore promotion receipt verified before metadata finalization. */
+/**
+ * The artifact service's signed confirmation that specific bytes are stored.
+ *
+ * Handed in already verified. Finalization compares every field against the stored lease row
+ * before publishing anything, because a receipt with a good signature could still describe a
+ * different lease or different bytes.
+ *
+ * @see {@link FinalizeArtifactRevisionCommand} which carries this into the commit.
+ */
+export interface ArtifactStorePromotionReceipt
+{
+	/** The lease this receipt answers. Must match the lease row the revision is committed against. */
+	readonly leaseId: string;
+	/** Hash of the stored bytes, as `sha256:` plus 64 lowercase hex characters. */
+	readonly contentAddress: string;
+	/** Byte count of the stored bytes. Must equal what the lease reserved. */
+	readonly byteLength: number;
+	/** Media type of the stored bytes. Must equal what the lease reserved. */
+	readonly mediaType: string;
+	/** Hash of the receipt string itself, stored on the lease row so the same receipt cannot commit twice. */
+	readonly receiptDigest: string;
+}
 export interface ArtifactStorePromotionReceipt
 {
 	/** Lease that authorized staging and promotion. */
@@ -13,7 +34,14 @@ export interface ArtifactStorePromotionReceipt
 	readonly receiptDigest: string;
 }
 
-/** Request to finalize promoted bytes into visible artifact metadata. */
+/**
+ * Everything needed to publish one revision for bytes that are already stored.
+ *
+ * All fields are validated before the transaction opens: ids must be non-blank, `revision` must
+ * be a positive safe integer, and the receipt's hash, digest, size, and media type must all be
+ * well formed. `idempotencyKey` is what makes a retry after a lost response commit nothing new
+ * instead of publishing a second revision.
+ */
 export interface FinalizeArtifactRevisionCommand
 {
 	/** Logical artifact receiving the revision. */
@@ -24,7 +52,7 @@ export interface FinalizeArtifactRevisionCommand
 	readonly artifactRevisionId: string;
 	/** Principal that completed the authorized write. */
 	readonly createdBy: string;
-	/** Structured source and lineage provenance. */
+	/** Where this revision came from, stored as JSON on the revision row. For converted output it records the pipeline version and the source revision id. */
 	readonly provenance: Readonly<Record<string, unknown>>;
 	/** Verified ArtifactStore promotion evidence. */
 	readonly promotion: ArtifactStorePromotionReceipt;
@@ -32,17 +60,58 @@ export interface FinalizeArtifactRevisionCommand
 	readonly idempotencyKey: string;
 }
 
-/** Atomic finalize result from the Artifact persistence authority. */
+/**
+ * What the finalize transaction did, in the database's own words.
+ *
+ * Two of these are success and four are refusals, and conflating them will make a caller report
+ * a revision as published when nothing was written. `finalized` committed. `idempotent` found
+ * the same idempotency key already produced this exact revision, so there was nothing left to
+ * do - also success. `artifact_not_found` means no Active artifact at that id.
+ * `lease_not_found` means the lease is missing, belongs to another artifact, or has expired.
+ * `receipt_consumed` means the lease was already promoted or finalized, so this receipt is spent.
+ * `conflict` means the lease exists but reserved different bytes, a different size, or a
+ * different media type than the receipt claims, or the database rolled the attempt back after
+ * exhausting its retries.
+ *
+ * Every non-success value leaves the database untouched.
+ *
+ * @see {@link FinalizeArtifactRevisionResult} for the shape the use case returns to its caller.
+ */
 export type AtomicFinalizeArtifactResult = { readonly status: "finalized" } | { readonly status: "idempotent" } | { readonly status: "conflict" } | { readonly status: "artifact_not_found" } | { readonly status: "lease_not_found" } | { readonly status: "receipt_consumed" };
 
-/** Persistence boundary committing revision metadata, current pointer, lease consumption, and outbox together. */
+/**
+ * Commits one revision and everything that must land with it.
+ *
+ * Four writes go in a single transaction - the revision row, the artifact's current-revision
+ * pointer, the spent lease, and the outbox event - so a retry can never publish the revision
+ * twice or publish it without its event. Implemented by `_ArtifactUploadAuthority`, which opens
+ * the transaction, over `PrismaArtifactAuthorityRepository`, which runs the SQL inside it.
+ *
+ * Called by: `__FinalizeArtifactRevision` in artifact-finalization.ts.
+ */
 export interface ArtifactAuthorityRepository
 {
-	/** Finalizes exact promoted bytes in one transaction with no byte I/O in this domain. */
+	/**
+	 * Publishes the revision for bytes the artifact service has already stored.
+	 *
+	 * @param command - Validated revision metadata plus the verified promotion receipt.
+	 * @returns One of the six statuses in {@link AtomicFinalizeArtifactResult}; only `finalized`
+	 *   and `idempotent` mean the revision is visible.
+	 * @throws Error when the database clock row cannot be read, since expiry checks would
+	 *   otherwise fall back to process time and could accept an expired lease.
+	 */
 	finalizeRevisionAtomically(command: FinalizeArtifactRevisionCommand): Promise<AtomicFinalizeArtifactResult>;
 }
 
-/** Browser-safe metadata for one asset owned by the signed-in user. */
+/**
+ * One asset as the browser is allowed to see it.
+ *
+ * Deliberately excludes content addresses, byte streams, leases, receipts, provenance, and
+ * outbox data. `byteLength` is a decimal string because the column is a 64-bit integer and JSON
+ * numbers would lose precision on large files.
+ *
+ * @see {@link PersonalArtifactCatalogueRepository.listOwnedCatalogue} which produces these.
+ */
 export interface PersonalArtifactEntry
 {
 	/** Stable logical asset identifier. */
@@ -65,14 +134,40 @@ export interface PersonalArtifactEntry
 	readonly updatedAt: string;
 }
 
-/** Reads browser-safe personal asset metadata from an exact owner and silo boundary. */
+/**
+ * Lists the signed-in user's own assets.
+ *
+ * Both the silo and the owner are required arguments rather than filters applied later, so
+ * there is no way to call this and get another user's assets. Implemented by
+ * `PrismaArtifactCatalogueRepository`, built through `_CreateArtifactCatalogueRepository`.
+ *
+ * Called by: the `GET /` handler in personal-artifact-catalogue.router.ts, mounted at
+ * `/api/v1/me/assets` by apps/opencrane/src/app/routes.ts.
+ */
 export interface PersonalArtifactCatalogueRepository
 {
-	/** Returns a bounded deterministic list of non-deleted assets owned by one user in one silo. */
+	/**
+	 * Lists assets owned by one user in one silo.
+	 *
+	 * @param siloId - Silo taken from the trusted request host, never from the request body.
+	 * @param ownerPrincipalId - Signed-in principal from the verified session.
+	 * @returns At most fifty non-deleted assets that have a current revision, newest updated
+	 *   first with the id breaking ties so paging order is stable. An empty array is a normal
+	 *   answer, not an error.
+	 * @throws Whatever the database driver throws; the router logs it and answers 503.
+	 */
 	listOwnedCatalogue(siloId: string, ownerPrincipalId: string): Promise<readonly PersonalArtifactEntry[]>;
 }
 
-/** Stable result of ArtifactRevision finalization. */
+/**
+ * What `__FinalizeArtifactRevision` returns.
+ *
+ * `finalized` means the revision is visible; `idempotent` only says whether this call did the
+ * writing or found them already done, and both are success. A `denied` result means nothing was
+ * written, and `reason` carries the database's own status through unchanged - `invalid_command`
+ * for a field that failed validation before the transaction, and the rest as described in
+ * {@link AtomicFinalizeArtifactResult}.
+ */
 export type FinalizeArtifactRevisionResult =
 	| { readonly outcome: "finalized"; readonly idempotent: boolean }
 	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "conflict" | "artifact_not_found" | "lease_not_found" | "receipt_consumed" };

--- a/libs/backend/server/agents/artifacts/main/src/artifact-preprocess-authority.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-preprocess-authority.ts
@@ -3,10 +3,22 @@ import type { ArtifactPreprocessorClaimCommand, ArtifactPreprocessorFailureComma
 import type { ArtifactPreprocessCompletionRequest, ArtifactPreprocessOutputLeaseRequest, ArtifactPreprocessRepository, ClaimNextArtifactPreprocessJobResult, CompleteArtifactPreprocessJobResult, FailArtifactPreprocessJobResult, IssueArtifactPreprocessOutputLeaseResult } from "./artifact-preprocessing.types.js";
 import type { ArtifactPreprocessUnitOfWork } from "./artifact-unit-of-work.types.js";
 
-/** Facade that runs each fenced preprocessing state transition inside its own opaque unit of work. */
+/**
+ * Wraps every preprocessing operation in its own database transaction.
+ *
+ * Each method does one thing: hand the call to the unit of work, which opens a transaction,
+ * builds a repository bound to it, runs the call, and commits. Nothing else is added, which is
+ * the point - the router and the brokers get an object that looks like a repository and can
+ * never open, hold, or leak a transaction across their HTTP calls.
+ *
+ * Errors are not translated here. A collision that exhausts its retries reaches the caller as
+ * the original database error, and the router answers HTTP 503.
+ *
+ * Called by: `_CreateArtifactPreprocessAuthority` in prisma-artifact-authority.composition.ts.
+ */
 export class _ArtifactPreprocessAuthority implements ArtifactPreprocessRepository
 {
-	/** Boundary that prevents router and broker code from owning a Prisma transaction. */
+	/** The only thing here allowed to open a transaction, so router and broker code never holds one. */
 	private readonly unitOfWork: ArtifactPreprocessUnitOfWork;
 
 	/** Creates the durable preprocessing authority. */

--- a/libs/backend/server/agents/artifacts/main/src/artifact-preprocessing.router.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-preprocessing.router.ts
@@ -16,6 +16,24 @@ import type { ArtifactPreprocessorRouterDependencies, ReviewedArtifactPreprocess
  * bytes are brokered through OpenCrane, so storage endpoints, leases, and receipts never reach the
  * worker namespace.
  *
+ * Four routes, in the order a worker uses them: `POST /jobs:claim` takes work (204 when idle),
+ * `POST /jobs/:jobId/source` streams the PDF, `PUT /jobs/:jobId/output` submits the text, and
+ * `PUT /jobs/:jobId/failure` reports a failed attempt. A 409 on any of the last three means the
+ * claim is no longer current and the worker must drop the job and poll again.
+ *
+ * A failure report may use only three codes: `source_read_failed`, `conversion_failed`, and
+ * `output_submission_failed`. The set is closed on purpose. The worker holds the untrusted PDF,
+ * so anything it can put in a failure report - an exception message, a temporary file path, text
+ * pulled out of the document - would flow straight into server logs and the job row. Three fixed
+ * words say which step broke, which is all the server-owned retry policy needs, and carry nothing
+ * an attacker-supplied document could influence. Adding a free-text field would reopen that.
+ *
+ * Called by: `_CreateOptionalRuntimeComposition` in apps/opencrane/src/app/runtime-composition.ts
+ * builds it; the worker's HTTP client is
+ * libs/backend/artifacts/preprocessor/main/src/remote.ts.
+ *
+ * @param dependencies - Token reviewer, allowed namespace, repository, both byte brokers, and logger.
+ * @returns An Express router to mount on the internal listener, never the public one.
  * @see apps/opencrane/helm/templates/_networkpolicy.tpl - protects the server internal listener.
  * @see apps/artifact-preprocessor/helm/templates/_resources.tpl - wires the sole caller identity.
  */
@@ -92,8 +110,10 @@ export function __CreateArtifactPreprocessorRouter(dependencies: ArtifactPreproc
 				_RespondProblem(response, 401, "preprocessor_identity_denied");
 				return;
 			}
-			// RFC 6648 deprecated the X- convention, but these request-only headers intentionally
-			// remain private OpenCrane protocol fields and are never represented as standard HTTP.
+			// RFC 6648 deprecated the X- prefix, but these two headers are private OpenCrane fields
+			// between the server and its own worker, never proposed as standard HTTP, so the prefix
+			// is kept to make that obvious. See https://www.rfc-editor.org/rfc/rfc6648 for the
+			// deprecation this deliberately does not follow.
 			const command = _ParseClaimHeaders(request.params["jobId"], request.header("x-opencrane-preprocess-attempt"), request.header("x-opencrane-preprocess-fence"));
 			if (command === null || !Buffer.isBuffer(request.body))
 			{
@@ -148,7 +168,7 @@ export function __CreateArtifactPreprocessorRouter(dependencies: ArtifactPreproc
 	return router;
 }
 
-/** TokenReview one bearer and require the fixed preprocessor identity. */
+/** Ask Kubernetes who the bearer token belongs to, and accept only the one preprocessor ServiceAccount. */
 async function _IsPreprocessor(request: Request, dependencies: ArtifactPreprocessorRouterDependencies): Promise<boolean>
 {
 	const token = _BearerValue(request.header("authorization"));
@@ -157,7 +177,7 @@ async function _IsPreprocessor(request: Request, dependencies: ArtifactPreproces
 	return identity !== null && _IdentityMatches(identity, dependencies.namespace);
 }
 
-/** Match every independently reviewed identity coordinate against the fixed worker contract. */
+/** Check the reviewed username, namespace, ServiceAccount name, and audience all match the one allowed worker. */
 function _IdentityMatches(identity: ReviewedArtifactPreprocessorIdentity, namespace: string): boolean
 {
 	return identity.username === `system:serviceaccount:${namespace}:${ARTIFACT_PREPROCESSOR_SERVICE_ACCOUNT_NAME}`
@@ -172,13 +192,13 @@ function _BearerValue(value: string | undefined): string | null
 	return value === undefined ? null : /^Bearer ([^\s,]+)$/u.exec(value)?.[1] ?? null;
 }
 
-/** Require an empty object for an authority-owned polling request. */
+/** Require the claim request body to be `{}`, so a worker cannot ask for a particular job. */
 function _IsEmptyObject(value: unknown): boolean
 {
 	return value !== null && typeof value === "object" && !Array.isArray(value) && Object.keys(value).length === 0;
 }
 
-/** Parse exact live-claim coordinates without accepting caller-added policy fields. */
+/** Read the job id, attempt, and fence from the body, rejecting any extra field so a worker cannot smuggle in a value the server owns. */
 function _ParseClaimCommand(jobId: unknown, value: unknown): ArtifactPreprocessorClaimCommand | null
 {
 	if (typeof jobId !== "string" || jobId.length === 0 || value === null || typeof value !== "object" || Array.isArray(value)) return null;
@@ -198,7 +218,7 @@ function _ParseClaimHeaders(jobId: unknown, attempt: string | undefined, claimFe
 		: null;
 }
 
-/** Parse one bounded failure category and exact live-claim coordinates. */
+/** Read the failure code plus the job id, attempt, and fence, rejecting anything else. */
 function _ParseFailure(jobId: unknown, value: unknown): ArtifactPreprocessorFailureCommand | null
 {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
@@ -208,7 +228,7 @@ function _ParseFailure(jobId: unknown, value: unknown): ArtifactPreprocessorFail
 	return claim === null ? null : { ...claim, failureCode: body["failureCode"] };
 }
 
-/** Keep failure reports within the protocol's stable non-sensitive vocabulary. */
+/** Accept only the three fixed failure codes, so nothing derived from the untrusted PDF - an exception message, a file path, document text - can reach server logs or the job row. */
 function _IsFailureCode(value: string): value is ArtifactPreprocessorFailureCode
 {
 	return value === "source_read_failed" || value === "conversion_failed" || value === "output_submission_failed";

--- a/libs/backend/server/agents/artifacts/main/src/artifact-preprocessing.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-preprocessing.ts
@@ -3,7 +3,22 @@ import { ___IsSha256ContentAddress } from "@opencrane/models/artifacts";
 
 import type { ArtifactPreprocessCompletionRequest, ArtifactPreprocessOutputLeaseProjection, ArtifactPreprocessOutputLeaseRequest, ArtifactPreprocessRepository, FailArtifactPreprocessJobResult } from "./artifact-preprocessing.types.js";
 
-/** Claims one PDF conversion job without exposing any storage coordinate or capability. */
+/**
+ * Take the next PDF conversion job and return only what the worker is allowed to know.
+ *
+ * The repository selects and fences the job; this trims the result down to the fenced claim, the
+ * fixed media type, and the source size. Everything else the database returned - the silo, the
+ * source artifact and revision ids - is dropped here, which is why the worker cannot name a
+ * revision or reach storage on its own.
+ *
+ * Called by: the `POST /jobs:claim` handler in artifact-preprocessing.router.ts.
+ *
+ * @param repository - The preprocessing repository, one transaction per call.
+ * @returns The claim to send to the worker, or null when no job is ready, which the router
+ *   answers as HTTP 204 so the worker keeps polling.
+ * @throws Whatever the repository throws, including when a stored source size is too large to
+ *   represent exactly in JavaScript. The router logs it and answers 503.
+ */
 export async function __ClaimArtifactPreprocessJob(repository: ArtifactPreprocessRepository): Promise<ArtifactPreprocessorJobClaim | null>
 {
 	const result = await repository.claimNextAtomically();
@@ -16,7 +31,23 @@ export async function __ClaimArtifactPreprocessJob(repository: ArtifactPreproces
 	};
 }
 
-/** Binds server-observed text bytes to the live claim without returning the lease to the worker. */
+/**
+ * Reserve write permission for text the server has already received and hashed.
+ *
+ * Checks the request's shape first so a malformed submission never reaches the database, then
+ * asks the repository to attach a write lease to the live claim. The returned lease is for
+ * server use only; the caller signs it, promotes the bytes, and completes the job.
+ *
+ * Called by: `_CreateArtifactPreprocessOutputBroker` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts.
+ *
+ * @param repository - The preprocessing repository, one transaction per call.
+ * @param command - The claim plus the server-computed content address and byte length.
+ * @returns The write lease and reserved revision id to promote with; `"completed"` when this
+ *   exact output was already published on this attempt, so the caller should report success
+ *   without promoting again; or null when the input failed validation or the claim is no longer
+ *   current, which the caller reports as a conflict.
+ */
 export async function __IssueArtifactPreprocessOutputLease(repository: ArtifactPreprocessRepository, command: ArtifactPreprocessOutputLeaseRequest): Promise<ArtifactPreprocessOutputLeaseProjection | "completed" | null>
 {
 	if (!_IsValidOutputLeaseCommand(command)) return null;
@@ -25,20 +56,47 @@ export async function __IssueArtifactPreprocessOutputLease(repository: ArtifactP
 	return result.status === "issued" ? result.lease : null;
 }
 
-/** Completes one active preprocessing claim after app composition verifies the service receipt. */
+/**
+ * Commit the converted text once its promotion receipt has been verified.
+ *
+ * Called only after the app-side broker has promoted the bytes and checked the receipt
+ * signature. The repository re-checks the receipt against the stored lease row, so a receipt for
+ * a different lease, size, or media type cannot publish anything.
+ *
+ * Called by: `_CreateArtifactPreprocessOutputBroker` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts.
+ *
+ * @param repository - The preprocessing repository, one transaction per call.
+ * @param command - The claim, reserved revision id, verified receipt, and receipt digest.
+ * @returns True when the revision is published, including when this repeats a completion that
+ *   already succeeded. False means nothing was published and the caller must report a conflict;
+ *   the bytes stay in storage unreferenced rather than being deleted here.
+ */
 export async function __CompleteArtifactPreprocessJob(repository: ArtifactPreprocessRepository, command: ArtifactPreprocessCompletionRequest): Promise<boolean>
 {
 	const result = await repository.completeAtomically(command);
 	return result.status === "completed";
 }
 
-/** Applies server-owned retry policy to one bounded worker failure under its current fence. */
+/**
+ * Record that an attempt failed and let the server decide whether the job runs again.
+ *
+ * The worker only says which step broke. Whether that becomes a retry with a wait or a permanent
+ * failure is the server's call, so a misbehaving worker cannot keep a job cycling or bury it.
+ *
+ * Called by: the `PUT /jobs/:jobId/failure` handler in artifact-preprocessing.router.ts.
+ *
+ * @param repository - The preprocessing repository, one transaction per call.
+ * @param command - The claim plus one of the three allowed failure codes.
+ * @returns `retryable`, `terminal`, or `conflict` when the report no longer matches the live
+ *   claim. The router answers 204 for the first two and 409 for the third.
+ */
 export async function __FailArtifactPreprocessJob(repository: ArtifactPreprocessRepository, command: ArtifactPreprocessorFailureCommand): Promise<FailArtifactPreprocessJobResult>
 {
 	return repository.failAtomically(command);
 }
 
-/** Require bounded exact text-output coordinates before consulting durable authority state. */
+/** Check the job id, attempt, fence, content address, and byte length are well formed before touching the database. */
 function _IsValidOutputLeaseCommand(command: ArtifactPreprocessOutputLeaseRequest): boolean
 {
 	return command.jobId.trim().length > 0

--- a/libs/backend/server/agents/artifacts/main/src/artifact-preprocessing.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-preprocessing.types.ts
@@ -1,16 +1,30 @@
 import type { ArtifactPromotionReceiptClaims, ArtifactReadLeaseClaims, ArtifactWriteLeaseClaims } from "@opencrane/backend/artifacts/authorization";
 import type { ArtifactPreprocessorClaimCommand, ArtifactPreprocessorFailureCommand } from "@opencrane/contracts";
 
-/** Immutable source and generated-output coordinates selected only by the catalogue authority. */
+/**
+ * Everything the server knows about one claimed PDF conversion job.
+ *
+ * The database picks the job and this describes it. There are no output fields here: the output
+ * artifact and its write lease are created later, by `issueOutputLeaseAtomically`, after the
+ * server has seen and hashed the submitted text. Note what is missing on purpose - no storage
+ * location and no storage credential. The PDF worker never learns where the bytes live and never
+ * holds a capability against storage; it reads and writes through OpenCrane, which brokers both
+ * directions.
+ *
+ * Only `jobId`, `attempt`, `claimFence`, and derived source limits ever reach the worker; see
+ * `ArtifactPreprocessorJobClaim` in libs/contracts for the trimmed shape sent over HTTP.
+ *
+ * @see {@link ArtifactPreprocessRepository.claimNextAtomically} which produces this.
+ */
 export interface ArtifactPreprocessClaimProjection
 {
 	/** Durable preprocessing job identifier. */
 	readonly jobId: string;
 	/** Monotonic attempt number allocated under the current claim. */
 	readonly attempt: number;
-	/** Fresh opaque fence that invalidates every previous worker attempt. */
+	/** New random value generated for this claim. Every later worker call must send it back; a call carrying an older fence is rejected as stale, which is how a worker whose claim expired cannot still report a result. */
 	readonly claimFence: string;
-	/** Absolute expiry of every operation admitted for this worker. */
+	/** Database-clock instant after which this claim is dead: source reads, output submissions, and failure reports are all rejected, and the next poller may reclaim the job. */
 	readonly claimExpiresAt: Date;
 	/** Source artifact silo selected from catalogue state. */
 	readonly siloId: string;
@@ -18,22 +32,39 @@ export interface ArtifactPreprocessClaimProjection
 	readonly sourceArtifactId: string;
 	/** Immutable PDF source revision identifier. */
 	readonly sourceRevisionId: string;
-	/** Exact PDF source byte length used only to bound worker resource use. */
+	/** Size of the source PDF in bytes, so the worker can refuse a file above its configured ceiling before downloading it. */
 	readonly sourceByteLength: number;
 }
 
-/** Exact read lease facts allocated under the current claim transaction. */
+/**
+ * A signed-ready read permission for the source PDF, plus the facts to check the download against.
+ *
+ * Issued only while the worker's attempt and fence are still current. This never leaves the
+ * server: the app-side source broker signs the lease, calls the artifact service itself, and
+ * streams the bytes on to the worker, so the worker sees only bytes and headers.
+ *
+ * @see {@link ArtifactPreprocessSourceLeaseIssuer.issueSourceLeaseAtomically} which produces this.
+ */
 export interface ArtifactPreprocessSourceLeaseProjection
 {
 	/** Read authority whose expiry never exceeds the current claim deadline. */
 	readonly readLease: ArtifactReadLeaseClaims;
-	/** Exact source length used to cross-check the broker response. */
+	/** Source byte count from the catalogue, compared against what the artifact service actually returns so a mismatch fails instead of being converted. */
 	readonly byteLength: number;
 	/** Fixed source media type admitted by this pipeline. */
 	readonly mediaType: "application/pdf";
 }
 
-/** Exact server-observed output digest that may become one internal write lease. */
+/**
+ * The claim plus the hash and size of the text the server has already received in full.
+ *
+ * The server reads the whole submitted body, enforces its byte ceiling, and hashes it before
+ * asking for a write lease. That order matters: the content address is computed by OpenCrane,
+ * never supplied by the worker, so the worker cannot reserve write authority for bytes the
+ * server has not seen.
+ *
+ * @see {@link ArtifactPreprocessRepository.issueOutputLeaseAtomically} which consumes this.
+ */
 export interface ArtifactPreprocessOutputLeaseRequest extends ArtifactPreprocessorClaimCommand
 {
 	/** SHA-256 content address computed from the bounded submitted text bytes. */
@@ -42,7 +73,21 @@ export interface ArtifactPreprocessOutputLeaseRequest extends ArtifactPreprocess
 	readonly byteLength: number;
 }
 
-/** Durable exact-byte lease projection that app composition signs internally. */
+/**
+ * The write permission for the converted text, together with the revision id reserved for it.
+ *
+ * This type is server-only and must stay that way. `writeLease` is a capability over artifact
+ * storage; the PDF worker never receives it, never receives the promotion receipt, and never
+ * learns a storage location. The app-side output broker signs this lease, promotes the bytes
+ * through the private artifact service, verifies the receipt, and only then completes the job.
+ * The worker's whole view of this step is a 204 or a 409.
+ *
+ * `derivedRevisionId` is derived from the lease id, so completion can prove the receipt belongs
+ * to the same lease that was handed out for this attempt.
+ *
+ * @see {@link ArtifactPreprocessRepository.issueOutputLeaseAtomically} which produces this.
+ * @see {@link ArtifactPreprocessCompletionRequest} for the next step.
+ */
 export interface ArtifactPreprocessOutputLeaseProjection
 {
 	/** Immutable job identifier. */
@@ -53,11 +98,20 @@ export interface ArtifactPreprocessOutputLeaseProjection
 	readonly claimFence: string;
 	/** Server-generated revision identity reserved by the catalogue authority. */
 	readonly derivedRevisionId: string;
-	/** Exact storage write lease claims that never cross into the worker. */
+	/** Write permission over artifact storage for exactly these bytes. Signed and spent inside the server; sending it to the worker would hand the worker direct storage authority. */
 	readonly writeLease: ArtifactWriteLeaseClaims;
 }
 
-/** Verified receipt and claim coordinates consumed only by the completion transaction. */
+/**
+ * Proof from the artifact service that the converted bytes are stored, ready to be committed.
+ *
+ * Built by the app-side output broker after it verifies the receipt signature. The completion
+ * transaction re-checks the receipt against the stored lease row before publishing anything, so
+ * a receipt for a different lease, size, or media type is refused rather than trusted.
+ *
+ * `receiptDigest` is stored so a replay of the same completion is recognised instead of
+ * publishing a second revision.
+ */
 export interface ArtifactPreprocessCompletionRequest extends ArtifactPreprocessorClaimCommand
 {
 	/** Server-reserved generated revision identifier. */
@@ -68,35 +122,127 @@ export interface ArtifactPreprocessCompletionRequest extends ArtifactPreprocesso
 	readonly receiptDigest: string;
 }
 
-/** Result of selecting one durable preprocessing job. */
+/**
+ * What a claim attempt returned: either a job now fenced to this worker, or nothing to do.
+ *
+ * `none` is the normal idle answer and the router turns it into HTTP 204, which tells the worker
+ * to keep polling. `claimed` means the job row is already marked Claimed with a fresh fence and
+ * expiry, so the worker owns it until that expiry passes.
+ */
 export type ClaimNextArtifactPreprocessJobResult = { readonly status: "claimed"; readonly claim: ArtifactPreprocessClaimProjection } | { readonly status: "none" };
 
-/** Result of binding extracted bytes to the live job attempt. */
+/**
+ * What happened when the server tried to reserve write authority for the submitted text.
+ *
+ * `issued` gives back the lease to sign and spend. `completed` means this exact output was
+ * already published on this attempt - a duplicate submission after a lost response - and the
+ * caller should report success without promoting anything again. `conflict` means stop: the job
+ * or its output artifact is gone (`claim_not_found`), another attempt has taken over or the
+ * claim expired (`stale_claim`), or the hash or size failed validation, or a previous lease for
+ * this attempt was for different bytes (`invalid_output`).
+ */
 export type IssueArtifactPreprocessOutputLeaseResult = { readonly status: "issued"; readonly lease: ArtifactPreprocessOutputLeaseProjection } | { readonly status: "completed" } | { readonly status: "conflict"; readonly reason: "claim_not_found" | "stale_claim" | "invalid_output" };
 
-/** Result of atomically publishing one preprocessed text revision. */
+/**
+ * What happened when the server tried to commit the converted revision.
+ *
+ * `completed` covers both the first successful commit and a repeat of the same completion, so a
+ * caller may treat it as plain success. `conflict` means nothing was published: the job or its
+ * lease is missing (`claim_not_found`), the attempt or fence moved on or the revision id does
+ * not match the lease (`stale_claim`), the receipt does not match the stored lease
+ * (`invalid_receipt`), or that receipt was already spent (`receipt_consumed`).
+ */
 export type CompleteArtifactPreprocessJobResult = { readonly status: "completed" } | { readonly status: "conflict"; readonly reason: "claim_not_found" | "stale_claim" | "invalid_receipt" | "receipt_consumed" };
 
-/** Result of applying the server-owned retry ceiling to one current failed attempt. */
+/**
+ * What the server decided after a worker reported its attempt failed.
+ *
+ * The worker does not choose. `retryable` means the job was parked with a wait before it can be
+ * claimed again, growing with the attempt number. `terminal` means the attempt limit is reached
+ * and the job will not run again. `conflict` means the report was ignored because the job is
+ * missing (`claim_not_found`) or the attempt, fence, or expiry no longer match (`stale_claim`);
+ * either way the worker should stop and poll for new work.
+ */
 export type FailArtifactPreprocessJobResult = { readonly status: "retryable" | "terminal" } | { readonly status: "conflict"; readonly reason: "claim_not_found" | "stale_claim" };
 
-/** Narrow issuer that freezes one current preprocessing source lease. */
+/**
+ * Hands out read permission for one job's source PDF.
+ *
+ * Split out from the full repository so the app-side source broker can be given just this one
+ * method and cannot claim, complete, or fail jobs. The `Atomically` suffix on the method is a
+ * standing rule in this package: every method carrying it does all its reads and writes inside
+ * one serializable database transaction opened by the unit of work, never by the caller.
+ *
+ * Called by: `_CreateArtifactPreprocessSourceBroker` in
+ * apps/opencrane/src/infra/artifacts/artifact-preprocess-source-broker.factory.ts.
+ */
 export interface ArtifactPreprocessSourceLeaseIssuer
 {
-	/** Allocates exact source-read facts only while the supplied attempt and fence remain current. */
+	/**
+	 * Issues read permission for the source PDF if this attempt still owns the job.
+	 *
+	 * @param command - The job id, attempt number, and fence the worker presented.
+	 * @returns The lease and the source facts to check the download against, or null when the job
+	 *   row does not match on state, attempt, fence, or expiry, or when the source revision is no
+	 *   longer a published active PDF. Null must be turned into a refusal, not a retry.
+	 */
 	issueSourceLeaseAtomically(command: ArtifactPreprocessorClaimCommand): Promise<ArtifactPreprocessSourceLeaseProjection | null>;
 }
 
-/** Catalogue persistence authority for the dedicated PDF preprocessing worker. */
+/**
+ * The complete set of database operations in the PDF-to-text job lifecycle.
+ *
+ * Every method runs in its own serializable transaction: claim, then issue a read lease, then
+ * issue a write lease, then complete or fail. Each one re-checks the attempt and fence, so no
+ * caller has to hold a transaction open across worker HTTP calls, and a worker that went quiet
+ * cannot come back and change a job another attempt has taken over.
+ *
+ * Implemented by `_ArtifactPreprocessAuthority` (adds the transaction per call) over
+ * `PrismaArtifactPreprocessRepository` (runs the SQL inside one). Build it with
+ * `_CreateArtifactPreprocessAuthority`.
+ *
+ * Called by: `_CreateOptionalRuntimeComposition` in apps/opencrane/src/app/runtime-composition.ts
+ * passes it to the router; `_CreateArtifactPreprocessOutputBroker` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts uses it for output and completion.
+ */
 export interface ArtifactPreprocessRepository extends ArtifactPreprocessSourceLeaseIssuer
 {
-	/** Claims one eligible PDF job, allocating a fresh fence and generated Artifact. */
+	/**
+	 * Takes the next job that is ready to run and fences it to this caller.
+	 *
+	 * Also recovers jobs whose claim expired, and creates the hidden output artifact row the first
+	 * time a job is claimed, so later steps have somewhere to attach the text revision.
+	 *
+	 * @returns `claimed` with the job's source facts, or `none` when nothing is ready.
+	 * @throws Error when a stored source byte count is too large to represent exactly in
+	 *   JavaScript, because passing it on would silently truncate the size the worker enforces.
+	 */
 	claimNextAtomically(): Promise<ClaimNextArtifactPreprocessJobResult>;
-	/** Attaches one exact, short-lived artifact write lease to the live claim. */
+	/**
+	 * Reserves write permission for text the server has already received and hashed.
+	 *
+	 * Re-submitting the same bytes for the same attempt returns the same lease rather than a
+	 * second one, so a lost response cannot create two parallel writes.
+	 *
+	 * @param request - The claim plus the server-computed content address and byte length.
+	 * @returns `issued`, `completed` if this output was already published, or `conflict`.
+	 */
 	issueOutputLeaseAtomically(request: ArtifactPreprocessOutputLeaseRequest): Promise<IssueArtifactPreprocessOutputLeaseResult>;
-	/** Finalizes the verified receipt, immutable derived revision, source lineage, and job together. */
+	/**
+	 * Commits the converted revision: spends the lease, publishes the revision, points the output
+	 * artifact at it, records that it came from the source revision, and closes the job.
+	 *
+	 * @param request - The claim, the reserved revision id, the verified receipt, and its digest.
+	 * @returns `completed` on success or on a repeat of the same completion, else `conflict`.
+	 */
 	completeAtomically(request: ArtifactPreprocessCompletionRequest): Promise<CompleteArtifactPreprocessJobResult>;
-	/** Records a bounded failure under the current fence and applies retry or terminal policy. */
+	/**
+	 * Records a failed attempt and decides whether the job may run again.
+	 *
+	 * @param command - The claim plus one of the three allowed failure codes.
+	 * @returns `retryable` with a wait before the next claim, `terminal` when the attempt limit is
+	 *   reached, or `conflict` when the report no longer matches the live claim.
+	 */
 	failAtomically(command: ArtifactPreprocessorFailureCommand): Promise<FailArtifactPreprocessJobResult>;
 }
 
@@ -113,14 +259,40 @@ export interface ReviewedArtifactPreprocessorIdentity
 	readonly audiences: readonly string[];
 }
 
-/** App-owned TokenReview adapter for the dedicated preprocessing workload identity. */
+/**
+ * Asks Kubernetes who a bearer token belongs to.
+ *
+ * This router has no user session and is not behind the normal auth middleware, so this is the
+ * only thing standing between the internal listener and any pod that can reach it. The adapter
+ * is supplied by the app so this package never holds a Kubernetes client.
+ *
+ * Called by: `_CreateArtifactPreprocessorTokenReviewer` in
+ * libs/backend/server/infra/workload-identity/src/projected-token-reviewer.ts supplies the
+ * implementation; `_IsPreprocessor` in artifact-preprocessing.router.ts calls it on every request.
+ */
 export interface ArtifactPreprocessorTokenReviewer
 {
-	/** Reviews one presented projected ServiceAccount token. */
+	/**
+	 * Reviews one token mounted into a pod by Kubernetes.
+	 *
+	 * @param token - The value taken from an `Authorization: Bearer` header.
+	 * @returns The reviewed identity, or null when the token is not valid. Null and a
+	 *   non-matching identity are treated the same way: HTTP 401 with no detail about which check
+	 *   failed.
+	 * @throws Whatever the Kubernetes client throws when the API server cannot be reached; the
+	 *   router logs it and answers 503 rather than 401, so an outage is not read as a denial.
+	 */
 	__Review(token: string): Promise<ReviewedArtifactPreprocessorIdentity | null>;
 }
 
-/** Server-brokered immutable source bytes that expose no storage coordinate or capability. */
+/**
+ * The source PDF as a stream the server is relaying, plus the facts it must agree with.
+ *
+ * The server has already spent the read lease against the private artifact service; what the
+ * worker receives is a plain byte stream with a length and a media type. No URL, no bucket, no
+ * token. The two metadata fields are checked against both the job row and the lease before any
+ * bytes are forwarded, so a stream that disagrees with the catalogue is refused.
+ */
 export interface ArtifactPreprocessSourceRead
 {
 	/** Exact length cross-checked against both job and read-lease catalogue facts. */
@@ -131,28 +303,77 @@ export interface ArtifactPreprocessSourceRead
 	readonly bytes: AsyncIterable<Uint8Array>;
 }
 
-/** App-composed source broker backed by the one generic catalogue read issuer. */
+/**
+ * Fetches the source PDF on the worker's behalf.
+ *
+ * The broker issues the read lease, signs it, calls the private artifact service, and returns
+ * the byte stream. Routing the read through here is what keeps the artifact service address and
+ * the lease inside the server.
+ *
+ * Called by: the `POST /jobs/:jobId/source` handler in artifact-preprocessing.router.ts.
+ * Implemented by `_CreateArtifactPreprocessSourceBroker` in
+ * apps/opencrane/src/infra/artifacts/artifact-preprocess-source-broker.factory.ts.
+ */
 export interface ArtifactPreprocessSourceBroker
 {
-	/** Reads bytes only while the supplied attempt and fence remain current. */
+	/**
+	 * Streams the source PDF if this attempt still owns the job.
+	 *
+	 * @param command - The job id, attempt, and fence the worker presented.
+	 * @returns The stream and its checked metadata, or null when the claim is no longer current,
+	 *   which the router reports as HTTP 409 so the worker abandons the job and polls again.
+	 * @throws When the artifact service is unreachable or answers badly; the router logs it and
+	 *   answers 503, or destroys the response if headers were already sent.
+	 */
 	read(command: ArtifactPreprocessorClaimCommand): Promise<ArtifactPreprocessSourceRead | null>;
 }
 
-/** App-composed output broker that keeps leases and receipts inside trusted server processes. */
+/**
+ * Takes the converted text from the worker and does everything needed to publish it.
+ *
+ * Five steps, all inside the server: read the body under a byte ceiling, hash it, reserve a
+ * write lease for exactly those bytes, promote them through the private artifact service and
+ * verify the receipt, then commit the revision. The worker gets one word back. It never sees the
+ * write lease, the receipt, or where the bytes went.
+ *
+ * Called by: the `PUT /jobs/:jobId/output` handler in artifact-preprocessing.router.ts.
+ * Implemented by `_CreateArtifactPreprocessOutputBroker` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts.
+ */
 export interface ArtifactPreprocessOutputBroker
 {
-	/** Bounds, hashes, promotes, verifies, and completes one submitted output body. */
+	/**
+	 * Publishes one submitted output body.
+	 *
+	 * @param command - The job id, attempt, and fence the worker presented in request headers.
+	 * @param bytes - The raw submitted body. Read once and fully before anything is reserved.
+	 * @returns `"completed"` when the text is published, including when this repeats an already
+	 *   published submission, or `"conflict"` when the claim is no longer current, which the
+	 *   router reports as HTTP 409.
+	 * @throws When the body exceeds the configured ceiling, or the artifact service is unreachable
+	 *   or returns a receipt that does not verify. The router logs it and answers 503; the job
+	 *   stays claimed until its expiry, then becomes retryable.
+	 */
 	publish(command: ArtifactPreprocessorClaimCommand, bytes: AsyncIterable<Uint8Array>): Promise<"completed" | "conflict">;
 }
 
-/** Minimal structured logger surface for the private preprocessor HTTP boundary. */
+/** The one logging method this router needs, kept this small so the package does not depend on a full logger type. */
 export interface ArtifactPreprocessorLogger
 {
 	/** Records one infrastructure failure without serialising credentials or request bodies. */
 	error(bindings: { readonly err: unknown; readonly operation: string }, message: string): void;
 }
 
-/** Dependencies of the workload-authenticated preprocessing router. */
+/**
+ * Everything `__CreateArtifactPreprocessorRouter` needs, supplied by the app composition root.
+ *
+ * The split is deliberate: `repository` owns database state, the two brokers own all byte
+ * movement and all lease handling, and `tokenReviewer` plus `namespace` decide who is allowed to
+ * call. Because the brokers sit here rather than in the worker, no storage address or lease is
+ * ever rendered into a response.
+ *
+ * Called by: `_CreateOptionalRuntimeComposition` in apps/opencrane/src/app/runtime-composition.ts.
+ */
 export interface ArtifactPreprocessorRouterDependencies
 {
 	/** Fixed projected-token identity reviewer. */

--- a/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-read-lease.types.ts
@@ -1,62 +1,147 @@
 import type { ArtifactReadLeaseClaims } from "@opencrane/backend/artifacts/authorization";
 
 /**
- * Stable serialized outcomes of the server-internal read-lease issuer.
+ * Says whether the server issued a read lease for one published artifact revision.
  *
- * These values cross the artifacts package boundary so callers can branch on
- * one owned vocabulary without changing the existing result wire shape.
+ * A server-side caller asks permission to read the bytes of one revision. Only two things can
+ * come back: a short-lived signed lease it can hand to the private artifact service, or a
+ * refusal. Nothing in this package hands back a storage location or a storage-provider
+ * credential - no bucket, no object key, no pre-signed storage URL. The caller gets metadata
+ * (content address, byte length, media type) plus an opaque signed lease, and only the artifact
+ * service turns that lease into bytes.
+ *
+ * These strings are serialized, so they are part of the contract, not a local detail.
+ *
+ * Called by: `_CreateSkillAuthoringArtifactReader` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts, which throws
+ * "artifact read lease denied" for any outcome other than `Issued`.
+ *
+ * @see {@link IssueArtifactReadLeaseResult} for the payload attached to each outcome.
  */
 export enum IssueArtifactReadLeaseOutcomes
 {
-	/** Exact catalogue facts were accepted and signed into a bounded read lease. */
+	/**
+	 * The revision was found active and published and the lease was signed. The result also
+	 * carries `compactLease` (the signed string to present to the artifact service) and `claims`
+	 * (the same facts unsigned, so the caller can check what the service returns against them).
+	 */
 	Issued = "issued",
-	/** Input or catalogue evidence failed closed without granting read authority. */
+	/**
+	 * Nothing was signed and nothing needs cleaning up. The result's `reason` says which check
+	 * failed: `invalid_command` means an id was malformed or the clock argument was not a
+	 * non-negative safe integer, so the catalogue was never queried; `revision_not_readable`
+	 * means the catalogue holds no active artifact with that published revision in that silo, or
+	 * the stored row failed a safety check. Retrying with the same input gives the same answer.
+	 */
 	Denied = "denied",
 }
 
-/** Server-owned coordinates for one exact published revision that may be read internally. */
+/**
+ * Names the one revision a server-side caller wants to read.
+ *
+ * All three ids must match the same row set, and each must match `^[A-Za-z0-9_-]{1,128}$` or the
+ * request is denied as `invalid_command` before the database is touched. The command carries no
+ * byte length, media type, or content address on purpose: those are reloaded from the catalogue
+ * so a caller cannot talk the server into signing byte facts it made up.
+ *
+ * @see {@link PublishedArtifactReadTarget} for the facts the catalogue returns for this command.
+ */
 export interface IssueArtifactReadLeaseCommand
 {
-	/** Silo whose artifact authority must contain the requested revision. */
+	/** Silo that must own the artifact. A revision in another silo is treated as not readable. */
 	readonly siloId: string;
-	/** Logical artifact that owns the revision. */
+	/** The artifact this revision belongs to. */
 	readonly artifactId: string;
-	/** Immutable published revision that owns the canonical bytes. */
+	/** The one published revision to read. Revisions never change once published. */
 	readonly artifactRevisionId: string;
 }
 
-/** Immutable catalogue facts loaded only after active-silo and published-revision checks. */
+/**
+ * The stored facts about one published revision, read back from the database.
+ *
+ * The issuer re-reads these instead of trusting the request, then checks that the three ids came
+ * back exactly as asked for. That check is why the ids are repeated here rather than assumed:
+ * if a repository ever returned a different row, the mismatch is caught before anything is
+ * signed. Everything here goes into the lease unchanged.
+ *
+ * @see {@link ArtifactReadLeaseRepository.loadPublishedReadTarget} which produces this.
+ */
 export interface PublishedArtifactReadTarget
 {
-	/** Silo independently loaded from the active artifact record. */
+	/** Silo read from the artifact row, which must be Active. */
 	readonly siloId: string;
-	/** Logical artifact independently loaded from the revision relation. */
+	/** Artifact id read from the revision's artifact relation. */
 	readonly artifactId: string;
-	/** Exact immutable revision independently loaded from the catalogue. */
+	/** Revision id read from the catalogue row. */
 	readonly artifactRevisionId: string;
-	/** Canonical SHA-256 object address approved by that revision. */
+	/** Stored content address, in the form `sha256:` plus 64 lowercase hex characters. */
 	readonly contentAddress: string;
-	/** Exact canonical byte count approved by that revision. */
+	/** Stored byte count. Must be a non-negative safe integer to survive the JSON boundary. */
 	readonly byteLength: number;
-	/** Catalogue-approved media type for the immutable bytes. */
+	/** Stored media type. Must pass `__IsSafeArtifactMediaType` before it is signed. */
 	readonly mediaType: string;
 }
 
-/** Persistence boundary exposing no artifact path, list, or caller-supplied byte metadata. */
+/**
+ * Reads the stored facts for one published revision, and nothing else.
+ *
+ * The port is deliberately this small: it has no list method and no way to hand back a storage
+ * location, so a caller holding it cannot enumerate a silo's artifacts or reach storage
+ * directly. Implemented by `PrismaArtifactCatalogueRepository`, built through
+ * `_CreateArtifactCatalogueRepository`.
+ *
+ * Called by: `__IssueArtifactReadLease` in artifact-read-lease.ts, which is in turn called by
+ * `_CreateSkillAuthoringArtifactReader` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts.
+ */
 export interface ArtifactReadLeaseRepository
 {
-	/** Loads one active artifact's exact published revision, or null for every other state. */
+	/**
+	 * Loads the requested revision when it is published and its artifact is active.
+	 *
+	 * @param command - The silo, artifact, and revision ids to look up.
+	 * @returns The stored facts, or null when there is no such row, the artifact is not Active,
+	 *   the revision is not Published, or the stored byte count is outside the range JavaScript
+	 *   can carry exactly. Null is not an error: the caller turns it into a `revision_not_readable`
+	 *   denial without saying which of those reasons applied.
+	 */
 	loadPublishedReadTarget(command: IssueArtifactReadLeaseCommand): Promise<PublishedArtifactReadTarget | null>;
 }
 
-/** Narrow signing port owned by server composition and backed by mounted key material. */
+/**
+ * Signs read-lease claims using the private key mounted into the server pod.
+ *
+ * This package never holds key material. The app composition root loads the key and passes an
+ * implementation in, which keeps the key out of every module that only needs a signature.
+ *
+ * Called by: satisfied inline as `{ sign: signLease }` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts, where `signLease` comes from
+ * `_CreateArtifactReadLeaseSigner`.
+ */
 export interface ArtifactReadLeaseSigner
 {
-	/** Signs only validated server-owned artifact-read claims. */
+	/**
+	 * Turns already-checked claims into the compact signed string the artifact service accepts.
+	 *
+	 * @param claims - Claims built from re-read catalogue facts, never from caller input.
+	 * @returns The compact signed lease to send to the private artifact service.
+	 * @throws Whatever the app-supplied signer throws, for example when the mounted key is
+	 *   missing or unreadable. The issuer does not catch this, so the failure reaches the caller
+	 *   instead of being reported as a denial.
+	 */
 	sign(claims: ArtifactReadLeaseClaims): string;
 }
 
-/** Stable outcome of one server-internal read-lease issuance attempt. */
+/**
+ * What `__IssueArtifactReadLease` returns.
+ *
+ * On `Issued` the caller gets `compactLease` to send to the artifact service, and `claims` so it
+ * can compare the service's `content-length` and `content-type` response headers against what
+ * was signed and reject a mismatch. On `Denied` there is no lease and nothing to undo; `reason`
+ * separates a malformed request from a revision that is simply not readable.
+ *
+ * @see {@link IssueArtifactReadLeaseOutcomes} for what each outcome means for a caller.
+ */
 export type IssueArtifactReadLeaseResult =
 	| { readonly outcome: IssueArtifactReadLeaseOutcomes.Issued; readonly compactLease: string; readonly claims: ArtifactReadLeaseClaims }
 	| { readonly outcome: IssueArtifactReadLeaseOutcomes.Denied; readonly reason: "invalid_command" | "revision_not_readable" };

--- a/libs/backend/server/agents/artifacts/main/src/artifact-unit-of-work.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-unit-of-work.types.ts
@@ -2,17 +2,37 @@ import type { ArtifactAuthorityRepository } from "./artifact-finalization.types.
 import type { ArtifactPreprocessRepository } from "./artifact-preprocessing.types.js";
 import type { ArtifactUploadLeaseRepository } from "./artifact-upload.types.js";
 
-/** Domain-neutral signal that a fully rolled-back artifact publication race exhausted safe retries. */
+/**
+ * Thrown when two publications collided and retrying inside the transaction did not help.
+ *
+ * The retry contract: `PrismaArtifactPublicationUnitOfWork` runs the work at PostgreSQL
+ * SERIALIZABLE isolation and makes up to three complete attempts. It retries only on the two
+ * Prisma error codes that prove the whole attempt rolled back with nothing written, and it
+ * rebuilds the repositories for each attempt so no stale transaction client is reused. If the
+ * third attempt still collides, it throws this.
+ *
+ * The error deliberately carries no Prisma code or database detail, so the application layer
+ * cannot start branching on the storage engine. `_ArtifactUploadAuthority` catches it and turns
+ * it into a plain `conflict` status. That means a caller normally sees `conflict`, never this
+ * exception - it escaping to a caller means someone is running the unit of work directly.
+ *
+ * Nothing was written when this is thrown, so retrying the same command later is safe.
+ */
 export class _ArtifactPublicationConflictError extends Error
 {
-	/** Marks a conflict without exposing persistence-adapter details to the application authority. */
+	/** Builds the conflict with a fixed message and no database detail attached. */
 	constructor()
 	{
 		super("artifact publication conflict");
 	}
 }
 
-/** Capability repositories bound to one artifact-publication database transaction. */
+/**
+ * The repositories available inside one publication transaction.
+ *
+ * Both fields are the same object in practice; they are named separately so a piece of work
+ * states which capability it uses. Neither can open or commit a transaction.
+ */
 export interface ArtifactPublicationTransaction
 {
 	/** Metadata finalization repository that consumes one promotion receipt. */
@@ -21,20 +41,53 @@ export interface ArtifactPublicationTransaction
 	readonly uploadLeases: ArtifactUploadLeaseRepository;
 }
 
-/** Work that must either commit wholly or leave no durable artifact-publication effect. */
+/** A function to run inside one publication transaction. It either commits completely or writes nothing, so it must be safe to run again from the start. */
 export type ArtifactPublicationWork<Result> = (transaction: ArtifactPublicationTransaction) => Promise<Result>;
 
-/** Opaque transaction boundary for one artifact publication or lease reservation. */
+/**
+ * Opens and commits the database transaction for one publication step.
+ *
+ * Only implementations of this interface create transactions. Keeping that here is what lets
+ * every repository in this package assume it is already inside one.
+ *
+ * Called by: `_ArtifactUploadAuthority` in artifact-authority.ts, for both the lease reservation
+ * and the revision commit. Implemented by `PrismaArtifactPublicationUnitOfWork`.
+ */
 export interface ArtifactPublicationUnitOfWork
 {
-	/** Runs repository work atomically; implementations translate only known rolled-back races. */
+	/**
+	 * Runs the work in one transaction, retrying only when the database rolled everything back.
+	 *
+	 * @param work - Function given transaction-scoped repositories. Must be safe to re-run.
+	 * @returns Whatever the work returned, from the attempt that committed.
+	 * @throws {@link _ArtifactPublicationConflictError} when every attempt collided; nothing was
+	 *   written. Any other error is passed through untouched, so an unrecognised failure is never
+	 *   silently retried.
+	 */
 	run<Result>(work: ArtifactPublicationWork<Result>): Promise<Result>;
 }
 
-/** Opaque transaction boundary for one fenced artifact-preprocessing lifecycle operation. */
+/**
+ * Opens and commits the database transaction for one preprocessing step.
+ *
+ * One transaction per step, never one spanning a worker's whole job. That is what makes the
+ * fence necessary and sufficient: each step re-checks the attempt and fence rather than relying
+ * on a lock held across HTTP calls.
+ *
+ * Called by: `_ArtifactPreprocessAuthority` in artifact-preprocess-authority.ts, once per
+ * method. Implemented by `PrismaArtifactPreprocessUnitOfWork`.
+ */
 export interface ArtifactPreprocessUnitOfWork
 {
-	/** Runs one preprocessing repository operation against one private transaction client. */
+	/**
+	 * Runs one preprocessing operation in its own transaction.
+	 *
+	 * @param work - Function given a repository bound to that transaction. Must be safe to re-run.
+	 * @returns Whatever the work returned, from the attempt that committed.
+	 * @throws The original database error when retries are exhausted. Unlike the publication unit
+	 *   of work, this one does not convert it - callers see the Prisma error, and the router turns
+	 *   it into HTTP 503.
+	 */
 	run<Result>(work: ArtifactPreprocessWork<Result>): Promise<Result>;
 }
 

--- a/libs/backend/server/agents/artifacts/main/src/artifact-upload.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-upload.ts
@@ -4,7 +4,33 @@ import { __FinalizeArtifactRevision } from "./artifact-finalization.js";
 import type { ArtifactAuthorityRepository } from "./artifact-finalization.types.js";
 import type { ArtifactServicePromotionPort, ArtifactUploadCryptoPort, ArtifactUploadLeaseRepository, ArtifactUploadResult, VerifiedArtifactUploadCommand } from "./artifact-upload.types.js";
 
-/** Execute a proof-authorized upload without giving artifact-service catalog authority. */
+/**
+ * Run one already-authorized upload: reserve, promote, commit.
+ *
+ * Two short database transactions with an external call in between, so no transaction is held
+ * open while bytes are in flight. First reserve a write lease bound to the expected hash, size,
+ * and media type. Then stream the bytes to the private artifact service and check its receipt
+ * against that lease field by field - a receipt that verifies but names a different lease, hash,
+ * size, or media type is refused. Only then commit the revision.
+ *
+ * The artifact service never writes catalogue rows: it stores bytes and signs a receipt, and
+ * this function decides what becomes visible. That is why the receipt is re-checked here rather
+ * than trusted.
+ *
+ * Called by: `_CreateArtifactUploadGateway` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts, which apps/opencrane/src/index.ts
+ * attaches as `publicApp.locals.artifactUploadGateway`.
+ *
+ * @param repository - Provides both transactions: lease reservation and revision commit.
+ * @param service - Streams the bytes to the private artifact service.
+ * @param crypto - Signs the lease, verifies the receipt, and digests it.
+ * @param command - An upload whose authorization was already verified by the caller.
+ * @returns `finalized` when the revision is visible, else a denial. Read
+ *   {@link ArtifactUploadResult} before handling a denial: two of the three leave promoted bytes
+ *   in storage with nothing pointing at them.
+ * @throws Whatever the artifact service or the crypto port throws. The bytes may already be
+ *   stored when that happens, so a caller must not treat a throw as "nothing happened".
+ */
 export async function __UploadArtifact(repository: ArtifactUploadLeaseRepository & ArtifactAuthorityRepository, service: ArtifactServicePromotionPort, crypto: ArtifactUploadCryptoPort, command: VerifiedArtifactUploadCommand): Promise<ArtifactUploadResult>
 {
 	const issued = await repository.issueLeaseAtomically(command);

--- a/libs/backend/server/agents/artifacts/main/src/artifact-upload.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/artifact-upload.types.ts
@@ -1,6 +1,48 @@
 import type { ArtifactPromotionReceiptClaims, ArtifactWriteLeaseClaims } from "@opencrane/backend/artifacts/authorization";
 
-/** Already proof-authorized artifact upload request. Proof verification/replay reservation happens before this use case. */
+/**
+ * One upload whose authorization has already been checked, ready to execute.
+ *
+ * The name is the contract: whoever builds this has already verified the caller's proof and
+ * reserved its replay key. `__UploadArtifact` does not re-check any of that, so constructing this
+ * type from unverified input would hand out write authority.
+ *
+ * The upload runs as two short database transactions with an external byte promotion in between:
+ * reserve a write lease, promote the bytes through the artifact service, then commit the
+ * revision. Nothing here is a storage location - the bytes are streamed to the artifact service,
+ * which is the only component that knows where they land.
+ *
+ * @see {@link ArtifactUploadResult} for what a caller must do when the second transaction fails.
+ */
+export interface VerifiedArtifactUploadCommand
+{
+	/** Logical artifact receiving the new revision. Must exist and be Active in `siloId`. */
+	readonly artifactId: string;
+	/** Silo that must own the artifact. */
+	readonly siloId: string;
+	/** Replay key from the caller's proof. Reusing it returns the same lease instead of a second one. */
+	readonly capabilityJti: string;
+	/** Content address the promoted bytes must hash to, as `sha256:` plus 64 lowercase hex characters. */
+	readonly expectedContentAddress: string;
+	/** Byte count the promoted bytes must have. A mismatch is refused rather than recorded. */
+	readonly expectedByteLength: number;
+	/** Media type the promoted bytes must have. `application/pdf` also schedules a text-conversion job. */
+	readonly mediaType: string;
+	/** Lease expiry, in whole seconds since the epoch. After it, promotion and finalization both fail. */
+	readonly expiresAtEpochSeconds: number;
+	/** Principal recorded as the author of the revision. */
+	readonly createdBy: string;
+	/** Revision number for this artifact, starting at 1. */
+	readonly revision: number;
+	/** Id to give the new revision row. */
+	readonly artifactRevisionId: string;
+	/** Source and lineage details stored as JSON on the revision. */
+	readonly provenance: Readonly<Record<string, unknown>>;
+	/** Key that makes the revision plus its outbox event commit once, however many times this runs. */
+	readonly idempotencyKey: string;
+	/** The bytes. Streamed straight to the artifact service and never buffered in this package. */
+	readonly bytes: AsyncIterable<Uint8Array>;
+}
 export interface VerifiedArtifactUploadCommand
 {
 	readonly artifactId: string;
@@ -18,25 +60,102 @@ export interface VerifiedArtifactUploadCommand
 	readonly bytes: AsyncIterable<Uint8Array>;
 }
 
-/** Durable lease writer owned only by the catalog authority. */
+/**
+ * Reserves the write permission for one upload - the first of the two transactions.
+ *
+ * The parameter drops the fields only finalization needs, so this step cannot write revision
+ * metadata. Implemented by `_ArtifactUploadAuthority` over `PrismaArtifactAuthorityRepository`.
+ *
+ * Called by: `__UploadArtifact` in artifact-upload.ts.
+ */
 export interface ArtifactUploadLeaseRepository
 {
+	/**
+	 * Creates the lease for this upload, or returns the existing one for the same replay key.
+	 *
+	 * @param command - The upload facts the lease is bound to, without the finalization-only fields.
+	 * @returns `issued` with the claims to sign; `artifact_not_found` when no Active artifact
+	 *   exists at those ids; `conflict` when a lease already exists for this replay key but was
+	 *   issued for different bytes, a different expiry, or is no longer usable. Neither refusal
+	 *   leaves anything to clean up, because no bytes have moved yet.
+	 */
 	issueLeaseAtomically(command: Omit<VerifiedArtifactUploadCommand, "bytes" | "createdBy" | "revision" | "artifactRevisionId" | "provenance" | "idempotencyKey">): Promise<{ readonly status: "issued"; readonly lease: ArtifactWriteLeaseClaims } | { readonly status: "artifact_not_found" | "conflict" }>;
 }
 
-/** Internal HTTP adapter for the private artifact-service boundary. */
+/**
+ * Sends the bytes to the private artifact service - the external step between the two transactions.
+ *
+ * The service stages the bytes, checks them against the lease, and returns a signed receipt. This
+ * package never learns where they were stored.
+ *
+ * Called by: `__UploadArtifact` in artifact-upload.ts. Implemented by
+ * `_CreateArtifactServicePromotionPort` in apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts.
+ */
 export interface ArtifactServicePromotionPort
 {
+	/**
+	 * Streams the bytes under one signed write lease.
+	 *
+	 * @param lease - The compact signed write lease.
+	 * @param bytes - The bytes to store, streamed rather than buffered.
+	 * @returns The compact signed receipt, still unverified at this point.
+	 * @throws When the service is unreachable, answers a non-2xx status, or returns no receipt.
+	 *   The bytes may or may not be stored, so the caller must not assume either way.
+	 */
 	promote(lease: string, bytes: AsyncIterable<Uint8Array>): Promise<{ readonly receipt: string }>;
 }
 
-/** Cryptographic functions injected so the workflow never holds raw key material itself. */
+/**
+ * Signing and verification, injected so this package never touches key material.
+ *
+ * The app loads the private signing key and the public receipt key from mounted files and passes
+ * these three functions in. That keeps key handling in one place instead of spreading it through
+ * the upload flow.
+ *
+ * Called by: `__UploadArtifact` in artifact-upload.ts. Supplied inline by
+ * `_CreateArtifactUploadGateway` in apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts.
+ */
 export interface ArtifactUploadCryptoPort
 {
+	/**
+	 * Signs the write lease so the artifact service will accept the promotion.
+	 *
+	 * @param claims - Lease claims as returned by the reservation transaction, unmodified.
+	 * @returns The compact signed lease.
+	 * @throws When the mounted signing key is missing or unusable.
+	 */
 	signLease(claims: ArtifactWriteLeaseClaims): string;
+	/**
+	 * Checks the receipt's signature and reads its claims.
+	 *
+	 * @param compact - The receipt string returned by the artifact service.
+	 * @returns The claims, or null when the signature does not verify. Null is refused as
+	 *   `promotion_invalid`; the caller then also compares each claim against the lease, because a
+	 *   valid signature over the wrong lease must not be accepted.
+	 */
 	verifyReceipt(compact: string): ArtifactPromotionReceiptClaims | null;
+	/**
+	 * Hashes the receipt string so the same receipt cannot be used twice.
+	 *
+	 * @param compact - The exact receipt string that was verified.
+	 * @returns A `sha256:` digest, stored on the lease row when the revision commits.
+	 */
 	digestReceipt(compact: string): string;
 }
 
-/** Complete verified upload result. */
+/**
+ * What `__UploadArtifact` returns, and what each answer obliges the caller to do.
+ *
+ * `finalized` means the revision is visible; `idempotent` distinguishes a first commit from a
+ * replay of the same one, and both are success.
+ *
+ * The three denials are not equivalent. `lease_issue_failed` happens before any bytes move, so
+ * nothing exists anywhere and the request can simply be reported as rejected.
+ * `promotion_invalid` and `finalization_failed` both happen after the bytes were promoted:
+ * something is sitting in artifact storage with no revision pointing at it. This package does
+ * not delete it, and a caller must not retry with a new revision id in the hope of tidying up -
+ * report the failure, keep the original request's replay key, and leave the unreferenced bytes to
+ * artifact-service cleanup. Retrying the identical command is safe, because the same replay key
+ * returns the same lease and the same idempotency key commits at most once.
+ */
 export type ArtifactUploadResult = { readonly outcome: "finalized"; readonly idempotent: boolean } | { readonly outcome: "denied"; readonly reason: "lease_issue_failed" | "promotion_invalid" | "finalization_failed" };

--- a/libs/backend/server/agents/artifacts/main/src/openapi.ts
+++ b/libs/backend/server/agents/artifacts/main/src/openapi.ts
@@ -1,4 +1,12 @@
-/** OpenAPI path fragment for the owner-only personal asset catalogue. */
+/**
+ * The OpenAPI description of `GET /me/assets`, merged into the published API document.
+ *
+ * Keep this in step with `PersonalArtifactEntry` and with the router's 401 and 503 replies; the
+ * two are not generated from each other.
+ *
+ * Called by: `domain-openapi-paths.ts` in libs/backend/server/api-spec/main/src, which spreads
+ * it into the combined paths object.
+ */
 export const _PersonalArtifactsOpenapiPaths = {
 	"/me/assets": {
 		get: {

--- a/libs/backend/server/agents/artifacts/main/src/personal-artifact-catalogue.router.ts
+++ b/libs/backend/server/agents/artifacts/main/src/personal-artifact-catalogue.router.ts
@@ -2,7 +2,21 @@ import { Router, type Request, type Response } from "express";
 
 import type { PersonalArtifactCatalogueRouterDependencies } from "./personal-artifact-catalogue.router.types.js";
 
-/** Create the browser-session-authenticated, owner-only personal asset catalogue router. */
+/**
+ * Build the one route a signed-in user calls to list their own assets.
+ *
+ * `GET /` returns `{ assets }`. The owner and silo come from `resolveCaller`, never from the
+ * query string or body, so a user cannot ask for someone else's assets. A missing session is 401
+ * and a database failure is 503 with a fixed error string - no artifact metadata is included in
+ * either, and only the silo id is logged.
+ *
+ * Called by: `_CreatePersonalArtifactCatalogueRouter` in
+ * prisma-personal-artifact-catalogue.router.ts, mounted at `/api/v1/me/assets` by
+ * apps/opencrane/src/app/routes.ts.
+ *
+ * @param dependencies - Caller resolver, catalogue repository, and logger.
+ * @returns An Express router to mount under the authenticated public API.
+ */
 export function __CreatePersonalArtifactCatalogueRouter(dependencies: PersonalArtifactCatalogueRouterDependencies): Router
 {
 	const router = Router();

--- a/libs/backend/server/agents/artifacts/main/src/personal-artifact-catalogue.router.types.ts
+++ b/libs/backend/server/agents/artifacts/main/src/personal-artifact-catalogue.router.types.ts
@@ -4,7 +4,12 @@ import type { Logger } from "@opencrane/backend/observability";
 
 import type { PersonalArtifactCatalogueRepository } from "./artifact-finalization.types.js";
 
-/** Trusted browser identity used only to select personal assets. */
+/**
+ * Who is asking, as established by the session and the request host.
+ *
+ * Both fields come from verified request facts, never from anything the browser can set freely.
+ * They are the only inputs to the asset query, which is what makes the listing owner-only.
+ */
 export interface PersonalArtifactCaller
 {
 	/** Silo derived from the trusted request host. */
@@ -13,7 +18,12 @@ export interface PersonalArtifactCaller
 	readonly ownerPrincipalId: string;
 }
 
-/** Composition ports for the owner-only personal asset catalogue. */
+/**
+ * Everything `__CreatePersonalArtifactCatalogueRouter` needs, supplied by the app.
+ *
+ * Called by: `_CreatePersonalArtifactCatalogueRouter` in
+ * prisma-personal-artifact-catalogue.router.ts.
+ */
 export interface PersonalArtifactCatalogueRouterDependencies
 {
 	/** Resolves an authenticated browser caller and trusted host silo. */

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.composition.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.composition.ts
@@ -9,19 +9,55 @@ import { PrismaArtifactCatalogueRepository } from "./prisma-artifact-catalogue-r
 import { PrismaArtifactPreprocessUnitOfWork } from "./prisma-artifact-preprocess-unit-of-work.js";
 import { PrismaArtifactPublicationUnitOfWork } from "./prisma-artifact-publication-unit-of-work.js";
 
-/** Composes the two short publication transactions that surround external artifact-service promotion. */
+/**
+ * Build the upload authority: the lease reservation and the revision commit, each its own transaction.
+ *
+ * Wiring the unit of work in here is what keeps transaction handling out of the use cases.
+ *
+ * Called by: `_CreateArtifactUploadGateway` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts.
+ *
+ * @param prisma - The product database client.
+ * @returns An object serving as both the lease repository and the finalization repository,
+ *   which reports an exhausted database collision as a `conflict` status rather than throwing.
+ */
 export function _CreateArtifactUploadAuthority(prisma: PrismaClient): _ArtifactUploadAuthority
 {
 	return new _ArtifactUploadAuthority(new PrismaArtifactPublicationUnitOfWork(prisma));
 }
 
-/** Composes durable preprocessing transitions whose private transactions never cross worker I/O. */
+/**
+ * Build the preprocessing authority, which opens one transaction per operation.
+ *
+ * No transaction is ever held across a call to the worker, so a worker that stops responding
+ * cannot hold a database lock. The fence on each call is what keeps the job safe instead.
+ *
+ * Called by: `_CreateArtifactPreprocessOutputBroker` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts, and
+ * `_CreateOptionalRuntimeComposition` in apps/opencrane/src/app/runtime-composition.ts.
+ *
+ * @param prisma - The product database client.
+ * @returns The repository the router and both brokers use. Unlike the upload authority, it lets
+ *   an exhausted database collision reach the caller, which the router answers as HTTP 503.
+ */
 export function _CreateArtifactPreprocessAuthority(prisma: PrismaClient): ArtifactPreprocessRepository
 {
 	return new _ArtifactPreprocessAuthority(new PrismaArtifactPreprocessUnitOfWork(prisma));
 }
 
-/** Composes read-only catalogue facts without acquiring publication or worker locks. */
+/**
+ * Build the read-only catalogue repository, which needs no transaction.
+ *
+ * Both of its jobs are plain reads, so it takes no locks and cannot block an upload or a
+ * preprocessing claim.
+ *
+ * Called by: `_CreateSkillAuthoringArtifactReader` in
+ * apps/opencrane/src/infra/artifacts/artifact-upload.factory.ts, and
+ * `_CreatePersonalArtifactCatalogueRouter` in prisma-personal-artifact-catalogue.router.ts.
+ *
+ * @param prisma - The product database client.
+ * @returns One object serving both the read-lease lookup and the owner-only asset listing.
+ */
 export function _CreateArtifactCatalogueRepository(prisma: PrismaClient): ArtifactReadLeaseRepository & PersonalArtifactCatalogueRepository
 {
 	return new PrismaArtifactCatalogueRepository(prisma);

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.ts
@@ -8,10 +8,21 @@ import type { ArtifactUploadLeaseRepository, VerifiedArtifactUploadCommand } fro
 /** First deterministic preprocessing pipeline scheduled for every published PDF source revision. */
 const _PDF_TO_TEXT_PIPELINE_VERSION = "pdf-to-text/v1";
 
-/** Transaction-scoped artifact publication repository; only its unit of work may construct it. */
+/**
+ * Runs the publication SQL inside a transaction someone else already opened.
+ *
+ * Built once per attempt by `PrismaArtifactPublicationUnitOfWork` and handed the transaction
+ * client. It cannot open, commit, or roll back anything, so a rolled-back attempt simply throws
+ * this instance away rather than leaving it holding a dead client.
+ *
+ * One object serves as both repositories in `ArtifactPublicationTransaction`.
+ *
+ * Called by: `PrismaArtifactPublicationUnitOfWork.run` in
+ * prisma-artifact-publication-unit-of-work.ts.
+ */
 export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepository, ArtifactUploadLeaseRepository
 {
-	/** Private transaction client; this repository can never open or commit a transaction itself. */
+	/** The already-open transaction to run every query against. This class cannot start or commit one. */
 	private readonly transaction: Prisma.TransactionClient;
 
 	/** Creates the repository for one already-open artifact publication transaction. */
@@ -20,7 +31,20 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 		this.transaction = transaction;
 	}
 
-	/** Creates or reloads the one durable proof-bound lease for the exact capability JTI. */
+	/**
+	 * Creates the write lease for this upload, or returns the existing one for the same replay key.
+	 *
+	 * The replay key (`capabilityJti`) has a unique index, so a repeated request finds the same row
+	 * instead of issuing a second lease over the same bytes.
+	 *
+	 * @param command - Upload facts without the finalization-only fields.
+	 * @returns `issued` with the lease claims; `artifact_not_found` when there is no Active artifact
+	 *   at those ids in that silo; `conflict` when a lease exists for this replay key but is no
+	 *   longer Active, has expired, or was issued for a different artifact, silo, hash, size, media
+	 *   type, or expiry.
+	 * @throws Error when the database clock row cannot be read, because expiry would otherwise be
+	 *   judged against process time.
+	 */
 	async issueLeaseAtomically(command: Omit<VerifiedArtifactUploadCommand, "bytes" | "createdBy" | "revision" | "artifactRevisionId" | "provenance" | "idempotencyKey">): ReturnType<ArtifactUploadLeaseRepository["issueLeaseAtomically"]>
 	{
 		// 1. Read the active logical artifact from the serializable transaction snapshot.
@@ -41,10 +65,21 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 		return { status: "issued", lease: { leaseId: lease.id, siloId: lease.siloId, artifactId: lease.artifactId, action: "artifact.write", expiresAtEpochSeconds: Math.floor(lease.expiresAt.getTime() / 1_000), expectedContentAddress: lease.expectedContentAddress, expectedByteLength: Number(lease.expectedByteLength), mediaType: lease.mediaType } };
 	}
 
-	/** Consumes one exact service receipt and publishes its immutable revision in this transaction. */
+	/**
+	 * Publishes the revision and spends its lease, in a fixed order that survives a retry.
+	 *
+	 * Recognises a replay from the outbox first, so a repeat commits nothing. Then records the
+	 * promotion on the lease before creating the revision, schedules a text-conversion job when the
+	 * media type is `application/pdf`, and writes the outbox event last so nothing outside the
+	 * database can see the revision before it is fully committed.
+	 *
+	 * @param command - Validated revision metadata plus the verified promotion receipt.
+	 * @returns One of the statuses in {@link AtomicFinalizeArtifactResult}.
+	 * @throws Error when the database clock row cannot be read.
+	 */
 	async finalizeRevisionAtomically(command: FinalizeArtifactRevisionCommand): Promise<AtomicFinalizeArtifactResult>
 	{
-		// 1. Recognize an exact outbox replay from the serializable transaction snapshot.
+		// 1. If the outbox already holds this idempotency key for the same artifact and revision, this is a repeat: report success and write nothing.
 		const existingOutbox = await this.transaction.artifactOutboxEvent.findUnique({ where: { idempotencyKey: command.idempotencyKey } });
 		if (existingOutbox !== null && existingOutbox.artifactId === command.artifactId && existingOutbox.revisionId === command.artifactRevisionId) return { status: "idempotent" };
 
@@ -56,21 +91,30 @@ export class PrismaArtifactAuthorityRepository implements ArtifactAuthorityRepos
 		if (lease.state !== ArtifactUploadLeaseState.Active) return { status: "receipt_consumed" };
 		if (lease.expectedContentAddress !== command.promotion.contentAddress || lease.expectedByteLength !== BigInt(command.promotion.byteLength) || lease.mediaType !== command.promotion.mediaType) return { status: "conflict" };
 
-		// 2. Persist promotion evidence before the revision so lifecycle triggers preserve immutable receipt lineage.
+		// 2. Mark the lease Promoted before creating the revision, so the record of which receipt stored these bytes exists before anything points at them.
 		await this.transaction.artifactUploadLease.update({ where: { id: lease.id }, data: { state: ArtifactUploadLeaseState.Promoted, promotionReceiptDigest: command.promotion.receiptDigest, promotedContentAddress: command.promotion.contentAddress, promotedByteLength: BigInt(command.promotion.byteLength), promotedAt: now } });
 		await this.transaction.artifactRevision.create({ data: { id: command.artifactRevisionId, artifactId: command.artifactId, revision: command.revision, contentAddress: command.promotion.contentAddress, byteLength: BigInt(command.promotion.byteLength), mediaType: command.promotion.mediaType, provenance: command.provenance as Prisma.InputJsonValue, createdBy: command.createdBy } });
 		await this.transaction.artifact.update({ where: { id: command.artifactId }, data: { currentRevisionId: command.artifactRevisionId } });
 
-		// 3. Record required derived work before the publication outbox makes the source externally observable.
+		// 3. Queue the PDF-to-text job before the outbox event, so the conversion is already scheduled the moment anything outside sees the revision.
 		if (command.promotion.mediaType === "application/pdf") await this.transaction.artifactPreprocessJob.create({ data: { sourceRevisionId: command.artifactRevisionId, pipelineVersion: _PDF_TO_TEXT_PIPELINE_VERSION } });
 
-		// 4. Publish the revision and consume the receipt together so no retry can duplicate either effect.
+		// 4. Write the outbox event and mark the lease Finalized in the same commit, so a retry cannot publish twice or spend the receipt twice.
 		await this.transaction.artifactOutboxEvent.create({ data: { artifactId: command.artifactId, revisionId: command.artifactRevisionId, kind: "RevisionPublished", idempotencyKey: command.idempotencyKey, payload: { contentAddress: command.promotion.contentAddress, byteLength: command.promotion.byteLength, mediaType: command.promotion.mediaType } } });
 		await this.transaction.artifactUploadLease.update({ where: { id: lease.id }, data: { state: ArtifactUploadLeaseState.Finalized, finalizedAt: now } });
 		return { status: "finalized" };
 	}
 
-	/** Reads one database-owned wall-clock sample through the read-only Prisma view. */
+	/**
+	 * Reads the current time from the database rather than this process.
+	 *
+	 * Lease expiry must be judged by one clock. A pod whose clock runs behind would otherwise
+	 * accept an expired lease.
+	 *
+	 * @returns The database's current timestamp.
+	 * @throws Error when the clock view returns no usable row, which fails the whole operation
+	 *   rather than falling back to process time.
+	 */
 	private async _databaseNow(): Promise<Date>
 	{
 		const clock = await this.transaction.artifactAuthorityClock.findUnique({ where: { singleton: 1 }, select: { now: true } });

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-preprocess-unit-of-work.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-preprocess-unit-of-work.ts
@@ -3,16 +3,28 @@ import { Prisma, type PrismaClient } from "@prisma/client";
 import { PrismaArtifactPreprocessRepository } from "./prisma-artifact-preprocessing.js";
 import type { ArtifactPreprocessUnitOfWork, ArtifactPreprocessWork } from "./artifact-unit-of-work.types.js";
 
-/** Maximum complete retries after a PostgreSQL serialization or uniqueness race rolls back. */
+/** Total attempts allowed, not retries on top of the first try: the loop runs attempts 1 to 3, so a collision is retried at most twice. */
 const _PREPROCESS_ATTEMPT_LIMIT = 3;
 
 /** Prisma codes that confirm no partial preprocessing transition committed. */
 const _RETRYABLE_PREPROCESS_CODES = new Set(["P2002", "P2034"]);
 
-/** Prisma transaction boundary for one independent fenced preprocessing operation. */
+/**
+ * Opens one SERIALIZABLE transaction per preprocessing operation and retries safe collisions.
+ *
+ * Up to three complete attempts. A fresh `PrismaArtifactPreprocessRepository` is built for each
+ * one, because a repository from a rolled-back attempt holds a dead transaction client. Only the
+ * two codes in `_RETRYABLE_PREPROCESS_CODES` are retried; anything else is rethrown immediately.
+ *
+ * Unlike `PrismaArtifactPublicationUnitOfWork`, this one does not convert an exhausted collision
+ * into a domain error - the Prisma error reaches the caller, and the preprocessing router turns
+ * it into HTTP 503.
+ *
+ * Called by: `_CreateArtifactPreprocessAuthority` in prisma-artifact-authority.composition.ts.
+ */
 export class PrismaArtifactPreprocessUnitOfWork implements ArtifactPreprocessUnitOfWork
 {
-	/** Canonical product database client isolated from router and broker dependencies. */
+	/** The product database client. Held privately so router and broker code cannot reach it and open its own transaction. */
 	private readonly prisma: PrismaClient;
 
 	/** Creates the preprocessing transaction boundary. */
@@ -21,7 +33,17 @@ export class PrismaArtifactPreprocessUnitOfWork implements ArtifactPreprocessUni
 		this.prisma = prisma;
 	}
 
-	/** Runs repository work atomically, rebuilding the repository after a safe rolled-back race. */
+	/**
+	 * Runs the work in one SERIALIZABLE transaction, up to three attempts.
+	 *
+	 * @param work - Function given a repository bound to the transaction. Must be safe to re-run,
+	 *   because a retry starts it from the beginning.
+	 * @returns Whatever the work returned, from the attempt that committed.
+	 * @throws The original Prisma error when the last attempt collides, or immediately for any
+	 *   error that does not prove a full rollback. Also throws
+	 *   "artifact preprocessing exhausted without a result" if the loop ever falls through, which
+	 *   should be unreachable and means the retry logic was changed incorrectly.
+	 */
 	async run<Result>(work: ArtifactPreprocessWork<Result>): Promise<Result>
 	{
 		for (let attempt = 1; attempt <= _PREPROCESS_ATTEMPT_LIMIT; attempt += 1)

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-preprocessing.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-preprocessing.ts
@@ -10,13 +10,13 @@ import type { ArtifactPreprocessClaimProjection, ArtifactPreprocessCompletionReq
 /** Maximum time one worker attempt may retain source and output authority. */
 const _CLAIM_LIFETIME_MILLISECONDS = 5 * 60_000;
 
-/** Maximum attempts before a deterministic conversion failure becomes terminal. */
+/** Total attempts a job gets. A failure reported on attempt 3 is marked TerminalFailed and the job never runs again. */
 const _MAX_ATTEMPTS = 3;
 
 /** Base delay applied before an eligible failed job may be reclaimed. */
 const _RETRY_DELAY_MILLISECONDS = 30_000;
 
-/** Maximum source-read authority, matched to the minimum quiet period before an early retry. */
+/** How long a source-read permission lasts. Deliberately equal to the shortest wait before a failed job can be reclaimed, so a lease from one attempt has expired by the time the next attempt starts.  */
 const _SOURCE_READ_LEASE_MILLISECONDS = _RETRY_DELAY_MILLISECONDS;
 
 /** Fixed source pipeline admitted by the dedicated worker. */
@@ -25,7 +25,18 @@ const _PDF_TO_TEXT_PIPELINE_VERSION = "pdf-to-text/v1";
 /** System principal recorded on server-finalized derived revisions. */
 const _PREPROCESSOR_PRINCIPAL = "system:artifact-preprocessor";
 
-/** Transaction-scoped repository for selecting, fencing, and completing dedicated PDF preprocessing work. */
+/**
+ * Runs the preprocessing SQL inside a transaction someone else already opened.
+ *
+ * Built per call by `PrismaArtifactPreprocessUnitOfWork` and handed the transaction client. Two
+ * rules hold across every method here: the current time always comes from the database, never
+ * from this process, so all pods agree on when a claim expires; and every method after the claim
+ * re-checks the job's state, attempt, fence, and expiry before writing, so a worker whose claim
+ * lapsed cannot change a job another attempt has taken over.
+ *
+ * Called by: `PrismaArtifactPreprocessUnitOfWork.run` in
+ * prisma-artifact-preprocess-unit-of-work.ts.
+ */
 export class PrismaArtifactPreprocessRepository implements ArtifactPreprocessRepository
 {
 	/** Private transaction client supplied only by the preprocessing unit of work. */
@@ -46,19 +57,19 @@ export class PrismaArtifactPreprocessRepository implements ArtifactPreprocessRep
 			const recoveryNow = await this._databaseNow();
 			await transaction.artifactPreprocessJob.updateMany({ where: { state: ArtifactPreprocessJobState.Claimed, claimExpiresAt: { lte: recoveryNow } }, data: { state: ArtifactPreprocessJobState.RetryableFailed, outputLeaseId: null, failureCode: "claim_expired", nextAttemptAt: recoveryNow } });
 
-			// 2. Read the database-owned SKIP LOCKED projection that retains the selected row locks.
+			// 2. Read the candidate view, whose query uses FOR UPDATE SKIP LOCKED: it hands back one job row already locked for this transaction and steps over rows another poller is holding, so two pollers never take the same job.
 			const candidate = await transaction.artifactPreprocessClaimCandidate.findFirst({ select: { jobId: true, attempt: true, derivedArtifactId: true, sourceRevisionId: true, sourceArtifactId: true, siloId: true, ownerPrincipalId: true, sourceByteLength: true } });
 			if (candidate === null) return { status: "none" };
 			if (!_IsSafeByteLength(candidate.sourceByteLength)) throw new Error("artifact preprocess source byte length exceeds the supported range");
 
-			// 3. Allocate the hidden generated Artifact once; catalogue listings require a current revision.
+			// 3. Create the output artifact row on the first claim only, reusing it on later attempts. It stays out of catalogue listings until it has a current revision.
 			const derivedArtifactId = candidate.derivedArtifactId ?? randomUUID();
 			if (candidate.derivedArtifactId === null)
 			{
 				await transaction.artifact.create({ data: { id: derivedArtifactId, siloId: candidate.siloId, ownerPrincipalId: candidate.ownerPrincipalId, kind: ArtifactKind.Generated } });
 			}
 
-			// 4. Advance from database time so every poller observes the same claim-expiry authority.
+			// 4. Compute the claim expiry from database time, so every poller agrees on when this claim dies.
 			const now = await this._databaseNow();
 			const claimFence = randomUUID();
 			const claimExpiresAt = new Date(now.getTime() + _CLAIM_LIFETIME_MILLISECONDS);
@@ -92,7 +103,7 @@ export class PrismaArtifactPreprocessRepository implements ArtifactPreprocessRep
 				return null;
 			}
 
-			// 2. Cap authority to both the claim and retry quiet period, so failure cannot create overlapping attempts.
+			// 2. End the read permission at whichever comes first, the claim expiry or the retry wait, so a lease from this attempt is dead before the next attempt can start.
 			const expiresAtEpochSeconds = Math.floor(Math.min(job.claimExpiresAt.getTime(), now.getTime() + _SOURCE_READ_LEASE_MILLISECONDS) / 1_000);
 			if (expiresAtEpochSeconds <= Math.floor(now.getTime() / 1_000)) return null;
 			return {
@@ -134,7 +145,7 @@ export class PrismaArtifactPreprocessRepository implements ArtifactPreprocessRep
 			if (job.state !== ArtifactPreprocessJobState.Claimed || job.claimExpiresAt === null || job.claimExpiresAt <= now) return { status: "conflict", reason: "stale_claim" };
 			if (!___IsSha256ContentAddress(request.contentAddress) || !Number.isSafeInteger(request.byteLength) || request.byteLength < 0) return { status: "conflict", reason: "invalid_output" };
 
-			// A repeated body after response loss reuses the same exact lease instead of creating parallel output authority.
+			// If the worker resends the same bytes because it never saw our reply, hand back the lease already attached to this attempt rather than creating a second one.
 			if (job.outputLease !== null)
 			{
 				if (job.outputLease.state !== ArtifactUploadLeaseState.Active
@@ -168,7 +179,7 @@ export class PrismaArtifactPreprocessRepository implements ArtifactPreprocessRep
 			if (job.state === ArtifactPreprocessJobState.Completed) return { status: "completed" };
 			if (job.state !== ArtifactPreprocessJobState.Claimed || job.claimExpiresAt === null || job.claimExpiresAt <= now) return { status: "conflict", reason: "stale_claim" };
 
-			// 1. Persist the service receipt before publishing any catalogue-visible revision.
+			// 1. Mark the lease Promoted and store the receipt digest first, so the receipt is on record before anything becomes visible.
 			await transaction.artifactUploadLease.update({ where: { id: job.outputLease.id }, data: { state: ArtifactUploadLeaseState.Promoted, promotionReceiptDigest: request.receiptDigest, promotedContentAddress: request.promotion.contentAddress, promotedByteLength: BigInt(request.promotion.byteLength), promotedAt: now } });
 
 			// 2. Publish the derived revision, current pointer, and immutable source lineage together.
@@ -176,7 +187,7 @@ export class PrismaArtifactPreprocessRepository implements ArtifactPreprocessRep
 			await transaction.artifact.update({ where: { id: job.derivedArtifact.id }, data: { currentRevisionId: request.derivedRevisionId } });
 			await transaction.artifactRevisionParent.create({ data: { childRevisionId: request.derivedRevisionId, parentRevisionId: job.sourceRevisionId } });
 
-			// 3. Emit the normal publication event and close both lease and job under deferred SQL guards.
+			// 3. Write the same publication event an ordinary upload writes, then mark the lease Finalized and the job Completed in this one commit.
 			await transaction.artifactOutboxEvent.create({ data: { artifactId: job.derivedArtifact.id, revisionId: request.derivedRevisionId, kind: "RevisionPublished", idempotencyKey: `artifact-preprocess:${job.id}:${job.attempt}:revision`, payload: { contentAddress: request.promotion.contentAddress, byteLength: request.promotion.byteLength, mediaType: "text/plain" } } });
 			await transaction.artifactUploadLease.update({ where: { id: job.outputLease.id }, data: { state: ArtifactUploadLeaseState.Finalized, finalizedAt: now } });
 			await transaction.artifactPreprocessJob.update({ where: { id: job.id }, data: { state: ArtifactPreprocessJobState.Completed, derivedRevisionId: request.derivedRevisionId, completedAt: now } });
@@ -214,19 +225,19 @@ export class PrismaArtifactPreprocessRepository implements ArtifactPreprocessRep
 	}
 }
 
-/** Prove a Postgres bigint can cross the JavaScript and HTTP boundaries without truncation. */
+/** Check a Postgres bigint fits in a JavaScript safe integer, so converting it for JSON cannot silently change the number. */
 function _IsSafeByteLength(value: bigint): boolean
 {
 	return value >= 0n && value <= BigInt(Number.MAX_SAFE_INTEGER);
 }
 
-/** Build the only output lease shape admitted by the app-owned signer. */
+/** Build the write-lease claims for the converted text, including the revision id derived from the lease id. */
 function _OutputLeaseProjection(jobId: string, attempt: number, claimFence: string, artifactId: string, leaseId: string, siloId: string, expiresAt: Date, contentAddress: string, byteLength: number): ArtifactPreprocessOutputLeaseProjection
 {
 	return { jobId, attempt, claimFence, derivedRevisionId: _DerivedRevisionId(leaseId), writeLease: { leaseId, siloId, artifactId, action: "artifact.write" as const, expiresAtEpochSeconds: Math.floor(expiresAt.getTime() / 1_000), expectedContentAddress: contentAddress, expectedByteLength: byteLength, mediaType: "text/plain" } };
 }
 
-/** Match the verified receipt to the exact durable lease before any catalogue publication. */
+/** Check the receipt's lease id, hash, size, and media type all match the stored lease row, and that the media type is text/plain. */
 function _MatchesPromotion(request: ArtifactPreprocessCompletionRequest, lease: { readonly id: string; readonly expectedContentAddress: string | null; readonly expectedByteLength: bigint | null; readonly mediaType: string }): boolean
 {
 	return request.promotion.leaseId === lease.id
@@ -238,7 +249,7 @@ function _MatchesPromotion(request: ArtifactPreprocessCompletionRequest, lease: 
 		&& lease.mediaType === "text/plain";
 }
 
-/** Derive the only allowed output revision coordinate from its durable exact-byte lease. */
+/** Build the output revision id from its lease id, so completion can prove the receipt belongs to the same lease this attempt was given. */
 function _DerivedRevisionId(leaseId: string): string
 {
 	return `artifact-preprocess:${leaseId}`;

--- a/libs/backend/server/agents/artifacts/main/src/prisma-artifact-publication-unit-of-work.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-artifact-publication-unit-of-work.ts
@@ -9,10 +9,20 @@ const _PUBLICATION_ATTEMPT_LIMIT = 3;
 /** Prisma conflict codes that prove the database rolled an attempt back before any durable effect. */
 const _RETRYABLE_PUBLICATION_CODES = new Set(["P2002", "P2034"]);
 
-/** Prisma implementation that solely owns artifact-publication transaction creation and retry. */
+/**
+ * Opens one SERIALIZABLE transaction per publication step and retries safe collisions.
+ *
+ * Up to three complete attempts, with fresh transaction-scoped repositories each time. Only the
+ * two codes in `_RETRYABLE_PUBLICATION_CODES` are retried, because they prove the attempt rolled
+ * back with nothing written. When the last attempt still collides, the Prisma error is converted
+ * into {@link _ArtifactPublicationConflictError} so nothing above this file has to know which
+ * database is underneath.
+ *
+ * Called by: `_CreateArtifactUploadAuthority` in prisma-artifact-authority.composition.ts.
+ */
 export class PrismaArtifactPublicationUnitOfWork implements ArtifactPublicationUnitOfWork
 {
-	/** Canonical product database client; it never leaves this composition seam. */
+	/** The product database client. Held privately so no repository or use case above this class can open its own transaction. */
 	private readonly prisma: PrismaClient;
 
 	/** Creates the transaction boundary for artifact publication. */
@@ -21,7 +31,15 @@ export class PrismaArtifactPublicationUnitOfWork implements ArtifactPublicationU
 		this.prisma = prisma;
 	}
 
-	/** Runs one complete operation with fresh transaction-scoped repositories on every safe retry. */
+	/**
+	 * Runs the work in one SERIALIZABLE transaction, up to three attempts.
+	 *
+	 * @param work - Function given repositories bound to the transaction. Must be safe to re-run.
+	 * @returns Whatever the work returned, from the attempt that committed.
+	 * @throws {@link _ArtifactPublicationConflictError} when the last attempt collides; nothing
+	 *   was written. Any error that does not prove a full rollback is rethrown unchanged, so an
+	 *   unrecognised failure is never retried.
+	 */
 	async run<Result>(work: ArtifactPublicationWork<Result>): Promise<Result>
 	{
 		for (let attempt = 1; attempt <= _PUBLICATION_ATTEMPT_LIMIT; attempt += 1)

--- a/libs/backend/server/agents/artifacts/main/src/prisma-personal-artifact-catalogue.router.ts
+++ b/libs/backend/server/agents/artifacts/main/src/prisma-personal-artifact-catalogue.router.ts
@@ -16,10 +16,16 @@ function _resolveCaller(request: Parameters<typeof _ResolveRequestPrincipal>[0])
 }
 
 /**
- * Composes the Prisma-backed owner-only personal artifact catalogue router.
- * @param prisma - Canonical product-authority client.
+ * Build the personal asset catalogue router with its Prisma repository already wired in.
+ *
+ * The app only has to supply the database client and a logger; the caller resolver and the
+ * read-only repository are chosen here.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, which mounts the result at `/api/v1/me/assets`.
+ *
+ * @param prisma - The product database client.
  * @param logger - Process logger supplied by the app composition root.
- * @returns The configured personal artifact catalogue router.
+ * @returns An Express router ready to mount under the authenticated public API.
  */
 export function _CreatePersonalArtifactCatalogueRouter(prisma: PrismaClient, logger: Logger): Router
 {

--- a/libs/backend/server/agents/channel-targets/main/src/channel-invocation-context-digest.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/channel-invocation-context-digest.ts
@@ -1,6 +1,19 @@
 import { createHash } from "node:crypto";
 
-/** Digest one presented opaque invocation context for storage and authority lookup. */
+/**
+ * Hash one opaque invocation context into the `sha256:<hex>` form used for storage and lookup.
+ *
+ * The opaque value itself is never written to the database - only this digest - so a stolen
+ * database row cannot be replayed as a valid pass. Both sides must use this same function: the
+ * resolver digests the value it mints before inserting the row, and the runtime digests the value
+ * it was presented before looking that row up. The `sha256:` prefix is part of the stored value.
+ *
+ * Called by: __ResolveChannelTarget in this package, and the replay route in
+ * libs/backend/server/conversations/main/src/conversation-replay.router.ts.
+ *
+ * @param invocationContext - The opaque value, read as UTF-8.
+ * @returns `sha256:` followed by the 64-character lower-case hex digest.
+ */
 export function __DigestChannelInvocationContext(invocationContext: string): string
 {
 	return `sha256:${createHash("sha256").update(invocationContext, "utf8").digest("hex")}`;

--- a/libs/backend/server/agents/channel-targets/main/src/channel-target-resolution.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/channel-target-resolution.ts
@@ -24,7 +24,26 @@ export class __RandomChannelOpaqueContextSource implements ChannelOpaqueContextS
 	}
 }
 
-/** Resolves a delegated browser operation to one authorized runtime route. */
+/**
+ * Decide whether one browser, proxied by channel-proxy, may read events on one conversation - and where.
+ *
+ * The seven numbered checks below run in a fixed order, cheapest and most sceptical first: validate
+ * the request and the resolver's own configuration, confirm the calling workload with a Kubernetes
+ * TokenReview, require a human subject that OpenCrane itself verified, bind the already
+ * origin-checked host to a silo and current signed membership, require an open agent session the
+ * subject participates in, authorize the read, and only then mint a short-lived opaque pass. Each
+ * stage fails closed with its own reason. The pass is returned to the proxy in full but stored only
+ * as a digest, and the final database call re-checks every binding inside one serializable
+ * transaction, because the conversation or the route can change while the earlier checks run.
+ *
+ * Called by: the POST handler in channel-targets.router.ts, which serves
+ * /api/internal/channel-targets:resolve.
+ *
+ * @param dependencies - Fixed policy plus the identity, membership, conversation, and route authorities.
+ * @param command - The request assembled by the router; never raw browser input.
+ * @returns `authorized` with the endpoint, opaque context and expiry, or `denied` with the reason
+ * that decides the router's status code.
+ */
 export async function __ResolveChannelTarget(dependencies: ChannelTargetResolutionDependencies, command: ResolveChannelTargetCommand): Promise<ResolveChannelTargetResult>
 {
 	const nowEpochMs = dependencies.clock.nowEpochMs();

--- a/libs/backend/server/agents/channel-targets/main/src/channel-target-resolution.types.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/channel-target-resolution.types.ts
@@ -1,13 +1,31 @@
 import type { AuthorizationScope } from "@opencrane/models/authorization";
 import type { SignedFleetMembershipAssertionAuthority } from "@opencrane/backend/server/iam/membership";
 
-/** Stable proxy operation presented to OpenCrane for resolution. */
+/**
+ * The one proxy operation channel-proxy may ask OpenCrane to resolve.
+ *
+ * Deliberately a single-member union: channel-proxy asks "may this browser read events on this
+ * conversation, and where do I send that read?" and nothing else. Adding a member means a new
+ * runtime receiver has to be registered and authorized too, so it is not a one-line change.
+ *
+ * @see {@link ChannelAuthorizedAction} for the product permission this maps onto.
+ */
 export type ChannelResolutionAction = "events.read";
 
 /** Product authorization actions required by a proxy operation. */
 export type ChannelAuthorizedAction = "conversation.read";
 
-/** Trusted input assembled only by the internal HTTP adapter. */
+/**
+ * The resolve request, assembled only by this package's internal HTTP adapter.
+ *
+ * `delegatedIdentity` is the security point of this type: the human subject is taken from the
+ * browser session OpenCrane itself verified, never from a header channel-proxy set. The router
+ * rejects the request outright when it carries any subject-asserting header, so a compromised proxy
+ * cannot name a user it is not entitled to. `trustedHost` is likewise the host the proxy already
+ * matched against the browser Origin, and it selects the silo - it is not a hint.
+ *
+ * Called by: __ResolveChannelTarget; built by `_parseCommand` in channel-targets.router.ts.
+ */
 export interface ResolveChannelTargetCommand
 {
 	/** Projected channel-proxy ServiceAccount token. */
@@ -24,7 +42,17 @@ export interface ResolveChannelTargetCommand
 	readonly cursor?: string;
 }
 
-/** Fixed trust and lifetime policy for one OpenCrane resolver instance. */
+/**
+ * The fixed trust and lifetime rules for one resolver, taken only from deployment configuration.
+ *
+ * Nothing here can be influenced by a request, which is the point: the ServiceAccount name and
+ * namespace decide who may call at all, the DNS suffixes stop a registered route from ever pointing
+ * outside the cluster, and the receiver id and endpoint are chosen by the deployment rather than
+ * discovered. `invocationContextTtlMs` is validated to be positive and at most 300000 (five
+ * minutes), and the real expiry is the earlier of that and the caller's membership trust.
+ *
+ * Built by: `_CreateResolutionConfig` in apps/opencrane/src/app/channel-target-composition.ts.
+ */
 export interface ChannelTargetResolutionConfig
 {
 	/** TokenReview audience required from channel-proxy. */
@@ -56,14 +84,37 @@ export interface VerifiedChannelWorkloadIdentity
 	readonly audiences: readonly string[];
 }
 
-/** TokenReview boundary implemented by the OpenCrane Kubernetes adapter. */
+/**
+ * Confirms the caller really is the channel-proxy workload, using a Kubernetes TokenReview.
+ *
+ * The projected ServiceAccount token from the Authorization header is sent to the API server, which
+ * answers with the identity it belongs to. The adapter fixes the audience, ServiceAccount name and
+ * namespace it will accept, so a token belonging to any other workload is rejected even though it is
+ * perfectly valid. A null return means "not this workload" and must fail the request.
+ *
+ * Called by: __ResolveChannelTarget (step 2); implemented by _CreateChannelProxyTokenReviewer in
+ * libs/backend/server/infra/workload-identity and wired in
+ * apps/opencrane/src/app/channel-target-composition.ts.
+ *
+ * @see Kubernetes TokenReview, API group `authentication.k8s.io/v1` - the request this port makes.
+ */
 export interface ChannelWorkloadIdentityPort
 {
 	/** Reviews one projected token against the adapter's fixed audience and workload subject. */
 	__Review(token: string): Promise<VerifiedChannelWorkloadIdentity | null>;
 }
 
-/** Verified browser subject produced by OpenCrane-owned identity validation. */
+/**
+ * Proof that OpenCrane itself verified which human is behind the proxied request.
+ *
+ * `trustworthySubject: true` and `source: "cookie"` are not decoration - they are the only shapes
+ * the resolver accepts, and they can only be produced by code that read the verified OpenCrane
+ * session cookie. Nothing here may ever be filled in from a header or body field supplied by
+ * channel-proxy, because that would let the proxy choose whose events a caller can read.
+ *
+ * Built by: `_parseCommand` in channel-targets.router.ts from `request.session.authUser.sub`;
+ * re-checked in __ResolveChannelTarget (step 3).
+ */
 export interface TrustedDelegatedBrowserIdentity
 {
 	/** Trustworthy issuer-bound human subject; never read from proxy assertions. */
@@ -133,7 +184,20 @@ export type ChannelActionAuthorizationDecision =
 	| { readonly outcome: "allowed"; readonly authorizationDigest: string }
 	| { readonly outcome: "denied"; readonly reason: string };
 
-/** Atomic invocation-context issuance request. */
+/**
+ * Everything the database needs to hand out one short-lived pass for a single event read.
+ *
+ * `digest` is the SHA-256 of the opaque value channel-proxy receives; the value itself is never
+ * stored, so a database dump cannot be replayed as a valid pass. Every other field is a binding
+ * that will be re-checked inside the transaction before the row is inserted - which is why the
+ * request repeats facts the resolver already checked. The conversation can close, a participant can
+ * be removed, and a route can be retired between the check and the insert. `receiverId` and
+ * `allowedRouteHostSuffixes` come from deployment configuration only, never from the request.
+ *
+ * Called by: __ResolveChannelTarget (step 7), through {@link ChannelTargetAuthorityRepository}.
+ *
+ * @see {@link IssueChannelInvocationContextResult} for the outcomes, including the re-check failures.
+ */
 export interface IssueChannelInvocationContextCommand
 {
 	/** SHA-256 digest of the opaque context returned to channel-proxy. */
@@ -180,7 +244,20 @@ export type IssueChannelInvocationContextResult =
 	| { readonly status: "issued"; readonly context: IssuedChannelInvocationContext }
 	| { readonly status: "conversation_conflict" | "participant_conflict" | "route_unavailable" | "route_ambiguous" };
 
-/** Online runtime-PEP consumption request. */
+/**
+ * A runtime's request to spend one invocation context, made at the moment of the event read.
+ *
+ * The runtime acts here as the policy enforcement point (PEP): it holds no permission logic of its
+ * own and simply presents the opaque value it was given, so this package makes the decision. Only
+ * the digest is sent, and `expectedReceiverId` is the receiver identity configured on that runtime,
+ * so a pass issued for one receiver cannot be spent at another. A context can be spent exactly once.
+ *
+ * Called by: the replay route in
+ * libs/backend/server/conversations/main/src/conversation-replay.router.ts, which digests the
+ * presented value with __DigestChannelInvocationContext first.
+ *
+ * @see {@link ConsumeChannelInvocationContextResult} for the outcomes and every denial reason.
+ */
 export interface ConsumeChannelInvocationContextCommand
 {
 	/** SHA-256 digest of the presented opaque context. */
@@ -212,7 +289,18 @@ export interface ConsumedChannelInvocationContext
 	readonly authorizationDigest: string;
 }
 
-/** One-time online consumption outcome. */
+/**
+ * The outcome of spending one invocation context, with the reason when it is refused.
+ *
+ * Every refusal fails closed, and the reasons are meant to be told apart in logs rather than shown
+ * to a browser: `not_found` (no such digest), `receiver_mismatch` (issued for a different runtime),
+ * `route_mismatch` (the stored route no longer agrees with the context's silo, service, or action),
+ * `expired` (past its hard expiry), `revoked` (deliberately withdrawn), `replayed` (already spent -
+ * treat as an attack signal, not as a retry), and `route_inactive` (the route was retired or
+ * replaced). On `consumed` the caller must use the returned bindings, not its own request fields.
+ *
+ * @see {@link ConsumedChannelInvocationContext} for what the consumed case carries.
+ */
 export type ConsumeChannelInvocationContextResult =
 	| { readonly status: "consumed"; readonly context: ConsumedChannelInvocationContext }
 	| { readonly status: "denied"; readonly reason: "not_found" | "receiver_mismatch" | "route_mismatch" | "expired" | "revoked" | "replayed" | "route_inactive" };
@@ -230,7 +318,22 @@ export interface ReconcileChannelRuntimeRoutesCommand
 	readonly allowedRouteHostSuffixes: readonly string[];
 }
 
-/** Durable conversation, route, and invocation-context authority. */
+/**
+ * The durable authority for conversations, runtime routes, and invocation contexts.
+ *
+ * The `Atomically` suffix on two methods is a promise, not decoration: each of those runs entirely
+ * inside one serializable transaction that re-reads the conversation, its participants and the
+ * route, and only then writes. That is necessary because the resolver checks those same facts
+ * outside any transaction, and a conversation can close or a participant can lose access in
+ * between. The plain `getConversationAuthority` read is only a cheap early rejection - it is never
+ * the decision.
+ *
+ * Called by: __ResolveChannelTarget and __ReconcileChannelTargetRoutes in this package, and the
+ * replay route in libs/backend/server/conversations; implemented by
+ * PrismaChannelTargetAuthorityUnitOfWork.
+ *
+ * @see {@link ChannelTargetAuthorityUnitOfWork} the alias used where the transaction matters.
+ */
 export interface ChannelTargetAuthorityRepository
 {
 	/** Loads current conversation coordinates for pre-authorization checks. */
@@ -243,7 +346,18 @@ export interface ChannelTargetAuthorityRepository
 	consumeInvocationContextAtomically(command: ConsumeChannelInvocationContextCommand): Promise<ConsumeChannelInvocationContextResult>;
 }
 
-/** Owns the serializable transaction that fences one channel-target authority operation. */
+/**
+ * The same operations as {@link ChannelTargetAuthorityRepository}, named for the implementation that
+ * wraps each call in its own serializable transaction.
+ *
+ * Use this name in composition and app wiring to make it obvious that one call means one
+ * transaction, and that the re-checks inside `issueInvocationContextAtomically` and
+ * `consumeInvocationContextAtomically` really are protected against a concurrent change. The two
+ * types are interchangeable; only the intent differs.
+ *
+ * Called by: apps/opencrane/src/app/channel-target-composition.ts and
+ * apps/opencrane/src/app/runtime-composition.ts.
+ */
 export type ChannelTargetAuthorityUnitOfWork = ChannelTargetAuthorityRepository;
 
 /** Injectable wall clock. */
@@ -292,7 +406,17 @@ export interface AuthorizedChannelTargetResult
 	readonly expiresAt: string;
 }
 
-/** Stable fail-closed resolution outcome. */
+/**
+ * The resolver's answer: one authorized route, or a refusal with a stable reason.
+ *
+ * Every refusal fails closed, and the reason picks the status the router returns: `workload_denied`
+ * and `identity_denied` are 401, `route_denied` is 503 because nothing is wrong with the request -
+ * no usable runtime route exists right now, so a retry can succeed - and everything else is 403.
+ * `invalid_request` means the request or the resolver's own configuration failed validation before
+ * any authority was consulted.
+ *
+ * @see {@link AuthorizedChannelTargetResult} for what the authorized case carries.
+ */
 export type ResolveChannelTargetResult =
 	| { readonly outcome: "authorized"; readonly target: AuthorizedChannelTargetResult }
 	| { readonly outcome: "denied"; readonly reason: "invalid_request" | "workload_denied" | "identity_denied" | "host_denied" | "membership_denied" | "conversation_denied" | "authorization_denied" | "route_denied" };

--- a/libs/backend/server/agents/channel-targets/main/src/channel-target-route-reconciler.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/channel-target-route-reconciler.ts
@@ -7,7 +7,22 @@ export async function __ReconcileChannelTargetRoutes(dependencies: ChannelTarget
 	return dependencies.repository.reconcileRuntimeRoutes(dependencies.command);
 }
 
-/** Start a bounded non-overlapping reconciliation loop whose next pass retries handled failures. */
+/**
+ * Start a repeating pass that keeps one route row per AgentService pointing at this deployment's receiver.
+ *
+ * Services created after startup would otherwise have no route, and every event read for them would
+ * be refused with `route_denied` - so the loop re-runs on an interval instead of only once. Passes
+ * never overlap: a tick that arrives while a pass is still running is skipped. A failed pass is
+ * logged and simply retried by the next one. The timer is unref'd so it cannot keep the process
+ * alive, and `stop()` waits for the pass in flight so the repository is not closed underneath it.
+ * When the capability is disabled (`command` is null) this returns a handle that does nothing.
+ *
+ * Called by: apps/opencrane/src/app/channel-target-composition.ts during startup.
+ *
+ * @param dependencies - Route authority, deployment route command (or null), logger, and interval.
+ * @returns A handle whose `stop()` ends the loop and drains the active pass.
+ * @throws Error when `intervalMilliseconds` is not a safe integer between 1 and 300000.
+ */
 export function __StartChannelTargetRouteReconciler(dependencies: ChannelTargetRouteReconcilerDependencies): ChannelTargetRouteReconciler
 {
 	if (!Number.isSafeInteger(dependencies.intervalMilliseconds) || dependencies.intervalMilliseconds < 1 || dependencies.intervalMilliseconds > 300_000) throw new Error("channel route reconciliation interval is invalid");

--- a/libs/backend/server/agents/channel-targets/main/src/channel-targets.router.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/channel-targets.router.ts
@@ -10,7 +10,23 @@ import { __ResolveChannelTarget } from "./channel-target-resolution.js";
 /** Public identity assertions that an internal workload must never submit on behalf of a browser. */
 const _FORBIDDEN_IDENTITY_HEADERS = ["x-opencrane-subject", "x-forwarded-user", "x-auth-request-user", "x-remote-user"];
 
-/** Builds the workload-authenticated internal channel target resolver router. */
+/**
+ * Build the internal resolver router for channel-proxy, served at /api/internal/channel-targets:resolve.
+ *
+ * The route is workload-authenticated, not user-authenticated: the bearer token must be a projected
+ * channel-proxy ServiceAccount token, while the human identity comes from the browser session this
+ * process has already verified. Any request carrying a subject-asserting header is rejected with
+ * 400 `forged_identity` before anything else runs, so a proxy can never name a user itself. A
+ * missing bearer token is 401 and a malformed body is 400 - kept apart so an operator can tell a
+ * misconfigured proxy from a broken one. Every decision is delegated to __ResolveChannelTarget; an
+ * unexpected throw is logged and answered 503 with no internal detail.
+ *
+ * Called by: _CreateChannelTargetResolver in apps/opencrane/src/app/channel-target-composition.ts.
+ *
+ * @param dependencies - Fixed resolver policy and its identity, membership, and route authorities.
+ * @param log - Structured logger, used only for unexpected authority failures.
+ * @returns A router ready to mount; it adds no authentication middleware of its own.
+ */
 export function __CreateChannelTargetsRouter(dependencies: ChannelTargetResolutionDependencies, log: Logger): Router
 {
 	const router = Router();
@@ -86,7 +102,7 @@ function _bearerValue(value: string | undefined): string | null
 	return match?.[1] ?? null;
 }
 
-/** Narrows an untrusted value to the public channel action vocabulary. */
+/** Accept only the one action name this resolver serves, so any other body value is rejected. */
 function _isAction(value: unknown): value is ChannelResolutionAction
 {
 	return value === "events.read";

--- a/libs/backend/server/agents/channel-targets/main/src/prisma-channel-target-authority.ts
+++ b/libs/backend/server/agents/channel-targets/main/src/prisma-channel-target-authority.ts
@@ -23,7 +23,20 @@ function _endpointIsAllowed(endpoint: string, allowedSuffixes: readonly string[]
 		&& allowedSuffixes.some(suffix => suffix.startsWith(".") && url.hostname.endsWith(suffix) && url.hostname.length > suffix.length);
 }
 
-/** Prisma unit of work that supplies one transaction snapshot to each channel authority operation. */
+/**
+ * The Prisma-backed channel authority: one serializable transaction per operation.
+ *
+ * Serializable is chosen deliberately. Issuing and spending an invocation context both re-read the
+ * conversation, its participants and the route and then write, and at a weaker isolation level a
+ * concurrent close, participant removal, or route swap could slip between the read and the write.
+ * Each operation is traced and its outcome recorded on the span, so a refusal can be explained
+ * afterwards without ever logging the opaque context itself.
+ *
+ * Called by: apps/opencrane/src/app/channel-target-composition.ts and
+ * apps/opencrane/src/app/runtime-composition.ts.
+ *
+ * @see {@link ChannelTargetAuthorityUnitOfWork} the port this satisfies.
+ */
 export class PrismaChannelTargetAuthorityUnitOfWork implements ChannelTargetAuthorityUnitOfWork
 {
 	/** Canonical OpenCrane product database. */
@@ -57,7 +70,7 @@ export class PrismaChannelTargetAuthorityUnitOfWork implements ChannelTargetAuth
 		});
 	}
 
-	/** Rechecks every mutable authority coordinate while persisting only the opaque digest. */
+	/** Re-reads the conversation, participants and route inside the transaction, then stores only the context's digest. */
 	async issueInvocationContextAtomically(command: IssueChannelInvocationContextCommand): Promise<IssueChannelInvocationContextResult>
 	{
 		const self = this;
@@ -138,7 +151,7 @@ class PrismaChannelTargetAuthorityTransactionRepository implements ChannelTarget
 		return services.length;
 	}
 
-	/** Rechecks every mutable authority coordinate while persisting only the opaque digest. */
+	/** Re-reads the conversation, participants and route inside the transaction, then stores only the context's digest. */
 	async issueInvocationContextAtomically(command: IssueChannelInvocationContextCommand): Promise<IssueChannelInvocationContextResult>
 	{
 		const conversation = await this.transaction.conversation.findUnique({ where: { id: command.conversationId }, include: { participants: true } });

--- a/libs/backend/server/agents/onboarding/main/src/openapi.ts
+++ b/libs/backend/server/agents/onboarding/main/src/openapi.ts
@@ -35,7 +35,16 @@ const _ChatResponses = {
 	503: { description: "Required onboarding, persona, or script evidence unavailable." },
 } as const;
 
-/** OpenAPI fragment for durable owner routing state and deterministic guided chat. */
+/**
+ * The OpenAPI path entries for the five `/me/onboarding` endpoints.
+ *
+ * Merged into the published API document rather than served from here, so a change to a route in
+ * user-onboarding.http.ts must be made here too or the document silently drifts. The `state` enums
+ * are generated from {@link UserOnboardingStates} with `Object.values`, so adding a state updates
+ * the document automatically.
+ *
+ * Called by: libs/backend/server/api-spec/main/src/domain-openapi-paths.ts.
+ */
 export const _UserOnboardingOpenapiPaths = {
 	"/me/onboarding": {
 		get: {

--- a/libs/backend/server/agents/onboarding/main/src/prisma-user-onboarding-repository.ts
+++ b/libs/backend/server/agents/onboarding/main/src/prisma-user-onboarding-repository.ts
@@ -9,7 +9,19 @@ import type { ApprovedPersonaEvidence, UserOnboardingOwner, UserOnboardingRecord
 /** Trigger text emitted when a concurrent starter loses after another transaction advanced the parent. */
 const _BOOTSTRAP_CONVERSATION_PENDING_TRIGGER = "bootstrap conversation must bind the exact pending onboarding owner and persona";
 
-/** App-composed user-onboarding repository backed by the canonical product database. */
+/**
+ * Build the one object that satisfies both onboarding persistence ports over Postgres.
+ *
+ * Returns both {@link UserOnboardingRepository} and {@link UserOnboardingChatRepository} from a
+ * single instance so the workflow row and its bootstrap conversation are written through the same
+ * client. Exists so the app's composition root never constructs the Prisma class directly.
+ *
+ * Called by: _CreateUserOnboardingComposition in
+ * apps/opencrane/src/app/user-onboarding-composition.ts.
+ *
+ * @param prisma - Product database client, or a transaction client in tests.
+ * @returns One adapter usable as either onboarding port.
+ */
 export function _CreateUserOnboardingRepository(prisma: PrismaClient): UserOnboardingRepository & UserOnboardingChatRepository
 {
 	return new PrismaUserOnboardingRepository(prisma);

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding-authority.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding-authority.ts
@@ -4,7 +4,21 @@ import { UserOnboardingDenialReasons, UserOnboardingTransitionStatuses } from ".
 import { _UserOnboardingLifecycleState } from "./user-onboarding-lifecycle-state.js";
 import type { ApprovedPersonaEvidence, UserOnboardingOwner, UserOnboardingPersonaEvidencePort, UserOnboardingRecord, UserOnboardingRepository, UserOnboardingTransitionResult } from "./user-onboarding.types.js";
 
-/** Server-owned orchestration for the resumable persona-survey phase of onboarding. */
+/**
+ * Runs the persona-survey half of onboarding: start or resume a survey, then pin the approved persona.
+ *
+ * Every method re-checks with the persona package before writing, dispatches through the state
+ * object for the row's current state, and reports a stable status instead of throwing when a race is
+ * lost - so any call here can be retried safely. `readOrCreate` also repairs one specific gap: if
+ * persona committed an approval but its notification to onboarding never arrived (a crash or a
+ * dropped call), reading the row finds that approval and pins it.
+ *
+ * Called by: __CreateUserOnboardingRouter and __UserOnboardingChatAuthority in this package, and
+ * UserOnboardingPersonaWorkflowCoordinator; constructed in
+ * apps/opencrane/src/app/user-onboarding-composition.ts.
+ *
+ * @see {@link UserOnboardingTransitionResult} for what the write methods report.
+ */
 export class __UserOnboardingAuthority
 {
 	/** Persistence authority for UserOnboarding rows only. */

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding-chat-authority.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding-chat-authority.ts
@@ -7,7 +7,17 @@ import type { ApprovedPersonaBootstrapEvidence, SubmitUserOnboardingAnswerComman
 import type { UserOnboardingOwner, UserOnboardingPersonaEvidencePort, UserOnboardingRecord } from "./user-onboarding.types.js";
 import type { __UserOnboardingAuthority } from "./user-onboarding-authority.js";
 
-/** Expected fail-closed chat denial carrying one stable HTTP-safe reason. */
+/**
+ * Thrown for a refusal the router is expected to translate, not to log as a fault.
+ *
+ * Carrying a {@link UserOnboardingChatFailureReasons} member lets the router choose a fixed status
+ * (400, 409, or 503) and send `onboarding_chat_<reason>` to the browser. Anything else thrown out of
+ * the chat authority is treated as an unexpected fault: logged, and answered 503. The message
+ * deliberately contains only the reason - never the user's answer text or their identifiers.
+ *
+ * Called by: thrown throughout __UserOnboardingChatAuthority and by the answer route in
+ * user-onboarding.http.ts; caught by `_ChatRequest` in that same file.
+ */
 export class UserOnboardingChatError extends Error
 {
 	/** Stable reason used by the HTTP adapter. */

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding-chat.types.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding-chat.types.ts
@@ -176,7 +176,17 @@ export interface StartUserOnboardingChatCommand
 	readonly content: UserOnboardingBootstrapContentRevision;
 }
 
-/** Owner answer intent fenced to the exact server-projected conversation question. */
+/**
+ * One answer submitted by the user, tied to the exact question the server had shown them.
+ *
+ * The two `expected*` fields are what stops a stale browser tab from writing an answer against the
+ * wrong question: the server compares them with the conversation and question it currently offers,
+ * and reports a conflict instead of storing a mismatched answer. The user never chooses which
+ * question comes next - the server derives it from how many answers are already stored.
+ *
+ * Parsed from the request body by _ParseUserOnboardingAnswerBody, which enforces the same bounds:
+ * 1-128 characters for the ids, question 1-3, and 1-4000 characters of text.
+ */
 export interface SubmitUserOnboardingAnswerCommand
 {
 	/** Exact server-issued conversation the owner saw. */
@@ -206,14 +216,36 @@ export interface AppendUserOnboardingAnswerCommand
 	readonly idempotencyKey: string;
 }
 
-/** Durable append outcome plus the winning answer when a retry collided. */
+/**
+ * What the repository did with one submitted answer.
+ *
+ * Only the outcome is returned. The stored answer itself is not, because the caller re-reads the
+ * whole conversation afterwards to build the projection it returns.
+ *
+ * @see {@link UserOnboardingAnswerStatuses} for what each status obliges the caller to do.
+ */
 export interface UserOnboardingAnswerPersistenceResult
 {
 	/** Whether a row was created, resumed, or conflicted. */
 	readonly status: UserOnboardingAnswerStatuses.Recorded | UserOnboardingAnswerStatuses.Resumed | UserOnboardingAnswerStatuses.IdempotencyConflict | UserOnboardingAnswerStatuses.StateConflict;
 }
 
-/** Persistence boundary for immutable script, conversation, answer, and conclusion facts. */
+/**
+ * Everything the guided bootstrap chat reads and writes: script, conversation, answers, completion.
+ *
+ * The script rows are immutable and reviewed ahead of time, and the browser never chooses one - the
+ * script is selected from the approved persona's colour. The conversation then freezes the persona
+ * name, archetype, script revision and its digest, so a later script edit can never rewrite a
+ * conversation a user already saw. `startConversation` and `conclude` return a boolean instead of
+ * throwing: `false` means the row was not in the state the call required because another request
+ * got there first, and the caller re-reads rather than failing.
+ *
+ * Called by: __UserOnboardingChatAuthority; implemented by PrismaUserOnboardingRepository and
+ * composed by _CreateUserOnboardingRepository in
+ * apps/opencrane/src/app/user-onboarding-composition.ts.
+ *
+ * @see {@link UserOnboardingRepository} for the workflow-row half of persistence.
+ */
 export interface UserOnboardingChatRepository
 {
 	/** Select the current reviewed revision for one approved persona colour. */

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding-lifecycle-state.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding-lifecycle-state.ts
@@ -2,7 +2,27 @@ import { UserOnboardingDenialReasons, UserOnboardingStates, UserOnboardingTransi
 import type { UserOnboardingApprovalReconciliationContext, UserOnboardingLifecycleState, UserOnboardingPersonaApprovalContext, UserOnboardingSurveyStartContext } from "./user-onboarding-lifecycle-state.types.js";
 import type { UserOnboardingRecord, UserOnboardingTransitionResult } from "./user-onboarding.types.js";
 
-/** Resolve the state object that exclusively owns one durable onboarding state. */
+/**
+ * Pick the object that owns the behaviour for the row's current state.
+ *
+ * Every state-changing operation in this package is written twice: once as "try it" and once as
+ * "decide what to report if the try did not take effect". Both live on the state object, so adding
+ * a state cannot leave a hole.
+ *
+ * All writes here are conditional updates - they apply only if the row still looks the way it did
+ * when it was read. When two requests race (two browser tabs, a retry, a persona callback arriving
+ * twice) one update applies and the other changes zero rows. Changing zero rows is NOT a failure:
+ * the row simply moved on. The caller re-reads the row, calls this function again with the new
+ * state, and the matching `reconcile*` method says whether the outcome is really what the caller
+ * wanted (report resumed), harmlessly late (report no-op), or genuinely wrong (report denied).
+ *
+ * Called by: __UserOnboardingAuthority.startSurvey / recordApprovedPersona / readOrCreate, and the
+ * re-read helpers in this file.
+ *
+ * @param onboarding - The row as it was just read.
+ * @returns The state object for `onboarding.state`; every state is mapped, so this never returns
+ * undefined.
+ */
 export function _UserOnboardingLifecycleState(onboarding: UserOnboardingRecord): UserOnboardingLifecycleState
 {
 	return _STATES[onboarding.state];
@@ -19,7 +39,7 @@ class _SurveyPendingState implements UserOnboardingLifecycleState
 		return _SurveyWriteResult(context.repository, context.owner, context.interviewId, advanced);
 	}
 
-	/** Deny a failed write that remained pending because no other valid transition won. */
+	/** Report a conflict: our update did not apply and the row is still survey-pending, so nothing valid happened. */
 	reconcileSurveyStart(context: UserOnboardingSurveyStartContext): UserOnboardingTransitionResult
 	{
 		return _Denied(UserOnboardingDenialReasons.StateConflict, context.onboarding);
@@ -47,7 +67,14 @@ class _SurveyPendingState implements UserOnboardingLifecycleState
 /** State behaviour while an owner-bound persona interview remains the current survey. */
 class _SurveyInProgressState implements UserOnboardingLifecycleState
 {
-	/** Resume the same interview or replace only the still-initial interview by CAS. */
+	/**
+	 * Report success for the same interview, or swap in a new one while the survey is still untouched.
+	 *
+	 * A repeat call naming the interview that is already pinned is reported as resumed. A different
+	 * interview is only allowed while no approved revision and no bootstrap data exist yet; the
+	 * conditional update enforces that, so a second request racing the same swap changes zero rows and
+	 * is re-read instead.
+	 */
 	async startSurvey(context: UserOnboardingSurveyStartContext): Promise<UserOnboardingTransitionResult>
 	{
 		if (context.onboarding.personaInterviewId === context.interviewId) return _Resumed(context.onboarding);
@@ -56,7 +83,13 @@ class _SurveyInProgressState implements UserOnboardingLifecycleState
 		return _SurveyWriteResult(context.repository, context.owner, context.interviewId, advanced);
 	}
 
-	/** Resume the winner when it pinned this interview; otherwise report its incompatible survey. */
+	/**
+	 * Decide what to report after our update did not apply and the row is now survey-in-progress.
+	 *
+	 * If the request that got there first pinned the same interview we wanted, the caller got what it
+	 * asked for: report resumed. If it pinned a different interview, report an interview conflict so
+	 * the client sends the user back to the survey that is actually running.
+	 */
 	reconcileSurveyStart(context: UserOnboardingSurveyStartContext): UserOnboardingTransitionResult
 	{
 		if (context.onboarding.personaInterviewId === context.interviewId) return _Resumed(context.onboarding);
@@ -111,7 +144,13 @@ class _BootstrapChatPendingState implements UserOnboardingLifecycleState
 			: _NoOp(context.onboarding);
 	}
 
-	/** Resume only a matching approval durable winner; preserve other maintenance as no-op. */
+	/**
+	 * Decide what to report after our approval update did not apply and the row is now bootstrap-chat-pending.
+	 *
+	 * If the stored interview and revision are exactly the ones we tried to pin, another request
+	 * already did our work: report resumed. Anything else is a later persona change arriving after the
+	 * survey closed - accepted, but it must not move the workflow, so report no-op.
+	 */
 	reconcilePersonaApprovalWrite(context: UserOnboardingPersonaApprovalContext): UserOnboardingTransitionResult
 	{
 		return context.onboarding.personaInterviewId === context.evidence.interviewId && context.onboarding.personaRevisionId === context.evidence.personaRevisionId

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding-lifecycle-state.types.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding-lifecycle-state.types.ts
@@ -39,12 +39,23 @@ export interface UserOnboardingApprovalReconciliationContext
 	readonly onboarding: UserOnboardingRecord;
 }
 
-/** State-owned behaviour for each durable user-onboarding lifecycle state. */
+/**
+ * The behaviour each onboarding state supplies, so no state is ever handled by an `if` chain.
+ *
+ * One class per stored state implements this, and `_STATES` in user-onboarding-lifecycle-state.ts
+ * maps every {@link UserOnboardingStates} member to one of them - that mapping is what makes the
+ * set complete. The three `reconcile*` methods exist because every write here is a conditional
+ * update: when a write applies to zero rows the row has moved on, and the method for the NEW state
+ * decides whether that outcome is what the caller wanted, harmlessly late, or wrong.
+ *
+ * Called by: _UserOnboardingLifecycleState in user-onboarding-lifecycle-state.ts, the only place
+ * these methods are reached from.
+ */
 export interface UserOnboardingLifecycleState
 {
 	/** Handle a verified request to start or resume a persona survey. */
 	startSurvey(context: UserOnboardingSurveyStartContext): Promise<UserOnboardingTransitionResult>;
-	/** Interpret the durable winner after a survey compare-and-set did not advance. */
+	/** Decide what to report when the survey update applied to zero rows, based on the state the row is in now. */
 	reconcileSurveyStart(context: UserOnboardingSurveyStartContext): UserOnboardingTransitionResult;
 	/** Handle verified persona approval evidence for the current workflow state. */
 	recordPersonaApproved(context: UserOnboardingPersonaApprovalContext): Promise<UserOnboardingTransitionResult>;

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding.enums.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding.enums.ts
@@ -1,8 +1,19 @@
 /**
- * Durable server-owned routing states for one user's pinned onboarding workflow.
+ * The state one user's onboarding is currently in, decided and stored by the server.
  *
- * The string values are the API and persistence vocabulary; callers must not invent parallel
- * browser-owned states.
+ * Each user has one UserOnboarding row. Its state decides where the browser is sent next: run the
+ * persona survey, run the guided bootstrap chat, or let the user into the main application. The
+ * browser never chooses the state; it reads it from `GET /api/v1/me/onboarding`.
+ *
+ * The string values here are exactly what the database column stores and exactly what the API
+ * returns, so changing a value breaks stored rows and every client at the same time. The Prisma
+ * enum `UserOnboardingState` is a second copy of the same set and is translated in
+ * prisma-user-onboarding-repository.ts; both must be changed together.
+ *
+ * States move in one direction only: SurveyPending -> SurveyInProgress -> BootstrapChatPending ->
+ * BootstrapChatInProgress -> Completed.
+ *
+ * @see {@link UserOnboardingTransitionStatuses} for what a state-changing call reports back.
  */
 export enum UserOnboardingStates
 {
@@ -12,13 +23,26 @@ export enum UserOnboardingStates
 	SurveyInProgress = "survey_in_progress",
 	/** The approved persona is pinned and bootstrap provisioning may begin. */
 	BootstrapChatPending = "bootstrap_chat_pending",
-	/** One exact bootstrap conversation and content revision are in progress. */
+	/** The guided bootstrap conversation is open and its script revision is pinned. */
 	BootstrapChatInProgress = "bootstrap_chat_in_progress",
 	/** Server-validated onboarding conclusion permits later main-application admission. */
 	Completed = "completed",
 }
 
-/** Durable proof categories for completed onboarding records. */
+/**
+ * Why a completed onboarding row was allowed to be marked complete.
+ *
+ * Read this when you need to tell a user who genuinely finished onboarding from a user who was let
+ * in by a migration. `BootstrapConcluded` means the server itself saw three valid answers and
+ * closed the conversation. `ExistingUserMigration` means a named migration admitted somebody who
+ * predates onboarding, so there is no conversation and no answers - a caller that tries to render a
+ * transcript for those users will find nothing.
+ *
+ * The string values are stored in the `completionProvenance` column and returned by the API, and
+ * they mirror the Prisma enum `UserOnboardingCompletionProvenance`.
+ *
+ * @see {@link UserOnboardingRecord.completionProvenance} the field that carries this value.
+ */
 export enum UserOnboardingCompletionProvenances
 {
 	/** Ordinary onboarding concluded through a server-validated bootstrap conversation. */
@@ -27,20 +51,48 @@ export enum UserOnboardingCompletionProvenances
 	ExistingUserMigration = "existing_user_migration",
 }
 
-/** Stable outcomes returned by survey transition methods. */
+/**
+ * What a survey or persona-approval call did to the stored workflow.
+ *
+ * These four are easy to confuse and a caller must handle them differently:
+ * - `Advanced` - this call changed the stored state. Re-read the record and re-route the user.
+ * - `Resumed` - the state was already exactly what this call wanted, usually a retry or a second
+ *   browser tab. Treat it as success; do not show an error.
+ * - `NoOp` - the call was valid but arrived too late to matter: the user is already past the survey,
+ *   so a later persona change is accepted without dragging the workflow backwards.
+ * - `Denied` - nothing changed and the request is not acceptable. Read
+ *   {@link UserOnboardingDenialReasons} to decide what to tell the user.
+ *
+ * A caller that lumps `Denied` in with `NoOp` silently swallows a real rejection, and one that
+ * treats `Resumed` as failure shows an error on every harmless retry.
+ *
+ * @see {@link UserOnboardingTransitionResult} the result union that carries this status.
+ */
 export enum UserOnboardingTransitionStatuses
 {
 	/** The durable workflow moved to its next state. */
 	Advanced = "advanced",
 	/** The same already-durable transition was safely resumed. */
 	Resumed = "resumed",
-	/** A valid persona maintenance event was accepted without changing initial-onboarding provenance. */
+	/** A later persona change was accepted, but the workflow was left where it was. */
 	NoOp = "no_op",
 	/** The requested transition conflicts with current durable state or evidence. */
 	Denied = "denied",
 }
 
-/** Stable fail-closed explanations for denied onboarding transitions. */
+/**
+ * Why a survey or persona-approval call was rejected without changing anything.
+ *
+ * Onboarding never guesses: if a check fails it refuses and says which check, so a client can tell
+ * a user mistake from a race. `InvalidReference` is a bad request (an empty id). `InterviewNotOwned`
+ * and `PersonaNotApproved` mean the persona package would not confirm the interview, or the
+ * approved revision, for this session's user - so the caller is asking about someone else's work or
+ * about work that is not approved yet. `InterviewConflict` means this user already has a different
+ * interview pinned; send them back to the one they started. `StateConflict` means another request
+ * got there first, or the workflow has moved on - re-read the record and route from its new state.
+ *
+ * @see {@link UserOnboardingTransitionDenial} the result shape that carries this reason.
+ */
 export enum UserOnboardingDenialReasons
 {
 	/** A required identifier was empty. */
@@ -101,7 +153,19 @@ export enum UserOnboardingChatMessageKinds
 	Answer = "answer",
 }
 
-/** Outcomes for append-only answer submission. */
+/**
+ * What happened when the user submitted one bootstrap-chat answer.
+ *
+ * Answers are append-only and each carries a retry key that is unique inside its conversation.
+ * `Recorded` means a new answer row was written (the route answers 201). `Resumed` means that same
+ * retry key, with the same text and the same question, was already stored - a double submit is
+ * harmless (200). `IdempotencyConflict` means the retry key was already used with DIFFERENT text,
+ * which is a client bug rather than a race. `StateConflict` means the conversation will not take
+ * that answer right now, most often because the user answered a stale question. The last two both
+ * return 409 together with the current chat, so the client re-renders instead of guessing.
+ *
+ * @see {@link UserOnboardingAnswerResult} the value returned to the HTTP layer.
+ */
 export enum UserOnboardingAnswerStatuses
 {
 	/** One new bounded answer was appended. */
@@ -114,7 +178,18 @@ export enum UserOnboardingAnswerStatuses
 	StateConflict = "state_conflict",
 }
 
-/** Stable fail-closed errors exposed by the guided onboarding chat boundary. */
+/**
+ * Why a guided-chat request was refused, in a form that is safe to send to the browser.
+ *
+ * Each of these is thrown as a {@link UserOnboardingChatError} and mapped to a fixed HTTP status by
+ * the router, so the grouping matters. `InvalidAnswer`, `InvalidIdempotencyKey`, and
+ * `InvalidCoordinate` are 400 - the client sent something out of bounds. `NotReady`,
+ * `StateConflict`, and `NotConcludable` are 409 - the request is well formed but the workflow is
+ * not at that point. `EvidenceUnavailable` is 503 because the approved persona row or its reviewed
+ * script could not be read, which is a server-side problem the user can retry.
+ *
+ * @see {@link UserOnboardingChatError} the error class that carries this reason to the router.
+ */
 export enum UserOnboardingChatFailureReasons
 {
 	/** The persona survey has not produced an approved revision yet. */

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding.http.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding.http.ts
@@ -7,7 +7,23 @@ import { _ParseUserOnboardingAnswerBody } from "./user-onboarding.http.validator
 import type { ApprovedPersonaEvidence, UserOnboardingOwner } from "./user-onboarding.types.js";
 import { __UserOnboardingAuthority } from "./user-onboarding-authority.js";
 
-/** Create the owner-only durable onboarding status router. */
+/**
+ * Build the Express router for the signed-in user's own onboarding, mounted at /api/v1/me/onboarding.
+ *
+ * Five routes: `GET /` returns the workflow state and creates a survey-pending row on the first
+ * visit; `GET /chat` and `POST /chat/start` read and start the guided bootstrap chat;
+ * `POST /chat/answers` appends one answer; `POST /chat/conclude` completes onboarding. Every route
+ * resolves the user from the session and answers 401 when there is none - no route accepts a user id
+ * from the request. Expected chat refusals become fixed status codes (400, 409, 503) with a stable
+ * `error` string, while anything unexpected is logged and returned as 503 so no internal detail
+ * reaches the browser.
+ *
+ * Called by: _CreateUserOnboardingComposition in
+ * apps/opencrane/src/app/user-onboarding-composition.ts, mounted in apps/opencrane/src/app/routes.ts.
+ *
+ * @param dependencies - Workflow authority, chat authority, session owner resolver, and logger.
+ * @returns A router ready to mount; it registers no authentication middleware of its own.
+ */
 export function __CreateUserOnboardingRouter(dependencies: UserOnboardingRouterDependencies): Router
 {
 	const router = Router();
@@ -43,7 +59,21 @@ export function __CreateUserOnboardingRouter(dependencies: UserOnboardingRouterD
 	return router;
 }
 
-/** Adapter that advances workflow state only after persona authority success. */
+/**
+ * Passes persona's survey and approval events into the durable onboarding workflow.
+ *
+ * Called only after the persona package has already committed its own change, so it must be safe to
+ * call twice: `surveyStarted` first re-reads the row, which also repairs the case where a persona
+ * approval was committed but its notification to onboarding never arrived. A refusal is turned into
+ * a thrown error rather than being reported, so the persona request fails instead of leaving the two
+ * sides disagreeing about the user's state.
+ *
+ * Called by: _CreatePersonaOnboardingWorkflow in
+ * apps/opencrane/src/app/user-onboarding-composition.ts.
+ *
+ * @implements {UserOnboardingPersonaWorkflowPort}
+ * @throws Error when the workflow denies the notification, with the denial reason in the message.
+ */
 export class UserOnboardingPersonaWorkflowCoordinator implements UserOnboardingPersonaWorkflowPort
 {
 	/** Durable workflow authority. */

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding.http.types.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding.http.types.ts
@@ -6,7 +6,17 @@ import type { ApprovedPersonaEvidence, UserOnboardingOwner } from "./user-onboar
 import type { __UserOnboardingAuthority } from "./user-onboarding-authority.js";
 import type { __UserOnboardingChatAuthority } from "./user-onboarding-chat-authority.js";
 
-/** Session owner resolver injected by the app composition root. */
+/**
+ * Turns one HTTP request into the user whose onboarding it may touch, or null when not signed in.
+ *
+ * This is the only place the router learns who is calling, and it must read the verified server
+ * session and nothing else - never a body field, a query parameter, or a header. Any other source
+ * would let a signed-in user drive somebody else's onboarding. Returning null makes the router
+ * answer 401 without reaching any authority.
+ *
+ * Called by: every route built in __CreateUserOnboardingRouter; supplied by the app as
+ * `_ResolveUserOnboardingOwner` in apps/opencrane/src/app/routes.ts.
+ */
 export interface UserOnboardingOwnerResolver
 {
 	/** Resolve trusted silo and subject facts, or null when unauthenticated. */
@@ -26,7 +36,17 @@ export interface UserOnboardingRouterDependencies
 	readonly logger: Logger;
 }
 
-/** Persona lifecycle notifications accepted by the onboarding workflow. */
+/**
+ * The two things the persona package tells onboarding about, so persona never writes onboarding rows.
+ *
+ * Both methods return void and throw on refusal, because a persona request that onboarding will not
+ * accept must fail the persona call rather than leave the two sides disagreeing. Onboarding
+ * re-verifies both notifications against the persona evidence port before writing anything, so a
+ * replayed or out-of-order notification is safe.
+ *
+ * Implemented by: UserOnboardingPersonaWorkflowCoordinator in user-onboarding.http.ts, adapted to
+ * persona's own port in apps/opencrane/src/app/user-onboarding-composition.ts.
+ */
 export interface UserOnboardingPersonaWorkflowPort
 {
 	/** Record the exact owner-bound survey interview. */

--- a/libs/backend/server/agents/onboarding/main/src/user-onboarding.types.ts
+++ b/libs/backend/server/agents/onboarding/main/src/user-onboarding.types.ts
@@ -1,7 +1,17 @@
 import type { UserOnboardingCompletionProvenances, UserOnboardingDenialReasons, UserOnboardingStates, UserOnboardingTransitionStatuses } from "./user-onboarding.enums.js";
 import type { ApprovedPersonaBootstrapEvidence } from "./user-onboarding-chat.types.js";
 
-/** Trusted owner coordinates derived from the authenticated server session. */
+/**
+ * The user whose onboarding is being read or changed, taken only from the verified server session.
+ *
+ * Both fields come from the authenticated request principal. Nothing in this package ever accepts a
+ * silo or a subject from a request body, a query string, or a header - if it did, any signed-in
+ * user could drive another user's onboarding. The app builds this value in
+ * apps/opencrane/src/app/routes.ts and passes it in as a {@link UserOnboardingOwnerResolver}.
+ *
+ * The two fields together are the lookup key for every row in this package (the `siloId_userId`
+ * unique key in Postgres).
+ */
 export interface UserOnboardingOwner
 {
 	/** Organisation silo derived from the verified request principal. */
@@ -10,7 +20,18 @@ export interface UserOnboardingOwner
 	readonly subjectId: string;
 }
 
-/** Server projection of one user's pinned onboarding workflow. */
+/**
+ * One user's stored onboarding row, converted for callers so no Prisma model leaks out.
+ *
+ * This is what every route and authority method hands back, and the only place to read the current
+ * state from. The nullable id fields fill in as the user moves forward and are then frozen:
+ * `personaInterviewId` when the survey starts, `personaRevisionId` when the persona is approved,
+ * then the three `bootstrap*` fields when the guided chat starts. A null therefore means "not
+ * reached yet", never "lost". Only `state` should drive routing; the ids are for showing and
+ * checking what is pinned.
+ *
+ * @see {@link UserOnboardingStates} for what each state means.
+ */
 export interface UserOnboardingRecord
 {
 	/** Stable workflow record identifier. */
@@ -58,7 +79,18 @@ export interface ApprovedPersonaEvidence
 	readonly personaRevisionId: string;
 }
 
-/** Persona-owned evidence checks required by onboarding without sharing persistence authority. */
+/**
+ * The four questions onboarding asks the persona package, so neither package touches the other's tables.
+ *
+ * Onboarding stores no persona data and never queries persona tables. Before it will pin an
+ * interview or an approved revision it asks here, and every method takes the session-derived
+ * {@link UserOnboardingOwner} so persona can scope its own query to that user. A null or false
+ * answer always means "refuse" - never "assume yes".
+ *
+ * Called by: __UserOnboardingAuthority and __UserOnboardingChatAuthority in this package;
+ * implemented in apps/opencrane/src/app/user-onboarding-composition.ts over
+ * PersonaWorkflowEvidenceRepository.
+ */
 export interface UserOnboardingPersonaEvidencePort
 {
 	/** Confirm that an interview belongs to the session-derived owner. */
@@ -71,14 +103,39 @@ export interface UserOnboardingPersonaEvidencePort
 	readApprovedBootstrapEvidence(owner: UserOnboardingOwner, personaRevisionId: string): Promise<ApprovedPersonaBootstrapEvidence | null>;
 }
 
-/** Persistence operations owned exclusively by the user-onboarding package. */
+/**
+ * The only writes onboarding may make to its own UserOnboarding row.
+ *
+ * The `mark*` and `replace*` methods return a boolean rather than a record. `true` means this call
+ * made the change; `false` means the row was not in the state the call required, because another
+ * request changed it first or the user is already further along. `false` is expected, not an error -
+ * the caller re-reads the row and lets the state object for the NEW state decide what to report.
+ * Nothing here throws for a lost race.
+ *
+ * Called by: __UserOnboardingAuthority and the state objects in user-onboarding-lifecycle-state.ts;
+ * implemented by PrismaUserOnboardingRepository, composed by _CreateUserOnboardingRepository in
+ * apps/opencrane/src/app/user-onboarding-composition.ts.
+ *
+ * @see {@link UserOnboardingChatRepository} for the guided-chat half of persistence.
+ */
 export interface UserOnboardingRepository
 {
 	/** Return the current workflow or create a pinned survey-pending workflow. */
 	ensure(owner: UserOnboardingOwner, currentWorkflowVersion: number): Promise<UserOnboardingRecord>;
 	/** Return the current owner-bound workflow without creating one. */
 	read(owner: UserOnboardingOwner): Promise<UserOnboardingRecord | null>;
-	/** Atomically pin an interview and enter survey-in-progress from a survey state. */
+	/**
+	 * Pin this interview and move the row to survey-in-progress, in one conditional update.
+	 *
+	 * Also succeeds when the row is already survey-in-progress with this exact interview, so a retry
+	 * is harmless. It will not touch a row that has a different interview pinned or that has moved
+	 * past the survey.
+	 *
+	 * @param owner - Session-derived user whose row may change.
+	 * @param interviewId - Interview the persona package has already confirmed belongs to this user.
+	 * @returns true when this call pinned or re-confirmed the interview; false when the row was in
+	 * some other state, in which case the caller must re-read it.
+	 */
 	markSurveyInProgress(owner: UserOnboardingOwner, interviewId: string): Promise<boolean>;
 	/** Atomically replace the expected initial-survey interview before any later evidence exists. */
 	replaceSurveyInterview(owner: UserOnboardingOwner, expectedInterviewId: string, replacementInterviewId: string): Promise<boolean>;

--- a/libs/backend/server/agents/scheduling/main/src/cron-schedule.ts
+++ b/libs/backend/server/agents/scheduling/main/src/cron-schedule.ts
@@ -80,7 +80,17 @@ export function __IsValidCronExpression(expression: string): boolean
 	return __ParseCronExpression(expression) !== null;
 }
 
-/** Return whether a string names a resolvable IANA timezone. */
+/**
+ * Check that a string is a time zone name this runtime can resolve.
+ *
+ * Used to fail a schedule closed rather than silently evaluating it in the wrong zone. The check is
+ * whatever the JavaScript runtime's own time-zone data accepts, so it follows the IANA time-zone
+ * database shipped with that runtime and can differ between Node versions after a zone is renamed.
+ *
+ * @param timezone - Candidate IANA zone name, for example "Europe/Brussels".
+ * @returns true when the runtime can build a formatter for it; false for anything it rejects.
+ * @see https://www.iana.org/time-zones for the zone names and the rename history behind that caveat.
+ */
 export function __IsValidTimezone(timezone: string): boolean
 {
 	try
@@ -112,8 +122,18 @@ export function __WallClockInZone(date: Date, timezone: string): WallClock
 }
 
 /**
- * Return whether a cron expression matches one wall clock, applying Vixie day-of-month/day-of-week
- * OR semantics: when both day fields are restricted the instant matches if EITHER field matches.
+ * Check whether one wall-clock minute matches the cron expression.
+ *
+ * Minute, hour and month must all match. The two day fields follow the Vixie cron rule, which is the
+ * one thing here that surprises people: when BOTH day-of-month and day-of-week are restricted, the
+ * instant matches if EITHER matches. So `0 0 1 * 1` fires on the 1st of every month AND on every
+ * Monday - not only on a Monday the 1st. When just one day field is restricted only that one
+ * decides, and when neither is, every day matches.
+ *
+ * @param expression - Parsed expression, including which day fields were restricted.
+ * @param wall - The candidate minute, already resolved into the schedule's time zone.
+ * @returns true when a run is due at that minute.
+ * @see Vixie cron `crontab(5)`, the day-field rule this implements.
  */
 export function __CronMatchesWallClock(expression: CronExpression, wall: WallClock): boolean
 {

--- a/libs/backend/server/agents/scheduling/main/src/cron-schedule.types.ts
+++ b/libs/backend/server/agents/scheduling/main/src/cron-schedule.types.ts
@@ -1,4 +1,16 @@
-/** One parsed standard 5-field cron expression evaluated against a wall clock. */
+/**
+ * A cron expression already parsed into the exact values it matches.
+ *
+ * Every field is expanded up front into a set, so matching one minute is a handful of set lookups
+ * with no re-parsing. Day-of-week is normalised so Sunday is always 0, because cron accepts both 0
+ * and 7 for it.
+ *
+ * The two `*Restricted` flags cannot be derived from the sets - a field written `*` expands to the
+ * same full set as `0-6` - and they are what makes the Vixie day rule possible: when both day fields
+ * were written as something other than `*`, a match on either one is enough.
+ *
+ * @see {@link __CronMatchesWallClock} which consumes these flags.
+ */
 export interface CronExpression
 {
 	/** Matching minute-of-hour values (0-59). */

--- a/libs/backend/server/agents/scheduling/main/src/schedule-tick.enums.ts
+++ b/libs/backend/server/agents/scheduling/main/src/schedule-tick.enums.ts
@@ -1,4 +1,13 @@
-/** Stable public outcome of evaluating one schedule tick. */
+/**
+ * The result of evaluating one schedule once.
+ *
+ * `Suspended` means the schedule is switched off: nothing is read, admitted, or written, and the row
+ * is left alone rather than deleted. `InvalidSchedule` means the stored configuration cannot be
+ * trusted (see {@link ScheduleInvalidReasons}), so the tick fails closed and logs a warning instead
+ * of guessing at an interpretation. `Ticked` is the only status that reports slots and the cursor
+ * the tick reached - note that a `Ticked` result with an empty outcome list just means nothing was
+ * due.
+ */
 export enum ScheduleTickStatuses
 {
 	/** The schedule is disabled and no persistence or run admission occurs. */
@@ -9,7 +18,16 @@ export enum ScheduleTickStatuses
 	Ticked = "ticked",
 }
 
-/** Stable reason that makes a schedule tick fail closed before it can admit a run. */
+/**
+ * Why a schedule could not be evaluated at all, so no run was admitted.
+ *
+ * All three are operator-side problems rather than transient faults, and none of them are retried in
+ * a tighter loop - the next ordinary tick tries again once the row or the service is fixed.
+ * `InvalidCron` and `InvalidTimezone` mean the stored expression or IANA zone name cannot be parsed,
+ * and the scheduler refuses to guess because a wrong reading would fire runs at wrong times.
+ * `ServiceNotRunnable` means the managed service has no active revision to hand the slot to - most
+ * often it is paused or mid-deploy - so there is nothing to run yet.
+ */
 export enum ScheduleInvalidReasons
 {
 	/** The persisted cron expression is malformed. */
@@ -20,7 +38,21 @@ export enum ScheduleInvalidReasons
 	ServiceNotRunnable = "service_not_runnable",
 }
 
-/** Stable per-slot outcome emitted by the scheduler after consulting run admission. */
+/**
+ * What happened to one due slot after the scheduler asked the run-admission authority.
+ *
+ * The five are easy to confuse, and they differ in whether the cursor may move past the slot:
+ * - `Accepted` - a new run was created for this slot; the cursor moves on.
+ * - `Idempotent` - a concurrent or repeated tick had already created that exact run, so this is
+ *   success and not a clash; the cursor moves on.
+ * - `SkippedOverlap` - the schedule's overlap policy is `skip` and an earlier scheduled run is still
+ *   going, so the slot is deliberately dropped and will not fire later; the cursor moves on.
+ * - `RetryHint` - admission was refused for a reason that may pass (stale membership, a concurrency
+ *   limit, the database unavailable). The tick stops here and the cursor does NOT move, so the next
+ *   tick retries the same slot. `retryAfterMs` is advice only; nothing in this package sleeps.
+ * - `Denied` - admission refused permanently. The refusal is recorded and the cursor moves past it,
+ *   so one bad slot cannot block the schedule forever.
+ */
 export enum ScheduledSlotOutcomes
 {
 	/** The shared run-admission authority accepted a new durable run. */
@@ -35,7 +67,23 @@ export enum ScheduledSlotOutcomes
 	Denied = "denied",
 }
 
-/** Durable cursor compare-and-set outcome returned by the scheduler persistence boundary. */
+/**
+ * Whether a finished tick was allowed to record how far it got.
+ *
+ * Each schedule keeps a cursor - `lastScheduledAt`, the newest slot it has already dealt with - and
+ * only slots after it are ever considered. The cursor must therefore never move backwards: if it
+ * did, slots that were already admitted would look due again and the same work would start twice.
+ * To guarantee that, the update applies only if the schedule row still holds both the version and
+ * the previous cursor the tick read before it began admitting runs.
+ *
+ * `Advanced` means it applied. `Stale` means somebody edited the schedule, or another tick moved the
+ * cursor, in the meantime - so this tick's cursor is discarded rather than written. The runs it
+ * already admitted stay safe because each slot carries its own idempotency key, and the next tick
+ * simply recomputes from the stored cursor. `Stale` is normal and is logged at debug, not as an
+ * error.
+ *
+ * @see {@link ScheduleCursorRepository.advanceIfUnchanged} the call that returns this.
+ */
 export enum ScheduleCursorAdvanceOutcomes
 {
 	/** The observed schedule version still matched and the cursor moved forward. */

--- a/libs/backend/server/agents/scheduling/main/src/schedule-tick.types.ts
+++ b/libs/backend/server/agents/scheduling/main/src/schedule-tick.types.ts
@@ -2,7 +2,21 @@ import type { AgentScheduleOverlapPolicies, ManagedRunAdmissionPort, ManagedRunA
 
 import type { ScheduleInvalidReasons, ScheduledSlotOutcomes, ScheduleTickStatuses } from "./schedule-tick.enums.js";
 
-/** One recurring schedule bound to a managed AgentService's active revision. */
+/**
+ * One recurring schedule, as the scheduler needs to see it.
+ *
+ * `cron` is a standard 5-field expression read in `timezone`, which is an IANA zone name - so a
+ * schedule keeps its local meaning across daylight-saving changes. `lastScheduledAt` is the cursor:
+ * the newest slot already dealt with, and the exclusive lower bound for the next evaluation.
+ * `catchupWindowSeconds` bounds how far back a restarted or delayed scheduler will reach, so a long
+ * outage does not produce a flood of old runs. Setting `enabled` to false suspends evaluation
+ * without deleting anything.
+ *
+ * This is the scheduler's own read model. The write-side record owned by the agent-services package
+ * is the separately named `AgentServiceScheduleRecord` - do not confuse the two.
+ *
+ * @see {@link CronExpression} for the cron subset that is actually supported.
+ */
 export interface AgentServiceSchedule
 {
 	/** Stable schedule identifier. */
@@ -50,10 +64,18 @@ export interface ActiveScheduledRunLookup
 	hasActiveScheduledRun(agentServiceId: string, siloId: string): Promise<boolean>;
 }
 
-/** Ports and bounds a schedule tick composes over. */
+/**
+ * Everything one tick needs injected, so the tick itself is a pure function of its inputs.
+ *
+ * The clock is injected rather than read, so a whole pass shares one instant and tests are
+ * deterministic. `maxSlotsPerTick` is the hard ceiling on catch-up work in one pass, and `backoff`
+ * only produces the delay hint reported with a `RetryHint` outcome - nothing here waits.
+ *
+ * Built by: ScheduleTicker.runOnce in schedule-ticker.ts.
+ */
 export interface ScheduleTickDependencies
 {
-	/** The EXISTING managed run-admission seam; the tick opens no second run-creation path. */
+	/** The one authority allowed to create an AgentRun; the scheduler never writes runs itself. */
 	readonly admission: ManagedRunAdmissionPort;
 	/** In-flight scheduled-run lookup consulted only for the `skip` overlap policy. */
 	readonly activeRuns: ActiveScheduledRunLookup;
@@ -67,14 +89,32 @@ export interface ScheduleTickDependencies
 	readonly backoff: RetryBackoffPolicy;
 }
 
-/** Why a due slot was not admitted, or how it was admitted. */
+/**
+ * One line of the tick's report: what happened to a single due slot.
+ *
+ * Every case carries `idempotencyKey`, so a caller can match the slot to whichever run a tick
+ * created for it. `runId` exists only on the two admitted cases and `reason` only on the two refused
+ * ones. Which case appears also decides whether the cursor moved past the slot.
+ *
+ * @see {@link ScheduledSlotOutcomes} for what each outcome obliges the caller to do.
+ */
 export type ScheduledSlotOutcome =
 	| { readonly slot: string; readonly outcome: ScheduledSlotOutcomes.Accepted | ScheduledSlotOutcomes.Idempotent; readonly runId: string; readonly idempotencyKey: string }
 	| { readonly slot: string; readonly outcome: ScheduledSlotOutcomes.SkippedOverlap; readonly idempotencyKey: string }
 	| { readonly slot: string; readonly outcome: ScheduledSlotOutcomes.RetryHint; readonly reason: string; readonly retryAfterMs: number; readonly idempotencyKey: string }
 	| { readonly slot: string; readonly outcome: ScheduledSlotOutcomes.Denied; readonly reason: string; readonly idempotencyKey: string };
 
-/** Result of evaluating one schedule at one instant. */
+/**
+ * Everything one evaluation of one schedule reports back.
+ *
+ * Only the `Ticked` case carries `nextLastScheduledAt`, and that value is a proposal rather than a
+ * stored fact: the caller still has to write it with a conditional update that may be refused. It is
+ * null when the schedule has never fired and nothing was due; otherwise it is the newest slot the
+ * cursor may safely move to - which is not always the newest slot in `outcomes`, because a
+ * `RetryHint` stops the cursor short on purpose.
+ *
+ * @see {@link ScheduleTickStatuses} for what each status means for the caller.
+ */
 export type ScheduleTickResult =
 	| { readonly status: ScheduleTickStatuses.Suspended }
 	| { readonly status: ScheduleTickStatuses.InvalidSchedule; readonly reason: ScheduleInvalidReasons }

--- a/libs/backend/server/agents/scheduling/main/src/schedule-ticker-unit-of-work.types.ts
+++ b/libs/backend/server/agents/scheduling/main/src/schedule-ticker-unit-of-work.types.ts
@@ -1,14 +1,22 @@
 import type { AgentServiceSchedule, ScheduleTickResult } from "./schedule-tick.types.js";
 import type { ScheduleCursorAdvanceOutcomes } from "./schedule-tick.enums.js";
 
-/** One enabled scheduler snapshot read from one stable schedule version. */
+/**
+ * One enabled schedule plus the service facts observed in the same read.
+ *
+ * Read together on purpose: the tick has to judge the schedule and whether its service can actually
+ * accept a run as of the same moment. `activeRevisionId` is null when the service is not runnable,
+ * which the tick reports as `ServiceNotRunnable` instead of admitting anything. `updatedAt` is
+ * carried along so the later cursor write can be made conditional on the row not having changed
+ * since this read.
+ */
 export interface EnabledScheduleSnapshot
 {
 	/** Scheduler-owned schedule coordinates and evaluation policy. */
 	readonly schedule: AgentServiceSchedule;
 	/** Active managed revision observed with the schedule, or null when the service is not runnable. */
 	readonly activeRevisionId: string | null;
-	/** Exact persisted update instant used to fence the subsequent cursor compare-and-set. */
+	/** The row's last-update time when it was read; the later cursor write only applies if it is still this. */
 	readonly updatedAt: string;
 }
 
@@ -26,7 +34,17 @@ export interface ActiveScheduledRunRepository
 	hasActiveScheduledRun(agentServiceId: string, siloId: string): Promise<boolean>;
 }
 
-/** Command that conditionally records a completed scheduler tick's newest durable cursor. */
+/**
+ * A request to record how far one tick got, which the database may refuse.
+ *
+ * The two `expected*` fields are the whole point: they are the schedule version and cursor the tick
+ * read BEFORE it began admitting runs, and the update applies only if both are still those values.
+ * Runs are admitted outside any transaction - they are slow, and holding a transaction across them
+ * would be worse - so a schedule edit or a second scheduler can land in between. This check is what
+ * stops a late tick from dragging the cursor back over slots that already fired.
+ *
+ * @see {@link ScheduleCursorAdvanceOutcomes} for the two possible answers.
+ */
 export interface AdvanceScheduleCursorCommand
 {
 	/** Schedule that owns the cursor. */
@@ -48,7 +66,17 @@ export interface AdvanceScheduleCursorResult
 	readonly outcome: ScheduleCursorAdvanceOutcomes;
 }
 
-/** Capability repository that advances a schedule cursor only through its observed version. */
+/**
+ * The only writer of a schedule's cursor, and it will not move one backwards.
+ *
+ * There is exactly one method and it is conditional by design: it updates the cursor only while the
+ * schedule row still matches the version and previous cursor the caller observed. That is what makes
+ * two schedulers, or a tick that overran, safe to run at the same time - the loser writes nothing
+ * and reports `Stale` rather than rewinding the schedule.
+ *
+ * Called by: ScheduleTicker._advanceCursorIfNeeded in schedule-ticker.ts, through
+ * {@link ScheduleTickerTransaction}.
+ */
 export interface ScheduleCursorRepository
 {
 	/** Performs the version-and-cursor compare-and-set without ever moving a newer cursor backwards. */
@@ -69,7 +97,19 @@ export interface ScheduleTickerTransaction
 /** Work performed only with capability repositories, never with a Prisma client. */
 export type ScheduleTickerWork<Result> = (transaction: ScheduleTickerTransaction) => Promise<Result>;
 
-/** Opaque, scheduler-specific transaction boundary that exclusively owns Prisma. */
+/**
+ * The scheduler's whole database boundary: short pieces of work, with no Prisma client in sight.
+ *
+ * Callers are handed capability repositories rather than a client, so the scheduler cannot reach
+ * tables it does not own. Each `run` call is deliberately brief and happens either before or after
+ * run admission, never around it - one tick therefore uses several small transactions instead of one
+ * long one, because holding a transaction open across external admission calls would pin a
+ * connection and invite deadlocks.
+ *
+ * Called by: ScheduleTicker in schedule-ticker.ts; implemented by PrismaScheduleTickerUnitOfWork
+ * over a read-committed Prisma transaction and constructed in
+ * apps/opencrane/src/app/background-workers.ts.
+ */
 export interface ScheduleTickerUnitOfWork
 {
 	/** Runs one short persistence operation against transaction-scoped capability repositories. */

--- a/libs/backend/server/agents/scheduling/main/src/schedule-ticker.ts
+++ b/libs/backend/server/agents/scheduling/main/src/schedule-ticker.ts
@@ -15,7 +15,22 @@ const _DEFAULT_BACKOFF_POLICY: RetryBackoffPolicy = { baseDelayMs: 1_000, factor
 /** Bounded number of missed slots a single schedule can process in one scheduler pass. */
 const _MAX_SLOTS_PER_TICK = 60;
 
-/** App-composed scheduler service that coordinates durable snapshots with the shared run-admission port. */
+/**
+ * Runs one pass over every enabled schedule and turns due slots into runs via the shared admission authority.
+ *
+ * One pass is: read all enabled schedules in a short transaction; then for each one work out what is
+ * due and admit it; then try to record the cursor it reached. Admission happens outside any
+ * transaction on purpose, so a slow admission call cannot hold a database connection - the price is
+ * that the schedule can change underneath, which is why the cursor write is conditional and a
+ * refusal is expected rather than an error. This class never creates an AgentRun itself and never
+ * dispatches a Kubernetes Job; it only asks the run-admission authority.
+ *
+ * Safe to run in more than one process: each slot's idempotency key collapses concurrent ticks to a
+ * single run, and the loser sees `Idempotent`.
+ *
+ * Called by: apps/opencrane/src/app/background-workers.ts, on an interval, built by
+ * _CreateScheduleTicker.
+ */
 export class ScheduleTicker
 {
 	/** Opaque scheduling persistence boundary that exclusively owns Prisma transactions. */
@@ -33,7 +48,19 @@ export class ScheduleTicker
 		this.logger = logger;
 	}
 
-	/** Evaluates each enabled schedule at one trusted instant and records only version-fenced cursors. */
+	/**
+	 * Do one pass over every enabled schedule at one instant.
+	 *
+	 * The instant is passed in rather than read here, so a whole pass shares one evaluation time and
+	 * tests are deterministic. Schedules are handled one after another; one whose stored configuration
+	 * is unusable is logged as a warning and reported, not thrown, so a single bad row cannot stop the
+	 * rest of the pass. A cursor that could not be recorded is logged at debug and left to the next
+	 * pass.
+	 *
+	 * @param now - The evaluation instant shared by every schedule in this pass.
+	 * @returns One entry per enabled schedule, each with its schedule id and full tick result.
+	 * @throws Errors from the database or the admission authority are not caught here and reach the caller.
+	 */
 	async runOnce(now: Date): Promise<readonly ScheduleTickerResult[]>
 	{
 		// 1. Snapshot enabled schedules briefly so no database transaction covers external run admission.
@@ -87,7 +114,19 @@ export class ScheduleTicker
 	}
 }
 
-/** Composes the scheduler service without granting the composition root direct persistence operations. */
+/**
+ * Build the scheduler from its persistence boundary and the existing run-admission authority.
+ *
+ * Exists so the app's composition root never holds a Prisma client or any direct database
+ * operation - it passes in the two authorities and gets back something with a single `runOnce`.
+ *
+ * Called by: apps/opencrane/src/app/background-workers.ts.
+ *
+ * @param unitOfWork - Scheduler-only database boundary; the only path to Prisma.
+ * @param admission - The one authority allowed to create an AgentRun.
+ * @param logger - Receives warnings for unusable schedules and debug lines for refused cursor writes.
+ * @returns A ready scheduler; nothing runs until `runOnce` is called.
+ */
 export function _CreateScheduleTicker(unitOfWork: ScheduleTickerUnitOfWork, admission: ManagedRunAdmissionPort, logger: Logger): ScheduleTicker
 {
 	return new ScheduleTicker(unitOfWork, admission, logger);

--- a/libs/backend/server/agents/skills/main/src/prisma-skill-catalogue-repository.ts
+++ b/libs/backend/server/agents/skills/main/src/prisma-skill-catalogue-repository.ts
@@ -7,7 +7,15 @@ import { SkillCatalogueRevisionStates, SkillCatalogueStates, type SkillCatalogue
 /** Maximum browser-safe skill summaries one silo can receive in one catalogue response. */
 const _CATALOGUE_ENTRY_LIMIT = 200;
 
-/** Prisma repository for the live, browser-safe governed skill catalogue. */
+/**
+ * Reads the skill catalogue from Postgres.
+ *
+ * The query selects only listing fields — id, name, description, states, timestamps — so no skill
+ * bundle, manifest, signature, or review evidence can reach a browser even by accident. It reads
+ * live rows with no cache, so a newly published revision shows up on the next request.
+ *
+ * Called by: `_CreateSkillCatalogueRouter` in `prisma-skill-catalogue.router.ts`.
+ */
 export class PrismaSkillCatalogueRepository implements SkillCatalogueRepository
 {
 	/** Canonical OpenCrane catalog database client. */
@@ -19,7 +27,7 @@ export class PrismaSkillCatalogueRepository implements SkillCatalogueRepository
 		this.prisma = prisma;
 	}
 
-	/** Lists bounded browser-safe metadata for the exact host-derived silo. */
+	/** Lists at most 200 skills from this silo, most recently updated first and tie-broken by id so repeated calls agree. Wrapped in a trace span named `skills.catalogue.list`. */
 	async listCatalogue(siloId: string): Promise<readonly SkillCatalogueEntry[]>
 	{
 		const self = this;
@@ -43,7 +51,7 @@ export class PrismaSkillCatalogueRepository implements SkillCatalogueRepository
 	}
 }
 
-/** Converts generated persistence lifecycle values into the browser catalogue vocabulary. */
+/** Converts a stored `SkillRevisionState` into the value returned over HTTP. The switch has no default arm, so adding a state to the Prisma schema without adding it here is a compile error rather than a runtime surprise. */
 function _RevisionState(state: SkillRevisionState): SkillCatalogueRevisionStates
 {
 	switch (state)

--- a/libs/backend/server/agents/skills/main/src/prisma-skill-catalogue.router.ts
+++ b/libs/backend/server/agents/skills/main/src/prisma-skill-catalogue.router.ts
@@ -16,10 +16,16 @@ function _resolveCaller(request: Parameters<typeof _ResolveRequestPrincipal>[0])
 }
 
 /**
- * Composes the Prisma-backed authenticated skill catalogue router.
- * @param prisma - Canonical product-authority client.
- * @param logger - Process logger supplied by the app composition root.
- * @returns The configured skill catalogue router.
+ * Builds the skill catalogue router with its Prisma-backed reader.
+ *
+ * Caller resolution comes from the shared request-principal helper, so the silo is taken from the
+ * authenticated session and request host and never from anything the caller sends.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at `/api/v1/skills`.
+ *
+ * @param prisma - The OpenCrane Prisma client.
+ * @param logger - Process logger from the app's composition root.
+ * @returns The router, ready to mount.
  */
 export function _CreateSkillCatalogueRouter(prisma: PrismaClient, logger: Logger): Router
 {

--- a/libs/backend/server/agents/skills/main/src/skill-catalogue.router.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-catalogue.router.ts
@@ -2,7 +2,22 @@ import { Router, type Request, type Response } from "express";
 
 import type { SkillCatalogueRouterDependencies } from "./skill-catalogue.router.types.js";
 
-/** Create the browser-session-authenticated, read-only skill catalogue router. */
+/**
+ * Builds the read-only skill catalogue router: one `GET /` returning the caller's silo's skills.
+ *
+ * The silo comes from the authenticated session, never from the request, so there is no way to ask
+ * for another silo's skills. There are no write endpoints here at all.
+ *
+ * Responses: 200 `{ skills }` on success; 401 `skill_catalogue_authentication_required` when the
+ * session does not resolve; 503 `skill_catalogue_unavailable` when the read throws, which is logged
+ * with the operation and silo but never with skill content.
+ *
+ * Called by: `_CreateSkillCatalogueRouter` in `prisma-skill-catalogue.router.ts`, mounted at
+ * `/api/v1/skills` by apps/opencrane/src/app/routes.ts.
+ *
+ * @param dependencies - Caller resolution, the catalogue reader, and the logger.
+ * @returns An Express router with no prefix of its own; the caller decides where it mounts.
+ */
 export function __CreateSkillCatalogueRouter(dependencies: SkillCatalogueRouterDependencies): Router
 {
 	const router = Router();

--- a/libs/backend/server/agents/skills/main/src/skill-catalogue.router.types.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-catalogue.router.types.ts
@@ -4,14 +4,26 @@ import type { Logger } from "@opencrane/backend/observability";
 
 import type { SkillCatalogueRepository } from "./skill-catalogue.types.js";
 
-/** Trusted browser identity used only to select a skill catalogue silo. */
+/**
+ * The one fact this router needs about the caller: which silo they are in.
+ *
+ * Nothing else is carried on purpose — the catalogue is read-only, so there is no role to check. The
+ * silo is derived from the authenticated session and request host, never from anything the caller
+ * sends, and it scopes every query.
+ */
 export interface SkillCatalogueCaller
 {
 	/** Silo derived from the authenticated request host. */
 	readonly siloId: string;
 }
 
-/** Composition ports for the read-only skill catalogue router. */
+/**
+ * What {@link __CreateSkillCatalogueRouter} needs supplied: how to identify the caller, where to read
+ * the catalogue, and where to log failures.
+ *
+ * Production values come from `prisma-skill-catalogue.router.ts`; tests substitute fakes so the
+ * handler can be exercised without a database.
+ */
 export interface SkillCatalogueRouterDependencies
 {
 	/** Resolves the authenticated browser caller and trusted host silo. */

--- a/libs/backend/server/agents/skills/main/src/skill-catalogue.types.ts
+++ b/libs/backend/server/agents/skills/main/src/skill-catalogue.types.ts
@@ -1,4 +1,14 @@
-/** Browser-safe lifecycle states returned by the governed skill catalogue. */
+/**
+ * Whether a skill can still supply a revision to new agent runs.
+ *
+ * `Active` means it can, if its current revision is published. `Retired` means it never will again:
+ * the skill stays listed so past runs and assignments still make sense, but nothing new may use it.
+ * A retired skill is not deleted and does not disappear from the catalogue.
+ *
+ * Both conditions must hold for a new run — an `Active` skill whose current revision is not
+ * {@link SkillCatalogueRevisionStates.Published} is equally unusable. The strings are stable; they
+ * appear in the `/skills` response and its OpenAPI schema.
+ */
 export enum SkillCatalogueStates
 {
 	/** The logical skill can provide its current published revision to future admissions. */
@@ -7,7 +17,20 @@ export enum SkillCatalogueStates
 	Retired = "retired",
 }
 
-/** Browser-safe lifecycle states returned for a selected current skill revision. */
+/**
+ * Where a skill revision is in its review lifecycle.
+ *
+ * Only {@link SkillCatalogueRevisionStates.Published} may be used by a new agent run. Every other
+ * value means the revision cannot be assigned: `Draft` and `Review` are not through review yet,
+ * `Rejected` failed it, and `Revoked` was withdrawn after having been published — so a run admitted
+ * earlier may still be using it, but no new one can start on it.
+ *
+ * A skill's entry can carry a non-`Published` revision state: the skill still shows in the catalogue,
+ * but nothing new can be pointed at that revision. Reading the state as "available" because the
+ * entry exists is the mistake this enum is here to prevent.
+ *
+ * The strings are stable — they appear in the `/skills` response and its OpenAPI schema.
+ */
 export enum SkillCatalogueRevisionStates
 {
 	/** The immutable revision is still being authored. */
@@ -43,9 +66,28 @@ export interface SkillCatalogueEntry
 	readonly updatedAt: string;
 }
 
-/** Reads the browser-safe skill catalogue within an already trusted silo boundary. */
+/**
+ * Reads the skill list for one silo.
+ *
+ * Read-only by design, and it returns names and lifecycle states only — never skill bundles,
+ * artifact addresses, manifests, review evidence, signatures, or workload details. The `siloId` is
+ * already trusted when it arrives: the router derives it from the authenticated session, never from
+ * the request.
+ *
+ * Implemented by: `PrismaSkillCatalogueRepository` in `prisma-skill-catalogue-repository.ts`.
+ * Called by: {@link __CreateSkillCatalogueRouter} in `skill-catalogue.router.ts`; wired in
+ * `prisma-skill-catalogue.router.ts`.
+ */
 export interface SkillCatalogueRepository
 {
-	/** Returns a bounded, deterministic list of skill summaries from one silo. */
+/**
+ * Lists the skills in one silo, most recently updated first, tie-broken by id so the order is
+ * repeatable. At most 200 rows; there is no paging, so a silo with more is silently truncated.
+ *
+ * @param siloId - Silo already derived from the authenticated session.
+ * @returns Catalogue summaries. An empty array means the silo has no skills — a silo that does not
+ *   exist is indistinguishable from an empty one.
+ * @throws Whatever the database layer throws; the router logs it and answers 503.
+ */
 	listCatalogue(siloId: string): Promise<readonly SkillCatalogueEntry[]>;
 }

--- a/libs/backend/server/api-spec/main/src/approval-schemas.ts
+++ b/libs/backend/server/api-spec/main/src/approval-schemas.ts
@@ -1,4 +1,17 @@
-/** Actor-safe deferred tool approval schema shared by the generated API contract. */
+/**
+ * A tool call waiting for the signed-in user's decision, as it appears in the API.
+ *
+ * Only what the person deciding needs is here: which run and attempt, which tool, the arguments
+ * being proposed, the schema their answer must satisfy, and when the request expires. There is
+ * deliberately no tool output, no provider detail, and no other user's context — it is shaped
+ * for the person being asked, not for an operator.
+ *
+ * `attempt` matters when answering: an approval belongs to one attempt of a run, so a decision
+ * carrying a stale attempt must be refused rather than applied to a newer one.
+ *
+ * Registered as the `SelfDeferredToolApproval` component by spec.ts, which means it also shapes
+ * the generated frontend client.
+ */
 export const _SelfDeferredToolApprovalSchema = {
 	type: "object",
 	required: ["approvalRequestId", "runId", "attempt", "toolRevisionId", "toolInvocationId", "state", "proposedArguments", "responseSchema", "expiresAt", "createdAt"],

--- a/libs/backend/server/api-spec/main/src/domain-openapi-paths.ts
+++ b/libs/backend/server/api-spec/main/src/domain-openapi-paths.ts
@@ -18,7 +18,17 @@ import { _GroupsOpenapiPaths } from "@opencrane/backend/server/iam/groups";
 import { _RetrievalOpenapiPaths } from "@opencrane/backend/server/knowledge/retrieval";
 import { _SpendOpenapiPaths } from "@opencrane/backend/server/reporting/spend";
 
-/** Domain-owned OpenAPI paths merged in deliberate JSON-serialization order by the API specification. */
+/**
+ * Every domain package's own OpenAPI paths, merged into one object.
+ *
+ * Each package documents the routes it serves, next to the code that serves them, and this file
+ * is the only place that knows about all of them. The spread order is deliberate: it is the
+ * order the paths appear in the emitted `openapi.json`, so reordering these lines produces a
+ * large diff in the generated document and the generated client without changing the API at
+ * all. Add a new domain at the end.
+ *
+ * Called by: spec.ts, which spreads this into `paths` before its own auth and meta routes.
+ */
 export const _DomainOpenapiPaths = {
 	..._McpOpenapiPaths,
 	..._GrantsOpenapiPaths,

--- a/libs/backend/server/api-spec/main/src/error-schemas.ts
+++ b/libs/backend/server/api-spec/main/src/error-schemas.ts
@@ -1,6 +1,16 @@
 import { API_ERROR_LIMITS, ApiValidationIssueLocations } from "@opencrane/contracts";
 
-/** Bounded request-field diagnostic safe for a public client to map onto a form control. */
+/**
+ * One field-level validation problem, shaped so a client can attach it to the right input.
+ *
+ * `path` is the field path in segments, so a form can look up the control directly instead of
+ * parsing a sentence. Every string is length-capped from `API_ERROR_LIMITS`, and the message is
+ * required never to quote the value that was rejected — that rule is what makes it safe to show
+ * a validation error verbatim in a UI.
+ *
+ * Registered as the `ValidationIssue` component by spec.ts and referenced from
+ * {@link _ErrorEnvelopeSchema}. Changing it changes the generated client.
+ */
 export const _ValidationIssueSchema = {
 	type: "object" as const,
 	additionalProperties: false,
@@ -12,7 +22,17 @@ export const _ValidationIssueSchema = {
 	},
 };
 
-/** Standard public error envelope shared by every documented error response. */
+/**
+ * The body every error response in this API uses. Registered as the `Error` component by
+ * spec.ts, and every documented 4xx/5xx across all domains references it, so a client can write
+ * one error handler.
+ *
+ * `error` is for people and `code` is for programs — branch on `code` only, since `error` text
+ * may be reworded. `issues` appears only for request-validation failures on public endpoints,
+ * so treat it as absent everywhere else rather than relying on an empty array.
+ *
+ * @see {@link _ValidationIssueSchema} for what `issues` contains.
+ */
 export const _ErrorEnvelopeSchema = {
 	type: "object" as const,
 	required: ["error", "code"],

--- a/libs/backend/server/api-spec/main/src/spec.ts
+++ b/libs/backend/server/api-spec/main/src/spec.ts
@@ -485,7 +485,21 @@ function paginated(itemSchema: object)
 // Spec document — Composed from domain path fragments
 // ---------------------------------------------------------------------------
 
-/** OpenAPI 3.1 document served by the control plane and emitted for SDK generation. */
+/**
+ * The complete API description: shared schema components, then the domain paths, then the auth
+ * and meta routes.
+ *
+ * This one object has two consumers, which is why edits here are not cosmetic. It is served at
+ * `/api/v1/openapi.json` (apps/opencrane/src/app/routes.ts), and it is emitted to a file that
+ * generates the typed frontend client — so renaming a component or changing a required field
+ * changes compiled frontend code, not just documentation. Regenerate the client in the same
+ * change; see the note at the top of this file for the commands.
+ *
+ * Paths are relative to the `/api/v1` server prefix declared below, and each must match what a
+ * router actually mounts.
+ *
+ * @see {@link _DomainOpenapiPaths} — the per-package path fragments spread into `paths`.
+ */
 export const spec = {
   openapi: "3.1.0",
   info: {

--- a/libs/backend/server/conversations/main/src/conversation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-authority.types.ts
@@ -1,27 +1,69 @@
 import { ConversationLifecycles, ConversationModes, MessageRoles, MessageSources, MessageStates, type ConversationCreationRequest, type MessageContentBlock } from "@opencrane/models/conversations";
 
-/** Browser-session identity derived by the server before conversation authority is consulted. */
+/**
+ * Who the caller is, as the server worked it out from the browser session.
+ *
+ * The router builds this itself from the session cookie and the request host — it is never
+ * read from the request body, query string, or a header, so a client cannot ask to act as a
+ * different user or in a different silo. Every method on {@link ConversationUnitOfWork} takes
+ * one of these as its first argument, and the database layer re-checks the membership behind
+ * it on each call rather than trusting it once at login.
+ *
+ * Called by: `_resolveCaller` in prisma-self-conversations.router.ts (built from
+ * `_ResolveRequestPrincipal`), then passed through `__CreateSelfConversationsRouter`.
+ */
 export interface ConversationCaller
 {
-	/** Silo selected from the authenticated request host. */
+	/** ClusterTenant (silo) the request host resolves to; scopes every read and write below it. */
 	readonly siloId: string;
-	/** Verified OIDC subject from the authenticated session. */
+	/** The user's OIDC `sub`, already verified by the session layer; matched against conversation participant rows. */
 	readonly subjectId: string;
 }
 
-/** Immutable-mode conversation creation request after model-owned transport validation. */
+/**
+ * Body accepted by {@link ConversationUnitOfWork.create}, already checked against the request
+ * schema owned by `@opencrane/models/conversations`.
+ *
+ * The `mode` picked here (agent session, direct, or group) is fixed for the life of the
+ * conversation — there is no API that changes it later, which is why the shape differs per
+ * mode: an agent session names one `agentServiceId`, direct and group name participants.
+ * Re-exported unchanged from the model package so the HTTP layer and the database layer
+ * cannot drift apart.
+ */
 export type CreateConversationRequest = ConversationCreationRequest;
 
-/** Participant-authored message request after bounded block validation. */
+/**
+ * One message a user is trying to post, after the router's size and shape checks passed.
+ *
+ * The blocks have already been limited (at most 32 blocks, 32000 characters each, by
+ * `___ParticipantInputBlocksSchema`) so nothing downstream has to defend against an
+ * unbounded body.
+ *
+ * @see {@link ConversationUnitOfWork.submitMessage} for what happens to it.
+ */
 export interface SubmitConversationMessageRequest
 {
-	/** Caller key scoped to one conversation and canonical body. */
+	/**
+	 * Client-chosen retry key, unique per conversation. Resending the SAME key with the SAME
+	 * blocks returns the stored message and outcome `idempotent`; resending it with DIFFERENT
+	 * blocks is refused with {@link ConversationWriteDenialReasons.IdempotencyConflict}. The
+	 * comparison is a digest of the blocks, so a client must reuse a key only for a true retry.
+	 */
 	readonly idempotencyKey: string;
-	/** Ordered validated render blocks. */
+	/** The message content, in display order. At least one block; order is preserved exactly as sent. */
 	readonly blocks: readonly MessageContentBlock[];
 }
 
-/** Participant-local conversation list row. */
+/**
+ * One row in the caller's own conversation list.
+ *
+ * `archivedAt` and `readThroughPosition` are per-participant: archiving hides the
+ * conversation for this user only and does not close it for anyone else. `lifecycle` is the
+ * opposite — it is shared, and once it reads closed it never reopens.
+ *
+ * @see {@link ConversationDetail}, which adds the message history and the caller's visible
+ * range.
+ */
 export interface ConversationSummary
 {
 	readonly id: string;
@@ -34,7 +76,14 @@ export interface ConversationSummary
 	readonly updatedAt: string;
 }
 
-/** Canonical participant-visible message ordered by its timeline position. */
+/**
+ * One stored message the caller is allowed to see.
+ *
+ * `position` is the shared timeline number as a decimal string (it is a 64-bit value in the
+ * database, so it is not sent as a JSON number). Sort by it to get the true order — do not
+ * sort by `createdAt`, which can tie. `runId` is set only when an agent run produced or
+ * answered this message; `userId` is set only for human-authored messages.
+ */
 export interface ConversationMessageView
 {
 	readonly id: string;
@@ -49,7 +98,17 @@ export interface ConversationMessageView
 	readonly completedAt: string | null;
 }
 
-/** Participant-visible conversation detail and bounded canonical message history. */
+/**
+ * A single conversation plus the slice of its history this caller may read.
+ *
+ * `visibleFromPosition` is where the caller's access starts, and `accessEndedPosition` is
+ * where it stopped (null while they are still a participant). A user added to a group part
+ * way through therefore does not receive the earlier messages, and one removed later does not
+ * receive the newer ones. `messages` is capped at the most recent 100 rows inside that range,
+ * so it is not the whole conversation — stream the replay endpoint for everything.
+ *
+ * @see {@link ConversationUnitOfWork.open}
+ */
 export interface ConversationDetail extends ConversationSummary
 {
 	readonly visibleFromPosition: string;
@@ -57,63 +116,234 @@ export interface ConversationDetail extends ConversationSummary
 	readonly messages: readonly ConversationMessageView[];
 }
 
-/** Stable fail-closed denials whose string values are preserved on the participant API wire. */
+/**
+ * Why a conversation write was refused. These string values ARE the API contract: the router
+ * sends the member value straight back as the `error` field, so renaming a value is a breaking
+ * change for every client.
+ *
+ * Two rules govern the whole set:
+ *
+ * 1. Refusals are deliberately vague about other people's data. A conversation that does not
+ *    exist, a conversation in another silo, and a conversation the caller was removed from all
+ *    return `ConversationUnavailable`. Do not try to tell those apart, and do not add a reason
+ *    that would — the shared value is what stops a client from probing for conversations it is
+ *    not in.
+ * 2. Anything unexpected becomes `PersistenceUnavailable` rather than a success. Nothing here
+ *    means "probably worked".
+ *
+ * Each member maps to exactly one HTTP status in `_STATUS_BY_DENIAL`
+ * (self-conversations.router.ts), so the retry advice below is what the status already implies.
+ *
+ * @see {@link ConversationAuthorityOutcomes} for the success side of the same results.
+ */
 export enum ConversationWriteDenialReasons
 {
-	/** The selected conversation or current caller authority is unavailable. */
+	/**
+	 * Sent as 404. The conversation is not there for this caller — it may never have existed,
+	 * may belong to another silo, or the caller may have lost their organisation membership.
+	 * Callers must treat all three the same: drop the conversation from the UI. Retrying will
+	 * not help.
+	 */
 	ConversationUnavailable = "conversation_unavailable",
-	/** The monotonic lifecycle already prevents future writes. */
+	/**
+	 * Sent as 409. The conversation is closed, and closing is one-way — no write will ever be
+	 * accepted again. Stop retrying and disable the composer.
+	 */
 	ConversationClosed = "conversation_closed",
-	/** The immutable mode does not own the requested command. */
+	/**
+	 * Sent as 409. The command does not exist for this conversation's mode — for example asking
+	 * an agent session to accept a plain group message. Since mode is fixed at creation, this
+	 * is a client bug, not a timing problem; retrying never succeeds.
+	 */
 	CommandNotSupported = "command_not_supported",
-	/** A foreground run already owns the agent-session write lane. */
+	/**
+	 * Sent as 409. An agent run for this conversation is still going, and only one may run at a
+	 * time. This one clears by itself: wait for the run to finish (the replay stream reports it)
+	 * and send again.
+	 */
 	ActiveRun = "active_run",
-	/** A durable idempotency key was reused with different authority or content. */
+	/**
+	 * Sent as 409. This `idempotencyKey` was already used in this conversation with different
+	 * content. The stored message is NOT returned, because it may be another participant's.
+	 * Generate a fresh key for genuinely new content; reuse a key only for a byte-identical
+	 * retry, which returns {@link ConversationAuthorityOutcomes.Idempotent} instead.
+	 */
 	IdempotencyConflict = "idempotency_conflict",
-	/** One or more requested participants lack active silo membership. */
+	/**
+	 * Sent as 404, only from create. At least one user named in `participantUserIds` has no
+	 * active membership in this silo. Which one is not disclosed. Re-pick participants from a
+	 * fresh directory read.
+	 */
 	ParticipantUnavailable = "participant_unavailable",
-	/** The requested personal agent service is unavailable for admission. */
+	/**
+	 * Sent as 404. The agent service asked for cannot start a run — missing, retired, or with
+	 * no usable revision or persona. Offer the user a different agent; retrying the same one
+	 * will keep failing until an operator fixes it.
+	 */
 	AgentServiceUnavailable = "agent_service_unavailable",
-	/** The bounded admission lane is full and the caller may retry later. */
+	/**
+	 * Sent as 429. The platform is at its concurrent-admission limit. Nothing is wrong with the
+	 * request — back off and send the same body with the same `idempotencyKey` again.
+	 */
 	CapacityLimited = "capacity_limited",
-	/** The canonical persistence authority could not complete the operation. */
+	/**
+	 * Sent as 503. The database refused or a write could not be confirmed. Whether it landed is
+	 * unknown, so retry with the SAME `idempotencyKey`: if it did land the retry comes back as
+	 * {@link ConversationAuthorityOutcomes.Idempotent}.
+	 */
 	PersistenceUnavailable = "persistence_unavailable",
 }
 
-/** Stable fail-closed write denial returned without exposing foreign authority facts. */
+/**
+ * Alias used in the result unions below, so a denial is always one of
+ * {@link ConversationWriteDenialReasons} and never a free-text string. Kept as its own name
+ * because the internal callers (run admission, the mutation repository) map their own refusal
+ * reasons onto this type before it reaches the wire — see `_runAdmissionDenial` in
+ * prisma-conversation-unit-of-work.ts.
+ */
 export type ConversationWriteDenial = ConversationWriteDenialReasons;
 
-/** Stable result discriminants whose readable values are preserved on the participant API wire. */
+/**
+ * How a conversation write ended. Read this field first — it decides which other fields the
+ * result object even has. `Denied` carries a `reason`; every other member carries the written
+ * row instead.
+ *
+ * Only `Accepted` and `Idempotent` share a result type, and the difference matters:
+ * `Accepted` means this call performed the write (the router answers 201), `Idempotent` means
+ * an earlier identical call already did and this one changed nothing (200). A client that
+ * treats them alike will double-count sends; a client that treats `Idempotent` as a failure
+ * will show a duplicate-send error for a successful message.
+ *
+ * These string values go out on the wire in the `outcome` field, so they are part of the API
+ * contract.
+ *
+ * @see {@link ConversationWriteDenialReasons} for what `Denied` can say.
+ */
 export enum ConversationAuthorityOutcomes
 {
-	/** A new immutable conversation was committed. */
+	/** Returned by create only: the conversation now exists, and the result carries its detail. */
 	Created = "created",
-	/** A fail-closed authority decision prevented the operation. */
+	/** Returned by any write: nothing changed, and the result carries a denial reason instead of a row. */
 	Denied = "denied",
-	/** A new canonical message was committed. */
+	/** Returned by submitMessage: this call stored the message. The router answers 201. */
 	Accepted = "accepted",
-	/** An exact retry returned its existing canonical message. */
+	/**
+	 * Returned by submitMessage: this `idempotencyKey` and this exact body were already stored,
+	 * so nothing new was written and the existing message is returned. The router answers 200.
+	 * Not an error.
+	 */
 	Idempotent = "idempotent",
-	/** An existing conversation or participant coordinate changed. */
+	/** Returned by setArchived and close: the conversation was updated, and its fresh detail is returned. */
 	Changed = "changed",
 }
 
-/** Result from creating a conversation. */
+/**
+ * What {@link ConversationUnitOfWork.create} returns. Branch on `outcome`: `Created` gives you
+ * the new conversation including its (initially empty) history; `Denied` gives a reason and no
+ * conversation was written.
+ *
+ * @see {@link ConversationWriteDenialReasons.ParticipantUnavailable} and
+ * {@link ConversationWriteDenialReasons.AgentServiceUnavailable}, the two denials only create
+ * can produce.
+ */
 export type CreateConversationResult = { readonly outcome: ConversationAuthorityOutcomes.Created; readonly conversation: ConversationDetail } | { readonly outcome: ConversationAuthorityOutcomes.Denied; readonly reason: ConversationWriteDenial };
 
-/** Result from admitting or deduplicating a participant message. */
+/**
+ * What {@link ConversationUnitOfWork.submitMessage} returns. `Accepted` and `Idempotent` both
+ * carry the stored message, so read `outcome` to know whether this call actually wrote
+ * anything; `Denied` carries a reason and no message.
+ *
+ * For an agent-session conversation an `Accepted` result also means a run was started in the
+ * same database transaction, so the message and the run can never exist without each other.
+ */
 export type SubmitConversationMessageResult = { readonly outcome: ConversationAuthorityOutcomes.Accepted | ConversationAuthorityOutcomes.Idempotent; readonly message: ConversationMessageView } | { readonly outcome: ConversationAuthorityOutcomes.Denied; readonly reason: ConversationWriteDenial };
 
-/** Result from one participant-owned conversation mutation. */
+/**
+ * What {@link ConversationUnitOfWork.setArchived} and {@link ConversationUnitOfWork.close}
+ * return. `Changed` carries the conversation as it now stands, so a caller can render straight
+ * from it without a follow-up read; `Denied` carries a reason and nothing was changed.
+ */
 export type MutateConversationResult = { readonly outcome: ConversationAuthorityOutcomes.Changed; readonly conversation: ConversationDetail } | { readonly outcome: ConversationAuthorityOutcomes.Denied; readonly reason: ConversationWriteDenial };
 
-/** Participant-bound application authority consumed by the self-service router. */
+/**
+ * Everything the conversation HTTP layer is allowed to do, as one port.
+ *
+ * Every method takes the {@link ConversationCaller} as its first argument and re-checks that
+ * caller's membership in the database on each call, so a long-lived session cannot keep
+ * writing after the user is removed from the silo. Each method also runs in its own database
+ * transaction — reads at repeatable-read, writes at serializable — so there is no shared state
+ * between calls and no ordering requirement between them.
+ *
+ * Failures arrive two different ways, and both must be handled: an expected refusal comes back
+ * as a `Denied` result, while an unexpected database fault is THROWN. The router turns a throw
+ * into 503.
+ *
+ * Called by: `__CreateSelfConversationsRouter` (self-conversations.router.ts) as
+ * `dependencies.authority`. Implemented by `PrismaConversationUnitOfWork`
+ * (prisma-conversation-unit-of-work.ts), wired up in `_CreateSelfConversationsRouter`
+ * (prisma-self-conversations.router.ts) and mounted at `/api/v1/me/conversations` by
+ * apps/opencrane/src/app/routes.ts.
+ *
+ * @see {@link ConversationReplayUnitOfWork} for the read-only streaming side.
+ */
 export interface ConversationUnitOfWork
 {
+	/**
+	 * Lists the conversations this caller participates in, newest activity first.
+	 *
+	 * @param includeArchived - When false, conversations this caller archived are left out.
+	 *   Archiving is per-participant, so this never hides a conversation from anyone else.
+	 * @returns The caller's conversations. An empty array is a normal answer and does not mean
+	 *   the caller lost access.
+	 * @throws When the database is unreachable; the router answers 503.
+	 */
 	list(caller: ConversationCaller, includeArchived: boolean): Promise<readonly ConversationSummary[]>;
+	/**
+	 * Reads one conversation with the most recent 100 messages inside the caller's visible range.
+	 *
+	 * @returns The conversation, or null when this caller may not see it — which covers "no such
+	 *   conversation", "another silo's conversation", and "was removed from it". The three are
+	 *   deliberately not distinguished, and the router answers 404 for all of them.
+	 * @throws When the database is unreachable.
+	 */
 	open(caller: ConversationCaller, conversationId: string): Promise<ConversationDetail | null>;
+	/**
+	 * Creates one conversation and its participant rows in a single transaction, so a
+	 * conversation with missing participants can never be left behind.
+	 *
+	 * @param request - Mode plus the fields that mode needs. Mode cannot be changed afterwards.
+	 * @returns `Created` with the new conversation, or `Denied` with a reason.
+	 * @throws When the database is unreachable.
+	 */
 	create(caller: ConversationCaller, request: CreateConversationRequest): Promise<CreateConversationResult>;
+	/**
+	 * Posts one message. In an agent-session conversation this also admits the agent run in the
+	 * same transaction; in a direct or group conversation no run is created.
+	 *
+	 * @param request - Blocks plus the retry key. Resending the same key with the same blocks is
+	 *   safe and returns `Idempotent`; the same key with different blocks is refused.
+	 * @returns `Accepted` (written now), `Idempotent` (already written), or `Denied`.
+	 * @throws When the database is unreachable, or when a unique-key collision cannot be
+	 *   resolved into either a duplicate or a conflict.
+	 */
 	submitMessage(caller: ConversationCaller, conversationId: string, request: SubmitConversationMessageRequest): Promise<SubmitConversationMessageResult>;
+	/**
+	 * Hides or unhides the conversation in THIS caller's list only. It does not close the
+	 * conversation, does not stop a run, and is invisible to the other participants.
+	 *
+	 * @returns `Changed` with the updated conversation, or `Denied`.
+	 * @throws When the database is unreachable.
+	 */
 	setArchived(caller: ConversationCaller, conversationId: string, archived: boolean): Promise<MutateConversationResult>;
+	/**
+	 * Closes the conversation for everyone, permanently. There is no reopen.
+	 *
+	 * The database re-checks for a live run inside the transaction, so a run that starts while
+	 * this call is in flight still blocks the close rather than being orphaned.
+	 *
+	 * @returns `Changed`, or `Denied` with
+	 *   {@link ConversationWriteDenialReasons.ActiveRun} when a run is still going.
+	 * @throws When the database is unreachable.
+	 */
 	close(caller: ConversationCaller, conversationId: string): Promise<MutateConversationResult>;
 }

--- a/libs/backend/server/conversations/main/src/conversation-replay.router.ts
+++ b/libs/backend/server/conversations/main/src/conversation-replay.router.ts
@@ -6,7 +6,30 @@ import { __DecodeConversationProjectionCursor, __StreamConversationProjection, C
 import { _CreateExpressConversationLiveReplaySink } from "./express-conversation-live-replay-sink.js";
 import type { ConversationReplayRouterDependencies } from "./conversation-replay.router.types.js";
 
-/** Create the internal consumed-context-authorized snapshot-to-live route. */
+/**
+ * Build the internal replay route used by callers that hold a single-use context token instead
+ * of a browser session.
+ *
+ * Authorisation works differently from the browser route: the caller presents a bearer token,
+ * the route digests it and spends it via `consumeInvocationContextAtomically`, and the
+ * conversation, silo, and subject are then read out of the CONSUMED context rather than from
+ * the request. Spending is atomic and one-shot, so replaying the same token cannot open a
+ * second stream. The context must also name the `events.read` action, and a supplied cursor
+ * must belong to the context's own conversation.
+ *
+ * Every refusal answers 403 with the same body — bad token, spent token, wrong action, wrong
+ * conversation, and lost access are not distinguished, so a caller cannot use the status to
+ * probe. Note this route takes no approval-overlay reader: overlays are for the browser
+ * surface only.
+ *
+ * Called by: apps/opencrane/src/app/runtime-composition.ts, which mounts it only when an
+ * expected receiver id is configured.
+ *
+ * @param dependencies - Channel context authority, replay repository, clock, limits, optional
+ *   shutdown signal, the receiver id the token must be addressed to, and the server clock.
+ * @returns An Express router carrying the single replay route.
+ * @see {@link __CreateSelfConversationReplayRouter} for the browser-session equivalent.
+ */
 export function __CreateConversationReplayRouter(dependencies: ConversationReplayRouterDependencies): Router
 {
 	const router = Router();
@@ -41,6 +64,13 @@ export function __CreateConversationReplayRouter(dependencies: ConversationRepla
 	return router;
 }
 
+/**
+ * Read the raw cursor from either the `cursor` query parameter or the `Last-Event-ID` header.
+ *
+ * @returns The raw token; `undefined` when the client sent none; or null meaning "reject this
+ *   request", used when the parameter is not a string or when the two sources disagree.
+ *   Accepting a disagreement could silently resume from the wrong point.
+ */
 function _SuppliedCursor(request: Request): string | undefined | null
 {
 	if (request.query.cursor !== undefined && typeof request.query.cursor !== "string") return null;

--- a/libs/backend/server/conversations/main/src/conversation-replay.router.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-replay.router.types.ts
@@ -6,7 +6,11 @@ import type { ConversationReplayUnitOfWork } from "./replay-reader.types.js";
 /** Dependencies owned by the server composition root for internal conversation replay. */
 export interface ConversationReplayRouterDependencies
 {
-	/** One-use channel-context authority. */
+	/**
+	 * Spends the caller's bearer token. The spend is atomic and single-use, so the same token
+	 * cannot open two streams, and the conversation, silo, and subject are then taken from the
+	 * consumed context rather than from the request.
+	 */
 	readonly contexts: ChannelTargetAuthorityRepository;
 	/** Canonical participant-bound replay reader. */
 	readonly repository: ConversationReplayUnitOfWork;
@@ -14,7 +18,7 @@ export interface ConversationReplayRouterDependencies
 	readonly limits: ConversationProjectionLimits;
 	/** Process shutdown signal that drains the stream before telemetry flush. */
 	readonly shutdownSignal?: AbortSignal;
-	/** Route selected only by server configuration. */
+	/** The receiver id an incoming context token must be addressed to. Set from server configuration; a token for any other receiver is refused with 403. */
 	readonly expectedReceiverId: string;
 	/** Trusted server clock. */
 	readonly nowEpochMs: () => number;

--- a/libs/backend/server/conversations/main/src/express-conversation-live-replay-sink.ts
+++ b/libs/backend/server/conversations/main/src/express-conversation-live-replay-sink.ts
@@ -1,7 +1,22 @@
 import type { Response } from "express";
 import type { ConversationProjectionSink } from "@opencrane/backend/conversations/projection";
 
-/** Adapt one Express response into the awaitable bounded replay sink contract. */
+/**
+ * Wrap an Express response as a replay sink.
+ *
+ * `open` is what commits the response to being a stream: it sends 200 with the SSE content
+ * type, `cache-control: no-store` so nothing is stored, and `x-accel-buffering: no` so an
+ * nginx-style proxy forwards each frame instead of holding them until the response ends —
+ * without that last header a live stream arrives in one lump at the end.
+ *
+ * Called by: `__CreateSelfConversationReplayRouter` (self-conversation-replay.router.ts) and
+ * `__CreateConversationReplayRouter` (conversation-replay.router.ts).
+ *
+ * @param response - The response to stream into. Not touched until `open` is called.
+ * @returns The sink the streaming loop writes through.
+ * @see https://html.spec.whatwg.org/multipage/server-sent-events.html — defines the
+ * `text/event-stream` framing these headers set up.
+ */
 export function _CreateExpressConversationLiveReplaySink(response: Response): ConversationProjectionSink
 {
 	return {
@@ -15,7 +30,7 @@ export function _CreateExpressConversationLiveReplaySink(response: Response): Co
 	};
 }
 
-/** Wait until Node's writable buffer accepts more bytes or the request is no longer writable. */
+/** Resolve when the socket can take more bytes, or immediately if the request is aborted, destroyed, or already ended. Never rejects, and removes all four listeners on the way out. */
 function _AwaitDrain(response: Response, signal: AbortSignal): Promise<void>
 {
 	if (signal.aborted || response.destroyed || response.writableEnded) return Promise.resolve();

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -1,4 +1,18 @@
-/** Public app-composition and API-description surface. */
+/**
+ * Public entry point for `@opencrane/backend/server/conversations`.
+ *
+ * Only what an app composition root needs is exported: ready-to-mount routers, the
+ * Prisma-backed replay reader, the production clock and limits, the OpenAPI path fragments, and
+ * the few port types an app must implement or pass through. Everything else — the authority
+ * ports, the redaction step, the cursor codec, the Prisma adapters — stays package-private, so
+ * the streaming and redaction rules can only be changed inside this package.
+ *
+ * Imported by: apps/opencrane/src/app/routes.ts (`_CreateSelfConversationsRouter`,
+ * `_CreateSelfConversationReplayRouter`), apps/opencrane/src/app/runtime-composition.ts
+ * (`__CreateConversationReplayRouter`, `_CreateConversationReplayRepository`,
+ * `CONVERSATION_LIVE_REPLAY_CLOCK`, `CONVERSATION_LIVE_REPLAY_LIMITS`), and
+ * libs/backend/server/api-spec (the two OpenAPI fragments).
+ */
 export { _CreateConversationReplayRepository } from "./prisma-conversation-replay.composition.js";
 export { __CreateConversationReplayRouter } from "./conversation-replay.router.js";
 export { _CreateSelfConversationReplayRouter } from "./prisma-self-conversation-replay.router.js";

--- a/libs/backend/server/conversations/main/src/openapi.ts
+++ b/libs/backend/server/conversations/main/src/openapi.ts
@@ -1,6 +1,18 @@
 import { ConversationLifecycles, ConversationModes, MessageContentBlockKinds, MessageRoles, MessageSources, MessageStates } from "@opencrane/models/conversations";
 
-/** OpenAPI path fragment for owner-bound canonical conversation timeline replay. */
+/**
+ * OpenAPI description of the live replay route, owned by this package rather than by the
+ * central spec file, so the route and its documentation move together.
+ *
+ * Merged into the full document by `_DomainOpenapiPaths`
+ * (libs/backend/server/api-spec/main/src/domain-openapi-paths.ts) and served at
+ * `/api/v1/openapi.json`. The paths are relative to that `/api/v1` prefix and must match what
+ * `__CreateSelfConversationReplayRouter` actually mounts — a mismatch here ships a wrong
+ * generated client, since the same document generates the frontend SDK.
+ *
+ * @see https://html.spec.whatwg.org/multipage/server-sent-events.html — the 200 response is a
+ * `text/event-stream`, which is why `Last-Event-ID` appears as a documented request header.
+ */
 export const _SelfConversationReplayOpenapiPaths = {
 	"/me/conversations/{conversationId}/events": {
 		get: {
@@ -108,7 +120,17 @@ const _IdempotentConversationMessageEnvelopeSchema = {
 	properties: { outcome: { type: "string", enum: ["idempotent"] }, message: _ConversationMessageSchema },
 } as const;
 
-/** OpenAPI path fragment for participant-owned immutable-mode conversation operations. */
+/**
+ * OpenAPI description of the five conversation routes, kept beside the router that serves them.
+ *
+ * Merged into the full document by `_DomainOpenapiPaths`
+ * (libs/backend/server/api-spec/main/src/domain-openapi-paths.ts) and used to generate the
+ * frontend client, so the documented statuses must match `_STATUS_BY_DENIAL` in
+ * self-conversations.router.ts. In particular the message route documents 201 for a new message
+ * and 200 for an identical retry — two different bodies, distinguished by the `outcome` field.
+ *
+ * @see {@link _SelfConversationReplayOpenapiPaths} for the live stream on the same path prefix.
+ */
 export const _SelfConversationsOpenapiPaths = {
 	"/me/conversations": {
 		get: {

--- a/libs/backend/server/conversations/main/src/prisma-conversation-mutation-repository.types.ts
+++ b/libs/backend/server/conversations/main/src/prisma-conversation-mutation-repository.types.ts
@@ -13,7 +13,19 @@ export interface ConversationMutationRepository
 	persistAgentMessage(caller: ConversationCaller, conversationId: string, messageId: string, runId: string, request: SubmitConversationMessageRequest, attachments: ConversationAttachmentAdmissionPort): Promise<void>;
 }
 
-/** Creates a mutation repository over run admission's exact final transaction. */
+/**
+ * Makes a {@link ConversationMutationRepository} bound to a transaction that run admission
+ * owns.
+ *
+ * This exists so the conversation package can write the user's message inside admission's
+ * transaction without ever holding a client of its own. Admission calls the factory with its
+ * live transaction at the moment the run is being committed, which is what makes "message and
+ * run commit together" true rather than merely intended.
+ *
+ * Called by: `PrismaConversationUnitOfWork._admitAgentMessage`
+ * (prisma-conversation-unit-of-work.ts). Supplied by `_CreateSelfConversationsRouter`
+ * (prisma-self-conversations.router.ts).
+ */
 export interface ConversationMutationRepositoryFactory
 {
 	(transaction: RunAdmissionTransaction): ConversationMutationRepository;

--- a/libs/backend/server/conversations/main/src/prisma-conversation-query-repository.ts
+++ b/libs/backend/server/conversations/main/src/prisma-conversation-query-repository.ts
@@ -8,7 +8,7 @@ import type { ConversationCommandContext, ConversationQueryRepository } from "./
 /** Maximum message rows returned by one participant-bound open operation. */
 const _MESSAGE_LIMIT = 100;
 
-/** Exhaustive adapter mapping from persisted modes to the dependency-light model vocabulary. */
+/** Database mode enum to API mode enum. Typed as a complete record, so adding a mode to the schema without mapping it fails the build. */
 const _MODE_BY_PERSISTED_MODE: Readonly<Record<ConversationMode, ConversationModes>> = {
 	[ConversationMode.AgentSession]: ConversationModes.AgentSession,
 	[ConversationMode.Direct]: ConversationModes.Direct,

--- a/libs/backend/server/conversations/main/src/prisma-conversation-query-repository.types.ts
+++ b/libs/backend/server/conversations/main/src/prisma-conversation-query-repository.types.ts
@@ -2,23 +2,76 @@ import type { ConversationLifecycles, ConversationModes } from "@opencrane/model
 
 import type { ConversationCaller, ConversationDetail, ConversationMessageView, ConversationSummary } from "./conversation-authority.types.js";
 
-/** Durable facts required by the pure immutable-mode command strategy. */
+/**
+ * The four stored facts the command decision needs, and nothing else.
+ *
+ * It is deliberately this small: `__DecideConversationCommand` in
+ * `@opencrane/models/conversations` is a pure function of these values, so the same inputs
+ * always give the same decision and the rule can be tested without a database. Widening this
+ * type quietly gives that rule more to depend on.
+ */
 export interface ConversationCommandContext
 {
+	/** Agent session, direct, or group. Fixed at creation, and it decides which commands exist at all. */
 	readonly mode: ConversationModes;
+	/** Open or closed. Closed refuses every write, permanently. */
 	readonly lifecycle: ConversationLifecycles;
+	/** The agent behind an agent-session conversation; null for direct and group. */
 	readonly agentServiceId: string | null;
+	/** The run currently in progress, or null. Non-null blocks both a new run and a close. */
 	readonly activeRunId: string | null;
 }
 
-/** Participant-scoped durable conversation reads over one exact transaction snapshot. */
+/**
+ * Every read the conversation authority performs, running inside a transaction the caller
+ * already opened.
+ *
+ * Implementations must never open or commit a transaction — that belongs to
+ * `PrismaConversationUnitOfWork`, which opens a repeatable-read transaction and then calls
+ * these. Reading several of these in one transaction is how a decision is made against a
+ * consistent picture instead of a moving one.
+ *
+ * Every method filters by the caller's participant row, so there is no way to read another
+ * user's conversation through this port.
+ *
+ * Called by: `PrismaConversationUnitOfWork` (prisma-conversation-unit-of-work.ts) via its
+ * private `_read` helper. Implemented by `PrismaConversationQueryRepository`.
+ */
 export interface ConversationQueryRepository
 {
-	/** Proves the current caller still has active organisation membership in the selected silo. */
+	/**
+	 * @returns True while the caller still has an active organisation membership in their silo.
+	 *   Re-checked on every write path, so a removed user cannot keep writing on an old session.
+	 */
 	hasActiveCallerMembership(caller: ConversationCaller): Promise<boolean>;
+	/**
+	 * @param includeArchived - When false, the caller's own archived conversations are left out.
+	 * @returns The caller's conversations; empty is a normal answer.
+	 */
 	list(caller: ConversationCaller, includeArchived: boolean): Promise<readonly ConversationSummary[]>;
+	/**
+	 * @returns The conversation with the most recent 100 messages inside the caller's visible
+	 *   range, or null when this caller may not see it — missing, foreign silo, and removed are
+	 *   deliberately not distinguished.
+	 */
 	open(caller: ConversationCaller, conversationId: string): Promise<ConversationDetail | null>;
+	/**
+	 * @returns The four facts needed to decide whether a command is allowed, or null when the
+	 *   caller may not see this conversation.
+	 */
 	loadCommandContext(caller: ConversationCaller, conversationId: string): Promise<ConversationCommandContext | null>;
+	/**
+	 * Finds a previous message THIS caller sent under this retry key.
+	 *
+	 * @returns The caller's own earlier message, or null. Restricted to the caller's own
+	 *   messages on purpose: on a key collision the answer must never be another participant's
+	 *   message, which is why {@link ConversationQueryRepository.hasMessageIdempotencyKey}
+	 *   exists as a separate question.
+	 */
 	findOwnMessage(caller: ConversationCaller, conversationId: string, idempotencyKey: string): Promise<ConversationMessageView | null>;
+	/**
+	 * @returns True when the key is already used in this conversation by ANYONE. Used only to
+	 *   turn a unique-key collision into a conflict denial, never to return the other message.
+	 */
 	hasMessageIdempotencyKey(caller: ConversationCaller, conversationId: string, idempotencyKey: string): Promise<boolean>;
 }

--- a/libs/backend/server/conversations/main/src/prisma-conversation-replay-repository.ts
+++ b/libs/backend/server/conversations/main/src/prisma-conversation-replay-repository.ts
@@ -4,7 +4,20 @@ import { ConversationSystemEventTypes } from "@opencrane/models/conversations";
 
 import type { ConversationReplayRepository } from "./replay-reader.types.js";
 
-/** Prisma adapter that reads only participant-visible run events through canonical timeline order. */
+/**
+ * The SQL side of a replay page: checks access, then reads rows in timeline order.
+ *
+ * Access is proved by two rows, not by anything the caller sent — an active organisation
+ * membership in the requested silo, and a participant row on a conversation in that same silo.
+ * The participant row also carries the range the caller may read, and that range is applied as
+ * a WHERE bound rather than filtered afterwards, so rows outside it never leave the database.
+ *
+ * Takes a `Prisma.TransactionClient`, so it cannot open its own transaction; the caller owns
+ * that.
+ *
+ * Called by: `PrismaConversationReplayUnitOfWork.readAuthorized`
+ * (prisma-conversation-replay-unit-of-work.ts).
+ */
 export class PrismaConversationReplayRepository implements ConversationReplayRepository
 {
 	/** Transaction-scoped canonical product database snapshot. */
@@ -16,19 +29,23 @@ export class PrismaConversationReplayRepository implements ConversationReplayRep
 		this.prisma = prisma;
 	}
 
-	/** Read a bounded page and retain the same-snapshot authority result for live streams. */
+	/**
+	 * @returns The access decision and up to `limit` rows in ascending position order. An
+	 *   authorized result with no rows means "nothing new yet"; a revoked result means stop.
+	 * @throws Whatever the database driver throws; the caller's transaction rolls back.
+	 */
 	async readAuthorized(command: ReadConversationProjectionCommand): Promise<ConversationProjectionReadResult>
 	{
 		// 1. Reject a foreign cursor before consulting any durable authority.
 		if (command.cursor !== null && command.cursor.conversationId !== command.conversationId) return { status: ConversationProjectionReadStatuses.RevokedOrMissing, rows: [] };
 
-		// 2. Require current organisation membership and participant bounds in this repeatable snapshot.
+		// 2. Prove access twice: an active membership in this silo, and a participant row on a conversation in the same silo. Both read in this transaction, so they agree with the rows below.
 		const membership = await this.prisma.orgMembership.findFirst({ where: { clusterTenant: command.siloId, subject: command.subjectId, status: OrgMemberStatus.Active }, select: { clusterTenant: true } });
 		if (membership === null) return { status: ConversationProjectionReadStatuses.RevokedOrMissing, rows: [] };
 		const participant = await this.prisma.conversationParticipant.findUnique({ where: { conversationId_userId: { conversationId: command.conversationId, userId: command.subjectId } }, include: { conversation: { select: { siloId: true } } } });
 		if (participant === null || participant.conversation.siloId !== command.siloId) return { status: ConversationProjectionReadStatuses.RevokedOrMissing, rows: [] };
 
-		// 3. Read and project only canonical run events within the durable participant bounds.
+		// 3. Read only rows inside the caller's visible range: start after the cursor (or at the range start), and stop at accessEndedPosition when their access has ended.
 		const afterPosition = command.cursor === null ? BigInt(participant.visibleFromPosition) - 1n : BigInt(command.cursor.position);
 		if (afterPosition < BigInt(participant.visibleFromPosition) - 1n) return { status: ConversationProjectionReadStatuses.RevokedOrMissing, rows: [] };
 		const position = command.cursor?.subframe === undefined ? { gt: afterPosition } : { gte: afterPosition };

--- a/libs/backend/server/conversations/main/src/prisma-conversation-replay-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/prisma-conversation-replay-unit-of-work.ts
@@ -4,7 +4,22 @@ import type { ConversationProjectionReadResult, ReadConversationProjectionComman
 import { PrismaConversationReplayRepository } from "./prisma-conversation-replay-repository.js";
 import type { ConversationReplayUnitOfWork } from "./replay-reader.types.js";
 
-/** Prisma transaction boundary that freezes participant bounds and visible timeline rows together. */
+/**
+ * Reads a replay page inside one repeatable-read transaction, so the access check and the rows
+ * come from the same instant.
+ *
+ * Repeatable-read matters here: without it a membership could be withdrawn between the check
+ * and the row read, and the page would go out to a user who had just lost access. This class
+ * only opens and closes the transaction — the query itself lives in
+ * `PrismaConversationReplayRepository`.
+ *
+ * Called by: `_CreateConversationReplayRepository`
+ * (prisma-conversation-replay.composition.ts).
+ *
+ * @see https://www.prisma.io/docs/orm/prisma-client/queries/transactions for the isolation
+ * level argument used here. NEEDS-HUMAN: confirm this is the right page for the pinned Prisma
+ * version before keeping the link.
+ */
 export class PrismaConversationReplayUnitOfWork implements ConversationReplayUnitOfWork
 {
 	/** Root client used only to open the replay snapshot transaction. */
@@ -16,7 +31,11 @@ export class PrismaConversationReplayUnitOfWork implements ConversationReplayUni
 		this.prisma = prisma;
 	}
 
-	/** Recheck authority and rows inside one repeatable-read transaction. */
+	/**
+	 * @returns The access decision and the page of rows, consistent with each other. Called
+	 *   once per turn of the live loop, so each page is authorised afresh.
+	 * @throws When the transaction cannot be opened or committed.
+	 */
 	async readAuthorized(command: ReadConversationProjectionCommand): Promise<ConversationProjectionReadResult>
 	{
 		return this.prisma.$transaction(async function _ReadReplaySnapshot(transaction)

--- a/libs/backend/server/conversations/main/src/prisma-conversation-replay.composition.ts
+++ b/libs/backend/server/conversations/main/src/prisma-conversation-replay.composition.ts
@@ -3,7 +3,20 @@ import type { PrismaClient } from "@prisma/client";
 import { PrismaConversationReplayUnitOfWork } from "./prisma-conversation-replay-unit-of-work.js";
 import type { ConversationReplayUnitOfWork } from "./replay-reader.types.js";
 
-/** Composes the stable replay reader surface over its transaction-owning Prisma adapter. */
+/**
+ * Build the replay reader an app hands to a router.
+ *
+ * Returns the port type, not the class, so an app composition root never depends on Prisma or
+ * on the transaction and query classes behind it — the streaming code sees only
+ * {@link ConversationReplayUnitOfWork}.
+ *
+ * Called by: `_CreateSelfConversationReplayRouter`
+ * (prisma-self-conversation-replay.router.ts) and
+ * apps/opencrane/src/app/runtime-composition.ts.
+ *
+ * @param prisma - Client used to open one short transaction per page read.
+ * @returns The replay reader, ready to pass as a router's `repository`.
+ */
 export function _CreateConversationReplayRepository(prisma: PrismaClient): ConversationReplayUnitOfWork
 {
 	return new PrismaConversationReplayUnitOfWork(prisma);

--- a/libs/backend/server/conversations/main/src/prisma-conversation-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/prisma-conversation-unit-of-work.ts
@@ -36,7 +36,7 @@ export class PrismaConversationUnitOfWork implements ConversationUnitOfWork
 		return ___DoWithTrace("conversation.open", { siloId: caller.siloId, conversationId }, async () => this._read(function _Open(query) { return query.open(caller, conversationId); }));
 	}
 
-	/** Creates one immutable-mode aggregate and its initial participant membership events atomically. */
+	/** Writes the conversation and its participant rows in one transaction, so a conversation with missing participants cannot be left behind. The mode chosen here can never change. */
 	async create(caller: ConversationCaller, request: CreateConversationRequest): Promise<CreateConversationResult>
 	{
 		return ___DoWithTrace("conversation.create", { siloId: caller.siloId, mode: request.mode }, async () =>
@@ -58,7 +58,7 @@ export class PrismaConversationUnitOfWork implements ConversationUnitOfWork
 		return ___DoWithTrace("conversation.archive", { siloId: caller.siloId, conversationId, archived }, async () => this._mutate(function _Archive(repository) { return repository.setArchived(caller, conversationId, archived); }));
 	}
 
-	/** Permanently closes one caller-owned conversation after the database rechecks active-run state. */
+	/** Closes the conversation for everyone, permanently. The run check happens inside the transaction, so a run starting concurrently still blocks the close rather than being orphaned. */
 	async close(caller: ConversationCaller, conversationId: string): Promise<MutateConversationResult>
 	{
 		return ___DoWithTrace("conversation.close", { siloId: caller.siloId, conversationId }, async () => this._mutate(function _Close(repository) { return repository.close(caller, conversationId); }));

--- a/libs/backend/server/conversations/main/src/prisma-self-conversation-replay.router.ts
+++ b/libs/backend/server/conversations/main/src/prisma-self-conversation-replay.router.ts
@@ -17,10 +17,17 @@ function _resolveCaller(request: Parameters<typeof _ResolveRequestPrincipal>[0])
 }
 
 /**
- * Composes the Prisma-backed participant-bound conversation replay router.
- * @param prisma - Canonical product-authority client.
- * @param logger - Process logger supplied by the app composition root.
- * @returns The configured self-conversation replay router.
+ * Build the ready-to-mount live replay router for an app, wired to the production clock and
+ * limits.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at `/api/v1/me/conversations`, which
+ * also supplies the approval-overlay reader and the shutdown signal.
+ *
+ * @param prisma - Product database client; one short transaction is opened per page read.
+ * @param logger - Used only for unexpected stream failures; never receives event content.
+ * @param options - Optional approval-overlay reader and process shutdown signal. Leave them
+ *   out and the stream carries stored events only and is not drained on shutdown.
+ * @returns An Express router carrying the events route.
  */
 export function _CreateSelfConversationReplayRouter(prisma: PrismaClient, logger: Logger, options: SelfConversationReplayCompositionOptions = {}): Router
 {

--- a/libs/backend/server/conversations/main/src/prisma-self-conversations.router.ts
+++ b/libs/backend/server/conversations/main/src/prisma-self-conversations.router.ts
@@ -26,7 +26,21 @@ function _createMutationRepository(transaction: RunAdmissionTransaction): Prisma
 	return new PrismaConversationMutationRepository(transaction.prisma);
 }
 
-/** Composes the Prisma-backed participant conversation router. */
+/**
+ * Build the ready-to-mount conversation router for an app.
+ *
+ * Everything Prisma-shaped is assembled here — the unit of work, the query and mutation
+ * repositories, and the factory that lets run admission write the user's message inside its own
+ * transaction — so the router itself stays free of database types.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at `/api/v1/me/conversations`.
+ *
+ * @param prisma - Product database client.
+ * @param runAdmission - Starts an agent run in the same transaction as the message that
+ *   triggered it.
+ * @param logger - Used only for unexpected failures; never receives message content.
+ * @returns An Express router ready to mount.
+ */
 export function _CreateSelfConversationsRouter(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, logger: Logger): Router
 {
 	const messageAdmission = new PrismaConversationMessageAdmissionUnitOfWork(prisma, runAdmission, _createMutationRepository, createAttachmentAdmission);

--- a/libs/backend/server/conversations/main/src/self-conversation-replay.router.ts
+++ b/libs/backend/server/conversations/main/src/self-conversation-replay.router.ts
@@ -4,7 +4,33 @@ import { __DecodeConversationProjectionCursor, __StreamConversationProjection, C
 import { _CreateExpressConversationLiveReplaySink } from "./express-conversation-live-replay-sink.js";
 import type { SelfConversationReplayRouterDependencies } from "./self-conversation-replay.router.types.js";
 
-/** Create the browser-session-authenticated snapshot-to-live surface. */
+/**
+ * Build the `GET /:conversationId/events` route a signed-in user's browser subscribes to for
+ * live conversation updates.
+ *
+ * The route resolves the caller from the session, decodes the resume cursor, and refuses a
+ * cursor for a different conversation with 400 before any streaming starts. It then hands off
+ * to `__StreamConversationLiveReplay` and stays out of the way.
+ *
+ * Because a stream is long-lived, the route wires an abort signal to three things — the
+ * response closing, a response error, and process shutdown — and removes those listeners in a
+ * `finally`, so a busy server does not accumulate listeners on the shutdown signal.
+ *
+ * Error handling depends on whether the response was opened. Before that, a revoked read
+ * answers 404 and an unexpected failure answers 503 with JSON; after that, headers are already
+ * sent and all the route can do is end the response.
+ *
+ * Called by: `_CreateSelfConversationReplayRouter`
+ * (prisma-self-conversation-replay.router.ts), mounted at `/api/v1/me/conversations` by
+ * apps/opencrane/src/app/routes.ts.
+ *
+ * @param dependencies - Caller resolver, replay repository, clock, limits, optional approval
+ *   overlay reader, optional shutdown signal, and logger.
+ * @returns An Express router carrying the single events route.
+ * @see https://html.spec.whatwg.org/multipage/server-sent-events.html — the response is an SSE
+ * stream, which is why `Last-Event-ID` is accepted as an alternative to the `cursor` query
+ * parameter.
+ */
 export function __CreateSelfConversationReplayRouter(dependencies: SelfConversationReplayRouterDependencies): Router
 {
 	const router = Router();
@@ -42,7 +68,16 @@ export function __CreateSelfConversationReplayRouter(dependencies: SelfConversat
 	return router;
 }
 
-/** Decode only one unambiguous, canonical replay cursor. */
+/**
+ * Work out where to resume from, accepting the cursor either as a `cursor` query parameter or
+ * as the `Last-Event-ID` header. When both are present they must be byte-identical — two
+ * different resume points is a client bug, and guessing which one is meant could silently skip
+ * events.
+ *
+ * @returns The decoded cursor to resume from; null to start from the beginning; or `undefined`
+ *   meaning "reject this request", which the caller turns into 400. The three-way answer is
+ *   why the return type is not just `cursor | null` — do not collapse `undefined` and null.
+ */
 function _cursor(request: Request)
 {
 	if (request.query["cursor"] !== undefined && typeof request.query["cursor"] !== "string") return undefined;

--- a/libs/backend/server/conversations/main/src/self-conversation-replay.router.types.ts
+++ b/libs/backend/server/conversations/main/src/self-conversation-replay.router.types.ts
@@ -13,29 +13,36 @@ export interface SelfConversationReplayCaller
 	readonly subjectId: string;
 }
 
-/** Optional process-owned seams supplied by the app composition root. */
+/**
+ * The two things only the running process can supply, both optional so tests and simple setups
+ * can leave them out.
+ *
+ * Called by: `_CreateSelfConversationReplayRouter`
+ * (prisma-self-conversation-replay.router.ts); both values are passed in from
+ * apps/opencrane/src/app/routes.ts.
+ */
 export interface SelfConversationReplayCompositionOptions
 {
-	/** Current open-approval overlay, kept outside canonical cursor authority. */
+	/** Reader for approvals currently awaiting the user. Its events carry no cursor, so they never move the client's resume point. Omit it and the stream carries stored events only. */
 	readonly interrupts?: ConversationOpenInterruptReader;
-	/** Process shutdown signal that drains long-lived streams before telemetry flush. */
+	/** Aborts on shutdown so open streams close before the process exits, rather than being cut off mid-frame with traces and logs still unflushed. */
 	readonly shutdownSignal?: AbortSignal;
 }
 
 /** App-composed ports for self-only canonical conversation replay. */
 export interface SelfConversationReplayRouterDependencies
 {
-	/** Resolves authenticated session and host identity without trusting request coordinates. */
+	/** Works out who is calling from the session cookie and the request host. Returns null when there is no session, which the route answers with 401. Nothing here comes from the path, query, or body. */
 	resolveCaller(request: Request): SelfConversationReplayCaller | null;
 	/** Reads canonical events only after the router derives owner coordinates. */
 	repository: ConversationReplayUnitOfWork;
-	/** Current open-approval overlay, kept outside canonical cursor authority. */
+	/** Reader for approvals currently awaiting the user. Its events carry no cursor, so they never move the client's resume point. Omit it and the stream carries stored events only. */
 	interrupts?: ConversationOpenInterruptReader;
 	/** Bounded live-tail clock. */
 	clock: ConversationProjectionClock;
 	/** Bounded page, heartbeat, polling, and response-duration limits. */
 	limits: ConversationProjectionLimits;
-	/** Process shutdown signal that drains long-lived streams before telemetry flush. */
+	/** Aborts on shutdown so open streams close before the process exits, rather than being cut off mid-frame with traces and logs still unflushed. */
 	shutdownSignal?: AbortSignal;
 	/** Records unexpected persistence failures without event content. */
 	logger: Logger;

--- a/libs/backend/server/conversations/main/src/self-conversations.router.ts
+++ b/libs/backend/server/conversations/main/src/self-conversations.router.ts
@@ -7,13 +7,31 @@ import { ___ConversationCreationRequestSchema, ___ParticipantInputBlocksSchema }
 import { ConversationAuthorityOutcomes, ConversationWriteDenialReasons, type ConversationWriteDenial } from "./conversation-authority.types.js";
 import type { SelfConversationsRouterDependencies } from "./self-conversations.router.types.js";
 
-/** Bounded idempotent participant message body. */
+/** Message body shape: a retry key of 1–128 characters plus the participant block list. Unknown fields are rejected, not ignored. */
 const _MessageSchema = z.object({ idempotencyKey: z.string().trim().min(1).max(128), blocks: ___ParticipantInputBlocksSchema }).strict();
 
 /** Participant-local archive mutation body. */
 const _ArchiveSchema = z.object({ archived: z.boolean() }).strict();
 
-/** Creates the browser-session-authenticated conversation router. */
+/**
+ * Build the HTTP routes a signed-in user uses for their own conversations: list, create, open,
+ * post a message, archive, close.
+ *
+ * The router owns three jobs and nothing else. It derives the caller from the session (never
+ * from the path or body, so there is no route for reading someone else's conversations), checks
+ * the request shape, and translates the result: a `Denied` outcome becomes the HTTP status from
+ * `_STATUS_BY_DENIAL` with the denial value as the `error` field, while an unexpected throw
+ * becomes 503 with a generic code. Authorisation itself happens in the database layer behind
+ * `dependencies.authority`.
+ *
+ * Called by: `_CreateSelfConversationsRouter` (prisma-self-conversations.router.ts), which is
+ * mounted at `/api/v1/me/conversations` by apps/opencrane/src/app/routes.ts.
+ *
+ * @param dependencies - Caller resolver, the conversation authority port, and the logger.
+ * @returns An Express router with the six participant routes mounted on it.
+ * @see _SelfConversationsOpenapiPaths in openapi.ts — the documented contract these routes
+ * must match.
+ */
 export function __CreateSelfConversationsRouter(dependencies: SelfConversationsRouterDependencies): Router
 {
 	const router = Router();
@@ -138,13 +156,24 @@ function _parameter(value: string | readonly string[] | undefined): string | nul
 	return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
 
-/** Maps stable authority denials to non-disclosing HTTP classes. */
+/** Look up the HTTP status for a denial reason. Total by construction, so an unmapped reason cannot fall through to a 200. */
 function _denialStatus(reason: ConversationWriteDenial): number
 {
 	return _STATUS_BY_DENIAL[reason];
 }
 
-/** Exhaustive HTTP mapping that keeps capacity refusal distinct from persistence failure. */
+/**
+ * One HTTP status per denial reason. Typed as a complete record, so adding a member to
+ * {@link ConversationWriteDenialReasons} without a status here fails the build rather than
+ * shipping a wrong status.
+ *
+ * Two groupings are deliberate. `ConversationUnavailable`, `ParticipantUnavailable`, and
+ * `AgentServiceUnavailable` all answer 404 so a client cannot probe for conversations, users,
+ * or agents it may not see. And 429 for `CapacityLimited` is kept apart from 503 for
+ * `PersistenceUnavailable`: the first means "we are busy, send the same request again", the
+ * second means "we could not confirm the write" — collapsing them would have clients retrying
+ * a possibly-applied write as though it were a queue delay.
+ */
 const _STATUS_BY_DENIAL: Readonly<Record<ConversationWriteDenialReasons, number>> = {
 	[ConversationWriteDenialReasons.ConversationUnavailable]: 404,
 	[ConversationWriteDenialReasons.ConversationClosed]: 409,
@@ -157,13 +186,13 @@ const _STATUS_BY_DENIAL: Readonly<Record<ConversationWriteDenialReasons, number>
 	[ConversationWriteDenialReasons.PersistenceUnavailable]: 503,
 };
 
-/** Emits only bounded operation and silo metadata; body content and identity remain excluded. */
+/** Log an unexpected failure with the operation name and silo only. Message content and the user's identity are deliberately left out. */
 function _log(logger: Logger, err: unknown, operation: string, siloId: string): void
 {
 	logger.error({ err, operation, siloId }, "Conversation operation failed");
 }
 
-/** Records handled persistence degradation without logging message content or participant identity. */
+/** Log a warning only for a database-unavailable denial. Every other denial is a normal client outcome and is not logged. */
 function _logUnavailable(logger: Logger, reason: ConversationWriteDenial, operation: string, siloId: string): void
 {
 	if (reason === ConversationWriteDenialReasons.PersistenceUnavailable) logger.warn({ operation, reason, siloId }, "Conversation operation unavailable");

--- a/libs/backend/server/conversations/main/src/self-conversations.router.types.ts
+++ b/libs/backend/server/conversations/main/src/self-conversations.router.types.ts
@@ -3,10 +3,16 @@ import type { Logger } from "pino";
 
 import type { ConversationCaller, ConversationUnitOfWork } from "./conversation-authority.types.js";
 
-/** Dependencies for the authenticated participant-owned conversation API. */
+/**
+ * What `__CreateSelfConversationsRouter` needs. Built by
+ * `_CreateSelfConversationsRouter` (prisma-self-conversations.router.ts).
+ */
 export interface SelfConversationsRouterDependencies
 {
+	/** Works out who is calling from the session and the request host. Null means no session, which the routes answer with 401. */
 	readonly resolveCaller: (request: Request) => ConversationCaller | null;
+	/** Does the actual work and owns authorisation; the router only translates its results into HTTP. */
 	readonly authority: ConversationUnitOfWork;
+	/** Used only for unexpected failures and database-unavailable denials. Never receives message content or user identity. */
 	readonly logger: Logger;
 }

--- a/libs/backend/server/gateways/integrations/main/src/integration-custody-provisioning.ts
+++ b/libs/backend/server/gateways/integrations/main/src/integration-custody-provisioning.ts
@@ -2,7 +2,38 @@ import type { ObotCustodyPort } from "@opencrane/backend/server/infra/obot-custo
 
 import type { IntegrationCustodyLogger, IntegrationCustodyRepository, ProvisionIntegrationCustodyCommand, ProvisionIntegrationCustodyResult } from "./integration-custody-provisioning.types.js";
 
-/** Provisions remote Obot custody and compensates if its product projection cannot persist. */
+/**
+ * Hand a credential to Obot for safekeeping, then record the handle Obot returns — and undo the
+ * remote side if the local record cannot be written.
+ *
+ * The order is deliberate. Obot goes first, because only Obot can mint the reference; this process
+ * never invents one. Obot's answer is then checked (right catalogue entry, non-blank reference,
+ * expiry in the future) and rejected if it is not usable. Only after that is anything written
+ * locally. If that local write fails, the remote custody just created is revoked, so a failed
+ * provisioning never leaves Obot holding usable custody that no row in this database tracks.
+ *
+ * The revoke can itself fail. That case returns `compensation_failed` rather than pretending
+ * nothing happened, because at that point untracked custody really does exist and an operator has
+ * to clean it up.
+ *
+ * The credential is never written to Postgres, never logged, and never returned. Failure logs
+ * carry only the silo, integration, catalogue entry, and the error's class name.
+ *
+ * Called by: `_CreateIntegrationCustodyRouter`'s `POST /:integrationId/custody` handler in
+ * ./integration-custody.router.ts, which apps/opencrane/src/app/routes.ts mounts at
+ * `/api/v1/integrations`.
+ *
+ * @param custody - Obot custody port; the fail-closed adapter when Obot is switched off.
+ * @param repository - Local write port, called only after Obot confirms.
+ * @param log - Logger for secret-safe failure records.
+ * @param command - Silo, integration, catalogue entry, and the write-only credential entries.
+ * @returns `provisioned` with the new custody row id, or `unavailable` with the reason — see
+ *          `ProvisionIntegrationCustodyResult`, where `compensation_failed` is the only outcome
+ *          that needs an operator.
+ * @see Obot MCP gateway, pinned to `v0.23.1` by `obot.image.tag` in
+ *      apps/_infra/deploy-k8s/values.yaml — NEEDS-HUMAN: add the URI for that release's custody
+ *      API once someone confirms the right page.
+ */
 export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, repository: IntegrationCustodyRepository, log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand): Promise<ProvisionIntegrationCustodyResult>
 {
 	// 1. Obtain the opaque custody reference from Obot; this process never invents one.
@@ -30,7 +61,8 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 		return { outcome: "unavailable", reason: "remote_unavailable" };
 	}
 
-	// 2. Persist only Obot-confirmed coordinates, preserving Postgres as a lifecycle projection.
+	// 2. Store only the values Obot confirmed — its reference, catalogue entry, and expiry. Postgres
+	//    tracks the lifecycle; Obot remains the place the secret actually lives.
 	try
 	{
 		const persisted = await repository.persistReady({ siloId: command.siloId, integrationId: command.integrationId, obotCatalogEntryId: provisioned.obotCatalogEntryId, obotCustodyReference: provisioned.obotCustodyReference, expiresAt: provisioned.expiresAt });
@@ -38,7 +70,7 @@ export async function __ProvisionIntegrationCustody(custody: ObotCustodyPort, re
 	}
 	catch (err)
 	{
-		// 3. Revoke the remote result so a persistence failure never leaves usable untracked custody.
+		// 3. Revoke the custody Obot just created, so a failed local write never leaves Obot holding a credential no row here tracks.
 		_Warn(log, command, err, "Integration custody persistence failed; starting compensation");
 		try
 		{
@@ -69,7 +101,7 @@ function _FailureLogFields(command: ProvisionIntegrationCustodyCommand, err: unk
 	};
 }
 
-/** Emits a warning without allowing observability failures to change the fail-closed custody result. */
+/** Log a warning, swallowing any logging error — a broken logger must not change which custody outcome is returned. */
 function _Warn(log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand, err: unknown, message: string): void
 {
 	try
@@ -79,7 +111,7 @@ function _Warn(log: IntegrationCustodyLogger, command: ProvisionIntegrationCusto
 	catch { /* Logging is diagnostic only; custody failure handling must remain fail closed. */ }
 }
 
-/** Emits an error without allowing observability failures to change the fail-closed custody result. */
+/** Log an error, swallowing any logging error — a broken logger must not change which custody outcome is returned. */
 function _Error(log: IntegrationCustodyLogger, command: ProvisionIntegrationCustodyCommand, err: unknown, message: string): void
 {
 	try

--- a/libs/backend/server/gateways/integrations/main/src/integration-custody-provisioning.types.ts
+++ b/libs/backend/server/gateways/integrations/main/src/integration-custody-provisioning.types.ts
@@ -1,10 +1,19 @@
 import type { ObotCustodyCredential } from "@opencrane/backend/server/infra/obot-custody";
 import type { Logger } from "@opencrane/backend/observability";
 
-/** Structured logger methods used by the custody provisioning operation. */
+/** Just the `warn` and `error` methods of the platform logger — the only two the custody provisioning path needs, so a test can pass two functions instead of a whole logger. */
 export type IntegrationCustodyLogger = Pick<Logger, "warn" | "error">;
 
-/** Request to provision remote custody for an integration. */
+/**
+ * Everything needed to hand a user's credential to Obot for safekeeping and record the handle
+ * Obot gives back.
+ *
+ * `credential` is the only place raw secret values appear in this package, and they travel
+ * one way: straight to Obot. They are never written to Postgres, never logged, and never echoed
+ * in a response. Everything stored afterwards is the opaque reference Obot returns.
+ *
+ * @see {@link ProvisionIntegrationCustodyResult} for the outcomes and the rollback rule.
+ */
 export interface ProvisionIntegrationCustodyCommand
 {
 	/** Silo owning the integration. */
@@ -13,16 +22,51 @@ export interface ProvisionIntegrationCustodyCommand
 	readonly integrationId: string;
 	/** Obot catalogue entry. */
 	readonly obotCatalogEntryId: string;
-	/** Write-only credential material. */
+	/**
+	 * The raw credential entries, passed straight to Obot. Write-only: never stored in Postgres,
+	 * never written to a log line, never returned in a response.
+	 */
 	readonly credential: readonly ObotCustodyCredential[];
 }
 
-/** Product persistence boundary for remote custody confirmation. */
+/**
+ * The one write this package makes after Obot has accepted a credential: record the handle Obot
+ * returned.
+ *
+ * It is an interface so the provisioning function can be tested without a database, and so the
+ * ordering rule is visible — nothing is written here until Obot has confirmed, which is why the
+ * method is named `persistReady` rather than `create`.
+ *
+ * Called by: `__ProvisionIntegrationCustody` in ./integration-custody-provisioning.ts.
+ * Implemented by `PrismaIntegrationCustodyRepository` in
+ * ./prisma-integration-custody-repository.ts, which `_CreateIntegrationCustodyRouter` constructs.
+ */
 export interface IntegrationCustodyRepository
 {
-	/** Stores an Obot-issued reference after remote provisioning succeeds. */
+	/**
+	 * Record the opaque reference Obot issued, as a Ready custody row for this integration.
+	 *
+	 * @param command - The silo, integration, catalogue entry, the Obot-issued reference, and the
+	 *                  expiry Obot reported. No credential value is included.
+	 * @returns The id of the custody row that was created.
+	 * @throws Error when the integration is no longer an active row in that silo naming that
+	 *         catalogue entry — which makes the caller revoke the remote custody it just created.
+	 */
+	persistReady(command: { readonly siloId: string; readonly integrationId: string; readonly obotCatalogEntryId: string; readonly obotCustodyReference: string; readonly expiresAt: Date }): Promise<{ readonly custodyReferenceId: string }>;
 	persistReady(command: { readonly siloId: string; readonly integrationId: string; readonly obotCatalogEntryId: string; readonly obotCustodyReference: string; readonly expiresAt: Date }): Promise<{ readonly custodyReferenceId: string }>;
 }
 
-/** Fail-closed custody provisioning outcome. */
+/**
+ * Either custody was provisioned, or it was not — and the reason says what state Obot is in.
+ *
+ * - `provisioned` — Obot holds the credential and a Ready custody row records the handle.
+ * - `remote_unavailable` — Obot refused, was unreachable, or returned something unusable. Nothing
+ *   was stored, and anything Obot did create has been revoked. Safe to retry.
+ * - `persistence_failed` — Obot accepted the credential but the local row could not be written, so
+ *   the remote custody was revoked again. Nothing is left behind. Safe to retry.
+ * - `compensation_failed` — the WORST case: the revoke itself failed, so Obot may still be holding
+ *   usable custody that no local row tracks. This needs an operator; retrying will not clean it up.
+ *
+ * No branch carries credential material.
+ */
 export type ProvisionIntegrationCustodyResult = { readonly outcome: "provisioned"; readonly custodyReferenceId: string } | { readonly outcome: "unavailable"; readonly reason: "remote_unavailable" | "persistence_failed" | "compensation_failed" };

--- a/libs/backend/server/gateways/integrations/main/src/integration-custody.router.ts
+++ b/libs/backend/server/gateways/integrations/main/src/integration-custody.router.ts
@@ -58,9 +58,10 @@ function _respond(response: Response, status: number, error: string): void
  * Obot. The response carries the provisioning outcome only; the credential is never echoed, logged,
  * or persisted by this process.
  *
- * @param prisma - Canonical product-authority database client.
- * @param custody - Composed Obot custody port (the fail-closed adapter when Obot is off).
- * @param logger - Structured process logger used for secret-safe failure evidence.
+ * @param prisma - Prisma client for the product database.
+ * @param custody - Obot custody port; when Obot is switched off this is the adapter that always
+ *                  fails, so the route reports unavailable rather than silently doing nothing.
+ * @param logger - Logger for failure records that carry ids and an error class name, never a secret.
  * @returns The configured Express router, mounted under `/api/v1/integrations`.
  */
 export function _CreateIntegrationCustodyRouter(prisma: PrismaClient, custody: ObotCustodyPort, logger: IntegrationCustodyLogger): Router
@@ -74,7 +75,7 @@ export function _CreateIntegrationCustodyRouter(prisma: PrismaClient, custody: O
 		const principal = _ResolveRequestPrincipal(request);
 		if (principal === null) { _respond(response, 401, "authentication_required"); return; }
 
-		// 2. Validate the untrusted coordinates and write-only credential shape before any lookup.
+		// 2. Check the integration id and the credential entries are well formed before any database or Obot call.
 		const integrationId = request.params["integrationId"];
 		const body = _parseBody(request.body);
 		if (!_isBoundedIdentifier(integrationId) || body === null) { _respond(response, 400, "invalid_custody_request"); return; }

--- a/libs/backend/server/gateways/integrations/main/src/integration-resolution.types.ts
+++ b/libs/backend/server/gateways/integrations/main/src/integration-resolution.types.ts
@@ -1,6 +1,15 @@
 import type { ReviewedIntegrationToolDefinition } from "@opencrane/models/agents";
 
-/** Request to resolve one immutable integration assignment for runtime preparation. */
+/**
+ * Asks the server which integration an agent revision may use, just before a run starts.
+ *
+ * All three ids are supplied by the caller, but the silo id is NOT taken from request input — the
+ * executor passes the silo it is already running for. The repository then requires the stored
+ * assignment to name that same silo, so one customer's revision can never resolve another
+ * customer's integration even if the integration id is guessed.
+ *
+ * @see {@link ResolveIntegrationAssignmentResult} for what comes back.
+ */
 export interface ResolveIntegrationAssignmentCommand
 {
 	/** Silo that owns the AgentRevision and integration. */
@@ -11,7 +20,15 @@ export interface ResolveIntegrationAssignmentCommand
 	readonly integrationId: string;
 }
 
-/** Credential-free result returned only for an active assigned integration. */
+/**
+ * The usable integration, returned only when it is active and its custody has not expired.
+ *
+ * No credential value is ever included. `obotCustodyReference` is an opaque handle the Obot
+ * gateway issued; the executor passes it back to Obot, which looks up the real secret on its own
+ * side. Reading this object gives an attacker nothing to authenticate with.
+ *
+ * @see {@link ResolveIntegrationAssignmentResult} for the failure side of the union.
+ */
 export interface ResolvedIntegrationAssignment
 {
 	/** Silo-scoped integration identity. */
@@ -20,25 +37,70 @@ export interface ResolvedIntegrationAssignment
 	readonly obotCatalogEntryId: string;
 	/** Opaque Obot-issued custody handle; it is not credential material. */
 	readonly obotCustodyReference: string;
-	/** Exact reviewed revision-scoped tool definitions. */
+	/** The tool definitions that were reviewed and stored on this revision; a deep copy, so the caller cannot mutate the stored row. */
 	readonly toolDefinitions: readonly ReviewedIntegrationToolDefinition[];
 }
 
-/** Credential-free integration assignment resolution outcome. */
+/**
+ * Either the integration is usable, or it is not — and the reason tells the caller what to do.
+ *
+ * - `not_found` — no such assignment, or it belongs to a different silo. Treat as a permanent
+ *   failure; retrying will not help.
+ * - `inactive` — the integration row is not Active, custody is not Ready, or the stored tool
+ *   definitions failed validation. Needs an operator to fix the integration.
+ * - `revoked` — custody was revoked. The user must reconnect the integration.
+ * - `expired` — custody's `expiresAt` has passed. Custody must be provisioned again; see
+ *   `__ProvisionIntegrationCustody` in ./integration-custody-provisioning.ts.
+ *
+ * Neither branch carries credential material.
+ */
 export type ResolveIntegrationAssignmentResult =
 	| { readonly outcome: "resolved"; readonly assignment: ResolvedIntegrationAssignment }
 	| { readonly outcome: "unavailable"; readonly reason: "not_found" | "inactive" | "revoked" | "expired" };
 
-/** Read-only authority boundary for runtime integration preparation. */
+/**
+ * The read side of integration resolution: the one way the agent runtime asks whether it may use
+ * an integration, and gets back the opaque handle to do so.
+ *
+ * Read-only on purpose — nothing behind this interface writes, so a compromised runtime cannot
+ * change an assignment, only ask about one. It is an interface so the executor can be tested
+ * against a fake.
+ *
+ * Called by: `integration-external-action-executor.ts` in
+ * libs/backend/agents/execution/protocol/src, through the `integrations` field of
+ * `ExternalActionExecutorDependencies`. Implemented by
+ * `PrismaIntegrationAuthorityRepository` (./prisma-integration-authority.ts), which
+ * apps/opencrane/src/app/external-action-composition.ts constructs.
+ */
 export interface IntegrationAuthorityRepository
 {
-	/** Resolves only an active same-silo revision assignment and its usable opaque custody reference. */
+	/**
+	 * Look up the integration a revision selected, and return it only if it is usable right now.
+	 *
+	 * @param command - The silo, revision, and integration to resolve. The silo must match the one
+	 *                  stored on the assignment.
+	 * @returns `{ outcome: "resolved" }` with the opaque custody handle and reviewed tool
+	 *          definitions, or `{ outcome: "unavailable" }` with the reason — see
+	 *          {@link ResolveIntegrationAssignmentResult} for what each reason means for the caller.
+	 */
+	resolveAssignment(command: ResolveIntegrationAssignmentCommand): Promise<ResolveIntegrationAssignmentResult>;
 	resolveAssignment(command: ResolveIntegrationAssignmentCommand): Promise<ResolveIntegrationAssignmentResult>;
 }
 
-/** Clock owned by the server authority rather than its runtime caller. */
+/**
+ * Supplies "now" for the custody expiry check.
+ *
+ * It is injected rather than read from the system clock inside the repository for two reasons: the
+ * expiry test becomes testable without waiting, and — the point that matters in production — the
+ * time comes from the server, never from the caller. A runtime that could pass its own timestamp
+ * could keep using custody that has already expired.
+ *
+ * Called by: `PrismaIntegrationAuthorityRepository.resolveAssignment`
+ * (./prisma-integration-authority.ts). Implemented by `__SystemIntegrationAuthorityClock` in the
+ * same file, which apps/opencrane/src/app/external-action-composition.ts constructs.
+ */
 export interface IntegrationAuthorityClock
 {
-	/** Returns the current trusted instant for custody expiry evaluation. */
+	/** @returns The current server time, compared against a custody reference's `expiresAt`. */
 	now(): Date;
 }

--- a/libs/backend/server/gateways/integrations/main/src/prisma-integration-authority.ts
+++ b/libs/backend/server/gateways/integrations/main/src/prisma-integration-authority.ts
@@ -5,7 +5,13 @@ import { ___CloneCanonicalJson, type JsonValue } from "@opencrane/util";
 
 import type { IntegrationAuthorityClock, IntegrationAuthorityRepository, ResolveIntegrationAssignmentCommand, ResolveIntegrationAssignmentResult } from "./integration-resolution.types.js";
 
-/** Production clock for integration-custody expiry checks. */
+/**
+ * The real system clock, used in production for custody expiry checks.
+ *
+ * Called by: constructed in apps/opencrane/src/app/external-action-composition.ts and handed to
+ * {@link PrismaIntegrationAuthorityRepository}. Tests substitute their own
+ * `IntegrationAuthorityClock` instead.
+ */
 export class __SystemIntegrationAuthorityClock implements IntegrationAuthorityClock
 {
 	/** Returns the current system instant used by the server authority. */
@@ -15,12 +21,27 @@ export class __SystemIntegrationAuthorityClock implements IntegrationAuthorityCl
 	}
 }
 
-/** Prisma-backed, credential-free read authority for immutable integration assignments. */
+/**
+ * Answers "may this revision use this integration right now?" out of Postgres, without ever
+ * returning credential material.
+ *
+ * The checks run in a fixed order and all of them must pass: the assignment exists, it belongs to
+ * the caller's silo, the integration row is Active, custody is not revoked, custody has not
+ * expired against the injected clock, custody state is Ready, and the stored tool definitions
+ * still validate. Any single failure returns `{ outcome: "unavailable" }` — the class never
+ * partially succeeds.
+ *
+ * Called by: constructed in apps/opencrane/src/app/external-action-composition.ts and passed as
+ * the `integrations` dependency to the external-action executor
+ * (libs/backend/agents/execution/protocol/src/integration-external-action-executor.ts).
+ *
+ * @see {@link ResolveIntegrationAssignmentResult} for how a caller should react to each reason.
+ */
 export class PrismaIntegrationAuthorityRepository implements IntegrationAuthorityRepository
 {
 	/** Canonical OpenCrane product database. */
 	private readonly prisma: PrismaClient;
-	/** Authority-owned clock that prevents callers from backdating custody expiry checks. */
+	/** Clock supplied by the server, not the caller, so nobody can pass a stale "now" and keep using expired custody. */
 	private readonly clock: IntegrationAuthorityClock;
 
 	/** Creates the integration authority adapter over the product Postgres database. */
@@ -30,7 +51,22 @@ export class PrismaIntegrationAuthorityRepository implements IntegrationAuthorit
 		this.clock = clock;
 	}
 
-	/** Resolves one currently usable integration assignment without exposing any credential material. */
+	/**
+	 * Look up one integration assignment and return it only if every usability check passes.
+	 *
+	 * The silo check comes first and deliberately reports `not_found` rather than a distinct
+	 * "wrong silo" reason, so a caller cannot probe for the existence of another customer's
+	 * integrations. Tool definitions are returned as a deep copy, so a caller cannot mutate what is
+	 * stored.
+	 *
+	 * @param command - Silo, revision, and integration to resolve.
+	 * @returns `resolved` with the opaque custody handle and reviewed tool definitions, or
+	 *          `unavailable` with `not_found` / `inactive` / `revoked` / `expired`.
+	 * @throws Whatever the Prisma client throws when the database is unreachable; a usability
+	 *         failure is a return value, not an exception.
+	 * @see https://www.rfc-editor.org/rfc/rfc8785 — `___CloneCanonicalJson` copies the stored tool
+	 *      definitions through RFC 8785 canonical JSON.
+	 */
 	async resolveAssignment(command: ResolveIntegrationAssignmentCommand): Promise<ResolveIntegrationAssignmentResult>
 	{
 		// 1. Read the immutable composite assignment so a foreign silo cannot select its own custody reference.
@@ -48,7 +84,9 @@ export class PrismaIntegrationAuthorityRepository implements IntegrationAuthorit
 		const toolDefinitions = assignment.toolDefinitions as unknown as readonly ReviewedIntegrationToolDefinition[];
 		if (!Array.isArray(toolDefinitions) || !__AreReviewedIntegrationToolDefinitionsValid(toolDefinitions)) return { outcome: "unavailable", reason: "inactive" };
 
-		// 3. Return only the opaque custody reference and reviewed definitions for the Obot PEP.
+		// 3. Return only the opaque custody reference and the reviewed definitions. Obot is the policy
+		//    enforcement point (PEP): it holds the real secret and decides whether the call is allowed,
+		//    so this side never needs the credential itself.
 		return { outcome: "resolved", assignment: { integrationId: assignment.integrationId, obotCatalogEntryId: assignment.integration.obotCatalogEntryId, obotCustodyReference: assignment.custodyReference.obotCustodyReference, toolDefinitions: ___CloneCanonicalJson(assignment.toolDefinitions as unknown as JsonValue) as unknown as readonly ReviewedIntegrationToolDefinition[] } };
 	}
 }

--- a/libs/backend/server/gateways/integrations/main/src/prisma-integration-custody-repository.ts
+++ b/libs/backend/server/gateways/integrations/main/src/prisma-integration-custody-repository.ts
@@ -2,7 +2,18 @@ import { IntegrationCustodyState, IntegrationState, Prisma, type PrismaClient } 
 
 import type { IntegrationCustodyRepository } from "./integration-custody-provisioning.types.js";
 
-/** Prisma persistence adapter that accepts custody only for an active exact-silo Integration. */
+/**
+ * Records an Obot-issued custody handle in Postgres, but only after re-checking that the
+ * integration is still an active row in the same silo.
+ *
+ * The re-check matters because time passed while the request was out at Obot: the integration
+ * could have been retired or moved in the meantime. Locking the integration row and checking again
+ * inside the transaction is what makes that race safe — and when the check fails the write throws,
+ * which is how `__ProvisionIntegrationCustody` knows to revoke the remote custody.
+ *
+ * Called by: constructed in `_CreateIntegrationCustodyRouter` (./integration-custody.router.ts)
+ * and passed to `__ProvisionIntegrationCustody`.
+ */
 export class PrismaIntegrationCustodyRepository implements IntegrationCustodyRepository
 {
 	/** Canonical product database authority. */
@@ -14,7 +25,16 @@ export class PrismaIntegrationCustodyRepository implements IntegrationCustodyRep
 		this.prisma = prisma;
 	}
 
-	/** Rechecks active same-silo integration authority before recording a remotely issued reference. */
+	/**
+	 * Lock the integration row, confirm it is still active in this silo and still names this
+	 * catalogue entry, then insert the Ready custody row.
+	 *
+	 * @param command - Silo, integration, catalogue entry, Obot's reference, and its expiry.
+	 * @returns The id of the custody row created.
+	 * @throws Error "integration authority changed" when the integration was deleted, moved to
+	 *         another silo, deactivated, or re-pointed at a different catalogue entry while the
+	 *         Obot call was in flight. The caller responds by revoking the remote custody.
+	 */
 	async persistReady(command: Parameters<IntegrationCustodyRepository["persistReady"]>[0]): Promise<{ readonly custodyReferenceId: string }>
 	{
 		return this.prisma.$transaction(async function _persist(transaction: Prisma.TransactionClient)

--- a/libs/backend/server/gateways/mcp/main/src/core/mcp-operator.logic.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/mcp-operator.logic.types.ts
@@ -1,16 +1,21 @@
 /**
- * Identity + entitlement context of the caller of a user-facing endpoint.
+ * Who is calling one of the user-facing MCP endpoints, and what they are allowed to see.
  *
- * `devOpen` mirrors the platform's fail-open dev posture: when no session is
- * established and no real auth is configured, the caller sees the full published
- * catalogue so a fresh local install / the OPEN dev backend isn't locked out.
+ * Built by `_ResolveCaller` in ../routes/mcp-operator.ts, then read by `listEntitledCatalog` and
+ * `_IsEntitled` in ./mcp-operator.logic.ts to decide which catalogue servers come back.
+ *
+ * `_ResolveCaller` sets `devOpen: false` on BOTH of its branches today — for an established
+ * session and for an unauthenticated request alike — so entitlement filtering always runs and an
+ * unauthenticated caller sees nothing. The field is still read: `_IsEntitled` returns true for
+ * every published server when it is set, so anything that ever starts producing `devOpen: true`
+ * opens the entire published catalogue to that caller.
  */
 export interface McpOperatorCaller
 {
-  /** Stable caller identifier (`authUser.sub ?? authUser.email`, or a dev fallback). */
+  /** Stable caller id: the session's `sub`, else its `email`, else the literal `"unknown"`. */
   userId: string;
   /** IdP-verified group claims used for group-based entitlement. */
   groups: string[];
-  /** True only when unauthenticated under dev-auth-mode — bypasses entitlement filtering. */
+  /** When true, entitlement filtering is skipped and every published server is visible. Nothing in this repo sets it to true today. */
   devOpen: boolean;
 }

--- a/libs/backend/server/gateways/mcp/main/src/core/mcp-server-mutation-repository.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/mcp-server-mutation-repository.types.ts
@@ -1,11 +1,32 @@
-/** One credential metadata row to persist beneath an MCP server. */
+/**
+ * One credential label to store as a child row of an MCP server.
+ *
+ * Only the label travels through this type. The real secret is held by the Obot gateway, which
+ * hands back an opaque reference; there is no field here that could carry a key, so a caller
+ * cannot get a secret into the database through the MCP write path even by accident.
+ *
+ * @see {@link CreateMcpServerWrite.credentials} and {@link UpdateMcpServerWrite.credentials}
+ *      for how these rows get attached to a server.
+ */
 export interface McpServerCredentialWrite
 {
-	/** Human-readable label returned to the user; secret material never enters this boundary. */
+	/** Label shown to the operator. No secret value is ever accepted on this type. */
 	readonly displayName: string;
 }
 
-/** Canonical persisted values for a new MCP server. */
+/**
+ * Everything needed to store a brand-new MCP server row plus its credential labels.
+ *
+ * The scope, transport and status strings here are already the Prisma enum MEMBER names, not the
+ * lowercase wire values the route accepts — `createMcpServer` in `mcp-servers.logic.ts` converts
+ * them through `_PRISMA_SCOPE_BY_ROUTE_SCOPE` and its siblings first. The repository writes them
+ * straight through, so passing a raw wire value here produces a Prisma enum error.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18 — the MCP revision this platform
+ *      pins (`_MCP_PROTOCOL_VERSION` in
+ *      libs/backend/server/infra/obot-custody/src/http-obot-mcp-invocation.ts); `endpoint` and
+ *      `transport` record how the upstream MCP server is reached.
+ */
 export interface CreateMcpServerWrite
 {
 	/** Operator-facing server name. */
@@ -20,17 +41,27 @@ export interface CreateMcpServerWrite
 	readonly transport: string;
 	/** Prisma-compatible lifecycle status. */
 	readonly status: string;
-	/** Canonical capability labels. */
+	/** Capability labels shown in the UI, already trimmed and de-duplicated by the caller. */
 	readonly capabilities: readonly string[];
 	/** Optional upstream source identifier. */
 	readonly sourceId?: string;
 	/** Optional last successful synchronization time. */
 	readonly lastSyncedAt?: Date;
-	/** Credential metadata that must become durable with the parent server. */
+	/** Credential labels written as child rows in the same transaction as the server row. */
 	readonly credentials: readonly McpServerCredentialWrite[];
 }
 
-/** Canonical values that may change on an existing MCP server. */
+/**
+ * The fields an update may change on an existing MCP server, plus its credential labels.
+ *
+ * Every scalar is optional and an omitted one is left alone in the database. `credentials` is the
+ * exception: it is required and it is a REPLACEMENT, not a merge — every existing credential row
+ * for the server is deleted first, so passing an empty list wipes them all. `sourceId` and
+ * `lastSyncedAt` accept null (rather than only being optional) so a caller can clear a stored
+ * value as well as change it.
+ *
+ * @see {@link McpServerMutationRepository.updateServer} for the write itself.
+ */
 export interface UpdateMcpServerWrite
 {
 	/** Existing MCP server identifier. */
@@ -53,30 +84,90 @@ export interface UpdateMcpServerWrite
 	readonly sourceId?: string | null;
 	/** Optional replacement synchronization time. */
 	readonly lastSyncedAt?: Date | null;
-	/** Complete replacement credential set. */
+	/**
+	 * The full credential set the server should have after the update. This replaces rather than
+	 * merges: every existing credential row is deleted first, so an empty list removes them all.
+	 */
 	readonly credentials: readonly McpServerCredentialWrite[];
 }
 
-/** Result returned after a durable MCP server mutation. */
+/**
+ * What a create returns: the new server's id, and nothing else.
+ *
+ * Kept deliberately narrow so a write never serialises server fields or credential rows back to
+ * the caller. The route answers `{ id, status: "created" }`; call `getMcpServer` when you actually
+ * need the stored row.
+ */
 export interface McpServerMutationWriteResult
 {
 	/** Stable MCP server identifier. */
 	readonly id: string;
 }
 
-/** Repository contract for the MCP server aggregate and its child credential metadata. */
+/**
+ * The write side of the MCP server catalogue: create, change, and delete a server together with
+ * its credential label rows.
+ *
+ * It is a separate interface so `mcp-servers.logic.ts` can be tested against a fake, and so the
+ * decision about which database transaction the writes run in belongs to the composition root
+ * rather than to the logic. Every implementation must write the server row, its credential rows,
+ * and one audit row as a single unit — see {@link McpServerMutationUnitOfWork}.
+ *
+ * No method here accepts a secret value. Credentials are label-only; the real secret lives in the
+ * Obot gateway.
+ *
+ * Called by: `createMcpServer`, `updateMcpServer` and `deleteMcpServer` in
+ * libs/backend/server/gateways/mcp/main/src/core/mcp-servers.logic.ts. Implemented by
+ * `PrismaMcpServerMutationRepository` (runs inside a transaction someone else opened) and
+ * `PrismaMcpServerMutationUnitOfWork` (opens one per call).
+ */
 export interface McpServerMutationRepository
 {
-	/** Creates an MCP server aggregate. */
+	/**
+	 * Store a new server and its credential label rows.
+	 *
+	 * @param input - Server fields already converted to Prisma enum member names, plus the labels.
+	 * @returns The new server's id only. Re-read the server if you need the rest of the row.
+	 * @throws Whatever the database client throws. The whole call is rolled back, so a server row
+	 *         without its credential rows or its audit row can never be left behind.
+	 */
 	createServer(input: CreateMcpServerWrite): Promise<McpServerMutationWriteResult>;
-	/** Updates an MCP server aggregate. */
+	/**
+	 * Change an existing server, and REPLACE its credential rows with the supplied list.
+	 *
+	 * @param input - The server id plus only the fields to change; `credentials` always replaces.
+	 * @throws Whatever the database client throws when no server has that id — the route does not
+	 *         check the row exists first.
+	 */
 	updateServer(input: UpdateMcpServerWrite): Promise<void>;
-	/** Deletes an MCP server aggregate. */
+	/**
+	 * Delete a server together with its credential rows.
+	 *
+	 * @param serverId - The server to delete.
+	 * @throws Whatever the database client throws when no server has that id — the route does not
+	 *         check the row exists first.
+	 */
 	deleteServer(serverId: string): Promise<void>;
 }
 
-/** Unit-of-work contract that commits an MCP aggregate and its audit record together. */
+/**
+ * The same three writes as {@link McpServerMutationRepository}, except each call opens and commits
+ * its own database transaction.
+ *
+ * Use this where nobody else owns a transaction — a route handler, a bootstrap step. Use the plain
+ * {@link McpServerMutationRepository} from code that is already running inside one. Keeping the two
+ * apart stops a route from nesting transactions and makes it obvious which layer decides when the
+ * commit happens.
+ *
+ * Called by: `mcpServersRouter` in
+ * libs/backend/server/gateways/mcp/main/src/routes/mcp-servers.ts, which builds one
+ * `PrismaMcpServerMutationUnitOfWork` and passes it in as the repository for every mutation route.
+ */
 export interface McpServerMutationUnitOfWork extends McpServerMutationRepository
 {
-	/** Each mutation persists the parent, credential children, and corresponding audit record atomically. */
+	/**
+	 * Each call writes the server row, its credential rows, and the audit row together. If any one of
+	 * them fails none of them is written, so the catalogue can never show a server whose credential
+	 * rows or audit trail are missing.
+	 */
 }

--- a/libs/backend/server/gateways/mcp/main/src/core/mcp-servers.logic.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/mcp-servers.logic.ts
@@ -12,7 +12,7 @@ type McpServerResponse = McpServer;
 /** Shared credential contract returned for normalized credential rows. */
 type McpServerCredentialResponse = McpServerCredential;
 
-/** Persist response shape returned after create/update/delete mutations. */
+/** What the create/update/delete routes answer with: the affected server id plus which of the three happened. */
 interface McpServerMutationResponse
 {
 	/** Stable server identifier. */
@@ -126,12 +126,21 @@ export async function getMcpServer(prisma: PrismaClient, serverId: string): Prom
 }
 
 /**
- * Create an MCP server and its child credential rows.
+ * Create one MCP server plus its credential label rows, through the supplied write port.
  *
- * @param prisma - Prisma client used for persistence.
- * @param mutationRepository - MCP aggregate persistence seam.
- * @param body - Route payload provided by the caller.
- * @returns Mutation response consumed by the route.
+ * Takes a repository rather than a Prisma client so the route can hand in a unit of work that
+ * commits the server row, its credential rows, and the audit row together. Credential entries are
+ * label-only: `_NormalizeCredentialWrites` trims each `displayName` and rejects a blank one, and
+ * no secret value is accepted anywhere on this path.
+ *
+ * Called by: the `POST /` handler in `mcpServersRouter` (../routes/mcp-servers.ts), which is gated
+ * by `_RequireOrgAdmin`.
+ *
+ * @param mutationRepository - Write port; the route passes `PrismaMcpServerMutationUnitOfWork`.
+ * @param body - Route payload. The lowercase wire values for scope/transport/status are converted
+ *               to Prisma enum member names here, and `status` defaults to `draft` when omitted.
+ * @returns `{ id, status: "created" }` — the id the route puts in its 201 response.
+ * @throws Error when a supplied credential has a missing or blank `displayName`.
  */
 export async function createMcpServer(mutationRepository: McpServerMutationRepository, body: McpServerWriteRequest): Promise<McpServerMutationResponse>
 {
@@ -152,12 +161,21 @@ export async function createMcpServer(mutationRepository: McpServerMutationRepos
 }
 
 /**
- * Update an MCP server and fully replace its child credential rows.
+ * Change an MCP server, and replace its credential rows with whatever the body carries.
  *
- * @param mutationRepository - MCP aggregate persistence seam.
- * @param serverId - Server identifier from the route.
- * @param body - Partial route payload provided by the caller.
- * @returns Mutation response consumed by the route.
+ * Any field the body omits is left as-is in the database. Credentials are the exception: they are
+ * always replaced, so a body with no `credentials` key deletes every credential row the server had.
+ * `sourceId` and `lastSyncedAt` accept an explicit null to clear the stored value.
+ *
+ * Called by: the `PUT /:id` handler in `mcpServersRouter` (../routes/mcp-servers.ts), gated by
+ * `_RequireOrgAdmin`.
+ *
+ * @param mutationRepository - Write port; the route passes `PrismaMcpServerMutationUnitOfWork`.
+ * @param serverId - Server identifier from the route path.
+ * @param body - Only the fields to change, in route wire values.
+ * @returns `{ id, status: "updated" }` for the route's response body.
+ * @throws Error when a supplied credential has a missing or blank `displayName`, and whatever the
+ *         database client throws when no server has that id.
  */
 export async function updateMcpServer(mutationRepository: McpServerMutationRepository, serverId: string, body: Partial<McpServerWriteRequest>): Promise<McpServerMutationResponse>
 {
@@ -178,7 +196,7 @@ export async function updateMcpServer(mutationRepository: McpServerMutationRepos
 	return { id: serverId, status: "updated" };
 }
 
-/** Projects an optional route timestamp without nesting conditional expressions. */
+/** Turn the optional route timestamp into an update fragment: absent leaves `lastSyncedAt` alone, null clears it, a string sets it. */
 function _OptionalLastSyncedAt(value: string | null | undefined): { readonly lastSyncedAt: Date | null } | Record<string, never>
 {
 	if (value === undefined) return {};
@@ -187,11 +205,16 @@ function _OptionalLastSyncedAt(value: string | null | undefined): { readonly las
 }
 
 /**
- * Delete an MCP server and its child credential rows.
+ * Delete an MCP server together with its credential rows.
  *
- * @param mutationRepository - MCP aggregate persistence seam.
- * @param serverId - Server identifier from the route.
- * @returns Mutation response consumed by the route.
+ * Called by: the `DELETE /:id` handler in `mcpServersRouter` (../routes/mcp-servers.ts), gated by
+ * `_RequireOrgAdmin`.
+ *
+ * @param mutationRepository - Write port; the route passes `PrismaMcpServerMutationUnitOfWork`.
+ * @param serverId - Server identifier from the route path.
+ * @returns `{ id, status: "deleted" }` for the route's response body.
+ * @throws Whatever the database client throws when no server has that id — the route does not
+ *         check the row exists first, so a bad id surfaces as a 500 rather than a 404.
  */
 export async function deleteMcpServer(mutationRepository: McpServerMutationRepository, serverId: string): Promise<McpServerMutationResponse>
 {
@@ -223,12 +246,20 @@ export async function listMcpServerCredentials(prisma: PrismaClient, serverId: s
 }
 
 /**
- * Add a single brokered credential to an MCP server.
+ * Add one brokered credential row to an MCP server.
+ *
+ * "Brokered" here means on-behalf-of (OBO): the row stores only an operator-facing label, and the
+ * actual secret is held by the Obot gateway, which exchanges it for the calling user at invocation
+ * time. Nothing on this path accepts, stores, or returns a secret value.
+ *
+ * Called by: the `POST /:id/credentials` handler in `mcpServersRouter` (../routes/mcp-servers.ts).
+ * That route is deliberately NOT org-admin gated — connecting a credential is a user action.
  *
  * @param prisma - Prisma client used for persistence.
- * @param serverId - Server identifier from the route.
- * @param input - OBO credential metadata to persist.
- * @returns The created credential response, or null when the server is absent.
+ * @param serverId - Server identifier from the route path.
+ * @param input - The credential label to store.
+ * @returns The created credential row, or null when no server has that id, which the route turns
+ *          into a 404.
  */
 export async function addMcpServerCredential(prisma: PrismaClient, serverId: string, input: McpServerCredentialInput): Promise<McpServerCredentialResponse | null>
 {
@@ -282,11 +313,17 @@ export async function deleteMcpServerCredential(prisma: PrismaClient, serverId: 
 }
 
 /**
- * Normalize an OBO-only credential write payload for persistence.
+ * Convert one credential label from the route body into the row shape Prisma stores.
+ *
+ * Label-only by design (see {@link addMcpServerCredential}): there is no field here that could
+ * carry a secret, so a caller cannot smuggle one into the database through this path.
+ *
+ * Called by: {@link addMcpServerCredential} in this file, and
+ * src/__tests__/mcp-credential-brokering.test.ts.
  *
  * @param serverId - Owning MCP server identifier.
- * @param credential - Raw credential payload from the route body.
- * @returns Prisma createMany input for the credential row.
+ * @param credential - The credential label from the route body.
+ * @returns The `mcpServerCredential` create input: the owning server id plus the label.
  */
 export function _NormalizeCredentialInput(serverId: string, credential: McpServerCredentialInput): Prisma.McpServerCredentialCreateManyInput
 {
@@ -296,7 +333,7 @@ export function _NormalizeCredentialInput(serverId: string, credential: McpServe
 	};
 }
 
-/** Validates and normalizes credential labels before any aggregate persistence begins. */
+/** Trim every credential label and reject a blank one, before any row is written. */
 function _NormalizeCredentialWrites(credentials: readonly McpServerCredentialInput[] | undefined): readonly McpServerCredentialWrite[]
 {
 	return credentials?.map(function _normalizeCredential(credential)
@@ -351,10 +388,10 @@ function _MapCredentialResponse(credential: _McpServerRow["credentials"][number]
 }
 
 /**
- * Normalize capability labels into a unique trimmed string array.
+ * Trim each capability label, drop the blanks, and drop duplicates.
  *
- * @param values - Raw request values.
- * @returns Canonical capability labels.
+ * @param values - Raw capability labels from the request body, or undefined.
+ * @returns The kept labels in first-seen order; an empty array when nothing was supplied.
  */
 function _NormalizeStringArray(values: string[] | undefined): string[]
 {

--- a/libs/backend/server/gateways/mcp/main/src/core/prisma-mcp-server-mutation-repository.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/prisma-mcp-server-mutation-repository.ts
@@ -2,10 +2,21 @@ import type { Prisma } from "@prisma/client";
 
 import type { CreateMcpServerWrite, McpServerCredentialWrite, McpServerMutationRepository, McpServerMutationWriteResult, UpdateMcpServerWrite } from "./mcp-server-mutation-repository.types.js";
 
-/** Transaction-scoped repository for MCP server, credential metadata, and audit rows. */
+/**
+ * Writes MCP server rows, their credential label rows, and the audit row — all through a Prisma
+ * transaction that someone else opened.
+ *
+ * It takes a transaction client rather than a `PrismaClient`, so it cannot commit on its own. That
+ * is deliberate: {@link PrismaMcpServerMutationUnitOfWork} owns the commit, and this class only
+ * describes the writes. Use this directly when you are already inside a transaction; otherwise use
+ * the unit of work.
+ *
+ * Called by: `PrismaMcpServerMutationUnitOfWork._withRepository` in
+ * ./prisma-mcp-server-mutation-unit-of-work.ts. No other construction site in this repo.
+ */
 export class PrismaMcpServerMutationRepository implements McpServerMutationRepository
 {
-	/** Exact transaction that owns every aggregate write. */
+	/** The Prisma transaction all writes in this class run on; it is committed by the caller, not here. */
 	private readonly _transaction: Prisma.TransactionClient;
 
 	/** Binds the repository to the transaction opened by its unit of work. */
@@ -14,7 +25,7 @@ export class PrismaMcpServerMutationRepository implements McpServerMutationRepos
 		this._transaction = transaction;
 	}
 
-	/** Creates the server, credential metadata, and audit record. */
+	/** Insert the server row, then its credential rows, then the audit row — all on the held transaction. @returns The new server's id. */
 	async createServer(input: CreateMcpServerWrite): Promise<McpServerMutationWriteResult>
 	{
 		const server = await this._transaction.mcpServer.create({
@@ -35,7 +46,7 @@ export class PrismaMcpServerMutationRepository implements McpServerMutationRepos
 		return { id: server.id };
 	}
 
-	/** Updates the server, replaces credential metadata, and writes the audit record. */
+	/** Patch the supplied server fields, delete and re-insert all credential rows, then add the audit row. */
 	async updateServer(input: UpdateMcpServerWrite): Promise<void>
 	{
 		await this._transaction.mcpServer.update({
@@ -64,7 +75,7 @@ export class PrismaMcpServerMutationRepository implements McpServerMutationRepos
 		await this._transaction.auditEntry.create({ data: { action: "Deleted", resource: `McpServer/${serverId}`, message: `MCP server ${serverId} deleted` } });
 	}
 
-	/** Replaces credential children through the transaction that owns their parent. */
+	/** Delete every credential row for this server, then insert the supplied labels. An empty list just deletes. */
 	private async _replaceCredentials(serverId: string, credentials: readonly McpServerCredentialWrite[]): Promise<void>
 	{
 		await this._transaction.mcpServerCredential.deleteMany({ where: { mcpServerId: serverId } });

--- a/libs/backend/server/gateways/mcp/main/src/core/prisma-mcp-server-mutation-unit-of-work.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/prisma-mcp-server-mutation-unit-of-work.ts
@@ -3,7 +3,21 @@ import type { PrismaClient } from "@prisma/client";
 import type { CreateMcpServerWrite, McpServerMutationRepository, McpServerMutationUnitOfWork, McpServerMutationWriteResult, UpdateMcpServerWrite } from "./mcp-server-mutation-repository.types.js";
 import { PrismaMcpServerMutationRepository } from "./prisma-mcp-server-mutation-repository.js";
 
-/** Prisma transaction owner for one MCP server aggregate and its audit trail. */
+/**
+ * Opens one Prisma transaction per call and runs the server write, its credential rows, and the
+ * audit row inside it, so all of them land or none of them do.
+ *
+ * This is what a route should use: it needs no ambient transaction, and it guarantees the
+ * catalogue can never show a server whose credential rows or audit entry are missing. Code that
+ * already holds a transaction should use `PrismaMcpServerMutationRepository` instead, so the two
+ * do not nest.
+ *
+ * Called by: `mcpServersRouter` in ../routes/mcp-servers.ts, which builds one instance and passes
+ * it to `createMcpServer`, `updateMcpServer` and `deleteMcpServer`.
+ *
+ * @see https://www.prisma.io/docs/orm/prisma-client/queries/transactions — the interactive
+ *      `$transaction` callback form used by `_withRepository`.
+ */
 export class PrismaMcpServerMutationUnitOfWork implements McpServerMutationUnitOfWork
 {
 	/** Canonical product-authority client that opens the transaction. */
@@ -15,7 +29,7 @@ export class PrismaMcpServerMutationUnitOfWork implements McpServerMutationUnitO
 		this._prisma = prisma;
 	}
 
-	/** Creates the complete MCP server aggregate atomically. */
+	/** Create the server, its credential rows, and the audit row in one transaction. @returns The new server's id. */
 	async createServer(input: CreateMcpServerWrite): Promise<McpServerMutationWriteResult>
 	{
 		return this._withRepository(async function _Create(repository)
@@ -24,7 +38,7 @@ export class PrismaMcpServerMutationUnitOfWork implements McpServerMutationUnitO
 		});
 	}
 
-	/** Updates the complete MCP server aggregate atomically. */
+	/** Change the server, replace its credential rows, and add the audit row in one transaction. */
 	async updateServer(input: UpdateMcpServerWrite): Promise<void>
 	{
 		await this._withRepository(async function _Update(repository): Promise<void>
@@ -33,7 +47,7 @@ export class PrismaMcpServerMutationUnitOfWork implements McpServerMutationUnitO
 		});
 	}
 
-	/** Deletes the complete MCP server aggregate atomically. */
+	/** Delete the credential rows, the server row, and add the audit row in one transaction. */
 	async deleteServer(serverId: string): Promise<void>
 	{
 		await this._withRepository(async function _Delete(repository): Promise<void>
@@ -42,7 +56,7 @@ export class PrismaMcpServerMutationUnitOfWork implements McpServerMutationUnitO
 		});
 	}
 
-	/** Opens one transaction and binds its exact client to the aggregate repository. */
+	/** Open one Prisma transaction, hand its client to a fresh `PrismaMcpServerMutationRepository`, and run the caller's writes on it. */
 	private async _withRepository<Result>(operation: (repository: McpServerMutationRepository) => Promise<Result>): Promise<Result>
 	{
 		return this._prisma.$transaction(async function _Run(transaction)

--- a/libs/backend/server/gateways/mcp/main/src/routes/mcp-operator.ts
+++ b/libs/backend/server/gateways/mcp/main/src/routes/mcp-operator.ts
@@ -7,18 +7,18 @@ import type { McpOperatorCaller } from "../core/mcp-operator.logic.types.js";
 import type { McpAccessPolicyRequest, McpEnabledRequest, McpInstallRequest } from "./mcp-operator.types.js";
 
 /**
- * Operator-API router for the MCP consumption + governance surface (`/api/v1/mcp/*`).
+ * Operator-API router for the MCP endpoints under `/api/v1/mcp/*` — using servers, and governing them.
  *
  * Layers the entitlement-scoped catalogue, per-user installs / credential connect,
  * and org-admin governance + access-policy endpoints ON TOP of the existing
- * `/mcp-servers` admin registry (which stays as-is). Two authorization postures:
+ * `/mcp-servers` admin registry (which stays as-is). Two authorization rules apply:
  *
  * - **User-facing** (`/catalog`, `/installed/*`) — scoped to the calling user via
  *   {@link _ResolveCaller}; entitlement filtering decides catalogue visibility.
  * - **Admin** (`/servers/*`, `/directory`) — gated by `_RequireOrgAdmin`, matching
  *   the registry's curate-is-an-admin-action posture (fail-open dev / fail-closed real auth).
  *
- * Custody: no response on any route serialises credential material — a connected
+ * Secrets: no response on any route returns credential material — a connected
  * install reports only its connection status (the secret is brokered by the gateway plane).
  *
  * @param prisma - Prisma client used for persistence.

--- a/libs/backend/server/gateways/model-routing/main/src/core/attempt-litellm-key.types.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/attempt-litellm-key.types.ts
@@ -1,13 +1,19 @@
 /**
- * Request to mint one attempt-scoped LiteLLM virtual key.
+ * Request to mint one LiteLLM virtual key for a single run attempt.
  *
- * The key is bound to exactly one model alias and one aggregate budget, expires with the attempt
- * lease, and is the runtime's only route to a model. It never carries or exposes the LiteLLM master
- * key or an upstream provider secret.
+ * A run's pod never gets the LiteLLM master key or a provider's key. It gets one of these instead:
+ * a key that can call exactly one model, has a total spend ceiling, and dies with the attempt.
+ * A leaked attempt key therefore costs at most one budget on one model for the rest of one lease.
+ *
+ * Every field is validated by `_IssueAttemptLiteLlmKey` before the mint, and issuance fails hard
+ * rather than falling back — a run cannot proceed without its own scoped key.
+ *
+ * @see LiteLLM proxy `POST /key/generate`, pinned to `main-v1.81.0-stable` by `litellm.image.tag`
+ *      in apps/_infra/deploy-k8s/values.yaml — NEEDS-HUMAN: add the docs URI for that release.
  */
 export interface AttemptLiteLlmKeyRequest
 {
-  /** Attempt-scoped key alias; must match the `attempt-<...>` grammar the issuer enforces. */
+  /** The key's alias. Must match `_ATTEMPT_KEY_ALIAS` (`attempt-` then lowercase letters, digits and dashes, 63 max) — issuance throws otherwise, so a caller cannot ask for an unscoped key by naming it something else. */
   keyAlias: string;
   /** Single LiteLLM model alias the minted key is permitted to call. */
   modelAlias: string;
@@ -17,7 +23,13 @@ export interface AttemptLiteLlmKeyRequest
   expirySeconds: number;
 }
 
-/** A minted attempt-scoped LiteLLM virtual key returned to the caller for Secret projection. */
+/**
+ * A freshly minted attempt key, plus the bindings it was issued under.
+ *
+ * `key` is a live credential: the caller writes it into a Kubernetes Secret for the run's pod to
+ * read, and it must not be logged or returned in an API response. The three echoed bindings are
+ * there so the caller can name that Secret and assert what the key can do without a second lookup.
+ */
 export interface AttemptLiteLlmKey
 {
   /** The short-lived virtual key value the runtime presents to the LiteLLM proxy. */

--- a/libs/backend/server/gateways/model-routing/main/src/core/byok-default-models.types.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/byok-default-models.types.ts
@@ -10,24 +10,39 @@ export interface ByokModelClass
   slug: string;
 }
 
-/** A provider's model catalog: one credential (key) shared across several model classes. */
+/**
+ * One provider's catalogue: the models a single BYOK key unlocks.
+ *
+ * The shape follows the hierarchy one provider ⇒ one key ⇒ many models. Setting a provider's key
+ * writes ONE Kubernetes Secret and ONE LiteLLM credential, and every class in `models` is then
+ * registered against that single credential — so LiteLLM can switch a call between tiers without
+ * a second key.
+ *
+ * `embeddingModel` is the exception and is handled entirely differently; read its own doc before
+ * touching it.
+ */
 export interface ByokProviderCatalog
 {
   /** LiteLLM `custom_llm_provider` for the credential + slug prefix (`glm` ⇒ `zai`). */
   litellmProvider: string;
-  /** The class whose model claims the silo default when no Global default exists yet. */
+  /** Which class becomes the installation default — but only the first time. If any Global default already exists, setting up another provider leaves it alone. */
   defaultClass: ByokModelClassName;
   /** Model classes for this provider (≥1); ALL share the provider's single credential/key. */
   models: readonly ByokModelClass[];
   /**
-   * Optional embedding model, registered directly with LiteLLM (see
-   * `provision-byok-key.ts` `_ensureProviderEmbeddingModel`) — deliberately NOT a `models[]`
-   * entry: every `models[]` class becomes a Global `ModelDefinition` row, and
-   * The target model registry exposes all Global rows unconditionally as selectable chat
-   * models. An embedding deployment must never appear there, so it bypasses `ModelDefinition`
-   * entirely — internal callers needing it (Cognee, via its own dedicated LiteLLM key; see
-   * `cognee-litellm-key.ts`) reference the slug directly. Absent ⇒ no embedding model for
-   * this provider yet (set only where needed, not required for every provider).
+   * The provider's embedding model, when it has one. Registered straight with LiteLLM by
+   * `_ensureProviderEmbeddingModel` in `provision-byok-key.ts`, and deliberately NOT listed in
+   * `models[]`.
+   *
+   * Here is why that matters. Every `models[]` class becomes a Global `ModelDefinition` row, and
+   * `modelRegistryRouter` returns every Global row to every tenant as a selectable chat model. So
+   * an embedding deployment listed in `models[]` would show up in tenants' chat-model pickers, and
+   * a tenant choosing it would get failed calls — an embedding model cannot answer a chat request.
+   * Keeping it out of `ModelDefinition` entirely is what prevents that.
+   *
+   * Internal callers that genuinely need it (Cognee, through its own dedicated LiteLLM key — see
+   * `cognee-litellm-key.ts`) reference the slug directly instead. Absent means this provider has
+   * no embedding model configured yet; that is normal, not every provider needs one.
    */
   embeddingModel?: { slug: string };
 }

--- a/libs/backend/server/gateways/model-routing/main/src/core/ope.types.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/ope.types.ts
@@ -1,13 +1,27 @@
 /**
- * Pure-function types for the AIR.7 off-policy evaluation (OPE) substrate.
+ * Types for the AIR.7 off-policy evaluation (OPE) maths.
  *
- * OPE assesses a *candidate* routing policy from logged decisions made under the *current* policy,
- * without ever serving the candidate to live traffic. This is the math substrate the live
- * improvement loop calls; the full RouteLLM/bandit training that produces candidate policies is an
- * explicit out-of-scope seam (see `app-specific.md`).
+ * The question OPE answers: if we had been routing with a different model-choice policy, would we
+ * have done better? It answers that from calls already logged under the CURRENT policy, so a
+ * candidate policy can be scored without ever being put in front of real traffic.
+ *
+ * These are plain functions over logged samples — no I/O. Producing candidate policies in the
+ * first place (RouteLLM-style training, bandits) is a separate job that is not implemented here;
+ * see `app-specific.md`.
  */
 
-/** One logged decision with the facts needed to score a candidate policy off-policy. */
+/**
+ * One logged call, with everything needed to score a candidate policy against it.
+ *
+ * `loggedAction` is the model that actually ran and earned `reward`. `candidateAction` is the model
+ * the policy under test would have picked. When the two differ there is no observed reward for the
+ * candidate, which is why the other two fields exist: `propensity` (how likely the logging policy
+ * was to pick what it picked) and `rewardModelPred` (a model's guess at the candidate's reward).
+ * `_ReplayEstimate` uses only the matching samples; `_DoublyRobustEstimate` uses all of them.
+ *
+ * `propensity` must be greater than zero. A matched sample with a non-positive propensity is not
+ * an error — `_DoublyRobustEstimate` skips its correction term rather than dividing by zero.
+ */
 export interface OpeSample
 {
   /** The action (model) the logging policy actually took on this call. */
@@ -31,7 +45,13 @@ export interface OpeCiOptions
   rng?: () => number;
 }
 
-/** An OPE value estimate with a bootstrap 95% confidence interval. */
+/**
+ * A candidate policy's estimated value, with a bootstrap 95% confidence interval.
+ *
+ * Read the interval before acting on `value`. All three fields are 0 for empty input, which means
+ * "no signal", not "no improvement" — a caller that treats 0 as a real measurement would ship a
+ * policy change on no evidence.
+ */
 export interface OpeEstimate
 {
   /** The point value estimate of the candidate policy's expected reward. */

--- a/libs/backend/server/gateways/model-routing/main/src/core/provision-byok-key.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/provision-byok-key.ts
@@ -14,20 +14,17 @@ import type { ByokProviderCatalog } from "./byok-default-models.types.js";
 import type { DeprovisionByokKeyOptions, ProvisionByokKeyOptions, ProvisionByokKeyResult } from "./provision-byok-key.types.js";
 
 /**
- * Reusable core for setting/removing a silo's BYOK provider key — the work behind both the HTTP
- * route (`providerByokRouter`) and the boot-time bootstrap. Writing it here (not in `routes/`) keeps
- * the provisioning logic out of the HTTP layer so the operator boot path can call it directly.
+ * Setting and removing a silo's BYOK provider key. Both the HTTP route (`providerByokRouter`) and
+ * the boot-time bootstrap call these functions, which is why they live here and not in `routes/` —
+ * the boot path has no HTTP request to go through.
  *
- * A set: write the raw key to a k8s Secret (durable source of truth) → push to LiteLLM's
- * `/credentials` dynamic path (best-effort) → upsert the Global ProviderCredential row → seed a
- * default model bound to it. A key is installation-wide or ClusterTenant-scoped.
+ * Setting a key, in order: write the raw key to a Kubernetes Secret (the durable copy), push it to
+ * LiteLLM's `/credentials` (best-effort), write the Global `ProviderCredential` row, then seed the
+ * models bound to it. NOTE: the row this file writes is always Global (`scope: "Global"`,
+ * `clusterTenant: null`) — the ClusterTenant-scoped variant is written through
+ * `providerCredentialsRouter`, not here.
  */
 
-/**
- * Public model name of the stable "auto" selection. Backed by the cheapest catalogued model
- * today (LiteLLM has no capability-aware routing); the AIR router can re-point it later without
- * callers/skills re-selecting. See `_ensureProviderModels` step 3.
- */
 /**
  * Public model name of the stable EMBEDDING selection — the embedding-side mirror of
  * {@link _AUTO_MODEL_NAME}. Backed by the configured provider's catalogued embedding model
@@ -41,15 +38,29 @@ import type { DeprovisionByokKeyOptions, ProvisionByokKeyOptions, ProvisionByokK
  */
 export const _AUTO_EMBEDDING_MODEL_NAME = "auto-embedding";
 
-/** Stable public model selection whose upstream provider model can improve without caller changes. */
+/**
+ * Public model name of the stable "auto" selection. Backed by the cheapest catalogued model today
+ * (LiteLLM has no capability-aware routing); the AIR router can re-point it later without
+ * callers/skills re-selecting. See `_ensureProviderModels` step 3.
+ */
 const _AUTO_MODEL_NAME = "auto";
 
 /**
- * Require LiteLLM to report one live public model deployment. This is deliberately stricter than
- * the interactive BYOK route: an installation bootstrap must not accept traffic until its default
- * model alias can actually be resolved by the release-local LiteLLM instance.
+ * Check that LiteLLM really has a given model registered, and throw if it does not.
  *
- * @param publicModelName - LiteLLM `model_name` required to be present in its live inventory.
+ * Stricter than the interactive BYOK route on purpose: a fresh install must not start accepting
+ * traffic until the model its default alias points at can actually be resolved by the LiteLLM
+ * instance deployed alongside it. Failing loudly at boot beats every later request failing.
+ *
+ * Called by: apps/opencrane/src/app/initial-model-bootstrap.ts, which calls it with `"auto"`
+ * after provisioning the first key.
+ *
+ * @param publicModelName - The LiteLLM `model_name` that must appear in `GET /model/info`.
+ * @throws Error when `LITELLM_ENDPOINT` or `LITELLM_MASTER_KEY` is unset, when `/model/info`
+ *         answers with a non-2xx status, when its body does not parse, or when the model is
+ *         simply not in the returned inventory.
+ * @see LiteLLM proxy `GET /model/info`, pinned to `main-v1.81.0-stable` by `litellm.image.tag`
+ *      in apps/_infra/deploy-k8s/values.yaml — NEEDS-HUMAN: add the docs URI for that release.
  */
 export async function _RequireLiteLlmModelRegistration(publicModelName: string): Promise<void>
 {
@@ -82,21 +93,60 @@ export async function _RequireLiteLlmModelRegistration(publicModelName: string):
   }
 }
 
-/** Name of the k8s Secret carrying a provider's raw BYOK key, in the operator's own namespace. */
+/**
+ * Build the name of the Kubernetes Secret that holds a provider's raw BYOK key.
+ *
+ * The name is fixed per provider, and that is a security constraint rather than a convenience: the
+ * server's Role grants it `get`/`update` on exactly these Secret names, so the server can rewrite
+ * a key it already has but cannot invent new Secret names or delete existing ones. Deployment
+ * pre-creates every Secret in the fixed provider catalogue — see `_clearProviderKeySecret`, which
+ * blanks the value instead of deleting the object.
+ *
+ * Called by: `_ProvisionByokKey`, `_DeprovisionByokKey`, `_applyProviderKeySecret` and
+ * `_clearProviderKeySecret` in this file.
+ *
+ * @param provider - Provider key, e.g. `openai`.
+ * @returns `byok-provider-key-<provider>`.
+ */
 export function _byokSecretName(provider: string): string
 {
   return `byok-provider-key-${provider}`;
 }
 
-/** Name of the LiteLLM `/credentials` entry for a provider's BYOK key. */
+/**
+ * Build the name a provider's key is stored under in LiteLLM's `/credentials` store.
+ *
+ * Derived from the provider rather than chosen, so the set path and the remove path always agree
+ * on the name, and so a model registration can reference it via `litellm_credential_name`.
+ *
+ * Called by: `_ProvisionByokKey` and `_DeprovisionByokKey` in this file.
+ *
+ * @param provider - Provider key, e.g. `openai`.
+ * @returns `byok-<provider>`.
+ */
 export function _byokCredentialName(provider: string): string
 {
   return `byok-${provider}`;
 }
 
 /**
- * Provision (set or refresh) a silo's raw BYOK key for a provider: persist the Secret, register the
- * LiteLLM credential, record the ProviderCredential row, and seed a default model bound to it.
+ * Set or refresh a provider's raw BYOK key, then get the platform ready to route on it.
+ *
+ * Five steps, in this order for a reason: write the key to its Kubernetes Secret first (that
+ * Secret is the durable copy and survives a LiteLLM database reset), push it to LiteLLM's
+ * `/credentials`, record the `ProviderCredential` row, register every model class for the
+ * provider, and finally register the provider's embedding model.
+ *
+ * Steps 2, 4 and 5 are best-effort by default: if LiteLLM is unconfigured or down, the key is
+ * still set and the platform converges on a later call. `requireLiveModels` flips that — see
+ * `ProvisionByokKeyOptions.requireLiveModels` — and is what the boot-time bootstrap uses so a
+ * fresh install refuses to come up half-configured instead of accepting traffic it cannot serve.
+ *
+ * The raw key is written only to the Secret and to LiteLLM. It is never logged and never returned.
+ *
+ * Called by: the `PUT /:provider` handler in `providerByokRouter`
+ * (libs/backend/server/gateways/providers/main/src/routes/provider-byok.ts, org-admin gated), and
+ * apps/opencrane/src/app/initial-model-bootstrap.ts, which passes `requireLiveModels: true`.
  *
  * @param opts.prisma            - Prisma client for the credential + model rows.
  * @param opts.coreApi           - Kubernetes Core V1 API for the Secret write.
@@ -104,7 +154,16 @@ export function _byokCredentialName(provider: string): string
  * @param opts.provider          - The provider the key is for (e.g. `openai`).
  * @param opts.apiKey            - The raw upstream key (never logged or echoed).
  * @param opts.log               - Scoped logger for the best-effort model-seed warning.
- * @returns Whether LiteLLM accepted the key, and the upserted credential row.
+ * @param opts.requireLiveModels - When true, a failed model or embedding registration throws
+ *                                 instead of only logging a warning. Defaults to false.
+ * @returns Whether LiteLLM accepted the key, and the `ProviderCredential` row that was written.
+ *          `litellmRegistered: false` means the key is set but only in its Secret.
+ * @throws Whatever the Kubernetes client throws when the Secret cannot be written — the key is
+ *         then not set at all. With `requireLiveModels: true`, also whatever a failed model or
+ *         embedding registration throws, after the Secret and row have already been written.
+ * @see LiteLLM proxy, pinned to `main-v1.81.0-stable` by `litellm.image.tag` in
+ *      apps/_infra/deploy-k8s/values.yaml — the `/credentials`, `/model/new` and `/model/info`
+ *      endpoints this path calls. NEEDS-HUMAN: add the docs URI for that release.
  */
 export async function _ProvisionByokKey(opts: ProvisionByokKeyOptions): Promise<ProvisionByokKeyResult>
 {
@@ -152,13 +211,25 @@ export async function _ProvisionByokKey(opts: ProvisionByokKeyOptions): Promise<
 }
 
 /**
- * Remove a silo's BYOK key for a provider: clear the fixed custody Secret, then remove the LiteLLM
- * credential and row. The placeholder Secret remains so the restricted server Role can re-add a key.
+ * Remove a provider's BYOK key: blank the Secret's value, drop the LiteLLM credential, delete the
+ * `ProviderCredential` row.
+ *
+ * The Secret OBJECT is deliberately kept, with an empty value. The server's Role can update these
+ * fixed Secret names but cannot create or delete them, so deleting the object would leave nothing
+ * for a later `PUT` to write into and the provider could never be re-enabled without a redeploy.
+ *
+ * Any `ModelDefinition` rows that referenced the credential are left in place; they simply stop
+ * resolving until a key is set again.
+ *
+ * Called by: the `DELETE /:provider` handler in `providerByokRouter`
+ * (libs/backend/server/gateways/providers/main/src/routes/provider-byok.ts, org-admin gated).
  *
  * @param opts.prisma            - Prisma client.
  * @param opts.coreApi           - Kubernetes Core V1 API.
  * @param opts.operatorNamespace - The operator's own namespace.
  * @param opts.provider          - The provider whose key to remove.
+ * @throws Error when the provider's Secret is missing entirely, which means deployment never
+ *         pre-created it; the LiteLLM credential and the row are then left untouched.
  */
 export async function _DeprovisionByokKey(opts: DeprovisionByokKeyOptions): Promise<void>
 {
@@ -206,7 +277,7 @@ async function _applyProviderKeySecret(coreApi: k8s.CoreV1Api, namespace: string
   }
 }
 
-/** Clear one pre-created provider custody Secret without deleting the name guarded by RBAC. */
+/** Blank a provider Secret's value while keeping the object itself — the server's Role may update these fixed names but not create or delete them, so deleting it would make the provider unrecoverable. */
 async function _clearProviderKeySecret(coreApi: k8s.CoreV1Api, namespace: string, provider: string): Promise<void>
 {
   try
@@ -278,9 +349,21 @@ async function _upsertCredentialRow(prisma: PrismaClient, provider: string, secr
 }
 
 /**
- * Converge one provider catalogue into global ModelDefinition rows and live LiteLLM deployments.
- * Strict startup records every deployment identifier returned by LiteLLM so subsequent restarts
- * converge rather than retaining a placeholder or stale deployment id.
+ * Make sure every model class in a provider's catalogue has a Global `ModelDefinition` row, and —
+ * at boot — a live LiteLLM deployment behind it.
+ *
+ * Three things happen. Each class gets its row created or re-pointed at this credential. The
+ * first-ever default is preserved, so setting up a second provider never steals the default from
+ * the first. And the stable `auto` alias is pointed at the provider's cheapest class.
+ *
+ * When `requireLiveModels` is true (the boot path) every registration must return a real LiteLLM
+ * deployment id, and that id is written back to the row. Without that, a row created while
+ * LiteLLM was unreachable would keep its placeholder id for good and never route.
+ *
+ * @param catalog - The provider's catalogue; undefined for an uncatalogued provider, which is a
+ *                  no-op — the key is still set, it just seeds no models.
+ * @throws Whatever `_RegisterLiteLlmModel` throws under `requireLiveModels`; `_ProvisionByokKey`
+ *         re-throws it at boot and only logs a warning otherwise.
  */
 async function _ensureProviderModels(prisma: PrismaClient, catalog: ByokProviderCatalog | undefined, providerCredentialId: string, litellmCredentialName: string | null, requireLiveModels: boolean): Promise<void>
 {

--- a/libs/backend/server/gateways/model-routing/main/src/core/provision-byok-key.types.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/provision-byok-key.types.ts
@@ -2,7 +2,16 @@ import type * as k8s from "@kubernetes/client-node";
 import type { Logger } from "pino";
 import type { PrismaClient, ProviderCredential as PrismaProviderCredential } from "@prisma/client";
 
-/** Inputs required to persist and register a provider's BYOK key. */
+/**
+ * Everything `_ProvisionByokKey` needs to set a provider's raw BYOK key.
+ *
+ * `apiKey` is the only raw secret here. It reaches exactly two places — the provider's Kubernetes
+ * Secret and LiteLLM's `/credentials` store — and is never logged, never stored in Postgres, and
+ * never returned. Only the Secret's NAME is recorded on the `ProviderCredential` row.
+ *
+ * @see {@link ProvisionByokKeyResult} for what comes back, and `requireLiveModels` below for the
+ *      one option that changes whether failures throw.
+ */
 export interface ProvisionByokKeyOptions
 {
   /** Prisma client for credential and model rows. */
@@ -17,11 +26,25 @@ export interface ProvisionByokKeyOptions
   apiKey: string;
   /** Scoped logger for best-effort registration warnings. */
   log: Logger;
-  /** Require exact model reconciliation instead of the interactive route's best-effort seed. */
+  /**
+   * Turns model registration from warn-on-failure into throw-on-failure.
+   *
+   * Left false (the interactive `PUT /providers/byok/:provider` route): if LiteLLM is unconfigured
+   * or down, the key is still set and the failure is only a log line, so an operator setting a key
+   * from the UI is not blocked by a flaky LiteLLM.
+   *
+   * Set true (apps/opencrane/src/app/initial-model-bootstrap.ts): every model and embedding
+   * registration must return a real LiteLLM deployment id, and the first failure throws out of
+   * `_ProvisionByokKey`. A fresh install would otherwise come up with placeholder deployment ids
+   * that never route, and only fail on real traffic.
+   *
+   * Either way the Secret and the `ProviderCredential` row are already written by the time a throw
+   * can happen — this switch changes when you find out, not what was stored.
+   */
   requireLiveModels?: boolean;
 }
 
-/** Inputs required to remove a provider's BYOK key. */
+/** Everything `_DeprovisionByokKey` needs to remove a provider's key. No `log` here, because removal has no best-effort step to warn about — every failure throws. */
 export interface DeprovisionByokKeyOptions
 {
   /** Prisma client for the credential row. */
@@ -34,7 +57,14 @@ export interface DeprovisionByokKeyOptions
   provider: string;
 }
 
-/** Outcome of provisioning a provider's BYOK key. */
+/**
+ * What `_ProvisionByokKey` reports back after a successful set.
+ *
+ * Reaching this result means the Secret and the `ProviderCredential` row were both written. It
+ * does NOT mean LiteLLM took the key: check `litellmRegistered`. When that is false the key works
+ * only through LiteLLM's environment-variable baseline, and models bound to the credential name
+ * will not resolve until a later set succeeds.
+ */
 export interface ProvisionByokKeyResult
 {
   /** True when LiteLLM's `/credentials` accepted the key (false means Secret-only / env baseline). */

--- a/libs/backend/server/gateways/model-routing/main/src/core/resolve-skill-model.types.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/resolve-skill-model.types.ts
@@ -1,15 +1,34 @@
 /**
- * Types for the pure per-skill model resolution helper (Track AIR.2).
+ * Types for `_ResolveSkillModel` — the helper that decides which model one skill actually runs on
+ * (Track AIR.2).
  *
- * The resolver is a pure function over already-fetched DB rows — it performs no I/O and never
- * calls LiteLLM. It encodes the locked precedence invariant: an explicit request model (handled
- * upstream, never here) > skill-pinned model > skill-`auto` > scope default (ClusterTenant then
- * Global). "auto" applies ONLY when a skill (or scope default) selects it.
+ * It is a plain function over rows someone else already loaded: no database calls, no HTTP, and it
+ * never talks to LiteLLM. That means it can be read and tested top to bottom without a live
+ * platform.
+ *
+ * The order of precedence is the whole contract, highest first:
+ *   1. a model named explicitly on the request — decided before this file is reached, never here;
+ *   2. the skill's own pinned model;
+ *   3. the skill choosing `auto`;
+ *   4. the ClusterTenant scope default;
+ *   5. the platform-wide Global default.
+ * Auto-routing is never inferred: it applies only because a skill, or a scope default, asked for
+ * it. When nothing in the chain names a model, the result is `model: null` and the pod uses
+ * whatever default it was configured with.
  */
 
 import type { AutoRoutingConfig, SkillModelMode } from "@opencrane/contracts";
 
-/** The model-posture inputs of a single entitled skill, as projected from a `Skill` row. */
+/**
+ * One skill's own model posture, read off its `Skill` row: does it pin a model, ask for
+ * auto-routing, or say nothing and inherit?
+ *
+ * The three fields are not independent. `modelMode` decides which of the other two is meaningful,
+ * and the resolver ignores the irrelevant one. A `pinned` mode with no `pinnedModel` is not an
+ * error — it simply falls through to the scope default, so a half-configured skill still runs.
+ *
+ * @see {@link SkillModelResolution} for what the resolver produces from this.
+ */
 export interface SkillModelPosture
 {
   /** `pinned` (use `pinnedModel`), `auto` (route within `autoConfig`), or null (inherit the scope default). */
@@ -29,7 +48,7 @@ export interface ScopeDefaultModel
   autoConfig: AutoRoutingConfig | null;
 }
 
-/** The scope defaults a skill may inherit from, in precedence order (ClusterTenant beats Global). */
+/** The two defaults a skill can inherit. The ClusterTenant one wins, but only if it actually names a model — an empty ClusterTenant row does not hide a usable Global default. */
 export interface ScopeDefaults
 {
   /** The owning ClusterTenant's default, when one is configured; null otherwise. */
@@ -38,7 +57,21 @@ export interface ScopeDefaults
   global: ScopeDefaultModel | null;
 }
 
-/** How a resolved model was selected — for observability/auditing of the precedence decision. */
+/**
+ * Which step of the precedence chain produced the answer. Recorded so an operator asking "why is
+ * this skill on that model?" gets a direct answer instead of having to re-derive it.
+ *
+ * - `skill-pinned` — the skill named the model itself.
+ * - `skill-auto` — the skill asked for auto-routing but no scope default named a base model, so
+ *   `model` is null while `auto` is still true.
+ * - `scope-default-cluster-tenant` — the owning ClusterTenant's default supplied the model.
+ * - `scope-default-global` — the platform-wide default supplied it.
+ * - `unresolved` — nothing in the chain named a model; the pod falls back to its own default.
+ *
+ * Note that `skill-auto` and `scope-default-*` can BOTH describe a skill in auto mode: when the
+ * skill asked for auto and a scope default did supply the base model, the source is the scope
+ * default, not `skill-auto`.
+ */
 export type SkillModelResolutionSource =
   | "skill-pinned"
   | "skill-auto"
@@ -46,7 +79,17 @@ export type SkillModelResolutionSource =
   | "scope-default-global"
   | "unresolved";
 
-/** The outcome of resolving one skill's effective model. */
+/**
+ * What the resolver decided: which model, whether it is auto-routing, the config to route with,
+ * and which step of the chain produced it.
+ *
+ * The combination a caller must not miss is `auto: true` with `model: null` — the skill asked for
+ * auto-routing but no scope default named a base model. That is not a failure; the runtime routes
+ * within `autoConfig` from its own default. Treating `model: null` as "unconfigured" would drop
+ * the auto-routing request.
+ *
+ * @see {@link SkillModelResolutionSource} for what each `source` value means.
+ */
 export interface SkillModelResolution
 {
   /** The resolved `publicModelName`, or null when nothing in the chain resolves (pod falls back to its own default). */

--- a/libs/backend/server/gateways/model-routing/main/src/log.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/log.ts
@@ -1,8 +1,8 @@
 /**
- * Package-local opencrane-ui logger.
+ * Package-local backend logger for the model-routing gateway.
  *
  * Same component name as the operator's root logger so every line from this
- * domain package lands in the one `clustertenant-manager` stream, and the
+ * package lands in the one `clustertenant-manager` stream, and the
  * AsyncLocalStorage mixin in `@opencrane/backend/observability` still stamps the
  * active request's `requestId` / `trace_id`.
  */

--- a/libs/backend/server/gateways/providers/main/src/log.ts
+++ b/libs/backend/server/gateways/providers/main/src/log.ts
@@ -1,8 +1,8 @@
 /**
- * Package-local opencrane-ui logger.
+ * Package-local backend logger for the providers gateway.
  *
  * Same component name as the operator's root logger so every line from this
- * domain package lands in the one `clustertenant-manager` stream, and the
+ * package lands in the one `clustertenant-manager` stream, and the
  * AsyncLocalStorage mixin in `@opencrane/backend/observability` still stamps the
  * active request's `requestId` / `trace_id`.
  */

--- a/libs/backend/server/gateways/providers/main/src/routes/model-registry.ts
+++ b/libs/backend/server/gateways/providers/main/src/routes/model-registry.ts
@@ -37,12 +37,13 @@ function _toPrismaScope(scope: ModelRoutingScope): "Global" | "ClusterTenant"
 }
 
 /**
- * Validate a {@link ModelDefinitionWrite} body. Returns a `{ error, code }` envelope when
- * invalid, or null when acceptable. Enforces required `publicModelName` + `upstreamModel`,
- * a valid scope, and `clusterTenant` when scope is `clusterTenant`.
+ * Check an untrusted {@link ModelDefinitionWrite} body: `publicModelName` and `upstreamModel` are
+ * both required, the scope must be `global` or `clusterTenant`, and a `clusterTenant`-scoped
+ * model must name its owning ClusterTenant.
  *
  * @param body - The untrusted request body.
- * @returns A `{ error, code }` payload when invalid; null when valid.
+ * @returns `null` when the body is acceptable; otherwise `{ error, code }` with code
+ *          `VALIDATION_ERROR`, which the route sends as the 400 body unchanged.
  */
 function _validateWrite(body: Record<string, unknown>): { error: string; code: string } | null
 {
@@ -77,17 +78,20 @@ function _validateWrite(body: Record<string, unknown>): { error: string; code: s
 }
 
 /**
- * Resolve and scope-check the backing credential for a model write. A model may bind only a
- * Global credential or one owned by its OWN ClusterTenant — never another customer's — which
- * stops a tenant-scoped model from borrowing another ClusterTenant's provider key. Shared by
- * create and update so the isolation rule cannot be bypassed via PUT.
+ * Look up the credential a model write wants to use, and refuse it if it belongs to someone else.
+ *
+ * A model may bind a Global credential, or one owned by its OWN ClusterTenant — never another
+ * customer's. That is what stops one tenant's model from spending another tenant's provider key.
+ * Create and update both call this, so a PUT cannot slip past the rule that a POST enforces.
  *
  * @param prisma - Prisma client used to look up the credential.
  * @param providerCredentialId - The requested credential id, or undefined/null when none.
  * @param modelClusterTenant - The owning ClusterTenant of the model (null for Global scope).
- * @returns `{ secretRef, litellmCredentialName }` (both null when no credential requested), or a
- *          `{ error, code }` envelope. `litellmCredentialName` is non-null for a BYOK credential on
- *          the dynamic path and selects `litellm_credential_name` over the `os.environ` baseline.
+ * @returns `{ secretRef, litellmCredentialName }` — both null when no credential was requested — or
+ *          `{ error, code }` with `VALIDATION_ERROR` (no such credential) or
+ *          `CREDENTIAL_SCOPE_MISMATCH` (owned by another ClusterTenant). A non-null
+ *          `litellmCredentialName` means the key is in LiteLLM's credential store, so registration
+ *          binds `litellm_credential_name` instead of the `os.environ` baseline.
  */
 async function _resolveCredential(prisma: PrismaClient, providerCredentialId: string | null | undefined, modelClusterTenant: string | null): Promise<{ secretRef: string | null; litellmCredentialName: string | null } | { error: string; code: string }>
 {
@@ -109,12 +113,21 @@ async function _resolveCredential(prisma: PrismaClient, providerCredentialId: st
 }
 
 /**
- * CRUD router for {@link ModelDefinition} — routable models registered in LiteLLM (BYOM).
+ * CRUD router for {@link ModelDefinition} — the routable models registered in LiteLLM (BYOM).
  *
- * On create the row is persisted and the model is registered GLOBALLY with LiteLLM via a
- * best-effort `POST /model/new` (guarded by `LITELLM_ENDPOINT` + `LITELLM_MASTER_KEY`); when
- * LiteLLM is unconfigured a deterministic placeholder id is stored and the create still
- * succeeds. Mutations are gated by the ClusterTenant scope guard (AIR.0b).
+ * On create the row is written and the model is registered GLOBALLY with LiteLLM via a best-effort
+ * `POST /model/new` (guarded by `LITELLM_ENDPOINT` + `LITELLM_MASTER_KEY`). With LiteLLM
+ * unconfigured a deterministic placeholder id is stored and the create still succeeds, so the row
+ * exists but will not route until it is reconciled. Update does NOT re-register, so changing
+ * `upstreamModel` here leaves the LiteLLM deployment pointing at the old model. Mutations are
+ * gated by the ClusterTenant scope guard (AIR.0b).
+ *
+ * `GET /` returns every row, including Global ones, to every caller — which is exactly why an
+ * embedding deployment must never be given a `ModelDefinition` row. See
+ * `ByokProviderCatalog.embeddingModel` in
+ * libs/backend/server/gateways/model-routing/main/src/core/byok-default-models.types.ts.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at `/api/v1/models`.
  *
  * @param prisma - Prisma client used for persistence.
  * @returns Configured Express router.

--- a/libs/backend/server/gateways/providers/main/src/routes/provider-byok.ts
+++ b/libs/backend/server/gateways/providers/main/src/routes/provider-byok.ts
@@ -11,13 +11,17 @@ import { _DeprovisionByokKey, _ProvisionByokKey } from "@opencrane/backend/serve
 const _BYOK_PROVIDERS = Object.values(ByokProvider) as readonly string[];
 
 /**
- * Project a persisted {@link PrismaProviderCredential} row (or its absence) into the read-side
- * status DTO. `litellmRegistered` reflects whether the row carries a `litellmCredentialName` — set
- * only when LiteLLM accepted the key on the dynamic path; a Secret-only key reports `false`. Never
- * carries key material.
+ * Build the read-only status for one provider from its credential row, or from the absence of one.
+ *
+ * `configured` says a key is set; `litellmRegistered` says LiteLLM also accepted it. The second can
+ * be false while the first is true — the key is then in its Kubernetes Secret only, and models
+ * bound to the credential name will not resolve until a later set succeeds. No key material is
+ * ever included.
  *
  * @param provider - The provider this status describes.
  * @param row      - The persisted credential row, or undefined when no key is set.
+ * @returns The status DTO: provider, whether a key is set, whether LiteLLM took it, and when it
+ *          last changed.
  */
 function _toStatus(provider: string, row: PrismaProviderCredential | undefined): ProviderKeyStatus
 {

--- a/libs/backend/server/gateways/providers/main/src/routes/provider-credentials.ts
+++ b/libs/backend/server/gateways/providers/main/src/routes/provider-credentials.ts
@@ -8,8 +8,11 @@ import { _ClusterTenantScopeGuard, type ClusterTenantScopedResource } from "@ope
 const _RAW_KEY_FIELDS = ["apiKey", "keyValue", "key"] as const;
 
 /**
- * Project a persisted provider-credential row into its contract DTO. The Prisma enum
- * values map 1:1 to the lowercase {@link ModelRoutingScope} string union.
+ * Convert a stored provider-credential row into the contract shape the API returns. The Prisma
+ * enum values map 1:1 to the lowercase {@link ModelRoutingScope} string union.
+ *
+ * Only the Secret's NAME (`secretRef`) is carried out, never a key — there is no key on the row
+ * to leak in the first place.
  *
  * @param row - The persisted `ProviderCredential` row.
  * @returns The contract-shaped credential (timestamps as ISO-8601 strings).
@@ -35,13 +38,19 @@ function _toPrismaScope(scope: ModelRoutingScope): "Global" | "ClusterTenant"
 }
 
 /**
- * Validate a {@link ProviderCredentialWrite} body. Returns an error envelope string when
- * invalid, or null when the body is acceptable. Enforces the locked decisions: required
- * `provider` + `secretRef`, `clusterTenant` required when scope is `clusterTenant`, and a
- * hard reject of any raw-key field — the raw key must live in a k8s Secret, never here.
+ * Check an untrusted {@link ProviderCredentialWrite} body, in this order:
+ *   1. reject the request outright if it carries any raw-key field (`apiKey`, `keyValue`, `key`) —
+ *      this endpoint stores only a `secretRef`, and the key itself belongs in a Kubernetes Secret;
+ *   2. require `provider` and `secretRef`;
+ *   3. require `clusterTenant` when the scope is `clusterTenant`, and reject any other scope value.
+ *
+ * The raw-key check runs first on purpose, so a request that would have leaked a key into Postgres
+ * is refused before any other reason can mask it.
  *
  * @param body - The untrusted request body.
- * @returns A `{ error, code }` payload when invalid; null when valid.
+ * @returns `null` when the body is acceptable; otherwise `{ error, code }` — `RAW_KEY_REJECTED`
+ *          for a raw key, `VALIDATION_ERROR` for everything else. The route sends it as the 400
+ *          body unchanged.
  */
 function _validateWrite(body: Record<string, unknown>): { error: string; code: string } | null
 {

--- a/libs/backend/server/iam/audit/main/src/audit-decision.ts
+++ b/libs/backend/server/iam/audit/main/src/audit-decision.ts
@@ -3,9 +3,21 @@ import { AuditDecisionActorKind, AuditDecisionOutcome, WorkloadKind, type Prisma
 import type { AuditDecisionRecord } from "./audit-decision.types.js";
 
 /**
- * Appends target authorization evidence through the caller's active transaction.
- * @param transaction - Driving-domain Prisma transaction that owns the authority change.
- * @param decision - Exact immutable authorization evidence to append atomically.
+ * Writes one row into the append-only decision log, using the transaction the caller is already in.
+ *
+ * It takes a transaction client, not a Prisma client, precisely so it cannot be called on its own:
+ * the audit row commits with the change it describes or not at all. It also translates the plain
+ * string fields (`actorKind`, `workloadKind`, `outcome`) into the Prisma enums, so callers do not
+ * import generated enums.
+ *
+ * Called by: libs/backend/server/iam/authorization/main/src/prisma-runtime-authority.ts,
+ * libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts,
+ * libs/backend/server/agents/agent-services/main/src/prisma-agent-publication.ts, and
+ * standalone-first-user-audit.ts in this package.
+ * @param transaction - The open transaction of the change being recorded.
+ * @param decision - The decision to record; treat it as final, nothing rewrites these rows.
+ * @throws Error propagated from Prisma when the insert fails, which deliberately rolls the caller's
+ *         change back rather than letting it commit unaudited.
  */
 export async function __AppendAuditDecision(transaction: Prisma.TransactionClient, decision: AuditDecisionRecord): Promise<void>
 {

--- a/libs/backend/server/iam/audit/main/src/audit-decision.types.ts
+++ b/libs/backend/server/iam/audit/main/src/audit-decision.types.ts
@@ -1,10 +1,42 @@
-/** Actor classes retained in the append-only target decision ledger. */
+/**
+ * Who caused a decision, as stored on every audit row.
+ *
+ * `user` is a person's OIDC subject (sharing, publishing). `workload` is a running pod, identified
+ * by its pod UID — what the runtime authority records. `system` is OpenCrane acting with no request
+ * behind it, such as accepting a signed membership revision. `agent-service` is an agent acting in
+ * its own name. Choose by who actually caused the row, not by which module writes it:
+ * {@link __AppendAuditDecision} maps these strings onto the Prisma enum and nothing rewrites these
+ * rows afterwards.
+ *
+ * @see AuditDecisionRecord
+ */
 export type AuditDecisionActorKind = "user" | "agent-service" | "workload" | "system";
 
-/** Stable authorization result retained in the append-only target decision ledger. */
+/**
+ * How a decision came out: `allow` permitted it, `deny` refused it, and `error` means no decision
+ * could be reached at all — a failure while evaluating, not a judgement about the request.
+ *
+ * Every call site in this repo records `allow` today, because refusals are returned before any
+ * transaction is open; `deny` and `error` exist for call sites that need to keep the refusal.
+ */
 export type AuditDecisionOutcome = "allow" | "deny" | "error";
 
-/** Exact target authorization evidence appended inside a driving-domain transaction. */
+/**
+ * One row of the append-only decision log: what was decided, about what, by whom, and under which
+ * policy and capability catalog.
+ *
+ * The rule that matters: this row is written inside the same transaction as the change it describes
+ * — the grant, the publish, the accepted membership revision. Write it separately and the two can
+ * drift, leaving either a change nobody can account for or an audit row for a change that rolled
+ * back. Most fields are optional because they only apply to some actors: the workload and pod fields
+ * describe a running pod, `runId`/`attempt` a run, and the proof-key fields a signed runtime request.
+ *
+ * Called by: libs/backend/server/iam/authorization/main/src/prisma-runtime-authority.ts,
+ * libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts,
+ * libs/backend/server/agents/agent-services (publication audit evidence), and
+ * standalone-first-user-audit.ts in this package.
+ * @see __AppendAuditDecision
+ */
 export interface AuditDecisionRecord
 {
 	/** RFC 8785 SHA-256 digest of the complete decision evidence. */
@@ -63,6 +95,6 @@ export interface AuditDecisionRecord
 	readonly outcome: AuditDecisionOutcome;
 	/** Stable machine-readable decision reason. */
 	readonly reasonCode: string;
-	/** Database-authoritative decision instant. */
+	/** When the decision happened; leave it unset to let the database stamp the row. */
 	readonly decidedAt?: Date;
 }

--- a/libs/backend/server/iam/audit/main/src/routes/audit.ts
+++ b/libs/backend/server/iam/audit/main/src/routes/audit.ts
@@ -7,10 +7,18 @@ import type { AuditEntry } from "./audit.types.js";
 const MAX_LIMIT = 1000;
 
 /**
- * Creates an Express router that queries the audit log from PostgreSQL.
- * Supports cursor-based keyset pagination via the `cursor` query parameter.
- * @param prisma - Prisma ORM client
- * @returns Configured Express Router
+ * Serves the operator-facing audit log, newest entry first.
+ *
+ * These are the readable entries the group and tenant routes write, not the append-only
+ * authorization decisions from __AppendAuditDecision. Paging is keyset-based: the cursor is the last
+ * entry's timestamp, base64url-encoded, and the handler asks for one row more than the page size so
+ * it can report `hasMore` without a second COUNT query. An unreadable cursor is ignored and the first
+ * page is returned; `limit` is capped at 1000.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at /api/v1/audit.
+ * @param prisma - Silo Prisma client.
+ * @returns Express router with the single GET / route.
+ * @see AuditEntry
  */
 export function auditRouter(prisma: PrismaClient): Router
 {

--- a/libs/backend/server/iam/audit/main/src/routes/audit.types.ts
+++ b/libs/backend/server/iam/audit/main/src/routes/audit.types.ts
@@ -2,7 +2,13 @@
  * API types for the audit-log route.
  */
 
-/** Single entry in the audit log. */
+/**
+ * One row of the operator-facing audit log, as returned by GET /audit.
+ *
+ * These are the readable entries written by the group and tenant routes, not the append-only
+ * authorization decisions from __AppendAuditDecision. `tenant` is part of the contract but the list
+ * route does not populate it today.
+ */
 export interface AuditEntry
 {
   /** ISO-8601 timestamp of the event. */

--- a/libs/backend/server/iam/audit/main/src/standalone-first-user-audit.ts
+++ b/libs/backend/server/iam/audit/main/src/standalone-first-user-audit.ts
@@ -3,7 +3,17 @@ import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 import { __AppendAuditDecision } from "./audit-decision.js";
 import type { StandaloneFirstUserAdmissionAuditAppender, StandaloneFirstUserAuditClaim } from "./standalone-first-user-audit.types.js";
 
-/** Creates the audit-owned adapter for one standalone first-owner admission transaction. */
+/**
+ * Builds the audit adapter identity uses when it admits a standalone silo's first owner.
+ *
+ * It exists so identity never imports the audit tables: identity owns the port, this package owns
+ * the row. The row records the claim (silo, subject, action) and deliberately does not keep the
+ * bootstrap email that made the subject eligible.
+ *
+ * Called by: apps/opencrane/src/app/public-app.ts, which passes the result into
+ * ___CreateOidcAuthService.
+ * @returns An appender that writes the first-owner row inside identity's own transaction.
+ */
 export function __CreateStandaloneFirstUserAdmissionAuditAppender(): StandaloneFirstUserAdmissionAuditAppender
 {
   return {

--- a/libs/backend/server/iam/audit/main/src/standalone-first-user-audit.types.ts
+++ b/libs/backend/server/iam/audit/main/src/standalone-first-user-audit.types.ts
@@ -1,4 +1,9 @@
-/** Structural input shared with the identity admission port without introducing an IAM cycle. */
+/**
+ * The two facts recorded when a silo's first owner is admitted.
+ *
+ * It is its own small type so identity and audit can agree on the shape without importing each
+ * other; identity's StandaloneFirstUserAdmissionAuditPort takes the same fields.
+ */
 export interface StandaloneFirstUserAuditClaim
 {
   /** Silo whose one-time owner row was admitted. */
@@ -7,9 +12,22 @@ export interface StandaloneFirstUserAuditClaim
   readonly subject: string;
 }
 
-/** Audit adapter interface supplied by the OpenCrane composition root to identity admission. */
+/**
+ * Writes the first-owner audit row inside the transaction that claims the owner slot.
+ *
+ * The transaction arrives as `unknown` on purpose: identity owns it, and this package must not
+ * depend on identity's Prisma types. The implementation casts it back to a transaction client.
+ *
+ * Called by: apps/opencrane/src/app/public-app.ts supplies
+ * {@link __CreateStandaloneFirstUserAdmissionAuditAppender} as the implementation; identity calls
+ * `append` from its owner-claim repository.
+ */
 export interface StandaloneFirstUserAdmissionAuditAppender
 {
-  /** Records first-owner evidence inside identity's active serializable transaction. */
+  /**
+   * @param transaction - Identity's open serializable transaction, passed as an opaque value.
+   * @param claim - Silo and subject being admitted as owner.
+   * @throws Error from the insert, which rolls the owner claim back rather than leaving it unaudited.
+   */
   append(transaction: unknown, claim: StandaloneFirstUserAuditClaim): Promise<void>;
 }

--- a/libs/backend/server/iam/authorization/main/src/capability-proof.ts
+++ b/libs/backend/server/iam/authorization/main/src/capability-proof.ts
@@ -319,10 +319,16 @@ function _capabilityBindingFailure(expectation: CapabilityProofExpectation): Cap
 }
 
 /**
- * Computes the RFC 7638 SHA-256 thumbprint for a public ES256 key.
+ * Compute the standard fingerprint of a public ES256 key.
+ *
+ * Rejects a key carrying a private component, and rejects a point that is not actually on P-256, so
+ * a thumbprint only ever exists for a key we could really verify with.
+ *
+ * Called by: ./runtime-proof.ts (`_validateBootstrap`) and `__VerifyCapabilityProof` below.
  * @param jwk - Public P-256 JSON Web Key.
- * @returns Unpadded base64url thumbprint over required canonical JWK members.
- * @throws TypeError when the key is malformed, private, or not on P-256.
+ * @returns Unpadded base64url SHA-256 thumbprint over the four required JWK members.
+ * @throws TypeError when the key is malformed, carries a private part, or is not a valid P-256
+ *   point. Callers that treat a bad key as a denial must catch this.
  */
 export function __ComputeEs256JwkThumbprint(jwk: Es256PublicJwk): string
 {
@@ -336,10 +342,15 @@ export function __ComputeEs256JwkThumbprint(jwk: Es256PublicJwk): string
 }
 
 /**
- * Normalizes an observed target URI to the RFC 9449 `htu` representation.
- * @param targetUri - Absolute HTTP or HTTPS request URI.
- * @returns Normalized URI without query or fragment.
- * @throws TypeError when the URI is not a safe absolute HTTP target.
+ * Reduce a request URI to the form a DPoP proof is expected to sign.
+ *
+ * Drops the query string and fragment, and refuses a URI carrying embedded credentials, so the
+ * value being compared cannot vary with per-request parameters.
+ *
+ * Called by: ./runtime-proof.ts (`_requestFingerprint`) and `__VerifyCapabilityProof` below.
+ * @param targetUri - Absolute http or https request URI.
+ * @returns Origin plus path only.
+ * @throws TypeError when the URI is relative, not http(s), or contains a username or password.
  */
 export function __NormalizeDpopTargetUri(targetUri: string): string
 {
@@ -352,10 +363,26 @@ export function __NormalizeDpopTargetUri(targetUri: string): string
 }
 
 /**
- * Verifies an ES256 RFC 9449-style compact proof against one exact action capability.
- * @param compactProof - Compact JWS carried in the request's DPoP proof field.
- * @param expectation - Trusted request and action-capability facts from the PEP.
- * @returns Fail-closed verification with claims only after every binding succeeds.
+ * Check that a request really was signed by the key registered to this run, for this exact action.
+ *
+ * Order matters and is deliberate: the caller's own trusted facts are validated first, then the
+ * issued capability is compared against what was actually observed, and only then is a single byte
+ * of the attacker-controlled proof parsed. The signature is verified before any claim inside the
+ * proof is believed.
+ *
+ * It then re-checks everything against everything: the key's thumbprint must match the signed
+ * claim, the issued capability, AND the key registered to the workload; the HTTP method and
+ * normalized path must match; and every workload, run, resource, action, and digest field must
+ * agree. Any single mismatch returns a reason and no claims, so a valid proof cannot be redirected
+ * at a different action or a different pod.
+ *
+ * Called by: ./runtime-proof.ts (`__ExecuteCapabilityAction`).
+ * @param compactProof - The compact JWS from the request's DPoP proof header. Untrusted.
+ * @param expectation - Facts the server established itself: the issued capability, the separately
+ *   observed workload binding, the request method and URI, and the current time. Never taken from
+ *   the request body.
+ * @returns On success, the parsed claims and the confirmed key thumbprint. On failure, only a
+ *   reason — never partially trusted claims.
  */
 export function __VerifyCapabilityProof(compactProof: string, expectation: CapabilityProofExpectation): CapabilityProofVerification
 {

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-decision.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-decision.types.ts
@@ -1,6 +1,16 @@
 import type { JsonValue } from "@opencrane/util";
 
-/** Terminal decision a reviewer may record for a deferred tool request. */
+/**
+ * The two answers a reviewer can give, and they are final.
+ *
+ * `Approved` MUST come with a complete replacement argument object; a partial edit is rejected as
+ * `invalid_arguments`, because merging a partial edit server-side would let a reviewer approve
+ * values they never saw. `Denied` must come with no arguments at all.
+ *
+ * These string values are also the wire values on the decision route, so they cannot be renamed
+ * without a client change.
+ * @see {@link DecideDeferredToolRequestCommand}
+ */
 export enum DeferredToolDecisionKinds
 {
 	/** Approves the exact complete argument object carried by the decision request. */
@@ -28,7 +38,12 @@ export interface DecideDeferredToolRequestCommand
 	readonly now: Date;
 }
 
-/** Trusted attempt coordinates used by runtime dispatch to close due approvals. */
+/**
+ * Which run attempt to sweep for approvals whose deadline has passed.
+ *
+ * Sent by the runtime's own command poll, so the sweep happens on a transaction that already
+ * holds the run, and no separate cron job is needed.
+ */
 export interface ExpireDeferredToolApprovalBatchCommand
 {
 	/** Exact run whose command poll owns the expiry sweep transaction. */
@@ -48,7 +63,22 @@ export interface ExpireDeferredToolApprovalBatchResult
 	readonly resumed: boolean;
 }
 
-/** Result of atomically deciding one pending deferred tool request. */
+/**
+ * What the decision attempt actually did, and what the caller should tell the user.
+ *
+ * - `approved` / `denied` — the decision was recorded now.
+ * - `already_decided` — the same decision was already recorded; safe to report as success. The
+ *   caller's retry did nothing, which is the point.
+ * - `expired` — the deadline had passed, so the request was closed instead of decided. The user
+ *   must be told their answer was not applied.
+ * - `invalid_arguments` — approval without a complete argument object, denial with arguments, or
+ *   arguments that fail the frozen schema.
+ * - `conflict` — the row is not what the caller thinks: wrong owner or silo, the run is no longer
+ *   waiting, the earlier decision went the other way, or the stored data failed its integrity
+ *   check. Never retry a `conflict`; re-read first.
+ *
+ * ./deferred-tool-approval.router.ts maps these to 200, 409, 400, and 404 respectively.
+ */
 export type DecideDeferredToolRequestResult =
 	| { readonly outcome: "approved"; readonly argumentsDigest: string }
 	| { readonly outcome: "denied" }
@@ -57,9 +87,25 @@ export type DecideDeferredToolRequestResult =
 	| { readonly outcome: "invalid_arguments" }
 	| { readonly outcome: "conflict" };
 
-/** Atomic persistence boundary for a session-authorized deferred-tool decision. */
+/**
+ * Records one browser-submitted approval decision in a single transaction.
+ *
+ * Exists so the HTTP route never touches Prisma and never gets to choose the transaction level:
+ * the decision re-reads the approval, the run, and the invocation, and applies the approved
+ * arguments, all serializably.
+ *
+ * Called by: ./deferred-tool-approval.router.ts (as `decisions`).
+ * Implemented by: ./prisma-deferred-tool-approval-decision-repository.ts.
+ */
 export interface DeferredToolApprovalDecisionRepository
 {
-	/** Decide one request only when its durable run coordinates still match the authenticated owner. */
+	/**
+	 * Applies one reviewer decision, or explains why it could not be applied.
+	 * @param command - The approval id, the authenticated owner and silo, the decision, and the
+	 *   trusted server time. Ownership is re-checked against the stored row, so a caller cannot
+	 *   decide someone else's approval by supplying its id.
+	 * @returns One of {@link DecideDeferredToolRequestResult}; see it for what each outcome obliges
+	 *   the caller to report.
+	 */
 	decideAtomically(command: DecideDeferredToolRequestCommand): Promise<DecideDeferredToolRequestResult>;
 }

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-interrupt.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-interrupt.types.ts
@@ -24,11 +24,27 @@ export interface ApprovalInterruptReadCommand
 /** Reader the conversations package calls; it is declared here so that package need not depend on this one. */
 export interface DeferredToolApprovalInterruptReader
 {
-	/** Read current owner-bound approval overlays without advancing a conversation cursor. */
+	/**
+	 * Lists the approvals this user still has to decide in one conversation.
+	 * @param command - Conversation, silo, and subject taken from the already-authenticated reader.
+	 * @returns Timeline-shaped entries for the live approvals, newest last. Reading these does not
+	 *   move the conversation's read position, so a caller may poll it as often as it likes.
+	 */
 	readOpen(command: ApprovalInterruptReadCommand): Promise<readonly AgUiProjectionSourceEvent[]>;
 }
 
-/** Stable actor-facing states returned for one owned deferred-tool interrupt. */
+/**
+ * The state of one approval as the owning user sees it.
+ *
+ * Not the stored column: `Expired` is also returned for a row still stored as pending whose
+ * deadline has passed, because a sweep may not have run yet. So `Pending` here really does mean
+ * "you can still decide this", and a client may show a decision button on it without re-checking
+ * the clock.
+ *
+ * `Denied` means the user refused. `Cancelled` means the run was torn down before anyone decided —
+ * do not present that as the user's own choice.
+ * @see {@link SelfDeferredToolApproval}
+ */
 export enum DeferredToolApprovalStates
 {
 	/** The interrupt remains actionable before its server-owned expiry. */
@@ -68,7 +84,17 @@ export interface SelfDeferredToolApproval
 	readonly createdAt: string;
 }
 
-/** Read-only persistence boundary for the signed-in owner's approval inbox and detail. */
+/**
+ * The owner-only reads behind the approvals inbox.
+ *
+ * Every method takes both `siloId` and `subjectId` and filters on them in the query, so one user
+ * can never read another's approval by guessing an id. Reads select only pre-redacted columns —
+ * never the reviewed arguments the server keeps for dispatch.
+ *
+ * Callers should use {@link SelfDeferredToolApprovalReadUnitOfWork} instead of this directly; it
+ * adds the membership check in the same transaction.
+ * Implemented by: ./prisma-self-deferred-tool-approval-list-repository.ts.
+ */
 export interface SelfDeferredToolApprovalListRepository
 {
 	/** Proves the caller still owns an active membership in the exact silo snapshot. */
@@ -81,7 +107,18 @@ export interface SelfDeferredToolApprovalListRepository
 	readOwned(approvalRequestId: string, siloId: string, subjectId: string, now: Date): Promise<SelfDeferredToolApproval | null>;
 }
 
-/** Atomic read boundary that snapshots membership and actor-safe approval data together. */
+/**
+ * The approvals inbox reads, each wrapped in one transaction with a membership check.
+ *
+ * Membership is verified and the data is read inside a single serializable transaction, so a user
+ * removed from the silo mid-request cannot come back with data from just before the removal. When
+ * membership fails, every method returns empty or null — never an error — so the API cannot be used
+ * to tell "no access" apart from "nothing pending".
+ *
+ * Called by: ./deferred-tool-approval.router.ts (as `pendingApprovals`) and
+ * ./prisma-deferred-tool-approval-interrupt-reader.ts.
+ * Implemented by: ./prisma-self-deferred-tool-approval-list-repository.ts.
+ */
 export interface SelfDeferredToolApprovalReadUnitOfWork
 {
 	/** Lists actionable approvals only while the caller's membership remains active. */

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-lifecycle.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-lifecycle.ts
@@ -44,10 +44,17 @@ const _STATE_HANDLERS: Readonly<Record<DeferredToolApprovalRunStates, DeferredTo
 };
 
 /**
- * Select the sole persistence action for one durable State x Event cell.
+ * Decide what happens to the RUN when one of its approvals opens or resolves.
  *
- * Decision kind is deliberately not interpreted here. Approved, denied, and expired payloads use
- * independent result strategies; this owner controls only pause, batching, resume, and rejection.
+ * Deliberately blind to whether the approval was approved, denied, or expired — those produce
+ * different results for the tool call, but the run pauses and resumes the same way regardless. So
+ * this only ever chooses: pause, add to the current batch, keep waiting, resume, cancel, or reject.
+ *
+ * Called by: ./deferred-tool-approval.ts (`__DeferToolRequest` for `Open`, and
+ * `_FinishDeferredToolApprovalBatch` for `Decision` and `Expiry`).
+ * @param input - Run state, the event, and the pending count after the approval row changed.
+ * @returns The single permitted write, or `Reject` when the event is invalid for that run state.
+ *   `_FinishDeferredToolApprovalBatch` throws on anything other than `KeepWaiting` or `Resume`.
  */
 export function __PlanDeferredToolApprovalLifecycle(input: DeferredToolApprovalLifecycleInput): DeferredToolApprovalLifecycleActions
 {

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-lifecycle.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-lifecycle.types.ts
@@ -1,4 +1,12 @@
-/** Dependency-light run states interpreted by the approval lifecycle owner. */
+/**
+ * The run states this package needs to reason about approvals.
+ *
+ * A deliberate copy of the runs package's state names rather than an import, so approval logic
+ * stays independent of the runs package. Only `Running` and `WaitingForApproval` can take part in
+ * an approval; every other member exists so the decision table is exhaustive and adding a run
+ * state forces an explicit choice here.
+ * @see {@link DeferredToolApprovalLifecycleActions}
+ */
 export enum DeferredToolApprovalRunStates
 {
 	/** Accepted but not yet queued. */
@@ -23,7 +31,12 @@ export enum DeferredToolApprovalRunStates
 	Cancelled = "cancelled",
 }
 
-/** Durable events interpreted by the deferred-tool approval run-state owner. */
+/**
+ * The four things that can happen to a run's approvals.
+ *
+ * `Decision` and `Expiry` both resolve one approval and are handled identically by the run-state
+ * table — which one it was matters only for the approval row, not for the run.
+ */
 export enum DeferredToolApprovalLifecycleEvents
 {
 	/** Adds one approval to a running or already-waiting batch. */
@@ -36,7 +49,18 @@ export enum DeferredToolApprovalLifecycleEvents
 	Cancellation = "cancellation",
 }
 
-/** Exhaustive persistence actions selected from run state, event, and pending cardinality. */
+/**
+ * The one write allowed for a run when an approval opens, resolves, or is cancelled.
+ *
+ * Chosen by {@link __PlanDeferredToolApprovalLifecycle} from the run state, the event, and how many
+ * approvals are still pending. The count is what separates the near-identical pairs:
+ * `PauseAndOpen` is the first approval on a running run (pause it), `OpenInBatch` is a later one
+ * (already paused). `Resume` fires only when the last pending approval resolves; `KeepWaiting`
+ * while any remain. Act on `KeepWaiting` as if it were `Resume` and the run restarts while a
+ * reviewer is still deciding.
+ *
+ * `Reject` means the event is invalid for the run's current state and nothing may be written.
+ */
 export enum DeferredToolApprovalLifecycleActions
 {
 	/** Move Running to WaitingForApproval before creating the first approval. */

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-open.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-open.types.ts
@@ -37,13 +37,26 @@ export interface DeferToolRequestCommand
 	readonly expiresAt: Date;
 }
 
-/** Result of creating or idempotently replaying one pending deferred-tool approval. */
+/**
+ * What opening an approval did.
+ *
+ * `deferred` created it; `already_deferred` found the identical approval from an earlier attempt —
+ * both mean the tool call is now correctly parked. `unavailable` means it could not be opened at
+ * all (the run's pod is gone, its proof key expired, the deadline is already past, or the run is
+ * not in a state that can pause), and the caller must fail the tool call rather than wait.
+ */
 export type DeferToolRequestResult =
 	| { readonly outcome: "deferred"; readonly approvalRequestId: string }
 	| { readonly outcome: "already_deferred"; readonly approvalRequestId: string }
 	| { readonly outcome: "unavailable" };
 
-/** Exact prepared external-action coordinates needed to open a deferred approval. */
+/**
+ * Everything needed to open an approval for one already-prepared tool call.
+ *
+ * The digests are re-computed and compared before anything is written, so a caller that passes an
+ * arguments or schema digest that does not match its value gets the tool call failed with
+ * `approval_arguments_invalid` rather than an approval a reviewer could not trust.
+ */
 export interface OpenDeferredToolApprovalCommand
 {
 	/** Interrupt id emitted for the reviewed proposal and reused as the approval id. */
@@ -74,18 +87,38 @@ export interface OpenDeferredToolApprovalCommand
 	readonly expiresAt: Date;
 }
 
-/** Transaction-scoped persistence operations used while opening or recovering one approval. */
+/**
+ * The three writes and reads needed to open one approval, or to clean up after an unclear commit.
+ *
+ * All three run on the caller's transaction. `hasLinkedApproval` exists purely for recovery: if the
+ * open transaction throws after the database may already have committed, a linked approval proves
+ * the create succeeded and the tool call must NOT be failed.
+ *
+ * Implemented by: ./prisma-deferred-tool-approval-opener.ts.
+ * @see {@link DeferredToolApprovalOpenUnitOfWork}
+ */
 export interface DeferredToolApprovalOpenRepository
 {
 	/** Creates the approval, checking the run's live workload assignment and proof key on this transaction. */
 	defer(command: DeferToolRequestCommand): Promise<DeferToolRequestResult>;
-	/** Compare-and-set one awaiting-approval invocation to a stable failure and delivery. */
+	/**
+	 * Fails one tool call that is still waiting for approval, and records its result delivery.
+	 * @returns False when the tool call is no longer awaiting approval, meaning something else
+	 *   already moved it and the caller must not assume it was failed.
+	 */
 	terminaliseAwaitingApproval(invocationId: string, failureCode: string, now: Date): Promise<boolean>;
 	/** Return whether the exact interrupt is durably linked to its invocation. */
 	hasLinkedApproval(command: OpenDeferredToolApprovalCommand): Promise<boolean>;
 }
 
-/** Atomic boundary for opening and ambiguity-recovering one deferred tool approval. */
+/**
+ * Opens one approval and guarantees the tool call never ends up stuck waiting.
+ *
+ * Either an approval exists afterwards, or the tool call has been failed. It never leaves a tool
+ * call in `AwaitingApproval` with no approval to decide.
+ *
+ * Implemented by: ./prisma-deferred-tool-approval-opener.ts (`__OpenDeferredToolApproval`).
+ */
 export interface DeferredToolApprovalOpenUnitOfWork
 {
 	/** Opens an approval or proves the invocation terminal without exposing Prisma. */

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-schema.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval-schema.ts
@@ -119,7 +119,19 @@ function _responseSchema(parametersSchema: JsonValue): JsonValue
 	};
 }
 
-/** Validate a complete argument value against the frozen reviewed JSON Schema. */
+/**
+ * Check one complete argument object against the tool's stored parameters schema.
+ *
+ * The schema is the one captured when the approval was opened, never the tool's current schema, so
+ * a reviewer is always judged against what they were actually shown.
+ *
+ * Called by: ./deferred-tool-approval.ts (on the stored arguments and again on the reviewer's
+ * replacement) and ./prisma-deferred-tool-approval-opener.ts.
+ * @param parametersSchema - The stored JSON Schema.
+ * @param argumentsValue - The complete argument object; partial edits are not supported.
+ * @returns True when valid. False for invalid arguments AND for an unusable schema — the schema
+ *   compile is wrapped in a try, so this never throws and always fails closed.
+ */
 export function __ValidateDeferredToolArguments(parametersSchema: JsonValue, argumentsValue: JsonValue): boolean
 {
 	try
@@ -133,7 +145,20 @@ export function __ValidateDeferredToolArguments(parametersSchema: JsonValue, arg
 	}
 }
 
-/** Return whether the frozen schema permits an actor-supplied replacement rather than denial only. */
+/**
+ * Decide whether a reviewer may edit the arguments at all, or may only approve or deny.
+ *
+ * False as soon as any part of the schema marks a value secret — anywhere, including through local
+ * `$ref`s and `allOf`/`anyOf`/`oneOf` branches. If a secret exists we cannot show the reviewer the
+ * real arguments, so we must not accept a replacement either; they would be editing values they
+ * never saw. An unresolvable or external `$ref` is also treated as secret, so an unreadable schema
+ * fails closed.
+ *
+ * Called by: ./deferred-tool-approval.ts (`__DecideDeferredToolRequest`) and
+ * `__ProjectDeferredToolApproval` below.
+ * @param parametersSchema - The stored parameters schema.
+ * @returns True when editing is safe, false when the reviewer may only approve or deny.
+ */
 export function __IsDeferredToolApprovalReplacementAllowed(parametersSchema: JsonValue): boolean
 {
 	return !_containsSecretSchema(parametersSchema, parametersSchema);

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.router.types.ts
@@ -21,7 +21,15 @@ export interface DeferredToolApprovalClock
 	now(): Date;
 }
 
-/** Composition ports for the self-only deferred-tool approval decision API. */
+/**
+ * Everything {@link __CreateDeferredToolApprovalRouter} needs, all injected.
+ *
+ * `resolveCaller` is the one that matters: identity comes from it and never from request input, so
+ * the router itself has no way to act as another user. The clock is injected so decision expiry can
+ * be tested without waiting.
+ *
+ * Composed in: ./prisma-deferred-tool-approval.router.ts.
+ */
 export interface DeferredToolApprovalRouterDependencies
 {
 	/** Resolves session and host identity, or null when no authenticated caller exists. */

--- a/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.ts
+++ b/libs/backend/server/iam/authorization/main/src/deferred-tool-approval.ts
@@ -238,7 +238,12 @@ export async function __ExpireDeferredToolApprovalBatch(transaction: Prisma.Tran
 	return { expiredCount, resumed: after?.state === AgentRunState.Running };
 }
 
-/** Expire one pending approval, fail its invocation, and apply the batch-resume strategy. */
+/**
+ * Close one overdue approval, fail the tool call it was gating, and resume the run if it was the
+ * last pending approval.
+ *
+ * Returns false without writing anything when the row was already decided by someone else.
+ */
 async function _ExpireDeferredToolApproval(transaction: Prisma.TransactionClient, approval: { id: string; runId: string; attempt: number; toolInvocationRowId: string | null }, now: Date): Promise<boolean>
 {
 	if (approval.toolInvocationRowId === null) return false;

--- a/libs/backend/server/iam/authorization/main/src/effective-access.ts
+++ b/libs/backend/server/iam/authorization/main/src/effective-access.ts
@@ -38,12 +38,26 @@ function _decideForSubject(command: ResolveEffectiveAccessCommand, subjectId: st
 }
 
 /**
- * Resolves effective access as the deterministic intersection of actor and AgentService grants.
- * Current signed membership is a mandatory first gate and may never be inferred from grants.
- * @param membershipAuthority - Signed fleet-membership authority port.
- * @param grantRepository - Candidate grant persistence port.
- * @param command - Actor, service, scope, membership, and capability request.
- * @returns Only capabilities independently allowed to both principals.
+ * Work out what an agent may do on a person's behalf, and nothing more.
+ *
+ * Runs in a fixed order, and the order is the security property:
+ * 1. Validate the request. A person acting as their own agent, or a mismatched scope, is rejected
+ *    before any query runs.
+ * 2. Require a current signed membership — never inferred from grants — and independently re-check
+ *    the expiry the membership authority returned.
+ * 3. Narrow the requested capabilities to what the agent revision published and what this run
+ *    compiled, before reading a single grant.
+ * 4. Read each principal's grants separately, so neither side can widen the other.
+ * 5. Keep only capabilities both sides allow. An empty result is a denial, never an empty allow.
+ *
+ * Called by: no caller in this repo yet — only its own tests in ./__tests__/effective-access.test.ts.
+ * @param membershipAuthority - The mandatory first gate; see
+ *   {@link AuthorizationMembershipAuthority}.
+ * @param grantRepository - Reads candidate grants for one subject.
+ * @param command - The person, the agent authority, the scope and resource, and the capabilities
+ *   being requested.
+ * @returns `allowed` with the surviving capabilities and the membership revision, or `denied` with
+ *   the reason the request died. See {@link ResolveEffectiveAccessResult}.
  */
 export async function __ResolveEffectiveAccess(membershipAuthority: AuthorizationMembershipAuthority, grantRepository: AuthorizationGrantRepository, command: ResolveEffectiveAccessCommand): Promise<ResolveEffectiveAccessResult>
 {

--- a/libs/backend/server/iam/authorization/main/src/effective-access.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/effective-access.types.ts
@@ -33,21 +33,49 @@ export type AuthorizationMembershipDecision =
 	| { readonly outcome: "trusted"; readonly revision: number; readonly trustedUntilEpochMs: number }
 	| { readonly outcome: "denied"; readonly reason: string; readonly revision: number };
 
-/** Port to the signed fleet-membership authority without coupling to its adapter. */
+/**
+ * Asks whether a person currently holds a signed membership for the requested scope.
+ *
+ * Kept as a port so access resolution never learns how memberships are signed or stored. This is a
+ * mandatory first gate: membership may never be inferred from the grants a subject happens to have.
+ *
+ * Called by: ./effective-access.ts (`__ResolveEffectiveAccess`).
+ * Implemented by: libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts.
+ */
 export interface AuthorizationMembershipAuthority
 {
-	/** Evaluates the current signed membership revision for the exact request scope. */
+	/**
+	 * Checks the caller's membership for one scope at one instant.
+	 * @param requirement - The scope, the subject, the trusted current time, and how stale a signed
+	 *   membership may be.
+	 * @returns `trusted` with the revision and the instant it stops being trusted, or `denied` with a
+	 *   reason. The caller must still check the returned expiry itself — see `membership_stale` in
+	 *   {@link ResolveEffectiveAccessResult}.
+	 */
 	verifyCurrentMembership(requirement: AuthorizationMembershipRequirement): Promise<AuthorizationMembershipDecision>;
 }
 
-/** Persistence boundary for grants assigned to one exact subject in one silo. */
+/**
+ * Reads the grants that might apply to one subject.
+ *
+ * Returns candidates only — no filtering by capability or resource — because the decision itself is
+ * pure domain code that must see every candidate to apply deny-over-allow and priority ordering.
+ *
+ * Called by: ./effective-access.ts. Implemented by: ./prisma-authorization-grants.ts.
+ */
 export interface AuthorizationGrantRepository
 {
 	/** Lists every candidate grant for deterministic domain evaluation. */
 	listSubjectGrants(siloId: string, subjectId: string): Promise<readonly AuthorizationGrant[]>;
 }
 
-/** Command that intersects a human actor's access with an AgentService's delegated access. */
+/**
+ * One request to work out what an agent may do on a person's behalf.
+ *
+ * The answer is an intersection: a capability survives only if the person is allowed it AND the
+ * agent's own authority is allowed it, and only if it is inside both the revision's published
+ * maximum and the set compiled for this run. Neither side can widen the other.
+ */
 export interface ResolveEffectiveAccessCommand
 {
 	/** Current signed membership requirement for the human actor. */
@@ -68,7 +96,12 @@ export interface ResolveEffectiveAccessCommand
 	readonly runCapabilitySet: readonly CapabilityReference[];
 }
 
-/** Per-capability evidence retained for deterministic effective-access decisions. */
+/**
+ * Both sides' decisions for one capability, kept whether it was allowed or not.
+ *
+ * Returned on denials too, so "why was this refused?" can be answered without re-running the
+ * evaluation.
+ */
 export interface EffectiveCapabilityEvidence
 {
 	/** Immutable capability that was evaluated. */
@@ -79,7 +112,16 @@ export interface EffectiveCapabilityEvidence
 	readonly agentServiceDecision: AuthorizationDecision;
 }
 
-/** Deterministic effective-access result after membership and grant intersection. */
+/**
+ * What the caller may actually do, or precisely why not.
+ *
+ * `allowed` lists only capabilities both sides permit, in a stable order, with the membership
+ * revision that authorised it. The denial reasons say where the request died: `invalid_command`
+ * (malformed input, checked before any query), `membership_denied` / `membership_stale` (the first
+ * gate), `outside_revision_ceiling` / `outside_run_capability_set` (asked for something this agent
+ * revision or run never published), `empty_intersection` (both sides were asked, neither pair
+ * agreed). Only the last one carries per-capability evidence.
+ */
 export type ResolveEffectiveAccessResult =
 	| { readonly outcome: "allowed"; readonly fleetMembershipRevision: number; readonly capabilities: readonly CapabilityReference[]; readonly evidence: readonly EffectiveCapabilityEvidence[] }
 	| { readonly outcome: "denied"; readonly reason: "invalid_command" | "membership_denied" | "membership_stale" | "outside_revision_ceiling" | "outside_run_capability_set" | "empty_intersection"; readonly membershipReason?: string; readonly evidence: readonly EffectiveCapabilityEvidence[] };

--- a/libs/backend/server/iam/authorization/main/src/prisma-authorization-grants.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-authorization-grants.ts
@@ -37,7 +37,15 @@ function _grant(row: { id: string; siloId: string; subjectId: string; scopeKind:
 	};
 }
 
-/** Prisma-backed candidate-grant reader for deterministic effective-access evaluation. */
+/**
+ * Reads a subject's grants from Postgres.
+ *
+ * Returns every grant for the subject, including expired and revoked ones, ordered by priority then
+ * id. Filtering is left to the pure decision code, which needs the full set to apply
+ * deny-over-allow and priority correctly, and the fixed order keeps results repeatable.
+ *
+ * Constructed by: ./prisma-share-authorization-unit-of-work.ts.
+ */
 export class PrismaAuthorizationGrantRepository implements AuthorizationGrantRepository
 {
 	/** OpenCrane product-authority database client. */

--- a/libs/backend/server/iam/authorization/main/src/prisma-deferred-tool-approval-decision-repository.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-deferred-tool-approval-decision-repository.ts
@@ -4,7 +4,17 @@ import { ___DoWithTrace } from "@opencrane/backend/observability";
 import { __DecideDeferredToolRequest } from "./deferred-tool-approval.js";
 import type { DecideDeferredToolRequestCommand, DecideDeferredToolRequestResult, DeferredToolApprovalDecisionRepository } from "./deferred-tool-approval-decision.types.js";
 
-/** Prisma-backed atomic persistence for session-authorized deferred-tool decisions. */
+/**
+ * Records one approval decision in a serializable transaction.
+ *
+ * Serializable is required, not a preference: the decision re-reads the approval, the run, and the
+ * tool call, and applies the reviewer's arguments, and none of that may see a torn state.
+ *
+ * A database trigger aborts the transaction if the run's workload authority changed underneath;
+ * that abort is translated into a plain `conflict` so the route answers 404 rather than 500.
+ *
+ * Called by: ./prisma-deferred-tool-approval.router.ts.
+ */
 export class PrismaDeferredToolApprovalDecisionRepository implements DeferredToolApprovalDecisionRepository
 {
 	/** Prisma client used to run the decision's read and its conditional update in one transaction. */

--- a/libs/backend/server/iam/authorization/main/src/prisma-deferred-tool-approval-opener.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-deferred-tool-approval-opener.ts
@@ -11,7 +11,7 @@ import { __MarkToolInvocationApprovalRejectedInTransaction } from "./prisma-tool
 /** One transaction-scoped operation over the approval-open repository. */
 type ApprovalOpenTransaction = <TResult>(operation: (repository: DeferredToolApprovalOpenRepository) => Promise<TResult>) => Promise<TResult>;
 
-/** Transaction-scoped deferred approval open/recovery repository. */
+/** The three operations used while opening one approval, all on the caller's transaction. */
 class PrismaDeferredToolApprovalOpenRepository implements DeferredToolApprovalOpenRepository
 {
 	/** The transaction every query here runs on; never the process-wide Prisma client. */
@@ -62,7 +62,7 @@ export async function __OpenDeferredToolApproval(prisma: PrismaClient, command: 
 	return new PrismaDeferredToolApprovalOpenUnitOfWork(prisma, logger).open(command);
 }
 
-/** Prisma unit of work for deferred-approval open and ambiguous-commit recovery. */
+/** Opens one approval, and cleans up when the open transaction throws without telling us whether it committed. */
 class PrismaDeferredToolApprovalOpenUnitOfWork implements DeferredToolApprovalOpenUnitOfWork
 {
 	/** Process-owned Prisma root used only to begin exact transactions. */

--- a/libs/backend/server/iam/authorization/main/src/prisma-runtime-authority.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-runtime-authority.ts
@@ -27,7 +27,20 @@ function _existing<TResult>(row: { state: string; jti: string; requestFingerprin
 	return { status: "existing_succeeded", receipt: _receipt<TResult>(row) };
 }
 
-/** Prisma-backed runtime bootstrap and proof-bound action receipt authority. */
+/**
+ * Stores runtime proof keys and action receipts in Postgres.
+ *
+ * Implements two ports at once because both hinge on the same rows: a bootstrap is spent and its
+ * public key registered in one transaction, and every action receipt is looked up against a
+ * registered key.
+ *
+ * Both transactions take explicit `FOR UPDATE` row locks in a fixed order — run, then assignment,
+ * then bootstrap — so two runtimes racing on the same bootstrap serialise instead of deadlocking.
+ * Reserving an action also appends its audit entry in the same transaction, so an action can never
+ * run without a recorded decision.
+ *
+ * Used by: ./prisma-runtime-bootstrap-exchange.ts, which delegates its consume step here.
+ */
 export class PrismaRuntimeAuthorityRepository implements RuntimeBootstrapRepository, CapabilityActionReceiptRepository
 {
 	/** OpenCrane product-authority database client. */
@@ -86,7 +99,14 @@ export class PrismaRuntimeAuthorityRepository implements RuntimeBootstrapReposit
 		}
 	}
 
-	/** Atomically reserves a verified JTI and appends its allow decision before external I/O. */
+	/**
+	 * Claims the right to run one verified action, and records the decision, before any external call.
+	 *
+	 * Committing this first is what makes the action at-most-once: a crash afterwards leaves a
+	 * `Reserved` row that blocks every retry.
+	 * @throws When the verified proof key is not registered to any run, or when a uniqueness conflict
+	 *   cannot be resolved by re-reading the existing row.
+	 */
 	async reserve<TResult>(intent: CapabilityActionIntent): Promise<CapabilityActionReservationResult<TResult>>
 	{
 		try

--- a/libs/backend/server/iam/authorization/main/src/prisma-runtime-bootstrap-exchange.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-runtime-bootstrap-exchange.ts
@@ -40,7 +40,13 @@ export class PrismaRuntimeBootstrapExchange implements RuntimeBootstrapExchangeR
 		this.authority = new PrismaRuntimeAuthorityRepository(prisma);
 	}
 
-	/** Loads the durable bootstrap and its registered assignment, or null when either is absent. */
+	/**
+	 * Loads one bootstrap plus the separately written assignment for the same run attempt.
+	 * @param bootstrapReference - The opaque one-use reference projected into the runtime pod.
+	 * @returns Both rows' fields side by side, deliberately not merged. Null when the bootstrap is
+	 *   missing, when no pod has registered yet, or when either row carries an audience we do not
+	 *   recognise — the router turns all three into one 409 so nothing about stored state leaks.
+	 */
 	async loadBootstrapExchange(bootstrapReference: string): Promise<RuntimeBootstrapExchangeRecord | null>
 	{
 		// 1. Load the bootstrap row keyed by the opaque reference.

--- a/libs/backend/server/iam/authorization/main/src/prisma-self-deferred-tool-approval-list-repository.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-self-deferred-tool-approval-list-repository.ts
@@ -32,7 +32,14 @@ type SafeApprovalRow = {
 /** Fields the actor reader is permitted to select from the approval authority. */
 const _SAFE_SELECT = { id: true, runId: true, attempt: true, resourceId: true, state: true, safeProposedArguments: true, responseSchema: true, expiresAt: true, createdAt: true, toolInvocation: { select: { toolInvocationId: true } } } as const;
 
-/** Prisma reader for the signed-in owner's approval inbox and interrupt detail. */
+/**
+ * Owner-only approval reads.
+ *
+ * Every query filters on `siloId` and `subjectId` and selects only `_SAFE_SELECT`, so the reviewed
+ * arguments the server keeps for dispatch cannot leave through this class even by mistake.
+ * Callers should use {@link PrismaSelfDeferredToolApprovalReadUnitOfWork}, which adds the
+ * membership check in the same transaction.
+ */
 export class PrismaSelfDeferredToolApprovalListRepository implements SelfDeferredToolApprovalListRepository
 {
 	/** Prisma client used to read only the caller's own approvals. */
@@ -118,7 +125,7 @@ export class PrismaSelfDeferredToolApprovalReadUnitOfWork implements SelfDeferre
 	}
 }
 
-/** Map a durable state into the actor-facing state, deriving an overdue pending row as expired. */
+/** Convert the stored state into what the owner should see. A row still stored as pending but past its deadline is reported as expired, because the expiry sweep may not have run yet. */
 function _state(approval: SafeApprovalRow, now: Date): DeferredToolApprovalStates
 {
 	if (approval.state === ApprovalRequestState.Pending) return approval.expiresAt.getTime() <= now.getTime() ? DeferredToolApprovalStates.Expired : DeferredToolApprovalStates.Pending;

--- a/libs/backend/server/iam/authorization/main/src/prisma-share-authorization-repository.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-share-authorization-repository.ts
@@ -51,7 +51,15 @@ function _share(row: ShareAuthorizationGrantRow): ShareAuthorizationGrant
 	};
 }
 
-/** Prisma adapter that owns the authorization rows required by the sharing capability. */
+/**
+ * Writes and reads the grant rows behind sharing.
+ *
+ * Takes a transaction client, not the root client, so a share can be created in the same
+ * transaction as the decision that authorised it. Every method scopes to one silo, and list and
+ * revoke also scope to `createdBy`.
+ *
+ * Constructed by: ./prisma-share-authorization-unit-of-work.ts.
+ */
 export class PrismaShareAuthorizationRepository implements ShareAuthorizationRepository
 {
 	/** Product-authority client that owns the catalog and authorization-grant tables. */
@@ -63,7 +71,13 @@ export class PrismaShareAuthorizationRepository implements ShareAuthorizationRep
 		this._prisma = prisma;
 	}
 
-	/** Creates the fixed share catalog revision once and returns its canonical stored digest. */
+	/**
+	 * Creates the share capability set if it is missing, and confirms the stored one matches.
+	 * @returns The stored digest, which always equals the one passed in.
+	 * @throws When a revision with this number already exists with a different digest — the capability
+	 *   set was changed without a new revision number, and existing shares would silently mean
+	 *   something else.
+	 */
 	async ensureCatalogRevision(revision: ShareCapabilityCatalogRevision): Promise<string>
 	{
 		const catalog = await this._prisma.capabilityCatalogRevision.upsert({

--- a/libs/backend/server/iam/authorization/main/src/prisma-share-authorization-unit-of-work.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-share-authorization-unit-of-work.ts
@@ -4,7 +4,14 @@ import { PrismaAuthorizationGrantRepository } from "./prisma-authorization-grant
 import { PrismaShareAuthorizationRepository } from "./prisma-share-authorization-repository.js";
 import type { ShareAuthorizationTransaction, ShareAuthorizationUnitOfWork } from "./share-authorization-unit-of-work.types.js";
 
-/** Prisma unit of work that keeps a share decision and its durable grant on one transaction client. */
+/**
+ * Runs one share procedure with both repositories on the same transaction.
+ *
+ * The grant read that authorises a share and the grant write that creates it must not straddle two
+ * transactions, or a revoked permission could still produce a share.
+ *
+ * Called by: libs/backend/server/iam/grants/main/src/routes/shares.ts.
+ */
 export class PrismaShareAuthorizationUnitOfWork implements ShareAuthorizationUnitOfWork
 {
 	/** Product-authority client that starts share transactions. */

--- a/libs/backend/server/iam/authorization/main/src/prisma-tool-invocation-repository.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-tool-invocation-repository.ts
@@ -26,14 +26,14 @@ const _RECOVERY_TO_PRISMA: Readonly<Record<ExternalActionRecoveryModes, External
 	[ExternalActionRecoveryModes.Manual]: ExternalActionRecoveryMode.Manual,
 };
 
-/** Map persisted recovery vocabulary onto the dependency-light strategy vocabulary. */
+/** Convert a stored recovery-mode name back into this package's enum. */
 const _RECOVERY_FROM_PRISMA: Readonly<Record<ExternalActionRecoveryMode, ExternalActionRecoveryModes>> = {
 	[ExternalActionRecoveryMode.ProviderIdempotency]: ExternalActionRecoveryModes.ProviderIdempotency,
 	[ExternalActionRecoveryMode.Reconciliation]: ExternalActionRecoveryModes.Reconciliation,
 	[ExternalActionRecoveryMode.Manual]: ExternalActionRecoveryModes.Manual,
 };
 
-/** Map provider operation vocabulary onto Prisma's generated adapter edge. */
+/** Convert this package's claim-kind enum into the name stored in the database. */
 const _CLAIM_TO_PRISMA: Readonly<Record<ExternalActionClaimKinds, ExternalActionClaimKind>> = {
 	[ExternalActionClaimKinds.Dispatch]: ExternalActionClaimKind.Dispatch,
 	[ExternalActionClaimKinds.Reconcile]: ExternalActionClaimKind.Reconcile,
@@ -154,7 +154,21 @@ function _completionEvent(kind: ExternalActionClaimKinds, outcome: ToolResultDel
 	return ToolInvocationLifecycleEvents.ReconcileFailed;
 }
 
-/** Prisma repository bound to exactly one caller-owned transaction. */
+/**
+ * Every tool-call write, on one open transaction.
+ *
+ * Two rules hold for each method here. It asks {@link __PlanToolInvocationLifecycle} what is
+ * allowed BEFORE writing and never invents a transition of its own. And it puts its optimistic
+ * check in the update's WHERE clause — the expected `revision`, or the exact claim `fence`, plus
+ * the owning run's attempt and state — so a stale worker's write simply matches no row instead of
+ * overwriting a newer one. After every attempt it re-reads the row and returns what actually
+ * stands.
+ *
+ * The `static *InTransaction` methods exist so other files in this package (approval decisions,
+ * candidate admission) can perform one of these writes inside a transaction they already own,
+ * without constructing an instance.
+ * @see {@link ToolInvocationTransactionRepository}
+ */
 export class PrismaToolInvocationRepository implements ToolInvocationTransactionRepository
 {
 	/** The transaction every query in this class runs on. */
@@ -447,25 +461,61 @@ export class PrismaToolInvocationRepository implements ToolInvocationTransaction
 
 }
 
-/** Transaction entrypoint used by runtime candidate admission. */
+/**
+ * Record one accepted tool-call candidate as a new invocation, in the caller's transaction.
+ *
+ * Exported as a plain function so the runtime-dispatch code can admit an invocation without
+ * importing this class. Idempotent on `(runId, attempt, candidateId)`.
+ *
+ * Called by: libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts.
+ * @param transaction - Transaction already accepting the runtime candidate.
+ * @param intent - Frozen candidate facts.
+ * @param now - Trusted server time; sets the retry deadline.
+ * @param policy - Must be exactly {@link TOOL_INVOCATION_PREPARATION_POLICY}, or the result is
+ *   `conflict`.
+ * @returns `admitted`, `idempotent`, or a permanent `conflict`. See
+ *   {@link ToolInvocationAdmissionResult}.
+ */
 export async function __AdmitPreparingToolInvocationInTransaction(transaction: Prisma.TransactionClient, intent: ToolInvocationIntent, now: Date, policy: ToolInvocationPreparationPolicy): Promise<ToolInvocationAdmissionResult>
 {
 	return PrismaToolInvocationRepository.admitInTransaction(transaction, intent, now, policy);
 }
 
-/** Load one ToolInvocation inside an approval owner's caller-held transaction. */
+/**
+ * Read one tool call by database id, using the caller's transaction.
+ *
+ * Called by: ./deferred-tool-approval.ts and ./prisma-deferred-tool-approval-opener.ts, which need
+ * the row inside the transaction that is deciding an approval.
+ * @returns The stored row, or null when it does not exist. Callers must also re-check that the
+ *   row's run, attempt, tool revision, and arguments digest match the approval.
+ */
 export async function __FindToolInvocationInTransaction(transaction: Prisma.TransactionClient, invocationId: string): Promise<ToolInvocationRecord | null>
 {
 	return PrismaToolInvocationRepository.findByIdInTransaction(transaction, invocationId);
 }
 
-/** Apply approved effective arguments inside the approval decision transaction. */
+/**
+ * Move one approved tool call to `Ready` with the reviewer's arguments.
+ *
+ * Called by: ./deferred-tool-approval.ts (`__DecideDeferredToolRequest`).
+ * @returns True when applied. False means the tool call was no longer awaiting approval on a
+ *   waiting run, or its stored arguments did not match what the reviewer was shown — the caller
+ *   throws, because approving arguments nobody reviewed must never commit.
+ */
 export async function __MarkToolInvocationApprovedInTransaction(transaction: Prisma.TransactionClient, invocationId: string, expectedArguments: JsonValue, expectedArgumentsDigest: string, effectiveArguments: JsonValue, effectiveArgumentsDigest: string): Promise<boolean>
 {
 	return PrismaToolInvocationRepository.markApprovedInTransaction(transaction, invocationId, expectedArguments, expectedArgumentsDigest, effectiveArguments, effectiveArgumentsDigest);
 }
 
-/** Terminalise rejected approval and delivery inside the approval decision transaction. */
+/**
+ * Fail one tool call whose approval was refused or expired, and store its result delivery.
+ *
+ * Called by: ./deferred-tool-approval.ts (denial and expiry) and
+ * ./prisma-deferred-tool-approval-opener.ts (when an approval could not be opened at all).
+ * @param failureCode - Short code recorded and delivered, for example `approval_denied` or
+ *   `approval_expired`. Anything not matching the safe pattern is replaced.
+ * @returns True when failed. False means the row was no longer awaiting approval; callers throw.
+ */
 export async function __MarkToolInvocationApprovalRejectedInTransaction(transaction: Prisma.TransactionClient, invocationId: string, now: Date, failureCode: string): Promise<boolean>
 {
 	return PrismaToolInvocationRepository.markApprovalRejectedInTransaction(transaction, invocationId, now, failureCode);

--- a/libs/backend/server/iam/authorization/main/src/prisma-tool-invocation-unit-of-work.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-tool-invocation-unit-of-work.ts
@@ -13,7 +13,23 @@ const _EXPIRED_CLAIM_FAILURE_CODE = "external_action_claim_expired";
 /** Safe failure category emitted when the start event could not be persisted. */
 const _START_EVENT_FAILURE_CODE = "external_action_start_event_failed";
 
-/** Process-scoped transaction owner for the complete ToolInvocation lifecycle. */
+/**
+ * Every tool-call transition, each as its own serializable transaction.
+ *
+ * This is what the external-action worker holds. Each method opens one transaction, performs the
+ * state change through {@link ToolInvocationTransactionRepository}, and appends the run-timeline
+ * event in that same transaction — so a timeline entry can never survive a rolled-back transition.
+ * The event sinks are ports rather than direct calls because the run-event and recovery tables
+ * belong to the runs package.
+ *
+ * The three sinks and authorities passed to the constructor all participate in the same
+ * transaction, and any of them refusing causes a throw that rolls the whole transition back. That
+ * is deliberate: a state change nobody can see is worse than a retried transaction.
+ *
+ * Composed in: apps/opencrane/src/app/external-action-composition.ts.
+ * Called by: libs/backend/agents/execution/protocol/src/external-action-worker.ts (through
+ * `ExternalActionWorkerDependencies.invocations`).
+ */
 export class PrismaToolInvocationUnitOfWork implements ToolInvocationUnitOfWork
 {
 	/** Product-authority client that opens serializable units of work. */
@@ -205,20 +221,20 @@ function _failedEvent(invocation: ToolInvocationRecord, reason: string, retrying
 	return { runId: invocation.runId, attempt: invocation.attempt, eventType: ToolInvocationEventTypes.Failed, payload: { toolInvocationId: invocation.toolInvocationId, reason, retryCount: invocation.preparationAttempt, retryLimit, retrying } };
 }
 
-/** Append one lifecycle event or roll back the owning transition. */
+/** Append the timeline entry, and throw if the run refuses it — that rolls back the state change too, so a transition can never happen invisibly. */
 async function _appendLifecycleEvent(sink: ToolInvocationLifecycleEventSink, transaction: Prisma.TransactionClient, event: ToolInvocationLifecycleEvent): Promise<void>
 {
 	if (!await sink.appendInTransaction(transaction, event)) throw new Error("tool invocation transition requires its canonical lifecycle event");
 }
 
-/** Append visible manual-recovery evidence or roll back the owning transition. */
+/** Append the "a person must decide this" entry, and throw if the run refuses it, so a tool call can never reach `RecoveryRequired` unnoticed. */
 async function _appendRecoveryEvent(sink: ToolInvocationRecoveryEventSink, transaction: Prisma.TransactionClient, invocation: ToolInvocationRecord): Promise<void>
 {
 	const event: ToolInvocationRecoveryEvent = { runId: invocation.runId, expectedAttempt: invocation.attempt, toolInvocationId: invocation.toolInvocationId, preparationRetryCount: invocation.preparationAttempt, preparationRetryLimit: TOOL_INVOCATION_PREPARATION_POLICY.attemptLimit, providerOutcome: "unknown_after_dispatch" };
 	if (!await sink.appendInTransaction(transaction, event)) throw new Error("tool recovery state requires its canonical recovery event");
 }
 
-/** Couple the authorization transition to the runs-owned recovery state and visible event. */
+/** Move the run into manual recovery and record it, in the same transaction as the tool call's change. See the comment inside for why a cancelling run is the one case that records nothing. */
 async function _enterRecoveryRequired(authority: ToolInvocationRunRecoveryAuthority, sink: ToolInvocationRecoveryEventSink, transaction: Prisma.TransactionClient, invocation: ToolInvocationRecord): Promise<void>
 {
 	const outcome = await authority.enterRecoveryRequiredInTransaction(transaction, { runId: invocation.runId, attempt: invocation.attempt });

--- a/libs/backend/server/iam/authorization/main/src/run-approval-cancellation.ts
+++ b/libs/backend/server/iam/authorization/main/src/run-approval-cancellation.ts
@@ -37,7 +37,14 @@ function _claimKind(kind: ExternalActionClaimKind | null): ExternalActionClaimKi
 	return kind === ExternalActionClaimKind.Dispatch ? ExternalActionClaimKinds.Dispatch : ExternalActionClaimKinds.Reconcile;
 }
 
-/** Prisma cancellation repository bound to the caller-owned run transaction. */
+/**
+ * The database writes cancellation needs, all on the caller's transaction.
+ *
+ * Exported for tests and for the unit of work in this file; production code should call
+ * {@link __CancelPendingRunApprovalAuthority}, which runs the three steps in the required order.
+ * Every query re-asserts that the run is on the expected attempt and in `Cancelling`, so a stale
+ * cancellation cannot close work on a newer attempt.
+ */
 export class PrismaRunApprovalCancellationRepository implements RunApprovalCancellationRepository
 {
 	/** Exact cancellation transaction. */
@@ -49,7 +56,7 @@ export class PrismaRunApprovalCancellationRepository implements RunApprovalCance
 		this._transaction = transaction;
 	}
 
-	/** Snapshot every nonterminal invocation after the run enters Cancelling. */
+	/** List the unfinished tool calls that can be closed safely — those holding no provider claim. The claim check is what keeps in-flight provider work out of this list. */
 	async findCancellableInvocations(runId: string, attempt: number): Promise<readonly RunCancellationToolInvocation[]>
 	{
 		const rows = await this._transaction.toolInvocation.findMany({ where: { runId, attempt, state: { in: [..._CANCELLABLE_INVOCATION_STATES] }, claimKind: null, run: { is: { attempt, state: AgentRunState.Cancelling } } }, select: { id: true, toolInvocationId: true, state: true, recoveryMode: true, claimKind: true, preparationAttempt: true, retryDeadlineAt: true, revision: true }, orderBy: { id: "asc" } });
@@ -93,12 +100,26 @@ export class PrismaRunApprovalCancellationRepository implements RunApprovalCance
 }
 
 /**
- * Cancels pending approval authority inside a caller-owned run cancellation transaction.
- * Decided approvals remain immutable; only Pending rows for the exact run attempt are closed, and
-	 * no late approval can resume cancelled work.
- * @param transaction - Prisma transaction already holding the owning run cancellation fence.
- * @param command - Exact run attempt and trusted cancellation instant.
- * @returns The number of Pending approvals transitioned to Cancelled.
+ * Shut down one cancelling run's approvals and its unfinished tool calls, in the caller's
+ * transaction.
+ *
+ * Does three things, in order: snapshot every tool call that can still be closed safely, cancel
+ * every pending approval (never resuming the run), and fail those tool calls with `run_cancelled`
+ * plus a result delivery each. Already-decided approvals are left untouched, so a late approval
+ * cannot resurrect cancelled work.
+ *
+ * Deliberately does NOT touch tool calls that currently hold a provider claim — those may have a
+ * request in flight. It counts them instead and returns the count, and the runs package must wait
+ * for that count to reach zero before reporting the run fully cancelled. Report the run as torn
+ * down while `activeClaimCount` is above zero and you will claim a pod is gone while it is still
+ * talking to a provider.
+ *
+ * Called by: libs/backend/agents/execution/runs/main/src/prisma-run-cancellation-repository.ts.
+ * @param transaction - Prisma transaction that has already moved the run to `Cancelling`.
+ * @param command - Run id, expected attempt, and the trusted cancellation time.
+ * @returns Counts of approvals cancelled, tool calls failed, and provider claims still active.
+ * @throws When a snapshotted tool call is no longer closable, or when the state machine refuses to
+ *   fail it — both mean the run moved unexpectedly and the transaction must roll back.
  */
 export async function __CancelPendingRunApprovalAuthority(transaction: Prisma.TransactionClient, command: CancelPendingRunApprovalAuthorityCommand): Promise<CancelPendingRunApprovalAuthorityResult>
 {

--- a/libs/backend/server/iam/authorization/main/src/run-approval-cancellation.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/run-approval-cancellation.types.ts
@@ -11,7 +11,14 @@ export interface CancelPendingRunApprovalAuthorityCommand
 	readonly now: Date;
 }
 
-/** Count of pending approval rows atomically closed for one run attempt. */
+/**
+ * What cancellation managed to close, and what it could not.
+ *
+ * `activeClaimCount` is the one that matters: it counts tool calls still holding a provider claim,
+ * which cancellation deliberately leaves alone. The runs package must keep the run in `Cancelling`
+ * until that reaches zero — treating a non-zero count as done reports a torn-down run while a
+ * provider request may still be in flight.
+ */
 export interface CancelPendingRunApprovalAuthorityResult
 {
 	/** Number of Pending approvals transitioned to Cancelled. */
@@ -22,7 +29,13 @@ export interface CancelPendingRunApprovalAuthorityResult
 	readonly activeClaimCount: number;
 }
 
-/** Minimal invocation identity needed to persist one cancellation delivery. */
+/**
+ * The snapshot of one tool call taken before cancellation closes it.
+ *
+ * Read once up front so the state machine can be consulted and the conditional update can check
+ * the same `state` and `revision` it planned against. `claimKind` must be null here — a non-null
+ * value means provider work may be in flight and the row must be left alone.
+ */
 export interface RunCancellationToolInvocation
 {
 	/** Trusted ToolInvocation database identity. */
@@ -43,7 +56,12 @@ export interface RunCancellationToolInvocation
 	readonly revision: number;
 }
 
-/** Transaction-scoped persistence used by the pure cancellation procedure. */
+/**
+ * The four database operations cancellation performs, in the order they must happen.
+ *
+ * Split out from the procedure so the ordering can be tested against a fake.
+ * Implemented by: ./run-approval-cancellation.ts (`PrismaRunApprovalCancellationRepository`).
+ */
 export interface RunApprovalCancellationRepository
 {
 	/** Snapshot every nonterminal invocation after the run enters Cancelling. */
@@ -56,7 +74,12 @@ export interface RunApprovalCancellationRepository
 	countActiveClaims(runId: string, attempt: number): Promise<number>;
 }
 
-/** Transaction binding that owns construction of the cancellation repository. */
+/**
+ * Runs the whole cancellation sequence as one call on the caller's transaction.
+ *
+ * Exists so a caller cannot build the repository itself and run the steps out of order.
+ * Implemented by: ./run-approval-cancellation.ts.
+ */
 export interface RunApprovalCancellationUnitOfWork
 {
 	/** Close pending approval and invocation authority on the caller-owned transaction. */

--- a/libs/backend/server/iam/authorization/main/src/runtime-bootstrap.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/runtime-bootstrap.types.ts
@@ -16,7 +16,12 @@ export interface RuntimeBootstrapReviewedIdentity
 	readonly podUid: string;
 }
 
-/** Projected-token reviewer supplied by the OpenCrane process boundary. */
+/**
+ * Asks Kubernetes who a projected ServiceAccount token belongs to.
+ *
+ * This is the only thing that authenticates the bootstrap route — there is no session and no API
+ * key — so the reviewer must be bound to the runtime audience, not a general-purpose one.
+ */
 export interface RuntimeBootstrapTokenReviewer
 {
 	/** Reviews one token against the dedicated agent-runtime audience. */
@@ -92,10 +97,24 @@ export interface RuntimeBootstrapExchangeRecord
 	readonly assignmentAgentRevisionId: string;
 }
 
-/** Persistence boundary that loads bootstrap authority and consumes it exactly once. */
+/**
+ * Loads a bootstrap together with the separate assignment row, then spends it.
+ *
+ * Extends {@link RuntimeBootstrapRepository} with the read half so one dependency covers both. The
+ * read deliberately returns BOTH rows' fields, un-merged, so the router can compare two independent
+ * sources rather than trust either alone.
+ *
+ * Implemented by: ./prisma-runtime-bootstrap-exchange.ts.
+ */
 export interface RuntimeBootstrapExchangeRepository extends RuntimeBootstrapRepository
 {
-	/** Loads the durable bootstrap and its independent assignment authority, or null when absent. */
+	/**
+	 * Loads one bootstrap and the assignment row for the same run attempt.
+	 * @param bootstrapReference - The opaque one-use reference projected into the runtime pod.
+	 * @returns Both rows' fields side by side, or null when the bootstrap is missing, no pod has
+	 *   registered yet, or either row's audience is not a recognised runtime audience. Null is not an
+	 *   error — the router answers 409.
+	 */
 	loadBootstrapExchange(bootstrapReference: string): Promise<RuntimeBootstrapExchangeRecord | null>;
 }
 
@@ -106,7 +125,15 @@ export interface RuntimeBootstrapLogger
 	error(bindings: { readonly err: unknown; readonly operation: string }, message: string): void;
 }
 
-/** Dependencies of the workload-authenticated runtime bootstrap-exchange router. */
+/**
+ * Everything {@link __CreateRuntimeBootstrapRouter} needs, all injected.
+ *
+ * Nothing here is read from the request. The clock in particular is a dependency so a runtime can
+ * never extend its own bootstrap deadline by sending a time. `runtimeNamespaces` is a fixed pair —
+ * personal and managed — and a reviewed pod outside both is rejected before any database read.
+ *
+ * Composed in: apps/opencrane/src/app/runtime-composition.ts.
+ */
 export interface RuntimeBootstrapRouterDependencies
 {
 	/** Dedicated projected-token identity reviewer for the runtime audience. */

--- a/libs/backend/server/iam/authorization/main/src/runtime-proof.ts
+++ b/libs/backend/server/iam/authorization/main/src/runtime-proof.ts
@@ -104,13 +104,20 @@ function _receiptMatchesIntent<TResult>(receipt: CapabilityActionReceipt<TResult
 }
 
 /**
- * Validate and atomically consume a one-time runtime bootstrap claim.
- * Cryptographic key shape and every independently observed workload coordinate are checked before
- * persistence; a replay or repository conflict remains a denial and never returns prior authority.
- * @param repository - Durable single-consumption and public-proof-key binding authority.
- * @param claim - Candidate bootstrap and runtime-generated public proof key.
- * @param expectation - Trusted assignment, TokenReview identity, attempt, and server time.
- * @returns A receipt only for the first exact bootstrap consumption, otherwise a typed denial.
+ * Check a runtime's bootstrap against independently observed facts, then spend it.
+ *
+ * Everything is verified before any write: the public key is a valid P-256 point, the thumbprint is
+ * re-derived from that key rather than trusted, and every workload and run-attempt field is
+ * compared against the assignment row and the TokenReview identity. Only then is the bootstrap
+ * spent. A second attempt is denied as `bootstrap_replay` and never receives the first receipt, so
+ * a leaked bootstrap reference cannot be reused.
+ *
+ * Called by: ./runtime-bootstrap.router.ts (the POST /bootstrap handler).
+ * @param repository - Spends the bootstrap and stores the public key in one transaction.
+ * @param claim - Bootstrap facts from the database plus the runtime's proposed public key.
+ * @param expectation - The independently sourced facts to compare against, and the server time.
+ * @returns `consumed` with a receipt id on first use only; otherwise `denied` with a reason from
+ *   {@link RuntimeBootstrapFailureReason}, or `bootstrap_replay` / `bootstrap_conflict`.
  */
 export async function __ConsumeRuntimeBootstrap(repository: RuntimeBootstrapRepository, claim: RuntimeBootstrapClaim, expectation: RuntimeBootstrapExpectation): Promise<ConsumeRuntimeBootstrapResult>
 {
@@ -123,11 +130,23 @@ export async function __ConsumeRuntimeBootstrap(repository: RuntimeBootstrapRepo
 }
 
 /**
- * Verifies a compact ES256 proof, reserves its JTI durably, then performs external I/O.
- * @param repository - Durable capability receipt and replay authority.
- * @param command - Compact proof, trusted expectation, and explicit replay mode.
- * @param executor - Deferred action invoked only for the first accepted JTI.
- * @returns First execution, allowed idempotent replay, or fail-closed denial.
+ * Run one signed action at most once, whatever crashes in between.
+ *
+ * The order is the safety property: verify the proof, commit a reservation keyed by the proof's
+ * `jti`, then perform the external call outside any transaction, then record the outcome. A crash
+ * after the reservation leaves a row that blocks every retry, so the action cannot run twice.
+ *
+ * An action that throws is recorded as failed and reported as `action_execution_failed`. If we
+ * cannot record the outcome at all, the result is `action_execution_ambiguous` — the action may
+ * have taken effect, so a caller must surface it as unresolved and must not retry.
+ *
+ * Called by: no caller in this repo yet — only its own tests in
+ * ./__tests__/runtime-proof.test.ts.
+ * @param repository - Reservation and receipt store; see {@link CapabilityActionReceiptRepository}.
+ * @param command - The compact proof, the trusted facts to verify it against, and the replay mode.
+ * @param executor - The external action; called at most once, and never inside a transaction.
+ * @returns `executed` on first success, `replayed` when an identical idempotent request already
+ *   succeeded, or `denied` with a reason. See {@link ExecuteCapabilityActionResult}.
  */
 export async function __ExecuteCapabilityAction<TResult>(repository: CapabilityActionReceiptRepository, command: ExecuteCapabilityActionCommand, executor: CapabilityActionExecutor<TResult>): Promise<ExecuteCapabilityActionResult<TResult>>
 {

--- a/libs/backend/server/iam/authorization/main/src/runtime-proof.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/runtime-proof.types.ts
@@ -4,7 +4,14 @@ import type { AgentRuntimeProjectedTokenAudience, ManagedAgentRuntimeProjectedTo
 /** The two accepted token audiences: one for personal runtimes, one for managed runtimes. */
 type RuntimeProjectedTokenAudience = AgentRuntimeProjectedTokenAudience | ManagedAgentRuntimeProjectedTokenAudience;
 
-/** One-time bootstrap claim bound to the exact runtime attempt and Pod identity. */
+/**
+ * A runtime's single chance to register the key it will sign requests with.
+ *
+ * Every field except `proofPublicJwk` and `proofKeyThumbprint` is read from the stored bootstrap
+ * row, not from the runtime — the runtime supplies only its freshly generated public key. The
+ * thumbprint it sends is re-derived from that key before anything is trusted.
+ * @see {@link RuntimeBootstrapExpectation} which every field is compared against.
+ */
 export interface RuntimeBootstrapClaim
 {
 	/** Globally unique one-time bootstrap identifier. */
@@ -41,7 +48,13 @@ export interface RuntimeBootstrapClaim
 	readonly expiresAtEpochMs: number;
 }
 
-/** Trusted facts expected while consuming a bootstrap claim. */
+/**
+ * The independently sourced facts a bootstrap claim must match.
+ *
+ * These come from a different place than the claim: the assignment row plus the Kubernetes
+ * TokenReview result. Comparing two independent sources is what makes a stolen bootstrap reference
+ * useless on its own.
+ */
 export interface RuntimeBootstrapExpectation
 {
 	/** Expected silo. */
@@ -72,23 +85,60 @@ export interface RuntimeBootstrapExpectation
 	readonly nowEpochMs: number;
 }
 
-/** Stable reason a runtime bootstrap failed closed. */
+/**
+ * Why a runtime bootstrap was refused.
+ *
+ * The first three describe malformed input: `invalid_bootstrap` (blank id, bad counter, bad time),
+ * `invalid_workload_kind`, `invalid_proof_key` (not an RFC 7638 SHA-256 thumbprint, or a key that
+ * is not a valid public P-256 point). `expired` means the bootstrap deadline passed.
+ *
+ * Everything ending in `_mismatch` means the bootstrap row and the independently observed workload
+ * disagree on one field — a stolen or misdirected bootstrap looks exactly like this. All of them
+ * are final; none is retryable, and the HTTP layer returns them as 409 without leaking which
+ * stored value differed.
+ */
 export type RuntimeBootstrapFailureReason = "invalid_bootstrap" | "invalid_workload_kind" | "invalid_proof_key" | "projected_token_audience_mismatch" | "silo_mismatch" | "subject_mismatch" | "service_account_mismatch" | "namespace_mismatch" | "workload_kind_mismatch" | "workload_uid_mismatch" | "pod_mismatch" | "agent_service_mismatch" | "run_mismatch" | "attempt_mismatch" | "revision_mismatch" | "proof_key_mismatch" | "expired";
 
 /** Atomic result from the one-time bootstrap repository. */
 export type RuntimeBootstrapConsumptionResult = { readonly status: "consumed"; readonly receiptId: string } | { readonly status: "already_consumed" | "conflict" };
 
-/** Persistence boundary that consumes one bootstrap claim exactly once. */
+/**
+ * Spends a runtime's one-time bootstrap and registers the public key it will sign with.
+ *
+ * One row, one use. The `Atomically` suffix on the method is there because consuming the bootstrap
+ * and storing the key must be one transaction: a bootstrap marked used with no key stored would
+ * leave the runtime unable to prove anything, with no second chance.
+ *
+ * Implemented by: ./prisma-runtime-authority.ts and ./prisma-runtime-bootstrap-exchange.ts.
+ * @see {@link __ConsumeRuntimeBootstrap} which validates before calling this.
+ */
 export interface RuntimeBootstrapRepository
 {
-	/** Atomically consumes the bootstrap and records the newly verified run proof key. */
+	/**
+	 * Spends the bootstrap and stores the runtime's public key in one transaction.
+	 * @param claim - The bootstrap facts and the public key, already fully validated by the caller.
+	 * @returns `consumed` with a receipt id for the first use only. `already_consumed` means a replay
+	 *   — deny it and never return the earlier receipt. `conflict` means the bootstrap is missing or
+	 *   a concurrent write won; also a denial.
+	 * @throws Any database error that is not a uniqueness or serialization failure.
+	 */
 	consumeAndBindProofKeyAtomically(claim: RuntimeBootstrapClaim): Promise<RuntimeBootstrapConsumptionResult>;
 }
 
 /** Result of validating and atomically consuming a runtime bootstrap. */
 export type ConsumeRuntimeBootstrapResult = { readonly outcome: "consumed"; readonly receiptId: string } | { readonly outcome: "denied"; readonly reason: RuntimeBootstrapFailureReason | "bootstrap_replay" | "bootstrap_conflict" };
 
-/** Replay policy attached to a proof-bound action capability. */
+/**
+ * What happens when the exact same signed action is presented twice.
+ *
+ * `one_shot` denies the second attempt outright. `idempotent` returns the stored result of the
+ * first execution, but only if the whole request still matches — same capability id, same request
+ * fingerprint, same replay mode. Any difference is denied as `jti_replay`, so this cannot be used
+ * to slip changed arguments past a completed action.
+ *
+ * Fixed by the first execution and stored on the receipt; a later call cannot change its mind.
+ * @see {@link CapabilityActionReceipt}
+ */
 export type ActionReplayMode = "one_shot" | "idempotent";
 
 /** Verified capability action submitted for exactly-once receipt handling. */
@@ -157,7 +207,13 @@ export interface CapabilityActionIntent
 	readonly argumentsDigest: string;
 }
 
-/** Deferred action executor invoked only after a durable JTI reservation exists. */
+/**
+ * The actual external action, wrapped so it can only run after its reservation is committed.
+ *
+ * Passed in rather than called directly so the action runs outside every transaction — a long
+ * external call must never hold a database transaction open.
+ * @see {@link __ExecuteCapabilityAction}
+ */
 export interface CapabilityActionExecutor<TResult>
 {
 	/** Executes the external action outside the repository transaction. */
@@ -191,18 +247,58 @@ export type CapabilityActionSuccessResult<TResult> =
 /** Compare-and-set result when completing a reserved action as failed. */
 export type CapabilityActionFailureResult = { readonly status: "failed" | "conflict" };
 
-/** Persistence boundary that reserves before I/O and completes the durable receipt afterward. */
+/**
+ * Stores an action's intent before it runs, and its outcome after.
+ *
+ * The order is the whole point: `reserve` commits first, so a crash mid-action leaves a `Reserved`
+ * row that blocks any retry instead of letting the action run twice. The external call then happens
+ * OUTSIDE any transaction, and `markSucceeded` / `markFailed` close the row.
+ *
+ * `Atomically` is not used in these names because each method already runs as one transaction —
+ * `reserve` in particular takes a row lock on the `jti` before deciding.
+ * Implemented by: ./prisma-runtime-authority.ts (`PrismaRuntimeAuthorityRepository`).
+ * @see {@link __ExecuteCapabilityAction} which is the only correct way to drive this order.
+ */
 export interface CapabilityActionReceiptRepository
 {
-	/** Atomically creates a Reserved receipt or returns the existing durable JTI state. */
+	/**
+	 * Claims the right to run this action, or reports that it is already claimed.
+	 * @param intent - The verified action, including the `jti` this row is keyed by.
+	 * @returns `reserved` with a `reservationId` — you may now perform the action. Any other status
+	 *   means DO NOT perform it: `existing_reserved` (another caller is mid-flight or crashed),
+	 *   `existing_failed` (already tried and failed), or `existing_succeeded` with the stored receipt,
+	 *   which may be returned to the caller only for a matching idempotent replay.
+	 * @throws When the verified proof key is not registered to any run, which means verification and
+	 *   stored authority disagree.
+	 */
 	reserve<TResult>(intent: CapabilityActionIntent): Promise<CapabilityActionReservationResult<TResult>>;
-	/** Atomically transitions the exact Reserved receipt to Succeeded with its canonical result. */
+	/**
+	 * Stores the result of a completed action against its reservation.
+	 * @param reservationId - Id returned by {@link CapabilityActionReceiptRepository.reserve}.
+	 * @param result - Value stored for any later idempotent replay.
+	 * @returns `succeeded` with the receipt, or `conflict` when the row is no longer `Reserved`.
+	 *   A `conflict` here is serious: the action already happened but we could not record it, so the
+	 *   caller must report an ambiguous outcome rather than retry.
+	 */
 	markSucceeded<TResult>(reservationId: string, result: TResult): Promise<CapabilityActionSuccessResult<TResult>>;
-	/** Atomically transitions the exact Reserved receipt to Failed with a stable internal code. */
+	/**
+	 * Marks a reserved action as failed so it is never retried.
+	 * @param reservationId - Id returned by {@link CapabilityActionReceiptRepository.reserve}.
+	 * @param failureCode - Short internal code; never a provider message.
+	 * @returns `failed` when recorded, `conflict` when the row is no longer `Reserved` — again an
+	 *   ambiguous outcome, not a retry signal.
+	 */
 	markFailed(reservationId: string, failureCode: string): Promise<CapabilityActionFailureResult>;
 }
 
-/** Result of cryptographically verifying and executing a proof-bound capability action. */
+/**
+ * What happened to one signed action request.
+ *
+ * `executed` ran it now; `replayed` returned the stored result of an earlier identical request.
+ * `denied` never performed the action — except for `action_execution_ambiguous`, which means the
+ * action MAY have happened but we could not record the outcome. Treat that one as unresolved, never
+ * as a failure, and never retry it.
+ */
 export type ExecuteCapabilityActionResult<TResult> =
 	| { readonly outcome: "executed" | "replayed"; readonly receipt: CapabilityActionReceipt<TResult> }
 	| { readonly outcome: "denied"; readonly reason: CapabilityProofFailureReason | "invalid_replay_mode" | "jti_replay" | "action_reservation_failed" | "action_execution_failed" | "action_execution_ambiguous" };

--- a/libs/backend/server/iam/authorization/main/src/share-authorization-repository.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/share-authorization-repository.types.ts
@@ -1,11 +1,12 @@
 import type { JsonValue } from "@opencrane/util";
 
 /**
- * Stable authorization scope categories supported by the sharing capability.
+ * How wide a share reaches.
  *
- * These domain values cross the grants-to-authorization package boundary. The Prisma adapter maps
- * them explicitly to its generated persistence enum rather than leaking database spellings into
- * callers.
+ * These four are a deliberate subset of the scopes authorization supports as a whole — sharing does
+ * not offer the others. Because these values cross into the grants package, the Prisma adapter maps
+ * each one to its database enum by hand rather than letting generated database names reach callers.
+ * A stored grant in any other scope makes `_shareScopeKind` throw.
  */
 export enum ShareAuthorizationScopeKinds
 {

--- a/libs/backend/server/iam/authorization/main/src/share-authorization-unit-of-work.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/share-authorization-unit-of-work.types.ts
@@ -10,7 +10,12 @@ export interface ShareAuthorizationTransaction
 	readonly shareRepository: ShareAuthorizationRepository;
 }
 
-/** Unit of work that binds every authorization repository in a share procedure to one transaction. */
+/**
+ * Runs a share procedure with all its repositories on one transaction.
+ *
+ * Kept as a port so the sharing routes depend on this shape rather than on Prisma.
+ * Implemented by: ./prisma-share-authorization-unit-of-work.ts.
+ */
 export interface ShareAuthorizationUnitOfWork
 {
 	/** Executes one share procedure against repositories bound to the same transaction client. */

--- a/libs/backend/server/iam/authorization/main/src/tool-invocation-lifecycle.ts
+++ b/libs/backend/server/iam/authorization/main/src/tool-invocation-lifecycle.ts
@@ -74,7 +74,7 @@ function _terminal(): ToolInvocationLifecycleActions
 	return ToolInvocationLifecycleActions.Reject;
 }
 
-/** Manual recovery is inert except for server-authoritative cancellation. */
+/** Once a person must decide, ignore every event except a cancellation from the server. */
 function _recoveryRequired(input: ToolInvocationLifecycleInput): ToolInvocationLifecycleActions
 {
 	return input.event === ToolInvocationLifecycleEvents.Cancelled ? ToolInvocationLifecycleActions.Fail : ToolInvocationLifecycleActions.Reject;
@@ -92,7 +92,25 @@ const _STATE_HANDLERS: Readonly<Record<ToolInvocationStates, ToolInvocationState
 	[ToolInvocationStates.RecoveryRequired]: _recoveryRequired,
 };
 
-/** Select the only valid persistence action for a durable ToolInvocation State x Event cell. */
+/**
+ * Decide the one database write allowed for a given invocation state and event.
+ *
+ * The whole state machine lives here, as pure code with no database and no clock, so it can be
+ * exhaustively tested. Adapters call this BEFORE writing and must obey the answer; that is what
+ * stops an adapter from inventing a transition that would repeat a provider call.
+ *
+ * It also rejects impossible inputs outright: a negative or non-integer retry count, a limit below
+ * one, `Claimed` without a dispatch claim, `Reconciling` with a dispatch claim, or any claim at all
+ * in a state that cannot hold one.
+ *
+ * Called by: ./prisma-tool-invocation-repository.ts (`_plan`, and directly in
+ * `recordPreparationFailure`) and ./run-approval-cancellation.ts (`terminaliseCancellable`, which
+ * throws if the answer is not `Fail`).
+ * @param input - Observed state, the event being applied, the frozen recovery mode, the active
+ *   claim kind, and the retry budget.
+ * @returns The single permitted write, or `Reject` meaning write nothing at all.
+ * @see {@link ToolInvocationLifecycleActions}
+ */
 export function __PlanToolInvocationLifecycle(input: ToolInvocationLifecycleInput): ToolInvocationLifecycleActions
 {
 	if (!Number.isSafeInteger(input.preparationAttempt) || input.preparationAttempt < 0) return ToolInvocationLifecycleActions.Reject;

--- a/libs/backend/server/iam/authorization/main/src/tool-invocation-lifecycle.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/tool-invocation-lifecycle.types.ts
@@ -7,7 +7,30 @@
  */
 export const TOOL_INVOCATION_PREPARATION_POLICY = Object.freeze({ attemptLimit: 3, retryWindowMilliseconds: 300_000, retryDelayMilliseconds: 1_000 } as const);
 
-/** Durable states owned by the external-action ToolInvocation authority. */
+/**
+ * The states one external tool call moves through in the database.
+ *
+ * Read this as three groups. Nothing has touched the provider yet in `Preparing`,
+ * `AwaitingApproval`, or `Ready`. Exactly one worker may be talking to the provider right now in
+ * `Claimed` (a real dispatch) or `Reconciling` (a read-only "did it happen?" check). `Succeeded`,
+ * `Failed`, and `RecoveryRequired` are the end of the line for the worker.
+ *
+ * The two pairs callers get wrong:
+ * - `Claimed` vs `Reconciling`. Both mean a claim is held, but `Claimed` permits one mutating
+ *   dispatch and `Reconciling` permits only a read. Treat `Reconciling` as if it were `Claimed`
+ *   and you re-fire an action the provider may already have performed.
+ * - `Failed` vs `RecoveryRequired`. `Failed` means we know the action did not take effect and a
+ *   result was delivered to the runtime. `RecoveryRequired` means we do NOT know: the provider may
+ *   have done the work. Reporting `RecoveryRequired` as a failure tells the user nothing happened
+ *   when money may already have moved. No automatic retry is allowed from that state; a person
+ *   must decide.
+ *
+ * Only `Cancelled` events are accepted once a state is terminal, and only server-side
+ * cancellation may send one.
+ * @see {@link ToolInvocationLifecycleActions} for the write each State x Event pair permits.
+ * @see {@link ExternalActionRecoveryModes} for what decides between reconcile, redispatch, and
+ *   manual recovery.
+ */
 export enum ToolInvocationStates
 {
 	/** The invocation is stored, but the work that runs before any provider call is not finished. */
@@ -28,7 +51,22 @@ export enum ToolInvocationStates
 	RecoveryRequired = "recovery_required",
 }
 
-/** Recovery capability frozen from the trusted adapter before dispatch starts. */
+/**
+ * What the tool adapter can do for us if a dispatch ends with an unknown outcome.
+ *
+ * This is read from the adapter and written onto the invocation row BEFORE the first provider
+ * call, so a later crash cannot change the answer to "how do we clean up?". When a dispatch
+ * result is ambiguous, this value alone decides the next state:
+ * - `ProviderIdempotency` -> go back to `Ready` and send the same request again with the stored
+ *   `recoveryKey`, because a duplicate cannot double-charge.
+ * - `Reconciliation` -> go to `Reconciling` and ask the provider what happened; never redispatch.
+ * - `Manual` -> go to `RecoveryRequired` and stop; a person decides.
+ *
+ * `Manual` requires `recoveryKey` to be null; the other two require a non-empty key (enforced by
+ * `_recoveryKeyIsValid` in prisma-tool-invocation-repository.ts). Pick a mode the adapter cannot
+ * actually honour and you either duplicate a real-world effect or strand a run.
+ * @see {@link ToolInvocationStates}
+ */
 export enum ExternalActionRecoveryModes
 {
 	/** The adapter guarantees repeated dispatches with the same key have one provider effect. */
@@ -48,7 +86,13 @@ export enum ExternalActionClaimKinds
 	Reconcile = "reconcile",
 }
 
-/** Events interpreted by the ToolInvocation state owner. */
+/**
+ * Things that happen to one tool call, fed into {@link __PlanToolInvocationLifecycle}.
+ *
+ * Each member is a fact already established by the caller — preparation finished, the provider
+ * answered, a lease expired — never a request for a transition. The planner turns a
+ * state-plus-event pair into a {@link ToolInvocationLifecycleActions} member.
+ */
 export enum ToolInvocationLifecycleEvents
 {
 	/** Provider-free preparation completed and no approval is required. */
@@ -124,7 +168,14 @@ export enum ToolInvocationLifecycleActions
 	Reject = "reject",
 }
 
-/** Complete input needed for one deterministic State x Event decision. */
+/**
+ * Everything {@link __PlanToolInvocationLifecycle} needs to pick the next write.
+ *
+ * Deliberately plain data with no database or clock access, so the decision can be unit-tested
+ * and replayed. The caller reads all of it from the invocation row it holds under a revision
+ * check, and computes `withinPreparationDeadline` from the trusted server clock rather than
+ * passing a clock in.
+ */
 export interface ToolInvocationLifecycleInput
 {
 	/** Durable state observed under the invocation CAS revision. */

--- a/libs/backend/server/iam/authorization/main/src/tool-invocation.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/tool-invocation.types.ts
@@ -43,7 +43,7 @@ export interface ToolInvocationIntent
 	readonly requestIdentity: ToolInvocationRequestIdentity;
 	/** Immutable tool revision admitted from the compiled input. */
 	readonly toolRevisionId: string;
-	/** Runtime tool-call idempotency coordinate. */
+	/** Id the runtime gave this tool call; repeat calls with the same id must not run twice. */
 	readonly toolInvocationId: string;
 	/** Canonical validated arguments, not a later runtime replacement. */
 	readonly arguments: JsonValue;
@@ -76,7 +76,7 @@ export interface ToolInvocationRecord
 	readonly attempt: number;
 	/** Candidate id accepted with the invocation. */
 	readonly candidateId: string;
-	/** Runtime tool-call idempotency coordinate. */
+	/** Id the runtime gave this tool call; repeat calls with the same id must not run twice. */
 	readonly toolInvocationId: string;
 	/** Immutable tool revision. */
 	readonly toolRevisionId: string;
@@ -120,7 +120,14 @@ export interface ToolInvocationRecord
 	readonly revision: number;
 }
 
-/** Result of atomic candidate and Preparing-invocation admission. */
+/**
+ * What admission decided for one candidate.
+ *
+ * `admitted` created the row; `idempotent` found the identical row from an earlier attempt — both
+ * carry the invocation and both mean "proceed". `conflict` carries nothing and is permanent: the
+ * candidate id already belongs to different arguments, the request fingerprint is already taken,
+ * or the preparation policy was not the fixed one. Do not retry a `conflict`.
+ */
 export type ToolInvocationAdmissionResult =
 	| { readonly outcome: "admitted" | "idempotent"; readonly invocation: ToolInvocationRecord }
 	| { readonly outcome: "conflict" };
@@ -138,7 +145,17 @@ export interface ToolInvocationClaim
 	readonly revision: number;
 }
 
-/** Outcome of claiming prepared work. */
+/**
+ * What happened when a worker tried to take the lease on one invocation.
+ *
+ * `claimed` means this worker holds the lease and may make exactly one provider call, using the
+ * returned `claim`. `winner` means another worker already moved this invocation, or its state no
+ * longer permits the claim — the row that won is returned so the caller can carry on from the real
+ * state instead of retrying. `missing` means the invocation row is gone.
+ *
+ * Making a provider call after anything other than `claimed` risks a duplicate real-world effect.
+ * @see {@link ToolInvocationClaim}
+ */
 export type ToolInvocationClaimResult =
 	| { readonly outcome: "claimed"; readonly claim: ToolInvocationClaim; readonly invocation: ToolInvocationRecord }
 	| { readonly outcome: "winner"; readonly invocation: ToolInvocationRecord }
@@ -149,13 +166,27 @@ export type ToolResultDeliveryPayload =
 	| { readonly toolInvocationId: string; readonly outcome: "succeeded"; readonly result: JsonValue }
 	| { readonly toolInvocationId: string; readonly outcome: "failed"; readonly failureCode: string };
 
-/** Terminal CAS result; a loser must replay the returned durable winner instead of dispatching. */
+/**
+ * What happened when a worker tried to record a finished provider call.
+ *
+ * `completed` means this worker's result was stored and `delivery` is the exact body to hand back
+ * to the runtime. `winner` means another worker recorded the outcome first: the returned row is
+ * the stored truth, and the caller must deliver from that row rather than send its own result or
+ * call the provider again. `missing` means the invocation row is gone.
+ */
 export type ToolInvocationCompletionResult =
 	| { readonly outcome: "completed"; readonly invocation: ToolInvocationRecord; readonly delivery: ToolResultDeliveryPayload }
 	| { readonly outcome: "winner"; readonly invocation: ToolInvocationRecord }
 	| { readonly outcome: "missing" };
 
-/** Internal transaction result that distinguishes a winning CAS from an observed winner. */
+/**
+ * Whether this transaction actually changed the invocation, and the row as it now stands.
+ *
+ * `changed` is true only when this caller's conditional update matched one row. False means the
+ * row moved under us — usually another worker got there first — and `invocation` is then the
+ * current stored row, not what we tried to write. Only a caller with `changed: true` may append
+ * the timeline event for the transition, otherwise the same event would be written twice.
+ */
 export interface ToolInvocationTransitionResult
 {
 	/** Whether this transaction committed the lifecycle transition. */
@@ -184,7 +215,15 @@ export type ToolInvocationLifecycleEvent =
 /** Appends tool lifecycle events using the caller's transaction. */
 export interface ToolInvocationLifecycleEventSink
 {
-	/** Append one lifecycle event in the invocation transition transaction. */
+	/**
+	 * Adds one timeline event using the caller's open transaction.
+	 * @param transaction - The Prisma transaction that is committing the state change. Typed
+	 *   `unknown` on purpose so this package never imports Prisma types from the runs package.
+	 * @param event - Event to append; carries no arguments and no provider response.
+	 * @returns True when the event was written. False means the run rejected it (wrong attempt or a
+	 *   run state that does not accept this kind), and the caller MUST abort the whole transition —
+	 *   ./prisma-tool-invocation-unit-of-work.ts throws so the transaction rolls back.
+	 */
 	appendInTransaction(transaction: unknown, event: ToolInvocationLifecycleEvent): Promise<boolean>;
 }
 
@@ -211,7 +250,13 @@ export interface ToolInvocationRecoveryEvent
  */
 export interface ToolInvocationRecoveryEventSink
 {
-	/** Append one recovery event in the invocation/run state transition transaction. */
+	/**
+	 * Adds one manual-recovery entry using the caller's open transaction.
+	 * @param transaction - The Prisma transaction moving the invocation into `RecoveryRequired`.
+	 * @param event - Fixed, non-secret summary; never a provider message or body.
+	 * @returns True when the entry was written. False means the caller must abort the transition, so
+	 *   an invocation can never reach `RecoveryRequired` invisibly.
+	 */
 	appendInTransaction(transaction: unknown, event: ToolInvocationRecoveryEvent): Promise<boolean>;
 }
 
@@ -225,10 +270,23 @@ export interface ToolInvocationRunRecoveryCommand
 }
 
 /**
- * Stable runs-owned decisions returned inside a ToolInvocation recovery transaction.
+ * What the runs package answers when this package asks to move a run into manual recovery.
  *
- * The serialized values cross the authorization-to-runs package boundary so callers can suppress
- * recovery events only for an already-cancelling run while treating every true conflict as fatal.
+ * The caller must react differently to each one, and ./prisma-tool-invocation-unit-of-work.ts
+ * (`_enterRecoveryRequired`) does:
+ * - `Entered` and `AlreadyRecoveryRequired` -> write the recovery entry and commit. The second is
+ *   a replay after a retried transaction, not an error.
+ * - `Cancelling` -> commit the invocation change but write NO recovery entry. The run is already
+ *   being torn down, and a recovery entry would ask a person to act on work that is going away.
+ *   The cleared provider claim still commits so cancellation can finish without repeating the
+ *   provider call.
+ * - `Conflict` -> throw. The run id, attempt, or state does not match, which means we are looking
+ *   at the wrong attempt; committing anyway would strand a run in the wrong state.
+ *
+ * These are string values on purpose because they cross a package boundary.
+ * Called by: libs/backend/agents/execution/runs/main/src/prisma-tool-invocation-run-recovery-authority.ts
+ * (returns them) and ./prisma-tool-invocation-unit-of-work.ts (branches on them).
+ * @see {@link ToolInvocationRunRecoveryAuthority}
  */
 export enum ToolInvocationRunRecoveryEnterResults
 {
@@ -248,9 +306,29 @@ export type ToolInvocationRunRecoveryEnterResult = ToolInvocationRunRecoveryEnte
 /** Run-state operations the runs package provides, called inside this package's invocation transaction. */
 export interface ToolInvocationRunRecoveryAuthority
 {
-	/** Enter visible manual recovery in the caller-owned invocation transaction. */
+	/**
+	 * Moves one run attempt into its manual-recovery state.
+	 * @param transaction - The Prisma transaction already changing the invocation. Typed `unknown`
+	 *   so this package holds no Prisma dependency from the runs side.
+	 * @param command - The run id and the attempt the caller believes is current; the runs package
+	 *   checks the attempt itself and answers `Conflict` if it moved on.
+	 * @returns Which of the four {@link ToolInvocationRunRecoveryEnterResults} happened. The caller
+	 *   must branch on all four — see that enum for what each one obliges it to do.
+	 */
 	enterRecoveryRequiredInTransaction(transaction: unknown, command: ToolInvocationRunRecoveryCommand): Promise<ToolInvocationRunRecoveryEnterResult>;
-	/** Resume only after authorization proves no invocation still requires manual recovery. */
+	/**
+	 * Puts a recovered run attempt back to running.
+	 *
+	 * Only legal once no invocation on that attempt is still in `RecoveryRequired` — resuming while
+	 * one is unresolved would let the worker pick up an action whose real-world outcome is still
+	 * unknown. The caller is responsible for that check; this port does not make it.
+	 * @param transaction - The Prisma transaction performing the resume.
+	 * @param command - Run id and the attempt expected to still be current.
+	 * @returns True when the run moved back to running. False when the attempt or state no longer
+	 *   matches, which the caller must treat as "someone else changed this run".
+	 * Called by: no caller in this repo yet — only the runs-side implementation and its tests
+	 * (libs/backend/agents/execution/runs/main/src/prisma-tool-invocation-run-recovery-authority.ts).
+	 */
 	resumeRunningInTransaction(transaction: unknown, command: ToolInvocationRunRecoveryCommand): Promise<boolean>;
 }
 
@@ -279,10 +357,33 @@ interface ToolInvocationOperations
 	recoverExpiredClaim(invocationId: string, now: Date): Promise<ToolInvocationRecord | null>;
 }
 
-/** Process-scoped transaction owner that exposes the ToolInvocation lifecycle as atomic calls. */
+/**
+ * The public way to move one tool call along; each method is its own transaction.
+ *
+ * Callers hold no transaction and never see Prisma. One call = one serializable transaction that
+ * changes the invocation, writes its result delivery if there is one, and appends its timeline
+ * event, so a partially applied transition cannot be observed. Methods that can lose a race
+ * return the durable row that won instead of throwing, and the caller must accept that row rather
+ * than retry its own intent.
+ *
+ * Called by: libs/backend/agents/execution/protocol/src/external-action-worker.types.ts (as the
+ * worker's `invocations` dependency); composed in
+ * apps/opencrane/src/app/external-action-composition.ts.
+ * Implemented by: ./prisma-tool-invocation-unit-of-work.ts.
+ */
 export interface ToolInvocationUnitOfWork extends ToolInvocationOperations {}
 
-/** Transaction-scoped persistence methods constructed only by the ToolInvocation unit of work. */
+/**
+ * Every database write for one tool call, all bound to a single open transaction.
+ *
+ * Only {@link ToolInvocationUnitOfWork} may build one of these, because each method assumes it is
+ * already inside a serializable transaction and enforces its own optimistic check (expected
+ * `revision`, or an exact claim `fence`) in the WHERE clause. Every method here asks the pure
+ * planner first and refuses to write a transition the planner did not choose.
+ *
+ * Implemented by: ./prisma-tool-invocation-repository.ts (`PrismaToolInvocationRepository`).
+ * @see {@link ToolInvocationUnitOfWork} for the process-level entry point callers actually use.
+ */
 export interface ToolInvocationTransactionRepository
 {
 	/** Admit one candidate as durable Preparing work in the caller transaction. */
@@ -320,5 +421,27 @@ export interface ToolInvocationAdmissionUnitOfWork
 	admit(intent: ToolInvocationIntent, now: Date, policy: ToolInvocationPreparationPolicy): Promise<ToolInvocationAdmissionResult>;
 }
 
-/** Atomically admit one candidate as durable Preparing work inside the stream transaction. */
+/**
+ * Records one accepted tool-call candidate as a new invocation in `Preparing`.
+ *
+ * Passed as a function so the runtime-stream code can admit an invocation without importing this
+ * package's Prisma adapter. It runs inside the caller's transaction, so it commits with the
+ * candidate acceptance.
+ *
+ * Idempotent on `(runId, attempt, candidateId)`: a repeat with the same `requestFingerprint`
+ * returns `idempotent` with the existing row, and a repeat with a different fingerprint returns
+ * `conflict` and writes nothing. A caller that treats `conflict` as retryable will spin forever —
+ * it means the same candidate id is being reused for different arguments.
+ *
+ * Called by: libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts.
+ * Implemented by: `__AdmitPreparingToolInvocationInTransaction` in
+ * ./prisma-tool-invocation-repository.ts.
+ * @param transaction - Prisma transaction accepting the runtime candidate, typed `unknown` to keep
+ *   Prisma out of this contract.
+ * @param intent - The frozen candidate facts to persist.
+ * @param now - Trusted server time; sets the retry deadline.
+ * @param policy - Must be exactly {@link TOOL_INVOCATION_PREPARATION_POLICY}; any other value is
+ *   rejected as `conflict`.
+ * @returns `admitted` for a new row, `idempotent` for an exact replay, `conflict` for anything else.
+ */
 export type AdmitPreparingToolInvocation = (transaction: unknown, intent: ToolInvocationIntent, now: Date, policy: ToolInvocationPreparationPolicy) => Promise<ToolInvocationAdmissionResult>;

--- a/libs/backend/server/iam/grants/main/src/routes/resource-shares.ts
+++ b/libs/backend/server/iam/grants/main/src/routes/resource-shares.ts
@@ -35,7 +35,7 @@ function _ResourceGroupName(resourceType: _ResourceTypeStr, resourceId: string):
   return `resource:${resourceType}:${resourceId}`;
 }
 
-/** Read a group's `members` JSON as a string list (the canonical stored shape). */
+/** Read a group's `members` JSON as a string list; non-strings are dropped. */
 function _MemberList(members: unknown): string[]
 {
   return Array.isArray(members) ? members.filter(function _isString(m): m is string { return typeof m === "string"; }) : [];
@@ -50,15 +50,18 @@ function _ToResourceShare(row: { id: string; name: string; members: unknown })
 }
 
 /**
- * Inter-user RESOURCE sharing (S4c) — distinct from `/shares` (which shares tool/skill
- * entitlements). In the unified model a direct share of a file/chat materialises a
- * **resource-scoped, Personal-tier Group** whose members are everyone the resource is shared
- * with; the recipient's user identity then receives read access through the derived dataset
- * membership → Cognee (S4c.2). The sharer must already be a member of the resource's group
- * (its owner on first share) to add others — no sharing a resource you don't hold.
+ * Lets one user share a file, chat, or dataset with another. Separate from `/shares`, which shares
+ * tool and skill entitlements.
  *
- * @param prisma - Prisma client for the group mirror.
- * @returns Configured Express router.
+ * Sharing a resource creates one Personal-scope Group named `resource:<type>:<id>`, and its members
+ * are everyone the resource is shared with; read access then follows from that group membership. The
+ * first share creates the group with the sharer and the recipient in it, which makes the sharer its
+ * owner. After that only a current member may add or remove others, so nobody can share a resource
+ * they have no access to.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at /api/v1/resource-shares.
+ * @param prisma - Silo Prisma client holding the group rows.
+ * @returns Express router with share, list, and unshare routes.
  */
 export function resourceSharesRouter(prisma: PrismaClient): Router
 {

--- a/libs/backend/server/iam/grants/main/src/routes/shares.ts
+++ b/libs/backend/server/iam/grants/main/src/routes/shares.ts
@@ -10,7 +10,7 @@ import type { CreateShareBody, SharePayloadType, ShareRecipientType, ShareScope 
 // Side-effect import: loads the express-session `SessionData.authUser` augmentation.
 import "@opencrane/backend/server/infra/auth";
 
-/** Payload families a user may share (the entitlement surfaces the runtime contract carries). */
+/** The payload kinds a user may share; MCP servers only, today. */
 const _PAYLOAD_TYPES: readonly SharePayloadType[] = ["mcp-server"];
 /** Recipient kinds a share may target. */
 const _RECIPIENT_TYPES: readonly ShareRecipientType[] = ["user", "group"];
@@ -25,7 +25,7 @@ const _SHARES_CATALOG_REVISION = 1;
 const _SHARES_CAPABILITY_ID = "mcp-server:use";
 /** Resource kind written to the AuthorizationGrant for MCP server shares. */
 const _SHARES_RESOURCE_KIND = "mcp-server";
-/** Priority for share-originated grants (user-to-user delegation, lowest tier). */
+/** Priority stamped on grants created by sharing: 0, the tier reserved for one user granting another. */
 const _SHARES_GRANT_PRIORITY = 0;
 
 /** Map each public API scope into the authorization-owned sharing vocabulary. */
@@ -61,13 +61,14 @@ function _DomainScope(scope: ShareScope, organizationId: string, subjectId: stri
 let _sharesCatalogDigest: string | null = null;
 
 /**
- * Ensures the well-known `opencrane-core` capability catalog revision exists.
+ * Makes sure the `opencrane-core` capability catalog revision exists before a grant references it.
  *
- * The authorization adapter performs an idempotent composite-key upsert so concurrent first
- * shares use the same immutable catalog revision rather than racing to create duplicates.
+ * The write is an upsert on the catalog id and revision, so two first shares at once land on the same
+ * catalog revision instead of one failing. The digest is cached for the process after the first call,
+ * since the catalog contents are fixed in this file.
  *
- * @param repository - Authorization-owned catalog persistence seam.
- * @returns The deterministic digest of the seeded catalog revision.
+ * @param repository - Authorization-owned store for capability catalogs.
+ * @returns The catalog revision's digest, which every grant written below needs.
  */
 async function _EnsureSharesCatalog(repository: ShareAuthorizationRepository): Promise<string>
 {
@@ -101,15 +102,19 @@ function _ToShare(row: ShareAuthorizationGrant)
 }
 
 /**
- * Inter-user sharing router (S4). A user shares an entitlement they themselves hold with
- * another user or group; the share is an `Allow` AuthorizationGrant on the recipient, which
- * the recipient's user identity then resolves through deterministic grant evaluation. Sharing
- * is **least-privilege bounded**: the caller may only share a payload for which their own
- * grants resolve to `Allow` -- there is no privilege escalation. The sharer is recorded
- * (`AuthorizationGrant.createdBy`) so they can list and revoke only their own shares.
+ * Lets one user share an MCP server they already have access to with another user or group.
  *
- * @param prisma - Prisma client for authorization grant + payload/recipient lookups.
- * @returns Configured Express router.
+ * A share is just an `Allow` AuthorizationGrant written on the recipient, which their own identity
+ * then resolves like any other grant. Two rules hold it in place. First, the caller's own grants
+ * must already resolve to `Allow` on that payload, so a share can never hand out more than the
+ * sharer holds. Second, the sharer's id is stored on the grant, so they can list and revoke their own
+ * shares and nobody else's. Re-sharing the same payload to the same recipient at the same scope
+ * returns the existing grant instead of creating a second one.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts via _CreateRateLimitedSharesRouter, mounted at
+ * /api/v1/shares behind a per-IP rate limiter.
+ * @param prisma - Silo Prisma client for grants and for payload/recipient existence checks.
+ * @returns Express router with create, list, and revoke routes.
  */
 export function sharesRouter(prisma: PrismaClient): Router
 {

--- a/libs/backend/server/iam/grants/main/src/routes/shares.types.ts
+++ b/libs/backend/server/iam/grants/main/src/routes/shares.types.ts
@@ -5,7 +5,11 @@ export type ShareRecipientType = "user" | "group";
 /** A valid API scope string for a share (mirrors GrantScope; defaults to personal). */
 export type ShareScope = "org" | "department" | "project" | "personal";
 
-/** Request body for creating a share. */
+/**
+ * Raw request body for creating a share. Every field is optional and typed as a plain string because
+ * this is what arrived over HTTP; the route checks each one against its closed set before touching
+ * the database, so a missing or unknown value becomes a 400 rather than a bad grant.
+ */
 export interface CreateShareBody
 {
   payloadType?: string;

--- a/libs/backend/server/iam/groups/main/src/core/groups.logic.ts
+++ b/libs/backend/server/iam/groups/main/src/core/groups.logic.ts
@@ -8,7 +8,7 @@ import type { GroupRouteScope, GroupWriteRequest } from "../routes/groups.types.
 
 type _GroupRow = Prisma.GroupGetPayload<{}>;
 
-/** Prisma scope lookup keyed by route values. */
+/** Route scope string ("org", "department", …) to the value stored in the group's scope column. */
 const _PRISMA_SCOPE_BY_ROUTE_SCOPE = {
 	org: "Org",
 	department: "Department",
@@ -16,7 +16,7 @@ const _PRISMA_SCOPE_BY_ROUTE_SCOPE = {
 	personal: "Personal",
 };
 
-/** Route scope lookup keyed by Prisma enum values. */
+/** The reverse: stored scope value to the GrantScope the API returns (includes Team, which routes cannot set). */
 const _ROUTE_SCOPE_BY_PRISMA_SCOPE: Record<string, GrantScope> = {
 	Org: GrantScope.Org,
 	Department: GrantScope.Department,
@@ -26,10 +26,14 @@ const _ROUTE_SCOPE_BY_PRISMA_SCOPE: Record<string, GrantScope> = {
 };
 
 /**
- * Load every persisted group.
+ * Load every group in the silo, newest first.
  *
- * @param prisma - Prisma client used for persistence.
- * @returns Normalized route response rows.
+ * There is no paging and no scope filter: a silo's group list is operator-sized. `grants` comes back
+ * empty — this loads groups only.
+ *
+ * Called by: the GET / handler of groupsRouter in routes/groups.ts.
+ * @param prisma - Silo Prisma client.
+ * @returns One row per group, with members de-duplicated, sorted, and counted.
  */
 export async function listGroups(prisma: PrismaClient): Promise<GroupResponse[]>
 {
@@ -60,11 +64,16 @@ export async function getGroup(prisma: PrismaClient, groupId: string): Promise<G
 }
 
 /**
- * Create a group.
+ * Create a group and record it in the audit-entry table.
  *
- * @param prisma - Prisma client used for persistence.
- * @param body - Route payload provided by the caller.
- * @returns Mutation response consumed by the route.
+ * The two writes are not one transaction, so a failed audit insert still leaves the group created —
+ * this is the operator-facing group list, not the append-only authorization decision log.
+ *
+ * Called by: the POST / handler of groupsRouter in routes/groups.ts.
+ * @param prisma - Silo Prisma client.
+ * @param body - Name, scope, optional description, and raw member list from the request.
+ * @returns The new group's id with status `created`.
+ * @throws Error from Prisma when the group name is already taken (unique constraint).
  */
 export async function createGroup(prisma: PrismaClient, body: GroupWriteRequest): Promise<GroupMutationResponse>
 {
@@ -124,11 +133,13 @@ export async function updateGroup(prisma: PrismaClient, groupId: string, body: P
 }
 
 /**
- * Delete a group.
+ * Delete a group and record it in the audit-entry table.
  *
- * @param prisma - Prisma client used for persistence.
- * @param groupId - Group identifier from the route.
- * @returns Mutation response consumed by the route.
+ * Called by: the DELETE /:id handler of groupsRouter in routes/groups.ts.
+ * @param prisma - Silo Prisma client.
+ * @param groupId - Group identifier from the route path.
+ * @returns The id with status `deleted`.
+ * @throws Error from Prisma when no group has that id.
  */
 export async function deleteGroup(prisma: PrismaClient, groupId: string): Promise<GroupMutationResponse>
 {
@@ -148,10 +159,13 @@ export async function deleteGroup(prisma: PrismaClient, groupId: string): Promis
 }
 
 /**
- * Normalize raw membership JSON into a unique, sorted string array.
+ * Turn a raw membership value into a de-duplicated, sorted list of non-empty strings.
  *
- * @param members - Raw request or database membership value.
- * @returns Canonical principal identifier list.
+ * Used both on the way in and on the way out, so a hand-edited or legacy `members` column still
+ * reads back as a clean list. Non-strings and blanks are dropped, not kept.
+ *
+ * @param members - Raw value from the request body or the database column.
+ * @returns Sorted, unique member identifiers.
  */
 function _NormalizeMembers(members: unknown): string[]
 {

--- a/libs/backend/server/iam/groups/main/src/core/groups.logic.types.ts
+++ b/libs/backend/server/iam/groups/main/src/core/groups.logic.types.ts
@@ -1,9 +1,20 @@
 import type { Group } from "@opencrane/contracts";
 
-/** Shared response contract returned by the groups routes. */
+/**
+ * The group shape the HTTP routes return. An alias of the shared `Group` contract from
+ * @opencrane/contracts, so the route layer and the generated API client cannot drift apart.
+ */
 export type GroupResponse = Group;
 
-/** Persist response shape returned after create, update, or delete mutations. */
+/**
+ * What a create, update, or delete returns: the group's id, plus which of the three happened.
+ *
+ * Deliberately not the group itself — a delete has no group left to return, so all three share one
+ * shape.
+ *
+ * Called by: createGroup, updateGroup, and deleteGroup in core/groups.logic.ts, whose values the
+ * groups router sends as JSON.
+ */
 export interface GroupMutationResponse
 {
   /** Stable group identifier. */

--- a/libs/backend/server/iam/groups/main/src/routes/groups.ts
+++ b/libs/backend/server/iam/groups/main/src/routes/groups.ts
@@ -5,10 +5,14 @@ import { createGroup, deleteGroup, getGroup, listGroups, updateGroup } from "../
 import type { GroupWriteRequest } from "./groups.types.js";
 
 /**
- * CRUD router for domain access groups.
+ * Create, read, update, and delete the silo's groups.
  *
- * @param prisma - Prisma client used for persistence.
- * @returns Configured Express router.
+ * The handlers do no authorization of their own — whatever the mount point applies is all there is.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at /api/v1/groups on the browser-session
+ * authenticated listener.
+ * @param prisma - Silo Prisma client.
+ * @returns Express router with the five group routes.
  */
 export function groupsRouter(prisma: PrismaClient): Router
 {

--- a/libs/backend/server/iam/identity/main/src/mirror-groups.ts
+++ b/libs/backend/server/iam/identity/main/src/mirror-groups.ts
@@ -8,7 +8,7 @@ import type { MirrorGroupsOnLoginOptions } from "./identity-workflows.types.js";
  * `AuthUser.groups` already carries every `group:*` the user holds. This module mirrors those
  * claims into the silo's persisted `Group.members` so operator-facing group management, grants,
  * and audit see the IdP-sourced membership — the token stays the live source for request-time
- * `{groups}`, this is the durable projection of it.
+ * `{groups}`, and this is the stored copy of it.
  *
  * Scope-aware retrieval keys on the live token groups, so this mirror is the persistence half,
  * not on the hot path.
@@ -21,7 +21,7 @@ import type { MirrorGroupsOnLoginOptions } from "./identity-workflows.types.js";
  *
  * DEFERRED (tracked on #126): opencrane-ui group mutations writing Zitadel role grants via
  * the fleet management client — for now org admins manage group roles in the Zitadel Console
- * they own (the decided native primitive).
+ * they own — Zitadel's own roles are the agreed mechanism.
  */
 
 /** Maps the scope segment of a `group:<scope>:<name>` claim to the `GrantScope` enum. */
@@ -67,7 +67,7 @@ export function _ParseGroupClaims(groups: readonly string[] | undefined): Parsed
   return out;
 }
 
-/** Coerce a stored `members` JSON value into a string array (defensive against nulls/non-arrays). */
+/** Read a stored `members` JSON value as a string array; anything else reads as empty. */
 function _asMemberArray(value: Prisma.JsonValue | undefined): string[]
 {
   return Array.isArray(value) ? value.filter((m): m is string => typeof m === "string") : [];

--- a/libs/backend/server/iam/identity/main/src/oidc.service.ts
+++ b/libs/backend/server/iam/identity/main/src/oidc.service.ts
@@ -15,7 +15,7 @@ import { _ResolveCallerClusterTenant } from "@opencrane/backend/server/tenancy/c
  * The clustertenant-manager's OIDC auth service. Extends the shared
  * {@link OidcAuthServiceBase} (provider discovery, PKCE login, token exchange, claim
  * validation, session lifecycle, membership-derived org-admin facts) with the two
- * silo-specific seams:
+ * parts that differ per silo:
  *
  *   - {@link resolveLoginClient} — per-org login. A host `<org>.<base>` (or a customer
  *     vanity domain) that maps to a fully-provisioned ClusterTenant authorizes against THAT
@@ -91,12 +91,16 @@ export class OidcAuthService extends OidcAuthServiceBase
   }
 
   /**
-   * Mirror optional OIDC group projection, then claim the configured standalone owner slot from
-   * verified callback facts. The durable claim is subject-bound and failure is browser-visible.
+   * Copy the login's group claims into the database, then, on a standalone install, claim the silo's
+   * single owner slot from the verified login facts.
+   *
+   * The group copy is best-effort: a failure is logged and nothing else. The owner claim is not — a
+   * refusal throws, and {@link isPostLoginFailureFatal} makes the browser see a failed login rather
+   * than landing the user in a silo they do not own. The stored owner is keyed on the OIDC subject.
    */
   protected override async onLoginEstablished(req: Request, authUser: AuthUser): Promise<void>
   {
-    // 1. Keep optional group projection independent so its outage cannot hide first-owner admission.
+    // 1. Copy group claims separately, so a failure there cannot hide the owner-claim result.
     try
     {
       await _MirrorGroupsOnLogin({ prisma: this.prisma, subject: authUser.sub, groups: authUser.groups, log: this.log });

--- a/libs/backend/server/iam/identity/main/src/prisma-standalone-first-user-admission-repository.ts
+++ b/libs/backend/server/iam/identity/main/src/prisma-standalone-first-user-admission-repository.ts
@@ -2,15 +2,19 @@ import { OrgMemberStatus, OrgRole, type Prisma } from "@prisma/client";
 
 import { StandaloneFirstUserAdmissionOutcomes, type StandaloneFirstUserAdmissionAuditPort, type StandaloneFirstUserOwnerClaim, type StandaloneFirstUserOwnerClaimRepository, type StandaloneFirstUserStoredMembership } from "./standalone-first-user-admission.types.js";
 
-/** Maps the precise stored fields used by one-time owner admission into the port's vocabulary. */
+/** Copies the three stored membership fields the decision needs into the port's type. */
 function _storedMembership(row: { subject: string; role: OrgRole; status: OrgMemberStatus }): StandaloneFirstUserStoredMembership
 {
   return { subject: row.subject, role: row.role, status: row.status };
 }
 
 /**
- * Transaction-scoped Prisma adapter for the standalone first-owner claim.
- * It owns typed OrgMembership reads/writes; the unit of work owns transaction selection.
+ * Reads and writes the OrgMembership rows for one owner-slot decision, inside a given transaction.
+ *
+ * It never opens a transaction of its own — {@link PrismaStandaloneFirstUserAdmissionUnitOfWork} does
+ * that and constructs one of these per attempt.
+ *
+ * @implements StandaloneFirstUserOwnerClaimRepository
  */
 export class PrismaStandaloneFirstUserAdmissionRepository implements StandaloneFirstUserOwnerClaimRepository
 {
@@ -19,7 +23,10 @@ export class PrismaStandaloneFirstUserAdmissionRepository implements StandaloneF
   /** Audit authority supplied by the app composition root. */
   private readonly audit: StandaloneFirstUserAdmissionAuditPort;
 
-  /** @param prisma - Exact serializable transaction for one owner-slot decision. @param audit - Audit authority bound to this transaction. */
+  /**
+   * @param prisma - The open serializable transaction for this one owner-slot decision.
+   * @param audit - Audit appender that writes into that same transaction.
+   */
   constructor(prisma: Prisma.TransactionClient, audit: StandaloneFirstUserAdmissionAuditPort)
   {
     this.prisma = prisma;
@@ -66,7 +73,21 @@ export class PrismaStandaloneFirstUserAdmissionRepository implements StandaloneF
   }
 }
 
-/** Decides one durable owner claim against a serializable transaction-scoped store. */
+/**
+ * Runs the owner-slot decision: is the slot already this subject's, already someone else's, or free?
+ *
+ * The order of the checks is the safety property. A membership row for this exact subject is the only
+ * idempotent success, and only while it is an active Owner — a suspended or demoted row counts as
+ * claimed. Any other existing owner ends it. Only a genuinely empty slot reaches the eligibility
+ * check, and the audit row is written in the same transaction as the new owner row.
+ *
+ * Called by: PrismaStandaloneFirstUserAdmissionUnitOfWork in this package.
+ * @param store - Transaction-scoped reads and writes for one attempt.
+ * @param claim - Silo, subject, and whether this login may create the owner row.
+ * @returns The outcome to report to the login; only `Admitted` created anything.
+ * @throws Error from Prisma when a concurrent login inserts the owner first (P2002); the unit of
+ *         work catches that and retries once.
+ */
 export async function _ClaimStandaloneFirstUserOwner(store: StandaloneFirstUserOwnerClaimRepository, claim: StandaloneFirstUserOwnerClaim): Promise<{ readonly outcome: StandaloneFirstUserAdmissionOutcomes }>
 {
   // 1. Preserve an exact active owner tuple as the only idempotent success case.

--- a/libs/backend/server/iam/identity/main/src/prisma-standalone-first-user-admission-unit-of-work.ts
+++ b/libs/backend/server/iam/identity/main/src/prisma-standalone-first-user-admission-unit-of-work.ts
@@ -4,8 +4,16 @@ import { _ClaimStandaloneFirstUserOwner, PrismaStandaloneFirstUserAdmissionRepos
 import { type StandaloneFirstUserAdmissionAuditPort, type StandaloneFirstUserAdmissionResult, type StandaloneFirstUserAdmissionUnitOfWork, type StandaloneFirstUserOwnerClaim } from "./standalone-first-user-admission.types.js";
 
 /**
- * Owns the serializable transaction that makes a standalone silo's first-owner claim atomic.
- * A one-time retry turns a concurrent unique/serialization collision into the durable result.
+ * Opens the serializable transaction for a first-owner claim and retries a lost race exactly once.
+ *
+ * Serializable isolation plus the unique constraint on the owner row means two simultaneous logins
+ * cannot both create an owner: one fails with a unique violation (P2002) or a serialization failure
+ * (P2034). Retrying once is enough, because the slot is now filled — the second attempt reads it and
+ * returns `AlreadyOwner` or `AlreadyClaimed` instead of racing again.
+ *
+ * Called by: OidcAuthService.onLoginEstablished in this package, composed with the audit appender
+ * from apps/opencrane/src/app/public-app.ts.
+ * @implements StandaloneFirstUserAdmissionUnitOfWork
  */
 export class PrismaStandaloneFirstUserAdmissionUnitOfWork implements StandaloneFirstUserAdmissionUnitOfWork
 {
@@ -14,7 +22,10 @@ export class PrismaStandaloneFirstUserAdmissionUnitOfWork implements StandaloneF
   /** Audit authority composed outside identity and invoked inside the selected transaction. */
   private readonly audit: StandaloneFirstUserAdmissionAuditPort;
 
-  /** @param prisma - Root client used solely to select serializable owner-claim transactions. @param audit - Audit authority for accepted claims. */
+  /**
+   * @param prisma - Full client, used only to open serializable owner-claim transactions.
+   * @param audit - Audit appender invoked inside each of those transactions.
+   */
   constructor(prisma: PrismaClient, audit: StandaloneFirstUserAdmissionAuditPort)
   {
     this.prisma = prisma;
@@ -49,7 +60,7 @@ export class PrismaStandaloneFirstUserAdmissionUnitOfWork implements StandaloneF
   }
 }
 
-/** Identifies Prisma's retryable unique or serialization outcomes for one owner-slot race. */
+/** Returns true for the two Prisma errors a concurrent owner claim raises: P2002 and P2034. */
 function _isConcurrentClaimError(error: unknown): boolean
 {
   return error instanceof Prisma.PrismaClientKnownRequestError

--- a/libs/backend/server/iam/identity/main/src/standalone-first-user-admission.ts
+++ b/libs/backend/server/iam/identity/main/src/standalone-first-user-admission.ts
@@ -1,8 +1,20 @@
 import { StandaloneFirstUserAdmissionOutcomes, type StandaloneFirstUserAdmissionCommand, type StandaloneFirstUserAdmissionConfig, type StandaloneFirstUserAdmissionRepository, type StandaloneFirstUserAdmissionResult } from "./standalone-first-user-admission.types.js";
 
 /**
- * Admit the configured first owner of one standalone silo from verified callback facts only.
- * Email is a one-time eligibility check; the durable record is always bound to the OIDC subject.
+ * Decides whether this login may become the standalone silo's first owner, then tries to claim it.
+ *
+ * Two gates. The request host, the issuer, and a non-empty subject must match this deployment's
+ * configuration, or the login was never a candidate. Then the configured email — and only a
+ * provider-verified one — decides whether an empty owner slot may be filled. The stored owner row is
+ * keyed on the OIDC subject, not the email, so a later email change cannot move ownership.
+ *
+ * Called by: OidcAuthService.onLoginEstablished in this package, on every login of a standalone
+ * install.
+ * @param config - Configured silo, verified email, and issuer for this deployment.
+ * @param repository - Owner-slot store that makes the claim atomic.
+ * @param command - Host-derived silo plus the verified issuer, subject, and email claims.
+ * @returns `Admitted` or `AlreadyOwner` when the caller owns the silo; `NotEligible` or
+ *          `AlreadyClaimed` when it must not proceed.
  */
 export async function _AdmitStandaloneFirstUser(config: StandaloneFirstUserAdmissionConfig, repository: StandaloneFirstUserAdmissionRepository, command: StandaloneFirstUserAdmissionCommand): Promise<StandaloneFirstUserAdmissionResult>
 {

--- a/libs/backend/server/iam/identity/main/src/standalone-first-user-admission.types.ts
+++ b/libs/backend/server/iam/identity/main/src/standalone-first-user-admission.types.ts
@@ -1,4 +1,8 @@
-/** Deployment-owned bootstrap coordinates for exactly one standalone-silo owner. */
+/**
+ * The three configured values that decide who may become a standalone silo's owner: which silo,
+ * which verified email, and which OIDC issuer. Read from the environment at startup, so a login can
+ * never widen its own eligibility.
+ */
 export interface StandaloneFirstUserAdmissionConfig
 {
   /** ClusterTenant served by this release and derived again from the callback host. */
@@ -24,7 +28,12 @@ export interface StandaloneFirstUserAdmissionCommand
   readonly emailVerified: boolean | undefined;
 }
 
-/** Durable owner-claim request after all trusted admission checks have passed. */
+/**
+ * The owner claim handed to persistence once the login's host, issuer, and subject have checked out.
+ *
+ * `mayCreateOwner` is the one permission left: it is true only when the login's verified email
+ * matched the configured one, and it decides whether an empty owner slot may be filled.
+ */
 export interface StandaloneFirstUserOwnerClaim
 {
   /** Silo in which the one-time owner claim is being made. */
@@ -35,7 +44,20 @@ export interface StandaloneFirstUserOwnerClaim
   readonly mayCreateOwner: boolean;
 }
 
-/** Stable outcomes of the standalone first-owner admission decision. */
+/**
+ * How a first-owner claim ended. Only `Admitted` and `AlreadyOwner` let the caller proceed.
+ *
+ * A standalone silo has exactly one owner slot and every login tries to fill it, so two logins can
+ * race for the same empty slot: both see it empty, both insert, and the unique constraint lets only
+ * one through. The loser retries and comes back with `AlreadyOwner` when it is the same subject, or
+ * `AlreadyClaimed` when someone else got there first. `AlreadyClaimed` also covers a subject whose
+ * membership exists but is not an active Owner, so a demoted or suspended user cannot promote itself
+ * back. `NotEligible` is different in kind: the login did not match the configured host, issuer, or
+ * verified email, so it was never a candidate. Both refusals make the login fail visibly in the
+ * browser instead of dropping the user into a silo they do not own.
+ *
+ * @see StandaloneFirstUserAdmissionResult
+ */
 export enum StandaloneFirstUserAdmissionOutcomes
 {
   /** The configured verified user was created as this silo's active owner. */
@@ -55,14 +77,28 @@ export interface StandaloneFirstUserAdmissionResult
   readonly outcome: StandaloneFirstUserAdmissionOutcomes;
 }
 
-/** Persistence port that atomically claims the single owner slot for one standalone silo. */
+/**
+ * Claims the silo's single owner slot, all or nothing.
+ *
+ * The implementation opens a serializable transaction and retries once if it collides with a
+ * concurrent login, so callers get a settled outcome and never handle the race themselves.
+ *
+ * Called by: _AdmitStandaloneFirstUser in this package; implemented by
+ * {@link PrismaStandaloneFirstUserAdmissionUnitOfWork}.
+ */
 export interface StandaloneFirstUserAdmissionRepository
 {
-  /** Claims one owner membership or returns an idempotent/denied durable outcome. */
+  /**
+   * @param claim - Silo, subject, and whether this login may create the owner row.
+   * @returns One of the four outcomes; only `Admitted` means this call created the owner.
+   */
   claimOwner(claim: StandaloneFirstUserOwnerClaim): Promise<StandaloneFirstUserAdmissionResult>;
 }
 
-/** Unit-of-work port that owns the serializable standalone first-owner transaction. */
+/**
+ * Marks the implementation that opens the transaction, as opposed to one that joins an existing one.
+ * It adds no methods; the only distinction is which layer may start a transaction.
+ */
 export interface StandaloneFirstUserAdmissionUnitOfWork extends StandaloneFirstUserAdmissionRepository
 {
 }
@@ -74,7 +110,12 @@ export interface StandaloneFirstUserAdmissionAuditPort
   append(transaction: unknown, claim: Pick<StandaloneFirstUserOwnerClaim, "clusterTenant" | "subject">): Promise<void>;
 }
 
-/** Transaction-scoped persistence operations needed to inspect and claim one owner slot. */
+/**
+ * The reads and writes one owner-slot decision needs, all against a single open transaction.
+ *
+ * Called by: _ClaimStandaloneFirstUserOwner in this package; implemented by
+ * {@link PrismaStandaloneFirstUserAdmissionRepository}.
+ */
 export interface StandaloneFirstUserOwnerClaimRepository
 {
   /** Finds the exact subject membership inside the selected silo. */

--- a/libs/backend/server/iam/membership/main/src/ed25519-fleet-membership-signature-verifier.ts
+++ b/libs/backend/server/iam/membership/main/src/ed25519-fleet-membership-signature-verifier.ts
@@ -7,10 +7,17 @@ import { __DigestFleetMembershipSignedPayload } from "./fleet-membership-payload
 import type { FleetMembershipSignatureVerifier } from "./membership-authority.types.js";
 
 /**
- * Verifies fleet membership payload digests with an exact Ed25519 issuer-key ring.
+ * Checks Ed25519 signatures on stored membership revisions against a fixed set of issuer keys.
  *
- * Fleet signs the UTF-8 `sha256:<hex>` payload-digest string. That digest covers the canonical
- * complete membership payload before the revision enters the verified local projection.
+ * The issuer signs the UTF-8 bytes of the `sha256:<hex>` digest string, and that digest covers the
+ * whole membership payload. So this class recomputes the digest itself and refuses a revision whose
+ * stored digest disagrees, before it even looks at the signature — a caller cannot get a signature
+ * checked against bytes of its own choosing.
+ *
+ * Called by: _CreateFleetMembershipEvidenceConfig in this package builds one per key read; the
+ * resulting verifier is used by __VerifyCurrentFleetMembershipEvidence.
+ * @implements FleetMembershipSignatureVerifier
+ * @throws Error from the constructor when a key is blank, not Ed25519, or absent entirely.
  */
 export class Ed25519FleetMembershipSignatureVerifier implements FleetMembershipSignatureVerifier
 {
@@ -18,9 +25,13 @@ export class Ed25519FleetMembershipSignatureVerifier implements FleetMembershipS
 	private readonly keys: ReadonlyMap<string, KeyObject>;
 
 	/**
-	 * Creates a verifier from mounted PEM public keys.
+	 * Creates a verifier from PEM public keys read off disk.
 	 *
-	 * @param publicKeysById - Trusted key identifiers and their SPKI PEM public keys.
+	 * @param publicKeysById - Key identifiers, as they appear in a revision's `issuerKeyId`, mapped to
+	 *                         their SPKI PEM public keys.
+	 * @throws Error when an identifier or PEM value is blank, when a key is not Ed25519, or when the
+	 *         map is empty — starting with no usable key is a configuration mistake, not a state to
+	 *         run in.
 	 */
 	constructor(publicKeysById: Readonly<Record<string, string>>)
 	{
@@ -36,7 +47,14 @@ export class Ed25519FleetMembershipSignatureVerifier implements FleetMembershipS
 		this.keys = keys;
 	}
 
-	/** Verifies the detached base64url signature over the canonical payload digest. */
+	/**
+	 * Recomputes the digest, then checks the base64url signature over it.
+	 *
+	 * @param revision - Stored revision with its claimed digest and signature.
+	 * @returns Evidence echoing what was seen, with `verified` true only when the key id is known, the
+	 *          stored digest matches the recomputed one, and the signature holds. An unknown key or a
+	 *          malformed signature gives `verified: false` rather than an exception.
+	 */
 	async verify(revision: SignedFleetMembershipRevision): Promise<FleetSignatureVerificationEvidence>
 	{
 		const key = this.keys.get(revision.issuerKeyId);

--- a/libs/backend/server/iam/membership/main/src/fleet-membership-evidence.factory.ts
+++ b/libs/backend/server/iam/membership/main/src/fleet-membership-evidence.factory.ts
@@ -8,10 +8,26 @@ import type { FleetMembershipEvidenceConfig, FleetMembershipSignatureVerifier } 
 /** Longest period a server may reuse its newest signed fleet-membership revision. */
 const _MAXIMUM_STALENESS_MILLISECONDS = 24 * 60 * 60 * 1_000;
 
-/** Synthetic issuer identifier used only to keep absent standalone evidence denied. */
+/** Placeholder issuer id for standalone mode; it matches no real issuer, so lookups find nothing. */
 const _STANDALONE_ISSUER_ID = "opencrane-standalone-unconfigured";
 
-/** Creates one reloadable mounted-key trust configuration without coupling it to an agent type. */
+/**
+ * Reads this deployment's membership trust settings out of the environment.
+ *
+ * `OPENCRANE_MEMBERSHIP_MODE` must say `fleet` or `standalone`; there is no default, because
+ * guessing would decide whether unsigned membership is possible. In `fleet` mode the issuer id, key
+ * id, and public-key file are all required, and the key file is re-read before every signature check
+ * so rotating the mounted key takes effect without a restart. In `standalone` mode there is no key,
+ * so the verifier returned refuses every revision — the silo simply has no fleet membership yet
+ * rather than an unchecked one.
+ *
+ * Called by: apps/opencrane/src/index.ts, apps/opencrane/src/app/channel-target-composition.ts, and
+ * libs/backend/server/agents/agent-services/main/src/prisma-managed-execution-evidence.factory.ts.
+ * @param environment - Process environment to read; defaults to `process.env`, overridden in tests.
+ * @returns Trusted issuer, staleness limit in milliseconds, and the verifier to use.
+ * @throws Error when the mode is missing or unrecognised, when a required `fleet` variable is
+ *         absent, or when the staleness override is not a positive integer of at most 24 hours.
+ */
 export function _CreateFleetMembershipEvidenceConfig(environment: NodeJS.ProcessEnv = process.env): FleetMembershipEvidenceConfig
 {
 	const mode = _DeploymentMode(environment);
@@ -27,7 +43,7 @@ export function _CreateFleetMembershipEvidenceConfig(environment: NodeJS.Process
 	return { trustedIssuerId, maximumStalenessMs, verifier: _CreateReloadingVerifier(source.read, issuerKeyId) };
 }
 
-/** Reads the explicitly selected issuer model; absent configuration never implies Fleet trust. */
+/** Reads the configured mode; a missing or unknown value throws instead of defaulting to fleet. */
 function _DeploymentMode(environment: NodeJS.ProcessEnv): FleetMembershipDeploymentModes
 {
 	const value = environment["OPENCRANE_MEMBERSHIP_MODE"]?.trim();
@@ -36,7 +52,7 @@ function _DeploymentMode(environment: NodeJS.ProcessEnv): FleetMembershipDeploym
 	throw new Error("OPENCRANE_MEMBERSHIP_MODE must be standalone or fleet");
 }
 
-/** Produces matching but unverified evidence so standalone startup can never convert missing trust into access. */
+/** Returns a verifier that always answers "not verified", so a silo with no key grants nothing. */
 function _CreateStandaloneDenyVerifier(): FleetMembershipSignatureVerifier
 {
 	return {
@@ -67,7 +83,7 @@ function _CreateReloadingVerifier(read: () => string, issuerKeyId: string): Flee
 	return { async verify(revision: SignedFleetMembershipRevision): Promise<FleetSignatureVerificationEvidence> { return _Load().verify(revision); } };
 }
 
-/** Reads one mandatory process-owned trust coordinate. */
+/** Reads one required environment variable and trims it. */
 function _Required(environment: NodeJS.ProcessEnv, name: string): string
 {
 	const value = environment[name]?.trim();

--- a/libs/backend/server/iam/membership/main/src/fleet-membership-payload-digest.ts
+++ b/libs/backend/server/iam/membership/main/src/fleet-membership-payload-digest.ts
@@ -2,10 +2,10 @@ import { __DigestCanonicalJson } from "@opencrane/backend/server/iam/authorizati
 import type { AuthorizationScope, SignedFleetMembershipRevision } from "@opencrane/models/authorization";
 import type { JsonValue } from "@opencrane/util";
 
-/** Signed membership fields whose canonical digest excludes only the digest and signature envelope. */
+/** The revision fields the digest covers: everything except the digest and signature themselves. */
 type FleetMembershipSignedPayload = Omit<SignedFleetMembershipRevision, "payloadDigest" | "signature">;
 
-/** Copies one typed scope into the canonical JSON vocabulary without weakening its type globally. */
+/** Copies one scope into plain JSON, keeping only the fields that scope kind actually has. */
 function _CanonicalScope(scope: AuthorizationScope): JsonValue
 {
 	if (scope.kind === "organization") return { kind: scope.kind, organizationId: scope.organizationId };
@@ -16,14 +16,16 @@ function _CanonicalScope(scope: AuthorizationScope): JsonValue
 }
 
 /**
- * Computes the canonical digest that a fleet issuer signs and OpenCrane independently verifies.
+ * Computes the digest a fleet issuer signs and that OpenCrane recomputes before trusting a revision.
  *
- * Assertions are sorted by their complete canonical content so database row order cannot change the
- * signed meaning, while any issuer, time, silo, subject, assertion, or scope mutation changes the
- * digest and invalidates the detached signature.
+ * Assertions are sorted by the digest of their own content, so the order rows came back from the
+ * database cannot change what was signed. Any change to the issuer, times, silo, subject, assertion,
+ * or scope changes this digest, which makes the issuer's existing signature stop matching.
  *
- * @param revision - Complete signer-owned membership payload without envelope digest or signature.
- * @returns Canonical SHA-256 digest signed as its UTF-8 `sha256:<hex>` representation.
+ * Called by: Ed25519FleetMembershipSignatureVerifier.verify in this package; no caller outside the
+ * package yet, though the barrel exports it for the signing side.
+ * @param revision - A revision's signed fields, without its digest or signature.
+ * @returns The digest as a `sha256:<hex>` string; that string's UTF-8 bytes are what gets signed.
  */
 export function __DigestFleetMembershipSignedPayload(revision: FleetMembershipSignedPayload): string
 {

--- a/libs/backend/server/iam/membership/main/src/membership-authority.ts
+++ b/libs/backend/server/iam/membership/main/src/membership-authority.ts
@@ -3,12 +3,19 @@ import { __EvaluateFleetMembershipRevision } from "@opencrane/models/authorizati
 import type { FleetMembershipAuthorityRepository, FleetMembershipSignatureVerifier, VerifyFleetMembershipCommand, VerifyFleetMembershipEvidenceResult, VerifyFleetMembershipResult } from "./membership-authority.types.js";
 
 /**
- * Verifies and monotonically accepts the latest signed fleet-membership revision.
- * A cached revision is trusted only until the earlier signed expiry or configured staleness limit.
- * @param repository - Signed-revision and accepted-high-watermark authority.
- * @param verifier - Cryptographic verifier for fleet envelopes.
- * @param command - Exact silo, subject, scope, and freshness expectation.
- * @returns Trusted membership window or a fail-closed denial.
+ * Checks one subject's fleet membership and reports how long it may be trusted.
+ *
+ * A thin wrapper over {@link __VerifyCurrentFleetMembershipEvidence} for callers that only need
+ * "yes, until when" and have no use for the signed facts. Trust ends at the earlier of the
+ * revision's own expiry and the configured staleness limit, so a silo that stops receiving new
+ * revisions loses membership by itself instead of coasting on an old one.
+ *
+ * Called by: SignedFleetMembershipAssertionVerifier in this package — the only caller today.
+ * @param repository - Store of signed revisions and of the newest accepted revision per silo.
+ * @param verifier - Holder of the issuer's public key.
+ * @param command - Silo, subject, assertion, scope, current time, and staleness limit.
+ * @returns `trusted` with the revision and the instant trust runs out, or `denied` with the reason
+ *          the check failed; a denial never means "retry without checking".
  */
 export async function __VerifyCurrentFleetMembership(repository: FleetMembershipAuthorityRepository, verifier: FleetMembershipSignatureVerifier, command: VerifyFleetMembershipCommand): Promise<VerifyFleetMembershipResult>
 {
@@ -18,20 +25,35 @@ export async function __VerifyCurrentFleetMembership(repository: FleetMembership
 }
 
 /**
- * Verifies current membership and returns only signer-produced evidence safe to freeze into a run.
- * The result never echoes caller claims as proof, and the acceptance high-watermark advances before
- * trusted evidence is returned so concurrent rollback attempts fail closed.
+ * Checks one subject's fleet membership and returns the signed facts to record on the run.
+ *
+ * Four steps, in this order: load the newest stored revision for the trusted issuer; check the
+ * issuer's signature; apply the ordering, scope, expiry, and staleness rules; and only then record
+ * that revision as the newest one this silo accepts. Doing that last step before returning is what
+ * makes a replay of an older signed revision fail — two concurrent admissions race on that number
+ * and the loser gets `acceptance_conflict` instead of trust. Every field of the returned evidence
+ * comes from the signed revision, never from the caller's input, so a run's stored membership can
+ * be checked against the issuer's signature later.
+ *
+ * Called by: libs/backend/agents/execution/inputs/main/src/personal-execution-identity-envelope-source.ts
+ * and libs/backend/server/agents/agent-services/main/src/prisma-managed-execution-evidence.ts, both
+ * passing the transaction of the run admission they are already inside.
+ * @param repository - Store of signed revisions and of the newest accepted revision per silo.
+ * @param verifier - Holder of the issuer's public key.
+ * @param command - Silo, subject, assertion, scope, current time, and staleness limit.
+ * @returns `trusted` with signed evidence, or `denied` with a reason: `missing_revision`,
+ *          `signature_verifier_failed`, `acceptance_conflict`, or a rule from the trust evaluation.
  */
 export async function __VerifyCurrentFleetMembershipEvidence(repository: FleetMembershipAuthorityRepository, verifier: FleetMembershipSignatureVerifier, command: VerifyFleetMembershipCommand): Promise<VerifyFleetMembershipEvidenceResult>
 {
-	// 1. Resolve only the freshest locally available signed revision; absence cannot imply membership.
+	// 1. Load the newest stored revision; if none exists, the subject is not a member.
 	const revision = await repository.getLatestSignedRevision(command.trustedIssuerId, command.siloId);
 	if (revision === null)
 	{
 		return { outcome: "denied", reason: "missing_revision", revision: 0 };
 	}
 
-	// 2. Obtain explicit cryptographic evidence; verifier failures never fall back to cached trust.
+	// 2. Check the signature; if the verifier throws, deny instead of reusing an earlier result.
 	let evidence;
 	try
 	{
@@ -59,7 +81,8 @@ export async function __VerifyCurrentFleetMembershipEvidence(repository: FleetMe
 		return { outcome: "denied", reason: decision.reason, revision: decision.revision };
 	}
 
-	// 4. Advance the high-watermark atomically so a newer concurrent acceptance defeats rollback.
+	// 4. Record this revision as the newest accepted one. If another admission already recorded a
+	//    newer one, this check loses and denies rather than trusting an older revision.
 	const acceptance = await repository.acceptRevisionAtomically({ issuerId: revision.issuerId, siloId: revision.siloId, revision: revision.revision, payloadDigest: revision.payloadDigest });
 	if (acceptance.status === "conflict")
 	{

--- a/libs/backend/server/iam/membership/main/src/membership-authority.types.ts
+++ b/libs/backend/server/iam/membership/main/src/membership-authority.types.ts
@@ -1,6 +1,18 @@
 import type { AuthorizationScope, FleetMembershipTrustReason, FleetSignatureVerificationEvidence, SignedFleetMembershipRevision } from "@opencrane/models/authorization";
 
-/** Command for trusting the freshest signed fleet-membership revision available to one silo. */
+/**
+ * One membership question: is this subject still a member of this silo, for this scope, right now?
+ *
+ * A fleet issuer signs a numbered revision that lists every membership assertion for a silo. This
+ * command names the single assertion the caller wants proved, plus how stale a revision it will
+ * accept. Take `assertionId` from the stored revision itself, never from a value that arrived with
+ * a request — {@link SignedFleetMembershipAssertionVerifier} exists to do that selection. Pass the
+ * admission transaction's start time as `nowEpochMs` so every check inside one admission judges
+ * freshness against the same instant.
+ *
+ * @see __VerifyCurrentFleetMembershipEvidence
+ * @see FleetMembershipAcceptance
+ */
 export interface VerifyFleetMembershipCommand
 {
 	/** Fleet issuer trusted for membership facts. */
@@ -9,20 +21,31 @@ export interface VerifyFleetMembershipCommand
 	readonly siloId: string;
 	/** Subject whose membership is required. */
 	readonly subjectId: string;
-	/** Stable signed assertion identifier required by the authorization request. */
+	/** Identifier of the one signed assertion to prove; read it from the stored revision, not from a request. */
 	readonly assertionId: string;
-	/** Exact independent scope required by the authorization request. */
+	/** Scope the assertion must cover, such as an organization, team, project, or personal scope. */
 	readonly scope: AuthorizationScope;
-	/** Trusted current epoch-millisecond time. */
+	/** Current time in epoch milliseconds, supplied by the caller so one admission uses one instant. */
 	readonly nowEpochMs: number;
 	/** Maximum permitted signed-revision age in milliseconds. */
 	readonly maximumStalenessMs: number;
 }
 
-/** Atomic high-watermark acceptance request after membership verification. */
+/**
+ * Asks the store to record that this silo has now accepted revision N from this issuer.
+ *
+ * Each issuer-and-silo pair keeps one number: the newest revision it has ever accepted. Every
+ * successful membership check moves that number forward, so a later request carrying an older
+ * signed revision is refused as a rollback instead of being trusted again. `payloadDigest` must be
+ * the digest of the exact revision that was verified, so accepting revision N twice with different
+ * content is refused rather than silently overwritten.
+ *
+ * @see FleetMembershipAcceptanceResult
+ * @see FleetMembershipAuthorityRepository
+ */
 export interface FleetMembershipAcceptance
 {
-	/** Fleet issuer whose independently ordered revision is being accepted. */
+	/** Issuer that signed the revision; each issuer has its own revision numbering per silo. */
 	readonly issuerId: string;
 	/** Silo whose accepted revision high-watermark changes. */
 	readonly siloId: string;
@@ -32,37 +55,114 @@ export interface FleetMembershipAcceptance
 	readonly payloadDigest: string;
 }
 
-/** Result of atomically advancing one issuer-and-silo membership high-watermark. */
+/**
+ * What happened when the store tried to record the newest accepted revision.
+ *
+ * `accepted` — the number moved forward to this revision. `already_accepted` — this revision and
+ * digest was already recorded, so a retry is safe and changes nothing. `conflict` — a newer
+ * revision is already recorded, or this revision number is recorded with a different digest; the
+ * caller must then treat membership as unproven and deny, never fall back to the older accepted
+ * revision. `highestAcceptedRevision` always reports the number the store now holds.
+ */
 export type FleetMembershipAcceptanceResult =
 	| { readonly status: "accepted" | "already_accepted"; readonly highestAcceptedRevision: number }
 	| { readonly status: "conflict"; readonly highestAcceptedRevision: number };
 
-/** Persistence boundary for signed revisions and monotonic acceptance state. */
+/**
+ * Stores the signed membership revisions a silo has received, plus the newest one it has accepted.
+ *
+ * Two kinds of state sit behind this port. The revisions are rows copied from the issuer, signature
+ * and all. Separately, each issuer-and-silo pair keeps a single number: the highest revision ever
+ * accepted here. That number only ever moves up. If an implementation lets it move down — or lets a
+ * caller keep using an older accepted revision after a newer one landed — then anyone who replays a
+ * stale signed revision gets membership the issuer has already withdrawn, because the old signature
+ * is still perfectly valid.
+ *
+ * Called by: __VerifyCurrentFleetMembershipEvidence and SignedFleetMembershipAssertionVerifier in
+ * this package. The live implementation is {@link PrismaFleetMembershipAuthorityRepository}, built by
+ * libs/backend/agents/execution/inputs (personal runs),
+ * libs/backend/server/agents/agent-services (managed runs), and
+ * apps/opencrane/src/app/channel-target-composition.ts.
+ *
+ * @see FleetMembershipAcceptanceResult
+ */
 export interface FleetMembershipAuthorityRepository
 {
-	/** Loads the newest locally available signed revision for the exact trusted issuer and silo. */
+	/**
+	 * Loads the highest-numbered signed revision this silo has stored for that issuer.
+	 *
+	 * @param trustedIssuerId - Issuer the deployment trusts; revisions from anyone else are ignored.
+	 * @param siloId - Silo whose membership is being checked.
+	 * @returns The newest stored revision, or null when none has ever arrived — which callers must
+	 *          treat as "not a member", never as "nothing to check".
+	 */
 	getLatestSignedRevision(trustedIssuerId: string, siloId: string): Promise<SignedFleetMembershipRevision | null>;
-	/** Loads the highest revision previously accepted for the exact trusted issuer and silo. */
+	/**
+	 * Reads the highest revision number this silo has ever accepted from that issuer.
+	 *
+	 * @param trustedIssuerId - Issuer the deployment trusts.
+	 * @param siloId - Silo whose membership is being checked.
+	 * @returns The accepted revision number, or 0 when this silo has accepted none yet.
+	 */
 	getHighestAcceptedRevision(trustedIssuerId: string, siloId: string): Promise<number>;
-	/** Atomically advances the exact issuer-and-silo high-watermark, rejecting rollback and digest changes. */
+	/**
+	 * Records a newly verified revision as the newest accepted one for its issuer and silo.
+	 *
+	 * The `Atomically` suffix is a promise to callers: reading the current number and writing the new
+	 * one happen under one lock, so two concurrent admissions cannot both believe they won. An older
+	 * revision, or the same number with a different payload digest, is refused.
+	 *
+	 * @param acceptance - Issuer, silo, revision number, and digest of the revision just verified.
+	 * @returns `accepted` or `already_accepted` when membership may be trusted; `conflict` when the
+	 *          caller must deny.
+	 */
 	acceptRevisionAtomically(acceptance: FleetMembershipAcceptance): Promise<FleetMembershipAcceptanceResult>;
 }
 
-/** Cryptographic verification boundary for fleet-issued signed revisions. */
+/**
+ * Checks the issuer's signature over a stored revision.
+ *
+ * An implementation holds the issuer's public key and nothing else — it answers "did this issuer
+ * sign exactly these bytes?" and leaves every ordering, scope, and freshness rule to the caller. A
+ * silo with no fleet key still gets an implementation: the standalone one answers `verified: false`
+ * for everything, so a missing key can never read as "membership is fine".
+ *
+ * Called by: __VerifyCurrentFleetMembershipEvidence and SignedFleetMembershipAssertionVerifier;
+ * supplied through {@link FleetMembershipEvidenceConfig} and implemented by
+ * {@link Ed25519FleetMembershipSignatureVerifier}.
+ */
 export interface FleetMembershipSignatureVerifier
 {
-	/** Verifies the exact envelope and returns evidence bound to every signed field. */
+	/**
+	 * Recomputes the payload digest, checks the signature over it, and reports what it found.
+	 *
+	 * @param revision - Stored signed revision, including its claimed digest and signature.
+	 * @returns Evidence repeating the issuer, key, revision, silo, digest, and signature actually
+	 *          seen, with `verified` false when the signature does not hold. Return false rather than
+	 *          throwing: __VerifyCurrentFleetMembershipEvidence treats a thrown error as a broken
+	 *          verifier and denies with `signature_verifier_failed`.
+	 */
 	verify(revision: SignedFleetMembershipRevision): Promise<FleetSignatureVerificationEvidence>;
 }
 
-/** Mounted-key-backed fleet-membership trust values shared by every admission composition. */
+/**
+ * The three deployment-owned values every membership check needs: who to trust, how stale is too
+ * stale, and the key to check signatures with.
+ *
+ * Built once at startup from environment variables by {@link _CreateFleetMembershipEvidenceConfig}
+ * and then passed down, so no request can pick its own issuer or widen its own staleness limit.
+ *
+ * Called by: apps/opencrane/src/index.ts and apps/opencrane/src/app/channel-target-composition.ts
+ * build it; libs/backend/agents/execution/admission, libs/backend/agents/execution/inputs, and
+ * libs/backend/server/agents/agent-services consume it.
+ */
 export interface FleetMembershipEvidenceConfig
 {
-	/** Only fleet issuer whose signed revisions can establish local membership. */
+	/** The single issuer id this silo will accept signed revisions from; all others are ignored. */
 	readonly trustedIssuerId: string;
 	/** Maximum permitted age of a signed revision at admission. */
 	readonly maximumStalenessMs: number;
-	/** Projected-key-backed verifier that proves an exact signed revision. */
+	/** Verifier holding the issuer's public key, re-read from its mounted file on every check. */
 	readonly verifier: FleetMembershipSignatureVerifier;
 }
 
@@ -82,7 +182,17 @@ export enum FleetMembershipDeploymentModes
 	Standalone = "standalone",
 }
 
-/** Stable outcomes from verifying and accepting signed fleet-membership evidence. */
+/**
+ * The two answers a membership check can give, as the exact string values that appear in `outcome`.
+ *
+ * Compare against these instead of typing the strings —
+ * libs/backend/agents/execution/inputs/main/src/personal-execution-identity-envelope-source.ts does
+ * exactly that when it turns `Denied` into a refused run. `Trusted` carries signer-produced
+ * evidence; `Denied` carries only a reason code and the revision number that was looked at, because
+ * a denial must never leak identity taken from an unproven assertion.
+ *
+ * @see VerifyFleetMembershipEvidenceResult
+ */
 export enum FleetMembershipEvidenceOutcomes
 {
 	/** The exact signed assertion is current and accepted for admission. */
@@ -91,7 +201,17 @@ export enum FleetMembershipEvidenceOutcomes
 	Denied = "denied",
 }
 
-/** Complete signed membership evidence pinned by one transaction-fenced run admission. */
+/**
+ * The membership facts a successful check produces, every one of them taken from the signed revision.
+ *
+ * Nothing here is copied from the request being admitted, and that is the point: a run stores this
+ * block and can later be checked against the issuer's own signature. Callers freeze it inside the
+ * admission transaction, so a run's recorded membership cannot change afterwards.
+ * `trustedUntilEpochMs` is the earlier of the revision's own expiry and the configured staleness
+ * limit — past that instant the membership must be checked again, not trusted on.
+ *
+ * @see VerifyFleetMembershipEvidenceResult
+ */
 export interface TrustedFleetMembershipEvidence
 {
 	/** Fleet issuer that signed and owns the accepted revision. */
@@ -100,7 +220,7 @@ export interface TrustedFleetMembershipEvidence
 	readonly issuerKeyId: string;
 	/** Accepted monotonic signed revision. */
 	readonly revision: number;
-	/** Exact assertion authorizing the execution subject and requested scope. */
+	/** Identifier of the assertion inside the revision that covered this subject and scope. */
 	readonly assertionId: string;
 	/** Subject whose membership was verified. */
 	readonly subjectId: string;
@@ -112,19 +232,55 @@ export interface TrustedFleetMembershipEvidence
 	readonly trustedUntilEpochMs: number;
 }
 
-/** Stable domain result for current fleet-membership trust. */
+/**
+ * Answer of a membership check that reports only the trust window, not the membership facts.
+ *
+ * `trusted` gives the accepted revision number and the instant trust runs out. `denied` gives a
+ * reason — `missing_revision` (nothing stored for this issuer and silo),
+ * `signature_verifier_failed` (the verifier threw), `acceptance_conflict` (a newer revision was
+ * accepted concurrently), or any {@link FleetMembershipTrustReason} from the signature, scope,
+ * expiry, and ordering rules — plus the revision looked at, which is 0 when nothing was stored.
+ *
+ * @see VerifyFleetMembershipEvidenceResult for the variant that also returns the signed facts.
+ */
 export type VerifyFleetMembershipResult =
 	| { readonly outcome: "trusted"; readonly revision: number; readonly trustedUntilEpochMs: number }
 	| { readonly outcome: "denied"; readonly reason: FleetMembershipTrustReason | "missing_revision" | "signature_verifier_failed" | "acceptance_conflict"; readonly revision: number };
 
-/** Current signed-assertion authority consumed by product admission boundaries. */
+/**
+ * Answers "may this subject act in this silo at this scope?" for callers that hold no assertion id.
+ *
+ * The implementation finds the matching assertion itself, so a request never gets to name the
+ * assertion that proves its own membership.
+ *
+ * Called by: libs/backend/server/agents/channel-targets declares it as a dependency
+ * (channel-target-resolution.types.ts); apps/opencrane/src/app/channel-target-composition.ts
+ * supplies {@link SignedFleetMembershipAssertionVerifier} as the implementation.
+ */
 export interface SignedFleetMembershipAssertionAuthority
 {
-	/** Selects one exact signed assertion and verifies its current membership evidence. */
+	/**
+	 * Finds the single assertion matching this subject, silo, and scope, then runs the full check.
+	 *
+	 * @param subjectId - Subject whose membership is in question.
+	 * @param siloId - Silo the request is happening in.
+	 * @param scope - Scope the subject must be a member at.
+	 * @param nowEpochMs - Current time in epoch milliseconds, from the caller.
+	 * @returns `trusted` with the trust window, or `denied` — including `assertion_mismatch` when the
+	 *          stored revision holds no matching assertion, or more than one.
+	 */
 	verifyCurrentMembership(subjectId: string, siloId: string, scope: AuthorizationScope, nowEpochMs: number): Promise<VerifyFleetMembershipResult>;
 }
 
-/** Stable result that exposes only signed evidence produced by current membership verification. */
+/**
+ * Answer of a membership check that also hands back the signed facts on success.
+ *
+ * On `trusted`, `evidence` is safe to store on the run: every field came from the signed revision.
+ * On `denied` there is deliberately no evidence — only a reason code and the revision number looked
+ * at — so a caller cannot pick identity out of an assertion that failed verification.
+ *
+ * @see TrustedFleetMembershipEvidence
+ */
 export type VerifyFleetMembershipEvidenceResult =
 	| { readonly outcome: "trusted"; readonly evidence: TrustedFleetMembershipEvidence }
 	| { readonly outcome: "denied"; readonly reason: FleetMembershipTrustReason | "missing_revision" | "signature_verifier_failed" | "acceptance_conflict"; readonly revision: number };

--- a/libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts
+++ b/libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts
@@ -28,7 +28,7 @@ function _assertion(row: { assertionId: string; siloId: string; subjectId: strin
 	return { assertionId: row.assertionId, siloId: row.siloId, subjectId: row.subjectId, scope: _scope(row.scopeKind, row.organizationId, row.scopeResourceId) };
 }
 
-/** Maps one verified revision row and its sealed assertions to the signed target contract. */
+/** Converts one stored revision row and its assertion rows into the signed-revision type. */
 function _revision(row: { revision: number; issuerId: string; issuerKeyId: string; siloId: string; issuedAt: Date; expiresAt: Date; payloadDigest: string; signature: string; assertions: Array<{ assertionId: string; siloId: string; subjectId: string; scopeKind: string; organizationId: string; scopeResourceId: string | null }> }): SignedFleetMembershipRevision
 {
 	return {
@@ -45,16 +45,27 @@ function _revision(row: { revision: number; issuerId: string; issuerKeyId: strin
 }
 
 /**
- * Prisma-backed verified fleet-membership projection and monotonic acceptance head.
- * A full client opens the atomic acceptance transaction; a supplied transaction client deliberately
- * reuses its caller's fence so membership evidence cannot commit separately from run admission.
+ * Reads stored membership revisions from Postgres and moves the newest-accepted-revision number.
+ *
+ * Hand it a full PrismaClient and it opens its own transaction to record an acceptance. Hand it a
+ * transaction client instead and it works inside that transaction on purpose: the accepted-revision
+ * row and its audit row then commit together with whatever run admission the caller is doing, so a
+ * run can never exist while the membership it relied on was rolled back.
+ *
+ * Called by: libs/backend/agents/execution/inputs/main/src/personal-execution-identity-envelope-source.ts
+ * and libs/backend/server/agents/agent-services/main/src/prisma-managed-execution-evidence.ts, which
+ * both pass their admission transaction, and apps/opencrane/src/app/channel-target-composition.ts.
+ * @implements FleetMembershipAuthorityRepository
  */
 export class PrismaFleetMembershipAuthorityRepository implements FleetMembershipAuthorityRepository
 {
 	/** OpenCrane product-authority database client. */
 	private readonly prisma: PrismaClient | Prisma.TransactionClient;
 
-	/** Creates an adapter that owns a transaction only when the caller has not already selected one. */
+	/**
+	 * @param prisma - A full client, and this adapter opens its own acceptance transaction; or an
+	 *                 existing transaction client, and it joins that transaction instead.
+	 */
 	constructor(prisma: PrismaClient | Prisma.TransactionClient)
 	{
 		this.prisma = prisma;
@@ -67,14 +78,20 @@ export class PrismaFleetMembershipAuthorityRepository implements FleetMembership
 		return row === null ? null : _revision(row);
 	}
 
-	/** Loads the accepted revision high-watermark for one exact issuer and silo. */
+	/** Reads the highest revision number ever accepted for this issuer and silo; 0 when none. */
 	async getHighestAcceptedRevision(trustedIssuerId: string, siloId: string): Promise<number>
 	{
 		const row = await this.prisma.highestAcceptedFleetMembership.findUnique({ where: { issuerId_siloId: { issuerId: trustedIssuerId, siloId } } });
 		return row?.revision ?? 0;
 	}
 
-	/** Atomically advances membership authority and appends the acceptance audit decision. */
+	/**
+	 * Records the verified revision as the newest accepted one, together with its audit row.
+	 *
+	 * @param acceptance - Issuer, silo, revision number, and digest of the revision just verified.
+	 * @returns `accepted`; `already_accepted` when the same revision and digest is already recorded;
+	 *          or `conflict` when a newer revision won or the digest disagrees.
+	 */
 	async acceptRevisionAtomically(acceptance: FleetMembershipAcceptance): Promise<FleetMembershipAcceptanceResult>
 	{
 		if (_ownsTransaction(this.prisma))
@@ -88,7 +105,7 @@ export class PrismaFleetMembershipAuthorityRepository implements FleetMembership
 	}
 }
 
-/** Returns whether a Prisma endpoint can open an independent database transaction. */
+/** Returns true for a full client (it has `$transaction`), false for a transaction client. */
 function _ownsTransaction(prisma: PrismaClient | Prisma.TransactionClient): prisma is PrismaClient
 {
 	return "$transaction" in prisma;
@@ -107,7 +124,7 @@ async function _acceptRevision(transaction: Prisma.TransactionClient, acceptance
 	}
 	if (current?.revision === acceptance.revision) return { status: "already_accepted", highestAcceptedRevision: current.revision } as const;
 
-	// 2. Require the exact locally verified payload before moving the sole trusted projection head.
+	// 2. Only move the number when this exact revision and digest is really stored here.
 	const revision = await transaction.verifiedFleetMembershipRevision.findFirst({ where: { issuerId: acceptance.issuerId, siloId: acceptance.siloId, revision: acceptance.revision, payloadDigest: acceptance.payloadDigest } });
 	if (revision === null) return { status: "conflict", highestAcceptedRevision: current?.revision ?? 0 } as const;
 	await transaction.highestAcceptedFleetMembership.upsert({
@@ -116,7 +133,7 @@ async function _acceptRevision(transaction: Prisma.TransactionClient, acceptance
 		update: { revisionId: revision.id, revision: acceptance.revision, acceptedAt: new Date() },
 	});
 
-	// 3. Append durable acceptance evidence before commit so projection and audit cannot diverge.
+	// 3. Write the audit row in the same transaction so the stored state and the audit log agree.
 	const decisionDigest = __DigestCanonicalJson({ issuerId: acceptance.issuerId, siloId: acceptance.siloId, revision: acceptance.revision, payloadDigest: acceptance.payloadDigest } as JsonValue);
 	await __AppendAuditDecision(transaction, {
 		decisionDigest,

--- a/libs/backend/server/iam/membership/main/src/signed-membership-assertion-authority.ts
+++ b/libs/backend/server/iam/membership/main/src/signed-membership-assertion-authority.ts
@@ -3,22 +3,44 @@ import { __AuthorizationScopesEqual, type AuthorizationScope } from "@opencrane/
 import { __VerifyCurrentFleetMembership } from "./membership-authority.js";
 import type { FleetMembershipAuthorityRepository, FleetMembershipEvidenceConfig, SignedFleetMembershipAssertionAuthority, VerifyFleetMembershipResult } from "./membership-authority.types.js";
 
-/** Signed membership adapter that selects assertion identity from verified fleet evidence. */
+/**
+ * Answers membership questions for callers that do not know which assertion applies.
+ *
+ * Given a subject, silo, and scope it reads the newest stored revision, finds the one assertion
+ * matching all three, and hands that assertion to the full check. Requiring exactly one match is
+ * deliberate: zero means no membership, and more than one means the stored revision is ambiguous, so
+ * picking one would be guessing at authority.
+ *
+ * Called by: apps/opencrane/src/app/channel-target-composition.ts, which supplies it as the
+ * `membership` dependency of channel-target resolution.
+ * @implements SignedFleetMembershipAssertionAuthority
+ */
 export class SignedFleetMembershipAssertionVerifier implements SignedFleetMembershipAssertionAuthority
 {
-	/** Signed revision and monotonic acceptance repository. */
+	/** Store of signed revisions and of the newest accepted revision per silo. */
 	private readonly repository: FleetMembershipAuthorityRepository;
 	/** Deployment-owned issuer, verifier, and staleness policy. */
 	private readonly evidence: FleetMembershipEvidenceConfig;
 
-	/** Creates the adapter over one signed membership authority and trust configuration. */
+	/**
+	 * @param repository - Store of signed revisions and of the newest accepted revision per silo.
+	 * @param evidence - Startup-built trusted issuer, staleness limit, and signature verifier.
+	 */
 	constructor(repository: FleetMembershipAuthorityRepository, evidence: FleetMembershipEvidenceConfig)
 	{
 		this.repository = repository;
 		this.evidence = evidence;
 	}
 
-	/** Selects exactly one matching signed assertion before invoking current-membership verification. */
+	/**
+	 * @param subjectId - Subject whose membership is in question.
+	 * @param siloId - Silo the request is happening in.
+	 * @param scope - Scope the subject must be a member at.
+	 * @param nowEpochMs - Current time in epoch milliseconds, from the caller.
+	 * @returns `trusted` with the trust window; `denied` with `missing_revision` when nothing is
+	 *          stored, `assertion_mismatch` when zero or several assertions match, or the reason the
+	 *          full check refused.
+	 */
 	async verifyCurrentMembership(subjectId: string, siloId: string, scope: AuthorizationScope, nowEpochMs: number): Promise<VerifyFleetMembershipResult>
 	{
 		// 1. Load only the newest revision from the deployment-trusted issuer; absence cannot imply membership.

--- a/libs/backend/server/infra/agent-runtime-stream/src/agent-runtime-stream.ts
+++ b/libs/backend/server/infra/agent-runtime-stream/src/agent-runtime-stream.ts
@@ -43,7 +43,7 @@ function _ReadBearerToken(value: string | undefined): string | null
 	return token.length > 0 ? token : null;
 }
 
-/** Validate candidate coordinates that the transport must know before authority admission. */
+/** Check that a request body has the candidate fields this transport needs before it can be forwarded — shape only, no permission or fence checks. */
 function _IsRuntimeCandidate(value: unknown): value is RuntimeCandidate
 {
 	if (!value || typeof value !== "object")
@@ -74,9 +74,12 @@ function _IsRuntimeCandidate(value: unknown): value is RuntimeCandidate
 }
 
 /**
- * Delegate credential verification without allowing transport code to interpret Kubernetes policy.
- * Returning `null` deliberately collapses every missing or rejected credential into the same public
- * denial so TokenReview detail cannot become an identity oracle.
+ * Hand the bearer token to the reviewer and return the identity it verified, or null.
+ *
+ * Null covers every failure without distinction: no header, an unparseable header, a
+ * rejected token, or the wrong audience. That is on purpose — the caller turns any null
+ * into the same bare 401, so a caller cannot probe which part was wrong and learn which
+ * ServiceAccounts or audiences exist.
  */
 async function _AuthenticateRuntime(
 	token: string | null,
@@ -91,8 +94,9 @@ async function _AuthenticateRuntime(
 }
 
 /**
- * Write one server-sent event using JSON data only.
- * Callers must validate and bound authority-owned frames before they reach this framing helper.
+ * Write one server-sent event: an `event:` line naming the type and a `data:` line holding
+ * the JSON. It checks nothing, so callers must have validated and size-bounded whatever
+ * they pass.
  */
 function _WriteEvent(response: Response, event: string, data: unknown): void
 {
@@ -100,14 +104,37 @@ function _WriteEvent(response: Response, event: string, data: unknown): void
 }
 
 /**
- * Build the runtime-initiated internal transport.
+ * Build the internal router that agent runtimes connect OUT to. Two routes:
  *
- * The adapter owns token verification, bounded HTTP/SSE framing, heartbeats, and tracing. Durable
- * assignments, command creation, command ordering, and candidate admission remain injected domain
- * concerns. This separation ensures a wire-format bug cannot grant work or make runtime output
- * durable by itself.
- * @param options - Fixed framing limits plus the identity and domain-authority ports.
- * @returns An Express router for the internal stream and candidate endpoints.
+ *   - `POST /stream` — the runtime opens a long-lived server-sent-event stream. After
+ *     TokenReview, and after checking that the Pod UID in the body matches the one
+ *     Kubernetes attached to the token, the handler loops: read the next command from
+ *     Postgres, write it as a `command` event, and otherwise sleep until a local wake-up
+ *     or the recovery deadline. A command whose sequence is not higher than the last one
+ *     sent ends the stream with a `protocol_error` event rather than delivering it out of
+ *     order. A `heartbeat` event goes out on the configured interval.
+ *   - `POST /candidates` — the runtime submits one event or external action. Replies 202
+ *     when accepted, 409 when rejected, 503 when the server wants the same candidate
+ *     retried, and 401 when the token or the body does not check out.
+ *
+ * This file frames and bounds; it never decides. Commands, their order, and whether a
+ * candidate becomes durable all come from the injected authority backed by Postgres, so a
+ * bug in the wire format cannot hand out work or make runtime output durable by itself.
+ *
+ * Every authentication failure — no header, bad token, wrong audience, mismatched Pod UID,
+ * malformed body — returns the same bare 401, so the response cannot be used to probe
+ * which part was wrong.
+ *
+ * Called by: apps/opencrane/src/app/runtime-composition.ts, which mounts the
+ * returned router on the server's internal listener.
+ *
+ * @param options - The two ports plus the fixed limits and timings; see
+ *                  {@link RuntimeStreamTransportOptions}.
+ * @returns An Express router with the two routes above, ready to mount.
+ * @see https://html.spec.whatwg.org/multipage/server-sent-events.html — the
+ *      `event:`/`data:` framing and the `text/event-stream` content type written here.
+ * @see https://kubernetes.io/docs/reference/access-authn-authz/authentication/ — TokenReview
+ *      and the bound-token audiences the reviewer checks before any of this runs.
  */
 export function _RegisterInternalAgentRuntimeStream(options: RuntimeStreamTransportOptions): Router
 {

--- a/libs/backend/server/infra/agent-runtime-stream/src/agent-runtime-stream.types.ts
+++ b/libs/backend/server/infra/agent-runtime-stream/src/agent-runtime-stream.types.ts
@@ -3,43 +3,130 @@ import type { RuntimeTokenReviewer, RuntimeWorkloadIdentity } from "@opencrane/b
 
 import type { RuntimeCommandWakeup } from "./runtime-command-wakeup.js";
 
-/** Durable command authority injected by the server app, never owned by this transport. */
+/**
+ * The port through which this transport asks the server's real decision-maker what to do.
+ *
+ * The split matters: Postgres decides everything — which commands exist, in what order,
+ * whether a candidate is accepted — and this package only frames those decisions as HTTP
+ * and server-sent events. Nothing in this package may create a command, reorder one, or
+ * accept work on its own, so a bug in the wire format cannot hand out work or make runtime
+ * output durable.
+ *
+ * The `__` prefix marks a port the composition root wires in, not something to import
+ * directly.
+ *
+ * Implemented by: `PrismaRuntimeDispatchAuthority` in
+ * libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts, built
+ * by `__CreateProductionRuntimeDispatchAuthority`.
+ * Called by: `_RegisterInternalAgentRuntimeStream` in ./agent-runtime-stream.ts; wired in
+ * apps/opencrane/src/app/runtime-composition.ts.
+ */
 export interface RuntimeCommandStreamAuthority
 {
-	/** Return the next server-issued command after the supplied sequence, or wait boundedly. */
+	/**
+	 * Read the next command for this runtime, or report that there is none right now.
+	 *
+	 * @param identity      - The workload identity TokenReview verified for this connection.
+	 * @param open          - The stream-open message, naming the runtime instance and Pod UID.
+	 * @param afterSequence - Return only a command with a strictly higher sequence number.
+	 * @returns The next command, or null meaning "nothing due yet" — the caller then sleeps
+	 *          until a local wake-up or the recovery deadline and asks again. Null is normal
+	 *          and expected, not an error.
+	 * @throws On a database failure; the transport lets it reach the Express error handler
+	 *         rather than pretending the stream is idle.
+	 */
 	__NextCommand(identity: RuntimeWorkloadIdentity, open: RuntimeStreamOpen, afterSequence: number): Promise<RuntimeCommandEnvelope | null>;
-	/** Admit a runtime candidate through the authoritative run boundary. */
+	/**
+	 * Offer one candidate — an event or an external action the runtime produced — to the
+	 * decision-maker, which decides whether it becomes durable.
+	 *
+	 * @param identity  - The workload identity TokenReview verified for this request.
+	 * @param candidate - The candidate, already shape-checked by the transport; its claim
+	 *                    fence and attempt number are checked here, not in the transport.
+	 * @returns Whether it was accepted, and if not, whether the runtime should retry the
+	 *          exact same candidate. See {@link RuntimeCandidateAdmission}.
+	 * @throws On a database failure; the transport turns that into a 500, not a rejection,
+	 *         so the runtime does not treat an outage as a permanent refusal.
+	 */
 	__AdmitCandidate(identity: RuntimeWorkloadIdentity, candidate: RuntimeCandidate): Promise<RuntimeCandidateAdmission>;
-	/** Signal that an authenticated runtime stream was lost so the authority can release its binding. */
+	/**
+	 * Tell the decision-maker that this stream is gone, so it can unbind the attempt from a
+	 * Pod that is no longer listening. Called exactly once per closed stream, from the
+	 * transport's cleanup, and its rejection is deliberately ignored — a failed release must
+	 * not keep the connection's timers alive.
+	 *
+	 * Optional: an implementation without it simply leaves the binding to expire by its own
+	 * timeout instead of being released promptly.
+	 *
+	 * @param identity - The identity verified when the stream opened.
+	 * @param open     - The stream-open message for the stream that closed.
+	 */
 	__ReleaseStream?(identity: RuntimeWorkloadIdentity, open: RuntimeStreamOpen): Promise<void>;
 }
 
-/** Stable result sent after a candidate reaches the authoritative run boundary. */
+/**
+ * The answer to `POST /candidates`, and what the runtime must do next.
+ *
+ * The transport maps it to a status code, and the runtime is expected to branch on the
+ * code: `retryable` gives 503, otherwise `accepted` gives 202 and a rejection gives 409.
+ * Read {@link RuntimeCandidateAdmission.retryable} FIRST — a retryable result is not a
+ * rejection, and treating it as one throws away work the server still expects.
+ */
 export interface RuntimeCandidateAdmission
 {
-	/** Whether the authority accepted this candidate or its idempotent replay. */
+	/**
+	 * True when this candidate is now durable. Also true when the server recognised it as a
+	 * repeat of one already stored, so a runtime that retries after a lost response gets the
+	 * same answer instead of a duplicate or a conflict.
+	 */
 	readonly accepted: boolean;
-	/** Machine-readable reason when the candidate was rejected. */
+	/** Short machine-readable code for why it was rejected; absent when accepted. */
 	readonly reason?: string;
-	/** Whether the runtime must retry this exact candidate instead of terminalising its attempt. */
+	/**
+	 * True when the runtime should send this exact candidate again rather than give up on
+	 * the attempt — a temporary condition on the server side, not a refusal.
+	 */
 	readonly retryable?: boolean;
-	/** Server-bounded retry delay for one retryable candidate admission. */
+	/** How long the runtime should wait before that retry, in milliseconds, when the server sets a delay. */
 	readonly retryAfterMilliseconds?: number;
 }
 
-/** Transport configuration that fixes bounded framing and heartbeat behavior. */
+/**
+ * Everything {@link _RegisterInternalAgentRuntimeStream} needs: the two ports it calls,
+ * plus the limits and timings that keep the connection bounded.
+ *
+ * All of it is fixed when the router is built and cannot change per request, so a caller
+ * cannot widen a limit by asking. apps/opencrane/src/app/runtime-composition.ts
+ * is the only place these values are chosen.
+ */
 export interface RuntimeStreamTransportOptions
 {
-	/** Token reviewer for the runtime's projected ServiceAccount credential. */
+	/** Verifies the runtime's projected ServiceAccount token; the only source of caller identity. */
 	readonly tokenReviewer: RuntimeTokenReviewer;
-	/** Server-owned command/candidate authority. */
+	/** The decision-maker this transport forwards to; see {@link RuntimeCommandStreamAuthority}. */
 	readonly authority: RuntimeCommandStreamAuthority;
-	/** Maximum accepted JSON request body in bytes. */
+	/**
+	 * Largest JSON body accepted on either route, in bytes. Enforced by the JSON parser, so
+	 * an oversized body is refused before any handler runs. Currently 64 KiB.
+	 */
 	readonly maxBodyBytes: number;
-	/** Heartbeat interval for an idle, runtime-initiated SSE connection. */
+	/**
+	 * How often to send a `heartbeat` event on an otherwise silent stream, in milliseconds.
+	 * Its job is to keep proxies from closing an idle connection and to let the runtime tell
+	 * a live stream from a dead one. Currently 15 000.
+	 */
 	readonly heartbeatMilliseconds: number;
-	/** Bounded durable recovery interval after a local wake-up is missed or unavailable. */
+	/**
+	 * How long a stream may sleep before re-reading Postgres anyway, in milliseconds. This is
+	 * the safety net that makes a lost in-process wake-up harmless: the worst case is a
+	 * command arriving this late, not one never arriving.
+	 */
 	readonly commandRecoveryMilliseconds: number;
-	/** Optional process-local wake-up fan-out; it never stores or authorizes commands. */
+	/**
+	 * Shared wake-up object, so a candidate arriving on one request can nudge streams held
+	 * open by others in the same process. Omit it and the router makes its own. It stores no
+	 * commands and grants nothing, so a missed wake-up only delays the next read until
+	 * {@link RuntimeStreamTransportOptions.commandRecoveryMilliseconds} expires.
+	 */
 	readonly commandWakeup?: RuntimeCommandWakeup;
 }

--- a/libs/backend/server/infra/agent-runtime-stream/src/runtime-command-wakeup.ts
+++ b/libs/backend/server/infra/agent-runtime-stream/src/runtime-command-wakeup.ts
@@ -6,11 +6,18 @@ interface _WakeWaiter
 }
 
 /**
- * Disposable process-local wake-up fan-out for idle runtime streams.
+ * Nudges streams that are sleeping inside this process, so a newly due command is read
+ * promptly instead of on the next timer.
  *
- * This is deliberately not an authority and holds neither command payloads nor run state. Postgres
- * remains the source of truth: a wake-up only asks a stream to perform its next fenced durable read,
- * while a bounded recovery wait prevents a dropped in-process signal from delaying that read forever.
+ * It holds no commands and no run state, and grants nothing. Postgres decides what exists;
+ * a wake-up only says "ask again now". That is why a lost wake-up is harmless: a stream
+ * that misses one still re-reads when its recovery timeout expires, so the worst outcome
+ * is a command arriving one recovery interval late, never one lost. It also only reaches
+ * streams in the SAME process — with several replicas, other replicas' streams rely on
+ * their own recovery timeout.
+ *
+ * Used by: `_RegisterInternalAgentRuntimeStream` in ./agent-runtime-stream.ts, which
+ * creates one per router unless the app passes a shared instance.
  */
 export class RuntimeCommandWakeup
 {
@@ -19,13 +26,24 @@ export class RuntimeCommandWakeup
 	/** Pending stream waits that may all re-check Postgres after one state-change hint. */
 	private readonly waiters = new Set<_WakeWaiter>();
 
-	/** Returns the current revision before a stream begins its durable command lookup. */
+	/**
+	 * The current counter value. Read it BEFORE the database lookup and pass it to
+	 * {@link RuntimeCommandWakeup.waitForChange}; reading it afterwards would hide a wake-up
+	 * that arrived during the lookup and cost a full recovery interval.
+	 *
+	 * @returns A counter that only ever increases within this process.
+	 */
 	currentRevision(): number
 	{
 		return this.revision;
 	}
 
-	/** Wakes all local streams after a candidate may have made a lifecycle command due. */
+	/**
+	 * Bump the counter and release every waiting stream in this process, so each re-reads
+	 * Postgres. Cheap and safe to over-call: a stream that finds nothing due just sleeps
+	 * again. The transport calls it only for an accepted external action, because waking on
+	 * every accepted event would turn frequent message updates into a read storm.
+	 */
 	wake(): void
 	{
 		this.revision += 1;
@@ -33,7 +51,24 @@ export class RuntimeCommandWakeup
 		this.waiters.clear();
 	}
 
-	/** Waits for a newer revision, recovery timeout, or stream-abort signal without retaining command state. */
+	/**
+	 * Sleep until it is worth asking Postgres again. Returns as soon as any of these happens:
+	 * the revision moved, the recovery timeout expired, or the stream was aborted.
+	 *
+	 * Returns immediately when the revision already moved or the signal is already aborted,
+	 * which is what closes the gap between a stream reading the revision and registering its
+	 * wait — a wake-up landing in between is not missed.
+	 *
+	 * @param observedRevision     - The value {@link RuntimeCommandWakeup.currentRevision}
+	 *                               returned BEFORE the durable read; passing a stale value
+	 *                               makes this return at once.
+	 * @param recoveryMilliseconds - Longest sleep, in milliseconds; the safety net that makes
+	 *                               a lost wake-up a delay rather than a hang.
+	 * @param signal               - Aborted when the stream closes, so a dead connection does
+	 *                               not hold a timer.
+	 * @returns Resolves when it is time to re-read. It never says WHY it woke, because the
+	 *          caller re-reads Postgres either way; it never rejects.
+	 */
 	waitForChange(observedRevision: number, recoveryMilliseconds: number, signal?: AbortSignal): Promise<void>
 	{
 		if (this.revision !== observedRevision || signal?.aborted === true) return Promise.resolve();

--- a/libs/backend/server/infra/api/src/index.ts
+++ b/libs/backend/server/infra/api/src/index.ts
@@ -1,7 +1,14 @@
 /**
- * `@opencrane/backend/server/infra/api` — Kubernetes API plumbing owned by the OpenCrane
- * server: CRD identity constants, normalized client errors, generic apply/watch
- * primitives, the ClusterTenant CR shape, and namespace builders.
+ * `@opencrane/backend/server/infra/api` — the small pieces of Kubernetes plumbing the
+ * OpenCrane server shares. Two things only:
+ *
+ *   - The custom-resource identity constants — API group, version, and the ClusterTenant
+ *     plural — so no caller retypes them (./crd-constants.ts).
+ *   - Helpers that recognise a Kubernetes 404 or 409 whatever shape the client library
+ *     reported it in (./k8s-errors.ts).
+ *
+ * @see https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+ *      — what the group, version, and plural below identify.
  */
 export * from "./crd-constants.js";
 export * from "./k8s-errors.js";

--- a/libs/backend/server/infra/api/src/k8s-errors.ts
+++ b/libs/backend/server/infra/api/src/k8s-errors.ts
@@ -1,8 +1,18 @@
 /**
- * Whether a Kubernetes API error carries a given numeric status code.
+ * Whether a thrown value is a Kubernetes API error with this HTTP status code.
  *
- * The @kubernetes/client-node library surfaces HTTP failures in at least three
- * shapes (`statusCode`, `code`, `body.code`); this helper normalises them.
+ * `@kubernetes/client-node` (^1.0.0) reports failures in several shapes depending on the
+ * call — `statusCode`, `code`, `response.statusCode`, or `body.code` — so checking one
+ * field misses real matches. This checks all of them, and returns false for anything that
+ * is not an object, so it is safe to call on an unknown catch value.
+ *
+ * Called by: {@link _IsK8sNotFound} and {@link _IsK8sConflict} in this file; those two are
+ * what callers use. `_IsK8sNotFound` is used by
+ * libs/backend/server/infra/auth/src/per-org-client.ts.
+ *
+ * @param err  - The value from a `catch`; any type is accepted.
+ * @param code - The HTTP status code to look for, for example 404.
+ * @returns True when any of those fields equals the code.
  */
 export function _IsK8sStatus(err: unknown, code: number): boolean
 {

--- a/libs/backend/server/infra/auth/src/auth-middleware.ts
+++ b/libs/backend/server/infra/auth/src/auth-middleware.ts
@@ -4,15 +4,25 @@ import { ___LoadOidcAuthConfig } from "./oidc-config.js";
 import type { OidcAuthConfig } from "./oidc-config.types.js";
 
 /**
- * OpenCrane server authentication middleware.
+ * Build the middleware that decides whether a request may proceed at all.
  *
- * Authentication is resolved in priority order:
- *   1. Public path bypass  — /healthz and /api/v1/auth/* never require a token.
- *   2. OIDC session        — a valid session cookie from the browser login flow.
+ * Checked in this order:
+ *   1. Public paths — `/healthz` and everything under `/api/v1/auth` always pass, since
+ *      the login routes themselves cannot require a login.
+ *   2. An established OIDC session — a valid session cookie from the browser login flow.
+ *   3. Anything else gets 401. In particular, a server with OIDC switched off rejects the
+ *      whole API rather than serving it without authentication.
  *
- * The OIDC config is snapshotted when the factory is called —
- * once at startup in production; per-test in tests, so setting the env before
- * calling the factory is enough (no module re-import needed).
+ * Configuration is read once, when this factory is called — at startup in production, and
+ * per test in tests, so a test only has to set the environment before calling the factory.
+ *
+ * This is authentication only. Roles are enforced separately by {@link _RequireOrgAdmin}
+ * and {@link _RequirePlatformOperator}.
+ *
+ * Called by: apps/opencrane/src/app/public-app.ts.
+ *
+ * @returns Middleware that calls `next()` for public paths and session callers, and sends
+ *          401 otherwise.
  */
 export function ___AuthMiddleware(): RequestHandler
 {

--- a/libs/backend/server/infra/auth/src/identity-claims.ts
+++ b/libs/backend/server/infra/auth/src/identity-claims.ts
@@ -1,20 +1,38 @@
 /**
- * Project the IdP's group/role claims into the introspection-only authorization
- * facts the server surfaces: the caller's `groups` and the derived `isPlatformOperator`
- * / `isOrgAdmin`. Pure (no I/O) so it is unit-testable and so the rule "operator iff a
- * group matches a configured operator group, OR the verified email matches the per-cluster
- * seed" is verified independently of the OIDC flow.
+ * Turn the identity provider's group and role claims into the three role facts stored on
+ * the session: the caller's `groups`, and the derived `isPlatformOperator` and
+ * `isOrgAdmin`.
  *
- * `clusterTenant` is intentionally not derived here. The identity domain resolves it
- * server-side from the verified email, never from a self-asserted claim.
+ * The rules, all fail-closed (an unset allowlist grants the role to nobody):
+ *   - `groups` is the union of the configured groups claim and the configured roles claim,
+ *     because Zitadel reports group memberships under one and application roles under the
+ *     other, and either may grant a role.
+ *   - Platform operator when one of those names is in the configured operator group list,
+ *     OR the caller's VERIFIED email equals the per-cluster seed email.
+ *   - Org admin when one of those names is in the configured org-admin list. A platform
+ *     operator is always an org admin. This is only the claim-derived half; `/auth/me`
+ *     ORs it with `OrgMembership` rows, so a user who creates an organisation becomes an
+ *     org admin without any group claim.
  *
- * TODO: this is the non-presumptuous stopgap until OpenCrane has a first-class
- * role model; a real RBAC model supersedes `isPlatformOperator`.
+ * Does no I/O, so these rules can be tested without running a login.
  *
- * @param claims        - The merged ID-token + UserInfo claims for the caller.
- * @param config        - OIDC config supplying the claim names, operator group set, and seed email.
- * @param verifiedEmail - The caller's email when it is verified (lowercased/trimmed); empty/undefined
- *                        when absent or NOT verified, so an unverified email can never match the seed.
+ * `clusterTenant` is deliberately NOT derived here: the identity domain resolves it
+ * server-side from the verified email, never from a claim the caller could assert.
+ *
+ * Called by: `OidcAuthServiceBase._buildAuthUser` in ./oidc-service.ts — the only caller.
+ *
+ * TODO: a stopgap until OpenCrane has a real role model, which will replace
+ * `isPlatformOperator`.
+ *
+ * @param claims        - The merged ID-token and UserInfo claims for the caller.
+ * @param config        - Supplies the two claim names, the two group allowlists, and the
+ *                        seed email.
+ * @param verifiedEmail - The caller's email ONLY when the provider marked it verified
+ *                        (lowercased and trimmed). Absent for an unverified email, which
+ *                        is how an unverified address is prevented from matching the seed.
+ * @returns The group names found, and the two derived role flags.
+ * @see https://zitadel.com/docs/apis/openidoauth/scopes — how Zitadel emits group and
+ *      role claims, which is why both claims are read and unioned.
  */
 export function _ResolveIdentityClaims(
   claims: Record<string, unknown>,
@@ -56,11 +74,19 @@ export function _ResolveIdentityClaims(
 }
 
 /**
- * Normalize a claim value into a list of non-empty strings. Identity providers
- * emit group/role claims as either an array or a single string, so both shapes are
- * accepted; anything else yields an empty list.
+ * Read a group or role claim as a list of names.
  *
- * @param value - The raw claim value.
+ * Providers send these claims either as an array of strings or as a single string, so
+ * both are accepted; blank entries are dropped and entries are trimmed. Any other shape
+ * (a number, an object, null) yields an empty list rather than an error, so one oddly
+ * shaped claim cannot break a login — it just grants no roles.
+ *
+ * Called by: {@link _ResolveIdentityClaims} in this file. Exported through the package
+ * barrel; no other caller in this repo.
+ *
+ * @param value - The raw claim value, straight off the claims object.
+ * @returns The names found, in claim order; empty when the claim is missing or not a
+ *          string or array of strings.
  */
 export function _ReadStringArrayClaim(value: unknown): string[]
 {

--- a/libs/backend/server/infra/auth/src/index.ts
+++ b/libs/backend/server/infra/auth/src/index.ts
@@ -1,10 +1,30 @@
 /**
- * `@opencrane/backend/server/infra/auth` — the OpenCrane server's OIDC login and authorization
- * substrate: environment-driven configuration, session lifecycle, per-organization login
- * seams, identity claims, membership facts, middleware, and authorization gates.
+ * `@opencrane/backend/server/infra/auth` — how the OpenCrane server logs a human in and
+ * decides what that human may do.
  *
- * Importing this package also applies the `express-session` `SessionData` augmentation
- * (see ./session.types) so `req.session.authUser` is typed in every consumer.
+ * What is in here:
+ *   - OIDC settings read from environment variables ({@link ___LoadOidcAuthConfig}).
+ *   - The whole browser login flow — redirect, callback, logout ({@link OidcAuthServiceBase}).
+ *   - Session cookie helpers (save, regenerate, destroy, safe return-to paths).
+ *   - The rules that turn identity-provider claims into `isPlatformOperator` /
+ *     `isOrgAdmin` ({@link _ResolveIdentityClaims}) and the `OrgMembership` lookup that
+ *     refreshes org-admin authority ({@link _ResolveOrgMembershipFacts}).
+ *   - Request-derived facts: host, silo (ClusterTenant), principal.
+ *   - The authentication middleware ({@link ___AuthMiddleware}) and the two route guards
+ *     ({@link _RequireOrgAdmin}, {@link _RequirePlatformOperator}).
+ *
+ * A newcomer should read {@link OidcAuthServiceBase} first (the login flow) and then
+ * {@link AuthUser} (what ends up in the session cookie).
+ *
+ * IMPORTANT: importing this package also runs `./session.types.js` for its side effect,
+ * and that is what adds `authUser`, `idToken`, and `oidcFlow` to the `express-session`
+ * `SessionData` type. Without the import on line 9 `req.session.authUser` stops
+ * type-checking in every consumer, so do not remove it as an unused import.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html — the OIDC Authorization
+ *      Code flow this package implements (login redirect, callback, ID-token claims).
+ * @see https://github.com/expressjs/session — `express-session` (^1.19.0), whose
+ *      `SessionData` interface this package augments.
  */
 import "./session.types.js";
 

--- a/libs/backend/server/infra/auth/src/mounted-public-key.ts
+++ b/libs/backend/server/infra/auth/src/mounted-public-key.ts
@@ -4,13 +4,25 @@ import { isAbsolute } from "node:path";
 import type { MountedPublicKeySource } from "./mounted-public-key.types.js";
 
 /**
- * Creates a reloadable source for one public key projected as a mounted file.
+ * Create a reader for one public key that Kubernetes mounts into this container as a file.
  *
- * Kubernetes replaces projected Secret files atomically. Reading on every use makes an in-place
- * rotation effective without extending old trust until a process restart.
+ * The file is re-read on every use rather than cached, because Kubernetes swaps a mounted
+ * Secret file in one step: re-reading means a rotated key takes effect on the next
+ * verification, instead of the old key staying trusted until the process restarts.
  *
- * @param publicKeyPath - Absolute mounted path containing the public key.
- * @returns A source that fails closed when the current projection cannot be read.
+ * The path must be absolute, so that a change of working directory cannot point trust at a
+ * different file, and the file is read once here so that missing key material fails at
+ * startup rather than on the first real request.
+ *
+ * Called by: libs/backend/server/iam/membership/main/src/fleet-membership-evidence.factory.ts
+ *.
+ *
+ * @param publicKeyPath - Absolute path of the mounted public-key file.
+ * @returns A reader whose `read()` returns the file contents as it is now.
+ * @throws When the path is not absolute, and when the file cannot be read at creation time
+ *         or on any later read — a key that cannot be read must fail, never verify.
+ * @see https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+ *      — projected volumes, whose atomic file replacement is what makes re-reading correct.
  */
 export function _CreateMountedPublicKeySource(publicKeyPath: string): MountedPublicKeySource
 {

--- a/libs/backend/server/infra/auth/src/oidc-config.ts
+++ b/libs/backend/server/infra/auth/src/oidc-config.ts
@@ -1,6 +1,27 @@
 import type { OidcAuthConfig } from "./oidc-config.types.js";
 
-/** Load OIDC session auth configuration from environment variables. */
+/**
+ * Read the OIDC login configuration out of environment variables and return it as a
+ * snapshot.
+ *
+ * Three outcomes:
+ *   - No OIDC variable is set at all — return a disabled config with safe defaults, so a
+ *     developer can run the server without an identity provider.
+ *   - Some but not all required variables are set — throw, naming the missing ones. A
+ *     half-configured login is treated as a deployment mistake, never as "disabled".
+ *   - All required variables are set — return an enabled config.
+ *
+ * Group allowlists, the operator seed email, and the org-admin groups are all read even
+ * in the disabled case, and all default to empty, so nobody gains a role by leaving a
+ * variable unset.
+ *
+ * Called by: {@link OidcAuthServiceBase} (its `config` field) and
+ * {@link ___AuthMiddleware}. Each call re-reads `process.env`, which is what lets a test
+ * set variables and then build the middleware without reloading the module.
+ *
+ * @returns A snapshot of the configuration; later `process.env` changes do not affect it.
+ * @throws When OIDC is partially configured, listing every missing variable.
+ */
 export function ___LoadOidcAuthConfig(): OidcAuthConfig
 {
   const issuerUrl = process.env.OIDC_ISSUER_URL?.trim() ?? "";

--- a/libs/backend/server/infra/auth/src/oidc-config.types.ts
+++ b/libs/backend/server/infra/auth/src/oidc-config.types.ts
@@ -1,7 +1,26 @@
-/** Runtime configuration for OIDC-backed manager sessions (fleet or clustertenant). */
+/**
+ * Everything the OIDC login flow needs, read from environment variables once and then
+ * treated as read-only.
+ *
+ * Built only by {@link ___LoadOidcAuthConfig}, which snapshots `process.env`; the values
+ * here are therefore fixed for the life of the process (or, in tests, for the life of the
+ * object). Two fields are computed rather than copied: {@link enabled} (is any OIDC
+ * variable set at all) and {@link cookieSecure} (production forces HTTPS-only cookies).
+ *
+ * Every allowlist field defaults to EMPTY and empty means "grants nothing", so a missing
+ * variable can never widen access.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html — the meaning of `issuer`,
+ *      `client_id`, `redirect_uri`, and `scope` below.
+ */
 export interface OidcAuthConfig
 {
-  /** Whether OIDC is enabled for human login flows. */
+  /**
+   * Whether browser login is possible. Computed, not read from a variable: true when the
+   * issuer, client id, redirect URI, and session secret are all present. When none of
+   * them is set this is false and the server runs in development mode; when only some are
+   * set {@link ___LoadOidcAuthConfig} throws instead of returning false.
+   */
   enabled: boolean;
 
   /** Issuer URL used for OIDC discovery. */
@@ -10,10 +29,19 @@ export interface OidcAuthConfig
   /** Registered OAuth client identifier. */
   clientId: string;
 
-  /** Optional confidential-client secret. */
+  /**
+   * Client secret, when this deployment registered a confidential client. Absent for the
+   * public per-organisation clients, which authenticate the code exchange with PKCE
+   * instead of a secret.
+   */
   clientSecret?: string;
 
-  /** Callback URI registered with the identity provider. */
+  /**
+   * The callback URI registered with the identity provider. Only its PATH is used at
+   * request time: the origin is rebuilt from the host the request arrived on, so a
+   * deployment serving several hosts returns each user to the host they logged in from
+   * (see `_buildRedirectUri`). The provider must allow every resulting URL.
+   */
   redirectUri: string;
 
   /**
@@ -37,16 +65,30 @@ export interface OidcAuthConfig
   /** Session cookie name. */
   cookieName: string;
 
-  /** Whether the session cookie must be HTTPS-only. */
+  /**
+   * Whether the session cookie is marked `Secure` (sent over HTTPS only). Computed:
+   * an explicit `OIDC_COOKIE_SECURE` wins; otherwise `NODE_ENV=production` forces true
+   * whatever the redirect URI says, so a mistyped `OIDC_REDIRECT_URI` cannot quietly
+   * downgrade the cookie; outside production it is inferred from the redirect URI scheme
+   * so plain-HTTP local development works.
+   */
   cookieSecure: boolean;
 
   /** Session lifetime in milliseconds. */
   sessionMaxAgeMs: number;
 
-  /** Lowercased allowlist of email domains. */
+  /**
+   * Email domains allowed to log in, lowercased. Empty means "do not filter by domain".
+   * Checked together with {@link allowedEmails}: a login passes when the address is in
+   * that list OR its domain is in this one.
+   */
   allowedEmailDomains: string[];
 
-  /** Lowercased allowlist of full email addresses. */
+  /**
+   * Individual email addresses allowed to log in, lowercased. Empty means "do not filter
+   * by address". Setting either this or {@link allowedEmailDomains} also makes an email
+   * claim mandatory, so a provider that returns no email can no longer log anyone in.
+   */
   allowedEmails: string[];
 
   /** Claim name carrying the caller's group memberships (default `groups`). */

--- a/libs/backend/server/infra/auth/src/oidc-service.ts
+++ b/libs/backend/server/infra/auth/src/oidc-service.ts
@@ -17,17 +17,48 @@ import type { AuthUser } from "./session.types.js";
 export type { AuthStatus, AuthStatusUser, LoginClient, ManagerAuthMode } from "./oidc-service.types.js";
 
 /**
- * OpenCrane server OIDC session base: owns provider discovery, the PKCE login redirect,
- * token exchange, claim validation, session lifecycle, and `/auth/me` status.
+ * Base class for the OpenCrane server's browser login. One instance per server process
+ * owns the whole human login story: discovering the identity provider, sending the
+ * browser there with PKCE, exchanging the returned code for tokens, checking the claims
+ * against the configured email allowlists, storing the user in an `express-session`
+ * cookie session, and answering `/auth/me`.
  *
- * Two seams are left for subclasses:
- *   - {@link resolveLoginClient} — which OIDC client + scope to use for a login. The base
- *     uses the single masters client; the identity domain overrides it to resolve a per-org
- *     client from the request host.
- *   - {@link enrichStatusUser} — extra `/auth/me` fields. The base adds none; the
+ * The order is fixed and a subclass cannot change it:
+ *   1. {@link buildLoginUrl} — pick the OIDC client through {@link resolveLoginClient},
+ *      generate the PKCE verifier plus `state` and `nonce`, save them in the session,
+ *      and return the provider URL to redirect to.
+ *   2. The browser returns to the callback route, which calls {@link completeLogin} —
+ *      exchange the code against the SAME client_id the session recorded, merge ID-token
+ *      and UserInfo claims, apply the allowlists, give the session a new id, then store
+ *      `authUser`.
+ *   3. {@link onLoginEstablished} runs last, once per login, with the session already
+ *      saved.
+ *
+ * Only two methods exist to be overridden:
+ *   - {@link resolveLoginClient} — which OIDC client and scope a login uses. The base
+ *     uses the single "masters" client from configuration; the identity domain overrides
+ *     it to look up a per-organisation client from the request host.
+ *   - {@link enrichStatusUser} — extra fields on `/auth/me`. The base adds none; the
  *     identity domain adds the caller's resolved `clusterTenant`.
+ * {@link onLoginEstablished} and {@link isPostLoginFailureFatal} are hooks for side
+ * effects, not for changing the flow above.
  *
- * The base resolves membership-derived `ownedOrgs` and effective `isOrgAdmin` values.
+ * `/auth/me` does not just echo the cookie: {@link getStatus} re-reads `OrgMembership`
+ * on every call, so a user who has just created an organisation counts as an org admin
+ * without logging in again.
+ *
+ * Called by: `OidcAuthService` in libs/backend/server/iam/identity/main/src/oidc.service.ts
+ * extends it; apps/opencrane/src/app/public-app.ts constructs it and mounts
+ * {@link createSessionMiddleware}; libs/backend/server/iam/identity/main/src/auth.router.ts
+ * calls {@link getStatus}, {@link isEnabled}, {@link buildLoginUrl}, and
+ * {@link completeLogin}.
+ *
+ * @see https://openid.net/specs/openid-connect-core-1_0.html — the Authorization Code
+ *      flow, the `state`/`nonce` replay checks, and the ID-token claims used here.
+ * @see https://www.rfc-editor.org/rfc/rfc7636 — PKCE (`code_challenge_method=S256`),
+ *      required because per-organisation clients are public clients with no secret.
+ * @see https://github.com/panva/node-openid-client — `openid-client` (^6.8.4), which
+ *      performs discovery, builds the redirect, and runs the code exchange.
  */
 export abstract class OidcAuthServiceBase
 {
@@ -56,21 +87,47 @@ export abstract class OidcAuthServiceBase
     this.membershipRepository = membershipRepository;
   }
 
-  /** Whether human login should use OIDC-backed sessions. */
+  /**
+   * Whether this process has usable OIDC configuration — that is, whether browser login
+   * is possible at all. False when no OIDC environment variables are set (development
+   * mode). A PARTIAL configuration never reaches here: {@link ___LoadOidcAuthConfig}
+   * throws at startup instead.
+   *
+   * Called by: libs/backend/server/iam/identity/main/src/auth.router.ts lines 46 and 71,
+   * which refuse `/auth/login` and `/auth/callback` when this is false.
+   *
+   * @returns True when a login redirect can be issued; false when this deployment can
+   *          never establish a session.
+   */
   isEnabled(): boolean
   {
     return this.config.enabled;
   }
 
   /**
-   * Build the Express session + CSRF middleware pair required by the OIDC login flow.
+   * Build the two Express handlers the login flow needs: the session itself and a CSRF
+   * check over it.
    *
-   * Returns two handlers that must be mounted together (spread into `app.use`):
-   *   1. `express-session` — establishes the cookie-backed session.
-   *   2. CSRF origin check — on state-changing requests from a session-authenticated caller,
-   *      validates the `Origin` header (or `Referer` when `Origin` is absent) against the
-   *      request's own host. Exempt: safe methods (GET/HEAD/OPTIONS), unauthenticated requests
-   *      (no session `authUser` — token-auth and public routes carry no CSRF surface).
+   * Mount them together, in this order, by spreading the array into `app.use`:
+   *   1. `express-session` — creates the cookie-backed session.
+   *   2. CSRF origin check — for a request that changes state AND comes from a caller with
+   *      a session, compare the `Origin` header (or `Referer` when `Origin` is missing)
+   *      against the host the request arrived on, and reject with 403 when they differ.
+   *      Skipped for GET/HEAD/OPTIONS and for callers with no `authUser`, because a
+   *      request that carries no session cookie cannot be a cross-site request that
+   *      abuses one.
+   *
+   * When OIDC is disabled the array holds a single pass-through handler, so an app can
+   * mount this unconditionally.
+   *
+   * Called by: apps/opencrane/src/app/public-app.ts.
+   *
+   * @returns Two handlers, in mount order; never empty.
+   * @see https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+   *      — the Origin/Referer check this implements, and why it is paired with a
+   *      SameSite cookie rather than relied on alone.
+   * @see https://www.rfc-editor.org/rfc/rfc6265 — the cookie attributes set below
+   *      (`HttpOnly`, `Secure`, `Max-Age`).
    */
   createSessionMiddleware(): RequestHandler[]
   {
@@ -98,7 +155,7 @@ export abstract class OidcAuthServiceBase
     ];
   }
 
-  /** CSRF protection via Origin / Referer header validation for session-authenticated mutations. */
+  /** Reject a state-changing request from a session caller whose Origin (or Referer) is not this host. */
   private _csrfOriginCheck(): RequestHandler
   {
     const _SAFE = new Set(["GET", "HEAD", "OPTIONS"]);
@@ -145,9 +202,26 @@ export abstract class OidcAuthServiceBase
   }
 
   /**
-   * Return the auth mode and current human session details. Resolves the
-   * membership-derived `isOrgAdmin` + `ownedOrgs` fresh (so a user who just created an org
-   * is an org admin without re-login) and merges any subclass enrichment.
+   * Answer `/auth/me`: which auth mode this server runs in, and who the caller is.
+   *
+   * Three outcomes:
+   *   - OIDC enabled and a session exists — `authenticated: true` plus the stored
+   *     `authUser`, with `isOrgAdmin` recomputed as "the value stored at login OR owns
+   *     or administers at least one organisation now", `ownedOrgs` read fresh from
+   *     `OrgMembership`, and whatever {@link enrichStatusUser} adds.
+   *   - OIDC enabled and no session — `authenticated: false`, `user: null`.
+   *   - OIDC disabled — `mode: "development"`, so the SPA knows not to offer login.
+   *
+   * `isOrgAdmin` is recomputed here rather than trusted from the cookie so that a user
+   * who created an organisation after logging in gets admin rights without logging in
+   * again. Nothing else on the user is recomputed.
+   *
+   * Called by: libs/backend/server/iam/identity/main/src/auth.router.ts.
+   *
+   * @param req - The `/auth/me` request; only its session and host are read.
+   * @returns The auth mode plus the caller, or a null user when nobody is logged in.
+   * @throws Whatever the membership repository throws when the database is unreachable —
+   *         a failed lookup must not be reported as "administers no organisation".
    */
   async getStatus(req: Request): Promise<AuthStatus>
   {
@@ -179,7 +253,31 @@ export abstract class OidcAuthServiceBase
     return { mode: "development", authenticated: false, user: null };
   }
 
-  /** Build the provider redirect URL and persist PKCE state in the local session. */
+  /**
+   * Start a login: produce the URL to redirect the browser to, and remember in the
+   * session everything {@link completeLogin} will need to finish.
+   *
+   * Stored in `req.session.oidcFlow`: the PKCE code verifier, the `state` and `nonce`
+   * values used to detect a replayed or injected callback, the sanitised page to return
+   * to, and — when {@link resolveLoginClient} chose a per-organisation client — that
+   * client_id, so the code is later exchanged against the SAME client. The session is
+   * saved before the URL is returned, because a redirect that outran the session write
+   * would come back to a callback with no flow to match.
+   *
+   * Called by: libs/backend/server/iam/identity/main/src/auth.router.ts.
+   *
+   * @param req      - The `/auth/login` request; supplies the session and the host the
+   *                   redirect_uri is built from.
+   * @param returnTo - Where to send the browser after login. Anything that is not a
+   *                   local path is replaced with `/` to prevent an open redirect.
+   * @param options  - `prompt` is passed straight through to the provider (for example
+   *                   to force a re-authentication prompt).
+   * @returns The absolute provider URL to redirect to.
+   * @throws When the session cannot be saved, or when provider discovery fails — the
+   *         caller should surface a login error rather than redirect.
+   * @see https://www.rfc-editor.org/rfc/rfc7636 — the PKCE verifier/challenge pair
+   *       generated here.
+   */
   async buildLoginUrl(req: Request, returnTo: string, options?: { prompt?: string }): Promise<string>
   {
     // 1. Resolve which OIDC client + scope to authorize against (base = masters client).
@@ -216,7 +314,32 @@ export abstract class OidcAuthServiceBase
     return loginUrl.href;
   }
 
-  /** Complete the OIDC callback, validate claims, and establish a local session. */
+  /**
+   * Finish a login that {@link buildLoginUrl} started, and return the page to redirect to.
+   *
+   * Steps, in order: read `oidcFlow` from the session; exchange the authorization code
+   * against the client_id the flow recorded (or the masters client when it recorded
+   * none), checking the stored `state` and `nonce`; merge ID-token claims with UserInfo
+   * claims; apply the email allowlists; give the session a new id so a session id fixed
+   * by an attacker before login is discarded; store `authUser` and the id_token; then run
+   * {@link onLoginEstablished}.
+   *
+   * A failure inside {@link onLoginEstablished} is either logged and ignored or destroys
+   * the session and reaches the browser, depending on
+   * {@link isPostLoginFailureFatal}. Everything before it always reaches the browser.
+   *
+   * Called by: libs/backend/server/iam/identity/main/src/auth.router.ts.
+   *
+   * @param req - The callback request; the full callback URL and the session are read.
+   * @returns The local path to redirect the browser to; `/` when the original return
+   *          target was missing or not a local path.
+   * @throws When no login is in flight for this session (a callback that was replayed or
+   *         forged), when the code exchange or the `state`/`nonce` check fails, when the
+   *         claims carry no subject, when the email is unverified or outside the
+   *         allowlists, or when a fatal post-login hook rejects.
+   * @see https://openid.net/specs/openid-connect-core-1_0.html — the token-exchange and
+   *      ID-token validation rules `openid-client` applies here.
+   */
   async completeLogin(req: Request): Promise<string>
   {
     const flow = req.session.oidcFlow;
@@ -270,9 +393,21 @@ export abstract class OidcAuthServiceBase
   }
 
   /**
-   * Destroy the current local session and, when configured, return the IdP's RP-Initiated
-   * Logout URL. Returns null when OIDC is disabled, the session had no captured id_token, or
-   * the IdP does not advertise an `end_session_endpoint`.
+   * Log the user out of THIS server, and say whether the browser should also be sent to
+   * the identity provider to end the session there.
+   *
+   * The local session is always destroyed, even when the provider URL cannot be built —
+   * a provider problem must never leave the user logged in here.
+   *
+   * Called by: libs/backend/server/iam/identity/main/src/auth.router.ts.
+   *
+   * @param req - The logout request; its session and host are read.
+   * @returns The provider's end-session URL to redirect to, or null when there is nothing
+   *          to redirect to: OIDC is disabled, the session captured no id_token, the
+   *          provider advertises no `end_session_endpoint`, or building the URL failed.
+   *          A null result means "logged out locally, stay on this page".
+   * @see https://openid.net/specs/openid-connect-rpinitiated-1_0.html — RP-Initiated
+   *      Logout, including the `id_token_hint` and `post_logout_redirect_uri` parameters.
    */
   async logout(req: Request): Promise<string | null>
   {
@@ -282,10 +417,24 @@ export abstract class OidcAuthServiceBase
   }
 
   /**
-   * Resolve the OIDC client + scope a login should use. The base uses the single masters
-   * client and the configured scopes. Override to select a per-request client (e.g. per-org).
+   * Override point 1 of 2: choose which OIDC client and which scope string this login
+   * uses. Called once, at the start of {@link buildLoginUrl}.
+   *
+   * The base returns the single masters client and the configured scopes. An override may
+   * return a different client, and should also return its `clientId` so
+   * {@link completeLogin} exchanges the code against the same client; it must NOT change
+   * anything else about the flow. Use {@link discoverForClient} to get a configuration
+   * for another client_id at the same issuer.
+   *
+   * Overridden by: `OidcAuthService.resolveLoginClient` in
+   * libs/backend/server/iam/identity/main/src/oidc.service.ts, which resolves a
+   * per-organisation client from the request host and falls back to `super` when the host
+   * maps to no fully provisioned organisation.
    *
    * @param _req - The incoming login request (unused by the base).
+   * @returns The client configuration, the scope string, and optionally the client_id to
+   *          record in the session. Omitting `clientId` means "the masters client".
+   * @throws Anything discovery throws; a login cannot proceed without a client.
    */
   protected async resolveLoginClient(_req: Request): Promise<LoginClient>
   {
@@ -293,11 +442,22 @@ export abstract class OidcAuthServiceBase
   }
 
   /**
-   * Resolve extra `/auth/me` fields beyond the base identity + membership facts. The base
-   * adds none. Override to enrich (for example, add the resolved `clusterTenant`).
+   * Override point 2 of 2: extra fields to add to the `/auth/me` user object. Called on
+   * every `/auth/me`, in parallel with the membership lookup, so keep it cheap.
+   *
+   * The base adds nothing. Returned keys are spread over the user object LAST, so an
+   * override can overwrite a base field — avoid reusing base field names unless that is
+   * the intent.
+   *
+   * Overridden by: `OidcAuthService.enrichStatusUser` in
+   * libs/backend/server/iam/identity/main/src/oidc.service.ts, which adds the caller's
+   * `clusterTenant` resolved server-side from their verified subject.
    *
    * @param _req      - The status request (unused by the base).
-   * @param _authUser - The cached session identity (unused by the base).
+   * @param _authUser - The identity stored in the session (unused by the base).
+   * @returns Extra fields for the `/auth/me` user; an empty object adds nothing.
+   * @throws A rejection fails the whole `/auth/me` call, so an override that talks to a
+   *         database should decide deliberately whether to swallow its own errors.
    */
   protected async enrichStatusUser(_req: Request, _authUser: AuthUser): Promise<Record<string, unknown>>
   {
@@ -305,25 +465,63 @@ export abstract class OidcAuthServiceBase
   }
 
   /**
-   * Extension point invoked exactly once per login, right after a fresh session is
-   * established (post token-exchange, claim validation, and session persistence). The base
-   * does nothing; identity domains may project optional facts or establish a required local
-   * admission record. {@link isPostLoginFailureFatal} controls whether a failure is surfaced.
+   * Side-effect hook, run once per login, after the session has already been saved with
+   * the new user in it.
+   *
+   * A subclass MAY: write rows derived from the verified login (mirror group names, claim
+   * a one-time owner record), and update `req.session.authUser` and save the session
+   * again if it changed a stored flag.
+   * A subclass MUST NOT: treat this as an authorization check for the login itself —
+   * the user is already logged in by the time it runs — and must not assume it runs
+   * before the browser is redirected on to `returnTo`.
+   *
+   * What a failure here does depends on {@link isPostLoginFailureFatal}: false (the base)
+   * logs a warning and the login still succeeds; true destroys the session and rethrows,
+   * so the browser sees the login fail. Nothing else in this class inspects the outcome.
+   *
+   * Overridden by: `OidcAuthService.onLoginEstablished` in
+   * libs/backend/server/iam/identity/main/src/oidc.service.ts, which mirrors group names
+   * (best effort) and then claims the standalone first-owner slot (fatal on failure).
    *
    * @param _req      - The completed callback request (unused by the base).
-   * @param _authUser - The freshly established session identity (unused by the base).
+   * @param _authUser - The identity just stored in the session (unused by the base).
+   * @throws Whatever the override throws; see above for what happens to it.
    */
   protected async onLoginEstablished(_req: Request, _authUser: AuthUser): Promise<void>
   {
   }
 
-  /** Whether a post-login extension failure must be returned to the browser rather than logged. */
+  /**
+   * Whether a failure inside {@link onLoginEstablished} must fail the login.
+   *
+   * False (the base) — log a warning, keep the session, redirect the user on. Choose this
+   * when the hook only does optional work.
+   * True — destroy the session and rethrow, so the user sees a failed login. Choose this
+   * when the hook establishes something the user cannot function without; letting them in
+   * would strand them in a half-set-up state.
+   *
+   * Overridden by: `OidcAuthService.isPostLoginFailureFatal` in
+   * libs/backend/server/iam/identity/main/src/oidc.service.ts, which returns true only
+   * when standalone first-owner admission is configured.
+   *
+   * @returns True to fail the login on a hook error; false to log and continue.
+   */
   protected isPostLoginFailureFatal(): boolean
   {
     return false;
   }
 
-  /** Discover and memoize the provider metadata and client configuration (masters client). */
+  /**
+   * Discover, and remember for this process, the provider metadata and client
+   * configuration for the masters client — the single client from environment
+   * configuration, used for every login that is not per-organisation.
+   *
+   * Unlike {@link discoverForClient}, a failed promise is NOT evicted here, so a
+   * discovery failure at startup persists until the process restarts.
+   *
+   * @returns The discovered masters-client configuration.
+   * @throws When OIDC is not configured for this process.
+   */
   protected async getDiscoveredConfig(): Promise<client.Configuration>
   {
     if (!this.config.enabled)
@@ -342,11 +540,22 @@ export abstract class OidcAuthServiceBase
   }
 
   /**
-   * Discover (and memoize) the OIDC configuration for a SPECIFIC client_id at the configured
-   * issuer. Used for per-org public PKCE clients (no secret). Evicts a rejected promise so a
-   * transient discovery failure is retried rather than cached for the process lifetime.
+   * Discover, and remember for this process, the OIDC configuration for one specific
+   * client_id at the configured issuer. Used for per-organisation public clients, which
+   * have no secret and therefore rely on PKCE.
    *
-   * @param clientId - The org's OIDC client_id resolved from the request host.
+   * A failed discovery is removed from the cache before rethrowing, so a temporary
+   * provider outage is retried on the next login instead of breaking that client for the
+   * lifetime of the process.
+   *
+   * Called by: {@link completeLogin} (for the client_id recorded in the session) and
+   * `OidcAuthService.resolveLoginClient` in
+   * libs/backend/server/iam/identity/main/src/oidc.service.ts.
+   *
+   * @param clientId - The organisation's OIDC client_id, resolved from the request host.
+   * @returns The discovered configuration for that client, ready to authorize against.
+   * @throws When OIDC is disabled for this process, or when discovery fails — login is
+   *         then unavailable for that client and the caller must not fall back silently.
    */
   protected async discoverForClient(clientId: string): Promise<client.Configuration>
   {
@@ -438,7 +647,22 @@ export abstract class OidcAuthServiceBase
     }
   }
 
-  /** Validate the resolved claims and project them into the local session user shape. */
+  /**
+   * Check the claims a login produced and convert them into the {@link AuthUser} stored
+   * in the session.
+   *
+   * The checks, in order: there must be a `sub`; when either email allowlist is
+   * configured there must be an email; an email the provider marked as NOT verified is
+   * rejected outright; and the email must appear in the allowed-addresses list or its
+   * domain in the allowed-domains list. Group and role claims are then turned into
+   * `groups`, `isPlatformOperator`, and `isOrgAdmin` by {@link _ResolveIdentityClaims}.
+   *
+   * @param claims - The merged ID-token and UserInfo claims.
+   * @returns The user to store in the session.
+   * @throws When there is no usable subject, when an email is required but absent, when
+   *         the email is not verified, or when it is outside the allowlists. Every one of
+   *         these aborts the login and reaches the browser.
+   */
   private _buildAuthUser(claims: Record<string, unknown>): AuthUser
   {
     const subject = typeof claims.sub === "string" ? claims.sub : "";

--- a/libs/backend/server/infra/auth/src/oidc-service.types.ts
+++ b/libs/backend/server/infra/auth/src/oidc-service.types.ts
@@ -19,7 +19,14 @@ export interface AuthStatusUser extends AuthUser
   ownedOrgs: OwnedOrg[];
 }
 
-/** Session auth status returned to the SPA bootstrap logic. */
+/**
+ * The `/auth/me` response: what the browser app reads at startup to decide whether to show
+ * the application or send the user to log in.
+ *
+ * Produced only by `OidcAuthServiceBase.getStatus`. `user` is null whenever
+ * `authenticated` is false, and `mode` is `development` on a server with no OIDC
+ * configuration, which tells the app not to offer login at all.
+ */
 export interface AuthStatus
 {
   /** Effective auth mode for the current server configuration. */
@@ -32,7 +39,15 @@ export interface AuthStatus
   user: (AuthStatusUser & Record<string, unknown>) | null;
 }
 
-/** The OIDC client and scope a login should use, resolved for the current request. */
+/**
+ * What `resolveLoginClient` returns: which OIDC client a login authorizes against, and
+ * with which scope.
+ *
+ * Omitting {@link LoginClient.clientId} means "the masters client". Setting it makes
+ * `buildLoginUrl` record that client_id in the session, so `completeLogin` exchanges the
+ * code against the same client — a per-organisation override must set it, or the exchange
+ * will use the wrong client and fail.
+ */
 export interface LoginClient
 {
   /** The discovered OIDC client configuration to authorize against. */

--- a/libs/backend/server/infra/auth/src/org-membership.ts
+++ b/libs/backend/server/infra/auth/src/org-membership.ts
@@ -6,22 +6,27 @@ export type { OrgMembershipFacts, OrgMembershipRepository, OrgMembershipRow, Own
 const _EMPTY: OrgMembershipFacts = { isOrgAdmin: false, ownedOrgs: [] };
 
 /**
- * Resolve the caller's org-admin facts from their `OrgMembership` rows, fail-closed.
+ * Work out, from the caller's `OrgMembership` rows, whether they administer any
+ * organisation and which ones.
  *
- * This is the single membership derivation used by OIDC session introspection:
+ * The rules:
+ *   - Holding `owner` or `admin` on at least one organisation makes the caller an org
+ *     admin, for exactly those organisations.
+ *   - `member` rows grant nothing and never appear in the returned list.
+ *   - No subject, or no rows, means no authority.
+ *   - A failed lookup is RETHROWN, never turned into an empty result. This matters: an
+ *     unreachable database would otherwise silently read as "administers nothing", and a
+ *     caller would strip a real admin's rights instead of reporting an error.
  *
- *   - A subject who holds `owner` or `admin` on ≥1 org IS an org admin, scoped to
- *     exactly those orgs.
- *   - `member` rows confer no admin authority and are excluded from the scope.
- *   - A missing subject or no rows ⇒ empty facts (no authority).
- *   - A lookup failure propagates so the caller cannot mistake an unavailable authority source
- *     for a successful empty membership result.
+ * Always keyed on the subject the identity provider verified (OIDC `sub`), never on
+ * anything from the request body or query.
  *
- * Keyed on the IdP-verified subject (OIDC `sub`), never request input.
+ * Called by: `OidcAuthServiceBase.getStatus` in ./oidc-service.ts, on every `/auth/me`.
  *
- * @param repository - Repository providing the membership rows.
- * @param subject - The caller's IdP-verified subject; empty/undefined ⇒ empty facts.
- * @returns The derived org-admin flag and the owned/administered org set.
+ * @param repository - Supplies the owner/admin rows; see {@link OrgMembershipRepository}.
+ * @param subject    - The caller's verified subject; empty or missing returns no authority.
+ * @returns Whether the caller administers at least one organisation, plus that list.
+ * @throws Whatever the repository throws when the lookup fails — deliberately not caught.
  */
 export async function _ResolveOrgMembershipFacts(repository: OrgMembershipRepository, subject: string | undefined): Promise<OrgMembershipFacts>
 {

--- a/libs/backend/server/infra/auth/src/org-membership.types.ts
+++ b/libs/backend/server/infra/auth/src/org-membership.types.ts
@@ -1,6 +1,10 @@
 /**
- * Minimal row returned by the membership repository after it has restricted the durable query to
- * owner and administrator memberships for one verified subject.
+ * One `OrgMembership` row, cut down to just what {@link _ResolveOrgMembershipFacts} needs.
+ *
+ * The repository has already filtered to owner and admin rows for one verified subject, so
+ * every row here carries authority — there is no "is this role high enough" check left for
+ * the reader to do. {@link PrismaOrgMembershipRepository} throws rather than return a row
+ * with any other role.
  */
 export interface OrgMembershipRow
 {
@@ -12,12 +16,31 @@ export interface OrgMembershipRow
 }
 
 /**
- * Repository authority for the membership facts resolver. The resolver owns the access rule;
- * this port owns only the durable lookup that supplies its rows.
+ * Supplies the membership rows that {@link _ResolveOrgMembershipFacts} reasons about.
+ *
+ * The split is deliberate: this interface only fetches rows from storage, and the resolver
+ * decides what they mean. Anything implementing it must therefore not filter further,
+ * reorder meaningfully, or swallow errors — an implementation that returned an empty list
+ * on a database error would silently strip an admin's rights.
+ *
+ * Implemented by: {@link PrismaOrgMembershipRepository} (./prisma-org-membership-repository.ts),
+ * and by hand-written stubs in ./__tests__.
+ * Called by: {@link _ResolveOrgMembershipFacts}; the instance is handed to
+ * `OidcAuthServiceBase` at construction (see
+ * libs/backend/server/iam/identity/main/src/oidc.service.ts line 56).
  */
 export interface OrgMembershipRepository
 {
-  /** Find owner/admin memberships for the verified caller subject. */
+  /**
+   * Fetch the caller's owner and admin memberships. `member` rows must not be returned.
+   *
+   * @param subject - The subject the identity provider verified (OIDC `sub`), already
+   *                  trimmed by the caller.
+   * @returns The matching rows, or an empty list when the subject administers nothing.
+   *          An empty list must mean exactly that — never "the lookup failed".
+   * @throws When the lookup cannot be performed. Throwing is required: the resolver
+   *         deliberately lets it propagate so an outage is never read as "no memberships".
+   */
   findAdminMemberships(subject: string): Promise<readonly OrgMembershipRow[]>;
 }
 

--- a/libs/backend/server/infra/auth/src/per-org-client.ts
+++ b/libs/backend/server/infra/auth/src/per-org-client.ts
@@ -33,27 +33,46 @@ interface ClusterTenantCrForLogin
 }
 
 /**
- * Resolve the per-org OIDC client for a request host (S3b) from the cluster-scoped
- * **ClusterTenant CR** — the single source of truth the fleet-manager projects the public
- * Zitadel ids onto (Option A). The silo holds no ClusterTenant read-model of its own.
+ * Find the per-organisation OIDC client for the host a request arrived on, by reading the
+ * cluster-scoped **ClusterTenant custom resource**. The fleet manager writes the public
+ * Zitadel ids onto that resource, and it is the only place this code looks — a silo keeps
+ * no database copy of them.
  *
- * A host resolves to a ClusterTenant two ways, both read from the CR:
- *  - **canonical** `<org>.<base>` — the first DNS label names the CR (one `get`), or
- *  - **customer-vanity** — the full host matches a CR's `spec.vanityDomain` (CNAMEd onto the
- *    org apex), found by listing the cluster-scoped CRs.
- * Either way we return the org's `{clientId, orgId, redirectUri}` so login authorizes against
- * that org's isolated user pool. Fail-closed: returns null for
- *  - no `customApi` wired (dev/test) or a bare host (no label and no vanity match),
- *  - a host matching no ClusterTenant CR by either label or vanity, or
- *  - a CR whose org is not fully provisioned (no `spec.zitadel.clientId`/`orgId`).
- * In every null case the caller falls through to the masters client config — never a partial
- * per-org login. The CR is the authority, so a spoofed host that names no real, fully-provisioned
- * org cannot pick up an org client.
+ * A host maps to a ClusterTenant in one of two ways:
+ *   - `<org>.<base>` — the first DNS label is the resource name, fetched with one `get`.
+ *     This is the common case and is tried first.
+ *   - A customer's own domain — the whole host (port stripped, lower-cased) equals some
+ *     resource's `spec.vanityDomain`, found by listing all of them.
+ *
+ * On a match the organisation's `{clientId, orgId, redirectUri}` is returned so login
+ * authorizes against that organisation's own user pool and nobody else's.
+ *
+ * Returns null — meaning "use the masters client" — in every one of these cases:
+ *   - no Kubernetes client was wired (development and tests),
+ *   - the request carried no host,
+ *   - the host matched no resource, by either name or vanity domain,
+ *   - the matched organisation is only half provisioned, that is missing
+ *     `spec.zitadel.clientId` or `spec.zitadel.orgId`,
+ *   - the `get` or the `list` failed.
+ * There is deliberately no partial per-organisation login: it is either a fully
+ * provisioned organisation client or the masters client. Because the custom resource
+ * decides, a made-up host cannot pick up a client belonging to someone else.
+ *
+ * Logging levels are chosen on purpose: an unmatched host is logged at debug (usually
+ * scanner traffic on the wildcard), while a matched-but-unprovisioned organisation is
+ * logged at warn, because that one is an operational fault a human must fix.
+ *
+ * Called by: `OidcAuthService.resolveLoginClient` in
+ * libs/backend/server/iam/identity/main/src/oidc.service.ts.
  *
  * @param customApi - Kubernetes custom-objects client, or null when no cluster is wired.
- * @param host      - The request host (typically from `_RequestHost`).
- * @param log - Structured logger supplied by the consuming application.
- * @returns The resolved per-org client, or null to fall through to the masters client.
+ * @param host      - The request host, normally from {@link _RequestHost}.
+ * @param log       - Logger supplied by the consuming application.
+ * @returns The organisation's client details, or null to fall back to the masters client.
+ * @see https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
+ *      — the custom-resource `get`/`list` calls used below.
+ * @see https://zitadel.com/docs/apis/openidoauth/scopes — what `orgId` is for; see
+ *      {@link _OrgScope}.
  */
 export async function _ResolvePerOrgClient(customApi: k8s.CustomObjectsApi | null, host: string | undefined, log: Logger): Promise<ResolvedPerOrgClient | null>
 {

--- a/libs/backend/server/infra/auth/src/per-org-client.types.ts
+++ b/libs/backend/server/infra/auth/src/per-org-client.types.ts
@@ -1,10 +1,16 @@
 /**
- * Types for host→ClusterTenant→per-org OIDC client resolution (S3b).
+ * Types for working out, from a request host, which organisation's OIDC client a login
+ * should use.
  *
- * Each ClusterTenant gets a dedicated Zitadel Organization + OIDC app on create (S3),
- * persisting `{zitadelOrgId, zitadelClientId, zitadelRedirectUri}`. A request arriving at
- * `<org>.<base>` must log in against THAT org's client (and only that org's user pool),
- * so login resolves the per-org client from the host's first DNS label.
+ * Every ClusterTenant gets its own Zitadel Organization and OIDC application when it is
+ * created, and the resulting org id, client id, and redirect URI are written onto its
+ * ClusterTenant custom resource. A request arriving at that organisation's host must log
+ * in against THAT client, so that only members of that organisation can authenticate
+ * there.
+ *
+ * A host is matched either by its first DNS label (`<org>.<base>`, treated as the resource
+ * name) or by the full host equalling a resource's `spec.vanityDomain`. See
+ * {@link _ResolvePerOrgClient} for the matching order and every fail-closed case.
  */
 
 /**
@@ -14,7 +20,12 @@
  */
 export interface ResolvedPerOrgClient
 {
-  /** The ClusterTenant (silo) name — the host's first DNS label, confirmed against the DB. */
+  /**
+   * The ClusterTenant (silo) name. Taken from the `metadata.name` of the ClusterTenant
+   * custom resource that matched the host — NOT confirmed against any database, and not
+   * always the host's first DNS label, since a customer vanity domain matches on
+   * `spec.vanityDomain` instead.
+   */
   clusterTenant: string;
 
   /** The org's OIDC client_id login authorizes with (the per-org credential). */
@@ -29,6 +40,10 @@ export interface ResolvedPerOrgClient
   /** IdP subject configured as the ClusterTenant owner, when present. */
   ownerSubject: string | null;
 
-  /** Owner email used only while the trusted owner subject has not been configured. */
+  /**
+   * The owner's email from the resource, lower-cased. A weaker match than
+   * {@link ResolvedPerOrgClient.ownerSubject} because a user can change their email at the
+   * provider, so use it only while no owner subject has been configured yet.
+   */
   ownerEmail: string | null;
 }

--- a/libs/backend/server/infra/auth/src/prisma-org-membership-repository.ts
+++ b/libs/backend/server/infra/auth/src/prisma-org-membership-repository.ts
@@ -3,10 +3,18 @@ import { OrgRole, type Prisma } from "@prisma/client";
 import type { OrgMembershipRepository, OrgMembershipRow } from "./org-membership.types.js";
 
 /**
- * Prisma adapter for organisation-membership facts used by the HTTP authentication seam.
+ * Reads organisation memberships out of Postgres with Prisma.
  *
- * The adapter owns only database queries. Authentication and authorization rules stay in the
- * services and middleware that depend on its narrow repository contracts.
+ * It runs one query and nothing else — who counts as an admin is decided by
+ * {@link _ResolveOrgMembershipFacts}, and whether a route is allowed by the guards. The
+ * query restricts to `Owner` and `Admin` roles and orders by organisation name so results
+ * are stable between calls, and it re-checks each returned role, throwing if the database
+ * ever hands back another one.
+ *
+ * Called by: constructed in libs/backend/server/iam/identity/main/src/oidc.service.ts
+ * and handed to `OidcAuthServiceBase`, which calls it on every `/auth/me`.
+ *
+ * @implements {OrgMembershipRepository}
  */
 export class PrismaOrgMembershipRepository implements OrgMembershipRepository
 {
@@ -19,7 +27,12 @@ export class PrismaOrgMembershipRepository implements OrgMembershipRepository
     this.prisma = prisma;
   }
 
-  /** @inheritdoc */
+  /**
+   * @inheritdoc
+   * @throws When Prisma cannot reach the database, and when a returned row carries a role
+   *         other than `Owner` or `Admin` — a widened query must fail loudly rather than
+   *         hand a `member` row to the resolver as if it granted authority.
+   */
   async findAdminMemberships(subject: string): Promise<readonly OrgMembershipRow[]>
   {
     const rows = await this.prisma.orgMembership.findMany({

--- a/libs/backend/server/infra/auth/src/request-principal.ts
+++ b/libs/backend/server/infra/auth/src/request-principal.ts
@@ -5,13 +5,25 @@ import type { RequestPrincipal } from "./request-principal.types.js";
 import { _ClusterTenantFromHost } from "./request-silo.js";
 
 /**
- * Resolves the authenticated human principal from the server session and trusted request host.
+ * Read the logged-in caller out of an Express request: who they are, which silo they are
+ * on, and whether the session says they are an org admin.
  *
- * The resolver is intentionally backend-type-free: capability routers translate this common
- * identity shape into their own caller contracts. Missing identity or silo facts fail closed.
+ * Both facts must be present. The identity comes from the session (`sub`, falling back to
+ * the lower-cased email), and the silo comes from the first DNS label of the trusted
+ * request host. Either one missing returns null, so a route can never act for "some
+ * caller in no silo".
  *
- * @param request - Incoming Express request after session authentication.
- * @returns The authenticated request principal, or null when required facts are absent.
+ * It deliberately returns a plain identity shape rather than any domain caller type: each
+ * router converts it into whatever caller type it owns, so this file needs no dependency
+ * on those domains.
+ *
+ * Called by: prisma-personal-configuration.router.ts, prisma-persona-onboarding.router.ts,
+ * prisma-steering-ingest.router.ts, and prisma-self-run-cancellation.router.ts (all under
+ * libs/backend/agents), each in its own local `_resolveCaller`.
+ *
+ * @param request - The request, after session authentication has run.
+ * @returns The caller, or null when there is no session or no silo can be derived from
+ *          the host — treat null as 401/403, never as an anonymous caller.
  */
 export function _ResolveRequestPrincipal(request: Request): RequestPrincipal | null
 {

--- a/libs/backend/server/infra/auth/src/request-silo.ts
+++ b/libs/backend/server/infra/auth/src/request-silo.ts
@@ -1,14 +1,16 @@
 /**
- * Derive the ClusterTenant (silo) the caller is currently on from the request host. Each org is
- * served at `<clusterTenant>.<base>`, so the first DNS label names the silo (port and case are
- * stripped). Returns undefined for a bare host with no subdomain (e.g. localhost) so the caller
- * falls back to an unscoped lookup. The label is only a candidate: the email→tenant query filters
- * on it and yields zero rows for a host whose first label is not a real silo, so a wrong guess
- * fail-closes rather than mis-resolving. Custom org domains that do not follow `<org>.<base>` are
- * not matched here (a future ingressHost-based lookup would cover them).
+ * Work out which ClusterTenant (silo) the caller is on from the request host. Each
+ * organisation is served at `<clusterTenant>.<base>`, so the first DNS label is the silo
+ * name; the port is dropped and the label is lower-cased.
  *
- * The generic `_RequestHost` helper now lives in `@opencrane/backend/server/infra/auth`; this silo-specific
- * label-extraction stays here.
+ * The label is only a GUESS — this function checks nothing. Callers must treat it that
+ * way: the email-to-tenant query filters on it and returns no rows for a host whose first
+ * label is not a real silo, so a wrong guess ends in "no silo" rather than the wrong one.
+ * A host with no subdomain (`localhost`) yields undefined, and the caller then does an
+ * unscoped lookup. Custom domains that do not follow `<org>.<base>` are not matched here.
+ *
+ * {@link _RequestHost} reads the host itself; this function only pulls the silo label out
+ * of it.
  *
  * @param host - The request host, typically from `_RequestHost`.
  * @returns The silo (first DNS label), or undefined when none can be derived.

--- a/libs/backend/server/infra/auth/src/require-org-admin.ts
+++ b/libs/backend/server/infra/auth/src/require-org-admin.ts
@@ -1,19 +1,33 @@
 import type { RequestHandler } from "express";
 
 /**
- * Reusable authorization guard restricting a route to organisation admins — the role
- * allowed to curate the MCP catalogue and approve servers (P0.5).
+ * Express guard that lets only organisation admins reach a route — the role allowed to
+ * curate the MCP catalogue and approve servers.
  *
- * IAM-first: the decision is derived purely from the caller's IdP-verified identity
- * (`session.authUser.isOrgAdmin`, set from `OPENCRANE_ORG_ADMIN_GROUPS`), never from
- * request input.
+ * The decision comes only from `session.authUser.isOrgAdmin`, which was set at login from
+ * the caller's verified group claims (`OPENCRANE_ORG_ADMIN_GROUPS`); nothing in the
+ * request body, query, or headers can influence it. Platform operators pass too, because
+ * the login rules already mark them as org admins.
  *
- * Posture:
- *   1. No established session — fail closed (403).
- *   2. Session present — allow iff `isOrgAdmin` (platform operators are org admins by
- *      derivation, being the broader role).
+ * Two cases, both fail-closed:
+ *   1. No session — 403.
+ *   2. Session present but `isOrgAdmin` is false — 403.
  *
- * @returns An Express middleware that continues for org admins and rejects others with 403.
+ * The 403 body is byte-for-byte the same in both cases, and identical for every route
+ * using this guard. That is a security property, not tidiness: a caller must not be able
+ * to tell "you are not logged in" from "you are logged in but not an admin", or probe
+ * which check failed. Do not add a reason field, a route name, or a differing message.
+ *
+ * NOTE: this reads the value stored at login. A user who became an org admin by creating
+ * an organisation after logging in is reported as an admin by `/auth/me` but still
+ * rejected here until their session is refreshed.
+ *
+ * Called by: libs/backend/server/gateways/mcp/main/src/routes/mcp-operator.ts (8 routes),
+ * .../routes/mcp-servers.ts (3 routes),
+ * libs/backend/server/gateways/providers/main/src/routes/provider-byok.ts (2 routes), and
+ * libs/backend/server/gateways/integrations/main/src/integration-custody.router.ts.
+ *
+ * @returns Middleware that calls `next()` for org admins and sends 403 to everyone else.
  */
 export function _RequireOrgAdmin(): RequestHandler
 {
@@ -40,7 +54,7 @@ export function _RequireOrgAdmin(): RequestHandler
   };
 }
 
-/** Emit the canonical 403 envelope; never leak which specific check failed. */
+/** Send the one fixed 403 body used for every rejection here, so a caller cannot tell which check failed. */
 function _deny(res: Parameters<RequestHandler>[1]): void
 {
   res.status(403).json({ error: "Organisation admin role required.", code: "FORBIDDEN_NOT_ORG_ADMIN" });

--- a/libs/backend/server/infra/auth/src/require-platform-operator.ts
+++ b/libs/backend/server/infra/auth/src/require-platform-operator.ts
@@ -1,23 +1,33 @@
 import type { RequestHandler } from "express";
 
 /**
- * Authorization guard restricting a route to the PLATFORM OPERATOR — the fleet-wide
- * superadmin (env-seeded via `OPENCRANE_PLATFORM_OPERATOR_GROUPS` / seed email). This is
- * the strongest gate and the only acceptable one for the master IdP-credential rotation
- * route: a per-org owner/admin must NEVER be able to rotate the platform's Zitadel
- * service-account key.
+ * Express guard that lets only the platform operator reach a route — the fleet-wide
+ * superadmin, granted by `OPENCRANE_PLATFORM_OPERATOR_GROUPS` or by the per-cluster seed
+ * email.
  *
- * IAM-first: the decision is derived purely from the caller's IdP-verified session
- * (`session.authUser.isPlatformOperator`), never from request input.
+ * This is the strongest gate in the server and the only correct one for anything touching
+ * platform-wide credentials: an organisation owner or admin must never be able to rotate
+ * the platform's Zitadel service-account key. Prefer {@link _RequireOrgAdmin} for
+ * anything scoped to a single organisation.
  *
- * Posture:
- *   1. No established session — fail closed (403).
- *   2. Session present — allow iff `isPlatformOperator`; else 403.
+ * The decision comes only from `session.authUser.isPlatformOperator`, computed at login
+ * from verified claims and the verified email; nothing in the request can influence it.
  *
- * TODO (S5): `isPlatformOperator` is the config-driven stopgap until OpenCrane has a role
- * model. This MUST tighten to a first-class super-admin role once that model lands.
+ * Two cases, both fail-closed:
+ *   1. No session — 403.
+ *   2. Session present but not a platform operator — 403.
  *
- * @returns Express middleware that continues for platform operators and rejects others (403).
+ * The 403 body is identical in both cases, so a caller cannot tell "not logged in" from
+ * "logged in but not an operator". Keep it that way.
+ *
+ * Called by: no caller in this repo yet — it is exported from the package barrel ready for
+ * the credential-rotation route.
+ *
+ * TODO (S5): `isPlatformOperator` is a configuration-driven stopgap until OpenCrane has a
+ * role model; this must tighten to a real super-admin role once that lands.
+ *
+ * @returns Middleware that calls `next()` for the platform operator and sends 403 to
+ *          everyone else.
  */
 export function _RequirePlatformOperator(): RequestHandler
 {
@@ -44,7 +54,7 @@ export function _RequirePlatformOperator(): RequestHandler
   };
 }
 
-/** Emit the canonical 403 envelope; never leak which specific check failed. */
+/** Send the one fixed 403 body used for every rejection here, so a caller cannot tell which check failed. */
 function _deny(res: Parameters<RequestHandler>[1]): void
 {
   res.status(403).json({ error: "Platform operator role required.", code: "FORBIDDEN_NOT_PLATFORM_OPERATOR" });

--- a/libs/backend/server/infra/auth/src/session.ts
+++ b/libs/backend/server/infra/auth/src/session.ts
@@ -50,7 +50,20 @@ export function _buildCurrentUrl(req: Request): URL
   return new URL(`${protocol}://${host}${req.originalUrl}`);
 }
 
-/** Limit return targets to local relative paths to prevent open redirects. */
+/**
+ * Reduce a post-login return target to something safe to redirect to.
+ *
+ * Only a path starting with a single `/` is kept. Anything else — an absolute URL, a
+ * protocol-relative `//evil.example`, or nothing at all — becomes `/`. Without this, an
+ * attacker could hand a user a login link that bounced them to another site after a real
+ * login, which is what makes it a phishing tool.
+ *
+ * Called by: `OidcAuthServiceBase.buildLoginUrl` and `completeLogin` in ./oidc-service.ts
+ * — the value is sanitised on the way in AND on the way out of the session.
+ *
+ * @param returnTo - The requested return path, straight from the query string.
+ * @returns A local path safe to redirect to; `/` when the input was not one.
+ */
 export function _sanitizeReturnTo(returnTo: string | undefined): string
 {
   if (!returnTo || !returnTo.startsWith("/") || returnTo.startsWith("//"))

--- a/libs/backend/server/infra/auth/src/session.types.ts
+++ b/libs/backend/server/infra/auth/src/session.types.ts
@@ -1,8 +1,20 @@
 import "express-session";
 
 /**
- * Authenticated human identity cached in an OpenCrane server session. The OIDC login
- * flow populates it and the server authorization gates consume it.
+ * The logged-in human, as stored in the session cookie store.
+ *
+ * Written once per login by `OidcAuthServiceBase.completeLogin` (through its private
+ * `_buildAuthUser`) and read afterwards by {@link ___AuthMiddleware}, the two route
+ * guards, and `_ResolveRequestPrincipal`. Treat it as a cache of what was true AT LOGIN:
+ * nothing here is refreshed while the session lives.
+ *
+ * The one exception is {@link AuthUser.isOrgAdmin}, which `/auth/me` recomputes on every
+ * call by OR-ing the stored value with current `OrgMembership` rows. So a route guard
+ * reading the session may still say "not an org admin" for a user whom `/auth/me` already
+ * reports as one, until they log in again or a login hook rewrites the session.
+ *
+ * @see https://github.com/expressjs/session — the `express-session` store that holds
+ *      this object; the augmentation at the bottom of this file is what types it.
  */
 export interface AuthUser
 {

--- a/libs/backend/server/infra/http/src/error-handler.ts
+++ b/libs/backend/server/infra/http/src/error-handler.ts
@@ -65,7 +65,11 @@ function _isPrismaUniqueViolation(err: unknown): boolean
  * the generic 500 path. Routes SHOULD still catch P2002 themselves for a domain-specific
  * message (e.g. POST /cluster-tenants → "workspace name").
  *
+ * Called by: apps/opencrane/src/app/public-app.ts and internal-app.ts, each as the final `app.use`.
+ *
  * @param log - Pino logger instance.
+ * @returns The Express 5 error middleware. Register it after every route, or Express will not select
+ *   it for errors.
  */
 export function _ErrorHandler(log: Logger)
 {

--- a/libs/backend/server/infra/http/src/healthz.ts
+++ b/libs/backend/server/infra/http/src/healthz.ts
@@ -5,12 +5,19 @@ import type { DbHealthProbeUnitOfWork } from "./healthz.types.js";
 export type { DbHealthProbeRepository, DbHealthProbeUnitOfWork } from "./healthz.types.js";
 
 /**
- * Build a `/healthz` handler that performs request-bearing database I/O.
- * Returns 200 `{ status: "ok", db: true }` on success, 503 `{ status: "degraded", db: false }`
- * when the database check rejects. Shared by the fleet registry DB and each silo's per-CT DB.
+ * Build the `/healthz` handler, which answers by actually querying the database.
  *
- * @param db - Narrow database health probe supplied by the composing process.
- * @returns Express handler for the `/healthz` endpoint.
+ * A cheap 200 would let a pod look healthy while its database was gone, so the handler awaits a real
+ * query: 200 `{ status: "ok", db: true }` when it succeeds, 503 `{ status: "degraded", db: false }`
+ * when it rejects. The error itself is swallowed on purpose — `/healthz` is unauthenticated, so it
+ * must not describe the failure; look in the logs instead. The same handler serves the fleet
+ * registry database and each silo's per-ClusterTenant database. Note that rate-limit.ts exempts
+ * `/healthz`, so probes are never throttled.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted as `GET /healthz`.
+ *
+ * @param db - Database check supplied by the composing process, which owns the Prisma client.
+ * @returns Express handler for `/healthz`. It never throws and never calls `next` with an error.
  */
 export function _CheckDbHealth(db: DbHealthProbeUnitOfWork): RequestHandler
 {

--- a/libs/backend/server/infra/http/src/healthz.types.ts
+++ b/libs/backend/server/infra/http/src/healthz.types.ts
@@ -1,6 +1,14 @@
 /**
- * Request-bearing database check supplied by the composing application. The infrastructure
- * library depends only on this port, not the generated Prisma package or a raw query.
+ * A database check that runs inside a transaction the caller has already opened.
+ *
+ * This library never imports the generated Prisma package, so the composing application supplies the
+ * check. This interface and {@link DbHealthProbeUnitOfWork} below have identical members on purpose:
+ * this one is implemented by the class that queries INSIDE a transaction, while the other OPENS the
+ * transaction and calls it. Both are live in apps/opencrane/src/infra/db/db.ts, so pick by which
+ * side you are writing.
+ *
+ * Called by: apps/opencrane/src/infra/db/db.ts, where `_PrismaDbHealthProbeRepository` implements it
+ * and runs a single indexed `findFirst`.
  */
 export interface DbHealthProbeRepository
 {
@@ -8,7 +16,17 @@ export interface DbHealthProbeRepository
   check: () => Promise<void>;
 }
 
-/** Selects one request-scoped database check. */
+/**
+ * Opens one transaction per health check and runs the check inside it.
+ *
+ * This is the port `_CheckDbHealth` takes: the `/healthz` handler needs a single call it can await,
+ * and the composing app decides how the transaction is opened. Same members as
+ * {@link DbHealthProbeRepository} above — the difference is who owns the transaction.
+ *
+ * Called by: healthz.ts (`_CheckDbHealth`); implemented and composed in
+ * apps/opencrane/src/infra/db/db.ts (`_PrismaDbHealthProbeUnitOfWork`, returned by
+ * `___CreateDbHealthProbe`).
+ */
 export interface DbHealthProbeUnitOfWork
 {
   /** Performs typed database I/O or rejects when the database is unavailable. */

--- a/libs/backend/server/infra/http/src/rate-limit.ts
+++ b/libs/backend/server/infra/http/src/rate-limit.ts
@@ -12,8 +12,14 @@ export type { RateLimitOptions } from "./rate-limit.types.js";
  *
  * The default cap is deliberately generous (1000/min/IP): real opencrane-ui traffic stays well
  * under it, so this never shapes normal use — it only sheds a flood. Health probes (`/healthz`,
- * `/readyz`) and the high-frequency trusted internal pod-poll surface (`/api/internal/*`) are
+ * `/readyz`) and the high-frequency trusted internal pod-poll routes (`/api/internal/*`) are
  * exempt so liveness checks and operator loops are never throttled.
+ *
+ * The counters live in this process's memory, so each replica enforces the cap on its own: with N
+ * replicas behind the ingress, one client can reach N times the configured limit overall.
+ *
+ * Called by: apps/opencrane/src/app/public-app.ts (once, for the whole app) and
+ * apps/opencrane/src/app/routes.ts (per-router, with the caller's overrides).
  *
  * @param opts - Optional window/max overrides.
  * @returns An Express middleware enforcing the per-IP limit.

--- a/libs/backend/server/infra/http/src/request-validation.ts
+++ b/libs/backend/server/infra/http/src/request-validation.ts
@@ -5,7 +5,15 @@ import { API_ERROR_LIMITS, ApiValidationIssueLocations, type ApiValidationIssue 
 
 import type { ValidatedPublicBodyHandler } from "./request-validation.types.js";
 
-/** Dedicated safe-to-expose failure produced only by the public request-body wrapper. */
+/**
+ * The one validation failure whose details may reach a client.
+ *
+ * It is produced ONLY by {@link ___WithValidatedPublicBody}, after the Zod issues have been trimmed
+ * to bounded messages that never echo a rejected value. error-handler.ts answers it with 400 and
+ * includes those issues, while a plain `ZodError` from anywhere else stays a generic 500. Never
+ * throw this from internal code — doing so would publish a schema shape that was not meant to be
+ * public.
+ */
 export class _RequestValidationProblem extends Error
 {
 	/** Bounded issues that may cross the public HTTP boundary. */
@@ -81,10 +89,24 @@ function _PublicIssues(issues: readonly ZodIssue[]): ApiValidationIssue[]
 }
 
 /**
- * Wrap one authenticated public route handler with model-adjacent Zod body validation.
+ * Wrap one public route handler so its body is validated by the owning model's Zod schema first.
  *
- * Mount authorization middleware before this handler whenever field diagnostics could disclose a
- * protected contract. Internal workload routes must keep their opaque, identity-first validation.
+ * The handler is reached only with an already-parsed body, so it never casts `request.body`. On a
+ * failure nothing reaches the handler: a {@link _RequestValidationProblem} goes to `next()`, and
+ * error-handler.ts turns it into a 400 with a bounded list of issues. Only issues produced here may
+ * cross the public boundary — a raw Zod error thrown anywhere else stays an internal 500, so
+ * internal schemas cannot be probed from outside.
+ *
+ * Mount authorization middleware BEFORE this handler wherever the field-level messages would tell an
+ * unauthorized caller about a protected contract. Internal workload routes keep their own opaque,
+ * identity-first validation instead of using this.
+ *
+ * Called by: libs/backend/server/gateways/model-routing/main/src/routes/model-routing-defaults.ts
+ * (`PUT /`, behind its authorization guard).
+ *
+ * @param schema - The owning model's Zod schema, so HTTP never keeps a second copy of the field list.
+ * @param handler - Route handler; it receives the validated body as its fourth argument.
+ * @returns An Express handler that validates, then delegates.
  */
 export function ___WithValidatedPublicBody<T>(schema: z.ZodType<T>, handler: ValidatedPublicBodyHandler<T>): RequestHandler
 {

--- a/libs/backend/server/infra/http/src/transport-security.middleware.ts
+++ b/libs/backend/server/infra/http/src/transport-security.middleware.ts
@@ -17,7 +17,10 @@ const _HSTS_VALUE = "max-age=63072000; includeSubDomains; preload";
  * an always-on redirect would 3xx internal plain-HTTP health probes; when enabled it
  * only redirects safe (GET/HEAD) methods.
  *
- * @returns Express request handler enforcing the transport-security posture.
+ * Called by: apps/opencrane/src/app/public-app.ts, mounted before the routes.
+ *
+ * @returns Express request handler that sets the HSTS header on secure requests and, when
+ *   `OPENCRANE_FORCE_HTTPS` is on, redirects safe plain-HTTP methods to HTTPS.
  */
 export function _TransportSecurity(): RequestHandler
 {

--- a/libs/backend/server/infra/memory-gateway-client/src/cognee-http.ts
+++ b/libs/backend/server/infra/memory-gateway-client/src/cognee-http.ts
@@ -16,7 +16,7 @@ const _MAX_RESPONSE_BYTES = 256 * 1024;
  */
 export class MemoryGatewayTransportError extends Error
 {
-	/** Bounded failure class safe to project into a durable invocation failure code. */
+	/** Which kind of failure it was. It carries no remote content, so it is safe to log or store as an invocation's failure code. */
 	readonly code: MemoryGatewayTransportFailureCode;
 
 	/** Creates a transport failure that names only its bounded class. */
@@ -28,7 +28,7 @@ export class MemoryGatewayTransportError extends Error
 	}
 }
 
-/** Validate and normalize the release-local memory-gateway origin. */
+/** Check that the configured gateway URL is one in-cluster Kubernetes Service origin, and return it parsed. */
 function _MemoryGatewayOrigin(value: string): URL
 {
 	const parsed = URL.parse(value);
@@ -99,16 +99,26 @@ function _CreateServerTokenReader(tokenFile: string): () => Promise<string>
 }
 
 /**
- * Create the authenticated Cognee exchange used by read-only memory-gateway search operations.
+ * Create the authenticated exchange the memory-gateway client uses for read-only search.
  *
- * Every exchange presents a freshly read, audience-bound projected ServiceAccount token. The memory
- * gateway TokenReviews it and admits only the OpenCrane server identity; Cognee itself remains
- * private and unauthenticated. Every fetch runs with automatic child tracing suppressed so bearer
- * headers and remote addresses cannot become child-span attributes. The caller's explicit
- * memory-gateway operation span remains active.
+ * Every exchange re-reads the projected ServiceAccount token and sends it as a bearer token. The
+ * memory gateway checks that token with a Kubernetes TokenReview and admits only the OpenCrane
+ * server identity; Cognee itself sits behind the gateway, private and unauthenticated, so the
+ * gateway is the only thing that ever authorizes a search. Every fetch runs with automatic child
+ * tracing switched off so the bearer header and the remote address cannot become span attributes;
+ * the caller's own memory-gateway span stays active. The token audience is
+ * `MEMORY_GATEWAY_PROJECTED_TOKEN_AUDIENCE` in libs/contracts/src/memory.types.ts.
  *
- * @param options - Gateway origin, timeout, projected token, and test seams.
- * @returns A session issuing bounded, timeout-guarded JSON exchanges.
+ * Called by: http-cognee-memory-gateway-client.ts, which builds one session per client.
+ *
+ * @param options - Gateway origin, per-exchange timeout, projected-token path, and the optional
+ *   fetch and token-reader overrides used by tests.
+ * @returns A session with a single `search` method — the only call allowed against Cognee.
+ * @throws Error When the origin is not a single in-cluster HTTP Service origin, or the mounted token
+ *   file is empty when it is first read.
+ * @see NEEDS-HUMAN - add the URI for the Kubernetes TokenReview API
+ *   (`authentication.k8s.io/v1`) that the "admits only the OpenCrane server identity" claim rests
+ *   on; I could not confirm the exact upstream doc URL.
  */
 export function __CreateCogneeSession(options: CogneeMemoryGatewayHttpOptions): CogneeSession
 {

--- a/libs/backend/server/infra/memory-gateway-client/src/cognee-payloads.ts
+++ b/libs/backend/server/infra/memory-gateway-client/src/cognee-payloads.ts
@@ -1,7 +1,7 @@
 import { MemoryGatewayProtocolError } from "./personal-memory-record.js";
 import type { MemoryFact, MemoryProvenance, ScopedMemoryFact } from "./memory-gateway-client.types.js";
 
-/** Envelope revision written around scoped content so provenance survives a Cognee round trip. */
+/** Version number written into each stored scoped record, so its provenance can be read back safely. A record with any other version is dropped on decode. */
 const _SCOPED_ENVELOPE_VERSION = 1;
 
 /** Return a plain object suitable for security-boundary parsing. */
@@ -48,15 +48,20 @@ export function __DecodeScopedEnvelope(raw: string): { readonly content: string;
 }
 
 /**
- * Project a Cognee search response into gateway-minted facts.
+ * Convert a Cognee search response into facts, keeping only entries the gateway fully identified.
  *
- * Only entries carrying BOTH a remote identifier and text become facts; a malformed entry is
- * dropped rather than given a synthesised id. An entirely unrecognised response shape is a protocol
- * violation, so a broken contract can never masquerade as an empty recall.
+ * An entry becomes a fact only if it carries BOTH an identifier and text; a malformed entry is
+ * dropped rather than given an invented id. The id may arrive as `id`, `data_id`, or `document_id`,
+ * and the text as `text`, `content`, or `chunk`. A response whose overall shape is unrecognised is a
+ * protocol failure, so a broken contract can never look like "no facts found".
+ *
+ * Called by: http-cognee-memory-gateway-client.ts inside `query`, and {@link __ParseScopedFacts}
+ * below with an unbounded limit.
  *
  * @param payload - Untrusted Cognee search response.
- * @param maxResults - Upper bound the caller requested.
- * @returns The validated facts, truncated to the requested bound.
+ * @param maxResults - Most facts to return.
+ * @returns The accepted facts, at most `maxResults` of them, in the order the gateway sent them.
+ * @throws {MemoryGatewayProtocolError} When the response is not an array of entries.
  */
 export function __ParseSearchFacts(payload: unknown, maxResults: number): readonly MemoryFact[]
 {
@@ -75,7 +80,21 @@ export function __ParseSearchFacts(payload: unknown, maxResults: number): readon
 	return facts;
 }
 
-/** Project a Cognee search response into scoped facts, dropping unattributable records. */
+/**
+ * Convert a Cognee search response into scoped facts, dropping any record that cannot prove complete
+ * provenance.
+ *
+ * It reads EVERY entry the response contains rather than just the first `maxResults`, because
+ * unattributable records are dropped along the way, and stops once `maxResults` usable facts have
+ * been collected. That is deliberate: a few bad records must not shrink a caller's result set.
+ *
+ * Called by: http-cognee-memory-gateway-client.ts inside `recallScoped`.
+ *
+ * @param payload - Untrusted Cognee search response.
+ * @param maxResults - Most facts to return.
+ * @returns Facts that carry complete provenance, at most `maxResults` of them.
+ * @throws {MemoryGatewayProtocolError} When the response is not an array of entries.
+ */
 export function __ParseScopedFacts(payload: unknown, maxResults: number): readonly ScopedMemoryFact[]
 {
 	const facts: ScopedMemoryFact[] = [];

--- a/libs/backend/server/infra/memory-gateway-client/src/http-cognee-memory-gateway-client.ts
+++ b/libs/backend/server/infra/memory-gateway-client/src/http-cognee-memory-gateway-client.ts
@@ -10,18 +10,25 @@ import { MemoryGatewayUnavailableError } from "./unavailable-memory-gateway-clie
 const _SEARCH_TYPE = "CHUNKS";
 
 /**
- * Create the authenticated, read-only Cognee memory gateway client.
+ * Create the authenticated, read-only memory-gateway client backed by Cognee.
  *
- * Every recall is validated: an unrecognised response is a protocol violation, never a silently
- * empty result, and a scoped record that cannot prove complete provenance is dropped rather than
- * returned with partial attribution. Record, correction, forgetting, and scoped injection remain
- * fail-closed until the gateway owns a durable, remotely correlatable write lifecycle.
+ * Every recall is checked: an unrecognised response is a protocol failure, never a silently empty
+ * result, and a scoped record that cannot prove complete provenance is dropped rather than returned
+ * with partial attribution. `recordPersonalFact`, `correct`, `forget`, and `injectScoped` all throw
+ * `MemoryGatewayUnavailableError` — they stay fail-closed until the gateway owns a durable write
+ * lifecycle that can be tied back to a remote record. `injectScoped` still checks the provenance
+ * first, so an unattributable write is refused for the right reason.
  *
- * Dataset selection always comes from the caller's frozen `cogneeDatasetId` — never from a subject
- * id, scope coordinate, or caller-derived dataset name.
+ * Which dataset is searched always comes from the caller's frozen `cogneeDatasetId`. It is never
+ * derived from a subject id, a scope name, or anything this client builds itself.
  *
- * @param options - Memory-gateway origin, timeout, projected-token path, and test seams.
- * @returns A client whose results are only ever gateway-originated.
+ * Called by: apps/opencrane/src/infra/memory/memory-gateway-client.factory.ts.
+ *
+ * @param options - Gateway origin, timeout, projected-token path, and the fetch/token-reader
+ *   overrides used by tests.
+ * @returns A client whose results only ever contain gateway-returned data.
+ * @throws Error When `requestTimeoutMilliseconds` is outside 1-300 seconds, or the gateway origin is
+ *   not a single in-cluster HTTP Service origin.
  */
 export function __CreateHttpCogneeMemoryGatewayClient(options: CogneeMemoryGatewayHttpOptions): MemoryGatewayClient
 {

--- a/libs/backend/server/infra/memory-gateway-client/src/http-cognee-memory-gateway-client.types.ts
+++ b/libs/backend/server/infra/memory-gateway-client/src/http-cognee-memory-gateway-client.types.ts
@@ -1,13 +1,41 @@
-/** Bounded transport failure classes reported without any remote or fact payload. */
+/**
+ * Why one memory-gateway exchange failed, with no detail that could leak a body or a fact.
+ *
+ * `timeout`  - the per-exchange deadline fired.
+ * `network`  - fetch itself rejected: DNS, connection refused, or a refused redirect.
+ * `oversize` - the response was larger than the 256 KiB ceiling and was cancelled unread.
+ * `http_<status>` - the gateway answered non-2xx; the body was cancelled, never read.
+ *
+ * This code is the only thing that leaves the transport, which is why it is safe to log or store as
+ * an invocation's failure code.
+ */
 export type MemoryGatewayTransportFailureCode = "timeout" | "network" | "oversize" | `http_${number}`;
 
 /** Fetch-compatible function injected into the HTTP adapter. */
 export type CogneeFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
-/** The single authenticated, read-only exchange allowed against Cognee. */
+/**
+ * The single authenticated, read-only call allowed against Cognee.
+ *
+ * There is deliberately just one method: the memory gateway exposes search and nothing else, so no
+ * code path in OpenCrane can write to Cognee through this session.
+ *
+ * Called by: cognee-http.ts (`__CreateCogneeSession` builds it) and
+ * http-cognee-memory-gateway-client.ts, which is its only consumer.
+ */
 export interface CogneeSession
 {
-	/** Search an admitted dataset and return the parsed response body. */
+	/**
+	 * Sends one search request and returns the parsed response body.
+	 *
+	 * @param body - The search request; the client fills in query, `search_type`, `dataset_ids`, and
+	 *   `top_k`.
+	 * @returns The parsed body, or null when the gateway answered 2xx with nothing. Untrusted — the
+	 *   caller converts it with `__ParseSearchFacts` or `__ParseScopedFacts`.
+	 * @throws MemoryGatewayTransportError When the gateway cannot be reached, times out, answers
+	 *   non-2xx, or exceeds the response ceiling.
+	 * @throws MemoryGatewayProtocolError When the body is not valid JSON.
+	 */
 	search(body: unknown): Promise<unknown>;
 }
 

--- a/libs/backend/server/infra/memory-gateway-client/src/index.ts
+++ b/libs/backend/server/infra/memory-gateway-client/src/index.ts
@@ -1,3 +1,17 @@
+/**
+ * `@opencrane/backend/server/infra/memory-gateway-client` — the OpenCrane server's only client for
+ * agent memory: one subject's personal memory, and shared knowledge scopes.
+ *
+ * Everything goes through the `MemoryGatewayClient` port. Cognee sits behind the in-cluster memory
+ * gateway, which checks the server's projected ServiceAccount token, so nothing here talks to Cognee
+ * directly. Two rules run through the whole package. Recall never degrades: an unrecognised response
+ * is a protocol failure, not an empty result. And attribution is all-or-nothing: a scoped record
+ * that cannot prove complete provenance is dropped rather than returned with partial attribution,
+ * and a scoped write without complete provenance is refused before it is sent.
+ *
+ * Only the two recalls are implemented today. The write methods throw
+ * `MemoryGatewayUnavailableError` in both shipped implementations.
+ */
 export { __UnavailableMemoryGatewayClient, MemoryGatewayUnavailableError } from "./unavailable-memory-gateway-client.js";
 export { __AssertMemoryProvenanceComplete, MemoryProvenanceIncompleteError } from "./memory-provenance.js";
 export { __AssertPersonalMemoryRecordResult, MemoryGatewayProtocolError } from "./personal-memory-record.js";

--- a/libs/backend/server/infra/memory-gateway-client/src/memory-gateway-client.types.ts
+++ b/libs/backend/server/infra/memory-gateway-client/src/memory-gateway-client.types.ts
@@ -1,4 +1,11 @@
-/** One recalled memory fact returned by the memory gateway. */
+/**
+ * One fact the memory gateway returned for a recall.
+ *
+ * Both fields come from the gateway. `factId` is its own identifier and is the ONLY handle a caller
+ * may later use to correct or forget the fact — nothing local ever names a fact. Facts arrive in the
+ * gateway's own order. Nothing here says which run or agent produced the fact; for that use
+ * {@link ScopedMemoryFact}, which carries provenance.
+ */
 export interface MemoryFact
 {
 	/** Opaque identifier minted by the gateway; never locally synthesized. */
@@ -7,7 +14,18 @@ export interface MemoryFact
 	readonly content: string;
 }
 
-/** Request to recall personal-memory facts for one subject within a silo. */
+/**
+ * A recall against one subject's personal memory.
+ *
+ * `cogneeDatasetId` is the Cognee dataset UUID frozen into the admitted run snapshot. It is never
+ * derived from `subjectId` and never built from a name, so a run can only read the dataset it was
+ * admitted for. `maxResults` is a hard ceiling: the adapter passes it to the gateway as `top_k` and
+ * truncates again on the way back.
+ *
+ * Called by: libs/backend/agents/execution/protocol/src/prisma-run-input-compiler.ts,
+ * memory-external-action-executor.ts, and gateway-memory-fact-selector.ts, all through
+ * {@link MemoryGatewayClient.query}.
+ */
 export interface MemoryQueryCommand
 {
 	/** Silo that owns the memory scope. */
@@ -29,7 +47,16 @@ export interface MemoryQueryResult
 	readonly facts: readonly MemoryFact[];
 }
 
-/** Request to durably retain one authenticated subject's personal-memory fact. */
+/**
+ * A request to store one fact in a subject's personal memory.
+ *
+ * Nothing here is derived by the client: the caller supplies the Cognee dataset UUID (OpenCrane's own
+ * catalog id never crosses this boundary), the exact text to store, and a delivery key it can repeat
+ * safely. No shipped client performs this write yet — both throw `MemoryGatewayUnavailableError` —
+ * so treat this as the contract a write-capable gateway must meet.
+ *
+ * @see {@link PersonalMemoryRecordResult} for the two outcomes a write can have.
+ */
 export interface PersonalMemoryRecordCommand
 {
 	/** Silo that owns the personal-memory dataset. */
@@ -40,32 +67,51 @@ export interface PersonalMemoryRecordCommand
 	readonly cogneeDatasetId: string;
 	/** Exact durable fact content, sent only to the remote memory gateway. */
 	readonly content: string;
-	/** Stable delivery key: it may be replayed only with byte-identical content in this subject and dataset. */
+	/**
+	 * Key that makes retrying a delivery safe.
+	 *
+	 * Sending the same key again with byte-identical `content`, for the same subject and dataset, is
+	 * allowed and stores nothing new — the result comes back with `idempotent` set. Sending the same
+	 * key with DIFFERENT content is refused; see {@link PersonalMemoryRecordDenied}.
+	 */
 	readonly idempotencyKey: string;
 }
 
-/** Gateway evidence returned only after a personal fact has durably been accepted. */
+/**
+ * The outcome of one personal-memory write: either accepted or refused.
+ *
+ * Callers MUST branch on `outcome`. {@link PersonalMemoryRecorded} means the fact is stored and
+ * carries the gateway's own identifier and digest; {@link PersonalMemoryRecordDenied} means nothing
+ * was stored because the delivery key was reused with different content. Neither arm throws, so code
+ * that assumes success silently loses a refused write.
+ */
 export type PersonalMemoryRecordResult = PersonalMemoryRecorded | PersonalMemoryRecordDenied;
 
-/** Gateway evidence returned only after a personal fact has durably been accepted. */
+/** The gateway stored the fact (or found it already stored) and returned its own record of it. */
 export interface PersonalMemoryRecorded
 {
-	/** Durable gateway acceptance outcome. */
+	/** Always "recorded". This is the tag that tells this arm apart from the refusal. */
 	readonly outcome: "recorded";
-	/** True when an identical earlier delivery already retained this exact content. */
+	/** True when an earlier delivery with the same key had already stored this exact content, so nothing new was written. */
 	readonly idempotent: boolean;
-	/** Stable fact identifier minted by the remote memory gateway. */
+	/** The fact's identifier, minted by the gateway. The only handle for a later correction or deletion. */
 	readonly cogneeExternalId: string;
-	/** Canonical lowercase sha256: content address computed over accepted durable content. */
+	/** Digest of the stored content, always lowercase `sha256:<64 hex chars>`; compare it against your own hash of what you sent. */
 	readonly contentDigest: string;
 }
 
-/** Gateway denial that leaves no new durable personal-memory fact. */
+/**
+ * The gateway refused the write and stored nothing new.
+ *
+ * This happens when the `idempotencyKey` has already been used for different content in this subject
+ * and dataset. Retrying is pointless: either resend the original content under that key, or choose a
+ * new key. The fact stored by the first delivery is untouched.
+ */
 export interface PersonalMemoryRecordDenied
 {
-	/** Durable gateway denial outcome. */
+	/** Always "denied". This is the tag that tells this arm apart from the acceptance. */
 	readonly outcome: "denied";
-	/** Reused delivery key names content different from its already accepted request. */
+	/** The only refusal reason: this delivery key was already used for different content. */
 	readonly reason: "idempotency_conflict";
 }
 
@@ -96,9 +142,15 @@ export interface MemoryForgetCommand
 /**
  * Provenance stamped on every record a central agent injects into a shared knowledge scope.
  *
- * A scoped write is only ever attributable when it names the central agent, the exact revision, the
- * run that produced it, when it was recorded, and the upstream source it derived from. All fields
- * are required; an incomplete provenance fails closed rather than writing an unattributable fact.
+ * A scoped write is only traceable when it names the central agent, the exact revision, the run that
+ * produced it, when it was recorded, and the upstream source it came from. All five fields are
+ * required; an incomplete provenance fails closed rather than writing a record nobody can attribute.
+ * `__AssertMemoryProvenanceComplete` in memory-provenance.ts is where that check happens, and
+ * `__DecodeScopedEnvelope` in cognee-payloads.ts re-checks the same five fields on the way back out.
+ *
+ * NOTE: this is NOT the same type as `MemoryProvenance` in libs/contracts/src/memory.types.ts, which
+ * describes stored-fact provenance in the API contract. Import the one that matches the boundary you
+ * are working on.
  */
 export interface MemoryProvenance
 {
@@ -114,7 +166,17 @@ export interface MemoryProvenance
 	readonly sourceRef: string;
 }
 
-/** Request to recall facts from a knowledge SCOPE (not a single subject's personal memory). */
+/**
+ * A recall against a shared knowledge scope rather than one person's memory.
+ *
+ * The difference from {@link MemoryQueryCommand} matters: there is no `subjectId`, because the facts
+ * belong to a scope many agents may read, and every fact that comes back carries provenance (see
+ * {@link ScopedMemoryFact}). Records that cannot prove complete provenance are dropped on the way
+ * out, so a result can be shorter than the store actually holds.
+ *
+ * Called by: no non-test caller in this repo yet; reached through
+ * {@link MemoryGatewayClient.recallScoped}.
+ */
 export interface ScopedMemoryRecallCommand
 {
 	/** Silo that owns the scope. */
@@ -127,7 +189,14 @@ export interface ScopedMemoryRecallCommand
 	readonly maxResults: number;
 }
 
-/** One recalled scoped fact, carrying the provenance stamped when it was injected. */
+/**
+ * A fact recalled from a shared knowledge scope, together with who put it there.
+ *
+ * The provenance is not decoration: only records that still prove all five provenance fields survive
+ * decoding, and `__ParseScopedFacts` in cognee-payloads.ts drops anything else instead of returning
+ * it with partial attribution. So every fact in a result is fully attributable, and a short result
+ * may mean records were dropped, not that the scope is empty.
+ */
 export interface ScopedMemoryFact extends MemoryFact
 {
 	/** Provenance recorded with the fact. */
@@ -141,7 +210,14 @@ export interface ScopedMemoryRecallResult
 	readonly facts: readonly ScopedMemoryFact[];
 }
 
-/** Request to inject one record into a knowledge scope with mandatory provenance. */
+/**
+ * A request to write one record into a shared knowledge scope.
+ *
+ * The provenance is checked before anything else happens: both the HTTP client and the unavailable
+ * stub call `__AssertMemoryProvenanceComplete` first, so an unattributable record is refused rather
+ * than written. No shipped client performs the write yet — after that check both throw
+ * `MemoryGatewayUnavailableError`.
+ */
 export interface ScopedMemoryInjectionCommand
 {
 	/** Silo that owns the scope. */
@@ -154,19 +230,79 @@ export interface ScopedMemoryInjectionCommand
 	readonly provenance: MemoryProvenance;
 }
 
-/** Runtime-neutral boundary for the personal-memory and scoped-knowledge gateway authority. */
+/**
+ * The one way OpenCrane reads and writes memory: a subject's personal memory, and shared knowledge
+ * scopes.
+ *
+ * Only the two recalls work today. `recordPersonalFact`, `correct`, `forget`, and `injectScoped`
+ * throw `MemoryGatewayUnavailableError` in BOTH shipped implementations, because the gateway does not
+ * yet own a durable write lifecycle that can be tied back to a remote record. Treat those four as
+ * the agreed contract, not as working calls.
+ *
+ * Two implementations: the HTTP client in http-cognee-memory-gateway-client.ts, and
+ * `__UnavailableMemoryGatewayClient`, which refuses everything when no gateway is configured.
+ *
+ * Called by: libs/backend/agents/execution/protocol/src/prisma-run-input-compiler.ts,
+ * gateway-memory-fact-selector.ts, memory-external-action-executor.ts, and
+ * external-action-executor.types.ts; composed in
+ * apps/opencrane/src/infra/memory/memory-gateway-client.factory.ts.
+ */
 export interface MemoryGatewayClient
 {
-	/** Recalls facts for a subject and returns only gateway-originated results. */
+	/**
+	 * Recalls facts from one subject's personal memory.
+	 *
+	 * @param command - Silo, frozen Cognee dataset UUID, subject, query text, and result ceiling.
+	 * @returns Only gateway-returned facts, at most `maxResults` of them. An empty list means the
+	 *   gateway matched nothing — a broken response shape throws instead, so empty is trustworthy.
+	 * @throws MemoryGatewayProtocolError When the response shape is unrecognised or is not valid JSON.
+	 * @throws MemoryGatewayTransportError When the gateway cannot be reached, times out, answers
+	 *   non-2xx, or exceeds the response ceiling.
+	 * @throws MemoryGatewayUnavailableError When no gateway is configured.
+	 */
 	query(command: MemoryQueryCommand): Promise<MemoryQueryResult>;
-	/** Retains one fact for the authenticated subject and returns gateway-minted evidence. */
+	/**
+	 * Stores one fact in the authenticated subject's personal memory.
+	 *
+	 * @param command - Subject, dataset, exact content, and the repeatable delivery key.
+	 * @returns Either the gateway's record of the stored fact, or a refusal when the delivery key was
+	 *   reused with different content. Branch on `outcome`; a refusal does not throw.
+	 * @throws MemoryGatewayUnavailableError Always, in both shipped implementations today.
+	 */
 	recordPersonalFact(command: PersonalMemoryRecordCommand): Promise<PersonalMemoryRecordResult>;
-	/** Corrects one stored fact's content remotely. */
+	/**
+	 * Replaces the content of one stored fact.
+	 *
+	 * @param command - Subject and the gateway-minted `factId`, plus the replacement content.
+	 * @throws MemoryGatewayUnavailableError Always, in both shipped implementations today.
+	 */
 	correct(command: MemoryCorrectionCommand): Promise<void>;
-	/** Forgets one stored fact remotely. */
+	/**
+	 * Deletes one stored fact.
+	 *
+	 * @param command - Subject and the gateway-minted `factId` to remove.
+	 * @throws MemoryGatewayUnavailableError Always, in both shipped implementations today.
+	 */
 	forget(command: MemoryForgetCommand): Promise<void>;
-	/** Recalls provenance-carrying facts from one knowledge scope. */
+	/**
+	 * Recalls facts from a shared knowledge scope, each with the provenance stamped when it was written.
+	 *
+	 * @param command - Silo, frozen dataset UUID, query text, and result ceiling.
+	 * @returns Only facts that still prove complete provenance; unattributable records are dropped, so
+	 *   a short result does not mean the scope is nearly empty.
+	 * @throws MemoryGatewayProtocolError When the response shape is unrecognised or is not valid JSON.
+	 * @throws MemoryGatewayTransportError For any transport failure.
+	 * @throws MemoryGatewayUnavailableError When no gateway is configured.
+	 */
 	recallScoped(command: ScopedMemoryRecallCommand): Promise<ScopedMemoryRecallResult>;
-	/** Injects one record into a knowledge scope; the provenance is mandatory and validated. */
+	/**
+	 * Writes one record into a shared knowledge scope.
+	 *
+	 * @param command - Silo, frozen dataset UUID, the content, and the mandatory provenance.
+	 * @throws MemoryProvenanceIncompleteError When any provenance field is missing, blank, or (for
+	 *   `recordedAt`) not a parseable date. Checked first, before anything else.
+	 * @throws MemoryGatewayUnavailableError After that check passes, in both shipped implementations
+	 *   today.
+	 */
 	injectScoped(command: ScopedMemoryInjectionCommand): Promise<void>;
 }

--- a/libs/backend/server/infra/memory-gateway-client/src/memory-provenance.ts
+++ b/libs/backend/server/infra/memory-gateway-client/src/memory-provenance.ts
@@ -1,6 +1,12 @@
 import type { MemoryProvenance } from "./memory-gateway-client.types.js";
 
-/** Typed failure raised when a scoped memory write lacks complete provenance. */
+/**
+ * Thrown when a scoped memory write does not name all five provenance fields.
+ *
+ * The message names the first field that was missing, and nothing else — the record content never
+ * appears in it. This is a refusal before any write happens: the caller must fix the provenance,
+ * because a record with partial attribution is not allowed to exist in a shared scope.
+ */
 export class MemoryProvenanceIncompleteError extends Error
 {
 	/** Creates a fail-closed provenance violation. */
@@ -12,14 +18,19 @@ export class MemoryProvenanceIncompleteError extends Error
 }
 
 /**
- * Assert that a provenance record is complete before a scoped memory write is allowed.
+ * Check that a provenance record is complete before a scoped memory write is allowed.
  *
- * Every record injected into a shared knowledge scope by a central agent MUST be attributable to the
- * agent, its revision, the run that produced it, when it was recorded, and the source it came from.
- * A missing field fails closed with {@link MemoryProvenanceIncompleteError} rather than writing an
- * unattributable fact.
+ * Every record a central agent writes into a shared knowledge scope MUST be traceable to the agent,
+ * its revision, the run that produced it, when it was recorded, and where it came from. A missing or
+ * blank field — or a `recordedAt` that is not a parseable date — fails closed with
+ * {@link MemoryProvenanceIncompleteError} rather than writing a record nobody can attribute later.
  *
- * @param provenance - The provenance to validate.
+ * Called by: http-cognee-memory-gateway-client.ts and unavailable-memory-gateway-client.ts, both as
+ * the first statement of `injectScoped`, so the check runs even when no gateway is configured.
+ *
+ * @param provenance - The provenance to check.
+ * @throws {MemoryProvenanceIncompleteError} Naming the first field that is missing, blank, or (for
+ *   `recordedAt`) not a parseable date.
  */
 export function __AssertMemoryProvenanceComplete(provenance: MemoryProvenance): void
 {

--- a/libs/backend/server/infra/memory-gateway-client/src/personal-memory-record.ts
+++ b/libs/backend/server/infra/memory-gateway-client/src/personal-memory-record.ts
@@ -1,6 +1,13 @@
 import type { PersonalMemoryRecordResult } from "./memory-gateway-client.types.js";
 
-/** Typed failure emitted when a gateway response cannot prove a valid durable personal-memory write. */
+/**
+ * Thrown when the memory gateway's answer cannot be trusted as a valid response.
+ *
+ * Used in two places: a body that is not valid JSON (cognee-http.ts), and a search or write response
+ * whose shape is unrecognised (cognee-payloads.ts and the check below). It is deliberately a failure
+ * rather than an empty result — a broken contract must never look like "this subject has no facts"
+ * or "the fact was stored". The message names only the check that failed, never the body.
+ */
 export class MemoryGatewayProtocolError extends Error
 {
 	/** Create an explicit protocol failure that callers must not reinterpret as an accepted fact. */
@@ -11,7 +18,22 @@ export class MemoryGatewayProtocolError extends Error
 	}
 }
 
-/** Validate untrusted gateway JSON and return only explicit collision or canonical write evidence. */
+/**
+ * Check an untrusted gateway write response and return it as a typed outcome.
+ *
+ * Exactly two shapes are accepted: an explicit denial for a reused delivery key, or an acceptance
+ * carrying the gateway's fact id and a `sha256:<64 hex chars>` digest. Anything else — a missing
+ * field, an unknown outcome, a blank id, a digest in another format — is a protocol failure, so a
+ * half-understood response can never be recorded as a stored fact.
+ *
+ * Called by: no caller in this repo yet. Only __tests__/unavailable-memory-gateway-client.test.ts
+ * exercises it; it is here ready for the write path that will replace the fail-closed
+ * `recordPersonalFact`.
+ *
+ * @param value - Parsed but untrusted gateway response body.
+ * @returns `recorded` with the gateway's id and digest, or `denied` for a delivery-key conflict.
+ * @throws {MemoryGatewayProtocolError} When the body is neither of those two shapes.
+ */
 export function __AssertPersonalMemoryRecordResult(value: unknown): PersonalMemoryRecordResult
 {
 	if (value === null || typeof value !== "object" || Array.isArray(value)) throw new MemoryGatewayProtocolError("Memory gateway returned a non-object personal-memory record response");

--- a/libs/backend/server/infra/obot-custody/src/http-obot-custody.ts
+++ b/libs/backend/server/infra/obot-custody/src/http-obot-custody.ts
@@ -56,20 +56,27 @@ function _IsNotFound(error: unknown): boolean
 }
 
 /**
- * Create the authenticated HTTP custody adapter over one Obot management session.
+ * Create the HTTP custody adapter that talks to Obot over one authenticated session.
  *
- * Provisioning creates the remote MCP server, then configures it with the write-only credential.
+ * Provisioning is two calls: create the remote MCP server, then configure it with the credential.
  * The credential values travel ONLY inside the configure request body — they are never logged,
- * persisted, or included in any thrown error. A configure failure is compensated by deleting the
- * just-created server so no half-configured remote custody survives, and the original failure is
- * rethrown. Revocation is idempotent: a 404 on deconfigure or delete counts as success.
+ * stored, or put into any thrown error. If configure fails, the adapter deletes the server it just
+ * created so no half-configured custody is left behind in Obot, and it still throws the ORIGINAL
+ * configure failure even when that delete also fails. Revoking is safe to repeat: a 404 from
+ * deconfigure or delete counts as success.
  *
- * The exact Obot response shapes are not pinned by contract (live qualification is gated on issue
- * #337), so every consumed field is validated and anything unrecognised raises a typed
- * {@link ObotProtocolError} instead of being trusted.
+ * The exact Obot response shapes are not pinned by any contract (live qualification is gated on
+ * issue #337), so every field this adapter reads is checked, and anything unexpected raises
+ * {@link ObotProtocolError} rather than being trusted.
  *
- * @param session - Authenticated bounded Obot management exchange.
+ * Called by: apps/opencrane/src/infra/obot/obot-adapters.factory.ts, which passes the port to
+ * libs/backend/server/gateways/integrations/main/src/integration-custody-provisioning.ts.
+ *
+ * @param session - Authenticated Obot management session; see `__CreateObotSession` in obot-http.ts.
  * @returns The production {@link ObotCustodyPort} implementation.
+ * @throws ObotProtocolError From `provision`, when Obot's create response carries no MCP server id.
+ * @throws ObotTransportError From either method, when Obot cannot be reached or refuses a call.
+ * @throws Error From `provision`, when a credential entry has a blank name.
  */
 export function __CreateHttpObotCustodyAdapter(session: ObotSession): ObotCustodyPort
 {
@@ -88,8 +95,8 @@ export function __CreateHttpObotCustodyAdapter(session: ObotSession): ObotCustod
 			}
 			catch (error)
 			{
-				// 3. Compensate the unconfigured server so a failed configure leaves nothing usable
-				// remotely; the original failure stays authoritative even if compensation also fails.
+				// 3. Delete the server we just created, so a failed configure leaves nothing usable in
+				// Obot. The original configure failure is still the one thrown, even if this delete fails.
 				try
 				{
 					await session.request(`/api/mcp-servers/${encodeURIComponent(mcpServerId)}`, "DELETE");
@@ -98,7 +105,7 @@ export function __CreateHttpObotCustodyAdapter(session: ObotSession): ObotCustod
 				throw error;
 			}
 
-			// 4. Return only Obot-originated coordinates plus the documented far-future fallback expiry.
+			// 4. Return only the ids Obot gave us, plus the far-future fallback expiry explained at the top.
 			const now = new Date();
 			return {
 				obotCatalogEntryId: command.obotCatalogEntryId,

--- a/libs/backend/server/infra/obot-custody/src/http-obot-mcp-invocation.ts
+++ b/libs/backend/server/infra/obot-custody/src/http-obot-mcp-invocation.ts
@@ -24,7 +24,15 @@ function _AsObject(value: unknown): Record<string, unknown> | null
 	return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
 }
 
-/** Extract one expected JSON-RPC result object without preserving remote error details. */
+/**
+ * Pull the `result` object out of one JSON-RPC reply, rejecting anything else.
+ *
+ * Requires `jsonrpc: "2.0"`, the exact id we sent, no `error` member, and an object `result`. Obot's
+ * own error text is deliberately dropped: only the caller-supplied `expectation` string reaches the
+ * thrown {@link ObotProtocolError}, so a remote message cannot end up in a log.
+ *
+ * @see https://www.jsonrpc.org/specification - JSON-RPC 2.0, which defines these members.
+ */
 function _JsonRpcResult(payload: unknown, expectedId: number, expectation: string): Record<string, unknown>
 {
 	const envelope = _AsObject(payload);
@@ -69,27 +77,39 @@ function _McpPath(obotCustodyReference: string): string
 }
 
 /**
- * Create the authenticated server-side MCP invocation adapter over one bounded Obot session.
+ * Create the MCP invocation adapter that calls tools through one authenticated Obot session.
  *
- * The adapter enforces the immutable revision allow-list before transport, performs the required
- * MCP initialize handshake, echoes only the validated session id, and returns only the validated
- * tool result. The service credential, remote bodies, and provider error details remain contained
- * by {@link ObotSession}.
+ * Order matters: the tool allow-list is checked before any path is built or any request is sent, so
+ * a tool the agent revision does not allow never reaches the network. The adapter then performs the
+ * MCP `initialize` handshake, requires Obot to echo the pinned revision, replays only the validated
+ * session id, and returns only a validated tool result. The service token, Obot's response bodies,
+ * and its error details all stay inside {@link ObotSession} — what comes out is the tool result or
+ * one of the typed errors below.
  *
- * @param session - Authenticated bounded Obot session owned by the server process.
- * @returns The production MCP invocation port.
+ * Called by: apps/opencrane/src/infra/obot/obot-adapters.factory.ts; the port it returns is used by
+ * libs/backend/agents/execution/protocol/src/integration-external-action-executor.ts.
+ *
+ * @param session - Authenticated Obot session owned by the server process.
+ * @returns The production `ObotMcpInvocationPort` implementation.
+ * @throws ObotMcpToolNotAllowedError When the tool is absent from the command's allow-list.
+ * @throws ObotMcpAuthenticationError When Obot answers 401 to the server's service token.
+ * @throws ObotMcpAuthorizationError When Obot answers 403 for this MCP endpoint.
+ * @throws ObotProtocolError When the handshake, the revision echo, or the tool result is unusable.
+ * @throws ObotTransportError For any other transport failure.
+ * @see https://modelcontextprotocol.io/specification/2025-06-18 - the `initialize` and `tools/call`
+ *   exchanges this adapter implements.
  */
 export function __CreateHttpObotMcpInvocationAdapter(session: ObotSession): ObotMcpInvocationPort
 {
 	return {
 		async invokeTool(command: ObotMcpToolInvocationCommand): Promise<ObotMcpToolResult>
 		{
-			// 1. Enforce revision authority before computing an endpoint or contacting Obot.
+			// 1. Check the revision's tool allow-list first, before building a path or contacting Obot.
 			__AssertToolAllowed(command);
 			const path = _McpPath(command.obotCustodyReference);
 
-			// 2. Keep the full two-exchange handshake under one safe operation span. Arguments, results,
-			// custody addressing, credentials, and remote error details are deliberately excluded.
+			// 2. Trace both exchanges as one operation. Arguments, results, the custody reference,
+			// credentials, and Obot's error details are deliberately kept out of the span.
 			return ___DoWithTrace("obot.mcp.invoke", { siloId: command.siloId, integrationId: command.integrationId, toolName: command.toolName }, async function _InvokeAllowedTool()
 			{
 				try

--- a/libs/backend/server/infra/obot-custody/src/index.ts
+++ b/libs/backend/server/infra/obot-custody/src/index.ts
@@ -1,3 +1,17 @@
+/**
+ * `@opencrane/backend/server/infra/obot-custody` — everything OpenCrane needs to keep integration
+ * credentials OUT of its own storage by holding them in Obot instead.
+ *
+ * Two ports live here. `ObotCustodyPort` creates and destroys the remote Obot MCP server that holds
+ * a credential, returning only an opaque reference. `ObotMcpInvocationPort` calls a tool through one
+ * of those references, and every implementation checks the agent revision's tool allow-list before
+ * it opens a transport. Both are backed either by the HTTP adapters over a shared `ObotSession`, or
+ * by fail-closed stubs that refuse every call when no Obot is configured — a deployment without Obot
+ * fails visibly rather than faking custody or inventing a tool result.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18 - the MCP revision the invocation
+ *   adapter pins; it refuses any other revision rather than adapting to it.
+ */
 export { __UnavailableObotCustodyAdapter, ObotCustodyUnavailableError } from "./unavailable-obot-custody.js";
 export type { ObotCustodyCredential, ObotCustodyPort, ProvisionObotCustodyCommand, ProvisionedObotCustody } from "./obot-custody.types.js";
 export { __AssertToolAllowed, ObotMcpAuthenticationError, ObotMcpAuthorizationError, ObotMcpInvocationUnavailableError, ObotMcpToolNotAllowedError } from "./obot-mcp-invocation.js";

--- a/libs/backend/server/infra/obot-custody/src/obot-custody.types.ts
+++ b/libs/backend/server/infra/obot-custody/src/obot-custody.types.ts
@@ -1,4 +1,16 @@
-/** Write-only credential material accepted only for the duration of a custody request. */
+/**
+ * One credential entry — a name and its secret value — handed to Obot while custody is set up.
+ *
+ * The value is accepted for exactly one request and is never written anywhere in OpenCrane: not
+ * stored in Postgres, not logged, not put in a trace attribute, and not returned to the caller.
+ * It travels only inside the body of the Obot configure call made by `ObotCustodyPort.provision`;
+ * afterwards OpenCrane holds nothing but the opaque reference in {@link ProvisionedObotCustody}.
+ * A caller therefore cannot read a credential back — to change one, revoke the custody reference
+ * and provision again.
+ *
+ * Called by: libs/backend/server/gateways/integrations/main/src/integration-custody.router.ts
+ * (parsed out of the POST body by `_isCredentialEntry`) and integration-custody-provisioning.types.ts.
+ */
 export interface ObotCustodyCredential
 {
 	/** Header name or provider-specific credential field. */
@@ -7,7 +19,17 @@ export interface ObotCustodyCredential
 	readonly value: string;
 }
 
-/** Request to provision one remote Obot custody reference. */
+/**
+ * Everything needed to set up one remote Obot MCP server that holds an integration's credential.
+ *
+ * `siloId` and `integrationId` are correlation context only — they name the product-side owner for
+ * logs and traces. Obot itself is addressed solely by `obotCatalogEntryId`. The `credential` array
+ * is the sensitive part; see {@link ObotCustodyCredential} for the rule that its values are sent
+ * once and never kept.
+ *
+ * Called by: libs/backend/server/gateways/integrations/main/src/integration-custody.router.ts and
+ * integration-custody-provisioning.ts, through `ObotCustodyPort.provision`.
+ */
 export interface ProvisionObotCustodyCommand
 {
 	/** Silo that owns the integration. */
@@ -20,22 +42,68 @@ export interface ProvisionObotCustodyCommand
 	readonly credential: readonly ObotCustodyCredential[];
 }
 
-/** Remote-only custody result issued by Obot after successful configuration. */
+/**
+ * What Obot gave back after it created and configured the remote MCP server.
+ *
+ * Every field except `expiresAt` comes from Obot; OpenCrane never invents a reference. A caller
+ * stores these as the product's record of the custody and checks them before trusting the result:
+ * integration-custody-provisioning.ts revokes and reports the integration as unavailable when the
+ * catalogue entry does not match what it asked for, the reference is blank, or `expiresAt` is
+ * already in the past.
+ */
 export interface ProvisionedObotCustody
 {
-	/** Obot catalogue entry confirmed by the remote authority. */
+	/** The catalogue entry Obot confirmed. Compare it against the one you asked for. */
 	readonly obotCatalogEntryId: string;
-	/** Opaque reference minted by Obot; never locally synthesized. */
+	/** Opaque reference minted by Obot; OpenCrane never builds one itself. */
 	readonly obotCustodyReference: string;
-	/** Remote expiry governing later redemption. */
+	/**
+	 * When the custody stops being usable.
+	 *
+	 * Obot v0.23.1 never expires a configured MCP server, so the HTTP adapter fills this with a
+	 * far-future date and revoking is the real way to end custody. A caller must still treat a past
+	 * date as unusable and fail closed.
+	 */
 	readonly expiresAt: Date;
 }
 
-/** Runtime-neutral boundary for the Obot credential custody authority. */
+/**
+ * Creates and destroys the remote Obot MCP servers that hold integration credentials.
+ *
+ * OpenCrane deliberately never holds an integration credential itself: it hands the secret to Obot
+ * once and afterwards keeps only the opaque reference Obot minted. Two implementations exist —
+ * `__CreateHttpObotCustodyAdapter` in http-obot-custody.ts talks to Obot over HTTP, and
+ * `__UnavailableObotCustodyAdapter` refuses every call when no Obot is configured, so a deployment
+ * without Obot fails visibly instead of faking custody.
+ *
+ * Called by: libs/backend/server/gateways/integrations/main/src/integration-custody-provisioning.ts
+ * and integration-custody.router.ts; composed in
+ * apps/opencrane/src/infra/obot/obot-adapters.factory.ts and threaded through
+ * apps/opencrane/src/app/routes.ts and public-app.ts.
+ */
 export interface ObotCustodyPort
 {
-	/** Provisions custody remotely and returns only Obot-originated opaque coordinates. */
+	/**
+	 * Sets up the remote MCP server and hands Obot the credential.
+	 *
+	 * @param command - Silo/integration context, the Obot catalogue entry, and the credential entries.
+	 * @returns The catalogue entry, opaque reference, and expiry — nothing derived locally, so the
+	 *   caller can compare them against what it asked for.
+	 * @throws ObotCustodyUnavailableError When no Obot transport is configured.
+	 * @throws ObotProtocolError When Obot's create response carries no usable MCP server id.
+	 * @throws ObotTransportError When Obot cannot be reached or refuses an exchange.
+	 * @throws Error When a credential entry has a blank name.
+	 */
 	provision(command: ProvisionObotCustodyCommand): Promise<ProvisionedObotCustody>;
-	/** Revokes one remotely issued custody reference. */
+	/**
+	 * Destroys the stored credential and then the remote MCP server.
+	 *
+	 * Safe to call twice: the HTTP adapter treats a 404 from either step as already-done. Callers use
+	 * it both to end a custody normally and to clean up after a failed provisioning.
+	 *
+	 * @param obotCustodyReference - The opaque reference Obot minted for this custody.
+	 * @throws ObotCustodyUnavailableError When no Obot transport is configured.
+	 * @throws ObotTransportError When Obot cannot be reached, or refuses with anything but a 404.
+	 */
 	revoke(obotCustodyReference: string): Promise<void>;
 }

--- a/libs/backend/server/infra/obot-custody/src/obot-http.ts
+++ b/libs/backend/server/infra/obot-custody/src/obot-http.ts
@@ -22,7 +22,7 @@ const _MAX_TIMEOUT_MILLISECONDS = 300_000;
  */
 export class ObotTransportError extends Error
 {
-	/** Bounded failure class safe to project into durable custody or key-issuance evidence. */
+	/** Which kind of failure it was. It carries no remote content, so it is safe to log or store on a failure row. */
 	readonly code: ObotTransportFailureCode;
 
 	/** Creates a transport failure that names only its bounded class. */
@@ -133,7 +133,16 @@ function _ParseJson(text: string): unknown
 	}
 }
 
-/** Parse the first complete data frame from an MCP server-sent event response. */
+/**
+ * Read the first complete `data:` frame out of a server-sent-events response.
+ *
+ * Obot may answer an MCP call as an event stream instead of plain JSON. One JSON-RPC reply always
+ * fits in a single frame, so the first frame — the one ended by a blank line — is all that is
+ * needed, and later frames are ignored.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18 - the MCP transport that permits an
+ *   event-stream reply to a JSON-RPC request.
+ */
 function _ParseEventStream(text: string): unknown
 {
 	const dataLines: string[] = [];
@@ -166,7 +175,7 @@ function _McpSessionId(value: string | null): string | null
 	return value;
 }
 
-/** Combine the per-exchange deadline with the process shutdown fence. */
+/** Abort the exchange when either its own timeout expires or the process starts shutting down. */
 function _RequestSignal(timeoutMilliseconds: number, shutdownSignal: AbortSignal): AbortSignal
 {
 	const timeoutSignal = AbortSignal.timeout(timeoutMilliseconds);
@@ -174,16 +183,26 @@ function _RequestSignal(timeoutMilliseconds: number, shutdownSignal: AbortSignal
 }
 
 /**
- * Create the authenticated Obot session used by server-owned custody and action adapters.
+ * Create the authenticated Obot session that the custody and MCP adapters share.
  *
- * Every exchange presents the freshly read Obot service credential as a bearer token, applies one
- * hard timeout, refuses redirects, and bounds the response read. Every fetch runs with automatic
- * child tracing suppressed so bearer headers cannot become child-span attributes; the caller's
- * explicit operation span remains active. Response bodies are returned as parsed JSON — the calling
- * adapter validates every field it consumes and treats anything unrecognised as a protocol error.
+ * Every exchange re-reads the mounted Obot service token and sends it as a bearer token, applies one
+ * hard timeout, refuses redirects, and stops reading after 256 KiB. Every fetch runs with automatic
+ * child tracing switched off so the bearer header cannot become a span attribute; the caller's own
+ * operation span stays active. Bodies come back as parsed JSON only — the calling adapter must check
+ * every field it reads and treat anything unexpected as a protocol error.
  *
- * @param options - Obot origin, timeout, mounted service token, and test seams.
- * @returns A session issuing bounded, timeout-guarded JSON exchanges.
+ * The origin, the timeout, and the token path are all validated here, before any credential file is
+ * read, so a misconfigured deployment fails while it is being composed rather than authenticating
+ * against an unintended host.
+ *
+ * Called by: apps/opencrane/src/infra/obot/obot-adapters.factory.ts, which hands the session to both
+ * `__CreateHttpObotCustodyAdapter` and `__CreateHttpObotMcpInvocationAdapter`.
+ *
+ * @param options - Obot origin, per-exchange timeout, mounted service-token path, shutdown signal,
+ *   and the optional fetch and token-reader overrides used by tests.
+ * @returns A session whose two methods are the only way OpenCrane calls Obot.
+ * @throws Error When the origin is not a single in-cluster HTTP Service origin, the timeout is
+ *   outside 1-300 seconds, or the service-token path is not absolute.
  */
 export function __CreateObotSession(options: ObotHttpOptions): ObotSession
 {

--- a/libs/backend/server/infra/obot-custody/src/obot-http.types.ts
+++ b/libs/backend/server/infra/obot-custody/src/obot-http.types.ts
@@ -1,4 +1,16 @@
-/** Bounded Obot transport failure classes reported without any remote body or credential. */
+/**
+ * Why one Obot exchange failed, with no detail that could leak a response body or a credential.
+ *
+ * `timeout`  - the per-exchange deadline fired, or the process began shutting down.
+ * `network`  - fetch itself rejected: DNS, connection refused, or a refused redirect.
+ * `oversize` - the response was larger than the 256 KiB ceiling and was cancelled unread.
+ * `http_<status>` - Obot answered non-2xx; the body was cancelled, never read.
+ *
+ * This code is the only thing that leaves the transport, which is why it is safe to log or store on
+ * a failure row. Callers match on it: http-obot-custody.ts treats `http_404` on revoke as
+ * already-done, and http-obot-mcp-invocation.ts turns `http_401`/`http_403` into
+ * `ObotMcpAuthenticationError`/`ObotMcpAuthorizationError`.
+ */
 export type ObotTransportFailureCode = "timeout" | "network" | "oversize" | `http_${number}`;
 
 /** Fetch-compatible function injected into the Obot HTTP session. */
@@ -7,21 +19,66 @@ export type ObotFetch = (input: string | URL | Request, init?: RequestInit) => P
 /** HTTP methods the authenticated Obot management session may issue. */
 export type ObotRequestMethod = "GET" | "POST" | "DELETE";
 
-/** The single authenticated exchange primitive shared by every Obot management adapter. */
+/**
+ * The one authenticated way anything in OpenCrane talks to Obot.
+ *
+ * Both Obot adapters share it, so the bearer-token handling, the hard timeout, the redirect refusal,
+ * the 256 KiB response ceiling, and the suppression of automatic HTTP tracing are written once. The
+ * session chooses no paths and validates no fields: each adapter picks its own path and must treat
+ * every response field as untrusted.
+ *
+ * Called by: obot-http.ts (`__CreateObotSession` builds it), and both adapters take one as their
+ * only dependency — http-obot-custody.ts and http-obot-mcp-invocation.ts. Composed in
+ * apps/opencrane/src/infra/obot/obot-adapters.factory.ts.
+ */
 export interface ObotSession
 {
-	/** Issue one bounded, timeout-guarded JSON exchange and return the parsed response body. */
+	/**
+	 * Sends one Obot management call and returns its parsed JSON body.
+	 *
+	 * @param path - Path on the configured Obot origin, for example `/api/mcp-servers`.
+	 * @param method - GET, POST, or DELETE.
+	 * @param body - Optional value serialised as the JSON request body.
+	 * @returns The parsed body, or null when Obot answered 2xx with nothing. Every field is untrusted
+	 *   and must be checked by the calling adapter.
+	 * @throws ObotTransportError When Obot cannot be reached, times out, answers non-2xx, or exceeds
+	 *   the response ceiling.
+	 * @throws ObotProtocolError When the body is not valid JSON.
+	 */
 	request(path: string, method: ObotRequestMethod, body?: unknown): Promise<unknown>;
-	/** Issue one bounded MCP JSON-RPC exchange, accepting JSON or server-sent events. */
+	/**
+	 * Sends one MCP JSON-RPC call and returns the reply plus the MCP session id.
+	 *
+	 * Obot may answer either as `application/json` or as a `text/event-stream`; both are accepted, and
+	 * only the first complete data frame of a stream is read. Pass the `sessionId` from the previous
+	 * exchange so a stateful MCP server keeps the same session.
+	 *
+	 * @param path - The MCP proxy path for one custody reference.
+	 * @param body - The JSON-RPC request object to send.
+	 * @param sessionId - Session id from the previous exchange, when there was one.
+	 * @returns The parsed reply and the validated session id, which is null when Obot sent none.
+	 * @throws ObotTransportError When Obot cannot be reached, times out, answers non-2xx, or exceeds
+	 *   the response ceiling.
+	 * @throws ObotProtocolError When the body is empty, uses an unsupported content type, carries no
+	 *   data frame, is not valid JSON, or returns an unusable session id.
+	 * @see https://modelcontextprotocol.io/specification/2025-06-18 - the MCP revision this transport
+	 *   serves, including the session header carried between exchanges.
+	 * @see https://www.jsonrpc.org/specification - JSON-RPC 2.0, the request/response shape of `body`.
+	 */
 	mcpRequest(path: string, body: unknown, sessionId?: string): Promise<ObotMcpExchangeResponse>;
 }
 
-/** Parsed response metadata from one bounded MCP JSON-RPC exchange. */
+/**
+ * The two things one MCP exchange gives back to an adapter.
+ *
+ * Raw bytes, response headers, and Obot's error details stop at the session; an adapter only ever
+ * sees these two fields.
+ */
 export interface ObotMcpExchangeResponse
 {
-	/** Parsed JSON-RPC payload; raw response bytes never leave the session. */
+	/** The parsed JSON-RPC reply. Untrusted: the adapter checks every field it reads. */
 	readonly payload: unknown;
-	/** Validated Obot session identifier to echo on the next exchange, when present. */
+	/** Session id to pass to the next exchange. Null when Obot sent none, which is normal for MCP servers that hold no session state. */
 	readonly sessionId: string | null;
 }
 

--- a/libs/backend/server/infra/obot-custody/src/obot-mcp-invocation.ts
+++ b/libs/backend/server/infra/obot-custody/src/obot-mcp-invocation.ts
@@ -1,6 +1,15 @@
 import type { ObotMcpToolInvocationCommand } from "./obot-mcp-invocation.types.js";
 
-/** Typed failure raised when a tool outside the revision's allow-list is invoked. */
+/**
+ * Thrown when a run tries to call a tool its agent revision does not allow.
+ *
+ * This is a refusal, not a transport problem: nothing was sent to Obot. It is raised by
+ * {@link __AssertToolAllowed}, which every invocation adapter calls first, so a stale or tampered
+ * tool name cannot reach a provider.
+ * libs/backend/agents/execution/protocol/src/production-external-action-adapter.ts maps it to the
+ * durable failure code `integration_tool_not_allowed`, which means "no provider request was made" —
+ * safe to fail the action outright with no recovery check.
+ */
 export class ObotMcpToolNotAllowedError extends Error
 {
 	/** Creates a fail-closed allow-list violation naming the rejected tool. */
@@ -11,7 +20,15 @@ export class ObotMcpToolNotAllowedError extends Error
 	}
 }
 
-/** Typed failure raised when no authenticated Obot MCP transport is configured. */
+/**
+ * Thrown when this process has no Obot MCP transport configured at all.
+ *
+ * Raised only by the fail-closed stub in unavailable-obot-mcp-invocation.ts, which
+ * apps/opencrane/src/infra/obot/obot-adapters.factory.ts composes when it finds no Obot
+ * configuration. It exists so a deployment without Obot fails visibly instead of returning an empty
+ * or invented tool result. production-external-action-adapter.ts maps it to the failure code
+ * `integration_provider_unavailable`.
+ */
 export class ObotMcpInvocationUnavailableError extends Error
 {
 	/** Creates a failure that cannot be mistaken for a successful invocation. */
@@ -22,7 +39,14 @@ export class ObotMcpInvocationUnavailableError extends Error
 	}
 }
 
-/** Safe failure raised when Obot rejects the server's mounted service credential. */
+/**
+ * Thrown when Obot rejects the server's own mounted service token (HTTP 401).
+ *
+ * Obot's response body is dropped on purpose, so this error carries no remote detail. It means the
+ * OpenCrane server itself is not authenticated to Obot — a deployment or token-mount problem, not
+ * something the end user did, and retrying will not help. production-external-action-adapter.ts
+ * maps it to the failure code `AuthenticationError`.
+ */
 export class ObotMcpAuthenticationError extends Error
 {
 	/** Creates an authentication failure without retaining any remote response body. */
@@ -33,7 +57,14 @@ export class ObotMcpAuthenticationError extends Error
 	}
 }
 
-/** Safe failure raised when Obot denies the authenticated server access to the MCP endpoint. */
+/**
+ * Thrown when Obot accepts the server's token but refuses it this MCP endpoint (HTTP 403).
+ *
+ * Again no remote body is kept. Retrying with the same custody reference will keep failing until
+ * the grant on the Obot side changes. production-external-action-adapter.ts maps it to the failure
+ * code `PermissionError` — note that this is a different code from the 401 case above, so the two
+ * must not be collapsed.
+ */
 export class ObotMcpAuthorizationError extends Error
 {
 	/** Creates an authorization failure without retaining any remote response body. */
@@ -45,10 +76,19 @@ export class ObotMcpAuthorizationError extends Error
 }
 
 /**
- * Assert an invocation names an allow-listed tool, throwing {@link ObotMcpToolNotAllowedError}
- * otherwise. This is the single enforcement point every adapter calls before any transport, so the
- * allow-list is honoured even by the fail-closed stub.
- * @param command - The invocation to validate.
+ * Check that an invocation names a tool the agent revision allows, and throw if it does not.
+ *
+ * This is the ONE enforcement point: every adapter calls it before touching a transport, so the
+ * allow-list holds even for the fail-closed stub that has no transport at all. It compares
+ * `command.toolName` against `command.allowedToolNames` and nothing else — filling that list from
+ * the frozen revision's integration assignment is the caller's job.
+ *
+ * Called by: http-obot-mcp-invocation.ts and unavailable-obot-mcp-invocation.ts, both as the first
+ * statement of `invokeTool`.
+ *
+ * @param command - The invocation to check.
+ * @throws {ObotMcpToolNotAllowedError} When the tool is absent from the allow-list — including when
+ *   the allow-list is empty, which rejects everything.
  */
 export function __AssertToolAllowed(command: ObotMcpToolInvocationCommand): void
 {

--- a/libs/backend/server/infra/obot-custody/src/obot-mcp-invocation.types.ts
+++ b/libs/backend/server/infra/obot-custody/src/obot-mcp-invocation.types.ts
@@ -20,27 +20,60 @@ export interface ObotMcpToolInvocationCommand
 	readonly toolName: string;
 	/** Validated, bounded tool arguments. */
 	readonly arguments: JsonValue;
-	/** Immutable allow-list from the revision's integration assignment. */
+	/** Tool names the frozen agent revision allows. The caller fills it from the assignment's tool definitions; an empty list rejects everything. */
 	readonly allowedToolNames: readonly string[];
 }
 
-/** Opaque, gateway-originated result of one MCP tool invocation. */
+/**
+ * What an MCP tool call returned, straight from Obot.
+ *
+ * OpenCrane does not interpret `content` — it is handed back to the agent run as-is. Check
+ * {@link ObotMcpToolResult.isError} first: a tool that failed still returns normally here, so a
+ * caller that ignores the flag will treat an error message as a successful answer.
+ * libs/backend/agents/execution/protocol/src/integration-external-action-executor.ts throws
+ * `IntegrationToolReturnedError` when the flag is set, which becomes the durable failure code
+ * `RuntimeError`.
+ */
 export interface ObotMcpToolResult
 {
 	/** Result payload as returned by Obot; opaque to OpenCrane. */
 	readonly content: JsonValue;
-	/** Whether the MCP provider completed the call with a tool-level failure result. */
+	/** True when the tool itself failed. The call and the transport both succeeded, so nothing threw — you must branch on this. */
 	readonly isError: boolean;
 }
 
 /**
- * Runtime-neutral boundary for invoking an MCP tool through Obot custody.
+ * Calls one MCP tool through a custody reference that Obot holds the credential for.
  *
- * Every implementation MUST enforce the `allowedToolNames` allow-list before contacting any transport,
- * so a tool outside the revision's assignment is rejected fail-closed regardless of transport state.
+ * Every implementation MUST check `allowedToolNames` before it opens any transport, so a tool the
+ * agent revision does not allow is refused even when the call would otherwise have worked. Both
+ * shipped implementations do this by calling `__AssertToolAllowed` as their first statement: the
+ * HTTP adapter in http-obot-mcp-invocation.ts and the fail-closed stub in
+ * unavailable-obot-mcp-invocation.ts.
+ *
+ * Called by: libs/backend/agents/execution/protocol/src/integration-external-action-executor.ts,
+ * through `ExternalActionExecutorDependencies.obotMcpInvocation`; composed in
+ * apps/opencrane/src/infra/obot/obot-adapters.factory.ts and
+ * apps/opencrane/src/app/external-action-composition.ts.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18 - the MCP revision the HTTP adapter
+ *   pins for `initialize` and `tools/call`.
  */
 export interface ObotMcpInvocationPort
 {
-	/** Invokes an allow-listed MCP tool, returning only the gateway-originated result. */
+	/**
+	 * Runs one allow-listed tool and returns whatever Obot answered.
+	 *
+	 * @param command - Custody reference, tool name, validated arguments, and the allow-list.
+	 * @returns The tool's payload plus its failure flag. A set flag is a tool-level failure, not a
+	 *   transport failure, so the caller must branch on it rather than assume success.
+	 * @throws ObotMcpToolNotAllowedError When the tool is not in `allowedToolNames`; checked first, so
+	 *   nothing was sent to Obot.
+	 * @throws ObotMcpInvocationUnavailableError When no Obot transport is configured.
+	 * @throws ObotMcpAuthenticationError When Obot rejects the server's own service token (401).
+	 * @throws ObotMcpAuthorizationError When Obot refuses the server this MCP endpoint (403).
+	 * @throws ObotProtocolError When the handshake, the pinned-revision echo, or the result is unusable.
+	 * @throws ObotTransportError For any other transport failure.
+	 */
 	invokeTool(command: ObotMcpToolInvocationCommand): Promise<ObotMcpToolResult>;
 }

--- a/libs/backend/server/infra/obot-custody/src/unavailable-obot-custody.ts
+++ b/libs/backend/server/infra/obot-custody/src/unavailable-obot-custody.ts
@@ -11,7 +11,19 @@ export class ObotCustodyUnavailableError extends Error
 	}
 }
 
-/** Fail-closed adapter used until an authenticated Obot API contract is verified. */
+/**
+ * Custody port used when no Obot is configured: every call fails instead of pretending.
+ *
+ * There is deliberately no local fallback — OpenCrane cannot hold an integration credential itself,
+ * so there is nothing safe to do without Obot. Both methods throw
+ * {@link ObotCustodyUnavailableError}, and
+ * libs/backend/server/gateways/integrations/main/src/integration-custody-provisioning.ts turns that
+ * into a `remote_unavailable` outcome with no custody row written, so an operator sees the
+ * integration stay unprovisioned rather than appear ready.
+ *
+ * Called by: apps/opencrane/src/infra/obot/obot-adapters.factory.ts; asserted against in
+ * apps/opencrane/src/infra/obot/__tests__/obot-adapters.factory.test.ts.
+ */
 export class __UnavailableObotCustodyAdapter implements ObotCustodyPort
 {
 	/** Rejects provisioning rather than minting a local custody handle. */

--- a/libs/backend/server/infra/obot-custody/src/unavailable-obot-mcp-invocation.ts
+++ b/libs/backend/server/infra/obot-custody/src/unavailable-obot-mcp-invocation.ts
@@ -2,15 +2,26 @@ import { __AssertToolAllowed, ObotMcpInvocationUnavailableError } from "./obot-m
 import type { ObotMcpInvocationPort, ObotMcpToolInvocationCommand, ObotMcpToolResult } from "./obot-mcp-invocation.types.js";
 
 /**
- * Fail-closed MCP-invocation adapter used until an authenticated Obot MCP transport is verified.
+ * MCP-invocation adapter used when this process has no Obot MCP transport configured.
  *
- * It still enforces the allow-list FIRST — a tool outside the revision's assignment is rejected with
- * {@link ObotMcpToolNotAllowedError} even while unavailable — then refuses every allow-listed call
- * rather than fabricating a tool result.
+ * It still checks the allow-list FIRST — a tool the revision does not allow is refused with
+ * `ObotMcpToolNotAllowedError`, even though nothing could have been invoked anyway — and only then
+ * refuses the call with {@link ObotMcpInvocationUnavailableError} instead of inventing a tool
+ * result. That order is what keeps the allow-list rule true of every implementation of the port; it
+ * is asserted by __tests__/obot-mcp-invocation.test.ts.
+ *
+ * Called by: apps/opencrane/src/infra/obot/obot-adapters.factory.ts when no Obot configuration is
+ * present; also used as a stand-in by tests in libs/backend/agents/execution/protocol.
  */
 export class __UnavailableObotMcpInvocationAdapter implements ObotMcpInvocationPort
 {
-	/** Enforces the allow-list, then refuses because no transport is configured. */
+	/**
+	 * Checks the allow-list, then always throws because there is no transport.
+	 *
+	 * @param command - The invocation to check.
+	 * @throws ObotMcpToolNotAllowedError When the tool is not in `command.allowedToolNames`.
+	 * @throws {ObotMcpInvocationUnavailableError} For every tool that IS allow-listed.
+	 */
 	async invokeTool(command: ObotMcpToolInvocationCommand): Promise<ObotMcpToolResult>
 	{
 		__AssertToolAllowed(command);

--- a/libs/backend/server/infra/sandbox-execution/src/sandbox-execution.types.ts
+++ b/libs/backend/server/infra/sandbox-execution/src/sandbox-execution.types.ts
@@ -1,6 +1,13 @@
 import type { JsonValue } from "@opencrane/util";
 
-/** Request to run one external tool call inside a sandboxed Kubernetes Job. */
+/**
+ * One tool call to run in a sandbox, with everything the executor needs to run it and
+ * everything the caller needs to match the answer back to its own records.
+ *
+ * The identity fields (silo, run, attempt, tool revision, invocation) are for correlation
+ * and for rejecting stale work; {@link RunSandboxJobCommand.arguments} is the only payload.
+ * Arguments may contain user data, so this boundary neither logs nor stores them.
+ */
 export interface RunSandboxJobCommand
 {
 	/** Silo that owns the run. */
@@ -19,7 +26,14 @@ export interface RunSandboxJobCommand
 	readonly arguments: JsonValue;
 }
 
-/** Result returned only after a sandboxed Job completes. */
+/**
+ * What a finished sandbox Job reported back. Only ever built from the executor's own
+ * output — a caller that cannot get a real result must throw instead of filling one in,
+ * since these values are stored as the tool's actual answer.
+ *
+ * A non-zero {@link SandboxJobResult.exitCode} is a Job that RAN and failed, which is
+ * different from a Job that could not be started at all.
+ */
 export interface SandboxJobResult
 {
 	/** Invocation this result answers; echoed back from the command. */
@@ -32,9 +46,32 @@ export interface SandboxJobResult
 	readonly completedAt: Date;
 }
 
-/** Runtime-neutral boundary for running a tool call inside a sandboxed Job. */
+/**
+ * The port for running one external tool call somewhere isolated — today a Kubernetes Job.
+ *
+ * It is deliberately free of any Kubernetes type, so the code that decides WHAT to run does
+ * not depend on HOW it runs and can be tested against a stub. An implementation must return
+ * only what the sandbox actually produced: never a locally invented exit code or output,
+ * because callers store the result as the tool's real answer.
+ *
+ * Implemented by: {@link __UnavailableSandboxJobExecutor} (./unavailable-sandbox-execution.ts),
+ * the fail-closed default until a real transport exists.
+ * Called by: the external-action path in
+ * libs/backend/agents/execution/protocol (it holds one as `sandboxExecutor`, see
+ * external-action-executor.types.ts line 66); wired in
+ * apps/opencrane/src/app/external-action-composition.ts.
+ */
 export interface SandboxJobExecutor
 {
-	/** Runs one tool call remotely and returns only executor-originated output. */
+	/**
+	 * Run one tool call and wait for it to finish.
+	 *
+	 * @param command - What to run; see {@link RunSandboxJobCommand}.
+	 * @returns The result, only once the Job has completed. Never a partial or predicted one.
+	 * @throws When the call could not be run at all — for example
+	 *         {@link SandboxExecutionUnavailableError} when no transport is configured. A
+	 *         throw must be distinguishable from a Job that ran and failed, which returns a
+	 *         non-zero `exitCode` instead.
+	 */
 	runJob(command: RunSandboxJobCommand): Promise<SandboxJobResult>;
 }

--- a/libs/backend/server/infra/sandbox-execution/src/unavailable-sandbox-execution.ts
+++ b/libs/backend/server/infra/sandbox-execution/src/unavailable-sandbox-execution.ts
@@ -1,6 +1,13 @@
 import type { RunSandboxJobCommand, SandboxJobExecutor, SandboxJobResult } from "./sandbox-execution.types.js";
 
-/** Typed failure emitted when no sandbox execution transport is configured. */
+/**
+ * Thrown when a tool call was asked for but this deployment has no sandbox transport wired.
+ *
+ * It has its own type so callers can tell "we never ran it" from "it ran and failed":
+ * libs/backend/agents/execution/protocol/src/production-external-action-adapter.ts
+ * checks with `instanceof` and reports the call as provider-unavailable, which is retried
+ * rather than recorded as a tool failure.
+ */
 export class SandboxExecutionUnavailableError extends Error
 {
 	/** Creates a failure that cannot be mistaken for a completed sandboxed Job. */
@@ -11,7 +18,18 @@ export class SandboxExecutionUnavailableError extends Error
 	}
 }
 
-/** Fail-closed executor used until a real sandbox Job transport is wired. */
+/**
+ * The placeholder executor a deployment gets when no real sandbox transport exists: every
+ * call throws {@link SandboxExecutionUnavailableError}.
+ *
+ * It exists so the external-action path always has an executor and can be composed and
+ * tested normally, while making it impossible to mistake "no sandbox configured" for a
+ * tool call that ran and produced nothing.
+ *
+ * Called by: apps/opencrane/src/app/external-action-composition.ts.
+ *
+ * @implements {SandboxJobExecutor}
+ */
 export class __UnavailableSandboxJobExecutor implements SandboxJobExecutor
 {
 	/** Rejects execution rather than inventing a Job result. */

--- a/libs/backend/server/infra/workload-identity/src/projected-token-reviewer.ts
+++ b/libs/backend/server/infra/workload-identity/src/projected-token-reviewer.ts
@@ -11,7 +11,23 @@ function _IsNamespace(value: string): boolean
 	return value.length <= 63 && /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(value);
 }
 
-/** Validate the server and two runtime namespaces as one fail-closed identity boundary. */
+/**
+ * Check the three namespaces the server needs to keep identities apart, at startup.
+ *
+ * All three must be valid DNS labels, both runtime namespaces must be present, and all
+ * three must differ from each other. Sharing a namespace would put the server and a
+ * runtime — or a personal and a managed runtime — in the same identity space, where one
+ * could present a token accepted for the other, so a missing or duplicated value stops the
+ * process instead of defaulting to something.
+ *
+ * Called by: apps/opencrane/src/app/runtime-composition.ts, before any reviewer
+ * is built.
+ *
+ * @param config - Namespaces as read from deployment configuration.
+ * @returns The same three names, now all present, for use where they are required.
+ * @throws When any name is missing, is not a valid DNS label, or repeats another — startup
+ *         must fail rather than run with runtime identities that overlap.
+ */
 export function _ValidateRuntimeIdentityNamespaces(config: RuntimeIdentityNamespaceInput): RuntimeIdentityNamespaces
 {
 	const { serverNamespace, personalRuntimeNamespace, managedRuntimeNamespace } = config;
@@ -22,7 +38,19 @@ export function _ValidateRuntimeIdentityNamespaces(config: RuntimeIdentityNamesp
 	return { serverNamespace, personalRuntimeNamespace, managedRuntimeNamespace };
 }
 
-/** Validate one restricted worker namespace is well formed and isolated from the server identity. */
+/**
+ * Check one worker namespace at startup: it must be present, a valid DNS label, and
+ * different from the server's own namespace, so a worker's token can never be mistaken for
+ * the server's.
+ *
+ * Called by: apps/opencrane/src/app/runtime-composition.ts, for the artifact
+ * preprocessor namespace.
+ *
+ * @param namespace       - Namespace from deployment configuration; may be undefined.
+ * @param serverNamespace - The already validated server namespace.
+ * @returns The namespace, confirmed usable.
+ * @throws When it is missing, malformed, or equal to the server namespace.
+ */
 export function _ValidateIsolatedWorkloadNamespace(namespace: string | undefined, serverNamespace: string): string
 {
 	if (!namespace || !_IsNamespace(namespace) || namespace === serverNamespace) throw new Error("restricted workload namespace must be valid and different from POD_NAMESPACE");
@@ -58,7 +86,14 @@ function _ParseServiceAccountSubject(username: string): { readonly namespace: st
 	return match ? { namespace: match[1]!, serviceAccountName: match[3]! } : null;
 }
 
-/** Build a fixed-subject reviewer whose audience and identity cannot be widened by its caller. */
+/**
+ * Shared body of every fixed-identity reviewer: verify a token for exactly one audience and
+ * accept it only if the ServiceAccount username is exactly
+ * `system:serviceaccount:{namespace}:{serviceAccountName}`.
+ *
+ * The audience and the expected username are captured when the reviewer is created, so no
+ * later call can widen them — a caller can only ask "is this token that one identity".
+ */
 function _CreateFixedServiceAccountTokenReviewer(authApi: ProjectedTokenReviewApi, audience: string, namespace: string, serviceAccountName: string): FixedServiceAccountTokenReviewer
 {
 	return {
@@ -72,7 +107,18 @@ function _CreateFixedServiceAccountTokenReviewer(authApi: ProjectedTokenReviewAp
 	};
 }
 
-/** Build the fixed TokenReview adapter for the sole agent-controller identity. */
+/**
+ * Build the reviewer that admits only the agent controller: the controller's own token
+ * audience and ServiceAccount name come from `@opencrane/contracts`, so a caller chooses
+ * only the namespace and cannot point it at a different account.
+ *
+ * Called by: apps/opencrane/src/app/runtime-composition.ts.
+ *
+ * @param authApi   - Kubernetes client used only to submit TokenReviews.
+ * @param namespace - Namespace holding the controller's ServiceAccount, normally the
+ *                    server's own namespace.
+ * @returns A reviewer that returns the confirmed identity, or null for any other token.
+ */
 export function _CreateAgentControllerTokenReviewer(authApi: ProjectedTokenReviewApi, namespace: string): FixedServiceAccountTokenReviewer
 {
 	return _CreateFixedServiceAccountTokenReviewer(authApi, AGENT_CONTROLLER_PROJECTED_TOKEN_AUDIENCE, namespace, AGENT_CONTROLLER_SERVICE_ACCOUNT_NAME);
@@ -103,7 +149,19 @@ export function _CreateMemoryGatewayServerTokenReviewer(authApi: ProjectedTokenR
 	return _CreateFixedServiceAccountTokenReviewer(authApi, config.audience, config.namespace, config.serviceAccountName);
 }
 
-/** Build the reviewer for an authoring worker whose coordinates are later checked by bootstrap authority. */
+/**
+ * Build the reviewer for authoring workers. Unlike the fixed reviewers, it fixes NO
+ * identity: the audience is supplied per call, and any valid ServiceAccount token with a
+ * bound Pod UID is returned. Deciding whether that worker is the expected one is left to
+ * the stored bootstrap record, so a non-null result here is authentication only, never
+ * authorization.
+ *
+ * Called by: apps/opencrane/src/app/runtime-composition.ts.
+ *
+ * @param authApi - Kubernetes client used only to submit TokenReviews.
+ * @returns A reviewer returning the worker's namespace, ServiceAccount name, and Pod UID,
+ *          or null when the token is invalid for the requested audience or has no Pod UID.
+ */
 export function _CreateSkillWorkloadTokenReviewer(authApi: ProjectedTokenReviewApi): SkillWorkloadTokenReviewer
 {
 	return {
@@ -117,7 +175,7 @@ export function _CreateSkillWorkloadTokenReviewer(authApi: ProjectedTokenReviewA
 	};
 }
 
-/** Parse one runtime identity only when namespace, account grammar, and bound Pod UID all match. */
+/** Return the runtime identity only when the subject parses, its namespace is the expected one, its ServiceAccount name passes the supplied name check, and the token carried a bound Pod UID. */
 function _ParseRuntimeSubject(subject: string, expectedNamespace: string, podUid: string | null, isServiceAccountName: (value: string) => boolean): RuntimeWorkloadIdentity | null
 {
 	const parsed = _ParseServiceAccountSubject(subject);
@@ -125,7 +183,29 @@ function _ParseRuntimeSubject(subject: string, expectedNamespace: string, podUid
 	return { subject, ...parsed, podUid };
 }
 
-/** Build the runtime transport's fail-closed projected Kubernetes TokenReview adapter. */
+/**
+ * Build the reviewer the runtime stream transport uses to authenticate agent runtimes.
+ *
+ * It submits the token for BOTH runtime audiences at once and then requires exactly one of
+ * them to have been accepted. A token accepted for both, or for neither, is rejected: the
+ * audience is what distinguishes a personal runtime from a managed one, and that choice
+ * then decides which namespace and which ServiceAccount naming rule must match. Allowing
+ * both would let one class of runtime be checked against the other's rules.
+ *
+ * After that, the ServiceAccount subject must parse, its namespace must equal the
+ * configured namespace for that class, its name must satisfy that class's naming rule, and
+ * the token must carry a bound Pod UID. Any failure returns null.
+ *
+ * Called by: apps/opencrane/src/app/runtime-composition.ts; the result is
+ * passed to both the runtime bootstrap router and the runtime stream transport.
+ *
+ * @param authApi - Kubernetes client used only to submit TokenReviews.
+ * @param config  - The two validated runtime namespaces; see
+ *                  {@link _ValidateRuntimeIdentityNamespaces}.
+ * @returns A reviewer that returns a verified identity or null; it never explains why.
+ * @see https://kubernetes.io/docs/reference/access-authn-authz/authentication/ — TokenReview,
+ *      token audiences, and the extra fields that carry the bound Pod UID.
+ */
 export function _CreateRuntimeTokenReviewer(authApi: ProjectedTokenReviewApi, config: RuntimeTokenReviewerConfig): RuntimeTokenReviewer
 {
 	return {

--- a/libs/backend/server/infra/workload-identity/src/workload-identity.types.ts
+++ b/libs/backend/server/infra/workload-identity/src/workload-identity.types.ts
@@ -3,7 +3,14 @@ import type * as k8s from "@kubernetes/client-node";
 /** Kubernetes client seam used only to submit projected-token reviews. */
 export type ProjectedTokenReviewApi = Pick<k8s.AuthenticationV1Api, "createTokenReview">;
 
-/** Reviewed fixed ServiceAccount identity used by controller and preprocessing transports. */
+/**
+ * The result of verifying a token against ONE ServiceAccount that deployment configuration
+ * fixed in advance.
+ *
+ * Because the namespace and account name were fixed before the check, the values here
+ * simply repeat what was expected — the information is that the token matched them at all.
+ * Returned by every {@link FixedServiceAccountTokenReviewer}.
+ */
 export interface ReviewedFixedServiceAccountIdentity
 {
 	/** Full Kubernetes ServiceAccount username returned by TokenReview. */
@@ -27,7 +34,15 @@ export interface ChannelProxyTokenReviewerConfig
 	readonly serviceAccountName: string;
 }
 
-/** Reviewed authoring-worker identity whose exact coordinates are checked by durable bootstrap authority. */
+/**
+ * Who an authoring worker is, as parsed out of a verified token: its namespace,
+ * ServiceAccount name, and bound Pod UID.
+ *
+ * Unlike the fixed reviewers, the reviewer that produces this does NOT check the namespace
+ * or the name — it only proves the token is valid for the requested audience. Whether this
+ * is the worker the server was expecting is decided later, against stored bootstrap rows.
+ * So do not treat a non-null value here as authorization.
+ */
 export interface ReviewedSkillWorkloadIdentity
 {
 	/** Namespace parsed from the authenticated Kubernetes subject. */
@@ -38,7 +53,14 @@ export interface ReviewedSkillWorkloadIdentity
 	readonly podUid: string;
 }
 
-/** Verified runtime workload identity associated with one runtime-initiated connection. */
+/**
+ * Who a runtime stream belongs to, as Kubernetes confirmed it.
+ *
+ * Every field is from the TokenReview response, never from the request body. The Pod UID
+ * matters most: the stream transport compares it against the Pod UID the runtime claims in
+ * its stream-open message and rejects a mismatch, so one Pod's token cannot be used to
+ * open a stream on behalf of another.
+ */
 export interface RuntimeWorkloadIdentity
 {
 	/** Kubernetes ServiceAccount subject returned by TokenReview. */
@@ -51,10 +73,32 @@ export interface RuntimeWorkloadIdentity
 	readonly podUid: string;
 }
 
-/** Minimal TokenReview seam consumed by the runtime stream transport. */
+/**
+ * The one thing the runtime stream transport may do with a credential: ask whether it is
+ * valid and, if so, whose it is.
+ *
+ * Kept this narrow on purpose — the transport gets an identity or nothing, and never sees
+ * the TokenReview response, so it cannot start interpreting Kubernetes results itself.
+ *
+ * Implemented by: {@link _CreateRuntimeTokenReviewer} in ./projected-token-reviewer.ts.
+ * Called by: `_RegisterInternalAgentRuntimeStream` in
+ * libs/backend/server/infra/agent-runtime-stream, on both of its routes.
+ *
+ * @see https://kubernetes.io/docs/reference/access-authn-authz/authentication/ — TokenReview
+ *      and the audience-bound ServiceAccount tokens being checked.
+ */
 export interface RuntimeTokenReviewer
 {
-	/** Verify a projected token and return the authenticated workload identity. */
+	/**
+	 * Verify one bearer token.
+	 *
+	 * @param token - The raw token from the `Authorization: Bearer` header.
+	 * @returns The verified workload identity, or null for EVERY failure — invalid token,
+	 *          wrong audience, wrong namespace, unexpected ServiceAccount name, or no bound
+	 *          Pod UID. Callers must treat null as one undifferentiated denial.
+	 * @throws When the Kubernetes API call itself fails; that is an outage, not a denial, and
+	 *         must not be reported to the caller as an authentication failure.
+	 */
 	__Review(token: string): Promise<RuntimeWorkloadIdentity | null>;
 }
 
@@ -74,7 +118,12 @@ export interface RuntimeIdentityNamespaces extends RuntimeTokenReviewerConfig
 	readonly serverNamespace: string;
 }
 
-/** Startup namespace input before fail-closed validation proves all runtime planes are configured. */
+/**
+ * The raw namespace values read from deployment configuration, before checking. The two
+ * runtime namespaces are optional here only because configuration may omit them;
+ * {@link _ValidateRuntimeIdentityNamespaces} then throws rather than defaulting, which is
+ * why the checked type {@link RuntimeIdentityNamespaces} has them required.
+ */
 export interface RuntimeIdentityNamespaceInput
 {
 	/** Namespace containing the trusted OpenCrane server workload. */

--- a/libs/backend/server/knowledge/retrieval/main/src/core/retrieval.types.ts
+++ b/libs/backend/server/knowledge/retrieval/main/src/core/retrieval.types.ts
@@ -3,13 +3,28 @@
  * Shared between the retrieval route and conformance tests.
  */
 
-/** Dataset scopes supported by retrieval authorization and dataset partitioning. */
+/**
+ * How wide a body of knowledge a retrieval query is asking against.
+ *
+ * The scope does two jobs at once, which is why it appears in both the request and the
+ * response: it decides which dataset is searched, and it decides what the caller must be
+ * allowed to read. Widening the scope on a request therefore widens the authorisation check
+ * too — it is not a filter applied afterwards.
+ *
+ * Declaration order here is NOT meaningful. For relevance ordering use
+ * {@link DATASET_SCOPE_RETRIEVAL_PRECEDENCE}, which is the single source of truth for it.
+ */
 export enum DatasetScope
 {
+  /** Everything shared across the whole organisation. The broadest scope, and the default when none is given. */
   Org = "org",
+  /** One team's material. */
   Team = "team",
+  /** One department's material; wider than a team, narrower than the organisation. */
   Department = "department",
+  /** One project's material. */
   Project = "project",
+  /** The caller's own material. The narrowest scope, and the most relevant to them. */
   Personal = "personal",
 }
 
@@ -30,7 +45,15 @@ export const DATASET_SCOPE_RETRIEVAL_PRECEDENCE: readonly DatasetScope[] = [
   DatasetScope.Org,
 ];
 
-/** Request body for a retrieval query. */
+/**
+ * Body of a retrieval query.
+ *
+ * `tenantName` is what the authorisation check is resolved against, so a caller cannot broaden
+ * their reach by naming a different tenant here. `datasetScope` defaults to
+ * {@link DatasetScope.Org} and `datasetId` defaults to `default` for org scope, which means
+ * omitting both gives the widest search rather than the narrowest — pass them explicitly when
+ * you mean something narrower.
+ */
 export interface RetrievalQueryRequest
 {
   /** Full-text search query string. */
@@ -83,7 +106,15 @@ export interface RetrievalResult
   ingestedAt: string;
 }
 
-/** Successful retrieval response. */
+/**
+ * A successful retrieval answer.
+ *
+ * `datasetScope` and `datasetId` are echoed back as the values actually USED after defaults
+ * were applied, so a client can see which body of knowledge answered. `count` is the number of
+ * results in this response, not the number of documents that matched. `authOutcome` records
+ * what was written to the audit log; a `denied` outcome still arrives as a success response
+ * with no results.
+ */
 export interface RetrievalQueryResponse
 {
   /** Documents that matched the query and passed authorization checks. */

--- a/libs/backend/server/knowledge/retrieval/main/src/routes/third-party-sources.ts
+++ b/libs/backend/server/knowledge/retrieval/main/src/routes/third-party-sources.ts
@@ -213,10 +213,16 @@ export function thirdPartySourcesRouter(prisma: PrismaClient): Router
 }
 
 /**
- * Map a raw third-party source record to the UI response shape.
+ * Convert a stored source row into the API shape.
  *
- * @param source - Raw persisted source record.
- * @returns JSON response payload.
+ * The enum conversion is by string replacement, not by a lookup table: a database value with no
+ * matching replacement is lower-cased and passed through as though it were valid, and the cast
+ * hides that from the compiler. So adding a kind or a status to the schema without adding its
+ * replacement here produces a wrong value in the response rather than a build failure.
+ *
+ * @param source - The stored row, typed loosely because the caller reaches the table
+ *   dynamically.
+ * @returns The source with its item list, ready to serialise.
  */
 function _MapThirdPartySource(source: Record<string, unknown>): ThirdPartySource
 {

--- a/libs/backend/server/knowledge/retrieval/main/src/routes/third-party-sources.types.ts
+++ b/libs/backend/server/knowledge/retrieval/main/src/routes/third-party-sources.types.ts
@@ -1,7 +1,15 @@
-/** Supported source kinds for Phase 4 discovery. */
+/**
+ * The kinds of upstream a third-party source can be: an MCP registry, an Anthropic skills
+ * collection, a git repository, or a manual upload.
+ *
+ * These hyphenated values are the API form. The database stores the same set in PascalCase, and
+ * `_MapThirdPartySource` in third-party-sources.ts converts between them by string
+ * replacement — so adding a kind means adding it in both places or the conversion silently
+ * passes the raw database value through.
+ */
 export type ThirdPartySourceRouteKind = "mcp-registry" | "anthropic-skills" | "git-repository" | "manual-upload";
 
-/** Supported sync and approval states for third-party sources. */
+/** State of a source: syncing normally, in progress, failed, or waiting for an operator to approve it. Same PascalCase-to-hyphen conversion caveat as the kind above. */
 export type ThirdPartySourceRouteStatus = "healthy" | "syncing" | "error" | "pending-approval";
 
 /** Supported discovered item kinds linked to a source. */

--- a/libs/backend/server/reporting/spend/main/src/core/ai-budget.logic.ts
+++ b/libs/backend/server/reporting/spend/main/src/core/ai-budget.logic.ts
@@ -8,7 +8,19 @@ interface AiBudgetLogicDeps
   prisma: PrismaClient;
 }
 
-/** Returns global monthly spend ceiling. */
+/**
+ * Answer with the platform-wide monthly spend ceiling.
+ *
+ * There is exactly one such row (id 1). When it has never been set the response is
+ * `{ currency: "USD", ceilingAmount: 0 }` rather than a 404 — so a client always gets a number,
+ * and a zero ceiling means "not configured", NOT "no spending allowed".
+ *
+ * Called by: `aiBudgetRouter` (routes/ai-budget.ts) for `GET /global`, mounted at
+ * `/api/v1/ai-budget` by apps/opencrane/src/app/routes.ts.
+ *
+ * @param deps - Carries the database client.
+ * @returns Nothing; writes a 200 JSON body to `res`.
+ */
 export async function _GetGlobalBudget(req: Request, res: Response, deps: AiBudgetLogicDeps): Promise<void>
 {
   const item = await deps.prisma.globalBudgetSetting.findUnique({ where: { id: 1 } });
@@ -22,7 +34,17 @@ export async function _GetGlobalBudget(req: Request, res: Response, deps: AiBudg
   res.json({ currency: item.currency, ceilingAmount: Number(item.ceilingAmount) });
 }
 
-/** Updates the global monthly spend ceiling. */
+/**
+ * Set the platform-wide monthly spend ceiling, creating the single row if it does not exist yet.
+ *
+ * Inputs are coerced rather than rejected: a missing currency becomes `USD` and is upper-cased,
+ * and a missing or unparseable amount becomes 0. A client sending a typo therefore gets 204 and
+ * a zero ceiling, not a validation error — worth knowing before relying on this endpoint.
+ *
+ * Called by: `aiBudgetRouter` (routes/ai-budget.ts) for `PUT /global`.
+ *
+ * @returns Nothing; answers 204 with no body.
+ */
 export async function _PutGlobalBudget(req: Request, res: Response, deps: AiBudgetLogicDeps): Promise<void>
 {
   const currency = String(req.body.currency ?? "USD").toUpperCase();
@@ -37,7 +59,15 @@ export async function _PutGlobalBudget(req: Request, res: Response, deps: AiBudg
   res.status(204).send();
 }
 
-/** Returns all per-account monthly spend ceilings. */
+/**
+ * List every per-user monthly ceiling, ordered by user id so the response is stable between
+ * calls. Users with no row of their own are simply absent — they fall back to the global
+ * ceiling.
+ *
+ * Called by: `aiBudgetRouter` (routes/ai-budget.ts) for `GET /accounts`.
+ *
+ * @returns Nothing; writes a 200 JSON array to `res`.
+ */
 export async function _GetAccountBudgets(req: Request, res: Response, deps: AiBudgetLogicDeps): Promise<void>
 {
   const accounts = await deps.prisma.accountBudgetSetting.findMany({ orderBy: { userId: "asc" } });
@@ -52,7 +82,16 @@ export async function _GetAccountBudgets(req: Request, res: Response, deps: AiBu
   }));
 }
 
-/** Creates or updates the budget ceiling for a specific account. */
+/**
+ * Set one user's monthly ceiling, creating the row if there is none.
+ *
+ * Same lenient coercion as the global setter: a missing currency becomes `USD`, a missing or
+ * unparseable amount becomes 0.
+ *
+ * Called by: `aiBudgetRouter` (routes/ai-budget.ts) for `PUT /accounts/:userId`.
+ *
+ * @returns Nothing; answers 204 with no body.
+ */
 export async function _PutAccountBudget(req: Request, res: Response, deps: AiBudgetLogicDeps): Promise<void>
 {
   const userId = Array.isArray(req.params.userId) ? req.params.userId[0] : req.params.userId;
@@ -68,7 +107,15 @@ export async function _PutAccountBudget(req: Request, res: Response, deps: AiBud
   res.status(204).send();
 }
 
-/** Deletes a per-account spend ceiling. */
+/**
+ * Remove one user's own ceiling, so they fall back to the global one.
+ *
+ * Answers 204 whether or not a row existed, so it is safe to call twice.
+ *
+ * Called by: `aiBudgetRouter` (routes/ai-budget.ts) for `DELETE /accounts/:userId`.
+ *
+ * @returns Nothing; answers 204 with no body.
+ */
 export async function _DeleteAccountBudget(req: Request, res: Response, deps: AiBudgetLogicDeps): Promise<void>
 {
   const userId = Array.isArray(req.params.userId) ? req.params.userId[0] : req.params.userId;

--- a/libs/backend/server/reporting/spend/main/src/routes/ai-budget.ts
+++ b/libs/backend/server/reporting/spend/main/src/routes/ai-budget.ts
@@ -4,7 +4,15 @@ import type { PrismaClient } from "@prisma/client";
 import { _DeleteAccountBudget, _GetAccountBudgets, _GetGlobalBudget, _PutAccountBudget, _PutGlobalBudget } from "../core/ai-budget.logic.js";
 
 /**
- * Router for AI spend control and budget management.
+ * Build the spend-ceiling routes: one platform-wide ceiling, plus per-user overrides.
+ *
+ * Every handler lives in core/ai-budget.logic.ts; this file only maps method and path onto
+ * them, so route wiring and behaviour can be reviewed separately.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at `/api/v1/ai-budget`.
+ *
+ * @param prisma - Database client passed through to the handlers.
+ * @returns An Express router with the five budget routes mounted on it.
  */
 export function aiBudgetRouter(prisma: PrismaClient): Router
 {

--- a/libs/backend/server/reporting/spend/main/src/routes/token-usage.ts
+++ b/libs/backend/server/reporting/spend/main/src/routes/token-usage.ts
@@ -2,9 +2,13 @@ import { Router } from "express";
 import type { PrismaClient } from "@prisma/client";
 
 /**
- * Creates router that returns token usage statistics by account.
- * @param prisma - Prisma ORM client
- * @returns Configured Express router
+ * Build the token-usage route: recorded usage per user, newest sample first, with each user's
+ * effective ceiling resolved for them — their own if they have one, otherwise the global one.
+ *
+ * Called by: apps/opencrane/src/app/routes.ts, mounted at `/api/v1/token-usage`.
+ *
+ * @param prisma - Database client used to read usage samples and both kinds of budget row.
+ * @returns An Express router carrying the usage route.
  */
 export function tokenUsageRouter(prisma: PrismaClient): Router
 {


### PR DESCRIPTION
Completes the comment-language work started in #616 (merged). That PR covered apps, agent-execution, frontend and shared libs; `libs/backend/server` only received the first pass, because its sweep was still running when #616 went in. This is the remaining area.

## What changed

**807 comment rewrites across 227 files** in `libs/backend/server`. Comment text only — no behaviour change.

Follows the four rules now in `docs/agents/typescript.md#comment-language`: plain English, fix the sentence rather than just the word, heavy JSDoc on exports (`Called by:` plus `@param`/`@returns`/`@throws`/`@see`), and `@see` with the URI for external specs at the pinned revision.

## URL verification

This batch adds 18 external `@see` URLs. Every one was checked, because a wrong link is worse than none:

- All 18 return HTTP 200.
- The two new RFC citations were read to confirm the number matches the claim: RFC 7636 is indeed PKCE and defines `S256`; RFC 6265 is indeed HTTP cookies and defines `HttpOnly`/`Secure`/`Max-Age`. Note the comment correctly does **not** attribute `SameSite` to RFC 6265 (it isn't there) — that point is carried by the OWASP CSRF link instead.
- Already-verified from #616 and reused: the pinned MCP revision, RFC 8785, RFC 6648.

## Also cleaned up

Stripped **19 `(line NN)` citations** from `Called by:` lines. They rot: one already pointed at line 30 when the call had moved to line 33. The file and symbol are cited instead.

## Verification

- `nx run-many -t lint` — **92/92 projects clean**
- `nx run-many -t test` — full suite passes (`backend-agents-personal-personas` failed once, then passed 103/103; nx flags it as a flaky task)
- All relative `Called by:` targets resolved against their own directory — no dangling pointers

## Pre-existing issues surfaced, NOT introduced here

The style script reports **176 Prisma-boundary errors across 33 files** on this diff. They are all pre-existing: the flagged lines are existing `prisma.*` delegate calls, `@prisma/client` imports and `$queryRaw` uses, none of them code this PR touches. They appear only because the checker scopes by git diff, so a comment-only change pulls those files into scope. Verified on `libs/backend/server/reporting/spend/main/src/routes/token-usage.ts`, where the flagged lines 21/23 are untouched Prisma calls while the diff is purely its JSDoc block.

Worth its own issue — 124 direct delegate calls outside a repository adapter is a real boundary problem — but not for a comment PR to fix.