### PR TITLE
♻️ Follow up #743: split OCI MCP runtime boundaries

### DIFF
--- a/apps/agent-controller/README.md
+++ b/apps/agent-controller/README.md
@@ -60,10 +60,12 @@ multiple Pods, and OpenCrane registers the first Pod before bootstrap exchange c
 
 ## Public surface
 
-`Entrypoint:` `src/index.ts` loads telemetry first, validates configuration, creates the narrow
-OpenCrane and Kubernetes adapters, runs the runtime assignment/release and suspended-skill-assignment
-poll loops, and flushes telemetry
-on `SIGTERM`/`SIGINT`.
+`Entrypoint:` `src/index.ts` loads telemetry, validates configuration, installs the shared shutdown
+signal, and delegates composition to `src/controller-runtime.ts`. That process starts three narrow
+polling domains together: personal/managed runtime assignment and release, governed skill Job
+assignment and release, and OCI MCP executor assignment, release, and first-Pod registration. The
+MCP domain receives the server-selected imported image digest while deployment configuration fixes
+its companion and Job profile. Telemetry flushes after `SIGTERM`/`SIGINT` drains all three loops.
 
 ## Boundary
 

--- a/apps/agent-controller/helm/Chart.yaml
+++ b/apps/agent-controller/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: opencrane-agent-controller
 description: App-owned named-template library for the personal-runtime workload controller.
 type: library
-version: 0.9.2
-appVersion: "0.9.2"
+version: 0.9.3
+appVersion: "0.9.3"

--- a/apps/agent-controller/helm/migrations/0.9.2-to-0.9.3.json
+++ b/apps/agent-controller/helm/migrations/0.9.2-to-0.9.3.json
@@ -1,0 +1,5 @@
+{
+  "fromChartVersion": "0.9.2",
+  "toChartVersion": "0.9.3",
+  "kind": "noop"
+}

--- a/apps/agent-controller/package.json
+++ b/apps/agent-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencrane/agent-controller",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",

--- a/apps/agent-controller/project.json
+++ b/apps/agent-controller/project.json
@@ -2,7 +2,7 @@
   "name": "agent-controller",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "projectType": "application",
-  "metadata": { "release": { "adaptedVersion": "0.9.2" } },
+  "metadata": { "release": { "adaptedVersion": "0.9.3" } },
   "sourceRoot": "apps/agent-controller/src",
   "tags": ["type:app", "layer:entrypoint", "scope:agent-controller"],
   "targets": {

--- a/apps/agent-controller/src/controller-runtime.ts
+++ b/apps/agent-controller/src/controller-runtime.ts
@@ -1,0 +1,41 @@
+import * as k8s from "@kubernetes/client-node";
+
+import { __CreateHttpAgentControllerAuthority, __CreateKubernetesAgentControllerStore, __RunAgentController } from "@opencrane/backend/agents/runtime/controller";
+import { __CreateHttpMcpExecutorControllerAuthority, __CreateKubernetesMcpExecutorControllerStore, __RunMcpExecutorController } from "@opencrane/backend/agents/runtime/mcp-executor/controller";
+import { __CreateHttpSkillWorkloadControllerAuthority, __CreateKubernetesSkillWorkloadControllerStore, __RunSkillWorkloadController } from "@opencrane/backend/agents/skills/controller";
+
+import type { AgentControllerProcessConfig } from "./config.types";
+import { _log as log } from "./log";
+
+/**
+ * Composes the three outbound controller loops from one checked process configuration.
+ *
+ * The application creates independent Kubernetes API clients for each narrow adapter, but all
+ * loops share the same shutdown signal. This keeps app startup separate from controller logic
+ * while preserving one process-wide drain boundary.
+ *
+ * Called by: src/index.ts.
+ * @param config - Fully checked deployment-owned controller configuration.
+ * @param signal - Process shutdown signal shared by every outbound request and poll loop.
+ * @returns A promise that settles after every controller loop drains.
+ */
+export async function _RunControllerRuntime(config: AgentControllerProcessConfig, signal: AbortSignal): Promise<void>
+{
+	// 1. Load the in-cluster identity once, then give each adapter its own narrow API client.
+	const kubeConfig = new k8s.KubeConfig();
+	kubeConfig.loadFromCluster();
+	const authority = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
+	const skillWorkloadAuthority = __CreateHttpSkillWorkloadControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
+	const mcpExecutorAuthority = __CreateHttpMcpExecutorControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
+	const kubernetes = __CreateKubernetesAgentControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: signal });
+	const skillKubernetes = __CreateKubernetesSkillWorkloadControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: signal });
+	const mcpKubernetes = __CreateKubernetesMcpExecutorControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: signal });
+
+	// 2. Start each bounded reconciler together, so a failure still reaches the one app-level drain path.
+	log.info({ profiles: Object.entries(config.profiles).map(function _Profile([name, profile]) { return { name, namespace: profile.namespace }; }) }, "agent controller started");
+	await Promise.all([
+		__RunAgentController({ authority, kubernetes, profiles: config.profiles, pollIntervalMilliseconds: config.pollIntervalMilliseconds, outboxPruneIntervalMilliseconds: config.outboxPruneIntervalMilliseconds, log }, signal),
+		__RunSkillWorkloadController({ authority: skillWorkloadAuthority, kubernetes: skillKubernetes, profiles: config.skillWorkloadProfiles, pollIntervalMilliseconds: config.pollIntervalMilliseconds, log }, signal),
+		__RunMcpExecutorController({ authority: mcpExecutorAuthority, kubernetes: mcpKubernetes, profile: config.mcpExecutorProfile, pollIntervalMilliseconds: config.pollIntervalMilliseconds, log }, signal),
+	]);
+}

--- a/apps/agent-controller/src/index.ts
+++ b/apps/agent-controller/src/index.ts
@@ -1,14 +1,25 @@
 import "./instrument";
 
-import * as k8s from "@kubernetes/client-node";
-
-import { __CreateHttpAgentControllerAuthority, __CreateKubernetesAgentControllerStore, __RunAgentController } from "@opencrane/backend/agents/runtime/controller";
-import { __CreateHttpMcpExecutorControllerAuthority, __CreateKubernetesMcpExecutorControllerStore, __RunMcpExecutorController } from "@opencrane/backend/agents/runtime/mcp-executor/controller";
-import { __CreateHttpSkillWorkloadControllerAuthority, __CreateKubernetesSkillWorkloadControllerStore, __RunSkillWorkloadController } from "@opencrane/backend/agents/skills/controller";
 import { ___BindConsole, ___ShutdownTelemetry } from "@opencrane/backend/observability";
 
 import { _ReadConfig } from "./config";
+import { _RunControllerRuntime } from "./controller-runtime";
 import { _log as log } from "./log";
+
+/** Installs both Kubernetes termination signals on the one process shutdown controller. */
+function _InstallShutdown(shutdown: AbortController): void
+{
+	/** Aborts each outbound loop after recording which process signal started the drain. */
+	function _Shutdown(signal: string): void
+	{
+		if (shutdown.signal.aborted)
+			return;
+		log.info({ signal }, "agent controller shutting down");
+		shutdown.abort(signal);
+	}
+	process.once("SIGTERM", function _Sigterm() { _Shutdown("SIGTERM"); });
+	process.once("SIGINT", function _Sigint() { _Shutdown("SIGINT"); });
+}
 
 /** Start the outbound-only controller and drain its loop and telemetry on shutdown. */
 async function _Main(): Promise<void>
@@ -17,34 +28,14 @@ async function _Main(): Promise<void>
 	const shutdown = new AbortController();
 	try
 	{
-		// 1. Validate the fixed silo/profile contract before loading any mutable desired state.
+		// 1. Validate fixed deployment configuration before any controller reads mutable desired state.
 		const config = _ReadConfig();
 
-		// 2. Compose only the projected-token authority and least-privilege namespaced clients.
-		const kubeConfig = new k8s.KubeConfig();
-		kubeConfig.loadFromCluster();
-		const authority = __CreateHttpAgentControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
-		const skillWorkloadAuthority = __CreateHttpSkillWorkloadControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
-		const mcpExecutorAuthority = __CreateHttpMcpExecutorControllerAuthority({ openCraneInternalUrl: config.openCraneInternalUrl, tokenPath: config.controllerTokenPath, requestTimeoutMilliseconds: config.requestTimeoutMilliseconds });
-		const kubernetes = __CreateKubernetesAgentControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: shutdown.signal });
-		const skillKubernetes = __CreateKubernetesSkillWorkloadControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: shutdown.signal });
-		const mcpKubernetes = __CreateKubernetesMcpExecutorControllerStore({ batchApi: kubeConfig.makeApiClient(k8s.BatchV1Api), coreApi: kubeConfig.makeApiClient(k8s.CoreV1Api), requestTimeoutMilliseconds: config.requestTimeoutMilliseconds, shutdownSignal: shutdown.signal });
+		// 2. Convert both Kubernetes termination signals into the single loop-drain signal.
+		_InstallShutdown(shutdown);
 
-		// 3. Convert both Kubernetes termination signals into one abortable poll loop.
-		function _Shutdown(signal: string): void
-		{
-			if (shutdown.signal.aborted) return;
-			log.info({ signal }, "agent controller shutting down");
-			shutdown.abort(signal);
-		}
-		process.once("SIGTERM", function _sigterm() { _Shutdown("SIGTERM"); });
-		process.once("SIGINT", function _sigint() { _Shutdown("SIGINT"); });
-		log.info({ profiles: Object.entries(config.profiles).map(function _profile([name, profile]) { return { name, namespace: profile.namespace }; }) }, "agent controller started");
-		await Promise.all([
-			__RunAgentController({ authority, kubernetes, profiles: config.profiles, pollIntervalMilliseconds: config.pollIntervalMilliseconds, outboxPruneIntervalMilliseconds: config.outboxPruneIntervalMilliseconds, log }, shutdown.signal),
-			__RunSkillWorkloadController({ authority: skillWorkloadAuthority, kubernetes: skillKubernetes, profiles: config.skillWorkloadProfiles, pollIntervalMilliseconds: config.pollIntervalMilliseconds, log }, shutdown.signal),
-			__RunMcpExecutorController({ authority: mcpExecutorAuthority, kubernetes: mcpKubernetes, profile: config.mcpExecutorProfile, pollIntervalMilliseconds: config.pollIntervalMilliseconds, log }, shutdown.signal),
-		]);
+		// 3. Compose and run the three least-privilege controller loops until shutdown.
+		await _RunControllerRuntime(config, shutdown.signal);
 	}
 	finally
 	{

--- a/libs/backend/agents/runtime/mcp-executor/companion/README.md
+++ b/libs/backend/agents/runtime/mcp-executor/companion/README.md
@@ -27,8 +27,13 @@ oversized, redirected, or timed-out exchange fails closed without exposing argum
 
 ## Public surface
 
-- `__CreateMcpCompanionRemote` creates the projected-token OpenCrane adapter.
-- `__CreateMcpCompanionServer` creates the fixed loopback MCP adapter.
+- `__CreateMcpCompanionRemote` creates the authenticated companion-to-OpenCrane control channel.
+  It rereads the companion's projected token on every request, sends only the Pod identity to the
+  fixed in-cluster executor route, receives one server-selected command, and reports through that
+  command's `executionId` and `claimFence`. It never contacts the uploaded MCP server or gives that
+  server the projected token or opaque execution reference.
+- `__CreateMcpCompanionServer` creates the separate fixed loopback adapter used to speak to the
+  uploaded MCP server. That server-facing adapter has no OpenCrane credential.
 - `__ReadMcpCompanionIdentity` reads and checks the mounted reference and Pod UID.
 - `__RunMcpCompanion` waits for controller Pod registration, runs one claim, and sends one terminal report.
   It exits without calling the uploaded server when OpenCrane reports that cancellation already ended the saved work.

--- a/libs/backend/agents/runtime/mcp-executor/companion/src/__tests__/mcp-companion.test.ts
+++ b/libs/backend/agents/runtime/mcp-executor/companion/src/__tests__/mcp-companion.test.ts
@@ -151,11 +151,11 @@ describe("MCP companion Pod-local adapter", function _DescribeServer()
 		{
 			const request = JSON.parse(String(init?.body)) as { readonly id: string; readonly method: string };
 			methods.push(request.method);
-			await new Promise<void>(function _Delay(resolve) { setTimeout(resolve, 15); });
+			await new Promise<void>(function _Delay(resolve) { setTimeout(resolve, 125); });
 			return _Json({ jsonrpc: "2.0", id: request.id, result: { resultType: "complete", supportedVersions: ["2026-07-28"] } });
 		});
 		const server = __CreateMcpCompanionServer({ serverUrl: "http://127.0.0.1:3000/mcp", requestTimeoutMilliseconds: 1_000, maximumRequestBytes: 4_096, maximumResponseBytes: 4_096, fetch: fetcher });
-		const command = { kind: McpCompanionCommandKinds.Invocation, lease: { ..._LEASE, expiresAt: new Date(Date.now() + 5).toISOString() }, invocationId: "invocation-1", toolName: "calendar.read", arguments: {} } as const;
+		const command = { kind: McpCompanionCommandKinds.Invocation, lease: { ..._LEASE, expiresAt: new Date(Date.now() + 100).toISOString() }, invocationId: "invocation-1", toolName: "calendar.read", arguments: {} } as const;
 		await expect(server.call(command, new AbortController().signal)).rejects.toThrow(/expired/u);
 		expect(methods).toEqual(["server/discover"]);
 	});

--- a/libs/backend/agents/runtime/mcp-executor/companion/src/opencrane-remote.ts
+++ b/libs/backend/agents/runtime/mcp-executor/companion/src/opencrane-remote.ts
@@ -7,12 +7,28 @@ import { _BoundedJsonBody, _FetchJson, _ReadBoundedJson } from "./bounded-json";
 import { __ParseMcpCompanionClaimResponse } from "./mcp-companion-wire";
 import { McpCompanionCommandKinds, McpCompanionRemoteClaimOutcomes, type McpCompanionCommand, type McpCompanionCommandLease, type McpCompanionCompletion, type McpCompanionFailureCodes, type McpCompanionIdentity, type McpCompanionRemote, type McpCompanionRemoteOptions } from "./mcp-companion.types";
 
-/** Create the authenticated OpenCrane command adapter for one companion Pod. */
+/**
+ * Creates the authenticated companion-to-OpenCrane command adapter for one executor Pod.
+ *
+ * The adapter is not the Pod-local connection to the uploaded MCP server. It calls only the fixed
+ * in-cluster OpenCrane executor route, rereads the rotating projected token for every request, and
+ * carries a server-issued `executionId` plus `claimFence` on each terminal report. The uploaded
+ * server never receives the token or the opaque execution reference.
+ *
+ * Called by: apps/mcp-executor/src/index.ts.
+ * @param options - Fixed destination, token reader, request deadline, and byte ceilings for one Pod.
+ * @returns The remote used to claim one server-selected command and report its fenced outcome.
+ */
 export function __CreateMcpCompanionRemote(options: McpCompanionRemoteOptions): McpCompanionRemote
 {
+	// 1. Refuse a substituted destination or unbounded transport before the Pod can make its first call.
 	_AssertOptions(options);
+
+	// 2. Keep the token reader injectable for tests, but use the projected file at every production request.
 	const fetcher = options.fetch ?? fetch;
 	const readToken = options.readToken ?? async function _ReadProjectedToken(): Promise<string> { return readFile(options.tokenPath, "utf8"); };
+
+	// 3. Expose only server-selected claim and fence-bound terminal operations to the companion loop.
 	return {
 		claim(identity, signal) { return _Claim(options, fetcher, readToken, identity, signal); },
 		complete(identity, lease, completion, signal) { return _Report(options, fetcher, readToken, identity, lease, { completion }, "completion", signal); },
@@ -34,6 +50,7 @@ async function _Claim(options: McpCompanionRemoteOptions, fetcher: NonNullable<M
 {
 	return ___DoWithTrace("mcp_companion.command.claim", {}, async function _ClaimCommand(): Promise<McpCompanionCommand | McpCompanionRemoteClaimOutcomes.Terminal | null>
 	{
+		// 1. Send only the Pod identity to OpenCrane, which chooses any discovery or invocation command.
 		const body = _BoundedJsonBody(identity, options.maximumRequestBytes);
 		const headers = await _Headers(readToken, body);
 		const response = await ___DoWithoutTrace(function _SendClaim() { return _FetchJson(fetcher, `${options.openCraneExecutorUrl}/claim`, { method: "POST", headers, body, redirect: "error" }, options.requestTimeoutMilliseconds, signal); });
@@ -45,6 +62,7 @@ async function _Claim(options: McpCompanionRemoteOptions, fetcher: NonNullable<M
 			throw new Error(`MCP companion claim failed with HTTP ${response.status}`);
 		const value = await _ReadBoundedJson(response, options.maximumResponseBytes);
 		const claim = __ParseMcpCompanionClaimResponse(value);
+		// 2. Preserve the server-issued lease so a terminal write cannot be replayed for another claim.
 		const lease = { executionId: claim.executionId, claimFence: claim.claimFence, expiresAt: claim.expiresAt };
 		return claim.kind === McpCompanionCommandKinds.Discovery ? { kind: claim.kind, lease } : { kind: claim.kind, lease, invocationId: claim.invocationId, toolName: claim.toolName, arguments: claim.arguments };
 	});
@@ -56,8 +74,11 @@ async function _Report(options: McpCompanionRemoteOptions, fetcher: NonNullable<
 	const fields = { outcome: suffix };
 	return ___DoWithTrace(`mcp_companion.command.${suffix}`, fields, async function _ReportOutcome(): Promise<void>
 	{
+		// 1. Bind the result to the current execution and fence instead of trusting a companion-selected target.
 		const body = _BoundedJsonBody({ ...identity, executionId: lease.executionId, claimFence: lease.claimFence, ...outcome }, options.maximumRequestBytes);
 		const headers = await _Headers(readToken, body);
+
+		// 2. Use the fixed terminal route and reject every non-empty-success result without a retry loop.
 		const path = `${options.openCraneExecutorUrl}/${suffix === "completion" ? "complete" : "fail"}`;
 		const response = await ___DoWithoutTrace(function _SendOutcome() { return _FetchJson(fetcher, path, { method: "POST", headers, body, redirect: "error" }, options.requestTimeoutMilliseconds, signal); });
 		if (response.status !== 204)

--- a/libs/backend/agents/runtime/mcp-executor/controller/src/http-mcp-executor-controller-authority.ts
+++ b/libs/backend/agents/runtime/mcp-executor/controller/src/http-mcp-executor-controller-authority.ts
@@ -1,50 +1,15 @@
 import { readFile } from "node:fs/promises";
 import { isAbsolute } from "node:path";
 
-import { RuntimeWorkloadClaimClasses, type RuntimeWorkloadBinding } from "@opencrane/backend/agents/runtime/workloads/contract";
+import { type RuntimeWorkloadBinding } from "@opencrane/backend/agents/runtime/workloads/contract";
 import { ___DoWithTrace } from "@opencrane/backend/observability";
 
+import { _ParseMcpExecutorControllerClaim, _ParseMcpExecutorControllerOutcome, _ParseMcpExecutorControllerReleaseClaim } from "./mcp-executor-controller.validator";
 import type { McpExecutorControllerAuthority, McpExecutorControllerClaim, McpExecutorControllerFetch, McpExecutorControllerHttpAuthorityOptions, McpExecutorControllerReleaseClaim, McpExecutorControllerTokenReader, McpExecutorPodRegistrationCommand, McpExecutorReleaseCommand } from "./mcp-executor-controller.types";
 
 /** Largest server response this controller accepts. */
 const _MAX_RESPONSE_BYTES = 32 * 1024;
 
-/** Accepts one database coordinate without control characters. */
-function _IsCoordinate(value: unknown): value is string { return typeof value === "string" && value.length > 0 && value.length <= 256 && !/[\u0000-\u001f\u007f]/.test(value); }
-
-/** Accepts a UTC instant with millisecond precision. */
-function _IsInstant(value: unknown): value is string { return typeof value === "string" && /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value) && Number.isFinite(Date.parse(value)); }
-
-/** Accepts an immutable OCI registry reference. */
-function _IsRegistryReference(value: unknown): value is string { return typeof value === "string" && /^[a-z0-9][a-z0-9._:-]*(?:\/[a-z0-9][a-z0-9._/-]*)+@sha256:[a-f0-9]{64}$/.test(value); }
-
-/** Parses an untrusted claim response into the MCP controller contract. */
-function _Claim(value: unknown): McpExecutorControllerClaim
-{
-	if (typeof value !== "object" || value === null || Array.isArray(value))
-		throw new Error("OpenCrane MCP executor claim was invalid");
-	const record = value as Record<string, unknown>;
-	const claim = record["claim"];
-	if (Object.keys(record).length !== 2 || typeof claim !== "object" || claim === null || Array.isArray(claim))
-		throw new Error("OpenCrane MCP executor claim was invalid");
-	const candidate = claim as Record<string, unknown>;
-	const keys = ["claimId", "siloId", "workloadClass", "profileName", "idempotencyKey", "claimedAt", "deliveryCount", "expiresAt", "executionReference"];
-	if (Object.keys(candidate).length !== keys.length || !keys.every(function _HasKey(key): boolean { return Object.hasOwn(candidate, key); }) || ![candidate["claimId"], candidate["siloId"], candidate["profileName"], candidate["idempotencyKey"], candidate["executionReference"]].every(_IsCoordinate) || candidate["workloadClass"] !== RuntimeWorkloadClaimClasses.McpExecutor || !_IsInstant(candidate["claimedAt"]) || !_IsInstant(candidate["expiresAt"]) || !Number.isSafeInteger(candidate["deliveryCount"]) || Number(candidate["deliveryCount"]) < 1 || !_IsRegistryReference(record["registryReference"]))
-		throw new Error("OpenCrane MCP executor claim was invalid");
-	return { claim: candidate as unknown as McpExecutorControllerClaim["claim"], registryReference: record["registryReference"] };
-}
-
-/** Parses a release claim and keeps its assignment and release fences. */
-function _ReleaseClaim(value: unknown): McpExecutorControllerReleaseClaim
-{
-	if (typeof value !== "object" || value === null || Array.isArray(value))
-		throw new Error("OpenCrane MCP executor release claim was invalid");
-	const record = value as Record<string, unknown>;
-	const base = _Claim({ claim: record["claim"], registryReference: record["registryReference"] });
-	if (Object.keys(record).length !== 6 || !_IsCoordinate(record["workloadUid"]) || !_IsInstant(record["releaseClaimedAt"]) || !Number.isSafeInteger(record["releaseDeliveryCount"]) || Number(record["releaseDeliveryCount"]) < 1 || !_IsInstant(record["releaseExpiresAt"]))
-		throw new Error("OpenCrane MCP executor release claim was invalid");
-	return { ...base, workloadUid: record["workloadUid"], releaseClaimedAt: record["releaseClaimedAt"], releaseDeliveryCount: record["releaseDeliveryCount"] as number, releaseExpiresAt: record["releaseExpiresAt"] };
-}
 
 /** Reads and parses a bounded JSON response. */
 async function _Json(response: Response): Promise<unknown>
@@ -107,13 +72,21 @@ function _Signal(signal: AbortSignal, timeout: number): AbortSignal { return Abo
 /** Checks an echoed outcome without trusting other response fields. */
 async function _Outcome(response: Response, allowed: readonly string[]): Promise<string>
 {
-	const value = await _Json(response);
-	if (typeof value !== "object" || value === null || Array.isArray(value) || Object.keys(value).length !== 1 || !allowed.includes(String((value as Record<string, unknown>)["outcome"])))
-		throw new Error("OpenCrane MCP executor outcome was invalid");
-	return String((value as Record<string, unknown>)["outcome"]);
+	return _ParseMcpExecutorControllerOutcome(await _Json(response), allowed);
 }
 
-/** Creates the authenticated server adapter for MCP workload claims and binding writes. */
+/**
+ * Creates the authenticated server adapter for MCP workload claims and binding writes.
+ *
+ * The controller runtime uses the adapter to read server-selected MCP work and report Kubernetes
+ * evidence. A missing claim becomes `null`; a conflict response becomes `"conflict"` so a
+ * reconciler can refuse to treat a lost fence as a completed write.
+ *
+ * Called by: apps/agent-controller/src/controller-runtime.ts.
+ * @param options - In-cluster destination, projected token reader, request deadline, and optional fetcher.
+ * @returns An authority that reads bounded responses through the controller validators.
+ * @throws Error When the configured origin, token path, timeout, HTTP response, or response body is invalid.
+ */
 export function __CreateHttpMcpExecutorControllerAuthority(options: McpExecutorControllerHttpAuthorityOptions): McpExecutorControllerAuthority
 {
 	const baseUrl = _BaseUrl(options.openCraneInternalUrl);
@@ -138,7 +111,7 @@ export function __CreateHttpMcpExecutorControllerAuthority(options: McpExecutorC
 					return null;
 				if (response.status !== 200)
 					throw new Error(`OpenCrane MCP executor claim failed with HTTP ${response.status}`);
-				return _Claim(await _Json(response));
+				return _ParseMcpExecutorControllerClaim(await _Json(response));
 			});
 		},
 		async __CommitAssignment(binding: RuntimeWorkloadBinding, signal: AbortSignal): Promise<"assigned" | "idempotent" | "conflict">
@@ -157,7 +130,7 @@ export function __CreateHttpMcpExecutorControllerAuthority(options: McpExecutorC
 				return null;
 			if (response.status !== 200)
 				throw new Error(`OpenCrane MCP executor release claim failed with HTTP ${response.status}`);
-			return _ReleaseClaim(await _Json(response));
+				return _ParseMcpExecutorControllerReleaseClaim(await _Json(response));
 		},
 		async __CommitRelease(claimId: string, command: McpExecutorReleaseCommand, signal: AbortSignal): Promise<"released" | "idempotent" | "conflict">
 		{

--- a/libs/backend/agents/runtime/mcp-executor/controller/src/mcp-executor-assignment-reconciler.ts
+++ b/libs/backend/agents/runtime/mcp-executor/controller/src/mcp-executor-assignment-reconciler.ts
@@ -1,0 +1,47 @@
+import { __BuildSuspendedMcpExecutorJob } from "@opencrane/backend/agents/runtime/mcp-executor/k8s-launcher";
+import { ___DoWithTrace } from "@opencrane/backend/observability";
+
+import { McpExecutorControllerOutcomes, type McpExecutorControllerOptions, type McpExecutorControllerReconcileResult } from "./mcp-executor-controller.types";
+
+/** Requires the immutable Kubernetes Job UID before it can be committed to the database authority. */
+function _RequiredJobUid(value: string | undefined): string
+{
+	if (!value || value.trim().length === 0)
+		throw new Error("Kubernetes did not return an immutable UID for the MCP executor Job");
+	return value;
+}
+
+/**
+ * Creates or adopts one suspended MCP Job, then commits its Kubernetes UID through the claim fence.
+ *
+ * Kubernetes receives the server-selected image and cannot release the Job until the assignment
+ * write succeeds. A conflict throws so the poll loop logs the stale delivery instead of adopting it.
+ *
+ * Called by: __RunMcpExecutorController.
+ * @param options - Server authority, Job store, profile, and logger for one controller silo.
+ * @param signal - Process shutdown signal passed to the server authority.
+ * @returns Idle when no claim exists; otherwise the assigned or idempotent Job UID.
+ */
+export async function __ReconcileNextMcpExecutorWorkload(options: McpExecutorControllerOptions, signal: AbortSignal): Promise<McpExecutorControllerReconcileResult>
+{
+	return ___DoWithTrace("agent_controller.mcp_executor.reconcile", {}, async function _Reconcile(): Promise<McpExecutorControllerReconcileResult>
+	{
+		// 1. Take one database claim so Kubernetes never chooses an image or unit of work.
+		const claimed = await options.authority.__Claim(signal);
+		if (claimed === null)
+			return { outcome: McpExecutorControllerOutcomes.Idle };
+
+		// 2. Rebuild the suspended Job from the imported digest and deployment-owned profile.
+		const job = __BuildSuspendedMcpExecutorJob({ claim: claimed.claim, registryReference: claimed.registryReference, namespace: options.profile.namespace }, options.profile, new Date(claimed.claim.claimedAt));
+		const persisted = await options.kubernetes.ensureSuspendedJob(job);
+		const workloadUid = _RequiredJobUid(persisted.metadata?.uid);
+
+		// 3. Fence the assignment against the same claim delivery before the Job can be released.
+		const binding = { claimId: claimed.claim.claimId, claimedAt: claimed.claim.claimedAt, deliveryCount: claimed.claim.deliveryCount, profileName: claimed.claim.profileName, workloadUid };
+		const outcome = await options.authority.__CommitAssignment(binding, signal);
+		if (outcome === "conflict")
+			throw new Error("MCP executor assignment lost its database claim fence");
+		options.log.info({ claimId: claimed.claim.claimId, workloadUid, outcome }, "MCP executor assigned to suspended Job");
+		return { outcome: outcome === "assigned" ? McpExecutorControllerOutcomes.Assigned : McpExecutorControllerOutcomes.Idempotent, claimId: claimed.claim.claimId, workloadUid };
+	});
+}

--- a/libs/backend/agents/runtime/mcp-executor/controller/src/mcp-executor-controller.ts
+++ b/libs/backend/agents/runtime/mcp-executor/controller/src/mcp-executor-controller.ts
@@ -1,90 +1,48 @@
 import { __BuildSuspendedMcpExecutorJob, type McpExecutorJobProfile } from "@opencrane/backend/agents/runtime/mcp-executor/k8s-launcher";
 import { RuntimeWorkloadClaimClasses } from "@opencrane/backend/agents/runtime/workloads/contract";
-import { ___DoWithTrace } from "@opencrane/backend/observability";
 
-import { McpExecutorControllerOutcomes, type McpExecutorControllerOptions, type McpExecutorControllerReconcileResult, type McpExecutorControllerReleaseResult } from "./mcp-executor-controller.types";
+import { __ReconcileNextMcpExecutorWorkload } from "./mcp-executor-assignment-reconciler";
+import { __ReconcileNextMcpExecutorRelease } from "./mcp-executor-release-reconciler";
+import { McpExecutorControllerOutcomes, type McpExecutorControllerOptions } from "./mcp-executor-controller.types";
+import { _ParseMcpExecutorControllerProfile } from "./mcp-executor-controller.validator";
 
-/** Returns one Kubernetes UID and refuses a missing value. */
-function _RequiredUid(value: string | undefined, kind: "Job" | "Pod"): string
-{
-	if (!value || value.trim().length === 0)
-		throw new Error(`Kubernetes did not return an immutable UID for the MCP executor ${kind}`);
-	return value;
-}
+/** Re-exports assignment reconciliation at the original controller module seam. */
+export { __ReconcileNextMcpExecutorWorkload } from "./mcp-executor-assignment-reconciler";
+/** Re-exports release reconciliation at the original controller module seam. */
+export { __ReconcileNextMcpExecutorRelease } from "./mcp-executor-release-reconciler";
 
-/** Checks the complete deployment profile by asking the pure Job builder to consume it. */
+/**
+ * Validates the deployment profile that the MCP executor Job builder will consume.
+ *
+ * Startup uses this before polling so a JSON value that passes its field checks but cannot build a
+ * Job stops the controller before it claims work.
+ *
+ * Called by: apps/agent-controller/src/config.ts.
+ * @param value - Parsed deployment configuration for the MCP executor profile.
+ * @returns The checked profile ready for controller reconciliation.
+ * @throws Error When the profile has unknown fields or the Job builder rejects its configuration.
+ */
 export function __ValidateMcpExecutorControllerProfile(value: unknown): McpExecutorJobProfile
 {
-	if (typeof value !== "object" || value === null || Array.isArray(value))
-		throw new Error("MCP executor controller profile must be one object");
-	const expectedKeys = ["companionImage", "imagePullPolicy", "serverNamespace", "namespace", "serviceAccountName", "opencraneInternalUrl", "projectedTokenTtlSeconds", "scratchSize", "activeDeadlineSeconds", "serverResources", "companionResources"];
-	if (Object.keys(value).length !== expectedKeys.length || !expectedKeys.every(function _HasKey(key): boolean { return Object.hasOwn(value, key); }))
-		throw new Error("MCP executor controller profile must contain only its deployment-owned fields");
-	const profile = structuredClone(value) as McpExecutorJobProfile;
+	const profile = _ParseMcpExecutorControllerProfile(value);
 	const now = new Date("2026-01-01T00:00:00.000Z");
 	__BuildSuspendedMcpExecutorJob({ claim: { claimId: "profile-validation", siloId: "profile-validation", workloadClass: RuntimeWorkloadClaimClasses.McpExecutor, profileName: "mcp-isolated", idempotencyKey: "profile-validation", claimedAt: now.toISOString(), deliveryCount: 1, expiresAt: new Date(now.getTime() + 60_000).toISOString(), executionReference: "profile-validation" }, registryReference: `registry.invalid/opencrane/mcp@sha256:${"a".repeat(64)}`, namespace: profile.namespace }, profile, now);
 	return profile;
 }
 
-/** Creates or adopts one suspended MCP Job and records its Kubernetes UID. */
-export async function __ReconcileNextMcpExecutorWorkload(options: McpExecutorControllerOptions, signal: AbortSignal): Promise<McpExecutorControllerReconcileResult>
-{
-	return ___DoWithTrace("agent_controller.mcp_executor.reconcile", {}, async function _Reconcile(): Promise<McpExecutorControllerReconcileResult>
-	{
-		// 1. Take one database claim so Kubernetes never chooses an image or unit of work.
-		const claimed = await options.authority.__Claim(signal);
-		if (claimed === null)
-			return { outcome: McpExecutorControllerOutcomes.Idle };
-
-		// 2. Rebuild the suspended Job from the imported digest and deployment-owned profile.
-		// Rebuild from the assignment instant because the later release lease, not the expired assignment
-		// lease, now authorises the saved manifest to run.
-		const job = __BuildSuspendedMcpExecutorJob({ claim: claimed.claim, registryReference: claimed.registryReference, namespace: options.profile.namespace }, options.profile, new Date(claimed.claim.claimedAt));
-		const persisted = await options.kubernetes.ensureSuspendedJob(job);
-		const workloadUid = _RequiredUid(persisted.metadata?.uid, "Job");
-
-		// 3. Fence the assignment against the same claim delivery before the Job can be released.
-		const binding = { claimId: claimed.claim.claimId, claimedAt: claimed.claim.claimedAt, deliveryCount: claimed.claim.deliveryCount, profileName: claimed.claim.profileName, workloadUid };
-		const outcome = await options.authority.__CommitAssignment(binding, signal);
-		if (outcome === "conflict")
-			throw new Error("MCP executor assignment lost its database claim fence");
-		options.log.info({ claimId: claimed.claim.claimId, workloadUid, outcome }, "MCP executor assigned to suspended Job");
-		return { outcome: outcome === "assigned" ? McpExecutorControllerOutcomes.Assigned : McpExecutorControllerOutcomes.Idempotent, claimId: claimed.claim.claimId, workloadUid };
-	});
-}
-
-/** Releases one assigned MCP Job and records its first Kubernetes Pod. */
-export async function __ReconcileNextMcpExecutorRelease(options: McpExecutorControllerOptions, signal: AbortSignal): Promise<McpExecutorControllerReleaseResult>
-{
-	return ___DoWithTrace("agent_controller.mcp_executor.release.reconcile", {}, async function _ReconcileRelease(): Promise<McpExecutorControllerReleaseResult>
-	{
-		// 1. Take a database-fenced release claim and rebuild the same expected Job.
-		const claimed = await options.authority.__ClaimRelease(signal);
-		if (claimed === null)
-			return { outcome: McpExecutorControllerOutcomes.Idle };
-		const job = __BuildSuspendedMcpExecutorJob({ claim: claimed.claim, registryReference: claimed.registryReference, namespace: options.profile.namespace }, options.profile, new Date(claimed.claim.claimedAt));
-
-		// 2. Release the saved Job UID, then record that external update against the release claim.
-		await options.kubernetes.releaseJob(job, claimed.workloadUid, claimed.releaseExpiresAt);
-		const command = { releaseClaimedAt: claimed.releaseClaimedAt, releaseDeliveryCount: claimed.releaseDeliveryCount, workloadUid: claimed.workloadUid };
-		const releaseOutcome = await options.authority.__CommitRelease(claimed.claim.claimId, command, signal);
-		if (releaseOutcome === "conflict")
-			throw new Error("MCP executor release lost its database claim fence");
-
-		// 3. Accept only the first Pod owned by that Job and persist its Kubernetes UID.
-		const pod = await options.kubernetes.findFirstPod(job, claimed.workloadUid, options.profile.serviceAccountName);
-		if (pod === null)
-			return { outcome: McpExecutorControllerOutcomes.PendingPod, claimId: claimed.claim.claimId, workloadUid: claimed.workloadUid };
-		const podUid = _RequiredUid(pod.metadata?.uid, "Pod");
-		const registration = await options.authority.__RegisterFirstPod(claimed.claim.claimId, { ...command, podUid }, signal);
-		if (registration === "conflict")
-			throw new Error("MCP executor Pod registration lost its database release fence");
-		options.log.info({ claimId: claimed.claim.claimId, workloadUid: claimed.workloadUid, podUid, outcome: registration }, "MCP executor released and first Pod registered");
-		return { outcome: registration === "registered" ? McpExecutorControllerOutcomes.Registered : McpExecutorControllerOutcomes.Idempotent, claimId: claimed.claim.claimId, workloadUid: claimed.workloadUid, podUid };
-	});
-}
-
-/** Runs assignment and release reconciliation until process shutdown. */
+/**
+ * Runs assignment and release reconciliation until process shutdown.
+ *
+ * Each pass logs an assignment or release failure and continues with the other kind of work. It
+ * waits only after both passes find no work, so a queued release does not wait behind an idle
+ * assignment poll.
+ *
+ * Called by: apps/agent-controller/src/controller-runtime.ts.
+ * @param options - The server authority, Kubernetes store, deployment profile, poll interval, and logger.
+ * @param signal - The process drain signal that stops requests and polling.
+ * @returns A promise that settles after the signal aborts the polling loop.
+ * @throws Error When the configured poll interval is outside the supported range.
+ */
 export async function __RunMcpExecutorController(options: McpExecutorControllerOptions, signal: AbortSignal): Promise<void>
 {
 	if (!Number.isSafeInteger(options.pollIntervalMilliseconds) || options.pollIntervalMilliseconds < 100 || options.pollIntervalMilliseconds > 60_000)

--- a/libs/backend/agents/runtime/mcp-executor/controller/src/mcp-executor-controller.validator.ts
+++ b/libs/backend/agents/runtime/mcp-executor/controller/src/mcp-executor-controller.validator.ts
@@ -1,0 +1,110 @@
+/**
+ * Validates the server responses and deployment profile before controller code uses them as MCP
+ * workload models. The HTTP adapter receives remote JSON and configuration arrives as JSON, so
+ * this module keeps their strict shapes in the one place that both controller entry points use.
+ */
+import { z } from "zod";
+
+import { RuntimeWorkloadClaimClasses } from "@opencrane/backend/agents/runtime/workloads/contract";
+import type { McpExecutorJobProfile } from "@opencrane/backend/agents/runtime/mcp-executor/k8s-launcher";
+
+import type { McpExecutorControllerClaim, McpExecutorControllerReleaseClaim } from "./mcp-executor-controller.types";
+
+/** Rejects control characters in one server-issued coordinate. */
+const _CoordinateSchema = z.string().min(1).max(256).regex(/^[^\u0000-\u001f\u007f]+$/u);
+
+/** Accepts the millisecond UTC format persisted by OpenCrane's database authority. */
+const _InstantSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u).refine(function _ValidInstant(value): boolean { return Number.isFinite(Date.parse(value)); });
+
+/** Accepts only the immutable registry reference created by OCI image import. */
+const _RegistryReferenceSchema = z.string().regex(/^[a-z0-9][a-z0-9._:-]*(?:\/[a-z0-9][a-z0-9._/-]*)+@sha256:[a-f0-9]{64}$/u);
+
+/** Validates a claim that the server, rather than a controller, selected. */
+const _WorkloadClaimSchema = z.object({
+	claimId: _CoordinateSchema,
+	siloId: _CoordinateSchema,
+	workloadClass: z.literal(RuntimeWorkloadClaimClasses.McpExecutor),
+	profileName: _CoordinateSchema.max(128),
+	idempotencyKey: _CoordinateSchema,
+	claimedAt: _InstantSchema,
+	deliveryCount: z.number().int().positive(),
+	expiresAt: _InstantSchema,
+	executionReference: _CoordinateSchema,
+}).strict();
+
+/** Validates one bounded server response that assigns an imported image to a claim. */
+const _ClaimResponseSchema = z.object({
+	claim: _WorkloadClaimSchema,
+	registryReference: _RegistryReferenceSchema,
+}).strict();
+
+/** Validates the additional durable fence fields required before an assigned Job can run. */
+const _ReleaseClaimResponseSchema = _ClaimResponseSchema.extend({
+	workloadUid: _CoordinateSchema,
+	releaseClaimedAt: _InstantSchema,
+	releaseDeliveryCount: z.number().int().positive(),
+	releaseExpiresAt: _InstantSchema,
+}).strict();
+
+/** Bounds CPU and memory requests or limits before they reach the pure Job builder. */
+const _ResourceMapSchema = z.object({
+	cpu: z.string().min(1),
+	memory: z.string().min(1),
+}).strict();
+
+/** Validates the exact resource shape owned by deployment configuration. */
+const _ResourcesSchema = z.object({
+	requests: _ResourceMapSchema,
+	limits: _ResourceMapSchema,
+}).strict();
+
+/** Validates one deployment-owned MCP executor profile before the Job builder applies its policy. */
+const _ProfileSchema = z.object({
+	companionImage: z.string().min(1),
+	imagePullPolicy: z.enum(["Always", "IfNotPresent", "Never"]),
+	serverNamespace: z.string().min(1),
+	namespace: z.string().min(1),
+	serviceAccountName: z.string().min(1),
+	opencraneInternalUrl: z.string().min(1),
+	projectedTokenTtlSeconds: z.number().int().positive(),
+	scratchSize: z.string().min(1),
+	activeDeadlineSeconds: z.number().int().positive(),
+	serverResources: _ResourcesSchema,
+	companionResources: _ResourcesSchema,
+}).strict();
+
+/** Parses the complete claim response from the internal controller route. */
+export function _ParseMcpExecutorControllerClaim(value: unknown): McpExecutorControllerClaim
+{
+	const result = _ClaimResponseSchema.safeParse(value);
+	if (!result.success)
+		throw new Error("OpenCrane MCP executor claim was invalid");
+	return result.data;
+}
+
+/** Parses the release claim, including the saved Job UID and current release delivery fence. */
+export function _ParseMcpExecutorControllerReleaseClaim(value: unknown): McpExecutorControllerReleaseClaim
+{
+	const result = _ReleaseClaimResponseSchema.safeParse(value);
+	if (!result.success)
+		throw new Error("OpenCrane MCP executor release claim was invalid");
+	return result.data;
+}
+
+/** Parses an exact one-field route outcome and rejects any unexpected server extension. */
+export function _ParseMcpExecutorControllerOutcome(value: unknown, allowed: readonly string[]): string
+{
+	const result = z.object({ outcome: z.string().refine(function _Allowed(outcome): boolean { return allowed.includes(outcome); }) }).strict().safeParse(value);
+	if (!result.success)
+		throw new Error("OpenCrane MCP executor outcome was invalid");
+	return result.data.outcome;
+}
+
+/** Parses profile JSON into the bounded shape accepted by the MCP Job builder. */
+export function _ParseMcpExecutorControllerProfile(value: unknown): McpExecutorJobProfile
+{
+	const result = _ProfileSchema.safeParse(value);
+	if (!result.success)
+		throw new Error("MCP executor controller profile must contain only its deployment-owned fields");
+	return result.data;
+}

--- a/libs/backend/agents/runtime/mcp-executor/controller/src/mcp-executor-release-reconciler.ts
+++ b/libs/backend/agents/runtime/mcp-executor/controller/src/mcp-executor-release-reconciler.ts
@@ -1,0 +1,53 @@
+import { __BuildSuspendedMcpExecutorJob } from "@opencrane/backend/agents/runtime/mcp-executor/k8s-launcher";
+import { ___DoWithTrace } from "@opencrane/backend/observability";
+
+import { McpExecutorControllerOutcomes, type McpExecutorControllerOptions, type McpExecutorControllerReleaseResult } from "./mcp-executor-controller.types";
+
+/** Requires the immutable Kubernetes Pod UID before it can be registered for companion bootstrap. */
+function _RequiredPodUid(value: string | undefined): string
+{
+	if (!value || value.trim().length === 0)
+		throw new Error("Kubernetes did not return an immutable UID for the MCP executor Pod");
+	return value;
+}
+
+/**
+ * Releases one assigned MCP Job and records the first Pod through the same release fence.
+ *
+ * The Job UID is already durable before unsuspension; registration waits for Kubernetes to expose
+ * a first owned Pod so the companion cannot use an unrecorded workload identity.
+ *
+ * Called by: __RunMcpExecutorController.
+ * @param options - Server authority, Job store, profile, and logger for one controller silo.
+ * @param signal - Process shutdown signal passed to the server authority.
+ * @returns Idle, pending-Pod, registered, or idempotent evidence for the completed pass.
+ */
+export async function __ReconcileNextMcpExecutorRelease(options: McpExecutorControllerOptions, signal: AbortSignal): Promise<McpExecutorControllerReleaseResult>
+{
+	return ___DoWithTrace("agent_controller.mcp_executor.release.reconcile", {}, async function _ReconcileRelease(): Promise<McpExecutorControllerReleaseResult>
+	{
+		// 1. Take a database-fenced release claim and rebuild the same expected Job.
+		const claimed = await options.authority.__ClaimRelease(signal);
+		if (claimed === null)
+			return { outcome: McpExecutorControllerOutcomes.Idle };
+		const job = __BuildSuspendedMcpExecutorJob({ claim: claimed.claim, registryReference: claimed.registryReference, namespace: options.profile.namespace }, options.profile, new Date(claimed.claim.claimedAt));
+
+		// 2. Release the saved Job UID, then record that external update against the release claim.
+		await options.kubernetes.releaseJob(job, claimed.workloadUid, claimed.releaseExpiresAt);
+		const command = { releaseClaimedAt: claimed.releaseClaimedAt, releaseDeliveryCount: claimed.releaseDeliveryCount, workloadUid: claimed.workloadUid };
+		const releaseOutcome = await options.authority.__CommitRelease(claimed.claim.claimId, command, signal);
+		if (releaseOutcome === "conflict")
+			throw new Error("MCP executor release lost its database claim fence");
+
+		// 3. Accept only the first Pod owned by that Job and persist its Kubernetes UID.
+		const pod = await options.kubernetes.findFirstPod(job, claimed.workloadUid, options.profile.serviceAccountName);
+		if (pod === null)
+			return { outcome: McpExecutorControllerOutcomes.PendingPod, claimId: claimed.claim.claimId, workloadUid: claimed.workloadUid };
+		const podUid = _RequiredPodUid(pod.metadata?.uid);
+		const registration = await options.authority.__RegisterFirstPod(claimed.claim.claimId, { ...command, podUid }, signal);
+		if (registration === "conflict")
+			throw new Error("MCP executor Pod registration lost its database release fence");
+		options.log.info({ claimId: claimed.claim.claimId, workloadUid: claimed.workloadUid, podUid, outcome: registration }, "MCP executor released and first Pod registered");
+		return { outcome: registration === "registered" ? McpExecutorControllerOutcomes.Registered : McpExecutorControllerOutcomes.Idempotent, claimId: claimed.claim.claimId, workloadUid: claimed.workloadUid, podUid };
+	});
+}

--- a/libs/backend/agents/runtime/mcp-executor/protocol/src/__tests__/mcp-executor-protocol.test.ts
+++ b/libs/backend/agents/runtime/mcp-executor/protocol/src/__tests__/mcp-executor-protocol.test.ts
@@ -16,6 +16,7 @@ describe("MCP executor protocol", function _DescribeMcpExecutorProtocol()
 		const valid = { jsonrpc: "2.0", id: "opencrane-mcp-tools", result: { tools: [{ name: "calendar.read", description: "Reads events", inputSchema: { type: "object" } }] } };
 		expect(__ParseMcpExecutorToolsListResponse(valid)).toEqual([{ name: "calendar.read", description: "Reads events", inputSchema: { type: "object" } }]);
 		expect(function _Duplicates() { __ParseMcpExecutorToolsListResponse({ jsonrpc: "2.0", id: "opencrane-mcp-tools", result: { tools: [valid.result.tools[0], valid.result.tools[0]] } }); }).toThrow(/invalid/);
+		expect(function _InjectedField() { __ParseMcpExecutorToolsListResponse({ jsonrpc: "2.0", id: "opencrane-mcp-tools", result: { tools: [{ ...valid.result.tools[0], registryReference: "controller-selected" }] } }); }).toThrow(/invalid/);
 		expect(function _NullSchema() { __ParseMcpExecutorToolsListResponse({ jsonrpc: "2.0", id: "opencrane-mcp-tools", result: { tools: [{ name: "invalid", inputSchema: null }] } }); }).toThrow(/invalid/);
 		expect(function _ArraySchema() { __ParseMcpExecutorToolsListResponse({ jsonrpc: "2.0", id: "opencrane-mcp-tools", result: { tools: [{ name: "invalid", inputSchema: [] }] } }); }).toThrow(/invalid/);
 	});

--- a/libs/backend/agents/runtime/mcp-executor/protocol/src/mcp-executor-protocol.ts
+++ b/libs/backend/agents/runtime/mcp-executor/protocol/src/mcp-executor-protocol.ts
@@ -1,7 +1,7 @@
 import type { JsonValue } from "@opencrane/util";
 
 import { McpExecutorProtocolError, type McpExecutorDiscoveredTool, type McpExecutorToolCallResult } from "./mcp-executor-protocol.types";
-import { _IsMcpExecutorToolInputSchema, _McpExecutorContentBlocks } from "./mcp-executor-protocol.validator";
+import { _McpExecutorContentBlocks, _ParseMcpExecutorDiscoveredTools as _ParseDiscoveredTools } from "./mcp-executor-protocol.validator";
 
 /**
  * Selects the Model Context Protocol revision admitted by the OCI MCP executor.
@@ -74,24 +74,32 @@ export function __ParseMcpExecutorToolsListResponse(payload: unknown): readonly 
 	return __ParseMcpExecutorDiscoveredTools(tools);
 }
 
-/** Validate the durable companion form of one discovered MCP tool list. */
+/**
+ * Validates discovered MCP tools before the companion accepts the server's tool list.
+ *
+ * The Zod parser rejects malformed tool records and this function rejects duplicate names across
+ * the complete list. Callers receive validated definitions or a protocol error; they must not
+ * persist a partial list.
+ *
+ * Called by: {@link __ParseMcpExecutorToolsListResponse} and mcp-companion-wire.ts.
+ * @param tools - The untrusted `tools` field from an MCP `tools/list` result.
+ * @returns At most 256 unique tool definitions with object-shaped input schemas.
+ * @throws McpExecutorProtocolError When a definition is malformed or a name is duplicated.
+ * @see https://modelcontextprotocol.io/specification/2026-07-28
+ */
 export function __ParseMcpExecutorDiscoveredTools(tools: unknown): readonly McpExecutorDiscoveredTool[]
 {
-	if (!Array.isArray(tools) || tools.length > 256)
+	const discoveredTools = _ParseDiscoveredTools(tools);
+	if (discoveredTools === null)
 		throw new McpExecutorProtocolError("MCP tool list was invalid");
 	const names = new Set<string>();
-	return tools.map(function _Tool(value): McpExecutorDiscoveredTool
+	for (const tool of discoveredTools)
 	{
-		if (typeof value !== "object" || value === null || Array.isArray(value))
+		if (names.has(tool.name))
 			throw new McpExecutorProtocolError("MCP tool definition was invalid");
-		const tool = value as Record<string, unknown>;
-		const name = tool["name"];
-		const description = tool["description"];
-		if (!_AllowedKeys(tool, ["name", "description", "inputSchema"]) || !Object.hasOwn(tool, "name") || !Object.hasOwn(tool, "inputSchema") || typeof name !== "string" || name.length === 0 || name.length > 128 || names.has(name) || (description !== undefined && description !== null && (typeof description !== "string" || description.length > 4_096)) || !_IsMcpExecutorToolInputSchema(tool["inputSchema"]))
-			throw new McpExecutorProtocolError("MCP tool definition was invalid");
-		names.add(name);
-		return { name, description: typeof description === "string" ? description : null, inputSchema: tool["inputSchema"] };
-	});
+		names.add(tool.name);
+	}
+	return discoveredTools;
 }
 
 /**
@@ -141,10 +149,4 @@ function _ExactKeys(value: Record<string, unknown>, keys: readonly string[]): bo
 	const actual = Object.keys(value).sort();
 	const expected = [...keys].sort();
 	return actual.length === expected.length && actual.every(function _Matches(key, index) { return key === expected[index]; });
-}
-
-/** Refuse unknown fields while allowing documented optional fields to be absent. */
-function _AllowedKeys(value: Record<string, unknown>, keys: readonly string[]): boolean
-{
-	return Object.keys(value).every(function _Allowed(key) { return keys.includes(key); });
 }

--- a/libs/backend/agents/runtime/mcp-executor/protocol/src/mcp-executor-protocol.validator.ts
+++ b/libs/backend/agents/runtime/mcp-executor/protocol/src/mcp-executor-protocol.validator.ts
@@ -1,6 +1,13 @@
+/**
+ * Validates MCP server data before the executor stores it or returns it across its JSON boundary.
+ * Keeping the schemas beside the protocol types lets a reader review the accepted wire form with
+ * the durable representation that the executor returns.
+ */
 import { z } from "zod";
 
 import type { JsonValue } from "@opencrane/util";
+
+import type { McpExecutorDiscoveredTool } from "./mcp-executor-protocol.types";
 
 /** Recursively accepts only values that can cross the executor's JSON boundary. */
 const _JsonValueSchema: z.ZodType<JsonValue> = z.lazy(function _JsonValue(): z.ZodType<JsonValue>
@@ -52,16 +59,35 @@ const _ContentBlockSchema = z.discriminatedUnion("type", [_TextContentSchema, _I
 
 const _ToolInputSchema = z.record(_JsonValueSchema).refine(function _ObjectSchema(value): boolean { return value["type"] === "object"; });
 
+/** Strict durable representation of one tool discovered from an MCP server. */
+const _DiscoveredToolSchema = z.object({
+	name: z.string().min(1).max(128),
+	description: z.string().max(4_096).nullable().optional(),
+	inputSchema: _ToolInputSchema,
+}).strict();
+
+/** Bounds a tools/list response before its names are checked for uniqueness. */
+const _DiscoveredToolsSchema = z.array(_DiscoveredToolSchema).max(256);
+
 /**
- * Returns whether a live tool input is one JSON Schema object.
+ * Parses the server-provided durable form of discovered MCP tools.
  *
- * {@link __ParseMcpExecutorToolsListResponse} uses this check before returning a discovered tool.
- * @returns True when the value is a JSON object whose `type` field is `object`.
- * @see https://modelcontextprotocol.io/specification/2026-07-28
+ * The schema rejects unknown fields before the protocol parser checks duplicate names. The latter
+ * remains a separate semantic rule because it applies across the complete returned list.
+ *
+ * Called by: __ParseMcpExecutorDiscoveredTools.
+ * @param value - Untrusted `tools/list` result field.
+ * @returns Strictly shaped tools without duplicate-name interpretation.
  */
-export function _IsMcpExecutorToolInputSchema(value: unknown): value is Readonly<Record<string, JsonValue>>
+export function _ParseMcpExecutorDiscoveredTools(value: unknown): readonly McpExecutorDiscoveredTool[] | null
 {
-	return _ToolInputSchema.safeParse(value).success;
+	const result = _DiscoveredToolsSchema.safeParse(value);
+	if (!result.success)
+		return null;
+	return result.data.map(function _Tool(tool): McpExecutorDiscoveredTool
+	{
+		return { name: tool.name, description: tool.description ?? null, inputSchema: tool.inputSchema };
+	});
 }
 
 /**

--- a/libs/backend/agents/skills/controller/src/skill-workload-assignment-reconciler.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-assignment-reconciler.ts
@@ -1,0 +1,49 @@
+import { __BuildGovernedSkillWorkloadJob } from "@opencrane/backend/agents/skills/k8s-launcher";
+import { __CreateSkillWorkloadBootstrapReference } from "@opencrane/contracts";
+import { ___DoWithTrace } from "@opencrane/backend/observability";
+
+import { SkillWorkloadControllerReconcileOutcomes, type SkillWorkloadControllerOptions, type SkillWorkloadControllerReconcileResult } from "./skill-workload-controller.types";
+
+/** Requires the immutable Job UID that Kubernetes issued for a suspended skill workload. */
+function _RequireWorkloadUid(uid: string | undefined): string
+{
+	if (!uid || uid.trim().length === 0)
+		throw new Error("Kubernetes did not return an immutable UID for the suspended governed skill Job");
+	return uid;
+}
+
+/**
+ * Turns at most one claimed skill workload into a suspended Kubernetes Job and commits its UID.
+ *
+ * The committed UID and opaque bootstrap reference bind a later release to the database claim; a
+ * conflict throws instead of allowing a stale controller replica to assign executable work.
+ *
+ * Called by: __RunSkillWorkloadController.
+ * @param options - Server authority, Job store, class profiles, and logger for one controller silo.
+ * @param signal - Process shutdown signal passed to the server authority.
+ * @returns Idle when no claim exists; otherwise the assigned or idempotent Job UID.
+ */
+export async function __ReconcileNextSkillWorkload(options: SkillWorkloadControllerOptions, signal: AbortSignal): Promise<SkillWorkloadControllerReconcileResult>
+{
+	return ___DoWithTrace("agent_controller.skill_workload.reconcile", {}, async function _ReconcileSkillWorkload(): Promise<SkillWorkloadControllerReconcileResult>
+	{
+		// 1. Read what the OpenCrane server says should run, because Kubernetes never chooses work.
+		const claim = await options.authority.__Claim(signal);
+		if (claim === null)
+			return { outcome: SkillWorkloadControllerReconcileOutcomes.Idle };
+
+		// 2. Rebuild the suspended Job from the selected class profile and opaque bootstrap reference.
+		const profile = options.profiles[claim.kind];
+		const capabilityReference = await __CreateSkillWorkloadBootstrapReference(claim.workloadId);
+		const job = __BuildGovernedSkillWorkloadJob({ jobId: claim.workloadId, siloId: claim.siloId, namespace: profile.namespace, capabilityReference }, profile);
+
+		// 3. Commit the Kubernetes-issued UID against the same claim before another controller can release it.
+		const persistedJob = await options.kubernetes.ensureSuspendedJob(job);
+		const workloadUid = _RequireWorkloadUid(persistedJob.metadata?.uid);
+		const outcome = await options.authority.__CommitAssignment(claim.workloadId, { claimedAt: claim.claimedAt, deliveryCount: claim.deliveryCount, workloadUid, bootstrapReference: capabilityReference, namespace: profile.namespace }, signal);
+		if (outcome === "conflict")
+			throw new Error("governed skill workload assignment lost its database claim fence");
+		options.log.info({ workloadId: claim.workloadId, workloadUid, outcome }, "governed skill workload assigned to suspended Job");
+		return { outcome: outcome === "assigned" ? SkillWorkloadControllerReconcileOutcomes.Assigned : SkillWorkloadControllerReconcileOutcomes.Idempotent, workloadId: claim.workloadId, workloadUid };
+	});
+}

--- a/libs/backend/agents/skills/controller/src/skill-workload-controller-profile.validator.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-controller-profile.validator.ts
@@ -1,0 +1,48 @@
+/**
+ * Validates deployment JSON before the skill controller passes a profile to its Job builder.
+ * The builder and profile types define the workload contract, so this schema rejects fields that
+ * neither one owns instead of letting a controller configuration silently drift.
+ */
+import { z } from "zod";
+
+import type { SkillWorkloadJobProfile } from "@opencrane/backend/agents/skills/k8s-launcher";
+
+
+/** Bounds a CPU and memory resource map owned by one workload class profile. */
+const _ResourceMapSchema = z.object({
+	cpu: z.string().min(1),
+	memory: z.string().min(1),
+}).strict();
+
+/** Bounds requests and limits before the pure Job builder applies its class policy. */
+const _ResourcesSchema = z.object({
+	requests: _ResourceMapSchema,
+	limits: _ResourceMapSchema,
+}).strict();
+
+/** Validates the complete configuration passed to one class-specific governed Job builder. */
+const _ProfileSchema = z.object({
+	kind: z.enum(["authoring", "tool-runner"]),
+	image: z.string().min(1),
+	imagePullPolicy: z.enum(["Always", "IfNotPresent", "Never"]),
+	serverNamespace: z.string().min(1),
+	namespace: z.string().min(1),
+	serviceAccountName: z.string().min(1),
+	capabilityTokenAudience: z.string().min(1),
+	bootstrapUrl: z.string().min(1),
+	capabilityTokenPath: z.string().min(1),
+	bootstrapReferencePath: z.string().min(1),
+	scratchSize: z.string().min(1),
+	activeDeadlineSeconds: z.number().int().positive(),
+	ttlSecondsAfterFinished: z.number().int().nonnegative(),
+	resources: _ResourcesSchema,
+}).strict();
+
+/** Parses one bounded profile without deciding whether its key has the matching workload class. */
+export function _ParseSkillWorkloadControllerProfile(value: unknown): SkillWorkloadJobProfile | null
+{
+	const result = _ProfileSchema.safeParse(value);
+	if (!result.success)
+		return null;
+	return result.data;
+}

--- a/libs/backend/agents/skills/controller/src/skill-workload-controller.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-controller.ts
@@ -1,80 +1,40 @@
-import { __BuildGovernedSkillWorkloadJob, type SkillWorkloadJobProfile } from "@opencrane/backend/agents/skills/k8s-launcher";
-import { __CreateSkillWorkloadBootstrapReference } from "@opencrane/contracts";
-import { ___DoWithTrace } from "@opencrane/backend/observability";
+import { __BuildGovernedSkillWorkloadJob } from "@opencrane/backend/agents/skills/k8s-launcher";
 
-import { SkillWorkloadControllerReconcileOutcomes, type SkillWorkloadControllerOptions, type SkillWorkloadControllerProfiles, type SkillWorkloadControllerReconcileResult, type SkillWorkloadControllerReleaseReconcileResult } from "./skill-workload-controller.types";
+import { _ParseSkillWorkloadControllerProfile } from "./skill-workload-controller-profile.validator";
+import { __ReconcileNextSkillWorkload } from "./skill-workload-assignment-reconciler";
+import { __ReconcileNextSkillWorkloadRelease } from "./skill-workload-release-reconciler";
+import { SkillWorkloadControllerReconcileOutcomes, type SkillWorkloadControllerOptions, type SkillWorkloadControllerProfiles } from "./skill-workload-controller.types";
 
-/** Return the Job UID Kubernetes assigned, and fail if the API did not send one. */
-function _RequireWorkloadUid(uid: string | undefined): string
-{
-	if (!uid || uid.trim().length === 0)
-	{
-		throw new Error("Kubernetes did not return an immutable UID for the suspended governed skill Job");
-	}
-	return uid;
-}
+/** Re-exports assignment reconciliation at the original controller module seam. */
+export { __ReconcileNextSkillWorkload } from "./skill-workload-assignment-reconciler";
+/** Re-exports release reconciliation at the original controller module seam. */
+export { __ReconcileNextSkillWorkloadRelease } from "./skill-workload-release-reconciler";
 
-/** Return the Pod UID Kubernetes assigned, and fail if the API did not send one. Never take it from the container. */
-function _RequirePodUid(uid: string | undefined): string
-{
-	if (!uid || uid.trim().length === 0)
-	{
-		throw new Error("Kubernetes did not return an immutable UID for the first governed skill worker Pod");
-	}
-	return uid;
-}
-
-/** Return whether a value is a plain object — not null and not an array — so its keys can be read. */
-function _IsRecord(value: unknown): value is Readonly<Record<string, unknown>> { return typeof value === "object" && value !== null && !Array.isArray(value); }
-
-/** Return whether an object contains exactly the expected own-property names. */
-function _HasOnlyKeys(value: Readonly<Record<string, unknown>>, expected: readonly string[]): boolean { return Object.keys(value).length === expected.length && expected.every(function _HasKey(key): boolean { return Object.prototype.hasOwnProperty.call(value, key); }); }
-
-/** Rebuild a resource map with only `cpu` and `memory`, dropping every other Kubernetes resource type. */
-function _ResourceMap(value: unknown): Readonly<Record<"cpu" | "memory", string>> | null
-{
-	if (!_IsRecord(value) || !_HasOnlyKeys(value, ["cpu", "memory"]) || typeof value["cpu"] !== "string" || typeof value["memory"] !== "string") return null;
-	return { cpu: value["cpu"], memory: value["memory"] };
-}
-
-/** Check one deployment profile field by field and rebuild it, so only known fields reach the Job builder. */
-function _SkillWorkloadJobProfile(value: unknown): SkillWorkloadJobProfile | null
-{
-	// 1. Check the workload class first, because the checks after this depend on which class it is.
-	if (!_IsRecord(value) || !_HasOnlyKeys(value, ["kind", "image", "imagePullPolicy", "serverNamespace", "namespace", "serviceAccountName", "capabilityTokenAudience", "bootstrapUrl", "capabilityTokenPath", "bootstrapReferencePath", "scratchSize", "activeDeadlineSeconds", "ttlSecondsAfterFinished", "resources"]) || (value["kind"] !== "authoring" && value["kind"] !== "tool-runner")) return null;
-
-	// 2. Check every simple field at runtime, so the builder never gets a value that only a TypeScript cast made look valid.
-	if (typeof value["image"] !== "string" || (value["imagePullPolicy"] !== "Always" && value["imagePullPolicy"] !== "IfNotPresent" && value["imagePullPolicy"] !== "Never") || typeof value["serverNamespace"] !== "string" || typeof value["namespace"] !== "string" || typeof value["serviceAccountName"] !== "string" || typeof value["capabilityTokenAudience"] !== "string" || typeof value["bootstrapUrl"] !== "string" || typeof value["capabilityTokenPath"] !== "string" || typeof value["bootstrapReferencePath"] !== "string" || typeof value["scratchSize"] !== "string" || typeof value["activeDeadlineSeconds"] !== "number" || typeof value["ttlSecondsAfterFinished"] !== "number") return null;
-
-	// 3. Copy the resource and profile fields one by one, so no extra field from the caller reaches Kubernetes.
-	const resources = value["resources"];
-	if (!_IsRecord(resources) || !_HasOnlyKeys(resources, ["requests", "limits"])) return null;
-	const requests = _ResourceMap(resources["requests"]);
-	const limits = _ResourceMap(resources["limits"]);
-	if (requests === null || limits === null) return null;
-	return { kind: value["kind"], image: value["image"], imagePullPolicy: value["imagePullPolicy"], serverNamespace: value["serverNamespace"], namespace: value["namespace"], serviceAccountName: value["serviceAccountName"], capabilityTokenAudience: value["capabilityTokenAudience"], bootstrapUrl: value["bootstrapUrl"], capabilityTokenPath: value["capabilityTokenPath"], bootstrapReferencePath: value["bootstrapReferencePath"], scratchSize: value["scratchSize"], activeDeadlineSeconds: value["activeDeadlineSeconds"], ttlSecondsAfterFinished: value["ttlSecondsAfterFinished"], resources: { requests, limits } };
-}
-
-/** Check both deployment profiles by running each one through the Job builder. */
+/**
+ * Validates both deployment profiles by passing each one through the matching Job builder.
+ *
+ * Startup requires both `authoring` and `tool-runner` profiles, because the controller dispatches
+ * each workload class by that key. A profile with the wrong class or an unbuildable Job fails
+ * configuration validation before the controller claims work.
+ *
+ * Called by: apps/agent-controller/src/config.ts.
+ * @param value - Parsed controller configuration containing the two workload-class profiles.
+ * @returns The checked profiles indexed by their workload class.
+ * @throws Error When a profile is missing, has unknown fields, has the wrong class, or cannot build a Job.
+ */
 export function __ValidateSkillWorkloadControllerProfiles(value: unknown): SkillWorkloadControllerProfiles
 {
 	if (typeof value !== "object" || value === null || Array.isArray(value))
-	{
 		throw new Error("skill workload controller profiles must be one object");
-	}
 	const candidate = value as Partial<Record<"authoring" | "tool-runner", unknown>>;
 	if (!("authoring" in candidate) || !("tool-runner" in candidate) || Object.keys(candidate).length !== 2)
-	{
 		throw new Error("skill workload controller requires exactly authoring and tool-runner profiles");
-	}
-	const profiles: Record<"authoring" | "tool-runner", SkillWorkloadJobProfile> = {} as Record<"authoring" | "tool-runner", SkillWorkloadJobProfile>;
+	const profiles = {} as Record<"authoring" | "tool-runner", SkillWorkloadControllerProfiles["authoring"]>;
 	for (const kind of ["authoring", "tool-runner"] as const)
 	{
-		const profile = _SkillWorkloadJobProfile(candidate[kind]);
+		const profile = _ParseSkillWorkloadControllerProfile(candidate[kind]);
 		if (profile === null)
-		{
 			throw new Error(`skill workload controller ${kind} profile must be one complete bounded object`);
-		}
 		if (profile.kind !== kind)
 		{
 			throw new Error(`skill workload controller ${kind} profile has the wrong workload class`);
@@ -85,70 +45,18 @@ export function __ValidateSkillWorkloadControllerProfiles(value: unknown): Skill
 	return profiles;
 }
 
-/** Unsuspend one assigned skill Job, then record the first Pod that Job created. */
-export async function __ReconcileNextSkillWorkloadRelease(options: SkillWorkloadControllerOptions, signal: AbortSignal): Promise<SkillWorkloadControllerReleaseReconcileResult>
-{
-	return ___DoWithTrace("agent_controller.skill_workload.release.reconcile", {}, async function _ReconcileSkillWorkloadRelease(): Promise<SkillWorkloadControllerReleaseReconcileResult>
-	{
-		// 1. Take a release claim from the database. Kubernetes never decides what to release, and never rebuilds this state.
-		const claim = await options.authority.__ClaimRelease(signal);
-		if (claim === null) return { outcome: SkillWorkloadControllerReconcileOutcomes.Idle };
-
-		// 2. Rebuild the same Job manifest from the deployment profile for this class plus the bootstrap reference.
-		const profile = options.profiles[claim.kind];
-		if (!profile || profile.serverNamespace === profile.namespace)
-		{
-			throw new Error("governed skill workload release does not match a bounded isolated profile");
-		}
-		const capabilityReference = await __CreateSkillWorkloadBootstrapReference(claim.workloadId);
-		const job = __BuildGovernedSkillWorkloadJob({ jobId: claim.workloadId, siloId: claim.siloId, namespace: profile.namespace, capabilityReference }, profile);
-
-		// 3. Flip suspend from true to false with a compare-and-swap, then record the release against the same claim.
-		await options.kubernetes.releaseJob(job, claim.workloadUid, claim.expiresAt);
-		const released = await options.authority.__CommitRelease(claim.workloadId, { releaseClaimedAt: claim.releaseClaimedAt, releaseDeliveryCount: claim.releaseDeliveryCount, workloadUid: claim.workloadUid }, signal);
-		if (released === "conflict") throw new Error("governed skill workload release lost its database claim fence");
-
-		// 4. Record the first Pod this Job owns. A worker cannot trade its bootstrap reference until that Pod is recorded.
-		const pod = await options.kubernetes.findFirstPod(job, claim.workloadUid, profile.serviceAccountName);
-		if (pod === null) return { outcome: SkillWorkloadControllerReconcileOutcomes.PendingPod, workloadId: claim.workloadId, workloadUid: claim.workloadUid };
-		const podUid = _RequirePodUid(pod.metadata?.uid);
-		const registered = await options.authority.__RegisterFirstPod(claim.workloadId, { releaseClaimedAt: claim.releaseClaimedAt, releaseDeliveryCount: claim.releaseDeliveryCount, workloadUid: claim.workloadUid, podUid }, signal);
-		if (registered === "conflict") throw new Error("governed skill workload Pod registration lost its durable release fence");
-		options.log.info({ workloadId: claim.workloadId, workloadUid: claim.workloadUid, podUid, outcome: registered }, "governed skill workload released and first Pod registered");
-		return { outcome: registered === "registered" ? SkillWorkloadControllerReconcileOutcomes.Registered : SkillWorkloadControllerReconcileOutcomes.Idempotent, workloadId: claim.workloadId, workloadUid: claim.workloadUid, podUid };
-	});
-}
-
-/** Turn at most one claimed skill workload into a suspended Kubernetes Job, and record that Job in the database. */
-export async function __ReconcileNextSkillWorkload(options: SkillWorkloadControllerOptions, signal: AbortSignal): Promise<SkillWorkloadControllerReconcileResult>
-{
-	return ___DoWithTrace("agent_controller.skill_workload.reconcile", {}, async function _ReconcileSkillWorkload(): Promise<SkillWorkloadControllerReconcileResult>
-	{
-		// 1. Read what the OpenCrane server says should run. Kubernetes never decides which work may run.
-		const claim = await options.authority.__Claim(signal);
-		if (claim === null) return { outcome: SkillWorkloadControllerReconcileOutcomes.Idle };
-
-		// 2. Rebuild the same suspended Job manifest from this class's profile plus the bootstrap reference.
-		const profile = options.profiles[claim.kind];
-		const capabilityReference = await __CreateSkillWorkloadBootstrapReference(claim.workloadId);
-		const job = __BuildGovernedSkillWorkloadJob({ jobId: claim.workloadId, siloId: claim.siloId, namespace: profile.namespace, capabilityReference }, profile);
-
-		// 3. Create the suspended Job, or adopt an identical one that already exists, and use only the UID Kubernetes returned.
-		const persistedJob = await options.kubernetes.ensureSuspendedJob(job);
-		const workloadUid = _RequireWorkloadUid(persistedJob.metadata?.uid);
-
-		// 4. Write the assignment back against the same claim, so an out-of-date controller replica cannot assign this Job.
-		const outcome = await options.authority.__CommitAssignment(claim.workloadId, { claimedAt: claim.claimedAt, deliveryCount: claim.deliveryCount, workloadUid, bootstrapReference: capabilityReference, namespace: profile.namespace }, signal);
-		if (outcome === "conflict")
-		{
-			throw new Error("governed skill workload assignment lost its database claim fence");
-		}
-		options.log.info({ workloadId: claim.workloadId, workloadUid, outcome }, "governed skill workload assigned to suspended Job");
-		return { outcome: outcome === "assigned" ? SkillWorkloadControllerReconcileOutcomes.Assigned : SkillWorkloadControllerReconcileOutcomes.Idempotent, workloadId: claim.workloadId, workloadUid };
-	});
-}
-
-/** Poll for work until shutdown. A failed pass is logged and the loop continues; no Kubernetes object is ever deleted or recreated. */
+/**
+ * Polls for skill assignments and releases until the process drain signal aborts.
+ *
+ * A failed pass is logged and does not stop the other reconciliation kind. The loop never deletes
+ * or recreates a Kubernetes object, so recovery continues from the server's saved claim fence.
+ *
+ * Called by: apps/agent-controller/src/controller-runtime.ts.
+ * @param options - The server authority, Kubernetes store, class profiles, poll interval, and logger.
+ * @param signal - The process drain signal that stops requests and polling.
+ * @returns A promise that settles after the signal aborts the polling loop.
+ * @throws Error When the configured poll interval is outside the supported range.
+ */
 export async function __RunSkillWorkloadController(options: SkillWorkloadControllerOptions, signal: AbortSignal): Promise<void>
 {
 	if (!Number.isSafeInteger(options.pollIntervalMilliseconds) || options.pollIntervalMilliseconds < 100 || options.pollIntervalMilliseconds > 60_000)

--- a/libs/backend/agents/skills/controller/src/skill-workload-release-reconciler.ts
+++ b/libs/backend/agents/skills/controller/src/skill-workload-release-reconciler.ts
@@ -1,0 +1,59 @@
+import { __BuildGovernedSkillWorkloadJob } from "@opencrane/backend/agents/skills/k8s-launcher";
+import { __CreateSkillWorkloadBootstrapReference } from "@opencrane/contracts";
+import { ___DoWithTrace } from "@opencrane/backend/observability";
+
+import { SkillWorkloadControllerReconcileOutcomes, type SkillWorkloadControllerOptions, type SkillWorkloadControllerReleaseReconcileResult } from "./skill-workload-controller.types";
+
+/** Requires the immutable Pod UID that Kubernetes issued for the first released worker Pod. */
+function _RequirePodUid(uid: string | undefined): string
+{
+	if (!uid || uid.trim().length === 0)
+		throw new Error("Kubernetes did not return an immutable UID for the first governed skill worker Pod");
+	return uid;
+}
+
+/**
+ * Unsuspends one assigned skill Job and records the first Pod that Job created.
+ *
+ * The release fence binds the Kubernetes update and Pod registration to one durable delivery. A
+ * pending Pod is not an error: the poll loop waits before it asks Kubernetes for the same evidence.
+ *
+ * Called by: __RunSkillWorkloadController.
+ * @param options - Server authority, Job store, class profiles, and logger for one controller silo.
+ * @param signal - Process shutdown signal passed to the server authority.
+ * @returns Idle, pending-Pod, registered, or idempotent evidence for the completed pass.
+ */
+export async function __ReconcileNextSkillWorkloadRelease(options: SkillWorkloadControllerOptions, signal: AbortSignal): Promise<SkillWorkloadControllerReleaseReconcileResult>
+{
+	return ___DoWithTrace("agent_controller.skill_workload.release.reconcile", {}, async function _ReconcileSkillWorkloadRelease(): Promise<SkillWorkloadControllerReleaseReconcileResult>
+	{
+		// 1. Take a release claim from the database, because Kubernetes never decides what to release.
+		const claim = await options.authority.__ClaimRelease(signal);
+		if (claim === null)
+			return { outcome: SkillWorkloadControllerReconcileOutcomes.Idle };
+
+		// 2. Rebuild the expected Job from its class profile and retained bootstrap reference.
+		const profile = options.profiles[claim.kind];
+		if (!profile || profile.serverNamespace === profile.namespace)
+			throw new Error("governed skill workload release does not match a bounded isolated profile");
+		const capabilityReference = await __CreateSkillWorkloadBootstrapReference(claim.workloadId);
+		const job = __BuildGovernedSkillWorkloadJob({ jobId: claim.workloadId, siloId: claim.siloId, namespace: profile.namespace, capabilityReference }, profile);
+
+		// 3. Release the saved Job UID, then record that effect through the same database release fence.
+		await options.kubernetes.releaseJob(job, claim.workloadUid, claim.expiresAt);
+		const released = await options.authority.__CommitRelease(claim.workloadId, { releaseClaimedAt: claim.releaseClaimedAt, releaseDeliveryCount: claim.releaseDeliveryCount, workloadUid: claim.workloadUid }, signal);
+		if (released === "conflict")
+			throw new Error("governed skill workload release lost its database claim fence");
+
+		// 4. Register the first Job-owned Pod before that worker can trade its bootstrap reference.
+		const pod = await options.kubernetes.findFirstPod(job, claim.workloadUid, profile.serviceAccountName);
+		if (pod === null)
+			return { outcome: SkillWorkloadControllerReconcileOutcomes.PendingPod, workloadId: claim.workloadId, workloadUid: claim.workloadUid };
+		const podUid = _RequirePodUid(pod.metadata?.uid);
+		const registered = await options.authority.__RegisterFirstPod(claim.workloadId, { releaseClaimedAt: claim.releaseClaimedAt, releaseDeliveryCount: claim.releaseDeliveryCount, workloadUid: claim.workloadUid, podUid }, signal);
+		if (registered === "conflict")
+			throw new Error("governed skill workload Pod registration lost its durable release fence");
+		options.log.info({ workloadId: claim.workloadId, workloadUid: claim.workloadUid, podUid, outcome: registered }, "governed skill workload released and first Pod registered");
+		return { outcome: registered === "registered" ? SkillWorkloadControllerReconcileOutcomes.Registered : SkillWorkloadControllerReconcileOutcomes.Idempotent, workloadId: claim.workloadId, workloadUid: claim.workloadUid, podUid };
+	});
+}

--- a/libs/backend/server/gateways/mcp/main/src/runtime/mcp-runtime-wire.ts
+++ b/libs/backend/server/gateways/mcp/main/src/runtime/mcp-runtime-wire.ts
@@ -1,5 +1,6 @@
 import type { RuntimeWorkloadBinding } from "@opencrane/backend/agents/runtime/workloads/contract";
 
+import { _ParseMcpRuntimeAssignment as _ParseAssignment, _ParseMcpRuntimeClaimId } from "./mcp-runtime-wire.validator";
 import type { McpOciServerPromotionCommand, McpRuntimePodRegistrationCommand, McpRuntimeReleaseCommand } from "./mcp-runtime.types";
 
 /** Parse the bounded administrator fields accepted by OCI server promotion. */
@@ -10,13 +11,33 @@ export function __ParseMcpOciServerPromotionCommand(value: unknown): McpOciServe
 	return { name: value["name"].trim(), description: value["description"].trim() };
 }
 
-/** Parse one controller assignment and require the path and body claim IDs to agree. */
+/**
+ * Parses controller assignment evidence and binds its body claim ID to the route claim ID.
+ *
+ * The router calls this before the authoritative repository writes the binding. It rejects an
+ * extra server-owned field and rejects a valid body sent through another claim URL, so callers get
+ * either one fenced binding or an error to map to a bad request.
+ *
+ * Called by: mcp-runtime-controller.router.ts.
+ * @param claimId - The controller-supplied claim coordinate from the request path.
+ * @param value - The controller-supplied assignment body.
+ * @returns The strict assignment binding whose claim ID matches the request path.
+ * @throws Error When the path, body, unknown fields, or claim-ID correlation is invalid.
+ */
 export function __ParseMcpRuntimeAssignment(claimId: string, value: unknown): RuntimeWorkloadBinding
 {
-	const keys = ["claimId", "claimedAt", "deliveryCount", "profileName", "workloadUid"];
-	if (!_Coordinate(claimId, 256) || !_Exact(value, keys) || value["claimId"] !== claimId || !_Instant(value["claimedAt"]) || !_PositiveInteger(value["deliveryCount"]) || !_Coordinate(value["profileName"], 128) || !_Coordinate(value["workloadUid"], 256))
+	// 1. Parse a strict body so the controller cannot inject a silo, image, class, or other server-owned field.
+	const assignment = _ParseAssignment(value);
+
+	// 2. Validate the path independently because it is supplied by the same untrusted controller request.
+	const routeClaimId = _ParseMcpRuntimeClaimId(claimId);
+
+	// 3. Bind both claim IDs so a valid controller body cannot be retargeted through another claim URL.
+	if (assignment.claimId !== routeClaimId)
 		throw new Error("MCP runtime assignment has an invalid shape");
-	return value as unknown as RuntimeWorkloadBinding;
+
+	// 4. Keep the delivery, time, profile, and Job UID fence intact for the authoritative repository write.
+	return assignment;
 }
 
 /** Parse one release fence without accepting a caller-selected silo, image, or profile. */

--- a/libs/backend/server/gateways/mcp/main/src/runtime/mcp-runtime-wire.validator.ts
+++ b/libs/backend/server/gateways/mcp/main/src/runtime/mcp-runtime-wire.validator.ts
@@ -1,0 +1,41 @@
+/**
+ * Validates controller assignment JSON before the MCP gateway treats it as a workload binding.
+ * The router receives an untrusted HTTP body, so this schema stays beside the binding model and
+ * admits no controller-selected silo, image, or workload class field.
+ */
+import { z } from "zod";
+
+import type { RuntimeWorkloadBinding } from "@opencrane/backend/agents/runtime/workloads/contract";
+
+/** Rejects empty or control-character coordinates before they become durable controller fences. */
+const _CoordinateSchema = z.string().min(1).max(256).regex(/^[^\u0000-\u001f\u007f]+$/u);
+
+/** Accepts only database instants serialized with millisecond UTC precision. */
+const _InstantSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u).refine(function _ValidInstant(value): boolean { return Number.isFinite(Date.parse(value)); });
+
+/** Validates controller assignment evidence without permitting a controller to select its silo or image. */
+const _AssignmentSchema = z.object({
+	claimId: _CoordinateSchema,
+	claimedAt: _InstantSchema,
+	deliveryCount: z.number().int().positive(),
+	profileName: _CoordinateSchema.max(128),
+	workloadUid: _CoordinateSchema,
+}).strict();
+
+/** Parses one exact assignment body before the router binds it to the claim ID in its path. */
+export function _ParseMcpRuntimeAssignment(value: unknown): RuntimeWorkloadBinding
+{
+	const result = _AssignmentSchema.safeParse(value);
+	if (!result.success)
+		throw new Error("MCP runtime assignment has an invalid shape");
+	return result.data;
+}
+
+/** Validates the route claim coordinate before correlating it with assignment evidence. */
+export function _ParseMcpRuntimeClaimId(value: string): string
+{
+	const result = _CoordinateSchema.safeParse(value);
+	if (!result.success)
+		throw new Error("MCP runtime assignment has an invalid shape");
+	return result.data;
+}

--- a/libs/backend/server/iam/authorization/main/src/mcp-tool-invocation-lifecycle-events.ts
+++ b/libs/backend/server/iam/authorization/main/src/mcp-tool-invocation-lifecycle-events.ts
@@ -1,0 +1,61 @@
+import { TOOL_INVOCATION_PREPARATION_POLICY } from "./tool-invocation-lifecycle.types";
+import { ToolInvocationEventTypes, ToolInvocationRunRecoveryEnterResults } from "./tool-invocation.types";
+import type { ToolInvocationLifecycleEvent, ToolInvocationLifecycleEventSink, ToolInvocationRecord, ToolInvocationRecoveryEvent, ToolInvocationRecoveryEventSink, ToolInvocationRunRecoveryAuthority, ToolInvocationRunRecoveryEnterResult } from "./tool-invocation.types";
+
+/** Exact database transaction type accepted by the runs-owned event writer. */
+type _Transaction = Parameters<ToolInvocationLifecycleEventSink["appendInTransaction"]>[0];
+
+/** Failure code stored when the companion cannot prove what the MCP server did. */
+export const _MCP_AMBIGUOUS_FAILURE_CODE = "external_action_provider_outcome_ambiguous";
+
+/** Builds the canonical timeline event after a checked MCP tool result succeeds. */
+function _CompletedEvent(invocation: ToolInvocationRecord): ToolInvocationLifecycleEvent
+{
+	return { runId: invocation.runId, attempt: invocation.attempt, eventType: ToolInvocationEventTypes.Completed, payload: { toolInvocationId: invocation.toolInvocationId } };
+}
+
+/** Builds the canonical timeline event after a definite or uncertain MCP tool failure. */
+function _FailedEvent(invocation: ToolInvocationRecord, reason: string, retrying: boolean): ToolInvocationLifecycleEvent
+{
+	return { runId: invocation.runId, attempt: invocation.attempt, eventType: ToolInvocationEventTypes.Failed, payload: { toolInvocationId: invocation.toolInvocationId, toolRevisionId: invocation.toolRevisionId, reason, retryCount: invocation.preparationAttempt, retryLimit: TOOL_INVOCATION_PREPARATION_POLICY.attemptLimit, retrying } };
+}
+
+/** Appends an event, or aborts the caller's transaction when the owning run rejects it. */
+async function _AppendLifecycleEvent(sink: ToolInvocationLifecycleEventSink, transaction: _Transaction, event: ToolInvocationLifecycleEvent): Promise<void>
+{
+	if (!await sink.appendInTransaction(transaction, event))
+		throw new Error("tool invocation transition requires its canonical lifecycle event");
+}
+
+/** Writes the successful terminal event in the same transaction as result delivery. */
+export async function _AppendMcpToolInvocationCompleted(sink: ToolInvocationLifecycleEventSink, transaction: _Transaction, invocation: ToolInvocationRecord): Promise<void>
+{
+	await _AppendLifecycleEvent(sink, transaction, _CompletedEvent(invocation));
+}
+
+/** Writes the failed terminal or retry event in the same transaction as its state transition. */
+export async function _AppendMcpToolInvocationFailed(sink: ToolInvocationLifecycleEventSink, transaction: _Transaction, invocation: ToolInvocationRecord, reason: string, retrying: boolean): Promise<void>
+{
+	await _AppendLifecycleEvent(sink, transaction, _FailedEvent(invocation, reason, retrying));
+}
+
+/** Builds the run-owned recovery event for an outcome the companion cannot prove. */
+function _RecoveryEvent(invocation: ToolInvocationRecord): ToolInvocationRecoveryEvent
+{
+	return { runId: invocation.runId, expectedAttempt: invocation.attempt, toolInvocationId: invocation.toolInvocationId, preparationRetryCount: invocation.preparationAttempt, preparationRetryLimit: TOOL_INVOCATION_PREPARATION_POLICY.attemptLimit, providerOutcome: "unknown_after_dispatch" };
+}
+
+/** Moves a run into recovery and commits the matching recovery event in the same transaction. */
+export async function _EnterMcpToolInvocationRecovery(authority: ToolInvocationRunRecoveryAuthority, sink: ToolInvocationRecoveryEventSink, transaction: _Transaction, invocation: ToolInvocationRecord): Promise<void>
+{
+	const outcome: ToolInvocationRunRecoveryEnterResult = await authority.enterRecoveryRequiredInTransaction(transaction, { runId: invocation.runId, attempt: invocation.attempt });
+	if (outcome === ToolInvocationRunRecoveryEnterResults.Entered || outcome === ToolInvocationRunRecoveryEnterResults.AlreadyRecoveryRequired)
+	{
+		if (!await sink.appendInTransaction(transaction, _RecoveryEvent(invocation)))
+			throw new Error("tool recovery state requires its canonical recovery event");
+		return;
+	}
+	if (outcome === ToolInvocationRunRecoveryEnterResults.Cancelling)
+		return;
+	throw new Error("tool recovery state conflicts with its owning run attempt");
+}

--- a/libs/backend/server/iam/authorization/main/src/prisma-mcp-tool-invocation-participant.ts
+++ b/libs/backend/server/iam/authorization/main/src/prisma-mcp-tool-invocation-participant.ts
@@ -2,62 +2,18 @@ import { type Prisma } from "@prisma/client";
 
 import type { JsonValue } from "@opencrane/util";
 
-import { PrismaToolInvocationRepository } from "./prisma-tool-invocation-repository";
-import { TOOL_INVOCATION_PREPARATION_POLICY, ExternalActionClaimKinds, ToolInvocationStates } from "./tool-invocation-lifecycle.types";
-import { ToolInvocationCompletionOutcomes, ToolInvocationEventTypes, ToolInvocationRunRecoveryEnterResults } from "./tool-invocation.types";
+import { _AppendMcpToolInvocationCompleted, _AppendMcpToolInvocationFailed, _EnterMcpToolInvocationRecovery, _MCP_AMBIGUOUS_FAILURE_CODE } from "./mcp-tool-invocation-lifecycle-events";
 import type { McpToolInvocationTransactionParticipant, McpToolInvocationTransactionParticipantFactory } from "./mcp-tool-invocation-participant.types";
-import type { ToolInvocationClaim, ToolInvocationClaimResult, ToolInvocationCompletionResult, ToolInvocationLifecycleEvent, ToolInvocationLifecycleEventSink, ToolInvocationRecord, ToolInvocationRecoveryEvent, ToolInvocationRecoveryEventSink, ToolInvocationRunRecoveryAuthority, ToolInvocationRunRecoveryEnterResult, ToolResultDeliveryPayload } from "./tool-invocation.types";
-
-/** Failure code stored when the companion cannot prove what the MCP server did. */
-const _AMBIGUOUS_FAILURE_CODE = "external_action_provider_outcome_ambiguous";
-
-/** Build the timeline event written after a checked MCP tool result succeeds. */
-function _CompletedEvent(invocation: ToolInvocationRecord): ToolInvocationLifecycleEvent
-{
-	return { runId: invocation.runId, attempt: invocation.attempt, eventType: ToolInvocationEventTypes.Completed, payload: { toolInvocationId: invocation.toolInvocationId } };
-}
-
-/** Build the timeline event written after a definite or uncertain MCP tool failure. */
-function _FailedEvent(invocation: ToolInvocationRecord, reason: string, retrying: boolean): ToolInvocationLifecycleEvent
-{
-	return { runId: invocation.runId, attempt: invocation.attempt, eventType: ToolInvocationEventTypes.Failed, payload: { toolInvocationId: invocation.toolInvocationId, toolRevisionId: invocation.toolRevisionId, reason, retryCount: invocation.preparationAttempt, retryLimit: TOOL_INVOCATION_PREPARATION_POLICY.attemptLimit, retrying } };
-}
-
-/** Append the timeline event or abort the transaction when the owning run refuses it. */
-async function _AppendLifecycleEvent(sink: ToolInvocationLifecycleEventSink, transaction: Prisma.TransactionClient, event: ToolInvocationLifecycleEvent): Promise<void>
-{
-	if (!await sink.appendInTransaction(transaction, event))
-		throw new Error("tool invocation transition requires its canonical lifecycle event");
-}
-
-/** Append the manual-recovery event or abort the transaction when the owning run refuses it. */
-async function _AppendRecoveryEvent(sink: ToolInvocationRecoveryEventSink, transaction: Prisma.TransactionClient, invocation: ToolInvocationRecord): Promise<void>
-{
-	const event: ToolInvocationRecoveryEvent = { runId: invocation.runId, expectedAttempt: invocation.attempt, toolInvocationId: invocation.toolInvocationId, preparationRetryCount: invocation.preparationAttempt, preparationRetryLimit: TOOL_INVOCATION_PREPARATION_POLICY.attemptLimit, providerOutcome: "unknown_after_dispatch" };
-	if (!await sink.appendInTransaction(transaction, event))
-		throw new Error("tool recovery state requires its canonical recovery event");
-}
-
-/** Move the run into recovery and write the matching event inside the same transaction. */
-async function _EnterRecoveryRequired(authority: ToolInvocationRunRecoveryAuthority, sink: ToolInvocationRecoveryEventSink, transaction: Prisma.TransactionClient, invocation: ToolInvocationRecord): Promise<void>
-{
-	const outcome: ToolInvocationRunRecoveryEnterResult = await authority.enterRecoveryRequiredInTransaction(transaction, { runId: invocation.runId, attempt: invocation.attempt });
-	if (outcome === ToolInvocationRunRecoveryEnterResults.Entered || outcome === ToolInvocationRunRecoveryEnterResults.AlreadyRecoveryRequired)
-	{
-		await _AppendRecoveryEvent(sink, transaction, invocation);
-		return;
-	}
-	if (outcome === ToolInvocationRunRecoveryEnterResults.Cancelling)
-		return;
-	throw new Error("tool recovery state conflicts with its owning run attempt");
-}
+import { PrismaToolInvocationRepository } from "./prisma-tool-invocation-repository";
+import { ExternalActionClaimKinds, ToolInvocationStates } from "./tool-invocation-lifecycle.types";
+import { ToolInvocationCompletionOutcomes } from "./tool-invocation.types";
+import type { ToolInvocationClaim, ToolInvocationClaimResult, ToolInvocationCompletionResult, ToolInvocationLifecycleEventSink, ToolInvocationRecord, ToolInvocationRecoveryEventSink, ToolInvocationRunRecoveryAuthority, ToolResultDeliveryPayload } from "./tool-invocation.types";
 
 /**
- * Applies the authorization half of an MCP unit of work inside the transaction the MCP package owns.
+ * Applies authorization-owned MCP state changes inside the transaction supplied by the MCP runtime.
  *
- * This adapter is a unit-of-work participant rather than a repository because it coordinates the
- * ToolInvocation row, result delivery, lifecycle event, and run recovery writers. It never opens a
- * transaction; the caller must create a new instance for each transaction callback.
+ * This unit of work owns ToolInvocation persistence but delegates matching timeline and recovery
+ * writes through existing runs-owned ports. It never opens a transaction.
  */
 export class PrismaMcpToolInvocationParticipantUnitOfWork implements McpToolInvocationTransactionParticipant
 {
@@ -72,7 +28,7 @@ export class PrismaMcpToolInvocationParticipantUnitOfWork implements McpToolInvo
 	/** Transaction shared with the MCP runtime write. */
 	private readonly _transaction: Prisma.TransactionClient;
 
-	/** Bind every authorization writer to the transaction already opened by the MCP authority. */
+	/** Binds every authorization writer to the transaction already opened by the MCP authority. */
 	constructor(transaction: Prisma.TransactionClient, lifecycleEvents: ToolInvocationLifecycleEventSink, recoveryEvents: ToolInvocationRecoveryEventSink, runRecovery: ToolInvocationRunRecoveryAuthority)
 	{
 		this._transaction = transaction;
@@ -82,19 +38,19 @@ export class PrismaMcpToolInvocationParticipantUnitOfWork implements McpToolInvo
 		this._runRecovery = runRecovery;
 	}
 
-	/** Return the invocation row owned by the authorization package. */
+	/** Returns the invocation row owned by the authorization package. */
 	async findById(invocationId: string): Promise<ToolInvocationRecord | null>
 	{
 		return this._repository.findById(invocationId);
 	}
 
-	/** Claim dispatch, because the companion is about to call the uploaded MCP server. */
+	/** Claims dispatch because the companion is about to call the uploaded MCP server. */
 	async claim(invocationId: string, now: Date, leaseMilliseconds: number): Promise<ToolInvocationClaimResult>
 	{
 		return this._repository.claim(invocationId, ExternalActionClaimKinds.Dispatch, now, leaseMilliseconds);
 	}
 
-	/** Save a checked success and its event without leaving the caller's transaction. */
+	/** Saves a checked success and its timeline event without leaving the caller's transaction. */
 	async completeSucceeded(claim: ToolInvocationClaim, result: JsonValue, now: Date): Promise<ToolInvocationCompletionResult>
 	{
 		const invocation = await this._repository.findById(claim.invocationId);
@@ -103,11 +59,11 @@ export class PrismaMcpToolInvocationParticipantUnitOfWork implements McpToolInvo
 		const payload: ToolResultDeliveryPayload = { toolInvocationId: invocation.toolInvocationId, outcome: "succeeded", result };
 		const completed = await this._repository.complete(claim, payload, now);
 		if (completed.outcome === ToolInvocationCompletionOutcomes.Completed)
-			await _AppendLifecycleEvent(this._lifecycleEvents, this._transaction, _CompletedEvent(completed.invocation));
+			await _AppendMcpToolInvocationCompleted(this._lifecycleEvents, this._transaction, completed.invocation);
 		return completed;
 	}
 
-	/** Save a definite failure and its event without leaving the caller's transaction. */
+	/** Saves a definite failure and its timeline event without leaving the caller's transaction. */
 	async completeFailed(claim: ToolInvocationClaim, failureCode: string, now: Date): Promise<ToolInvocationCompletionResult>
 	{
 		const invocation = await this._repository.findById(claim.invocationId);
@@ -116,11 +72,11 @@ export class PrismaMcpToolInvocationParticipantUnitOfWork implements McpToolInvo
 		const payload: ToolResultDeliveryPayload = { toolInvocationId: invocation.toolInvocationId, outcome: "failed", failureCode };
 		const completed = await this._repository.complete(claim, payload, now);
 		if (completed.outcome === ToolInvocationCompletionOutcomes.Completed)
-			await _AppendLifecycleEvent(this._lifecycleEvents, this._transaction, _FailedEvent(completed.invocation, completed.invocation.failureCode ?? "external_action_failed", false));
+			await _AppendMcpToolInvocationFailed(this._lifecycleEvents, this._transaction, completed.invocation, completed.invocation.failureCode ?? "external_action_failed", false);
 		return completed;
 	}
 
-	/** Save an uncertain outcome and enter the existing run recovery flow. */
+	/** Saves an uncertain outcome before it enters the existing run-owned recovery flow. */
 	async completeAmbiguous(claim: ToolInvocationClaim, now: Date): Promise<ToolInvocationRecord | null>
 	{
 		const transition = await this._repository.completeAmbiguous(claim, now);
@@ -128,9 +84,9 @@ export class PrismaMcpToolInvocationParticipantUnitOfWork implements McpToolInvo
 			return transition.invocation;
 		const invocation = transition.invocation;
 		const retrying = invocation.state === ToolInvocationStates.Ready || invocation.state === ToolInvocationStates.Reconciling;
-		await _AppendLifecycleEvent(this._lifecycleEvents, this._transaction, _FailedEvent(invocation, _AMBIGUOUS_FAILURE_CODE, retrying));
+		await _AppendMcpToolInvocationFailed(this._lifecycleEvents, this._transaction, invocation, _MCP_AMBIGUOUS_FAILURE_CODE, retrying);
 		if (invocation.state === ToolInvocationStates.RecoveryRequired)
-			await _EnterRecoveryRequired(this._runRecovery, this._recoveryEvents, this._transaction, invocation);
+			await _EnterMcpToolInvocationRecovery(this._runRecovery, this._recoveryEvents, this._transaction, invocation);
 		return invocation;
 	}
 }

--- a/releases/0.9.3.json
+++ b/releases/0.9.3.json
@@ -21,10 +21,10 @@
     },
     "agent-controller": {
       "root": "apps/agent-controller",
-      "adaptedVersion": "0.9.2",
-      "packageVersion": "0.9.2",
-      "chartVersion": "0.9.2",
-      "chartAppVersion": "0.9.2"
+      "adaptedVersion": "0.9.3",
+      "packageVersion": "0.9.3",
+      "chartVersion": "0.9.3",
+      "chartAppVersion": "0.9.3"
     },
     "agent-runtime": {
       "root": "apps/agent-runtime",


### PR DESCRIPTION
## Summary

- split agent-controller startup composition and MCP/skill assignment, release, and Pod-registration reconciliation leaves
- replace handwritten MCP controller, discovered-tool, profile, and assignment wire parsing with strict Zod validators while preserving route/body and claim fences
- separate authorization lifecycle-event construction from its transaction-bound participant; clarify the companion credential boundary and package docs
- stamp the directly adapted agent-controller app, chart, manifest entry, and no-op Helm transition to 0.9.3
- make the companion lease-expiry test deterministic

## Validation

- 7 focused Nx lint and test targets: agent-controller, MCP controller/protocol/companion, skill controller, authorization, MCP gateway
- agent-controller Helm contract
- agent style, Prisma boundary, module-growth, and whitespace checks
- uncached MCP companion test after timing adjustment
- release-versioning tests

## Review

- architecture preflight: PASS
- independent review: no Critical/High/Medium findings; addressed its public reconciler JSDoc finding
- reaper: deleted superseded imperative validator residue and fully split skill reconcilers
- comments gate: PASS

## Remaining release gate

The release-versioning check still reports the pre-existing release-manifest project inventory and database-baseline digest mismatch. This PR resolves the agent-controller version, mirror, and migration issues.