### PR TITLE
🏗️ Share MCP bundle controller contract

### DIFF
--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.router.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.router.ts
@@ -1,11 +1,11 @@
 import { Router, type Request, type Response } from "express";
 
 import { z } from "zod";
+import { ___ParseAgentControllerMcpbValidationAssignmentCommand } from "@opencrane/contracts";
 
 import type { McpbValidationControllerRouterDependencies } from "./mcpb-validation-controller.types";
 
 /** Accepts the claim fence and bounded Job UID needed to record one controller assignment. */
-const _ASSIGNMENT = z.object({ claimedAt: z.string().datetime({ offset: true }), deliveryCount: z.number().int().min(1), workloadUid: z.string().trim().min(1).max(256) }).strict();
 /** Accepts no claim fields, so a caller cannot choose which saved workload to receive. */
 const _EMPTY_COMMAND = z.object({}).strict();
 
@@ -76,20 +76,20 @@ export function __CreateMcpbValidationControllerRouter(dependencies: McpbValidat
 				_Problem(response, 401, "controller_identity_denied");
 				return;
 			}
-			const assignment = _ASSIGNMENT.safeParse(request.body);
+			const assignment = ___ParseAgentControllerMcpbValidationAssignmentCommand(request.body);
 			const workloadId = request.params["workloadId"];
-			if (!assignment.success || typeof workloadId !== "string" || workloadId.trim().length === 0)
+			if (assignment === null || typeof workloadId !== "string" || workloadId.trim().length === 0)
 			{
 				_Problem(response, 400, "invalid_assignment");
 				return;
 			}
-			const outcome = await dependencies.authority.commitAssignmentAtomically(workloadId, assignment.data);
+			const outcome = await dependencies.authority.commitAssignmentAtomically(workloadId, assignment);
 			if (outcome === "conflict")
 			{
 				_Problem(response, 409, "stale_or_conflicting_assignment");
 				return;
 			}
-			response.status(200).json({ outcome, workloadId, workloadUid: assignment.data.workloadUid });
+			response.status(200).json({ outcome, workloadId, workloadUid: assignment.workloadUid });
 		}
 		catch (err)
 		{

--- a/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.router.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcpb-validation/mcpb-validation-controller.router.ts
@@ -5,7 +5,6 @@ import { ___ParseAgentControllerMcpbValidationAssignmentCommand } from "@opencra
 
 import type { McpbValidationControllerRouterDependencies } from "./mcpb-validation-controller.types";
 
-/** Accepts the claim fence and bounded Job UID needed to record one controller assignment. */
 /** Accepts no claim fields, so a caller cannot choose which saved workload to receive. */
 const _EMPTY_COMMAND = z.object({}).strict();
 

--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -107,7 +107,7 @@ runtime from silently interpreting a frozen snapshot with different assembly rul
 - `RuntimeCommandKinds` and `RuntimeCandidateKinds` — documented string-backed discriminants that
   keep workload command and candidate control flow exhaustive while preserving protocol bytes.
 - `AGENT_CONTROLLER_PROJECTED_TOKEN_AUDIENCE`, `AGENT_CONTROLLER_SERVICE_ACCOUNT_NAME`, and
-  `AgentControllerRunAttempt*`/`AgentControllerSkillWorkload*` — the private controller handshake for claiming one authorised run or governed skill workload,
+  `AgentControllerRunAttempt*`/`AgentControllerSkillWorkload*`/`AgentControllerMcpbValidation*` — the private controller handshake for claiming one authorised run, governed skill workload, or MCP bundle inspection job,
   reporting the Kubernetes-issued Job identity, and committing that identity under the same database
   lease. `AgentControllerRunWorkloadRelease*` then carries the separate durable command, including
   the assignment's absolute expiry, for releasing only that assigned Job and registering its first

--- a/libs/contracts/src/__tests__/agent-controller.validator.test.ts
+++ b/libs/contracts/src/__tests__/agent-controller.validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { ___ParseAgentControllerSkillWorkloadAssignmentCommand, ___ParseAgentControllerSkillWorkloadAssignmentResult, ___ParseAgentControllerSkillWorkloadClaim, ___ParseAgentControllerSkillWorkloadPodRegistrationCommand, ___ParseAgentControllerSkillWorkloadPodRegistrationResult, ___ParseAgentControllerSkillWorkloadReleaseClaim, ___ParseAgentControllerSkillWorkloadReleaseCommand, ___ParseAgentControllerSkillWorkloadReleaseResult } from "../agent-controller-skill-workload.validator";
+import { ___ParseAgentControllerMcpbValidationAssignmentCommand, ___ParseAgentControllerMcpbValidationAssignmentResult, ___ParseAgentControllerMcpbValidationClaim } from "../agent-controller-mcpb-validation.validator";
 import { ___ParseAgentControllerOutboxPrunedCount, ___ParseAgentControllerRunAttemptAssignmentCommand, ___ParseAgentControllerRunAttemptAssignmentResult, ___ParseAgentControllerRunAttemptClaim, ___ParseAgentControllerRunWorkloadRegistrationCommand, ___ParseAgentControllerRunWorkloadRegistrationResult, ___ParseAgentControllerRunWorkloadReleaseClaim } from "../agent-controller.validator";
 
 /** Return one valid runtime attempt claim with optional untrusted response extensions. */
@@ -37,6 +38,12 @@ function _SkillReleaseClaim()
 	return { workloadId: "workload-1", siloId: "silo-1", kind: "tool-runner", workloadUid: "job-1", releaseClaimedAt: "2026-07-20T00:02:00.000Z", releaseDeliveryCount: 2, expiresAt: "2026-07-20T00:03:00.000Z", ignored: true };
 }
 
+/** Return one valid MCP bundle inspection claim. */
+function _McpbValidationClaim()
+{
+	return { workloadId: "workload-1", siloId: "silo-1", validationId: "validation-1", claimedAt: "2026-07-20T00:00:00.000Z", deliveryCount: 1, expiresAt: "2026-07-20T00:01:00.000Z", ignored: true };
+}
+
 describe("agent-controller contract validators", function _DescribeValidators()
 {
 	it("strips untrusted response extensions while retaining exact typed claims", function _StripsResponseExtensions()
@@ -62,6 +69,17 @@ describe("agent-controller contract validators", function _DescribeValidators()
 		expect(___ParseAgentControllerRunAttemptAssignmentCommand({ ...assignment, policy: "self-asserted" })).toBeNull();
 		expect(___ParseAgentControllerRunWorkloadRegistrationCommand(registration)).toEqual(registration);
 		expect(___ParseAgentControllerRunWorkloadRegistrationCommand({ ...registration, attempt: 0 })).toBeNull();
+	});
+
+	it("validates MCP bundle inspection claims and Job assignments", function _ValidatesMcpbValidationCommands()
+	{
+		const claim = _McpbValidationClaim();
+		const assignment = { claimedAt: "2026-07-20T00:00:00.000Z", deliveryCount: 1, workloadUid: "job-1" };
+		expect(___ParseAgentControllerMcpbValidationClaim(claim)).toEqual({ workloadId: "workload-1", siloId: "silo-1", validationId: "validation-1", claimedAt: "2026-07-20T00:00:00.000Z", deliveryCount: 1, expiresAt: "2026-07-20T00:01:00.000Z" });
+		expect(___ParseAgentControllerMcpbValidationAssignmentCommand(assignment)).toEqual(assignment);
+		expect(___ParseAgentControllerMcpbValidationAssignmentCommand({ ...assignment, callerSelected: "workload-2" })).toBeNull();
+		expect(___ParseAgentControllerMcpbValidationAssignmentResult({ outcome: "assigned", workloadId: "workload-1", workloadUid: "job-1" }, "workload-1", assignment).outcome).toBe("assigned");
+		expect(function _MismatchedMcpbAssignment() { ___ParseAgentControllerMcpbValidationAssignmentResult({ outcome: "assigned", workloadId: "workload-2", workloadUid: "job-1" }, "workload-1", assignment); }).toThrow("mismatched MCP bundle validation assignment result");
 	});
 
 	it("validates every governed skill mutation command with strict schemas", function _ValidatesSkillCommands()

--- a/libs/contracts/src/agent-controller-mcpb-validation.types.ts
+++ b/libs/contracts/src/agent-controller-mcpb-validation.types.ts
@@ -1,0 +1,38 @@
+/** A saved MCP bundle inspection job claimed by the agent controller. */
+export interface AgentControllerMcpbValidationClaim
+{
+	/** Identifies the saved inspection job for the later assignment call. */
+	readonly workloadId: string;
+	/** Identifies the silo that owns the bundle validation. */
+	readonly siloId: string;
+	/** Identifies the validation used to derive the Kubernetes Job name. */
+	readonly validationId: string;
+	/** Records when the database granted this controller's claim. */
+	readonly claimedAt: string;
+	/** Increases when the database grants the work to another controller pass. */
+	readonly deliveryCount: number;
+	/** Records when this claim stops permitting a Job assignment. */
+	readonly expiresAt: string;
+}
+
+/** The Kubernetes Job evidence the controller sends back for one saved claim. */
+export interface AgentControllerMcpbValidationAssignmentCommand
+{
+	/** Repeats the database time from the claim. */
+	readonly claimedAt: string;
+	/** Repeats the database counter from the claim. */
+	readonly deliveryCount: number;
+	/** Identifies the immutable suspended Kubernetes Job that the controller created. */
+	readonly workloadUid: string;
+}
+
+/** The server response after it saves, or replays, a matching Job assignment. */
+export interface AgentControllerMcpbValidationAssignmentResult
+{
+	/** Says whether this request saved the assignment or returned the earlier matching assignment. */
+	readonly outcome: "assigned" | "idempotent";
+	/** Identifies the saved inspection job. */
+	readonly workloadId: string;
+	/** Identifies the Kubernetes Job saved for that inspection job. */
+	readonly workloadUid: string;
+}

--- a/libs/contracts/src/agent-controller-mcpb-validation.types.ts
+++ b/libs/contracts/src/agent-controller-mcpb-validation.types.ts
@@ -1,4 +1,9 @@
-/** A saved MCP bundle inspection job claimed by the agent controller. */
+/**
+ * Carries the database lease for one MCP bundle inspection job claimed by the agent controller.
+ *
+ * The controller must return the claim timestamp and delivery count when it records a Job UID. Once
+ * the lease expires, those fields can no longer authorise that assignment.
+ */
 export interface AgentControllerMcpbValidationClaim
 {
 	/** Identifies the saved inspection job for the later assignment call. */
@@ -15,7 +20,12 @@ export interface AgentControllerMcpbValidationClaim
 	readonly expiresAt: string;
 }
 
-/** The Kubernetes Job evidence the controller sends back for one saved claim. */
+/**
+ * Carries the claim fence and Kubernetes Job UID that the controller submits for one inspection job.
+ *
+ * The command deliberately excludes workload selection fields: the server selected the workload when
+ * it issued the claim, and the strict parser rejects additional caller fields.
+ */
 export interface AgentControllerMcpbValidationAssignmentCommand
 {
 	/** Repeats the database time from the claim. */
@@ -26,7 +36,12 @@ export interface AgentControllerMcpbValidationAssignmentCommand
 	readonly workloadUid: string;
 }
 
-/** The server response after it saves, or replays, a matching Job assignment. */
+/**
+ * Carries the saved result of a matching MCP bundle inspection Job assignment.
+ *
+ * `assigned` means this request saved the Job UID; `idempotent` means the same UID was already
+ * saved. The controller must verify the echoed workload and Job IDs before trusting either outcome.
+ */
 export interface AgentControllerMcpbValidationAssignmentResult
 {
 	/** Says whether this request saved the assignment or returned the earlier matching assignment. */

--- a/libs/contracts/src/agent-controller-mcpb-validation.validator.ts
+++ b/libs/contracts/src/agent-controller-mcpb-validation.validator.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 import type { AgentControllerMcpbValidationAssignmentCommand, AgentControllerMcpbValidationAssignmentResult, AgentControllerMcpbValidationClaim } from "./agent-controller-mcpb-validation.types";
 import { _AgentControllerBoundedIdentifierSchema, _AgentControllerMillisecondInstantSchema, _AgentControllerPositiveIntegerSchema, _ParseAgentControllerCommand, _ParseAgentControllerModel } from "./agent-controller-wire.validator";
 
-/** Keep MCP bundle controller messages in one place so the server and controller validate the same fields. */
+/**
+ * Keeps the MCP bundle controller's private messages in one shared contract.
+ *
+ * Claim and response parsers remove untrusted extra fields, while the assignment parser rejects
+ * them before they reach the server authority.
+ */
 
 /** Validate a claimed inspection job and ensure its database lease timestamps are in the right order. */
 const _McpbValidationClaimSchema: z.ZodType<AgentControllerMcpbValidationClaim> = z.object({
@@ -33,19 +38,41 @@ const _McpbValidationAssignmentResultSchema: z.ZodType<AgentControllerMcpbValida
 	workloadUid: _AgentControllerBoundedIdentifierSchema,
 }).strip();
 
-/** Parse one MCP bundle inspection claim from the internal server response. */
+/**
+ * Parses one inspection claim returned by the internal server.
+ * @param value - Untrusted response body returned to the controller.
+ * @returns The validated claim and its database lease fence.
+ * @throws Error when the response is not a valid claim or its lease timestamps are invalid.
+ */
 export function ___ParseAgentControllerMcpbValidationClaim(value: unknown): AgentControllerMcpbValidationClaim
 {
 	return _ParseAgentControllerModel(_McpbValidationClaimSchema, value, "MCP bundle validation claim");
 }
 
-/** Parse an exact Job-assignment command, or return null for an HTTP rejection. */
+/**
+ * Parses the controller's Job-assignment command at the server route boundary.
+ *
+ * The route treats `null` as a 400 response, so extra or malformed fields never reach the database authority.
+ * Called by: `__CreateMcpbValidationControllerRouter`.
+ * @param value - Untrusted request body sent by the controller.
+ * @returns The accepted command, or `null` when the route must reject it.
+ */
 export function ___ParseAgentControllerMcpbValidationAssignmentCommand(value: unknown): AgentControllerMcpbValidationAssignmentCommand | null
 {
 	return _ParseAgentControllerCommand(_McpbValidationAssignmentCommandSchema, value);
 }
 
-/** Parse an assignment response and reject it unless it confirms the same Job the controller submitted. */
+/**
+ * Parses an assignment response and binds it to the Job assignment the controller submitted.
+ *
+ * A mismatched workload or Job UID means the response cannot confirm this controller's lease, so the
+ * parser throws instead of returning an assignment that belongs to another request.
+ * @param value - Untrusted response body returned by the internal server.
+ * @param workloadId - Workload ID from the controller's request path.
+ * @param command - Claim fence and Job UID submitted by the controller.
+ * @returns The matching saved or replayed assignment result.
+ * @throws Error when the response is malformed or does not match the submitted assignment.
+ */
 export function ___ParseAgentControllerMcpbValidationAssignmentResult(value: unknown, workloadId: string, command: AgentControllerMcpbValidationAssignmentCommand): AgentControllerMcpbValidationAssignmentResult
 {
 	const result = _ParseAgentControllerModel(_McpbValidationAssignmentResultSchema, value, "MCP bundle validation assignment result");

--- a/libs/contracts/src/agent-controller-mcpb-validation.validator.ts
+++ b/libs/contracts/src/agent-controller-mcpb-validation.validator.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+import type { AgentControllerMcpbValidationAssignmentCommand, AgentControllerMcpbValidationAssignmentResult, AgentControllerMcpbValidationClaim } from "./agent-controller-mcpb-validation.types";
+import { _AgentControllerBoundedIdentifierSchema, _AgentControllerMillisecondInstantSchema, _AgentControllerPositiveIntegerSchema, _ParseAgentControllerCommand, _ParseAgentControllerModel } from "./agent-controller-wire.validator";
+
+/** Keep MCP bundle controller messages in one place so the server and controller validate the same fields. */
+
+/** Validate a claimed inspection job and ensure its database lease has not already ended. */
+const _McpbValidationClaimSchema: z.ZodType<AgentControllerMcpbValidationClaim> = z.object({
+	workloadId: _AgentControllerBoundedIdentifierSchema,
+	siloId: _AgentControllerBoundedIdentifierSchema,
+	validationId: _AgentControllerBoundedIdentifierSchema,
+	claimedAt: _AgentControllerMillisecondInstantSchema,
+	deliveryCount: _AgentControllerPositiveIntegerSchema,
+	expiresAt: _AgentControllerMillisecondInstantSchema,
+}).strip().superRefine(function _ValidateChronology(claim, context)
+{
+	if (Date.parse(claim.claimedAt) >= Date.parse(claim.expiresAt))
+		context.addIssue({ code: z.ZodIssueCode.custom, message: "must expire after it is claimed" });
+});
+
+/** Accept only the Job evidence that the database needs to bind an assignment to its claim. */
+const _McpbValidationAssignmentCommandSchema: z.ZodType<AgentControllerMcpbValidationAssignmentCommand> = z.object({
+	claimedAt: _AgentControllerMillisecondInstantSchema,
+	deliveryCount: _AgentControllerPositiveIntegerSchema,
+	workloadUid: _AgentControllerBoundedIdentifierSchema,
+}).strict();
+
+/** Validate a successful assignment response before binding it to the controller's command. */
+const _McpbValidationAssignmentResultSchema: z.ZodType<AgentControllerMcpbValidationAssignmentResult> = z.object({
+	outcome: z.enum(["assigned", "idempotent"]),
+	workloadId: _AgentControllerBoundedIdentifierSchema,
+	workloadUid: _AgentControllerBoundedIdentifierSchema,
+}).strip();
+
+/** Parse one MCP bundle inspection claim from the internal server response. */
+export function ___ParseAgentControllerMcpbValidationClaim(value: unknown): AgentControllerMcpbValidationClaim
+{
+	return _ParseAgentControllerModel(_McpbValidationClaimSchema, value, "MCP bundle validation claim");
+}
+
+/** Parse an exact Job-assignment command, or return null for an HTTP rejection. */
+export function ___ParseAgentControllerMcpbValidationAssignmentCommand(value: unknown): AgentControllerMcpbValidationAssignmentCommand | null
+{
+	return _ParseAgentControllerCommand(_McpbValidationAssignmentCommandSchema, value);
+}
+
+/** Parse an assignment response and reject it unless it confirms the same Job the controller submitted. */
+export function ___ParseAgentControllerMcpbValidationAssignmentResult(value: unknown, workloadId: string, command: AgentControllerMcpbValidationAssignmentCommand): AgentControllerMcpbValidationAssignmentResult
+{
+	const result = _ParseAgentControllerModel(_McpbValidationAssignmentResultSchema, value, "MCP bundle validation assignment result");
+	if (result.workloadId !== workloadId || result.workloadUid !== command.workloadUid)
+		throw new Error("OpenCrane returned a mismatched MCP bundle validation assignment result");
+	return result;
+}

--- a/libs/contracts/src/agent-controller-mcpb-validation.validator.ts
+++ b/libs/contracts/src/agent-controller-mcpb-validation.validator.ts
@@ -5,7 +5,7 @@ import { _AgentControllerBoundedIdentifierSchema, _AgentControllerMillisecondIns
 
 /** Keep MCP bundle controller messages in one place so the server and controller validate the same fields. */
 
-/** Validate a claimed inspection job and ensure its database lease has not already ended. */
+/** Validate a claimed inspection job and ensure its database lease timestamps are in the right order. */
 const _McpbValidationClaimSchema: z.ZodType<AgentControllerMcpbValidationClaim> = z.object({
 	workloadId: _AgentControllerBoundedIdentifierSchema,
 	siloId: _AgentControllerBoundedIdentifierSchema,

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -28,6 +28,8 @@ export * from "./skill-workload-bootstrap-reference";
 export * from "./run-input-snapshot.types";
 export type * from "./agent-controller-skill-workload.types";
 export * from "./agent-controller-skill-workload.validator";
+export type * from "./agent-controller-mcpb-validation.types";
+export * from "./agent-controller-mcpb-validation.validator";
 export * from "./agent-controller.types";
 // Keep sibling-only `_...` wire schemas and parsers out of the cross-package public surface.
 export { ___IsAgentControllerIdentifier, ___IsEmptyAgentControllerCommand } from "./agent-controller-wire.validator";


### PR DESCRIPTION
## Summary

- define the shared private messages for an MCP bundle inspection claim and Kubernetes Job assignment
- give both the server and future agent controller the same strict parser
- reject added assignment fields and mismatched assignment replies before they reach the database or controller

## Validation

- `npx nx run contracts:test` — 30 passing
- `npx nx run backend-server-mcp:test` — 71 passing
- `npx nx run contracts:lint`
- `npx nx run backend-server-mcp:lint`
- `scripts/agent-style-check.sh`
- `git diff --check`

## Review

- independent review found no critical, high, or medium issue
- the one low wording finding is fixed
- final comments/documentation gate passed

## Review order

1. #714
2. #715
3. #716
4. #717
5. #718
6. #719
7. #720
8. #721
9. #722
10. #723

The next PR uses this contract to create the suspended Kubernetes Job.