### PR TITLE
📝 resolve reaper documentation residue across four packages

### DIFF
--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -432,7 +432,7 @@ _run_preflight() {
 
   # 3. First-party images pullable — catch a private/typo'd registry before the rollout
   #    sits in ImagePullBackOff. Validate the resolved browser, memory, and database operands
-  #    before the database transition can fence the existing server. A missing local inspector
+  #    before the database migration runs. A missing local inspector
   #    warns rather than changing cluster state.
   local _img
   local _images=("$CONTROL_PLANE_SPA_IMAGE" "$COGNEE_IMAGE" "$POSTGRES_OPERAND_IMAGE")
@@ -1025,7 +1025,7 @@ if [[ "$RELEASE_PREEXISTED" == "1" ]]; then
     "${RELEASE}-opencrane-server" "${RELEASE}-litellm" "${RELEASE}-mcp-gateway" || exit $?
 fi
 
-# 4. Wait for the core workloads. The database schema was created by CNPG initdb or converged by
+# 4. Wait for the core workloads. The database schema was created by CNPG initdb or applied by
 # the bounded deployment-owned migration Job; application startup never mutates it.
 # Wait only on the deployment(s) this chart actually rendered: the fleet chart ships
 # the fleet-manager, the silo chart the clustertenant-manager. A fleet-only (or silo-only)

--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -67,10 +67,11 @@ caller input.
   and memory-scope sources. It freezes only the verified user's active Cognee dataset coordinates.
   Admission never stores the recall query, reads fact content, or calls Cognee. The model chooses a
   query only through the approval-required `memory_recall` tool; safe content delivery is deferred to #601.
-- `PersonalExecutionIdentityEnvelopeSource` — selects the sole current personal-scope assertion
-  from signed fleet membership, re-reads that exact verified revision after its high-watermark is
-  advanced, and digests the user's still-valid, unrevoked personal grants in the admission
-  transaction. Browser input never selects the organisation, assertion, or capabilities.
+- `PersonalExecutionIdentityEnvelopeSource` — resolves the exact local `Principal` for the verified
+  OIDC issuer and subject, selects the sole current silo-membership assertion from signed fleet
+  membership, re-reads that exact verified revision after its high-watermark is advanced, and
+  digests the Principal's still-valid, unrevoked boundary-filtered grants in the admission
+  transaction. Browser input never selects the issuer, Principal, assertion, or capabilities.
 - `PrismaSkillRevisionEligibilitySource` — locks the AgentRevision's skill assignments
   at admission and refuses an invented, foreign, revoked, or unpublished revision with
   `skill_unavailable`.

--- a/libs/backend/agents/execution/inputs/main/src/personal-execution-identity-envelope-source.ts
+++ b/libs/backend/agents/execution/inputs/main/src/personal-execution-identity-envelope-source.ts
@@ -11,11 +11,12 @@ import type { IdentityEnvelopeInput, IdentityEnvelopeSource, SessionAssemblyComm
 import { PrismaPersonalExecutionIdentityAuthorityRepository } from "./prisma-personal-execution-identity-authority-repository";
 
 /**
- * Verifies the one signed personal-scope assertion for a browser session, inside the admission
+ * Verifies the one signed personal membership assertion for a browser session, inside the admission
  * transaction.
  *
- * All the request supplies is the subject (from the session) and the silo (from the host), both
- * through the assembly command. Everything else — assertion, organisation, scope, capability digest
+ * All the request supplies is the issuer-bound subject (from the verified session) and the silo
+ * (from the host), both through the assembly command. Everything else — assertion, Principal,
+ * capability digest
  * — this source reads from the database inside the transaction. A browser request body never
  * becomes identity evidence.
  */
@@ -47,11 +48,12 @@ export class PersonalExecutionIdentityEnvelopeSource implements IdentityEnvelope
 	 * Verifies one personal assertion and returns the signed identity evidence.
 	 *
 	 * Refuses when more than one assertion matches rather than picking one: an ambiguous entitlement
-	 * means the organisation the run would act for is unclear, and guessing it could cross an
-	 * organisation boundary.
+	 * means the issuer-bound identity the run would act for is unclear, and guessing it could cross
+	 * a silo boundary.
 	 *
-	 * @param command - The admission command. Only `siloId` (from the request host) and
-	 * `executionSubjectId` (from the session) are used; nothing from a request body.
+	 * @param command - The admission command. Only `siloId` (from the request host),
+	 * `executionIssuer` and `executionSubjectId` (from the verified session identity) are used;
+	 * nothing from a request body.
 	 * @param run - Facts from the run authority. Must be a personal run whose `delegatedUserId`
 	 * equals the command's subject.
 	 * @param transaction - The admission transaction; the signature check, the re-read, and the grant

--- a/libs/backend/agents/execution/inputs/main/src/personal-execution-identity-envelope-source.types.ts
+++ b/libs/backend/agents/execution/inputs/main/src/personal-execution-identity-envelope-source.types.ts
@@ -2,7 +2,7 @@
  * Holds one signed silo-membership assertion, taken from a revision that named exactly one.
  *
  * A fleet-membership revision is a batch of assertions signed by a trusted issuer and stored locally
- * after verification, so admission can check "is this user still a member of this organisation"
+ * after verification, so admission can check "is this OIDC-bound user still a member of this silo"
  * against a signature rather than by calling the identity provider on every run. The subjects in it
  * are OIDC subject identifiers issued by Zitadel.
  */

--- a/libs/backend/agents/execution/inputs/main/src/prisma-personal-execution-identity-authority-repository.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prisma-personal-execution-identity-authority-repository.ts
@@ -3,7 +3,7 @@ import type { Prisma } from "@prisma/client";
 import type { PersonalExecutionIdentityAuthorityRepository, PersonalFleetMembershipAssertion } from "./personal-execution-identity-envelope-source.types";
 
 /**
- * Reads personal membership assertions and active capability grants with Prisma.
+ * Reads personal membership assertions and active boundary-filtered capability grants with Prisma.
  *
  * Takes a transaction client rather than a Prisma client, so it can never open a second transaction
  * of its own: every read here has to see the same rows as the membership check that runs beside it.
@@ -30,7 +30,7 @@ export class PrismaPersonalExecutionIdentityAuthorityRepository implements Perso
 		return principal?.id ?? null;
 	}
 
-	/** Loads the one current personal assertion available before signature verification. */
+	/** Loads the one current silo-membership assertion available before signature verification. */
 	async loadLatestPersonalAssertion(trustedIssuerId: string, siloId: string, subjectId: string): Promise<PersonalFleetMembershipAssertion | null>
 	{
 		const revision = await this.prisma.verifiedFleetMembershipRevision.findFirst({
@@ -41,7 +41,7 @@ export class PrismaPersonalExecutionIdentityAuthorityRepository implements Perso
 		return _OneAssertion(revision?.assertions ?? []);
 	}
 
-	/** Re-reads the one personal assertion from the exact signed revision just verified. */
+	/** Re-reads the one silo-membership assertion from the exact signed revision just verified. */
 	async loadVerifiedPersonalAssertion(issuerId: string, siloId: string, revision: number, payloadDigest: string, subjectId: string): Promise<PersonalFleetMembershipAssertion | null>
 	{
 		const membership = await this.prisma.verifiedFleetMembershipRevision.findFirst({

--- a/libs/backend/server/gateways/mcp/main/README.md
+++ b/libs/backend/server/gateways/mcp/main/README.md
@@ -64,11 +64,11 @@ another product domain's persistence adapter.
 ## Data & persistence
 
 Owns the public governance behavior over `McpServer` and `McpServerInstall` in
-`apps/opencrane/prisma/schema/mcp.prisma`. MCP entitlement rows remain generic
-`AuthorizationGrant` records owned by the authorization domain. The named
-The `PrismaMcpOperatorUnitOfWork` is the only public MCP persistence seam: it keeps catalogue state,
-installs, generic grants, and audit evidence in one authenticated transaction. The cutover refuses to
-run while any legacy custody reference remains, then removes the obsolete local custody columns.
+`apps/opencrane/prisma/schema/mcp.prisma`. MCP entitlement rows are generic `AuthorizationGrant`
+records owned by the authorization domain. The `PrismaMcpOperatorUnitOfWork` is the only public MCP
+persistence seam: it keeps catalogue state, installs, generic grants, and audit evidence in one
+authenticated transaction. Installation never starts a connection flow; connecting happens through
+the gateway plane after an operator approves the server.
 
 ## See also
 

--- a/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-operator.test.ts
+++ b/libs/backend/server/gateways/mcp/main/src/__tests__/mcp-operator.test.ts
@@ -136,10 +136,10 @@ describe("mcp-operator router", function _suite()
       _enableOidc();
       const { prisma, spies } = _mockPrisma();
       const res = await request(_buildApp(prisma, { sub: "u1", isOrgAdmin: false }))
-        .put("/api/v1/mcp/servers/srv-1/access").send({ everyoneInOrg: true, groups: [], users: [] });
+        .put("/api/v1/mcp/servers/srv-1/access").send({ groupIds: [], principalIds: [] });
 
       expect(res.status).toBe(403);
-      expect(spies["mcpServerAccessPolicy.upsert"]).toBeUndefined();
+    expect(spies["authorizationGrant.create"]).toBeUndefined();
     });
 
     it("denies GET /directory for a non-admin session", async function _denyDirectory()

--- a/libs/contracts/src/mcp-operator.types.ts
+++ b/libs/contracts/src/mcp-operator.types.ts
@@ -1,10 +1,9 @@
 /**
  * Operator-API contracts for consuming and governing MCP servers.
  *
- * These shapes back the `/api/v1/mcp/*` API the WeOwnAI frontend targets: the
- * entitlement-scoped catalogue, per-user installs / credential connect, and the
- * org-admin governance + access-policy endpoints. This is the sole public MCP contract; there is
- * no parallel unsiloed registry or credential-inventory API.
+ * These shapes back the `/api/v1/mcp/*` API the browser targets: the entitlement-scoped
+ * catalogue, per-user installs, and org-admin governance + access endpoints. This is the sole
+ * public MCP contract; there is no parallel unsiloed registry or credential-inventory API.
  *
  * Custody contract: NO type here ever carries credential material. A connected
  * install reports only its {@link McpConnectionStatus}; the secret lives in the
@@ -14,10 +13,9 @@
 /**
  * How a caller consumes a downstream MCP server.
  *
- * Returned as the `type` field on {@link McpCatalogServer}, and it decides what happens when a
- * user installs the server: a single-user server starts at `NeedsCredential` and must collect
- * the fields in `credentialSchema`; a multi-user server is already usable via the org-wide key;
- * a remote-OAuth server needs an OAuth handshake instead of a form.
+ * Returned as the `type` field on {@link McpCatalogServer}. Installing never starts a connection:
+ * a single-user server still needs its credential collected before use; a multi-user server is
+ * already usable via the org-wide key; a remote-OAuth server needs an OAuth handshake before use.
  * @see https://modelcontextprotocol.io/specification/2025-06-18
  */
 export enum McpServerType

--- a/libs/frontend/core/src/lib/models/session.types.ts
+++ b/libs/frontend/core/src/lib/models/session.types.ts
@@ -7,7 +7,7 @@ export interface SessionSummary
 	name: string;
 	/** Session accent colour (dot + active border). */
 	color: string;
-	/** Department key (see DEPARTMENTS). */
+	/** Department key used for sidebar grouping. */
 	dept: string;
 	/** Optional secondary line under the name. */
 	subtitle?: string;


### PR DESCRIPTION
## Summary

  Resolves every documentation residue finding from the reaper audit over feat/group-parent-hierarchy. No behavior changes — this is comments,
  JSDoc, README text, one stale test payload, and one dangling type reference across 9 files.

  ## Changes

  - apps/_infra/deploy-k8s — Rewrote two comments in k8s-deploy.sh that still described the removed database fencing and convergence-classifier
    behavior; now accurately describe the direct migration flow.

  - libs/backend/server/gateways/mcp/main — Updated mcp-operator.test.ts:138 to send the current { groupIds, principalIds } access payload
    instead of the retired { everyoneInOrg, groups, users } shape, and to assert against authorizationGrant.create (the live managed-grant
    method) instead of the deleted mcpServerAccessPolicy.upsert. Cleaned duplicated fragment and completed-transition wording in the package
    README.

  - libs/contracts/src/mcp-operator.types.ts — Removed "credential connect" and "install starts connection" language that contradicted the new
    no-activation-on-install contract; now describes install-only semantics with connection deferred to the gateway plane.

  - libs/backend/agents/execution/inputs/main — Replaced superseded "personal-scope / organisation / scope" framing in source JSDoc, types, and
    package README with the current issuer-bound Principal + silo-membership boundary model.

  - libs/frontend/core/src/lib/models/session.types.ts — Removed the dangling "see DEPARTMENTS" JSDoc reference left behind when scope.types.ts
    was deleted.

  ## Verification

-    MCP tests                              12/12 PASS
-    API spec contract                      1/1 PASS
-    Execution inputs tests                 59/59 PASS
-    Frontend core tests                    14/14 PASS
-    Deploy-k8s full Helm contract suite    PASS

  ## Test Plan

  - [x] npx nx test backend-server-mcp
  - [x] npx nx test backend-server-api-spec
  - [x] npx nx test backend-agents-execution-inputs
  - [x] npx nx test frontend-core
  - [x] bash apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
