### PR TITLE
✨ Split MCP bundle inspection into a child workflow

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -10993,3 +10993,4 @@ END;
 $$;
 
 SELECT absurd.create_queue('control-plane');
+SELECT absurd.create_queue('mcpb-inspection');

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
@@ -1,9 +1,9 @@
 {
   "fromSchemaVersion": "0.9.0",
   "toSchemaVersion": "0.9.3",
-  "sqlSha256": "2dac64aa0002959c8e724eb5bf931ed31da3044498d99a14f9857eb4f34c2d69",
+  "sqlSha256": "f83a6023912e8cff7337529cdbb7a9da685f8ef401a0b16f889d51d0a231b6e0",
   "owner": "apps/opencrane",
   "privilegedExtension": "pg_cron",
   "sourceTargetBaselineSha256": "5e16b35aedce54bf6ff7bd79bca04f92f6b6aee6315dec5c4b4797604342ab5f",
-  "targetBaselineSha256": "4a2da895e60744aa2fe85cdaf3729a7439cd29e57a3ca6ec463898593c6b00f5"
+  "targetBaselineSha256": "cc19d4fc620e7d6906467913169cfc2b771481dadd73a484f6d201e2f3f5d05a"
 }

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
@@ -4317,13 +4317,14 @@ END;
 $$;
 
 SELECT absurd.create_queue('control-plane');
+SELECT absurd.create_queue('mcpb-inspection');
 
 INSERT INTO "opencrane_migrations"."schema_history" (
     "schema_version", "source_schema_version", "source_baseline_sha256",
     "target_baseline_sha256", "sql_sha256", "migration_id"
 ) VALUES (
     '0.9.3', '0.9.0', :'source_baseline_sha256',
-    '7fa60a4bb68888a69ff2c9cdf23cd85e972c9521f9a51dacd564dead15b0c949',
+    'cc19d4fc620e7d6906467913169cfc2b771481dadd73a484f6d201e2f3f5d05a',
     :'migration_sql_sha256', '0.9.0-to-0.9.3'
 );
 

--- a/apps/opencrane/src/app/mcp-workflow-composition.ts
+++ b/apps/opencrane/src/app/mcp-workflow-composition.ts
@@ -35,6 +35,7 @@ export function _CreateMcpWorkflowComposition(prisma: PrismaClient, config: Open
 	const queueAuthority = __CreateWorkflowTaskQueueAuthority([
 		{ taskName: McpEraProbeTaskNames.Probe, queue: "control-plane" },
 		{ taskName: McpbValidationTaskNames.Verify, queue: "control-plane" },
+		{ taskName: McpbValidationTaskNames.Inspect, queue: "mcpb-inspection" },
 	]);
 	const runtime = _CreateAbsurdWorkflowEngine({ databasePoolSize: config.databasePoolSize, databaseUrl: config.databaseUrl, log: _log, pollIntervalMs: config.pollIntervalMilliseconds, queueAuthority, workerConcurrency: config.workerConcurrency });
 	const execution = __CreateWorkflowGuard({ execution: runtime, log: _log, queueAuthority, siloId: config.siloId });

--- a/libs/backend/server/gateways/mcp/main/README.md
+++ b/libs/backend/server/gateways/mcp/main/README.md
@@ -36,14 +36,17 @@ check a newly registered MCP server and a submitted signed MCP bundle.
    └── save an Absurd background job
         │
         ▼
- worker checks the signed bundle and its manifest
+ parent job waits for a separate package-inspection job
+        ├── checks the signed bundle and its manifest
+        └── returns one saved answer to the parent job
    ├── trusted signature + valid manifest ──► verified
    └── invalid package ─────────────────────► rejected
 ```
 
-The bundle check currently verifies the signature and the package manifest. Running the bundle in
-an isolated environment, scanning it, building an image, and publishing it are later workflow
-steps.
+The parent job and inspection job use different queues, so Absurd can save the wait safely. The
+inspection job currently verifies the signature, safe archive layout, and package manifest. Running
+the bundle in an isolated environment, scanning it, building an image, and publishing it are later
+workflow steps.
 
 The draft server and its background job use one database transaction. Either both are saved, or
 neither is saved. A repeated registration request returns the same draft and the same job.
@@ -68,7 +71,7 @@ returns credentials and never labels an install connected before a real connecti
 - `registerRemoteServer` — saves a draft server and its protocol-check job together.
 - `__CreateMcpEraProbeWorkflow` — registers the saved background job that checks the server.
 - `submitMcpbValidation` and `getMcpbValidation` — save and read signed MCP bundle checks.
-- `__CreateMcpbValidationWorkflow` — registers the saved bundle verification job.
+- `__CreateMcpbValidationWorkflow` — registers the saved parent and package-inspection jobs.
 - Operator services: `listEntitledCatalog`, `listInstalled`, `installServer`, `approveServer`,
   `publishServer`, and the access editor.
 - `_McpOpenapiPaths` — the OpenAPI path descriptions for this API.

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcpb-validation.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcpb-validation.test.ts
@@ -6,7 +6,7 @@ import { __FakeWorkflowEngine } from "@opencrane/backend/server/infra/workflows/
 
 import type { McpOperatorTransaction, McpOperatorUnitOfWork } from "../core/mcp-operator-repository.types";
 import type { McpbValidationRecord } from "../mcpb-validation/mcpb-validation-repository.types";
-import { __CreateMcpbValidationWorkflow, __McpbValidationTaskKey } from "../mcpb-validation/mcpb-validation";
+import { __CreateMcpbValidationWorkflow, __McpbValidationInspectionTaskKey, __McpbValidationTaskKey } from "../mcpb-validation/mcpb-validation";
 import { McpbValidationStates, McpbVerificationFailureCodes } from "../mcpb-validation/mcpb-validation.types";
 import type { McpbValidationTaskInput, McpbVerificationResult } from "../mcpb-validation/mcpb-validation.types";
 
@@ -85,6 +85,7 @@ describe("MCP bundle validation workflow", function _McpbValidationSuite()
 		expect(execution.taskSnapshot(admitted.receipt)).toMatchObject({ state: WorkflowTaskStates.Completed, result });
 		expect(state.validation).toMatchObject({ state: McpbValidationStates.Verified, manifestName: "example-server", publisher: "Example Publisher" });
 		expect(state.auditCount).toBe(1);
+		expect(verifier.verify).toHaveBeenCalledWith(expect.objectContaining({ validationId: "validation-private", artifactRevisionId: "revision-private" }));
 	});
 
 	it("stores one bounded rejection reason", async function _StoresRejectedResult()
@@ -130,10 +131,14 @@ describe("MCP bundle validation workflow", function _McpbValidationSuite()
 	it("uses the same opaque key for repeated admission", function _UsesStableOpaqueTaskKey()
 	{
 		const taskKey = __McpbValidationTaskKey(_Input());
+		const inspectionTaskKey = __McpbValidationInspectionTaskKey(_Input());
 
 		expect(taskKey).toBe(__McpbValidationTaskKey(_Input()));
+		expect(inspectionTaskKey).toBe(__McpbValidationInspectionTaskKey(_Input()));
+		expect(inspectionTaskKey).not.toBe(taskKey);
 		expect(taskKey).not.toContain(_Input().siloId);
 		expect(taskKey).not.toContain(_Input().validationId);
 		expect(taskKey).not.toContain(_Input().artifactRevisionId);
+		expect(inspectionTaskKey).not.toContain(_Input().validationId);
 	});
 });

--- a/libs/backend/server/gateways/mcp/main/src/index.ts
+++ b/libs/backend/server/gateways/mcp/main/src/index.ts
@@ -14,7 +14,7 @@ export { __CreateMcpbBundleVerifier } from "./mcpb-validation/mcpb-bundle-verifi
 export { getMcpbValidation, submitMcpbValidation } from "./mcpb-validation/mcpb-validation-submission";
 export { McpbValidationSubmissionOutcomes } from "./mcpb-validation/mcpb-validation-submission.types";
 export type { McpbBundleArtifactResolver, McpbValidationSubmissionCommand, McpbValidationSubmissionResult } from "./mcpb-validation/mcpb-validation-submission.types";
-export { __CreateMcpbValidationWorkflow, __McpbValidationTaskKey } from "./mcpb-validation/mcpb-validation";
+export { __CreateMcpbValidationWorkflow, __McpbValidationInspectionTaskKey, __McpbValidationTaskKey } from "./mcpb-validation/mcpb-validation";
 export { MCPB_MANIFEST_VERSION, MCPB_MAXIMUM_BUNDLE_BYTES, McpbValidationStates, McpbValidationTaskNames, McpbVerificationFailureCodes } from "./mcpb-validation/mcpb-validation.types";
 export type { McpbBundleArtifactReader, McpbBundleArtifactTarget, McpbBundleVerifier, McpbValidationAdmission, McpbValidationTaskInput, McpbValidationWorkflow, McpbValidationWorkflowOptions, McpbVerificationResult, McpbVerifiedManifest } from "./mcpb-validation/mcpb-validation.types";
 export * from "./routes/mcp-operator";

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation.ts
@@ -74,6 +74,16 @@ async function _Record(options: McpbValidationWorkflowOptions, input: McpbValida
 	});
 }
 
+/** Run the expensive package read in its own saved task so the parent can safely wait for it. */
+async function _Inspect(context: IWorkflowTaskContext, options: McpbValidationWorkflowOptions, input: McpbValidationTaskInput): Promise<McpbVerificationResult>
+{
+	return await context.checkpoint({ stepName: "verify-package" }, async function _VerifyPackage(): Promise<McpbVerificationResult>
+	{
+		try { return await options.verifier.verify(input); }
+		catch { throw new WorkflowTaskRetryableError("MCP bundle verifier is temporarily unavailable."); }
+	});
+}
+
 /** Run the replay-safe manifest and signature check through two saved checkpoints. */
 async function _Run(context: IWorkflowTaskContext, options: McpbValidationWorkflowOptions, input: McpbValidationTaskInput): Promise<McpbVerificationResult>
 {
@@ -83,10 +93,10 @@ async function _Run(context: IWorkflowTaskContext, options: McpbValidationWorkfl
 	catch { throw new WorkflowTaskTerminalError("MCP bundle validation stored state is invalid."); }
 	if (replay)
 		return replay;
-	const result = await context.checkpoint({ stepName: "verify-package" }, async function _VerifyPackage(): Promise<McpbVerificationResult>
+	const result = await context.checkpoint({ stepName: "inspect-package" }, async function _InspectPackage(): Promise<McpbVerificationResult>
 	{
-		try { return await options.verifier.verify(_Target(record)); }
-		catch { throw new WorkflowTaskRetryableError("MCP bundle verifier is temporarily unavailable."); }
+		const child = await context.spawnChild({ taskName: McpbValidationTaskNames.Inspect, idempotencyKey: __McpbValidationInspectionTaskKey(input), input: { ...input, ..._Target(record) } });
+		return await context.awaitChild<McpbVerificationResult>(child);
 	});
 	return await context.checkpoint({ stepName: "record-decision" }, async function _RecordDecision(): Promise<McpbVerificationResult>
 	{
@@ -102,6 +112,14 @@ export function __McpbValidationTaskKey(input: McpbValidationTaskInput): string
 	return `workflows:mcpb-validation:${digest}`;
 }
 
+/** Derive the child key from the parent identity without putting product coordinates in engine logs. */
+export function __McpbValidationInspectionTaskKey(input: McpbValidationTaskInput): string
+{
+	__AssertMcpbValidationTaskInput(input);
+	const digest = createHash("sha256").update(JSON.stringify([input.siloId, input.validationId, input.artifactRevisionId, input.contentAddress, input.submissionDigest, McpbValidationTaskNames.Inspect])).digest("hex");
+	return `workflows:mcpb-validation-inspect:${digest}`;
+}
+
 /** Register the saved MCP bundle verifier and return its transaction-bound admission API. */
 export function __CreateMcpbValidationWorkflow(options: McpbValidationWorkflowOptions): McpbValidationWorkflow
 {
@@ -112,6 +130,15 @@ export function __CreateMcpbValidationWorkflow(options: McpbValidationWorkflowOp
 		{
 			__AssertMcpbValidationTaskInput(input);
 			return await _Run(context, options, input);
+		},
+	});
+	options.execution.register({
+		taskName: McpbValidationTaskNames.Inspect,
+		retryPolicy: { maximumAttempts: _MAXIMUM_ATTEMPTS, backoff: { kind: WorkflowTaskRetryBackoffKinds.Exponential, initialDelaySeconds: 30, multiplier: 2, maximumDelaySeconds: 300 } },
+		async run(context: IWorkflowTaskContext, input: McpbValidationTaskInput): Promise<McpbVerificationResult>
+		{
+			__AssertMcpbValidationTaskInput(input);
+			return await _Inspect(context, options, input);
 		},
 	});
 	return {

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation.types.ts
@@ -52,8 +52,10 @@ export enum McpbValidationStates
 /** Stable task names registered for MCP bundle work. */
 export enum McpbValidationTaskNames
 {
-	/** Reads one saved bundle and stores its manifest and signature decision. */
+	/** Coordinates the saved package inspection and stores its final product decision. */
 	Verify = "mcpb-validation.verify",
+	/** Reads one exact bundle revision and checks its signature and archive layout. */
+	Inspect = "mcpb-validation.inspect",
 }
 
 /** Immutable artifact facts saved before a bundle verification job starts. */

--- a/releases/0.9.3.json
+++ b/releases/0.9.3.json
@@ -10,7 +10,7 @@
   "database": {
     "schemaVersion": "0.9.3",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "4a2da895e60744aa2fe85cdaf3729a7439cd29e57a3ca6ec463898593c6b00f5",
+    "baselineSha256": "cc19d4fc620e7d6906467913169cfc2b771481dadd73a484f6d201e2f3f5d05a",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {


### PR DESCRIPTION
## Summary

- split MCP bundle package inspection into its own durable child workflow
- run that child on the dedicated `mcpb-inspection` queue
- create the queue in clean-baseline and 0.9.3 upgrade database setup

## Validation

- focused MCP gateway and OpenCrane tests
- TypeScript lint, migration contract, release-versioning, and boundary checks

## Review order

#714 → #715 → #716