### PR TITLE
🏗️ Expose MCP bundle controller authority

### DIFF
--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -60,7 +60,7 @@ The route registry is deliberately a catalogue rather than a second application 
 | Public `:8080` | Personal workspace | guided onboarding, assets, persona, approvals, runs, configuration, conversations |
 | Public `:8080` | Gateways | MCP, model routing, providers, bring-your-own-key, model registry |
 | Public `:8080` | Knowledge and reporting | retrieval sources, budgets, token usage |
-| Internal `:8081` | Controller | run-attempt and skill-workload dispatch |
+| Internal `:8081` | Controller | run-attempt, skill-workload, and MCP bundle-inspection dispatch |
 | Internal `:8081` | Runtime | one-use bootstrap, command stream, candidate ingest, skill-authoring exchange |
 | Internal `:8081` | Workers and replay | artifact preprocessing and controller-selected conversation replay |
 
@@ -92,8 +92,10 @@ its resources to the lifecycle owner.
 - `src/app/internal-app.ts` builds the workload-facing API on its separate socket.
 - `src/app/routes.ts` contains named per-area route lists and app-owned transport composition. The
   sharing authority is mounted behind the shared per-IP limiter before identity or database work.
-- `src/app/runtime-composition.ts` binds controller, skill-workload, runtime, and optional-worker
-  authorities by caller plane without choosing transport paths.
+- `src/app/runtime-composition.ts` binds controller, skill-workload, MCP bundle-inspection, runtime,
+  and optional-worker authorities by caller plane without choosing transport paths. The
+  bundle-inspection controller can claim saved package-inspection work and attach the Kubernetes Job
+  that will handle it; it cannot run a bundle through this API.
 - `src/app/mcp-workflow-composition.ts` creates one Absurd worker for both remote MCP protocol
   checks and saved MCP bundle checks. A workflow is saved work that may continue later; here it
   checks a registered server or signed bundle without keeping the administrator's request open.

--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -60,7 +60,7 @@ The route registry is deliberately a catalogue rather than a second application 
 | Public `:8080` | Personal workspace | guided onboarding, assets, persona, approvals, runs, configuration, conversations |
 | Public `:8080` | Gateways | MCP, model routing, providers, bring-your-own-key, model registry |
 | Public `:8080` | Knowledge and reporting | retrieval sources, budgets, token usage |
-| Internal `:8081` | Controller | run-attempt, skill-workload, and MCP bundle-inspection dispatch |
+| Internal `:8081` | Controller | run attempts, skill workloads, and MCP bundle inspection claims and Job assignment |
 | Internal `:8081` | Runtime | one-use bootstrap, command stream, candidate ingest, skill-authoring exchange |
 | Internal `:8081` | Workers and replay | artifact preprocessing and controller-selected conversation replay |
 

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -189,6 +189,7 @@ export function _RegisterInternalRoutes(app: Express, prisma: PrismaClient, auth
 	const internalControllerRoutes: readonly RouteMount[] = [
 		{ method: "use", path: "/api/internal/agent-controller", handler: runtime.agentControllerRunDispatch },
 		{ method: "use", path: "/api/internal/agent-controller", handler: runtime.skillWorkloadDispatch },
+		{ method: "use", path: "/api/internal/agent-controller", handler: runtime.mcpbValidationController },
 	];
 	const internalRuntimeRoutes: readonly RouteMount[] = [
 		{ method: "use", path: "/api/internal/agent-runtime", handler: runtime.skillWorkloadBootstrap },

--- a/apps/opencrane/src/app/runtime-composition.ts
+++ b/apps/opencrane/src/app/runtime-composition.ts
@@ -2,6 +2,7 @@ import * as k8s from "@kubernetes/client-node";
 import type { PrismaClient } from "@prisma/client";
 
 import { _IssueAttemptLiteLlmKey } from "@opencrane/backend/server/gateways/model-routing";
+import { __CreateMcpbValidationControllerAuthority, __CreateMcpbValidationControllerRouter, PrismaMcpOperatorUnitOfWork } from "@opencrane/backend/server/gateways/mcp";
 import { _RegisterInternalAgentRuntimeStream } from "@opencrane/backend/server/infra/agent-runtime-stream";
 import { PrismaRunDispatchRepository, __CreateAgentControllerRunDispatchRouter, type AttemptModelKeyMintRequest, type MintedAttemptModelKey } from "@opencrane/backend/agents/execution/runs";
 import { PrismaSkillWorkloadUnitOfWork, _CreateSkillWorkloadExecutionAuthority, __CreateSkillAuthoringCompletionRouter, __CreateSkillAuthoringInputRouter, __CreateSkillWorkloadBootstrapRouter, __CreateSkillWorkloadDispatchRouter } from "@opencrane/backend/agents/skills/execution";
@@ -68,10 +69,15 @@ function _CreateControllerRuntimeComposition(prisma: PrismaClient, config: Inter
 			repository: runDispatchRepository,
 			logger: _log,
 		}),
-		skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({
+		 skillWorkloadDispatch: __CreateSkillWorkloadDispatchRouter({
 			tokenReviewer,
 			namespace: namespaces.serverNamespace,
 			authority: skillWorkloadAuthority,
+			logger: _log,
+		}),
+		mcpbValidationController: __CreateMcpbValidationControllerRouter({
+			tokenReviewer,
+			authority: __CreateMcpbValidationControllerAuthority(new PrismaMcpOperatorUnitOfWork(prisma), config.claimLeaseMilliseconds),
 			logger: _log,
 		}),
 	};

--- a/apps/opencrane/src/app/runtime-composition.types.ts
+++ b/apps/opencrane/src/app/runtime-composition.types.ts
@@ -19,6 +19,8 @@ export interface InternalRuntimeComposition
 	readonly agentControllerRunDispatch: Router;
 	/** Controller-only router for governed skill workload dispatch. */
 	readonly skillWorkloadDispatch: Router;
+	/** Controller-only router for MCP bundle validator workload dispatch. */
+	readonly mcpbValidationController: Router;
 	/** Runtime router for one-use workload bootstrap claims. */
 	readonly skillWorkloadBootstrap: Router;
 	/** Runtime router for reading fenced skill-authoring input. */
@@ -55,7 +57,7 @@ export interface InternalRuntimeComposition
 /** The subset of routers built by the controller-only composition step. */
 export type ControllerRuntimeComposition = Pick<
 	InternalRuntimeComposition,
-	"agentControllerRunDispatch" | "skillWorkloadDispatch"
+	"agentControllerRunDispatch" | "skillWorkloadDispatch" | "mcpbValidationController"
 >;
 
 /** The subset of routers built by the isolated skill-workload composition step. */

--- a/apps/opencrane/src/app/runtime-composition.types.ts
+++ b/apps/opencrane/src/app/runtime-composition.types.ts
@@ -19,7 +19,7 @@ export interface InternalRuntimeComposition
 	readonly agentControllerRunDispatch: Router;
 	/** Controller-only router for governed skill workload dispatch. */
 	readonly skillWorkloadDispatch: Router;
-	/** Controller-only router for MCP bundle validator workload dispatch. */
+	/** Controller-only router that claims MCP bundle validation work and records its Kubernetes Job. */
 	readonly mcpbValidationController: Router;
 	/** Runtime router for one-use workload bootstrap claims. */
 	readonly skillWorkloadBootstrap: Router;

--- a/libs/backend/server/gateways/mcp/main/README.md
+++ b/libs/backend/server/gateways/mcp/main/README.md
@@ -48,10 +48,10 @@ inspection job currently verifies the signature, safe archive layout, and packag
 the bundle in an isolated environment, scanning it, building an image, and publishing it are later
 workflow steps.
 
-The future package-inspection worker asks this package for work through a small internal controller
-API. It can claim one saved inspection job, then record the Kubernetes Job that will handle it. The
-server checks the controller's own Kubernetes identity and the database lease each time. A controller
-that has lost its lease cannot attach a Job to the work.
+A future controller asks this package for work through a small internal API. It can claim one saved
+inspection job, then record the Kubernetes Job that will handle it. The server checks the
+controller's own Kubernetes identity and the database lease each time. A controller that has lost
+its lease cannot attach a Job to the work.
 
 The draft server and its background job use one database transaction. Either both are saved, or
 neither is saved. A repeated registration request returns the same draft and the same job.

--- a/libs/backend/server/gateways/mcp/main/README.md
+++ b/libs/backend/server/gateways/mcp/main/README.md
@@ -48,6 +48,11 @@ inspection job currently verifies the signature, safe archive layout, and packag
 the bundle in an isolated environment, scanning it, building an image, and publishing it are later
 workflow steps.
 
+The future package-inspection worker asks this package for work through a small internal controller
+API. It can claim one saved inspection job, then record the Kubernetes Job that will handle it. The
+server checks the controller's own Kubernetes identity and the database lease each time. A controller
+that has lost its lease cannot attach a Job to the work.
+
 The draft server and its background job use one database transaction. Either both are saved, or
 neither is saved. A repeated registration request returns the same draft and the same job.
 
@@ -72,6 +77,10 @@ returns credentials and never labels an install connected before a real connecti
 - `__CreateMcpEraProbeWorkflow` — registers the saved background job that checks the server.
 - `submitMcpbValidation` and `getMcpbValidation` — save and read signed MCP bundle checks.
 - `__CreateMcpbValidationWorkflow` — registers the saved parent and package-inspection jobs.
+- `__CreateMcpbValidationControllerRouter` — protects the internal claim and Job-assignment API for
+  package-inspection work.
+- `__CreateMcpbValidationControllerAuthority` — changes a saved inspection-work lease inside a
+  database transaction.
 - Operator services: `listEntitledCatalog`, `listInstalled`, `installServer`, `approveServer`,
   `publishServer`, and the access editor.
 - `_McpOpenapiPaths` — the OpenAPI path descriptions for this API.
@@ -85,6 +94,15 @@ background jobs, and records audit entries in one database transaction.
 This package does not run agents or call tools. It governs which servers are available and whether a
 user may use them. The external HTTP adapter performs the actual protocol check for the workflow.
 
+The internal controller API is for the `agent-controller` workload only:
+
+- `POST /api/internal/agent-controller/mcpb-validations:claim` claims one available inspection job.
+- `PUT /api/internal/agent-controller/mcpb-validations/:workloadId/assignment` records the
+  Kubernetes Job only while the matching saved lease is still valid.
+
+These routes do not run the Kubernetes Job or execute a bundle. The controller and worker that use
+them are the next pieces of the flow.
+
 ## Dependency direction
 
 Tagged `scope:mcp`: it may depend on the authentication guard, the shared authorization package, the
@@ -96,7 +114,8 @@ an Absurd package directly.
 This package owns the public behavior around `McpServer`, `McpServerInstall`, and
 `McpbValidation` in
 `apps/opencrane/prisma/schema/mcp.prisma`. General `AuthorizationGrant` rows remain owned by the
-authorization package. `PrismaMcpOperatorUnitOfWork` is the public MCP database boundary.
+authorization package. `McpbValidationWorkload` saves the inspection-work lease and recorded
+Kubernetes Job assignment. `PrismaMcpOperatorUnitOfWork` is the public MCP database boundary.
 
 ## See also
 

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcpb-validation-controller.router.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcpb-validation-controller.router.test.ts
@@ -1,0 +1,61 @@
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import { __CreateMcpbValidationControllerRouter } from "../mcpb-validation/mcpb-validation-controller.router";
+import type { McpbValidationControllerRouterDependencies } from "../mcpb-validation/mcpb-validation-controller.types";
+
+/** Build an internal controller app with replaceable authority dependencies. */
+function _App(overrides: Partial<McpbValidationControllerRouterDependencies> = {})
+{
+	const dependencies: McpbValidationControllerRouterDependencies = {
+		tokenReviewer: { __Review: vi.fn().mockResolvedValue({}) },
+		authority: { claimNextAtomically: vi.fn().mockResolvedValue(null), commitAssignmentAtomically: vi.fn().mockResolvedValue("conflict") },
+		logger: { error: vi.fn() },
+		...overrides,
+	};
+	const app = express();
+	app.use(express.json());
+	app.use(__CreateMcpbValidationControllerRouter(dependencies));
+	return { app, dependencies };
+}
+
+describe("MCP bundle validation controller router", function _McpbValidationControllerRouterSuite()
+{
+	it("does not expose workload state without the reviewed controller token", async function _RejectsUnknownCaller()
+	{
+		const { app, dependencies } = _App({ tokenReviewer: { __Review: vi.fn().mockResolvedValue(null) } });
+
+		const response = await request(app).post("/mcpb-validations:claim").set("authorization", "Bearer rejected-token").send({});
+
+		expect(response.status).toBe(401);
+		expect(response.body).toEqual({ error: "controller_identity_denied" });
+		expect(dependencies.authority.claimNextAtomically).not.toHaveBeenCalled();
+	});
+
+	it("returns only the database-fenced claim to the reviewed controller", async function _ReturnsClaim()
+	{
+		const claim = { workloadId: "workload-1", siloId: "silo-1", validationId: "validation-1", claimedAt: "2026-08-25T00:00:00.000Z", deliveryCount: 1, expiresAt: "2026-08-25T00:00:30.000Z" };
+		const { app } = _App({ authority: { claimNextAtomically: vi.fn().mockResolvedValue(claim), commitAssignmentAtomically: vi.fn() } });
+
+		const response = await request(app).post("/mcpb-validations:claim").set("authorization", "Bearer projected-token").send({});
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual(claim);
+	});
+
+	it("records a bounded Job UID assignment and rejects added caller fields", async function _CommitsAssignment()
+	{
+		const assignment = { claimedAt: "2026-08-25T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-uid-1" };
+		const authority = { claimNextAtomically: vi.fn(), commitAssignmentAtomically: vi.fn().mockResolvedValue("assigned") };
+		const { app } = _App({ authority });
+
+		const response = await request(app).put("/mcpb-validations/workload-1/assignment").set("authorization", "Bearer projected-token").send(assignment);
+		const invalid = await request(app).put("/mcpb-validations/workload-1/assignment").set("authorization", "Bearer projected-token").send({ ...assignment, callerSelected: "untrusted" });
+
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ outcome: "assigned", workloadId: "workload-1", workloadUid: "job-uid-1" });
+		expect(authority.commitAssignmentAtomically).toHaveBeenCalledWith("workload-1", assignment);
+		expect(invalid.status).toBe(400);
+	});
+});

--- a/libs/backend/server/gateways/mcp/main/src/index.ts
+++ b/libs/backend/server/gateways/mcp/main/src/index.ts
@@ -11,6 +11,9 @@ export { McpRemoteServerRegistrationValidationError, registerRemoteServer } from
 export { MCP_ERA_PROTOCOL_VERSION, McpEraProbeDecisions, McpEraProbeStates, McpEraProbeTaskNames, McpRemoteServerRegistrationOutcomes } from "./era-probe/mcp-era-probe.types";
 export type { McpEraProbeAdmission, McpEraProbeClient, McpEraProbeObservation, McpEraProbeRequest, McpEraProbeTaskInput, McpEraProbeTaskResult, McpEraProbeWorkflow, McpEraProbeWorkflowOptions, McpRemoteServerRegistration, McpRemoteServerRegistrationCommand, McpRemoteServerRegistrationResult } from "./era-probe/mcp-era-probe.types";
 export { __CreateMcpbBundleVerifier } from "./mcpb-validation/mcpb-bundle-verifier";
+export { __CreateMcpbValidationControllerAuthority } from "./mcpb-validation/mcpb-validation-controller-authority";
+export { __CreateMcpbValidationControllerRouter } from "./mcpb-validation/mcpb-validation-controller.router";
+export type { McpbValidationControllerAuthority, McpbValidationControllerLogger, McpbValidationControllerRouterDependencies, McpbValidationControllerTokenReviewer } from "./mcpb-validation/mcpb-validation-controller.types";
 export { getMcpbValidation, submitMcpbValidation } from "./mcpb-validation/mcpb-validation-submission";
 export { McpbValidationSubmissionOutcomes } from "./mcpb-validation/mcpb-validation-submission.types";
 export type { McpbBundleArtifactResolver, McpbValidationSubmissionCommand, McpbValidationSubmissionResult } from "./mcpb-validation/mcpb-validation-submission.types";

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller-authority.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller-authority.ts
@@ -1,0 +1,24 @@
+import type { McpOperatorUnitOfWork } from "../core/mcp-operator-repository.types";
+import type { McpbValidationWorkloadAssignment, McpbValidationWorkloadClaim } from "./mcpb-validation-repository.types";
+import type { McpbValidationControllerAuthority } from "./mcpb-validation-controller.types";
+
+/** Creates the transaction-bound authority behind the MCP bundle validator controller routes. */
+export function __CreateMcpbValidationControllerAuthority(unitOfWork: McpOperatorUnitOfWork, claimLeaseMilliseconds: number): McpbValidationControllerAuthority
+{
+	return {
+		claimNextAtomically(): Promise<McpbValidationWorkloadClaim | null>
+		{
+			return unitOfWork.execute(async function _Claim(transaction): Promise<McpbValidationWorkloadClaim | null>
+			{
+				return await transaction.mcpbValidations.claimNextWorkload(claimLeaseMilliseconds);
+			});
+		},
+		commitAssignmentAtomically(workloadId: string, assignment: McpbValidationWorkloadAssignment): Promise<"assigned" | "idempotent" | "conflict">
+		{
+			return unitOfWork.execute(async function _CommitAssignment(transaction): Promise<"assigned" | "idempotent" | "conflict">
+			{
+				return await transaction.mcpbValidations.commitWorkloadAssignment(workloadId, assignment);
+			});
+		},
+	};
+}

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller-authority.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller-authority.ts
@@ -2,7 +2,16 @@ import type { McpOperatorUnitOfWork } from "../core/mcp-operator-repository.type
 import type { McpbValidationWorkloadAssignment, McpbValidationWorkloadClaim } from "./mcpb-validation-repository.types";
 import type { McpbValidationControllerAuthority } from "./mcpb-validation-controller.types";
 
-/** Creates the transaction-bound authority behind the MCP bundle validator controller routes. */
+/**
+ * Builds the controller authority that changes claims and Job assignments through one unit of work.
+ *
+ * Each method enters the transaction before it delegates to the repository, so the route never
+ * exposes a partly saved claim or assignment.
+ * Called by: `_CreateControllerRuntimeComposition` in the OpenCrane app.
+ * @param unitOfWork - Owns the MCP validation repository transaction.
+ * @param claimLeaseMilliseconds - Limits how long a controller can hold a returned claim.
+ * @returns The authority used by the internal controller router.
+ */
 export function __CreateMcpbValidationControllerAuthority(unitOfWork: McpOperatorUnitOfWork, claimLeaseMilliseconds: number): McpbValidationControllerAuthority
 {
 	return {

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.router.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.router.ts
@@ -1,0 +1,93 @@
+import { Router, type Request, type Response } from "express";
+
+import { z } from "zod";
+
+import type { McpbValidationControllerRouterDependencies } from "./mcpb-validation-controller.types";
+
+/** Controller assignment input accepted only after the projected token has been reviewed. */
+const _ASSIGNMENT = z.object({ claimedAt: z.string().datetime({ offset: true }), deliveryCount: z.number().int().min(1), workloadUid: z.string().trim().min(1).max(256) }).strict();
+/** Empty controller claim command; extra caller fields are rejected. */
+const _EMPTY_COMMAND = z.object({}).strict();
+
+/** Return a bearer token without exposing it to logs or response bodies. */
+function _Bearer(request: Request): string | null
+{
+	const value = request.header("authorization");
+	if (!value?.startsWith("Bearer "))
+		return null;
+	const token = value.slice("Bearer ".length).trim();
+	return token.length > 0 ? token : null;
+}
+
+/** Write the one fixed problem shape for an internal controller request. */
+function _Problem(response: Response, status: number, error: string): void
+{
+	response.status(status).json({ error });
+}
+
+/** Check the controller identity before parsing or exposing workload data. */
+async function _IsController(request: Request, dependencies: McpbValidationControllerRouterDependencies): Promise<boolean>
+{
+	const token = _Bearer(request);
+	return token !== null && await dependencies.tokenReviewer.__Review(token) !== null;
+}
+
+/** Build the internal controller API for MCP bundle validator workload claims and Job assignments. */
+export function __CreateMcpbValidationControllerRouter(dependencies: McpbValidationControllerRouterDependencies): Router
+{
+	const router = Router();
+	router.post("/mcpb-validations:claim", async function _Claim(request: Request, response: Response): Promise<void>
+	{
+		try
+		{
+			if (!await _IsController(request, dependencies) || !_EMPTY_COMMAND.safeParse(request.body).success)
+			{
+				_Problem(response, 401, "controller_identity_denied");
+				return;
+			}
+			const claim = await dependencies.authority.claimNextAtomically();
+			if (claim === null)
+			{
+				response.status(204).end();
+				return;
+			}
+			response.status(200).json(claim);
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "agent_controller.mcpb_validation_claim" }, "MCP bundle validation workload claim failed");
+			_Problem(response, 503, "mcpb_validation_authority_unavailable");
+		}
+	});
+	router.put("/mcpb-validations/:workloadId/assignment", async function _Assignment(request: Request, response: Response): Promise<void>
+	{
+		try
+		{
+			if (!await _IsController(request, dependencies))
+			{
+				_Problem(response, 401, "controller_identity_denied");
+				return;
+			}
+			const assignment = _ASSIGNMENT.safeParse(request.body);
+			const workloadId = request.params["workloadId"];
+			if (!assignment.success || typeof workloadId !== "string" || workloadId.trim().length === 0)
+			{
+				_Problem(response, 400, "invalid_assignment");
+				return;
+			}
+			const outcome = await dependencies.authority.commitAssignmentAtomically(workloadId, assignment.data);
+			if (outcome === "conflict")
+			{
+				_Problem(response, 409, "stale_or_conflicting_assignment");
+				return;
+			}
+			response.status(200).json({ outcome, workloadId, workloadUid: assignment.data.workloadUid });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "agent_controller.mcpb_validation_assignment" }, "MCP bundle validation workload assignment failed");
+			_Problem(response, 503, "mcpb_validation_authority_unavailable");
+		}
+	});
+	return router;
+}

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.router.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.router.ts
@@ -4,9 +4,9 @@ import { z } from "zod";
 
 import type { McpbValidationControllerRouterDependencies } from "./mcpb-validation-controller.types";
 
-/** Controller assignment input accepted only after the projected token has been reviewed. */
+/** Accepts the claim fence and bounded Job UID needed to record one controller assignment. */
 const _ASSIGNMENT = z.object({ claimedAt: z.string().datetime({ offset: true }), deliveryCount: z.number().int().min(1), workloadUid: z.string().trim().min(1).max(256) }).strict();
-/** Empty controller claim command; extra caller fields are rejected. */
+/** Accepts no claim fields, so a caller cannot choose which saved workload to receive. */
 const _EMPTY_COMMAND = z.object({}).strict();
 
 /** Return a bearer token without exposing it to logs or response bodies. */
@@ -32,7 +32,15 @@ async function _IsController(request: Request, dependencies: McpbValidationContr
 	return token !== null && await dependencies.tokenReviewer.__Review(token) !== null;
 }
 
-/** Build the internal controller API for MCP bundle validator workload claims and Job assignments. */
+/**
+ * Builds the controller-only API that claims MCP bundle validation work and records its Kubernetes Job.
+ *
+ * It reviews the projected token before it returns a claim or changes an assignment. A conflict
+ * returns 409, so a controller that lost its database lease cannot treat its Job as assigned.
+ * Called by: `_CreateControllerRuntimeComposition` in the OpenCrane app.
+ * @param dependencies - Supplies token review, database authority, and structured error logging.
+ * @returns A router mounted below `/api/internal/agent-controller`.
+ */
 export function __CreateMcpbValidationControllerRouter(dependencies: McpbValidationControllerRouterDependencies): Router
 {
 	const router = Router();

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.types.ts
@@ -2,30 +2,60 @@ import type { Router } from "express";
 
 import type { McpbValidationWorkloadAssignment, McpbValidationWorkloadClaim } from "./mcpb-validation-repository.types";
 
-/** Reviews the single projected-token identity that may dispatch MCP bundle validator Jobs. */
+/**
+ * Reviews the projected token used by the agent-controller route.
+ *
+ * The router uses the result only to allow or deny a request; it never accepts a caller-selected
+ * controller identity. `null` makes the router return its fixed 401 response.
+ * Called by: {@link __CreateMcpbValidationControllerRouter}.
+ */
 export interface McpbValidationControllerTokenReviewer
 {
-	/** Returns a fixed controller identity, or null when the projected token is not accepted. */
+	/**
+	 * Reviews the supplied projected token.
+	 * @param token - Bearer token read from the controller request.
+	 * @returns An accepted identity, or `null` when the router must deny the request.
+	 */
 	__Review(token: string): Promise<unknown | null>;
 }
 
-/** Opens the transaction that owns MCP bundle workload claims and assignments. */
+/**
+ * Changes MCP bundle validation workload claims and Kubernetes Job assignments in a database transaction.
+ *
+ * A claim supplies the fence that must accompany its Job UID. The result prevents a stale controller
+ * from treating a newer claim as assigned.
+ * Called by: {@link __CreateMcpbValidationControllerRouter}.
+ */
 export interface McpbValidationControllerAuthority
 {
-	/** Claims one pending workload, or returns null when the controller has nothing to do. */
+	/**
+	 * Claims the next available workload through the database authority.
+	 * @returns The saved claim fence, or `null` when no workload is available for this controller pass.
+	 */
 	claimNextAtomically(): Promise<McpbValidationWorkloadClaim | null>;
-	/** Saves a Kubernetes Job UID under the exact controller claim that produced it. */
+	/**
+	 * Records a Job UID under the claim fence returned to this controller.
+	 * @param workloadId - Identifies the workload claimed by this controller.
+	 * @param assignment - Carries the returned claim fence and Kubernetes Job UID.
+	 * @returns `assigned` when saved, `idempotent` when the same assignment already exists, or `conflict` when the controller must not use its Job.
+	 */
 	commitAssignmentAtomically(workloadId: string, assignment: McpbValidationWorkloadAssignment): Promise<"assigned" | "idempotent" | "conflict">;
 }
 
-/** Minimal logger surface used by the internal controller transport. */
+/** Lets the internal route report authority failures without owning a logging implementation. */
 export interface McpbValidationControllerLogger
 {
 	/** Records a controller authority outage without logging bearer tokens or request bodies. */
 	error(bindings: { readonly err: unknown; readonly operation: string }, message: string): void;
 }
 
-/** Dependencies for the controller-only MCP bundle validator route. */
+/**
+ * Supplies the three boundaries that the controller route needs.
+ *
+ * Keeping token review, database authority, and error reporting separate stops the HTTP layer from
+ * deciding which workload is valid or changing database state itself.
+ * Called by: OpenCrane's internal runtime composition.
+ */
 export interface McpbValidationControllerRouterDependencies
 {
 	/** Verifies that the caller is the fixed agent-controller workload identity. */
@@ -36,5 +66,5 @@ export interface McpbValidationControllerRouterDependencies
 	readonly logger: McpbValidationControllerLogger;
 }
 
-/** Builds the internal router that the agent controller uses for MCP bundle validator workloads. */
+/** Names the controller-router factory used by application composition. */
 export type CreateMcpbValidationControllerRouter = (dependencies: McpbValidationControllerRouterDependencies) => Router;

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.types.ts
@@ -1,0 +1,40 @@
+import type { Router } from "express";
+
+import type { McpbValidationWorkloadAssignment, McpbValidationWorkloadClaim } from "./mcpb-validation-repository.types";
+
+/** Reviews the single projected-token identity that may dispatch MCP bundle validator Jobs. */
+export interface McpbValidationControllerTokenReviewer
+{
+	/** Returns a fixed controller identity, or null when the projected token is not accepted. */
+	__Review(token: string): Promise<unknown | null>;
+}
+
+/** Opens the transaction that owns MCP bundle workload claims and assignments. */
+export interface McpbValidationControllerAuthority
+{
+	/** Claims one pending workload, or returns null when the controller has nothing to do. */
+	claimNextAtomically(): Promise<McpbValidationWorkloadClaim | null>;
+	/** Saves a Kubernetes Job UID under the exact controller claim that produced it. */
+	commitAssignmentAtomically(workloadId: string, assignment: McpbValidationWorkloadAssignment): Promise<"assigned" | "idempotent" | "conflict">;
+}
+
+/** Minimal logger surface used by the internal controller transport. */
+export interface McpbValidationControllerLogger
+{
+	/** Records a controller authority outage without logging bearer tokens or request bodies. */
+	error(bindings: { readonly err: unknown; readonly operation: string }, message: string): void;
+}
+
+/** Dependencies for the controller-only MCP bundle validator route. */
+export interface McpbValidationControllerRouterDependencies
+{
+	/** Verifies that the caller is the fixed agent-controller workload identity. */
+	readonly tokenReviewer: McpbValidationControllerTokenReviewer;
+	/** Claims validator work and records exact Job assignments. */
+	readonly authority: McpbValidationControllerAuthority;
+	/** Receives bounded operational errors from this transport boundary. */
+	readonly logger: McpbValidationControllerLogger;
+}
+
+/** Builds the internal router that the agent controller uses for MCP bundle validator workloads. */
+export type CreateMcpbValidationControllerRouter = (dependencies: McpbValidationControllerRouterDependencies) => Router;


### PR DESCRIPTION
## Summary

- expose controller-only MCP bundle validation claim and Job-assignment routes on the internal listener
- review the fixed agent-controller Kubernetes identity before every request
- enforce strict commands and return a conflict when the saved database lease no longer permits assignment
- document the controller boundary: it coordinates saved inspection work but does not yet run a bundle

## Validation

- `npx nx run backend-server-mcp:test` — 71 passing
- `npx nx run opencrane:lint`
- `scripts/agent-style-check.sh --diff 554a6c1a8d968a4b1e991a7ef22db8bdcb40dd00`
- `git diff --check`

## Review

- independent review found no critical, high, or medium issue
- the one low documentation finding is fixed
- final comments/documentation gate passed

## Review order

1. #714
2. #715
3. #716
4. #717
5. #718
6. #719
7. #720
8. #721
9. #722

Live Kubernetes and PostgreSQL qualification remain deferred until the deployment-validation pass.