### PR TITLE
🔒 Bound MCP bundle validator Job manifests

### DIFF
--- a/docs/agents/app-specific.md
+++ b/docs/agents/app-specific.md
@@ -45,6 +45,7 @@ app's source.
 | [`libs/backend/channel-proxy`](../../libs/backend/channel-proxy/main/README.md) | Reusable inbound-channel trust-boundary logic. |
 | [`libs/backend/conversations/projection`](../../libs/backend/conversations/projection/main/README.md) | Transport-neutral redaction, AG-UI mapping, cursoring, and live streaming for every conversation mode. |
 | [`libs/backend/server`](../../libs/backend/server/README.md) | API capabilities grouped by agents, IAM, gateways, knowledge, reporting, and organisation scope. |
+| [`libs/backend/server/gateways/mcp/validator-k8s-launcher`](../../libs/backend/server/gateways/mcp/validator-k8s-launcher/README.md) | Restricted Kubernetes Job builder for MCP bundle validation. |
 | [`libs/backend/server/iam/organization-members`](../../libs/backend/server/iam/organization-members/main/README.md) | Settings member directory and standalone invitation authority, or fail-closed delegation of the whole capability to Fleet billing. |
 | [`libs/backend/server/agents/onboarding`](../../libs/backend/server/agents/onboarding/main/README.md) | Durable, session-owner-bound onboarding route state and exact persona/bootstrap references. |
 | [`libs/backend/server/conversations`](../../libs/backend/server/conversations/main/README.md) | Mode-correct conversation authority, participant visibility, canonical timeline, authorised stream readers, and HTTP routes. |

--- a/libs/backend/server/gateways/mcp/README.md
+++ b/libs/backend/server/gateways/mcp/README.md
@@ -1,0 +1,30 @@
+# MCP gateway packages
+
+> [backend](../../../../README.md) › [server](../../../README.md) › [gateways](../../README.md) › mcp
+
+MCP means Model Context Protocol, a common way for an AI agent to use tools. These packages govern
+which MCP services OpenCrane may use and how an MCP bundle is checked before it can be trusted.
+
+| Package | What it does |
+|---|---|
+| [`main`](./main/README.md) | Owns MCP catalogue rules, protocol checks, and bundle validation records. |
+| [`validator-k8s-launcher`](./validator-k8s-launcher/README.md) | Builds the restricted one-shot Job shape for a future bundle validator worker. |
+
+```
+ MCP catalogue and validation record
+               │
+               ▼
+         main package
+          │        │
+          │        └──► validator-k8s-launcher ──► isolated validator Job
+          ▼
+    permitted MCP service
+```
+
+MCP packages may use IAM decisions and infrastructure ports, but they do not own agent runtime
+execution or Kubernetes mutation. The agent controller is the only process that can create Jobs.
+
+## See also
+
+- [Gateway packages](../README.md)
+- [Server packages](../../../README.md)

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/README.md
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/README.md
@@ -34,8 +34,8 @@ or assignment would widen those limits, it refuses to make a manifest.
 
 ## Boundary
 
-The future MCPB controller is the only caller that may submit this Job. This package never handles
-artifact locations, bundle bytes, commands, database connections, or long-lived credentials.
+No production code calls this package yet. This package never handles artifact locations, bundle
+bytes, commands, database connections, or long-lived credentials.
 
 ## Dependency direction
 

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/README.md
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/README.md
@@ -1,0 +1,49 @@
+# @opencrane/backend/server/gateways/mcp/validator-k8s-launcher — MCP bundle validator Job builder
+
+> [backend](../../../../../README.md) › [server](../../../../README.md) › [gateways](../../../README.md) › mcp › validator-k8s-launcher
+
+## What it owns
+
+An MCP bundle is a packaged Model Context Protocol server. Before OpenCrane can trust one, a future
+validator worker must inspect it in a small, isolated Kubernetes Job. This package builds that Job
+shape; it does not submit the Job, read bundle bytes, or run a bundle.
+
+```
+ saved validation + opaque reference
+              │
+              ▼
+ ┌──────────────────────────────────────┐
+ │ validator-k8s-launcher  ◄── HERE      │ checks the fixed worker identity,
+ └──────────────────────────────────────┘ token, resources, and Job shape
+              │
+              ▼
+ agent controller ──► one suspended validator Job
+```
+
+**In this flow:** [MCP governance](../main/README.md) · [agent controller](../../../../../../../apps/agent-controller/README.md) · [validator app](../../../../../../../apps/mcpb-validator/README.md).
+
+It guarantees the Job is one-shot, starts suspended, has no Kubernetes permissions, uses a
+read-only filesystem, and receives only a short-lived token plus an opaque reference. If the profile
+or assignment would widen those limits, it refuses to make a manifest.
+
+## Public surface
+
+- `__BuildMcpbValidatorJob` builds one restricted, suspended Kubernetes Job.
+- `__McpbValidatorJobName` derives its opaque deterministic Kubernetes name.
+- `McpbValidatorJobProfile` and `McpbValidatorJobAssignment` describe trusted deployment settings and controller input.
+
+## Boundary
+
+The future MCPB controller is the only caller that may submit this Job. This package never handles
+artifact locations, bundle bytes, commands, database connections, or long-lived credentials.
+
+## Dependency direction
+
+Tagged `scope:mcp-validator-launcher`, this infrastructure package only uses Kubernetes value types
+and Node's hashing helper. It does not import apps, database adapters, or MCP business rules.
+
+## See also
+
+- [Gateway packages](../../../README.md)
+- [MCP governance](../main/README.md)
+- [Validator application](../../../../../../../apps/mcpb-validator/README.md)

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/project.json
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend-server-gateways-mcp-validator-k8s-launcher",
+  "$schema": "../../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/server/gateways/mcp/validator-k8s-launcher/src",
+  "tags": ["type:lib", "layer:infra", "scope:mcp-validator-launcher"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/server/gateways/mcp/validator-k8s-launcher" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/server/gateways/mcp/validator-k8s-launcher" } }
+  }
+}

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/__tests__/validator-job.test.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/__tests__/validator-job.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { __BuildMcpbValidatorJob } from "../validator-job";
+
+/** Return one deployment-owned validator profile. */
+function _Profile()
+{
+	return { image: `ghcr.io/elewa-git/opencrane-mcpb-validator@sha256:${"a".repeat(64)}`, imagePullPolicy: "IfNotPresent" as const, serverNamespace: "opencrane", namespace: "opencrane-mcpb-validation", serviceAccountName: "mcpb-validator-default", tokenAudience: "opencrane-mcpb-validator", bootstrapUrl: "http://opencrane-server.opencrane.svc.cluster.local:8081/api/internal/mcpb-validator", tokenPath: "/var/run/opencrane/tokens/validator.token", bootstrapReferencePath: "/var/run/opencrane/bootstrap/reference", scratchSize: "128Mi", activeDeadlineSeconds: 300, ttlSecondsAfterFinished: 0, resources: { requests: { cpu: "250m", memory: "256Mi" }, limits: { cpu: "1", memory: "1Gi" } } };
+}
+
+/** Return opaque controller-owned coordinates for one validation. */
+function _Assignment()
+{
+	return { validationId: "validation-1", siloId: "silo-1", namespace: "opencrane-mcpb-validation", bootstrapReference: `mcpb-validator-v1_${"b".repeat(64)}` };
+}
+
+describe("MCP bundle validator Job", function _McpbValidatorJobSuite()
+{
+	it("is suspended, one-shot, restricted, and free of artifact coordinates", function _BuildsRestrictedJob()
+	{
+		const job = __BuildMcpbValidatorJob(_Assignment(), _Profile());
+		expect(job.spec).toMatchObject({ suspend: true, backoffLimit: 0, completions: 1, parallelism: 1, ttlSecondsAfterFinished: 0 });
+		expect(job.spec?.template.spec).toMatchObject({ automountServiceAccountToken: false, restartPolicy: "Never", serviceAccountName: "mcpb-validator-default", securityContext: { runAsNonRoot: true } });
+		expect(job.spec?.template.spec?.containers[0]?.securityContext).toMatchObject({ allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: { drop: ["ALL"] } });
+		expect(JSON.stringify(job)).not.toContain("artifactRevisionId");
+		expect(JSON.stringify(job)).not.toContain("contentAddress");
+		expect(job.spec?.template.spec?.containers[0]?.env).not.toEqual(expect.arrayContaining([expect.objectContaining({ name: "OPENCRANE_MCPB_BOOTSTRAP_REFERENCE", value: expect.any(String) })]));
+		expect(job.spec?.template.spec?.volumes).toEqual(expect.arrayContaining([expect.objectContaining({ name: "validator-token", projected: expect.anything() }), expect.objectContaining({ name: "bootstrap-reference", downwardAPI: expect.anything() })]));
+	});
+
+	it("rejects widened identity, route, namespace, resources, scratch, and reference input", function _RejectsWidening()
+	{
+		expect(function _WrongIdentity() { __BuildMcpbValidatorJob(_Assignment(), { ..._Profile(), serviceAccountName: "opencrane-server" }); }).toThrow(/fixed identity/);
+		expect(function _WrongRoute() { __BuildMcpbValidatorJob(_Assignment(), { ..._Profile(), bootstrapUrl: "http://opencrane-server.opencrane.svc.cluster.local:8081/api/internal/agent-runtime" }); }).toThrow(/fixed identity/);
+		expect(function _WrongNamespace() { __BuildMcpbValidatorJob({ ..._Assignment(), namespace: "other-namespace" }, _Profile()); }).toThrow(/deployment-owned namespace/);
+		expect(function _OversizedResources() { __BuildMcpbValidatorJob(_Assignment(), { ..._Profile(), resources: { requests: { cpu: "3", memory: "1Gi" }, limits: { cpu: "3", memory: "1Gi" } } }); }).toThrow(/bounded resources/);
+		expect(function _SmallScratch() { __BuildMcpbValidatorJob(_Assignment(), { ..._Profile(), scratchSize: "64Mi" }); }).toThrow(/bounded resources/);
+		expect(function _ReadableReference() { __BuildMcpbValidatorJob({ ..._Assignment(), bootstrapReference: "validation-1" }, _Profile()); }).toThrow(/opaque reference/);
+	});
+});

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/__tests__/validator-job.test.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/__tests__/validator-job.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { __BuildMcpbValidatorJob } from "../validator-job";
 
-/** Return one deployment-owned validator profile. */
+/** Provide a complete deployment-owned profile that the builder should accept. */
 function _Profile()
 {
 	return { image: `ghcr.io/elewa-git/opencrane-mcpb-validator@sha256:${"a".repeat(64)}`, imagePullPolicy: "IfNotPresent" as const, serverNamespace: "opencrane", namespace: "opencrane-mcpb-validation", serviceAccountName: "mcpb-validator-default", tokenAudience: "opencrane-mcpb-validator", bootstrapUrl: "http://opencrane-server.opencrane.svc.cluster.local:8081/api/internal/mcpb-validator", tokenPath: "/var/run/opencrane/tokens/validator.token", bootstrapReferencePath: "/var/run/opencrane/bootstrap/reference", scratchSize: "128Mi", activeDeadlineSeconds: 300, ttlSecondsAfterFinished: 0, resources: { requests: { cpu: "250m", memory: "256Mi" }, limits: { cpu: "1", memory: "1Gi" } } };
 }
 
-/** Return opaque controller-owned coordinates for one validation. */
+/** Provide opaque-shaped controller coordinates accepted by the builder. */
 function _Assignment()
 {
 	return { validationId: "validation-1", siloId: "silo-1", namespace: "opencrane-mcpb-validation", bootstrapReference: `mcpb-validator-v1_${"b".repeat(64)}` };

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/index.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/index.ts
@@ -1,0 +1,2 @@
+export { __BuildMcpbValidatorJob, __McpbValidatorJobName } from "./validator-job";
+export type { McpbValidatorImagePullPolicy, McpbValidatorJobAssignment, McpbValidatorJobProfile } from "./validator-job.types";

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
@@ -1,0 +1,144 @@
+import { createHash } from "node:crypto";
+
+import type { V1Job } from "@kubernetes/client-node";
+
+import type { McpbValidatorJobAssignment, McpbValidatorJobProfile } from "./validator-job.types";
+
+/** Fixed identity assigned to the MCP bundle validator worker. */
+const _SERVICE_ACCOUNT_NAME = "mcpb-validator-default";
+/** Fixed projected-token audience that no other workload class may use. */
+const _TOKEN_AUDIENCE = "opencrane-mcpb-validator";
+/** Read-only file containing the worker's short-lived projected token. */
+const _TOKEN_PATH = "/var/run/opencrane/tokens/validator.token";
+/** Read-only file containing the controller-created opaque bootstrap reference. */
+const _REFERENCE_PATH = "/var/run/opencrane/bootstrap/reference";
+/** Smallest scratch volume that can hold a bounded MCP bundle and extracted manifest. */
+const _MIN_SCRATCH_BYTES = 134_217_728n;
+/** Largest scratch volume the validator plane may request. */
+const _MAX_SCRATCH_BYTES = 536_870_912n;
+/** Largest validator Job lifetime. */
+const _MAX_ACTIVE_DEADLINE_SECONDS = 600;
+/** Largest CPU limit that this untrusted one-shot worker may receive. */
+const _MAX_CPU_MILLICORES = 2_000;
+/** Largest memory limit that this untrusted one-shot worker may receive. */
+const _MAX_MEMORY_BYTES = 2_147_483_648n;
+
+/** Return true only for a bounded Kubernetes-safe trace coordinate. */
+function _IsBoundedCoordinate(value: string): boolean
+{
+	return value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/u.test(value);
+}
+
+/** Parse Ki, Mi, and Gi quantities into bytes. */
+function _ParseBinaryBytes(value: string): bigint | null
+{
+	const match = /^([1-9][0-9]*)(Ki|Mi|Gi)$/u.exec(value);
+	if (match === null)
+	{
+		return null;
+	}
+	const exponents = { Ki: 1n, Mi: 2n, Gi: 3n } as const;
+	return BigInt(match[1]) * (1024n ** exponents[match[2] as keyof typeof exponents]);
+}
+
+/** Parse an integer millicore or decimal core quantity into millicores. */
+function _ParseCpuMillis(value: string): number | null
+{
+	const millicores = /^([1-9][0-9]*)m$/u.exec(value);
+	const cores = /^([1-9][0-9]*(?:\.[0-9]+)?)$/u.exec(value);
+	let parsed = 0;
+	if (millicores !== null)
+	{
+		parsed = Number(millicores[1]);
+	}
+	else if (cores !== null)
+	{
+		parsed = Number(cores[1]) * 1_000;
+	}
+	return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+/** Accept the deployment-owned internal worker endpoint only when it has the fixed path and an in-cluster host. */
+function _IsBootstrapUrl(value: string): boolean
+{
+	try
+	{
+		const parsed = new URL(value);
+		const port = Number(parsed.port);
+		return parsed.protocol === "http:" && /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?\.svc\.cluster\.local$/u.test(parsed.hostname) && Number.isSafeInteger(port) && port >= 1 && port <= 65_535 && parsed.pathname === "/api/internal/mcpb-validator" && parsed.username === "" && parsed.password === "" && parsed.search === "" && parsed.hash === "";
+	}
+	catch
+	{
+		return false;
+	}
+}
+
+/** Reject a profile that could widen the validator worker's identity, resources, or internal route. */
+function _AssertProfile(profile: McpbValidatorJobProfile): void
+{
+	const scratchBytes = _ParseBinaryBytes(profile.scratchSize);
+	const requestedCpu = _ParseCpuMillis(String(profile.resources.requests?.cpu ?? ""));
+	const limitedCpu = _ParseCpuMillis(String(profile.resources.limits?.cpu ?? ""));
+	const requestedMemory = _ParseBinaryBytes(String(profile.resources.requests?.memory ?? ""));
+	const limitedMemory = _ParseBinaryBytes(String(profile.resources.limits?.memory ?? ""));
+	if (!/^[a-z0-9][a-z0-9._:/-]*@sha256:[a-f0-9]{64}$/u.test(profile.image) || !["Always", "IfNotPresent", "Never"].includes(profile.imagePullPolicy) || profile.serviceAccountName !== _SERVICE_ACCOUNT_NAME || profile.tokenAudience !== _TOKEN_AUDIENCE || !_IsBootstrapUrl(profile.bootstrapUrl) || profile.tokenPath !== _TOKEN_PATH || profile.bootstrapReferencePath !== _REFERENCE_PATH || profile.namespace === profile.serverNamespace || !/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/u.test(profile.namespace) || profile.namespace.length > 63 || scratchBytes === null || scratchBytes < _MIN_SCRATCH_BYTES || scratchBytes > _MAX_SCRATCH_BYTES || !Number.isSafeInteger(profile.activeDeadlineSeconds) || profile.activeDeadlineSeconds < 1 || profile.activeDeadlineSeconds > _MAX_ACTIVE_DEADLINE_SECONDS || profile.ttlSecondsAfterFinished !== 0 || requestedCpu === null || limitedCpu === null || requestedCpu > limitedCpu || limitedCpu > _MAX_CPU_MILLICORES || requestedMemory === null || limitedMemory === null || requestedMemory > limitedMemory || limitedMemory > _MAX_MEMORY_BYTES)
+	{
+		throw new Error("MCP bundle validator Job profile requires its fixed identity, route, bounded resources, scratch, and lifetime");
+	}
+}
+
+/** Reject caller values before they become labels, annotations, mounts, or Kubernetes resource names. */
+function _AssertAssignment(assignment: McpbValidatorJobAssignment, profile: McpbValidatorJobProfile): void
+{
+	if (![assignment.validationId, assignment.siloId, assignment.namespace, assignment.bootstrapReference].every(function _IsValid(value): boolean { return _IsBoundedCoordinate(value); }) || !/^mcpb-validator-v1_[a-f0-9]{64}$/u.test(assignment.bootstrapReference) || assignment.namespace !== profile.namespace)
+	{
+		throw new Error("MCP bundle validator Job assignment requires bounded coordinates, an opaque reference, and the deployment-owned namespace");
+	}
+}
+
+/** Build a deterministic opaque Kubernetes Job name without exposing the validation identifier. */
+export function __McpbValidatorJobName(assignment: McpbValidatorJobAssignment): string
+{
+	const digest = createHash("sha256").update(`${assignment.siloId}\u0000${assignment.validationId}`).digest("hex").slice(0, 24);
+	return `mcpb-validate-${digest}`;
+}
+
+/** Build the suspended, one-shot, restricted Job that a future controller may submit after durable assignment. */
+export function __BuildMcpbValidatorJob(assignment: McpbValidatorJobAssignment, profile: McpbValidatorJobProfile): V1Job
+{
+	// 1. Check fixed deployment policy before Kubernetes sees a manifest that could widen this worker's authority.
+	_AssertProfile(profile);
+	_AssertAssignment(assignment, profile);
+
+	// 2. Derive opaque metadata. The manifest carries no bundle bytes, artifact address, command, or credentials.
+	const name = __McpbValidatorJobName(assignment);
+	const annotations = { "opencrane.ai/silo-id": assignment.siloId, "opencrane.ai/mcpb-validation": assignment.validationId, "opencrane.ai/mcpb-bootstrap-reference": assignment.bootstrapReference };
+
+	// 3. Keep the Job suspended until the controller writes its Kubernetes UID to the durable validation assignment.
+	return {
+		apiVersion: "batch/v1",
+		kind: "Job",
+		metadata: { name, namespace: assignment.namespace, labels: { "app.kubernetes.io/name": "opencrane-mcpb-validator", "app.kubernetes.io/component": "mcpb-validator", "opencrane.ai/mcpb-validator": name }, annotations },
+		spec: {
+			suspend: true,
+			backoffLimit: 0,
+			completions: 1,
+			parallelism: 1,
+			activeDeadlineSeconds: profile.activeDeadlineSeconds,
+			ttlSecondsAfterFinished: profile.ttlSecondsAfterFinished,
+			template: {
+				metadata: { labels: { "app.kubernetes.io/component": "mcpb-validator", "opencrane.ai/mcpb-validator": name }, annotations },
+				spec: {
+					serviceAccountName: profile.serviceAccountName,
+					automountServiceAccountToken: false,
+					enableServiceLinks: false,
+					restartPolicy: "Never",
+					terminationGracePeriodSeconds: 0,
+					securityContext: { runAsNonRoot: true, runAsUser: 65532, runAsGroup: 65532, fsGroup: 65532, seccompProfile: { type: "RuntimeDefault" } },
+					containers: [{ name: "mcpb-validator", image: profile.image, imagePullPolicy: profile.imagePullPolicy, securityContext: { allowPrivilegeEscalation: false, capabilities: { drop: ["ALL"] }, readOnlyRootFilesystem: true }, env: [{ name: "OPENCRANE_MCPB_BOOTSTRAP_URL", value: profile.bootstrapUrl }, { name: "OPENCRANE_MCPB_TOKEN_PATH", value: profile.tokenPath }, { name: "OPENCRANE_MCPB_BOOTSTRAP_REFERENCE_PATH", value: profile.bootstrapReferencePath }], resources: structuredClone(profile.resources), volumeMounts: [{ name: "validator-token", mountPath: "/var/run/opencrane/tokens", readOnly: true }, { name: "bootstrap-reference", mountPath: "/var/run/opencrane/bootstrap", readOnly: true }, { name: "scratch", mountPath: "/tmp" }] }],
+					volumes: [{ name: "validator-token", projected: { defaultMode: 0o440, sources: [{ serviceAccountToken: { path: "validator.token", audience: profile.tokenAudience, expirationSeconds: 600 } }] } }, { name: "bootstrap-reference", downwardAPI: { defaultMode: 0o440, items: [{ path: "reference", fieldRef: { fieldPath: "metadata.annotations['opencrane.ai/mcpb-bootstrap-reference']" } }] } }, { name: "scratch", emptyDir: { sizeLimit: profile.scratchSize } }],
+				},
+			},
+		},
+	};
+}

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
@@ -99,9 +99,9 @@ function _AssertAssignment(assignment: McpbValidatorJobAssignment, profile: Mcpb
 /**
  * Build a deterministic opaque Kubernetes Job name without exposing the validation identifier.
  *
- * Called by: `__BuildMcpbValidatorJob` and the future MCPB controller. It hashes the silo and
- * validation identifiers, so Kubernetes resource names and selectors do not reveal the durable
- * validation record.
+ * Called by: `__BuildMcpbValidatorJob` and the focused builder test. Production has no caller yet.
+ * It hashes the silo and validation identifiers, so Kubernetes resource names and selectors do not
+ * reveal the durable validation record.
  *
  * @param assignment - Database-admitted coordinates for the one validator Job.
  * @returns A DNS-safe name that stays stable for the same validation in the same silo.
@@ -115,8 +115,8 @@ export function __McpbValidatorJobName(assignment: McpbValidatorJobAssignment): 
 /**
  * Build the suspended, one-shot, restricted Job a future controller may submit after durable assignment.
  *
- * Called by: the future MCPB-specific controller in `apps/agent-controller`. The returned Job has no
- * bundle bytes, artifact address, command, database connection, or long-lived credential. The
+ * Called by: the focused builder test. Production has no caller yet. The returned Job has no bundle
+ * bytes, artifact address, command, database connection, or long-lived credential. The future
  * controller must save Kubernetes' returned UID against the same durable assignment before it
  * removes `suspend`.
  *

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
@@ -96,14 +96,36 @@ function _AssertAssignment(assignment: McpbValidatorJobAssignment, profile: Mcpb
 	}
 }
 
-/** Build a deterministic opaque Kubernetes Job name without exposing the validation identifier. */
+/**
+ * Build a deterministic opaque Kubernetes Job name without exposing the validation identifier.
+ *
+ * Called by: `__BuildMcpbValidatorJob` and the future MCPB controller. It hashes the silo and
+ * validation identifiers, so Kubernetes resource names and selectors do not reveal the durable
+ * validation record.
+ *
+ * @param assignment - Database-admitted coordinates for the one validator Job.
+ * @returns A DNS-safe name that stays stable for the same validation in the same silo.
+ */
 export function __McpbValidatorJobName(assignment: McpbValidatorJobAssignment): string
 {
 	const digest = createHash("sha256").update(`${assignment.siloId}\u0000${assignment.validationId}`).digest("hex").slice(0, 24);
 	return `mcpb-validate-${digest}`;
 }
 
-/** Build the suspended, one-shot, restricted Job that a future controller may submit after durable assignment. */
+/**
+ * Build the suspended, one-shot, restricted Job a future controller may submit after durable assignment.
+ *
+ * Called by: the future MCPB-specific controller in `apps/agent-controller`. The returned Job has no
+ * bundle bytes, artifact address, command, database connection, or long-lived credential. The
+ * controller must save Kubernetes' returned UID against the same durable assignment before it
+ * removes `suspend`.
+ *
+ * @param assignment - Database-admitted opaque identifiers and the deployment-owned namespace.
+ * @param profile - Trusted deployment limits for this worker class.
+ * @returns A suspended Kubernetes Job with the exact validator identity, token audience, and limits.
+ * @throws Error when either input could widen the worker's identity, route, resources, namespace, or reference.
+ * @see __McpbValidatorJobName
+ */
 export function __BuildMcpbValidatorJob(assignment: McpbValidatorJobAssignment, profile: McpbValidatorJobProfile): V1Job
 {
 	// 1. Check fixed deployment policy before Kubernetes sees a manifest that could widen this worker's authority.

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
@@ -4,23 +4,23 @@ import type { V1Job } from "@kubernetes/client-node";
 
 import type { McpbValidatorJobAssignment, McpbValidatorJobProfile } from "./validator-job.types";
 
-/** Fixed identity assigned to the MCP bundle validator worker. */
+/** Set the fixed validator ServiceAccount name. */
 const _SERVICE_ACCOUNT_NAME = "mcpb-validator-default";
-/** Fixed projected-token audience that no other workload class may use. */
+/** Set the fixed projected-token audience. */
 const _TOKEN_AUDIENCE = "opencrane-mcpb-validator";
-/** Read-only file containing the worker's short-lived projected token. */
+/** Set the path where the Job mounts its projected token. */
 const _TOKEN_PATH = "/var/run/opencrane/tokens/validator.token";
-/** Read-only file containing the controller-created opaque bootstrap reference. */
+/** Mount the opaque bootstrap reference separately from the token. */
 const _REFERENCE_PATH = "/var/run/opencrane/bootstrap/reference";
-/** Smallest scratch volume that can hold a bounded MCP bundle and extracted manifest. */
+/** Minimum scratch volume accepted by this validator Job policy. */
 const _MIN_SCRATCH_BYTES = 134_217_728n;
-/** Largest scratch volume the validator plane may request. */
+/** Cap the scratch volume requested by one validator Job. */
 const _MAX_SCRATCH_BYTES = 536_870_912n;
-/** Largest validator Job lifetime. */
+/** End a stuck validator Job before it can hold a cluster slot indefinitely. */
 const _MAX_ACTIVE_DEADLINE_SECONDS = 600;
-/** Largest CPU limit that this untrusted one-shot worker may receive. */
+/** Cap CPU for this untrusted one-shot worker. */
 const _MAX_CPU_MILLICORES = 2_000;
-/** Largest memory limit that this untrusted one-shot worker may receive. */
+/** Cap memory for this untrusted one-shot worker. */
 const _MAX_MEMORY_BYTES = 2_147_483_648n;
 
 /** Return true only for a bounded Kubernetes-safe trace coordinate. */
@@ -97,13 +97,13 @@ function _AssertAssignment(assignment: McpbValidatorJobAssignment, profile: Mcpb
 }
 
 /**
- * Build a deterministic opaque Kubernetes Job name without exposing the validation identifier.
+ * Build a deterministic Kubernetes Job name without exposing the validation identifier.
  *
- * Called by: `__BuildMcpbValidatorJob` and the focused builder test. Production has no caller yet.
- * It hashes the silo and validation identifiers, so Kubernetes resource names and selectors do not
- * reveal the durable validation record.
+ * Called by: `__BuildMcpbValidatorJob`. Production has no direct caller yet. It hashes the silo and
+ * validation identifiers, so Kubernetes resource names and selectors do not reveal the durable
+ * validation record.
  *
- * @param assignment - Database-admitted coordinates for the one validator Job.
+ * @param assignment - Opaque coordinates used to derive the Job name.
  * @returns A DNS-safe name that stays stable for the same validation in the same silo.
  */
 export function __McpbValidatorJobName(assignment: McpbValidatorJobAssignment): string
@@ -113,14 +113,12 @@ export function __McpbValidatorJobName(assignment: McpbValidatorJobAssignment): 
 }
 
 /**
- * Build the suspended, one-shot, restricted Job a future controller may submit after durable assignment.
+ * Build the suspended, one-shot, restricted Job manifest.
  *
  * Called by: the focused builder test. Production has no caller yet. The returned Job has no bundle
- * bytes, artifact address, command, database connection, or long-lived credential. The future
- * controller must save Kubernetes' returned UID against the same durable assignment before it
- * removes `suspend`.
+ * bytes, artifact address, command, database connection, or long-lived credential.
  *
- * @param assignment - Database-admitted opaque identifiers and the deployment-owned namespace.
+ * @param assignment - Opaque identifiers and the deployment-owned namespace.
  * @param profile - Trusted deployment limits for this worker class.
  * @returns A suspended Kubernetes Job with the exact validator identity, token audience, and limits.
  * @throws Error when either input could widen the worker's identity, route, resources, namespace, or reference.
@@ -128,15 +126,12 @@ export function __McpbValidatorJobName(assignment: McpbValidatorJobAssignment): 
  */
 export function __BuildMcpbValidatorJob(assignment: McpbValidatorJobAssignment, profile: McpbValidatorJobProfile): V1Job
 {
-	// 1. Check fixed deployment policy before Kubernetes sees a manifest that could widen this worker's authority.
 	_AssertProfile(profile);
 	_AssertAssignment(assignment, profile);
 
-	// 2. Derive opaque metadata. The manifest carries no bundle bytes, artifact address, command, or credentials.
 	const name = __McpbValidatorJobName(assignment);
 	const annotations = { "opencrane.ai/silo-id": assignment.siloId, "opencrane.ai/mcpb-validation": assignment.validationId, "opencrane.ai/mcpb-bootstrap-reference": assignment.bootstrapReference };
 
-	// 3. Keep the Job suspended until the controller writes its Kubernetes UID to the durable validation assignment.
 	return {
 		apiVersion: "batch/v1",
 		kind: "Job",

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
@@ -1,9 +1,22 @@
 import type { V1ResourceRequirements } from "@kubernetes/client-node";
 
-/** Kubernetes image pull behaviour allowed for the immutable validator image. */
+/**
+ * Kubernetes image pull behaviour allowed for the immutable validator image.
+ *
+ * Called by: {@link McpbValidatorJobProfile}. The controller uses this setting only after the
+ * profile's digest-pinned image has passed the builder's checks; it never selects an image.
+ */
 export type McpbValidatorImagePullPolicy = "Always" | "IfNotPresent" | "Never";
 
-/** Deployment-owned settings that bound every one-shot MCP bundle validator Job. */
+/**
+ * Deployment-owned settings that bound every one-shot MCP bundle validator Job.
+ *
+ * Called by: `__BuildMcpbValidatorJob` in `validator-job.ts`. The controller receives this complete
+ * object from trusted deployment configuration, not from a bundle submitter or a worker. An invalid
+ * setting makes the builder throw before a Kubernetes Job exists.
+ *
+ * @see McpbValidatorJobAssignment
+ */
 export interface McpbValidatorJobProfile
 {
 	/** Immutable image that contains the validator program. */
@@ -34,7 +47,15 @@ export interface McpbValidatorJobProfile
 	readonly resources: V1ResourceRequirements;
 }
 
-/** Controller-owned coordinates for one database-admitted validator Job. */
+/**
+ * Controller-owned coordinates for one database-admitted validator Job.
+ *
+ * Called by: `__BuildMcpbValidatorJob` in `validator-job.ts`. A future MCPB controller creates this
+ * only after the database has admitted the validation; it must not contain a bundle URL, bytes,
+ * command, or secret. An invalid coordinate makes the builder throw before Kubernetes sees it.
+ *
+ * @see McpbValidatorJobProfile
+ */
 export interface McpbValidatorJobAssignment
 {
 	/** Opaque durable validation identifier; it is hashed before it becomes a Kubernetes name. */

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
@@ -1,0 +1,48 @@
+import type { V1ResourceRequirements } from "@kubernetes/client-node";
+
+/** Kubernetes image pull behaviour allowed for the immutable validator image. */
+export type McpbValidatorImagePullPolicy = "Always" | "IfNotPresent" | "Never";
+
+/** Deployment-owned settings that bound every one-shot MCP bundle validator Job. */
+export interface McpbValidatorJobProfile
+{
+	/** Immutable image that contains the validator program. */
+	readonly image: string;
+	/** Image pull behaviour for the immutable image. */
+	readonly imagePullPolicy: McpbValidatorImagePullPolicy;
+	/** Namespace where the OpenCrane server receives the worker's internal calls. */
+	readonly serverNamespace: string;
+	/** Dedicated namespace for MCP bundle validator Jobs. */
+	readonly namespace: string;
+	/** Exact ServiceAccount assigned to every validator Job. */
+	readonly serviceAccountName: string;
+	/** Audience of the sole projected token available to the worker. */
+	readonly tokenAudience: string;
+	/** Fixed internal endpoint where the worker exchanges its opaque reference. */
+	readonly bootstrapUrl: string;
+	/** Read-only path of the projected token. */
+	readonly tokenPath: string;
+	/** Read-only path of the opaque reference supplied by the controller. */
+	readonly bootstrapReferencePath: string;
+	/** Size of the temporary archive and inspection workspace. */
+	readonly scratchSize: string;
+	/** Maximum wall-clock runtime for one validator Job. */
+	readonly activeDeadlineSeconds: number;
+	/** Delay before Kubernetes removes a finished Job. */
+	readonly ttlSecondsAfterFinished: number;
+	/** CPU and memory requests and limits available to the worker. */
+	readonly resources: V1ResourceRequirements;
+}
+
+/** Controller-owned coordinates for one database-admitted validator Job. */
+export interface McpbValidatorJobAssignment
+{
+	/** Opaque durable validation identifier; it is hashed before it becomes a Kubernetes name. */
+	readonly validationId: string;
+	/** Silo that owns the validation, retained only as trace metadata. */
+	readonly siloId: string;
+	/** Namespace selected by the deployment profile. */
+	readonly namespace: string;
+	/** Opaque reference that the worker presents with its projected token. */
+	readonly bootstrapReference: string;
+}

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
@@ -1,21 +1,19 @@
 import type { V1ResourceRequirements } from "@kubernetes/client-node";
 
 /**
- * Kubernetes image pull behaviour allowed for the immutable validator image.
+ * Name a Kubernetes image-pull behaviour that the validator profile may supply.
  *
- * Called by: {@link McpbValidatorJobProfile} and the focused builder test. Production has no caller
- * yet. The builder uses this setting only after the profile's digest-pinned image has passed its
- * checks; it never selects an image.
+ * Used by: {@link McpbValidatorJobProfile}. Production has no caller yet. The builder accepts these
+ * values only with a digest-pinned image; it never selects an image.
  */
 export type McpbValidatorImagePullPolicy = "Always" | "IfNotPresent" | "Never";
 
 /**
- * Deployment-owned settings that bound every one-shot MCP bundle validator Job.
+ * Describe the limits that the builder requires for every one-shot MCP bundle validator Job.
  *
- * Called by: `__BuildMcpbValidatorJob` in `validator-job.ts` and the focused builder test.
- * Production has no caller yet. The eventual caller must take this complete object from trusted
- * deployment configuration, not from a bundle submitter or a worker. An invalid setting makes the
- * builder throw before a Kubernetes Job exists.
+ * Used by: `__BuildMcpbValidatorJob` in `validator-job.ts`. Production has no caller yet. The
+ * builder throws before it returns a Job when a setting changes the worker identity, route,
+ * resource bounds, scratch size, or lifetime.
  *
  * @see McpbValidatorJobAssignment
  */
@@ -50,12 +48,11 @@ export interface McpbValidatorJobProfile
 }
 
 /**
- * Controller-owned coordinates for one database-admitted validator Job.
+ * Carry the opaque coordinates that the builder places in one validator Job.
  *
- * Called by: `__BuildMcpbValidatorJob` in `validator-job.ts` and the focused builder test.
- * Production has no caller yet. The eventual caller must create this only after the database has
- * admitted the validation; it must not contain a bundle URL, bytes, command, or secret. An invalid
- * coordinate makes the builder throw before Kubernetes sees it.
+ * Used by: `__BuildMcpbValidatorJob` in `validator-job.ts`. Production has no caller yet. The
+ * builder hashes the silo and validation identifiers for the Job name and rejects a reference or
+ * namespace that does not match its profile before it returns a Job.
  *
  * @see McpbValidatorJobProfile
  */

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
@@ -3,17 +3,19 @@ import type { V1ResourceRequirements } from "@kubernetes/client-node";
 /**
  * Kubernetes image pull behaviour allowed for the immutable validator image.
  *
- * Called by: {@link McpbValidatorJobProfile}. The controller uses this setting only after the
- * profile's digest-pinned image has passed the builder's checks; it never selects an image.
+ * Called by: {@link McpbValidatorJobProfile} and the focused builder test. Production has no caller
+ * yet. The builder uses this setting only after the profile's digest-pinned image has passed its
+ * checks; it never selects an image.
  */
 export type McpbValidatorImagePullPolicy = "Always" | "IfNotPresent" | "Never";
 
 /**
  * Deployment-owned settings that bound every one-shot MCP bundle validator Job.
  *
- * Called by: `__BuildMcpbValidatorJob` in `validator-job.ts`. The controller receives this complete
- * object from trusted deployment configuration, not from a bundle submitter or a worker. An invalid
- * setting makes the builder throw before a Kubernetes Job exists.
+ * Called by: `__BuildMcpbValidatorJob` in `validator-job.ts` and the focused builder test.
+ * Production has no caller yet. The eventual caller must take this complete object from trusted
+ * deployment configuration, not from a bundle submitter or a worker. An invalid setting makes the
+ * builder throw before a Kubernetes Job exists.
  *
  * @see McpbValidatorJobAssignment
  */
@@ -50,9 +52,10 @@ export interface McpbValidatorJobProfile
 /**
  * Controller-owned coordinates for one database-admitted validator Job.
  *
- * Called by: `__BuildMcpbValidatorJob` in `validator-job.ts`. A future MCPB controller creates this
- * only after the database has admitted the validation; it must not contain a bundle URL, bytes,
- * command, or secret. An invalid coordinate makes the builder throw before Kubernetes sees it.
+ * Called by: `__BuildMcpbValidatorJob` in `validator-job.ts` and the focused builder test.
+ * Production has no caller yet. The eventual caller must create this only after the database has
+ * admitted the validation; it must not contain a bundle URL, bytes, command, or secret. An invalid
+ * coordinate makes the builder throw before Kubernetes sees it.
  *
  * @see McpbValidatorJobProfile
  */

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/tsconfig.json
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../../../tsconfig.json",
+  "compilerOptions": { "types": ["node", "vitest/globals"] },
+  "include": ["src/**/*.ts"]
+}

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/vitest.config.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../../vitest.cache";
+
+/** Configure focused tests for the MCP bundle validator Job builder. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../../tsconfig.vitest.json"] })], test: { globals: true, environment: "node" } });

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/vitest.config.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/vitest.config.ts
@@ -3,5 +3,5 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 import { _PackageCacheDir } from "../../../../../../vitest.cache";
 
-/** Configure focused tests for the MCP bundle validator Job builder. */
+/** Configure this package's test cache and workspace aliases. */
 export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../../tsconfig.vitest.json"] })], test: { globals: true, environment: "node" } });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -73,6 +73,9 @@
       "@opencrane/backend/server/gateways/mcp": [
         "./libs/backend/server/gateways/mcp/main/src/index.ts"
       ],
+      "@opencrane/backend/server/gateways/mcp/validator-k8s-launcher": [
+        "./libs/backend/server/gateways/mcp/validator-k8s-launcher/src/index.ts"
+      ],
       "@opencrane/backend/server/iam/identity": [
         "./libs/backend/server/iam/identity/main/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

- add a pure MCP bundle validator Job builder with fixed worker identity, short-lived token, bounded scratch/resources, and opaque references
- keep Jobs suspended until a later MCPB-specific controller records their durable assignment
- add focused rejection tests and plain-language package documentation

## Validation

- `npx nx run backend-server-gateways-mcp-validator-k8s-launcher:lint`
- `npx nx run backend-server-gateways-mcp-validator-k8s-launcher:test`
- `scripts/agent-style-check.sh`
- `npm run lint:boundaries`
- `npm run check:prisma-boundaries -- --diff b7e17d69d`
- `npm run check:module-growth -- --diff b7e17d69d`
- `npm run check:release-versioning -- --base b7e17d69d`

## Review order

#714 → #715 → #716 → #717 → #718

## Deferred

- no deployment qualification tonight
- no controller, worker protocol, artifact broker, or bundle execution yet; those must arrive together