### PR TITLE
📝 Document long-term memory and governed dreaming

### DIFF
--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -122,7 +122,8 @@ export default defineConfig({
         items: [
           { text: 'Governed agent runtime', link: '/integrators/agent-runtime' },
           { text: 'MCP gateway (Obot)', link: '/integrators/mcp-gateway' },
-          { text: 'Retrieval & memory (Cognee)', link: '/integrators/retrieval-memory' },
+          { text: 'Memory write, manage & read', link: '/integrators/retrieval-memory' },
+          { text: 'Long-term memory & dreaming', link: '/integrators/long-term-memory-cognee' },
           { text: 'Silo IAM: inheritance & sharing', link: '/integrators/silo-iam' },
         ],
       },

--- a/website/guide/knowledge.md
+++ b/website/guide/knowledge.md
@@ -1,47 +1,55 @@
 # Connect organisational knowledge
 
-Give agents something worth remembering. OpenCrane keeps a durable memory store (backed by
-Cognee) behind its own access control, so what an agent can recall always matches what its owner
-is allowed to see — never a raw, ungoverned document dump.
+OpenCrane has the authority and schema foundations for governed semantic memory, but the live
+product does not yet ingest knowledge into Cognee or return Cognee recall results to an agent. The
+current administrator API manages a third-party source inventory; it is not a memory-ingestion API.
 
-::: tip Personal memory vs shared knowledge
-Your [personal assistant](/guide/persona) recalls from **your own** personal dataset — no one
-else's assistant can read it, and it can't read anyone else's. A managed agent recalls only from
-the **shared** organisation, department or project knowledge it was explicitly configured with.
-Neither kind can wander into the other's memory.
+::: tip Current boundary
+Personal dataset identity is bound to the verified silo, organisation and subject at admission.
+That binding is live, but fact retrieval is not. Managed agents currently receive a memory policy
+with scope `none`; organisation, department and project recall remain target capabilities.
 :::
 
-## Register sources and datasets
+## Manage the source inventory
 
-Register the organisation's supported sources through the current API. The current UI does not
-expose knowledge management. Place content in datasets whose scope matches the intended
-audience: personal, project, department or organisation.
+The authenticated `/api/v1/third-party-sources` API can list, create, update and delete source
+records and their discovered-item metadata. Supported inventory kinds include MCP registries,
+Anthropic Skills, Git repositories and manual uploads. The current UI does not expose this
+administration surface.
 
-## Grant access
+An inventory record describes where knowledge may come from and its observed status. Creating one
+does not ingest its content into Cognee, create a semantic-memory dataset, or make it available in a
+run.
 
-Grant both the acting subject and the agent service the required dataset capability. OpenCrane
-resolves those grants before admission and freezes the selected memory policy in the
-`RunInputSnapshot`.
+## Memory foundations
+
+OpenCrane's memory catalogue models dataset identity, lifecycle, consent, sensitivity, provenance
+and fact digests without duplicating fact text. A personal run can freeze the gateway-native dataset
+coordinates selected from verified identity. The repository also contains an authenticated memory
+gateway client and content-free catalogue commands, but neither the recall client nor a memory
+writer is composed into the production server path.
 
 ## During a run
 
-The runtime cannot select an arbitrary dataset. Memory actions pass through OpenCrane, which
-derives personal dataset identity from the verified silo, organisation and subject, then
-records provenance for durable facts.
+The runtime cannot select an arbitrary personal dataset. A personal agent may propose the
+approval-required `memory_recall` action. OpenCrane verifies the exact participant permission and
+one-use receipt, then stops with `safe_delivery_required` before calling Cognee. No recalled fact
+content reaches the model. Managed agents receive no memory-recall scope, and memory writes remain
+fail closed.
 
-::: info
-Reads are live: run admission freezes gateway-selected fact references (id and content digest only)
-into the `RunInputSnapshot`, and prompt compilation inlines each statement only after verifying it
-against the frozen digest. Mid-run memory actions can use the durable server-worker result channel;
-every write remains fail closed until its durable recovery lifecycle exists.
+::: info Current memory-recall status
+Run admission freezes only verified dataset coordinates, not a query, fact references or fact text.
+These coordinates constrain a future read; they do not mean a read happened.
 :::
 
 ::: warning
-Do not use dataset names as the security boundary. Membership and grants decide access; a
-caller-provided dataset parameter cannot widen it.
+Do not treat a healthy source-inventory record, a frozen dataset coordinate or an approved
+permission request as proof that content was ingested or recalled.
 :::
 
 ## Going deeper
 
-See [Retrieval and memory](/integrators/retrieval-memory) for fact provenance, personal
-dataset binding and failure behaviour.
+See [Memory write, manage and read](/integrators/retrieval-memory) for the current and target
+memory loop, provenance, return boundaries and failure behaviour. See
+[Long-term memory, Cognee and dreaming](/integrators/long-term-memory-cognee) for personal versus
+organisation datasets, RBAC and governed consolidation.

--- a/website/integrators/agent-runtime.md
+++ b/website/integrators/agent-runtime.md
@@ -4,7 +4,8 @@ OpenCrane executes each accepted **AgentRun attempt** in a fresh, bounded Kubern
 The control plane remains authoritative for identity, inputs, events, approvals and outcomes.
 
 > See also: [Agent delegation](/guide/child-runs) (governed child-run limits),
-> [MCP gateway](/integrators/mcp-gateway) (tool custody), and
+> [MCP gateway](/integrators/mcp-gateway) (tool custody),
+> [Memory write, manage and read](/integrators/retrieval-memory) (memory and return boundaries), and
 > [Identity and runtime authentication](/security/identity) (workload proof).
 
 ## One runtime, two admission authorities

--- a/website/integrators/long-term-memory-cognee.md
+++ b/website/integrators/long-term-memory-cognee.md
@@ -1,0 +1,368 @@
+# Long-term memory, Cognee and dreaming
+
+OpenCrane's **long-term-memory design** is for durable facts that may remain useful after a
+conversation ends. Cognee is the intended content and retrieval store; OpenCrane decides whose
+memory it is, who may use it, why it was retained and how it may be corrected or forgotten.
+
+> See also: [Memory write, manage and read](/integrators/retrieval-memory) (the runtime loop),
+> [Silo IAM](/integrators/silo-iam) (membership and grant evaluation),
+> [Organisation boundary](/operators/organisation-boundary) (silo isolation), and
+> [Connect organisational knowledge](/guide/knowledge) (current administrator-facing status).
+
+Status markers on this page mean ✅ live, 🔶 partially implemented or scaffold-only, and ◇ target
+design.
+
+## Memory is scoped, not global
+
+There is no one database called “the agent's memory”. A `MemoryDataset` belongs to one silo and one
+authorisation scope. Its Cognee dataset UUID is an internal coordinate selected by OpenCrane, not a
+capability a caller may present.
+
+| Scope | Intended content | Who may select it today |
+|---|---|---|
+| Personal ✅ / 🔶 | Facts and preferences belonging to one authenticated person | Personal-run admission derives the one active dataset from the verified silo, organisation and subject. There is no production dataset provisioner, and recall content is still blocked before Cognee. |
+| Project, team or department 🔶 | Knowledge shared inside one bounded organisational group | The scope vocabulary and gateway contracts exist, but managed runs currently freeze memory scope `none`. |
+| Organisation 🔶 | Knowledge deliberately shared across the whole organisation | The dataset schema supports organisation scope. No production admission or recall path selects it yet. |
+
+Personal memory and organisation memory are therefore **separate datasets with separate authority**.
+Organisation memory is not the union of every employee's personal memory.
+
+::: warning
+A dataset name, UUID, Kubernetes namespace or network location never grants memory access. Authority
+comes from verified identity, current membership, grants, scope, action and consent.
+:::
+
+## What OpenCrane and Cognee each own
+
+Role-based access control (RBAC) stays in OpenCrane; Cognee never evaluates it.
+
+```text
+ authenticated person or service
+              │
+              ▼
+ ┌──────────────────────────────────────────┐
+ │ OpenCrane                                │
+ │ identity · RBAC · consent · sensitivity │
+ │ dataset selection · provenance · digest │
+ │ correction/forget state · audit evidence│
+ └────────────────────┬─────────────────────┘
+                      │ exact frozen Cognee dataset UUID
+                      ▼
+ ┌──────────────────────────────────────────┐
+ │ private memory gateway                   │
+ │ server TokenReview · bounded search only │
+ │ canonical request · defensive response   │
+ └────────────────────┬─────────────────────┘
+                      │ private HTTP
+                      ▼
+ ┌──────────────────────────────────────────┐
+ │ Cognee                                   │
+ │ fact content · indexes · graph/vector    │
+ │ state                                    │
+ └──────────────────────────────────────────┘
+```
+
+| Owner | Durable responsibility | Must not decide |
+|---|---|---|
+| OpenCrane PostgreSQL | Dataset scope, Cognee identifiers, content digests, consent, sensitivity, provenance, correction/forget state and outbox intent | Semantic relevance or fact text |
+| Memory gateway | Authenticate the deployment-fixed server ServiceAccount identity and constrain one Cognee exchange | Human membership, grants or dataset choice |
+| Cognee | Store and search indexed fact content and its graph/vector representation | OpenCrane RBAC or cross-scope sharing |
+| Runtime Job | Propose a query or memory candidate for its current attempt | Dataset selection, durable retention or direct Cognee access |
+
+OpenCrane deliberately does not duplicate fact text in its catalogue. A catalogue row can explain
+which external fact was accepted and why without becoming a shadow memory store.
+
+## RBAC before retrieval
+
+Memory access has two independent questions:
+
+1. **May this principal perform this action in this scope?** Membership and grants answer that.
+2. **Which exact dataset represents that scope?** The memory authority answers that from trusted
+   coordinates.
+
+The dataset lookup happens after identity has been established. A query or tool argument cannot
+widen it.
+
+### Personal recall today
+
+```text
+ OIDC session
+      │
+      ▼
+ signed personal membership assertion
+      │ exact silo · organisation · subject
+      ▼
+ active, time-valid personal grants
+      │ hashed into the run capability evidence
+      ▼
+ personal AgentService + active personal MemoryDataset
+      │ dataset id + Cognee dataset UUID
+      ▼
+ immutable RunInputSnapshot
+      │ model proposes memory_recall
+      ▼
+ exact participant permission + one-use receipt
+      │
+      ▼
+ `safe_delivery_required` — current stop, before Cognee
+```
+
+✅ The membership, personal grant, dataset-selection, frozen-snapshot and permission boundaries are
+live. 🔶 The final read is not: production execution stops before the memory gateway because recalled
+content does not yet have an ephemeral, attempt-fenced return path.
+
+The permission receipt is one-use and binds the run, attempt, invocation revision, query digest,
+snapshot digest, persona revision and expiry. A later or altered request cannot reuse it.
+
+The current path includes active personal grants in the run's capability evidence, but it does not
+evaluate a memory-specific grant before selecting the personal dataset. Identity-bound selection
+and exact interactive permission are real controls; they are not yet the complete read-capability
+decision the target design requires.
+
+### Organisation recall target
+
+Organisation recall must reuse the IAM intersection rather than invent a second memory ACL:
+
+```text
+ current organisation membership
+              │
+              ▼
+ acting principal grants ∩ AgentService grants
+              │
+              ▼
+ exact read capability + organisation scope + dataset resource
+              │
+              ▼
+ active organisation MemoryDataset
+              │ frozen into admitted run/dream manifest
+              ▼
+ bounded gateway search → transient result for that exact workload
+```
+
+◇ The general grant model and a dual-principal effective-access algorithm exist, but the algorithm
+has no production caller for organisation memory. Managed runs explicitly freeze scope `none` so
+they cannot fall back to a delegated user's personal dataset.
+
+Agent revisions can declare exact organisation, department, team or project scope attachments, but
+an attachment requests scope—it does not grant it. The current production scope-grant resolver
+returns no grants, so every non-empty shared attachment set fails closed before it can become
+managed-memory authority.
+
+An organisation-wide agent may be broadly useful without being universally authorised. Both the
+person asking and the AgentService performing the work must remain inside the accepted capability
+and scope. A deny, revocation, expired membership or empty grant intersection wins.
+
+## Network isolation is not RBAC
+
+The private deployment uses several layers because each one answers a different question.
+
+| Layer | Question it answers |
+|---|---|
+| OpenCrane IAM | Is this person or service allowed to read, derive, publish, correct or forget memory in this scope? |
+| Run or dream admission | Which immutable identity, capabilities, datasets, policy and budget were accepted for this workload? |
+| Projected ServiceAccount token | Is the caller the expected OpenCrane server workload? |
+| Kubernetes RBAC | May the gateway ask the Kubernetes API to perform `TokenReview`? It grants no memory content access. |
+| Memory-gateway validation | Is this one bounded search request well formed and tied to exactly one dataset UUID? |
+| NetworkPolicy | Can this pod establish a connection to that pod and port at all? |
+| Cognee | Can the accepted content be indexed or searched? |
+
+Cognee's own login middleware is disabled in the bundled private deployment. This is safe only
+because the authenticated memory gateway is the sole network caller admitted to Cognee. NetworkPolicy
+is a transport wall; OpenCrane remains the product RBAC authority.
+
+## What “dreaming” means
+
+**Dreaming** is a proposed offline consolidation process over long-term memory. It turns many small,
+already-authorised facts into **candidate** summaries, patterns, corrections or links. It is not a
+long-running agent thinking without supervision, and it is not permission to retain everything a
+model has seen.
+
+::: info Current status
+OpenCrane does not implement dreaming today. Cognee indexing is not dreaming, and no scheduled
+worker currently reads a memory corpus and publishes derived facts.
+:::
+
+A dream should improve memory quality by:
+
+- consolidating duplicates without losing their sources;
+- detecting contradictions and proposing a correction;
+- identifying stable preferences or recurring organisational knowledge;
+- linking related facts so retrieval needs fewer, better results; and
+- marking stale or low-value candidates for review instead of silently deleting them.
+
+The output is never immediately trusted fact content. It first enters the **Manage** stage as a
+candidate with complete derivation evidence.
+
+## Personal dreaming
+
+A personal dream is confined to one person's dataset and their policy. It may connect patterns
+across that person's authorised facts, but it cannot inspect another person's personal dataset or
+publish into organisation memory.
+
+```text
+ one personal dataset + owner policy
+                │ frozen dataset and source-fact digests
+                ▼
+ ┌──────────────────────────────────────┐
+ │ bounded personal dream Job ◇         │
+ │ deduplicate · relate · detect conflict │
+ └──────────────────┬───────────────────┘
+                    │ derived candidates only
+                    ▼
+ ┌──────────────────────────────────────┐
+ │ Manage                               │
+ │ provenance · consent · sensitivity  │
+ │ conflict · retention · owner review │
+ └──────────────┬───────────────┬───────┘
+                │ accepted      │ rejected/expired
+                ▼               ▼
+        same personal dataset   discard candidate
+```
+
+The owner remains the authority. Initially, every candidate requires exact owner approval. A
+personal dream must not infer and retain protected or highly sensitive attributes merely because
+the model can guess them. A rejected or expired candidate never reaches Cognee.
+
+## Organisation dreaming
+
+An organisation dream operates over an organisation-scoped corpus: approved policies, decisions,
+artifacts and facts already shared with the organisation. It does **not** scan every personal
+dataset.
+
+```text
+ personal datasets                     organisation-scoped inputs
+ ┌───────┐ ┌───────┐ ┌───────┐         policies · artifacts · shared facts
+ │ user A│ │ user B│ │ user C│                         │
+ └───┬───┘ └───┬───┘ └───┬───┘                         ▼
+     │         │         │              ┌──────────────────────────┐
+     └─────────┴─────────┘              │ organisation MemoryDataset│
+          privacy wall                  └─────────────┬────────────┘
+     no implicit aggregation                          │ frozen corpus
+                                                     ▼
+                                         ┌──────────────────────────┐
+ explicit owner-approved promotion ────► │ organisation dream Job ◇ │
+ into organisation scope only            └─────────────┬────────────┘
+                                                     │ derived candidates
+                                                     ▼
+                                         owner/policy review → publish
+```
+
+The safe default is a one-way privacy wall: personal facts remain personal. Moving a fact from a
+personal dataset into organisation memory is a separate, explicit promotion decision with its own
+purpose, sensitivity classification and provenance. It is not a search fallback or a side effect of
+dreaming.
+
+When a future dream combines several non-personal scopes, the output audience must be no broader
+than the intersection of every input audience. An empty intersection discards the candidate.
+Promotion into a broader destination needs a separate source-owner and destination-steward decision;
+the broadest input must never become the default output scope.
+
+An ordinary cross-scope candidate keeps every source audience and grant revision as a read-time
+dependency. Later membership loss, revocation or scope narrowing immediately removes it from the
+effective audience. The only way to detach those dependencies is an explicit independent promotion:
+every source authority and the destination steward approve a newly scoped fact and its reviewed
+content.
+
+If a future product needs patterns across personal memories, that is a separate privacy-preserving
+aggregation capability—not ordinary organisation dreaming. It would need explicit participation,
+minimum cohort sizes, suppression of identifying details, purpose limitation and proof that the
+result cannot reconstruct a contributor's personal facts.
+
+## The governed dream lifecycle
+
+```text
+ schedule / event / operator request
+                  │
+                  ▼
+ admission: identity + scope + grants + policy + budget
+                  │ immutable dream manifest
+                  ▼
+ bounded reads through memory gateway
+                  │ source ids + digests
+                  ▼
+ model synthesis in an ephemeral Job
+                  │ candidate, never direct write
+                  ▼
+ Manage: validate + classify + review + deduplicate
+                  │ accepted derived fact
+                  ▼
+ Cognee durable acceptance
+                  │ external id + content digest
+                  ▼
+ OpenCrane catalogue + outbox commit
+```
+
+The dream Job should be as disposable as an agent-runtime Job. It receives an immutable manifest,
+bounded source material, a model route, token/cost limits and a deadline. It receives no database
+credential and cannot call Cognee directly. Completion, failure and cancellation remain
+server-owned outcomes.
+
+## Derived facts need stronger lineage
+
+The current catalogue accepts exactly one immediate source: an artifact revision, conversation
+message or explicit user statement. That is sufficient for a directly recorded fact, but not for a
+dream that derives one candidate from many facts.
+
+◇ Before dreaming can ship, the durable model needs:
+
+- a dream-run manifest with the frozen dataset, source set, policy revision, model route and prompt
+  digest;
+- a candidate lifecycle separate from accepted facts;
+- many-to-many source edges with the source fact id and content digest;
+- source audience, membership and grant revisions that are re-evaluated on every future read;
+- an explicit derived-fact provenance kind;
+- reviewer or policy-decision evidence for promotion;
+- idempotent publication across Cognee and the OpenCrane catalogue; and
+- dependency invalidation when any source is corrected, forgotten, loses consent or its audience
+  authority narrows.
+
+A derived fact cannot outlive the evidence that made it valid. Forgetting a source should mark its
+dependants stale or forget-pending, then re-evaluate or remove them without erasing the historical
+decision evidence.
+
+The delivery path must also join every Cognee result back to active OpenCrane catalogue metadata by
+dataset and external fact id. Only `Active` facts may reach a workload. Correction or forgetting
+must revoke catalogue read eligibility before asynchronous Cognee mutation begins, so a stale
+indexed result is dropped even while remote deletion is pending.
+
+## Roles in the target design
+
+| Principal | Permitted role | Prohibited shortcut |
+|---|---|---|
+| Memory owner | Consent, review, correct, forget and explicitly promote their own memory | Granting access by sharing a dataset UUID |
+| Organisation knowledge owner | Approve sources, retention and organisation-derived candidates | Reading personal datasets by virtue of being an administrator |
+| AgentService | Query only within the capabilities and scope accepted for its run | Expanding the actor's rights or selecting a broader dataset |
+| Dream service ◇ | Read one frozen corpus and emit candidates under a dedicated policy and budget | Publishing directly or crossing scopes |
+| OpenCrane server | Evaluate authority, freeze manifests, manage candidates and commit evidence | Treating network reachability as authorisation |
+| Memory gateway | Authenticate the server and constrain Cognee transport | Evaluating human RBAC or choosing datasets |
+| Cognee | Index and retrieve accepted content | Deciding consent, sharing, correction or forgetting policy |
+
+## Maturity
+
+| Capability | Status |
+|---|---|
+| Private, persistent Cognee deployment | ✅ PVC-capable and digest-aware chart; the supported real-silo deploy workflow requires an exact image digest. This is not proof of end-to-end recall qualification. |
+| TokenReview and NetworkPolicy-protected search gateway | ✅ Implemented and charted; the server client factory has no production caller |
+| Identity-bound personal dataset selection at run admission | ✅ Live selection; no production dataset provisioner |
+| Personal recall content returned to the active attempt | 🔶 Blocked at `safe_delivery_required` |
+| Organisation, department, team or project recall | 🔶 Schema and port groundwork; managed scope is `none` |
+| Fact record, correction, forgetting and scoped injection | 🔶 Contracts/catalogue groundwork; production writes fail closed |
+| Personal or organisation dreaming | ◇ Target design; no worker, candidate authority or derived lineage yet |
+
+::: warning Current cut-line
+The repository provides a private search boundary, identity-bound personal dataset selection, an
+exact recall-permission receipt, metadata schemas and fail-closed future ports. It does not yet
+provide usable personal recall, organisation recall, memory ingestion, correction, forgetting,
+derived-fact lineage or dreaming.
+:::
+
+## Sources
+
+- [`Memory dataset and fact catalogue schema`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/prisma/schema/memory.prisma)
+- [`Authorisation grant schema`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/prisma/schema/authorization.prisma)
+- [`Personal memory admission`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/personal/memory/main/src/prisma-personal-memory-admission-repository.ts)
+- [`Managed no-memory policy`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/execution/inputs/main/src/managed-no-personal-memory-scope-source.ts)
+- [`Shared scope-grant resolver`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/server/agents/agent-services/main/src/prisma-scope-grant-resolver.ts)
+- [`Uncomposed server client factory`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/src/infra/memory/memory-gateway-client.factory.ts)
+- [`Memory gateway app`](https://github.com/elewa-git/opencrane/blob/main/apps/memory-gateway/README.md)
+- [`Cognee deployment`](https://github.com/elewa-git/opencrane/blob/main/apps/_infra/cognee/README.md)

--- a/website/integrators/retrieval-memory.md
+++ b/website/integrators/retrieval-memory.md
@@ -1,75 +1,265 @@
-# Retrieval and memory
+# Memory write, manage and read
 
-OpenCrane keeps **durable memory content in Cognee** and **governance metadata in its own
-authority**. A runtime can request memory actions only through the control plane.
+OpenCrane separates **session history**, **run context**, **long-term semantic memory** and the
+**authority ledger** that governs them. This page follows the boundaries around the loop so an
+integrator can see what a running agent may receive, what it may propose, and what remains
+server-owned.
 
-> See also: [Silo IAM](/integrators/silo-iam) (scope and grants),
-> [Governed agent runtime](/integrators/agent-runtime) (action custody), and
-> [MCP gateway](/integrators/mcp-gateway) (external tools).
+> See also: [Governed agent runtime](/integrators/agent-runtime) (runtime and action custody),
+> [MCP gateway](/integrators/mcp-gateway) (provider execution),
+> [Long-term memory, Cognee and dreaming](/integrators/long-term-memory-cognee) (datasets and
+> consolidation), and [Silo IAM](/integrators/silo-iam) (scope and grants).
 
-## Responsibility split
+## Four kinds of information
 
-| Component | Responsibility |
-|---|---|
-| Cognee | Durable memory content and retrieval |
-| OpenCrane agent-memory catalogue | Dataset identity, digest, provenance, consent and sensitivity metadata |
-| Personal-memory selector | Selects a verified user's dataset coordinates for one run snapshot |
-| Runtime | Proposes a memory action; never selects another user's dataset |
+These terms are deliberately not interchangeable. A transcript is not long-term memory, and a
+runtime's context is not a permission to retain what it saw.
 
-OpenCrane does not duplicate fact text in its product database. The catalogue records a content
-digest and exact provenance only after Cognee has durably accepted the content.
+Status markers on this page mean ✅ live and 🔶 partially implemented or scaffold-only.
 
-## Personal dataset binding
+| Kind | What it is | Current owner | What reaches the runtime |
+|---|---|---|---|
+| Session history ✅ | Ordered conversation messages and run events for an authorised conversation | OpenCrane conversation authority | The sealed snapshot selects message identifiers; the compiler expands the authorised non-memory content for the attempt. |
+| Run context ✅ | Bounded, disposable model input compiled for one attempt from an immutable `RunInputSnapshot` | OpenCrane run admission | Selected message content, instructions, tool definitions, model route and budgets. The runtime cannot amend it. |
+| Long-term semantic memory 🔶 | Durable fact content and semantic search in Cognee | Cognee behind the private memory gateway | Admission currently freezes verified dataset coordinates only. Recalled fact content is not yet delivered to the model. |
+| Authority ledger ✅ / 🔶 | Scope, consent, provenance, approval, receipt, event and terminal-outcome evidence | OpenCrane PostgreSQL authorities | No raw ledger access. The runtime receives only the command or saved result that the control plane accepts. Generic memory catalogue writes are foundation-only. |
 
-A personal memory dataset resolves from the verified `(silo, organisation, subject)` tuple.
-The browser and runtime cannot supply a different dataset id. Organisation and shared datasets
-are filtered through the same membership and grant authority used at run admission.
-
-## Planned recording contract
-
-The target write sequence is:
-
-```text
-authorised memory action
-       │
-       ▼
-Cognee accepts content
-       │  external id + digest + provenance
-       ▼
-OpenCrane commits catalogue row + outbox event
-```
-
-Exactly one provenance source is required: an artifact revision, a conversation message or an
-explicit user statement. Explicit statements must identify the same authenticated author as
-the target personal dataset.
-
-::: info Current transport status
-Admission freezes only the verified gateway-native dataset coordinates. The model may propose a
-bounded query through the approval-required `memory_recall` tool, but recalled content is not yet
-delivered back to the model. Safe transient content delivery is deferred to
-[#601](https://github.com/elewa-git/opencrane/issues/601). No memory write transport is implemented yet.
-:::
+Here, **authority ledger** is a descriptive term for the product's durable records and decisions;
+it is not a second fact-text store. The memory catalogue records identifiers, digests, consent,
+sensitivity and provenance, while Cognee is the intended holder of fact content.
 
 ::: tip
-The catalogue and its event commit atomically. OpenCrane cannot claim that a fact exists when
-its governance record was not accepted.
+Keep the four layers separate in an integration. Put conversational material in the conversation
+authority, freeze the inputs for one attempt, retrieve durable knowledge only through the gateway,
+and record decisions and evidence in the relevant OpenCrane authority.
 :::
 
-## Retrieval during a run
+## The write–manage–read loop
 
-The control plane freezes only the verified dataset coordinates in the `RunInputSnapshot`. The
-model chooses the query through the approval-required `memory_recall` tool. Further memory reads or
-writes remain governed external actions subject to the same approval, receipt and audit boundaries
-as other tools; content delivery remains deferred to [#601](https://github.com/elewa-git/opencrane/issues/601).
+The loop is a control-plane concern, not a property of the model. **Write** proposes what may become
+durable. **Manage** validates, scopes, classifies and records it. **Read** assembles only the material
+authorised for one attempt. The result of read is **context**: a bounded, disposable input to the
+runtime, not another store.
+
+```text
+                                      outside the loop
+                  participant answers / provider results / child status (scaffold)
+                                               │
+                                               ▼
+┌───────────────┐    candidates     ┌───────────────────────┐
+│ runtime turn  │ ────────────────► │ WRITE                 │
+│ bounded Job   │                   │ messages, events,     │
+└───────▲───────┘                   │ actions, memory facts │
+        │                           └───────────┬───────────┘
+        │ context                               │ proposals only
+        │                                       ▼
+┌───────┴────────────────┐          ┌───────────────────────┐
+│ READ                   │ ◄─────── │ MANAGE                │
+│ authorise + select +   │          │ validate + consent +  │
+│ compile one attempt    │          │ deduplicate + retain  │
+└───────▲────────────────┘          └─────┬────────┬────────┘
+        │                                 │        │
+        │                 ┌───────────────┘        └───────────────┐
+        │                 ▼                                        ▼
+┌───────┴──────────┐  ┌──────────────────┐               ┌─────────────────┐
+│ session history │  │ semantic memory  │               │ authority ledger│
+│ messages/events │  │ fact content     │               │ scope, approval,│
+│ OpenCrane       │  │ Cognee (target)  │               │ receipts/outcome│
+└──────────────────┘  └──────────────────┘               └─────────────────┘
+```
+
+The stores have different retention and authority. Session history supports replay and continuity.
+Semantic memory is intended for useful facts across conversations. The authority ledger proves why
+an input or action was allowed. Read may draw from all three, but it must not collapse them into one
+unbounded transcript.
+
+### Session read is currently the inefficient part
+
+✅ Conversation writes are durable and ordered. 🔶 At admission, however, OpenCrane currently selects
+**every completed message** in the conversation, and the prompt compiler expands every selected
+message into the model input. `ConversationContextRevision` provides a schema for compacted context,
+but no production writer or reader uses it yet.
+
+The target read path is therefore:
+
+```text
+active context revision + recent uncompacted message tail
+                         + authorised artifact/skill summaries
+                         + approved transient semantic-memory recall
+                                      │
+                                      ▼
+                         bounded context for one attempt
+```
+
+Compaction should write a new immutable context revision with provenance through a specific message;
+it should not rewrite or delete the transcript. The recent tail remains verbatim, while the revision
+carries forward only the decisions, commitments and unresolved state needed for the next turn.
+
+## The current loop
+
+Run admission commits one immutable snapshot with the run. For a personal run, the snapshot may
+name only the active Cognee dataset selected from the verified `(silo, organisation, subject)`
+tuple. It does not call Cognee, select a query, freeze fact references, or place fact text in the
+prompt. The model can subsequently propose `memory_recall`; that proposal follows the same
+server-owned external-action lifecycle as a tool call.
+
+```text
+authorised conversation history + current grants
+                         │
+                         ▼
+┌──────────────────────────────────────────────────────┐
+│ OpenCrane admission                                   │
+│ seals RunInputSnapshot: messages, identity, policies, │
+│ tool revisions and verified dataset coordinates       │
+└───────────────────────┬──────────────────────────────┘
+                        │ compiled non-memory context
+                        ▼
+                ┌───────────────┐
+                │ runtime Job   │
+                │ bounded loop  │
+                └───────┬───────┘
+                        │ proposes memory_recall
+                        ▼
+┌──────────────────────────────────────────────────────┐
+│ server external-action authority                      │
+│ creates invocation → asks exact participant → checks  │
+│ one-use receipt and current claim                     │
+└───────────────────────┬──────────────────────────────┘
+                        │
+                        ▼
+      `safe_delivery_required` — no Cognee call, no fact content
+```
+
+The repository contains an authenticated client capable of a bounded Cognee search for a frozen
+dataset UUID, and a deployable private gateway. Neither is composed into the production recall
+worker. The action stops before the gateway until OpenCrane has an ephemeral, attempt-fenced delivery
+channel that cannot leak recalled content into durable tool results, events, logs, Activity or A2UI.
+
+::: warning
+Do not treat a successful memory-permission response as a read. Today it only authorises the exact
+invocation; the action then returns `safe_delivery_required` before Cognee is contacted.
+:::
+
+## Write, manage and read status
+
+| Loop stage | Current behaviour | Target behaviour |
+|---|---|---|
+| Write | 🔶 The schema, provenance validation, content-free catalogue command and outbox contract exist, but no production writer or outbox dispatcher is composed. Gateway writes fail closed. | Cognee accepts content first; OpenCrane then atomically records its external id, digest, consent, provenance and outbox intent. |
+| Manage | ✅ Personal dataset selection is identity-bound at admission. Dataset and fact metadata have active, correction and forgetting states, but generic record/correct/forget execution is not composed. | Governance changes retain an explainable metadata trail without duplicating fact text. |
+| Read | 🔶 The private gateway accepts only authenticated, bounded search. A personal run can propose an approval-required recall, but its content delivery is blocked before the gateway. | The server delivers gateway-originated results transiently to the exact active attempt, then resumes the paused loop. |
+| Audit | ✅ Run snapshots, action invocations, approvals, receipts, ordered events and terminal outcomes are durable authorities. | Memory actions join the same evidence chain once safe delivery and writing are enabled. |
+
+Exactly one provenance source is required for a future fact record: an artifact revision, a
+conversation message or an explicit user statement. An explicit statement must name the same
+authenticated author as the target personal dataset. Missing or ambiguous provenance, an inactive
+dataset, and a conflicting correction must fail closed.
+
+## Outbound and return boundaries
+
+The runtime has an outbound stream to OpenCrane, not direct access to people, external integration
+providers, child agents or durable storage. The separately fenced model-provider call is shown as
+its own boundary. Each outgoing path reaches a different server authority, and only an accepted,
+saved result may return to the same active attempt.
+
+```text
+                                model provider
+                                  ▲       │
+        attempt-scoped LiteLLM request    │ model output
+                                  │       ▼
+                                agent-runtime Job
+                                        │
+      ┌──────────────┬──────────────────┼─────────────────┬────────────────┐
+      │              │                  │                 │                │
+      ▼              ▼                  ▼                 ▼                ▼
+ elicitation    external-action    artifact output   parent delivery  terminal report
+ proposal       candidate          bytes + ticket    bounded status   complete / fail
+      │              │                  │                 │                │
+      ▼              ▼                  ▼                 ▼                ▼
+ exact person   server worker      ArtifactStore +   parent thread    run authority
+ + purpose      + approval         quarantine scan   authority        fences attempt
+      │              │                  │                 │                │
+      ▼              ▼                  ▼                 ▼                ├──► durable outcome
+ saved result   Obot integration   verified receipt  saved display-   ├──► release / cleanup
+      │         or fail-closed      + ready/failed    safe delivery    └──► ordered event
+      │         memory/sandbox      state
+      │              │
+      └──────┬───────┘
+             ▼
+       saved resume_attempt ───────────────────────────────► same active Job
+
+ server-side authorities ───────► durable audit evidence where instrumented
+ processes ─────────────────────► redacted logs and optional OTLP traces
+                                  (operational output; no return into context)
+```
+
+### Model provider
+
+✅ The control plane dispatches immutable compiled input and an attempt-scoped LiteLLM credential.
+The runtime uses that credential to call the selected model and returns neutral protocol events over
+its authenticated stream. The model provider does not receive OpenCrane database authority, and its
+output does not bypass the run and event authorities.
+
+### Participant elicitation
+
+✅ A runtime may propose a bounded question, choice, approval-required action or protected
+memory-permission request. The server chooses one exact participant, binds the request to its run,
+attempt, expiry and purpose, and validates the response before saving the result used to resume that
+attempt. Ordinary elicitation may return answer content. Protected-purpose responses, including
+personal-memory permission, return an outcome or receipt instead of recalled fact content.
+
+### External tool and provider execution
+
+✅ A runtime's `external_action` candidate becomes a durable `ToolInvocation` before any provider
+I/O. The server reconstructs the frozen context, rechecks arguments and policy, obtains an
+approval where required, claims the invocation, and calls the selected custody boundary. The
+runtime receives only a saved, validated result on resume. Obot holds integration credentials.
+The sandbox executor and memory-recall transport currently fail closed. An unclear provider outcome
+enters visible recovery rather than being repeated blindly.
+
+### Parent delivery and child runs
+
+✅ A user-created Agent thread can deliver bounded, display-safe status to its immediate parent
+conversation. The parent receives a kind, label, detail and optional asset reference—not the child
+transcript—and the server verifies live assignment, ownership and idempotency before saving it.
+
+🔶 Model-created child runs are different. Reservation and completion-ledger infrastructure exists,
+including terminal child events and explicit suppression when a parent cannot receive them, but no
+production caller currently lets the runtime spawn such a child.
+
+### Generated artifacts
+
+✅ Where artifact scanning is enabled, a runtime reserves an output ticket and streams exact bytes
+through the server to `ArtifactStore`. The server persists a verified receipt and quarantined
+revision; only a successful scan makes the asset ready for browser access. Without the scanner,
+reservation and publishing fail closed. Artifact bytes do not become memory implicitly.
+
+### Terminal outcomes, audit and observability
+
+✅ Only the control plane finalises a run as `completed`, `failed` or `cancelled`, with a terminal
+reason. The authenticated runtime can report only protocol-fenced completion or failure for its
+current attempt; it cannot cancel itself. Completion waits for pending tool results. User-requested
+cancellation revokes assignment authority, emits cleanup work and reaches `cancelled` only after the
+server-owned lifecycle finalises it.
+
+Ordered conversation events provide authorised replay. Instrumented authorities append durable
+audit evidence, while processes emit structured, redacted logs and optional OTLP traces. Audit and
+telemetry are not memory and are not automatically injected into later context. Provider bodies,
+credentials, raw tool arguments and raw tool results are not projected into the conversation stream.
 
 ## Failure posture
 
-- An unresolved personal dataset is denied.
-- Missing or ambiguous provenance is denied.
-- A retired dataset or conflicting correction is denied.
-- An unavailable memory transport does not fabricate a result.
-- Runtime-local scratch is never promoted to durable memory implicitly.
+- A request cannot choose a personal dataset by identifier; verified admission coordinates choose it.
+- Runtime-local scratch and checkpoint data never become durable memory implicitly.
+- A gateway failure never becomes an empty, fabricated recall result.
+- A rejected, expired or unavailable participant response does not dispatch a provider action.
+- A stale attempt, mismatched snapshot, cancelled run or ambiguous provider outcome does not
+  produce a successful result.
+- Durable semantic memory remains unavailable to the model until the safe return path exists.
 
-Source: [`libs/backend/agents/memory/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/memory/main/README.md),
-[`libs/backend/agents/personal/memory/main`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/personal/memory/main/README.md),
-and [`libs/backend/server/infra/memory-gateway-client`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/server/infra/memory-gateway-client/README.md).
+## Source
+
+- [`Run input assembly`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/execution/inputs/main/README.md)
+- [`Runtime protocol and external-action worker`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/execution/protocol/README.md)
+- [`Personal memory selection`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/agents/personal/memory/main/README.md)
+- [`Memory gateway client`](https://github.com/elewa-git/opencrane/blob/main/libs/backend/server/infra/memory-gateway-client/README.md)
+- [`Memory and run schema`](https://github.com/elewa-git/opencrane/blob/main/apps/opencrane/prisma/schema/memory.prisma)

--- a/website/integrators/silo-iam.md
+++ b/website/integrators/silo-iam.md
@@ -5,7 +5,7 @@ run. Grants can narrow what an agent may do, but cannot manufacture organisation
 
 > See also: [Organisation boundary](/operators/organisation-boundary) (silo identity),
 > [Governed agent runtime](/integrators/agent-runtime) (run authority), and
-> [Retrieval and memory](/integrators/retrieval-memory) (dataset binding).
+> [Long-term memory, Cognee and dreaming](/integrators/long-term-memory-cognee) (memory RBAC).
 
 ## Decision order
 


### PR DESCRIPTION
## Summary

- explain context, session history, long-term memory, and authority evidence
- document personal versus organisation-scoped Cognee datasets and the RBAC/network boundary
- define governed personal and organisation dreaming as target architecture with lineage, audience-intersection, approval, correction, and forgetting rules
- correct stale claims about live recall, ingestion, and managed memory scope

## Current maturity

- personal dataset selection and recall approval are live
- recall content still stops at `safe_delivery_required`
- managed runs freeze memory scope `none` and shared-scope grants fail closed
- memory writes, organisation recall, derived lineage, and dreaming remain explicitly target-only

## Validation

- VitePress production build
- agent style and Prisma boundary checks
- module-growth check
- release-versioning check
- 39 release-versioning tests
- independent memory architecture and exact-commit reviews

## Review

This PR is intentionally independent of #652 and targets `develop` directly. It contains only website documentation and can be reviewed in either order.
