### PR TITLE
🐛 Keep validator profiles behind controller boundary

### DIFF
--- a/apps/agent-controller/src/config.types.ts
+++ b/apps/agent-controller/src/config.types.ts
@@ -1,8 +1,13 @@
 import type { AgentControllerRuntimeProfiles } from "@opencrane/backend/agents/runtime/controller";
 import type { SkillWorkloadControllerProfiles } from "@opencrane/backend/agents/skills/controller";
-import type { McpbValidatorJobProfile } from "@opencrane/backend/server/gateways/mcp/validator-k8s-launcher";
+import type { McpbValidationControllerOptions } from "@opencrane/backend/agents/mcpb/controller";
 
-/** Fully validated process configuration for the per-silo agent controller. */
+/**
+ * Carries controller settings after startup validates the process environment.
+ * The entrypoint passes these profiles to the agent, skill-workload, and MCPB controllers, so all
+ * profiles are validated before any controller starts.
+ * @see _ReadConfig
+ */
 export interface AgentControllerProcessConfig
 {
 	/** Internal OpenCrane origin used for claim and assignment calls. */
@@ -19,6 +24,6 @@ export interface AgentControllerProcessConfig
 	readonly profiles: AgentControllerRuntimeProfiles;
 	/** Immutable profiles for the only governed skill Job classes. */
 	readonly skillWorkloadProfiles: SkillWorkloadControllerProfiles;
-	/** Immutable profile for the only MCP bundle validator Job class. */
-	readonly mcpbValidatorProfile: McpbValidatorJobProfile;
+	/** Keeps the agent controller on the MCPB controller public API instead of its validator Job launcher. */
+	readonly mcpbValidatorProfile: McpbValidationControllerOptions["profile"];
 }


### PR DESCRIPTION
## Summary

- derive the MCP bundle validator profile from the existing MCPB controller public API
- keep the agent controller outside the validator launcher dependency boundary

## Validation

- `npx nx run agent-controller:lint`
- `npx nx run agent-controller:test`
- `npx nx run backend-agents-mcpb-controller:test`
- `npm run lint:boundaries`
- `npm run check:release-versioning -- --base 7cc01c14e70971d7874e85c233cda647f665cca9`
- `scripts/agent-style-check.sh`

## Review

- independent correctness and boundary review: PASS
- deletion audit: PASS
- comments gate: PASS

## Review order

#714 → #715 → #716 → #717 → #718 → #719 → #720 → #721 → #722 → #723 → #724 → #725 → #726 → #727 → #728 → #729 → #730