### PR TITLE
📝 Stop the comment ratio rule misreading declaration-dense files

### DIFF
--- a/.agents/skills/comments/SKILL.md
+++ b/.agents/skills/comments/SKILL.md
@@ -123,10 +123,12 @@ where comments outnumber code is usually telling you something is misplaced, rep
 padded — go back and cut rather than rationalising it. A two-line barrel does not carry a
 twenty-line essay.
 
-Very small modules are the honest exception. A file holding one constant that exists for a
-non-obvious reason will be mostly comment whatever you do, and that is fine: judge those by
-whether any single sentence could go, not by the ratio. The ratio is a smell test for files
-with real code in them, not a target to hit.
+Two things make that number lie, and neither is a reason to keep padding. A file holding one
+constant that exists for a non-obvious reason will be mostly comment whatever you do. And a
+file of one-line declarations has a floor built in, because every JSDoc block spends three
+lines on `/**`, ` *` and ` */` before it says anything. In both cases judge by the prose: ask
+whether any single sentence could go, and ignore the ratio. It is a smell test for files with
+real code in them, not a target to hit.
 
 Either way, aim to leave a file more readable, not longer: if a reader would skip your block
 to reach the code, it failed.

--- a/.claude/agents/comments.md
+++ b/.claude/agents/comments.md
@@ -123,10 +123,12 @@ where comments outnumber code is usually telling you something is misplaced, rep
 padded — go back and cut rather than rationalising it. A two-line barrel does not carry a
 twenty-line essay.
 
-Very small modules are the honest exception. A file holding one constant that exists for a
-non-obvious reason will be mostly comment whatever you do, and that is fine: judge those by
-whether any single sentence could go, not by the ratio. The ratio is a smell test for files
-with real code in them, not a target to hit.
+Two things make that number lie, and neither is a reason to keep padding. A file holding one
+constant that exists for a non-obvious reason will be mostly comment whatever you do. And a
+file of one-line declarations has a floor built in, because every JSDoc block spends three
+lines on `/**`, ` *` and ` */` before it says anything. In both cases judge by the prose: ask
+whether any single sentence could go, and ignore the ratio. It is a smell test for files with
+real code in them, not a target to hit.
 
 Either way, aim to leave a file more readable, not longer: if a reader would skip your block
 to reach the code, it failed.

--- a/.codex/agents/comments.toml
+++ b/.codex/agents/comments.toml
@@ -111,10 +111,12 @@ where comments outnumber code is usually telling you something is misplaced, rep
 padded — go back and cut rather than rationalising it. A two-line barrel does not carry a
 twenty-line essay.
 
-Very small modules are the honest exception. A file holding one constant that exists for a
-non-obvious reason will be mostly comment whatever you do, and that is fine: judge those by
-whether any single sentence could go, not by the ratio. The ratio is a smell test for files
-with real code in them, not a target to hit.
+Two things make that number lie, and neither is a reason to keep padding. A file holding one
+constant that exists for a non-obvious reason will be mostly comment whatever you do. And a
+file of one-line declarations has a floor built in, because every JSDoc block spends three
+lines on `/**`, ` *` and ` */` before it says anything. In both cases judge by the prose: ask
+whether any single sentence could go, and ignore the ratio. It is a smell test for files with
+real code in them, not a target to hit.
 
 Either way, aim to leave a file more readable, not longer: if a reader would skip your block
 to reach the code, it failed.


### PR DESCRIPTION
## Outcome

- keep the ratio check in #638 from flagging files that are already proportionate
- fold the fix into the small-module exception that #638 added, so the two cases read as one rule rather than a list of exemptions

## Why

#638 added a sanity check: compare comment lines to code lines, and treat a file with more comment than code as a signal to cut. Applying it to the four PRs the gate had documented showed it firing on files that were already fine.

A file of one-line declarations has a floor built into the syntax. Every JSDoc block spends three lines on `/**`, ` *` and ` */` before it says anything, so N declarations cost 3N lines before a single word of prose. The injection-token file that triggered this sat at 3.6:1 — which sounds bad, and is actually two blocks of three prose lines each with a couple of `@see` tags.

#638 already carved out the other case, a very small module whose one constant needs a reason. Both are the same underlying point, so they now read as one rule instead of accumulating as separate exemptions.

## What changes

One paragraph, in all three harness surfaces. The rule is now: judge by the prose, ask whether any single sentence could go, and treat the ratio as a smell test for files with real code in them rather than a target to hit.

Nothing else moves. The tiers, the "say it once" rule, and the evidence-or-a-question rule are untouched.

## Validation

- three surfaces regenerated from the single source: `.codex/agents/comments.toml` parses via `tomllib` and its body byte-matches the Claude definition; `.agents/skills/comments/SKILL.md` is `diff`-clean against it
- rebased onto `develop` after #638 merged; the conflict was that same paragraph, resolved in favour of the combined wording

## Provenance

This came out of the gate reviewing its own output: the agent documented 89 files, measuring showed a median of 2.19 comment lines per line of code, #638 calibrated for that, applying the calibration cut 178 lines from six files on one PR, and trimming those exposed the two ways the ratio misreads. Related trims: #640 and the commits on the 629/630/631 branches.