### PR TITLE
♻️ Split elicitation permission persistence

### DIFF
--- a/libs/backend/agents/execution/elicitation/main/README.md
+++ b/libs/backend/agents/execution/elicitation/main/README.md
@@ -46,6 +46,10 @@ That unit constructs one repository from the same transaction and reuses it for 
 keeps the run lock, request change, candidate acceptance, and expiry decision in one commit without
 letting a generic function carry a Prisma client across the boundary.
 
+The internal personal-memory payload module owns construction, reconstruction, and receipt matching
+for the protected memory-permission envelope. The Prisma repository supplies the live invocation,
+snapshot, and receipt; the module never opens a transaction or reads remembered facts.
+
 ## Dependency direction
 
 Tagged `scope:execution-elicitation` in the backend layer. It may depend on execution-run,

--- a/libs/backend/agents/execution/elicitation/main/src/personal-memory-permission-payload.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/personal-memory-permission-payload.ts
@@ -6,24 +6,57 @@ import type { JsonValue } from "@opencrane/util";
 import type { PersonalMemoryPermissionPayload } from "./personal-memory-permission-payload.types.js";
 import { _ParsePersonalMemoryPermissionPayload } from "./personal-memory-permission-payload.validator.js";
 
-/** Permission remains actionable for fifteen minutes from invocation admission. */
+/** Adds fifteen minutes to the invocation retry deadline when calculating permission expiry. */
 const _EXTENSION_MILLISECONDS = 10 * 60 * 1_000;
 
-/** Derive the protected permission payload from an exact invocation that is awaiting approval. */
+/**
+ * Builds the personal-memory permission envelope for an invocation that is waiting for approval.
+ *
+ * The envelope retains the invocation revision and the frozen run coordinates so the later receipt
+ * can be tied back to the same request. It returns `null` unless the invocation is still awaiting
+ * approval; callers must then avoid opening a permission request.
+ *
+ * Called by: {@link PrismaElicitationRepository.openMemoryPermission}.
+ * @param invocation - The protected tool invocation that may ask for personal-memory permission.
+ * @param snapshot - The frozen inputs for the invocation's run attempt.
+ * @returns The envelope to persist with the elicitation request, or `null` when it cannot be opened.
+ */
 export function _OpenPersonalMemoryPermissionPayload(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot): PersonalMemoryPermissionPayload | null
 {
 	if (invocation.state !== ToolInvocationStates.AwaitingApproval) return null;
 	return _PayloadAtRevision(invocation, snapshot, invocation.revision);
 }
 
-/** Reconstruct the original protected payload after approval and claim each advanced the revision. */
+/**
+ * Rebuilds the permission envelope that existed before approval and dispatch claim changed its revision.
+ *
+ * Approval and claim each advance the invocation revision, while the receipt records the original
+ * envelope. It returns `null` unless the invocation is claimed with both revisions present, so the
+ * caller must deny verification rather than compare a payload from another state.
+ *
+ * Called by: {@link PrismaElicitationRepository.verifyMemoryPermission}.
+ * @param invocation - The claimed tool invocation whose earlier approval envelope is needed.
+ * @param snapshot - The frozen inputs for the invocation's run attempt.
+ * @returns The original envelope, or `null` when the claimed invocation has no matching history.
+ */
 export function _ClaimedPersonalMemoryPermissionPayload(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot): PersonalMemoryPermissionPayload | null
 {
 	if (invocation.state !== ToolInvocationStates.Claimed || invocation.revision < 2) return null;
 	return _PayloadAtRevision(invocation, snapshot, invocation.revision - 2);
 }
 
-/** Compare a protected request envelope with the receipt that may allow safe memory delivery. */
+/**
+ * Checks whether a persisted request envelope has every coordinate recorded by a permission receipt.
+ *
+ * A receipt is not enough on its own: verification also checks the live dispatch claim and request
+ * state. A malformed envelope or any differing coordinate returns `false`, so the caller denies
+ * delivery instead of treating a partial match as permission.
+ *
+ * Called by: {@link PrismaElicitationRepository.verifyMemoryPermission}.
+ * @param value - The untrusted JSON envelope stored with the elicitation request.
+ * @param receipt - The personal-memory receipt that the request must match.
+ * @returns `true` when the parsed envelope and receipt have identical protected coordinates.
+ */
 export function _PersonalMemoryPurposeMatchesReceipt(value: unknown, receipt: { readonly toolInvocationId: string; readonly toolInvocationRevision: number; readonly runId: string; readonly attempt: number; readonly executionSubjectId: string; readonly queryDigest: string; readonly inputSnapshotDigest: string; readonly personaRevisionId: string; readonly expiresAt: Date }): boolean
 {
 	const payload = _ParsePersonalMemoryPermissionPayload(value);
@@ -39,7 +72,18 @@ export function _PersonalMemoryPurposeMatchesReceipt(value: unknown, receipt: { 
 		&& payload.expiresAt === receipt.expiresAt.toISOString();
 }
 
-/** Bind immutable invocation, execution-user, query, snapshot, persona, and expiry coordinates. */
+/**
+ * Builds a permission envelope from one invocation revision and its frozen run inputs.
+ *
+ * The checks keep a permission tied to the personal-memory recall tool, its execution user, and the
+ * same run, conversation, persona, query, and snapshot. A failed check returns `null` so callers do
+ * not persist an envelope that cannot later be verified.
+ *
+ * @param invocation - The invocation that supplies the tool, run, user, and deadline coordinates.
+ * @param snapshot - The frozen run inputs that supply identity, conversation, persona, and digest.
+ * @param toolInvocationRevision - The invocation revision that the permission envelope represents.
+ * @returns A fully bound envelope, or `null` when the invocation and snapshot do not match.
+ */
 function _PayloadAtRevision(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot, toolInvocationRevision: number): PersonalMemoryPermissionPayload | null
 {
 	const queryDigest = _PersonalMemoryQueryDigest(invocation.effectiveArguments);
@@ -58,7 +102,17 @@ function _PayloadAtRevision(invocation: ToolInvocationRecord, snapshot: RunInput
 	return { toolInvocationId: invocation.id, toolInvocationRevision, runId: invocation.runId, attempt: invocation.attempt, executionSubjectId: invocation.subjectId, queryDigest, inputSnapshotDigest: snapshot.digest, personaRevisionId: snapshot.personaRevisionId, expiresAt: expiresAt.toISOString() };
 }
 
-/** Digest the exact admitted memory query without retaining it in permission persistence. */
+/**
+ * Digests the memory-recall query without storing the query in the permission envelope.
+ *
+ * The digest lets request opening and receipt application compare the same effective arguments while
+ * keeping the query out of permission persistence. It returns `null` when the arguments have no
+ * string `query` field, and callers treat that as an invalid permission request.
+ *
+ * Called by: {@link _PayloadAtRevision} and {@link PrismaElicitationRepository._applyMemoryPermission}.
+ * @param argumentsValue - The effective JSON arguments admitted for the tool invocation.
+ * @returns The query digest, or `null` when the arguments do not contain a string query.
+ */
 export function _PersonalMemoryQueryDigest(argumentsValue: JsonValue): string | null
 {
 	if (!_JsonRecord(argumentsValue)) return null;
@@ -66,7 +120,12 @@ export function _PersonalMemoryQueryDigest(argumentsValue: JsonValue): string | 
 	return typeof query === "string" ? __DigestCanonicalJson(query) : null;
 }
 
-/** Return whether one generic JSON value is a non-array object. */
+/**
+ * Checks whether a JSON value is an object with string keys rather than an array.
+ *
+ * @param value - The JSON value whose shape is checked.
+ * @returns `true` when the value can be read as a JSON record.
+ */
 function _JsonRecord(value: JsonValue): value is { readonly [key: string]: JsonValue }
 {
 	return value !== null && typeof value === "object" && !Array.isArray(value);

--- a/libs/backend/agents/execution/elicitation/main/src/personal-memory-permission-payload.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/personal-memory-permission-payload.ts
@@ -30,9 +30,10 @@ export function _OpenPersonalMemoryPermissionPayload(invocation: ToolInvocationR
 /**
  * Rebuilds the permission envelope that existed before approval and dispatch claim changed its revision.
  *
- * Approval and claim each advance the invocation revision, while the receipt records the original
- * envelope. It returns `null` unless the invocation is claimed with both revisions present, so the
- * caller must deny verification rather than compare a payload from another state.
+ * The elicitation request records the original envelope. Approval records the next revision in the
+ * receipt, and dispatch claim advances it once more. It returns `null` unless the invocation is
+ * claimed with both revisions present, so the caller must deny verification rather than compare a
+ * payload from another state.
  *
  * Called by: {@link PrismaElicitationRepository.verifyMemoryPermission}.
  * @param invocation - The claimed tool invocation whose earlier approval envelope is needed.

--- a/libs/backend/agents/execution/elicitation/main/src/personal-memory-permission-payload.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/personal-memory-permission-payload.ts
@@ -6,7 +6,7 @@ import type { JsonValue } from "@opencrane/util";
 import type { PersonalMemoryPermissionPayload } from "./personal-memory-permission-payload.types.js";
 import { _ParsePersonalMemoryPermissionPayload } from "./personal-memory-permission-payload.validator.js";
 
-/** Adds fifteen minutes to the invocation retry deadline when calculating permission expiry. */
+/** Adds ten minutes to the invocation retry deadline when calculating permission expiry. */
 const _EXTENSION_MILLISECONDS = 10 * 60 * 1_000;
 
 /**

--- a/libs/backend/agents/execution/elicitation/main/src/personal-memory-permission-payload.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/personal-memory-permission-payload.ts
@@ -1,0 +1,73 @@
+import { __DigestCanonicalJson, ToolInvocationStates, type ToolInvocationRecord } from "@opencrane/backend/server/iam/authorization";
+import { RunInputSnapshotIdentityKinds, type RunInputSnapshot } from "@opencrane/contracts";
+import { PERSONAL_MEMORY_RECALL_TOOL_REVISION } from "@opencrane/models/agents";
+import type { JsonValue } from "@opencrane/util";
+
+import type { PersonalMemoryPermissionPayload } from "./personal-memory-permission-payload.types.js";
+import { _ParsePersonalMemoryPermissionPayload } from "./personal-memory-permission-payload.validator.js";
+
+/** Permission remains actionable for fifteen minutes from invocation admission. */
+const _EXTENSION_MILLISECONDS = 10 * 60 * 1_000;
+
+/** Derive the protected permission payload from an exact invocation that is awaiting approval. */
+export function _OpenPersonalMemoryPermissionPayload(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot): PersonalMemoryPermissionPayload | null
+{
+	if (invocation.state !== ToolInvocationStates.AwaitingApproval) return null;
+	return _PayloadAtRevision(invocation, snapshot, invocation.revision);
+}
+
+/** Reconstruct the original protected payload after approval and claim each advanced the revision. */
+export function _ClaimedPersonalMemoryPermissionPayload(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot): PersonalMemoryPermissionPayload | null
+{
+	if (invocation.state !== ToolInvocationStates.Claimed || invocation.revision < 2) return null;
+	return _PayloadAtRevision(invocation, snapshot, invocation.revision - 2);
+}
+
+/** Compare a protected request envelope with the receipt that may allow safe memory delivery. */
+export function _PersonalMemoryPurposeMatchesReceipt(value: unknown, receipt: { readonly toolInvocationId: string; readonly toolInvocationRevision: number; readonly runId: string; readonly attempt: number; readonly executionSubjectId: string; readonly queryDigest: string; readonly inputSnapshotDigest: string; readonly personaRevisionId: string; readonly expiresAt: Date }): boolean
+{
+	const payload = _ParsePersonalMemoryPermissionPayload(value);
+	return payload !== null
+		&& payload.toolInvocationId === receipt.toolInvocationId
+		&& payload.toolInvocationRevision + 1 === receipt.toolInvocationRevision
+		&& payload.runId === receipt.runId
+		&& payload.attempt === receipt.attempt
+		&& payload.executionSubjectId === receipt.executionSubjectId
+		&& payload.queryDigest === receipt.queryDigest
+		&& payload.inputSnapshotDigest === receipt.inputSnapshotDigest
+		&& payload.personaRevisionId === receipt.personaRevisionId
+		&& payload.expiresAt === receipt.expiresAt.toISOString();
+}
+
+/** Bind immutable invocation, execution-user, query, snapshot, persona, and expiry coordinates. */
+function _PayloadAtRevision(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot, toolInvocationRevision: number): PersonalMemoryPermissionPayload | null
+{
+	const queryDigest = _PersonalMemoryQueryDigest(invocation.effectiveArguments);
+	if (invocation.toolRevisionId !== PERSONAL_MEMORY_RECALL_TOOL_REVISION
+		|| snapshot.identitySnapshot.kind !== RunInputSnapshotIdentityKinds.User
+		|| snapshot.identitySnapshot.executionSubjectId !== invocation.subjectId
+		|| snapshot.runId !== invocation.runId
+		|| snapshot.siloId !== invocation.siloId
+		|| snapshot.agentRevisionId !== invocation.agentRevisionId
+		|| snapshot.conversationId === null
+		|| snapshot.conversationId.trim().length === 0
+		|| snapshot.personaRevisionId === null
+		|| snapshot.personaRevisionId.trim().length === 0
+		|| queryDigest === null) return null;
+	const expiresAt = new Date(invocation.retryDeadlineAt.getTime() + _EXTENSION_MILLISECONDS);
+	return { toolInvocationId: invocation.id, toolInvocationRevision, runId: invocation.runId, attempt: invocation.attempt, executionSubjectId: invocation.subjectId, queryDigest, inputSnapshotDigest: snapshot.digest, personaRevisionId: snapshot.personaRevisionId, expiresAt: expiresAt.toISOString() };
+}
+
+/** Digest the exact admitted memory query without retaining it in permission persistence. */
+export function _PersonalMemoryQueryDigest(argumentsValue: JsonValue): string | null
+{
+	if (!_JsonRecord(argumentsValue)) return null;
+	const query = argumentsValue["query"];
+	return typeof query === "string" ? __DigestCanonicalJson(query) : null;
+}
+
+/** Return whether one generic JSON value is a non-array object. */
+function _JsonRecord(value: JsonValue): value is { readonly [key: string]: JsonValue }
+{
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/libs/backend/agents/execution/elicitation/main/src/prisma-elicitation-unit-of-work.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/prisma-elicitation-unit-of-work.ts
@@ -2,7 +2,7 @@ import { AgentRunState, ApprovalRequestState, ElicitationBodyKind, ElicitationPu
 
 import { ___DoWithTrace } from "@opencrane/backend/observability";
 import { __DecideDeferredToolRequest, __DigestCanonicalJson, __ExpireDeferredToolApprovalBatch, DeferredToolDecisionKinds, DeferredToolDecisionOutcomes, PrismaToolInvocationElicitationRepository, ToolInvocationStates, type ToolInvocationClaim, type ToolInvocationElicitationRepository, type ToolInvocationRecord } from "@opencrane/backend/server/iam/authorization";
-import { CONVERSATION_ELICITATION_VERSION, ElicitationBodyKinds, ElicitationPurposes, ElicitationRequestStates, RunInputSnapshotIdentityKinds, type ConversationElicitation, type ElicitationBody, type ElicitationResponseValue, type RunInputSnapshot } from "@opencrane/contracts";
+import { CONVERSATION_ELICITATION_VERSION, ElicitationBodyKinds, ElicitationPurposes, ElicitationRequestStates, type ConversationElicitation, type ElicitationBody, type ElicitationResponseValue, type RunInputSnapshot } from "@opencrane/contracts";
 import { PERSONAL_MEMORY_RECALL_TOOL_REVISION } from "@opencrane/models/agents";
 import type { JsonValue } from "@opencrane/util";
 
@@ -10,11 +10,8 @@ import { _ElicitationStateForResponse, _IsElicitationResponseValid } from "./eli
 import { _ElicitationPurposeStrategies } from "./elicitation-purpose-strategies.js";
 import type { ElicitationPurposeRequest, ElicitationPurposeStrategyRegistry } from "./elicitation-purpose-strategy.types.js";
 import { PersonalMemoryPermissionVerificationOutcomes, type ElicitationRepository, type ElicitationUnitOfWork, type ExpireElicitationBatchCommand, type ExpireElicitationBatchResult, type OpenElicitationCommand, type PersonalMemoryPermissionAuthority, type PersonalMemoryPermissionVerificationResult, type RespondToElicitationCommand, type RespondToElicitationResult } from "./elicitation.types.js";
-import type { PersonalMemoryPermissionPayload } from "./personal-memory-permission-payload.types.js";
+import { _ClaimedPersonalMemoryPermissionPayload, _OpenPersonalMemoryPermissionPayload, _PersonalMemoryPurposeMatchesReceipt, _PersonalMemoryQueryDigest } from "./personal-memory-permission-payload.js";
 import { _ParsePersonalMemoryPermissionPayload } from "./personal-memory-permission-payload.validator.js";
-
-/** Permission remains actionable for fifteen minutes from invocation admission. */
-const _PERSONAL_MEMORY_PERMISSION_EXTENSION_MILLISECONDS = 10 * 60 * 1_000;
 
 /** Prisma repository bound to exactly one serializable elicitation transaction. */
 export class PrismaElicitationRepository implements ElicitationRepository
@@ -74,7 +71,7 @@ export class PrismaElicitationRepository implements ElicitationRepository
 	/** Open or replay one exact personal-memory permission for the execution user. */
 	async openMemoryPermission(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot, now: Date): Promise<boolean>
 	{
-		const payload = _MemoryPermissionPayload(invocation, snapshot);
+		const payload = _OpenPersonalMemoryPermissionPayload(invocation, snapshot);
 		if (payload === null) return false;
 		const body = { kind: ElicitationBodyKinds.Approval, prompt: "Allow this agent to use your personal memory for this answer?", action: "Use personal memory", target: "Your saved memory", dataUse: "Use remembered facts only for this answer", consequence: "The agent will answer this request using relevant saved memory" } as const;
 		const opened = await this.open({
@@ -99,7 +96,7 @@ export class PrismaElicitationRepository implements ElicitationRepository
 	/** Verify an accepted exact receipt without consuming it or reading personal-memory content. */
 	async verifyMemoryPermission(invocation: ToolInvocationRecord, claim: ToolInvocationClaim, snapshot: RunInputSnapshot, now: Date): Promise<PersonalMemoryPermissionVerificationResult>
 	{
-		const expectedPayload = _MemoryPermissionPayloadForClaimedInvocation(invocation, snapshot);
+		const expectedPayload = _ClaimedPersonalMemoryPermissionPayload(invocation, snapshot);
 		if (expectedPayload === null || !await this._toolInvocations.verifyActiveDispatchClaim(invocation, claim, now)) return { outcome: PersonalMemoryPermissionVerificationOutcomes.Denied };
 		const receipt = await this._transaction.personalMemoryPermissionReceipt.findUnique({ where: { toolInvocationId: invocation.id }, include: { request: true } });
 		if (receipt === null) return { outcome: PersonalMemoryPermissionVerificationOutcomes.Denied };
@@ -120,7 +117,7 @@ export class PrismaElicitationRepository implements ElicitationRepository
 			&& request.assignedParticipantId === invocation.subjectId
 			&& request.resolvedBy === invocation.subjectId
 			&& request.purposePayloadDigest === receipt.purposeDigest
-			&& _MemoryPurposeMatchesReceipt(request.purposePayload, receipt);
+			&& _PersonalMemoryPurposeMatchesReceipt(request.purposePayload, receipt);
 		return { outcome: matches ? PersonalMemoryPermissionVerificationOutcomes.Authorized : PersonalMemoryPermissionVerificationOutcomes.Denied };
 	}
 
@@ -241,7 +238,7 @@ export class PrismaElicitationRepository implements ElicitationRepository
 			&& invocation.subjectId === subjectId
 			&& request.assignedParticipantId === subjectId
 			&& payload.executionSubjectId === subjectId
-			&& payload.queryDigest === _QueryDigest(invocation.effectiveArguments as unknown as JsonValue)
+			&& payload.queryDigest === _PersonalMemoryQueryDigest(invocation.effectiveArguments as unknown as JsonValue)
 			&& payload.inputSnapshotDigest === snapshot.digest
 			&& payload.personaRevisionId === snapshot.personaRevisionId
 			&& payload.expiresAt === request.expiresAt.toISOString()
@@ -446,69 +443,6 @@ function _PublicState(state: ElicitationRequestState): ElicitationRequestStates
 
 /** Whether one protected purpose payload is a non-array JSON record. */
 function _Record(value: unknown): value is { readonly [key: string]: JsonValue }
-{
-	return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-/** Derive the protected permission payload only from an exact awaiting invocation and snapshot. */
-function _MemoryPermissionPayload(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot): PersonalMemoryPermissionPayload | null
-{
-	if (invocation.state !== ToolInvocationStates.AwaitingApproval) return null;
-	return _MemoryPermissionPayloadAtRevision(invocation, snapshot, invocation.revision);
-}
-
-/** Reconstruct the original protected payload after approval and claim advanced two revisions. */
-function _MemoryPermissionPayloadForClaimedInvocation(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot): PersonalMemoryPermissionPayload | null
-{
-	if (invocation.state !== ToolInvocationStates.Claimed || invocation.revision < 2) return null;
-	return _MemoryPermissionPayloadAtRevision(invocation, snapshot, invocation.revision - 2);
-}
-
-/** Bind immutable invocation, execution-user, query, snapshot, persona, and expiry coordinates. */
-function _MemoryPermissionPayloadAtRevision(invocation: ToolInvocationRecord, snapshot: RunInputSnapshot, toolInvocationRevision: number): PersonalMemoryPermissionPayload | null
-{
-	const queryDigest = _QueryDigest(invocation.effectiveArguments);
-	if (invocation.toolRevisionId !== PERSONAL_MEMORY_RECALL_TOOL_REVISION
-		|| snapshot.identitySnapshot.kind !== RunInputSnapshotIdentityKinds.User
-		|| snapshot.identitySnapshot.executionSubjectId !== invocation.subjectId
-		|| snapshot.runId !== invocation.runId
-		|| snapshot.siloId !== invocation.siloId
-		|| snapshot.agentRevisionId !== invocation.agentRevisionId
-		|| snapshot.conversationId === null
-		|| snapshot.conversationId.trim().length === 0
-		|| snapshot.personaRevisionId === null
-		|| snapshot.personaRevisionId.trim().length === 0
-		|| queryDigest === null) return null;
-	const expiresAt = new Date(invocation.retryDeadlineAt.getTime() + _PERSONAL_MEMORY_PERMISSION_EXTENSION_MILLISECONDS);
-	return { toolInvocationId: invocation.id, toolInvocationRevision, runId: invocation.runId, attempt: invocation.attempt, executionSubjectId: invocation.subjectId, queryDigest, inputSnapshotDigest: snapshot.digest, personaRevisionId: snapshot.personaRevisionId, expiresAt: expiresAt.toISOString() };
-}
-
-/** Digest the exact admitted memory query without retaining it in permission persistence. */
-function _QueryDigest(argumentsValue: JsonValue): string | null
-{
-	if (!_JsonRecord(argumentsValue)) return null;
-	const query = argumentsValue["query"];
-	return typeof query === "string" ? __DigestCanonicalJson(query) : null;
-}
-
-/** Compare the hidden purpose envelope with the receipt that may authorize safe delivery. */
-function _MemoryPurposeMatchesReceipt(value: Prisma.JsonValue | null, receipt: { toolInvocationId: string; toolInvocationRevision: number; runId: string; attempt: number; executionSubjectId: string; queryDigest: string; inputSnapshotDigest: string; personaRevisionId: string; expiresAt: Date }): boolean
-{
-	const payload = _ParsePersonalMemoryPermissionPayload(value);
-	return payload !== null
-		&& payload.toolInvocationId === receipt.toolInvocationId
-		&& payload.toolInvocationRevision + 1 === receipt.toolInvocationRevision
-		&& payload.runId === receipt.runId
-		&& payload.attempt === receipt.attempt
-		&& payload.executionSubjectId === receipt.executionSubjectId
-		&& payload.queryDigest === receipt.queryDigest
-		&& payload.inputSnapshotDigest === receipt.inputSnapshotDigest
-		&& payload.personaRevisionId === receipt.personaRevisionId
-		&& payload.expiresAt === receipt.expiresAt.toISOString();
-}
-
-/** Whether one generic JSON value is a non-array object. */
-function _JsonRecord(value: JsonValue): value is { readonly [key: string]: JsonValue }
 {
 	return value !== null && typeof value === "object" && !Array.isArray(value);
 }


### PR DESCRIPTION
## Summary
- split protected personal-memory permission payload construction from the Prisma unit of work
- preserve the merged #604 transaction semantics while removing the module-growth failure
- document the new internal ownership boundary
## Validation
- elicitation lint
- focused unit test (15 passing)
- Prisma boundary and module-growth checks
- style, release-versioning, and diff checks
## Review
- Corrective follow-up to merged #623; no schema or API change.