### PR TITLE
🏗️ Run MCP bundle validator controller

### DIFF
--- a/apps/_infra/deploy-k8s/README.md
+++ b/apps/_infra/deploy-k8s/README.md
@@ -128,7 +128,8 @@ package imports it.
   Job quota; it contains no standing worker. The deploy engine derives `<release>-tools` for the
   same per-silo ownership boundary.
 - `opencrane-mcpb-validator.mcpbValidator` — the empty, default-deny MCP bundle worker namespace.
-  The deploy engine derives `<release>-mcpb-validation`; it creates no worker Job yet.
+  The deploy engine derives `<release>-mcpb-validation`. The agent controller may create one exact,
+  suspended validator Job in this namespace; no component can start it yet.
 - `--release` — optional only as a restatement of the silo identity. The wrapper derives and
   enforces `opencrane-<cluster-tenant>` so all Helm-owned namespaces stay inside one release.
 - `crds.install` — resolved authoritatively by the deploy engine: the first silo installs the

--- a/apps/_infra/deploy-k8s/values.yaml
+++ b/apps/_infra/deploy-k8s/values.yaml
@@ -438,6 +438,16 @@ agentController:
       resources:
         requests: { cpu: 100m, memory: 128Mi }
         limits: { cpu: 500m, memory: 256Mi }
+  mcpbValidatorProfile:
+    image:
+      repository: ghcr.io/elewa-git/opencrane-mcpb-validator
+      digest: ""
+      pullPolicy: IfNotPresent
+    scratchSize: 128Mi
+    activeDeadlineSeconds: 300
+    resources:
+      requests: { cpu: 250m, memory: 256Mi }
+      limits: { cpu: "1", memory: 1Gi }
   resources:
     requests:
       cpu: 25m

--- a/apps/agent-controller/README.md
+++ b/apps/agent-controller/README.md
@@ -25,6 +25,11 @@ Service; it does not inherit the controller's configurable runtime endpoint. The
 acknowledge that reference, and the server TokenReviews the exact first worker Pod before consuming
 it once.
 
+The controller also creates one suspended MCP bundle validator Job for each durable validation request.
+An MCP bundle is a packaged MCP server. The Job gets only an opaque bootstrap reference and a short-lived
+token; it has no database or Kubernetes credentials. This slice only creates or adopts that fixed Job.
+It does not start the Job or allow a bundle to run.
+
 Keeping this work in a separate, narrowly privileged process prevents the API server and the runtime
 itself from becoming general Kubernetes workload launchers. OpenCrane decides *what* may run; this app
 only projects that decision into the restricted runtime namespace named by the selected profile's RoleBinding.
@@ -56,8 +61,8 @@ multiple Pods, and OpenCrane registers the first Pod before bootstrap exchange c
 ## Public surface
 
 `Entrypoint:` `src/index.ts` loads telemetry first, validates configuration, creates the narrow
-OpenCrane and Kubernetes adapters, runs the runtime assignment/release and suspended-skill-assignment
-poll loops, and flushes telemetry
+OpenCrane and Kubernetes adapters, runs the runtime assignment/release, suspended-skill-assignment,
+and suspended-MCP-bundle-validator poll loops, and flushes telemetry
 on `SIGTERM`/`SIGINT`.
 
 ## Boundary
@@ -70,7 +75,9 @@ read/update/delete Secrets, mutate Pods, or get, replace, delete, or watch any P
 virtual key rides the claim response and is written straight into the Secret; the controller never
 holds the LiteLLM master key. Its ServiceAccount and Deployment remain in the server namespace, so
 compromising a runtime Pod does not place it beside the controller identity. The projected bootstrap
-reference is an opaque lookup key, not a credential, and the controller never logs it.
+reference is an opaque lookup key, not a credential, and the controller never logs it. It has one
+separate Role in the MCP bundle validator namespace that can only create and get validator Jobs; the
+matching admission policy accepts one exact suspended worker shape.
 
 ## Dependency direction
 
@@ -96,6 +103,10 @@ outside the app root.
 - `AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON` — exactly one immutable authoring and tool-runner
   profile, each using a class-bound ServiceAccount, projected-token audience, and fixed bootstrap
   file paths and same-silo acknowledgement URL.
+- `AGENT_CONTROLLER_MCPB_VALIDATOR_PROFILE_JSON` — the one immutable profile for suspended MCP bundle
+  validator Jobs: namespace, image digest, ServiceAccount, token audience, fixed bootstrap URL and
+  file paths, resource limits, and deadline. It cannot supply a command, bundle location, or database
+  credential.
 
 The image runs as an unprivileged numeric user with a read-only root filesystem. Helm provides two
 separate projected tokens: one for OpenCrane and one for the Kubernetes API. Structured logs go to

--- a/apps/agent-controller/helm/Chart.yaml
+++ b/apps/agent-controller/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrane-agent-controller
 description: App-owned named-template library for the personal-runtime workload controller.
 type: library
-version: 0.9.2
-appVersion: "0.9.2"
+version: 0.9.3
+appVersion: "0.9.3"

--- a/apps/agent-controller/helm/migrations/0.9.2-to-0.9.3.json
+++ b/apps/agent-controller/helm/migrations/0.9.2-to-0.9.3.json
@@ -1,0 +1,5 @@
+{
+  "fromChartVersion": "0.9.2",
+  "toChartVersion": "0.9.3",
+  "kind": "noop"
+}

--- a/apps/agent-controller/helm/templates/_resources.tpl
+++ b/apps/agent-controller/helm/templates/_resources.tpl
@@ -282,7 +282,6 @@ roleRef:
   kind: Role
   name: {{ $controllerName }}-mcpb-validator
 ---
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -701,7 +700,7 @@ spec:
     resourceRules:
       - apiGroups: ["batch"]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["jobs"]
         scope: "Namespaced"
     namespaceSelector:
@@ -720,13 +719,24 @@ spec:
         object.metadata.labels['opencrane.ai/mcpb-validator'] == object.metadata.name &&
         object.metadata.annotations.size() == 1 &&
         object.metadata.annotations['opencrane.ai/mcpb-bootstrap-reference'].matches('^mcpb-validator-v1_[a-f0-9]{64}$') &&
+        (!has(object.metadata.ownerReferences) || object.metadata.ownerReferences.size() == 0) &&
+        (!has(object.metadata.finalizers) || object.metadata.finalizers.size() == 0) &&
+        (!has(object.metadata.generateName) || object.metadata.generateName == '') &&
         object.spec.suspend == true && object.spec.parallelism == 1 && object.spec.completions == 1 &&
         object.spec.backoffLimit == 0 && object.spec.ttlSecondsAfterFinished == 0 &&
         object.spec.activeDeadlineSeconds == {{ .Values.agentController.mcpbValidatorProfile.activeDeadlineSeconds }} &&
         object.spec.template.spec.serviceAccountName == 'mcpb-validator-default' &&
         object.spec.template.spec.automountServiceAccountToken == false &&
         object.spec.template.spec.enableServiceLinks == false && object.spec.template.spec.restartPolicy == 'Never' &&
+        object.spec.template.spec.terminationGracePeriodSeconds == 0 &&
+        object.spec.template.spec.securityContext.runAsNonRoot == true &&
+        object.spec.template.spec.securityContext.runAsUser == 65532 &&
+        object.spec.template.spec.securityContext.runAsGroup == 65532 &&
+        object.spec.template.spec.securityContext.fsGroup == 65532 &&
+        object.spec.template.spec.securityContext.seccompProfile.type == 'RuntimeDefault' &&
         object.spec.template.spec.containers.size() == 1 && object.spec.template.spec.containers[0].name == 'mcpb-validator' &&
+        (!has(object.spec.template.spec.initContainers) || object.spec.template.spec.initContainers.size() == 0) &&
+        (!has(object.spec.template.spec.ephemeralContainers) || object.spec.template.spec.ephemeralContainers.size() == 0) &&
         object.spec.template.spec.containers[0].image == {{ $mcpbValidatorImage | toJson }} &&
         object.spec.template.spec.containers[0].imagePullPolicy == {{ .Values.agentController.mcpbValidatorProfile.image.pullPolicy | toJson }} &&
         object.spec.template.spec.containers[0].resources.requests.cpu == {{ .Values.agentController.mcpbValidatorProfile.resources.requests.cpu | toString | toJson }} &&
@@ -736,6 +746,14 @@ spec:
         object.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation == false &&
         object.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem == true &&
         object.spec.template.spec.containers[0].securityContext.capabilities.drop == ['ALL'] &&
+        (!has(object.spec.template.spec.containers[0].securityContext.capabilities.add) || object.spec.template.spec.containers[0].securityContext.capabilities.add.size() == 0) &&
+        (!has(object.spec.template.spec.containers[0].command) || object.spec.template.spec.containers[0].command.size() == 0) &&
+        (!has(object.spec.template.spec.containers[0].args) || object.spec.template.spec.containers[0].args.size() == 0) &&
+        !has(object.spec.template.spec.containers[0].lifecycle) &&
+        !has(object.spec.template.spec.containers[0].livenessProbe) &&
+        !has(object.spec.template.spec.containers[0].readinessProbe) &&
+        !has(object.spec.template.spec.containers[0].startupProbe) &&
+        !has(object.spec.template.spec.containers[0].envFrom) &&
         object.spec.template.spec.containers[0].env.size() == 3 &&
         object.spec.template.spec.containers[0].env[0].name == 'OPENCRANE_MCPB_BOOTSTRAP_URL' &&
         object.spec.template.spec.containers[0].env[0].value == {{ $mcpbValidatorBootstrapUrl | toJson }} &&
@@ -743,9 +761,38 @@ spec:
         object.spec.template.spec.containers[0].env[1].value == '/var/run/opencrane/tokens/validator.token' &&
         object.spec.template.spec.containers[0].env[2].name == 'OPENCRANE_MCPB_BOOTSTRAP_REFERENCE_PATH' &&
         object.spec.template.spec.containers[0].env[2].value == '/var/run/opencrane/bootstrap/reference' &&
+        object.spec.template.spec.containers[0].volumeMounts.size() == 3 &&
+        object.spec.template.spec.containers[0].volumeMounts[0].name == 'validator-token' &&
+        object.spec.template.spec.containers[0].volumeMounts[0].mountPath == '/var/run/opencrane/tokens' &&
+        object.spec.template.spec.containers[0].volumeMounts[0].readOnly == true &&
+        object.spec.template.spec.containers[0].volumeMounts[1].name == 'bootstrap-reference' &&
+        object.spec.template.spec.containers[0].volumeMounts[1].mountPath == '/var/run/opencrane/bootstrap' &&
+        object.spec.template.spec.containers[0].volumeMounts[1].readOnly == true &&
+        object.spec.template.spec.containers[0].volumeMounts[2].name == 'scratch' &&
+        object.spec.template.spec.containers[0].volumeMounts[2].mountPath == '/tmp' &&
         object.spec.template.spec.volumes.size() == 3 &&
+        object.spec.template.spec.volumes[0].name == 'validator-token' &&
+        object.spec.template.spec.volumes[0].projected.defaultMode == 288 &&
+        object.spec.template.spec.volumes[0].projected.sources.size() == 1 &&
+        object.spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.path == 'validator.token' &&
         object.spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.audience == 'opencrane-mcpb-validator' &&
-        quantity(object.spec.template.spec.volumes[2].emptyDir.sizeLimit).compareTo(quantity({{ .Values.agentController.mcpbValidatorProfile.scratchSize | toJson }})) == 0
+        object.spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.expirationSeconds == 600 &&
+        object.spec.template.spec.volumes[1].name == 'bootstrap-reference' &&
+        object.spec.template.spec.volumes[1].downwardAPI.defaultMode == 288 &&
+        object.spec.template.spec.volumes[1].downwardAPI.items.size() == 1 &&
+        object.spec.template.spec.volumes[1].downwardAPI.items[0].path == 'reference' &&
+        object.spec.template.spec.volumes[1].downwardAPI.items[0].fieldRef.fieldPath == "metadata.annotations['opencrane.ai/mcpb-bootstrap-reference']" &&
+        object.spec.template.spec.volumes[2].name == 'scratch' &&
+        quantity(object.spec.template.spec.volumes[2].emptyDir.sizeLimit).compareTo(quantity({{ .Values.agentController.mcpbValidatorProfile.scratchSize | toJson }})) == 0 &&
+        object.spec.template.metadata.labels.size() == 2 &&
+        object.spec.template.metadata.labels['app.kubernetes.io/component'] == 'mcpb-validator' &&
+        object.spec.template.metadata.labels['opencrane.ai/mcpb-validator'] == object.metadata.name &&
+        object.spec.template.metadata.annotations == object.metadata.annotations &&
+        (!has(object.spec.template.metadata.ownerReferences) || object.spec.template.metadata.ownerReferences.size() == 0) &&
+        (!has(object.spec.template.metadata.finalizers) || object.spec.template.metadata.finalizers.size() == 0) &&
+        (!has(object.spec.template.metadata.name) || object.spec.template.metadata.name == '') &&
+        (!has(object.spec.template.metadata.generateName) || object.spec.template.metadata.generateName == '') &&
+        (!has(object.spec.template.metadata.namespace) || object.spec.template.metadata.namespace == '')
       message: MCP bundle validator Job must remain the exact suspended worker shape
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/apps/agent-controller/helm/templates/_resources.tpl
+++ b/apps/agent-controller/helm/templates/_resources.tpl
@@ -44,6 +44,9 @@
 {{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.agentController.skillWorkloadProfiles.toolRunner.image.digest) }}
 {{- fail "agentController.enabled=true requires an immutable sha256 tool-runner worker image digest" }}
 {{- end }}
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.agentController.mcpbValidatorProfile.image.digest) }}
+{{- fail "agentController.enabled=true requires an immutable sha256 MCP bundle validator image digest" }}
+{{- end }}
 {{- $controllerName := "agent-controller" -}}
 {{- $runtimeNamespace := include "opencrane.agentController.runtimeNamespace" . -}}
 {{- $runtimeNamespaceLabel := include "opencrane.agentController.runtimeNamespaceLabelValue" . -}}
@@ -77,12 +80,16 @@
 {{- $toolRunnerImage := printf "%s@%s" .Values.agentController.skillWorkloadProfiles.toolRunner.image.repository .Values.agentController.skillWorkloadProfiles.toolRunner.image.digest -}}
 {{- $authoringNamespace := (index .Values "opencrane-skill-authoring").skillAuthoring.namespace -}}
 {{- $toolRunnerNamespace := (index .Values "opencrane-tool-runner").toolRunner.namespace -}}
-{{- if or (eq $authoringNamespace .Release.Namespace) (eq $toolRunnerNamespace .Release.Namespace) (eq $authoringNamespace $toolRunnerNamespace) }}
-{{- fail "governed skill workload namespaces must be distinct from the server and from each other" }}
+{{- $mcpbValidatorNamespace := (index .Values "opencrane-mcpb-validator").mcpbValidator.namespace -}}
+{{- $mcpbValidatorImage := printf "%s@%s" .Values.agentController.mcpbValidatorProfile.image.repository .Values.agentController.mcpbValidatorProfile.image.digest -}}
+{{- $mcpbValidatorBootstrapUrl := printf "http://%s-opencrane-server.%s.svc.cluster.local:%v/api/internal/mcpb-validator" (include "opencrane.fullname" .) .Release.Namespace .Values.clustertenantManager.service.internalPort -}}
+{{- if or (eq $authoringNamespace .Release.Namespace) (eq $toolRunnerNamespace .Release.Namespace) (eq $mcpbValidatorNamespace .Release.Namespace) (eq $authoringNamespace $toolRunnerNamespace) (eq $authoringNamespace $mcpbValidatorNamespace) (eq $toolRunnerNamespace $mcpbValidatorNamespace) }}
+{{- fail "governed worker namespaces must be distinct from the server and from each other" }}
 {{- end }}
 {{- $controllerImage := printf "%s@%s" .Values.agentController.image.repository .Values.agentController.image.digest -}}
 {{- $controllerUsername := printf "system:serviceaccount:%s:%s" .Release.Namespace $controllerName -}}
 {{- $skillAdmissionName := printf "%s-skill-workloads" (include "opencrane.agentController.admissionName" .) -}}
+{{- $mcpbAdmissionName := printf "%s-mcpb-validator" (include "opencrane.agentController.admissionName" .) -}}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -251,6 +258,31 @@ roleRef:
 ---
 {{- end }}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $controllerName }}-mcpb-validator
+  namespace: {{ $mcpbValidatorNamespace }}
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $controllerName }}-mcpb-validator
+  namespace: {{ $mcpbValidatorNamespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $controllerName }}
+    namespace: {{ $.Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $controllerName }}-mcpb-validator
+---
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -306,6 +338,8 @@ spec:
               value: {{ dict .Values.agentController.runtimeProfile.name $personalProfileEnv $managedRuntimeProfileName $managedProfileEnv | toJson | quote }}
             - name: AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON
               value: {{ dict "authoring" (dict "kind" "authoring" "image" $authoringImage "imagePullPolicy" .Values.agentController.skillWorkloadProfiles.authoring.image.pullPolicy "serverNamespace" .Release.Namespace "namespace" $authoringNamespace "serviceAccountName" "skill-authoring-default" "capabilityTokenAudience" "opencrane-skill-authoring" "bootstrapUrl" $skillBootstrapUrl "capabilityTokenPath" "/var/run/opencrane/tokens/capability.token" "bootstrapReferencePath" "/var/run/opencrane/bootstrap/reference" "scratchSize" .Values.agentController.skillWorkloadProfiles.authoring.scratchSize "activeDeadlineSeconds" .Values.agentController.skillWorkloadProfiles.authoring.activeDeadlineSeconds "ttlSecondsAfterFinished" 0 "resources" .Values.agentController.skillWorkloadProfiles.authoring.resources) "tool-runner" (dict "kind" "tool-runner" "image" $toolRunnerImage "imagePullPolicy" .Values.agentController.skillWorkloadProfiles.toolRunner.image.pullPolicy "serverNamespace" .Release.Namespace "namespace" $toolRunnerNamespace "serviceAccountName" "tool-runner-default" "capabilityTokenAudience" "opencrane-tool-runner" "bootstrapUrl" $skillBootstrapUrl "capabilityTokenPath" "/var/run/opencrane/tokens/capability.token" "bootstrapReferencePath" "/var/run/opencrane/bootstrap/reference" "scratchSize" .Values.agentController.skillWorkloadProfiles.toolRunner.scratchSize "activeDeadlineSeconds" .Values.agentController.skillWorkloadProfiles.toolRunner.activeDeadlineSeconds "ttlSecondsAfterFinished" 0 "resources" .Values.agentController.skillWorkloadProfiles.toolRunner.resources) | toJson | quote }}
+            - name: AGENT_CONTROLLER_MCPB_VALIDATOR_PROFILE_JSON
+              value: {{ dict "image" $mcpbValidatorImage "imagePullPolicy" .Values.agentController.mcpbValidatorProfile.image.pullPolicy "serverNamespace" .Release.Namespace "namespace" $mcpbValidatorNamespace "serviceAccountName" "mcpb-validator-default" "tokenAudience" "opencrane-mcpb-validator" "bootstrapUrl" $mcpbValidatorBootstrapUrl "tokenPath" "/var/run/opencrane/tokens/validator.token" "bootstrapReferencePath" "/var/run/opencrane/bootstrap/reference" "scratchSize" .Values.agentController.mcpbValidatorProfile.scratchSize "activeDeadlineSeconds" .Values.agentController.mcpbValidatorProfile.activeDeadlineSeconds "ttlSecondsAfterFinished" 0 "resources" .Values.agentController.mcpbValidatorProfile.resources | toJson | quote }}
             {{- include "opencrane.observabilityEnv" (dict "ctx" $ "component" "agent-controller") | nindent 12 }}
           volumeMounts:
             - name: opencrane-token
@@ -653,6 +687,78 @@ spec:
         - key: app.kubernetes.io/component
           operator: In
           values: ["skill-authoring", "tool-runner"]
+---
+# The controller's create permission in the validator namespace is safe only because this policy
+# accepts the one fixed suspended Job shape produced by the MCP bundle Job builder.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ $mcpbAdmissionName }}
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    matchPolicy: Exact
+    resourceRules:
+      - apiGroups: ["batch"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["jobs"]
+        scope: "Namespaced"
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ $mcpbValidatorNamespace | quote }}
+  validations:
+    - expression: >-
+        request.userInfo.username == {{ $controllerUsername | toJson }}
+      message: only this release's controller ServiceAccount may create MCP bundle validator Jobs
+    - expression: >-
+        request.operation == 'CREATE' && object.metadata.namespace == {{ $mcpbValidatorNamespace | toJson }} &&
+        object.metadata.name.matches('^mcpb-validate-[a-f0-9]{24}$') &&
+        object.metadata.labels.size() == 3 &&
+        object.metadata.labels['app.kubernetes.io/name'] == 'opencrane-mcpb-validator' &&
+        object.metadata.labels['app.kubernetes.io/component'] == 'mcpb-validator' &&
+        object.metadata.labels['opencrane.ai/mcpb-validator'] == object.metadata.name &&
+        object.metadata.annotations.size() == 1 &&
+        object.metadata.annotations['opencrane.ai/mcpb-bootstrap-reference'].matches('^mcpb-validator-v1_[a-f0-9]{64}$') &&
+        object.spec.suspend == true && object.spec.parallelism == 1 && object.spec.completions == 1 &&
+        object.spec.backoffLimit == 0 && object.spec.ttlSecondsAfterFinished == 0 &&
+        object.spec.activeDeadlineSeconds == {{ .Values.agentController.mcpbValidatorProfile.activeDeadlineSeconds }} &&
+        object.spec.template.spec.serviceAccountName == 'mcpb-validator-default' &&
+        object.spec.template.spec.automountServiceAccountToken == false &&
+        object.spec.template.spec.enableServiceLinks == false && object.spec.template.spec.restartPolicy == 'Never' &&
+        object.spec.template.spec.containers.size() == 1 && object.spec.template.spec.containers[0].name == 'mcpb-validator' &&
+        object.spec.template.spec.containers[0].image == {{ $mcpbValidatorImage | toJson }} &&
+        object.spec.template.spec.containers[0].imagePullPolicy == {{ .Values.agentController.mcpbValidatorProfile.image.pullPolicy | toJson }} &&
+        object.spec.template.spec.containers[0].resources.requests.cpu == {{ .Values.agentController.mcpbValidatorProfile.resources.requests.cpu | toString | toJson }} &&
+        object.spec.template.spec.containers[0].resources.requests.memory == {{ .Values.agentController.mcpbValidatorProfile.resources.requests.memory | toString | toJson }} &&
+        object.spec.template.spec.containers[0].resources.limits.cpu == {{ .Values.agentController.mcpbValidatorProfile.resources.limits.cpu | toString | toJson }} &&
+        object.spec.template.spec.containers[0].resources.limits.memory == {{ .Values.agentController.mcpbValidatorProfile.resources.limits.memory | toString | toJson }} &&
+        object.spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation == false &&
+        object.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem == true &&
+        object.spec.template.spec.containers[0].securityContext.capabilities.drop == ['ALL'] &&
+        object.spec.template.spec.containers[0].env.size() == 3 &&
+        object.spec.template.spec.containers[0].env[0].name == 'OPENCRANE_MCPB_BOOTSTRAP_URL' &&
+        object.spec.template.spec.containers[0].env[0].value == {{ $mcpbValidatorBootstrapUrl | toJson }} &&
+        object.spec.template.spec.containers[0].env[1].name == 'OPENCRANE_MCPB_TOKEN_PATH' &&
+        object.spec.template.spec.containers[0].env[1].value == '/var/run/opencrane/tokens/validator.token' &&
+        object.spec.template.spec.containers[0].env[2].name == 'OPENCRANE_MCPB_BOOTSTRAP_REFERENCE_PATH' &&
+        object.spec.template.spec.containers[0].env[2].value == '/var/run/opencrane/bootstrap/reference' &&
+        object.spec.template.spec.volumes.size() == 3 &&
+        object.spec.template.spec.volumes[0].projected.sources[0].serviceAccountToken.audience == 'opencrane-mcpb-validator' &&
+        quantity(object.spec.template.spec.volumes[2].emptyDir.sizeLimit).compareTo(quantity({{ .Values.agentController.mcpbValidatorProfile.scratchSize | toJson }})) == 0
+      message: MCP bundle validator Job must remain the exact suspended worker shape
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ $mcpbAdmissionName }}
+spec:
+  policyName: {{ $mcpbAdmissionName }}
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: {{ $mcpbValidatorNamespace | quote }}
 ---
 # The policy is cluster-scoped only because Kubernetes admission policies are cluster-scoped. Its
 # namespace selector binds it to one exact profile namespace; no controller RBAC covers a namespace

--- a/apps/agent-controller/package.json
+++ b/apps/agent-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrane/agent-controller",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/apps/agent-controller/project.json
+++ b/apps/agent-controller/project.json
@@ -2,7 +2,7 @@
   "name": "agent-controller",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "metadata": { "release": { "adaptedVersion": "0.9.2" } },
+  "metadata": { "release": { "adaptedVersion": "0.9.3" } },
   "sourceRoot": "apps/agent-controller/src",
   "tags": ["type:app", "layer:entrypoint", "scope:agent-controller"],
   "targets": {

--- a/apps/agent-controller/src/__tests__/config.test.ts
+++ b/apps/agent-controller/src/__tests__/config.test.ts
@@ -47,10 +47,16 @@ function _SkillProfilesJson(): string
 	});
 }
 
+/** Return the Helm-equivalent fixed MCP bundle validator profile. */
+function _McpbValidatorProfileJson(): string
+{
+	return JSON.stringify({ image: `ghcr.io/elewa-git/opencrane-mcpb-validator@sha256:${"c".repeat(64)}`, imagePullPolicy: "IfNotPresent", serverNamespace: "silo-a", namespace: "opencrane-mcpb-validation", serviceAccountName: "mcpb-validator-default", tokenAudience: "opencrane-mcpb-validator", bootstrapUrl: "http://opencrane-server.silo-a.svc.cluster.local:8081/api/internal/mcpb-validator", tokenPath: "/var/run/opencrane/tokens/validator.token", bootstrapReferencePath: "/var/run/opencrane/bootstrap/reference", scratchSize: "128Mi", activeDeadlineSeconds: 300, ttlSecondsAfterFinished: 0, resources: { requests: { cpu: "250m", memory: "256Mi" }, limits: { cpu: "1", memory: "1Gi" } } });
+}
+
 /** Return the minimal complete process environment. */
 function _Environment(): NodeJS.ProcessEnv
 {
-	return { OPENCRANE_INTERNAL_URL: "http://opencrane-server.silo-a.svc.cluster.local:3001", OPENCRANE_CONTROLLER_TOKEN_PATH: "/var/run/opencrane/tokens/opencrane.token", AGENT_CONTROLLER_POLL_INTERVAL_MS: "1000", AGENT_CONTROLLER_PROFILES_JSON: _ProfilesJson(), AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON: _SkillProfilesJson() };
+	return { OPENCRANE_INTERNAL_URL: "http://opencrane-server.silo-a.svc.cluster.local:3001", OPENCRANE_CONTROLLER_TOKEN_PATH: "/var/run/opencrane/tokens/opencrane.token", AGENT_CONTROLLER_POLL_INTERVAL_MS: "1000", AGENT_CONTROLLER_PROFILES_JSON: _ProfilesJson(), AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON: _SkillProfilesJson(), AGENT_CONTROLLER_MCPB_VALIDATOR_PROFILE_JSON: _McpbValidatorProfileJson() };
 }
 
 describe("agent-controller process config", function _Suite()
@@ -67,6 +73,7 @@ describe("agent-controller process config", function _Suite()
 		expect(config.outboxPruneIntervalMilliseconds).toBe(3_600_000);
 		expect(config.profiles["personal-default"]?.serviceAccountName).toBe("agent-runtime-default");
 		expect(config.skillWorkloadProfiles.authoring.serviceAccountName).toBe("skill-authoring-default");
+		expect(config.mcpbValidatorProfile.serviceAccountName).toBe("mcpb-validator-default");
 	});
 
 	it("rejects a collapsed namespace or moving image tag", function _RejectsUnsafeConfig()

--- a/apps/agent-controller/src/config.ts
+++ b/apps/agent-controller/src/config.ts
@@ -2,6 +2,7 @@ import { isAbsolute } from "node:path";
 
 import { __ValidateAgentControllerRuntimeProfiles } from "@opencrane/backend/agents/runtime/controller";
 import { __ValidateSkillWorkloadControllerProfiles } from "@opencrane/backend/agents/skills/controller";
+import { __ValidateMcpbValidationControllerProfile } from "@opencrane/backend/agents/mcpb/controller";
 import { ___ParseAndValidateJson } from "@opencrane/util";
 
 import type { AgentControllerProcessConfig } from "./config.types";
@@ -39,6 +40,7 @@ export function _ReadConfig(environment: NodeJS.ProcessEnv = process.env): Agent
 	// 2. Validate every immutable profile and its dedicated runtime namespace at startup.
 	const profiles = ___ParseAndValidateJson(_Required(environment, "AGENT_CONTROLLER_PROFILES_JSON"), "AGENT_CONTROLLER_PROFILES_JSON", __ValidateAgentControllerRuntimeProfiles);
 	const skillWorkloadProfiles = ___ParseAndValidateJson(_Required(environment, "AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON"), "AGENT_CONTROLLER_SKILL_WORKLOAD_PROFILES_JSON", __ValidateSkillWorkloadControllerProfiles);
+	const mcpbValidatorProfile = ___ParseAndValidateJson(_Required(environment, "AGENT_CONTROLLER_MCPB_VALIDATOR_PROFILE_JSON"), "AGENT_CONTROLLER_MCPB_VALIDATOR_PROFILE_JSON", __ValidateMcpbValidationControllerProfile);
 	return {
 		openCraneInternalUrl: _Required(environment, "OPENCRANE_INTERNAL_URL"),
 		controllerTokenPath,
@@ -47,5 +49,6 @@ export function _ReadConfig(environment: NodeJS.ProcessEnv = process.env): Agent
 		requestTimeoutMilliseconds: _Integer(environment, "AGENT_CONTROLLER_REQUEST_TIMEOUT_MS", 10_000, 1_000, 60_000),
 		profiles,
 		skillWorkloadProfiles,
+		mcpbValidatorProfile,
 	};
 }

--- a/apps/agent-controller/src/config.types.ts
+++ b/apps/agent-controller/src/config.types.ts
@@ -1,5 +1,6 @@
 import type { AgentControllerRuntimeProfiles } from "@opencrane/backend/agents/runtime/controller";
 import type { SkillWorkloadControllerProfiles } from "@opencrane/backend/agents/skills/controller";
+import type { McpbValidatorJobProfile } from "@opencrane/backend/server/gateways/mcp/validator-k8s-launcher";
 
 /** Fully validated process configuration for the per-silo agent controller. */
 export interface AgentControllerProcessConfig
@@ -18,4 +19,6 @@ export interface AgentControllerProcessConfig
 	readonly profiles: AgentControllerRuntimeProfiles;
 	/** Immutable profiles for the only governed skill Job classes. */
 	readonly skillWorkloadProfiles: SkillWorkloadControllerProfiles;
+	/** Immutable profile for the only MCP bundle validator Job class. */
+	readonly mcpbValidatorProfile: McpbValidatorJobProfile;
 }

--- a/apps/agent-controller/src/index.ts
+++ b/apps/agent-controller/src/index.ts
@@ -4,6 +4,7 @@ import * as k8s from "@kubernetes/client-node";
 
 import { __CreateHttpAgentControllerAuthority, __CreateKubernetesAgentControllerStore, __RunAgentController } from "@opencrane/backend/agents/runtime/controller";
 import { __CreateHttpSkillWorkloadControllerAuthority, __CreateKubernetesSkillWorkloadControllerStore, __RunSkillWorkloadController } from "@opencrane/backend/agents/skills/controller";
+import { __CreateHttpMcpbValidationControllerAuthority, __CreateKubernetesMcpbValidationControllerStore, __RunMcpbValidationController } from "@opencrane/backend/agents/mcpb/controller";
 import { ___BindConsole, ___ShutdownTelemetry } from "@opencrane/backend/observability";
 
 import { _ReadConfig } from "./config";
@@ -24,8 +25,10 @@ async function _Main(): Promise<void>
 		kubeConfig.loadFromCluster();
 		const authority = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
 		const skillWorkloadAuthority = __CreateHttpSkillWorkloadControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
+		const mcpbValidationAuthority = __CreateHttpMcpbValidationControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
 		const kubernetes = __CreateKubernetesAgentControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: shutdown.signal });
 		const skillKubernetes = __CreateKubernetesSkillWorkloadControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: shutdown.signal });
+		const mcpbKubernetes = __CreateKubernetesMcpbValidationControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: shutdown.signal });
 
 		// 3. Convert both Kubernetes termination signals into one abortable poll loop.
 		function _Shutdown(signal: string): void
@@ -40,6 +43,7 @@ async function _Main(): Promise<void>
 		await Promise.all([
 			__RunAgentController({ authority, kubernetes, profiles: config.profiles, pollIntervalMilliseconds: config.pollIntervalMilliseconds, outboxPruneIntervalMilliseconds: config.outboxPruneIntervalMilliseconds, log }, shutdown.signal),
 			__RunSkillWorkloadController({ authority: skillWorkloadAuthority, kubernetes: skillKubernetes, profiles: config.skillWorkloadProfiles, pollIntervalMilliseconds: config.pollIntervalMilliseconds, log }, shutdown.signal),
+			__RunMcpbValidationController({ authority: mcpbValidationAuthority, kubernetes: mcpbKubernetes, profile: config.mcpbValidatorProfile, pollIntervalMilliseconds: config.pollIntervalMilliseconds, log }, shutdown.signal),
 		]);
 	}
 	finally

--- a/apps/agent-controller/tests/helm-contract.sh
+++ b/apps/agent-controller/tests/helm-contract.sh
@@ -15,13 +15,14 @@ RUNTIME_NAMESPACE="$(mktemp)"
 RUNTIME_QUOTA="$(mktemp)"
 MANAGED_RUNTIME_QUOTA="$(mktemp)"
 ADMISSION="$(mktemp)"
+MCPB_ADMISSION="$(mktemp)"
 SKILL_URL_OVERRIDE="$(mktemp)"
 SERVER_POLICY="$(mktemp)"
 CONTROLLER_POLICY="$(mktemp)"
 RUNTIME_DENY="$(mktemp)"
 RUNTIME_EGRESS="$(mktemp)"
 prepare_current_chart_sources
-trap 'cleanup_current_chart_sources; rm -f "$MANIFEST" "$DISABLED" "$ROLE" "$BINDING" "$CLEANUP_ROLE" "$CLEANUP_BINDING" "$RUNTIME_NAMESPACE" "$RUNTIME_QUOTA" "$MANAGED_RUNTIME_QUOTA" "$ADMISSION" "$SKILL_URL_OVERRIDE" "$SERVER_POLICY" "$CONTROLLER_POLICY" "$RUNTIME_DENY" "$RUNTIME_EGRESS"' EXIT
+trap 'cleanup_current_chart_sources; rm -f "$MANIFEST" "$DISABLED" "$ROLE" "$BINDING" "$CLEANUP_ROLE" "$CLEANUP_BINDING" "$RUNTIME_NAMESPACE" "$RUNTIME_QUOTA" "$MANAGED_RUNTIME_QUOTA" "$ADMISSION" "$MCPB_ADMISSION" "$SKILL_URL_OVERRIDE" "$SERVER_POLICY" "$CONTROLLER_POLICY" "$RUNTIME_DENY" "$RUNTIME_EGRESS"' EXIT
 CHART_ROOT="$(current_chart_sources_dir)"
 
 render_enabled() {
@@ -55,6 +56,7 @@ awk 'BEGIN { RS="---" } $0 ~ /\nkind: Namespace\n/ && $0 ~ /\n  name: oc-opencra
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: ResourceQuota\n/ && $0 ~ /\n  name: oc-opencrane-agent-runtime\n/ { print $0 }' "$MANIFEST" > "$RUNTIME_QUOTA"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: ResourceQuota\n/ && $0 ~ /\n  name: managed-agent-runtime\n/ && $0 ~ /\n  namespace: oc-opencrane-managed-runtime\n/ { print $0 }' "$MANIFEST" > "$MANAGED_RUNTIME_QUOTA"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: ValidatingAdmissionPolicy\n/ { print $0 }' "$MANIFEST" > "$ADMISSION"
+awk 'BEGIN { RS="---" } $0 ~ /\nkind: ValidatingAdmissionPolicy\n/ && $0 ~ /mcpb-validator/ { print $0 }' "$MANIFEST" > "$MCPB_ADMISSION"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: NetworkPolicy\n/ && $0 ~ /\n  name: oc-opencrane-opencrane-server\n/ { print $0 }' "$MANIFEST" > "$SERVER_POLICY"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: NetworkPolicy\n/ && $0 ~ /\n  name: oc-opencrane-agent-controller\n/ { print $0 }' "$MANIFEST" > "$CONTROLLER_POLICY"
 awk 'BEGIN { RS="---" } $0 ~ /\nkind: NetworkPolicy\n/ && $0 ~ /\n  name: oc-opencrane-agent-runtime-default-deny\n/ { print $0 }' "$MANIFEST" > "$RUNTIME_DENY"
@@ -142,6 +144,12 @@ if grep -A14 -F 'name: agent-controller-mcpb-validator' "$MANIFEST" | grep -E '"
 fi
 grep -Fq 'MCP bundle validator Job must remain the exact suspended worker shape' "$ADMISSION"
 grep -Fq "mcpb-validator-default" "$ADMISSION"
+test -s "$MCPB_ADMISSION"
+grep -Fq 'operations: ["CREATE"]' "$MCPB_ADMISSION"
+grep -Fq "object.spec.template.spec.securityContext.runAsUser == 65532" "$MCPB_ADMISSION"
+grep -Fq "!has(object.spec.template.spec.containers[0].command)" "$MCPB_ADMISSION"
+grep -Fq "object.spec.template.spec.containers[0].volumeMounts[1].mountPath == '/var/run/opencrane/bootstrap'" "$MCPB_ADMISSION"
+grep -Fq "object.spec.template.spec.volumes[1].downwardAPI.items[0].fieldRef.fieldPath == \"metadata.annotations['opencrane.ai/mcpb-bootstrap-reference']\"" "$MCPB_ADMISSION"
 
 # The controller receives both profile-owned namespaces in one immutable map; it never gets a
 # process-wide runtime namespace that could let one profile borrow another's RoleBinding.

--- a/apps/agent-controller/tests/helm-contract.sh
+++ b/apps/agent-controller/tests/helm-contract.sh
@@ -34,6 +34,7 @@ render_enabled() {
     --set-string managedAgentRuntimePlane.managedAgentRuntime.serviceAccountName=managed-agent-runtime-default \
     --set-string agentController.skillWorkloadProfiles.authoring.image.digest=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc \
     --set-string agentController.skillWorkloadProfiles.toolRunner.image.digest=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd \
+    --set-string agentController.mcpbValidatorProfile.image.digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee \
     --set-string 'agentController.kubernetesApiServerCidrs[0]=10.43.0.1/32' \
     --set-string 'agentController.kubernetesApiServerEndpointCidrs[0]=172.18.0.2/32' \
     --set-string 'memoryGateway.kubernetesApiServerCidrs[0]=10.43.0.1/32' \
@@ -131,6 +132,16 @@ if grep -A16 -F 'name: agent-controller-skill-workloads' "$MANIFEST" | grep -E '
   echo "skill workload Roles exceed fenced Job release and Pod discovery authority" >&2
   exit 1
 fi
+# MCP bundle validation has a separate namespace, create/get-only controller Role, and an admission
+# policy that permits only the fixed suspended validator Job profile.
+grep -A14 -F 'name: agent-controller-mcpb-validator' "$MANIFEST" | grep -F 'namespace: opencrane-mcpb-validation' >/dev/null
+grep -A14 -F 'name: agent-controller-mcpb-validator' "$MANIFEST" | grep -F 'verbs: ["get", "create"]' >/dev/null
+if grep -A14 -F 'name: agent-controller-mcpb-validator' "$MANIFEST" | grep -E '"(delete|update|patch|watch|list)"' >/dev/null; then
+  echo "MCP bundle validator controller Role exceeds get/create" >&2
+  exit 1
+fi
+grep -Fq 'MCP bundle validator Job must remain the exact suspended worker shape' "$ADMISSION"
+grep -Fq "mcpb-validator-default" "$ADMISSION"
 
 # The controller receives both profile-owned namespaces in one immutable map; it never gets a
 # process-wide runtime namespace that could let one profile borrow another's RoleBinding.

--- a/apps/mcpb-validator/README.md
+++ b/apps/mcpb-validator/README.md
@@ -4,13 +4,13 @@
 
 ## What it owns
 
-This app owns the future worker image and Kubernetes namespace for checking and running accepted
-MCP bundles. An MCP bundle is a packaged MCP server. The worker has its own empty namespace and a
-service account with no Kubernetes permissions.
+This app owns the worker image and Kubernetes namespace for checking MCP bundles. An MCP bundle is a
+packaged MCP server. The worker has its own empty namespace and a service account with no Kubernetes
+permissions.
 
 ```
  saved MCP bundle check
-          │ future controller creates one Job
+          │ agent controller creates one suspended Job
           ▼
  ┌─────────────────────────────────┐
  │ mcpb-validator  ◄── HERE         │
@@ -18,10 +18,11 @@ service account with no Kubernetes permissions.
  └─────────────────────────────────┘
 ```
 
-**In this flow:** [OpenCrane server](../opencrane/README.md) · the future MCPB controller.
+**In this flow:** [OpenCrane server](../opencrane/README.md) ·
+[agent controller](../agent-controller/README.md).
 
-The image currently refuses to run because the server assignment protocol does not exist yet. This
-is deliberate: creating the image and namespace must not accidentally make third-party bundle code
+The image currently refuses to run because the server assignment and release protocol does not exist
+yet. This is deliberate: creating a suspended Job must not accidentally make third-party bundle code
 executable.
 
 ## Public surface
@@ -33,8 +34,8 @@ executable.
 ## Boundary
 
 The image accepts no command, artifact URL, database credential, registry credential, or Kubernetes
-credential. It has no running Job or network exception until the later controller and server route
-are reviewed together.
+credential. The agent controller can create a suspended Job with the fixed worker shape, but no
+component can unsuspend it yet.
 
 ## Dependency direction
 
@@ -44,8 +45,8 @@ or library source.
 ## Runtime & config
 
 The chart creates a namespace but no Pod. Its only settings are the namespace, the fixed service
-account name, and resource quota. A future release must publish the worker image by digest before a
-controller can create a Job.
+account name, and resource quota. The controller requires a worker image digest before it can create
+a Job.
 
 ## See also
 

--- a/apps/mcpb-validator/README.md
+++ b/apps/mcpb-validator/README.md
@@ -21,8 +21,8 @@ permissions.
 **In this flow:** [OpenCrane server](../opencrane/README.md) ·
 [agent controller](../agent-controller/README.md).
 
-The image currently refuses to run because the server assignment and release protocol does not exist
-yet. This is deliberate: creating a suspended Job must not accidentally make third-party bundle code
+The image currently refuses to run because the worker assignment and Job-release protocols do not
+exist yet. This is deliberate: creating a suspended Job must not accidentally make third-party bundle code
 executable.
 
 ## Public surface

--- a/docs/agents/cluster-architecture.md
+++ b/docs/agents/cluster-architecture.md
@@ -58,7 +58,7 @@ Cluster-wide ingress, certificate, DNS, and CloudNativePG controllers are extern
 | Malware scanning | `apps/artifact-scanner` | none; brokered quarantined bytes and fenced result only |
 | Skill authoring Job | `apps/skill-authoring` | none; one governed workload |
 | Tool execution Job | `apps/tool-runner` | none; one governed workload |
-| MCP bundle validation Job | `apps/mcpb-validator` | none; future governed workload |
+| MCP bundle validation Job | `apps/mcpb-validator` | none; one suspended governed workload |
 
 Every independently deployed workload has one `apps/<name>` owner. Libraries under `libs/*` contain
 reusable behaviour and never own a deployment.
@@ -71,8 +71,8 @@ reusable behaviour and never own a deployment.
   service-account class.
 - **Skill-authoring namespace** — candidate-skill Jobs with no standing worker.
 - **Tool-runner namespace** — governed tool Jobs with no standing worker.
-- **MCP bundle validator namespace** — empty restricted worker plane until its Job controller and
-  server assignment route are delivered together.
+- **MCP bundle validator namespace** — restricted worker plane where the controller may create one
+  fixed suspended Job per admitted validation. No component can start the Job yet.
 - **Artifact-preprocessor namespace** — bounded document-extraction Jobs with broker-only byte flow.
 - **Artifact-scanner namespace** — an outbound-only scanner Deployment with broker-only quarantined
   byte flow, pinned offline definitions, and no database or ArtifactStore authority.

--- a/docs/agents/workload-ownership.json
+++ b/docs/agents/workload-ownership.json
@@ -13,6 +13,7 @@
     "agent-runtime",
     "skill-authoring",
     "tool-runner",
+    "mcpb-validator",
     "cognee",
     "litellm",
     "obot-gateway-controller",
@@ -59,7 +60,8 @@
         "agentController.image.digest=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         "agentController.runtimeProfile.image.digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "agentController.skillWorkloadProfiles.authoring.image.digest=sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-        "agentController.skillWorkloadProfiles.toolRunner.image.digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+        "agentController.skillWorkloadProfiles.toolRunner.image.digest=sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "agentController.mcpbValidatorProfile.image.digest=sha256:9999999999999999999999999999999999999999999999999999999999999999"
       ],
       "expectedRenderedPodClasses": [
         "Deployment/opencrane-opencrane-server",
@@ -101,6 +103,16 @@
       "path": "libs/backend/agents/skills/controller/src/kubernetes-skill-workload-controller-store.ts",
       "anchor": "options.batchApi.createNamespacedJob({ namespace, body: expected }, _RequestOptions(options.shutdownSignal, options.requestTimeoutMilliseconds))",
       "workloadIds": ["skill-authoring", "tool-runner"]
+    },
+    {
+      "path": "libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts",
+      "anchor": "kind: \"Job\"",
+      "workloadIds": ["mcpb-validator"]
+    },
+    {
+      "path": "libs/backend/agents/mcpb/controller/src/kubernetes-mcpb-validation-controller-store.ts",
+      "anchor": "options.batchApi.createNamespacedJob({ namespace, body: expected }, _RequestOptions(options.shutdownSignal, options.requestTimeoutMilliseconds))",
+      "workloadIds": ["mcpb-validator"]
     }
   ],
   "nonProducingRuntimeMatches": [
@@ -224,6 +236,13 @@
       "image": "ghcr.io/elewa-git/opencrane-tool-runner@sha256:<release-digest>",
       "owner": "apps/tool-runner",
       "source": { "type": "file", "path": "libs/backend/agents/skills/k8s-launcher/src/tool-runner-workload-job.ts", "anchor": "kind: \"Job\"" }
+    },
+    {
+      "id": "mcpb-validator",
+      "podClass": "Job/mcpb-validator",
+      "image": "ghcr.io/elewa-git/opencrane-mcpb-validator@sha256:<release-digest>",
+      "owner": "apps/mcpb-validator",
+      "source": { "type": "file", "path": "libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.ts", "anchor": "kind: \"Job\"" }
     },
     {
       "id": "cognee",

--- a/libs/backend/agents/mcpb/controller/src/__tests__/kubernetes-mcpb-validation-controller-store.test.ts
+++ b/libs/backend/agents/mcpb/controller/src/__tests__/kubernetes-mcpb-validation-controller-store.test.ts
@@ -29,8 +29,9 @@ function _KubernetesJob(job: V1Job): V1Job
 		throw new Error("expected test Job name");
 	}
 	const generatedLabels = { "batch.kubernetes.io/controller-uid": uid, "batch.kubernetes.io/job-name": name, "controller-uid": uid, "job-name": name };
+	const generatedSelector = { "batch.kubernetes.io/controller-uid": uid };
 	const labels = { ...job.spec?.template.metadata?.labels, ...generatedLabels };
-	return { ...job, metadata: { ...job.metadata, uid }, spec: { ...job.spec!, selector: { matchLabels: generatedLabels }, template: { ...job.spec!.template, metadata: { ...job.spec!.template.metadata, labels } } } };
+	return { ...job, metadata: { ...job.metadata, uid }, spec: { ...job.spec!, selector: { matchLabels: generatedSelector }, template: { ...job.spec!.template, metadata: { ...job.spec!.template.metadata, labels } } } };
 }
 
 describe("MCP bundle validation Kubernetes store", function _McpbValidationStoreSuite()

--- a/libs/backend/agents/mcpb/controller/src/kubernetes-mcpb-validation-controller-store.ts
+++ b/libs/backend/agents/mcpb/controller/src/kubernetes-mcpb-validation-controller-store.ts
@@ -86,12 +86,13 @@ function _RemoveGeneratedJobSelectors(job: Record<string, unknown>): void
 	{
 		throw new Error("refusing to adopt a Job with incomplete Kubernetes ownership selectors");
 	}
-	const expected = { "batch.kubernetes.io/controller-uid": uid, "batch.kubernetes.io/job-name": name, "controller-uid": uid, "job-name": name };
-	if (!isDeepStrictEqual(matchLabels, expected))
+	const expectedLabels = { "batch.kubernetes.io/controller-uid": uid, "batch.kubernetes.io/job-name": name, "controller-uid": uid, "job-name": name };
+	const expectedSelector = { "batch.kubernetes.io/controller-uid": uid };
+	if (!isDeepStrictEqual(matchLabels, expectedSelector))
 	{
 		throw new Error("refusing to adopt a Job with unexpected Kubernetes ownership selectors");
 	}
-	for (const [key, value] of Object.entries(expected))
+	for (const [key, value] of Object.entries(expectedLabels))
 	{
 		if (labels[key] !== value)
 		{

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/README.md
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/README.md
@@ -34,8 +34,8 @@ or assignment would widen those limits, it refuses to make a manifest.
 
 ## Boundary
 
-No production code calls this package yet. This package never handles artifact locations, bundle
-bytes, commands, database connections, or long-lived credentials.
+The agent controller uses this package to create or adopt the suspended Job. This package never
+handles artifact locations, bundle bytes, commands, database connections, or long-lived credentials.
 
 ## Dependency direction
 

--- a/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
+++ b/libs/backend/server/gateways/mcp/validator-k8s-launcher/src/validator-job.types.ts
@@ -3,7 +3,8 @@ import type { V1ResourceRequirements } from "@kubernetes/client-node";
 /**
  * Name a Kubernetes image-pull behaviour that the validator profile may supply.
  *
- * Used by: {@link McpbValidatorJobProfile}. Production has no caller yet. The builder accepts these
+ * Used by: {@link McpbValidatorJobProfile}. The agent controller passes this value through its
+ * validated profile. The builder accepts these
  * values only with a digest-pinned image; it never selects an image.
  */
 export type McpbValidatorImagePullPolicy = "Always" | "IfNotPresent" | "Never";
@@ -11,8 +12,8 @@ export type McpbValidatorImagePullPolicy = "Always" | "IfNotPresent" | "Never";
 /**
  * Describe the limits that the builder requires for every one-shot MCP bundle validator Job.
  *
- * Used by: `__BuildMcpbValidatorJob` in `validator-job.ts`. Production has no caller yet. The
- * builder throws before it returns a Job when a setting changes the worker identity, route,
+ * Used by: `__BuildMcpbValidatorJob` in `validator-job.ts`, called by the MCP bundle controller.
+ * The builder throws before it returns a Job when a setting changes the worker identity, route,
  * resource bounds, scratch size, or lifetime.
  *
  * @see McpbValidatorJobAssignment
@@ -50,8 +51,8 @@ export interface McpbValidatorJobProfile
 /**
  * Carry the opaque coordinates that the builder places in one validator Job.
  *
- * Used by: `__BuildMcpbValidatorJob` in `validator-job.ts`. Production has no caller yet. The
- * builder hashes the silo and validation identifiers for the Job name and rejects a reference or
+ * Used by: `__BuildMcpbValidatorJob` in `validator-job.ts`, called by the MCP bundle controller.
+ * The builder hashes the silo and validation identifiers for the Job name and rejects a reference or
  * namespace that does not match its profile before it returns a Job.
  *
  * @see McpbValidatorJobProfile

--- a/releases/0.9.3.json
+++ b/releases/0.9.3.json
@@ -21,10 +21,10 @@
     },
     "agent-controller": {
       "root": "apps/agent-controller",
-      "adaptedVersion": "0.9.2",
-      "packageVersion": "0.9.2",
-      "chartVersion": "0.9.2",
-      "chartAppVersion": "0.9.2"
+      "adaptedVersion": "0.9.3",
+      "packageVersion": "0.9.3",
+      "chartVersion": "0.9.3",
+      "chartAppVersion": "0.9.3"
     },
     "agent-runtime": {
       "root": "apps/agent-runtime",


### PR DESCRIPTION
## Summary

- run the MCP bundle validation controller from agent-controller
- give it a separate create/get-only Kubernetes Role and a fixed suspended Job admission policy
- register the dynamic validator Job in workload ownership and stamp the controller for 0.9.3
- correct Kubernetes 1.30 Job-selector adoption and document the worker boundary in plain language

## Validation

- agent-controller test and lint
- backend-agents-mcpb-controller test and lint
- workload ownership guard and negative tests
- release-version checks
- style and whitespace checks

## Review

- architecture gate passed
- independent correctness review passed
- final comments and documentation gate passed

## Review order

1. #714
2. #715
3. #716
4. #717
5. #718
6. #719
7. #720
8. #721
9. #722
10. #723
11. #724
12. #725

## Deferred

- live Kubernetes/API-server conformance is deferred with the deployment checks until tomorrow, as requested.