### PR TITLE
🐛 Handle empty initial model provider during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,8 +204,10 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
   migration, convergence and privilege checks, and post-failure recovery remain mandatory. A
   database whose migration already completed can now finish convergence and privilege
   reconciliation because the proof query binds its validated history values through psql's script
-  input instead of treating them as literal placeholders, allowing the fence to clear. The path is
-  contract-tested; live-cluster redeployment qualification remains pending.
+  input instead of treating them as literal placeholders, allowing the fence to clear. Deployments
+  that omit `--initial-model-provider` can also complete Helm argument construction under strict
+  shell checks instead of aborting on an unset optional argument array. The path is contract-tested;
+  live-cluster redeployment qualification remains pending.
 
 - **BYOK model calls no longer return 401 when the operator fetches the tenant model list.**
   The `/api/internal/*` routes (`/tenant-models`, `/bundles`, `/contract`,

--- a/apps/_infra/deploy-k8s/platform/initial-model-provider.sh
+++ b/apps/_infra/deploy-k8s/platform/initial-model-provider.sh
@@ -51,14 +51,14 @@ publish_initial_model_provider_secret()
     --dry-run=client -o yaml | kubectl apply -f -
 }
 
-build_initial_model_provider_helm_args()
+# Appends directly so an omitted provider never requires expanding an unset array under Bash 3.2 with `set -u`.
+append_initial_model_provider_helm_args()
 {
   local provider="$1"
-  INITIAL_MODEL_PROVIDER_HELM_ARGS=()
   if [[ -z "$provider" ]]; then
     return 0
   fi
-  INITIAL_MODEL_PROVIDER_HELM_ARGS=(
+  helm_args+=(
     --set-string "clustertenantManager.initialModel.provider=$provider"
     --set-string "clustertenantManager.initialModel.existingSecret=byok-provider-key-${provider}"
   )

--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -952,8 +952,7 @@ fi
 if [[ -n "$FIRST_USER_EMAIL" ]]; then
   helm_args+=(--set-string "clustertenantManager.firstUser.email=$FIRST_USER_EMAIL")
 fi
-build_initial_model_provider_helm_args "$INITIAL_MODEL_PROVIDER"
-helm_args+=("${INITIAL_MODEL_PROVIDER_HELM_ARGS[@]}")
+append_initial_model_provider_helm_args "$INITIAL_MODEL_PROVIDER"
 [[ -n "$VALUES_FILE" ]] && helm_args+=(--values "$VALUES_FILE")
 helm_args+=("${EXTRA_SET[@]}")
 # Raw helm-arg passthrough for sanctioned one-time fixes (e.g. --take-ownership).

--- a/apps/_infra/deploy-k8s/platform/tests/initial-model-provider-helm-args-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/initial-model-provider-helm-args-contract.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/initial-model-provider.sh"
+
+helm_args=(upgrade)
+append_initial_model_provider_helm_args ""
+[[ "${#helm_args[@]}" -eq 1 ]]
+[[ "${helm_args[0]}" == "upgrade" ]]
+
+append_initial_model_provider_helm_args openai
+[[ "${#helm_args[@]}" -eq 5 ]]
+[[ " ${helm_args[*]} " == *" clustertenantManager.initialModel.provider=openai "* ]]
+[[ " ${helm_args[*]} " == *" clustertenantManager.initialModel.existingSecret=byok-provider-key-openai "* ]]
+
+echo "initial model provider Helm arguments contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
@@ -9,6 +9,7 @@ for contract in \
   current-chart-sources-contract.sh \
   provision-contract.sh \
   kubernetes-api-helm-args-contract.sh \
+  initial-model-provider-helm-args-contract.sh \
   pooler-deploy-contract.sh \
   database-migration-deploy-contract.sh \
   database-convergence-classifier-contract.sh \

--- a/apps/_infra/deploy-k8s/platform/tests/silo-deploy-profile-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/silo-deploy-profile-contract.sh
@@ -17,7 +17,7 @@ grep -Fq -- 'Fresh silo deploys require `--opencrane-ui-digest` and `--cognee-di
 grep -Fq -- 'OPENCRANE_INITIAL_MODEL_API_KEY' "$DEPLOY_SCRIPT"
 grep -Fq -- 'validate_initial_model_provider' "$MODEL_HELPER"
 grep -Fq -- 'publish_initial_model_provider_secret' "$MODEL_HELPER"
-grep -Fq -- 'build_initial_model_provider_helm_args' "$MODEL_HELPER"
+grep -Fq -- 'append_initial_model_provider_helm_args' "$MODEL_HELPER"
 grep -Fq -- '--from-file=apiKey=<(printf' "$MODEL_HELPER"
 if grep -Fq -- '--from-literal=apiKey="$api_key"' "$MODEL_HELPER"; then
   echo "initial model provider key is exposed through kubectl command arguments" >&2


### PR DESCRIPTION
## Summary

- append optional initial-provider Helm arguments through one shared helper
- avoid expanding an unset array under Bash 3.2 with set -u when no provider is configured
- execute the exact empty and configured provider seam in focused and aggregate deploy contracts

## Live evidence

After the corrected PostgreSQL privilege Job succeeded on testv4, final application installation stopped before Helm with `INITIAL_MODEL_PROVIDER_HELM_ARGS[@]: unbound variable`. The application remains safely fenced.

## Validation

- full deploy-k8s contract suite
- focused Bash 3.2/set-u regression contract
- release-versioning, shell syntax, mechanical gates
- independent correctness review and comments gate

## Deployment

Merge and rerun the app-owned 0.9.1 deployment; the database and privilege reconciliation are already complete.