### PR TITLE
🐛 generate the database client before any project's tests

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -31,6 +31,7 @@
     },
     "test": {
       "dependsOn": [
+        { "projects": ["opencrane"], "target": "db:generate" },
         "^build"
       ],
       "inputs": [
@@ -41,6 +42,7 @@
     },
     "lint": {
       "dependsOn": [
+        { "projects": ["opencrane"], "target": "db:generate" },
         "^build"
       ],
       "inputs": [


### PR DESCRIPTION
## What broke

#688 failed the `test` job with 64 failures across suites it does not touch:

```
FAIL src/__tests__/prisma-child-run-reservation-repository.test.ts
TypeError: Cannot read properties of undefined (reading 'Preparing')
  at server/iam/authorization/main/src/run-approval-cancellation.ts:9:93

FAIL src/__tests__/prisma-run-cancellation-repository.test.ts   <- untouched by that PR
Caused by: TypeError: Right-hand side of 'instanceof' is not an object
  at PrismaRunAdmissionRepository.admit:167
```

`ToolInvocationState.Preparing` and `Prisma.PrismaClientKnownRequestError` are both **generated** Prisma exports. Both read as `undefined`, so the generated client was missing in that job.

## Cause

`db:generate` was declared as a dependency of `test` and `lint` only on the **opencrane** project. Libraries across the workspace import generated enums and error classes at module scope but declared no such dependency, so whether the client existed when a library's tests ran depended on which projects the affected graph selected and in what order.

That is a race, and it fails in a way that reads like a code defect rather than a missing build step — whole suites break at import, in files the change never touched. It also means a fresh clone cannot run one library's tests successfully.

## What changed

`db:generate` is now a dependency of the `test` and `lint` **target defaults**, so it holds for every project rather than one.

## Verification

Removed the generated client entirely, then ran a single library's tests:

```
> nx run opencrane:"db:generate"
Test Files  22 passed (22)
     Tests  141 passed (141)
```

The same command before this change left 12 suites failing at import. No workflow edit is needed — fixing the graph fixes CI and local runs together.

## Merge order

Merge this before #688; that PR is red only because of this race and needs no change of its own.

## Review order

Single PR, no stack.
