### PR TITLE
🎱 default checkpoint PRs to native GitHub stacks

### DIFF
--- a/docs/agents/workflow.md
+++ b/docs/agents/workflow.md
@@ -25,6 +25,19 @@ Three files track work, each with a distinct role — keep them from drifting:
 
 ## PR Ancestry And Single-Review Gate
 
+### Native GitHub stacks are the default
+
+Use GitHub's native stack workflow for every change that has an open predecessor. After committing
+the incremental checkpoint, add its branch to the current stack with `gh stack add <branch>` and
+publish or refresh the complete chain with `gh stack submit --auto --open`. This creates each pull
+request against its immediate predecessor rather than repeating its ancestor's diff against
+`develop`.
+
+Start a new chain with `gh stack init` only when the stack does not already exist. Before opening,
+refreshing, rebasing, or reporting a stack, inspect it with `gh stack view` and run the repository
+stack-integrity check below. Use `gh stack sync` or `gh stack rebase` when a predecessor changes;
+do not manually retarget child pull requests as a substitute for restacking.
+
 Before creating, refreshing, rebasing, or reporting a pull request, inspect the **live** PR list and
 the candidate's actual commit/diff ancestry. Identify every earlier PR whose branch, commits, or
 functional diff the candidate builds on. Resolve each predecessor in exactly one of these ways:
@@ -61,7 +74,7 @@ earlier conclusion, and at least once per hour while a task remains active:
 |-------|---------------------|
 | Slice/wave commit or review-fix commit | Record the new `HEAD`; review the explicit `WAVE_BASE...HEAD` range plus staged, unstaged, and untracked overlays. |
 | Parent push, force-update, or rebase | Re-fetch the parent SHA and restack every descendant before unrelated work continues. |
-| Parent PR merged | Before merging its child, retarget that child to the integration branch and prove the merged parent head is now ancestral there. Never merge a child into an already-merged feature branch. |
+| Parent PR merged | Run `gh stack sync` to cascade-rebase every open child onto the updated stack, push their refreshed ancestry, and sync their PR bases. Before merging a child, prove the merged parent head is ancestral there. Never merge a child into an already-merged feature branch. |
 | Authorized push | Confirm the remote head equals the reviewed local `HEAD`; stale local evidence is invalid. |
 | PR open, refresh, edit, or base change | Run the live stack checker and record the PR number, base ref/SHA, head ref/SHA, and review order. |
 | Pre-handoff or pre-merge report | Validate both the incremental `base...head` diff and the cumulative integration-base-to-stack-tip range. If integration is not ancestral to the tip, require a clean `git merge-tree --write-tree <integration-sha> <tip-sha>` simulation. |

--- a/scripts/__tests__/pr-stack-integrity.test.mjs
+++ b/scripts/__tests__/pr-stack-integrity.test.mjs
@@ -33,6 +33,7 @@ function _Validate(pullRequests, options = {})
 	const input = {
 		repository: "example/opencrane",
 		pullRequests,
+		mergedPullRequests: options.mergedPullRequests ?? [],
 		integrationBranches: new Set(["develop"]),
 		baseHeads: new Map(pullRequests.map(function _BaseHead(pr) { return [pr.base.ref, pr.base.sha]; })),
 		ancestry: options.ancestry ?? new Set(),
@@ -41,6 +42,16 @@ function _Validate(pullRequests, options = {})
 		event: options.event,
 	};
 	return validationResult(input, evaluateStack(input));
+}
+
+/** Create a merged native-stack PR fixture that can bridge open layers. */
+function _MergedPullRequest(number, headRef, headSha, baseRef, baseSha, mergeCommitSha)
+{
+	return {
+		..._PullRequest(number, headRef, headSha, baseRef, baseSha),
+		mergedAt: "2026-09-01T00:00:00Z",
+		mergeCommitSha,
+	};
 }
 
 test("canonicalizes GitHub API order and parses only the Review order section", function _CanonicalEvidence()
@@ -52,6 +63,30 @@ test("canonicalizes GitHub API order and parses only the Review order section", 
 	});
 	assert.deepEqual(github.openPullRequests("example/opencrane").map(function _Number(pr) { return pr.number; }), [1, 2]);
 	assert.deepEqual(parseReviewOrder(first.body), [1, 2]);
+});
+
+test("queries only unresolved base branches for merged native stack layers", function _RelevantMergedQueries()
+{
+	const calls = [];
+	const github = createGitHubAdapter({
+		run(command, arguments_)
+		{
+			calls.push([command, arguments_]);
+			return JSON.stringify([[]]);
+		},
+	});
+	github.mergedPullRequests("example/opencrane", [
+		_PullRequest(1, "feat/one", "a", "develop", "d"),
+		_PullRequest(2, "feat/two", "b", "feat/one", "a"),
+		_PullRequest(3, "feat/three", "c", "feat/deleted", "m"),
+	]);
+	assert.equal(calls.length, 2);
+	assert.ok(calls.some(function _DeletedBase(call) {
+		return call[1].at(-1).includes("head=example%3Afeat%2Fdeleted");
+	}));
+	assert.ok(calls.some(function _IntegrationBase(call) {
+		return call[1].at(-1).includes("head=example%3Adevelop");
+	}));
 });
 
 test("accepts an independent integration-root PR", function _Independent()
@@ -95,6 +130,69 @@ test("rejects stale parent SHAs and non-ancestral stack edges", function _StaleP
 test("rejects a feature base whose predecessor is no longer open", function _OrphanedBase()
 {
 	const result = _Validate([_PullRequest(2, "feat/two", "b", "feat/merged-one", "a")]);
+	assert.equal(result.valid, false);
+	assert.equal(result.evidence.findings[0].code, "ORPHANED_BASE");
+});
+
+test("bridges only merge-commit-pinned native stack layers", function _MergedStackBridge()
+{
+	const pullRequests = [
+		_PullRequest(1, "feat/one", "merged-tip", "develop", "d"),
+		_PullRequest(3, "feat/three", "c", "feat/two", "merged-tip", "## Review order\n\n1. #1\n2. #3"),
+	];
+	const mergedPullRequests = [_MergedPullRequest(2, "feat/two", "merged-tip", "feat/one", "previous-tip", "merged-tip")];
+	const result = _Validate(pullRequests, {
+		mergedPullRequests,
+		ancestry: new Set(["1:3"]),
+		event: { number: 3, action: "synchronize", headSha: "c" },
+	});
+	assert.equal(result.valid, true);
+	assert.deepEqual(result.evidence.currentChain, [1, 3]);
+	assert.deepEqual(result.evidence.mergedBridges, [{
+		child: 3,
+		mergedLayers: [{
+			number: 2,
+			head: { ref: "feat/two", sha: "merged-tip" },
+			base: { ref: "feat/one", sha: "previous-tip" },
+			mergeCommitSha: "merged-tip",
+		}],
+	}]);
+});
+
+test("selects a merged stack layer by its recorded merge commit", function _RepeatedMergedHead()
+{
+	const pullRequests = [
+		_PullRequest(1, "feat/one", "merged-tip", "develop", "d"),
+		_PullRequest(3, "feat/three", "c", "feat/two", "merged-tip", "## Review order\n\n1. #1\n2. #3"),
+	];
+	const mergedPullRequests = [
+		_MergedPullRequest(2, "feat/two", "old-tip", "develop", "d", "old-tip"),
+		_MergedPullRequest(4, "feat/two", "merged-tip", "feat/one", "previous-tip", "merged-tip"),
+	];
+	const result = _Validate(pullRequests, {
+		mergedPullRequests,
+		ancestry: new Set(["1:3"]),
+	});
+	assert.equal(result.valid, true);
+});
+
+test("binds merged stack layers into the inspection snapshot digest", function _MergedSnapshotDigest()
+{
+	const pullRequests = [_PullRequest(3, "feat/three", "c", "feat/two", "merged-tip")];
+	const matching = _Validate(pullRequests, {
+		mergedPullRequests: [_MergedPullRequest(2, "feat/two", "merged-tip", "develop", "d", "merged-tip")],
+	});
+	const missing = _Validate(pullRequests);
+	assert.equal(matching.valid, true);
+	assert.deepEqual(matching.evidence.mergedBridges.map(function _Child(bridge) { return bridge.child; }), [3]);
+	assert.notEqual(matching.evidence.snapshotDigest, missing.evidence.snapshotDigest);
+});
+
+test("rejects a merged-layer base that is not pinned to its merge commit", function _UnpinnedMergedStackBase()
+{
+	const pullRequests = [_PullRequest(3, "feat/three", "c", "feat/two", "stale-tip")];
+	const mergedPullRequests = [_MergedPullRequest(2, "feat/two", "merged-tip", "develop", "d", "merged-tip")];
+	const result = _Validate(pullRequests, { mergedPullRequests });
 	assert.equal(result.valid, false);
 	assert.equal(result.evidence.findings[0].code, "ORPHANED_BASE");
 });
@@ -300,6 +398,28 @@ test("fails when a fetched PR ref does not match GitHub's head SHA", function _F
 	assert.throws(function _Fetch() {
 		git.fetchAndVerify([_PullRequest(1, "feat/one", "expected", "develop", "d")]);
 	}, /FETCHED_HEAD_DRIFT/u);
+});
+
+test("does not fetch a deleted merged parent branch", function _DeletedMergedBase()
+{
+	const calls = [];
+	const git = createGitAdapter({
+		run(command, arguments_)
+		{
+			calls.push([command, arguments_]);
+			if (arguments_[0] === "rev-parse")
+			{
+				return "child";
+			}
+			return "";
+		},
+	});
+	git.fetchAndVerify([_PullRequest(3, "feat/three", "child", "feat/deleted-merged", "merge")]);
+	const fetch = calls.find(function _Fetch(call) { return call[1][0] === "fetch"; });
+	assert.ok(fetch);
+	assert.equal(fetch[1].some(function _DeletedBase(argument) {
+		return argument.includes("refs/heads/feat/deleted-merged");
+	}), false);
 });
 
 test("keeps distinct binary identities without buffering patch payloads", function _BinaryDiffMetadata()

--- a/scripts/pr-stack-integrity/cli.mjs
+++ b/scripts/pr-stack-integrity/cli.mjs
@@ -27,6 +27,7 @@ function _Failure(repository, event, error)
 			event,
 			pullRequests: [],
 			edges: [],
+			mergedBridges: [],
 			reviewLevels: [],
 			currentChain: [],
 			current: null,
@@ -70,10 +71,14 @@ export function runCli(arguments_, dependencies = {})
 				valid: true,
 				evidence: {
 					repository,
-					snapshotDigest: digestEvidence(inspection.pullRequests),
+					snapshotDigest: digestEvidence({
+						pullRequests: inspection.pullRequests,
+						mergedPullRequests: inspection.mergedPullRequests ?? [],
+					}),
 					event: null,
 					pullRequests: inspection.pullRequests,
 					edges: [],
+					mergedBridges: [],
 					reviewLevels: [],
 					currentChain: [],
 					current: null,

--- a/scripts/pr-stack-integrity/evidence.mjs
+++ b/scripts/pr-stack-integrity/evidence.mjs
@@ -16,7 +16,10 @@ export function buildEvidence(input, evaluation)
 	});
 	return {
 		repository: input.repository,
-		snapshotDigest: digestEvidence(input.pullRequests),
+		snapshotDigest: digestEvidence({
+			pullRequests: input.pullRequests,
+			mergedPullRequests: input.mergedPullRequests ?? [],
+		}),
 		event: input.event ?? null,
 		pullRequests: input.pullRequests.map(function _EvidencePullRequest(pullRequest) {
 			return {
@@ -30,6 +33,19 @@ export function buildEvidence(input, evaluation)
 		}),
 		edges: Array.from(evaluation.topology.parents, function _Edge([child, parent]) { return { parent, child }; })
 			.sort(function _ByChild(left, right) { return left.child - right.child; }),
+		mergedBridges: Array.from(evaluation.topology.bridges, function _Bridge([child, mergedLayers]) {
+			return {
+				child,
+				mergedLayers: mergedLayers.map(function _MergedLayer(layer) {
+					return {
+						number: layer.number,
+						head: layer.head,
+						base: layer.base,
+						mergeCommitSha: layer.mergeCommitSha,
+					};
+				}),
+			};
+		}).sort(function _ByChild(left, right) { return left.child - right.child; }),
 		reviewLevels: reviewLevels(input.pullRequests, evaluation.topology.parents),
 		currentChain: evaluation.currentChain,
 		current: evaluation.current ? {

--- a/scripts/pr-stack-integrity/git.mjs
+++ b/scripts/pr-stack-integrity/git.mjs
@@ -1,5 +1,19 @@
 import { createHash } from "node:crypto";
 
+/** Look up remote base refs without fetching them because merged parent branches may have been deleted. */
+function _RemoteBaseHeads(commands, baseRefs)
+{
+	const references = baseRefs.map(function _Reference(baseRef) { return `refs/heads/${baseRef}`; });
+	const output = commands.run("git", ["ls-remote", "--refs", "origin", ...references]);
+	const remoteHeads = new Map();
+	for (const line of output.split("\n").filter(Boolean))
+	{
+		const [sha, reference] = line.split(/\s+/u);
+		remoteHeads.set(reference.slice("refs/heads/".length), sha);
+	}
+	return remoteHeads;
+}
+
 /** Create the Git evidence adapter over an injected bounded command runner. */
 export function createGitAdapter(commands)
 {
@@ -12,12 +26,8 @@ export function createGitAdapter(commands)
 			const baseRefs = Array.from(new Set(pullRequests.map(function _Base(pullRequest) {
 				return pullRequest.base.ref;
 			}))).sort();
-			for (const baseRef of baseRefs)
-			{
-				refspecs.push(`+refs/heads/${baseRef}:refs/remotes/origin/${baseRef}`);
-			}
 			commands.run("git", ["fetch", "--quiet", "--no-tags", "origin", ...refspecs]);
-			const baseHeads = new Map();
+			const baseHeads = _RemoteBaseHeads(commands, baseRefs);
 			for (const pullRequest of pullRequests)
 			{
 				const fetchedHead = commands.run("git", ["rev-parse", `refs/remotes/origin/open-pr/${pullRequest.number}`]);
@@ -32,15 +42,7 @@ export function createGitAdapter(commands)
 		},
 		remoteBaseHeads(baseRefs)
 		{
-			const references = baseRefs.map(function _Reference(baseRef) { return `refs/heads/${baseRef}`; });
-			const output = commands.run("git", ["ls-remote", "--refs", "origin", ...references]);
-			const remoteHeads = new Map();
-			for (const line of output.split("\n").filter(Boolean))
-			{
-				const [sha, reference] = line.split(/\s+/u);
-				remoteHeads.set(reference.slice("refs/heads/".length), sha);
-			}
-			return remoteHeads;
+			return _RemoteBaseHeads(commands, baseRefs);
 		},
 		evidence(pullRequests)
 		{

--- a/scripts/pr-stack-integrity/github.mjs
+++ b/scripts/pr-stack-integrity/github.mjs
@@ -8,12 +8,51 @@ function _PullRequest(payload)
 		body: payload.body ?? "",
 		head: { ref: payload.head.ref, sha: payload.head.sha },
 		base: { ref: payload.base.ref, sha: payload.base.sha },
+		mergedAt: payload.merged_at ?? null,
+		mergeCommitSha: payload.merge_commit_sha ?? null,
 	};
 }
 
 /** Create a GitHub adapter over an injected bounded command runner. */
 export function createGitHubAdapter(commands)
 {
+	/** Follow closed base branches so a native stack remains connected after a parent PR merges. */
+	function _MergedPullRequests(repository, pullRequests)
+	{
+		const owner = repository.split("/", 1)[0];
+		const openHeads = new Set(pullRequests.map(function _Head(pullRequest) { return pullRequest.head.ref; }));
+		const pending = new Set(pullRequests.map(function _Base(pullRequest) { return pullRequest.base.ref; }));
+		const inspected = new Set();
+		const mergedPullRequests = [];
+		while (pending.size > 0)
+		{
+			const head = Array.from(pending).sort()[0];
+			pending.delete(head);
+			if (openHeads.has(head) || inspected.has(head))
+			{
+				continue;
+			}
+			inspected.add(head);
+			const response = JSON.parse(commands.run("gh", [
+				"api",
+				"--paginate",
+				"--slurp",
+				`repos/${repository}/pulls?state=closed&head=${encodeURIComponent(`${owner}:${head}`)}&per_page=100`,
+			]));
+			for (const pullRequest of response.flat().map(_PullRequest).filter(function _Merged(candidate) {
+				return candidate.mergedAt !== null && candidate.mergeCommitSha !== null;
+			}))
+			{
+				mergedPullRequests.push(pullRequest);
+				if (!openHeads.has(pullRequest.base.ref))
+				{
+					pending.add(pullRequest.base.ref);
+				}
+			}
+		}
+		return mergedPullRequests.sort(function _ByNumber(left, right) { return left.number - right.number; });
+	}
+
 	return {
 		repositoryName()
 		{
@@ -29,6 +68,10 @@ export function createGitHubAdapter(commands)
 			]));
 			return response.flat().map(_PullRequest)
 				.sort(function _ByNumber(left, right) { return left.number - right.number; });
+		},
+		mergedPullRequests(repository, pullRequests)
+		{
+			return _MergedPullRequests(repository, pullRequests);
 		},
 	};
 }

--- a/scripts/pr-stack-integrity/inspection.mjs
+++ b/scripts/pr-stack-integrity/inspection.mjs
@@ -16,6 +16,7 @@ function _IsRetryable(error)
 export function inspectLiveStack(input)
 {
 	const snapshotA = input.github.openPullRequests(input.repository);
+	const mergedSnapshotA = input.github.mergedPullRequests?.(input.repository, snapshotA) ?? [];
 	let selectedEventNumber = input.event?.number ?? 0;
 	if (!selectedEventNumber && input.currentBranch)
 	{
@@ -33,7 +34,9 @@ export function inspectLiveStack(input)
 
 	const baseHeads = input.git.fetchAndVerify(snapshotA);
 	const snapshotB = input.github.openPullRequests(input.repository);
-	if (JSON.stringify(snapshotA) !== JSON.stringify(snapshotB))
+	const mergedSnapshotB = input.github.mergedPullRequests?.(input.repository, snapshotB) ?? [];
+	if (JSON.stringify(snapshotA) !== JSON.stringify(snapshotB)
+		|| JSON.stringify(mergedSnapshotA) !== JSON.stringify(mergedSnapshotB))
 	{
 		throw new Error("SNAPSHOT_DRIFT: the live PR graph changed during inspection; rerun against a stable snapshot.");
 	}
@@ -44,7 +47,9 @@ export function inspectLiveStack(input)
 	}
 	const gitEvidence = input.git.evidence(snapshotA);
 	const snapshotC = input.github.openPullRequests(input.repository);
-	if (JSON.stringify(snapshotA) !== JSON.stringify(snapshotC))
+	const mergedSnapshotC = input.github.mergedPullRequests?.(input.repository, snapshotC) ?? [];
+	if (JSON.stringify(snapshotA) !== JSON.stringify(snapshotC)
+		|| JSON.stringify(mergedSnapshotA) !== JSON.stringify(mergedSnapshotC))
 	{
 		throw new Error("FINAL_SNAPSHOT_DRIFT: the live PR graph changed while Git evidence was computed; rerun against a stable snapshot.");
 	}
@@ -55,6 +60,7 @@ export function inspectLiveStack(input)
 	}
 	return {
 		pullRequests: snapshotA,
+		mergedPullRequests: mergedSnapshotA,
 		baseHeads,
 		...gitEvidence,
 		event: selectedEventNumber ? {

--- a/scripts/pr-stack-integrity/policy.mjs
+++ b/scripts/pr-stack-integrity/policy.mjs
@@ -4,7 +4,7 @@ import { buildTopology, stackChain } from "./topology.mjs";
 /** Evaluate ancestry, absorption, replay, event, and review-order policy. */
 export function evaluateStack(input)
 {
-	const topology = buildTopology(input.pullRequests, input.integrationBranches);
+	const topology = buildTopology(input.pullRequests, input.integrationBranches, input.mergedPullRequests);
 	const findings = [...topology.findings];
 	for (const [childNumber, parentNumber] of topology.parents)
 	{

--- a/scripts/pr-stack-integrity/report.mjs
+++ b/scripts/pr-stack-integrity/report.mjs
@@ -13,6 +13,12 @@ export function renderMarkdown(result)
 	{
 		lines.push(`Review chain: ${result.evidence.currentChain.map(function _PR(number) { return `#${number}`; }).join(" -> ")}`);
 	}
+	for (const bridge of result.evidence.mergedBridges ?? [])
+	{
+		lines.push(`Merged bridge: #${bridge.child} via ${bridge.mergedLayers.map(function _Layer(layer) {
+			return `#${layer.number} (${layer.mergeCommitSha})`;
+		}).join(" -> ")}`);
+	}
 	lines.push("", "Review levels:");
 	for (let index = 0; index < result.evidence.reviewLevels.length; index += 1)
 	{

--- a/scripts/pr-stack-integrity/topology.mjs
+++ b/scripts/pr-stack-integrity/topology.mjs
@@ -1,8 +1,39 @@
-/** Build direct open-PR parent edges and rule-coded structural findings. */
-export function buildTopology(pullRequests, integrationBranches)
+/** Follow closed base layers until an open PR or integration branch is reached, accepting each layer only when GitHub records its merge commit. */
+function _MergedStackParent(pullRequest, byHead, mergedByHead, integrationBranches)
+{
+	let base = pullRequest.base;
+	let bridged = false;
+	const mergedLayers = [];
+	const seen = new Set();
+	while (!integrationBranches.has(base.ref))
+	{
+		const openParent = byHead.get(base.ref);
+		if (openParent)
+		{
+			return { parent: openParent, base, bridged, mergedLayers };
+		}
+		const mergedParent = mergedByHead.get(base.ref)?.find(function _MergeCommitMatches(candidate) {
+			return candidate.mergeCommitSha === base.sha;
+		});
+		if (!mergedParent || seen.has(mergedParent.number))
+		{
+			return undefined;
+		}
+		seen.add(mergedParent.number);
+		bridged = true;
+		mergedLayers.push(mergedParent);
+		base = mergedParent.base;
+	}
+	return { parent: undefined, base, bridged, mergedLayers };
+}
+
+/** Build open-PR edges while treating merge-commit-pinned closed layers as bridges so a native stack remains reviewable after a parent merges. */
+export function buildTopology(pullRequests, integrationBranches, mergedPullRequests = [])
 {
 	const findings = [];
 	const byHead = new Map();
+	const mergedByHead = new Map();
+	const bridges = new Map();
 	const byNumber = new Map(pullRequests.map(function _Entry(pullRequest) {
 		return [pullRequest.number, pullRequest];
 	}));
@@ -17,11 +48,22 @@ export function buildTopology(pullRequests, integrationBranches)
 		}
 		byHead.set(pullRequest.head.ref, pullRequest);
 	}
+	for (const pullRequest of mergedPullRequests)
+	{
+		const mergedLayers = mergedByHead.get(pullRequest.head.ref) ?? [];
+		mergedLayers.push(pullRequest);
+		mergedByHead.set(pullRequest.head.ref, mergedLayers);
+	}
 
 	const parents = new Map();
 	for (const pullRequest of pullRequests)
 	{
-		const parent = byHead.get(pullRequest.base.ref);
+		const resolved = _MergedStackParent(pullRequest, byHead, mergedByHead, integrationBranches);
+		const parent = resolved?.parent;
+		if (resolved && resolved.mergedLayers.length > 0)
+		{
+			bridges.set(pullRequest.number, resolved.mergedLayers);
+		}
 		if (parent)
 		{
 			parents.set(pullRequest.number, parent.number);
@@ -29,15 +71,15 @@ export function buildTopology(pullRequests, integrationBranches)
 			{
 				findings.push({ code: "SELF_BASE", message: `#${pullRequest.number} targets its own head branch.` });
 			}
-			if (pullRequest.base.sha !== parent.head.sha)
+			if (!resolved.bridged && resolved.base.sha !== parent.head.sha)
 			{
 				findings.push({
 					code: "STALE_PARENT_SHA",
-					message: `#${pullRequest.number} records ${pullRequest.base.sha} for #${parent.number}, whose live head is ${parent.head.sha}.`,
+					message: `#${pullRequest.number} records ${resolved.base.sha} for #${parent.number}, whose live head is ${parent.head.sha}.`,
 				});
 			}
 		}
-		else if (!integrationBranches.has(pullRequest.base.ref))
+		else if (!resolved)
 		{
 			findings.push({
 				code: "ORPHANED_BASE",
@@ -61,7 +103,7 @@ export function buildTopology(pullRequests, integrationBranches)
 			cursor = parents.get(cursor);
 		}
 	}
-	return { findings, parents, byNumber };
+	return { findings, parents, byNumber, bridges };
 }
 
 /** Return the open ancestry chain from root to the selected PR. */


### PR DESCRIPTION
## Summary

- make native GitHub Stacks the repository default for checkpoints with an open predecessor
- require `gh stack add` and `gh stack submit --auto --open` for incremental publication
- require `gh stack sync` after a parent merge, preserving SHA-bound ancestry proof
- retain a native stack after an intermediate PR merges by bridging only when the child base is pinned to that merged PR’s recorded merge commit
- emit the merged-layer proof in the integrity evidence, avoid fetching deleted merged branches, and query only unresolved bases rather than the repository’s complete closed-PR history

## Validation

- `node --test scripts/__tests__/pr-stack-integrity.test.mjs` — 31 passing
- live `node scripts/pr-stack-integrity.mjs --current-branch feat/issue-759-conversation-computer-runtime-route` — passed with #783 bridged through merged #782
- `git diff --check`
- `npm run check:module-growth -- --diff origin/develop` — 0 errors; unrelated existing review candidates reported
- the isolated worktree lacks `typescript`, so the repository-wide style and Prisma-boundary scripts cannot resolve their runtime there

## Review

- independent review: pass after fixing the deleted-base fetch path, snapshot/evidence binding, and direct-to-integration bridge evidence
- comments gate: pass; comments describe the merge-commit fence and deleted-base rationale from regression coverage

## Stack

- this PR contains two focused commits: making native GitHub Stacks the checkpoint default and preserving validated ancestry after an intermediate layer merges
- the follow-on ConversationComputer layers were cascaded with `gh stack rebase`, `gh stack push`, and `gh stack submit --auto`

## Review order

1. #766
2. #767
3. #769
4. #770
