### PR TITLE
✨ Add OAuth refresh workflow

### DIFF
--- a/libs/backend/server/infra/workflows/README.md
+++ b/libs/backend/server/infra/workflows/README.md
@@ -2,9 +2,9 @@
 
 > [infra](../README.md) › workflows
 
-These Phase-0 libraries define how a future control-plane action can persist work that survives a
-server restart. No OpenCrane application composes an engine or starts a worker yet. Product code will
-depend on the engine-neutral contract; it will never import an execution engine or control a worker.
+These libraries define how a future control-plane action can save work that survives a server restart.
+No OpenCrane application composes an engine or starts a worker yet. Product code will depend on the
+engine-neutral contract; it will never import an execution engine or control a worker.
 
 ## Map
 
@@ -12,6 +12,7 @@ depend on the engine-neutral contract; it will never import an execution engine 
 | --- | --- |
 | [contract](./contract/README.md) | The engine-neutral durable-task port, shared queue authority, and server-only worker lifecycle types. |
 | [kit](./kit/README.md) | Silo, task-name, payload, queue, and tracing guardrails. |
+| [oauth-refresh](./oauth-refresh/README.md) | One saved refresh task for each person and OAuth connection, without storing a credential in the task. |
 | [scheduler](./scheduler/README.md) | Finite respawn chains for product-owned recurrence. |
 | [infra_absurd](./infra_absurd/README.md) | The pinned Absurd engine adapter and its typed transaction procedure gateway. |
 | [testing](./testing/README.md) | Deterministic contract tests and an in-memory execution fake. |

--- a/libs/backend/server/infra/workflows/README.md
+++ b/libs/backend/server/infra/workflows/README.md
@@ -12,7 +12,7 @@ engine-neutral contract; it will never import an execution engine or control a w
 | --- | --- |
 | [contract](./contract/README.md) | The engine-neutral durable-task port, shared queue authority, and server-only worker lifecycle types. |
 | [kit](./kit/README.md) | Silo, task-name, payload, queue, and tracing guardrails. |
-| [oauth-refresh](./oauth-refresh/README.md) | One saved refresh task for each person and OAuth connection, without storing a credential in the task. |
+| [oauth-refresh](./oauth-refresh/README.md) | One saved refresh task for each connection scope and OAuth connection, without storing a credential in the task. |
 | [scheduler](./scheduler/README.md) | Finite respawn chains for product-owned recurrence. |
 | [infra_absurd](./infra_absurd/README.md) | The pinned Absurd engine adapter and its typed transaction procedure gateway. |
 | [testing](./testing/README.md) | Deterministic contract tests and an in-memory execution fake. |

--- a/libs/backend/server/infra/workflows/oauth-refresh/README.md
+++ b/libs/backend/server/infra/workflows/oauth-refresh/README.md
@@ -1,0 +1,60 @@
+# @opencrane/backend/server/infra/workflows/oauth-refresh — saved OAuth connection checks
+
+> [infra](../../README.md) › [workflows](../README.md) › oauth-refresh
+
+## What it owns
+
+This package defines a workflow that rechecks one OAuth connection. OAuth is a way for a person to
+allow an external service to act without giving OpenCrane their password. A workflow is saved work
+that can run later or continue after the server restarts.
+
+The product decides that a connection needs checking, then saves the product change and the task in
+the same database transaction. When a worker runs the task, this package calls the connection owner.
+That owner refreshes the external connection and stores any credential outside OpenCrane's database.
+
+```text
+ product change
+     │  save change + task in the same database transaction
+     ▼
+ ┌───────────────────────────────────┐
+ │ oauth-refresh  ◄── HERE            │  silo + subject + connection identifiers
+ └────────────────┬──────────────────┘
+                  │  replay-safe refresh check
+                  ▼
+ connection owner ──► external OAuth service
+                  │  refreshed · reconnect needed · removed
+                  ▼
+             product connection state
+```
+
+**In this flow:** the [workflow contract](../contract/README.md) saves and runs the task; the product
+connection owner keeps OAuth credentials out of task input and out of this package.
+
+There is at most one saved task for a silo, subject, connection, and refresh time. Repeating the same
+request returns that task; a later refresh time creates the next task for the same connection. The
+task key and diagnostic fields use a hash, so they do not contain the subject or connection identifier.
+The saved input carries identifiers and the refresh time only; it never carries an access token,
+refresh token, or password.
+
+## Public surface
+
+- `__CreateOAuthRefreshWorkflow` — registers the task and returns the admission API.
+- `__OAuthRefreshTaskKey` — derives the stable, identifier-hiding task key.
+- `OAuthRefreshConnectionPort` — the product-owned connection refresh operation.
+- `OAuthRefreshTaskInput` and `OAuthRefreshResult` — the credential-free task request and outcome.
+
+## Boundary
+
+Application composition supplies an approved workflow engine and the connection port. This package
+does not store OAuth credentials, open an OAuth browser flow, choose a worker queue, or own product
+connection records.
+
+## Dependency direction
+
+This is an infrastructure library with `scope:workflows`. It imports only the workflow contract and
+must never import an application or product domain.
+
+## See also
+
+- Parent: [workflows](../README.md)
+- Shared workflow rules: [contract](../contract/README.md)

--- a/libs/backend/server/infra/workflows/oauth-refresh/README.md
+++ b/libs/backend/server/infra/workflows/oauth-refresh/README.md
@@ -17,7 +17,7 @@ That owner refreshes the external connection and stores any credential outside O
      │  save change + task in the same database transaction
      ▼
  ┌───────────────────────────────────┐
- │ oauth-refresh  ◄── HERE            │  silo + subject + connection identifiers
+ │ oauth-refresh  ◄── HERE            │  silo + scope + subject + connection identifiers
  └────────────────┬──────────────────┘
                   │  replay-safe refresh check
                   ▼
@@ -30,8 +30,9 @@ That owner refreshes the external connection and stores any credential outside O
 **In this flow:** the [workflow contract](../contract/README.md) saves and runs the task; the product
 connection owner keeps OAuth credentials out of task input and out of this package.
 
-There is at most one saved task for a silo, subject, connection, and refresh time. Repeating the same
-request returns that task; a later refresh time creates the next task for the same connection. The
+The scope says who owns a connection: a person, team, department, project, or organisation. There
+is at most one saved task for a silo, scope, subject, connection, and refresh time. Repeating the
+same request returns that task; a later refresh time creates the next task for the same connection. The
 task key and diagnostic fields use a hash, so they do not contain the subject or connection identifier.
 The saved input carries identifiers and the refresh time only; it never carries an access token,
 refresh token, or password.
@@ -40,6 +41,8 @@ refresh token, or password.
 
 - `__CreateOAuthRefreshWorkflow` — registers the task and returns the admission API.
 - `__OAuthRefreshTaskKey` — derives the stable, identifier-hiding task key.
+- `OAuthRefreshScopeKinds` and `OAuthRefreshTaskInputSchema` — name and check the connection owner
+  before the task can be stored.
 - `OAuthRefreshConnectionPort` — the product-owned connection refresh operation.
 - `OAuthRefreshTaskInput` and `OAuthRefreshResult` — the credential-free task request and outcome.
 

--- a/libs/backend/server/infra/workflows/oauth-refresh/project.json
+++ b/libs/backend/server/infra/workflows/oauth-refresh/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend-server-infra-workflows-oauth-refresh",
+  "$schema": "../../../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/server/infra/workflows/oauth-refresh/src",
+  "tags": ["type:lib", "layer:infra", "scope:workflows"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/server/infra/workflows/oauth-refresh" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/server/infra/workflows/oauth-refresh" } }
+  }
+}

--- a/libs/backend/server/infra/workflows/oauth-refresh/src/__tests__/oauth-refresh.test.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/src/__tests__/oauth-refresh.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { __FakeDurableExecution } from "@opencrane/backend/server/infra/workflows/testing";
 import type { DurableExecutionTransaction } from "@opencrane/backend/server/infra/workflows/contract";
 
-import { __CreateOAuthRefreshWorkflow, __OAuthRefreshTaskKey, OAuthRefreshOutcomes, OAuthRefreshTaskNames } from "../index";
+import { __CreateOAuthRefreshWorkflow, __OAuthRefreshTaskKey, OAuthRefreshOutcomes, OAuthRefreshScopeKinds, OAuthRefreshTaskNames } from "../index";
 import type { OAuthRefreshConnectionPort, OAuthRefreshTaskInput } from "../index";
 
 /** Return a transaction-shaped object for an engine-free workflow test. */
@@ -12,10 +12,10 @@ function _Transaction(): DurableExecutionTransaction
 	return { client: {} };
 }
 
-/** Return a credential-free task input owned by one subject, connection, and refresh cycle. */
+/** Return a credential-free task input owned by one scope, subject, connection, and refresh cycle. */
 function _Input(refreshAt: string = "2026-08-23T12:00:00.000Z"): OAuthRefreshTaskInput
 {
-	return { siloId: "silo-a", subjectId: "principal-a", connectionId: "connection-a", refreshAt };
+	return { siloId: "silo-a", scopeKind: OAuthRefreshScopeKinds.Personal, subjectId: "principal-a", connectionId: "connection-a", refreshAt };
 }
 
 /** Start the deterministic fake workers after one OAuth task has been admitted. */
@@ -47,13 +47,18 @@ describe("OAuth refresh workflow", function _OAuthRefreshWorkflowSuite()
 		expect(reconcile).toHaveBeenCalledTimes(2);
 	});
 
-	it("keeps person and connection identifiers out of the engine task key", function _HidesIdentifiers()
+	it("keeps scope, subject, and connection identifiers out of the engine task key", function _HidesIdentifiers()
 	{
 		const key = __OAuthRefreshTaskKey(_Input());
 
 		expect(key).not.toContain("principal-a");
 		expect(key).not.toContain("connection-a");
 		expect(key).toMatch(/^workflows:oauth-refresh:[a-f0-9]{64}$/u);
+	});
+
+	it("keeps independently scoped connections in separate tasks", function _SeparatesScopes()
+	{
+		expect(__OAuthRefreshTaskKey(_Input())).not.toBe(__OAuthRefreshTaskKey({ ..._Input(), scopeKind: OAuthRefreshScopeKinds.Team }));
 	});
 
 	it("rejects a blank task identity before a task can be admitted", async function _RejectsBlankIdentity()
@@ -64,6 +69,7 @@ describe("OAuth refresh workflow", function _OAuthRefreshWorkflowSuite()
 
 		await expect(workflow.admit(_Transaction(), { ..._Input(), connectionId: " " })).rejects.toThrow("connectionId");
 		await expect(workflow.admit(_Transaction(), { ..._Input(), refreshAt: "tomorrow" })).rejects.toThrow("refreshAt");
+		await expect(workflow.admit(_Transaction(), { ..._Input(), scopeKind: "unknown" } as unknown as OAuthRefreshTaskInput)).rejects.toThrow("scopeKind");
 	});
 
 	it("refuses input or output fields that could save a credential", async function _RejectsCredentialFields()

--- a/libs/backend/server/infra/workflows/oauth-refresh/src/__tests__/oauth-refresh.test.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/src/__tests__/oauth-refresh.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { __FakeDurableExecution } from "@opencrane/backend/server/infra/workflows/testing";
+import type { DurableExecutionTransaction } from "@opencrane/backend/server/infra/workflows/contract";
+
+import { __CreateOAuthRefreshWorkflow, __OAuthRefreshTaskKey, OAuthRefreshOutcomes, OAuthRefreshTaskNames } from "../index";
+import type { OAuthRefreshConnectionPort, OAuthRefreshTaskInput } from "../index";
+
+/** Return a transaction-shaped object for an engine-free workflow test. */
+function _Transaction(): DurableExecutionTransaction
+{
+	return { client: {} };
+}
+
+/** Return a credential-free task input owned by one subject, connection, and refresh cycle. */
+function _Input(refreshAt: string = "2026-08-23T12:00:00.000Z"): OAuthRefreshTaskInput
+{
+	return { siloId: "silo-a", subjectId: "principal-a", connectionId: "connection-a", refreshAt };
+}
+
+/** Start the deterministic fake workers after one OAuth task has been admitted. */
+async function _Drain(execution: __FakeDurableExecution): Promise<void>
+{
+	await execution.startWorkers({ workerName: "oauth-refresh-test" });
+}
+
+describe("OAuth refresh workflow", function _OAuthRefreshWorkflowSuite()
+{
+	it("de-duplicates one refresh cycle, then admits the next cycle for the same connection", async function _RefreshesConnection()
+	{
+		const execution = new __FakeDurableExecution();
+		const reconcile = vi.fn().mockResolvedValue({ outcome: OAuthRefreshOutcomes.Refreshed });
+		const workflow = __CreateOAuthRefreshWorkflow({ execution, connections: { reconcile } });
+		const first = await workflow.admit(_Transaction(), _Input());
+		const repeated = await workflow.admit(_Transaction(), _Input());
+
+		expect(first.taskKey).toBe(repeated.taskKey);
+		expect(first.receipt).toBe(repeated.receipt);
+		expect(first.receipt.taskName).toBe(OAuthRefreshTaskNames.Reconcile);
+		await _Drain(execution);
+		expect(reconcile).toHaveBeenCalledWith(_Input());
+		expect(execution.taskSnapshot(first.receipt).result).toEqual({ outcome: OAuthRefreshOutcomes.Refreshed });
+
+		const next = await workflow.admit(_Transaction(), _Input("2026-08-23T13:00:00.000Z"));
+		expect(next.receipt).not.toBe(first.receipt);
+		await _Drain(execution);
+		expect(reconcile).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps person and connection identifiers out of the engine task key", function _HidesIdentifiers()
+	{
+		const key = __OAuthRefreshTaskKey(_Input());
+
+		expect(key).not.toContain("principal-a");
+		expect(key).not.toContain("connection-a");
+		expect(key).toMatch(/^workflows:oauth-refresh:[a-f0-9]{64}$/u);
+	});
+
+	it("rejects a blank task identity before a task can be admitted", async function _RejectsBlankIdentity()
+	{
+		const execution = new __FakeDurableExecution();
+		const connections: OAuthRefreshConnectionPort = { reconcile: vi.fn().mockResolvedValue({ outcome: OAuthRefreshOutcomes.Removed }) };
+		const workflow = __CreateOAuthRefreshWorkflow({ execution, connections });
+
+		await expect(workflow.admit(_Transaction(), { ..._Input(), connectionId: " " })).rejects.toThrow("connectionId");
+		await expect(workflow.admit(_Transaction(), { ..._Input(), refreshAt: "tomorrow" })).rejects.toThrow("refreshAt");
+	});
+
+	it("refuses input or output fields that could save a credential", async function _RejectsCredentialFields()
+	{
+		const execution = new __FakeDurableExecution();
+		const workflow = __CreateOAuthRefreshWorkflow({ execution, connections: { reconcile: vi.fn().mockResolvedValue({ outcome: OAuthRefreshOutcomes.Refreshed, refreshToken: "must-not-save" }) } });
+
+		await expect(workflow.admit(_Transaction(), { ..._Input(), accessToken: "must-not-save" } as unknown as OAuthRefreshTaskInput)).rejects.toThrow("may contain only");
+		const admitted = await workflow.admit(_Transaction(), _Input());
+		await _Drain(execution);
+		const error = execution.taskSnapshot(admitted.receipt).error;
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("may contain only outcome");
+	});
+});

--- a/libs/backend/server/infra/workflows/oauth-refresh/src/index.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/src/index.ts
@@ -1,0 +1,4 @@
+/** OAuth refresh task registration, admission, and credential-free task types. */
+export { __CreateOAuthRefreshWorkflow, __OAuthRefreshTaskKey } from "./oauth-refresh";
+export { OAuthRefreshOutcomes, OAuthRefreshTaskNames } from "./oauth-refresh.types";
+export type { OAuthRefreshConnectionPort, OAuthRefreshResult, OAuthRefreshTaskAdmission, OAuthRefreshTaskInput, OAuthRefreshWorkflow, OAuthRefreshWorkflowOptions } from "./oauth-refresh.types";

--- a/libs/backend/server/infra/workflows/oauth-refresh/src/index.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/src/index.ts
@@ -1,4 +1,4 @@
 /** OAuth refresh task registration, admission, and credential-free task types. */
 export { __CreateOAuthRefreshWorkflow, __OAuthRefreshTaskKey } from "./oauth-refresh";
-export { OAuthRefreshOutcomes, OAuthRefreshTaskNames } from "./oauth-refresh.types";
+export { OAuthRefreshOutcomes, OAuthRefreshScopeKinds, OAuthRefreshTaskInputSchema, OAuthRefreshTaskNames } from "./oauth-refresh.types";
 export type { OAuthRefreshConnectionPort, OAuthRefreshResult, OAuthRefreshTaskAdmission, OAuthRefreshTaskInput, OAuthRefreshWorkflow, OAuthRefreshWorkflowOptions } from "./oauth-refresh.types";

--- a/libs/backend/server/infra/workflows/oauth-refresh/src/oauth-refresh.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/src/oauth-refresh.ts
@@ -2,37 +2,20 @@ import { createHash } from "node:crypto";
 
 import type { DurableExecution, DurableExecutionTransaction, DurableTaskContext } from "@opencrane/backend/server/infra/workflows/contract";
 
-import { OAuthRefreshOutcomes, OAuthRefreshTaskNames, type OAuthRefreshConnectionPort, type OAuthRefreshResult, type OAuthRefreshTaskAdmission, type OAuthRefreshTaskInput, type OAuthRefreshWorkflow, type OAuthRefreshWorkflowOptions } from "./oauth-refresh.types";
-
-/** Reject a blank identifier before it can merge work for different OAuth connections. */
-function _RequireIdentifier(name: string, value: string): void
-{
-	if (value.trim().length === 0)
-	{
-		throw new Error(`${name} must be a non-empty string.`);
-	}
-}
+import { OAuthRefreshOutcomes, OAuthRefreshTaskInputSchema, OAuthRefreshTaskNames, type OAuthRefreshConnectionPort, type OAuthRefreshResult, type OAuthRefreshTaskAdmission, type OAuthRefreshTaskInput, type OAuthRefreshWorkflow, type OAuthRefreshWorkflowOptions } from "./oauth-refresh.types";
 
 /** Validate the identifiers and refresh cycle that are allowed to enter a saved OAuth refresh task. */
 function _AssertTaskInput(input: OAuthRefreshTaskInput): void
 {
-	if (typeof input !== "object" || input === null || Array.isArray(input))
-	{
-		throw new Error("OAuth refresh task input must be an object.");
-	}
-	const names = Object.keys(input);
-	if (names.length !== 4 || !names.every(function _AllowedName(name: string): boolean { return name === "siloId" || name === "subjectId" || name === "connectionId" || name === "refreshAt"; }))
-	{
-		throw new Error("OAuth refresh task input may contain only siloId, subjectId, connectionId, and refreshAt.");
-	}
-	_RequireIdentifier("siloId", input.siloId);
-	_RequireIdentifier("subjectId", input.subjectId);
-	_RequireIdentifier("connectionId", input.connectionId);
-	const refreshAt = new Date(input.refreshAt);
-	if (Number.isNaN(refreshAt.getTime()) || refreshAt.toISOString() !== input.refreshAt)
-	{
-		throw new Error("refreshAt must be a UTC ISO-8601 instant.");
-	}
+	const parsed = OAuthRefreshTaskInputSchema.safeParse(input);
+	if (parsed.success) return;
+	const issue = parsed.error.issues[0];
+	if (issue?.code === "unrecognized_keys") throw new Error("OAuth refresh task input may contain only siloId, scopeKind, subjectId, connectionId, and refreshAt.");
+	const field = issue?.path[0];
+	if (field === "scopeKind") throw new Error("scopeKind must identify a supported OAuth connection boundary.");
+	if (field === "refreshAt") throw new Error("refreshAt must be a UTC ISO-8601 instant.");
+	if (typeof field === "string") throw new Error(`${field} must be a non-empty string.`);
+	throw new Error("OAuth refresh task input must be an object.");
 }
 
 /** Reject a connection-port response that would save data beyond the three reviewed outcomes. */
@@ -54,15 +37,15 @@ function _AssertResult(result: OAuthRefreshResult): void
 }
 
 /**
- * Build a stable key without writing a person or connection identifier into engine diagnostics.
+ * Build a stable key without putting silo, scope, subject, or connection identifiers into engine diagnostics.
  *
- * The refresh time distinguishes later cycles for one connection. Repeating the same four values
+ * The refresh time distinguishes later cycles for one connection. Repeating the same scope-bound values
  * returns the same engine task, which prevents concurrent retries from doing the refresh twice.
  */
 export function __OAuthRefreshTaskKey(input: OAuthRefreshTaskInput): string
 {
 	_AssertTaskInput(input);
-	return `workflows:oauth-refresh:${createHash("sha256").update(JSON.stringify([input.siloId, input.subjectId, input.connectionId, input.refreshAt])).digest("hex")}`;
+	return `workflows:oauth-refresh:${createHash("sha256").update(JSON.stringify([input.siloId, input.scopeKind, input.subjectId, input.connectionId, input.refreshAt])).digest("hex")}`;
 }
 
 /** Run the connection-owned refresh through a replay-safe checkpoint. */

--- a/libs/backend/server/infra/workflows/oauth-refresh/src/oauth-refresh.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/src/oauth-refresh.ts
@@ -1,0 +1,107 @@
+import { createHash } from "node:crypto";
+
+import type { DurableExecution, DurableExecutionTransaction, DurableTaskContext } from "@opencrane/backend/server/infra/workflows/contract";
+
+import { OAuthRefreshOutcomes, OAuthRefreshTaskNames, type OAuthRefreshConnectionPort, type OAuthRefreshResult, type OAuthRefreshTaskAdmission, type OAuthRefreshTaskInput, type OAuthRefreshWorkflow, type OAuthRefreshWorkflowOptions } from "./oauth-refresh.types";
+
+/** Reject a blank identifier before it can merge work for different OAuth connections. */
+function _RequireIdentifier(name: string, value: string): void
+{
+	if (value.trim().length === 0)
+	{
+		throw new Error(`${name} must be a non-empty string.`);
+	}
+}
+
+/** Validate the identifiers and refresh cycle that are allowed to enter a saved OAuth refresh task. */
+function _AssertTaskInput(input: OAuthRefreshTaskInput): void
+{
+	if (typeof input !== "object" || input === null || Array.isArray(input))
+	{
+		throw new Error("OAuth refresh task input must be an object.");
+	}
+	const names = Object.keys(input);
+	if (names.length !== 4 || !names.every(function _AllowedName(name: string): boolean { return name === "siloId" || name === "subjectId" || name === "connectionId" || name === "refreshAt"; }))
+	{
+		throw new Error("OAuth refresh task input may contain only siloId, subjectId, connectionId, and refreshAt.");
+	}
+	_RequireIdentifier("siloId", input.siloId);
+	_RequireIdentifier("subjectId", input.subjectId);
+	_RequireIdentifier("connectionId", input.connectionId);
+	const refreshAt = new Date(input.refreshAt);
+	if (Number.isNaN(refreshAt.getTime()) || refreshAt.toISOString() !== input.refreshAt)
+	{
+		throw new Error("refreshAt must be a UTC ISO-8601 instant.");
+	}
+}
+
+/** Reject a connection-port response that would save data beyond the three reviewed outcomes. */
+function _AssertResult(result: OAuthRefreshResult): void
+{
+	if (typeof result !== "object" || result === null || Array.isArray(result))
+	{
+		throw new Error("OAuth refresh result must be an object.");
+	}
+	const names = Object.keys(result);
+	if (names.length !== 1 || names[0] !== "outcome")
+	{
+		throw new Error("OAuth refresh result may contain only outcome.");
+	}
+	if (result.outcome !== OAuthRefreshOutcomes.Refreshed && result.outcome !== OAuthRefreshOutcomes.NeedsAuthorization && result.outcome !== OAuthRefreshOutcomes.Removed)
+	{
+		throw new Error("OAuth refresh result has an unsupported outcome.");
+	}
+}
+
+/**
+ * Build a stable key without writing a person or connection identifier into engine diagnostics.
+ *
+ * The refresh time distinguishes later cycles for one connection. Repeating the same four values
+ * returns the same engine task, which prevents concurrent retries from doing the refresh twice.
+ */
+export function __OAuthRefreshTaskKey(input: OAuthRefreshTaskInput): string
+{
+	_AssertTaskInput(input);
+	return `workflows:oauth-refresh:${createHash("sha256").update(JSON.stringify([input.siloId, input.subjectId, input.connectionId, input.refreshAt])).digest("hex")}`;
+}
+
+/** Run the connection-owned refresh through a replay-safe checkpoint. */
+async function _RunRefresh(context: DurableTaskContext, connections: OAuthRefreshConnectionPort, input: OAuthRefreshTaskInput): Promise<OAuthRefreshResult>
+{
+	return await context.checkpoint({ stepName: "refresh-connection" }, async function _RefreshConnection(): Promise<OAuthRefreshResult>
+	{
+		const result = await connections.reconcile(input);
+		_AssertResult(result);
+		return result;
+	});
+}
+
+/**
+ * Register the OAuth refresh task and return its transaction-bound admission API.
+ *
+ * Application composition passes an execution port that already enforces its silo and queue policy.
+ * The returned API then keeps a product write and the selected refresh task in the same database
+ * transaction.
+ */
+export function __CreateOAuthRefreshWorkflow(options: OAuthRefreshWorkflowOptions): OAuthRefreshWorkflow
+{
+	const execution = options.execution;
+	const connections = options.connections;
+	execution.register({
+		taskName: OAuthRefreshTaskNames.Reconcile,
+		async run(context: DurableTaskContext, input: OAuthRefreshTaskInput): Promise<OAuthRefreshResult>
+		{
+			_AssertTaskInput(input);
+			return await _RunRefresh(context, connections, input);
+		},
+	});
+
+	return {
+		async admit(transaction: DurableExecutionTransaction, input: OAuthRefreshTaskInput): Promise<OAuthRefreshTaskAdmission>
+		{
+			const taskKey = __OAuthRefreshTaskKey(input);
+			const receipt = await execution.spawn(transaction, { taskName: OAuthRefreshTaskNames.Reconcile, idempotencyKey: taskKey, input });
+			return { taskKey, receipt };
+		},
+	};
+}

--- a/libs/backend/server/infra/workflows/oauth-refresh/src/oauth-refresh.types.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/src/oauth-refresh.types.ts
@@ -1,0 +1,99 @@
+import type { DurableExecution, DurableExecutionTransaction, DurableTaskReceipt } from "@opencrane/backend/server/infra/workflows/contract";
+
+/**
+ * Stable task names that workflow composition may place on an approved queue.
+ *
+ * The queue policy must include {@link OAuthRefreshTaskNames.Reconcile} before this workflow is
+ * registered. Keeping this name in one enum prevents an application and its worker from accepting
+ * different strings for the same saved work.
+ */
+export enum OAuthRefreshTaskNames
+{
+	/** Rechecks one person's connection without persisting any OAuth credential. */
+	Reconcile = "oauth-refresh.reconcile",
+}
+
+/**
+ * Identifies one due refresh without carrying any OAuth credential.
+ *
+ * Product code creates this input after it decides a connection needs refreshing. The same
+ * `refreshAt` value represents one refresh cycle, so a retry admits the existing task while a later
+ * refresh cycle can create new work for the same subject and connection.
+ */
+export interface OAuthRefreshTaskInput
+{
+	/** Silo that owns the person and connection. */
+	readonly siloId: string;
+	/** Product-owned person or service identity that owns the connection. */
+	readonly subjectId: string;
+	/** Product-owned identifier for the OAuth connection to recheck. */
+	readonly connectionId: string;
+	/** UTC ISO-8601 time that identifies this connection's refresh cycle. */
+	readonly refreshAt: string;
+}
+
+/** A saved OAuth refresh task together with its stable de-duplication key. */
+export interface OAuthRefreshTaskAdmission
+{
+	/** Stable key for this silo, subject, and connection task. */
+	readonly taskKey: string;
+	/** Engine receipt for the admitted task. */
+	readonly receipt: DurableTaskReceipt;
+}
+
+/**
+ * The safe result of refreshing or checking one OAuth connection.
+ *
+ * The durable engine saves this result as the task output. Every member ends this refresh task; a
+ * later `refreshAt` value is required to admit another task for the same connection.
+ */
+export enum OAuthRefreshOutcomes
+{
+	/** The remote service accepted the refresh, so this task ends with a usable connection. */
+	Refreshed = "refreshed",
+	/** The connection owner marks the connection as needing reconnection, then this task ends. */
+	NeedsAuthorization = "needs-authorization",
+	/** The connection no longer exists, so this task ends and no refresh is needed. */
+	Removed = "removed",
+}
+
+/** The outcome the connection owner returns after it rechecks one connection. */
+export interface OAuthRefreshResult
+{
+	/** Result that contains no credential material and is safe to save as task output. */
+	readonly outcome: OAuthRefreshOutcomes;
+}
+
+/**
+ * Owns connection lookup, OAuth refresh, and any product-state update.
+ *
+ * Called by: the registered refresh task. An implementation must read credentials from its own
+ * custody boundary and return only {@link OAuthRefreshResult}; it must never return a token or a
+ * remote response body because the workflow saves this result for replay.
+ */
+export interface OAuthRefreshConnectionPort
+{
+	/** Recheck one connection using its own credential custody boundary. */
+	reconcile(input: OAuthRefreshTaskInput): Promise<OAuthRefreshResult>;
+}
+
+/** Dependencies used to register and admit the OAuth refresh task. */
+export interface OAuthRefreshWorkflowOptions
+{
+	/** Durable execution that registers and saves the task. */
+	readonly execution: DurableExecution;
+	/** Product-owned port that refreshes the connection without exposing credentials. */
+	readonly connections: OAuthRefreshConnectionPort;
+}
+
+/**
+ * API that product composition uses to save one OAuth refresh task.
+ *
+ * Repeating an admission with the same input returns the original task. A later `refreshAt` value
+ * creates a separate task for the next refresh cycle of the same connection.
+ */
+export interface OAuthRefreshWorkflow
+{
+	/** Save or return the task for one person and OAuth connection in this database transaction. */
+	admit(transaction: DurableExecutionTransaction, input: OAuthRefreshTaskInput): Promise<OAuthRefreshTaskAdmission>;
+}

--- a/libs/backend/server/infra/workflows/oauth-refresh/src/oauth-refresh.types.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/src/oauth-refresh.types.ts
@@ -1,4 +1,5 @@
 import type { DurableExecution, DurableExecutionTransaction, DurableTaskReceipt } from "@opencrane/backend/server/infra/workflows/contract";
+import { z } from "zod";
 
 /**
  * Stable task names that workflow composition may place on an approved queue.
@@ -9,33 +10,63 @@ import type { DurableExecution, DurableExecutionTransaction, DurableTaskReceipt 
  */
 export enum OAuthRefreshTaskNames
 {
-	/** Rechecks one person's connection without persisting any OAuth credential. */
+	/** Rechecks one scoped connection without persisting any OAuth credential. */
 	Reconcile = "oauth-refresh.reconcile",
 }
 
 /**
- * Identifies one due refresh without carrying any OAuth credential.
+ * Names the product boundary that owns an OAuth connection.
+ *
+ * The task stores this value and includes it in its idempotency key, so a personal connection can
+ * never merge with a connection shared by a group. This enum describes ownership only; it grants
+ * no access to a credential.
+ */
+export enum OAuthRefreshScopeKinds
+{
+	/** One person's private connection. */
+	Personal = "personal",
+	/** A connection shared by one team. */
+	Team = "team",
+	/** A connection shared by one department. */
+	Department = "department",
+	/** A connection shared by one project. */
+	Project = "project",
+	/** A connection shared across the organisation. */
+	Organization = "organization",
+}
+
+/**
+ * Checks the small, credential-free input that may be stored and replayed by the workflow engine.
  *
  * Product code creates this input after it decides a connection needs refreshing. The same
  * `refreshAt` value represents one refresh cycle, so a retry admits the existing task while a later
- * refresh cycle can create new work for the same subject and connection.
+ * refresh cycle can create new work for the same scoped connection. This schema rejects unknown
+ * fields before task admission because engine storage must never receive OAuth credentials.
  */
-export interface OAuthRefreshTaskInput
-{
-	/** Silo that owns the person and connection. */
-	readonly siloId: string;
-	/** Product-owned person or service identity that owns the connection. */
-	readonly subjectId: string;
-	/** Product-owned identifier for the OAuth connection to recheck. */
-	readonly connectionId: string;
-	/** UTC ISO-8601 time that identifies this connection's refresh cycle. */
-	readonly refreshAt: string;
-}
+export const OAuthRefreshTaskInputSchema = z.object({
+	/** Stores the silo that owns the connection. */
+	siloId: z.string().trim().min(1),
+	/** Stores the product boundary that owns the connection. */
+	scopeKind: z.nativeEnum(OAuthRefreshScopeKinds),
+	/** Stores the product identity inside the connection's scope. */
+	subjectId: z.string().trim().min(1),
+	/** Stores the product identifier for the OAuth connection to recheck. */
+	connectionId: z.string().trim().min(1),
+	/** Stores the UTC ISO-8601 time that identifies this connection's refresh cycle. */
+	refreshAt: z.string().refine(function _IsUtcInstant(value: string): boolean
+	{
+		const instant = new Date(value);
+		return !Number.isNaN(instant.getTime()) && instant.toISOString() === value;
+	}, "refreshAt must be a UTC ISO-8601 instant."),
+}).strict();
+
+/** Credential-free input stored by the workflow engine for one scoped OAuth refresh cycle. */
+export type OAuthRefreshTaskInput = z.infer<typeof OAuthRefreshTaskInputSchema>;
 
 /** A saved OAuth refresh task together with its stable de-duplication key. */
 export interface OAuthRefreshTaskAdmission
 {
-	/** Stable key for this silo, subject, and connection task. */
+	/** Stable key for this silo, scope, subject, and connection task. */
 	readonly taskKey: string;
 	/** Engine receipt for the admitted task. */
 	readonly receipt: DurableTaskReceipt;
@@ -94,6 +125,6 @@ export interface OAuthRefreshWorkflowOptions
  */
 export interface OAuthRefreshWorkflow
 {
-	/** Save or return the task for one person and OAuth connection in this database transaction. */
+	/** Save or return the task for one scoped OAuth connection in this database transaction. */
 	admit(transaction: DurableExecutionTransaction, input: OAuthRefreshTaskInput): Promise<OAuthRefreshTaskAdmission>;
 }

--- a/libs/backend/server/infra/workflows/oauth-refresh/tsconfig.json
+++ b/libs/backend/server/infra/workflows/oauth-refresh/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/backend/server/infra/workflows/oauth-refresh/vitest.config.ts
+++ b/libs/backend/server/infra/workflows/oauth-refresh/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../../vitest.cache";
+
+/** Vitest configuration for the OAuth refresh workflow. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../../tsconfig.vitest.json"] })] });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -211,6 +211,9 @@
       "@opencrane/backend/server/infra/workflows/kit": [
         "./libs/backend/server/infra/workflows/kit/src/index.ts"
       ],
+      "@opencrane/backend/server/infra/workflows/oauth-refresh": [
+        "./libs/backend/server/infra/workflows/oauth-refresh/src/index.ts"
+      ],
       "@opencrane/backend/server/infra/workflows/scheduler": [
         "./libs/backend/server/infra/workflows/scheduler/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

- add a credential-free OAuth refresh workflow for each silo, subject, connection, and refresh cycle
- save the product decision and task through the same database transaction
- hash task keys and reject unexpected task input or output fields
- document the workflow in plain language, including how a later refresh time creates new work

## Validation

- npx nx test backend-server-infra-workflows-oauth-refresh
- npx nx lint backend-server-infra-workflows-oauth-refresh
- scripts/agent-style-check.sh
- npm run lint:boundaries
- npm run check:module-growth -- --diff b8116a40da9a69822b3fdc3a9f8df929e660b05e
- npm run check:prisma-boundaries -- --diff b8116a40da9a69822b3fdc3a9f8df929e660b05e
- npm run check:release-versioning -- --base b8116a40da9a69822b3fdc3a9f8df929e660b05e

## Review order

#697 -> #700

Review the parent before this pull request. This pull request is stacked on feat/group-parent-hierarchy and contains only the OAuth workflow increment.