### PR TITLE
✨ deploy only the workloads when the data plane already matches

### DIFF
--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -27,7 +27,7 @@
 #                            [--platform-operator-groups CSV]
 #                            [--first-user-email EMAIL]
 #                            [--initial-model-provider PROVIDER]
-#                            [--preflight] [--multi-ct] [--verify] [--verify-insecure]
+#                            [--preflight] [--workloads-only] [--multi-ct] [--verify] [--verify-insecure]
 #                            --postgres-credentials-secret NAME
 #                            [--postgres-owner OWNER]
 #                            --obot-postgres-credentials-secret NAME [--obot-postgres-owner OWNER]
@@ -101,6 +101,7 @@ source "$SCRIPT_DIR/postgres-connection.sh"
 source "$SCRIPT_DIR/registry-pull-secret.sh"
 source "$SCRIPT_DIR/current-chart-sources.sh"
 source "$SCRIPT_DIR/control-plane-image-policy.sh"
+source "$SCRIPT_DIR/workloads-only-policy.sh"
 source "$SCRIPT_DIR/qualified-release-image-policy.sh"
 source "$SCRIPT_DIR/cluster-tenant-crd-policy.sh"
 source "$SCRIPT_DIR/dns-authority.sh"
@@ -227,6 +228,8 @@ ALLOW_UNBACKED_DATABASE_MIGRATION="0"
 # a base domain whose NS delegation does not resolve. Also via
 # OPENCRANE_PREFLIGHT=1. It is advisory unless run — the install itself does not auto-run it.
 PREFLIGHT="${OPENCRANE_PREFLIGHT:-0}"
+# Skips the database stage for a run that only moves workload images. Gated on live evidence.
+WORKLOADS_ONLY="${OPENCRANE_WORKLOADS_ONLY:-0}"
 
 # --multi-ct is the EXPLICIT multi-ClusterTenant predicate: this install hosts many orgs
 # (ClusterTenants) or many isolated instances in one cluster, so cross-tenant isolation is
@@ -277,6 +280,7 @@ while [[ $# -gt 0 ]]; do
     --first-user-email)             FIRST_USER_EMAIL="$2"; shift 2 ;;
     --initial-model-provider)       INITIAL_MODEL_PROVIDER="$2"; shift 2 ;;
     --preflight)        PREFLIGHT="1"; shift ;;
+    --workloads-only)   WORKLOADS_ONLY="1"; shift ;;
     --multi-ct)         MULTI_CT="1"; shift ;;
     --verify)           VERIFY="1"; shift ;;
     --verify-insecure)  VERIFY_INSECURE="1"; shift ;;
@@ -682,7 +686,27 @@ DATABASE_FENCED_RELEASE_REVISION=""
 if [[ "$MEMBERSHIP_MODE" == "standalone" ]]; then
   ensure_invitation_signing_secret "$NAMESPACE" "$INVITATION_SIGNING_SECRET"
 fi
-run_database_release_transition
+# A run that only moves workload images can skip the whole database stage — the PostgreSQL upgrade
+# and its privileges Job — but only when the live data plane already matches this release. Every fact
+# below is read-only, and the policy refuses unless all of them agree, because a wrongly skipped
+# stage leaves privileges unreconciled in a way the deploy would report as success.
+if [[ "$WORKLOADS_ONLY" == "1" ]]; then
+  workloads_only_status="$(helm status "$POSTGRES_RELEASE" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.info.status // empty')"
+  workloads_only_live_chart="$(helm get metadata "$POSTGRES_RELEASE" -n "$NAMESPACE" -o json 2>/dev/null | jq -r '.version // empty')"
+  workloads_only_intended_chart="$(awk '$1 == "version:" { print $2; exit }' "$POSTGRES_CHART_DIR/Chart.yaml")"
+  # A classifier that cannot read the database returns nothing, which the policy treats as a refusal.
+  workloads_only_convergence="$(classify_live_database_convergence 2>/dev/null || true)"
+  assert_workloads_only_preconditions \
+    "$POSTGRES_CLUSTER_EXISTS" \
+    "$DATABASE_TRANSITION_KIND" \
+    "${workloads_only_status:-unknown}" \
+    "$workloads_only_live_chart" \
+    "$workloads_only_intended_chart" \
+    "$workloads_only_convergence" || exit 1
+  log "Skipping the database stage: the live database already matches release $RELEASE_VERSION and PostgreSQL chart $workloads_only_live_chart is unchanged. Only workloads change."
+else
+  run_database_release_transition
+fi
 POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-opencrane-app"
 OBOT_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-obot-app"
 LITELLM_POSTGRES_APP_SECRET="${POSTGRES_RELEASE}-litellm-app"

--- a/apps/_infra/deploy-k8s/platform/tests/database-migration-deploy-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/database-migration-deploy-contract.sh
@@ -46,8 +46,12 @@ grep -q 'DATABASE_CARRY_FORWARD_RELEASE=' "$DEPLOY_SCRIPT"
 grep -q 'valid only for an approved carry-forward repair' "$ORCHESTRATOR"
 ! grep -q 'OPENCRANE_ALLOW_UNBACKED_DATABASE_MIGRATION' "$DEPLOY_SCRIPT"
 invitation_secret_line="$(grep -n 'ensure_invitation_signing_secret "$NAMESPACE" "$INVITATION_SIGNING_SECRET"' "$DEPLOY_SCRIPT" | cut -d: -f1)"
-database_transition_line="$(grep -n '^run_database_release_transition$' "$DEPLOY_SCRIPT" | cut -d: -f1)"
+database_transition_line="$(grep -n '^[[:space:]]*run_database_release_transition$' "$DEPLOY_SCRIPT" | cut -d: -f1)"
 (( invitation_secret_line < database_transition_line ))
+# The database stage may be skipped only through the evidence-gated workloads-only policy. A skip
+# that reached Helm without it would leave privileges unreconciled and still report success.
+grep -q 'assert_workloads_only_preconditions' "$DEPLOY_SCRIPT"
+grep -q 'if \[\[ "$WORKLOADS_ONLY" == "1" \]\]; then' "$DEPLOY_SCRIPT"
 grep -q 'source "$SCRIPT_DIR/database-convergence-classifier.sh"' "$DEPLOY_SCRIPT"
 grep -q 'TIMEOUT_SECONDS must be an integer from 1 through 3600' "$DEPLOY_SCRIPT"
 grep -q 'migrationFence.active=true' "$RECOVERY"

--- a/apps/_infra/deploy-k8s/platform/tests/develop-smoke.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/develop-smoke.sh
@@ -529,4 +529,45 @@ kubectl wait --for=condition=Ready "certificate/${RELEASE_NAME}-clustertenant-tl
 _assert_database_isolation
 _assert_ingress_health
 
+# A fresh install always runs the database stage, so nothing here would exercise --workloads-only.
+# Deploy a second time at the same version with the flag: the PostgreSQL release must come out at the
+# same revision (the stage really was skipped) while the umbrella still advances (workloads really
+# were applied). Without this, the flag's only proof would be that its policy unit-refuses.
+echo "[develop-smoke] Proving the workloads-only path leaves the database stage untouched"
+WORKLOADS_ONLY_LOG="$(mktemp)"
+postgres_revision_before="$(helm get metadata "${RELEASE_NAME}-postgres" -n "$NAMESPACE" -o json | jq -r '.revision')"
+umbrella_revision_before="$(helm get metadata "$RELEASE_NAME" -n "$NAMESPACE" -o json | jq -r '.revision')"
+# No --values or --postgres-values on this run: the engine refuses a values file once a standalone
+# first owner exists, and reset-then-reuse already carries the first run's values forward.
+"$ROOT_DIR/apps/_infra/deploy-k8s/deploy.sh" \
+  --base-domain "$BASE_DOMAIN" \
+  --cluster-tenant "$CLUSTER_TENANT" \
+  --acme-email "$SMOKE_ACME_EMAIL" \
+  --first-user-email "$SMOKE_FIRST_USER_EMAIL" \
+  --namespace "$NAMESPACE" \
+  --release "$RELEASE_NAME" \
+  --release-version "$(jq -r '.version' "$ROOT_DIR/package.json")" \
+  --from-release-version "$(jq -r '.version' "$ROOT_DIR/package.json")" \
+  --image-tag develop-smoke \
+  --cognee-tag develop-smoke \
+  --workloads-only \
+  --postgres-credentials-secret "$POSTGRES_CREDENTIALS_SECRET" \
+  --obot-postgres-credentials-secret "$OBOT_POSTGRES_CREDENTIALS_SECRET" \
+  --litellm-postgres-credentials-secret "$LITELLM_POSTGRES_CREDENTIALS_SECRET" \
+  --postgres-admin-credentials-secret "$POSTGRES_ADMIN_CREDENTIALS_SECRET" \
+  2>&1 | tee "$WORKLOADS_ONLY_LOG"
+grep -q "Skipping the database stage" "$WORKLOADS_ONLY_LOG"
+postgres_revision_after="$(helm get metadata "${RELEASE_NAME}-postgres" -n "$NAMESPACE" -o json | jq -r '.revision')"
+umbrella_revision_after="$(helm get metadata "$RELEASE_NAME" -n "$NAMESPACE" -o json | jq -r '.revision')"
+if [[ "$postgres_revision_after" != "$postgres_revision_before" ]]; then
+  echo "[develop-smoke] --workloads-only changed the PostgreSQL release from revision $postgres_revision_before to $postgres_revision_after" >&2
+  exit 1
+fi
+if (( umbrella_revision_after <= umbrella_revision_before )); then
+  echo "[develop-smoke] --workloads-only did not apply the umbrella release (revision stayed $umbrella_revision_before)" >&2
+  exit 1
+fi
+rm -f "$WORKLOADS_ONLY_LOG"
+_assert_ingress_health
+
 echo "[develop-smoke] PASS: current silo, database isolation, TLS ingress, all enabled workloads, and $SMOKE_STORAGE_MODE storage qualification are healthy"

--- a/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
@@ -21,6 +21,7 @@ for contract in \
   post-deploy-health-contract.sh \
   qualified-release-image-contract.sh \
   control-plane-image-policy-contract.sh \
+  workloads-only-policy-contract.sh \
   cluster-tenant-crd-policy-contract.sh \
   silo-deploy-profile-contract.sh \
   silo-teardown-contract.sh \

--- a/apps/_infra/deploy-k8s/platform/tests/workloads-only-policy-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/workloads-only-policy-contract.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+POLICY="$ROOT_DIR/apps/_infra/deploy-k8s/platform/workloads-only-policy.sh"
+
+source "$POLICY"
+
+err()
+{
+  printf '%s\n' "$*" >&2
+}
+
+# Evidence from a silo whose data plane already matches the release being deployed.
+_converged()
+{
+  assert_workloads_only_preconditions 1 current deployed 0.9.1 0.9.1 "completed|$(printf 'a%.0s' {1..64})"
+}
+
+_converged
+
+# A fresh silo has no data plane to compare against, so the stage cannot be skipped.
+if assert_workloads_only_preconditions 0 fresh "" "" 0.9.1 "" 2>/dev/null; then
+  echo "workloads-only accepted a silo with no PostgreSQL cluster" >&2
+  exit 1
+fi
+
+# Schema work must never be skipped, however healthy the release looks.
+if assert_workloads_only_preconditions 1 migration deployed 0.9.1 0.9.1 "source|$(printf 'a%.0s' {1..64})" 2>/dev/null; then
+  echo "workloads-only accepted a migration transition" >&2
+  exit 1
+fi
+
+# Skipping over a failed PostgreSQL release would leave it failed and report success.
+if assert_workloads_only_preconditions 1 current failed 0.9.1 0.9.1 "current|$(printf 'a%.0s' {1..64})" 2>/dev/null; then
+  echo "workloads-only accepted a failed PostgreSQL release" >&2
+  exit 1
+fi
+
+# A chart version bump carries template changes — privileges among them — that must be applied.
+if assert_workloads_only_preconditions 1 current deployed 0.9.1 0.9.2 "current|$(printf 'a%.0s' {1..64})" 2>/dev/null; then
+  echo "workloads-only accepted an unapplied PostgreSQL chart version" >&2
+  exit 1
+fi
+
+# An unreadable classifier verdict is not evidence of convergence.
+if assert_workloads_only_preconditions 1 current deployed 0.9.1 0.9.1 "" 2>/dev/null; then
+  echo "workloads-only accepted a missing convergence verdict" >&2
+  exit 1
+fi
+
+# A database the classifier calls incompatible is the case this path must never step over.
+if assert_workloads_only_preconditions 1 current deployed 0.9.1 0.9.1 "incompatible|$(printf 'a%.0s' {1..64})" 2>/dev/null; then
+  echo "workloads-only accepted an incompatible database" >&2
+  exit 1
+fi
+
+# A 'current' verdict is accepted alongside 'completed': both mean the schema is already in place.
+assert_workloads_only_preconditions 1 current deployed 0.9.1 0.9.1 "current|$(printf 'a%.0s' {1..64})"
+
+echo "workloads-only policy contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/workloads-only-policy.sh
+++ b/apps/_infra/deploy-k8s/platform/workloads-only-policy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Decides whether one deploy may skip the database stage and change only the app workloads.
+#
+# A normal deploy always reconciles the PostgreSQL release and runs the privileges Job, even when the
+# run changes nothing but a container image. That is the slowest part of a deploy and the part that
+# can fail closed, so a run that only moves workload images can skip it — but only when the data
+# plane is provably already where this release expects it. This module makes that decision from
+# evidence the engine has already read; it never reads or changes the cluster itself.
+#
+# k8s-deploy.sh gathers the evidence and runs Helm.
+
+# Refuses the workloads-only path unless every fact says the data plane is already converged.
+#
+# The checks are ordered cheapest-explanation-first so an operator reads the real reason, not a
+# consequence of it. Each refusal names the full deploy as the way forward, because that is always
+# correct — this path is an optimisation, never the only way to reach a state.
+#
+# `convergence_state` is the classifier's verdict for the live database, or the empty string when the
+# engine could not read one. An unreadable verdict refuses: silence is not evidence.
+#
+# Called by: k8s-deploy.sh, before run_database_release_transition.
+assert_workloads_only_preconditions()
+{
+  local cluster_exists="$1"
+  local transition_kind="$2"
+  local live_release_status="$3"
+  local live_chart_version="$4"
+  local intended_chart_version="$5"
+  local convergence_state="$6"
+
+  if [[ "$cluster_exists" != "1" ]]; then
+    err "--workloads-only cannot install a silo that has no PostgreSQL cluster yet. Deploy this silo once in full first."
+    return 1
+  fi
+  if [[ "$transition_kind" != "current" ]]; then
+    err "--workloads-only refuses a '$transition_kind' database transition, which has schema work to do. Deploy in full."
+    return 1
+  fi
+  if [[ "$live_release_status" != "deployed" ]]; then
+    err "--workloads-only refuses to skip over a PostgreSQL release in state '$live_release_status'. Deploy in full so the data plane is repaired first."
+    return 1
+  fi
+  if [[ -z "$intended_chart_version" || "$live_chart_version" != "$intended_chart_version" ]]; then
+    err "--workloads-only requires the live PostgreSQL chart ('$live_chart_version') to already be the version this run installs ('$intended_chart_version'). Deploy in full to apply the chart change."
+    return 1
+  fi
+  if [[ ! "$convergence_state" =~ ^(current|completed)\| ]]; then
+    err "--workloads-only requires the live database to already match this release; the classifier reported '${convergence_state:-no readable evidence}'. Deploy in full."
+    return 1
+  fi
+}

--- a/docs/ci-and-deploy.md
+++ b/docs/ci-and-deploy.md
@@ -139,6 +139,17 @@ flowchart TD
   Every run logs the image it resolved for each component. Read those lines before assuming an
   upgrade shipped new code — a silo that deploys cleanly at a new chart version while still running
   the old server build looks healthy and behaves like the old release.
+- **A run that only changes workload images can skip the database stage.** `--workloads-only` skips
+  the PostgreSQL upgrade and its privileges Job — the slowest part of a deploy, and the part that can
+  fail closed. It is gated on live evidence, not on trust: the silo must already have a PostgreSQL
+  cluster, the resolved transition must be `current` (no schema work), the live PostgreSQL release
+  must be `deployed`, its chart version must already be the one this run installs, and the
+  convergence classifier must report `current` or `completed` for the live database. Any other
+  answer — including a classifier that cannot be read — refuses the run and names the full deploy as
+  the way forward. Use it for a frontend or server image bump; never to make a failing deploy pass.
+  The umbrella upgrade still renders every subchart, because the silo is one Helm release and Helm
+  has no per-subchart upgrade; that render is fast and idempotent, and only workloads whose image or
+  config actually changed roll.
 - Cluster-wide prerequisites (ingress-nginx, cert-manager, CloudNativePG) are installed once per
   cluster by `bootstrap-prerequisites.sh` and are never part of a silo release.
 - The PostgreSQL transition is resolved and schema-validated *before* the cluster is touched;

--- a/website/contributing/deploying.md
+++ b/website/contributing/deploying.md
@@ -53,6 +53,43 @@ platform/k8s-deploy.sh
   unchanged checksum is a no-op; a changed one triggers exactly one rollout. This replaced an
   unconditional `rollout restart` that double-started the heaviest workloads on every deploy.
 
+## Deploying only the workloads
+
+A normal deploy always reconciles the PostgreSQL release and runs its privileges Job, even when the
+run changes nothing but a container image. That is the slowest stage and the one that can fail
+closed, so a run that only moves workload images can skip it with `--workloads-only`:
+
+```bash
+apps/_infra/deploy-k8s/deploy.sh --cluster-tenant testv4 --base-domain dev.opencrane.ai \
+  --acme-email you@example.com --first-user-email you@example.com \
+  --oidc-issuer-url https://issuer.example/ --oidc-client-id 123 \
+  --release-version 0.9.2 --from-release-version 0.9.2 \
+  --workloads-only --opencrane-ui-digest sha256:NEW_SPA_DIGEST
+```
+
+The flag is gated on live evidence, never on trust. All five must hold, or the run refuses and tells
+you to deploy in full:
+
+| Check | Why |
+| --- | --- |
+| The silo already has a PostgreSQL cluster | There is nothing to compare a fresh install against |
+| The resolved transition is `current` | A migration must never be skipped |
+| The live PostgreSQL release is `deployed` | Skipping over a failed release would report success |
+| Its chart version is already the one this run installs | A chart bump carries template and privilege changes |
+| The convergence classifier reports `current` or `completed` | The schema must already be in place |
+
+A classifier that cannot be read counts as a refusal — silence is not evidence.
+
+::: warning Never use it to make a failing deploy pass
+This path is an optimisation, not a repair. If a deploy is failing in the database stage, that stage
+is telling you something true; skipping it leaves privileges unreconciled while the deploy reports
+success. Fix the cause and deploy in full.
+:::
+
+The umbrella upgrade still renders every subchart, because the silo is one Helm release and Helm has
+no per-subchart upgrade. That render is fast and idempotent, and only workloads whose image or config
+actually changed will roll — so a SPA-only deploy restarts the SPA and nothing else.
+
 ## Bootstrap prerequisites
 
 Before any silo installs, the cluster needs a default StorageClass, a `NetworkPolicy`-enforcing


### PR DESCRIPTION
## Why

Every deploy reconciles the PostgreSQL release and runs its privileges Job, even when the run changes nothing but a container image. On testv4 yesterday that produced postgres revisions 22 → 25 from four deploys, all on the identical chart `postgres-0.9.1`. It is the slowest stage and the one that can fail closed — so a frontend image bump was paying for schema machinery it never used.

## What this adds

`--workloads-only` skips the database stage. It is gated on **live evidence, not on the operator's word** — all five must hold:

| Check | Why it matters |
| --- | --- |
| The silo already has a PostgreSQL cluster | Nothing to compare a fresh install against |
| The resolved transition is `current` | A migration must never be skipped |
| The live PostgreSQL release is `deployed` | Skipping over a failed release would report success |
| Its chart version is already the one this run installs | A chart bump carries template and privilege changes |
| The classifier reports `current` or `completed` | The schema must already be in place |

A classifier that cannot be read refuses — silence is not evidence. Every refusal names the full deploy as the way forward, because that is always correct; this path is an optimisation, never a repair.

The umbrella upgrade still renders every subchart, because the silo is one Helm release and Helm has no per-subchart upgrade. That render is fast and idempotent, and only workloads whose image or config actually changed roll — so a SPA-only deploy restarts the SPA alone.

## Verification

- **New `workloads-only-policy-contract.sh`** — the policy is a pure module, so the contract proves all six refusals (fresh silo, migration transition, failed release, unapplied chart version, unreadable verdict, incompatible database) and both accepted verdicts, with no cluster. PASS.
- **Full `run-helm-contracts.sh`** — PASS, 20 contracts.
- **`database-migration-deploy-contract.sh`** caught the change: it pinned `^run_database_release_transition$` at column 0 to enforce that the invitation-signing Secret is created before the database stage. That ordering guarantee is real, so the locator now tolerates the guard's indentation and the contract additionally asserts the skip cannot exist without the policy behind it.
- **`npm run docs:build`** — clean.

**The skip path is exercised end to end by the k3d smoke.** A fresh install always takes the other branch, so the smoke now deploys a second time at the same version with the flag and asserts the PostgreSQL release keeps its revision while the umbrella advances, plus the log line proving the branch was taken. Without that, the flag's only evidence would be that its policy unit-refuses.

## Costs and limits

- The smoke gains one extra umbrella upgrade — roughly a minute on develop pushes. I judged an unexercised gate around a safety stage to be the worse trade, but say the word and I will drop it to contract-only.
- I have **not** run this against a live cluster. Something else was mid-deploy on testv4 while I worked (a privileges Job pod appeared at 11:02 today), and two writers is how drift starts.
- `database-migration-deploy-contract.sh` still has two `rg`-based assertions that silently no-op where ripgrep is absent locally; CI installs a pinned binary so they do run there. Pre-existing, unrelated to this change, and worth its own fix.

## Review order

Single PR, no stack.
