### PR TITLE
Add Storybook states for tools UI

### DIFF
--- a/libs/frontend/core/src/lib/models/mcp.types.ts
+++ b/libs/frontend/core/src/lib/models/mcp.types.ts
@@ -43,7 +43,7 @@ export enum McpApprovalStatus
 /**
  * Per-user connection state of a server the user has installed.
  *
- * Activation in the user's agent runtime ("Claw") is automatic once connected;
+ * Activation in the OpenCrane agent runtime is automatic once connected;
  * `Activating` and `ActivationFailed` surface that backend step.
  */
 export enum McpConnectionStatus

--- a/libs/frontend/elements/ui/.storybook/main.ts
+++ b/libs/frontend/elements/ui/.storybook/main.ts
@@ -20,6 +20,7 @@ const config: StorybookConfig =
 		,"../../../features/agent-threads/src/**/__tests__/*.stories.@(js|jsx|mjs|ts|tsx)"
 		,"../../../features/conversation-workspace/src/**/__tests__/*.stories.@(js|jsx|mjs|ts|tsx)"
 		,"../../../features/settings/src/**/__tests__/*.stories.@(js|jsx|mjs|ts|tsx)"
+		,"../../../features/tools/src/**/__tests__/*.stories.@(js|jsx|mjs|ts|tsx)"
 	],
 	addons:
 	[

--- a/libs/frontend/elements/ui/.storybook/tsconfig.json
+++ b/libs/frontend/elements/ui/.storybook/tsconfig.json
@@ -29,6 +29,7 @@
 	"../../conversation/src/**/__tests__/*.stories.ts",
 	"../../../features/agent-threads/src/**/__tests__/*.stories.ts",
 	"../../../features/conversation-workspace/src/**/__tests__/*.stories.ts",
+	"../../../features/settings/src/**/__tests__/*.stories.ts",
 	"../../../features/tools/src/**/__tests__/*.stories.ts",
     "preview.ts"
   ]

--- a/libs/frontend/elements/ui/.storybook/tsconfig.json
+++ b/libs/frontend/elements/ui/.storybook/tsconfig.json
@@ -29,7 +29,7 @@
 	"../../conversation/src/**/__tests__/*.stories.ts",
 	"../../../features/agent-threads/src/**/__tests__/*.stories.ts",
 	"../../../features/conversation-workspace/src/**/__tests__/*.stories.ts",
-	"../../../features/settings/src/**/__tests__/*.stories.ts",
+	"../../../features/tools/src/**/__tests__/*.stories.ts",
     "preview.ts"
   ]
 }

--- a/libs/frontend/elements/ui/project.json
+++ b/libs/frontend/elements/ui/project.json
@@ -41,7 +41,8 @@
 				"{workspaceRoot}/libs/frontend/elements/conversation/src/**/*",
 				"{workspaceRoot}/libs/frontend/features/agent-threads/src/**/*",
 				"{workspaceRoot}/libs/frontend/features/conversation-workspace/src/**/*",
-				"{workspaceRoot}/libs/frontend/features/settings/src/**/*"
+				"{workspaceRoot}/libs/frontend/features/settings/src/**/*",
+				"{workspaceRoot}/libs/frontend/features/tools/src/**/*"
 			],
 			"options": {
 				"browserTarget": "frontend-elements-ui:build-storybook",
@@ -78,7 +79,8 @@
 				"{workspaceRoot}/libs/frontend/elements/conversation/src/**/*",
 				"{workspaceRoot}/libs/frontend/features/agent-threads/src/**/*",
 				"{workspaceRoot}/libs/frontend/features/conversation-workspace/src/**/*",
-				"{workspaceRoot}/libs/frontend/features/settings/src/**/*"
+				"{workspaceRoot}/libs/frontend/features/settings/src/**/*",
+				"{workspaceRoot}/libs/frontend/features/tools/src/**/*"
 			],
 			"outputs": [
 				"{options.outputDir}"

--- a/libs/frontend/features/tools/src/lib/admin/access-policy/__tests__/access-policy.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/admin/access-policy/__tests__/access-policy.component.stories.ts
@@ -1,0 +1,127 @@
+import { provideRouter } from "@angular/router";
+import { signal } from "@angular/core";
+import { applicationConfig } from "@storybook/angular";
+import type { Meta, StoryObj } from "@storybook/angular";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { McpAccessPolicy } from "@opencrane/core";
+import { MCP_ACCESS_POLICIES, MCP_CATALOGUE, MCP_DIRECTORY } from "@opencrane/core/testing";
+import { SessionStore, type Capabilities } from "@opencrane/state/core";
+import { MCP_GATEWAY, McpGateway } from "@opencrane/state/mcp/adapter";
+
+import { AccessPolicyComponent } from "../access-policy.component";
+
+/** Session fixture that behaves like a customer admin. */
+const _ADMIN_SESSION =
+{
+	capabilities: signal<Capabilities>({
+		isOperator: false,
+		isPlatformOperator: false,
+		customerAdmin: true,
+		manageCustomers: false,
+		managePolicies: true,
+		manageBudgets: false
+	})
+} as Pick<SessionStore, "capabilities">;
+
+/** Session fixture that shows the denied state. */
+const _DENIED_SESSION =
+{
+	capabilities: signal<Capabilities>({
+		isOperator: false,
+		isPlatformOperator: false,
+		customerAdmin: false,
+		manageCustomers: false,
+		managePolicies: false,
+		manageBudgets: false
+	})
+} as Pick<SessionStore, "capabilities">;
+
+/** Creates an isolated policy gateway that returns saved grants on the next read. */
+function _CreateAccessPolicyGateway(): Pick<McpGateway, "listCatalogue" | "getDirectory" | "getAccessPolicy" | "updateAccessPolicy">
+{
+	const policies = new Map<string, McpAccessPolicy>(Object.values(MCP_ACCESS_POLICIES).map(function byServer(policy: McpAccessPolicy): [string, McpAccessPolicy] { return [policy.serverId, { ...policy, groups: [...policy.groups], users: [...policy.users] }]; }));
+
+	return {
+		listCatalogue: function listCatalogue() { return Promise.resolve(MCP_CATALOGUE.map(function clone(server) { return { ...server }; })); },
+		getDirectory: function getDirectory() { return Promise.resolve({ users: [...MCP_DIRECTORY.users], groups: [...MCP_DIRECTORY.groups] }); },
+		getAccessPolicy: function getAccessPolicy(serverId: string)
+		{
+			const policy = policies.get(serverId) ?? { serverId, everyoneInOrg: false, groups: [], users: [] };
+			return Promise.resolve({ ...policy, groups: [...policy.groups], users: [...policy.users] });
+		},
+		updateAccessPolicy: function updateAccessPolicy(serverId: string, policy: McpAccessPolicy)
+		{
+			const updated = { ...policy, serverId, groups: [...policy.groups], users: [...policy.users] };
+			policies.set(serverId, updated);
+			return Promise.resolve({ ...updated, groups: [...updated.groups], users: [...updated.users] });
+		}
+	};
+}
+
+/** Storybook metadata for the admin access-policy surface. */
+const meta: Meta<AccessPolicyComponent> =
+{
+	title: "Tools/Access policy",
+	component: AccessPolicyComponent,
+	tags: ["autodocs"],
+	decorators: [applicationConfig({ providers: [provideRouter([{ path: "**", children: [] }]), { provide: MCP_GATEWAY, useFactory: _CreateAccessPolicyGateway }, { provide: SessionStore, useValue: _ADMIN_SESSION }] })],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "The entitlement editor for one MCP server. Stories keep the everyone-in-org, group, and user grants readable without a live policy backend."
+			}
+		}
+	}
+};
+
+export default meta;
+
+/** Local Storybook story type for the access-policy surface. */
+type Story = StoryObj<AccessPolicyComponent>;
+
+/** The editor opens on a selected server with live entitlement chips. */
+export const SelectedPolicy: Story =
+{
+	tags: ["visual-test"],
+	play: async function play({ canvasElement })
+	{
+		const canvas = within(canvasElement);
+		await waitFor(function policyControlsLoaded() { expect(canvas.getAllByRole("combobox").length).toBeGreaterThan(0); });
+		await userEvent.selectOptions(canvas.getAllByRole("combobox")[0], "Marketing");
+		await waitFor(function savedGroup() { expect(canvas.getByText("Marketing", { selector: "span.wo-ap__chip" })).toBeVisible(); });
+	},
+	render: function render()
+	{
+		return { props: { server: "github" }, template: `<wo-access-policy [server]="server" />` };
+	},
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				story: "The normal edit state for a selected server, with org-wide, group, and user grants visible."
+			}
+		}
+	}
+};
+
+/** The denied state explains the admin-only boundary. */
+export const Denied: Story =
+{
+	decorators: [applicationConfig({ providers: [provideRouter([{ path: "**", children: [] }]), { provide: MCP_GATEWAY, useFactory: _CreateAccessPolicyGateway }, { provide: SessionStore, useValue: _DENIED_SESSION }] })],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				story: "The access-gated state for users without the customer-admin capability."
+			}
+		}
+	}
+};

--- a/libs/frontend/features/tools/src/lib/admin/access-policy/access-policy.component.html
+++ b/libs/frontend/features/tools/src/lib/admin/access-policy/access-policy.component.html
@@ -36,7 +36,7 @@
 									<p class="wo-ap__everyone-title">Everyone in org</p>
 									<p class="wo-ap__everyone-hint">All current and future members can install this server.</p>
 								</div>
-								<p-toggleswitch [ngModel]="pol.everyoneInOrg" (ngModelChange)="onToggleEveryone($event)" />
+								<p-toggleswitch inputId="everyone-in-org" ariaLabel="Everyone in org" [ngModel]="pol.everyoneInOrg" (ngModelChange)="onToggleEveryone($event)" />
 							</div>
 
 							<p class="wo-ap__group-label">Groups</p>
@@ -51,7 +51,7 @@
 									<span class="wo-ap__none">No groups</span>
 								}
 								@if (availableGroups().length > 0) {
-									<select class="wo-select wo-ap__add" (change)="addGroup($event)">
+									<select class="wo-select wo-ap__add" aria-label="Add group" (change)="addGroup($event)">
 										<option value="">+ Add group</option>
 										@for (group of availableGroups(); track group) {
 											<option [value]="group">{{ group }}</option>
@@ -72,7 +72,7 @@
 									<span class="wo-ap__none">No individual users</span>
 								}
 								@if (availableUsers().length > 0) {
-									<select class="wo-select wo-ap__add" (change)="addUser($event)">
+									<select class="wo-select wo-ap__add" aria-label="Add user" (change)="addUser($event)">
 										<option value="">+ Add user</option>
 										@for (user of availableUsers(); track user.id) {
 											<option [value]="user.id">{{ user.name }}</option>

--- a/libs/frontend/features/tools/src/lib/admin/catalogue-admin/__tests__/catalogue-admin.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/admin/catalogue-admin/__tests__/catalogue-admin.component.stories.ts
@@ -1,0 +1,132 @@
+import { provideRouter } from "@angular/router";
+import { signal } from "@angular/core";
+import { applicationConfig } from "@storybook/angular";
+import type { Meta, StoryObj } from "@storybook/angular";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { McpApprovalStatus, McpServer } from "@opencrane/core";
+import { MCP_CATALOGUE } from "@opencrane/core/testing";
+import { SessionStore, type Capabilities } from "@opencrane/state/core";
+import { MCP_GATEWAY, McpGateway } from "@opencrane/state/mcp/adapter";
+
+import { CatalogueAdminComponent } from "../catalogue-admin.component";
+
+/** Gives the governance story one approved server while retaining every other shared state. */
+const _ADMIN_CATALOGUE = MCP_CATALOGUE.map(function withApprovedState(server: McpServer): McpServer
+{
+	if (server.id !== "linear") return { ...server };
+	return { ...server, approvalStatus: McpApprovalStatus.Approved };
+});
+
+/** Session fixture that behaves like a customer admin. */
+const _ADMIN_SESSION =
+{
+	capabilities: signal<Capabilities>({
+		isOperator: false,
+		isPlatformOperator: false,
+		customerAdmin: true,
+		manageCustomers: false,
+		managePolicies: true,
+		manageBudgets: false
+	})
+} as Pick<SessionStore, "capabilities">;
+
+/** Session fixture that shows the denied state. */
+const _DENIED_SESSION =
+{
+	capabilities: signal<Capabilities>({
+		isOperator: false,
+		isPlatformOperator: false,
+		customerAdmin: false,
+		manageCustomers: false,
+		managePolicies: false,
+		manageBudgets: false
+	})
+} as Pick<SessionStore, "capabilities">;
+
+/** Creates an isolated governance gateway that retains lifecycle changes after reloads. */
+function _CreateAdminCatalogueGateway(): Pick<McpGateway, "listCatalogue" | "approve" | "publish" | "reject" | "setEnabled">
+{
+	const catalogue = new Map<string, McpServer>(_ADMIN_CATALOGUE.map(function byId(server: McpServer): [string, McpServer] { return [server.id, { ...server }]; }));
+
+	/** Applies one governance state transition to the requested server. */
+	function _SetStatus(serverId: string, approvalStatus: McpApprovalStatus): McpServer
+	{
+		const current = catalogue.get(serverId);
+		if (!current) throw new Error(`Unknown MCP server: ${serverId}`);
+		const updated = { ...current, approvalStatus };
+		catalogue.set(serverId, updated);
+		return { ...updated };
+	}
+
+	return {
+		listCatalogue: function listCatalogue() { return Promise.resolve(Array.from(catalogue.values(), function clone(server) { return { ...server }; })); },
+		approve: function approve(serverId: string) { return Promise.resolve(_SetStatus(serverId, McpApprovalStatus.Approved)); },
+		publish: function publish(serverId: string) { return Promise.resolve(_SetStatus(serverId, McpApprovalStatus.Published)); },
+		reject: function reject(serverId: string) { return Promise.resolve(_SetStatus(serverId, McpApprovalStatus.Disabled)); },
+		setEnabled: function setEnabled(serverId: string, enabled: boolean) { return Promise.resolve(_SetStatus(serverId, enabled ? McpApprovalStatus.Published : McpApprovalStatus.Disabled)); }
+	};
+}
+
+/** Storybook metadata for the admin catalogue surface. */
+const meta: Meta<CatalogueAdminComponent> =
+{
+	title: "Tools/Admin catalogue",
+	component: CatalogueAdminComponent,
+	tags: ["autodocs"],
+	decorators: [applicationConfig({ providers: [provideRouter([{ path: "**", children: [] }]), { provide: MCP_GATEWAY, useFactory: _CreateAdminCatalogueGateway }, { provide: SessionStore, useValue: _ADMIN_SESSION }] })],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "The org-admin governance surface for MCP servers. Stories keep approved, pending-review, published, and disabled states visible without a live control plane."
+			}
+		}
+	}
+};
+
+export default meta;
+
+/** Local Storybook story type for the admin catalogue surface. */
+type Story = StoryObj<CatalogueAdminComponent>;
+
+/** The admin catalogue shows governance actions for every server state. */
+export const AdminView: Story =
+{
+	tags: ["visual-test"],
+	play: async function play({ canvasElement })
+	{
+		const canvas = within(canvasElement);
+		await waitFor(function catalogueRowsLoaded() { expect(canvas.getByRole("button", { name: "Approve" })).toBeVisible(); });
+		await userEvent.click(canvas.getAllByRole("button", { name: "Approve" })[0]);
+		await waitFor(function approvedState() { expect(canvas.getByRole("button", { name: "Publish" })).toBeVisible(); });
+	},
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				story: "The governance table with pending-review, approved, published, and disabled rows plus their action buttons."
+			}
+		}
+	}
+};
+
+/** The denied state explains why a non-admin cannot reach the governance table. */
+export const Denied: Story =
+{
+	decorators: [applicationConfig({ providers: [provideRouter([{ path: "**", children: [] }]), { provide: MCP_GATEWAY, useFactory: _CreateAdminCatalogueGateway }, { provide: SessionStore, useValue: _DENIED_SESSION }] })],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				story: "The access-gated state for users without the customer-admin capability."
+			}
+		}
+	}
+};

--- a/libs/frontend/features/tools/src/lib/admin/catalogue-admin/catalogue-admin.component.html
+++ b/libs/frontend/features/tools/src/lib/admin/catalogue-admin/catalogue-admin.component.html
@@ -14,7 +14,7 @@
 						<th>Type</th>
 						<th>Entitlements</th>
 						<th>Status</th>
-						<th></th>
+						<th>Actions</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/libs/frontend/features/tools/src/lib/admin/catalogue-admin/catalogue-admin.component.scss
+++ b/libs/frontend/features/tools/src/lib/admin/catalogue-admin/catalogue-admin.component.scss
@@ -29,5 +29,5 @@
 }
 
 .wo-admin__row--off {
-	opacity: 0.55;
+	background: var(--oc-surface-subtle);
 }

--- a/libs/frontend/features/tools/src/lib/catalogue/__tests__/catalogue.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/catalogue/__tests__/catalogue.component.stories.ts
@@ -1,0 +1,82 @@
+import { provideRouter } from "@angular/router";
+import { applicationConfig } from "@storybook/angular";
+import type { Meta, StoryObj } from "@storybook/angular";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { McpApprovalStatus, McpConnectionStatus, McpInstalledServer, McpServerType } from "@opencrane/core";
+import { MCP_CATALOGUE, MCP_INSTALLED } from "@opencrane/core/testing";
+import { MCP_GATEWAY, McpGateway } from "@opencrane/state/mcp/adapter";
+
+import { CatalogueComponent } from "../catalogue.component";
+
+/** Creates an isolated catalogue gateway whose install results match each server type. */
+function _CreateCatalogueGateway(): Pick<McpGateway, "listEntitledCatalogue" | "listInstalled" | "install">
+{
+	const installed = new Map<string, McpInstalledServer>(MCP_INSTALLED.map(function byServer(record: McpInstalledServer): [string, McpInstalledServer] { return [record.serverId, { ...record }]; }));
+
+	return {
+		listEntitledCatalogue: function listEntitledCatalogue()
+		{
+			return Promise.resolve(MCP_CATALOGUE.filter(function published(server) { return server.approvalStatus === McpApprovalStatus.Published; }).map(function clone(server) { return { ...server }; }));
+		},
+		listInstalled: function listInstalled()
+		{
+			return Promise.resolve(Array.from(installed.values(), function clone(record) { return { ...record }; }));
+		},
+		install: function install(serverId: string)
+		{
+			const server = MCP_CATALOGUE.find(function matching(candidate) { return candidate.id === serverId; });
+			const connectionStatus = server?.type === McpServerType.MultiUser ? McpConnectionStatus.SharedKey : McpConnectionStatus.NeedsCredential;
+			const record: McpInstalledServer = { serverId, connectionStatus, lastUsed: null };
+			installed.set(serverId, record);
+			return Promise.resolve({ ...record });
+		}
+	};
+}
+
+/** Storybook metadata for the user-facing MCP catalogue. */
+const meta: Meta<CatalogueComponent> =
+{
+	title: "Tools/Catalogue",
+	component: CatalogueComponent,
+	tags: ["autodocs"],
+	decorators: [applicationConfig({ providers: [provideRouter([{ path: "**", children: [] }]), { provide: MCP_GATEWAY, useFactory: _CreateCatalogueGateway }] })],
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				component: "The browse-and-install surface for entitled MCP servers. Stories keep the published catalogue and installed markers reviewable without a live control plane."
+			}
+		}
+	}
+};
+
+export default meta;
+
+/** Local Storybook story type for the catalogue surface. */
+type Story = StoryObj<CatalogueComponent>;
+
+/** The default catalogue shows installed and installable servers together. */
+export const Default: Story =
+{
+	tags: ["visual-test"],
+	play: async function play({ canvasElement })
+	{
+		const canvas = within(canvasElement);
+		await waitFor(function catalogueCardsLoaded() { expect(canvas.getByRole("button", { name: "Install" })).toBeVisible(); });
+		await userEvent.click(canvas.getByRole("button", { name: "Install" }));
+		await waitFor(function installedState() { expect(canvas.queryByRole("button", { name: "Install" })).not.toBeInTheDocument(); });
+	},
+	parameters:
+	{
+		docs:
+		{
+			description:
+			{
+				story: "The standard browse view with published servers, installed markers, and the approved-only explanation note."
+			}
+		}
+	}
+};

--- a/libs/frontend/features/tools/src/lib/catalogue/catalogue.component.html
+++ b/libs/frontend/features/tools/src/lib/catalogue/catalogue.component.html
@@ -10,7 +10,7 @@
 				<i class="pi pi-search"></i>
 				<input class="wo-text-input" type="text" placeholder="Search tools…" [value]="search()" (input)="onSearch($event)" />
 			</div>
-			<select class="wo-select" (change)="onTypeFilter($event)">
+			<select class="wo-select" aria-label="Filter tools by type" (change)="onTypeFilter($event)">
 				<option value="all">All types</option>
 				<option [value]="serverType.RemoteOauth">OAuth</option>
 				<option [value]="serverType.SingleUser">API token</option>

--- a/libs/frontend/features/tools/src/lib/catalogue/catalogue.component.scss
+++ b/libs/frontend/features/tools/src/lib/catalogue/catalogue.component.scss
@@ -116,7 +116,7 @@
 		margin-top: 18px;
 
 		a {
-			color: var(--oc-accent);
+			color: var(--oc-accent-active);
 			text-decoration: none;
 		}
 	}

--- a/libs/frontend/features/tools/src/lib/connect-drawer/__tests__/connect-drawer.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/connect-drawer/__tests__/connect-drawer.component.stories.ts
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/angular";
+import { expect, fn, userEvent, within } from "storybook/test";
 
+import { McpConnectionStatus } from "@opencrane/core";
 import { MCP_CATALOGUE, MCP_INSTALLED } from "@opencrane/core/testing";
 
 import { ConnectDrawerComponent } from "../connect-drawer.component";
@@ -10,6 +12,9 @@ const _POSTGRES = MCP_CATALOGUE.find(function find(server) { return server.id ==
 const _STRIPE_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "stripe" })!;
 const _GITHUB_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "github" })!;
 const _POSTGRES_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "postgres-prod" })!;
+const _CONNECT_REQUESTED = fn();
+const _DISCONNECT_REQUESTED = fn();
+const _CLOSED = fn();
 
 const meta: Meta<ConnectDrawerComponent> = {
 	title: "Tools/Connect drawer",
@@ -29,15 +34,59 @@ type Story = StoryObj<ConnectDrawerComponent>;
 
 /** A single-user server starts with an empty write-only credential form. */
 export const SingleUserCredential: Story = {
-	args: { server: _STRIPE, installed: _STRIPE_INSTALLED }
+	tags: ["visual-test"],
+	args: { server: _STRIPE, installed: _STRIPE_INSTALLED },
+	play: async function play({ canvasElement })
+	{
+		const canvas = within(canvasElement);
+		await expect(canvas.getByRole("button", { name: "Save & connect" })).toBeDisabled();
+	}
+};
+
+/** A stored single-user credential stays masked until the user chooses Replace. */
+export const StoredCredential: Story = {
+	tags: ["visual-test"],
+	args: { server: _STRIPE, installed: { ..._STRIPE_INSTALLED, connectionStatus: McpConnectionStatus.Connected } },
+	play: async function play({ canvasElement })
+	{
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Replace" }));
+		await expect(canvas.getAllByRole("textbox")[0]).toBeVisible();
+	}
+};
+
+/** A disconnected OAuth server offers the provider consent action. */
+export const DisconnectedOauth: Story = {
+	tags: ["visual-test"],
+	args: { server: _GITHUB, installed: { ..._GITHUB_INSTALLED, connectionStatus: McpConnectionStatus.NeedsCredential }, connectRequested: _CONNECT_REQUESTED },
+	play: async function play({ canvasElement })
+	{
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: /Connect with OAuth/iu }));
+		await expect(_CONNECT_REQUESTED).toHaveBeenCalled();
+	}
 };
 
 /** A connected OAuth server shows the account identity and disconnect action. */
 export const ConnectedOauth: Story = {
-	args: { server: _GITHUB, installed: _GITHUB_INSTALLED }
+	tags: ["visual-test"],
+	args: { server: _GITHUB, installed: _GITHUB_INSTALLED, disconnectRequested: _DISCONNECT_REQUESTED },
+	play: async function play({ canvasElement })
+	{
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Disconnect" }));
+		await expect(_DISCONNECT_REQUESTED).toHaveBeenCalled();
+	}
 };
 
 /** An administrator-managed server explains why no participant credential is required. */
 export const SharedKey: Story = {
-	args: { server: _POSTGRES, installed: _POSTGRES_INSTALLED }
+	tags: ["visual-test"],
+	args: { server: _POSTGRES, installed: _POSTGRES_INSTALLED, closed: _CLOSED },
+	play: async function play({ canvasElement })
+	{
+		const canvas = within(canvasElement);
+		await userEvent.click(canvas.getByRole("button", { name: "Close" }));
+		await expect(_CLOSED).toHaveBeenCalled();
+	}
 };

--- a/libs/frontend/features/tools/src/lib/connect-drawer/__tests__/connect-drawer.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/connect-drawer/__tests__/connect-drawer.component.stories.ts
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/angular";
+
+import { MCP_CATALOGUE, MCP_INSTALLED } from "@opencrane/core/testing";
+
+import { ConnectDrawerComponent } from "../connect-drawer.component";
+
+const _STRIPE = MCP_CATALOGUE.find(function find(server) { return server.id === "stripe" })!;
+const _GITHUB = MCP_CATALOGUE.find(function find(server) { return server.id === "github" })!;
+const _POSTGRES = MCP_CATALOGUE.find(function find(server) { return server.id === "postgres-prod" })!;
+const _STRIPE_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "stripe" })!;
+const _GITHUB_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "github" })!;
+const _POSTGRES_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "postgres-prod" })!;
+
+const meta: Meta<ConnectDrawerComponent> = {
+	title: "Tools/Connect drawer",
+	component: ConnectDrawerComponent,
+	tags: ["autodocs"],
+	parameters: {
+		docs: {
+			description: {
+				component: "The secure connection surface for MCP servers. Stories keep write-only credentials, OAuth account state, and administrator-managed credentials visibly distinct."
+			}
+		}
+	}
+};
+
+export default meta;
+type Story = StoryObj<ConnectDrawerComponent>;
+
+/** A single-user server starts with an empty write-only credential form. */
+export const SingleUserCredential: Story = {
+	args: { server: _STRIPE, installed: _STRIPE_INSTALLED }
+};
+
+/** A connected OAuth server shows the account identity and disconnect action. */
+export const ConnectedOauth: Story = {
+	args: { server: _GITHUB, installed: _GITHUB_INSTALLED }
+};
+
+/** An administrator-managed server explains why no participant credential is required. */
+export const SharedKey: Story = {
+	args: { server: _POSTGRES, installed: _POSTGRES_INSTALLED }
+};

--- a/libs/frontend/features/tools/src/lib/connect-drawer/__tests__/connect-drawer.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/connect-drawer/__tests__/connect-drawer.component.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/angular";
-import { expect, fn, userEvent, within } from "storybook/test";
+import { expect, userEvent, within } from "storybook/test";
 
 import { McpConnectionStatus } from "@opencrane/core";
 import { MCP_CATALOGUE, MCP_INSTALLED } from "@opencrane/core/testing";
@@ -12,9 +12,6 @@ const _POSTGRES = MCP_CATALOGUE.find(function find(server) { return server.id ==
 const _STRIPE_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "stripe" })!;
 const _GITHUB_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "github" })!;
 const _POSTGRES_INSTALLED = MCP_INSTALLED.find(function find(record) { return record.serverId === "postgres-prod" })!;
-const _CONNECT_REQUESTED = fn();
-const _DISCONNECT_REQUESTED = fn();
-const _CLOSED = fn();
 
 const meta: Meta<ConnectDrawerComponent> = {
 	title: "Tools/Connect drawer",
@@ -58,35 +55,38 @@ export const StoredCredential: Story = {
 /** A disconnected OAuth server offers the provider consent action. */
 export const DisconnectedOauth: Story = {
 	tags: ["visual-test"],
-	args: { server: _GITHUB, installed: { ..._GITHUB_INSTALLED, connectionStatus: McpConnectionStatus.NeedsCredential }, connectRequested: _CONNECT_REQUESTED },
+	args: { server: _GITHUB, installed: { ..._GITHUB_INSTALLED, connectionStatus: McpConnectionStatus.NeedsCredential } },
+	render: function render(args) { return { props: { ...args, connectCount: 0 }, template: `<wo-connect-drawer [server]="server" [installed]="installed" (connectRequested)="connectCount = connectCount + 1" /><output data-testid="connect-count" [attr.data-count]="connectCount"></output>` }; },
 	play: async function play({ canvasElement })
 	{
 		const canvas = within(canvasElement);
 		await userEvent.click(canvas.getByRole("button", { name: /Connect with OAuth/iu }));
-		await expect(_CONNECT_REQUESTED).toHaveBeenCalled();
+		await expect(canvas.getByTestId("connect-count")).toHaveAttribute("data-count", "1");
 	}
 };
 
 /** A connected OAuth server shows the account identity and disconnect action. */
 export const ConnectedOauth: Story = {
 	tags: ["visual-test"],
-	args: { server: _GITHUB, installed: _GITHUB_INSTALLED, disconnectRequested: _DISCONNECT_REQUESTED },
+	args: { server: _GITHUB, installed: _GITHUB_INSTALLED },
+	render: function render(args) { return { props: { ...args, disconnectCount: 0 }, template: `<wo-connect-drawer [server]="server" [installed]="installed" (disconnectRequested)="disconnectCount = disconnectCount + 1" /><output data-testid="disconnect-count" [attr.data-count]="disconnectCount"></output>` }; },
 	play: async function play({ canvasElement })
 	{
 		const canvas = within(canvasElement);
 		await userEvent.click(canvas.getByRole("button", { name: "Disconnect" }));
-		await expect(_DISCONNECT_REQUESTED).toHaveBeenCalled();
+		await expect(canvas.getByTestId("disconnect-count")).toHaveAttribute("data-count", "1");
 	}
 };
 
 /** An administrator-managed server explains why no participant credential is required. */
 export const SharedKey: Story = {
 	tags: ["visual-test"],
-	args: { server: _POSTGRES, installed: _POSTGRES_INSTALLED, closed: _CLOSED },
+	args: { server: _POSTGRES, installed: _POSTGRES_INSTALLED },
+	render: function render(args) { return { props: { ...args, closeCount: 0 }, template: `<wo-connect-drawer [server]="server" [installed]="installed" (closed)="closeCount = closeCount + 1" /><output data-testid="close-count" [attr.data-count]="closeCount"></output>` }; },
 	play: async function play({ canvasElement })
 	{
 		const canvas = within(canvasElement);
 		await userEvent.click(canvas.getByRole("button", { name: "Close" }));
-		await expect(_CLOSED).toHaveBeenCalled();
+		await expect(canvas.getByTestId("close-count")).toHaveAttribute("data-count", "1");
 	}
 };

--- a/libs/frontend/features/tools/src/lib/connect-drawer/connect-drawer.component.html
+++ b/libs/frontend/features/tools/src/lib/connect-drawer/connect-drawer.component.html
@@ -4,6 +4,7 @@
 	position="right"
 	[modal]="true"
 	[header]="title()"
+	ariaCloseLabel="Close connection drawer"
 	[style]="{ width: '420px' }"
 	styleClass="wo-connect-drawer"
 >
@@ -31,6 +32,7 @@
 								[class.wo-mono]="field.sensitive"
 								[type]="field.sensitive ? 'password' : 'text'"
 								[attr.autocomplete]="field.sensitive ? 'new-password' : 'off'"
+								[attr.aria-label]="field.label"
 								[placeholder]="field.placeholder ?? ''"
 								[value]="formValues()[field.key]"
 								(input)="onFieldInput(field.key, $event)"

--- a/libs/frontend/features/tools/src/lib/connect-drawer/connect-drawer.component.scss
+++ b/libs/frontend/features/tools/src/lib/connect-drawer/connect-drawer.component.scss
@@ -19,7 +19,7 @@
 	}
 
 	&__req {
-		color: var(--oc-accent);
+		color: var(--oc-accent-active);
 		font-size: 11px;
 	}
 

--- a/libs/frontend/features/tools/src/lib/my-tools/__tests__/my-tools.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/my-tools/__tests__/my-tools.component.stories.ts
@@ -1,0 +1,41 @@
+import { provideRouter } from "@angular/router";
+import { applicationConfig } from "@storybook/angular";
+import type { Meta, StoryObj } from "@storybook/angular";
+
+import { McpApprovalStatus } from "@opencrane/core";
+import { MCP_CATALOGUE, MCP_INSTALLED } from "@opencrane/core/testing";
+import { MCP_GATEWAY } from "@opencrane/state/mcp/adapter";
+
+import { MyToolsComponent } from "../my-tools.component";
+
+const _MCP_GATEWAY_FIXTURE = {
+	listEntitledCatalogue: function listEntitledCatalogue() { return Promise.resolve(MCP_CATALOGUE.filter(function published(server) { return server.approvalStatus === McpApprovalStatus.Published; })); },
+	listInstalled: function listInstalled() { return Promise.resolve(MCP_INSTALLED); },
+	uninstall: function uninstall() { return Promise.resolve(); },
+	setCredential: function setCredential() { return Promise.resolve(MCP_INSTALLED[0]); },
+	removeCredential: function removeCredential() { return Promise.resolve(MCP_INSTALLED[0]); },
+	connectOauth: function connectOauth() { return Promise.resolve(MCP_INSTALLED[0]); },
+	disconnect: function disconnect() { return Promise.resolve(MCP_INSTALLED[0]); }
+};
+
+const meta: Meta<MyToolsComponent> = {
+	title: "Tools/My tools",
+	component: MyToolsComponent,
+	tags: ["autodocs"],
+	decorators: [applicationConfig({ providers: [provideRouter([]), { provide: MCP_GATEWAY, useValue: _MCP_GATEWAY_FIXTURE }] })],
+	parameters: {
+		docs: {
+			description: {
+				component: "The participant-facing inventory of installed MCP servers. The story uses shared fixture data so representative connection states remain reviewable without a live control plane."
+			}
+		}
+	}
+};
+
+export default meta;
+type Story = StoryObj<MyToolsComponent>;
+
+/** Installed tools cover pending credentials, OAuth, token, shared-key, and activation states. */
+export const InstalledStates: Story = {
+	parameters: { docs: { description: { story: "The default fixture shows the status table, the pending-credential callout, and the catalogue navigation affordance." } } }
+};

--- a/libs/frontend/features/tools/src/lib/my-tools/__tests__/my-tools.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/my-tools/__tests__/my-tools.component.stories.ts
@@ -38,7 +38,7 @@ const meta: Meta<MyToolsComponent> = {
 	title: "Tools/My tools",
 	component: MyToolsComponent,
 	tags: ["autodocs"],
-	decorators: [applicationConfig({ providers: [provideRouter([]), { provide: MCP_GATEWAY, useFactory: _CreateMyToolsGateway }] })],
+	decorators: [applicationConfig({ providers: [provideRouter([{ path: "**", children: [] }]), { provide: MCP_GATEWAY, useFactory: _CreateMyToolsGateway }] })],
 	parameters: {
 		docs: {
 			description: {

--- a/libs/frontend/features/tools/src/lib/my-tools/__tests__/my-tools.component.stories.ts
+++ b/libs/frontend/features/tools/src/lib/my-tools/__tests__/my-tools.component.stories.ts
@@ -2,27 +2,43 @@ import { provideRouter } from "@angular/router";
 import { applicationConfig } from "@storybook/angular";
 import type { Meta, StoryObj } from "@storybook/angular";
 
-import { McpApprovalStatus } from "@opencrane/core";
+import { McpApprovalStatus, McpConnectionStatus, McpInstalledServer } from "@opencrane/core";
 import { MCP_CATALOGUE, MCP_INSTALLED } from "@opencrane/core/testing";
-import { MCP_GATEWAY } from "@opencrane/state/mcp/adapter";
+import { MCP_GATEWAY, McpGateway } from "@opencrane/state/mcp/adapter";
 
 import { MyToolsComponent } from "../my-tools.component";
 
-const _MCP_GATEWAY_FIXTURE = {
-	listEntitledCatalogue: function listEntitledCatalogue() { return Promise.resolve(MCP_CATALOGUE.filter(function published(server) { return server.approvalStatus === McpApprovalStatus.Published; })); },
-	listInstalled: function listInstalled() { return Promise.resolve(MCP_INSTALLED); },
-	uninstall: function uninstall() { return Promise.resolve(); },
-	setCredential: function setCredential() { return Promise.resolve(MCP_INSTALLED[0]); },
-	removeCredential: function removeCredential() { return Promise.resolve(MCP_INSTALLED[0]); },
-	connectOauth: function connectOauth() { return Promise.resolve(MCP_INSTALLED[0]); },
-	disconnect: function disconnect() { return Promise.resolve(MCP_INSTALLED[0]); }
-};
+/** Creates an isolated gateway that preserves connection changes after each reload. */
+function _CreateMyToolsGateway(): Pick<McpGateway, "listEntitledCatalogue" | "listInstalled" | "uninstall" | "setCredential" | "removeCredential" | "connectOauth" | "disconnect">
+{
+	const installed = new Map<string, McpInstalledServer>(MCP_INSTALLED.map(function byServer(record: McpInstalledServer): [string, McpInstalledServer] { return [record.serverId, { ...record }]; }));
+
+	/** Updates the requested server and returns the same state that the next read will expose. */
+	function _SetConnection(serverId: string, connectionStatus: McpConnectionStatus, connectedAccount?: string): McpInstalledServer
+	{
+		const current = installed.get(serverId);
+		if (!current) throw new Error(`Unknown installed MCP server: ${serverId}`);
+		const updated: McpInstalledServer = { ...current, connectionStatus, connectedAccount };
+		installed.set(serverId, updated);
+		return { ...updated };
+	}
+
+	return {
+		listEntitledCatalogue: function listEntitledCatalogue() { return Promise.resolve(MCP_CATALOGUE.filter(function published(server) { return server.approvalStatus === McpApprovalStatus.Published; }).map(function clone(server) { return { ...server }; })); },
+		listInstalled: function listInstalled() { return Promise.resolve(Array.from(installed.values(), function clone(record) { return { ...record }; })); },
+		uninstall: function uninstall(serverId: string) { installed.delete(serverId); return Promise.resolve(); },
+		setCredential: function setCredential(serverId: string) { return Promise.resolve(_SetConnection(serverId, McpConnectionStatus.Connected)); },
+		removeCredential: function removeCredential(serverId: string) { return Promise.resolve(_SetConnection(serverId, McpConnectionStatus.NeedsCredential)); },
+		connectOauth: function connectOauth(serverId: string) { return Promise.resolve(_SetConnection(serverId, McpConnectionStatus.OauthConnected, "storybook@example.com")); },
+		disconnect: function disconnect(serverId: string) { return Promise.resolve(_SetConnection(serverId, McpConnectionStatus.NeedsCredential)); }
+	};
+}
 
 const meta: Meta<MyToolsComponent> = {
 	title: "Tools/My tools",
 	component: MyToolsComponent,
 	tags: ["autodocs"],
-	decorators: [applicationConfig({ providers: [provideRouter([]), { provide: MCP_GATEWAY, useValue: _MCP_GATEWAY_FIXTURE }] })],
+	decorators: [applicationConfig({ providers: [provideRouter([]), { provide: MCP_GATEWAY, useFactory: _CreateMyToolsGateway }] })],
 	parameters: {
 		docs: {
 			description: {

--- a/libs/frontend/features/tools/src/lib/my-tools/my-tools.component.html
+++ b/libs/frontend/features/tools/src/lib/my-tools/my-tools.component.html
@@ -2,7 +2,7 @@
 	<div class="wo-tools-page__inner">
 		<wo-section-heading
 			title="My tools"
-			subtitle="Servers you've installed. Connected servers are active in your agent runtime (Claw) and ready to use in chat."
+			subtitle="Servers you've installed. Connected servers are active in the OpenCrane agent runtime and ready to use in chat."
 		/>
 
 		@if (rows().length > 0) {
@@ -64,7 +64,7 @@
 
 			@if (firstNeedsCredential(); as pending) {
 				<div class="wo-callout wo-mytools__prompt">
-					<b>{{ pending.name }}</b> needs a credential before your agent can use it. Until then its tools are installed but inactive in Claw.
+					<b>{{ pending.name }}</b> needs a credential before your agent can use it. Until then its tools are installed but inactive in the OpenCrane agent runtime.
 					<button type="button" class="wo-tools__act" (click)="openConnect(pending)">{{ connectLabel(pending) }}</button>
 				</div>
 			}

--- a/libs/frontend/features/tools/src/lib/my-tools/my-tools.component.html
+++ b/libs/frontend/features/tools/src/lib/my-tools/my-tools.component.html
@@ -13,7 +13,7 @@
 						<th>Type</th>
 						<th>Status</th>
 						<th>Last used</th>
-						<th></th>
+						<th>Actions</th>
 					</tr>
 				</thead>
 				<tbody>

--- a/libs/frontend/features/tools/src/lib/my-tools/my-tools.component.ts
+++ b/libs/frontend/features/tools/src/lib/my-tools/my-tools.component.ts
@@ -22,8 +22,8 @@ interface _McpToolRow
  * Joins each install record to its catalogue detail, renders the connection
  * state (the one terracotta CTA is the "needs credential" row), and opens the
  * {@link ConnectDrawerComponent} for the secure connect/credential flow. All
- * writes go through the injected gateway; activation in the agent runtime
- * ("Claw") is automatic once connected.
+ * writes go through the injected gateway; activation in the OpenCrane agent
+ * runtime is automatic once connected.
  */
 @Component({
 	selector: "wo-my-tools",

--- a/libs/frontend/features/tools/theme.scss
+++ b/libs/frontend/features/tools/theme.scss
@@ -81,6 +81,10 @@
 	color: var(--oc-ink-muted);
 	line-height: 1.5;
 
+	a {
+		color: var(--oc-accent-active);
+	}
+
 	&--info {
 		border-left-color: var(--oc-info);
 		background: var(--oc-info-soft);


### PR DESCRIPTION
## Summary

This PR completes the tools Storybook implementation by aligning component stories, fixtures, accessibility states, and visual styling with the real tools workflows. Removes `OpenClaw` references

## Changes

- Added Storybook coverage for:
  -   My Tools 
  - Connect Drawer
  - Catalogue
  - Catalogue administration
  - Access policies

- Added shared, mutable fixture behavior for install, approval, connection, and policy interactions.
- Added async interaction assertions for Storybook play functions.
- Improved accessibility:
  - Added labels for inputs, selects, toggles, and close actions.
  - Added table action headers.
  - Added accessible policy controls.
- Improved visual consistency and contrast for:
  - Links
  - Required text
  - Disabled catalogue rows
  - Callout content
- Ensured catalogue installation state reflects multi-user MCP servers correctly.
- Kept admin approval state synchronized with the shared catalogue fixture.
- Added explicit event assertions for Connect Drawer connection flows.

## Validation

- `npm run test:storybook` passed
- `npx tsc -p libs/frontend/features/tools/tsconfig.lint.json --noEmit` passed
- `git diff --check` passed
- `scripts/agent-style-check.sh` passed
- `npm run check:prisma-boundaries` passed
- `npm run check:module-growth` passed

