### PR TITLE
🏗️ preserve elicitation in ConversationComputer history

### DIFF
--- a/libs/contracts/src/__tests__/conversation-entry.validator.test.ts
+++ b/libs/contracts/src/__tests__/conversation-entry.validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { ___ConversationComputerEntrySchema, ___ConversationEntrySchema } from "../index";
-import type { A2UIRemoveEntry, ConversationEntry, MessageEntry, ToolCallLogEntry } from "../index";
+import { ConversationElicitationEntryKinds, ConversationElicitationEntryStates, ConversationEntryKinds } from "../index";
+import type { A2UIRemoveEntry, ConversationEntry, ElicitationRequestEntry, ElicitationResolutionEntry, MessageEntry, ToolCallLogEntry } from "../index";
 
 const _BASE = {
 	schemaVersion: 1 as const,
@@ -16,6 +17,25 @@ const _BASE = {
 	idempotencyKey: "source-event-1",
 	occurredAt: "2026-08-31T20:00:00.000Z",
 	attestation: null,
+};
+
+const _ELICITATION_BASE = {
+	schemaVersion: 1 as const,
+	conversationId: "conversation-1",
+	position: "13",
+	author: { kind: "system" as const, systemId: "opencrane" as const, name: "OpenCrane" as const },
+	provenance: "service-attested" as const,
+	visibility: { audience: "participant_subset" as const, participantIds: ["participant-1"] },
+	causationId: "command-elicitation-1",
+	correlationId: "request-elicitation-1",
+	idempotencyKey: "source-elicitation-1",
+	occurredAt: "2026-08-31T20:00:00.000Z",
+	attestation: { serviceId: "opencrane", receiptId: "receipt-elicitation-1", domainStream: "authorization-1", domainRevision: "12", decisionEvidenceId: "decision-1" },
+	elicitationId: "elicitation-1",
+	computerId: "computer-1",
+	computerExecutionId: "computer-execution-1",
+	leaseGeneration: 2,
+	elicitationKind: ConversationElicitationEntryKinds.RuntimeInput,
 };
 
 describe("conversation entry validation", function ()
@@ -74,6 +94,93 @@ describe("conversation entry validation", function ()
 		const entries: readonly ConversationEntry[] = [entry];
 
 		expect(entries[0]).toMatchObject({ kind: "a2ui", operation: "remove", payloadRef: null });
+	});
+
+	it("accepts only a server-attested opaque elicitation request", function ()
+	{
+		const entry: ElicitationRequestEntry = {
+			..._ELICITATION_BASE,
+			id: "entry-elicitation-1",
+			kind: ConversationEntryKinds.Elicitation,
+			state: ConversationElicitationEntryStates.Requested,
+			addressedParticipantId: "participant-1",
+			requestPayloadRef: "payload://elicitation-request-1",
+			requestPayloadDigest: `sha256:${"a".repeat(64)}`,
+			expiresAt: "2026-08-31T20:05:00.000Z",
+		};
+
+		expect(___ConversationEntrySchema.safeParse(entry).success).toBe(true);
+		expect(___ConversationComputerEntrySchema.safeParse(entry).success).toBe(false);
+	});
+
+	it("accepts opaque answers and rejects plaintext or incomplete response data", function ()
+	{
+		const answer: ElicitationResolutionEntry = {
+			..._ELICITATION_BASE,
+			id: "entry-elicitation-2",
+			kind: ConversationEntryKinds.Elicitation,
+			state: ConversationElicitationEntryStates.Answered,
+			requestEntryId: "entry-elicitation-1",
+			responsePayloadRef: "payload://elicitation-response-1",
+			responsePayloadDigest: `sha256:${"b".repeat(64)}`,
+		};
+		const missingPayloadReference = { ...answer, responsePayloadRef: null };
+		const missingPayloadDigest = { ...answer, responsePayloadDigest: null };
+		const plaintext = { ...answer, responseText: "Approve payment" };
+		const plaintextReference = { ...answer, responsePayloadRef: "Approve payment" };
+
+		expect(___ConversationEntrySchema.safeParse(answer).success).toBe(true);
+		expect(___ConversationEntrySchema.safeParse(missingPayloadReference).success).toBe(false);
+		expect(___ConversationEntrySchema.safeParse(missingPayloadDigest).success).toBe(false);
+		expect(___ConversationEntrySchema.safeParse(plaintext).success).toBe(false);
+		expect(___ConversationEntrySchema.safeParse(plaintextReference).success).toBe(false);
+	});
+
+	it("keeps governed tool and memory decisions in the target elicitation vocabulary", function ()
+	{
+		const governedKinds = [ConversationElicitationEntryKinds.ToolApproval, ConversationElicitationEntryKinds.PersonalMemoryPermission] as const;
+
+		for (const elicitationKind of governedKinds)
+		{
+			const entry: ElicitationResolutionEntry = {
+				..._ELICITATION_BASE,
+				id: `entry-${elicitationKind}`,
+				kind: ConversationEntryKinds.Elicitation,
+				elicitationKind,
+				state: ConversationElicitationEntryStates.Declined,
+				requestEntryId: `request-${elicitationKind}`,
+				responsePayloadRef: null,
+				responsePayloadDigest: null,
+			};
+
+			expect(___ConversationEntrySchema.safeParse(entry).success).toBe(true);
+		}
+
+		const unsupported = { ..._ELICITATION_BASE, id: "entry-unsupported-elicitation", kind: ConversationEntryKinds.Elicitation, elicitationKind: "recovery_required", state: ConversationElicitationEntryStates.Declined, requestEntryId: "request-unsupported-elicitation", responsePayloadRef: null, responsePayloadDigest: null };
+
+		expect(___ConversationEntrySchema.safeParse(unsupported).success).toBe(false);
+	});
+
+	it("rejects every partial response coordinate on terminal non-answer outcomes", function ()
+	{
+		const terminalStates = [ConversationElicitationEntryStates.Declined, ConversationElicitationEntryStates.Expired, ConversationElicitationEntryStates.Cancelled] as const;
+
+		for (const state of terminalStates)
+		{
+			const terminal: ElicitationResolutionEntry = {
+				..._ELICITATION_BASE,
+				id: `entry-${state}`,
+				kind: ConversationEntryKinds.Elicitation,
+				state,
+				requestEntryId: `request-${state}`,
+				responsePayloadRef: null,
+				responsePayloadDigest: null,
+			};
+
+			expect(___ConversationEntrySchema.safeParse(terminal).success).toBe(true);
+			expect(___ConversationEntrySchema.safeParse({ ...terminal, responsePayloadRef: "payload://stale" }).success).toBe(false);
+			expect(___ConversationEntrySchema.safeParse({ ...terminal, responsePayloadDigest: `sha256:${"c".repeat(64)}` }).success).toBe(false);
+		}
 	});
 
 	it("rejects duplicate participant visibility and a fabricated A2UI removal payload", function ()

--- a/libs/contracts/src/conversation-entry.types.ts
+++ b/libs/contracts/src/conversation-entry.types.ts
@@ -134,6 +134,24 @@ export interface MessageContentBlockBase
 /** Lists the safe payload references a participant-visible message may contain. */
 export type MessageContentBlock = TextMessageContentBlock | ArtifactMessageContentBlock | MentionMessageContentBlock;
 
+/**
+ * Selects how a history reader decodes a persisted conversation entry.
+ *
+ * The validator accepts this closed set when it reads `conversation-{id}`. A new member therefore
+ * needs a reader and validator change before any writer may append it.
+ */
+export enum ConversationEntryKinds
+{
+	/** Records a participant-visible message. */
+	Message = "message",
+	/** Records a structured execution or policy fact. */
+	Log = "log",
+	/** Records a server-attested request for participant input or its resolution. */
+	Elicitation = "elicitation",
+	/** Records a participant-visible A2UI surface mutation. */
+	A2ui = "a2ui",
+}
+
 /** References encrypted text without embedding plaintext in the event ledger. */
 export interface TextMessageContentBlock extends MessageContentBlockBase
 {
@@ -291,6 +309,114 @@ export interface ApprovalLogEntry extends LogEntryBase
 }
 
 /**
+ * States where an elicitation request ended up in conversation history.
+ *
+ * Readers branch on this closed set to decide whether the request still awaits a server-accepted
+ * resolution. The validator rejects an unknown state instead of letting a projector guess whether
+ * the request is still open.
+ */
+export enum ConversationElicitationEntryStates
+{
+	/** The request awaits a server-accepted resolution before its deadline. */
+	Requested = "requested",
+	/** The addressed participant supplied a server-accepted response payload. */
+	Answered = "answered",
+	/** The server accepted that the addressed participant declined the request. */
+	Declined = "declined",
+	/** The response window ended before an answer was accepted. */
+	Expired = "expired",
+	/** The server cancelled the request for its fenced computer before it accepted a response. */
+	Cancelled = "cancelled",
+}
+
+/**
+ * Names the interaction a ConversationComputer asks the server to present.
+ *
+ * The server records the selected member in immutable history, so projectors can render the right
+ * private payload without inferring an interaction from a free-form prompt. The validator rejects
+ * any member outside this set.
+ */
+export enum ConversationElicitationEntryKinds
+{
+	/** Requests ordinary participant input for the model loop. */
+	RuntimeInput = "runtime_input",
+	/** Requests a decision for one governed tool operation. */
+	ToolApproval = "tool_approval",
+	/** Requests one-use permission before a personal-memory operation. */
+	PersonalMemoryPermission = "personal_memory_permission",
+	/** Requests confirmation before the server applies an A2UI action. */
+	A2uiAction = "a2ui_action",
+}
+
+/** Lists the durable request and terminal-response entries for one computer elicitation. */
+export type ElicitationEntry = ElicitationRequestEntry | ElicitationResolutionEntry;
+
+/** Holds the conversation coordinates that no longer identify a retired AgentRun. */
+export type ConversationComputerEntryBase = Omit<ConversationEntryBase, "runId">;
+
+/**
+ * Holds the coordinates shared by every immutable elicitation entry.
+ *
+ * The service-attested entry binds a request and its resolution to the computer execution and
+ * lease generation that opened it. A later command authority uses those coordinates to reject a
+ * response from another execution or lease.
+ */
+export interface ElicitationEntryBase extends ConversationComputerEntryBase
+{
+	/** Selects the conversation elicitation entry handler. */
+	readonly kind: ConversationEntryKinds.Elicitation;
+	/** Identifies the request whose lifecycle this entry records. */
+	readonly elicitationId: string;
+	/** Identifies the computer that owns the elicitation. */
+	readonly computerId: string;
+	/** Identifies the fenced execution instance that opened the elicitation. */
+	readonly computerExecutionId: string;
+	/** Fences this interaction to the computer lease generation that opened it. */
+	readonly leaseGeneration: number;
+	/** Names the interaction selected by the server. */
+	readonly elicitationKind: ConversationElicitationEntryKinds;
+}
+
+/**
+ * Records an opaque request that the server accepted from an active ConversationComputer.
+ *
+ * The history entry names an addressed participant but does not give that participant a writer.
+ * The later command authority authorizes a response and appends its separate service-attested
+ * resolution entry.
+ */
+export interface ElicitationRequestEntry extends ElicitationEntryBase
+{
+	/** States that the request remains open for the addressed participant. */
+	readonly state: ConversationElicitationEntryStates.Requested;
+	/** Identifies the participant whose response the server must authorize. */
+	readonly addressedParticipantId: string;
+	/** Identifies the private request payload outside immutable history. */
+	readonly requestPayloadRef: string;
+	/** Stores the request payload digest. */
+	readonly requestPayloadDigest: string;
+	/** Records the server-owned deadline after which no answer may be accepted. */
+	readonly expiresAt: string;
+}
+
+/**
+ * Records the server-accepted answer or terminal no-answer outcome for one request.
+ *
+ * The addressed participant never appends this entry directly. The service attestation records the
+ * authorization result separately from the private response payload.
+ */
+export interface ElicitationResolutionEntry extends ElicitationEntryBase
+{
+	/** States the accepted answer or terminal non-answer outcome. */
+	readonly state: ConversationElicitationEntryStates.Answered | ConversationElicitationEntryStates.Declined | ConversationElicitationEntryStates.Expired | ConversationElicitationEntryStates.Cancelled;
+	/** Identifies the earlier request entry that this terminal entry resolves. */
+	readonly requestEntryId: string;
+	/** References the private response payload when the addressed participant answered. */
+	readonly responsePayloadRef: string | null;
+	/** Stores the response payload digest when the addressed participant answered. */
+	readonly responsePayloadDigest: string | null;
+}
+
+/**
  * Lists append-only A2UI surface mutations a conversation stream may carry.
  *
  * Each event holds a governed payload reference or records a removal, so replay can reconstruct the
@@ -338,4 +464,4 @@ export interface A2UIRemoveEntry extends A2UIEntryBase
  * not grant a writer access to another conversation or let an entry claim an external effect without
  * the service-attestation boundary.
  */
-export type ConversationEntry = MessageEntry | LogEntry | A2UIEntry;
+export type ConversationEntry = MessageEntry | LogEntry | ElicitationEntry | A2UIEntry;

--- a/libs/contracts/src/conversation-entry.validator.ts
+++ b/libs/contracts/src/conversation-entry.validator.ts
@@ -7,11 +7,13 @@
  */
 import { z } from "zod";
 
-import type { ConversationEntry } from "./conversation-entry.types";
+import { ConversationElicitationEntryKinds, ConversationElicitationEntryStates, ConversationEntryKinds, type ConversationEntry } from "./conversation-entry.types";
 
 const _IdentifierSchema = z.string().trim().min(1);
 const _InstantSchema = z.string().datetime({ offset: true });
 const _PositionSchema = z.string().regex(/^(0|[1-9][0-9]*)$/);
+const _OpaquePayloadReferenceSchema = z.string().regex(/^payload:\/\/[A-Za-z0-9][A-Za-z0-9._-]*$/);
+const _PayloadDigestSchema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
 const _HumanAuthoredProvenance = "human-authored";
 const _AgentAuthoredProvenance = "agent-authored";
 const _ServiceAttestedProvenance = "service-attested";
@@ -69,13 +71,56 @@ const _LogEntrySchema = z.discriminatedUnion("logKind", [
 	z.object({ ..._LogEntryBase, logKind: z.literal("memory"), operation: z.enum(["recall", "write"]), phase: z.enum(["requested", "completed", "failed", "denied"]) }).strict(),
 	z.object({ ..._LogEntryBase, logKind: z.literal("approval"), approvalId: _IdentifierSchema, action: _IdentifierSchema, phase: z.enum(["requested", "granted", "denied", "expired", "revoked"]) }).strict(),
 ]);
+const { runId: _RetiredRunId, ..._ConversationComputerEntryBase } = _EntryBase;
+const _ElicitationEntryBase = {
+	..._ConversationComputerEntryBase,
+	kind: z.literal(ConversationEntryKinds.Elicitation),
+	elicitationId: _IdentifierSchema,
+	computerId: _IdentifierSchema,
+	computerExecutionId: _IdentifierSchema,
+	leaseGeneration: z.number().int().positive(),
+	elicitationKind: z.enum([
+		ConversationElicitationEntryKinds.RuntimeInput,
+		ConversationElicitationEntryKinds.ToolApproval,
+		ConversationElicitationEntryKinds.PersonalMemoryPermission,
+		ConversationElicitationEntryKinds.A2uiAction,
+	]),
+};
+const _ElicitationRequestEntrySchema = z.object({
+	..._ElicitationEntryBase,
+	state: z.literal(ConversationElicitationEntryStates.Requested),
+	addressedParticipantId: _IdentifierSchema,
+	requestPayloadRef: _OpaquePayloadReferenceSchema,
+	requestPayloadDigest: _PayloadDigestSchema,
+	expiresAt: _InstantSchema,
+}).strict();
+const _ElicitationResolutionEntrySchema = z.object({
+	..._ElicitationEntryBase,
+	state: z.enum([ConversationElicitationEntryStates.Answered, ConversationElicitationEntryStates.Declined, ConversationElicitationEntryStates.Expired, ConversationElicitationEntryStates.Cancelled]),
+	requestEntryId: _IdentifierSchema,
+	responsePayloadRef: _OpaquePayloadReferenceSchema.nullable(),
+	responsePayloadDigest: _PayloadDigestSchema.nullable(),
+}).strict().superRefine(function _ValidateElicitationResolutionPayload(entry, context): void
+{
+	const hasResponseCoordinates = entry.responsePayloadRef !== null && entry.responsePayloadDigest !== null;
+	const hasNoResponseCoordinates = entry.responsePayloadRef === null && entry.responsePayloadDigest === null;
+	if (entry.state === ConversationElicitationEntryStates.Answered && !hasResponseCoordinates)
+	{
+		context.addIssue({ code: z.ZodIssueCode.custom, path: ["responsePayloadRef"], message: "answered elicitations require both response payload coordinates" });
+	}
+	if (entry.state !== ConversationElicitationEntryStates.Answered && !hasNoResponseCoordinates)
+	{
+		context.addIssue({ code: z.ZodIssueCode.custom, path: ["responsePayloadRef"], message: "terminal non-answer outcomes require neither response payload coordinate" });
+	}
+});
+const _ElicitationEntrySchema = z.union([_ElicitationRequestEntrySchema, _ElicitationResolutionEntrySchema]);
 const _A2UIEntrySchema = z.discriminatedUnion("operation", [
 	z.object({ ..._EntryBase, kind: z.literal("a2ui"), surfaceId: _IdentifierSchema, a2uiSchemaVersion: _IdentifierSchema, operation: z.literal("replace"), payloadRef: _IdentifierSchema, payloadDigest: _IdentifierSchema }).strict(),
 	z.object({ ..._EntryBase, kind: z.literal("a2ui"), surfaceId: _IdentifierSchema, a2uiSchemaVersion: _IdentifierSchema, operation: z.literal("patch"), payloadRef: _IdentifierSchema, payloadDigest: _IdentifierSchema }).strict(),
 	z.object({ ..._EntryBase, kind: z.literal("a2ui"), surfaceId: _IdentifierSchema, a2uiSchemaVersion: _IdentifierSchema, operation: z.literal("remove"), payloadRef: z.null(), payloadDigest: z.null() }).strict(),
 ]);
 
-const _ConversationEntrySchema = z.union([_MessageEntrySchema, _LogEntrySchema, _A2UIEntrySchema]);
+const _ConversationEntrySchema = z.union([_MessageEntrySchema, _LogEntrySchema, _ElicitationEntrySchema, _A2UIEntrySchema]);
 
 function _ValidateProvenance(entry: ConversationEntry, context: z.RefinementCtx): void
 {
@@ -98,6 +143,10 @@ function _ValidateProvenance(entry: ConversationEntry, context: z.RefinementCtx)
 	if (entry.author.kind === _SystemAuthorKind && (entry.provenance !== _ServiceAttestedProvenance || entry.attestation === null || entry.attestation.serviceId !== _OpenCraneServiceId))
 	{
 		context.addIssue({ code: z.ZodIssueCode.custom, path: ["attestation"], message: "a system author requires an OpenCrane service attestation" });
+	}
+	if (entry.kind === ConversationEntryKinds.Elicitation && (entry.author.kind !== _SystemAuthorKind || entry.provenance !== _ServiceAttestedProvenance || entry.attestation === null || entry.attestation.serviceId !== _OpenCraneServiceId))
+	{
+		context.addIssue({ code: z.ZodIssueCode.custom, path: ["author"], message: "elicitation entries require an OpenCrane system attestation" });
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `ElicitationEntry` as a fourth `ConversationEntry` variant, so a request for participant input and its terminal outcome survive in `conversation-{id}` history instead of living only in run state
- split the lifecycle into an immutable `ElicitationRequestEntry` and a separate `ElicitationResolutionEntry`, so the answer never rewrites the request
- scope elicitation to the computer rather than a run: `ConversationComputerEntryBase` drops `runId`, and each entry carries `computerId`, `computerExecutionId`, and `leaseGeneration` so a later command authority can reject a response from another execution or lease
- close three vocabularies the validator enforces — `ConversationEntryKinds`, `ConversationElicitationEntryStates` (requested, answered, declined, expired, cancelled), and `ConversationElicitationEntryKinds` (runtime input, tool approval, personal-memory permission, A2UI action)
- keep prompts and answers out of immutable history behind `payload://` references with `sha256:` digests

## Enforcement

The validator requires an OpenCrane system author and service attestation on every elicitation
entry, so a bound conversation writer cannot author one and no participant appends a resolution
directly. A `superRefine` pairs the response coordinates with the outcome: `answered` requires both
`responsePayloadRef` and `responsePayloadDigest`, and every terminal non-answer outcome requires
neither, so a declined or expired request cannot smuggle a payload.

## Validation

- `git diff --check`
- four added validator tests covering the server-attested opaque request, opaque answers versus plaintext or incomplete response data, the governed tool and memory vocabulary, and partial response coordinates on non-answer outcomes
- `npm run check:pr-stack-integrity -- --event-pr 773` (the #766 → #773 chain passes; the repository-wide result remains blocked by unrelated #713 → #737 metadata)

## Review order

1. #766
2. #767
3. #769
4. #770
5. #771
6. #772
7. #773
