### PR TITLE
🔒 hide MCP bundle identities from validator Jobs

### DIFF
--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/__tests__/validator-job.test.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/__tests__/validator-job.test.ts
@@ -24,6 +24,8 @@ describe("MCP bundle validator Job", function _McpbValidatorJobSuite()
 		expect(job.spec?.template.spec?.containers[0]?.securityContext).toMatchObject({ allowPrivilegeEscalation: false, readOnlyRootFilesystem: true, capabilities: { drop: ["ALL"] } });
 		expect(JSON.stringify(job)).not.toContain("artifactRevisionId");
 		expect(JSON.stringify(job)).not.toContain("contentAddress");
+		expect(JSON.stringify(job)).not.toContain(_Assignment().siloId);
+		expect(JSON.stringify(job)).not.toContain(_Assignment().validationId);
 		expect(job.spec?.template.spec?.containers[0]?.env).not.toEqual(expect.arrayContaining([expect.objectContaining({ name: "OPENCRANE_MCPB_BOOTSTRAP_REFERENCE", value: expect.any(String) })]));
 		expect(job.spec?.template.spec?.volumes).toEqual(expect.arrayContaining([expect.objectContaining({ name: "validator-token", projected: expect.anything() }), expect.objectContaining({ name: "bootstrap-reference", downwardAPI: expect.anything() })]));
 	});

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
@@ -130,7 +130,7 @@ export function __BuildMcpbValidatorJob(assignment: McpbValidatorJobAssignment, 
 	_AssertAssignment(assignment, profile);
 
 	const name = __McpbValidatorJobName(assignment);
-	const annotations = { "opencrane.ai/silo-id": assignment.siloId, "opencrane.ai/mcpb-validation": assignment.validationId, "opencrane.ai/mcpb-bootstrap-reference": assignment.bootstrapReference };
+	const annotations = { "opencrane.ai/mcpb-bootstrap-reference": assignment.bootstrapReference };
 
 	return {
 		apiVersion: "batch/v1",

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts
@@ -130,6 +130,7 @@ export function __BuildMcpbValidatorJob(assignment: McpbValidatorJobAssignment, 
 	_AssertAssignment(assignment, profile);
 
 	const name = __McpbValidatorJobName(assignment);
+	// Keep the opaque bootstrap reference in annotations because the downward API volume reads it there; omit durable silo and validation IDs from Job metadata.
 	const annotations = { "opencrane.ai/mcpb-bootstrap-reference": assignment.bootstrapReference };
 
 	return {


### PR DESCRIPTION
## Summary

- remove raw silo and validation identifiers from MCP bundle validator Job annotations
- retain only the opaque bootstrap reference needed by the downward-API mount
- prove serialized Job manifests do not contain either raw identifier

## Validation

- `npx nx run backend-server-gateways-mcp-validator-k8s-launcher:lint`
- `npx nx run backend-server-gateways-mcp-validator-k8s-launcher:test` (2 tests)
- `scripts/agent-style-check.sh`

## Review

- independent review: PASS
- documentation gate: PASS

## Review order

#714 -> #715 -> #716 -> #717 -> #718 -> #719 -> #720