### PR TITLE
🏇 Run heavyweight validation on GitHub Actions -> Reduce build time drastically

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,16 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      heavy_qualification:
+        description: Run heavyweight qualification even when the affected graph does not select it
+        required: true
+        type: choice
+        default: none
+        options:
+          - none
+          - image-smoke
+          - k3d
+          - all
       publish_deployables:
         description: Publish the named deployable image set from this exact commit
         required: true
@@ -46,6 +56,8 @@ jobs:
       guard_base: ${{ steps.guard-base.outputs.guard_base }}
       deployables: ${{ steps.affected.outputs.deployables }}
       has_deployables: ${{ steps.affected.outputs.has_deployables }}
+      image_smokes: ${{ steps.affected.outputs.image_smokes }}
+      has_image_smokes: ${{ steps.affected.outputs.has_image_smokes }}
       api_contract_changed: ${{ steps.affected.outputs.api_contract_changed }}
       develop_smoke_required: ${{ steps.affected.outputs.develop_smoke_required }}
       guard_inputs_changed: ${{ steps.affected.outputs.guard_inputs_changed }}
@@ -93,6 +105,7 @@ jobs:
         id: affected
         env:
           FORCE_DEPLOYABLES: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_deployables || '' }}
+          FORCE_HEAVY_QUALIFICATION: ${{ github.event_name == 'workflow_dispatch' && inputs.heavy_qualification || '' }}
         run: node scripts/affected-deployables.mjs
 
   test:
@@ -297,7 +310,9 @@ jobs:
     if: >-
       ${{
         (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
-        (github.event_name == 'pull_request' && needs.prepare.outputs.develop_smoke_required == 'true')
+        (github.event_name == 'pull_request' && needs.prepare.outputs.develop_smoke_required == 'true') ||
+        (github.event_name == 'workflow_dispatch' &&
+          (inputs.heavy_qualification == 'k3d' || inputs.heavy_qualification == 'all'))
       }}
     steps:
       - uses: actions/checkout@v6
@@ -342,16 +357,50 @@ jobs:
           KEEP_CLUSTER: "0"
           TIMEOUT_SECONDS: "300"
 
+  image_smoke:
+    name: Image smoke (${{ matrix.project }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [prepare, test]
+    if: needs.test.result == 'success' && needs.prepare.outputs.has_image_smokes == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.image_smokes) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}
+
+      - name: Install image smoke dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run the app-owned image smoke
+        env:
+          IMAGE_SMOKE_PROJECT: ${{ matrix.project }}
+        run: npx nx run "$IMAGE_SMOKE_PROJECT:image-smoke"
+
   build-and-push:
     name: Build and publish affected images
     runs-on: ubuntu-latest
-    needs: [prepare, test, develop_smoke]
+    needs: [prepare, test, develop_smoke, image_smoke]
     if: >-
       ${{
         always() &&
         needs.prepare.outputs.has_deployables == 'true' &&
         needs.test.result == 'success' &&
-        (needs.develop_smoke.result == 'success' || needs.develop_smoke.result == 'skipped')
+        (needs.develop_smoke.result == 'success' || needs.develop_smoke.result == 'skipped') &&
+        (needs.image_smoke.result == 'success' || needs.image_smoke.result == 'skipped')
       }}
     permissions:
       contents: read

--- a/apps/skill-authoring/tests/image-smoke.sh
+++ b/apps/skill-authoring/tests/image-smoke.sh
@@ -21,7 +21,7 @@ docker run --rm --network none --no-healthcheck --entrypoint /bin/sh "$image" -e
   clamscan --database=/opt/opencrane/clamav-db --infected --no-summary /tmp/eicar.com > /tmp/scan.txt 2>&1
   result=$?
   set -e
-  if test "$result" != 1 || ! grep -Fq "Eicar-Signature FOUND" /tmp/scan.txt; then
+  if test "$result" != 1 || ! grep -Eq "Eicar(-Test)?-Signature FOUND" /tmp/scan.txt; then
     cat /tmp/scan.txt >&2
     exit 1
   fi

--- a/docs/agents/infra.md
+++ b/docs/agents/infra.md
@@ -17,6 +17,24 @@ Use focused project tasks while editing and the affected graph at a slice gate. 
 changes also require the matching contract scripts under `apps/*/tests` or
 `apps/_infra/deploy-k8s/platform/tests`.
 
+### Remote heavyweight validation
+
+Container-backed validation runs on GitHub Actions, not in a VM created on a developer workstation.
+Agents must never create, start, or restart Colima, Lima, Docker Desktop, Rancher Desktop, or another
+local VM-backed container runtime for repository validation unless the user explicitly requests that
+local runtime in the current task.
+
+- Keep focused validation that does not require a container runtime local.
+- Push the exact scoped commit and use the affected workflow for Docker image smokes, PostgreSQL
+  migration convergence, Storybook browser contracts, and k3d qualification.
+- Use the workflow's `heavy_qualification` dispatch input when an image smoke, k3d smoke, or both must
+  run even though the affected graph would not select them.
+- Bind reported evidence to the tested commit SHA and Actions run URL. A local Docker result is not a
+  substitute for the required remote job.
+
+If a required container-backed target has no Actions owner, wire it into the affected workflow before
+treating the target as a completion gate. Do not fill that CI gap by starting a local VM.
+
 Read [`versioning.md`](./versioning.md) before changing a chart or deploy path. A chart change must
 carry its new app/chart stamp, immutable release-manifest entry, and one-way transition record; an
 explicit no-op is required when upgrade impact was reviewed and no transformation is needed.

--- a/scripts/__tests__/affected-deployables.test.mjs
+++ b/scripts/__tests__/affected-deployables.test.mjs
@@ -3,7 +3,14 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-import { selectAffectedDeployables, selectApiContractChanged, selectDevelopSmokeRequired, selectForcedContainerProjects, selectGuardInputsChanged } from "../affected-deployables.core.mjs";
+import {
+	selectAffectedDeployables,
+	selectApiContractChanged,
+	selectDevelopSmokeRequired,
+	selectForcedContainerProjects,
+	selectGuardInputsChanged,
+	selectImageSmokeProjects,
+} from "../affected-deployables.core.mjs";
 import { hasSuccessfulDevelopValidation, selectGuardComparisonBase, selectPromotionSource } from "../promotion-guard-base.core.mjs";
 
 /** Reads the stable selector fixture. */
@@ -47,6 +54,21 @@ test("uses an explicit publication set and makes manual dispatch validation-only
 	assert.throws(function _UnknownForce() { selectForcedContainerProjects("all"); }, /unsupported FORCE_DEPLOYABLES value: all/u);
 });
 
+test("selects affected image smokes unless manual qualification expands to every owner", function _SelectsImageSmokes()
+{
+	const affected = ["skill-authoring", "skill-authoring"];
+	const all = ["tool-runner", "skill-authoring"];
+	assert.deepEqual(selectImageSmokeProjects(affected, all, ""), [{ project: "skill-authoring" }]);
+	assert.deepEqual(selectImageSmokeProjects(affected, all, "k3d"), [{ project: "skill-authoring" }]);
+	const allProjects = [{ project: "skill-authoring" }, { project: "tool-runner" }];
+	assert.deepEqual(selectImageSmokeProjects(affected, all, "image-smoke"), allProjects);
+	assert.deepEqual(selectImageSmokeProjects(affected, all, "all"), allProjects);
+	assert.throws(
+		function _UnknownForce() { selectImageSmokeProjects(affected, all, "everything"); },
+		/unsupported FORCE_HEAVY_QUALIFICATION value/u,
+	);
+});
+
 test("uses all affected projects for contract verification and changed files for guard fixtures", function _SelectsPipelineInputs()
 {
 	const fixture = _Fixture();
@@ -66,20 +88,34 @@ test("runs the develop smoke for deployment surfaces and not ordinary applicatio
 	assert.equal(selectDevelopSmokeRequired(["website/guide.md"]), false);
 });
 
-test("keeps the blocking smoke on develop and ahead of image publication", function _ProtectsDevelopSmokeWiring()
+test("keeps heavyweight remote qualification ahead of image publication", function _ProtectsHeavyQualificationWiring()
 {
 	const workflow = _Workflow();
-	const smokeJob = workflow.match(/\n  develop_smoke:[\s\S]*?\n  build-and-push:/u);
-	assert.ok(smokeJob, "develop smoke job must remain independently inspectable");
+	const developSmokeJob = workflow.match(/\n  develop_smoke:[\s\S]*?\n  image_smoke:/u);
+	const imageSmokeJob = workflow.match(/\n  image_smoke:[\s\S]*?\n  build-and-push:/u);
+	assert.ok(developSmokeJob, "develop smoke job must remain independently inspectable");
+	assert.ok(imageSmokeJob, "image smoke job must remain independently inspectable");
+	assert.match(workflow, /heavy_qualification:[\s\S]*?- image-smoke[\s\S]*?- k3d[\s\S]*?- all/u);
 	assert.match(workflow, /github\.ref == 'refs\/heads\/develop'/u);
 	assert.match(workflow, /run: \.\/apps\/_infra\/deploy-k8s\/platform\/tests\/develop-smoke\.sh/u);
-	assert.match(workflow, /needs: \[prepare, test, develop_smoke\]/u);
+	assert.match(workflow, /inputs\.heavy_qualification == 'k3d'/u);
+	assert.match(workflow, /inputs\.heavy_qualification == 'all'/u);
+	assert.match(workflow, /needs: \[prepare, test, develop_smoke, image_smoke\]/u);
 	assert.match(workflow, /needs\.develop_smoke\.result == 'success'/u);
+	assert.match(workflow, /needs\.image_smoke\.result == 'success'/u);
 	assert.match(workflow, /K3D_LINUX_AMD64_SHA256: [0-9a-f]{64}/u);
 	assert.match(workflow, /sha256sum --check/u);
-	assert.match(smokeJob[0], /uses: actions\/setup-node@v6/u);
-	assert.match(smokeJob[0], /key: node-modules-\$\{\{ runner\.os \}\}-node24-\$\{\{ hashFiles\('package-lock\.json'\) \}\}/u);
-	assert.match(smokeJob[0], /name: Install deploy validation dependencies[\s\S]*?run: npm ci/u);
+	assert.match(developSmokeJob[0], /uses: actions\/setup-node@v6/u);
+	assert.match(
+		developSmokeJob[0],
+		/key: node-modules-\$\{\{ runner\.os \}\}-node24-\$\{\{ hashFiles\('package-lock\.json'\) \}\}/u,
+	);
+	assert.match(developSmokeJob[0], /name: Install deploy validation dependencies[\s\S]*?run: npm ci/u);
+	assert.match(imageSmokeJob[0], /matrix: \$\{\{ fromJSON\(needs\.prepare\.outputs\.image_smokes\) \}\}/u);
+	assert.match(
+		imageSmokeJob[0],
+		/IMAGE_SMOKE_PROJECT: \$\{\{ matrix\.project \}\}[\s\S]*?npx nx run "\$IMAGE_SMOKE_PROJECT:image-smoke"/u,
+	);
 });
 
 test("trusts only an exact develop-to-main promotion source", function _SelectsPromotionSource()

--- a/scripts/affected-deployables.core.mjs
+++ b/scripts/affected-deployables.core.mjs
@@ -44,7 +44,18 @@ export function selectAffectedDeployables(containerProjects)
 		.map(function _Descriptor(project) { return _ReleaseDescriptor(project); });
 }
 
-/** Selects deterministic image-smoke matrix entries, with explicit manual expansion when requested. */
+/**
+ * Selects deterministic image-smoke matrix entries for `scripts/affected-deployables.mjs`.
+ *
+ * Automatic qualification keeps only affected owners. Manual `image-smoke` and `all`
+ * qualification expand the matrix to every project that owns the target; `k3d` does not.
+ *
+ * @param {string[]} affectedProjects Image-smoke owners selected by the affected-project range.
+ * @param {string[]} allProjects Every project that owns an image-smoke target.
+ * @param {string | undefined} heavyQualification Explicit manual heavyweight selector.
+ * @returns {{ project: string }[]} Sorted, de-duplicated GitHub Actions matrix entries.
+ * @throws {Error} When the manual heavyweight selector is not supported.
+ */
 export function selectImageSmokeProjects(affectedProjects, allProjects, heavyQualification)
 {
 	if (heavyQualification && !["none", "image-smoke", "k3d", "all"].includes(heavyQualification))

--- a/scripts/affected-deployables.core.mjs
+++ b/scripts/affected-deployables.core.mjs
@@ -44,6 +44,22 @@ export function selectAffectedDeployables(containerProjects)
 		.map(function _Descriptor(project) { return _ReleaseDescriptor(project); });
 }
 
+/** Selects deterministic image-smoke matrix entries, with explicit manual expansion when requested. */
+export function selectImageSmokeProjects(affectedProjects, allProjects, heavyQualification)
+{
+	if (heavyQualification && !["none", "image-smoke", "k3d", "all"].includes(heavyQualification))
+	{
+		throw new Error(`unsupported FORCE_HEAVY_QUALIFICATION value: ${heavyQualification}`);
+	}
+
+	const selected = heavyQualification === "image-smoke" || heavyQualification === "all"
+		? allProjects
+		: affectedProjects;
+	return [...new Set(selected)]
+		.sort(function _ByName(left, right) { return left.localeCompare(right); })
+		.map(function _MatrixEntry(project) { return { project }; });
+}
+
 /** Determines whether an affected project can change the generated API contract. */
 export function selectApiContractChanged(affectedProjects)
 {

--- a/scripts/affected-deployables.mjs
+++ b/scripts/affected-deployables.mjs
@@ -3,7 +3,14 @@
 import { execFileSync } from "node:child_process";
 import { appendFileSync } from "node:fs";
 
-import { selectAffectedDeployables, selectApiContractChanged, selectDevelopSmokeRequired, selectForcedContainerProjects, selectGuardInputsChanged } from "./affected-deployables.core.mjs";
+import {
+  selectAffectedDeployables,
+  selectApiContractChanged,
+  selectDevelopSmokeRequired,
+  selectForcedContainerProjects,
+  selectGuardInputsChanged,
+  selectImageSmokeProjects,
+} from "./affected-deployables.core.mjs";
 
 /** Run a command and return trimmed stdout. */
 function _run(command, args)
@@ -16,6 +23,12 @@ function _AffectedProjects(target)
 {
   const targetArguments = target ? [`--withTarget=${target}`] : [];
   return JSON.parse(_run("npx", ["nx", "show", "projects", "--affected", ...targetArguments, "--json"]));
+}
+
+/** Lists all NX projects that own a named target. */
+function _Projects(target)
+{
+  return JSON.parse(_run("npx", ["nx", "show", "projects", `--withTarget=${target}`, "--json"]));
 }
 
 function _ContainerProjects()
@@ -55,6 +68,11 @@ if (!base || !head)
 const affectedProjects = _AffectedProjects();
 const affectedContainerProjects = _ContainerProjects();
 const deployables = selectAffectedDeployables(affectedContainerProjects.map(function _Config(project) { return _Project(project); }));
+const imageSmokes = selectImageSmokeProjects(
+  _AffectedProjects("image-smoke"),
+  _Projects("image-smoke"),
+  process.env.FORCE_HEAVY_QUALIFICATION,
+);
 const changedFiles = _run("git", ["diff", "--name-only", base, head]).split("\n").filter(Boolean);
 
 const apiContractChanged = selectApiContractChanged(affectedProjects);
@@ -65,6 +83,8 @@ _output("nx_base", base);
 _output("nx_head", head);
 _output("deployables", JSON.stringify({ include: deployables }));
 _output("has_deployables", String(deployables.length > 0));
+_output("image_smokes", JSON.stringify({ include: imageSmokes }));
+_output("has_image_smokes", String(imageSmokes.length > 0));
 _output("api_contract_changed", String(apiContractChanged));
 _output("develop_smoke_required", String(developSmokeRequired));
 _output("guard_inputs_changed", String(guardInputsChanged));


### PR DESCRIPTION
## Summary

- make GitHub Actions the default owner for container-backed validation and explicitly prohibit agents from starting local VM runtimes unless the user asks
- discover app-owned `image-smoke` targets and run affected owners remotely before image publication
- add a manual `heavy_qualification` selector for `image-smoke`, `k3d`, or `all` remote qualification
- accept both current ClamAV EICAR signature labels while still requiring the malware-detected exit status

## Validation

- final remote all-heavy run: https://github.com/elewa-git/opencrane/actions/runs/31598276381
  - shared build, policy, database convergence, and PostgreSQL authority gate: pass
  - `skill-authoring:image-smoke`: pass
  - `artifact-scanner:image-smoke`: pass
  - current-silo k3d smoke: pass
  - image publication: intentionally skipped
- affected-deployables tests: 10/10
- release-versioning tests: 38/38
- release-versioning, style, module-growth, shell syntax, workflow YAML, and diff gates: pass
- independent fresh-context review: PASS, no remaining findings

## Review topology

- targets `develop` directly and is intentionally independent of open PRs #622 and #623
- shares only the current `develop` base; no overlap with this PR's six changed files
- exact qualified head: `e6a9b26a28b1fadc55709551c947e6bad98555a9`

No local Colima, Docker Desktop, or equivalent VM runtime was started for this work.