### PR TITLE
🐛 Harden Absurd MCP workflow recovery

### DIFF
--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-era-probe.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-era-probe.test.ts
@@ -61,12 +61,12 @@ function _UnitOfWork(state: _EraState): McpOperatorUnitOfWork
 			}
 			return Promise.resolve({ changed, server: _Server(state) });
 		}),
-		recordEraProbeRetry: vi.fn().mockImplementation(function _Retry(_siloId: string, _serverId: string, _registrationDigest: string, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult)
+		recordEraProbeRetry: vi.fn().mockImplementation(function _Retry(_siloId: string, _serverId: string, _registrationDigest: string, attempt: number, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult)
 		{
 			const changed = state.target.eraProbeStatus === McpEraProbeStates.Pending;
 			if (changed)
 			{
-				const eraProbeAttempts = state.target.eraProbeAttempts + 1;
+				const eraProbeAttempts = Math.max(state.target.eraProbeAttempts + 1, attempt);
 				state.target = eraProbeAttempts >= maximumAttempts
 					? { ...state.target, eraProbeStatus: McpEraProbeStates.Rejected, eraProbeEvidenceDigest: exhaustedResult.evidenceDigest, eraProbeFailureCode: exhaustedResult.failureCode ?? null, eraProbeAttempts }
 					: { ...state.target, eraProbeAttempts };
@@ -219,7 +219,7 @@ describe("MCP era-probe workflow", function _McpEraProbeSuite()
 		expect(state.auditCount).toBe(1);
 	});
 
-	it("keeps the external check budget after earlier handler failures", async function _PreservesExternalCheckBudget()
+	it("uses the engine attempt after earlier failures happened before the remote check", async function _UsesEngineAttempt()
 	{
 		const state = _State();
 		const execution = new __FakeWorkflowEngine();
@@ -230,9 +230,9 @@ describe("MCP era-probe workflow", function _McpEraProbeSuite()
 
 		await _Drain(execution);
 
-		expect(execution.taskSnapshot(admitted.receipt).error).toBeInstanceOf(WorkflowTaskRetryableError);
-		expect(state.target).toMatchObject({ eraProbeStatus: McpEraProbeStates.Pending, eraProbeAttempts: 1 });
-		expect(state.auditCount).toBe(0);
+		expect(execution.taskSnapshot(admitted.receipt).result).toMatchObject({ decision: McpEraProbeDecisions.Rejected, failureCode: McpEraProbeFailureCodes.RetryExhausted });
+		expect(state.target).toMatchObject({ eraProbeStatus: McpEraProbeStates.Rejected, eraProbeAttempts: 5 });
+		expect(state.auditCount).toBe(1);
 	});
 
 	it.each([McpEraProbeFailureCodes.UnsafeEndpoint, McpEraProbeFailureCodes.InvalidResponse])("stores terminal failure %s as a rejected result", async function _StoresTerminalFailure(code)

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-era-probe.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-era-probe.test.ts
@@ -61,12 +61,12 @@ function _UnitOfWork(state: _EraState): McpOperatorUnitOfWork
 			}
 			return Promise.resolve({ changed, server: _Server(state) });
 		}),
-		recordEraProbeRetry: vi.fn().mockImplementation(function _Retry(_siloId: string, _serverId: string, _registrationDigest: string, attempt: number, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult)
+		recordEraProbeRetry: vi.fn().mockImplementation(function _Retry(_siloId: string, _serverId: string, _registrationDigest: string, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult)
 		{
 			const changed = state.target.eraProbeStatus === McpEraProbeStates.Pending;
 			if (changed)
 			{
-				const eraProbeAttempts = Math.max(state.target.eraProbeAttempts + 1, attempt);
+				const eraProbeAttempts = state.target.eraProbeAttempts + 1;
 				state.target = eraProbeAttempts >= maximumAttempts
 					? { ...state.target, eraProbeStatus: McpEraProbeStates.Rejected, eraProbeEvidenceDigest: exhaustedResult.evidenceDigest, eraProbeFailureCode: exhaustedResult.failureCode ?? null, eraProbeAttempts }
 					: { ...state.target, eraProbeAttempts };
@@ -78,6 +78,21 @@ function _UnitOfWork(state: _EraState): McpOperatorUnitOfWork
 	} as unknown as IMcpOperatorRepository;
 	const transaction = { mcp: repository, workflowTransaction: _Transaction() } as unknown as McpOperatorTransaction;
 	return { execute: async function _Execute<Result>(operation: (value: McpOperatorTransaction) => Promise<Result>): Promise<Result> { return await operation(transaction); } };
+}
+
+/** Fail one selected transaction call while leaving every other workflow transaction unchanged. */
+function _FailTransaction(unitOfWork: McpOperatorUnitOfWork, callToFail: number): McpOperatorUnitOfWork
+{
+	let calls = 0;
+	return {
+		execute: async function _Execute<Result>(operation: (value: McpOperatorTransaction) => Promise<Result>): Promise<Result>
+		{
+			calls += 1;
+			if (calls === callToFail)
+				throw new Error("database unavailable");
+			return await unitOfWork.execute(operation);
+		},
+	};
 }
 
 /** Return an opaque database transaction for fake task admission. */
@@ -157,6 +172,37 @@ describe("MCP era-probe workflow", function _McpEraProbeSuite()
 		expect(state.auditCount).toBe(0);
 	});
 
+	it("asks the engine to retry when recording an accepted result temporarily fails", async function _RetriesResultWriteFailure()
+	{
+		const state = _State();
+		const execution = new __FakeWorkflowEngine();
+		const probe = vi.fn().mockResolvedValue({ protocolVersion: MCP_ERA_PROTOCOL_VERSION, evidenceDigest: `sha256:${"e".repeat(64)}` });
+		const workflow = __CreateMcpEraProbeWorkflow({ execution, unitOfWork: _FailTransaction(_UnitOfWork(state), 2), probe: { probe } });
+		const admitted = await workflow.admit(_Transaction(), _Input());
+
+		await _Drain(execution);
+
+		expect(execution.taskSnapshot(admitted.receipt).error).toBeInstanceOf(WorkflowTaskRetryableError);
+		expect(state.target.eraProbeStatus).toBe(McpEraProbeStates.Pending);
+		expect(state.auditCount).toBe(0);
+	});
+
+	it("asks the engine to retry when recording a temporary failure cannot reach the database", async function _RetriesRetryWriteFailure()
+	{
+		const state = _State();
+		const execution = new __FakeWorkflowEngine();
+		const probe = { probe: vi.fn().mockRejectedValue(new McpEraProbeFailure(McpEraProbeFailureCodes.RetryableUnavailable)) };
+		const workflow = __CreateMcpEraProbeWorkflow({ execution, unitOfWork: _FailTransaction(_UnitOfWork(state), 2), probe });
+		const admitted = await workflow.admit(_Transaction(), _Input());
+
+		await _Drain(execution);
+
+		expect(execution.taskSnapshot(admitted.receipt).error).toBeInstanceOf(WorkflowTaskRetryableError);
+		expect(state.target.eraProbeStatus).toBe(McpEraProbeStates.Pending);
+		expect(state.target.eraProbeAttempts).toBe(0);
+		expect(state.auditCount).toBe(0);
+	});
+
 	it("stores a final rejection when temporary failures consume all attempts", async function _ExhaustsTemporaryFailures()
 	{
 		const state = _State();
@@ -173,7 +219,7 @@ describe("MCP era-probe workflow", function _McpEraProbeSuite()
 		expect(state.auditCount).toBe(1);
 	});
 
-	it("uses the engine attempt after earlier failures happened before the remote check", async function _ExhaustsAfterEarlierHandlerFailures()
+	it("keeps the external check budget after earlier handler failures", async function _PreservesExternalCheckBudget()
 	{
 		const state = _State();
 		const execution = new __FakeWorkflowEngine();
@@ -184,9 +230,9 @@ describe("MCP era-probe workflow", function _McpEraProbeSuite()
 
 		await _Drain(execution);
 
-		expect(execution.taskSnapshot(admitted.receipt).result).toMatchObject({ decision: McpEraProbeDecisions.Rejected, failureCode: McpEraProbeFailureCodes.RetryExhausted });
-		expect(state.target).toMatchObject({ eraProbeStatus: "Rejected", eraProbeFailureCode: McpEraProbeFailureCodes.RetryExhausted, eraProbeAttempts: 5 });
-		expect(state.auditCount).toBe(1);
+		expect(execution.taskSnapshot(admitted.receipt).error).toBeInstanceOf(WorkflowTaskRetryableError);
+		expect(state.target).toMatchObject({ eraProbeStatus: McpEraProbeStates.Pending, eraProbeAttempts: 1 });
+		expect(state.auditCount).toBe(0);
 	});
 
 	it.each([McpEraProbeFailureCodes.UnsafeEndpoint, McpEraProbeFailureCodes.InvalidResponse])("stores terminal failure %s as a rejected result", async function _StoresTerminalFailure(code)

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-operator.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-operator.test.ts
@@ -216,7 +216,24 @@ describe("mcp-operator router", function _suite()
       expect(response.status).toBe(200);
       expect(response.body).toMatchObject({ id: "srv-1", approvalStatus: "published" });
       expect(spies["mcpServer.updateMany"]).toHaveBeenCalledWith({ where: { id: "srv-1", siloId: "silo-1", eraProbeStatus: { in: ["Accepted", "NotRequired"] }, approvalStatus: "Disabled" }, data: { approvalStatus: "Published" } });
+	  expect(spies["auditEntry.create"]).toHaveBeenCalledWith({ data: expect.objectContaining({ metadata: { siloId: "silo-1", actorPrincipalId: "principal-1" } }) });
     });
+
+	it("records the authenticated administrator with an access-policy change", async function _AuditsAccessPolicyActor()
+	{
+		_enableOidc();
+		const server = { id: "srv-1", name: "Server", description: "", publisher: null, glyph: null, serverType: "SingleUser", approvalStatus: "Published", credentialSchema: [], entitlementSummary: null, eraProbeStatus: McpEraProbeStates.Accepted };
+		const { prisma, spies } = _mockPrisma({
+			"mcpServer.findFirst": function _Find() { return Promise.resolve(server); },
+			"authorizationGrant.findMany": function _FindGrants() { return Promise.resolve([]); },
+			"auditEntry.create": function _Audit() { return Promise.resolve({}); },
+		});
+
+		const response = await request(_buildApp(prisma, { sub: "admin", isOrgAdmin: true })).put("/api/v1/mcp/servers/srv-1/access").send({ groupIds: [], principalIds: [] });
+
+		expect(response.status).toBe(200);
+		expect(spies["auditEntry.create"]).toHaveBeenCalledWith({ data: expect.objectContaining({ metadata: { siloId: "silo-1", actorPrincipalId: "principal-1" } }) });
+	});
 
     it("fails closed when no session is established", async function _denyUnauthenticated()
     {

--- a/libs/backend/server/gateways/mcp/main/src/core/mcp-operator-repository.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/mcp-operator-repository.types.ts
@@ -274,11 +274,12 @@ export interface IMcpOperatorRepository
 	 * @param siloId - Keeps the update inside the task's admitted silo.
 	 * @param serverId - Identifies the draft server whose failed check is being counted.
 	 * @param registrationDigest - Prevents a task admitted for replaced fields from changing the server.
+	 * @param attempt - Gives the current workflow-engine attempt, including earlier handler failures.
 	 * @param maximumAttempts - Sets the attempt count at which the server becomes rejected.
 	 * @param exhaustedResult - Supplies the rejection evidence stored when no attempts remain.
 	 * @returns The stored server, whether this call changed it, and whether it is now rejected; or `null` when the registration no longer matches.
 	 */
-	recordEraProbeRetry(siloId: string, serverId: string, registrationDigest: string, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult): Promise<McpEraProbeRetryResult | null>;
+	recordEraProbeRetry(siloId: string, serverId: string, registrationDigest: string, attempt: number, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult): Promise<McpEraProbeRetryResult | null>;
 	/**
 	 * Lists groups in the requested silo, optionally restricted to the supplied group IDs.
 	 *

--- a/libs/backend/server/gateways/mcp/main/src/core/mcp-operator-repository.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/mcp-operator-repository.types.ts
@@ -29,14 +29,21 @@ export interface McpOperatorServerRecord
 	readonly credentialSchema: unknown;
 	/** Gives the optional entitlement summary exposed in catalog responses. */
 	readonly entitlementSummary: string | null;
+	/** Gives the public HTTPS endpoint saved for the protocol-check worker. */
 	readonly endpoint: string;
+	/** Carries the request-key digest used to find a repeated remote registration, or `null` for other rows. */
 	readonly registrationKeyDigest: string | null;
+	/** Carries the digest that binds a probe task to its registration fields, or `null` for other rows. */
 	readonly registrationDigest: string | null;
 	/** Gives the checked protocol state translated from the database enum. */
 	readonly eraProbeStatus: McpEraProbeStates;
+	/** Gives the protocol revision returned by a completed check, or `null` when none was observed. */
 	readonly eraProtocolVersion: string | null;
+	/** Gives the response or failure digest saved when the check finishes. */
 	readonly eraProbeEvidenceDigest: string | null;
+	/** Gives the saved failure reason when the check ended without a usable protocol revision. */
 	readonly eraProbeFailureCode: string | null;
+	/** Counts the external checks recorded for this registration. */
 	readonly eraProbeAttempts: number;
 }
 
@@ -232,10 +239,46 @@ export interface IMcpOperatorRepository
 	 * @returns The updated server row, or `null` when no server with this ID belongs to the silo.
 	 */
 	setApprovalStatus(siloId: string, serverId: string, approvalStatus: string, requiredEraProbeStatuses?: readonly McpEraProbeStates[], requiredApprovalStatus?: string): Promise<McpOperatorServerRecord | null>;
+	/**
+	 * Creates a draft remote server or returns the server previously claimed by the request key.
+	 *
+	 * Called by: `registerRemoteServer` before it admits the protocol-check task in the transaction.
+	 * @param registration - Supplies the silo, server fields, and digests used to claim the request key and name.
+	 * @returns A new draft, the draft already claimed by the request key, or `null` when the name belongs to another registration.
+	 */
 	createOrFindRemoteServer(registration: McpRemoteServerRegistrationRecord): Promise<McpRemoteServerCreateResult | null>;
+	/**
+	 * Loads the server fields that a protocol-check task must compare before contacting its endpoint.
+	 *
+	 * Called by: `_LoadTarget` before the workflow replays or performs an external check.
+	 * @param siloId - Keeps the lookup inside the task's admitted silo.
+	 * @param serverId - Identifies the draft server the task was admitted for.
+	 * @returns The stored target, or `null` when the server is absent, belongs to another silo, or has no registration digest.
+	 */
 	loadEraProbeTarget(siloId: string, serverId: string): Promise<McpEraProbeTargetRecord | null>;
+	/**
+	 * Stores a pending protocol check's accepted or rejected result when its registration still matches.
+	 *
+	 * Called by: `_RecordResult` after the workflow obtains discovery evidence or a final failure.
+	 * @param siloId - Keeps the update inside the task's admitted silo.
+	 * @param serverId - Identifies the draft server whose pending check should finish.
+	 * @param registrationDigest - Prevents a task admitted for replaced fields from changing the server.
+	 * @param result - Supplies the protocol decision and the evidence saved with it.
+	 * @returns The stored server and whether this call changed it, or `null` when the registration no longer matches.
+	 */
 	recordEraProbeResult(siloId: string, serverId: string, registrationDigest: string, result: McpEraProbeTaskResult): Promise<McpEraProbeWriteResult | null>;
-	recordEraProbeRetry(siloId: string, serverId: string, registrationDigest: string, attempt: number, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult): Promise<McpEraProbeRetryResult | null>;
+	/**
+	 * Records another temporary failure and rejects the server when the stored attempt count reaches the limit.
+	 *
+	 * Called by: `_RecordRetry` after the remote check reports a failure that may clear later.
+	 * @param siloId - Keeps the update inside the task's admitted silo.
+	 * @param serverId - Identifies the draft server whose failed check is being counted.
+	 * @param registrationDigest - Prevents a task admitted for replaced fields from changing the server.
+	 * @param maximumAttempts - Sets the attempt count at which the server becomes rejected.
+	 * @param exhaustedResult - Supplies the rejection evidence stored when no attempts remain.
+	 * @returns The stored server, whether this call changed it, and whether it is now rejected; or `null` when the registration no longer matches.
+	 */
+	recordEraProbeRetry(siloId: string, serverId: string, registrationDigest: string, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult): Promise<McpEraProbeRetryResult | null>;
 	/**
 	 * Lists groups in the requested silo, optionally restricted to the supplied group IDs.
 	 *

--- a/libs/backend/server/gateways/mcp/main/src/core/mcp-operator-repository.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/mcp-operator-repository.types.ts
@@ -43,7 +43,7 @@ export interface McpOperatorServerRecord
 	readonly eraProbeEvidenceDigest: string | null;
 	/** Gives the saved failure reason when the check ended without a usable protocol revision. */
 	readonly eraProbeFailureCode: string | null;
-	/** Counts the external checks recorded for this registration. */
+	/** Gives the latest workflow-engine attempt recorded for this registration. */
 	readonly eraProbeAttempts: number;
 }
 
@@ -88,7 +88,7 @@ export interface McpEraProbeTargetRecord
 	readonly eraProbeEvidenceDigest: string | null;
 	/** Bounded reason stored when the endpoint or response was terminally invalid. */
 	readonly eraProbeFailureCode: string | null;
-	/** Number of external checks already recorded for this registration. */
+	/** Gives the latest workflow-engine attempt already recorded for this registration. */
 	readonly eraProbeAttempts: number;
 }
 

--- a/libs/backend/server/gateways/mcp/main/src/core/mcp-operator.logic.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/mcp-operator.logic.ts
@@ -268,7 +268,7 @@ export function setAccessPolicy(unitOfWork: McpOperatorUnitOfWork, caller: McpOp
 			],
 			now: new Date(),
 		});
-		await transaction.mcp.appendAudit("Updated", `McpServer/${serverId}`, `MCP server ${serverId} authorization grants updated`);
+		await transaction.mcp.appendAudit("Updated", `McpServer/${serverId}`, `MCP server ${serverId} authorization grants updated`, { siloId: caller.siloId, actorPrincipalId: caller.principalId });
 		return { serverId, groups: [...groups], users: principals.map(_MapPrincipal) };
 	});
 }
@@ -343,7 +343,7 @@ function _Approval(unitOfWork: McpOperatorUnitOfWork, caller: McpOperatorCaller,
 		const server = await transaction.mcp.setApprovalStatus(caller.siloId, serverId, status, __McpEraProbeRequiredStates(status), requiredApprovalStatus);
 		if (!server)
 			return null;
-		await transaction.mcp.appendAudit("Updated", `McpServer/${serverId}`, `MCP server ${serverId} ${verb}`);
+		await transaction.mcp.appendAudit("Updated", `McpServer/${serverId}`, `MCP server ${serverId} ${verb}`, { siloId: caller.siloId, actorPrincipalId: caller.principalId });
 		return _MapServer(server);
 	});
 }

--- a/libs/backend/server/gateways/mcp/main/src/core/prisma-mcp-operator-repository.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/prisma-mcp-operator-repository.ts
@@ -166,13 +166,13 @@ export class PrismaMcpOperatorRepository implements IMcpOperatorRepository
 	}
 
 	/** Count a temporary failure and store rejection evidence when it consumes the last attempt. */
-	async recordEraProbeRetry(siloId: string, serverId: string, registrationDigest: string, attempt: number, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult): Promise<McpEraProbeRetryResult | null>
+	async recordEraProbeRetry(siloId: string, serverId: string, registrationDigest: string, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult): Promise<McpEraProbeRetryResult | null>
 	{
 		const storedTarget = await this._transaction.mcpServer.findFirst({ where: { id: serverId, siloId, registrationDigest }, select: _ERA_PROBE_TARGET_SELECT });
 		if (!storedTarget)
 			return null;
 		const target = _EraProbeTargetRecord(storedTarget);
-		const nextAttempt = Math.max(target.eraProbeAttempts + 1, attempt);
+		const nextAttempt = target.eraProbeAttempts + 1;
 		const exhausted = nextAttempt >= maximumAttempts;
 		const data: Prisma.McpServerUpdateManyMutationInput = exhausted
 			? { eraProbeStatus: McpEraProbeStates.Rejected, eraProtocolVersion: null, eraProbeEvidenceDigest: exhaustedResult.evidenceDigest, eraProbeFailureCode: exhaustedResult.failureCode, eraProbeAttempts: nextAttempt, eraProbedAt: new Date(), status: "Degraded", approvalStatus: "Disabled" }

--- a/libs/backend/server/gateways/mcp/main/src/core/prisma-mcp-operator-repository.ts
+++ b/libs/backend/server/gateways/mcp/main/src/core/prisma-mcp-operator-repository.ts
@@ -166,13 +166,13 @@ export class PrismaMcpOperatorRepository implements IMcpOperatorRepository
 	}
 
 	/** Count a temporary failure and store rejection evidence when it consumes the last attempt. */
-	async recordEraProbeRetry(siloId: string, serverId: string, registrationDigest: string, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult): Promise<McpEraProbeRetryResult | null>
+	async recordEraProbeRetry(siloId: string, serverId: string, registrationDigest: string, attempt: number, maximumAttempts: number, exhaustedResult: McpEraProbeTaskResult): Promise<McpEraProbeRetryResult | null>
 	{
 		const storedTarget = await this._transaction.mcpServer.findFirst({ where: { id: serverId, siloId, registrationDigest }, select: _ERA_PROBE_TARGET_SELECT });
 		if (!storedTarget)
 			return null;
 		const target = _EraProbeTargetRecord(storedTarget);
-		const nextAttempt = target.eraProbeAttempts + 1;
+		const nextAttempt = Math.max(target.eraProbeAttempts + 1, attempt);
 		const exhausted = nextAttempt >= maximumAttempts;
 		const data: Prisma.McpServerUpdateManyMutationInput = exhausted
 			? { eraProbeStatus: McpEraProbeStates.Rejected, eraProtocolVersion: null, eraProbeEvidenceDigest: exhaustedResult.evidenceDigest, eraProbeFailureCode: exhaustedResult.failureCode, eraProbeAttempts: nextAttempt, eraProbedAt: new Date(), status: "Degraded", approvalStatus: "Disabled" }

--- a/libs/backend/server/gateways/mcp/main/src/era-probe/mcp-era-probe.ts
+++ b/libs/backend/server/gateways/mcp/main/src/era-probe/mcp-era-probe.ts
@@ -10,7 +10,7 @@ import { McpEraProbeFailure, McpEraProbeFailureCodes } from "./mcp-era-probe-fai
 import { __McpEraProbeObservationResult, __McpEraProbeReplayResult, __McpEraProbeTerminalResult, __McpEraProbeTransition, McpEraProbeActions, McpEraProbeEvents, McpEraProbeStates } from "./mcp-era-probe-state";
 import { __AssertMcpEraProbeTaskInput, __ParseMcpEraProbeObservation } from "./mcp-era-probe.validator";
 
-/** Total external checks allowed before the catalogue records a final unavailable result. */
+/** Stop the workflow after five handler attempts. */
 const MCP_ERA_PROBE_MAXIMUM_ATTEMPTS = 5;
 
 /** Keep temporary database failures retryable without changing deliberate workflow outcomes. */
@@ -81,14 +81,14 @@ async function _RecordResult(unitOfWork: McpOperatorUnitOfWork, input: McpEraPro
 }
 
 /** Record a temporary failure and return the final result when the retry budget is exhausted. */
-async function _RecordRetry(unitOfWork: McpOperatorUnitOfWork, input: McpEraProbeTaskInput): Promise<McpEraProbeTaskResult | null>
+async function _RecordRetry(unitOfWork: McpOperatorUnitOfWork, input: McpEraProbeTaskInput, attempt: number): Promise<McpEraProbeTaskResult | null>
 {
 	const exhaustedResult = __McpEraProbeTerminalResult(McpEraProbeFailureCodes.RetryExhausted);
 	return await _RetryablePersistence(async function _RecordRetryWithRetry(): Promise<McpEraProbeTaskResult | null>
 	{
 		return await unitOfWork.execute(async function _WriteRetry(transaction): Promise<McpEraProbeTaskResult | null>
 		{
-			const retry = await transaction.mcp.recordEraProbeRetry(input.siloId, input.serverId, input.registrationDigest, MCP_ERA_PROBE_MAXIMUM_ATTEMPTS, exhaustedResult);
+			const retry = await transaction.mcp.recordEraProbeRetry(input.siloId, input.serverId, input.registrationDigest, attempt, MCP_ERA_PROBE_MAXIMUM_ATTEMPTS, exhaustedResult);
 			if (!retry)
 				throw new WorkflowTaskTerminalError("MCP era-probe registration is unavailable.");
 			let stored: McpEraProbeTaskResult | null;
@@ -128,7 +128,7 @@ async function _Run(context: IWorkflowTaskContext, options: McpEraProbeWorkflowO
 				const action = __McpEraProbeTransition(McpEraProbeStates.Pending, McpEraProbeEvents.RetryableFailure);
 				if (action !== McpEraProbeActions.Retry)
 					throw new WorkflowTaskTerminalError("MCP era-probe retry policy is invalid.");
-				const exhausted = await _RecordRetry(options.unitOfWork, input);
+				const exhausted = await _RecordRetry(options.unitOfWork, input, context.attempt);
 				if (exhausted)
 					return exhausted;
 				throw new WorkflowTaskRetryableError("MCP server protocol check is temporarily unavailable.");

--- a/libs/backend/server/gateways/mcp/main/src/era-probe/mcp-era-probe.ts
+++ b/libs/backend/server/gateways/mcp/main/src/era-probe/mcp-era-probe.ts
@@ -13,17 +13,35 @@ import { __AssertMcpEraProbeTaskInput, __ParseMcpEraProbeObservation } from "./m
 /** Total external checks allowed before the catalogue records a final unavailable result. */
 const MCP_ERA_PROBE_MAXIMUM_ATTEMPTS = 5;
 
+/** Keep temporary database failures retryable without changing deliberate workflow outcomes. */
+async function _RetryablePersistence<TResult>(operation: () => Promise<TResult>): Promise<TResult>
+{
+	try
+	{
+		return await operation();
+	}
+	catch (error)
+	{
+		if (error instanceof WorkflowTaskRetryableError || error instanceof WorkflowTaskTerminalError)
+			throw error;
+		throw new WorkflowTaskRetryableError("MCP era-probe persistence is temporarily unavailable.");
+	}
+}
+
 /** Load the product-owned endpoint and reject a task whose registration was replaced. */
 async function _LoadTarget(unitOfWork: McpOperatorUnitOfWork, input: McpEraProbeTaskInput): Promise<McpEraProbeTargetRecord>
 {
-	return await unitOfWork.execute(async function _Load(transaction): Promise<McpEraProbeTargetRecord>
+	return await _RetryablePersistence(async function _LoadWithRetry(): Promise<McpEraProbeTargetRecord>
 	{
-		const target = await transaction.mcp.loadEraProbeTarget(input.siloId, input.serverId);
-		if (!target || target.registrationDigest !== input.registrationDigest)
+		return await unitOfWork.execute(async function _Load(transaction): Promise<McpEraProbeTargetRecord>
 		{
-			throw new WorkflowTaskTerminalError("MCP era-probe registration is unavailable.");
-		}
-		return target;
+			const target = await transaction.mcp.loadEraProbeTarget(input.siloId, input.serverId);
+			if (!target || target.registrationDigest !== input.registrationDigest)
+			{
+				throw new WorkflowTaskTerminalError("MCP era-probe registration is unavailable.");
+			}
+			return target;
+		});
 	});
 }
 
@@ -36,46 +54,52 @@ function _TargetFromServer(server: McpOperatorServerRecord): McpEraProbeTargetRe
 /** Store one result and verify that an earlier retry did not record different evidence. */
 async function _RecordResult(unitOfWork: McpOperatorUnitOfWork, input: McpEraProbeTaskInput, result: McpEraProbeTaskResult): Promise<McpEraProbeTaskResult>
 {
-	return await unitOfWork.execute(async function _Record(transaction): Promise<McpEraProbeTaskResult>
+	return await _RetryablePersistence(async function _RecordWithRetry(): Promise<McpEraProbeTaskResult>
 	{
-		const write = await transaction.mcp.recordEraProbeResult(input.siloId, input.serverId, input.registrationDigest, result);
-		if (!write)
+		return await unitOfWork.execute(async function _Record(transaction): Promise<McpEraProbeTaskResult>
 		{
-			throw new WorkflowTaskTerminalError("MCP era-probe registration is unavailable.");
-		}
-		let winner: McpEraProbeTaskResult | null;
-		try
-		{
-			winner = __McpEraProbeReplayResult(_TargetFromServer(write.server));
-		}
-		catch { throw new WorkflowTaskTerminalError("MCP era-probe stored winner is invalid."); }
-		if (!winner)
-			throw new WorkflowTaskTerminalError("MCP era-probe stored winner is unavailable.");
-		if (write.changed)
-		{
-			await transaction.mcp.appendAudit("Updated", `McpServer/${input.serverId}`, `MCP server era probe ${result.decision}`);
-		}
-		return winner;
+			const write = await transaction.mcp.recordEraProbeResult(input.siloId, input.serverId, input.registrationDigest, result);
+			if (!write)
+			{
+				throw new WorkflowTaskTerminalError("MCP era-probe registration is unavailable.");
+			}
+			let winner: McpEraProbeTaskResult | null;
+			try
+			{
+				winner = __McpEraProbeReplayResult(_TargetFromServer(write.server));
+			}
+			catch { throw new WorkflowTaskTerminalError("MCP era-probe stored winner is invalid."); }
+			if (!winner)
+				throw new WorkflowTaskTerminalError("MCP era-probe stored winner is unavailable.");
+			if (write.changed)
+			{
+				await transaction.mcp.appendAudit("Updated", `McpServer/${input.serverId}`, `MCP server era probe ${result.decision}`);
+			}
+			return winner;
+		});
 	});
 }
 
 /** Record a temporary failure and return the final result when the retry budget is exhausted. */
-async function _RecordRetry(unitOfWork: McpOperatorUnitOfWork, input: McpEraProbeTaskInput, attempt: number): Promise<McpEraProbeTaskResult | null>
+async function _RecordRetry(unitOfWork: McpOperatorUnitOfWork, input: McpEraProbeTaskInput): Promise<McpEraProbeTaskResult | null>
 {
 	const exhaustedResult = __McpEraProbeTerminalResult(McpEraProbeFailureCodes.RetryExhausted);
-	return await unitOfWork.execute(async function _WriteRetry(transaction): Promise<McpEraProbeTaskResult | null>
+	return await _RetryablePersistence(async function _RecordRetryWithRetry(): Promise<McpEraProbeTaskResult | null>
 	{
-		const retry = await transaction.mcp.recordEraProbeRetry(input.siloId, input.serverId, input.registrationDigest, attempt, MCP_ERA_PROBE_MAXIMUM_ATTEMPTS, exhaustedResult);
-		if (!retry)
-			throw new WorkflowTaskTerminalError("MCP era-probe registration is unavailable.");
-		let stored: McpEraProbeTaskResult | null;
-		try { stored = __McpEraProbeReplayResult(_TargetFromServer(retry.server)); }
-		catch { throw new WorkflowTaskTerminalError("MCP era-probe stored retry state is invalid."); }
-		if (retry.exhausted && !stored)
-			throw new WorkflowTaskTerminalError("MCP era-probe exhausted result is unavailable.");
-		if (retry.exhausted && retry.changed)
-			await transaction.mcp.appendAudit("Updated", `McpServer/${input.serverId}`, "MCP server era probe retry limit exhausted");
-		return stored;
+		return await unitOfWork.execute(async function _WriteRetry(transaction): Promise<McpEraProbeTaskResult | null>
+		{
+			const retry = await transaction.mcp.recordEraProbeRetry(input.siloId, input.serverId, input.registrationDigest, MCP_ERA_PROBE_MAXIMUM_ATTEMPTS, exhaustedResult);
+			if (!retry)
+				throw new WorkflowTaskTerminalError("MCP era-probe registration is unavailable.");
+			let stored: McpEraProbeTaskResult | null;
+			try { stored = __McpEraProbeReplayResult(_TargetFromServer(retry.server)); }
+			catch { throw new WorkflowTaskTerminalError("MCP era-probe stored retry state is invalid."); }
+			if (retry.exhausted && !stored)
+				throw new WorkflowTaskTerminalError("MCP era-probe exhausted result is unavailable.");
+			if (retry.exhausted && retry.changed)
+				await transaction.mcp.appendAudit("Updated", `McpServer/${input.serverId}`, "MCP server era probe retry limit exhausted");
+			return stored;
+		});
 	});
 }
 
@@ -104,7 +128,7 @@ async function _Run(context: IWorkflowTaskContext, options: McpEraProbeWorkflowO
 				const action = __McpEraProbeTransition(McpEraProbeStates.Pending, McpEraProbeEvents.RetryableFailure);
 				if (action !== McpEraProbeActions.Retry)
 					throw new WorkflowTaskTerminalError("MCP era-probe retry policy is invalid.");
-				const exhausted = await _RecordRetry(options.unitOfWork, input, context.attempt);
+				const exhausted = await _RecordRetry(options.unitOfWork, input);
 				if (exhausted)
 					return exhausted;
 				throw new WorkflowTaskRetryableError("MCP server protocol check is temporarily unavailable.");

--- a/libs/backend/server/infra/mcp-era-probe/README.md
+++ b/libs/backend/server/infra/mcp-era-probe/README.md
@@ -1,4 +1,4 @@
-# mcp-era-probe — external MCP protocol check
+# @opencrane/backend/server/infra/mcp-era-probe — external MCP protocol check
 
 > [OpenCrane](../../../../../README.md) › [backend](../../../README.md) › [server](../../README.md) › [infra](../README.md) › mcp-era-probe
 
@@ -8,8 +8,6 @@ This library makes the one external request needed to check a reviewed MCP serve
 domain records it. It owns HTTPS, DNS review, response limits, JSON-RPC validation, and the evidence
 digest. It does not own server registration, database writes, workflow scheduling, session setup, or
 tool execution.
-
-## What it checks
 
 ```text
 MCP domain port
@@ -39,6 +37,12 @@ In this flow:
   of the validated JSON-RPC result.
 - `McpEraProbeConfigurationError`, `McpEraProbeTransportError`, and `McpEraProbeProtocolError` carry
   bounded error codes that are safe to store or log.
+
+## Boundary
+
+The MCP domain decides when an endpoint may be checked and what each checked result means. This
+adapter only performs the bounded network exchange. It never registers or approves a server, saves
+catalogue data, starts a workflow, creates an MCP session, or runs a remote tool.
 
 ## Dependency direction
 

--- a/libs/backend/server/infra/mcp-era-probe/src/__tests__/mcp-era-probe.test.ts
+++ b/libs/backend/server/infra/mcp-era-probe/src/__tests__/mcp-era-probe.test.ts
@@ -13,7 +13,7 @@ function _DiscoveryResponse(protocolVersion = "2026-07-28"): McpEraProbeHttpsRes
 	return { status: 200, headers: { "content-type": "application/json" }, body: new TextEncoder().encode(JSON.stringify({ jsonrpc: "2.0", id: "opencrane-mcp-era-probe", result: { resultType: "complete", supportedVersions: [protocolVersion], capabilities: {}, ttlMs: 3_600_000, cacheScope: "public" } })) };
 }
 
-/** Builds the client with public DNS by default and a deterministic HTTPS request seam. */
+/** Builds the client with public DNS by default and a deterministic HTTPS request function. */
 function _Client(request: McpEraProbeHttpsRequest, resolve?: McpEraProbeDnsResolver)
 {
 	return __CreateHttpsMcpEraProbeClient({ protocolVersion: "2026-07-28", requestTimeoutMilliseconds: 1_000, maximumResponseBytes: 1_024, resolve: resolve ?? async function _resolve(): Promise<readonly McpEraProbeDnsAddress[]> { return [_PUBLIC_ADDRESS]; }, request });

--- a/libs/backend/server/infra/mcp-era-probe/src/mcp-era-probe.ts
+++ b/libs/backend/server/infra/mcp-era-probe/src/mcp-era-probe.ts
@@ -18,7 +18,7 @@ import type { McpEraProbeClient, McpEraProbeDnsAddress, McpEraProbeDnsResolver, 
  * Called by: OpenCrane application composition, which supplies the protocol revision owned by the
  * MCP domain.
  *
- * @param options - Protocol revision, timeout, response limit, and optional deterministic seams.
+ * @param options - Protocol revision, timeout, response limit, and optional test functions.
  * @returns An external transport client with no registration or approval authority.
  * @throws McpEraProbeConfigurationError When its options are invalid.
  * @see https://modelcontextprotocol.io/specification/2026-07-28

--- a/libs/backend/server/infra/mcp-era-probe/src/mcp-era-probe.types.ts
+++ b/libs/backend/server/infra/mcp-era-probe/src/mcp-era-probe.types.ts
@@ -31,7 +31,7 @@ export interface McpEraProbeHttpsRequestCommand
 	readonly signal: AbortSignal;
 }
 
-/** The bounded response returned by the low-level HTTPS request seam. */
+/** The bounded response returned by the low-level HTTPS request operation. */
 export interface McpEraProbeHttpsResponse
 {
 	/** HTTP status returned before the body is interpreted. */
@@ -42,10 +42,10 @@ export interface McpEraProbeHttpsResponse
 	readonly body: Uint8Array;
 }
 
-/** Sends one prevalidated HTTPS request; tests use this seam instead of a live socket. */
+/** Sends one prevalidated HTTPS request; tests provide this function instead of opening a live socket. */
 export type McpEraProbeHttpsRequest = (command: McpEraProbeHttpsRequestCommand) => Promise<McpEraProbeHttpsResponse>;
 
-/** Configures the production HTTPS era-probe client and its deterministic test seams. */
+/** Configures the production HTTPS era-probe client and its deterministic test overrides. */
 export interface McpEraProbeHttpsClientOptions
 {
 	/** MCP protocol revision sent in the discovery request. */
@@ -79,7 +79,7 @@ export interface McpEraProbeResult
 /**
  * Checks whether a remote endpoint speaks the only MCP revision OpenCrane admits.
  *
- * This is a structural adapter seam for the MCP domain. The infrastructure package owns DNS,
+ * This is the adapter contract used by the MCP domain. The infrastructure package owns DNS,
  * HTTPS, response limits, and JSON-RPC validation but never decides whether a successful probe
  * authorizes registration. Called by: `__CreateMcpEraProbeWorkflow` during remote-server review.
  */

--- a/libs/backend/server/infra/workflows/infra_absurd/README.md
+++ b/libs/backend/server/infra/workflows/infra_absurd/README.md
@@ -1,4 +1,4 @@
-# backend-server-infra-workflows-infra-absurd — Absurd workflow engine adapter
+# @opencrane/backend/server/infra/workflows/infra_absurd — Absurd workflow engine adapter
 
 > [backend](../../../../README.md) › [server](../../../README.md) › [infra](../../README.md) › [workflows](../README.md) › infra_absurd
 


### PR DESCRIPTION
## Summary

Follow-up to #709.

- retry temporary database write failures without changing deliberate workflow failures
- finish the MCP protocol check on the fifth workflow attempt instead of leaving the server pending
- record the authenticated administrator on approval and access-policy audit entries
- clarify the workflow adapter and repository boundaries in plain language

## Validation

- MCP workflow: 45 tests
- MCP network adapter: 39 tests
- TypeScript checks for both packages
- workflow and Prisma boundary checks
- style and module-growth checks
- release version check
- production OpenCrane build
- independent correctness and security reviews: no remaining findings