### PR TITLE
🔧 Cache Playwright browsers in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -288,6 +288,15 @@ jobs:
             echo "required=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Restore Playwright browser cache
+        if: steps.storybook-regression.outputs.required == 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - name: Install Chromium for affected Storybook regressions
         if: steps.storybook-regression.outputs.required == 'true'
         run: npx playwright install --with-deps chromium


### PR DESCRIPTION
## Summary

- restore the Playwright browser cache before affected Storybook regressions install Chromium
- key the cache by operating system and lockfile, with a safe OS-prefix fallback
- retain the unconditional install so an older restored cache is reconciled to the locked browser revision

## Validation

- YAML parser
- git diff --check
- independent review: no findings
- documentation gate: PASS

## Review

- independent PR based directly on develop; it does not include any open predecessor work
- resolves the repeated 19-minute Chromium download seen in run 32247063619 for subsequent eligible runs