### PR TITLE
🏗️ claim MCP bundle validator workloads

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -3011,6 +3011,18 @@ ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workload
     "delivery_count" >= 0
 );
 
+CREATE FUNCTION "enforce_mcpb_validation_workload_assignment"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF OLD."state" = 'claimed' AND NEW."state" = 'assigned' AND (OLD."claim_expires_at" IS NULL OR OLD."claim_expires_at" <= clock_timestamp()) THEN
+        RAISE EXCEPTION 'MCP bundle validation workload assignment requires a live controller lease';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "mcpb_validation_workloads_live_claim_assignment"
+    BEFORE UPDATE OF "state" ON "mcpb_validation_workloads"
+    FOR EACH ROW EXECUTE FUNCTION "enforce_mcpb_validation_workload_assignment"();
+
 -- AddForeignKey
 ALTER TABLE "mcp_server_installs" ADD CONSTRAINT "mcp_server_installs_mcp_server_id_fkey" FOREIGN KEY ("mcp_server_id") REFERENCES "mcp_servers"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 

--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -3012,7 +3012,18 @@ ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workload
 );
 
 CREATE FUNCTION "enforce_mcpb_validation_workload_assignment"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    requested_lease INTERVAL;
+    transition_time TIMESTAMP(3) := date_trunc('milliseconds', clock_timestamp())::TIMESTAMP(3);
 BEGIN
+    IF NEW."state" = 'claimed' AND (OLD."state" = 'pending' OR (OLD."state" = 'claimed' AND OLD."claim_expires_at" <= transition_time)) THEN
+        requested_lease := NEW."claim_expires_at" - NEW."claimed_at";
+        IF NEW."delivery_count" <> OLD."delivery_count" + 1 OR NEW."workload_uid" IS NOT NULL OR requested_lease <= '0 milliseconds'::INTERVAL OR requested_lease > '5 minutes'::INTERVAL THEN
+            RAISE EXCEPTION 'MCP bundle validation workload claim requires one bounded fresh lease';
+        END IF;
+        NEW."claimed_at" := transition_time;
+        NEW."claim_expires_at" := transition_time + requested_lease;
+    END IF;
     IF OLD."state" = 'claimed' AND NEW."state" = 'assigned' AND (OLD."claim_expires_at" IS NULL OR OLD."claim_expires_at" <= clock_timestamp()) THEN
         RAISE EXCEPTION 'MCP bundle validation workload assignment requires a live controller lease';
     END IF;
@@ -3020,7 +3031,7 @@ BEGIN
 END;
 $$;
 CREATE TRIGGER "mcpb_validation_workloads_live_claim_assignment"
-    BEFORE UPDATE OF "state" ON "mcpb_validation_workloads"
+    BEFORE UPDATE OF "state", "claimed_at", "claim_expires_at", "delivery_count" ON "mcpb_validation_workloads"
     FOR EACH ROW EXECUTE FUNCTION "enforce_mcpb_validation_workload_assignment"();
 
 -- AddForeignKey

--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -3016,6 +3016,9 @@ DECLARE
     requested_lease INTERVAL;
     transition_time TIMESTAMP(3) := date_trunc('milliseconds', clock_timestamp())::TIMESTAMP(3);
 BEGIN
+    IF OLD."state" = 'claimed' AND NEW."state" = 'claimed' AND OLD."claim_expires_at" > transition_time AND (NEW."claimed_at" IS DISTINCT FROM OLD."claimed_at" OR NEW."claim_expires_at" IS DISTINCT FROM OLD."claim_expires_at" OR NEW."delivery_count" IS DISTINCT FROM OLD."delivery_count") THEN
+        RAISE EXCEPTION 'MCP bundle validation workload cannot replace a live controller lease';
+    END IF;
     IF NEW."state" = 'claimed' AND (OLD."state" = 'pending' OR (OLD."state" = 'claimed' AND OLD."claim_expires_at" <= transition_time)) THEN
         requested_lease := NEW."claim_expires_at" - NEW."claimed_at";
         IF NEW."delivery_count" <> OLD."delivery_count" + 1 OR NEW."workload_uid" IS NOT NULL OR requested_lease <= '0 milliseconds'::INTERVAL OR requested_lease > '5 minutes'::INTERVAL THEN

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
@@ -1,9 +1,9 @@
 {
   "fromSchemaVersion": "0.9.0",
   "toSchemaVersion": "0.9.3",
-  "sqlSha256": "33c65145954158e7d69bfeacd3ab8e1c389fbf2f326d309d5e0114c7624d5e26",
+  "sqlSha256": "446c04404ef4bc96a789b73ae974ecdd0b34551cbe9f20a750c5970ca456f298",
   "owner": "apps/opencrane",
   "privilegedExtension": "pg_cron",
   "sourceTargetBaselineSha256": "5e16b35aedce54bf6ff7bd79bca04f92f6b6aee6315dec5c4b4797604342ab5f",
-  "targetBaselineSha256": "3ec6ab02e2a1239cf2835a000184d5180de1cb78dd0877b83a66a8693f39a8ef"
+  "targetBaselineSha256": "779ed5d6c5cdddedb690a1496908beaed14cba66d47b6b2ae331bb85d79bb046"
 }

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
@@ -1,9 +1,9 @@
 {
   "fromSchemaVersion": "0.9.0",
   "toSchemaVersion": "0.9.3",
-  "sqlSha256": "f3f9a32c4061df907f7ce7e37db4b465ebb3779ca71462449d5d904e96295c1e",
+  "sqlSha256": "a8249b3dd089803662a72d41331db2e1adffb772958fabd6d89cc91dca95525c",
   "owner": "apps/opencrane",
   "privilegedExtension": "pg_cron",
   "sourceTargetBaselineSha256": "5e16b35aedce54bf6ff7bd79bca04f92f6b6aee6315dec5c4b4797604342ab5f",
-  "targetBaselineSha256": "bfaa37caecc76459f0679eb6bcba0da98c77891b785685d04e763e7e4be87106"
+  "targetBaselineSha256": "6d55791da5abf657a7388cec2a3909e497969e80126141970688edd086819c93"
 }

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/manifest.json
@@ -1,9 +1,9 @@
 {
   "fromSchemaVersion": "0.9.0",
   "toSchemaVersion": "0.9.3",
-  "sqlSha256": "a8249b3dd089803662a72d41331db2e1adffb772958fabd6d89cc91dca95525c",
+  "sqlSha256": "33c65145954158e7d69bfeacd3ab8e1c389fbf2f326d309d5e0114c7624d5e26",
   "owner": "apps/opencrane",
   "privilegedExtension": "pg_cron",
   "sourceTargetBaselineSha256": "5e16b35aedce54bf6ff7bd79bca04f92f6b6aee6315dec5c4b4797604342ab5f",
-  "targetBaselineSha256": "6d55791da5abf657a7388cec2a3909e497969e80126141970688edd086819c93"
+  "targetBaselineSha256": "3ec6ab02e2a1239cf2835a000184d5180de1cb78dd0877b83a66a8693f39a8ef"
 }

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
@@ -3855,7 +3855,18 @@ ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workload
     "delivery_count" >= 0
 );
 CREATE FUNCTION "enforce_mcpb_validation_workload_assignment"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+    requested_lease INTERVAL;
+    transition_time TIMESTAMP(3) := date_trunc('milliseconds', clock_timestamp())::TIMESTAMP(3);
 BEGIN
+    IF NEW."state" = 'claimed' AND (OLD."state" = 'pending' OR (OLD."state" = 'claimed' AND OLD."claim_expires_at" <= transition_time)) THEN
+        requested_lease := NEW."claim_expires_at" - NEW."claimed_at";
+        IF NEW."delivery_count" <> OLD."delivery_count" + 1 OR NEW."workload_uid" IS NOT NULL OR requested_lease <= '0 milliseconds'::INTERVAL OR requested_lease > '5 minutes'::INTERVAL THEN
+            RAISE EXCEPTION 'MCP bundle validation workload claim requires one bounded fresh lease';
+        END IF;
+        NEW."claimed_at" := transition_time;
+        NEW."claim_expires_at" := transition_time + requested_lease;
+    END IF;
     IF OLD."state" = 'claimed' AND NEW."state" = 'assigned' AND (OLD."claim_expires_at" IS NULL OR OLD."claim_expires_at" <= clock_timestamp()) THEN
         RAISE EXCEPTION 'MCP bundle validation workload assignment requires a live controller lease';
     END IF;
@@ -3863,7 +3874,7 @@ BEGIN
 END;
 $$;
 CREATE TRIGGER "mcpb_validation_workloads_live_claim_assignment"
-    BEFORE UPDATE OF "state" ON "mcpb_validation_workloads"
+    BEFORE UPDATE OF "state", "claimed_at", "claim_expires_at", "delivery_count" ON "mcpb_validation_workloads"
     FOR EACH ROW EXECUTE FUNCTION "enforce_mcpb_validation_workload_assignment"();
 ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workloads_validation_id_fkey" FOREIGN KEY ("validation_id") REFERENCES "mcpb_validations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "mcp_servers" ADD CONSTRAINT "mcp_servers_registration_digest_check" CHECK (

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
@@ -3854,6 +3854,17 @@ ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workload
     "task_name" = 'mcpb-validation.verify' AND "task_key" ~ '^workflows:mcpb-validation:[0-9a-f]{64}$' AND
     "delivery_count" >= 0
 );
+CREATE FUNCTION "enforce_mcpb_validation_workload_assignment"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF OLD."state" = 'claimed' AND NEW."state" = 'assigned' AND (OLD."claim_expires_at" IS NULL OR OLD."claim_expires_at" <= clock_timestamp()) THEN
+        RAISE EXCEPTION 'MCP bundle validation workload assignment requires a live controller lease';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "mcpb_validation_workloads_live_claim_assignment"
+    BEFORE UPDATE OF "state" ON "mcpb_validation_workloads"
+    FOR EACH ROW EXECUTE FUNCTION "enforce_mcpb_validation_workload_assignment"();
 ALTER TABLE "mcpb_validation_workloads" ADD CONSTRAINT "mcpb_validation_workloads_validation_id_fkey" FOREIGN KEY ("validation_id") REFERENCES "mcpb_validations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 ALTER TABLE "mcp_servers" ADD CONSTRAINT "mcp_servers_registration_digest_check" CHECK (
     ("registration_key_digest" IS NULL AND "registration_digest" IS NULL)

--- a/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
+++ b/apps/opencrane/prisma/migrations/0.9.0-to-0.9.3/migration.sql
@@ -3859,6 +3859,9 @@ DECLARE
     requested_lease INTERVAL;
     transition_time TIMESTAMP(3) := date_trunc('milliseconds', clock_timestamp())::TIMESTAMP(3);
 BEGIN
+    IF OLD."state" = 'claimed' AND NEW."state" = 'claimed' AND OLD."claim_expires_at" > transition_time AND (NEW."claimed_at" IS DISTINCT FROM OLD."claimed_at" OR NEW."claim_expires_at" IS DISTINCT FROM OLD."claim_expires_at" OR NEW."delivery_count" IS DISTINCT FROM OLD."delivery_count") THEN
+        RAISE EXCEPTION 'MCP bundle validation workload cannot replace a live controller lease';
+    END IF;
     IF NEW."state" = 'claimed' AND (OLD."state" = 'pending' OR (OLD."state" = 'claimed' AND OLD."claim_expires_at" <= transition_time)) THEN
         requested_lease := NEW."claim_expires_at" - NEW."claimed_at";
         IF NEW."delivery_count" <> OLD."delivery_count" + 1 OR NEW."workload_uid" IS NOT NULL OR requested_lease <= '0 milliseconds'::INTERVAL OR requested_lease > '5 minutes'::INTERVAL THEN

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/prisma-mcpb-validation-workload-repository.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/prisma-mcpb-validation-workload-repository.test.ts
@@ -35,10 +35,11 @@ describe("Prisma MCP bundle validation workload repository", function _McpbValid
 		const transaction = _Transaction();
 		transaction.mcpbValidationWorkload.findFirst.mockResolvedValue(_PendingWorkload());
 		transaction.mcpbValidationWorkload.updateMany.mockResolvedValue({ count: 1 });
+		transaction.mcpbValidationWorkload.findUnique.mockResolvedValue({ ..._PendingWorkload(), state: "Claimed", claimedAt: new Date("2099-07-26T05:00:03.000Z"), claimExpiresAt: new Date("2099-07-26T05:00:33.000Z"), deliveryCount: 1 });
 
 		const claim = await new PrismaMcpbValidationRepository(transaction as never).claimNextWorkload(30_000);
 
-		expect(claim).toEqual({ workloadId: "workload-1", siloId: "silo-1", validationId: "validation-1", claimedAt: "2099-07-26T05:00:01.000Z", deliveryCount: 1, expiresAt: "2099-07-26T05:00:31.000Z" });
+		expect(claim).toEqual({ workloadId: "workload-1", siloId: "silo-1", validationId: "validation-1", claimedAt: "2099-07-26T05:00:03.000Z", deliveryCount: 1, expiresAt: "2099-07-26T05:00:33.000Z" });
 		expect(transaction.mcpbValidationWorkload.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ state: "Pending", deliveryCount: 0 }), data: expect.objectContaining({ state: "Claimed", deliveryCount: 1 }) }));
 		vi.useRealTimers();
 	});

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/prisma-mcpb-validation-workload-repository.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/prisma-mcpb-validation-workload-repository.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaMcpbValidationRepository } from "../mcpb-validation/prisma-mcpb-validation-repository";
+
+/** Return one Prisma transaction double with only the validator-workload delegates this suite needs. */
+function _Transaction()
+{
+	return {
+		mcpbValidationWorkload: {
+			findFirst: vi.fn(),
+			findUnique: vi.fn(),
+			updateMany: vi.fn(),
+		},
+	};
+}
+
+/** Return one pending validator workload that a controller may lease. */
+function _PendingWorkload()
+{
+	return { id: "workload-1", siloId: "silo-1", validationId: "validation-1", state: "Pending" as const, claimedAt: null, claimExpiresAt: null, deliveryCount: 0, workloadUid: null };
+}
+
+/** Return one claimed validator workload whose lease remains valid. */
+function _ClaimedWorkload()
+{
+	return { ..._PendingWorkload(), state: "Claimed" as const, claimedAt: new Date("2099-07-26T05:00:00.000Z"), claimExpiresAt: new Date("2099-07-26T05:00:30.000Z"), deliveryCount: 1 };
+}
+
+describe("Prisma MCP bundle validation workload repository", function _McpbValidationWorkloadRepositorySuite()
+{
+	it("claims one pending workload with a bounded controller lease", async function _ClaimsPendingWorkload()
+	{
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2099-07-26T05:00:01.000Z"));
+		const transaction = _Transaction();
+		transaction.mcpbValidationWorkload.findFirst.mockResolvedValue(_PendingWorkload());
+		transaction.mcpbValidationWorkload.updateMany.mockResolvedValue({ count: 1 });
+
+		const claim = await new PrismaMcpbValidationRepository(transaction as never).claimNextWorkload(30_000);
+
+		expect(claim).toEqual({ workloadId: "workload-1", siloId: "silo-1", validationId: "validation-1", claimedAt: "2099-07-26T05:00:01.000Z", deliveryCount: 1, expiresAt: "2099-07-26T05:00:31.000Z" });
+		expect(transaction.mcpbValidationWorkload.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ state: "Pending", deliveryCount: 0 }), data: expect.objectContaining({ state: "Claimed", deliveryCount: 1 }) }));
+		vi.useRealTimers();
+	});
+
+	it("records the Kubernetes Job UID only for the controller lease that still matches", async function _RecordsAssignedJob()
+	{
+		const transaction = _Transaction();
+		transaction.mcpbValidationWorkload.findUnique.mockResolvedValue(_ClaimedWorkload());
+		transaction.mcpbValidationWorkload.updateMany.mockResolvedValue({ count: 1 });
+
+		const outcome = await new PrismaMcpbValidationRepository(transaction as never).commitWorkloadAssignment("workload-1", { claimedAt: "2099-07-26T05:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" });
+
+		expect(outcome).toBe("assigned");
+		expect(transaction.mcpbValidationWorkload.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ state: "Claimed", deliveryCount: 1, workloadUid: null }), data: { state: "Assigned", workloadUid: "job-uid-1" } }));
+	});
+
+	it("does not assign a workload after its controller lease expires", async function _RejectsExpiredLease()
+	{
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2099-07-26T05:00:31.000Z"));
+		const transaction = _Transaction();
+		transaction.mcpbValidationWorkload.findUnique.mockResolvedValue(_ClaimedWorkload());
+
+		const outcome = await new PrismaMcpbValidationRepository(transaction as never).commitWorkloadAssignment("workload-1", { claimedAt: "2099-07-26T05:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" });
+
+		expect(outcome).toBe("conflict");
+		expect(transaction.mcpbValidationWorkload.updateMany).not.toHaveBeenCalled();
+		vi.useRealTimers();
+	});
+});

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/prisma-mcpb-validation-workload-repository.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/prisma-mcpb-validation-workload-repository.test.ts
@@ -68,4 +68,13 @@ describe("Prisma MCP bundle validation workload repository", function _McpbValid
 		expect(transaction.mcpbValidationWorkload.updateMany).not.toHaveBeenCalled();
 		vi.useRealTimers();
 	});
+
+	it("does not report an assignment when the database rejects an expired lease during the compare-and-swap", async function _SurfacesDatabaseLeaseRejection()
+	{
+		const transaction = _Transaction();
+		transaction.mcpbValidationWorkload.findUnique.mockResolvedValue(_ClaimedWorkload());
+		transaction.mcpbValidationWorkload.updateMany.mockRejectedValue(new Error("MCP bundle validation workload assignment requires a live controller lease"));
+
+		await expect(new PrismaMcpbValidationRepository(transaction as never).commitWorkloadAssignment("workload-1", { claimedAt: "2099-07-26T05:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" })).rejects.toThrow("live controller lease");
+	});
 });

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-repository.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-repository.types.ts
@@ -17,7 +17,14 @@ export interface McpbValidationWorkloadTask
 	readonly taskKey: string;
 }
 
-/** One temporary controller lease for a pending MCP bundle validator Job. */
+/**
+ * Carries the database-saved fence for one controller claim on a pending MCP bundle validator Job.
+ *
+ * The `enforce_mcpb_validation_workload_assignment` trigger replaces a successful claim's
+ * timestamps with database time and checks its next delivery count. A controller must return these
+ * values when it records the Job UID so an older controller cannot turn a newer lease into an
+ * assignment.
+ */
 export interface McpbValidationWorkloadClaim
 {
 	/** Durable workload identifier used in the later assignment command. */
@@ -26,20 +33,20 @@ export interface McpbValidationWorkloadClaim
 	readonly siloId: string;
 	/** Validation used to derive the deterministic validator Job name. */
 	readonly validationId: string;
-	/** Exact timestamp the repository stored for this controller lease. */
+	/** Timestamp the database stored after accepting this claim. */
 	readonly claimedAt: string;
-	/** Delivery generation that fences an older controller replica. */
+	/** Next delivery count the database accepted for this claim. */
 	readonly deliveryCount: number;
-	/** Timestamp after which another controller may take an unassigned workload. */
+	/** Timestamp after which the database may admit another controller claim. */
 	readonly expiresAt: string;
 }
 
-/** Kubernetes Job identity returned after a controller creates one suspended validator Job. */
+/** Carries a Kubernetes Job UID together with the database fence required to save it. */
 export interface McpbValidationWorkloadAssignment
 {
-	/** Exact controller-lease timestamp returned by {@link McpbValidationWorkloadClaim}. */
+	/** Database-saved claim timestamp returned by {@link McpbValidationWorkloadClaim}. */
 	readonly claimedAt: string;
-	/** Exact controller delivery generation returned by {@link McpbValidationWorkloadClaim}. */
+	/** Database-accepted delivery count returned by {@link McpbValidationWorkloadClaim}. */
 	readonly deliveryCount: number;
 	/** Immutable Kubernetes Job UID returned by the Kubernetes API. */
 	readonly workloadUid: string;
@@ -132,18 +139,33 @@ export interface McpbValidationRepository
 	 */
 	ensureWorkload(siloId: string, validationId: string, task: McpbValidationWorkloadTask): Promise<string | null>;
 	/**
-	 * Claims one pending workload for a short controller lease.
+	 * Tries to claim one pending or expired workload for a controller pass.
+	 *
+	 * The compare-and-swap discards a competing writer, then
+	 * `enforce_mcpb_validation_workload_assignment` stores the database-time lease and validates the
+	 * next delivery count. A `null` result means the caller must not create a Job because no claim
+	 * was saved.
+	 *
+	 * Called by: the focused repository test. Production has no caller yet.
 	 *
 	 * @param leaseMilliseconds - Maximum time that one controller may hold the assignment lease.
-	 * @returns The saved validation coordinates and claim fence, or `null` when no workload is ready.
+	 * @returns The database-saved validation coordinates and claim fence, or `null` when no claim was saved.
+	 * @throws Error when the lease is outside the configured range or the database rejects the update.
 	 */
 	claimNextWorkload(leaseMilliseconds: number): Promise<McpbValidationWorkloadClaim | null>;
 	/**
-	 * Records a Kubernetes Job UID only when the controller still holds the workload lease.
+	 * Tries to record a Kubernetes Job UID under the claim that created it.
+	 *
+	 * `enforce_mcpb_validation_workload_assignment` makes the final live-lease decision with
+	 * database time. `assigned` means the UID was saved, `idempotent` means the same assignment was
+	 * already saved, and `conflict` means the caller must not treat the Job as assigned.
+	 *
+	 * Called by: the focused repository test. Production has no caller yet.
 	 *
 	 * @param workloadId - Identifies the workload the controller claimed.
 	 * @param assignment - Lease fence and immutable Job UID returned by Kubernetes.
-	 * @returns Whether the assignment was saved, already saved, or lost its controller lease.
+	 * @returns `assigned`, `idempotent`, or `conflict` with the meanings described above.
+	 * @throws Error when the database rejects the compare-and-swap update.
 	 */
 	commitWorkloadAssignment(workloadId: string, assignment: McpbValidationWorkloadAssignment): Promise<"assigned" | "idempotent" | "conflict">;
 	/**

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-repository.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-repository.types.ts
@@ -17,6 +17,34 @@ export interface McpbValidationWorkloadTask
 	readonly taskKey: string;
 }
 
+/** One temporary controller lease for a pending MCP bundle validator Job. */
+export interface McpbValidationWorkloadClaim
+{
+	/** Durable workload identifier used in the later assignment command. */
+	readonly workloadId: string;
+	/** Silo that owns the validation selected for this controller pass. */
+	readonly siloId: string;
+	/** Validation used to derive the deterministic validator Job name. */
+	readonly validationId: string;
+	/** Exact timestamp the repository stored for this controller lease. */
+	readonly claimedAt: string;
+	/** Delivery generation that fences an older controller replica. */
+	readonly deliveryCount: number;
+	/** Timestamp after which another controller may take an unassigned workload. */
+	readonly expiresAt: string;
+}
+
+/** Kubernetes Job identity returned after a controller creates one suspended validator Job. */
+export interface McpbValidationWorkloadAssignment
+{
+	/** Exact controller-lease timestamp returned by {@link McpbValidationWorkloadClaim}. */
+	readonly claimedAt: string;
+	/** Exact controller delivery generation returned by {@link McpbValidationWorkloadClaim}. */
+	readonly deliveryCount: number;
+	/** Immutable Kubernetes Job UID returned by the Kubernetes API. */
+	readonly workloadUid: string;
+}
+
 /** Fields required to create or replay one MCP bundle submission. */
 export interface McpbValidationSubmissionRecord extends McpbBundleArtifactTarget
 {
@@ -103,6 +131,21 @@ export interface McpbValidationRepository
 	 * @returns The workload identifier, or `null` when a different task is already bound.
 	 */
 	ensureWorkload(siloId: string, validationId: string, task: McpbValidationWorkloadTask): Promise<string | null>;
+	/**
+	 * Claims one pending workload for a short controller lease.
+	 *
+	 * @param leaseMilliseconds - Maximum time that one controller may hold the assignment lease.
+	 * @returns The saved validation coordinates and claim fence, or `null` when no workload is ready.
+	 */
+	claimNextWorkload(leaseMilliseconds: number): Promise<McpbValidationWorkloadClaim | null>;
+	/**
+	 * Records a Kubernetes Job UID only when the controller still holds the workload lease.
+	 *
+	 * @param workloadId - Identifies the workload the controller claimed.
+	 * @param assignment - Lease fence and immutable Job UID returned by Kubernetes.
+	 * @returns Whether the assignment was saved, already saved, or lost its controller lease.
+	 */
+	commitWorkloadAssignment(workloadId: string, assignment: McpbValidationWorkloadAssignment): Promise<"assigned" | "idempotent" | "conflict">;
 	/**
 	 * Finds one validation for an authenticated administrator without exposing another silo.
 	 *

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
@@ -125,7 +125,10 @@ export class PrismaMcpbValidationRepository implements McpbValidationRepository
 		});
 		if (updated.count !== 1)
 			return null;
-		return _Claim({ ...candidate, state: McpbValidationWorkloadState.Claimed, claimedAt, claimExpiresAt, deliveryCount });
+		const claimed = await this._transaction.mcpbValidationWorkload.findUnique({ where: { id: candidate.id }, select: _WORKLOAD_CLAIM_SELECT });
+		if (claimed === null || claimed.state !== McpbValidationWorkloadState.Claimed || claimed.deliveryCount !== deliveryCount)
+			return null;
+		return _Claim(claimed);
 	}
 
 	/** Record the Kubernetes Job UID only while the controller's original claim is still valid. */

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
@@ -13,7 +13,7 @@ const _VALIDATION_SELECT = { id: true, siloId: true, artifactId: true, artifactR
 /** Prisma projection returned for the bounded MCP bundle validation selection. */
 type _ValidationProjection = Prisma.McpbValidationGetPayload<{ select: typeof _VALIDATION_SELECT }>;
 
-/** Fields needed to fence one controller claim without returning bundle or task input. */
+/** Read the database-saved fields needed to fence one controller claim without returning bundle or task input. */
 const _WORKLOAD_CLAIM_SELECT = { id: true, siloId: true, validationId: true, state: true, claimedAt: true, claimExpiresAt: true, deliveryCount: true, workloadUid: true } as const satisfies Prisma.McpbValidationWorkloadSelect;
 
 /** Prisma projection returned while the controller claims or assigns one validator workload. */
@@ -45,7 +45,7 @@ function _Record(value: _ValidationProjection): McpbValidationRecord
 	return { ...value, byteLength: Number(value.byteLength), state: _State(value.state), failureCode: value.failureCode as McpbVerificationFailureCodes | null };
 }
 
-/** Return a controller claim only when every persisted field forms one complete lease. */
+/** Return a controller fence only when the database saved every field of one lease. */
 function _Claim(value: _WorkloadClaimProjection): McpbValidationWorkloadClaim
 {
 	if (value.claimedAt === null || value.claimExpiresAt === null || !Number.isSafeInteger(value.deliveryCount) || value.deliveryCount < 1)
@@ -104,7 +104,7 @@ export class PrismaMcpbValidationRepository implements McpbValidationRepository
 		return workload.id;
 	}
 
-	/** Claim one pending or expired workload for the bounded controller lease. */
+	/** Try a compare-and-swap claim, then return the lease fields the database stored. */
 	async claimNextWorkload(leaseMilliseconds: number): Promise<McpbValidationWorkloadClaim | null>
 	{
 		if (!Number.isSafeInteger(leaseMilliseconds) || leaseMilliseconds < 1 || leaseMilliseconds > 300_000)
@@ -131,7 +131,7 @@ export class PrismaMcpbValidationRepository implements McpbValidationRepository
 		return _Claim(claimed);
 	}
 
-	/** Record the Kubernetes Job UID only while the controller's original claim is still valid. */
+	/** Try to save a Kubernetes Job UID while the database accepts the controller's original claim. */
 	async commitWorkloadAssignment(workloadId: string, assignment: McpbValidationWorkloadAssignment): Promise<"assigned" | "idempotent" | "conflict">
 	{
 		if (!_IsAssignmentValid(workloadId, assignment))

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/prisma-mcpb-validation-repository.ts
@@ -1,17 +1,23 @@
 import { createHash } from "node:crypto";
 
-import { Prisma } from "@prisma/client";
+import { McpbValidationWorkloadState, Prisma } from "@prisma/client";
 import type { McpbValidationState } from "@prisma/client";
 
 import { McpbValidationStates } from "./mcpb-validation.types";
 import type { McpbVerificationFailureCodes, McpbVerificationResult } from "./mcpb-validation.types";
-import type { McpbValidationCreateResult, McpbValidationRecord, McpbValidationRepository, McpbValidationSubmissionRecord, McpbValidationWorkloadTask, McpbValidationWriteResult } from "./mcpb-validation-repository.types";
+import type { McpbValidationCreateResult, McpbValidationRecord, McpbValidationRepository, McpbValidationSubmissionRecord, McpbValidationWorkloadAssignment, McpbValidationWorkloadClaim, McpbValidationWorkloadTask, McpbValidationWriteResult } from "./mcpb-validation-repository.types";
 
 /** Product fields returned after every MCP bundle validation read or write. */
 const _VALIDATION_SELECT = { id: true, siloId: true, artifactId: true, artifactRevisionId: true, contentAddress: true, byteLength: true, mediaType: true, submissionDigest: true, state: true, manifestName: true, bundleVersion: true, manifestDigest: true, publisher: true, signerFingerprint: true, failureCode: true } as const satisfies Prisma.McpbValidationSelect;
 
 /** Prisma projection returned for the bounded MCP bundle validation selection. */
 type _ValidationProjection = Prisma.McpbValidationGetPayload<{ select: typeof _VALIDATION_SELECT }>;
+
+/** Fields needed to fence one controller claim without returning bundle or task input. */
+const _WORKLOAD_CLAIM_SELECT = { id: true, siloId: true, validationId: true, state: true, claimedAt: true, claimExpiresAt: true, deliveryCount: true, workloadUid: true } as const satisfies Prisma.McpbValidationWorkloadSelect;
+
+/** Prisma projection returned while the controller claims or assigns one validator workload. */
+type _WorkloadClaimProjection = Prisma.McpbValidationWorkloadGetPayload<{ select: typeof _WORKLOAD_CLAIM_SELECT }>;
 
 /** Derive the claim identity used to serialize one submission key. */
 function _ClaimDigest(submissionKeyDigest: string): string
@@ -37,6 +43,20 @@ function _Record(value: _ValidationProjection): McpbValidationRecord
 	if (value.byteLength > BigInt(Number.MAX_SAFE_INTEGER) || value.byteLength < 0n)
 		throw new Error("MCP bundle validation has an invalid byte length.");
 	return { ...value, byteLength: Number(value.byteLength), state: _State(value.state), failureCode: value.failureCode as McpbVerificationFailureCodes | null };
+}
+
+/** Return a controller claim only when every persisted field forms one complete lease. */
+function _Claim(value: _WorkloadClaimProjection): McpbValidationWorkloadClaim
+{
+	if (value.claimedAt === null || value.claimExpiresAt === null || !Number.isSafeInteger(value.deliveryCount) || value.deliveryCount < 1)
+		throw new Error("MCP bundle validation workload has an invalid controller claim.");
+	return { workloadId: value.id, siloId: value.siloId, validationId: value.validationId, claimedAt: value.claimedAt.toISOString(), deliveryCount: value.deliveryCount, expiresAt: value.claimExpiresAt.toISOString() };
+}
+
+/** Reject an assignment before it can select or change any database row. */
+function _IsAssignmentValid(workloadId: string, assignment: McpbValidationWorkloadAssignment): boolean
+{
+	return workloadId.trim().length > 0 && assignment.workloadUid.trim().length > 0 && Number.isSafeInteger(assignment.deliveryCount) && assignment.deliveryCount >= 1 && Number.isFinite(Date.parse(assignment.claimedAt));
 }
 
 /** Transaction-scoped Prisma adapter for MCP bundle validation product state. */
@@ -82,6 +102,49 @@ export class PrismaMcpbValidationRepository implements McpbValidationRepository
 			return null;
 		const workload = await this._transaction.mcpbValidationWorkload.create({ data: { siloId, validationId, taskId: task.taskId, taskName: task.taskName, taskKey: task.taskKey }, select: { id: true } });
 		return workload.id;
+	}
+
+	/** Claim one pending or expired workload for the bounded controller lease. */
+	async claimNextWorkload(leaseMilliseconds: number): Promise<McpbValidationWorkloadClaim | null>
+	{
+		if (!Number.isSafeInteger(leaseMilliseconds) || leaseMilliseconds < 1 || leaseMilliseconds > 300_000)
+			throw new Error("MCP bundle validation workload claim lease must be bounded.");
+		const claimedAt = new Date();
+		const candidate = await this._transaction.mcpbValidationWorkload.findFirst({
+			where: { OR: [{ state: McpbValidationWorkloadState.Pending }, { state: McpbValidationWorkloadState.Claimed, claimExpiresAt: { lte: claimedAt } }] },
+			orderBy: { createdAt: "asc" },
+			select: _WORKLOAD_CLAIM_SELECT,
+		});
+		if (candidate === null)
+			return null;
+		const claimExpiresAt = new Date(claimedAt.getTime() + leaseMilliseconds);
+		const deliveryCount = candidate.deliveryCount + 1;
+		const updated = await this._transaction.mcpbValidationWorkload.updateMany({
+			where: { id: candidate.id, state: candidate.state, claimedAt: candidate.claimedAt, claimExpiresAt: candidate.claimExpiresAt, deliveryCount: candidate.deliveryCount, workloadUid: null },
+			data: { state: McpbValidationWorkloadState.Claimed, claimedAt, claimExpiresAt, deliveryCount },
+		});
+		if (updated.count !== 1)
+			return null;
+		return _Claim({ ...candidate, state: McpbValidationWorkloadState.Claimed, claimedAt, claimExpiresAt, deliveryCount });
+	}
+
+	/** Record the Kubernetes Job UID only while the controller's original claim is still valid. */
+	async commitWorkloadAssignment(workloadId: string, assignment: McpbValidationWorkloadAssignment): Promise<"assigned" | "idempotent" | "conflict">
+	{
+		if (!_IsAssignmentValid(workloadId, assignment))
+			return "conflict";
+		const workload = await this._transaction.mcpbValidationWorkload.findUnique({ where: { id: workloadId }, select: _WORKLOAD_CLAIM_SELECT });
+		if (workload === null)
+			return "conflict";
+		if (workload.state === McpbValidationWorkloadState.Assigned)
+			return workload.workloadUid === assignment.workloadUid && workload.claimedAt?.getTime() === Date.parse(assignment.claimedAt) && workload.deliveryCount === assignment.deliveryCount ? "idempotent" : "conflict";
+		if (workload.state !== McpbValidationWorkloadState.Claimed || workload.claimedAt?.getTime() !== Date.parse(assignment.claimedAt) || workload.claimExpiresAt === null || workload.deliveryCount !== assignment.deliveryCount || Date.now() >= workload.claimExpiresAt.getTime())
+			return "conflict";
+		const updated = await this._transaction.mcpbValidationWorkload.updateMany({
+			where: { id: workloadId, state: McpbValidationWorkloadState.Claimed, claimedAt: workload.claimedAt, claimExpiresAt: workload.claimExpiresAt, deliveryCount: workload.deliveryCount, workloadUid: null },
+			data: { state: McpbValidationWorkloadState.Assigned, workloadUid: assignment.workloadUid },
+		});
+		return updated.count === 1 ? "assigned" : "conflict";
 	}
 
 	/** Find one validation only inside the authenticated silo. */

--- a/releases/0.9.3.json
+++ b/releases/0.9.3.json
@@ -10,7 +10,7 @@
   "database": {
     "schemaVersion": "0.9.3",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "3ec6ab02e2a1239cf2835a000184d5180de1cb78dd0877b83a66a8693f39a8ef",
+    "baselineSha256": "779ed5d6c5cdddedb690a1496908beaed14cba66d47b6b2ae331bb85d79bb046",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {

--- a/releases/0.9.3.json
+++ b/releases/0.9.3.json
@@ -10,7 +10,7 @@
   "database": {
     "schemaVersion": "0.9.3",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "bfaa37caecc76459f0679eb6bcba0da98c77891b785685d04e763e7e4be87106",
+    "baselineSha256": "6d55791da5abf657a7388cec2a3909e497969e80126141970688edd086819c93",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {

--- a/releases/0.9.3.json
+++ b/releases/0.9.3.json
@@ -10,7 +10,7 @@
   "database": {
     "schemaVersion": "0.9.3",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "6d55791da5abf657a7388cec2a3909e497969e80126141970688edd086819c93",
+    "baselineSha256": "3ec6ab02e2a1239cf2835a000184d5180de1cb78dd0877b83a66a8693f39a8ef",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {


### PR DESCRIPTION
## Summary

- add durable controller claims and fenced Kubernetes Job UID assignments for MCP bundle validations
- make PostgreSQL own claim timestamps and prevent lease replacement or assignment after database expiry
- retain the current verifier path; the HTTP authority, Kubernetes controller, and worker protocol follow in later slices

## Validation

- `npx nx run backend-server-mcp:lint`
- `npx nx run backend-server-mcp:test` (68 tests)
- `npm run check:database-migrations`
- `npm run test:authority-baseline -w @opencrane/server`
- `npm run check:prisma-boundaries -- --diff 9c255adb9878890a29d81aac962af48e13dca5e9`
- `npm run check:module-growth -- --diff 9c255adb9878890a29d81aac962af48e13dca5e9`
- `npm run check:release-versioning -- --base 9c255adb9878890a29d81aac962af48e13dca5e9`
- `scripts/agent-style-check.sh`

## Review

- independent review resolved two lease-race findings; final residual is live PostgreSQL trigger execution, deferred to tomorrow
- documentation gate: PASS

## Review order

#714 -> #715 -> #716 -> #717 -> #718 -> #719 -> #720 -> #721