### PR TITLE
🔧 stamp PostgreSQL adaptation for 0.9.2

### DIFF
--- a/apps/postgres/project.json
+++ b/apps/postgres/project.json
@@ -2,7 +2,7 @@
   "name": "postgres",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "metadata": { "release": { "adaptedVersion": "0.9.1" } },
+  "metadata": { "release": { "adaptedVersion": "0.9.2" } },
   "tags": ["type:app", "layer:entrypoint", "scope:postgres"],
   "targets": {
     "helm-lint": {

--- a/releases/0.9.2.json
+++ b/releases/0.9.2.json
@@ -109,7 +109,7 @@
     },
     "postgres": {
       "root": "apps/postgres",
-      "adaptedVersion": "0.9.1",
+      "adaptedVersion": "0.9.2",
       "chartVersion": "0.9.1",
       "externalAppVersion": "17"
     },


### PR DESCRIPTION
## Summary

- stamp PostgreSQL as adapted in the untagged 0.9.2 release manifest and Nx metadata
- retain chart version 0.9.1 because the chart did not change

## Validation

- `node scripts/release-versioning-check.mjs --base 2d9fb7f01fa660138bcdd2a2e813c2dad9afebe9`
- `npm run test:release-versioning` (49 passing)
- independent review and documentation gate passed

## Incident

#675 changed the PostgreSQL release-contract test. The exact-SHA publish job correctly rejected the stale adaptation stamp.