### PR TITLE
🐛 Repair PostgreSQL privilege proof substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,8 +201,11 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   migration, and rejects altered, undeclared, skipped, or multi-hop sources. For this specifically
   approved repair, operators may explicitly skip unavailable physical-backup creation with
   `--allow-unbacked-database-migration`; source classification, the write fence, transactional
-  migration, convergence and privilege checks, and post-failure recovery remain mandatory. The
-  path is contract-tested; live-cluster qualification remains pending.
+  migration, convergence and privilege checks, and post-failure recovery remain mandatory. A
+  database whose migration already completed can now finish convergence and privilege
+  reconciliation because the proof query binds its validated history values through psql's script
+  input instead of treating them as literal placeholders, allowing the fence to clear. The path is
+  contract-tested; live-cluster redeployment qualification remains pending.
 
 - **BYOK model calls no longer return 401 when the operator fetches the tenant model list.**
   The `/api/internal/*` routes (`/tenant-models`, `/bundles`, `/contract`,

--- a/apps/postgres/helm/Chart.yaml
+++ b/apps/postgres/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgres
 description: OpenCrane-owned durable PostgreSQL deployment through CloudNativePG.
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: "17"

--- a/apps/postgres/helm/migrations/0.9.0-to-0.9.1.json
+++ b/apps/postgres/helm/migrations/0.9.0-to-0.9.1.json
@@ -1,0 +1,5 @@
+{
+  "fromChartVersion": "0.9.0",
+  "toChartVersion": "0.9.1",
+  "kind": "noop"
+}

--- a/apps/postgres/helm/templates/database-privileges-job.yaml
+++ b/apps/postgres/helm/templates/database-privileges-job.yaml
@@ -59,14 +59,17 @@ spec:
                 history_exists="$(psql --no-psqlrc -v ON_ERROR_STOP=1 -d "$PGDATABASE" -tA \
                   -c "SELECT to_regclass('opencrane_migrations.schema_history') IS NOT NULL")"
                 if [ "$history_exists" = "t" ]; then
+                  # Sends the query over stdin because psql does not substitute -v variables in a -c string.
                   exact_history="$(psql --no-psqlrc -v ON_ERROR_STOP=1 -d "$PGDATABASE" -tA \
                     -v current_schema_version="$CURRENT_SCHEMA_VERSION" \
                     -v target_baseline_sha256="$TARGET_BASELINE_SHA256" \
                     -v previous_migration_id="$PREVIOUS_MIGRATION_ID" \
                     -v previous_migration_sql_sha256="$PREVIOUS_MIGRATION_SQL_SHA256" \
                     -v previous_schema_version="$PREVIOUS_SCHEMA_VERSION" \
-                    -v selected_source_protected_baseline_sha256="$SELECTED_SOURCE_PROTECTED_BASELINE_SHA256" \
-                    -c "SELECT count(*) = 1 FROM opencrane_migrations.schema_history WHERE schema_version = :'current_schema_version' AND source_schema_version = :'previous_schema_version' AND source_baseline_sha256 = :'selected_source_protected_baseline_sha256' AND target_baseline_sha256 = :'target_baseline_sha256' AND migration_id = :'previous_migration_id' AND sql_sha256 = :'previous_migration_sql_sha256'")"
+                    -v selected_source_protected_baseline_sha256="$SELECTED_SOURCE_PROTECTED_BASELINE_SHA256" <<'SQL'
+              SELECT count(*) = 1 FROM opencrane_migrations.schema_history WHERE schema_version = :'current_schema_version' AND source_schema_version = :'previous_schema_version' AND source_baseline_sha256 = :'selected_source_protected_baseline_sha256' AND target_baseline_sha256 = :'target_baseline_sha256' AND migration_id = :'previous_migration_id' AND sql_sha256 = :'previous_migration_sql_sha256';
+              SQL
+              )"
                   [ "$exact_history" = "t" ] && convergence=current
                 fi
               fi

--- a/apps/postgres/tests/helm-contract.sh
+++ b/apps/postgres/tests/helm-contract.sh
@@ -128,7 +128,50 @@ grep -q 'name: CURRENT_SCHEMA_VERSION' "$OUTPUT"
 grep -q 'name: TARGET_BASELINE_SHA256' "$OUTPUT"
 grep -q 'name: CURRENT_PROTECTED_BASELINE_SHA256' "$OUTPUT"
 grep -q 'SELECT "baseline_sha256" FROM "opencrane_bootstrap"."target_baseline"' "$OUTPUT"
+grep -Fq "<<'SQL'" "$OUTPUT"
+if grep -Fq -- '-c "SELECT count(*) = 1 FROM opencrane_migrations.schema_history' "$OUTPUT"; then
+  echo "postgres privilege proof must let psql substitute bound history values" >&2
+  exit 1
+fi
 grep -q 'is not an exact fresh or migrated' "$OUTPUT"
+
+PRIVILEGE_SCRIPT_FILE="$(mktemp)"
+PSQL_STUB_DIR="$(mktemp -d)"
+trap 'rm -f "$OUTPUT" "$PRIVILEGE_SCRIPT_FILE"; rm -rf "$PSQL_STUB_DIR"' EXIT
+node - "$OUTPUT" >"$PRIVILEGE_SCRIPT_FILE" <<'NODE'
+const { readFileSync } = require("node:fs");
+const { parseAllDocuments } = require("yaml");
+const documents = parseAllDocuments(readFileSync(process.argv[2], "utf8")).map((document) => document.toJSON());
+const job = documents.find((document) => document?.kind === "Job"
+  && document.metadata?.name === "opencrane-postgres-database-privileges");
+const container = job.spec.template.spec.containers.find((candidate) => candidate.name === "opencrane-privileges");
+process.stdout.write(container.args[0]);
+NODE
+printf '%s\n' '#!/bin/sh' \
+  'input="$(cat)"' \
+  'case "$*" in' \
+  '  *opencrane_bootstrap*) printf "%s\n" "$SELECTED_SOURCE_PROTECTED_BASELINE_SHA256" ;;' \
+  '  *to_regclass*) printf "%s\n" t ;;' \
+  '  *)' \
+  '    if printf "%s\n" "$input" | grep -q schema_history; then' \
+  '      if printf "%s\n" "$input" | grep -Eq "^[[:space:]]*SQL$"; then exit 70; fi' \
+  '      printf "%s\n" t' \
+  '    fi' \
+  '    ;;' \
+  'esac' >"$PSQL_STUB_DIR/psql"
+chmod +x "$PSQL_STUB_DIR/psql"
+PATH="$PSQL_STUB_DIR:$PATH" \
+PGDATABASE=opencrane \
+PGUSER=opencrane \
+CURRENT_SCHEMA_VERSION=0.8.0 \
+TARGET_BASELINE_SHA256=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+CURRENT_PROTECTED_BASELINE_SHA256=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+PREVIOUS_MIGRATION_AVAILABLE=true \
+PREVIOUS_MIGRATION_ID=0.7.0-to-0.8.0 \
+PREVIOUS_MIGRATION_SQL_SHA256=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd \
+PREVIOUS_SCHEMA_VERSION=0.7.0 \
+SELECTED_SOURCE_PROTECTED_BASELINE_SHA256=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee \
+/bin/sh "$PRIVILEGE_SCRIPT_FILE"
 
 if grep -qE '^kind: (ServiceAccount|Role|RoleBinding|ClusterRole|ClusterRoleBinding)$' "$OUTPUT"; then
   echo "postgres chart must not duplicate the deterministic CloudNativePG runtime identity" >&2
@@ -136,7 +179,7 @@ if grep -qE '^kind: (ServiceAccount|Role|RoleBinding|ClusterRole|ClusterRoleBind
 fi
 
 MIGRATION_OUTPUT="$(mktemp)"
-trap 'rm -f "$OUTPUT" "$MIGRATION_OUTPUT"' EXIT
+trap 'rm -f "$OUTPUT" "$MIGRATION_OUTPUT" "$PRIVILEGE_SCRIPT_FILE"; rm -rf "$PSQL_STUB_DIR"' EXIT
 helm template opencrane-postgres "$CHART" --namespace opencrane \
   "${COMMON_VALUES[@]}" "${MIGRATION_VALUES[@]}" >"$MIGRATION_OUTPUT"
 MIGRATION_JOB="$(awk 'BEGIN { RS="---" } /kind: Job/ && /name: opencrane-postgres-database-migration/ { print }' "$MIGRATION_OUTPUT")"

--- a/releases/0.9.1.json
+++ b/releases/0.9.1.json
@@ -111,7 +111,7 @@
     "postgres": {
       "root": "apps/postgres",
       "adaptedVersion": "0.9.1",
-      "chartVersion": "0.9.0",
+      "chartVersion": "0.9.1",
       "externalAppVersion": "17"
     },
     "skill-authoring": {


### PR DESCRIPTION
## Summary

- execute the migrated-schema history proof through psql stdin so bound variables are substituted
- execute the rendered privilege Job shell in the Helm contract to catch heredoc/runtime regressions
- advance the PostgreSQL chart to 0.9.1 in the still-untagged 0.9.1 release ledger

## Live evidence

The testv4 0.8.1 to 0.9.1 database migration completed, then the privilege Job failed because PostgreSQL received the literal token `:'current_schema_version'`. The application remains safely fenced.

## Validation

- PostgreSQL full contract suite
- PostgreSQL Helm lint
- rendered privilege Job script execution through migrated-history path
- release-versioning and mechanical gates
- independent correctness review and comments gate

## Deployment

Merge and rerun the app-owned 0.9.1 deploy against the completed migrated database to reconcile privileges and clear the fence.