### PR TITLE
📝 Cut the agent-runtime comments back to proportion

### DIFF
--- a/apps/agent-runtime/src/attempts/pending_result_lock.py
+++ b/apps/agent-runtime/src/attempts/pending_result_lock.py
@@ -1,17 +1,12 @@
 """Holds the lock that guards both pending-result registries.
 
-One resume command can carry saved tool results, saved participant answers, or both. Those two kinds
-live in separate registries (``pending_tools`` and ``pending_elicitations``), but a resume has to
-check and empty both of them as a single step. They therefore share this lock instead of taking one
-each: with two locks, a second resume arriving at the same moment could see the tool calls already
-taken while the questions were still waiting, and resume the model with half an answer set.
-
-The lock sits in its own module so both registries can import it without importing each other.
+A resume can carry saved tool results and saved participant answers, and has to check and empty both
+registries as one step — so they share this lock rather than taking one each. The lock lives in its
+own module so ``pending_tools`` and ``pending_elicitations`` can use it without importing each other.
 """
 
 import threading
 
 
-# Re-entrant because one caller holds this lock while calling helpers that take it again. A plain
-# Lock would deadlock on the second acquire.
+# Re-entrant: a caller holds this while calling helpers that take it again.
 PENDING_RESULT_LOCK = threading.RLock()

--- a/apps/agent-runtime/src/attempts/pending_tools.py
+++ b/apps/agent-runtime/src/attempts/pending_tools.py
@@ -14,12 +14,10 @@ from .pending_result_lock import PENDING_RESULT_LOCK
 # Upper bound on simultaneously pending proposed calls; a run beyond this is already pathological.
 _MAX_PENDING_TOOL_CALLS = 256
 
-# Looking up and removing are separate functions so that one caller can hold the shared lock across
-# both this registry and the questions registry, and treat the pair as a single step. Do not rely on
-# the GIL for that: it does not make a lookup and a delete one operation, and the stream and the worker
-# can run on different threads.
-# Keys include run and attempt so a provider-chosen call id cannot alias a call from another fenced
-# execution. Stored values are model-loop correlation data, never approval or execution receipts.
+# Looking up and removing are separate so one caller can hold the shared lock across this registry and
+# the questions registry and treat the pair as one step. The GIL does not make a lookup and a delete one
+# operation, and the stream and the worker run on different threads.
+# Keys include run and attempt so a provider-chosen call id cannot alias a call from another attempt.
 _PENDING: dict[tuple[str, int, str], dict[str, object]] = {}
 
 
@@ -36,29 +34,22 @@ def record_pending_tool_call(
     invocation instead of this registry growing without limit.
     """
     with PENDING_RESULT_LOCK:
-        # Capacity is checked while holding the same lock as insertion. Concurrent proposals cannot
-        # both observe free capacity and push the process registry past its defensive ceiling.
+        # Checked under the insert's own lock, so two proposals cannot both find room.
         if len(_PENDING) >= _MAX_PENDING_TOOL_CALLS:
             return
-        # Below the ceiling, re-recording the same composite identity replaces only ephemeral
-        # correlation data. Durable idempotency and action execution remain control-plane concerns.
         _PENDING[(run_id, attempt, tool_invocation_id)] = {"toolName": tool_name, "arguments": arguments}
 
 
 def peek_pending_tool_calls(run_id: str, attempt: int, tool_invocation_ids: list[str]) -> dict[str, dict[str, object]] | None:
     """Look up the calls a resume names, without removing them.
 
-    The caller must already hold ``PENDING_RESULT_LOCK``, because it also checks the questions in the
-    same resume and both lookups have to describe the same moment. Nothing is removed here, so a resume
-    rejected for some other reason leaves this registry as it was and the server can send the same
-    command again.
-
-    Called by: ``resolve_resume_results`` in ``resume_results.py``.
+    The caller must already hold ``PENDING_RESULT_LOCK``: it checks the questions registry in the same
+    resume, and both lookups have to describe the same moment. Removing nothing here is what lets a
+    resume rejected for some other reason be sent again.
 
     Returns:
-        The matching entries, keyed by invocation id. ``None`` when an id is repeated, or when any id
-        was not proposed by this attempt — in that case no id in the batch counts as found, and calls
-        belonging to a different resume are left where they are.
+        The matching entries, keyed by invocation id. ``None`` if an id repeats or was not proposed by
+        this attempt, in which case none of the batch counts as found.
     """
     keys = [(run_id, attempt, tool_invocation_id) for tool_invocation_id in tool_invocation_ids]
     if len(keys) != len(set(keys)) or any(key not in _PENDING for key in keys):
@@ -69,16 +60,11 @@ def peek_pending_tool_calls(run_id: str, attempt: int, tool_invocation_ids: list
 def consume_pending_tool_calls(run_id: str, attempt: int, tool_invocation_ids: list[str]) -> None:
     """Remove calls that ``peek_pending_tool_calls`` has already found.
 
-    Call this only after that lookup succeeded while holding the same lock, and never on its own. The
-    deletes below assume every id is present.
-
-    Removing the ids is what stops one result being used twice. Because the caller still holds the lock
-    it took for the lookup, no second resume can slip in between the two steps.
-
-    Called by: ``resolve_resume_results`` in ``resume_results.py``.
+    Call this only after that lookup succeeded under the same held lock — the deletes assume every id is
+    present. Removing them under that lock is what stops one result being used twice.
 
     Raises:
-        KeyError: When an id is not in the registry, which means the caller skipped the lookup.
+        KeyError: When an id is missing, which means the caller skipped the lookup.
     """
     for tool_invocation_id in tool_invocation_ids:
         del _PENDING[(run_id, attempt, tool_invocation_id)]


### PR DESCRIPTION
## Outcome

- bring the two worst-proportioned files from the elicitation comment pass back in line: `pending_result_lock.py` from 8 comment lines per line of code to 5.5, `pending_tools.py` from 3.5 to 2.7
- keep every reason a reader cannot get from the code; drop the repeats and the padding

Applies the calibration in #638 to the files that already merged with #623.

## What was wrong

The comment pass on #623 was measured afterwards at a median of 2.19 comment lines per line of code. These two files were the Python offenders:

- **`pending_result_lock.py`** stated the shared-lock rationale twice — once in the module docstring, then again beside the constant.
- **`pending_tools.py`** carried `Called by:` pointers to the same single caller on three separate docstrings, plus prose restating what the signatures already say.

## What is kept

Every *why* that is not recoverable from the code:

- why the two registries share one lock rather than taking one each
- why the lock is re-entrant
- why looking up and removing are separate functions
- why the GIL does not make a lookup-and-delete atomic
- why removing under the caller's held lock is what stops a result reaching the model twice

## A note on the ratio

`pending_result_lock.py` is still 5.5:1 and that is correct. It holds two lines of code — an import and a constant — so it cannot reach 1:1 and still explain why it exists. #638 was amended to say this explicitly: the ratio is a smell test for files with real code in them, not a target, and a very small module that exists for one non-obvious reason will be mostly comment.

## Validation

- comments only: the AST of both files with docstrings stripped is **identical** before and after
- `python3 -B -m unittest discover -s tests` in `apps/agent-runtime`: 127 passed, 10 skipped
- the repo's lint/build target for the app (`ast.parse` over every `src/**/*.py`) passes