### PR TITLE
✨ Expose durable MCP task API

### DIFF
--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -6,7 +6,7 @@ import { aiBudgetRouter, tokenUsageRouter } from "@opencrane/backend/server/repo
 import { auditRouter } from "@opencrane/backend/server/iam/audit";
 import { groupsRouter } from "@opencrane/backend/server/iam/groups";
 import { _IssueAttemptLiteLlmKey, modelRoutingDefaultsRouter } from "@opencrane/backend/server/gateways/model-routing";
-import { mcpOperatorRouter } from "@opencrane/backend/server/gateways/mcp";
+import { _CreateMcpCallerResolver, mcpOperatorRouter, mcpTaskRouter } from "@opencrane/backend/server/gateways/mcp";
 import { _CreateIntegrationCustodyRouter } from "@opencrane/backend/server/gateways/integrations";
 import type { ObotCustodyPort } from "@opencrane/backend/server/infra/obot-custody";
 import { providerCredentialsRouter, providerByokRouter, modelRegistryRouter } from "@opencrane/backend/server/gateways/providers";
@@ -82,8 +82,11 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, coreApi: k8s
 		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfElicitationRouter(prisma, _log) },
 		{ method: "use", path: "/api/v1/me/activity", handler: _CreateSelfElicitationActivityRouter(prisma, _log) },
 	];
+	const mcpPrincipalDirectory = new PrismaAuthenticatedPrincipalDirectoryUnitOfWork(prisma);
+	const resolveMcpCaller = _CreateMcpCallerResolver(mcpPrincipalDirectory);
 	const gatewayRoutes: readonly RouteMount[] = [
-		{ method: "use", path: "/api/v1/mcp", handler: mcpOperatorRouter(mcpWorkflows.unitOfWork, new PrismaAuthenticatedPrincipalDirectoryUnitOfWork(prisma), mcpWorkflows.eraProbeWorkflow, mcpWorkflows.mcpbValidationWorkflow, mcpWorkflows.mcpbArtifacts) },
+		{ method: "use", path: "/api/v1/mcp", handler: mcpOperatorRouter(mcpWorkflows.unitOfWork, mcpPrincipalDirectory, mcpWorkflows.eraProbeWorkflow, mcpWorkflows.mcpbValidationWorkflow, mcpWorkflows.mcpbArtifacts) },
+		{ method: "use", path: "/api/v1/mcp", handler: mcpTaskRouter(mcpWorkflows.unitOfWork, mcpWorkflows.mcpTaskWorkflow, resolveMcpCaller) },
 		{ method: "use", path: "/api/v1/integrations", handler: _CreateIntegrationCustodyRouter(prisma, obotCustody, _log) },
 		{ method: "use", path: "/api/v1/model-routing/defaults", handler: modelRoutingDefaultsRouter(prisma) },
 		{ method: "use", path: "/api/v1/providers/credentials", handler: providerCredentialsRouter(prisma) },

--- a/libs/backend/server/api-spec/main/src/mcp-iam-schemas.ts
+++ b/libs/backend/server/api-spec/main/src/mcp-iam-schemas.ts
@@ -109,6 +109,52 @@ export const _McpIamOpenapiSchemas = {
 			failureCode: { type: ["string", "null"], enum: ["artifact_mismatch", "bundle_too_large", "invalid_archive", "invalid_manifest", "invalid_signature", "unsupported_manifest_version", null], description: "Bounded rejection reason, or null while pending or verified." },
 		},
 	},
+	McpTaskInputRequest: {
+		type: "object",
+		description: "One value an MCP task needs before its workflow can continue.",
+		required: ["requestId", "message"],
+		additionalProperties: false,
+		properties: {
+			requestId: { type: "string", minLength: 1, maxLength: 128, pattern: "\\S", description: "Identifier the client repeats when it supplies the requested value." },
+			message: { type: "string", minLength: 1, maxLength: 4_000, pattern: "\\S", description: "Plain-language explanation of the value the task needs." },
+		},
+	},
+	McpTaskInputResponse: {
+		type: "object",
+		description: "A client value saved before the task workflow receives its input event.",
+		required: ["requestId", "value"],
+		additionalProperties: false,
+		properties: {
+			requestId: { type: "string", minLength: 1, maxLength: 128, pattern: "\\S", description: "Identifier of the task input request this value answers." },
+			value: { type: "string", minLength: 1, maxLength: 16_000, pattern: "\\S", description: "Text value supplied for the saved input request." },
+		},
+	},
+	McpTaskSubmission: {
+		type: "object",
+		description: "A user request to save an asynchronous MCP tool call and start its workflow.",
+		required: ["idempotencyKey", "toolName", "arguments", "inputRequest"],
+		additionalProperties: false,
+		properties: {
+			idempotencyKey: { type: "string", minLength: 1, maxLength: 128, pattern: "\\S", description: "Caller-chosen key that safely retries the same tool call." },
+			toolName: { type: "string", minLength: 1, maxLength: 256, pattern: "\\S", description: "Name of the selected MCP tool." },
+			arguments: { description: "Tool arguments saved only as a digest that binds the workflow to this call." },
+			inputRequest: { $ref: "#/components/schemas/McpTaskInputRequest" },
+		},
+	},
+	McpTask: {
+		type: "object",
+		description: "The caller-visible progress of an asynchronous MCP tool call. It excludes product ownership and workflow engine details.",
+		required: ["id", "toolName", "state", "inputRequest", "inputResponse", "result", "failureCode"],
+		properties: {
+			id: { type: "string", description: "Stable task identifier used to read progress or submit requested input." },
+			toolName: { type: "string", description: "Name of the MCP tool selected for this task." },
+			state: { type: "string", enum: ["working", "input_required", "completed", "cancelled", "failed"], description: "Saved task state. Input is accepted only while the task is input_required." },
+			inputRequest: { $ref: "#/components/schemas/McpTaskInputRequest", description: "Requested value saved with the task." },
+			inputResponse: { anyOf: [{ $ref: "#/components/schemas/McpTaskInputResponse" }, { type: "null" }], description: "Saved client response, or null before one is accepted." },
+			result: { type: ["string", "null"], description: "Final result when the task has completed, otherwise null." },
+			failureCode: { type: ["string", "null"], description: "Stable failure reason when the task has failed, otherwise null." },
+		},
+	},
 	ResourceShare: {
 		type: "object",
 		description: "A direct file, chat, or dataset share. Each recipient relation is backed by an explicit authorization grant.",

--- a/libs/backend/server/gateways/mcp/main/README.md
+++ b/libs/backend/server/gateways/mcp/main/README.md
@@ -53,6 +53,12 @@ task lifecycle accepts a call, asks the client for one needed value, and saves t
 workflow continues. It does not run a real Skill yet; the next slice will connect this lifecycle to
 the Skills worker.
 
+The signed-in caller starts a task with `POST /api/v1/mcp/tasks`, reads its progress with
+`GET /api/v1/mcp/tasks/:id`, and sends the requested value with `POST /api/v1/mcp/tasks/:id/input`.
+Each route uses the caller's saved local Principal, so a task owned by someone else is reported as
+not found. The response shows task progress but does not expose the caller's IDs, the saved call
+digest, or Absurd's engine receipt.
+
 ```
  MCP client starts a tool call
         │
@@ -93,6 +99,7 @@ returns credentials and never labels an install connected before a real connecti
 ## Public surface
 
 - `mcpOperatorRouter` — the Express router mounted at `/api/v1/mcp`.
+- `mcpTaskRouter` — the separate caller-owned router mounted at `/api/v1/mcp` for saved tool calls.
 - `registerRemoteServer` — saves a draft server and its protocol-check job together.
 - `__CreateMcpEraProbeWorkflow` — registers the saved background job that checks the server.
 - `submitMcpbValidation` and `getMcpbValidation` — save and read signed MCP bundle checks.
@@ -103,6 +110,8 @@ returns credentials and never labels an install connected before a real connecti
   database transaction.
 - `submitMcpTask`, `getMcpTask`, and `submitMcpTaskInput` — save, read, and continue the durable
   lifecycle behind a future asynchronous MCP tool call.
+- `POST /mcp/tasks`, `GET /mcp/tasks/:id`, and `POST /mcp/tasks/:id/input` — the authenticated
+  public API for starting a task, reading its progress, and providing requested input.
 - `__CreateMcpTaskWorkflow` — registers the saved task lifecycle with Absurd.
 - Operator services: `listEntitledCatalog`, `listInstalled`, `installServer`, `approveServer`,
   `publishServer`, and the access editor.

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-task-router.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-task-router.test.ts
@@ -1,0 +1,139 @@
+import express from "express";
+import type { Express } from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+import type { McpOperatorTransaction, McpOperatorUnitOfWork } from "../core/mcp-operator-repository.types";
+import { McpTaskStates } from "../mcp-tasks/mcp-task.types";
+import type { McpTaskRecord, McpTaskWorkflow } from "../mcp-tasks/mcp-task.types";
+import type { McpCallerResolver } from "../routes/mcp-caller.types";
+import { mcpTaskRouter } from "../routes/mcp-task";
+
+/** Builds one saved task with private fields that the public route must not return. */
+function _Task(overrides: Partial<McpTaskRecord> = {}): McpTaskRecord
+{
+  return {
+    id: "task-1",
+    siloId: "silo-1",
+    principalId: "principal-1",
+    callDigest: "sha256:private-call-digest",
+    toolName: "collect-details",
+    state: McpTaskStates.InputRequired,
+    inputRequest: { requestId: "details", message: "What details should this task use?" },
+    inputResponse: null,
+    result: null,
+    failureCode: null,
+    workflowTask: { taskId: "engine-task-1", taskName: "mcp-task.call", idempotencyKey: "workflows:mcp-task:task-1" },
+    ...overrides,
+  };
+}
+
+/** Wraps a task repository in the same transaction callback shape used by task lifecycle code. */
+function _UnitOfWork(mcpTasks: Record<string, unknown>): McpOperatorUnitOfWork
+{
+  return {
+    async execute<Result>(operation: (transaction: McpOperatorTransaction) => Promise<Result>): Promise<Result>
+    {
+      return await operation({ mcpTasks, workflowTransaction: {} } as unknown as McpOperatorTransaction);
+    },
+  };
+}
+
+const _ResolveCaller: McpCallerResolver = async function _Caller()
+{
+  return { siloId: "silo-1", principalId: "principal-1" };
+};
+
+/** Mounts the task router with a durable local caller resolved by the trusted request boundary. */
+function _App(unitOfWork: McpOperatorUnitOfWork, workflow: McpTaskWorkflow, resolveCaller: McpCallerResolver = _ResolveCaller): Express
+{
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/mcp", mcpTaskRouter(unitOfWork, workflow, resolveCaller));
+  return app;
+}
+
+/** Supplies an admitted workflow receipt and records input delivery. */
+function _Workflow(): McpTaskWorkflow
+{
+  return {
+    admit: vi.fn().mockResolvedValue({ taskKey: "workflows:mcp-task:task-1", receipt: { taskId: "engine-task-1", taskName: "mcp-task.call", idempotencyKey: "workflows:mcp-task:task-1" } }),
+    deliverInput: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("mcp-task router", function _suite()
+{
+	it("requires a local caller before it saves a task", async function _RejectsAnonymousSubmission()
+	{
+		const createOrFind = vi.fn();
+		const response = await request(_App(_UnitOfWork({ createOrFind }), _Workflow(), async function _Anonymous()
+		{
+			return null;
+		}))
+			.post("/api/v1/mcp/tasks")
+			.send({ idempotencyKey: "call-1", toolName: "collect-details", arguments: {}, inputRequest: { requestId: "details", message: "What details should this task use?" } });
+
+		expect(response.status).toBe(401);
+		expect(createOrFind).not.toHaveBeenCalled();
+	});
+
+	it("rejects malformed task input before task persistence", async function _RejectsMalformedSubmission()
+	{
+		const createOrFind = vi.fn();
+		const response = await request(_App(_UnitOfWork({ createOrFind }), _Workflow()))
+			.post("/api/v1/mcp/tasks")
+			.send({ idempotencyKey: "call-1", toolName: "collect-details", inputRequest: { requestId: "details", message: "What details should this task use?" } });
+
+		expect(response.status).toBe(400);
+		expect(createOrFind).not.toHaveBeenCalled();
+	});
+
+	it("saves a task and returns only its caller-visible progress", async function _SubmitsTask()
+	{
+		const saved = _Task();
+		const response = await request(_App(_UnitOfWork({ createOrFind: vi.fn().mockResolvedValue({ created: true, task: _Task({ workflowTask: null }) }), ensureWorkflow: vi.fn().mockResolvedValue(saved) }), _Workflow()))
+			.post("/api/v1/mcp/tasks")
+			.send({ idempotencyKey: "call-1", toolName: "collect-details", arguments: { source: "client" }, inputRequest: { requestId: "details", message: "What details should this task use?" } });
+
+		expect(response.status).toBe(201);
+		expect(response.body).toMatchObject({ id: "task-1", toolName: "collect-details", state: "input_required" });
+		expect(response.body).not.toHaveProperty("workflowTask");
+	});
+
+	it("returns a caller-owned saved task without product ownership or engine details", async function _RedactsTask()
+  {
+    const task = _Task();
+    const response = await request(_App(_UnitOfWork({ find: vi.fn().mockResolvedValue(task) }), _Workflow()))
+      .get("/api/v1/mcp/tasks/task-1");
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ id: "task-1", toolName: "collect-details", state: "input_required", inputRequest: { requestId: "details", message: "What details should this task use?" }, inputResponse: null, result: null, failureCode: null });
+    expect(response.body).not.toHaveProperty("siloId");
+    expect(response.body).not.toHaveProperty("principalId");
+    expect(response.body).not.toHaveProperty("callDigest");
+    expect(response.body).not.toHaveProperty("workflowTask");
+  });
+
+	it("does not reveal whether an unavailable task belongs to another caller", async function _HidesUnavailableTask()
+	{
+		const response = await request(_App(_UnitOfWork({ find: vi.fn().mockResolvedValue(null) }), _Workflow()))
+			.get("/api/v1/mcp/tasks/task-1");
+
+		expect(response.status).toBe(404);
+		expect(response.body).toMatchObject({ code: "MCP_TASK_NOT_FOUND" });
+	});
+
+  it("saves accepted input before delivering it to the admitted workflow", async function _DeliversInput()
+  {
+    const workflow = _Workflow();
+    const waiting = _Task();
+    const saved = _Task({ inputResponse: { requestId: "details", value: "Use the signed brief." } });
+    const response = await request(_App(_UnitOfWork({ find: vi.fn().mockResolvedValue(waiting), recordInput: vi.fn().mockResolvedValue(saved) }), workflow))
+      .post("/api/v1/mcp/tasks/task-1/input")
+      .send({ requestId: "details", value: "Use the signed brief." });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(workflow.deliverInput)).toHaveBeenCalledWith(waiting.workflowTask, { siloId: "silo-1", mcpTaskId: "task-1", callDigest: "sha256:private-call-digest" }, { requestId: "details", value: "Use the signed brief." });
+  });
+});

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-task.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-task.test.ts
@@ -56,6 +56,18 @@ describe("MCP task lifecycle", function _DescribeMcpTaskLifecycle()
 		expect(ensureWorkflow).toHaveBeenCalledWith("silo-1", "mcp-task-1", expect.objectContaining({ taskId: "absurd-task-1", taskName: McpTaskTaskNames.Call }));
 	});
 
+	it("uses the same call digest when JSON object keys arrive in a different order", async function _ItCanonicalizesCallArguments()
+	{
+		const createOrFind = vi.fn().mockResolvedValue({ created: true, task: _Task({ workflowTask: null }) });
+		const unitOfWork = _UnitOfWork({ createOrFind, ensureWorkflow: vi.fn().mockResolvedValue(_Task()) });
+		const workflow = { admit: vi.fn().mockResolvedValue({ receipt: _Task().workflowTask, taskKey: _Task().workflowTask!.idempotencyKey }), deliverInput: vi.fn() };
+
+		await submitMcpTask(unitOfWork, workflow, { siloId: "silo-1", principalId: "principal-1" }, { idempotencyKey: "call-1", toolName: "collect-details", arguments: { first: "one", second: "two" }, inputRequest: { requestId: "details", message: "What details should this task use?" } });
+		await submitMcpTask(unitOfWork, workflow, { siloId: "silo-1", principalId: "principal-1" }, { idempotencyKey: "call-1", toolName: "collect-details", arguments: { second: "two", first: "one" }, inputRequest: { requestId: "details", message: "What details should this task use?" } });
+
+		expect(createOrFind.mock.calls[0]![0].callDigest).toBe(createOrFind.mock.calls[1]![0].callDigest);
+	});
+
 	it("keeps a task private to its authenticated principal", async function _ItKeepsTaskPrivate()
 	{
 		const find = vi.fn().mockResolvedValue(null);

--- a/libs/backend/server/gateways/mcp/main/src/index.ts
+++ b/libs/backend/server/gateways/mcp/main/src/index.ts
@@ -24,5 +24,8 @@ export { __CreateMcpTaskWorkflow, __McpTaskInputEventName, __McpTaskWorkflowKey 
 export { getMcpTask, submitMcpTask, submitMcpTaskInput } from "./mcp-tasks/mcp-task-submission";
 export { McpTaskEvents, McpTaskInputSubmissionOutcomes, McpTaskStates, McpTaskTaskNames } from "./mcp-tasks/mcp-task.types";
 export type { McpTaskAdmission, McpTaskCaller, McpTaskInputRequest, McpTaskInputResponse, McpTaskInputSubmissionResult, McpTaskRecord, McpTaskSubmissionCommand, McpTaskWorkflow, McpTaskWorkflowInput, McpTaskWorkflowOptions } from "./mcp-tasks/mcp-task.types";
+export { _CreateMcpCallerResolver } from "./routes/mcp-caller";
+export type { McpCallerResolver } from "./routes/mcp-caller.types";
 export * from "./routes/mcp-operator";
+export * from "./routes/mcp-task";
 export * from "./openapi";

--- a/libs/backend/server/gateways/mcp/main/src/mcp-tasks/mcp-task-submission.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcp-tasks/mcp-task-submission.ts
@@ -1,4 +1,5 @@
-import { createHash } from "node:crypto";
+import { ___DigestCanonicalJson } from "@opencrane/util";
+import type { JsonValue } from "@opencrane/util";
 
 import type { McpOperatorUnitOfWork } from "../core/mcp-operator-repository.types";
 import { McpTaskInputSubmissionOutcomes } from "./mcp-task.types";
@@ -7,7 +8,7 @@ import type { McpTaskCaller, McpTaskInputResponse, McpTaskInputSubmissionResult,
 /** Return a SHA-256 digest without retaining a client key or tool argument value. */
 function _Digest(value: unknown): string
 {
-	return `sha256:${createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
+	return ___DigestCanonicalJson(value as JsonValue);
 }
 
 /** Reject a task command before it reaches product storage or workflow admission. */
@@ -32,7 +33,7 @@ export async function submitMcpTask(unitOfWork: McpOperatorUnitOfWork, workflow:
 {
 	_AssertSubmission(command);
 	const requestKeyDigest = _Digest([caller.siloId, caller.principalId, command.idempotencyKey]);
-	const callDigest = _Digest([caller.siloId, caller.principalId, command.toolName, command.arguments, command.inputRequest]);
+	const callDigest = _Digest([caller.siloId, caller.principalId, command.toolName, command.arguments, { requestId: command.inputRequest.requestId, message: command.inputRequest.message }]);
 	return await unitOfWork.execute(async function _Submit(transaction): Promise<McpTaskRecord | null>
 	{
 		const stored = await transaction.mcpTasks.createOrFind({ siloId: caller.siloId, principalId: caller.principalId, requestKeyDigest, callDigest, toolName: command.toolName, inputRequest: command.inputRequest });

--- a/libs/backend/server/gateways/mcp/main/src/mcp-tasks/mcp-task.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcp-tasks/mcp-task.types.ts
@@ -1,4 +1,5 @@
 import type { IWorkflowEngine, IWorkflowTaskReceipt, IWorkflowTransaction } from "@opencrane/backend/server/infra/workflows/contract";
+import type { JsonValue } from "@opencrane/util";
 
 import type { McpOperatorUnitOfWork } from "../core/mcp-operator-repository.types";
 
@@ -69,7 +70,7 @@ export interface McpTaskSubmissionCommand
 	/** MCP tool name selected by the client. */
 	readonly toolName: string;
 	/** Tool arguments bound into the immutable call digest without retaining their contents. */
-	readonly arguments: unknown;
+	readonly arguments: JsonValue;
 	/** The one bounded value this initial lifecycle task will wait for. */
 	readonly inputRequest: McpTaskInputRequest;
 }

--- a/libs/backend/server/gateways/mcp/main/src/mcp-tasks/mcp-task.validator.ts
+++ b/libs/backend/server/gateways/mcp/main/src/mcp-tasks/mcp-task.validator.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+import type { JsonValue } from "@opencrane/util";
+
+import type { McpTaskInputResponse, McpTaskSubmissionCommand } from "./mcp-task.types";
+
+/** Builds the strict public task shape before the transform returns the lifecycle command. */
+const _McpTaskSubmissionSchema = z.object({
+	idempotencyKey: z.string().trim().min(1).max(128),
+	toolName: z.string().trim().min(1).max(256),
+	arguments: z.unknown(),
+	inputRequest: z.object({
+		requestId: z.string().trim().min(1).max(128),
+		message: z.string().trim().min(1).max(4_000),
+	}).strict(),
+}).strict().refine(function _RequiresArguments(value): boolean
+{
+	return Object.hasOwn(value, "arguments");
+}, "arguments is required");
+
+/** Validates the public task commands next to the lifecycle types they create. */
+export const ___McpTaskSubmissionSchema: z.ZodType<McpTaskSubmissionCommand, z.ZodTypeDef, unknown> = _McpTaskSubmissionSchema.transform(function _TaskSubmission(value): McpTaskSubmissionCommand
+{
+  return { idempotencyKey: value.idempotencyKey, toolName: value.toolName, arguments: value.arguments as JsonValue, inputRequest: value.inputRequest };
+});
+
+/** Validates the saved response that wakes a task waiting for client input. */
+export const ___McpTaskInputResponseSchema: z.ZodType<McpTaskInputResponse> = z.object({
+	requestId: z.string().trim().min(1).max(128),
+	value: z.string().trim().min(1).max(16_000),
+}).strict();
+
+/** Accepts the opaque task identifier produced by a successful task submission. */
+export const ___McpTaskIdSchema = z.string().trim().min(1).max(256);

--- a/libs/backend/server/gateways/mcp/main/src/openapi.ts
+++ b/libs/backend/server/gateways/mcp/main/src/openapi.ts
@@ -234,6 +234,56 @@ export const _McpOpenapiPaths = {
     },
   },
 
+  "/mcp/tasks": {
+    post: {
+      operationId: "submitMcpTask",
+      summary: "Save an asynchronous MCP tool call and start its workflow",
+      tags: ["MCP Operator"],
+      requestBody: {
+        required: true,
+        content: { "application/json": { schema: { $ref: "#/components/schemas/McpTaskSubmission" } } },
+      },
+      responses: {
+        201: created("Task and background workflow saved.", { $ref: "#/components/schemas/McpTask" }),
+        400: badRequest("MCP task fields are invalid."),
+        409: { description: "Task key conflicts with a different call.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+      },
+    },
+  },
+
+  "/mcp/tasks/{id}": {
+    get: {
+      operationId: "getMcpTask",
+      summary: "Read a saved MCP task owned by the calling user",
+      tags: ["MCP Operator"],
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", minLength: 1, maxLength: 256, pattern: "\\S" } }],
+      responses: {
+        200: ok("Saved task progress.", { $ref: "#/components/schemas/McpTask" }),
+        400: badRequest("MCP task identifier is invalid."),
+        404: notFound("MCP task not found."),
+      },
+    },
+  },
+
+  "/mcp/tasks/{id}/input": {
+    post: {
+      operationId: "submitMcpTaskInput",
+      summary: "Save requested input and wake an MCP task workflow",
+      tags: ["MCP Operator"],
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string", minLength: 1, maxLength: 256, pattern: "\\S" } }],
+      requestBody: {
+        required: true,
+        content: { "application/json": { schema: { $ref: "#/components/schemas/McpTaskInputResponse" } } },
+      },
+      responses: {
+        200: ok("Task input accepted.", { $ref: "#/components/schemas/McpTask" }),
+        400: badRequest("MCP task identifier or input fields are invalid."),
+        404: notFound("MCP task not found."),
+        409: { description: "Input conflicts with the saved task request or response.", content: { "application/json": { schema: { $ref: "#/components/schemas/Error" } } } },
+      },
+    },
+  },
+
   "/mcp/directory": {
     get: {
       operationId: "getMcpDirectory",

--- a/libs/backend/server/gateways/mcp/main/src/routes/mcp-caller.ts
+++ b/libs/backend/server/gateways/mcp/main/src/routes/mcp-caller.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from "express";
+
+import type { AuthenticatedPrincipalDirectory } from "@opencrane/backend/server/iam/identity";
+import { _ResolveRequestPrincipal } from "@opencrane/backend/server/infra/auth";
+
+import type { McpOperatorCaller } from "../core/mcp-operator.logic.types";
+import type { McpCallerResolver } from "./mcp-caller.types";
+
+export type { McpCallerResolver } from "./mcp-caller.types";
+
+/** Creates the request-bound resolver shared by MCP user-facing HTTP routers. */
+export function _CreateMcpCallerResolver(principalDirectory: AuthenticatedPrincipalDirectory): McpCallerResolver
+{
+  return async function _ResolveMcpCaller(req: Request): Promise<McpOperatorCaller | null>
+  {
+    const requestPrincipal = _ResolveRequestPrincipal(req);
+    const authUser = req.session?.authUser;
+    if (!requestPrincipal || !authUser?.issuer || !authUser.sub)
+      return null;
+    return principalDirectory.resolveAuthenticatedPrincipal(requestPrincipal.siloId, authUser.issuer, authUser.sub);
+  };
+}
+
+/** Sends 401 when a caller-owned MCP route has no authenticated local Principal. */
+export function _RequireMcpCaller(res: Response, caller: McpOperatorCaller | null): caller is McpOperatorCaller
+{
+  if (caller)
+    return true;
+  res.status(401).json({ error: "Authentication required.", code: "UNAUTHORIZED" });
+  return false;
+}

--- a/libs/backend/server/gateways/mcp/main/src/routes/mcp-caller.types.ts
+++ b/libs/backend/server/gateways/mcp/main/src/routes/mcp-caller.types.ts
@@ -1,0 +1,6 @@
+import type { Request } from "express";
+
+import type { McpOperatorCaller } from "../core/mcp-operator.logic.types";
+
+/** Resolves one request to the durable MCP caller that may use a caller-owned endpoint. */
+export type McpCallerResolver = (request: Request) => Promise<McpOperatorCaller | null>;

--- a/libs/backend/server/gateways/mcp/main/src/routes/mcp-operator.ts
+++ b/libs/backend/server/gateways/mcp/main/src/routes/mcp-operator.ts
@@ -1,9 +1,8 @@
 import { Router, type Request, type Response } from "express";
 
 import type { AuthenticatedPrincipalDirectory } from "@opencrane/backend/server/iam/identity";
-import { _RequireOrgAdmin, _ResolveRequestPrincipal } from "@opencrane/backend/server/infra/auth";
+import { _RequireOrgAdmin } from "@opencrane/backend/server/infra/auth";
 import { approveServer, getAccessPolicy, getDirectory, installServer, listAllServers, listEntitledCatalog, listInstalled, publishServer, rejectServer, setAccessPolicy, setServerEnabled, uninstallServer } from "../core/mcp-operator.logic";
-import type { McpOperatorCaller } from "../core/mcp-operator.logic.types";
 import type { McpOperatorUnitOfWork } from "../core/mcp-operator-repository.types";
 import { McpRemoteServerRegistrationValidationError, registerRemoteServer } from "../era-probe/mcp-remote-registration";
 import { ___McpRemoteServerRegistrationSchema } from "../era-probe/mcp-remote-registration.validator";
@@ -14,6 +13,7 @@ import { McpbValidationSubmissionOutcomes } from "../mcpb-validation/mcpb-valida
 import type { McpbBundleArtifactResolver } from "../mcpb-validation/mcpb-validation-submission.types";
 import type { McpbValidationWorkflow } from "../mcpb-validation/mcpb-validation.types";
 import { ___McpbValidationIdSchema, ___McpbValidationSubmissionSchema } from "../mcpb-validation/mcpb-validation-submission.validator";
+import { _CreateMcpCallerResolver, _RequireMcpCaller } from "./mcp-caller";
 import { ___McpAccessPolicySchema, ___McpEnabledSchema, ___McpInstallSchema } from "./mcp-operator.validator";
 
 /**
@@ -22,7 +22,7 @@ import { ___McpAccessPolicySchema, ___McpEnabledSchema, ___McpInstallSchema } fr
  * Serves the entitlement-scoped catalog, per-Principal installs, and organization-admin governance
  * endpoints from the same authenticated authority. Two authorization rules apply:
  *
- * - **User-facing** (`/catalog`, `/installed/*`) — {@link _ResolveCaller} binds the request to a
+ * - **User-facing** (`/catalog`, `/installed/*`) — the shared caller resolver binds the request to a
  *   local Principal before entitlement filtering or install work begins.
  * - **Admin** (`/servers/*`, `/directory`) — gated by `_RequireOrgAdmin` and bound to the
  *   authenticated silo and local Principal projection.
@@ -37,6 +37,7 @@ import { ___McpAccessPolicySchema, ___McpEnabledSchema, ___McpInstallSchema } fr
 export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDirectory: AuthenticatedPrincipalDirectory, eraProbeWorkflow: McpEraProbeWorkflow, mcpbValidationWorkflow: McpbValidationWorkflow, mcpbArtifacts: McpbBundleArtifactResolver): Router
 {
   const router = Router();
+  const resolveCaller = _CreateMcpCallerResolver(principalDirectory);
 
   // -------------------------------------------------------------------------
   // User-facing — entitlement-scoped catalogue + per-user installs
@@ -45,8 +46,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** List the published servers the calling user is entitled to. */
   router.get("/catalog", async function _listCatalog(req, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     res.json(await listEntitledCatalog(unitOfWork, caller));
   });
@@ -54,8 +55,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** List the servers the calling user has installed. */
   router.get("/installed", async function _listInstalled(req, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     res.json(await listInstalled(unitOfWork, caller.principalId));
   });
@@ -63,8 +64,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** Install a catalogue server for the calling user. */
   router.post("/installed", async function _install(req, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     const parsed = ___McpInstallSchema.safeParse(req.body);
     if (!parsed.success)
@@ -86,8 +87,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** Removes the calling Principal's install and returns 404 when that Principal has none. */
   router.delete("/installed/:serverId", async function _uninstall(req: Request<{ serverId: string }>, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     const removed = await uninstallServer(unitOfWork, caller.principalId, req.params.serverId);
     if (removed === "not_found")
@@ -106,8 +107,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** List every catalogue server regardless of status (governance view). Org-admin only. */
   router.get("/servers", _RequireOrgAdmin(), async function _listServers(req, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     res.json(await listAllServers(unitOfWork, caller));
   });
@@ -115,8 +116,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
 	 /** Register a remote server and its era-probe task in one transaction. Org-admin only. */
   router.post("/servers", _RequireOrgAdmin(), async function _registerServer(req, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     const parsed = ___McpRemoteServerRegistrationSchema.safeParse(req.body);
     if (!parsed.success)
@@ -146,8 +147,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
 	/** Submit one published `.mcpb` artifact and its saved verification job. Org-admin only. */
 	router.post("/bundle-validations", _RequireOrgAdmin(), async function _SubmitMcpBundle(req, res)
 	{
-		const caller = await _ResolveCaller(principalDirectory, req);
-		if (!_SendUnauthorizedWhenMissing(res, caller))
+      const caller = await resolveCaller(req);
+      if (!_RequireMcpCaller(res, caller))
 			return;
 		const parsed = ___McpbValidationSubmissionSchema.safeParse(req.body);
 		if (!parsed.success)
@@ -172,8 +173,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
 	/** Return one saved MCP bundle validation inside the authenticated silo. Org-admin only. */
 	router.get("/bundle-validations/:id", _RequireOrgAdmin(), async function _GetMcpBundleValidation(req: Request<{ id: string }>, res)
 	{
-		const caller = await _ResolveCaller(principalDirectory, req);
-		if (!_SendUnauthorizedWhenMissing(res, caller))
+      const caller = await resolveCaller(req);
+      if (!_RequireMcpCaller(res, caller))
 			return;
 		if (!___McpbValidationIdSchema.safeParse(req.params.id).success)
 		{
@@ -192,8 +193,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
 	 /** Approve a server after its saved protocol check succeeds. Org-admin only. */
   router.post("/servers/:id/approve", _RequireOrgAdmin(), async function _approve(req: Request<{ id: string }>, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     _sendServerOrNotFound(res, await approveServer(unitOfWork, caller, req.params.id));
   });
@@ -201,8 +202,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** Publish an approved server after its saved protocol check succeeds. Org-admin only. */
   router.post("/servers/:id/publish", _RequireOrgAdmin(), async function _publish(req: Request<{ id: string }>, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     _sendServerOrNotFound(res, await publishServer(unitOfWork, caller, req.params.id));
   });
@@ -210,8 +211,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** Sets a server's status to disabled. This endpoint does not require a prior status. Org-admin only. */
   router.post("/servers/:id/reject", _RequireOrgAdmin(), async function _reject(req: Request<{ id: string }>, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     _sendServerOrNotFound(res, await rejectServer(unitOfWork, caller, req.params.id));
   });
@@ -226,8 +227,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
       return;
     }
 
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     _sendServerOrNotFound(res, await setServerEnabled(unitOfWork, caller, req.params.id, parsed.data.enabled));
   });
@@ -235,8 +236,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** Read a server's access policy. Org-admin only. */
   router.get("/servers/:id/access", _RequireOrgAdmin(), async function _getAccess(req: Request<{ id: string }>, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     const policy = await getAccessPolicy(unitOfWork, caller, req.params.id);
     if (!policy)
@@ -251,8 +252,8 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** Replace a server's access policy wholesale. Org-admin only. */
   router.put("/servers/:id/access", _RequireOrgAdmin(), async function _setAccess(req: Request<{ id: string }>, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     const parsed = ___McpAccessPolicySchema.safeParse(req.body);
     if (!parsed.success)
@@ -274,55 +275,13 @@ export function mcpOperatorRouter(unitOfWork: McpOperatorUnitOfWork, principalDi
   /** List the selectable users and groups for the access editor. Org-admin only. */
   router.get("/directory", _RequireOrgAdmin(), async function _directory(req, res)
   {
-    const caller = await _ResolveCaller(principalDirectory, req);
-    if (!_SendUnauthorizedWhenMissing(res, caller))
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
       return;
     res.json(await getDirectory(unitOfWork, caller));
   });
 
   return router;
-}
-
-/**
- * Resolves the request into the caller's authenticated silo and local Principal.
- *
- * The request must carry a verified identity and trusted silo, then the directory must resolve that
- * identity to a persisted Principal. Returning `null` makes every route send 401 instead of using
- * request claims as MCP authorization.
- *
- * @param principalDirectory - Resolves the verified identity to a local Principal.
- * @param req - Carries the authenticated session and resolved request silo.
- * @returns The authenticated caller context, or `null` when local Principal resolution fails.
- */
-async function _ResolveCaller(principalDirectory: AuthenticatedPrincipalDirectory, req: Request): Promise<McpOperatorCaller | null>
-{
-  // 1. Resolve the verified OIDC subject and trusted request silo without accepting either from
-  //    the request body.
-  const requestPrincipal = _ResolveRequestPrincipal(req);
-  const authUser = req.session?.authUser;
-  if (!requestPrincipal || !authUser?.issuer || !authUser.sub)
-  {
-    return null;
-  }
-
-  // 2. Bind the external identity to the durable local Principal. Missing or stale projections
-  //    fail closed, so raw OIDC claims never become MCP authority by themselves.
-  return principalDirectory.resolveAuthenticatedPrincipal(requestPrincipal.siloId, authUser.issuer, authUser.sub);
-}
-
-/**
- * Sends the shared unauthenticated response when local Principal resolution failed.
- *
- * @param res - Express response.
- * @param caller - Resolved local caller, or null when authentication cannot authorize work.
- * @returns True when the route may continue with the caller.
- */
-function _SendUnauthorizedWhenMissing(res: Response, caller: McpOperatorCaller | null): caller is McpOperatorCaller
-{
-  if (caller)
-    return true;
-  res.status(401).json({ error: "Authentication required.", code: "UNAUTHORIZED" });
-  return false;
 }
 
 /**

--- a/libs/backend/server/gateways/mcp/main/src/routes/mcp-task.ts
+++ b/libs/backend/server/gateways/mcp/main/src/routes/mcp-task.ts
@@ -1,0 +1,117 @@
+import { Router, type Request } from "express";
+
+import type { McpOperatorUnitOfWork } from "../core/mcp-operator-repository.types";
+import { getMcpTask, submitMcpTask, submitMcpTaskInput } from "../mcp-tasks/mcp-task-submission";
+import { McpTaskInputSubmissionOutcomes } from "../mcp-tasks/mcp-task.types";
+import type { McpTaskRecord, McpTaskWorkflow } from "../mcp-tasks/mcp-task.types";
+import { ___McpTaskIdSchema, ___McpTaskInputResponseSchema, ___McpTaskSubmissionSchema } from "../mcp-tasks/mcp-task.validator";
+import { _RequireMcpCaller } from "./mcp-caller";
+import type { McpCallerResolver } from "./mcp-caller.types";
+
+/**
+ * Creates the caller-owned HTTP API for saved asynchronous MCP tool calls.
+ *
+ * Called by: `apps/opencrane/src/app/routes.ts`, alongside the MCP operator router at the same
+ * `/api/v1/mcp` mount. Each handler resolves a trusted local caller, accepts only validated task
+ * data, and returns a redacted task response. Missing callers receive 401; invalid fields receive
+ * 400; unavailable caller-owned tasks receive 404; and conflicting retries or input receive 409.
+ *
+ * @param unitOfWork - Runs task reads and writes in their product database transaction.
+ * @param workflow - Admits the saved task and delivers accepted input to its workflow.
+ * @param resolveCaller - Resolves verified request evidence to the durable local caller.
+ * @returns Express router for creating, reading, and continuing MCP tasks.
+ */
+export function mcpTaskRouter(unitOfWork: McpOperatorUnitOfWork, workflow: McpTaskWorkflow, resolveCaller: McpCallerResolver): Router
+{
+  const router = Router();
+
+  /** Saves an asynchronous MCP tool call and starts its background workflow. */
+  router.post("/tasks", async function _SubmitTask(req, res)
+  {
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
+      return;
+    const parsed = ___McpTaskSubmissionSchema.safeParse(req.body);
+    if (!parsed.success)
+    {
+      res.status(400).json({ error: "MCP task fields are invalid.", code: "VALIDATION_ERROR" });
+      return;
+    }
+    const task = await submitMcpTask(unitOfWork, workflow, caller, parsed.data);
+    if (task === null)
+    {
+      res.status(409).json({ error: "The task key is already used by different input.", code: "MCP_TASK_CONFLICT" });
+      return;
+    }
+    res.status(201).json(_TaskResponse(task));
+  });
+
+  /** Returns a task owned by the authenticated caller. */
+  router.get("/tasks/:id", async function _GetTask(req: Request<{ id: string }>, res)
+  {
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
+      return;
+    if (!___McpTaskIdSchema.safeParse(req.params.id).success)
+    {
+      res.status(400).json({ error: "MCP task id is invalid.", code: "VALIDATION_ERROR" });
+      return;
+    }
+    const task = await getMcpTask(unitOfWork, caller, req.params.id);
+    if (task === null)
+    {
+      res.status(404).json({ error: "MCP task not found.", code: "MCP_TASK_NOT_FOUND" });
+      return;
+    }
+    res.json(_TaskResponse(task));
+  });
+
+  /** Saves one answer and wakes the background task that requested it. */
+  router.post("/tasks/:id/input", async function _SubmitTaskInput(req: Request<{ id: string }>, res)
+  {
+    const caller = await resolveCaller(req);
+    if (!_RequireMcpCaller(res, caller))
+      return;
+    if (!___McpTaskIdSchema.safeParse(req.params.id).success)
+    {
+      res.status(400).json({ error: "MCP task id is invalid.", code: "VALIDATION_ERROR" });
+      return;
+    }
+    const parsed = ___McpTaskInputResponseSchema.safeParse(req.body);
+    if (!parsed.success)
+    {
+      res.status(400).json({ error: "MCP task input fields are invalid.", code: "VALIDATION_ERROR" });
+      return;
+    }
+    const result = await submitMcpTaskInput(unitOfWork, workflow, caller, req.params.id, parsed.data);
+    if (result.outcome === McpTaskInputSubmissionOutcomes.NotAvailable)
+    {
+      res.status(404).json({ error: "MCP task not found.", code: "MCP_TASK_NOT_FOUND" });
+      return;
+    }
+    if (result.outcome === McpTaskInputSubmissionOutcomes.Conflict)
+    {
+      res.status(409).json({ error: "MCP task input conflicts with saved input.", code: "MCP_TASK_INPUT_CONFLICT" });
+      return;
+    }
+    if (result.task === undefined)
+      throw new Error("Accepted MCP task input has no saved task.");
+    res.json(_TaskResponse(result.task));
+  });
+
+  return router;
+}
+
+/** Removes private task ownership and engine details before returning a task to its caller. */
+function _TaskResponse(task: McpTaskRecord)
+{
+  return {
+    id: task.id,
+    toolName: task.toolName,
+    state: task.state,
+    inputRequest: task.inputRequest,
+    inputResponse: task.inputResponse,
+    result: task.result,
+    failureCode: task.failureCode,
+  };
+}

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -194,6 +194,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/mcp/tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Save an asynchronous MCP tool call and start its workflow */
+        post: operations["submitMcpTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/tasks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read a saved MCP task owned by the calling user */
+        get: operations["getMcpTask"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/mcp/tasks/{id}/input": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Save requested input and wake an MCP task workflow */
+        post: operations["submitMcpTaskInput"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/mcp/directory": {
         parameters: {
             query?: never;
@@ -1691,6 +1742,50 @@ export interface components {
              */
             failureCode?: "artifact_mismatch" | "bundle_too_large" | "invalid_archive" | "invalid_manifest" | "invalid_signature" | "unsupported_manifest_version" | null;
         };
+        /** @description One value an MCP task needs before its workflow can continue. */
+        McpTaskInputRequest: {
+            /** @description Identifier the client repeats when it supplies the requested value. */
+            requestId: string;
+            /** @description Plain-language explanation of the value the task needs. */
+            message: string;
+        };
+        /** @description A client value saved before the task workflow receives its input event. */
+        McpTaskInputResponse: {
+            /** @description Identifier of the task input request this value answers. */
+            requestId: string;
+            /** @description Text value supplied for the saved input request. */
+            value: string;
+        };
+        /** @description A user request to save an asynchronous MCP tool call and start its workflow. */
+        McpTaskSubmission: {
+            /** @description Caller-chosen key that safely retries the same tool call. */
+            idempotencyKey: string;
+            /** @description Name of the selected MCP tool. */
+            toolName: string;
+            /** @description Tool arguments saved only as a digest that binds the workflow to this call. */
+            arguments: unknown;
+            inputRequest: components["schemas"]["McpTaskInputRequest"];
+        };
+        /** @description The caller-visible progress of an asynchronous MCP tool call. It excludes product ownership and workflow engine details. */
+        McpTask: {
+            /** @description Stable task identifier used to read progress or submit requested input. */
+            id: string;
+            /** @description Name of the MCP tool selected for this task. */
+            toolName: string;
+            /**
+             * @description Saved task state. Input is accepted only while the task is input_required.
+             * @enum {string}
+             */
+            state: "working" | "input_required" | "completed" | "cancelled" | "failed";
+            /** @description Requested value saved with the task. */
+            inputRequest: components["schemas"]["McpTaskInputRequest"];
+            /** @description Saved client response, or null before one is accepted. */
+            inputResponse: components["schemas"]["McpTaskInputResponse"] | null;
+            /** @description Final result when the task has completed, otherwise null. */
+            result: string | null;
+            /** @description Stable failure reason when the task has failed, otherwise null. */
+            failureCode: string | null;
+        };
         /** @description A direct file, chat, or dataset share. Each recipient relation is backed by an explicit authorization grant. */
         ResourceShare: {
             /** @description Stable share identifier used to manage recipients. */
@@ -2710,6 +2805,141 @@ export interface operations {
             };
             /** @description MCP bundle validation not found. */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    submitMcpTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["McpTaskSubmission"];
+            };
+        };
+        responses: {
+            /** @description Task and background workflow saved. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpTask"];
+                };
+            };
+            /** @description MCP task fields are invalid. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Task key conflicts with a different call. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getMcpTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Saved task progress. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpTask"];
+                };
+            };
+            /** @description MCP task identifier is invalid. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP task not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    submitMcpTaskInput: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["McpTaskInputResponse"];
+            };
+        };
+        responses: {
+            /** @description Task input accepted. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["McpTask"];
+                };
+            };
+            /** @description MCP task identifier or input fields are invalid. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description MCP task not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Input conflicts with the saved task request or response. */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Summary

- expose caller-owned MCP task create, read, and input routes
- keep task ownership and workflow-engine data out of public responses
- align the OpenAPI contract and generated client with route validation
- keep retries stable when JSON argument keys arrive in a different order

## Validation

- contracts generation and lint
- MCP and OpenCrane TypeScript lint
- MCP test suite: 13 files, 83 tests
- style, Prisma-boundary, module-growth, and release-versioning checks

## Review

- architecture gate passed
- residue audit passed
- independent code review passed

## Review order

#714 -> #715 -> #716 -> #717 -> #718 -> #719 -> #720 -> #721 -> #722 -> #723 -> #724 -> #725 -> #726 -> #727 -> #728