### PR TITLE
🐛 scope release validation to its predecessor

### DIFF
--- a/scripts/__tests__/release-versioning-check.test.mjs
+++ b/scripts/__tests__/release-versioning-check.test.mjs
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import test from "node:test";
 import {
 	releaseStampComparable,
+	__SelectDirectReleaseComparisonBase,
 	validateWorkspace,
 } from "../release-versioning/core.mjs";
 import { resolveDatabaseTransition } from "../release-versioning/database-validation.mjs";
@@ -167,6 +168,18 @@ test("rejects an invalid Git base instead of suppressing changed files", () =>
 	);
 	assert.notEqual(result.status, 0);
 	assert.match(`${result.stdout}${result.stderr}`, /definitely-not-a-ref/u);
+});
+
+test("scopes current release ownership to its declared predecessor", () =>
+{
+	assert.equal(__SelectDirectReleaseComparisonBase("0.9.0", "0.9.1"), "0.9.1");
+	assert.equal(__SelectDirectReleaseComparisonBase("0.9.1", null), "0.9.1");
+});
+
+test("keeps the CLI's direct release diff scoped to the declared predecessor", () =>
+{
+	const source = readFileSync(join(import.meta.dirname, "../release-versioning-check.mjs"), "utf8");
+	assert.match(source, /_ChangedFiles\(\[__SelectDirectReleaseComparisonBase\(base, versionBase\)\]\)/u);
 });
 
 test("accepts a complete mirrored release fixture", async () =>

--- a/scripts/release-versioning-check.mjs
+++ b/scripts/release-versioning-check.mjs
@@ -2,7 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { releaseStampComparable, validateWorkspace } from "./release-versioning/core.mjs";
+import { __SelectDirectReleaseComparisonBase, releaseStampComparable, validateWorkspace } from "./release-versioning/core.mjs";
 
 const _GIT_TEXT_MAX_BUFFER = 16 * 1024 * 1024;
 
@@ -93,7 +93,7 @@ const releaseManifest = JSON.parse(readFileSync(join(repositoryRoot, "releases",
 const versionBase = releaseManifest.previousRepositoryVersion;
 if (versionBase) _GitFiles(["rev-parse", "--verify", `${versionBase}^{commit}`]);
 const releaseTag = _ExistingReleaseTag(rootVersion);
-const directChangedFiles = _ChangedFiles([base]);
+const directChangedFiles = _ChangedFiles([__SelectDirectReleaseComparisonBase(base, versionBase)]);
 const changedFiles = _ChangedFiles([...new Set([base, versionBase, releaseTag].filter(Boolean))]);
 const newFiles = changedFiles.filter((file) => _BaseText(base, file) === null);
 const errors = await validateWorkspace(

--- a/scripts/release-versioning/core.mjs
+++ b/scripts/release-versioning/core.mjs
@@ -11,6 +11,22 @@ import { validateDatabase } from "./database-validation.mjs";
 import { createReleaseManifestValidator } from "./manifest-validation.mjs";
 import { compareSemver, isAdjacentMinor, parseSemver, readJson, sha256 } from "./version-utils.mjs";
 
+/**
+ * Selects the revision that owns the candidate release's direct changes.
+ *
+ * CI can validate cumulatively from an older successful base, but the declared predecessor
+ * keeps that base's already-released changes out of the candidate's direct diff.
+ * Called by: `release-versioning-check.mjs` before it validates the workspace.
+ * @param {string} base The last successful workflow revision used for cumulative validation.
+ * @param {string | null} versionBase The candidate manifest's declared predecessor.
+ * @returns {string} The predecessor when present, otherwise the cumulative base for adoption.
+ * @see validateWorkspace
+ */
+export function __SelectDirectReleaseComparisonBase(base, versionBase)
+{
+	return versionBase ?? base;
+}
+
 const _IGNORED_TOUCH = [
 	/(?:^|\/)README\.md$/u,
 	/(?:^|\/)helm\/migrations\//u,


### PR DESCRIPTION
## Summary

- scope direct release-version ownership checks to the candidate manifest’s declared predecessor
- retain the cumulative successful-workflow base for broader validation
- cover the stale-base CI regression and CLI wiring

## Validation

- `node --test scripts/__tests__/release-versioning-check.test.mjs` (49 passing)
- `node scripts/release-versioning-check.mjs --base 2d9fb7f01fa660138bcdd2a2e813c2dad9afebe9`
- module-growth, Prisma boundary, style, diff checks

## Incident

The current 0.9.2 develop workflow selected the stale successful base `2d9fb7f` and incorrectly classified the already released 0.9.1 manifest as newly introduced historical state. This repair preserves release immutability while allowing the 0.9.2 image publication to proceed.