### PR TITLE
♻️ Simplify group claim projection

### DIFF
--- a/docs/agents/typescript.md
+++ b/docs/agents/typescript.md
@@ -97,6 +97,26 @@ if (decision.outcome !== AuthorizationDecisionOutcomes.Allow)
 }
 ```
 
+## Named Work Steps
+
+Do not combine construction, a large input object, and a method call in one expression. When a
+database unit of work or service receives several values, name the input and the work object before
+calling its method. The reader can then inspect the command and the operation separately.
+
+```typescript
+// WRONG — the command and the database operation are both hidden inside one expression.
+await new PrismaGroupClaimProjectionUnitOfWork(prisma).reconcile({ siloId, issuer, subject, groups, log });
+
+// CORRECT — each meaningful step has a stable name.
+const cmd = { siloId, issuer, subject, groups, log };
+const task = new PrismaGroupClaimProjectionUnitOfWork(prisma);
+await task.reconcile(cmd);
+```
+
+Keep a short expression when its constructed value is self-explanatory and needs no review on its
+own. This rule applies when extracting the values or the object makes a business operation easier to
+read; it is not a general ban on fluent APIs.
+
 ## Self-Review Before Finishing
 
 After writing or editing any TypeScript file, run `scripts/agent-style-check.sh` — it checks

--- a/libs/backend/server/iam/identity/main/src/auth/oidc.service.ts
+++ b/libs/backend/server/iam/identity/main/src/auth/oidc.service.ts
@@ -148,7 +148,9 @@ export class OidcAuthService extends OidcAuthServiceBase
       }
     }
 
-    await new PrismaGroupClaimProjectionUnitOfWork(this.prisma).reconcile({ siloId: hostClusterTenant, issuer: authUser.issuer, subject: authUser.sub, email: authUser.email, displayName: authUser.name, groups: authUser.groups, log: this.log });
+    const cmd = { siloId: hostClusterTenant, issuer: authUser.issuer, subject: authUser.sub, email: authUser.email, displayName: authUser.name, groups: authUser.groups, log: this.log };
+    const task = new PrismaGroupClaimProjectionUnitOfWork(this.prisma);
+    await task.reconcile(cmd);
     req.session.authUser = { ...authUser, siloId: hostClusterTenant };
     await _saveSession(req);
 

--- a/libs/backend/server/iam/identity/main/src/auth/oidc.service.ts
+++ b/libs/backend/server/iam/identity/main/src/auth/oidc.service.ts
@@ -7,7 +7,7 @@ import type { PrismaClient } from "@prisma/client";
 
 import { OidcAuthServiceBase, PrismaOrgMembershipRepository, _ClusterTenantFromHost, _OrgScope, _RequestHost, _ResolvePerOrgClient, _saveSession, type AuthUser, type LoginClient } from "@opencrane/backend/server/infra/auth";
 
-import { _MirrorGroupsOnLogin, PrismaGroupClaimProjectionUnitOfWork } from "../group-claims/mirror-groups";
+import { PrismaGroupClaimProjectionUnitOfWork } from "../group-claims/mirror-groups";
 import { _AdmitStandaloneFirstUser } from "../standalone-first-user/standalone-first-user-admission";
 import { PrismaStandaloneFirstUserAdmissionUnitOfWork } from "../standalone-first-user/prisma-standalone-first-user-admission-unit-of-work";
 import { StandaloneFirstUserAdmissionOutcomes, type StandaloneFirstUserAdmissionAuditPort, type StandaloneFirstUserAdmissionConfig } from "../standalone-first-user/standalone-first-user-admission.types";
@@ -148,7 +148,7 @@ export class OidcAuthService extends OidcAuthServiceBase
       }
     }
 
-    await _MirrorGroupsOnLogin({ siloId: hostClusterTenant, issuer: authUser.issuer, subject: authUser.sub, email: authUser.email, displayName: authUser.name, groups: authUser.groups, log: this.log }, new PrismaGroupClaimProjectionUnitOfWork(this.prisma));
+    await new PrismaGroupClaimProjectionUnitOfWork(this.prisma).reconcile({ siloId: hostClusterTenant, issuer: authUser.issuer, subject: authUser.sub, email: authUser.email, displayName: authUser.name, groups: authUser.groups, log: this.log });
     req.session.authUser = { ...authUser, siloId: hostClusterTenant };
     await _saveSession(req);
 

--- a/libs/backend/server/iam/identity/main/src/group-claims/__tests__/mirror-groups.test.ts
+++ b/libs/backend/server/iam/identity/main/src/group-claims/__tests__/mirror-groups.test.ts
@@ -45,7 +45,7 @@ describe("_ParseGroupClaims", function _ParseGroupClaimSuite()
 	});
 });
 
-describe("PrismaGroupClaimProjectionUnitOfWork", function _ProjectionSuite()
+describe("PrismaGroupClaimProjectionUnitOfWork", function _projectionSuite()
 {
 	it("projects the issuer-scoped Principal and reconciles resolved external group IDs", async function _ReconcileExternalGroups()
 	{

--- a/libs/backend/server/iam/identity/main/src/group-claims/__tests__/mirror-groups.test.ts
+++ b/libs/backend/server/iam/identity/main/src/group-claims/__tests__/mirror-groups.test.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 import type { Logger } from "pino";
 import { describe, expect, it, vi } from "vitest";
 
-import { _MirrorGroupsOnLogin, _ParseGroupClaims, PrismaGroupClaimProjectionUnitOfWork } from "../mirror-groups";
+import { _ParseGroupClaims, PrismaGroupClaimProjectionUnitOfWork } from "../mirror-groups";
 
 /** Logger spy used by group-claim reconciliation cases. */
 const _log = { warn: vi.fn(), info: vi.fn() } as unknown as Logger;
@@ -10,6 +10,7 @@ const _log = { warn: vi.fn(), info: vi.fn() } as unknown as Logger;
 /** Build a transaction-backed Prisma stub for stable-ID group reconciliation. */
 function _MockPrisma(externalGroupIds: readonly string[]): {
 	prisma: PrismaClient;
+	transaction: ReturnType<typeof vi.fn>;
 	principalUpsert: ReturnType<typeof vi.fn>;
 	groupFindMany: ReturnType<typeof vi.fn>;
 	membershipDeleteMany: ReturnType<typeof vi.fn>;
@@ -20,13 +21,14 @@ function _MockPrisma(externalGroupIds: readonly string[]): {
 	const groupFindMany = vi.fn().mockResolvedValue(externalGroupIds.map(function _Group(id) { return { id }; }));
 	const membershipDeleteMany = vi.fn().mockResolvedValue({ count: 0 });
 	const membershipCreateMany = vi.fn().mockResolvedValue({ count: externalGroupIds.length });
+	const transaction = vi.fn(async function _Transaction(callback: (transaction: PrismaClient) => Promise<unknown>) { return callback(prisma as unknown as PrismaClient); });
 	const prisma = {
-		$transaction: vi.fn(async function _Transaction(callback: (transaction: PrismaClient) => Promise<unknown>) { return callback(prisma as unknown as PrismaClient); }),
+		$transaction: transaction,
 		principal: { upsert: principalUpsert },
 		group: { findMany: groupFindMany },
 		groupMembership: { deleteMany: membershipDeleteMany, createMany: membershipCreateMany },
 	} as unknown as PrismaClient;
-	return { prisma, principalUpsert, groupFindMany, membershipDeleteMany, membershipCreateMany };
+	return { prisma, transaction, principalUpsert, groupFindMany, membershipDeleteMany, membershipCreateMany };
 }
 
 describe("_ParseGroupClaims", function _ParseGroupClaimSuite()
@@ -43,12 +45,12 @@ describe("_ParseGroupClaims", function _ParseGroupClaimSuite()
 	});
 });
 
-describe("_MirrorGroupsOnLogin", function _MirrorGroupsOnLoginSuite()
+describe("PrismaGroupClaimProjectionUnitOfWork", function _ProjectionSuite()
 {
 	it("projects the issuer-scoped Principal and reconciles resolved external group IDs", async function _ReconcileExternalGroups()
 	{
 		const { prisma, principalUpsert, groupFindMany, membershipDeleteMany, membershipCreateMany } = _MockPrisma(["group-a"]);
-		await _MirrorGroupsOnLogin({ siloId: "silo-1", issuer: "https://issuer.example", subject: "subject-1", email: "person@example.com", displayName: "Person", groups: ["group:group-a"], log: _log }, new PrismaGroupClaimProjectionUnitOfWork(prisma));
+		await new PrismaGroupClaimProjectionUnitOfWork(prisma).reconcile({ siloId: " silo-1 ", issuer: " https://issuer.example ", subject: " subject-1 ", email: "person@example.com", displayName: "Person", groups: ["group:group-a"], log: _log });
 
 		expect(principalUpsert).toHaveBeenCalledWith({
 			where: { siloId_issuer_subject: { siloId: "silo-1", issuer: "https://issuer.example", subject: "subject-1" } },
@@ -64,7 +66,7 @@ describe("_MirrorGroupsOnLogin", function _MirrorGroupsOnLoginSuite()
 	it("removes stale external memberships while the relation filter protects local memberships", async function _PruneExternalOnly()
 	{
 		const { prisma, membershipDeleteMany, membershipCreateMany } = _MockPrisma([]);
-		await _MirrorGroupsOnLogin({ siloId: "silo-1", issuer: "https://issuer.example", subject: "subject-1", email: undefined, displayName: undefined, groups: [], log: _log }, new PrismaGroupClaimProjectionUnitOfWork(prisma));
+		await new PrismaGroupClaimProjectionUnitOfWork(prisma).reconcile({ siloId: "silo-1", issuer: "https://issuer.example", subject: "subject-1", email: undefined, displayName: undefined, groups: [], log: _log });
 
 		expect(membershipDeleteMany).toHaveBeenCalledWith({ where: { siloId: "silo-1", principalId: "principal-1", group: { membershipAuthority: "External" } } });
 		expect(membershipCreateMany).not.toHaveBeenCalled();
@@ -75,7 +77,7 @@ describe("_MirrorGroupsOnLogin", function _MirrorGroupsOnLoginSuite()
 		const warn = vi.fn();
 		const log = { warn, info: vi.fn() } as unknown as Logger;
 		const { prisma, membershipCreateMany } = _MockPrisma([]);
-		await _MirrorGroupsOnLogin({ siloId: "silo-1", issuer: "https://issuer.example", subject: "subject-1", email: undefined, displayName: undefined, groups: ["group:unknown"], log }, new PrismaGroupClaimProjectionUnitOfWork(prisma));
+		await new PrismaGroupClaimProjectionUnitOfWork(prisma).reconcile({ siloId: "silo-1", issuer: "https://issuer.example", subject: "subject-1", email: undefined, displayName: undefined, groups: ["group:unknown"], log });
 
 		expect(membershipCreateMany).not.toHaveBeenCalled();
 		expect(warn).toHaveBeenCalledWith({ siloId: "silo-1", subject: "subject-1", groupIds: ["unknown"] }, "OIDC group claims did not resolve to external groups in this silo");
@@ -83,8 +85,9 @@ describe("_MirrorGroupsOnLogin", function _MirrorGroupsOnLoginSuite()
 
 	it("performs no persistence without the full trusted identity tuple", async function _RequireIdentityTuple()
 	{
-		const { prisma, principalUpsert } = _MockPrisma([]);
-		await _MirrorGroupsOnLogin({ siloId: "", issuer: "https://issuer.example", subject: "subject-1", email: undefined, displayName: undefined, groups: [], log: _log }, new PrismaGroupClaimProjectionUnitOfWork(prisma));
+		const { prisma, transaction, principalUpsert } = _MockPrisma([]);
+		await new PrismaGroupClaimProjectionUnitOfWork(prisma).reconcile({ siloId: "", issuer: "https://issuer.example", subject: "subject-1", email: undefined, displayName: undefined, groups: [], log: _log });
+		expect(transaction).not.toHaveBeenCalled();
 		expect(principalUpsert).not.toHaveBeenCalled();
 	});
 });

--- a/libs/backend/server/iam/identity/main/src/group-claims/identity-workflows.types.ts
+++ b/libs/backend/server/iam/identity/main/src/group-claims/identity-workflows.types.ts
@@ -7,16 +7,16 @@ export interface MirrorGroupsOnLoginOptions
 	siloId: string | undefined;
 	/** IdP issuer that namespaces the verified subject. */
 	issuer: string | undefined;
-  /** IdP-verified subject. */
-  subject: string | undefined;
+	/** IdP-verified subject. */
+	subject: string | undefined;
 	/** Verified email retained as profile data, never as an identity key. */
 	email: string | undefined;
 	/** Provider display name retained as profile data, never as authority. */
 	displayName: string | undefined;
-  /** Group claims carried by the verified identity token. */
-  groups: readonly string[] | undefined;
-  /** Scoped logger. */
-  log: Logger;
+	/** Group claims carried by the verified identity token. */
+	groups: readonly string[] | undefined;
+	/** Scoped logger. */
+	log: Logger;
 }
 
 /** Validated identity and parsed group IDs passed into one projection transaction. */

--- a/libs/backend/server/iam/identity/main/src/group-claims/identity-workflows.types.ts
+++ b/libs/backend/server/iam/identity/main/src/group-claims/identity-workflows.types.ts
@@ -19,6 +19,25 @@ export interface MirrorGroupsOnLoginOptions
   log: Logger;
 }
 
+/** Validated identity and parsed group IDs passed into one projection transaction. */
+export interface GroupClaimProjectionCommand
+{
+	/** Silo that owns the Principal and groups. */
+	readonly siloId: string;
+	/** Identity-provider issuer that namespaces the subject. */
+	readonly issuer: string;
+	/** Identity-provider subject projected as the Principal. */
+	readonly subject: string;
+	/** Optional verified email stored as profile data. */
+	readonly email: string | undefined;
+	/** Optional provider display name stored as profile data. */
+	readonly displayName: string | undefined;
+	/** Parsed stable group IDs claimed by the verified identity. */
+	readonly groupIds: readonly string[];
+	/** Scoped logger used for unresolved claim warnings. */
+	readonly log: Logger;
+}
+
 /** Transaction boundary that reconciles verified external group claims. */
 export interface GroupClaimProjectionUnitOfWork
 {
@@ -29,6 +48,6 @@ export interface GroupClaimProjectionUnitOfWork
 /** Transaction-scoped repository that writes the Principal projection and direct memberships. */
 export interface GroupClaimProjectionRepository
 {
-	/** Reconcile already parsed stable group IDs for one verified identity. */
-	reconcile(options: MirrorGroupsOnLoginOptions, claimedGroupIds: readonly string[]): Promise<void>;
+	/** Reconcile one validated identity and its parsed stable group IDs. */
+	reconcile(command: GroupClaimProjectionCommand): Promise<void>;
 }

--- a/libs/backend/server/iam/identity/main/src/group-claims/mirror-groups.ts
+++ b/libs/backend/server/iam/identity/main/src/group-claims/mirror-groups.ts
@@ -25,7 +25,7 @@ export function _ParseGroupClaims(groups: readonly string[] | undefined): string
 }
 
 /** Validates the identity tuple once and prepares the transaction command. */
-function _ProjectionCommand(options: MirrorGroupsOnLoginOptions): GroupClaimProjectionCommand | null
+function _projectionCommand(options: MirrorGroupsOnLoginOptions): GroupClaimProjectionCommand | null
 {
 	// 1. Trim the identity coordinates because they become the Principal's stable lookup key.
 	const siloId = options.siloId?.trim() ?? "";
@@ -111,7 +111,7 @@ export class PrismaGroupClaimProjectionUnitOfWork implements GroupClaimProjectio
 	/** Validate the trusted identity tuple before opening its projection transaction. */
 	reconcile(options: MirrorGroupsOnLoginOptions): Promise<void>
 	{
-		const command = _ProjectionCommand(options);
+		const command = _projectionCommand(options);
 		if (command === null)
 			return Promise.resolve();
 		return this.prisma.$transaction(async function _Project(transaction)

--- a/libs/backend/server/iam/identity/main/src/group-claims/mirror-groups.ts
+++ b/libs/backend/server/iam/identity/main/src/group-claims/mirror-groups.ts
@@ -1,6 +1,6 @@
-import { Prisma, type PrismaClient } from "@prisma/client";
+import { GroupMembershipAuthority, Prisma, type PrismaClient } from "@prisma/client";
 
-import type { GroupClaimProjectionRepository, GroupClaimProjectionUnitOfWork, MirrorGroupsOnLoginOptions } from "./identity-workflows.types";
+import type { GroupClaimProjectionCommand, GroupClaimProjectionRepository, GroupClaimProjectionUnitOfWork, MirrorGroupsOnLoginOptions } from "./identity-workflows.types";
 
 /** Stable prefix used by Zitadel roles that refer to an existing OpenCrane Group ID. */
 const _GROUP_CLAIM_PREFIX = "group:";
@@ -11,47 +11,88 @@ export function _ParseGroupClaims(groups: readonly string[] | undefined): string
 	const ids = new Set<string>();
 	for (const raw of groups ?? [])
 	{
-		if (typeof raw !== "string") continue;
+		if (typeof raw !== "string")
+			continue;
 		const claim = raw.trim();
-		if (!claim.startsWith(_GROUP_CLAIM_PREFIX)) continue;
+		if (!claim.startsWith(_GROUP_CLAIM_PREFIX))
+			continue;
 		const id = claim.slice(_GROUP_CLAIM_PREFIX.length);
-		if (id.length === 0 || id.includes(":")) continue;
+		if (id.length === 0 || id.includes(":"))
+			continue;
 		ids.add(id);
 	}
 	return Array.from(ids).sort();
 }
 
-/** Delegate verified login projection through its transaction boundary. */
-export function _MirrorGroupsOnLogin(options: MirrorGroupsOnLoginOptions, projection: GroupClaimProjectionUnitOfWork): Promise<void>
+/** Validates the identity tuple once and prepares the transaction command. */
+function _ProjectionCommand(options: MirrorGroupsOnLoginOptions): GroupClaimProjectionCommand | null
 {
-	return projection.reconcile(options);
+	// 1. Trim the identity coordinates because they become the Principal's stable lookup key.
+	const siloId = options.siloId?.trim() ?? "";
+	const issuer = options.issuer?.trim() ?? "";
+	const subject = options.subject?.trim() ?? "";
+
+	// 2. Refuse incomplete identities before opening a database transaction.
+	if (!siloId || !issuer || !subject)
+		return null;
+
+	// 3. Parse the verified claims once, so the repository receives only stable group IDs.
+	return { siloId, issuer, subject, email: options.email, displayName: options.displayName, groupIds: _ParseGroupClaims(options.groups), log: options.log };
 }
 
-/** Owns Principal and GroupMembership delegates inside a caller-owned transaction. */
+/**
+ * Replaces one Principal's login-owned group memberships inside the caller's transaction.
+ *
+ * The unit of work validates the identity and parses group claims before constructing this adapter.
+ * This class therefore owns only database reads and writes: upsert the Principal, resolve existing
+ * external groups, replace their direct memberships, and report claims that did not resolve.
+ *
+ * Called by: `PrismaGroupClaimProjectionUnitOfWork.reconcile` in this file.
+ * @see GroupClaimProjectionRepository for the transaction-scoped contract.
+ */
 class PrismaGroupClaimProjectionRepository implements GroupClaimProjectionRepository
 {
 	/** Transaction-scoped Prisma surface. */
 	private readonly prisma: Prisma.TransactionClient;
 
-	/** Store the transaction supplied by the unit of work. */
-	constructor(prisma: Prisma.TransactionClient) { this.prisma = prisma; }
-
-	/** Project the Principal and replace only direct external memberships. */
-	async reconcile(options: MirrorGroupsOnLoginOptions, claimedGroupIds: readonly string[]): Promise<void>
+	/** Stores the transaction supplied by the unit of work. */
+	constructor(prisma: Prisma.TransactionClient)
 	{
-		const siloId = options.siloId?.trim() ?? "";
-		const issuer = options.issuer?.trim() ?? "";
-		const subject = options.subject?.trim() ?? "";
-		const create: { siloId: string; issuer: string; subject: string; email?: string; displayName?: string } = { siloId, issuer, subject };
-		if (options.email) create.email = options.email;
-		if (options.displayName) create.displayName = options.displayName;
-		const principal = await this.prisma.principal.upsert({ where: { siloId_issuer_subject: { siloId, issuer, subject } }, create, update: { email: options.email ?? null, displayName: options.displayName ?? null }, select: { id: true } });
-		const externalGroups = claimedGroupIds.length === 0 ? [] : await this.prisma.group.findMany({ where: { siloId, id: { in: [...claimedGroupIds] }, membershipAuthority: "External" }, select: { id: true } });
+		this.prisma = prisma;
+	}
+
+	/** Projects the Principal and replaces only direct external memberships. */
+	async reconcile(command: GroupClaimProjectionCommand): Promise<void>
+	{
+		const { siloId, issuer, subject } = command;
+
+		// 1. Upsert the verified identity before writing memberships that reference its Principal.
+		const create: Prisma.PrincipalUncheckedCreateInput = { siloId, issuer, subject };
+		if (command.email)
+			create.email = command.email;
+		if (command.displayName)
+			create.displayName = command.displayName;
+		const principal = await this.prisma.principal.upsert({ where: { siloId_issuer_subject: { siloId, issuer, subject } }, create, update: { email: command.email ?? null, displayName: command.displayName ?? null }, select: { id: true } });
+
+		// 2. Resolve claims only to existing external groups, so login never creates or takes over groups.
+		let externalGroups: readonly { id: string }[] = [];
+		if (command.groupIds.length > 0)
+			externalGroups = await this.prisma.group.findMany({ where: { siloId, id: { in: [...command.groupIds] }, membershipAuthority: GroupMembershipAuthority.External }, select: { id: true } });
 		const externalIds = externalGroups.map(function _Id(group) { return group.id; }).sort();
-		await this.prisma.groupMembership.deleteMany({ where: { siloId, principalId: principal.id, group: { membershipAuthority: "External" }, ...(externalIds.length > 0 ? { groupId: { notIn: externalIds } } : {}) } });
-		if (externalIds.length > 0) await this.prisma.groupMembership.createMany({ data: externalIds.map(function _Membership(groupId) { return { siloId, groupId, principalId: principal.id }; }), skipDuplicates: true });
-		const unresolved = claimedGroupIds.filter(function _Unresolved(groupId) { return !externalIds.includes(groupId); });
-		if (unresolved.length > 0) options.log.warn({ siloId, subject, groupIds: unresolved }, "OIDC group claims did not resolve to external groups in this silo");
+
+		// 3. Replace login-owned memberships while the relation filter protects locally managed rows.
+		const deleteWhere: Prisma.GroupMembershipWhereInput = { siloId, principalId: principal.id, group: { membershipAuthority: GroupMembershipAuthority.External } };
+		if (externalIds.length > 0)
+			deleteWhere.groupId = { notIn: externalIds };
+		await this.prisma.groupMembership.deleteMany({ where: deleteWhere });
+		if (externalIds.length > 0)
+			await this.prisma.groupMembership.createMany({ data: externalIds.map(function _Membership(groupId) { return { siloId, groupId, principalId: principal.id }; }), skipDuplicates: true });
+
+		// 4. Warn about unknown or local group IDs because neither may become login-owned membership.
+		const resolvedIds = new Set(externalIds);
+		const unresolved = command.groupIds.filter(function _Unresolved(groupId) { return !resolvedIds.has(groupId); });
+		if (unresolved.length > 0)
+			command.log.warn({ siloId, subject, groupIds: unresolved }, "OIDC group claims did not resolve to external groups in this silo");
 	}
 }
 
@@ -61,17 +102,21 @@ export class PrismaGroupClaimProjectionUnitOfWork implements GroupClaimProjectio
 	/** Root Prisma client that owns transaction lifetime. */
 	private readonly prisma: PrismaClient;
 
-	/** Store the composed root client. */
-	constructor(prisma: PrismaClient) { this.prisma = prisma; }
+	/** Stores the composed root client. */
+	constructor(prisma: PrismaClient)
+	{
+		this.prisma = prisma;
+	}
 
 	/** Validate the trusted identity tuple before opening its projection transaction. */
 	reconcile(options: MirrorGroupsOnLoginOptions): Promise<void>
 	{
-		const siloId = options.siloId?.trim() ?? "";
-		const issuer = options.issuer?.trim() ?? "";
-		const subject = options.subject?.trim() ?? "";
-		if (!siloId || !issuer || !subject) return Promise.resolve();
-		const ids = _ParseGroupClaims(options.groups);
-		return this.prisma.$transaction(async function _Project(transaction) { return new PrismaGroupClaimProjectionRepository(transaction).reconcile(options, ids); });
+		const command = _ProjectionCommand(options);
+		if (command === null)
+			return Promise.resolve();
+		return this.prisma.$transaction(async function _Project(transaction)
+		{
+			return new PrismaGroupClaimProjectionRepository(transaction).reconcile(command);
+		});
 	}
 }

--- a/libs/backend/server/iam/identity/main/src/group-claims/mirror-groups.ts
+++ b/libs/backend/server/iam/identity/main/src/group-claims/mirror-groups.ts
@@ -44,8 +44,8 @@ function _ProjectionCommand(options: MirrorGroupsOnLoginOptions): GroupClaimProj
  * Replaces one Principal's login-owned group memberships inside the caller's transaction.
  *
  * The unit of work validates the identity and parses group claims before constructing this adapter.
- * This class therefore owns only database reads and writes: upsert the Principal, resolve existing
- * external groups, replace their direct memberships, and report claims that did not resolve.
+ * The adapter owns the transaction-scoped projection and reports claims that did not resolve;
+ * identity validation and claim parsing stay outside the database workflow.
  *
  * Called by: `PrismaGroupClaimProjectionUnitOfWork.reconcile` in this file.
  * @see GroupClaimProjectionRepository for the transaction-scoped contract.


### PR DESCRIPTION
## Summary

- validate and parse login identity data once before opening the transaction
- pass one normalized command into the Prisma repository
- remove the pass-through mirror helper and call the unit of work directly
- keep repository and transaction ownership required by the checked Prisma policy
- preserve external-only membership replacement and unresolved-claim warnings

## Validation

- Prisma boundary check: pass
- module growth check: pass
- git diff check: pass
- independent review: clean
- reaper and final comments gates: pass
- focused tests updated for trimmed identity input and pre-transaction rejection
- local Nx execution was unavailable because this isolated worktree has no installed dependencies; CI will run code, test, and type checks
- smoke testing is not used as acceptance evidence for this refactor