### PR TITLE
🐛 Accept parent-served deployment DNS

### DIFF
--- a/apps/_infra/deploy-k8s/platform/dns-authority.sh
+++ b/apps/_infra/deploy-k8s/platform/dns-authority.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Accepts a name when it or one of its parent domains publishes an SOA record, because a parent zone can serve the requested record subtree.
+# It stops before querying a single-label TLD so public TLD authority cannot qualify an unserved base domain.
+# It returns 2 for an unsupported inspector and 1 when neither the name nor an eligible parent publishes an SOA record.
+dns_authority_resolves()
+{
+  local candidate="$1"
+  local inspector="$2"
+  local response
+
+  while [[ "$candidate" == *.* ]]; do
+    response=""
+    case "$inspector" in
+      dig)
+        response="$(dig +short SOA "$candidate" 2>/dev/null || true)"
+        ;;
+      host)
+        if ! response="$(host -t SOA "$candidate" 2>/dev/null)"; then response=""; fi
+        ;;
+      *)
+        return 2
+        ;;
+    esac
+
+    if [[ -n "$response" ]]; then return 0; fi
+    candidate="${candidate#*.}"
+  done
+
+  return 1
+}

--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -99,6 +99,7 @@ source "$SCRIPT_DIR/current-chart-sources.sh"
 source "$SCRIPT_DIR/control-plane-image-policy.sh"
 source "$SCRIPT_DIR/qualified-release-image-policy.sh"
 source "$SCRIPT_DIR/cluster-tenant-crd-policy.sh"
+source "$SCRIPT_DIR/dns-authority.sh"
 COGNEE_IMAGE_POLICY="$SCRIPT_DIR/../../cognee/deploy/image-policy.sh"
 if [[ ! -f "$COGNEE_IMAGE_POLICY" ]]; then
   echo "[k8s-deploy] Cognee image policy is missing at '$COGNEE_IMAGE_POLICY'." >&2
@@ -453,11 +454,11 @@ _run_preflight() {
   #    required. Its SOA lookup must nevertheless reach an authoritative serving zone.
   if [[ -n "$BASE_DOMAIN" ]]; then
     if command -v dig >/dev/null 2>&1; then
-      [[ -n "$(dig +noall +authority SOA "$BASE_DOMAIN" 2>/dev/null)" ]] || PF_FAILS+=("No authoritative DNS service resolves for '$BASE_DOMAIN'. Delegate its zone or create the base-domain record under an existing served parent zone.")
+      dns_authority_resolves "$BASE_DOMAIN" dig || PF_FAILS+=("No authoritative DNS service resolves for '$BASE_DOMAIN'. Delegate its zone or create the base-domain record under an existing served parent zone.")
     elif command -v host >/dev/null 2>&1; then
-      host -t SOA "$BASE_DOMAIN" >/dev/null 2>&1 || PF_FAILS+=("No authoritative DNS service resolves for '$BASE_DOMAIN'. Delegate its zone or create the base-domain record under an existing served parent zone.")
+      dns_authority_resolves "$BASE_DOMAIN" host || PF_FAILS+=("No authoritative DNS service resolves for '$BASE_DOMAIN'. Delegate its zone or create the base-domain record under an existing served parent zone.")
     else
-      warn "Preflight: no dig/host — skipping the NS-delegation check for '$BASE_DOMAIN'."
+      warn "Preflight: no dig/host — skipping the DNS-authority check for '$BASE_DOMAIN'."
     fi
   fi
 

--- a/apps/_infra/deploy-k8s/platform/tests/dns-authority-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/dns-authority-contract.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/dns-authority.sh"
+
+dig()
+{
+  case "${3:-}" in
+    opencrane.ai) printf 'ns-cloud-b1.googledomains.com. hostmaster.google.com. 1 21600 3600 259200 300\n' ;;
+  esac
+}
+
+dns_authority_resolves dev.opencrane.ai dig
+dns_authority_resolves opencrane.ai dig
+
+dig()
+{
+  case "${3:-}" in
+    isolated.example.test) printf 'ns.example.test. hostmaster.example.test. 1 2 3 4 5\n' ;;
+  esac
+}
+
+dns_authority_resolves isolated.example.test dig
+
+dig()
+{
+  [[ "${3:-}" == "ai" ]] && printf 'tld.example. hostmaster.example. 1 2 3 4 5\n'
+}
+
+if dns_authority_resolves missing.opencrane.ai dig; then
+  echo "a top-level zone incorrectly qualified an unserved base domain" >&2
+  exit 1
+fi
+
+host()
+{
+  [[ "${3:-}" == "opencrane.ai" ]] || return 1
+  printf 'opencrane.ai has SOA record ns-cloud-b1.googledomains.com. hostmaster.google.com.\n'
+}
+
+dns_authority_resolves dev.opencrane.ai host
+
+echo "DNS authority contract: PASS"


### PR DESCRIPTION
## Summary

- accept DNS record subtrees served by an authoritative parent zone
- keep single-label TLD authority from qualifying an unserved base domain
- cover parent-served, delegated, invalid, and host-fallback authority checks

## Validation

- DNS authority contract
- shell syntax checks
- agent style check
- Prisma boundary check
- release versioning check
- module growth check
- independent review and comments gates

## Deployment evidence

The corrected onboarding UI is live on testv4 at application revision 6 and database revision 11. This change fixes the false-negative preflight observed for dev.opencrane.ai so the successful app-owned deployment path is reproducible.