### PR TITLE
🏗️ add deterministic Agent Sandbox claim authority

### DIFF
--- a/apps/_infra/agent-sandbox/helm/templates/_resources.tpl
+++ b/apps/_infra/agent-sandbox/helm/templates/_resources.tpl
@@ -56,7 +56,7 @@ metadata:
 rules:
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
-    verbs: ["create", "get", "delete"]
+    verbs: ["create", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/apps/_infra/agent-sandbox/tests/helm-contract.sh
+++ b/apps/_infra/agent-sandbox/tests/helm-contract.sh
@@ -47,9 +47,9 @@ grep -Fq 'sandboxTemplateRef:' <<<"$pool"
 grep -Fq 'name: opencrane-testv5-developer-template' <<<"$pool"
 grep -Fq 'apiGroups: ["extensions.agents.x-k8s.io"]' <<<"$role"
 grep -Fq 'resources: ["sandboxclaims"]' <<<"$role"
-grep -Fq 'verbs: ["create", "get", "delete"]' <<<"$role"
-if grep -Eq '"(list|watch|patch|update)"' <<<"$role"; then
-  echo "Agent Sandbox server Role is broader than create/get/delete" >&2
+grep -Fq 'verbs: ["create", "get"]' <<<"$role"
+if grep -Eq '"(delete|list|watch|patch|update)"' <<<"$role"; then
+  echo "Agent Sandbox server Role is broader than create/get" >&2
   exit 1
 fi
 grep -Fq 'apiVersions: ["v1beta1"]' <<<"$policy"

--- a/docs/agents/app-specific.md
+++ b/docs/agents/app-specific.md
@@ -49,6 +49,7 @@ app's source.
 | [`libs/backend/server/conversations`](../../libs/backend/server/conversations/main/README.md) | Mode-correct conversation authority, participant visibility, canonical timeline, authorised stream readers, and HTTP routes. |
 | [`libs/backend/server/conversation-assets`](../../libs/backend/server/conversation-assets/main/README.md) | Participant upload, quarantine, scan, and message-attachment authority. |
 | [`libs/backend/server/infra`](../../libs/backend/server/infra/README.md) | OpenCrane server runtime, transport, identity, and external-I/O seams. |
+| [`libs/backend/server/infra/agent-sandbox-claims`](../../libs/backend/server/infra/agent-sandbox-claims/README.md) | Deterministic create-or-read Agent Sandbox leases for admitted ConversationComputer generations. |
 | [`libs/backend/server/infra/agent-runtime-continuation`](../../libs/backend/server/infra/agent-runtime-continuation/README.md) | Secret-backed encryption for durable AgentRun continuation checkpoints. |
 | [`libs/backend/server/infra/history-store`](../../libs/backend/server/infra/history-store/README.md) | KurrentDB stream reads, checked appends, and subscriptions for event-history owners. |
 | [`apps/_infra/kurrentdb`](../../apps/_infra/kurrentdb/README.md) | Private KurrentDB HistoryStore deployment with persistent TLS-only storage. |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -130,6 +130,7 @@ export default [
             { sourceTag: "scope:agent-runtime-continuation", onlyDependOnLibsWithTags: ["scope:agent-runtime-continuation", "scope:shared"] },
             { sourceTag: "scope:workload-identity", onlyDependOnLibsWithTags: ["scope:workload-identity", "scope:shared"] },
             { sourceTag: "scope:history-store", onlyDependOnLibsWithTags: ["scope:history-store", "scope:shared"] },
+			{ sourceTag: "scope:agent-sandbox-claims", onlyDependOnLibsWithTags: ["scope:agent-sandbox-claims", "scope:k8s-api", "scope:shared"] },
             { sourceTag: "scope:workflows", onlyDependOnLibsWithTags: ["scope:shared", "scope:workflows"] },
             { sourceTag: "scope:runtime-workloads", onlyDependOnLibsWithTags: ["scope:runtime-workloads", "scope:shared"] },
             { sourceTag: "scope:mcp-runtime", onlyDependOnLibsWithTags: ["scope:mcp-runtime", "scope:runtime-workloads", "scope:shared"] },

--- a/libs/backend/server/infra/README.md
+++ b/libs/backend/server/infra/README.md
@@ -11,6 +11,7 @@ remaining grouped with the server code that composes them.
 | Package | What it owns |
 | --- | --- |
 | [`api`](./api/README.md) | Kubernetes API constants and error normalisation. |
+| [`agent-sandbox-claims`](./agent-sandbox-claims/README.md) | Exact create-or-read leases for admitted ConversationComputer generations. |
 | [`auth`](./auth/README.md) | OIDC login, sessions, and request-principal resolution. |
 | [`agent-runtime-stream`](./agent-runtime-stream/README.md) | Projected-token runtime HTTP/SSE framing. |
 | [`agent-runtime-continuation`](./agent-runtime-continuation/README.md) | Secret-backed encryption for durable model-loop checkpoints. |

--- a/libs/backend/server/infra/agent-sandbox-claims/README.md
+++ b/libs/backend/server/infra/agent-sandbox-claims/README.md
@@ -1,0 +1,51 @@
+# @opencrane/backend/server/infra/agent-sandbox-claims — deterministic computer leases
+
+> [backend](../../../README.md) › [server](../../README.md) › [infra](../README.md) › agent-sandbox-claims
+
+## What it owns
+
+This package turns an already-admitted ConversationComputer generation into exactly one
+Agent Sandbox `SandboxClaim`. It creates the release-policy-safe resource body, and treats an
+already-existing claim as idempotent only when every immutable lease field matches exactly.
+
+```
+ durable computer activation
+             │ admitted generation + shutdown deadline
+             ▼
+ ┌─────────────────────────────────┐
+ │ agent-sandbox-claims  ◄── HERE   │
+ └──────────────┬──────────────────┘
+                │ create / exact get on 409
+                ▼
+       Agent Sandbox SandboxClaim
+```
+
+## Public surface
+
+- `AgentSandboxClaimAuthority` exposes `ensure` as the sole application operation.
+- `_KubernetesAgentSandboxClaimAuthority` calls only namespaced custom-object `create` and `get`.
+- `AgentSandboxClaimReason` restricts claims to activation or recovery.
+
+## Boundary
+
+The caller must authorise the computer action, fence its generation, choose an admitted profile,
+and persist durable intent before calling this adapter. This adapter neither authorises a caller,
+selects a profile, watches Pods, patches claims, nor implements a Pod controller. The cluster-wide
+Agent Sandbox controller remains the sole reconciler for sandbox resources.
+
+## Dependency direction
+
+Tagged `scope:agent-sandbox-claims` at the infra layer, this package imports only shared
+observability and Kubernetes API error normalisation. It must not import a backend domain, Prisma,
+or an app entrypoint.
+
+## Runtime & config
+
+The composing server supplies its own Kubernetes `CustomObjectsApi`. The server's release-scoped
+Role admits only `create` and `get` on `sandboxclaims`; the Kubernetes admission policy rejects any
+resource body outside the generated immutable shape.
+
+## See also
+
+- Parent index: [infra](../README.md)
+- Release boundary: [Agent Sandbox chart](../../../../../apps/_infra/agent-sandbox/README.md)

--- a/libs/backend/server/infra/agent-sandbox-claims/project.json
+++ b/libs/backend/server/infra/agent-sandbox-claims/project.json
@@ -1,0 +1,11 @@
+{
+  "name": "backend-server-infra-agent-sandbox-claims",
+  "$schema": "../../../../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "libs/backend/server/infra/agent-sandbox-claims/src",
+  "tags": ["type:lib", "layer:infra", "scope:agent-sandbox-claims"],
+  "targets": {
+    "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/server/infra/agent-sandbox-claims" } },
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/server/infra/agent-sandbox-claims" } }
+  }
+}

--- a/libs/backend/server/infra/agent-sandbox-claims/src/__tests__/kubernetes-agent-sandbox-claim-authority.test.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/src/__tests__/kubernetes-agent-sandbox-claim-authority.test.ts
@@ -1,0 +1,138 @@
+import type { CustomObjectsApi } from "@kubernetes/client-node";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@opencrane/backend/observability", function _MockObservability()
+{
+	return {
+		___DoWithTrace: async function _DoWithTrace<Result>(_name: string, _fields: Readonly<Record<string, unknown>>, operation: () => Promise<Result>): Promise<Result>
+		{
+			return operation();
+		},
+	};
+});
+
+import { AgentSandboxClaimReason, type AgentSandboxClaimCommand, type AgentSandboxClaimCustomObjectsApi } from "../agent-sandbox-claims.types";
+import { _KubernetesAgentSandboxClaimAuthority } from "../kubernetes-agent-sandbox-claim-authority";
+
+/** Builds the valid command produced after ConversationComputer activation admission. */
+function _command(overrides: Partial<AgentSandboxClaimCommand> = {}): AgentSandboxClaimCommand
+{
+	return {
+		namespace: "testv5",
+		siloId: "testv5",
+		computerId: "computer-41",
+		generation: 2,
+		profile: "personal",
+		warmPoolName: "personal-pool",
+		reason: AgentSandboxClaimReason.ActivationRequested,
+		shutdownTime: new Date("2026-09-01T06:00:00.000Z"),
+		...overrides,
+	};
+}
+
+/** Builds the two-method Kubernetes client this authority is allowed to use. */
+function _api(): { readonly api: AgentSandboxClaimCustomObjectsApi; readonly create: ReturnType<typeof vi.fn>; readonly get: ReturnType<typeof vi.fn> }
+{
+	const create = vi.fn().mockResolvedValue({});
+	const get = vi.fn();
+	return { api: { createNamespacedCustomObject: create, getNamespacedCustomObject: get }, create, get };
+}
+
+/** Confirms the narrow port accepts the public object-parameter Kubernetes client API. */
+function _realCustomObjectsApi(api: CustomObjectsApi): AgentSandboxClaimCustomObjectsApi
+{
+	return api;
+}
+
+/** Recreates the resource body Kubernetes returns for an idempotent existing-claim read. */
+function _claim(command: AgentSandboxClaimCommand, includeServerMetadata = false): Record<string, unknown>
+{
+	return {
+		apiVersion: "extensions.agents.x-k8s.io/v1beta1",
+		kind: "SandboxClaim",
+		metadata: {
+			name: `${command.computerId}-g${command.generation}`,
+			namespace: command.namespace,
+			labels: {
+				"opencrane.ai/silo-id": command.siloId,
+				"opencrane.ai/computer-id": command.computerId,
+				"opencrane.ai/computer-generation": String(command.generation),
+				"opencrane.ai/profile": command.profile,
+			},
+			annotations: { "opencrane.ai/lease-reason": command.reason },
+			...(includeServerMetadata ? { creationTimestamp: "2026-09-01T00:00:00.000Z" } : {}),
+		},
+		spec: {
+			warmPoolRef: { name: command.warmPoolName },
+			lifecycle: { shutdownPolicy: "DeleteForeground", shutdownTime: command.shutdownTime.toISOString() },
+		},
+	};
+}
+
+describe("_KubernetesAgentSandboxClaimAuthority", function _ClaimAuthoritySuite()
+{
+	it("accepts the public object-parameter CustomObjectsApi when server composition arrives", function _AcceptsKubernetesClient()
+	{
+		const realApi = {} as CustomObjectsApi;
+
+		expect(_realCustomObjectsApi(realApi)).toBe(realApi);
+	});
+
+	it("creates the exact admission-policy-safe deterministic claim", async function _CreatesClaim()
+	{
+		const { api, create } = _api();
+		const command = _command();
+
+		await expect(new _KubernetesAgentSandboxClaimAuthority(api).ensure(command)).resolves.toEqual({ namespace: "testv5", claimName: "computer-41-g2", disposition: "created" });
+
+		expect(create).toHaveBeenCalledWith({
+			group: "extensions.agents.x-k8s.io",
+			version: "v1beta1",
+			namespace: "testv5",
+			plural: "sandboxclaims",
+			body: _claim(command),
+		});
+	});
+
+	it("accepts a 409 only after an exact get confirms the immutable prior lease", async function _AcceptsExactExistingClaim()
+	{
+		const { api, create, get } = _api();
+		const command = _command();
+		create.mockRejectedValue(Object.assign(new Error("already exists"), { code: 409 }));
+		get.mockResolvedValue(_claim(command, true));
+
+		await expect(new _KubernetesAgentSandboxClaimAuthority(api).ensure(command)).resolves.toEqual({ namespace: "testv5", claimName: "computer-41-g2", disposition: "existing" });
+
+		expect(get).toHaveBeenCalledWith({ group: "extensions.agents.x-k8s.io", version: "v1beta1", namespace: "testv5", plural: "sandboxclaims", name: "computer-41-g2" });
+	});
+
+	it("rejects a 409 claim that would attach the generation to a different profile", async function _RejectsDifferentLease()
+	{
+		const { api, create, get } = _api();
+		const command = _command();
+		create.mockRejectedValue(Object.assign(new Error("already exists"), { response: { statusCode: 409 } }));
+		get.mockResolvedValue(_claim(_command({ profile: "managed" }), true));
+
+		await expect(new _KubernetesAgentSandboxClaimAuthority(api).ensure(command)).rejects.toThrow("conflicts with a different immutable lease");
+	});
+
+	it("does not call Kubernetes for malformed computer or generation coordinates", async function _RejectsMalformedCommand()
+	{
+		const { api, create, get } = _api();
+
+		await expect(new _KubernetesAgentSandboxClaimAuthority(api).ensure(_command({ computerId: "run-41", generation: 0 }))).rejects.toThrow("computerId");
+
+		expect(create).not.toHaveBeenCalled();
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	it("propagates a non-conflict Kubernetes failure without a read", async function _PropagatesFailure()
+	{
+		const { api, create, get } = _api();
+		create.mockRejectedValue(Object.assign(new Error("forbidden"), { statusCode: 403 }));
+
+		await expect(new _KubernetesAgentSandboxClaimAuthority(api).ensure(_command())).rejects.toThrow("forbidden");
+
+		expect(get).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/infra/agent-sandbox-claims/src/agent-sandbox-claims.types.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/src/agent-sandbox-claims.types.ts
@@ -1,0 +1,112 @@
+/**
+ * States why an already-admitted ConversationComputer generation requests a sandbox lease.
+ *
+ * These values are serialized into the claim annotation that the release admission policy accepts.
+ * Adding a reason therefore requires a matching policy change instead of letting a caller attach
+ * arbitrary activation state to a Kubernetes resource.
+ */
+export enum AgentSandboxClaimReason
+{
+	/** Starts the generation that was just activated from durable computer history. */
+	ActivationRequested = "activation_requested",
+	/** Replaces a generation whose durable computer authority has requested recovery. */
+	RecoveryRequested = "recovery_requested",
+}
+
+/**
+ * Carries the Kubernetes coordinates and immutable lease details for one SandboxClaim.
+ *
+ * A domain authority must authorize the action, fence the generation, select the admitted profile,
+ * and persist the desired activation before it creates this command. This adapter validates the
+ * claim shape; it never treats that validation as authorization.
+ */
+export interface AgentSandboxClaimCommand
+{
+	/** Names the release-owned namespace where Agent Sandbox resources live. */
+	readonly namespace: string;
+	/** Names the bounded silo that owns the ConversationComputer. */
+	readonly siloId: string;
+	/** Names the ConversationComputer; it must begin with `computer-`. */
+	readonly computerId: string;
+	/** Fences the computer generation that may use this claim. */
+	readonly generation: number;
+	/** Selects one release-admitted sandbox profile. */
+	readonly profile: string;
+	/** Selects the release-owned warm pool mapped to that profile. */
+	readonly warmPoolName: string;
+	/** States whether activation or recovery requested the lease. */
+	readonly reason: AgentSandboxClaimReason;
+	/** Sets the foreground-delete deadline accepted by the admission policy. */
+	readonly shutdownTime: Date;
+}
+
+/**
+ * Reports the deterministic SandboxClaim that represents one computer generation.
+ *
+ * `created` means this call submitted the generation's claim. `existing` means a retry received a
+ * conflict and confirmed every lease field on the claim already stored by Kubernetes.
+ */
+export interface AgentSandboxClaimReceipt
+{
+	/** Names the Kubernetes namespace containing the claim. */
+	readonly namespace: string;
+	/** Names the claim derived from computer id and generation. */
+	readonly claimName: string;
+	/** Identifies whether this call created the claim or confirmed an exact prior claim. */
+	readonly disposition: "created" | "existing";
+}
+
+/**
+ * Requests the claim that realizes a previously admitted computer generation.
+ *
+ * The port provides convergence for activation retries and upstream-controller restarts without
+ * giving application code authority to select images, change a claim, watch Pods, or reconcile
+ * their lifecycle.
+ */
+export interface AgentSandboxClaimAuthority
+{
+	/**
+	 * Creates a deterministic claim or verifies that an existing claim has the requested lease.
+	 *
+	 * @param command - The already-authorized generation, profile, pool, and shutdown deadline.
+	 * @returns `created` after the Kubernetes create succeeds, or `existing` after a 409 read matches.
+	 * @throws {Error} When the command is malformed or a conflicting claim has different lease fields.
+	 */
+	ensure(command: AgentSandboxClaimCommand): Promise<AgentSandboxClaimReceipt>;
+}
+
+/**
+ * Limits a Kubernetes client to the two namespaced SandboxClaim calls this adapter needs.
+ *
+ * The release Role grants the same create-and-get pair. Keeping the port equally narrow prevents
+ * this infrastructure adapter from growing its own claim lifecycle or Pod-controller authority.
+ */
+export interface AgentSandboxClaimCustomObjectsApi
+{
+	/**
+	 * Requests creation of a namespaced custom object.
+	 *
+	 * @param request - The Agent Sandbox API coordinates and admission-policy-safe resource body.
+	 * @returns The untrusted Kubernetes response, which this adapter does not need to interpret.
+	 */
+	createNamespacedCustomObject(request: {
+		readonly group: string;
+		readonly version: string;
+		readonly namespace: string;
+		readonly plural: string;
+		readonly body: Record<string, unknown>;
+	}): Promise<unknown>;
+	/**
+	 * Reads one namespaced custom object by its deterministic name after a create conflict.
+	 *
+	 * @param request - The Agent Sandbox API coordinates and deterministic claim name.
+	 * @returns The untrusted Kubernetes response for exact immutable-field comparison.
+	 */
+	getNamespacedCustomObject(request: {
+		readonly group: string;
+		readonly version: string;
+		readonly namespace: string;
+		readonly plural: string;
+		readonly name: string;
+	}): Promise<unknown>;
+}

--- a/libs/backend/server/infra/agent-sandbox-claims/src/index.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/src/index.ts
@@ -1,0 +1,3 @@
+export { AgentSandboxClaimReason } from "./agent-sandbox-claims.types";
+export type { AgentSandboxClaimAuthority, AgentSandboxClaimCommand, AgentSandboxClaimCustomObjectsApi, AgentSandboxClaimReceipt } from "./agent-sandbox-claims.types";
+export { _KubernetesAgentSandboxClaimAuthority } from "./kubernetes-agent-sandbox-claim-authority";

--- a/libs/backend/server/infra/agent-sandbox-claims/src/kubernetes-agent-sandbox-claim-authority.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/src/kubernetes-agent-sandbox-claim-authority.ts
@@ -1,0 +1,192 @@
+import { ___DoWithTrace } from "@opencrane/backend/observability";
+import { _IsK8sConflict } from "@opencrane/backend/server/infra/api";
+
+import { AgentSandboxClaimReason, type AgentSandboxClaimAuthority, type AgentSandboxClaimCommand, type AgentSandboxClaimCustomObjectsApi, type AgentSandboxClaimReceipt } from "./agent-sandbox-claims.types";
+
+const _AGENT_SANDBOX_API_GROUP = "extensions.agents.x-k8s.io";
+const _AGENT_SANDBOX_API_VERSION = "v1beta1";
+const _AGENT_SANDBOX_CLAIM_PLURAL = "sandboxclaims";
+const _DNS_LABEL = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+const _COMPUTER_ID = /^computer-[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+
+/**
+ * Adapts a release-scoped Kubernetes client to deterministic Agent Sandbox claims.
+ *
+ * A conflict triggers one name-based read because the plan requires duplicate activation attempts
+ * and controller restarts to converge on the admitted generation. The adapter rejects a different
+ * resource rather than adopting it, and it has no permission to patch, delete, list, or watch.
+ */
+export class _KubernetesAgentSandboxClaimAuthority implements AgentSandboxClaimAuthority
+{
+	/** Connects this authority to the server identity's create-and-get custom-object client. */
+	public constructor(private readonly customApi: AgentSandboxClaimCustomObjectsApi) {}
+
+	/**
+	 * Creates the generation's claim or proves that a conflicting prior claim represents the same lease.
+	 *
+	 * @param command - The validated input produced after a computer generation is admitted.
+	 * @returns A receipt distinguishing a new claim from a verified idempotent retry.
+	 * @throws {Error} When input is malformed, Kubernetes fails, or an existing claim differs.
+	 */
+	public async ensure(command: AgentSandboxClaimCommand): Promise<AgentSandboxClaimReceipt>
+	{
+		// 1. Build the fixed body before I/O so malformed coordinates never reach Kubernetes.
+		const expected = _BuildExpectedClaim(command);
+		const self = this;
+		return ___DoWithTrace("agent_sandbox.claim.ensure", {
+			namespace: command.namespace,
+			siloId: command.siloId,
+			computerId: command.computerId,
+			generation: command.generation,
+			claimName: expected.claimName,
+		}, async function _Ensure(): Promise<AgentSandboxClaimReceipt>
+		{
+			try
+			{
+				// 2. Create first because the deterministic name makes the common path one request.
+				await self.customApi.createNamespacedCustomObject({
+					group: _AGENT_SANDBOX_API_GROUP,
+					version: _AGENT_SANDBOX_API_VERSION,
+					namespace: command.namespace,
+					plural: _AGENT_SANDBOX_CLAIM_PLURAL,
+					body: expected.manifest,
+				});
+				return { namespace: command.namespace, claimName: expected.claimName, disposition: "created" };
+			}
+			catch (error)
+			{
+				if (!_IsK8sConflict(error))
+					throw error;
+				// 3. Read the same name after a 409; no broad lookup can adopt another generation.
+				const existing = await self.customApi.getNamespacedCustomObject({
+					group: _AGENT_SANDBOX_API_GROUP,
+					version: _AGENT_SANDBOX_API_VERSION,
+					namespace: command.namespace,
+					plural: _AGENT_SANDBOX_CLAIM_PLURAL,
+					name: expected.claimName,
+				});
+				if (!_MatchesExpectedClaim(existing, expected.manifest))
+					throw new Error(`Agent Sandbox claim '${expected.claimName}' conflicts with a different immutable lease`);
+				return { namespace: command.namespace, claimName: expected.claimName, disposition: "existing" };
+			}
+		});
+	}
+}
+
+/** Creates the complete, admission-policy-safe resource body from an already admitted command. */
+function _BuildExpectedClaim(command: AgentSandboxClaimCommand): { readonly claimName: string; readonly manifest: Record<string, unknown> }
+{
+	// 1. Reject an impossible claim before deriving the deterministic Kubernetes name.
+	_ValidateCommand(command);
+	// 2. Bind retries to a computer generation rather than a transient request identifier.
+	const claimName = `${command.computerId}-g${command.generation}`;
+	return {
+		claimName,
+		manifest: {
+			apiVersion: `${_AGENT_SANDBOX_API_GROUP}/${_AGENT_SANDBOX_API_VERSION}`,
+			kind: "SandboxClaim",
+			metadata: {
+				name: claimName,
+				namespace: command.namespace,
+				labels: {
+					"opencrane.ai/silo-id": command.siloId,
+					"opencrane.ai/computer-id": command.computerId,
+					"opencrane.ai/computer-generation": String(command.generation),
+					"opencrane.ai/profile": command.profile,
+				},
+				annotations: { "opencrane.ai/lease-reason": command.reason },
+			},
+			spec: {
+				warmPoolRef: { name: command.warmPoolName },
+				lifecycle: { shutdownPolicy: "DeleteForeground", shutdownTime: command.shutdownTime.toISOString() },
+			},
+		},
+	};
+}
+
+/** Refuses malformed input before this authority can submit a Kubernetes request. */
+function _ValidateCommand(command: AgentSandboxClaimCommand): void
+{
+	// 1. Keep the Kubernetes location within the chart's DNS-label admission boundary.
+	if (!_IsDnsLabel(command.namespace))
+		throw new Error("Agent Sandbox claim namespace must be a DNS label");
+	if (!_IsDnsLabel(command.siloId))
+		throw new Error("Agent Sandbox claim siloId must be a DNS label");
+	// 2. Preserve the claim-name and generation fence required by the admission policy.
+	if (command.computerId.length > 63 || !_COMPUTER_ID.test(command.computerId))
+		throw new Error("Agent Sandbox claim computerId must be a bounded computer DNS label");
+	if (!Number.isSafeInteger(command.generation) || command.generation < 1)
+		throw new Error("Agent Sandbox claim generation must be a positive safe integer");
+	// 3. Restrict profile and pool selection to names the release policy can admit.
+	if (!_IsDnsLabel(command.profile))
+		throw new Error("Agent Sandbox claim profile must be a DNS label");
+	if (!_IsDnsLabel(command.warmPoolName))
+		throw new Error("Agent Sandbox claim warmPoolName must be a DNS label");
+	// 4. Preserve the policy's closed reason vocabulary and valid foreground-delete deadline.
+	if (!Object.values(AgentSandboxClaimReason).includes(command.reason))
+		throw new Error("Agent Sandbox claim reason is unsupported");
+	if (!(command.shutdownTime instanceof Date) || Number.isNaN(command.shutdownTime.getTime()))
+		throw new Error("Agent Sandbox claim shutdownTime must be a valid Date");
+	if (`${command.computerId}-g${command.generation}`.length > 253)
+		throw new Error("Agent Sandbox claim name is too long");
+}
+
+/** Returns whether one value is a Kubernetes DNS label accepted by the released admission policy. */
+function _IsDnsLabel(value: string): boolean
+{
+	return value.length <= 63 && _DNS_LABEL.test(value);
+}
+
+/** Compares a 409-retrieved claim to every immutable field this authority would create. */
+function _MatchesExpectedClaim(value: unknown, expected: Record<string, unknown>): boolean
+{
+	// 1. Refuse an unreadable Kubernetes response before checking its claimed identity.
+	if (!_IsRecord(value) || !_IsRecord(expected.metadata) || !_IsRecord(expected.spec))
+		return false;
+	if (value.apiVersion !== expected.apiVersion || value.kind !== expected.kind)
+		return false;
+	const metadata = value.metadata;
+	const expectedMetadata = expected.metadata;
+	const spec = value.spec;
+	const expectedSpec = expected.spec;
+	// 2. Check the resource envelope before considering the mutable-looking nested values.
+	if (!_IsRecord(metadata) || !_IsRecord(spec))
+		return false;
+	// 3. Compare every policy-controlled lease field before accepting a duplicate as idempotent.
+	return _MatchesRequiredRecord(metadata, expectedMetadata, ["name", "namespace"])
+		&& _HasExactKeys(spec, ["warmPoolRef", "lifecycle"])
+		&& _MatchesExactRecord(metadata.labels, expectedMetadata.labels, ["opencrane.ai/silo-id", "opencrane.ai/computer-id", "opencrane.ai/computer-generation", "opencrane.ai/profile"])
+		&& _MatchesExactRecord(metadata.annotations, expectedMetadata.annotations, ["opencrane.ai/lease-reason"])
+		&& _MatchesExactRecord(spec.warmPoolRef, expectedSpec.warmPoolRef, ["name"])
+		&& _MatchesExactRecord(spec.lifecycle, expectedSpec.lifecycle, ["shutdownPolicy", "shutdownTime"]);
+}
+
+/** Checks that an untrusted Kubernetes record contains each named immutable field. */
+function _MatchesRequiredRecord(value: unknown, expected: unknown, keys: readonly string[]): boolean
+{
+	if (!_IsRecord(value) || !_IsRecord(expected))
+		return false;
+	return keys.every(function _MatchesKey(key): boolean { return value[key] === expected[key]; });
+}
+
+/** Checks that an untrusted Kubernetes record has no extra mutable claim fields. */
+function _MatchesExactRecord(value: unknown, expected: unknown, keys: readonly string[]): boolean
+{
+	if (!_IsRecord(value) || !_IsRecord(expected))
+		return false;
+	if (!_HasExactKeys(value, keys) || !_HasExactKeys(expected, keys))
+		return false;
+	return keys.every(function _MatchesKey(key): boolean { return value[key] === expected[key]; });
+}
+
+/** Checks that an untrusted Kubernetes record contains no fields outside one immutable shape. */
+function _HasExactKeys(value: unknown, keys: readonly string[]): boolean
+{
+	return _IsRecord(value) && Object.keys(value).length === keys.length && keys.every(function _HasKey(key): boolean { return Object.hasOwn(value, key); });
+}
+
+/** Narrows a Kubernetes response object without trusting its shape. */
+function _IsRecord(value: unknown): value is Record<string, unknown>
+{
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/libs/backend/server/infra/agent-sandbox-claims/tsconfig.json
+++ b/libs/backend/server/infra/agent-sandbox-claims/tsconfig.json
@@ -1,0 +1,1 @@
+{ "extends": "../../../../../tsconfig.json", "compilerOptions": { "noEmit": true }, "include": ["src/**/*"], "exclude": ["node_modules", "dist"] }

--- a/libs/backend/server/infra/agent-sandbox-claims/vitest.config.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+import { _PackageCacheDir } from "../../../../../vitest.cache";
+
+/** Resolves workspace aliases when this infrastructure library runs directly under Vitest. */
+export default defineConfig({ cacheDir: _PackageCacheDir(import.meta.url), plugins: [tsconfigPaths({ projects: ["../../../../../tsconfig.vitest.json"] })] });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -181,6 +181,9 @@
       "@opencrane/backend/server/infra/api": [
         "./libs/backend/server/infra/api/src/index.ts"
       ],
+      "@opencrane/backend/server/infra/agent-sandbox-claims": [
+        "./libs/backend/server/infra/agent-sandbox-claims/src/index.ts"
+      ],
       "@opencrane/backend/server/infra/auth": [
         "./libs/backend/server/infra/auth/src/index.ts"
       ],


### PR DESCRIPTION
## Summary

- add `@opencrane/backend/server/infra/agent-sandbox-claims`, which turns one already-admitted ConversationComputer generation into exactly one Agent Sandbox `SandboxClaim`
- derive the claim name from the computer id and generation, and treat a create conflict as idempotent only when every immutable lease field on the stored claim matches exactly
- restrict the adapter to namespaced custom-object `create` and `get`, so it never authorises a caller, selects an image, patches a claim, watches Pods, or reconciles a lifecycle
- keep `AgentSandboxClaimReason` closed to activation and recovery, so a caller cannot attach arbitrary activation state to a Kubernetes resource through the claim annotation
- register the package in the infra index, workspace docs, ESLint scope, and tsconfig paths, and admit only the generated claim shape in the release Role and admission policy

## Boundary

The cluster-wide Agent Sandbox controller stays the sole reconciler of sandbox resources. A domain
authority must authorise the computer action, fence its generation, choose an admitted profile, and
persist durable intent before calling this adapter; validating the claim shape is never treated as
authorisation.

## Validation

- `git diff --check`
- `npm run check:pr-stack-integrity -- --event-pr 771` (the #766 → #771 chain passes; the repository-wide result remains blocked by unrelated #713 → #737 metadata)

## Review order

1. #766
2. #767
3. #769
4. #770
5. #771
