### PR TITLE
🐛 Repair CI guard migrations after #697

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "agent-context:refresh": "node scripts/rag-rat.mjs refresh",
     "agent-context:doctor": "node scripts/rag-rat.mjs doctor",
     "test:agent-context": "node --test scripts/__tests__/rag-rat-integration.test.mjs",
-    "test:agent-style": "node --test scripts/__tests__/inline-conditional-check.test.mjs",
+    "test:agent-style": "node --test scripts/__tests__/inline-conditional-check.test.mjs scripts/__tests__/if-body-newline-check.test.mjs",
     "check:prisma-boundaries": "node scripts/prisma-boundary-check.mjs",
     "test:prisma-boundaries": "node --test scripts/__tests__/prisma-boundary-check.test.mjs",
     "check:durable-boundary": "node scripts/durable-boundary-check.mjs",

--- a/scripts/__tests__/if-body-newline-check.test.mjs
+++ b/scripts/__tests__/if-body-newline-check.test.mjs
@@ -1,7 +1,15 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
-import { addedLineNumbers, findInlineIfBodies } from "../if-body-newline-check.mjs";
+import { findInlineIfBodies } from "../if-body-newline-check.mjs";
+
+/** Checker entrypoint used by the temporary Git repository regression test. */
+const _CHECKER = fileURLToPath(new URL("../if-body-newline-check.mjs", import.meta.url));
 
 test("reports a braceless body on the condition line", function _Test()
 {
@@ -28,7 +36,40 @@ test("checks nested else-if statements independently", function _Test()
 	assert.deepEqual(findInlineIfBodies("if (first)\n\treturn;\nelse if (second) throw new Error();"), [{ line: 3, text: "throw new Error();" }]);
 });
 
-test("identifies only new-side lines from zero-context Git hunks", function _Test()
+test("enforces active-base additions without reclassifying introductions or renames", function _Test(context)
 {
-	assert.deepEqual([...addedLineNumbers("@@ -2 +2,2 @@\n-old\n+new\n+line\n@@ -8,0 +10 @@\n+last\n")], [2, 3, 10]);
+	const repository = mkdtempSync(join(tmpdir(), "opencrane-if-body-"));
+	context.after(function _Cleanup() { rmSync(repository, { recursive: true, force: true }); });
+	function _Git(...arguments_)
+	{
+		return execFileSync("git", arguments_, { cwd: repository, encoding: "utf8" }).trim();
+	}
+	_Git("init", "-q");
+	_Git("config", "user.name", "OpenCrane test");
+	_Git("config", "user.email", "test@opencrane.invalid");
+	_Git("config", "commit.gpgSign", "false");
+	writeFileSync(join(repository, "legacy.ts"), "if (legacy) return;\n");
+	_Git("add", "legacy.ts");
+	_Git("commit", "-m", "base without checker");
+	const introductionBase = _Git("rev-parse", "HEAD");
+	writeFileSync(join(repository, "legacy.ts"), "if (legacy) return;\nif (introduced) continue;\n");
+	assert.equal(execFileSync(process.execPath, [_CHECKER, "--diff", introductionBase, "legacy.ts"], { cwd: repository, encoding: "utf8" }), "");
+	_Git("checkout", "--", "legacy.ts");
+	mkdirSync(join(repository, "scripts"));
+	writeFileSync(join(repository, "scripts/if-body-newline-check.mjs"), "// activates the rule\n");
+	writeFileSync(join(repository, "old.ts"), "if (inherited) return;\n");
+	_Git("add", "scripts/if-body-newline-check.mjs", "old.ts");
+	_Git("commit", "-m", "activate checker");
+	const activeBase = _Git("rev-parse", "HEAD");
+	_Git("mv", "old.ts", "renamed.ts");
+	writeFileSync(join(repository, "renamed.ts"), "if (inherited) return;\nif (added) continue;\n");
+	writeFileSync(join(repository, "batched.ts"), "if (batched) throw new Error();\n");
+	writeFileSync(join(repository, "untracked.ts"), "if (untracked) return;\n");
+	_Git("add", "renamed.ts", "batched.ts");
+	const output = execFileSync(process.execPath, [_CHECKER, "--diff", activeBase, "renamed.ts", "batched.ts", "untracked.ts"], { cwd: repository, encoding: "utf8" });
+	assert.deepEqual(output.trim().split("\n"), [
+		"renamed.ts:2:continue;",
+		"batched.ts:1:throw new Error();",
+		"untracked.ts:1:return;",
+	]);
 });

--- a/scripts/__tests__/if-body-newline-check.test.mjs
+++ b/scripts/__tests__/if-body-newline-check.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { findInlineIfBodies } from "../if-body-newline-check.mjs";
+import { addedLineNumbers, findInlineIfBodies } from "../if-body-newline-check.mjs";
 
 test("reports a braceless body on the condition line", function _Test()
 {
@@ -26,4 +26,9 @@ test("uses the closing condition line for a multiline condition", function _Test
 test("checks nested else-if statements independently", function _Test()
 {
 	assert.deepEqual(findInlineIfBodies("if (first)\n\treturn;\nelse if (second) throw new Error();"), [{ line: 3, text: "throw new Error();" }]);
+});
+
+test("identifies only new-side lines from zero-context Git hunks", function _Test()
+{
+	assert.deepEqual([...addedLineNumbers("@@ -2 +2,2 @@\n-old\n+new\n+line\n@@ -8,0 +10 @@\n+last\n")], [2, 3, 10]);
 });

--- a/scripts/__tests__/prisma-boundary-check.test.mjs
+++ b/scripts/__tests__/prisma-boundary-check.test.mjs
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { findingDelta, inspectPrismaBoundary, prismaModelDelegates, resolveExemptions, validateOwnerDeclarations, validatePolicy, validateRawProcedureDeclarations } from "../prisma-boundary/core.mjs";
+import { findingDelta, inspectPrismaBoundary, prepareBasePolicyForComparison, prismaModelDelegates, resolveExemptions, validateOwnerDeclarations, validatePolicy, validateRawProcedureDeclarations } from "../prisma-boundary/core.mjs";
 
 /** Fixture directory for deterministic ownership examples. */
 const _FIXTURES = fileURLToPath(new URL("./fixtures/prisma-boundary/", import.meta.url));
@@ -38,6 +38,13 @@ test("allows imported repository and unit-of-work contract owners", function _Al
 	assert.doesNotThrow(function _ValidPolicy() { validatePolicy({ version: 1, owners: _OWNERS, rawProcedureCalls: [], exemptions: [] }); });
 	assert.deepEqual(inspectPrismaBoundary("libs/widgets/prisma-widget-repository.ts", _Fixture("positive-repository"), ["widget"], _OWNERS), []);
 	assert.deepEqual(inspectPrismaBoundary("libs/widgets/prisma-widget-unit-of-work.ts", _Fixture("positive-unit-of-work"), ["widget"], _OWNERS), []);
+});
+
+test("treats an older base policy as having no approved raw procedures", function _AllowsOlderBasePolicy()
+{
+	const basePolicy = prepareBasePolicyForComparison({ version: 1, owners: _OWNERS, exemptions: [] });
+	assert.deepEqual(basePolicy.rawProcedureCalls, []);
+	assert.doesNotThrow(function _ValidBasePolicy() { validatePolicy(basePolicy); });
 });
 
 test("allows exact live contracts without empty repository aliases", function _AllowsLiveContracts()

--- a/scripts/__tests__/prisma-boundary-check.test.mjs
+++ b/scripts/__tests__/prisma-boundary-check.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
@@ -10,6 +12,8 @@ import { findingDelta, inspectPrismaBoundary, prepareBasePolicyForComparison, pr
 const _FIXTURES = fileURLToPath(new URL("./fixtures/prisma-boundary/", import.meta.url));
 /** Repository root used to verify reviewer pipeline integration. */
 const _ROOT = fileURLToPath(new URL("../../", import.meta.url));
+/** Prisma boundary checker copied into temporary Git repositories for CLI regression coverage. */
+const _CHECKER = fileURLToPath(new URL("../prisma-boundary-check.mjs", import.meta.url));
 /** Authoritative owner contracts used by checker fixtures. */
 const _OWNERS = {
 	repositories: [{ path: "libs/widgets/prisma-widget-repository.ts", adapter: "PrismaWidgetRepository", contract: "WidgetRepository", contractImportPath: "./widget.types.js", constructs: [] }],
@@ -45,6 +49,36 @@ test("treats an older base policy as having no approved raw procedures", functio
 	const basePolicy = prepareBasePolicyForComparison({ version: 1, owners: _OWNERS, exemptions: [] });
 	assert.deepEqual(basePolicy.rawProcedureCalls, []);
 	assert.doesNotThrow(function _ValidBasePolicy() { validatePolicy(basePolicy); });
+});
+
+test("normalizes only a historical policy when the diff CLI compares schema revisions", function _ComparesOlderPolicy(context)
+{
+	const repository = mkdtempSync(join(tmpdir(), "opencrane-prisma-policy-"));
+	context.after(function _Cleanup() { rmSync(repository, { recursive: true, force: true }); });
+	function _Git(...arguments_)
+	{
+		return execFileSync("git", arguments_, { cwd: repository, encoding: "utf8" }).trim();
+	}
+	mkdirSync(join(repository, "scripts/prisma-boundary"), { recursive: true });
+	mkdirSync(join(repository, "docs/agents"), { recursive: true });
+	mkdirSync(join(repository, "apps/opencrane/prisma/schema"), { recursive: true });
+	cpSync(_CHECKER, join(repository, "scripts/prisma-boundary-check.mjs"));
+	cpSync(fileURLToPath(new URL("../prisma-boundary", import.meta.url)), join(repository, "scripts/prisma-boundary"), { recursive: true });
+	writeFileSync(join(repository, "apps/opencrane/prisma/schema/core.prisma"), "model Widget {\n id String @id\n}\n");
+	const olderPolicy = { version: 1, owners: { repositories: [], unitsOfWork: [], compositions: [] }, exemptions: [] };
+	writeFileSync(join(repository, "docs/agents/prisma-boundary-policy.json"), JSON.stringify(olderPolicy));
+	_Git("init", "-q");
+	_Git("config", "user.name", "OpenCrane test");
+	_Git("config", "user.email", "test@opencrane.invalid");
+	_Git("config", "commit.gpgSign", "false");
+	_Git("add", ".");
+	_Git("commit", "-m", "older policy");
+	const base = _Git("rev-parse", "HEAD");
+	writeFileSync(join(repository, "docs/agents/prisma-boundary-policy.json"), JSON.stringify({ ...olderPolicy, rawProcedureCalls: [] }));
+	const output = execFileSync(process.execPath, ["scripts/prisma-boundary-check.mjs", "--diff", base], { cwd: repository, encoding: "utf8" });
+	assert.match(output, /0 error\(s\)/u);
+	writeFileSync(join(repository, "docs/agents/prisma-boundary-policy.json"), JSON.stringify(olderPolicy));
+	assert.throws(function _RejectCurrentPolicy() { execFileSync(process.execPath, ["scripts/prisma-boundary-check.mjs", "--all"], { cwd: repository, stdio: "pipe" }); }, /Command failed/u);
 });
 
 test("allows exact live contracts without empty repository aliases", function _AllowsLiveContracts()

--- a/scripts/agent-style-check.sh
+++ b/scripts/agent-style-check.sh
@@ -41,10 +41,20 @@ cd "$REPO_ROOT"
 # 1. Resolve the file list — diff vs HEAD by default, so the check always
 #    scopes to what the current change actually touched.
 FILES=()
+IF_DIFF_BASE=""
+IF_CHECK_ENABLED=1
 if [[ $# -eq 0 ]]; then
+	IF_DIFF_BASE="HEAD"
 	while IFS= read -r -d '' f; do FILES+=("$f"); done < <(git diff --name-only --diff-filter=ACMR -z HEAD -- '*.ts' 2>/dev/null || true)
 	while IFS= read -r -d '' f; do FILES+=("$f"); done < <(git ls-files --others --exclude-standard -z -- '*.ts' 2>/dev/null || true)
 elif [[ "${1:-}" == "--diff" ]]; then
+	IF_DIFF_BASE="${2:?--diff needs a ref}"
+	# A branch that introduces this rule cannot retroactively reformat earlier commits in the same
+	# cumulative PR. Once the checker exists in the comparison base, every new line is enforced.
+	if ! git cat-file -e "$IF_DIFF_BASE:scripts/if-body-newline-check.mjs" 2>/dev/null
+	then
+		IF_CHECK_ENABLED=0
+	fi
 	while IFS= read -r -d '' f; do FILES+=("$f"); done < <(git diff --name-only --diff-filter=ACMR -z "${2:?--diff needs a ref}" -- '*.ts')
 	while IFS= read -r -d '' f; do FILES+=("$f"); done < <(git ls-files --others --exclude-standard -z -- '*.ts' 2>/dev/null || true)
 else
@@ -103,11 +113,11 @@ done
 # IF-BODY-NEWLINE — every `if` starts its body on the next physical line, including braceless
 # `return`, `continue`, `throw`, and assignment bodies. The AST check also covers multiline
 # conditions and nested else-if statements without mistaking strings or comments for code.
-for f in ${INLINE_CHECKABLE[@]+"${INLINE_CHECKABLE[@]}"}; do
-	while IFS=: read -r ln _; do
+if [[ "$IF_CHECK_ENABLED" -eq 1 && ${#INLINE_CHECKABLE[@]} -gt 0 ]]; then
+	while IFS=: read -r f ln _; do
 		_report "$f" "$ln" ERROR IF-BODY-NEWLINE "if body starts on the condition line — move the body to the following line"
-	done < <(node scripts/if-body-newline-check.mjs "$f")
-done
+	done < <(if [[ -n "$IF_DIFF_BASE" ]]; then node scripts/if-body-newline-check.mjs --diff "$IF_DIFF_BASE" ${INLINE_CHECKABLE[@]+"${INLINE_CHECKABLE[@]}"}; else node scripts/if-body-newline-check.mjs ${INLINE_CHECKABLE[@]+"${INLINE_CHECKABLE[@]}"}; fi)
+fi
 
 # MISSING-README / README-SECTIONS — package docs (docs/agents/package-docs.md).
 # A changed package must ship a README, and a changed leaf-package README must

--- a/scripts/agent-style-check.sh
+++ b/scripts/agent-style-check.sh
@@ -42,19 +42,12 @@ cd "$REPO_ROOT"
 #    scopes to what the current change actually touched.
 FILES=()
 IF_DIFF_BASE=""
-IF_CHECK_ENABLED=1
 if [[ $# -eq 0 ]]; then
 	IF_DIFF_BASE="HEAD"
 	while IFS= read -r -d '' f; do FILES+=("$f"); done < <(git diff --name-only --diff-filter=ACMR -z HEAD -- '*.ts' 2>/dev/null || true)
 	while IFS= read -r -d '' f; do FILES+=("$f"); done < <(git ls-files --others --exclude-standard -z -- '*.ts' 2>/dev/null || true)
 elif [[ "${1:-}" == "--diff" ]]; then
 	IF_DIFF_BASE="${2:?--diff needs a ref}"
-	# A branch that introduces this rule cannot retroactively reformat earlier commits in the same
-	# cumulative PR. Once the checker exists in the comparison base, every new line is enforced.
-	if ! git cat-file -e "$IF_DIFF_BASE:scripts/if-body-newline-check.mjs" 2>/dev/null
-	then
-		IF_CHECK_ENABLED=0
-	fi
 	while IFS= read -r -d '' f; do FILES+=("$f"); done < <(git diff --name-only --diff-filter=ACMR -z "${2:?--diff needs a ref}" -- '*.ts')
 	while IFS= read -r -d '' f; do FILES+=("$f"); done < <(git ls-files --others --exclude-standard -z -- '*.ts' 2>/dev/null || true)
 else
@@ -113,7 +106,7 @@ done
 # IF-BODY-NEWLINE — every `if` starts its body on the next physical line, including braceless
 # `return`, `continue`, `throw`, and assignment bodies. The AST check also covers multiline
 # conditions and nested else-if statements without mistaking strings or comments for code.
-if [[ "$IF_CHECK_ENABLED" -eq 1 && ${#INLINE_CHECKABLE[@]} -gt 0 ]]; then
+if [[ ${#INLINE_CHECKABLE[@]} -gt 0 ]]; then
 	while IFS=: read -r f ln _; do
 		_report "$f" "$ln" ERROR IF-BODY-NEWLINE "if body starts on the condition line — move the body to the following line"
 	done < <(if [[ -n "$IF_DIFF_BASE" ]]; then node scripts/if-body-newline-check.mjs --diff "$IF_DIFF_BASE" ${INLINE_CHECKABLE[@]+"${INLINE_CHECKABLE[@]}"}; else node scripts/if-body-newline-check.mjs ${INLINE_CHECKABLE[@]+"${INLINE_CHECKABLE[@]}"}; fi)

--- a/scripts/if-body-newline-check.mjs
+++ b/scripts/if-body-newline-check.mjs
@@ -31,7 +31,7 @@ export function findInlineIfBodies(sourceText, fileName = "source.ts")
 }
 
 /** Returns the new-side line numbers represented by zero-context Git diff hunks. */
-export function addedLineNumbers(diff)
+function _AddedLineNumbers(diff)
 {
 	const lines = new Set();
 	for (const match of diff.matchAll(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gmu))
@@ -49,7 +49,7 @@ function _FindAddedInlineIfBodies(sourceText, fileName, base, basePath)
 {
 	const paths = basePath === undefined || basePath === fileName ? [fileName] : [basePath, fileName];
 	const diff = execFileSync("git", ["diff", "--find-renames=50%", "--unified=0", "--no-ext-diff", base, "--", ...paths], { encoding: "utf8" });
-	const added = addedLineNumbers(diff);
+	const added = _AddedLineNumbers(diff);
 	if (diff.length === 0 && !_IsTracked(fileName))
 		return findInlineIfBodies(sourceText, fileName);
 	return findInlineIfBodies(sourceText, fileName).filter(function _Added(finding) { return added.has(finding.line); });
@@ -90,12 +90,29 @@ function _IsTracked(fileName)
 	}
 }
 
+/** Returns whether the comparison base already contains this rule. */
+function _BaseContainsRule(base)
+{
+	try
+	{
+		execFileSync("git", ["cat-file", "-e", `${base}:scripts/if-body-newline-check.mjs`], { stdio: "ignore" });
+		return true;
+	}
+	catch
+	{
+		return false;
+	}
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url) && process.argv[2] !== undefined)
 {
 	const diffMode = process.argv[2] === "--diff";
 	const base = diffMode ? process.argv[3] : undefined;
 	const fileNames = process.argv.slice(diffMode ? 4 : 2);
 	if (fileNames.length === 0 || (diffMode && base === undefined)) throw new Error("usage: if-body-newline-check.mjs [--diff <base>] <file> [...files]");
+	// A branch that introduces the rule cannot reclassify earlier commits in the same cumulative PR.
+	// The next comparison base contains the checker, so every later added line is enforced.
+	if (base !== undefined && !_BaseContainsRule(base)) process.exit(0);
 	const basePaths = base === undefined ? new Map() : _BasePaths(base);
 	for (const fileName of fileNames)
 	{

--- a/scripts/if-body-newline-check.mjs
+++ b/scripts/if-body-newline-check.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
@@ -29,8 +30,77 @@ export function findInlineIfBodies(sourceText, fileName = "source.ts")
 	return findings;
 }
 
+/** Returns the new-side line numbers represented by zero-context Git diff hunks. */
+export function addedLineNumbers(diff)
+{
+	const lines = new Set();
+	for (const match of diff.matchAll(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/gmu))
+	{
+		const start = Number.parseInt(match[1] ?? "0", 10);
+		const count = Number.parseInt(match[2] ?? "1", 10);
+		for (let offset = 0; offset < count; offset += 1)
+			lines.add(start + offset);
+	}
+	return lines;
+}
+
+/** Finds inline `if` bodies introduced after the supplied Git base. */
+function _FindAddedInlineIfBodies(sourceText, fileName, base, basePath)
+{
+	const paths = basePath === undefined || basePath === fileName ? [fileName] : [basePath, fileName];
+	const diff = execFileSync("git", ["diff", "--find-renames=50%", "--unified=0", "--no-ext-diff", base, "--", ...paths], { encoding: "utf8" });
+	const added = addedLineNumbers(diff);
+	if (diff.length === 0 && !_IsTracked(fileName))
+		return findInlineIfBodies(sourceText, fileName);
+	return findInlineIfBodies(sourceText, fileName).filter(function _Added(finding) { return added.has(finding.line); });
+}
+
+/** Resolves the former path of every renamed or copied TypeScript file in a Git diff. */
+function _BasePaths(base)
+{
+	const fields = execFileSync("git", ["diff", "--find-renames=50%", "--name-status", "-z", base, "--", "*.ts"], { encoding: "utf8" }).split("\0").filter(Boolean);
+	const basePaths = new Map();
+	for (let index = 0; index < fields.length;)
+	{
+		const status = fields[index++] ?? "";
+		if (!status.startsWith("R") && !status.startsWith("C"))
+		{
+			index += 1;
+			continue;
+		}
+		const basePath = fields[index++] ?? "";
+		const fileName = fields[index++] ?? "";
+		if (fileName.length > 0 && basePath.length > 0)
+			basePaths.set(fileName, basePath);
+	}
+	return basePaths;
+}
+
+/** Returns whether Git tracks the candidate file. */
+function _IsTracked(fileName)
+{
+	try
+	{
+		execFileSync("git", ["ls-files", "--error-unmatch", "--", fileName], { stdio: "ignore" });
+		return true;
+	}
+	catch
+	{
+		return false;
+	}
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url) && process.argv[2] !== undefined)
 {
-	const fileName = process.argv[2];
-	for (const finding of findInlineIfBodies(readFileSync(fileName, "utf8"), fileName)) process.stdout.write(`${finding.line}:${finding.text}\n`);
+	const diffMode = process.argv[2] === "--diff";
+	const base = diffMode ? process.argv[3] : undefined;
+	const fileNames = process.argv.slice(diffMode ? 4 : 2);
+	if (fileNames.length === 0 || (diffMode && base === undefined)) throw new Error("usage: if-body-newline-check.mjs [--diff <base>] <file> [...files]");
+	const basePaths = base === undefined ? new Map() : _BasePaths(base);
+	for (const fileName of fileNames)
+	{
+		const sourceText = readFileSync(fileName, "utf8");
+		const findings = base === undefined ? findInlineIfBodies(sourceText, fileName) : _FindAddedInlineIfBodies(sourceText, fileName, base, basePaths.get(fileName));
+		for (const finding of findings) process.stdout.write(`${fileName}:${finding.line}:${finding.text}\n`);
+	}
 }

--- a/scripts/if-body-newline-check.mjs
+++ b/scripts/if-body-newline-check.mjs
@@ -44,7 +44,12 @@ function _AddedLineNumbers(diff)
 	return lines;
 }
 
-/** Finds inline `if` bodies introduced after the supplied Git base. */
+/**
+ * Finds inline `if` bodies on lines added after the supplied Git base.
+ *
+ * Git emits no diff for an untracked file, so every inline body in that file is new. For a rename,
+ * comparing the former and current paths keeps inherited lines out of the findings.
+ */
 function _FindAddedInlineIfBodies(sourceText, fileName, base, basePath)
 {
 	const paths = basePath === undefined || basePath === fileName ? [fileName] : [basePath, fileName];

--- a/scripts/prisma-boundary-check.mjs
+++ b/scripts/prisma-boundary-check.mjs
@@ -3,7 +3,7 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
-import { findingDelta, inspectPrismaBoundary, isProductionTypeScript, prismaModelDelegates, resolveExemptions, validateOwnerDeclarations, validatePolicy, validateRawProcedureDeclarations } from "./prisma-boundary/core.mjs";
+import { findingDelta, inspectPrismaBoundary, isProductionTypeScript, prepareBasePolicyForComparison, prismaModelDelegates, resolveExemptions, validateOwnerDeclarations, validatePolicy, validateRawProcedureDeclarations } from "./prisma-boundary/core.mjs";
 
 /** Repository root for all path and Git operations. */
 const _ROOT = execFileSync("git", ["rev-parse", "--show-toplevel"], { encoding: "utf8" }).trim();
@@ -154,7 +154,7 @@ function _BasePolicy(base)
 {
 	const source = _BaseSource(base, "docs/agents/prisma-boundary-policy.json");
 	if (source === undefined) throw new Error(`base ref ${base} has no Prisma-boundary policy`);
-	const policy = JSON.parse(source);
+	const policy = prepareBasePolicyForComparison(JSON.parse(source));
 	validatePolicy(policy);
 	return policy;
 }

--- a/scripts/prisma-boundary/core.mjs
+++ b/scripts/prisma-boundary/core.mjs
@@ -1,2 +1,2 @@
 export { findingDelta, inspectPrismaBoundary, isProductionTypeScript, prismaModelDelegates, validateOwnerDeclarations, validateRawProcedureDeclarations } from "./inspection.mjs";
-export { resolveExemptions, validatePolicy } from "./policy.mjs";
+export { prepareBasePolicyForComparison, resolveExemptions, validatePolicy } from "./policy.mjs";

--- a/scripts/prisma-boundary/policy.mjs
+++ b/scripts/prisma-boundary/policy.mjs
@@ -119,6 +119,22 @@ export function validatePolicy(policy)
 	}
 }
 
+/**
+ * Supplies the empty raw-procedure list implied by a policy written before that field existed.
+ *
+ * The current policy remains strict; only a historical Git base may omit the list because that
+ * revision could not have approved a raw procedure.
+ *
+ * Called by: the diff-scoped Prisma boundary checker before it compares old findings.
+ * @see scripts/prisma-boundary-check.mjs
+ */
+export function prepareBasePolicyForComparison(policy)
+{
+	if (policy?.version === 1 && policy.rawProcedureCalls === undefined)
+		return { ...policy, rawProcedureCalls: [] };
+	return policy;
+}
+
 /** Returns whether an owner path is exact, repository-relative, and TypeScript. */
 function _IsExactTypeScriptPath(path)
 {


### PR DESCRIPTION
## Summary

- activate `IF-BODY-NEWLINE` only after the comparison base contains the rule, then enforce added lines without reclassifying renamed or inherited code
- batch checker inputs and keep untracked files covered
- compare older Prisma policies as having zero raw-procedure approvals while keeping the current policy schema strict
- add temporary-Git CLI regression tests for both migration boundaries

## Why

PR #697 introduced both guards inside a large cumulative diff. Its main validation job failed because the new style rule retroactively classified earlier commits and the Prisma checker required the new policy field from the older comparison base.

## Validation

- `scripts/agent-style-check.sh --diff origin/develop`
- `npm run test:agent-style` — 10 passed
- `npm run test:prisma-boundaries` — 19 passed
- `npm run check:prisma-boundaries -- --diff origin/develop`
- `npm run check:module-growth -- --diff origin/develop`
- `npm run check:release-versioning -- --base origin/develop`
- independent review: clean
- final comments gate: pass

## Ancestry

- base: merged PR #697 on `develop` (`6a1485cd0`)
- no predecessor diff is repeated outside that merged base