### PR TITLE
🐛 move the server image when a deploy states --image-tag

### DIFF
--- a/apps/_infra/deploy-k8s/platform/control-plane-image-policy.sh
+++ b/apps/_infra/deploy-k8s/platform/control-plane-image-policy.sh
@@ -6,6 +6,31 @@
 # run may use an imported tag under `.test`. k8s-deploy.sh supplies the already-read
 # context, looks up prior releases, and runs Helm.
 
+# Decides whether a release that already pins the server image keeps that pin. Helm's
+# reset-then-reuse does not preserve an omitted component override in a visible argument, so a run
+# that states no tag inherits the prior one rather than falling back to the chart default. A run that
+# passes --image-tag has stated its choice, so the server moves with every other component image —
+# otherwise an operator bumping the release would silently leave the server behind.
+# --opencrane-server-tag is a deliberate per-component override and always wins over both.
+#
+# Called by: k8s-deploy.sh (_resolve_release_images), before resolve_control_plane_image_reference.
+select_control_plane_tag()
+{
+  local prior_server_tag="$1"
+
+  if [[ -n "$CONTROL_PLANE_TAG" || -z "$prior_server_tag" ]]; then
+    return 0
+  fi
+  if [[ "$IMAGE_TAG_SUPPLIED" == "1" ]]; then
+    if [[ "$prior_server_tag" != "$IMAGE_TAG" ]]; then
+      log "Moving the OpenCrane server off its prior pin '$prior_server_tag' to the requested --image-tag '$IMAGE_TAG'."
+    fi
+    return 0
+  fi
+  warn "Prior release pins the OpenCrane server to '$prior_server_tag'; reusing it. Pass --image-tag or --opencrane-server-tag to move it."
+  CONTROL_PLANE_TAG="$prior_server_tag"
+}
+
 resolve_control_plane_image_reference()
 {
   local requested_spa_tag="$CONTROL_PLANE_SPA_TAG"

--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -73,8 +73,11 @@
 # provider-custody Secret; the server then registers it with LiteLLM's encrypted credentials API
 # and seeds the provider model catalogue before it becomes ready. Never pass the API key as a flag.
 #
-# --image-tag pins the OpenCrane server image. The SPA and Cognee require exact OCI digests from the
-# reviewed build output. Their tag flags are available only with OPENCRANE_ALLOW_TAG_FLOAT=1 for a
+# --image-tag pins the OpenCrane server image along with every other tag-built component, on a fresh
+# install and on an upgrade alike; --opencrane-server-tag moves the server on its own. An upgrade that
+# passes neither keeps the tag the prior release recorded. The SPA and Cognee require exact OCI digests
+# from the reviewed build output, and an upgrade that omits a digest keeps the recorded one, so bumping
+# them is always explicit. Their tag flags are available only with OPENCRANE_ALLOW_TAG_FLOAT=1 for a
 # disposable local install. Always bump component images this way —
 # never `kubectl set image` / `kubectl patch` a managed deployment. An imperative
 # patch creates a `kubectl-*` field manager that owns the image field on the live
@@ -148,6 +151,7 @@ fi
 NAMESPACE="opencrane-system"
 RELEASE="opencrane"
 IMAGE_TAG="latest"
+IMAGE_TAG_SUPPLIED=0    # 1 → this run stated a tag, so it moves the server past any prior pin
 CONTROL_PLANE_TAG=""    # empty → falls back to IMAGE_TAG
 CONTROL_PLANE_SPA_TAG="${OPENCRANE_UI_TAG:-}" # empty → falls back to IMAGE_TAG
 CONTROL_PLANE_SPA_DIGEST="${OPENCRANE_UI_DIGEST:-}"
@@ -254,7 +258,7 @@ while [[ $# -gt 0 ]]; do
     --base-domain)   BASE_DOMAIN="$2"; shift 2 ;;
     --namespace)     NAMESPACE="$2"; shift 2 ;;
     --release)       RELEASE="$2"; shift 2 ;;
-    --image-tag)        IMAGE_TAG="$2"; shift 2 ;;
+    --image-tag)        IMAGE_TAG="$2"; IMAGE_TAG_SUPPLIED=1; shift 2 ;;
     --opencrane-server-tag) CONTROL_PLANE_TAG="$2"; shift 2 ;;
     --opencrane-ui-tag) CONTROL_PLANE_SPA_TAG="$2"; shift 2 ;;
     --opencrane-ui-digest) CONTROL_PLANE_SPA_DIGEST="$2"; shift 2 ;;
@@ -353,10 +357,7 @@ _resolve_release_images() {
     prior_server_tag="$(jq -r '.clustertenantManager.image.tag // empty' <<<"$prior_values")"
     prior_spa_digest="$(jq -r '.controlPlaneSpa.image.digest // empty' <<<"$prior_values")"
     prior_cognee_digest="$(jq -r '.clustertenantManager.cognee.image.digest // empty' <<<"$prior_values")"
-    if [[ -n "$prior_server_tag" && -z "$CONTROL_PLANE_TAG" ]]; then
-      warn "Prior release pins the OpenCrane server to '$prior_server_tag'; reusing it. Pass OPENCRANE_ALLOW_TAG_FLOAT=1 to choose a chart default deliberately."
-      CONTROL_PLANE_TAG="$prior_server_tag"
-    fi
+    select_control_plane_tag "$prior_server_tag"
     if [[ -n "$prior_spa_digest" && -z "$CONTROL_PLANE_SPA_DIGEST" ]]; then
       warn "Prior release pins the OpenCrane SPA to '$prior_spa_digest'; reusing it."
       CONTROL_PLANE_SPA_DIGEST="$prior_spa_digest"
@@ -891,7 +892,7 @@ _guard_standalone_first_user_issuer
 ensure_registry_pull_secret "$NAMESPACE" "$REGISTRY_PULL_SECRET" "$REGISTRY_PULL_CONFIG_FILE"
 
 # 3. The OpenCrane chart.
-log "Using current app-owned chart sources from the committed dependency lock…"
+log "Using the app-owned chart sources packaged from this checkout…"
 
 log "Installing the OpenCrane Helm release '$RELEASE'…"
 # --force-conflicts: Helm 4 applies server-side, so any out-of-band actor that has

--- a/apps/_infra/deploy-k8s/platform/tests/control-plane-image-policy-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/control-plane-image-policy-contract.sh
@@ -11,11 +11,22 @@ err()
   printf '%s\n' "$*" >&2
 }
 
+warn()
+{
+  printf '%s\n' "$*" >&2
+}
+
+log()
+{
+  printf '%s\n' "$*" >&2
+}
+
 _reset_inputs()
 {
   ALLOW_TAG_FLOAT=0
   BASE_DOMAIN="testv4.dev.opencrane.ai"
   IMAGE_TAG="sha-server"
+  IMAGE_TAG_SUPPLIED=0
   CONTROL_PLANE_TAG=""
   CONTROL_PLANE_SPA_TAG=""
   CONTROL_PLANE_SPA_DIGEST="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -50,5 +61,36 @@ _reset_inputs
 resolve_control_plane_image_reference
 [[ "$CP_TAG" == "sha-server" ]]
 [[ "$CONTROL_PLANE_SPA_IMAGE" == "ghcr.io/elewa-git/opencrane-ui@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ]]
+
+# An explicit --image-tag moves the server past the pin the prior release recorded. Inheriting the
+# pin here is how a release upgrade silently kept running the previous server build.
+_reset_inputs
+IMAGE_TAG="sha-requested"
+IMAGE_TAG_SUPPLIED=1
+select_control_plane_tag "sha-prior"
+resolve_control_plane_image_reference
+[[ "$CP_TAG" == "sha-requested" ]]
+
+# A run that states no tag still inherits the pin, because reset-then-reuse would otherwise drop the
+# server to the chart default.
+_reset_inputs
+select_control_plane_tag "sha-prior"
+resolve_control_plane_image_reference
+[[ "$CP_TAG" == "sha-prior" ]]
+
+# A per-component override wins over both the prior pin and --image-tag.
+_reset_inputs
+IMAGE_TAG="sha-requested"
+IMAGE_TAG_SUPPLIED=1
+CONTROL_PLANE_TAG="sha-override"
+select_control_plane_tag "sha-prior"
+resolve_control_plane_image_reference
+[[ "$CP_TAG" == "sha-override" ]]
+
+# A fresh install has no pin to inherit.
+_reset_inputs
+select_control_plane_tag ""
+resolve_control_plane_image_reference
+[[ "$CP_TAG" == "sha-server" ]]
 
 echo "control-plane image policy contract: PASS"

--- a/docs/ci-and-deploy.md
+++ b/docs/ci-and-deploy.md
@@ -124,6 +124,21 @@ flowchart TD
   databases. Required flags: `--base-domain`, `--cluster-tenant`, `--acme-email`,
   `--first-user-email`; fresh installs also need `--opencrane-ui-digest` and `--cognee-digest`
   (immutable digests, never tags).
+- **An upgrade keeps every image the prior release recorded unless this run names it.** Helm's
+  reset-then-reuse cannot preserve an omitted override in a visible argument, so the engine reads
+  the previous release's values and inherits whatever it finds. That means a version bump alone
+  changes no image at all. To move images, name them:
+
+  | To move | Pass |
+  | --- | --- |
+  | Server, channel proxy, memory gateway, artifact service | `--image-tag sha-<sha>` |
+  | Server only | `--opencrane-server-tag sha-<sha>` |
+  | Browser SPA | `--opencrane-ui-digest sha256:<digest>` |
+  | Cognee | `--cognee-digest sha256:<digest>` |
+
+  Every run logs the image it resolved for each component. Read those lines before assuming an
+  upgrade shipped new code — a silo that deploys cleanly at a new chart version while still running
+  the old server build looks healthy and behaves like the old release.
 - Cluster-wide prerequisites (ingress-nginx, cert-manager, CloudNativePG) are installed once per
   cluster by `bootstrap-prerequisites.sh` and are never part of a silo release.
 - The PostgreSQL transition is resolved and schema-validated *before* the cluster is touched;

--- a/website/contributing/deploying.md
+++ b/website/contributing/deploying.md
@@ -84,6 +84,23 @@ Public releases require `sha-*` build tags or digests; the qualified-release-ima
 `latest` and similar tags. Tag floating exists only for the disposable local k3d smoke.
 :::
 
+::: warning An upgrade keeps every image you do not name
+Helm's reset-then-reuse cannot preserve an omitted override in a visible argument, so the engine
+reads the previous release's values and inherits whatever image it finds there. A version bump on
+its own therefore changes no image at all: the silo reports the new chart version and keeps running
+the old build. To move an image, name it.
+
+| To move | Pass |
+| --- | --- |
+| Server, channel proxy, memory gateway, artifact service | `--image-tag sha-<sha>` |
+| Server only | `--opencrane-server-tag sha-<sha>` |
+| Browser SPA | `--opencrane-ui-digest sha256:<digest>` |
+| Cognee | `--cognee-digest sha256:<digest>` |
+
+Every run logs the image it resolved per component, and says so explicitly when it inherits a pin
+or moves off one. Read those lines before concluding that an upgrade shipped new code.
+:::
+
 - **The tenant's openclaw version pin lives in `values.yaml`, not in code defaults.**
 - **Watch the queue, not only the jobs.** The organisation has a fixed number of concurrent
   runners; a workflow storm (or a hung job) can queue runs for 30+ minutes. If a run seems stuck


### PR DESCRIPTION
## What broke

Deploying testv4 to 0.9.2 today reported success at the new chart version while the server kept running `sha-698920585` — a build from before #670. The silo looked healthy and behaved like the old release.

Cause: `_resolve_release_images` reads the previous release's values and inherits the server tag it finds, and that inheritance also won over an `--image-tag` the run had explicitly passed. The inheritance itself is necessary (Helm's reset-then-reuse cannot preserve an omitted component override in a visible argument) — overriding a *stated* tag is not.

Run evidence, first deploy:

```
[k8s-deploy] OpenCrane server image: ghcr.io/elewa-git/opencrane-server:sha-698920585b4cf0b2f82601e9be33ed9b53a5e18e
```

…despite `--image-tag sha-1707b462c8d91ee26fcaf2a42c0be871d687c248`. A second run with `--opencrane-server-tag` was needed to move it.

## What changed

- A stated `--image-tag` now moves the server along with every other tag-built component. A run that states no tag still inherits the prior pin. `--opencrane-server-tag` overrides both.
- The decision moved into `control-plane-image-policy.sh` as `select_control_plane_tag`, so the existing contract proves all four cases with no cluster: stated tag moves, omitted tag inherits, per-component override wins, fresh install has no pin.
- The warning now names the flags that move the image instead of suggesting `OPENCRANE_ALLOW_TAG_FLOAT=1`, which is local-k3d only and the wrong advice for a public silo.
- Dropped the chart-sources log line's reference to a "committed dependency lock" — #686 removed the lock.
- Documented which flag moves which image in `docs/ci-and-deploy.md` and the website's deploying page, including that a version bump alone changes no image.

## Verification

- `control-plane-image-policy-contract.sh` — PASS, with the four new cases
- `run-helm-contracts.sh` — full suite PASS
- `npm run docs:build` — clean

## Review order

Single PR, no stack.