### PR TITLE
📝 Calibrate the comments gate so a pass cannot double a file

### DIFF
--- a/.agents/skills/comments/SKILL.md
+++ b/.agents/skills/comments/SKILL.md
@@ -71,13 +71,65 @@ Hold on to its distinctions:
 - Keep a term that names something real in the code — a field, an enum member, a state, a
   standard's own name. Grep before you delete a word. Precision beats plainness, and you
   never trade away accuracy to sound simpler.
-- Exported declarations get heavy documentation: what it does, why you hit it, what each
-  outcome means for the caller, `Called by:`, and the tags. A one-line label on an
-  exported function is a finding.
+- Exported declarations get real documentation rather than a label: what it does, why you
+  hit it, and what each outcome means for the caller. A one-line label on an exported
+  function is a finding — but see the length rules below, because the opposite mistake is
+  just as real.
 - Enums get the most care of anything, documented as the state a reader is about to branch
   on.
 - External specs and third-party services get a `@see` with a URI. Link the pinned
   revision, never invent a URL, and confirm it resolves before you commit it.
+
+## Say it once, in the place that owns it
+
+This is the rule that keeps a documentation pass from doubling a file. Each fact has one home:
+the port carries what an implementer owes, the enum carries what each state means, the
+boundary file carries the trust rule. Everywhere else **points** with `@see` or `{@link}`
+instead of restating it.
+
+Re-explaining a neighbour is how volume explodes: with N declarations each carrying the
+whole subsystem's context, you write the subsystem N times and every copy can drift
+separately. A forty-line block on an injection token that repeats its interface, its error
+enum, and its store's behaviour is a worked example of the failure — the content was true
+and still wrong to put there.
+
+Before you write a paragraph, ask where it belongs. If the answer is another declaration,
+write it there and link.
+
+## Length follows consequence
+
+Depth is earned by what a reader loses if they get it wrong, not by whether something is
+exported. Three tiers:
+
+- **A paragraph or more** — enums and status unions someone will branch on, persist, or
+  compare across versions; ports another team implements; security, consent, and
+  transaction boundaries. These are where a wrong assumption is expensive.
+- **One to three sentences** — ordinary exported functions, classes, and components. What
+  it does, the one thing a caller would otherwise get wrong, and stop.
+- **One line** — properties, fields, config entries, barrels. The repo standard asks for
+  *coverage* here, not prose: a property whose name and type already say it needs a short
+  line, not a story. `id: string` needs almost nothing.
+
+Two things stay conditional rather than automatic:
+
+- **`Called by:`** earns its place when the caller explains the *why*, or when callers are
+  genuinely hard to find. On a symbol with obvious local callers it is noise that goes stale.
+- **Numbered step comments** are for steps whose *order* is load-bearing — this must happen
+  before that, or the guarantee breaks. A three-statement function whose order is obvious
+  does not need them.
+
+**Sanity check before you finish.** Compare comment lines to code lines per file. A file
+where comments outnumber code is usually telling you something is misplaced, repeated, or
+padded — go back and cut rather than rationalising it. A two-line barrel does not carry a
+twenty-line essay.
+
+Very small modules are the honest exception. A file holding one constant that exists for a
+non-obvious reason will be mostly comment whatever you do, and that is fine: judge those by
+whether any single sentence could go, not by the ratio. The ratio is a smell test for files
+with real code in them, not a target to hit.
+
+Either way, aim to leave a file more readable, not longer: if a reader would skip your block
+to reach the code, it failed.
 
 ## Match the language's own convention
 
@@ -141,7 +193,9 @@ label passes that script today and still fails this gate.
   needs a decision you cannot make.
 - **OUT-OF-SCOPE** — comment debt you noticed outside the slice. One line each. Do not fix
   it here.
-- **Verification** — the code-unchanged proof and the build/test/lint results.
+- **Verification** — the code-unchanged proof, the build/test/lint results, and the
+  comment-to-code ratio of the files you touched, so the caller can see whether the pass
+  stayed proportionate.
 - **Verdict** — **PASS** when every changed export and non-obvious guard either carries a
   grounded comment or appears in ASK. **BLOCK** when a comment in the slice is actively
   wrong and you could not correct it.

--- a/.claude/agents/comments.md
+++ b/.claude/agents/comments.md
@@ -71,13 +71,65 @@ Hold on to its distinctions:
 - Keep a term that names something real in the code — a field, an enum member, a state, a
   standard's own name. Grep before you delete a word. Precision beats plainness, and you
   never trade away accuracy to sound simpler.
-- Exported declarations get heavy documentation: what it does, why you hit it, what each
-  outcome means for the caller, `Called by:`, and the tags. A one-line label on an
-  exported function is a finding.
+- Exported declarations get real documentation rather than a label: what it does, why you
+  hit it, and what each outcome means for the caller. A one-line label on an exported
+  function is a finding — but see the length rules below, because the opposite mistake is
+  just as real.
 - Enums get the most care of anything, documented as the state a reader is about to branch
   on.
 - External specs and third-party services get a `@see` with a URI. Link the pinned
   revision, never invent a URL, and confirm it resolves before you commit it.
+
+## Say it once, in the place that owns it
+
+This is the rule that keeps a documentation pass from doubling a file. Each fact has one home:
+the port carries what an implementer owes, the enum carries what each state means, the
+boundary file carries the trust rule. Everywhere else **points** with `@see` or `{@link}`
+instead of restating it.
+
+Re-explaining a neighbour is how volume explodes: with N declarations each carrying the
+whole subsystem's context, you write the subsystem N times and every copy can drift
+separately. A forty-line block on an injection token that repeats its interface, its error
+enum, and its store's behaviour is a worked example of the failure — the content was true
+and still wrong to put there.
+
+Before you write a paragraph, ask where it belongs. If the answer is another declaration,
+write it there and link.
+
+## Length follows consequence
+
+Depth is earned by what a reader loses if they get it wrong, not by whether something is
+exported. Three tiers:
+
+- **A paragraph or more** — enums and status unions someone will branch on, persist, or
+  compare across versions; ports another team implements; security, consent, and
+  transaction boundaries. These are where a wrong assumption is expensive.
+- **One to three sentences** — ordinary exported functions, classes, and components. What
+  it does, the one thing a caller would otherwise get wrong, and stop.
+- **One line** — properties, fields, config entries, barrels. The repo standard asks for
+  *coverage* here, not prose: a property whose name and type already say it needs a short
+  line, not a story. `id: string` needs almost nothing.
+
+Two things stay conditional rather than automatic:
+
+- **`Called by:`** earns its place when the caller explains the *why*, or when callers are
+  genuinely hard to find. On a symbol with obvious local callers it is noise that goes stale.
+- **Numbered step comments** are for steps whose *order* is load-bearing — this must happen
+  before that, or the guarantee breaks. A three-statement function whose order is obvious
+  does not need them.
+
+**Sanity check before you finish.** Compare comment lines to code lines per file. A file
+where comments outnumber code is usually telling you something is misplaced, repeated, or
+padded — go back and cut rather than rationalising it. A two-line barrel does not carry a
+twenty-line essay.
+
+Very small modules are the honest exception. A file holding one constant that exists for a
+non-obvious reason will be mostly comment whatever you do, and that is fine: judge those by
+whether any single sentence could go, not by the ratio. The ratio is a smell test for files
+with real code in them, not a target to hit.
+
+Either way, aim to leave a file more readable, not longer: if a reader would skip your block
+to reach the code, it failed.
 
 ## Match the language's own convention
 
@@ -141,7 +193,9 @@ label passes that script today and still fails this gate.
   needs a decision you cannot make.
 - **OUT-OF-SCOPE** — comment debt you noticed outside the slice. One line each. Do not fix
   it here.
-- **Verification** — the code-unchanged proof and the build/test/lint results.
+- **Verification** — the code-unchanged proof, the build/test/lint results, and the
+  comment-to-code ratio of the files you touched, so the caller can see whether the pass
+  stayed proportionate.
 - **Verdict** — **PASS** when every changed export and non-obvious guard either carries a
   grounded comment or appears in ASK. **BLOCK** when a comment in the slice is actively
   wrong and you could not correct it.

--- a/.codex/agents/comments.toml
+++ b/.codex/agents/comments.toml
@@ -59,13 +59,65 @@ Hold on to its distinctions:
 - Keep a term that names something real in the code — a field, an enum member, a state, a
   standard's own name. Grep before you delete a word. Precision beats plainness, and you
   never trade away accuracy to sound simpler.
-- Exported declarations get heavy documentation: what it does, why you hit it, what each
-  outcome means for the caller, `Called by:`, and the tags. A one-line label on an
-  exported function is a finding.
+- Exported declarations get real documentation rather than a label: what it does, why you
+  hit it, and what each outcome means for the caller. A one-line label on an exported
+  function is a finding — but see the length rules below, because the opposite mistake is
+  just as real.
 - Enums get the most care of anything, documented as the state a reader is about to branch
   on.
 - External specs and third-party services get a `@see` with a URI. Link the pinned
   revision, never invent a URL, and confirm it resolves before you commit it.
+
+## Say it once, in the place that owns it
+
+This is the rule that keeps a documentation pass from doubling a file. Each fact has one home:
+the port carries what an implementer owes, the enum carries what each state means, the
+boundary file carries the trust rule. Everywhere else **points** with `@see` or `{@link}`
+instead of restating it.
+
+Re-explaining a neighbour is how volume explodes: with N declarations each carrying the
+whole subsystem's context, you write the subsystem N times and every copy can drift
+separately. A forty-line block on an injection token that repeats its interface, its error
+enum, and its store's behaviour is a worked example of the failure — the content was true
+and still wrong to put there.
+
+Before you write a paragraph, ask where it belongs. If the answer is another declaration,
+write it there and link.
+
+## Length follows consequence
+
+Depth is earned by what a reader loses if they get it wrong, not by whether something is
+exported. Three tiers:
+
+- **A paragraph or more** — enums and status unions someone will branch on, persist, or
+  compare across versions; ports another team implements; security, consent, and
+  transaction boundaries. These are where a wrong assumption is expensive.
+- **One to three sentences** — ordinary exported functions, classes, and components. What
+  it does, the one thing a caller would otherwise get wrong, and stop.
+- **One line** — properties, fields, config entries, barrels. The repo standard asks for
+  *coverage* here, not prose: a property whose name and type already say it needs a short
+  line, not a story. `id: string` needs almost nothing.
+
+Two things stay conditional rather than automatic:
+
+- **`Called by:`** earns its place when the caller explains the *why*, or when callers are
+  genuinely hard to find. On a symbol with obvious local callers it is noise that goes stale.
+- **Numbered step comments** are for steps whose *order* is load-bearing — this must happen
+  before that, or the guarantee breaks. A three-statement function whose order is obvious
+  does not need them.
+
+**Sanity check before you finish.** Compare comment lines to code lines per file. A file
+where comments outnumber code is usually telling you something is misplaced, repeated, or
+padded — go back and cut rather than rationalising it. A two-line barrel does not carry a
+twenty-line essay.
+
+Very small modules are the honest exception. A file holding one constant that exists for a
+non-obvious reason will be mostly comment whatever you do, and that is fine: judge those by
+whether any single sentence could go, not by the ratio. The ratio is a smell test for files
+with real code in them, not a target to hit.
+
+Either way, aim to leave a file more readable, not longer: if a reader would skip your block
+to reach the code, it failed.
 
 ## Match the language's own convention
 
@@ -129,7 +181,9 @@ label passes that script today and still fails this gate.
   needs a decision you cannot make.
 - **OUT-OF-SCOPE** — comment debt you noticed outside the slice. One line each. Do not fix
   it here.
-- **Verification** — the code-unchanged proof and the build/test/lint results.
+- **Verification** — the code-unchanged proof, the build/test/lint results, and the
+  comment-to-code ratio of the files you touched, so the caller can see whether the pass
+  stayed proportionate.
 - **Verdict** — **PASS** when every changed export and non-obvious guard either carries a
   grounded comment or appears in ASK. **BLOCK** when a comment in the slice is actively
   wrong and you could not correct it.


### PR DESCRIPTION
## Outcome

- stop a documentation pass from restating a subsystem once per declaration, by giving each fact one home and pointing at it from everywhere else
- scale comment length to what a reader loses by getting it wrong, rather than to whether a symbol is exported
- make `Called by:` and numbered step comments conditional instead of automatic
- require a comment-to-code ratio in the agent's report, so a disproportionate pass is visible before it lands rather than after

Follows #636, which added the `comments` agent and is now merged.

## Why

The agent from #636 was run over four stacked PRs (623, 629, 630, 631) and documented 89 files. Measured afterwards:

| | |
|---|---|
| median comment lines per line of code | **2.19** |
| files where comments outnumber code | **55 of 77** |
| worst ratio | **14.8:1** — 74 comment lines over 5 lines of code |

The worst case was a forty-line JSDoc on a one-line `new InjectionToken(...)` that re-explained the interface it links to, the error enum it links to, and the calling store's behaviour. **The content was accurate; putting it there was the mistake.** With every declaration carrying the whole subsystem's context, a pass writes the subsystem N times and each copy is free to drift separately.

A two-line barrel picked up a twenty-line essay. `conversation-workspace.validator.ts` reached 220 comment lines against 60 of code.

## What changes

**"Say it once, in the place that owns it."** The port carries what an implementer owes, the enum carries what each state means, the boundary file carries the trust rule. Everywhere else points with `@see` or `{@link}`. Before writing a paragraph, ask where it belongs; if the answer is another declaration, write it there and link.

**"Length follows consequence."** Three tiers:

| Depth | Applies to |
|---|---|
| A paragraph or more | enums and status unions someone will branch on, persist, or compare across versions; ports another team implements; security, consent and transaction boundaries |
| One to three sentences | ordinary exported functions, classes and components |
| One line | properties, fields, config entries, barrels — the repo standard asks for *coverage* here, not prose |

**Conditional, not automatic:** `Called by:` earns its place when the caller explains the *why* or callers are hard to find — on a symbol with obvious local callers it is noise that goes stale. Numbered step comments are for steps whose *order* is load-bearing, not for any function with three statements.

**A ratio check before finishing**, and the ratio reported back, so the next pass is measurable rather than discovered late.

## What this does not change

The standard in `docs/agents/typescript.md#comment-language` is untouched, and so is the agent's core rule — evidence or a question, never a plausible why. This is calibration of *how much*, not of *what counts as grounded*. A one-line label on an exported function is still a finding; the point is that the opposite mistake is equally real.

## Validation

- three surfaces regenerated from the single source: `.codex/agents/comments.toml` parses via `tomllib` and its body byte-matches the Claude definition; `.agents/skills/comments/SKILL.md` is `diff`-clean against it
- rebased onto `develop` after #636 merged; no change to `AGENTS.md`, the hooks, or the gate wiring, which landed there

## Follow-up

Trimming the 89 already-documented files is tracked separately. The offenders are concentrated: 12 files above 3:1, 43 between 1:1 and 3:1, 22 below 1:1.