### PR TITLE
🐛 Restore develop style baseline

### DIFF
--- a/libs/backend/server/agents/scheduling/main/src/cron-schedule.ts
+++ b/libs/backend/server/agents/scheduling/main/src/cron-schedule.ts
@@ -36,7 +36,18 @@ function _parseField(field: string, min: number, max: number): Set<number> | nul
 			const bounds = rangePart.split("-");
 			if (bounds.length > 2 || bounds.some(part => !/^[0-9]+$/.test(part))) return null;
 			low = Number(bounds[0]);
-			high = bounds.length === 2 ? Number(bounds[1]) : (term.includes("/") ? max : low);
+			if (bounds.length === 2)
+			{
+				high = Number(bounds[1]);
+			}
+			else if (term.includes("/"))
+			{
+				high = max;
+			}
+			else
+			{
+				high = low;
+			}
 			if (low < min || high > max || low > high) return null;
 		}
 		for (let value = low; value <= high; value += step) values.add(value);

--- a/libs/backend/server/iam/audit/main/src/audit-decision.ts
+++ b/libs/backend/server/iam/audit/main/src/audit-decision.ts
@@ -2,6 +2,26 @@ import { AuditDecisionActorKind, AuditDecisionOutcome, WorkloadKind, type Prisma
 
 import type { AuditDecisionRecord } from "./audit-decision.types.js";
 
+function _WorkloadKind(value: AuditDecisionRecord["workloadKind"]): WorkloadKind | undefined
+{
+	if (value === undefined) return undefined;
+	if (value === "job") return WorkloadKind.Job;
+	return WorkloadKind.Deployment;
+}
+
+function _Outcome(value: AuditDecisionRecord["outcome"]): AuditDecisionOutcome
+{
+	switch (value)
+	{
+		case "allow":
+			return AuditDecisionOutcome.Allow;
+		case "deny":
+			return AuditDecisionOutcome.Deny;
+		case "error":
+			return AuditDecisionOutcome.Error;
+	}
+}
+
 /**
  * Writes one row into the append-only decision log, using the transaction the caller is already in.
  *
@@ -35,7 +55,7 @@ export async function __AppendAuditDecision(transaction: Prisma.TransactionClien
 			audience: decision.audience,
 			namespace: decision.namespace,
 			serviceAccountName: decision.serviceAccountName,
-			workloadKind: decision.workloadKind === undefined ? undefined : decision.workloadKind === "job" ? WorkloadKind.Job : WorkloadKind.Deployment,
+			workloadKind: _WorkloadKind(decision.workloadKind),
 			workloadUid: decision.workloadUid,
 			podUid: decision.podUid,
 			runId: decision.runId,
@@ -54,7 +74,7 @@ export async function __AppendAuditDecision(transaction: Prisma.TransactionClien
 			policyRevisionHash: decision.policyRevisionHash,
 			effectiveAuthorizationDigest: decision.effectiveAuthorizationDigest,
 			membershipRevision: decision.membershipRevision,
-			outcome: decision.outcome === "allow" ? AuditDecisionOutcome.Allow : decision.outcome === "deny" ? AuditDecisionOutcome.Deny : AuditDecisionOutcome.Error,
+			outcome: _Outcome(decision.outcome),
 			reasonCode: decision.reasonCode,
 			decidedAt: decision.decidedAt,
 		},

--- a/libs/backend/server/knowledge/retrieval/main/src/routes/third-party-sources.ts
+++ b/libs/backend/server/knowledge/retrieval/main/src/routes/third-party-sources.ts
@@ -5,9 +5,10 @@ import type { PrismaClient } from "@prisma/client";
 import type { ThirdPartySourceWriteRequest } from "./third-party-sources.types.js";
 
 /** Convert an optional API timestamp into the database value for a named update field. */
-function _OptionalTimestamp(value: string | undefined): Date | null | undefined
+function _OptionalTimestamp(value: string | null | undefined): Date | null | undefined
 {
 	if (value === undefined) return undefined;
+	if (value === null) return null;
 	if (value.length === 0) return null;
 	return new Date(value);
 }

--- a/libs/backend/server/knowledge/retrieval/main/src/routes/third-party-sources.ts
+++ b/libs/backend/server/knowledge/retrieval/main/src/routes/third-party-sources.ts
@@ -4,6 +4,20 @@ import type { PrismaClient } from "@prisma/client";
 
 import type { ThirdPartySourceWriteRequest } from "./third-party-sources.types.js";
 
+/** Convert an optional API timestamp into the database value for a named update field. */
+function _OptionalTimestamp(value: string | undefined): Date | null | undefined
+{
+	if (value === undefined) return undefined;
+	if (value.length === 0) return null;
+	return new Date(value);
+}
+
+function _OptionalUpdate<T>(key: string, value: T | undefined): Record<string, T>
+{
+	if (value === undefined) return {};
+	return { [key]: value };
+}
+
 /**
  * CRUD router for third-party source inventory and discovery results.
  *
@@ -138,8 +152,8 @@ export function thirdPartySourcesRouter(prisma: PrismaClient): Router
         ...(body.status ? { status: body.status } : {}),
         ...(body.originUrl ? { originUrl: body.originUrl } : {}),
         ...(body.syncMode ? { syncMode: body.syncMode } : {}),
-        ...(body.lastSyncedAt !== undefined ? { lastSyncedAt: body.lastSyncedAt ? new Date(body.lastSyncedAt) : null } : {}),
-        ...(body.nextRunAt !== undefined ? { nextRunAt: body.nextRunAt ? new Date(body.nextRunAt) : null } : {}),
+        ..._OptionalUpdate("lastSyncedAt", _OptionalTimestamp(body.lastSyncedAt)),
+        ..._OptionalUpdate("nextRunAt", _OptionalTimestamp(body.nextRunAt)),
         ...(body.notes !== undefined ? { notes: body.notes } : {}),
       },
     });


### PR DESCRIPTION
## Summary

Removes the five inline-conditional errors already failing required CI on `develop`, without changing behavior.

- expands cron range-end selection
- maps audit values through small explicit helpers
- reuses timestamp/update helpers for the two source-update fields

## Validation

- `scripts/agent-style-check.sh --diff origin/develop` — 0 errors
- `git diff --check`

## Review

Independent review, deletion review, and documentation gate follow before readiness.