### PR TITLE
🐛 Restore conversation admission and routed selection

### DIFF
--- a/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
+++ b/libs/backend/agents/execution/protocol/src/__tests__/prisma-runtime-dispatch-authority.test.ts
@@ -299,6 +299,7 @@ describe("PrismaRuntimeDispatchAuthority", function _describeDispatchAuthority()
 		await context.authority.__NextCommand(_identity, _open, 0);
 		const queries = context.queryRaw.mock.calls.map(function _sql(call) { return ((call[0] as { strings?: readonly string[] }).strings ?? []).join(" "); });
 		expect(queries[0]).toContain("pg_advisory_xact_lock");
+		expect(queries[0]).toContain('::text AS "lock"');
 		expect(queries[1]).toContain('FROM "agent_runs"');
 	});
 

--- a/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
@@ -515,9 +515,8 @@ async function _loadContext(transaction: Prisma.TransactionClient, config: Runti
 	const discovered = await transaction.workloadAssignment.findUnique({ where: { namespace_podUid: { namespace: identity.namespace, podUid: identity.podUid } } });
 	if (discovered === null) return null;
 	// Cancellation and terminal reports also take the advisory lock before the row locks. Taking them
-	// in this order lets only one writer at a time work on a run, and no two writers can end up each
-	// holding one lock and waiting for the other. Cast the lock result because Prisma cannot deserialize
-	// PostgreSQL's void return type from a raw query.
+	// in this order lets only one writer work on a run without deadlocking. The text cast lets Prisma
+	// deserialize PostgreSQL's void lock result from this raw query.
 	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${discovered.runId}, 0))::text AS "lock"`);
 	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${discovered.runId} FOR UPDATE`);
 	await transaction.$queryRaw(Prisma.sql`SELECT "run_id" FROM "workload_assignments" WHERE "namespace" = ${identity.namespace} AND "pod_uid" = ${identity.podUid} FOR UPDATE`);

--- a/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
+++ b/libs/backend/agents/execution/protocol/src/prisma-runtime-dispatch-authority.ts
@@ -516,8 +516,9 @@ async function _loadContext(transaction: Prisma.TransactionClient, config: Runti
 	if (discovered === null) return null;
 	// Cancellation and terminal reports also take the advisory lock before the row locks. Taking them
 	// in this order lets only one writer at a time work on a run, and no two writers can end up each
-	// holding one lock and waiting for the other.
-	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${discovered.runId}, 0))`);
+	// holding one lock and waiting for the other. Cast the lock result because Prisma cannot deserialize
+	// PostgreSQL's void return type from a raw query.
+	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${discovered.runId}, 0))::text AS "lock"`);
 	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${discovered.runId} FOR UPDATE`);
 	await transaction.$queryRaw(Prisma.sql`SELECT "run_id" FROM "workload_assignments" WHERE "namespace" = ${identity.namespace} AND "pod_uid" = ${identity.podUid} FOR UPDATE`);
 	const assignment = await transaction.workloadAssignment.findUnique({ where: { namespace_podUid: { namespace: identity.namespace, podUid: identity.podUid } } });

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-reservation-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-child-run-reservation-repository.test.ts
@@ -212,6 +212,7 @@ describe("PrismaChildRunReservationRepository", function _describeReservationRep
 
 		expect(result).toEqual({ outcome: "idempotent", snapshot: childSnapshot });
 		expect(transaction.$queryRaw).toHaveBeenCalledTimes(1);
+		expect((transaction.$queryRaw.mock.calls[0]?.[0] as { sql: string }).sql).toContain('::text AS "lock"');
 		// The advisory-lock key is a text parameter, and PostgreSQL rejects a NUL byte in text with
 		// SQLSTATE 22021, failing the whole reservation.
 		for (const [statement] of transaction.$queryRaw.mock.calls)

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-admission-repository.test.ts
@@ -57,6 +57,7 @@ describe("PrismaRunAdmissionRepository", function _describeAdmissionRepository()
 
 		await expect(repository.admit(_command(), async function _build() { return { outcome: "ready", value: { authority: _authority(), snapshot: _snapshot() } } as const; })).resolves.toEqual({ outcome: "accepted", snapshot: _snapshot() });
 		expect(transaction.$queryRaw).toHaveBeenCalledTimes(2);
+		expect((transaction.$queryRaw.mock.calls[0]?.[0] as { sql: string }).sql).toContain('::text AS "lock"');
 		// PostgreSQL rejects a NUL byte in text with SQLSTATE 22021 and fails the whole statement, so
 		// an advisory-lock key carrying one made every admission return 503 against a real database.
 		for (const [statement] of transaction.$queryRaw.mock.calls)

--- a/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-dispatch-repository.test.ts
+++ b/libs/backend/agents/execution/runs/main/src/__tests__/prisma-run-dispatch-repository.test.ts
@@ -127,6 +127,7 @@ describe("PrismaRunDispatchRepository", function _DescribeDispatchRepository()
 		});
 		expect(_SqlText(queryRaw.mock.calls[1]?.[0])).toContain("agent_services");
 		expect(_SqlText(queryRaw.mock.calls[2]?.[0])).toContain("pg_advisory_xact_lock");
+		expect(_SqlText(queryRaw.mock.calls[2]?.[0])).toContain('::text AS "lock"');
 		expect(_SqlText(queryRaw.mock.calls[3]?.[0])).toContain("agent_runs");
 		expect(_SqlText(queryRaw.mock.calls[4]?.[0])).toContain("run_outbox_events");
 		expect(transaction.outboxEvent.updateMany).toHaveBeenCalledWith({ where: expect.objectContaining({ id: "event-1", deliveryCount: 0 }), data: { claimedAt: new Date("2026-07-20T00:00:00.000Z"), deliveryCount: 1 } });
@@ -386,6 +387,7 @@ describe("PrismaRunDispatchRepository", function _DescribeDispatchRepository()
 		expect(selectionSql).not.toContain('bootstrap."expires_at" > clock_timestamp()');
 		expect(_SqlText(queryRaw.mock.calls[1]?.[0])).toContain("agent_services");
 		expect(_SqlText(queryRaw.mock.calls[2]?.[0])).toContain("pg_advisory_xact_lock");
+		expect(_SqlText(queryRaw.mock.calls[2]?.[0])).toContain('::text AS "lock"');
 		expect(_SqlText(queryRaw.mock.calls[3]?.[0])).toContain("agent_runs");
 		expect(_SqlText(queryRaw.mock.calls[4]?.[0])).toContain("workload_assignments");
 		expect(_SqlText(queryRaw.mock.calls[5]?.[0])).toContain("workload_bootstraps");

--- a/libs/backend/agents/execution/runs/main/src/prisma-child-run-completion-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-child-run-completion-repository.ts
@@ -38,12 +38,21 @@ export class PrismaChildRunCompletionRepository implements ChildRunCompletionRep
 	}
 }
 
-/** Delivers a terminal child through an already-open authority transaction. */
+/**
+ * Delivers a terminal child through an already-open authority transaction.
+ *
+ * The child ledger and parent event stay in the caller's transaction so they cannot commit separately.
+ * Both advisory-lock queries cast their results because Prisma cannot deserialize PostgreSQL's void
+ * return type from a raw query.
+ *
+ * Called by: {@link PrismaChildRunCompletionRepository.deliverAtomically} and
+ * {@link PrismaRuntimeTerminalReporter.reportInTransaction}.
+ */
 export async function __DeliverChildRunCompletionInTransaction(transaction: Prisma.TransactionClient, command: ChildRunCompletionCommand): Promise<ChildRunCompletionResult>
 {
 	if (command.childRunId.trim().length === 0) return { outcome: "denied", reason: "not_child_run" };
 	// 1. Lock immutable child evidence before deriving any cross-run notification.
-	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.childRunId}, 0))`);
+	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.childRunId}, 0))::text AS "lock"`);
 	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.childRunId} FOR UPDATE`);
 	const child = await transaction.agentRun.findUnique({ where: { id: command.childRunId } });
 	if (child === null) return { outcome: "ignored", reason: "child_not_found" };
@@ -53,7 +62,7 @@ export async function __DeliverChildRunCompletionInTransaction(transaction: Pris
 	if (replay !== null) return _replay(child.parentRunId, replay);
 
 	// 2. Lock the direct parent stream before choosing its next sequence or terminal outcome.
-	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${child.parentRunId}, 0))`);
+	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${child.parentRunId}, 0))::text AS "lock"`);
 	await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${child.parentRunId} FOR UPDATE`);
 	await transaction.$queryRaw(Prisma.sql`SELECT "child_run_id" FROM "child_run_reservations" WHERE "child_run_id" = ${child.id} FOR UPDATE`);
 	const parent = await transaction.agentRun.findUnique({ where: { id: child.parentRunId } });

--- a/libs/backend/agents/execution/runs/main/src/prisma-child-run-reservation-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-child-run-reservation-repository.ts
@@ -10,7 +10,11 @@ import { _InitialRunOutboxData, _RunInputSnapshot, _RunInputSnapshotData } from 
 import { __DigestRunInputSnapshot } from "./run-input-snapshot-digest";
 import type { ChildRunReservationBuild, ChildRunReservationCommand, ChildRunReservationRepository, ChildRunReservationResult } from "./child-run-reservation.types";
 
-/** Atomically persists one child admission while its direct parent is locked. */
+/**
+ * Atomically persists one child admission while its direct parent is locked.
+ * Its advisory-lock query casts the result because Prisma cannot deserialize PostgreSQL's void return
+ * type from a raw query.
+ */
 export class PrismaChildRunReservationRepository implements ChildRunReservationRepository
 {
 	/** Canonical product-authority database client. */
@@ -34,7 +38,7 @@ export class PrismaChildRunReservationRepository implements ChildRunReservationR
 			return await this.prisma.$transaction(async function _reserve(transaction): Promise<ChildRunReservationResult>
 			{
 				// 1. Serialize one inherited-silo key before observing or creating a child.
-				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${__AdmissionLockKey(command.prepared.siloId, command.requestIdempotencyKey)}, 0))`);
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${__AdmissionLockKey(command.prepared.siloId, command.requestIdempotencyKey)}, 0))::text AS "lock"`);
 				const existing = await transaction.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.prepared.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
 				if (existing !== null)
 				{

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-admission-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-admission-repository.ts
@@ -59,6 +59,8 @@ class _PreparedAdmissionDenied<TDenial> extends Error
  * client they are given and must not open a transaction of their own, which would commit separately and
  * break the all-or-nothing guarantee above. The single read outside the transaction is the duplicate
  * recovery in the catch block, which uses the root client because the transaction is already gone.
+ * The advisory-lock query casts its result because Prisma cannot deserialize PostgreSQL's void return
+ * type from a raw query.
  *
  * Called by: `__AssembleRunInputSnapshot` (execution/inputs/main/src/session-assembly.ts), wired in by
  * `prisma-session-assembly-authorities.ts`.
@@ -117,7 +119,7 @@ export class PrismaRunAdmissionRepository implements RunAdmissionRepository
 			return await this.prisma.$transaction(async function _admit(transaction: Prisma.TransactionClient): Promise<RunAdmissionResult<TDenial>>
 			{
 				// 1. Serialize the user-visible key before loading inputs so a duplicate never recompiles at a later instant.
-				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${__AdmissionLockKey(command.siloId, command.requestIdempotencyKey)}, 0))`);
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${__AdmissionLockKey(command.siloId, command.requestIdempotencyKey)}, 0))::text AS "lock"`);
 				const existing = await transaction.agentRun.findUnique({ where: { siloId_requestIdempotencyKey: { siloId: command.siloId, requestIdempotencyKey: command.requestIdempotencyKey } } });
 				if (existing !== null)
 				{

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-cancellation-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-cancellation-repository.ts
@@ -19,7 +19,11 @@ interface CleanupCandidateRow
 	readonly agentServiceId: string;
 }
 
-/** Prisma-backed authority for fencing a run before its physical Job is removed. */
+/**
+ * Fences a run in Postgres before its physical Job is removed.
+ * Its advisory-lock queries cast their results because Prisma cannot deserialize PostgreSQL's void
+ * return type from a raw query.
+ */
 export class PrismaRunCancellationRepository implements RunCancellationRepository
 {
 	/** Canonical OpenCrane product-authority database client. */
@@ -46,7 +50,7 @@ export class PrismaRunCancellationRepository implements RunCancellationRepositor
 			const discovered = await transaction.agentRun.findUnique({ where: { id: command.runId } });
 			if (discovered === null) return { status: "not_found" };
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${discovered.agentServiceId} FOR UPDATE`);
-			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${discovered.id}, 0))`);
+			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${discovered.id}, 0))::text AS "lock"`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${discovered.id} FOR UPDATE`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "run_id" FROM "workload_assignments" WHERE "run_id" = ${discovered.id} AND "attempt" = ${command.expectedAttempt} FOR UPDATE`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "workload_bootstraps" WHERE "run_id" = ${discovered.id} AND "attempt" = ${command.expectedAttempt} FOR UPDATE`);
@@ -118,7 +122,7 @@ export class PrismaRunCancellationRepository implements RunCancellationRepositor
 			const candidate = candidates[0];
 			if (!candidate) return { status: "none" };
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${candidate.agentServiceId} FOR UPDATE`);
-			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${candidate.runId}, 0))`);
+			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${candidate.runId}, 0))::text AS "lock"`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${candidate.runId} FOR UPDATE`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "run_outbox_events" WHERE "id" = ${candidate.eventId} FOR UPDATE`);
 			const event = await transaction.outboxEvent.findUnique({ where: { id: candidate.eventId } });
@@ -146,7 +150,7 @@ export class PrismaRunCancellationRepository implements RunCancellationRepositor
 			const discoveredRun = await transaction.agentRun.findUnique({ where: { id: discoveredEvent.runId } });
 			if (!discoveredRun) return { status: "conflict", reason: "authority_conflict" };
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${discoveredRun.agentServiceId} FOR UPDATE`);
-			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${discoveredRun.id}, 0))`);
+			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${discoveredRun.id}, 0))::text AS "lock"`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${discoveredRun.id} FOR UPDATE`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "run_outbox_events" WHERE "id" = ${eventId} FOR UPDATE`);
 			const event = await transaction.outboxEvent.findUnique({ where: { id: eventId } });
@@ -184,7 +188,7 @@ export class PrismaRunCancellationRepository implements RunCancellationRepositor
 		{
 			const event = await transaction.outboxEvent.findUnique({ where: { id: eventId } });
 			if (!event || event.runId !== claim.workload.runId || event.attempt !== claim.workload.attempt) return "conflict";
-			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${event.runId}, 0))`);
+			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${event.runId}, 0))::text AS "lock"`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "run_outbox_events" WHERE "id" = ${eventId} FOR UPDATE`);
 			const locked = await transaction.outboxEvent.findUnique({ where: { id: eventId } });
 			const now = (await transaction.$queryRaw<Array<{ now: Date }>>(Prisma.sql`SELECT clock_timestamp()::timestamp(3) AS "now"`))[0]?.now;
@@ -205,7 +209,7 @@ export class PrismaRunCancellationRepository implements RunCancellationRepositor
 			const candidate = rows[0];
 			if (!candidate) return { status: "none" };
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${candidate.agentServiceId} FOR UPDATE`);
-			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${candidate.runId}, 0))`);
+			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${candidate.runId}, 0))::text AS "lock"`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${candidate.runId} FOR UPDATE`);
 			const run = await transaction.agentRun.findUnique({ where: { id: candidate.runId } });
 			const assignment = run === null ? null : await transaction.workloadAssignment.findUnique({ where: { runId_attempt: { runId: run.id, attempt: run.attempt } } });

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
@@ -29,11 +29,9 @@ interface SnapshotExecutionIdentity
 /**
  * Prisma-backed authority for handing one accepted run to the Kubernetes controller.
  *
- * Claims use database time plus a monotonically increasing delivery generation, so a controller
- * whose lease expired cannot publish an assignment after a newer replica reclaimed the event. Every
- * commit locks service, run, and outbox authority before creating the immutable PendingPod binding.
- * The advisory-lock queries cast their results because Prisma cannot deserialize PostgreSQL's void
- * return type from a raw query.
+ * Claims use database time plus a monotonic delivery generation, so a controller with an expired lease
+ * cannot publish after a newer replica reclaims the event. Every commit locks service, run, and outbox
+ * before PendingPod creation; text casts replace void lock results so Prisma can deserialize the queries.
  */
 export class PrismaRunDispatchRepository implements RunDispatchRepository
 {

--- a/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-run-dispatch-repository.ts
@@ -32,6 +32,8 @@ interface SnapshotExecutionIdentity
  * Claims use database time plus a monotonically increasing delivery generation, so a controller
  * whose lease expired cannot publish an assignment after a newer replica reclaimed the event. Every
  * commit locks service, run, and outbox authority before creating the immutable PendingPod binding.
+ * The advisory-lock queries cast their results because Prisma cannot deserialize PostgreSQL's void
+ * return type from a raw query.
  */
 export class PrismaRunDispatchRepository implements RunDispatchRepository
 {
@@ -79,7 +81,7 @@ export class PrismaRunDispatchRepository implements RunDispatchRepository
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${candidate.agentServiceId} FOR UPDATE`);
 			// ConversationRunEvent appends take this advisory lock before the run row. Preserve the
 			// global service -> run-advisory -> run -> outbox order before terminal event creation.
-			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${candidate.runId}, 0))`);
+			await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${candidate.runId}, 0))::text AS "lock"`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${candidate.runId} FOR UPDATE`);
 			await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "run_outbox_events" WHERE "id" = ${candidate.eventId} FOR UPDATE`);
 
@@ -334,7 +336,7 @@ export class PrismaRunDispatchRepository implements RunDispatchRepository
 
 				// 2. Lock service, run, assignment, bootstrap, then outbox in the shared authority order.
 				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_services" WHERE "id" = ${candidate.agentServiceId} FOR UPDATE`);
-				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${candidate.runId}, 0))`);
+				await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${candidate.runId}, 0))::text AS "lock"`);
 				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${candidate.runId} FOR UPDATE`);
 				await transaction.$queryRaw(Prisma.sql`SELECT "run_id" FROM "workload_assignments" WHERE "run_id" = ${candidate.runId} AND "attempt" = ${candidate.attempt} FOR UPDATE`);
 				await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "workload_bootstraps" WHERE "id" = ${candidate.bootstrapReference} FOR UPDATE`);

--- a/libs/backend/agents/execution/runs/main/src/prisma-runtime-terminal-reporter.ts
+++ b/libs/backend/agents/execution/runs/main/src/prisma-runtime-terminal-reporter.ts
@@ -4,14 +4,18 @@ import { __DeliverChildRunCompletionInTransaction } from "./prisma-child-run-com
 import { RuntimeRunFailureReasons } from "./runtime-event-reporter.types";
 import type { RuntimeTerminalEventType, RuntimeTerminalPendingToolRepository, RuntimeTerminalPendingToolUnitOfWork, RuntimeTerminalReportCommand, RuntimeTerminalReporter, RuntimeTerminalReportResult } from "./runtime-terminal-reporter.types";
 
-/** Prisma authority that turns a fenced runtime result into the sole terminal run outcome. */
+/**
+ * Turns a fenced runtime result into the sole terminal run outcome in Postgres.
+ * Its advisory-lock query casts the result because Prisma cannot deserialize PostgreSQL's void return
+ * type from a raw query.
+ */
 export class PrismaRuntimeTerminalReporter implements RuntimeTerminalReporter
 {
 	/** Persist one terminal report with its own stream event and child-to-parent hand-off. */
 	async reportInTransaction(transaction: Prisma.TransactionClient, command: RuntimeTerminalReportCommand): Promise<RuntimeTerminalReportResult>
 	{
 		// Serialise all terminal writers for this run before choosing the next stream sequence.
-		await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.runId}, 0))`);
+		await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${command.runId}, 0))::text AS "lock"`);
 		await transaction.$queryRaw(Prisma.sql`SELECT "id" FROM "agent_runs" WHERE "id" = ${command.runId} FOR UPDATE`);
 		const run = await transaction.agentRun.findUnique({ where: { id: command.runId } });
 		const sourceState = run === null || run.attempt !== command.attempt ? null : _TerminalSourceState(run.state, command);

--- a/libs/backend/server/iam/membership/main/src/__tests__/prisma-membership-authority.test.ts
+++ b/libs/backend/server/iam/membership/main/src/__tests__/prisma-membership-authority.test.ts
@@ -47,6 +47,10 @@ describe("Prisma fleet-membership authority adapter", function _suite()
 
 		await expect(repository.acceptRevisionAtomically({ issuerId: "fleet-1", siloId: "silo-1", revision: 7, payloadDigest: `sha256:${"1".repeat(64)}` })).resolves.toEqual({ status: "accepted", highestAcceptedRevision: 7 });
 		expect(transaction.$queryRaw).toHaveBeenCalledOnce();
+		const lockStatement = transaction.$queryRaw.mock.calls[0]?.[0] as { readonly sql: string; readonly values: readonly unknown[] };
+		expect(lockStatement.sql).toContain('::text AS "lock"');
+		expect(lockStatement.values).toContain("7:fleet-1silo-1");
+		expect(lockStatement.values.filter(function _IsText(value): value is string { return typeof value === "string"; }).join("")).not.toContain(String.fromCharCode(0));
 		expect(upsert).toHaveBeenCalledOnce();
 		expect(auditCreate).toHaveBeenCalledOnce();
 	});

--- a/libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts
+++ b/libs/backend/server/iam/membership/main/src/prisma-membership-authority.ts
@@ -114,9 +114,11 @@ function _ownsTransaction(prisma: PrismaClient | Prisma.TransactionClient): pris
 /** Advances the membership high-watermark and audit inside the caller's already selected transaction. */
 async function _acceptRevision(transaction: Prisma.TransactionClient, acceptance: FleetMembershipAcceptance): Promise<FleetMembershipAcceptanceResult>
 {
-	// 1. Serialize even the first acceptance for an issuer/silo pair, where no row exists to lock.
-	const lockKey = `${acceptance.issuerId}\u0000${acceptance.siloId}`;
-	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
+	// 1. Serialize even the first acceptance for an issuer/silo pair, where no row exists to lock. The
+	// length prefix keeps pairs distinct without a NUL byte, which PostgreSQL text rejects. Cast the
+	// lock result because Prisma cannot deserialize PostgreSQL's void return type from a raw query.
+	const lockKey = `${acceptance.issuerId.length}:${acceptance.issuerId}${acceptance.siloId}`;
+	await transaction.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))::text AS "lock"`);
 	const current = await transaction.highestAcceptedFleetMembership.findUnique({ where: { issuerId_siloId: { issuerId: acceptance.issuerId, siloId: acceptance.siloId } }, include: { verified: true } });
 	if (current !== null && (current.revision > acceptance.revision || (current.revision === acceptance.revision && current.verified.payloadDigest !== acceptance.payloadDigest)))
 	{

--- a/libs/frontend/features/conversation-workspace/src/lib/__tests__/conversation-workspace-shell.stories.ts
+++ b/libs/frontend/features/conversation-workspace/src/lib/__tests__/conversation-workspace-shell.stories.ts
@@ -1,4 +1,5 @@
 import { type Meta, moduleMetadata, type StoryObj } from "@storybook/angular";
+import { Router } from "@angular/router";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { ConversationLifecycles, ConversationModes, MessageRoles, MessageSources, MessageStates } from "@opencrane/models/conversations";
@@ -7,8 +8,9 @@ import { CONVERSATION_ASSETS_GATEWAY } from "@opencrane/state/conversation/asset
 import { ELICITATION_GATEWAY } from "@opencrane/state/conversation/elicitation";
 import { ConversationEventStreamStatuses, type ConversationEventStream, type StreamConversationEventsCommand } from "@opencrane/state/conversation/stream";
 import { CONVERSATION_WORKSPACE_EVENT_STREAM, CONVERSATION_WORKSPACE_GATEWAY, ConversationOnboardingHistoryStatuses, ConversationPersonalAgentStatuses, ConversationRunStates, type ConversationCreationDirectory, type ConversationOnboardingHistoryProjection, type ConversationRun, type ConversationWorkspaceDetail, type ConversationWorkspaceGateway } from "@opencrane/state/conversation/workspace";
+import { PLATFORM_BRIDGE } from "@opencrane/platform";
 
-import { ConversationWorkspacePageComponent } from "../components/conversation-workspace-page/conversation-workspace-page.component";
+import { ConversationWorkspaceRouteComponent } from "../conversation-workspace-route/conversation-workspace-route.component";
 
 /** Privacy-safe directory used by the full workspace stories. */
 const _DIRECTORY: ConversationCreationDirectory = { participants: [{ participantRef: "self", isSelf: true, label: "You" }, { participantRef: "participant-1", isSelf: false, label: "Participant 1" }], personalAgentStatus: ConversationPersonalAgentStatuses.Ready, personalAgent: { personalAgentRef: "agent-1", displayName: "Nova" } };
@@ -33,6 +35,12 @@ function _DirectDetail(): ConversationWorkspaceDetail
 {
 	const detail = _Detail("Can we review the handoff together?");
 	return { ...detail, mode: ConversationModes.Direct, agentServiceId: null, participantRefs: ["self", "participant-1"], messages: [{ ...detail.messages[0]!, role: MessageRoles.User, source: MessageSources.UserInput, runId: null, participantRef: "participant-1" }] };
+}
+
+/** Build one second direct conversation used to hold a stale route while the participant selects it. */
+function _SecondDirectDetail(): ConversationWorkspaceDetail
+{
+	return { ..._DirectDetail(), id: "conversation-2", updatedAt: "2026-08-12T19:31:00.000Z" };
 }
 
 /** Build one completed onboarding projection with no conversation mode or run. */
@@ -69,7 +77,7 @@ class _StoryGateway implements ConversationWorkspaceGateway
 	/** Return the configured separate onboarding history projection. */
 	public async onboardingHistory() { return this._onboardingHistory; }
 	/** Return or reject the configured authorized snapshot. */
-	public async open(): Promise<ConversationWorkspaceDetail> { if (this._detail instanceof Error) throw this._detail; return this._detail; }
+	public async open(_conversationId: string): Promise<ConversationWorkspaceDetail> { if (this._detail instanceof Error) throw this._detail; return this._detail; }
 	/** Return the configured snapshot for unused create interactions. */
 	public async create(): Promise<ConversationWorkspaceDetail> { return _Detail(); }
 	/** Accept no story message command. */
@@ -86,6 +94,23 @@ class _StoryGateway implements ConversationWorkspaceGateway
 	public async cancel(): Promise<ConversationRun> { return { ...this._run, state: ConversationRunStates.Cancelled }; }
 	/** Return a fresh story retry. */
 	public async retry(): Promise<ConversationRun> { return { ...this._run, attempt: this._run.attempt + 1, state: ConversationRunStates.Accepted }; }
+}
+
+/** Participant API that exposes two rows so the routed story can exercise selection handoff. */
+class _StoryNavigationGateway extends _StoryGateway
+{
+	/** Stores two authorized snapshots selected by their canonical route coordinate. */
+	private readonly _details = [_Detail(), _SecondDirectDetail()];
+
+	/** Return both rows in stable order. */
+	public override async list() { return this._details; }
+	/** Return the snapshot named by the requested route coordinate. */
+	public override async open(conversationId: string): Promise<ConversationWorkspaceDetail>
+	{
+		const detail = this._details.find(candidate => candidate.id === conversationId);
+		if (detail === undefined) throw new Error("Conversation not found.");
+		return detail;
+	}
 }
 
 /** Test-only live stream that emits one exact browser phase and state. */
@@ -115,18 +140,22 @@ class _StoryStream implements ConversationEventStream
 const _ASSETS = { list: async function _List() { return []; }, read: async function _Read() { throw new Error("No asset selected."); }, reserve: async function _Reserve() { throw new Error("Story command unavailable."); }, upload: async function _Upload() { throw new Error("Story command unavailable."); }, remove: async function _Remove() { throw new Error("Story command unavailable."); } };
 /** Test-only elicitation API; these shell states contain no open question. */
 const _ELICITATION = { read: async function _Read() { throw new Error("No question selected."); }, respond: async function _Respond() { throw new Error("Story command unavailable."); }, listActivity: async function _List() { return []; } };
+/** Test-only router that keeps the old input in place while the page finishes a rail selection. */
+const _ROUTER = { navigate: async function _Navigate() { return true; } };
+/** Supplies the test runtime API; routed workspace stories never open native capabilities. */
+const _PLATFORM = { isDesktop: false, bindFolder: async function _BindFolder() { throw new Error("Story command unavailable."); }, openAuthenticationWindow: function _OpenAuthenticationWindow() { return null; } };
 
 /** Supply explicit test-only ports around the real production shell. */
 function _Providers(gateway: ConversationWorkspaceGateway, stream: ConversationEventStream)
 {
-	return moduleMetadata({ providers: [{ provide: CONVERSATION_WORKSPACE_GATEWAY, useValue: gateway }, { provide: CONVERSATION_WORKSPACE_EVENT_STREAM, useValue: stream }, { provide: CONVERSATION_ASSETS_GATEWAY, useValue: _ASSETS }, { provide: ELICITATION_GATEWAY, useValue: _ELICITATION }] });
+	return moduleMetadata({ providers: [{ provide: CONVERSATION_WORKSPACE_GATEWAY, useValue: gateway }, { provide: CONVERSATION_WORKSPACE_EVENT_STREAM, useValue: stream }, { provide: CONVERSATION_ASSETS_GATEWAY, useValue: _ASSETS }, { provide: ELICITATION_GATEWAY, useValue: _ELICITATION }, { provide: Router, useValue: _ROUTER }, { provide: PLATFORM_BRIDGE, useValue: _PLATFORM }] });
 }
 
 /** Shared full-shell catalogue metadata. */
-const meta: Meta<ConversationWorkspacePageComponent> = { title: "Conversations/Workspace shell", component: ConversationWorkspacePageComponent, tags: ["autodocs"], parameters: { layout: "fullscreen" } };
+const meta: Meta<ConversationWorkspaceRouteComponent> = { title: "Conversations/Workspace shell", component: ConversationWorkspaceRouteComponent, tags: ["autodocs"], parameters: { layout: "fullscreen" } };
 
 export default meta;
-type Story = StoryObj<ConversationWorkspacePageComponent>;
+type Story = StoryObj<ConversationWorkspaceRouteComponent>;
 
 /** Complete desktop shell using the real page and component-scoped stores. */
 export const Desktop: Story =
@@ -144,6 +173,29 @@ export const Desktop: Story =
 		}, { timeout: 5000 });
 		attachInput.focus();
 		await expect(attachInput).toHaveFocus();
+	}
+};
+
+/** A stale route coordinate cannot reopen the old row while a new rail selection completes. */
+export const NavigationSelection: Story =
+{
+	args: { conversationId: "conversation-1" },
+	decorators: [_Providers(new _StoryNavigationGateway(_Detail()), new _StoryStream(ConversationEventStreamStatuses.Live, __CreateAgUiStreamState()))],
+	play: async function play({ canvasElement })
+	{
+		const rows = await waitFor(function _FindSessionRows()
+		{
+			const candidates = canvasElement.querySelectorAll<HTMLButtonElement>("wo-conversation-session-rail-row button");
+			expect(candidates).toHaveLength(2);
+			return candidates;
+		});
+		await userEvent.click(rows[1]!);
+		await waitFor(function _WaitForSelection()
+		{
+			const selectedRows = canvasElement.querySelectorAll('[aria-current="page"]');
+			expect(selectedRows).toHaveLength(1);
+			expect(selectedRows[0]).toBe(rows[1]);
+		});
 	}
 };
 

--- a/libs/frontend/features/conversation-workspace/src/lib/components/conversation-workspace-page/conversation-workspace-page.component.ts
+++ b/libs/frontend/features/conversation-workspace/src/lib/components/conversation-workspace-page/conversation-workspace-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ElementRef, ViewChild, afterRenderEffect, effect, input, output, signal } from "@angular/core";
+import { ChangeDetectionStrategy, Component, ElementRef, ViewChild, afterRenderEffect, effect, input, output, signal, untracked } from "@angular/core";
 import { ConversationAssetsStore } from "@opencrane/state/conversation/assets";
 import { ConversationElicitationStore, type ConversationActivityTarget } from "@opencrane/state/conversation/elicitation";
 import { ConversationOnboardingHistoryStore, ConversationRunStore, ConversationWorkspaceRouteStates, ConversationWorkspaceStore } from "@opencrane/state/conversation/workspace";
@@ -152,12 +152,19 @@ export class ConversationWorkspacePageComponent extends ConversationWorkspacePre
 	/** Reconcile the request after the app's verified sign-in window closes. */
 	public async recoverAfterStepUp(): Promise<void> { await this.elicitationStore.recoverAfterStepUp(); }
 
-	/** Adopt only a route coordinate that differs from the selected authorized snapshot. */
+	/**
+	 * Adopts a route coordinate after the workspace becomes ready.
+	 *
+	 * The route input and readiness stay reactive, but the current selection is read without tracking it.
+	 * Otherwise a rail selection would retrigger this effect while the old route coordinate is still in
+	 * place and reopen the conversation the participant just left.
+	 */
 	private _OpenRouteSelection(): void
 	{
 		const conversationId = this.conversationId();
 		if (this.store.routeState() !== this.routeStates.Ready) return;
-		if (conversationId !== null && this.store.selected()?.id !== conversationId) void this.open(conversationId);
+		const selectedConversationId = untracked(this.store.selected)?.id;
+		if (conversationId !== null && selectedConversationId !== conversationId) void this.open(conversationId);
 	}
 
 	/** Focus the original ask after recovery adopted its current server projection. */

--- a/libs/frontend/features/conversation-workspace/src/lib/conversation-workspace-route/conversation-workspace-route.component.scss
+++ b/libs/frontend/features/conversation-workspace/src/lib/conversation-workspace-route/conversation-workspace-route.component.scss
@@ -1,0 +1,6 @@
+:host {
+	overflow: hidden;
+	display: block;
+	// Follow the visible viewport when mobile browser controls expand or collapse.
+	block-size: 100dvh;
+}

--- a/libs/frontend/features/conversation-workspace/src/lib/conversation-workspace-route/conversation-workspace-route.component.ts
+++ b/libs/frontend/features/conversation-workspace/src/lib/conversation-workspace-route/conversation-workspace-route.component.ts
@@ -8,7 +8,7 @@ import { ConversationWorkspacePageComponent } from "../components/conversation-w
 import { _ConversationRouteCommands, _ConversationThreadRouteNavigation } from "./conversation-workspace-route.state";
 
 /** Feature-local coordinator for canonical chat URLs and breadcrumb child navigation. */
-@Component({ selector: "wo-conversation-workspace-route", standalone: true, imports: [ConversationWorkspacePageComponent], templateUrl: "./conversation-workspace-route.component.html", changeDetection: ChangeDetectionStrategy.OnPush })
+@Component({ selector: "wo-conversation-workspace-route", standalone: true, imports: [ConversationWorkspacePageComponent], templateUrl: "./conversation-workspace-route.component.html", styleUrl: "./conversation-workspace-route.component.scss", changeDetection: ChangeDetectionStrategy.OnPush })
 export class ConversationWorkspaceRouteComponent
 {
 	/** Optional canonical conversation route coordinate. */

--- a/tests/storybook/storybook.visual.spec.ts
+++ b/tests/storybook/storybook.visual.spec.ts
@@ -58,6 +58,8 @@ test("intermediate conversation workspace keeps its rail and context inside the 
 		await page.setViewportSize(viewport);
 		await _OpenStableStory(page, "conversations-workspace-shell--long-content");
 
+		const routeHost = page.locator("wo-conversation-workspace-route");
+		const pageHost = page.locator("wo-conversation-workspace-page");
 		const workspace = page.locator(".conversation-workspace");
 		const rail = page.locator("wo-conversation-list");
 		const contextPanel = page.locator("wo-conversation-workspace-context-panel");
@@ -65,6 +67,8 @@ test("intermediate conversation workspace keeps its rail and context inside the 
 		const transcript = page.locator(".conversation-workspace__transcript");
 		const composer = page.locator(".conversation-workspace__composer");
 		const railFooter = page.locator(".conversation-list__identity");
+		await expect(routeHost).toHaveCount(1);
+		await expect(pageHost).toHaveCount(1);
 		await expect(workspace).toHaveCount(1);
 		await expect(rail).toHaveCount(1);
 		await expect(contextPanel).toHaveCount(1);
@@ -73,14 +77,18 @@ test("intermediate conversation workspace keeps its rail and context inside the 
 		await expect(composer).toHaveCount(1);
 		await expect(railFooter).toHaveCount(1);
 
+		const routeHostBox = await routeHost.boundingBox();
+		const pageHostBox = await pageHost.boundingBox();
 		const workspaceBox = await workspace.boundingBox();
 		const railBox = await rail.boundingBox();
 		const contextPanelBox = await contextPanel.boundingBox();
 		const headerBox = await header.boundingBox();
 		const composerBox = await composer.boundingBox();
 		const railFooterBox = await railFooter.boundingBox();
-		if (workspaceBox === null || railBox === null || contextPanelBox === null || headerBox === null || composerBox === null || railFooterBox === null) throw new Error("The workspace layout is not visible.");
+		if (routeHostBox === null || pageHostBox === null || workspaceBox === null || railBox === null || contextPanelBox === null || headerBox === null || composerBox === null || railFooterBox === null) throw new Error("The routed workspace layout is not visible.");
 
+		expect(Math.round(routeHostBox.height)).toBe(viewport.height);
+		expect(Math.round(pageHostBox.height)).toBe(viewport.height);
 		expect(Math.round(workspaceBox.height)).toBe(viewport.height);
 		expect(Math.round(railBox.height)).toBe(viewport.height);
 		expect(contextPanelBox.x).toBeGreaterThanOrEqual(railBox.width);


### PR DESCRIPTION
## Outcome

- restore Agent-message admission by returning a Prisma-supported text result from every PostgreSQL advisory-lock query
- remove the NUL byte from the fleet membership lock key while keeping issuer/silo pairs unambiguous
- stop a stale route coordinate from reopening the previous conversation after a sidebar selection
- make the production conversation route own the visible viewport at narrow, intermediate, and wide widths

Sending a message remains an authenticated, idempotent `POST /messages`. Realtime delivery remains the separate long-lived `GET /events` SSE stream; this repair does not replace the canonical write with a WebSocket command.

## Live diagnosis

On testv4, the corrected server reached run admission but Prisma rejected `pg_advisory_xact_lock(...)` because PostgreSQL returns `void` and `$queryRaw` could not deserialize it (`P2010`). Casting the result to text preserves the transaction lock and satisfies Prisma. A read-only query against the testv4 CNPG primary confirmed the exact cast succeeds and returns one empty text value.

## Validation

- backend execution-runs: 144 tests passed
- backend execution-protocol: 109 tests passed
- backend membership: 15 tests passed
- conversation workspace: 17 tests passed; lint/typecheck passed
- Storybook routed navigation regression passed
- Playwright viewport geometry passed at 1073x900 and 1768x900
- Prisma boundary, module-growth, release-versioning, diff, and PR-stack gates passed
- independent review: no medium-or-higher findings; low comment findings fixed
- component-system and final comment gates: PASS

## Deployment status

This PR is independent of the current open PRs and targets `develop`. Testv4 still runs the previous image until this change is reviewed, merged, published, and deployed.
