### PR TITLE
🔧 Bootstrap the pinned Agent Sandbox controller

### DIFF
--- a/apps/_infra/agent-sandbox/README.md
+++ b/apps/_infra/agent-sandbox/README.md
@@ -36,8 +36,9 @@ chart renders with its unchanged release context.
 
 The chart creates release-scoped profiles, server claim RBAC and admission policy only. It never
 installs Agent Sandbox CRDs or its controller, selects a Pod image at claim time, creates a bespoke
-Pod controller, or keeps a legacy warm-runtime workload. The upstream controller and CRDs are external
-cluster prerequisites.
+Pod controller, or keeps a legacy warm-runtime workload. In standalone mode the explicit platform
+bootstrap installs the pinned upstream controller and CRDs once for the cluster; a silo never owns
+or upgrades those shared resources.
 
 ## Dependency direction
 

--- a/apps/_infra/deploy-k8s/README.md
+++ b/apps/_infra/deploy-k8s/README.md
@@ -54,8 +54,10 @@ Deployment rollout gates.
 Cluster-wide controllers (ingress, CloudNativePG, cert-manager, and the Agent Sandbox controller)
 and serving DNS are external prerequisites a silo never installs.
 "External" here means outside the organisation release: a cluster operator may explicitly install
-the pinned development controller set with `platform/bootstrap-prerequisites.sh`, but `deploy.sh`
-never invokes that helper. The app-owned chart helper runs `helm dependency update --skip-refresh`
+the pinned development controller set with `platform/bootstrap-prerequisites.sh`—including the
+Agent Sandbox v1beta1 controller and CRDs—but `deploy.sh` never invokes that helper. Serving DNS
+remains Terraform- and DNS-provider-owned, and gVisor remains a verified cluster runtime capability.
+The app-owned chart helper runs `helm dependency update --skip-refresh`
 against the checked-out in-repo `file://` sources. The commit is the version authority; ignored
 `Chart.lock` and `charts/` outputs are derived packaging, not release inputs.
 

--- a/apps/_infra/deploy-k8s/platform/README.md
+++ b/apps/_infra/deploy-k8s/platform/README.md
@@ -24,8 +24,8 @@ cluster does not match the assumptions needed to do that job safely.
 | `qualify-workflow-engine.sh` | Proves on a live silo that newly queued agent work is picked up within the expected time. It opens a temporary connection to the database proxy, runs the application-owned timing check, and keeps the application password out of its output. |
 | `database-release-finalization.sh` | Restarts database consumers when connection details change and waits for the normal application rollout. |
 | `k8s-teardown.sh` | Retires one standalone silo without touching shared cluster services or another tenant. It requires the exact cluster, tenant name, and expected release ownership, blocks protected tenants, and can inventory the planned deletion before removing anything. |
-| `bootstrap-prerequisites.sh` | Prepares a development cluster with the shared ingress, certificate, and PostgreSQL controllers OpenCrane expects. It validates the selected cluster and network address first and refuses to take over resources it does not own. A normal silo deployment never runs it automatically. |
-| `prerequisite-chart-lock.sh` | Pins the exact upstream controller packages accepted by the bootstrap. Checksums and expected cluster resources make downloaded dependencies reproducible and tamper-evident. |
+| `bootstrap-prerequisites.sh` | Prepares a development cluster with the shared ingress, certificate, PostgreSQL, and Agent Sandbox controllers OpenCrane expects. It validates the selected cluster and network address first and refuses to take over resources it does not own. A normal silo deployment never runs it automatically. |
+| `prerequisite-chart-lock.sh` | Pins the exact upstream controller packages accepted by the bootstrap. Checksums, controller image digests, and expected cluster resources make downloaded dependencies reproducible and tamper-evident. |
 | `configure-oidc.sh` | Updates OpenID Connect login settings on an existing silo without redeploying unrelated configuration. |
 | `provision.sh` | Creates a supported local, Google Kubernetes Engine (GKE), or virtual-private-server cluster before OpenCrane is installed. The GKE path also creates private storage for Terraform's infrastructure record. |
 | `terraform/` | Defines the optional Google Cloud infrastructure used by a GKE deployment, including encryption, networking, DNS, and the image registry. Application installation remains the deployer's responsibility. |
@@ -113,7 +113,11 @@ cert-manager leader election in its own namespace because Autopilot denies third
 managed `kube-system` namespace. It never installs
 external-dns or DNS credentials and it does not create a cluster-wide certificate issuer. Each silo
 owns its namespaced HTTP-01 `Issuer`; the operator creates the serving DNS record only after the
-ingress Service reports the reserved address.
+ingress Service reports the reserved address. The same explicit bootstrap installs the pinned Agent
+Sandbox controller and v1beta1 CRDs with extension reconcilers enabled, then rewrites its controller
+image to the locked immutable digest. The per-silo chart owns only namespaced profiles and claims;
+it never takes ownership of the shared controller. gVisor remains a GKE runtime prerequisite that
+the testv5 deploy preflight verifies.
 
 The short-lived PostgreSQL privilege proof uses ordinary GKE Autopilot scheduling. Its single Job
 runs one PostgreSQL client container for each logical database, which means two containers in the

--- a/apps/_infra/deploy-k8s/platform/agent-sandbox-prerequisite.sh
+++ b/apps/_infra/deploy-k8s/platform/agent-sandbox-prerequisite.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# Manages the Agent Sandbox controller as a cluster prerequisite without giving a silo ownership of
+# the controller, its CRDs, or its cross-namespace RBAC.
+
+resource_is_expected_manifest_residue()
+{
+  local resource="$1" release="$2" namespace="$3"
+  local managed_by owner_release
+  managed_by="$(kubectl --context "$EXPECTED_CONTEXT" --namespace "$namespace" get "$resource" \
+    --output=jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}')"
+  owner_release="$(kubectl --context "$EXPECTED_CONTEXT" --namespace "$namespace" get "$resource" \
+    --output=jsonpath='{.metadata.annotations.opencrane\.ai/prerequisite-release}')"
+  [[ "$managed_by" == "opencrane-prerequisite-bootstrap" && "$owner_release" == "$release" ]]
+}
+
+assert_absent_manifest_is_clean()
+{
+  local release="$1" namespace="$2"
+  shift 2
+
+  if resource_exists namespace "$namespace"; then
+    namespace_is_bootstrap_owned "$namespace" "$release" || fail \
+      "namespace '$namespace' exists without bootstrap ownership for '$release'; refusing to adopt it"
+  fi
+
+  local resource
+  for resource in "$@"; do
+    if resource_exists --namespace "$namespace" "$resource"; then
+      resource_is_expected_manifest_residue "$resource" "$release" "$namespace" || fail \
+        "resource '$resource' exists without bootstrap ownership for '$release'; refusing to adopt it"
+    fi
+  done
+}
+
+prepare_agent_sandbox_manifest()
+{
+  local downloaded_manifest actual_sha256
+  downloaded_manifest="$CHART_CACHE_DIR/agent-sandbox-${AGENT_SANDBOX_VERSION}.yaml"
+  AGENT_SANDBOX_MANIFEST="$CHART_CACHE_DIR/agent-sandbox-${AGENT_SANDBOX_VERSION}-pinned.yaml"
+
+  curl --fail --location --silent --show-error \
+    --output "$downloaded_manifest" \
+    "$AGENT_SANDBOX_MANIFEST_URL"
+  actual_sha256="$(sha256_file "$downloaded_manifest")"
+  [[ "$actual_sha256" == "$AGENT_SANDBOX_MANIFEST_SHA256" ]] || fail \
+    "Agent Sandbox manifest has SHA-256 '$actual_sha256', expected '$AGENT_SANDBOX_MANIFEST_SHA256'"
+
+  sed \
+    "s|registry.k8s.io/agent-sandbox/agent-sandbox-controller:${AGENT_SANDBOX_VERSION}|${AGENT_SANDBOX_CONTROLLER_IMAGE}|" \
+    "$downloaded_manifest" >"$AGENT_SANDBOX_MANIFEST"
+  grep -Fq "image: $AGENT_SANDBOX_CONTROLLER_IMAGE" "$AGENT_SANDBOX_MANIFEST" || fail \
+    "Agent Sandbox release manifest did not contain its expected controller image tag"
+  grep -Fxq '        - --extensions' "$AGENT_SANDBOX_MANIFEST" || fail \
+    "Agent Sandbox release manifest does not enable extension reconcilers"
+}
+
+mark_agent_sandbox_manifest_resources()
+{
+  local resource
+  for resource in "${AGENT_SANDBOX_CLUSTER_RESOURCES[@]}" "${AGENT_SANDBOX_NAMESPACE_RESOURCES[@]}"; do
+    kubectl --context "$EXPECTED_CONTEXT" --namespace "$AGENT_SANDBOX_NAMESPACE" label "$resource" \
+      app.kubernetes.io/managed-by=opencrane-prerequisite-bootstrap --overwrite >/dev/null
+    kubectl --context "$EXPECTED_CONTEXT" --namespace "$AGENT_SANDBOX_NAMESPACE" annotate "$resource" \
+      "opencrane.ai/prerequisite-release=$AGENT_SANDBOX_RELEASE" --overwrite >/dev/null
+  done
+}
+
+install_agent_sandbox_prerequisite()
+{
+  log "installing Agent Sandbox $AGENT_SANDBOX_VERSION..."
+  ensure_bootstrap_namespace "$AGENT_SANDBOX_NAMESPACE" "$AGENT_SANDBOX_RELEASE"
+  kubectl --context "$EXPECTED_CONTEXT" apply \
+    --server-side \
+    --field-manager=opencrane-prerequisite-bootstrap \
+    --filename "$AGENT_SANDBOX_MANIFEST" >/dev/null
+  mark_agent_sandbox_manifest_resources
+}
+
+verify_agent_sandbox_prerequisite()
+{
+  kubectl --context "$EXPECTED_CONTEXT" --namespace "$AGENT_SANDBOX_NAMESPACE" \
+    rollout status deployment/agent-sandbox-controller --timeout=5m
+  wait_for_established_crds "${AGENT_SANDBOX_CLUSTER_RESOURCES[@]}"
+
+  local crd version_state
+  for crd in "${AGENT_SANDBOX_V1BETA1_CRDS[@]}"; do
+    version_state="$(kubectl --context "$EXPECTED_CONTEXT" get crd "$crd" \
+      --output='jsonpath={range .spec.versions[?(@.name=="v1beta1")]}{.served}:{.storage}{end}')"
+    [[ "$version_state" == "true:true" ]] || fail \
+      "Agent Sandbox CRD '$crd' must serve and store v1beta1 resources"
+  done
+
+  local controller_image controller_args
+  controller_image="$(kubectl --context "$EXPECTED_CONTEXT" --namespace "$AGENT_SANDBOX_NAMESPACE" \
+    get deployment agent-sandbox-controller \
+    --output=jsonpath='{.spec.template.spec.containers[0].image}')"
+  [[ "$controller_image" == "$AGENT_SANDBOX_CONTROLLER_IMAGE" ]] || fail \
+    "Agent Sandbox controller image is '$controller_image', expected '$AGENT_SANDBOX_CONTROLLER_IMAGE'"
+  controller_args="$(kubectl --context "$EXPECTED_CONTEXT" --namespace "$AGENT_SANDBOX_NAMESPACE" \
+    get deployment agent-sandbox-controller \
+    --output=jsonpath='{range .spec.template.spec.containers[0].args[*]}{.}{"\\n"}{end}')"
+  grep -Fx -- '--extensions' <<<"$controller_args" >/dev/null || fail \
+    "Agent Sandbox controller does not enable extension reconcilers"
+}

--- a/apps/_infra/deploy-k8s/platform/bootstrap-prerequisites.sh
+++ b/apps/_infra/deploy-k8s/platform/bootstrap-prerequisites.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROFILE_DIR="$SCRIPT_DIR/values/prerequisites/gke-autopilot-dev"
 source "$SCRIPT_DIR/prerequisite-chart-lock.sh"
+source "$SCRIPT_DIR/agent-sandbox-prerequisite.sh"
 
 EXPECTED_CONTEXT=""
 PROJECT_ID=""
@@ -18,6 +19,7 @@ CHART_CACHE_DIR=""
 INGRESS_ARCHIVE=""
 CERT_MANAGER_ARCHIVE=""
 CNPG_ARCHIVE=""
+AGENT_SANDBOX_MANIFEST=""
 
 log()
 {
@@ -40,7 +42,7 @@ Usage: bootstrap-prerequisites.sh \
   --ingress-address-name NAME \
   [--yes]
 
-Installs the pinned ingress-nginx, cert-manager, and CloudNativePG controllers
+Installs the pinned ingress-nginx, cert-manager, CloudNativePG, and Agent Sandbox controllers
 needed by an OpenCrane silo. The command fails closed when the target context,
 regional static address, or existing cluster-wide resources do not match.
 USAGE
@@ -93,7 +95,7 @@ parse_args()
 require_commands()
 {
   local command_name
-  for command_name in gcloud kubectl helm jq; do
+  for command_name in curl gcloud kubectl helm jq; do
     command -v "$command_name" >/dev/null 2>&1 || fail "missing required command: $command_name"
   done
 }
@@ -258,6 +260,11 @@ validate_existing_ownership()
     "$CNPG_NAMESPACE" \
     "${CNPG_CHART}-${CNPG_VERSION}" \
     "${CNPG_CLUSTER_RESOURCES[@]}"
+  assert_absent_manifest_is_clean \
+    "$AGENT_SANDBOX_RELEASE" \
+    "$AGENT_SANDBOX_NAMESPACE" \
+    "${AGENT_SANDBOX_CLUSTER_RESOURCES[@]}" \
+    "${AGENT_SANDBOX_NAMESPACE_RESOURCES[@]}"
 }
 
 sha256_file()
@@ -301,8 +308,9 @@ prepare_chart_archives()
 
 render_pinned_charts()
 {
-  log "rendering the three pinned controller charts before mutation..."
+  log "rendering the pinned controller packages before mutation..."
   prepare_chart_archives
+  prepare_agent_sandbox_manifest
   helm template "$INGRESS_RELEASE" "$INGRESS_ARCHIVE" \
     --namespace "$INGRESS_NAMESPACE" \
     --include-crds \
@@ -316,6 +324,11 @@ render_pinned_charts()
     --namespace "$CNPG_NAMESPACE" \
     --include-crds \
     --values "$PROFILE_DIR/cloudnative-pg.yaml" >/dev/null
+  kubectl --context "$EXPECTED_CONTEXT" apply \
+    --server-side \
+    --dry-run=server \
+    --field-manager=opencrane-prerequisite-bootstrap \
+    --filename "$AGENT_SANDBOX_MANIFEST" >/dev/null
 }
 
 confirm_mutation()
@@ -388,6 +401,8 @@ install_prerequisites()
     "$CNPG_ARCHIVE" \
     "$CNPG_NAMESPACE" \
     "$PROFILE_DIR/cloudnative-pg.yaml"
+
+  install_agent_sandbox_prerequisite
 }
 
 wait_for_ingress_address()
@@ -434,6 +449,7 @@ verify_prerequisites()
   kubectl --context "$EXPECTED_CONTEXT" get ingressclass nginx >/dev/null
   wait_for_established_crds "${CERT_MANAGER_CLUSTER_RESOURCES[@]}"
   wait_for_established_crds "${CNPG_CLUSTER_RESOURCES[@]}"
+  verify_agent_sandbox_prerequisite
   wait_for_ingress_address
 
   log "shared prerequisites are ready; ingress address: $INGRESS_ADDRESS_IP"

--- a/apps/_infra/deploy-k8s/platform/prerequisite-chart-lock.sh
+++ b/apps/_infra/deploy-k8s/platform/prerequisite-chart-lock.sh
@@ -83,3 +83,33 @@ CNPG_CLUSTER_RESOURCES=(
   "mutatingwebhookconfiguration/cnpg-mutating-webhook-configuration"
   "validatingwebhookconfiguration/cnpg-validating-webhook-configuration"
 )
+
+# Agent Sandbox publishes a versioned Kubernetes manifest instead of a Helm repository. The
+# bootstrap verifies those exact release bytes before it server-side applies the controller.
+AGENT_SANDBOX_RELEASE="agent-sandbox"
+AGENT_SANDBOX_NAMESPACE="agent-sandbox-system"
+AGENT_SANDBOX_VERSION="v1.0.0"
+AGENT_SANDBOX_MANIFEST_URL="https://github.com/kubernetes-sigs/agent-sandbox/releases/download/v1.0.0/sandbox-with-extensions.yaml"
+AGENT_SANDBOX_MANIFEST_SHA256="3a22f89ca1d1d6084e0a351797224842ee413641d6945f9e5b2cb5e1f6cf026c"
+AGENT_SANDBOX_CONTROLLER_IMAGE="registry.k8s.io/agent-sandbox/agent-sandbox-controller@sha256:bdde1a3150bd385f7318c974c1516e880b4f826b6b51a3e7f127c2f8c95b55cd"
+AGENT_SANDBOX_CLUSTER_RESOURCES=(
+  "crd/sandboxes.agents.x-k8s.io"
+  "crd/sandboxclaims.extensions.agents.x-k8s.io"
+  "crd/sandboxtemplates.extensions.agents.x-k8s.io"
+  "crd/sandboxwarmpools.extensions.agents.x-k8s.io"
+  "clusterrole/agent-sandbox-controller"
+  "clusterrole/agent-sandbox-controller-extensions"
+  "clusterrolebinding/agent-sandbox-controller"
+  "clusterrolebinding/agent-sandbox-controller-extensions"
+)
+AGENT_SANDBOX_NAMESPACE_RESOURCES=(
+  "serviceaccount/agent-sandbox-controller"
+  "service/agent-sandbox-controller"
+  "deployment/agent-sandbox-controller"
+)
+AGENT_SANDBOX_V1BETA1_CRDS=(
+  "sandboxes.agents.x-k8s.io"
+  "sandboxclaims.extensions.agents.x-k8s.io"
+  "sandboxtemplates.extensions.agents.x-k8s.io"
+  "sandboxwarmpools.extensions.agents.x-k8s.io"
+)

--- a/apps/_infra/deploy-k8s/platform/tests/bootstrap-prerequisites-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/bootstrap-prerequisites-contract.sh
@@ -56,6 +56,17 @@ case "$command_name" in
         ;;
     esac
     ;;
+  curl)
+    output=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --output) output="$2"; shift 2 ;;
+        *) shift ;;
+      esac
+    done
+    printf '%s\n' '        image: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v1.0.0' >"$output"
+    printf '%s\n' '        - --extensions' >>"$output"
+    ;;
   kubectl)
     if [[ "$*" == "config current-context" ]]; then
       printf '%s\n' "${MOCK_CURRENT_CONTEXT:-gke_weownai-proto_europe-west1_opencrane-dev}"
@@ -88,7 +99,7 @@ case "$command_name" in
       esac
       exit 0
     fi
-    if [[ -n "${MOCK_FOREIGN_RESOURCE:-}" && "$*" == *" get ${MOCK_FOREIGN_RESOURCE}"* ]]; then
+    if [[ -n "${MOCK_FOREIGN_RESOURCE:-}" && "$*" == *"${MOCK_FOREIGN_RESOURCE}"* ]]; then
       exit 0
     fi
     if [[ "$*" == *" get service ingress-nginx-controller "* ]]; then
@@ -98,6 +109,18 @@ case "$command_name" in
     if [[ "$*" == *" rollout status "* ]]; then
       [[ "${MOCK_ROLLOUT_FAIL:-0}" == "0" ]]
       exit
+    fi
+    if [[ "$*" == *"get deployment agent-sandbox-controller"* && "$*" == *"containers[0].image"* ]]; then
+      printf '%s' 'registry.k8s.io/agent-sandbox/agent-sandbox-controller@sha256:bdde1a3150bd385f7318c974c1516e880b4f826b6b51a3e7f127c2f8c95b55cd'
+      exit 0
+    fi
+    if [[ "$*" == *"get deployment agent-sandbox-controller"* && "$*" == *"containers[0].args"* ]]; then
+      printf '%s\n' '--extensions'
+      exit 0
+    fi
+    if [[ "$*" == *"get crd "* && "$*" == *"spec.versions"* ]]; then
+      printf '%s' "${MOCK_AGENT_SANDBOX_VERSION_STATE:-true:true}"
+      exit 0
     fi
     if [[ "$*" == *" wait --for=condition=Established crd/"* ]]; then
       [[ "${MOCK_CRD_ESTABLISHED_FAIL:-0}" == "0" ]]
@@ -125,6 +148,7 @@ case "$command_name" in
       ingress-nginx-4.15.1.tgz) digest='3eff0bd18151d6e6b1c441463410571443dda1ac78292cb189346628de784f0c' ;;
       cert-manager-v1.21.1.tgz) digest='c27101f3f3e2349fb4a9e704316105bf7b52ad73b8c8257d3498ef7f2f6a4adc' ;;
       cloudnative-pg-0.29.0.tgz) digest='668e065ff53508d58238788fd35b355a925060843629a951df0e6a9362e6d32f' ;;
+      agent-sandbox-v1.0.0.yaml) digest='3a22f89ca1d1d6084e0a351797224842ee413641d6945f9e5b2cb5e1f6cf026c' ;;
       *) digest='invalid' ;;
     esac
     [[ "${MOCK_BAD_DIGEST:-0}" == "0" ]] || digest='invalid'
@@ -133,7 +157,7 @@ case "$command_name" in
 esac
 MOCK
 chmod +x "$MOCK_BIN/command-mock"
-for command_name in gcloud helm kubectl shasum sleep; do
+for command_name in curl gcloud helm kubectl shasum sleep; do
   ln -s "$MOCK_BIN/command-mock" "$MOCK_BIN/$command_name"
 done
 
@@ -170,11 +194,14 @@ grep -Fq 'helm list --deployed --failed --pending --uninstalled --superseded --u
 grep -Fq 'helm pull ingress-nginx --repo https://kubernetes.github.io/ingress-nginx --version 4.15.1' "$SUCCESS_CALLS"
 grep -Fq 'helm pull cert-manager --repo https://charts.jetstack.io --version v1.21.1' "$SUCCESS_CALLS"
 grep -Fq 'helm pull cloudnative-pg --repo https://cloudnative-pg.github.io/charts --version 0.29.0' "$SUCCESS_CALLS"
+grep -Fq 'curl --fail --location --silent --show-error --output ' "$SUCCESS_CALLS"
+grep -Fq 'sandbox-with-extensions.yaml' "$SUCCESS_CALLS"
 grep -Eq 'helm template ingress-nginx .*/ingress-nginx-4\.15\.1\.tgz --namespace ingress-nginx' "$SUCCESS_CALLS"
 grep -Eq 'helm upgrade --install ingress-nginx .*/ingress-nginx-4\.15\.1\.tgz --namespace ingress-nginx' "$SUCCESS_CALLS"
 grep -Fq -- '--set-string controller.service.loadBalancerIP=35.205.225.244' "$SUCCESS_CALLS"
 grep -Fq -- '--atomic --wait --wait-for-jobs --timeout 20m' "$SUCCESS_CALLS"
 grep -Fq 'kubectl --context gke_weownai-proto_europe-west1_opencrane-dev wait --for=condition=Established crd/subscriptions.postgresql.cnpg.io --timeout=2m' "$SUCCESS_CALLS"
+grep -Fq 'kubectl --context gke_weownai-proto_europe-west1_opencrane-dev wait --for=condition=Established crd/sandboxclaims.extensions.agents.x-k8s.io --timeout=2m' "$SUCCESS_CALLS"
 
 if run_case context-mismatch MOCK_CURRENT_CONTEXT=other-context; then
   echo 'context mismatch unexpectedly succeeded' >&2
@@ -257,6 +284,18 @@ if run_case leftover-crd MOCK_FOREIGN_RESOURCE=crd/backups.postgresql.cnpg.io; t
   exit 1
 fi
 ! grep -Fq 'helm upgrade' "$TEST_DIR/leftover-crd.calls"
+
+if run_case foreign-agent-sandbox-crd MOCK_FOREIGN_RESOURCE=crd/sandboxclaims.extensions.agents.x-k8s.io; then
+  echo 'foreign Agent Sandbox CRD unexpectedly succeeded' >&2
+  exit 1
+fi
+! grep -Fq 'helm upgrade' "$TEST_DIR/foreign-agent-sandbox-crd.calls"
+
+if run_case agent-sandbox-v1beta1-mismatch MOCK_AGENT_SANDBOX_VERSION_STATE=true:false; then
+  echo 'non-storage Agent Sandbox v1beta1 CRD unexpectedly succeeded' >&2
+  exit 1
+fi
+grep -Fq 'helm upgrade --install cloudnative-pg' "$TEST_DIR/agent-sandbox-v1beta1-mismatch.calls"
 
 if run_case owned-namespace-foreign-crd \
   MOCK_FOREIGN_NAMESPACE=cnpg-system \


### PR DESCRIPTION
## Summary

- add Agent Sandbox v1.0.0 to the explicit standalone cluster bootstrap, while keeping every silo release namespaced
- verify the upstream release manifest SHA-256, replace its mutable controller tag with an immutable image digest, and dry-run it before mutation
- refuse foreign controller residue and verify v1beta1 CRDs, extension reconcilers, and the exact controller image after rollout
- document that serving DNS remains Terraform/provider-owned and gVisor remains a verified cluster capability

## Validation

- bootstrap prerequisite contract, including foreign-residue and v1beta1-storage rejection paths
- real pinned-chart bootstrap render contract
- complete platform Helm contract suite
- release-versioning, Prisma boundary, style, module-growth, architecture, independent review, and comments gates

## Review order

1. #766
2. #767
3. #769