### PR TITLE
⚡ Share the guarded workflow engine

### DIFF
--- a/apps/opencrane/src/app/mcp-workflow-composition.ts
+++ b/apps/opencrane/src/app/mcp-workflow-composition.ts
@@ -29,7 +29,11 @@ export function _McpEraProbeFailure(error: unknown): McpEraProbeFailure
 	throw error;
 }
 
-/** Compose one guarded Absurd engine for both remote-server and MCP bundle jobs. */
+/**
+ * Creates the guarded Absurd engine that the server's durable domain workflows share.
+ *
+ * The internal workload composition uses this engine instead of creating another worker runtime.
+ */
 export function _CreateMcpWorkflowComposition(prisma: PrismaClient, config: OpenCraneWorkflowConfig): McpWorkflowComposition
 {
 	const queueAuthority = __CreateWorkflowTaskQueueAuthority([
@@ -59,5 +63,5 @@ export function _CreateMcpWorkflowComposition(prisma: PrismaClient, config: Open
 			return await artifactCatalogue.loadPublishedReadTarget({ siloId, artifactId, artifactRevisionId });
 		},
 	};
-	return { runtime, unitOfWork, eraProbeWorkflow, mcpbValidationWorkflow, mcpTaskWorkflow, mcpbArtifacts };
+	return { execution, runtime, unitOfWork, eraProbeWorkflow, mcpbValidationWorkflow, mcpTaskWorkflow, mcpbArtifacts };
 }

--- a/apps/opencrane/src/app/mcp-workflow-composition.types.ts
+++ b/apps/opencrane/src/app/mcp-workflow-composition.types.ts
@@ -1,9 +1,15 @@
 import type { McpEraProbeWorkflow, McpOperatorUnitOfWork, McpbBundleArtifactResolver, McpbValidationWorkflow, McpTaskWorkflow } from "@opencrane/backend/server/gateways/mcp";
-import type { IWorkflowWorkerRuntime } from "@opencrane/backend/server/infra/workflows/contract";
+import type { IWorkflowEngine, IWorkflowWorkerRuntime } from "@opencrane/backend/server/infra/workflows/contract";
 
-/** MCP product authority and the one process-owned worker runtime shared by its saved jobs. */
+/**
+ * Groups MCP workflow dependencies with the guarded engine shared by this server process.
+ *
+ * Internal domain composition reuses {@link execution}; {@link runtime} remains the process-owned worker lifecycle.
+ */
 export interface McpWorkflowComposition
 {
+	/** Makes the guarded workflow engine available to other server domain compositions. */
+	readonly execution: IWorkflowEngine;
 	/** Transaction owner shared by MCP catalogue and bundle operations. */
 	readonly unitOfWork: McpOperatorUnitOfWork;
 	/** Absurd worker lifecycle started and drained by the OpenCrane process. */


### PR DESCRIPTION
## Summary

- expose the server's existing guarded workflow engine to internal domain composition
- retain separate process ownership of the worker lifecycle
- prepare the skill-workload migration to use the one durable engine

## Validation

- `npx nx run opencrane:lint`
- focused MCP workflow composition test (10 tests)
- full OpenCrane test target (91 tests)
- agent style, Prisma boundary, module growth, release versioning, and PR-stack checks

## Review

- independent review: PASS
- documentation gate: PASS

## Review order

#714 -> #715 -> #716 -> #717 -> #718 -> #719 -> #720 -> #721 -> #722 -> #723 -> #724 -> #725 -> #726 -> #727 -> #728 -> #729