### PR TITLE
🐛 Accept complete conversation responses

### DIFF
--- a/libs/frontend/features/conversation-workspace/src/lib/__tests__/conversation-workspace-page.component.spec.ts
+++ b/libs/frontend/features/conversation-workspace/src/lib/__tests__/conversation-workspace-page.component.spec.ts
@@ -73,7 +73,7 @@ class _EventStream implements ConversationEventStream
 /** Build one authorized empty conversation for route-state tests. */
 function _Conversation(): ConversationWorkspaceDetail
 {
-	return { id: "conversation-1", mode: ConversationModes.Group, lifecycle: ConversationLifecycles.Open, agentServiceId: null, participantRefs: ["participant-1"], archivedAt: null, updatedAt: "2026-08-12T08:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [] };
+	return { id: "conversation-1", mode: ConversationModes.Group, lifecycle: ConversationLifecycles.Open, agentServiceId: null, participantRefs: ["participant-1"], archivedAt: null, readThroughPosition: "0", updatedAt: "2026-08-12T08:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [] };
 }
 
 /** Build one requested free-text projection used by recovery tests. */

--- a/libs/frontend/features/conversation-workspace/src/lib/__tests__/conversation-workspace-shell.stories.ts
+++ b/libs/frontend/features/conversation-workspace/src/lib/__tests__/conversation-workspace-shell.stories.ts
@@ -25,7 +25,7 @@ const _NO_MEMBERSHIP_DIRECTORY: ConversationCreationDirectory = { participants: 
 /** Build one authorized conversation with optional hostile source text. */
 function _Detail(body = "I reviewed the proposal and kept the important constraints."): ConversationWorkspaceDetail
 {
-	return { id: "conversation-1", mode: ConversationModes.AgentSession, lifecycle: ConversationLifecycles.Open, agentServiceId: "agent-1", participantRefs: ["self"], archivedAt: null, updatedAt: "2026-08-12T19:30:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [{ id: "message-1", position: "1", role: MessageRoles.Assistant, state: MessageStates.Completed, source: MessageSources.ModelOutput, blocks: [{ id: "block-1", kind: "text", value: body }], runId: "run-1", participantRef: null, createdAt: "2026-08-12T19:30:00.000Z", agentThread: null }] };
+	return { id: "conversation-1", mode: ConversationModes.AgentSession, lifecycle: ConversationLifecycles.Open, agentServiceId: "agent-1", participantRefs: ["self"], archivedAt: null, readThroughPosition: "0", updatedAt: "2026-08-12T19:30:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [{ id: "message-1", position: "1", role: MessageRoles.Assistant, state: MessageStates.Completed, source: MessageSources.ModelOutput, blocks: [{ id: "block-1", kind: "text", value: body }], runId: "run-1", participantRef: null, createdAt: "2026-08-12T19:30:00.000Z", completedAt: "2026-08-12T19:30:01.000Z", agentThread: null }] };
 }
 
 /** Build one direct conversation carrying a stale run coordinate only in the stream fixture. */

--- a/libs/frontend/features/conversation-workspace/src/lib/__tests__/conversation-workspace.mapper.spec.ts
+++ b/libs/frontend/features/conversation-workspace/src/lib/__tests__/conversation-workspace.mapper.spec.ts
@@ -6,13 +6,13 @@ import { ConversationSessionRailIconStates } from "../conversation-workspace-fea
 /** Builds a direct-conversation summary without introducing display names. */
 function _Summary(): ConversationSummary
 {
-	return { id: "conversation-1", mode: ConversationModes.Direct, lifecycle: ConversationLifecycles.Open, agentServiceId: null, participantRefs: ["subject-secret", "other-secret"], archivedAt: null, updatedAt: "2026-08-12T11:08:00.000Z" };
+	return { id: "conversation-1", mode: ConversationModes.Direct, lifecycle: ConversationLifecycles.Open, agentServiceId: null, participantRefs: ["subject-secret", "other-secret"], archivedAt: null, readThroughPosition: "0", updatedAt: "2026-08-12T11:08:00.000Z" };
 }
 
 /** Builds a participant message containing unsafe markup. */
 function _Message(): ConversationMessage
 {
-	return { id: "message-1", position: "1", role: MessageRoles.User, state: MessageStates.Completed, source: MessageSources.UserInput, blocks: [{ id: "block-1", kind: "text", value: "Hello <script>alert('secret')</script>" }], runId: null, participantRef: "other-secret", createdAt: "2026-08-12T11:08:00.000Z", agentThread: null };
+	return { id: "message-1", position: "1", role: MessageRoles.User, state: MessageStates.Completed, source: MessageSources.UserInput, blocks: [{ id: "block-1", kind: "text", value: "Hello <script>alert('secret')</script>" }], runId: null, participantRef: "other-secret", createdAt: "2026-08-12T11:08:00.000Z", completedAt: "2026-08-12T11:08:01.000Z", agentThread: null };
 }
 
 describe("Conversation workspace presentation", function _ConversationWorkspacePresentation()

--- a/libs/frontend/state/conversation/workspace/README.md
+++ b/libs/frontend/state/conversation/workspace/README.md
@@ -33,6 +33,9 @@ The package also owns the Zod response validators used by its transport adapter.
   does not define a second stream contract.
 - `ConversationWorkspaceStore` owns ordinary list, selection, snapshot-tail state, immutable creation mode,
   drafts, and conversation commands.
+- Conversation summaries retain the server's decimal `readThroughPosition`, and messages retain
+  `completedAt`; strict validation accepts both response fields without giving browser state authority
+  to advance the participant coordinate or complete a message.
 - `ConversationOnboardingHistoryStore` keeps the optional transcript read and selection independent from
   ordinary snapshot, stream, draft, and run state.
 - `ConversationRunStore` owns run status and exact-attempt run commands.

--- a/libs/frontend/state/conversation/workspace/adapter/src/lib/__tests__/conversation-workspace.dto.spec.ts
+++ b/libs/frontend/state/conversation/workspace/adapter/src/lib/__tests__/conversation-workspace.dto.spec.ts
@@ -1,8 +1,9 @@
+import type { paths } from "@opencrane/contracts";
 import { ConversationLifecycles, ConversationModes, MessageRoles, MessageSources, MessageStates } from "@opencrane/models/conversations";
 import { PersonaFirstChatArchetypes, PersonaFirstChatColours, PersonaFirstChatTranscriptKinds, PersonaFirstChatTranscriptRoles, UserOnboardingRouteStates, type PersonaFirstChatSnapshot } from "@opencrane/models/user-onboarding";
 import { ConversationOnboardingHistoryStatuses, ConversationPersonalAgentStatuses, ConversationRunStates } from "@opencrane/state/conversation/workspace";
 
-import { _ConversationDetail, _ConversationRun, _ConversationWorkspaceDirectory } from "../conversation-workspace.dto";
+import { _ConversationDetail, _ConversationRun, _ConversationSummary, _ConversationWorkspaceDirectory } from "../conversation-workspace.dto";
 
 describe("conversation workspace DTO mapping", function _ConversationWorkspaceDto()
 {
@@ -13,12 +14,20 @@ describe("conversation workspace DTO mapping", function _ConversationWorkspaceDt
 		expect(JSON.stringify(directory)).not.toContain("subject");
 	});
 
-	it("sorts canonical messages by decimal position rather than timestamp", function _TimelineOrder()
+	it("accepts the server's participant read position in conversation lists", function _ReadThroughPosition()
 	{
-		const detail = _ConversationDetail({ id: "conversation-1", mode: "group", lifecycle: "open", agentServiceId: null, participantRefs: ["member-1"], archivedAt: null, updatedAt: "2026-08-12T09:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [{ id: "later", position: "10", role: "user", state: "completed", source: "user_input", blocks: [{ id: "block-2", kind: "text", value: "Later" }], runId: null, participantRef: "member-1", createdAt: "2026-08-12T08:00:00.000Z", agentThread: null }, { id: "earlier", position: "2", role: "assistant", state: "completed", source: "model_output", blocks: [{ id: "block-1", kind: "text", value: "Earlier" }], runId: "run-1", participantRef: null, createdAt: "2026-08-12T09:00:00.000Z", agentThread: null }] });
+		const summary = _ConversationSummary({ id: "conversation-1", mode: "direct", lifecycle: "open", agentServiceId: null, participantRefs: ["member-1", "member-2"], archivedAt: null, readThroughPosition: "0", updatedAt: "2026-08-12T09:00:00.000Z" } satisfies paths["/me/conversations"]["get"]["responses"][200]["content"]["application/json"]["conversations"][number]);
+		expect(summary.readThroughPosition).toBe("0");
+	});
+
+	it("accepts server detail fields and sorts messages by timeline position", function _TimelineOrder()
+	{
+		const detail = _ConversationDetail({ id: "conversation-1", mode: "group", lifecycle: "open", agentServiceId: null, participantRefs: ["member-1"], archivedAt: null, readThroughPosition: "0", updatedAt: "2026-08-12T09:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [{ id: "later", position: "10", role: "user", state: "completed", source: "user_input", blocks: [{ id: "block-2", kind: "text", value: "Later" }], runId: null, participantRef: "member-1", createdAt: "2026-08-12T08:00:00.000Z", completedAt: "2026-08-12T08:00:01.000Z", agentThread: null }, { id: "earlier", position: "2", role: "assistant", state: "completed", source: "model_output", blocks: [{ id: "block-1", kind: "text", value: "Earlier" }], runId: "run-1", participantRef: null, createdAt: "2026-08-12T09:00:00.000Z", completedAt: "2026-08-12T09:00:01.000Z", agentThread: null }] } satisfies paths["/me/conversations"]["post"]["responses"][201]["content"]["application/json"]["conversation"]);
 		expect(detail.mode).toBe(ConversationModes.Group);
 		expect(detail.lifecycle).toBe(ConversationLifecycles.Open);
+		expect(detail.readThroughPosition).toBe("0");
 		expect(detail.messages.map(message => message.id)).toEqual(["earlier", "later"]);
+		expect(detail.messages[0]?.completedAt).toBe("2026-08-12T09:00:01.000Z");
 		expect(detail.messages[0]).toMatchObject({ role: MessageRoles.Assistant, state: MessageStates.Completed, source: MessageSources.ModelOutput });
 	});
 
@@ -33,7 +42,15 @@ describe("conversation workspace DTO mapping", function _ConversationWorkspaceDt
 	{
 		expect(function _InvalidNestedMessage()
 		{
-			_ConversationDetail({ id: "conversation-1", mode: "group", lifecycle: "open", agentServiceId: null, participantRefs: ["member-1"], archivedAt: null, updatedAt: "2026-08-12T09:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [{ id: "message-1", position: "1", role: "user", state: "completed", source: "user_input", blocks: [{ id: "", kind: "text", value: "Invalid" }], runId: null, participantRef: "member-1", createdAt: "2026-08-12T09:00:00.000Z", agentThread: null }] });
+			_ConversationDetail({ id: "conversation-1", mode: "group", lifecycle: "open", agentServiceId: null, participantRefs: ["member-1"], archivedAt: null, readThroughPosition: "0", updatedAt: "2026-08-12T09:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [{ id: "message-1", position: "1", role: "user", state: "completed", source: "user_input", blocks: [{ id: "", kind: "text", value: "Invalid" }], runId: null, participantRef: "member-1", createdAt: "2026-08-12T09:00:00.000Z", completedAt: "2026-08-12T09:00:01.000Z", agentThread: null }] });
 		}).toThrow();
+	});
+
+	it("rejects message completion times that contradict message state", function _MessageCompletionInvariant()
+	{
+		const detail = { id: "conversation-1", mode: "group", lifecycle: "open", agentServiceId: null, participantRefs: ["member-1"], archivedAt: null, readThroughPosition: "0", updatedAt: "2026-08-12T09:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [{ id: "message-1", position: "1", role: "assistant", state: "completed", source: "model_output", blocks: [{ id: "block-1", kind: "text", value: "Done" }], runId: "run-1", participantRef: null, createdAt: "2026-08-12T09:00:00.000Z", completedAt: "2026-08-12T09:00:01.000Z", agentThread: null }] } satisfies paths["/me/conversations"]["post"]["responses"][201]["content"]["application/json"]["conversation"];
+		const message = detail.messages[0];
+		expect(function _TerminalWithoutCompletion() { _ConversationDetail({ ...detail, messages: [{ ...message, completedAt: null }] }); }).toThrow();
+		expect(function _NonTerminalWithCompletion() { _ConversationDetail({ ...detail, messages: [{ ...message, state: "streaming" }] }); }).toThrow();
 	});
 });

--- a/libs/frontend/state/conversation/workspace/src/lib/__tests__/conversation-workspace.store.spec.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/__tests__/conversation-workspace.store.spec.ts
@@ -24,7 +24,7 @@ function _OnboardingHistory(): ConversationOnboardingHistoryProjection
 /** Build one complete authorized conversation snapshot. */
 function _Detail(id = "conversation-1"): ConversationWorkspaceDetail
 {
-	return { id, mode: ConversationModes.Group, lifecycle: ConversationLifecycles.Open, agentServiceId: null, participantRefs: ["self-ref", "other-ref"], archivedAt: null, updatedAt: "2026-08-12T09:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [] };
+	return { id, mode: ConversationModes.Group, lifecycle: ConversationLifecycles.Open, agentServiceId: null, participantRefs: ["self-ref", "other-ref"], archivedAt: null, readThroughPosition: "0", updatedAt: "2026-08-12T09:00:00.000Z", visibleFromPosition: "1", accessEndedPosition: null, messages: [] };
 }
 
 /** Controllable promise used to prove stale load completions cannot mutate current state. */

--- a/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.types.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.types.ts
@@ -177,6 +177,8 @@ export interface ConversationSummary
 	readonly participantRefs: readonly string[];
 	/** Per-participant archive time. */
 	readonly archivedAt: string | null;
+	/** Latest timeline position the participant has read, kept as a decimal string. */
+	readonly readThroughPosition: string;
 	/** Latest browser-safe update time. */
 	readonly updatedAt: string;
 }
@@ -202,6 +204,8 @@ export interface ConversationMessage
 	readonly participantRef: string | null;
 	/** Server timestamp used only for a display label. */
 	readonly createdAt: string;
+	/** Server completion time for `Completed`, `Failed`, or `Cancelled`; null for `Pending` or `Streaming`. */
+	readonly completedAt: string | null;
 	/** Child Agent-session origin created by an @agent message. */
 	readonly agentThread: { readonly childConversationId: string; readonly parentMessageId: string } | null;
 }

--- a/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.validator.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.validator.ts
@@ -21,7 +21,7 @@
 // the matching schema admits it.
 import { z } from "zod";
 
-import { ConversationLifecycles, ConversationModes, MessageRoles, MessageSources, MessageStates } from "@opencrane/models/conversations";
+import { __HasValidMessageCompletion, ConversationLifecycles, ConversationModes, MessageRoles, MessageSources, MessageStates } from "@opencrane/models/conversations";
 
 import { ConversationPersonalAgentStatuses, ConversationRunStates, type ConversationCreationDirectory, type ConversationMessage, type ConversationRun, type ConversationSummary, type ConversationWorkspaceDetail } from "./conversation-workspace.types";
 
@@ -80,6 +80,7 @@ const _Summary = z.object({
 	agentServiceId: _NullableRequiredString,
 	participantRefs: z.array(_RequiredString),
 	archivedAt: z.string().datetime().nullable(),
+	readThroughPosition: _Position,
 	updatedAt: z.string().datetime()
 }).strict();
 
@@ -93,6 +94,10 @@ const _Summary = z.object({
  *
  * `agentThread` is present when an `@agent` mention in this message started a child Agent session; it
  * is null on every other message.
+ *
+ * `completedAt` follows the same state invariant as a stored message: terminal states require a
+ * timestamp and unfinished states require null. The adapter's `rejects message completion times that
+ * contradict message state` case pins both mismatch directions at this response boundary.
  */
 const _Message = z.object({
 	id: _RequiredString,
@@ -104,8 +109,13 @@ const _Message = z.object({
 	runId: _NullableRequiredString,
 	participantRef: _NullableRequiredString,
 	createdAt: z.string().datetime(),
+	completedAt: z.string().datetime().nullable(),
 	agentThread: z.object({ childConversationId: _RequiredString, parentMessageId: _RequiredString }).strict().nullable()
-}).strict();
+}).strict().superRefine(function _ValidateMessageCompletion(message, context)
+{
+	if (__HasValidMessageCompletion(message)) return;
+	context.addIssue({ code: z.ZodIssueCode.custom, path: ["completedAt"], message: "must be present exactly when message state is terminal" });
+});
 
 /**
  * Shape of the snapshot for the one open conversation: a summary plus the two access positions and the
@@ -176,8 +186,8 @@ export function _ParseConversationWorkspaceDirectory(value: unknown): Conversati
  * Checks one conversation row for the left rail.
  *
  * Admits the conversation's id, its fixed mode, its open or closed lifecycle, the opaque participant
- * references, and the archive and update timestamps. Rejects an unknown mode or lifecycle, a timestamp
- * that is not ISO-8601, and any extra field.
+ * and Agent references, the participant's read-through position, and the archive and update timestamps.
+ * Rejects an unknown mode or lifecycle, an invalid position or timestamp, and any extra field.
  *
  * A rejection fails the whole list, not one row: the adapter maps this over every entry the API
  * returned, so one bad row means the participant sees the recoverable error instead of a list that is

--- a/libs/models/conversations/main/src/conversation-invariants.ts
+++ b/libs/models/conversations/main/src/conversation-invariants.ts
@@ -87,8 +87,20 @@ export function __CanAppendConversationTimelineEntry(previous: ConversationTimel
 	return previous.conversationId === next.conversationId && BigInt(next.position) === BigInt(previous.position) + 1n;
 }
 
-/** Determine whether `completedAt` matches the message's state: present for a terminal state, absent otherwise. Neither half may be true on its own. */
-export function __HasValidMessageCompletion(message: Message): boolean
+/**
+ * Checks whether a message projection pairs its assembly state with a completion timestamp.
+ *
+ * This accepts any projection containing `state` and `completedAt`, so the stored-message schema and
+ * frontend response boundary can enforce the same rule without supplying unrelated message fields.
+ * `Completed`, `Failed`, and `Cancelled` require a timestamp; `Pending` and `Streaming` require null.
+ *
+ * Called by: {@link ___MessageSchema} and the conversation-workspace response schema used by
+ * `_ParseConversationDetail`.
+ * @param message - A message projection containing the state and completion timestamp to compare.
+ * @returns True when the timestamp is present exactly for a terminal state; false for either mismatch.
+ * @see MessageStates for the states this invariant distinguishes.
+ */
+export function __HasValidMessageCompletion(message: Pick<Message, "state" | "completedAt">): boolean
 {
 	const terminalStates: readonly MessageStates[] = [MessageStates.Completed, MessageStates.Failed, MessageStates.Cancelled];
 	return terminalStates.includes(message.state) === (message.completedAt !== null);


### PR DESCRIPTION
## Summary

- accept the server-required read-through position on conversation summaries and completion timestamp on messages
- enforce the shared terminal-state/completion-time invariant at the frontend response boundary
- bind list and create-response regression fixtures to the generated OpenAPI contract

## Root cause

The server returned successful conversation responses containing readThroughPosition and completedAt, while the frontend strict Zod schemas omitted those fields. Creation persisted with HTTP 201, but the browser rejected the response; refreshing then rejected the conversation list and showed the workspace-unavailable state. This affected both personal Agent sessions and direct private chats.

## Validation

- models-conversations lint and 15 tests
- conversation workspace adapter lint and 6 tests
- conversation workspace state lint and 27 tests
- conversation workspace feature lint and 17 tests
- opencrane-ui production build
- release versioning, style, module-growth, Prisma-boundary, and diff checks
- independent review: no findings
- final comments/docstring gate: PASS

## Delivery and ancestry

- base: current develop at 06b3d56c
- head: 2c406a13
- PRs #665 and #667 are merged and ancestral
- intentionally independent of the remaining release-migration CI work in #666; this diff contains no release or chart files

## Data impact

No conversation data is deleted or migrated. Conversations already persisted by the successful 201 responses should become visible when the fixed UI is deployed.