### PR TITLE
🏗️ persist MCP bundle workflow handoffs

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -150,6 +150,9 @@ CREATE TYPE "McpEraProbeStatus" AS ENUM ('not-required', 'pending', 'accepted', 
 CREATE TYPE "McpbValidationState" AS ENUM ('pending', 'verified', 'rejected');
 
 -- CreateEnum
+CREATE TYPE "McpbValidationWorkloadState" AS ENUM ('pending', 'claimed', 'assigned');
+
+-- CreateEnum
 CREATE TYPE "McpServerStatus" AS ENUM ('active', 'degraded', 'draft');
 
 -- CreateEnum
@@ -1034,6 +1037,26 @@ CREATE TABLE "mcpb_validations" (
     "updated_at" TIMESTAMP(3) NOT NULL,
 
     CONSTRAINT "mcpb_validations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "mcpb_validation_workloads" (
+    "id" TEXT NOT NULL,
+    "silo_id" TEXT NOT NULL,
+    "validation_id" TEXT NOT NULL,
+    "task_id" TEXT NOT NULL,
+    "task_name" TEXT NOT NULL,
+    "task_key" TEXT NOT NULL,
+    "state" "McpbValidationWorkloadState" NOT NULL DEFAULT 'pending',
+    "claimed_at" TIMESTAMP(3),
+    "claim_expires_at" TIMESTAMP(3),
+    "delivery_count" INTEGER NOT NULL DEFAULT 0,
+    "workload_uid" TEXT,
+    "worker_pod_uid" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "mcpb_validation_workloads_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -2294,6 +2317,27 @@ CREATE UNIQUE INDEX "mcpb_validations_silo_id_submission_key_digest_key" ON "mcp
 CREATE INDEX "mcpb_validations_silo_id_state_created_at_idx" ON "mcpb_validations"("silo_id", "state", "created_at");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "mcpb_validation_workloads_validation_id_key" ON "mcpb_validation_workloads"("validation_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcpb_validation_workloads_task_id_key" ON "mcpb_validation_workloads"("task_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcpb_validation_workloads_workload_uid_key" ON "mcpb_validation_workloads"("workload_uid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcpb_validation_workloads_worker_pod_uid_key" ON "mcpb_validation_workloads"("worker_pod_uid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcpb_validation_workloads_silo_id_task_key_key" ON "mcpb_validation_workloads"("silo_id", "task_key");
+
+-- CreateIndex
+CREATE INDEX "mcpb_validation_workloads_silo_id_state_created_at_idx" ON "mcpb_validation_workloads"("silo_id", "state", "created_at");
+
+-- CreateIndex
+CREATE INDEX "mcpb_validation_workloads_state_claim_expires_at_idx" ON "mcpb_validation_workloads"("state", "claim_expires_at");
+
+-- CreateIndex
 CREATE INDEX "mcp_server_installs_principal_id_idx" ON "mcp_server_installs"("principal_id");
 
 -- CreateIndex
@@ -2961,11 +3005,20 @@ ALTER TABLE "mcpb_validations" ADD CONSTRAINT "mcpb_validations_result_check" CH
     OR ("state" = 'rejected' AND "manifest_name" IS NULL AND "bundle_version" IS NULL AND "manifest_digest" IS NULL AND "publisher" IS NULL AND "signer_fingerprint" IS NULL AND "failure_code" IN ('artifact_mismatch', 'bundle_too_large', 'invalid_archive', 'invalid_manifest', 'invalid_signature', 'unsupported_manifest_version') AND "completed_at" IS NOT NULL)
 );
 
+ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workloads_identity_check" CHECK (
+    btrim("silo_id") <> '' AND btrim("validation_id") <> '' AND btrim("task_id") <> '' AND
+    "task_name" = 'mcpb-validation.verify' AND "task_key" ~ '^workflows:mcpb-validation:[0-9a-f]{64}$' AND
+    "delivery_count" >= 0
+);
+
 -- AddForeignKey
 ALTER TABLE "mcp_server_installs" ADD CONSTRAINT "mcp_server_installs_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "mcp_server_installs" ADD CONSTRAINT "mcp_server_installs_principal_id_fkey" FOREIGN KEY ("principal_id") REFERENCES "principals"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workloads_validation_id_fkey" FOREIGN KEY ("validation_id") REFERENCES "mcpb_validations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "verified_fleet_membership_assertions" ADD CONSTRAINT "verified_fleet_membership_assertions_revision_id_silo_id_fkey" FOREIGN KEY ("revision_id", "silo_id") REFERENCES "verified_fleet_membership_revisions"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/README.md
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/README.md
@@ -30,6 +30,8 @@ issuer. It records 0.9.3 only after the whole cutover commits. If it fails, repa
 forward; deployment does not create a backup, inspect the source schema, pause writes, or restore a
 previous release. Those safeguards are deferred to issue #699.
 
-The same 0.9.3 transition also adds MCP bundle validation records. Each record pins one immutable
-artifact revision and stores only its manifest and trusted-signature decision. Absurd keeps the job
-attempts and checkpoints in its own tables; these MCP rows hold the result shown to administrators.
+The same 0.9.3 transition also adds MCP bundle validation records and their durable worker handoff.
+Each validation pins one immutable artifact revision and stores only its manifest and
+trusted-signature decision. Its linked workload records the admitted Absurd task before a controller
+can assign an isolated worker. The MCP rows hold the result shown to administrators; Absurd keeps the
+task attempts and checkpoints in its own tables.

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/README.md
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/README.md
@@ -32,6 +32,6 @@ previous release. Those safeguards are deferred to issue #699.
 
 The same 0.9.3 transition also adds MCP bundle validation records and their durable worker handoff.
 Each validation pins one immutable artifact revision and stores only its manifest and
-trusted-signature decision. Its linked workload records the admitted Absurd task before a controller
-can assign an isolated worker. The MCP rows hold the result shown to administrators; Absurd keeps the
-task attempts and checkpoints in its own tables.
+trusted-signature decision. Its linked workload records the admitted Absurd task. This transition
+does not mean that a controller has claimed or assigned a worker. The MCP rows hold the result shown
+to administrators; Absurd keeps the task attempts and checkpoints in its own tables.

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
@@ -1,9 +1,9 @@
 {
   "fromSchemaVersion": "0.9.0",
   "toSchemaVersion": "0.9.3",
-  "sqlSha256": "f83a6023912e8cff7337529cdbb7a9da685f8ef401a0b16f889d51d0a231b6e0",
+  "sqlSha256": "f3f9a32c4061df907f7ce7e37db4b465ebb3779ca71462449d5d904e96295c1e",
   "owner": "apps/opencrane",
   "privilegedExtension": "pg_cron",
   "sourceTargetBaselineSha256": "5e16b35aedce54bf6ff7bd79bca04f92f6b6aee6315dec5c4b4797604342ab5f",
-  "targetBaselineSha256": "cc19d4fc620e7d6906467913169cfc2b771481dadd73a484f6d201e2f3f5d05a"
+  "targetBaselineSha256": "bfaa37caecc76459f0679eb6bcba0da98c77891b785685d04e763e7e4be87106"
 }

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
@@ -3417,6 +3417,7 @@ DROP TYPE "McpConnectionStatus_legacy";
 
 CREATE TYPE "McpEraProbeStatus" AS ENUM ('not-required', 'pending', 'accepted', 'rejected');
 CREATE TYPE "McpbValidationState" AS ENUM ('pending', 'verified', 'rejected');
+CREATE TYPE "McpbValidationWorkloadState" AS ENUM ('pending', 'claimed', 'assigned');
 
 CREATE TEMPORARY TABLE "_iam_group_reference" (
     "reference" TEXT NOT NULL,
@@ -3823,6 +3824,37 @@ ALTER TABLE "mcpb_validations" ADD CONSTRAINT "mcpb_validations_result_check" CH
     OR ("state" = 'verified' AND btrim("manifest_name") <> '' AND btrim("bundle_version") <> '' AND "manifest_digest" ~ '^sha256:[0-9a-f]{64}$' AND btrim("publisher") <> '' AND "signer_fingerprint" ~ '^sha256:[0-9a-f]{64}$' AND "failure_code" IS NULL AND "completed_at" IS NOT NULL)
     OR ("state" = 'rejected' AND "manifest_name" IS NULL AND "bundle_version" IS NULL AND "manifest_digest" IS NULL AND "publisher" IS NULL AND "signer_fingerprint" IS NULL AND "failure_code" IN ('artifact_mismatch', 'bundle_too_large', 'invalid_archive', 'invalid_manifest', 'invalid_signature', 'unsupported_manifest_version') AND "completed_at" IS NOT NULL)
 );
+
+CREATE TABLE "mcpb_validation_workloads" (
+    "id" TEXT NOT NULL,
+    "silo_id" TEXT NOT NULL,
+    "validation_id" TEXT NOT NULL,
+    "task_id" TEXT NOT NULL,
+    "task_name" TEXT NOT NULL,
+    "task_key" TEXT NOT NULL,
+    "state" "McpbValidationWorkloadState" NOT NULL DEFAULT 'pending',
+    "claimed_at" TIMESTAMP(3),
+    "claim_expires_at" TIMESTAMP(3),
+    "delivery_count" INTEGER NOT NULL DEFAULT 0,
+    "workload_uid" TEXT,
+    "worker_pod_uid" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "mcpb_validation_workloads_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "mcpb_validation_workloads_validation_id_key" ON "mcpb_validation_workloads"("validation_id");
+CREATE UNIQUE INDEX "mcpb_validation_workloads_task_id_key" ON "mcpb_validation_workloads"("task_id");
+CREATE UNIQUE INDEX "mcpb_validation_workloads_workload_uid_key" ON "mcpb_validation_workloads"("workload_uid");
+CREATE UNIQUE INDEX "mcpb_validation_workloads_worker_pod_uid_key" ON "mcpb_validation_workloads"("worker_pod_uid");
+CREATE UNIQUE INDEX "mcpb_validation_workloads_silo_id_task_key_key" ON "mcpb_validation_workloads"("silo_id", "task_key");
+CREATE INDEX "mcpb_validation_workloads_silo_id_state_created_at_idx" ON "mcpb_validation_workloads"("silo_id", "state", "created_at");
+CREATE INDEX "mcpb_validation_workloads_state_claim_expires_at_idx" ON "mcpb_validation_workloads"("state", "claim_expires_at");
+ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workloads_identity_check" CHECK (
+    btrim("silo_id") <> '' AND btrim("validation_id") <> '' AND btrim("task_id") <> '' AND
+    "task_name" = 'mcpb-validation.verify' AND "task_key" ~ '^workflows:mcpb-validation:[0-9a-f]{64}$' AND
+    "delivery_count" >= 0
+);
+ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workloads_validation_id_fkey" FOREIGN KEY ("validation_id") REFERENCES "mcpb_validations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "mcp_servers" ADD CONSTRAINT "mcp_servers_registration_digest_check" CHECK (
     ("registration_key_digest" IS NULL AND "registration_digest" IS NULL)
     OR ("registration_key_digest" ~ '^sha256:[0-9a-f]{64}$' AND "registration_digest" ~ '^sha256:[0-9a-f]{64}$')

--- a/apps/opencrane/prisma/schema/mcp.prisma
+++ b/apps/opencrane/prisma/schema/mcp.prisma
@@ -19,6 +19,13 @@ enum McpbValidationState {
   Rejected @map("rejected")
 }
 
+// Records where one saved MCP bundle validation is in the isolated worker handoff.
+enum McpbValidationWorkloadState {
+  Pending  @map("pending")
+  Claimed  @map("claimed")
+  Assigned @map("assigned")
+}
+
 enum McpServerStatus {
   Active   @map("active")
   Degraded @map("degraded")
@@ -131,10 +138,35 @@ model McpbValidation {
   completedAt             DateTime?           @map("completed_at")
   createdAt               DateTime            @default(now()) @map("created_at")
   updatedAt               DateTime            @updatedAt @map("updated_at")
+  workload                McpbValidationWorkload?
 
   @@unique([siloId, submissionKeyDigest])
   @@index([siloId, state, createdAt])
   @@map("mcpb_validations")
+}
+
+// Keeps the database-owned handoff from an admitted workflow task to an isolated MCP bundle worker.
+model McpbValidationWorkload {
+  id             String                       @id @default(cuid())
+  siloId         String                       @map("silo_id")
+  validationId   String                       @unique @map("validation_id")
+  taskId         String                       @unique @map("task_id")
+  taskName       String                       @map("task_name")
+  taskKey        String                       @map("task_key")
+  state          McpbValidationWorkloadState  @default(Pending)
+  claimedAt      DateTime?                    @map("claimed_at")
+  claimExpiresAt DateTime?                    @map("claim_expires_at")
+  deliveryCount  Int                          @default(0) @map("delivery_count")
+  workloadUid    String?                      @unique @map("workload_uid")
+  workerPodUid   String?                      @unique @map("worker_pod_uid")
+  createdAt      DateTime                     @default(now()) @map("created_at")
+  updatedAt      DateTime                     @updatedAt @map("updated_at")
+  validation     McpbValidation               @relation(fields: [validationId], references: [id], onDelete: Restrict)
+
+  @@unique([siloId, taskKey])
+  @@index([siloId, state, createdAt])
+  @@index([state, claimExpiresAt])
+  @@map("mcpb_validation_workloads")
 }
 
 // Per-principal installation of an MCP server (operator API).

--- a/apps/opencrane/prisma/schema/mcp.prisma
+++ b/apps/opencrane/prisma/schema/mcp.prisma
@@ -145,7 +145,8 @@ model McpbValidation {
   @@map("mcpb_validations")
 }
 
-// Keeps the database-owned handoff from an admitted workflow task to an isolated MCP bundle worker.
+// Stores the workflow task admitted for one MCP bundle validation before a controller assigns a
+// worker. Its unique task and validation fields let submission retries reuse the same handoff.
 model McpbValidationWorkload {
   id             String                       @id @default(cuid())
   siloId         String                       @map("silo_id")

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcpb-validation-submission.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcpb-validation-submission.test.ts
@@ -32,14 +32,15 @@ function _Record(byteLength = 1_024): McpbValidationRecord
 }
 
 /** Build a transaction-bound MCP harness and preserve the calls that prove atomic admission. */
-function _Harness(record: McpbValidationRecord, created: boolean): { unitOfWork: McpOperatorUnitOfWork; transaction: McpOperatorTransaction; createOrFind: ReturnType<typeof vi.fn>; find: ReturnType<typeof vi.fn>; appendAudit: ReturnType<typeof vi.fn> }
+function _Harness(record: McpbValidationRecord, created: boolean): { unitOfWork: McpOperatorUnitOfWork; transaction: McpOperatorTransaction; createOrFind: ReturnType<typeof vi.fn>; ensureWorkload: ReturnType<typeof vi.fn>; find: ReturnType<typeof vi.fn>; appendAudit: ReturnType<typeof vi.fn> }
 {
 	const createOrFind = vi.fn().mockResolvedValue({ created, validation: record });
+	const ensureWorkload = vi.fn().mockResolvedValue("workload-1");
 	const find = vi.fn().mockResolvedValue(record);
 	const appendAudit = vi.fn().mockResolvedValue(undefined);
 	const transaction = {
 		mcp: { appendAudit },
-		mcpbValidations: { createOrFind, find },
+		mcpbValidations: { createOrFind, ensureWorkload, find },
 		workflowTransaction: { client: {} },
 	} as unknown as McpOperatorTransaction;
 	const unitOfWork: McpOperatorUnitOfWork = {
@@ -48,7 +49,7 @@ function _Harness(record: McpbValidationRecord, created: boolean): { unitOfWork:
 			return await operation(transaction);
 		},
 	};
-	return { unitOfWork, transaction, createOrFind, find, appendAudit };
+	return { unitOfWork, transaction, createOrFind, ensureWorkload, find, appendAudit };
 }
 
 /** Return the workflow stub that records whether it received the caller's database transaction. */
@@ -86,6 +87,7 @@ describe("MCP bundle validation submission", function _McpbValidationSubmissionS
 		expect(harness.createOrFind).toHaveBeenCalledWith(expect.objectContaining({ siloId: "silo-1", createdByPrincipalId: "principal-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" }));
 		expect(harness.appendAudit).toHaveBeenCalledWith("Created", "McpbValidation/validation-1", "MCP bundle validation validation-1 submitted", { siloId: "silo-1", actorPrincipalId: "principal-1" });
 		expect(workflow.admit).toHaveBeenCalledWith(harness.transaction.workflowTransaction, expect.objectContaining({ siloId: "silo-1", validationId: "validation-1", artifactId: "artifact-1", artifactRevisionId: "revision-1" }));
+		expect(harness.ensureWorkload).toHaveBeenCalledWith("silo-1", "validation-1", { taskId: "task-1", taskName: "mcpb-validation.verify", taskKey: "workflows:mcpb-validation:test" });
 	});
 
 	it("does not admit a task when a caller reuses its submission key for different input", async function _RejectsConflict()

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-repository.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-repository.types.ts
@@ -1,13 +1,19 @@
 import type { McpbBundleArtifactTarget, McpbValidationStates, McpbVerificationFailureCodes, McpbVerificationResult } from "./mcpb-validation.types";
 
-/** Task facts saved with an MCP bundle worker handoff. */
+/**
+ * Identifies the workflow task admitted for an MCP bundle validation.
+ *
+ * The repository saves these facts with the validation in the admission transaction. A retry may
+ * reuse that workload record only when every task fact still matches.
+ * @see McpbValidationRepository.ensureWorkload
+ */
 export interface McpbValidationWorkloadTask
 {
-	/** Engine-owned task identifier. */
+	/** Lets a retry reject a workload record for a different admitted task. */
 	readonly taskId: string;
-	/** Registered workflow task name. */
+	/** Lets a retry reject a task that names a different registered handler. */
 	readonly taskName: string;
-	/** Stable task key used for replay-safe admission. */
+	/** Lets a retry reject a task with a different workflow idempotency key. */
 	readonly taskKey: string;
 }
 
@@ -86,12 +92,15 @@ export interface McpbValidationRepository
 	 */
 	createOrFind(submission: McpbValidationSubmissionRecord): Promise<McpbValidationCreateResult | null>;
 	/**
-	 * Saves the one worker handoff record for a validation task admitted in this database transaction.
+	 * Saves or reuses the workload record for a task admitted with this validation.
 	 *
+	 * Submission retries admit the workflow task again, so an existing record is reusable only when
+	 * its silo and every task fact still match. `null` tells the caller that a different task is
+	 * already bound to the validation and the transaction must fail.
 	 * @param siloId - Keeps the saved workload inside its owning silo.
 	 * @param validationId - Binds the workload to one immutable validation.
 	 * @param task - Identifies the admitted workflow task that owns the validation decision.
-	 * @returns The workload identifier, or `null` when a replay names different task facts.
+	 * @returns The workload identifier, or `null` when a different task is already bound.
 	 */
 	ensureWorkload(siloId: string, validationId: string, task: McpbValidationWorkloadTask): Promise<string | null>;
 	/**

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-repository.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-repository.types.ts
@@ -1,5 +1,16 @@
 import type { McpbBundleArtifactTarget, McpbValidationStates, McpbVerificationFailureCodes, McpbVerificationResult } from "./mcpb-validation.types";
 
+/** Task facts saved with an MCP bundle worker handoff. */
+export interface McpbValidationWorkloadTask
+{
+	/** Engine-owned task identifier. */
+	readonly taskId: string;
+	/** Registered workflow task name. */
+	readonly taskName: string;
+	/** Stable task key used for replay-safe admission. */
+	readonly taskKey: string;
+}
+
 /** Fields required to create or replay one MCP bundle submission. */
 export interface McpbValidationSubmissionRecord extends McpbBundleArtifactTarget
 {
@@ -74,6 +85,15 @@ export interface McpbValidationRepository
 	 * @returns A new or existing validation; `null` means the key belongs to different input.
 	 */
 	createOrFind(submission: McpbValidationSubmissionRecord): Promise<McpbValidationCreateResult | null>;
+	/**
+	 * Saves the one worker handoff record for a validation task admitted in this database transaction.
+	 *
+	 * @param siloId - Keeps the saved workload inside its owning silo.
+	 * @param validationId - Binds the workload to one immutable validation.
+	 * @param task - Identifies the admitted workflow task that owns the validation decision.
+	 * @returns The workload identifier, or `null` when a replay names different task facts.
+	 */
+	ensureWorkload(siloId: string, validationId: string, task: McpbValidationWorkloadTask): Promise<string | null>;
 	/**
 	 * Finds one validation for an authenticated administrator without exposing another silo.
 	 *

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-submission.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-submission.ts
@@ -35,7 +35,10 @@ export async function submitMcpbValidation(unitOfWork: McpOperatorUnitOfWork, wo
 		const validation = stored.validation;
 		if (stored.created)
 			await transaction.mcp.appendAudit("Created", `McpbValidation/${validation.id}`, `MCP bundle validation ${validation.id} submitted`, { siloId: caller.siloId, actorPrincipalId: caller.principalId });
-		await workflow.admit(transaction.workflowTransaction, { siloId: validation.siloId, validationId: validation.id, artifactId: validation.artifactId, artifactRevisionId: validation.artifactRevisionId, contentAddress: validation.contentAddress, byteLength: validation.byteLength, mediaType: validation.mediaType, submissionDigest: validation.submissionDigest });
+		const admission = await workflow.admit(transaction.workflowTransaction, { siloId: validation.siloId, validationId: validation.id, artifactId: validation.artifactId, artifactRevisionId: validation.artifactRevisionId, contentAddress: validation.contentAddress, byteLength: validation.byteLength, mediaType: validation.mediaType, submissionDigest: validation.submissionDigest });
+		const workloadId = await transaction.mcpbValidations.ensureWorkload(validation.siloId, validation.id, { taskId: admission.receipt.taskId, taskName: admission.receipt.taskName, taskKey: admission.taskKey });
+		if (workloadId === null)
+			throw new Error("MCP bundle validation worker handoff conflicts with the admitted task.");
 		return { outcome: McpbValidationSubmissionOutcomes.Submitted, validation };
 	});
 }

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-submission.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-submission.ts
@@ -15,7 +15,19 @@ function _Digest(value: unknown): string
 	return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
 }
 
-/** Submit one immutable bundle and save its background job in the same database transaction. */
+/**
+ * Submits an immutable MCP bundle validation and saves its admitted workflow task in the same database transaction.
+ *
+ * The workload record proves admission, not that a controller has claimed or assigned a worker.
+ * @param unitOfWork - Runs the validation, audit, workflow admission, and workload save atomically.
+ * @param workflow - Admits the task that will verify the submitted bundle.
+ * @param artifacts - Resolves the caller's published immutable artifact revision.
+ * @param caller - Supplies the authenticated silo and administrator to record.
+ * @param command - Supplies the idempotency key and artifact revision to validate.
+ * @returns `ArtifactNotFound` when the caller cannot read the revision, `Conflict` when a reused key names different input, or `Submitted` with the saved validation.
+ * @throws Error when the command is invalid or the admitted task conflicts with an existing workload record.
+ * @see McpbValidationRepository.ensureWorkload
+ */
 export async function submitMcpbValidation(unitOfWork: McpOperatorUnitOfWork, workflow: McpbValidationWorkflow, artifacts: McpbBundleArtifactResolver, caller: McpOperatorCaller, command: McpbValidationSubmissionCommand): Promise<McpbValidationSubmissionResult>
 {
 	const parsed = ___McpbValidationSubmissionSchema.safeParse(command);

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
@@ -5,7 +5,7 @@ import type { McpbValidationState } from "@prisma/client";
 
 import { McpbValidationStates } from "./mcpb-validation.types";
 import type { McpbVerificationFailureCodes, McpbVerificationResult } from "./mcpb-validation.types";
-import type { McpbValidationCreateResult, McpbValidationRecord, McpbValidationRepository, McpbValidationSubmissionRecord, McpbValidationWriteResult } from "./mcpb-validation-repository.types";
+import type { McpbValidationCreateResult, McpbValidationRecord, McpbValidationRepository, McpbValidationSubmissionRecord, McpbValidationWorkloadTask, McpbValidationWriteResult } from "./mcpb-validation-repository.types";
 
 /** Product fields returned after every MCP bundle validation read or write. */
 const _VALIDATION_SELECT = { id: true, siloId: true, artifactId: true, artifactRevisionId: true, contentAddress: true, byteLength: true, mediaType: true, submissionDigest: true, state: true, manifestName: true, bundleVersion: true, manifestDigest: true, publisher: true, signerFingerprint: true, failureCode: true } as const satisfies Prisma.McpbValidationSelect;
@@ -65,6 +65,23 @@ export class PrismaMcpbValidationRepository implements McpbValidationRepository
 		}
 		const created = await this._transaction.mcpbValidation.create({ data: submission, select: _VALIDATION_SELECT });
 		return { created: true, validation: _Record(created) };
+	}
+
+	/** Save the task-to-worker handoff once, and reject a replay that names different task facts. */
+	async ensureWorkload(siloId: string, validationId: string, task: McpbValidationWorkloadTask): Promise<string | null>
+	{
+		const existing = await this._transaction.mcpbValidationWorkload.findUnique({ where: { validationId }, select: { id: true, siloId: true, taskId: true, taskName: true, taskKey: true } });
+		if (existing)
+		{
+			if (existing.siloId !== siloId || existing.taskId !== task.taskId || existing.taskName !== task.taskName || existing.taskKey !== task.taskKey)
+				return null;
+			return existing.id;
+		}
+		const validation = await this._transaction.mcpbValidation.findFirst({ where: { id: validationId, siloId }, select: { id: true } });
+		if (validation === null)
+			return null;
+		const workload = await this._transaction.mcpbValidationWorkload.create({ data: { siloId, validationId, taskId: task.taskId, taskName: task.taskName, taskKey: task.taskKey }, select: { id: true } });
+		return workload.id;
 	}
 
 	/** Find one validation only inside the authenticated silo. */

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
@@ -67,7 +67,7 @@ export class PrismaMcpbValidationRepository implements McpbValidationRepository
 		return { created: true, validation: _Record(created) };
 	}
 
-	/** Save the task-to-worker handoff once, and reject a replay that names different task facts. */
+	/** Saves the admitted task once and rejects a retry that names different task facts. */
 	async ensureWorkload(siloId: string, validationId: string, task: McpbValidationWorkloadTask): Promise<string | null>
 	{
 		const existing = await this._transaction.mcpbValidationWorkload.findUnique({ where: { validationId }, select: { id: true, siloId: true, taskId: true, taskName: true, taskKey: true } });

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/__tests__/validator-job.test.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/__tests__/validator-job.test.ts
@@ -24,6 +24,8 @@ describe("MCP bundle validator Job", function _McpbValidatorJobSuite()
 		expect(job.spec?.template.spec?.containers[0]?.securityContext).toMatchObject({ allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: { drop: ["ALL"] } });
 		expect(JSON.stringify(job)).not.toContain("artifactRevisionId");
 		expect(JSON.stringify(job)).not.toContain("contentAddress");
+		expect(JSON.stringify(job)).not.toContain(_Assignment().siloId);
+		expect(JSON.stringify(job)).not.toContain(_Assignment().validationId);
 		expect(job.spec?.template.spec?.containers[0]?.env).not.toEqual(expect.arrayContaining([expect.objectContaining({ name: "OPENCRANE_MCPB_BOOTSTRAP_REFERENCE", value: expect.any(String) })]));
 		expect(job.spec?.template.spec?.volumes).toEqual(expect.arrayContaining([expect.objectContaining({ name: "validator-token", projected: expect.anything() }), expect.objectContaining({ name: "bootstrap-reference", downwardAPI: expect.anything() })]));
 	});

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
@@ -130,7 +130,7 @@ export function __BuildMcpbValidatorJob(assignment: McpbValidatorJobAssignment, 
 	_AssertAssignment(assignment, profile);
 
 	const name = __McpbValidatorJobName(assignment);
-	const annotations = { "opencrane.ai/silo-id": assignment.siloId, "opencrane.ai/mcpb-validation": assignment.validationId, "opencrane.ai/mcpb-bootstrap-reference": assignment.bootstrapReference };
+	const annotations = { "opencrane.ai/mcpb-bootstrap-reference": assignment.bootstrapReference };
 
 	return {
 		apiVersion: "batch/v1",

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
@@ -130,6 +130,7 @@ export function __BuildMcpbValidatorJob(assignment: McpbValidatorJobAssignment, 
 	_AssertAssignment(assignment, profile);
 
 	const name = __McpbValidatorJobName(assignment);
+	// Keep the opaque bootstrap reference in annotations because the downward API volume reads it there; omit durable silo and validation IDs from Job metadata.
 	const annotations = { "opencrane.ai/mcpb-bootstrap-reference": assignment.bootstrapReference };
 
 	return {

--- a/releases/0.9.3.json
+++ b/releases/0.9.3.json
@@ -10,7 +10,7 @@
   "database": {
     "schemaVersion": "0.9.3",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "cc19d4fc620e7d6906467913169cfc2b771481dadd73a484f6d201e2f3f5d05a",
+    "baselineSha256": "bfaa37caecc76459f0679eb6bcba0da98c77891b785685d04e763e7e4be87106",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {


### PR DESCRIPTION
## Summary

- persist one durable MCP bundle workload record with each admitted Absurd task
- bind the validation, task receipt, and replay-safe task key in the same database transaction
- add matching 0.9.3 baseline, upgrade SQL, digests, and migration explanation
- retain the current in-process verifier while the controller and isolated worker are built in the next slice

## Validation

- `npx nx run backend-server-mcp:lint`
- `npx nx run backend-server-mcp:test` (64 tests)
- `npm run check:database-migrations`
- `npm run test:authority-baseline -w @opencrane/server`
- `npm run check:prisma-boundaries -- --diff 69a24c64d026c7b9252ddf595cf0d1651bb020b9`
- `npm run check:module-growth -- --diff 69a24c64d026c7b9252ddf595cf0d1651bb020b9`
- `npm run check:release-versioning -- --base 69a24c64d026c7b9252ddf595cf0d1651bb020b9`
- `scripts/agent-style-check.sh`

## Review

- independent review: PASS
- residue review: no DELETE / REWRITE / ASK findings
- documentation gate: PASS

## Review order

#714 -> #715 -> #716 -> #717 -> #718 -> #719