### PR TITLE
🐛 Support Helm 4 workflow qualification

### DIFF
--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -944,7 +944,11 @@ if [[ -n "$FIRST_USER_EMAIL" ]]; then
 fi
 append_initial_model_provider_helm_args "$INITIAL_MODEL_PROVIDER"
 [[ -n "$VALUES_FILE" ]] && helm_args+=(--values "$VALUES_FILE")
-helm_args+=("${EXTRA_SET[@]}")
+# macOS Bash 3.2 aborts under `set -u` when it expands an empty array here.
+# Check its length before expansion so a deploy without --set still reaches Helm.
+if [[ ${#EXTRA_SET[@]} -gt 0 ]]; then
+  helm_args+=("${EXTRA_SET[@]}")
+fi
 # Raw helm-arg passthrough for sanctioned one-time fixes (e.g. --take-ownership).
 [[ ${#EXTRA_HELM_ARGS[@]} -gt 0 ]] && helm_args+=("${EXTRA_HELM_ARGS[@]}")
 CRDS_INSTALL="$(resolve_cluster_tenant_crd_install \

--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -718,12 +718,32 @@ _copy_cnpg_uri_secret "$LITELLM_POSTGRES_APP_SECRET" "$LITELLM_DATABASE_SECRET" 
 ARTIFACT_NAMESPACE="${RELEASE}-artifacts"
 ARTIFACT_CATALOG_KEY_SECRET="${RELEASE}-artifact-catalog-keys"
 ARTIFACT_SERVICE_KEY_SECRET="${RELEASE}-artifact-service-keys"
+# Teardown reads this label before it deletes an auxiliary namespace after its Helm objects are gone.
+RETIREMENT_OWNER_LABEL="opencrane.ai/retirement-owner"
 # Candidate-skill and tenant-tool Jobs need the same release boundary as the
 # application and artifact planes. Static chart defaults would make every silo
 # compete for one cluster-wide namespace and let the first Helm release claim it.
 SKILL_AUTHORING_NAMESPACE="${RELEASE}-skill-authoring"
 TOOL_RUNNER_NAMESPACE="${RELEASE}-tools"
-kubectl create namespace "$ARTIFACT_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+set +e
+ARTIFACT_NAMESPACE_RESOURCE="$(kubectl get namespace "$ARTIFACT_NAMESPACE" --ignore-not-found -o name)"
+ARTIFACT_NAMESPACE_STATUS=$?
+set -e
+if (( ARTIFACT_NAMESPACE_STATUS != 0 )); then
+  err "Unable to determine whether artifact namespace '$ARTIFACT_NAMESPACE' exists."
+  exit "$ARTIFACT_NAMESPACE_STATUS"
+fi
+if [[ -n "$ARTIFACT_NAMESPACE_RESOURCE" ]]; then
+  ARTIFACT_NAMESPACE_OWNER="$(kubectl get namespace "$ARTIFACT_NAMESPACE" -o "jsonpath={.metadata.labels.${RETIREMENT_OWNER_LABEL//./\\.}}")"
+  if [[ "$ARTIFACT_NAMESPACE_OWNER" != "$RELEASE" ]]; then
+    err "Artifact namespace '$ARTIFACT_NAMESPACE' belongs to '${ARTIFACT_NAMESPACE_OWNER:-an unknown owner}', not '$RELEASE'."
+    exit 1
+  fi
+else
+  kubectl create namespace "$ARTIFACT_NAMESPACE" --dry-run=client -o yaml \
+    | kubectl label --local --filename - "$RETIREMENT_OWNER_LABEL=$RELEASE" --overwrite --output yaml \
+    | kubectl create -f -
+fi
 _ensure_artifact_keys() {
   local key_dir
   local key

--- a/apps/_infra/deploy-k8s/platform/k8s-teardown.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-teardown.sh
@@ -195,8 +195,8 @@ assert_auxiliary_namespace_owner()
     && "$POSTGRES_RELEASE_EXISTS" == "1" && "$CNPG_CLUSTER_EXISTS" == "1" ]]; then
     local catalog_key
     local service_key
-    catalog_key="$(kubectl --context "$CONTEXT" get secret "${RELEASE}-artifact-catalog-keys" --namespace "$NAMESPACE" -o 'jsonpath={.data.lease-private\\.pem}' 2>/dev/null || true)"
-    service_key="$(kubectl --context "$CONTEXT" get secret "${RELEASE}-artifact-service-keys" --namespace "$auxiliary_namespace" -o 'jsonpath={.data.receipt-private\\.pem}' 2>/dev/null || true)"
+    catalog_key="$(kubectl --context "$CONTEXT" get secret "${RELEASE}-artifact-catalog-keys" --namespace "$NAMESPACE" -o 'jsonpath={.data.lease-private\.pem}' 2>/dev/null || true)"
+    service_key="$(kubectl --context "$CONTEXT" get secret "${RELEASE}-artifact-service-keys" --namespace "$auxiliary_namespace" -o 'jsonpath={.data.receipt-private\.pem}' 2>/dev/null || true)"
     [[ -n "$catalog_key" && -n "$service_key" ]] || {
       err "Cannot prove interrupted artifact namespace '$auxiliary_namespace' belongs to '$RELEASE'; its two deploy-created key Secrets are incomplete."
       exit 1

--- a/apps/_infra/deploy-k8s/platform/k8s-teardown.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-teardown.sh
@@ -189,6 +189,20 @@ assert_auxiliary_namespace_owner()
   if [[ "$retirement_owner" == "$RELEASE" ]]; then
     return
   fi
+  # An interrupted install can create the artifact namespace and both keys before Helm records the main release.
+  # When the PostgreSQL release and cluster remain, those keys prove its owner for recovery teardown.
+  if [[ "$auxiliary_namespace" == "${RELEASE}-artifacts" && "$MAIN_RELEASE_EXISTS" == "0" \
+    && "$POSTGRES_RELEASE_EXISTS" == "1" && "$CNPG_CLUSTER_EXISTS" == "1" ]]; then
+    local catalog_key
+    local service_key
+    catalog_key="$(kubectl --context "$CONTEXT" get secret "${RELEASE}-artifact-catalog-keys" --namespace "$NAMESPACE" -o 'jsonpath={.data.lease-private\\.pem}' 2>/dev/null || true)"
+    service_key="$(kubectl --context "$CONTEXT" get secret "${RELEASE}-artifact-service-keys" --namespace "$auxiliary_namespace" -o 'jsonpath={.data.receipt-private\\.pem}' 2>/dev/null || true)"
+    [[ -n "$catalog_key" && -n "$service_key" ]] || {
+      err "Cannot prove interrupted artifact namespace '$auxiliary_namespace' belongs to '$RELEASE'; its two deploy-created key Secrets are incomplete."
+      exit 1
+    }
+    return
+  fi
   [[ "$MAIN_RELEASE_EXISTS" == "1" ]] || {
     err "Cannot prove auxiliary namespace '$auxiliary_namespace' belongs to '$RELEASE'; its release and retirement marker are absent."
     exit 1

--- a/apps/_infra/deploy-k8s/platform/k8s-teardown.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-teardown.sh
@@ -261,14 +261,16 @@ assert_cluster_rbac_owner_if_present()
 {
   local resource_kind="$1"
   local resource_name="$2"
-  local instance
   local managed_by
+  local release_name
+  local release_namespace
   if ! resource_exists "$resource_kind" "$resource_name"; then
     return
   fi
-  instance="$(kubectl --context "$CONTEXT" get "$resource_kind/$resource_name" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/instance}')"
   managed_by="$(kubectl --context "$CONTEXT" get "$resource_kind/$resource_name" -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}')"
-  [[ "$instance" == "$RELEASE" && "$managed_by" == "Helm" ]] || {
+  release_name="$(kubectl --context "$CONTEXT" get "$resource_kind/$resource_name" -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}')"
+  release_namespace="$(kubectl --context "$CONTEXT" get "$resource_kind/$resource_name" -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-namespace}')"
+  [[ "$managed_by" == "Helm" && "$release_name" == "$RELEASE" && "$release_namespace" == "$NAMESPACE" ]] || {
     err "Foreign ownership on $resource_kind/$resource_name; refusing cluster-scoped deletion."
     exit 1
   }

--- a/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
+++ b/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
@@ -64,9 +64,11 @@ for bounded_integer in "$LOCAL_PORT" "$SAMPLE_COUNT" "$POLL_INTERVAL_MS" "$THRES
 done
 (( LOCAL_PORT >= 1024 && LOCAL_PORT <= 65535 )) || { _error "--local-port must be from 1024 through 65535"; exit 2; }
 
-for command in base64 helm jq kubectl node npx; do
+for command in base64 helm jq kubectl node; do
   command -v "$command" >/dev/null 2>&1 || { _error "missing required command '$command'"; exit 1; }
 done
+QUALIFICATION_RUNNER="$REPOSITORY_ROOT/node_modules/.bin/tsx"
+[[ -x "$QUALIFICATION_RUNNER" ]] || { _error "qualification runner is unavailable"; exit 1; }
 
 CURRENT_CONTEXT="$(kubectl config current-context)"
 [[ "$CURRENT_CONTEXT" == "$KUBE_CONTEXT" ]] || { _error "current context does not match --context"; exit 1; }
@@ -121,7 +123,7 @@ export OPENCRANE_D2_DATABASE_POOL_SIZE="$DATABASE_POOL_SIZE"
 QUALIFICATION_RESULT="$(
 (
   cd "$REPOSITORY_ROOT/libs/backend/server/infra/workflows/infra_absurd"
-  npx tsx src/qualification/qualify-durable-execution.cli.ts
+  "$QUALIFICATION_RUNNER" src/qualification/qualify-durable-execution.cli.ts
 )
 )"
 jq -e '

--- a/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
+++ b/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
@@ -13,8 +13,12 @@ SAMPLE_COUNT="40"
 POLL_INTERVAL_MS="50"
 THRESHOLD_MS="250"
 DATABASE_POOL_SIZE="2"
+RUNNER_TIMEOUT_SECONDS="300"
 PORT_FORWARD_PID=""
 PORT_FORWARD_LOG=""
+QUALIFICATION_OUTPUT=""
+QUALIFICATION_ERROR=""
+QUALIFICATION_PID=""
 
 _error()
 {
@@ -25,12 +29,23 @@ _cleanup()
 {
   local status=$?
   unset DATABASE_URL
+  if [[ -n "$QUALIFICATION_PID" ]]; then
+    kill "$QUALIFICATION_PID" >/dev/null 2>&1 || true
+    wait "$QUALIFICATION_PID" >/dev/null 2>&1 || true
+    QUALIFICATION_PID=""
+  fi
   if [[ -n "$PORT_FORWARD_PID" ]]; then
     kill "$PORT_FORWARD_PID" >/dev/null 2>&1 || true
     wait "$PORT_FORWARD_PID" >/dev/null 2>&1 || true
   fi
   if [[ -n "$PORT_FORWARD_LOG" ]]; then
     rm -f -- "$PORT_FORWARD_LOG"
+  fi
+  if [[ -n "$QUALIFICATION_OUTPUT" ]]; then
+    rm -f -- "$QUALIFICATION_OUTPUT"
+  fi
+  if [[ -n "$QUALIFICATION_ERROR" ]]; then
+    rm -f -- "$QUALIFICATION_ERROR"
   fi
   return "$status"
 }
@@ -50,6 +65,7 @@ while [[ $# -gt 0 ]]; do
     --poll-interval-ms) POLL_INTERVAL_MS="$2"; shift 2 ;;
     --threshold-ms) THRESHOLD_MS="$2"; shift 2 ;;
     --database-pool-size) DATABASE_POOL_SIZE="$2"; shift 2 ;;
+    --runner-timeout-seconds) RUNNER_TIMEOUT_SECONDS="$2"; shift 2 ;;
     -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     *) _error "unknown flag '$1'"; exit 2 ;;
   esac
@@ -59,10 +75,11 @@ done
 [[ "$CLUSTER_TENANT" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { _error "--cluster-tenant must be a DNS label"; exit 2; }
 [[ -n "$NAMESPACE" ]] || NAMESPACE="opencrane-${CLUSTER_TENANT}"
 [[ "$NAMESPACE" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { _error "--namespace must be a DNS label"; exit 2; }
-for bounded_integer in "$LOCAL_PORT" "$SAMPLE_COUNT" "$POLL_INTERVAL_MS" "$THRESHOLD_MS" "$DATABASE_POOL_SIZE"; do
+for bounded_integer in "$LOCAL_PORT" "$SAMPLE_COUNT" "$POLL_INTERVAL_MS" "$THRESHOLD_MS" "$DATABASE_POOL_SIZE" "$RUNNER_TIMEOUT_SECONDS"; do
   [[ "$bounded_integer" =~ ^[1-9][0-9]*$ ]] || { _error "numeric inputs must be positive integers"; exit 2; }
 done
 (( LOCAL_PORT >= 1024 && LOCAL_PORT <= 65535 )) || { _error "--local-port must be from 1024 through 65535"; exit 2; }
+(( RUNNER_TIMEOUT_SECONDS <= 900 )) || { _error "--runner-timeout-seconds must not exceed 900"; exit 2; }
 
 for command in base64 helm jq kubectl node; do
   command -v "$command" >/dev/null 2>&1 || { _error "missing required command '$command'"; exit 1; }
@@ -120,12 +137,35 @@ export OPENCRANE_D2_POLL_INTERVAL_MS="$POLL_INTERVAL_MS"
 export OPENCRANE_D2_THRESHOLD_MS="$THRESHOLD_MS"
 export OPENCRANE_D2_DATABASE_POOL_SIZE="$DATABASE_POOL_SIZE"
 
-QUALIFICATION_RESULT="$(
+QUALIFICATION_OUTPUT="$(mktemp)"
+QUALIFICATION_ERROR="$(mktemp)"
 (
   cd "$REPOSITORY_ROOT/libs/backend/server/infra/workflows/infra_absurd"
   "$QUALIFICATION_RUNNER" src/qualification/qualify-durable-execution.cli.ts
-)
-)"
+) >"$QUALIFICATION_OUTPUT" 2>"$QUALIFICATION_ERROR" &
+QUALIFICATION_PID=$!
+_error "starting qualifier runner"
+QUALIFICATION_STATUS=0
+for (( attempt = 1; attempt <= RUNNER_TIMEOUT_SECONDS; attempt += 1 )); do
+  if ! kill -0 "$QUALIFICATION_PID" >/dev/null 2>&1; then
+    wait "$QUALIFICATION_PID" || QUALIFICATION_STATUS=$?
+    QUALIFICATION_PID=""
+    break
+  fi
+  sleep 1
+done
+if [[ -n "$QUALIFICATION_PID" ]]; then
+  kill "$QUALIFICATION_PID" >/dev/null 2>&1 || true
+  wait "$QUALIFICATION_PID" >/dev/null 2>&1 || true
+  QUALIFICATION_PID=""
+  _error "qualifier runner exceeded ${RUNNER_TIMEOUT_SECONDS}s without a result"
+  exit 1
+fi
+if ! grep -Fxq "Durable execution qualification started." "$QUALIFICATION_ERROR"; then
+  _error "qualifier runner exited before it reported startup"
+  exit 1
+fi
+QUALIFICATION_RESULT="$(<"$QUALIFICATION_OUTPUT")"
 jq -e '
   type == "object"
   and (.passed | type == "boolean")
@@ -146,3 +186,4 @@ jq -e '
   and (if .connectionEvidence.available then (.connectionEvidence.peakConnections | type == "number") else (.connectionEvidence | has("peakConnections") | not) end)
 ' <<<"$QUALIFICATION_RESULT" >/dev/null || { _error "qualifier did not emit a complete result"; exit 1; }
 printf '%s\n' "$QUALIFICATION_RESULT"
+exit "$QUALIFICATION_STATUS"

--- a/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
+++ b/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
@@ -118,7 +118,29 @@ export OPENCRANE_D2_POLL_INTERVAL_MS="$POLL_INTERVAL_MS"
 export OPENCRANE_D2_THRESHOLD_MS="$THRESHOLD_MS"
 export OPENCRANE_D2_DATABASE_POOL_SIZE="$DATABASE_POOL_SIZE"
 
+QUALIFICATION_RESULT="$(
 (
   cd "$REPOSITORY_ROOT/libs/backend/server/infra/workflows/infra_absurd"
   npx tsx src/qualification/qualify-durable-execution.cli.ts
 )
+)"
+jq -e '
+  type == "object"
+  and (.passed | type == "boolean")
+  and (.sampleCount | type == "number")
+  and (.warmupCount | type == "number")
+  and (.pollIntervalMs | type == "number")
+  and (.thresholdMs | type == "number")
+  and (.databasePoolSize | type == "number")
+  and (.connectionCeiling | type == "number")
+  and (.transport == "kubectl-port-forward")
+  and (.latencyMs | type == "object")
+  and (.latencyMs.p50 | type == "number")
+  and (.latencyMs.p95 | type == "number")
+  and (.latencyMs.p99 | type == "number")
+  and (.latencyMs.max | type == "number")
+  and (.connectionEvidence | type == "object")
+  and (.connectionEvidence.available | type == "boolean")
+  and (if .connectionEvidence.available then (.connectionEvidence.peakConnections | type == "number") else (.connectionEvidence | has("peakConnections") | not) end)
+' <<<"$QUALIFICATION_RESULT" >/dev/null || { _error "qualifier did not emit a complete result"; exit 1; }
+printf '%s\n' "$QUALIFICATION_RESULT"

--- a/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
+++ b/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
@@ -118,4 +118,7 @@ export OPENCRANE_D2_POLL_INTERVAL_MS="$POLL_INTERVAL_MS"
 export OPENCRANE_D2_THRESHOLD_MS="$THRESHOLD_MS"
 export OPENCRANE_D2_DATABASE_POOL_SIZE="$DATABASE_POOL_SIZE"
 
-npx nx run backend-server-infra-workflows-infra-absurd:qualify-live
+(
+  cd "$REPOSITORY_ROOT/libs/backend/server/infra/workflows/infra_absurd"
+  npx tsx src/qualification/qualify-durable-execution.cli.ts
+)

--- a/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
+++ b/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh
@@ -78,10 +78,12 @@ EXPECTED_VERSION="$(jq -r '.repositoryVersion' "$REPOSITORY_ROOT/releases/0.9.3.
 
 SILO_STATUS="$(helm status "$RELEASE" --namespace "$NAMESPACE" --output json)"
 POSTGRES_STATUS="$(helm status "$POSTGRES_RELEASE" --namespace "$NAMESPACE" --output json)"
+SILO_METADATA="$(helm get metadata "$RELEASE" --namespace "$NAMESPACE" --output json)"
+POSTGRES_METADATA="$(helm get metadata "$POSTGRES_RELEASE" --namespace "$NAMESPACE" --output json)"
 [[ "$(jq -r '.info.status' <<<"$SILO_STATUS")" == "deployed" ]] || { _error "silo release is not deployed"; exit 1; }
-[[ "$(jq -r '.chart' <<<"$SILO_STATUS")" == "opencrane-silo-${EXPECTED_VERSION}" ]] || { _error "silo release is not the qualification version"; exit 1; }
+[[ "$(jq -r '.chart' <<<"$SILO_METADATA")" == "opencrane-silo" && "$(jq -r '.version' <<<"$SILO_METADATA")" == "$EXPECTED_VERSION" ]] || { _error "silo release is not the qualification version"; exit 1; }
 [[ "$(jq -r '.info.status' <<<"$POSTGRES_STATUS")" == "deployed" ]] || { _error "PostgreSQL release is not deployed"; exit 1; }
-[[ "$(jq -r '.chart' <<<"$POSTGRES_STATUS")" == "postgres-${EXPECTED_VERSION}" ]] || { _error "PostgreSQL release is not the qualification version"; exit 1; }
+[[ "$(jq -r '.chart' <<<"$POSTGRES_METADATA")" == "postgres" && "$(jq -r '.version' <<<"$POSTGRES_METADATA")" == "$EXPECTED_VERSION" ]] || { _error "PostgreSQL release is not the qualification version"; exit 1; }
 
 [[ "$(kubectl get service "$POOLER_SERVICE" --namespace "$NAMESPACE" -o jsonpath='{.metadata.labels.cnpg\.io/cluster}')" == "$POSTGRES_RELEASE" ]] || { _error "pooler service does not belong to the named silo"; exit 1; }
 kubectl get secret "$APPLICATION_SECRET" --namespace "$NAMESPACE" -o jsonpath='{.data.uri}' | grep -q . || { _error "application database credential is unavailable"; exit 1; }

--- a/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
@@ -40,7 +40,8 @@ EOF
 
 cat >"$MOCK_BIN/npx" <<'EOF'
 #!/usr/bin/env bash
-[[ "$*" == "nx run backend-server-infra-workflows-infra-absurd:qualify-live" ]]
+[[ "$*" == "tsx src/qualification/qualify-durable-execution.cli.ts" ]]
+[[ "$PWD" == */libs/backend/server/infra/workflows/infra_absurd ]]
 [[ "$DATABASE_URL" == 'postgresql://opencrane:super-secret@127.0.0.1:65431/opencrane' ]]
 [[ "$OPENCRANE_D2_SILO_ID" == 'testlynn' ]]
 [[ "$OPENCRANE_D2_SAMPLE_COUNT" == '40' ]]

--- a/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
@@ -53,6 +53,7 @@ cat >"$RUNNER_ROOT/node_modules/.bin/tsx" <<'EOF'
 [[ "$OPENCRANE_D2_POLL_INTERVAL_MS" == '50' ]]
 [[ "$OPENCRANE_D2_THRESHOLD_MS" == '250' ]]
 [[ "$OPENCRANE_D2_DATABASE_POOL_SIZE" == '2' ]]
+printf '%s\n' 'Durable execution qualification started.' >&2
 printf '%s\n' '{"passed":true,"sampleCount":40,"warmupCount":5,"pollIntervalMs":50,"thresholdMs":250,"databasePoolSize":2,"connectionCeiling":3,"transport":"kubectl-port-forward","latencyMs":{"p50":100,"p95":120,"p99":140,"max":140},"connectionEvidence":{"available":true,"peakConnections":2}}'
 EOF
 
@@ -78,6 +79,7 @@ fi
 grep -Fq 'silo release is not the qualification version' "$TEST_DIR/version-mismatch"
 cat >"$RUNNER_ROOT/node_modules/.bin/tsx" <<'EOF'
 #!/usr/bin/env bash
+printf '%s\n' 'Durable execution qualification started.' >&2
 printf '%s\n' '{"passed":true,"latencyMs":{"p50":100,"p95":120},"connectionEvidence":{"available":true}}'
 EOF
 chmod +x "$RUNNER_ROOT/node_modules/.bin/tsx"
@@ -88,6 +90,7 @@ fi
 grep -Fq 'qualifier did not emit a complete result' "$TEST_DIR/partial-result"
 cat >"$RUNNER_ROOT/node_modules/.bin/tsx" <<'EOF'
 #!/usr/bin/env bash
+printf '%s\n' 'Durable execution qualification started.' >&2
 exit 0
 EOF
 chmod +x "$RUNNER_ROOT/node_modules/.bin/tsx"
@@ -96,6 +99,31 @@ if PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluste
   exit 1
 fi
 grep -Fq 'qualifier did not emit a complete result' "$TEST_DIR/missing-result"
+cat >"$RUNNER_ROOT/node_modules/.bin/tsx" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' 'Durable execution qualification started.' >&2
+printf '%s\n' '{"passed":false,"sampleCount":40,"warmupCount":5,"pollIntervalMs":50,"thresholdMs":250,"databasePoolSize":2,"connectionCeiling":3,"transport":"kubectl-port-forward","latencyMs":{"p50":100,"p95":400,"p99":450,"max":450},"connectionEvidence":{"available":true,"peakConnections":2}}'
+exit 2
+EOF
+chmod +x "$RUNNER_ROOT/node_modules/.bin/tsx"
+if PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 >"$TEST_DIR/failed-result" 2>&1; then
+  printf 'durable execution qualifier accepted a failed latency result\n' >&2
+  exit 1
+else
+  qualifier_status=$?
+fi
+[[ "$qualifier_status" -eq 2 ]]
+grep -Fq '"passed":false' "$TEST_DIR/failed-result"
+cat >"$RUNNER_ROOT/node_modules/.bin/tsx" <<'EOF'
+#!/usr/bin/env bash
+sleep 2
+EOF
+chmod +x "$RUNNER_ROOT/node_modules/.bin/tsx"
+if PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 --runner-timeout-seconds 1 >"$TEST_DIR/runner-timeout" 2>&1; then
+  printf 'durable execution qualifier accepted a stalled runner\n' >&2
+  exit 1
+fi
+grep -Fq 'qualifier runner exceeded 1s without a result' "$TEST_DIR/runner-timeout"
 grep -Fq 'QUALIFICATION_RUNNER="$REPOSITORY_ROOT/node_modules/.bin/tsx"' "$QUALIFIER_SOURCE"
 bash -n "$QUALIFIER_SOURCE"
 echo "durable execution qualification contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
@@ -2,12 +2,17 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
-QUALIFIER="$ROOT_DIR/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh"
+QUALIFIER_SOURCE="$ROOT_DIR/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh"
 TEST_DIR="$(mktemp -d)"
 MOCK_BIN="$TEST_DIR/bin"
 CAPTURE="$TEST_DIR/capture"
 mkdir -p "$MOCK_BIN"
 trap 'rm -rf -- "$TEST_DIR"' EXIT
+RUNNER_ROOT="$TEST_DIR/repository"
+QUALIFIER="$RUNNER_ROOT/apps/_infra/deploy-k8s/platform/qualify-durable-execution.sh"
+mkdir -p "$RUNNER_ROOT/apps/_infra/deploy-k8s/platform" "$RUNNER_ROOT/libs/backend/server/infra/workflows/infra_absurd" "$RUNNER_ROOT/node_modules/.bin"
+ln -s "$QUALIFIER_SOURCE" "$QUALIFIER"
+ln -s "$ROOT_DIR/releases" "$RUNNER_ROOT/releases"
 
 cat >"$MOCK_BIN/helm" <<'EOF'
 #!/usr/bin/env bash
@@ -38,9 +43,9 @@ fi
 exit 1
 EOF
 
-cat >"$MOCK_BIN/npx" <<'EOF'
+cat >"$RUNNER_ROOT/node_modules/.bin/tsx" <<'EOF'
 #!/usr/bin/env bash
-[[ "$*" == "tsx src/qualification/qualify-durable-execution.cli.ts" ]]
+[[ "$*" == "src/qualification/qualify-durable-execution.cli.ts" ]]
 [[ "$PWD" == */libs/backend/server/infra/workflows/infra_absurd ]]
 [[ "$DATABASE_URL" == 'postgresql://opencrane:super-secret@127.0.0.1:65431/opencrane' ]]
 [[ "$OPENCRANE_D2_SILO_ID" == 'testlynn' ]]
@@ -59,7 +64,7 @@ if [[ "$*" == *"net.createServer"* ]]; then exit 0; fi
 printf '%s' 'postgresql://opencrane:super-secret@127.0.0.1:65431/opencrane'
 EOF
 
-chmod +x "$MOCK_BIN/helm" "$MOCK_BIN/kubectl" "$MOCK_BIN/node" "$MOCK_BIN/npx"
+chmod +x "$MOCK_BIN/helm" "$MOCK_BIN/kubectl" "$MOCK_BIN/node" "$RUNNER_ROOT/node_modules/.bin/tsx"
 PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 >"$CAPTURE"
 grep -Fq '"passed":true' "$CAPTURE"
 if grep -Fq 'super-secret' "$CAPTURE"; then
@@ -71,25 +76,26 @@ if MOCK_SILO_VERSION=0.9.2 PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gk
   exit 1
 fi
 grep -Fq 'silo release is not the qualification version' "$TEST_DIR/version-mismatch"
-cat >"$MOCK_BIN/npx" <<'EOF'
+cat >"$RUNNER_ROOT/node_modules/.bin/tsx" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' '{"passed":true,"latencyMs":{"p50":100,"p95":120},"connectionEvidence":{"available":true}}'
 EOF
-chmod +x "$MOCK_BIN/npx"
+chmod +x "$RUNNER_ROOT/node_modules/.bin/tsx"
 if PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 >"$TEST_DIR/partial-result" 2>&1; then
   printf 'durable execution qualifier accepted a partial result\n' >&2
   exit 1
 fi
 grep -Fq 'qualifier did not emit a complete result' "$TEST_DIR/partial-result"
-cat >"$MOCK_BIN/npx" <<'EOF'
+cat >"$RUNNER_ROOT/node_modules/.bin/tsx" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-chmod +x "$MOCK_BIN/npx"
+chmod +x "$RUNNER_ROOT/node_modules/.bin/tsx"
 if PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 >"$TEST_DIR/missing-result" 2>&1; then
   printf 'durable execution qualifier accepted an empty result\n' >&2
   exit 1
 fi
 grep -Fq 'qualifier did not emit a complete result' "$TEST_DIR/missing-result"
-bash -n "$QUALIFIER"
+grep -Fq 'QUALIFICATION_RUNNER="$REPOSITORY_ROOT/node_modules/.bin/tsx"' "$QUALIFIER_SOURCE"
+bash -n "$QUALIFIER_SOURCE"
 echo "durable execution qualification contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
@@ -48,7 +48,7 @@ cat >"$MOCK_BIN/npx" <<'EOF'
 [[ "$OPENCRANE_D2_POLL_INTERVAL_MS" == '50' ]]
 [[ "$OPENCRANE_D2_THRESHOLD_MS" == '250' ]]
 [[ "$OPENCRANE_D2_DATABASE_POOL_SIZE" == '2' ]]
-printf '%s\n' '{"passed":true}'
+printf '%s\n' '{"passed":true,"sampleCount":40,"warmupCount":5,"pollIntervalMs":50,"thresholdMs":250,"databasePoolSize":2,"connectionCeiling":3,"transport":"kubectl-port-forward","latencyMs":{"p50":100,"p95":120,"p99":140,"max":140},"connectionEvidence":{"available":true,"peakConnections":2}}'
 EOF
 
 cat >"$MOCK_BIN/node" <<'EOF'
@@ -61,7 +61,7 @@ EOF
 
 chmod +x "$MOCK_BIN/helm" "$MOCK_BIN/kubectl" "$MOCK_BIN/node" "$MOCK_BIN/npx"
 PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 >"$CAPTURE"
-grep -Fq '{"passed":true}' "$CAPTURE"
+grep -Fq '"passed":true' "$CAPTURE"
 if grep -Fq 'super-secret' "$CAPTURE"; then
   printf 'durable execution qualifier exposed the application credential\n' >&2
   exit 1
@@ -71,5 +71,25 @@ if MOCK_SILO_VERSION=0.9.2 PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gk
   exit 1
 fi
 grep -Fq 'silo release is not the qualification version' "$TEST_DIR/version-mismatch"
+cat >"$MOCK_BIN/npx" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' '{"passed":true,"latencyMs":{"p50":100,"p95":120},"connectionEvidence":{"available":true}}'
+EOF
+chmod +x "$MOCK_BIN/npx"
+if PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 >"$TEST_DIR/partial-result" 2>&1; then
+  printf 'durable execution qualifier accepted a partial result\n' >&2
+  exit 1
+fi
+grep -Fq 'qualifier did not emit a complete result' "$TEST_DIR/partial-result"
+cat >"$MOCK_BIN/npx" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$MOCK_BIN/npx"
+if PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 >"$TEST_DIR/missing-result" 2>&1; then
+  printf 'durable execution qualifier accepted an empty result\n' >&2
+  exit 1
+fi
+grep -Fq 'qualifier did not emit a complete result' "$TEST_DIR/missing-result"
 bash -n "$QUALIFIER"
 echo "durable execution qualification contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/durable-execution-qualification-contract.sh
@@ -11,11 +11,19 @@ trap 'rm -rf -- "$TEST_DIR"' EXIT
 
 cat >"$MOCK_BIN/helm" <<'EOF'
 #!/usr/bin/env bash
-if [[ "$2" == "opencrane-testlynn-postgres" ]]; then
-  printf '%s\n' '{"chart":"postgres-0.9.3","info":{"status":"deployed"}}'
-else
-  printf '%s\n' '{"chart":"opencrane-silo-0.9.3","info":{"status":"deployed"}}'
+if [[ "$1" == "status" ]]; then
+  printf '%s\n' '{"info":{"status":"deployed"}}'
+  exit 0
 fi
+if [[ "$1" == "get" && "$2" == "metadata" && "$3" == "opencrane-testlynn-postgres" ]]; then
+  printf '%s\n' '{"chart":"postgres","version":"0.9.3"}'
+  exit 0
+fi
+if [[ "$1" == "get" && "$2" == "metadata" && "$3" == "opencrane-testlynn" ]]; then
+  printf '{"chart":"opencrane-silo","version":"%s"}\n' "${MOCK_SILO_VERSION:-0.9.3}"
+  exit 0
+fi
+exit 1
 EOF
 
 cat >"$MOCK_BIN/kubectl" <<'EOF'
@@ -57,5 +65,10 @@ if grep -Fq 'super-secret' "$CAPTURE"; then
   printf 'durable execution qualifier exposed the application credential\n' >&2
   exit 1
 fi
+if MOCK_SILO_VERSION=0.9.2 PATH="$MOCK_BIN:$PATH" bash "$QUALIFIER" --context gke_opencrane-dev --cluster-tenant testlynn --local-port 65431 >"$TEST_DIR/version-mismatch" 2>&1; then
+  printf 'durable execution qualifier accepted an out-of-date silo release\n' >&2
+  exit 1
+fi
+grep -Fq 'silo release is not the qualification version' "$TEST_DIR/version-mismatch"
 bash -n "$QUALIFIER"
 echo "durable execution qualification contract: PASS"

--- a/apps/_infra/deploy-k8s/platform/tests/silo-deploy-profile-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/silo-deploy-profile-contract.sh
@@ -66,6 +66,7 @@ grep -Fq -- 'Do not override clustertenantManager.firstUser through --helm-arg' 
 grep -Fq -- 'clustertenantManager.firstUser.clusterTenant=$prior_first_user_cluster_tenant' "$DEPLOY_CORE"
 grep -Fq -- '"$extra_set_flag" == "--set-string"' "$DEPLOY_CORE"
 grep -Fq -- '"${EXTRA_HELM_ARGS[@]-}"' "$DEPLOY_CORE"
+grep -Fq -- 'if [[ ${#EXTRA_SET[@]} -gt 0 ]]; then' "$DEPLOY_CORE"
 grep -Fq -- 'SKILL_AUTHORING_NAMESPACE="${RELEASE}-skill-authoring"' "$DEPLOY_CORE"
 grep -Fq -- 'TOOL_RUNNER_NAMESPACE="${RELEASE}-tools"' "$DEPLOY_CORE"
 grep -Fq -- '--set-string "opencrane-skill-authoring.skillAuthoring.namespace=$SKILL_AUTHORING_NAMESPACE"' "$DEPLOY_CORE"

--- a/apps/_infra/deploy-k8s/platform/tests/silo-deploy-profile-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/silo-deploy-profile-contract.sh
@@ -69,6 +69,16 @@ grep -Fq -- '"${EXTRA_HELM_ARGS[@]-}"' "$DEPLOY_CORE"
 grep -Fq -- 'if [[ ${#EXTRA_SET[@]} -gt 0 ]]; then' "$DEPLOY_CORE"
 grep -Fq -- 'SKILL_AUTHORING_NAMESPACE="${RELEASE}-skill-authoring"' "$DEPLOY_CORE"
 grep -Fq -- 'TOOL_RUNNER_NAMESPACE="${RELEASE}-tools"' "$DEPLOY_CORE"
+grep -Fq -- 'ARTIFACT_NAMESPACE_RESOURCE="$(kubectl get namespace "$ARTIFACT_NAMESPACE" --ignore-not-found -o name)"' "$DEPLOY_CORE"
+grep -Fq -- 'if [[ -n "$ARTIFACT_NAMESPACE_RESOURCE" ]]; then' "$DEPLOY_CORE"
+grep -Fq -- 'if [[ "$ARTIFACT_NAMESPACE_OWNER" != "$RELEASE" ]]; then' "$DEPLOY_CORE"
+grep -Fq -- "Artifact namespace '\$ARTIFACT_NAMESPACE' belongs to '\${ARTIFACT_NAMESPACE_OWNER:-an unknown owner}', not '\$RELEASE'." "$DEPLOY_CORE"
+grep -Fq -- 'kubectl label --local --filename - "$RETIREMENT_OWNER_LABEL=$RELEASE" --overwrite --output yaml' "$DEPLOY_CORE"
+grep -Fq -- '| kubectl create -f -' "$DEPLOY_CORE"
+if grep -Fq -- 'kubectl label namespace "$ARTIFACT_NAMESPACE" "opencrane.ai/retirement-owner=$RELEASE" --overwrite' "$DEPLOY_CORE"; then
+  echo 'artifact namespace ownership is overwritten imperatively' >&2
+  exit 1
+fi
 grep -Fq -- '--set-string "opencrane-skill-authoring.skillAuthoring.namespace=$SKILL_AUTHORING_NAMESPACE"' "$DEPLOY_CORE"
 grep -Fq -- '--set-string "opencrane-tool-runner.toolRunner.namespace=$TOOL_RUNNER_NAMESPACE"' "$DEPLOY_CORE"
 grep -Fq -- 'EXPECTED_RELEASE="opencrane-${CLUSTER_TENANT}"' "$DEPLOY_SCRIPT"

--- a/apps/_infra/deploy-k8s/platform/tests/silo-teardown-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/silo-teardown-contract.sh
@@ -118,6 +118,17 @@ case "$command_name" in
       esac
       exit 0
     fi
+    if [[ "$*" == *" get clusterrole/"* || "$*" == *" get clusterrolebinding/"* ]]; then
+      case "$*" in
+        *" -o name"*) printf '%s' 'rbac' ;;
+        *"app\\.kubernetes\\.io/managed-by"*) printf '%s' 'Helm' ;;
+        *"meta\\.helm\\.sh/release-namespace"*)
+          if [[ "${MOCK_FOREIGN_RBAC_NAMESPACE:-0}" == "1" ]]; then printf '%s' 'foreign-namespace'; else printf '%s' 'opencrane-retired-fixture'; fi ;;
+        *"meta\\.helm\\.sh/release-name"*)
+          if [[ "${MOCK_FOREIGN_RBAC:-0}" == "1" ]]; then printf '%s' 'foreign'; else printf '%s' 'opencrane-retired-fixture'; fi ;;
+      esac
+      exit 0
+    fi
     if [[ "$*" == *" get "* ]]; then
       [[ "$*" == *"--ignore-not-found"* ]] && exit 0
       exit 1
@@ -162,6 +173,10 @@ fi
 
 if run_core foreign-owner MOCK_FOREIGN_CNPG=1; then echo 'foreign CNPG ownership unexpectedly succeeded' >&2; exit 1; fi
 ! grep -Fq ' delete ' "$TEST_DIR/foreign-owner.calls"
+if run_core foreign-rbac MOCK_FOREIGN_RBAC=1; then echo 'foreign RBAC ownership unexpectedly succeeded' >&2; exit 1; fi
+! grep -Fq ' delete ' "$TEST_DIR/foreign-rbac.calls"
+if run_core foreign-rbac-namespace MOCK_FOREIGN_RBAC_NAMESPACE=1; then echo 'foreign RBAC namespace unexpectedly succeeded' >&2; exit 1; fi
+! grep -Fq ' delete ' "$TEST_DIR/foreign-rbac-namespace.calls"
 if run_core foreign-release MOCK_FOREIGN_RELEASE=1; then
   echo 'foreign Helm ownership unexpectedly succeeded' >&2
   cat "$TEST_DIR/foreign-release.output" >&2

--- a/apps/_infra/deploy-k8s/platform/tests/silo-teardown-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/silo-teardown-contract.sh
@@ -9,6 +9,13 @@ MOCK_BIN="$TEST_DIR/bin"
 mkdir -p "$MOCK_BIN"
 trap 'rm -rf -- "$TEST_DIR"' EXIT
 
+grep -Fq "jsonpath={.data.lease-private\\.pem}" "$CORE"
+grep -Fq "jsonpath={.data.receipt-private\\.pem}" "$CORE"
+if grep -Fq "jsonpath={.data.lease-private\\\\.pem}" "$CORE" || grep -Fq "jsonpath={.data.receipt-private\\\\.pem}" "$CORE"; then
+  echo 'interrupted artifact key JSONPath is over-escaped' >&2
+  exit 1
+fi
+
 cat >"$MOCK_BIN/command-mock" <<'MOCK'
 #!/usr/bin/env bash
 set -euo pipefail

--- a/apps/_infra/deploy-k8s/platform/tests/silo-teardown-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/silo-teardown-contract.sh
@@ -71,6 +71,14 @@ case "$command_name" in
       printf 'namespace/opencrane-retired-fixture'; exit 0
     fi
     if [[ "$*" == *" get namespace/"* || "$*" == *" get namespace "* ]]; then exit 0; fi
+    if [[ "$*" == *" get secret opencrane-retired-fixture-artifact-catalog-keys "* ]]; then
+      [[ "${MOCK_INTERRUPTED_ARTIFACT_KEYS:-0}" == "1" ]] && printf 'catalog-key'
+      exit 0
+    fi
+    if [[ "$*" == *" get secret opencrane-retired-fixture-artifact-service-keys "* ]]; then
+      [[ "${MOCK_INTERRUPTED_ARTIFACT_KEYS:-0}" == "1" ]] && printf 'service-key'
+      exit 0
+    fi
     if [[ "$*" == *" get deployment/opencrane-retired-fixture-artifact-service "*"app\\.kubernetes\\.io/instance"* ]]; then
       printf 'opencrane-retired-fixture'; exit 0
     fi
@@ -165,6 +173,37 @@ if run_core foreign-sentinel-owner MOCK_FOREIGN_SENTINEL_OWNER=1; then
   exit 1
 fi
 ! grep -Fq ' delete ' "$TEST_DIR/foreign-sentinel-owner.calls"
+
+mkdir -p "$TEST_DIR/interrupted-missing-keys.state"
+touch "$TEST_DIR/interrupted-missing-keys.state/main-uninstalled"
+if env PATH="$MOCK_BIN:$PATH" MOCK_CALLS="$TEST_DIR/interrupted-missing-keys.calls" MOCK_STATE="$TEST_DIR/interrupted-missing-keys.state" \
+  bash "$CORE" "${common_core_args[@]}" --preflight >"$TEST_DIR/interrupted-missing-keys.output" 2>&1; then
+  echo 'interrupted artifact namespace without both keys unexpectedly succeeded' >&2
+  exit 1
+fi
+grep -Fq 'two deploy-created key Secrets are incomplete' "$TEST_DIR/interrupted-missing-keys.output"
+! grep -Fq ' delete ' "$TEST_DIR/interrupted-missing-keys.calls"
+
+mkdir -p "$TEST_DIR/interrupted-preflight.state"
+touch "$TEST_DIR/interrupted-preflight.state/main-uninstalled"
+if ! env PATH="$MOCK_BIN:$PATH" MOCK_CALLS="$TEST_DIR/interrupted-preflight.calls" MOCK_STATE="$TEST_DIR/interrupted-preflight.state" \
+  MOCK_INTERRUPTED_ARTIFACT_KEYS=1 bash "$CORE" "${common_core_args[@]}" --preflight >"$TEST_DIR/interrupted-preflight.output" 2>&1; then
+  cat "$TEST_DIR/interrupted-preflight.output" >&2
+  exit 1
+fi
+! grep -Eq 'helm uninstall|kubectl .* (delete|label) ' "$TEST_DIR/interrupted-preflight.calls"
+
+mkdir -p "$TEST_DIR/interrupted-success.state"
+touch "$TEST_DIR/interrupted-success.state/main-uninstalled"
+if ! env PATH="$MOCK_BIN:$PATH" MOCK_CALLS="$TEST_DIR/interrupted-success.calls" MOCK_STATE="$TEST_DIR/interrupted-success.state" \
+  MOCK_INTERRUPTED_ARTIFACT_KEYS=1 bash "$CORE" "${common_core_args[@]}" >"$TEST_DIR/interrupted-success.output" 2>&1; then
+  cat "$TEST_DIR/interrupted-success.output" >&2
+  cat "$TEST_DIR/interrupted-success.calls" >&2
+  exit 1
+fi
+grep -Fq 'helm uninstall opencrane-retired-fixture-postgres --kube-context gke_opencrane-dev --namespace opencrane-retired-fixture --wait' "$TEST_DIR/interrupted-success.calls"
+grep -Fq 'delete namespace opencrane-retired-fixture-artifacts --ignore-not-found=true --wait=true' "$TEST_DIR/interrupted-success.calls"
+grep -Fq 'delete namespace opencrane-retired-fixture --ignore-not-found=true --wait=true' "$TEST_DIR/interrupted-success.calls"
 
 mkdir -p "$TEST_DIR/testv3.state"
 : >"$TEST_DIR/testv3.calls"

--- a/apps/_infra/deploy-k8s/protected-cluster-tenants.json
+++ b/apps/_infra/deploy-k8s/protected-cluster-tenants.json
@@ -3,6 +3,9 @@
   "contexts": {
     "gke_opencrane-dev": {
       "protectedClusterTenants": ["testv3"]
+    },
+    "gke_weownai-proto_europe-west1_opencrane-dev": {
+      "protectedClusterTenants": ["testjos", "testlynn", "testv3", "testv4"]
     }
   }
 }

--- a/libs/backend/server/infra/workflows/infra_absurd/src/qualification/qualify-durable-execution.cli.ts
+++ b/libs/backend/server/infra/workflows/infra_absurd/src/qualification/qualify-durable-execution.cli.ts
@@ -16,6 +16,7 @@ function _Number(name: string): number
 
 try
 {
+	process.stderr.write("Durable execution qualification started.\n");
 	const result = await __QualifyDurableExecutionPickup({
 		databaseUrl: _Required("DATABASE_URL"),
 		siloId: _Required("OPENCRANE_D2_SILO_ID"),


### PR DESCRIPTION
## Summary

- read Helm 4 release metadata instead of the removed status chart field
- prove both the exact chart name and version before measuring task pickup
- register the actual development-cluster tenants that teardown must protect

## Validation

- durable execution qualification contract
- deploy-k8s test suite
- agent style, module-growth, release-versioning, and diff checks

## Review

- independent correctness/security review: pass
- documentation gate: pass

## Review order

1. #697
2. #701