### PR TITLE
🏗️ establish trusted ConversationComputer command inputs

### DIFF
--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -138,6 +138,9 @@ transport for workloads; it is not a browser fallback.
   deterministic KurrentDB stream. `loadActiveExecution` returns only an open execution whose
   identity and lease generation match the checked current head, so a later command authority can
   fence its participant append to the active loop attempt.
+- `ConversationHistoryReader.readCurrent` replays every participant-visible entry from the
+  immutable first position and returns only the KurrentDB head condition that a later atomic
+  command append may use. It does not authorize a participant or append an entry itself.
 
 ## Boundary
 

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-history-reader.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-history-reader.test.ts
@@ -1,5 +1,5 @@
 import type { ConversationEntry } from "@opencrane/contracts";
-import type { HistoryRecordedEvent } from "@opencrane/backend/server/infra/history-store";
+import { HistoryExpectedRevisions, type HistoryRecordedEvent } from "@opencrane/backend/server/infra/history-store";
 import { describe, expect, it, vi } from "vitest";
 
 import { ConversationHistoryReader } from "../conversation-history-reader";
@@ -61,7 +61,7 @@ describe("ConversationHistoryReader", function ()
 	it("requests only the derived conversation stream and returns entries from the first position in stream order", async function ()
 	{
 		const readStream = vi.fn().mockReturnValue(_Events([_Event(0n), _Event(1n, _SECOND_ENTRY_ID)]));
-		const reader = new ConversationHistoryReader({ readStream });
+		const reader = new ConversationHistoryReader({ readStream, readHead: vi.fn() });
 
 		const result = await reader.read(_Command());
 
@@ -73,7 +73,7 @@ describe("ConversationHistoryReader", function ()
 	it("requests an explicit inclusive revision and preserves its ordered entries", async function ()
 	{
 		const readStream = vi.fn().mockReturnValue(_Events([_Event(4n), _Event(5n, _SECOND_ENTRY_ID)]));
-		const reader = new ConversationHistoryReader({ readStream });
+		const reader = new ConversationHistoryReader({ readStream, readHead: vi.fn() });
 
 		const result = await reader.read(_Command({ fromRevision: 4n }));
 
@@ -88,9 +88,9 @@ describe("ConversationHistoryReader", function ()
 		const foreignConversationEvent = _Event(0n);
 		const foreignConversation = { ...foreignConversationEvent, data: { entry: { ..._FixtureEntry(foreignConversationEvent), conversationId: "conversation-2" } } };
 
-		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([foreignStream])) }).read(_Command())).rejects.toThrow("different stream");
-		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([foreignSilo])) }).read(_Command())).rejects.toThrow("different silo");
-		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([foreignConversation])) }).read(_Command())).rejects.toThrow("different conversation");
+		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([foreignStream])), readHead: vi.fn() }).read(_Command())).rejects.toThrow("different stream");
+		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([foreignSilo])), readHead: vi.fn() }).read(_Command())).rejects.toThrow("different silo");
+		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([foreignConversation])), readHead: vi.fn() }).read(_Command())).rejects.toThrow("different conversation");
 	});
 
 	it("fails closed when an event envelope or entry is malformed", async function ()
@@ -101,8 +101,27 @@ describe("ConversationHistoryReader", function ()
 		const malformedEntryEvent = _Event(0n);
 		const malformedEntry = { ...malformedEntryEvent, data: { entry: { ..._FixtureEntry(malformedEntryEvent), occurredAt: "not-a-time" } } };
 
-		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([mismatchedEnvelope])) }).read(_Command())).rejects.toThrow("does not match its envelope");
-		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([mismatchedIdempotency])) }).read(_Command())).rejects.toThrow("invalid idempotency key");
-		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([malformedEntry])) }).read(_Command())).rejects.toThrow("invalid participant-visible entry");
+		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([mismatchedEnvelope])), readHead: vi.fn() }).read(_Command())).rejects.toThrow("does not match its envelope");
+		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([mismatchedIdempotency])), readHead: vi.fn() }).read(_Command())).rejects.toThrow("invalid idempotency key");
+		await expect(new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([malformedEntry])), readHead: vi.fn() }).read(_Command())).rejects.toThrow("invalid participant-visible entry");
+	});
+
+	it("returns the checked current head as the only condition a later atomic append may use", async function ()
+	{
+		const readHead = vi.fn().mockResolvedValue({ streamName: "conversation-conversation-1", revision: 1n });
+		const reader = new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n), _Event(1n, _SECOND_ENTRY_ID)])), readHead });
+
+		await expect(reader.readCurrent(_Command())).resolves.toEqual(expect.objectContaining({ streamName: "conversation-conversation-1", expectedRevision: 1n, entries: expect.arrayContaining([expect.objectContaining({ position: "0" }), expect.objectContaining({ position: "1" })]) }));
+		expect(readHead).toHaveBeenCalledWith("conversation-conversation-1");
+	});
+
+	it("preserves the no-stream condition and fails closed when the current head moves or a partial range is requested", async function ()
+	{
+		const empty = new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([])), readHead: vi.fn().mockResolvedValue({ streamName: "conversation-conversation-1", revision: null }) });
+		const stale = new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n)])), readHead: vi.fn().mockResolvedValue({ streamName: "conversation-conversation-1", revision: 1n }) });
+
+		await expect(empty.readCurrent(_Command())).resolves.toEqual(expect.objectContaining({ expectedRevision: HistoryExpectedRevisions.NoStream, entries: [] }));
+		await expect(stale.readCurrent(_Command())).rejects.toThrow("changed while loading");
+		await expect(empty.readCurrent(_Command({ fromRevision: 1n }))).rejects.toThrow("cannot start after");
 	});
 });

--- a/libs/backend/server/conversations/main/src/conversation-history-reader.ts
+++ b/libs/backend/server/conversations/main/src/conversation-history-reader.ts
@@ -1,7 +1,7 @@
 import { ___ConversationEntrySchema, type ConversationEntry } from "@opencrane/contracts";
-import { type HistoryRecordedEvent, type HistoryStore } from "@opencrane/backend/server/infra/history-store";
+import { HistoryExpectedRevisions, type HistoryRecordedEvent, type HistoryStore } from "@opencrane/backend/server/infra/history-store";
 
-import type { ConversationHistoryReadCommand, ConversationHistoryReadResult } from "./conversation-history-reader.types";
+import type { ConversationHistoryReadCommand, ConversationHistoryReadResult, CurrentConversationHistory } from "./conversation-history-reader.types";
 
 /** Names the sole versioned event that this reader exposes as a participant-visible entry. */
 const _CONVERSATION_ENTRY_EVENT_TYPE = "opencrane.conversation-entry.v1";
@@ -19,8 +19,8 @@ const _UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{
  */
 export class ConversationHistoryReader
 {
-	/** Connects the reader to the stream-only HistoryStore port without granting append access. */
-	public constructor(private readonly historyStore: Pick<HistoryStore, "readStream">) {}
+	/** Connects the reader to the checked HistoryStore read ports without granting append access. */
+	public constructor(private readonly historyStore: Pick<HistoryStore, "readHead" | "readStream">) {}
 
 	/**
 	 * Reads one validated stream range and returns only its participant-visible entries in revision order.
@@ -47,6 +47,33 @@ export class ConversationHistoryReader
 
 		// 3. Return the finite ordered stream result without constructing a relational or projection fallback.
 		return { streamName, entries };
+	}
+
+	/**
+	 * Replays the complete current conversation stream and verifies its head did not move.
+	 *
+	 * ConversationComputer command admission uses the returned condition with HistoryStore.appendAtomic.
+	 * It therefore cannot authorize an elicitation against a stale transcript and append it after a
+	 * concurrent participant event changed the current conversation.
+	 *
+	 * @param command - Supplies trusted silo and conversation coordinates for the complete stream.
+	 * @returns Every validated current entry and the exact later append condition for its checked head.
+	 * @throws {Error} Rejects malformed history, a missing event before a reported head, or a changed head.
+	 */
+	public async readCurrent(command: ConversationHistoryReadCommand): Promise<CurrentConversationHistory>
+	{
+		if (command.fromRevision !== undefined)
+			throw new Error("Conversation history current read cannot start after the immutable first entry");
+		const current = await this.read(command);
+		const head = await this.historyStore.readHead(current.streamName);
+		const lastEntry = current.entries.at(-1);
+		const expectedHeadRevision = lastEntry === undefined ? null : BigInt(lastEntry.position);
+		if (head.streamName !== current.streamName || head.revision !== expectedHeadRevision)
+			throw new Error("Conversation history changed while loading its current state");
+		return {
+			...current,
+			expectedRevision: head.revision ?? HistoryExpectedRevisions.NoStream,
+		};
 	}
 }
 

--- a/libs/backend/server/conversations/main/src/conversation-history-reader.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-history-reader.types.ts
@@ -1,4 +1,5 @@
 import type { ConversationEntry } from "@opencrane/contracts";
+import type { HistoryExpectedRevisions } from "@opencrane/backend/server/infra/history-store";
 
 /**
  * Identifies a finite read that an authorized conversation transport may make from a KurrentDB stream.
@@ -24,4 +25,18 @@ export interface ConversationHistoryReadResult
 	readonly streamName: string;
 	/** Lists the participant-visible entries in their validated immutable stream order. */
 	readonly entries: readonly ConversationEntry[];
+}
+
+/**
+ * Carries a fully replayed participant transcript and the checked head for a later atomic append.
+ *
+ * A ConversationComputer command uses this result after it has checked the whole transcript, then
+ * includes {@link expectedRevision} in its append. The result does not authorize a participant or
+ * grant permission to write; it prevents that later authorization from acting on a transcript that
+ * has changed since the replay.
+ */
+export interface CurrentConversationHistory extends ConversationHistoryReadResult
+{
+	/** Requires the KurrentDB revision that was current when the transcript was replayed. */
+	readonly expectedRevision: HistoryExpectedRevisions.NoStream | bigint;
 }

--- a/libs/backend/server/iam/identity/main/README.md
+++ b/libs/backend/server/iam/identity/main/README.md
@@ -72,9 +72,11 @@ acceptance route can establish membership; it gains no Owner or administrator fa
   verified `{siloId, issuer, subject}` tuple.
 - `StandaloneFirstUserAdmissionConfig`, `StandaloneFirstUserAdmissionAuditPort` — composition
   contracts that configure the optional standalone first-owner claim.
-- `AgentIdentityHistory` — appends and loads the checked KurrentDB history of an agent identity,
-  returning current state and stream-head evidence only when silo, service, and acting-principal
-  coordinates agree.
+- `AgentIdentityHistory` — appends and loads the checked KurrentDB history of an agent identity.
+  Its ordinary loader requires exact silo, service, and acting-principal coordinates; its runtime
+  loader accepts only a ConversationComputer's silo and identity, then derives the active service,
+  Principal, actor class, and every checked child/parent stream-head condition from the identity
+  history. A later command append must preserve every returned condition atomically.
 
 The OIDC service keeps login group projection and standalone first-owner admission as internal
 steps. They are not package entry points because the login flow coordinates their verified inputs,

--- a/libs/backend/server/iam/identity/main/src/agent-identities/__tests__/agent-identity-history.test.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/__tests__/agent-identity-history.test.ts
@@ -197,6 +197,39 @@ describe("AgentIdentityHistory", function ()
 		await expect(history.loadActive(_CurrentCommand())).rejects.toThrow("non-active identity");
 	});
 
+	it("derives a computer-selected active identity's authorization actor without caller service or principal coordinates", async function ()
+	{
+		const managed = _ManagedIdentity({ id: "identity-managed-1", principalId: "principal-managed-1", agentServiceId: "service-managed-1" });
+		const proxied = _ProxiedIdentity({ id: "identity-proxied-1", proxiedPrincipalId: "principal-proxied-1", agentServiceId: "service-proxied-1" });
+		const managedResult = await new AgentIdentityHistory(_StreamStore({ "agent-identity-identity-managed-1": [_Event(0n, managed)] })).loadActiveAuthorization({ siloId: "silo-1", agentIdentityId: "identity-managed-1" });
+		const proxiedResult = await new AgentIdentityHistory(_StreamStore({ "agent-identity-identity-proxied-1": [_Event(0n, proxied)] })).loadActiveAuthorization({ siloId: "silo-1", agentIdentityId: "identity-proxied-1" });
+
+		expect(managedResult).toEqual(expect.objectContaining({ identity: managed, agentServiceId: "service-managed-1", principalId: "principal-managed-1", actorKind: "agent-service", actorId: "identity-managed-1", revision: 0n }));
+		expect(proxiedResult).toEqual(expect.objectContaining({ identity: proxied, agentServiceId: "service-proxied-1", principalId: "principal-proxied-1", actorKind: "user", actorId: "principal-proxied-1", revision: 0n }));
+	});
+
+	it("fails closed when a computer-selected authorization identity is foreign, missing, or no longer active", async function ()
+	{
+		const foreign = _ManagedIdentity({ siloId: "silo-2" });
+		const revoked = _ManagedIdentity({ state: AgentIdentityStates.Revoked });
+
+		await expect(new AgentIdentityHistory(_Store()).loadActiveAuthorization({ siloId: "silo-1", agentIdentityId: "identity-1" })).rejects.toThrow("missing identity");
+		await expect(new AgentIdentityHistory(_Store({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n, foreign)])), readHead: vi.fn().mockResolvedValue({ streamName: "agent-identity-identity-1", revision: 0n }) })).loadActiveAuthorization({ siloId: "silo-1", agentIdentityId: "identity-1" })).rejects.toThrow("different silo");
+		await expect(new AgentIdentityHistory(_Store({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n, revoked)])), readHead: vi.fn().mockResolvedValue({ streamName: "agent-identity-identity-1", revision: 0n }) })).loadActiveAuthorization({ siloId: "silo-1", agentIdentityId: "identity-1" })).rejects.toThrow("non-active identity");
+	});
+
+	it("returns every active managed sub-chat identity head that a later atomic command append must preserve", async function ()
+	{
+		const child = _SubChatIdentity({ id: "identity-child-1", principalId: "principal-child-1", parentAgentIdentityId: "identity-parent-1", parentPrincipalId: "principal-parent-1" });
+		const parent = _ManagedIdentity({ id: "identity-parent-1", principalId: "principal-parent-1" });
+		const history = new AgentIdentityHistory(_StreamStore({ "agent-identity-identity-child-1": [_Event(0n, child)], "agent-identity-identity-parent-1": [_Event(0n, parent)] }));
+
+		await expect(history.loadActiveAuthorization({ siloId: "silo-1", agentIdentityId: "identity-child-1" })).resolves.toEqual(expect.objectContaining({ expectedIdentityHeads: [
+			{ streamName: "agent-identity-identity-child-1", revision: 0n },
+			{ streamName: "agent-identity-identity-parent-1", revision: 0n },
+		] }));
+	});
+
 	it("does not inherit a parent identity's authority for a managed sub-chat", async function ()
 	{
 		const subchat = _SubChatIdentity();

--- a/libs/backend/server/iam/identity/main/src/agent-identities/agent-identity-history-validation.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/agent-identity-history-validation.ts
@@ -1,7 +1,7 @@
 import { AgentIdentityStates, type AgentIdentity } from "@opencrane/contracts";
 import type { HistoryRecordedEvent } from "@opencrane/backend/server/infra/history-store";
 
-import type { AgentIdentityCurrentCommand } from "./agent-identity-history.types";
+import type { AgentIdentityCurrentCommand, AgentIdentityRuntimeAuthorizationCommand } from "./agent-identity-history.types";
 
 /** Names the one versioned event schema this history authority accepts. */
 const _AGENT_IDENTITY_EVENT_TYPE = "opencrane.agent-identity.v1";
@@ -27,6 +27,15 @@ export function _ValidateCurrentAgentIdentityCommand(command: AgentIdentityCurre
 		throw new Error("Agent identity history load requires a server-provided agent service identifier");
 	if (!_PrincipalIdentifier(command.principalId))
 		throw new Error("Agent identity history load requires a server-provided principal identifier");
+}
+
+/** Validates the only computer-derived coordinates that may select a runtime identity actor. */
+export function _ValidateAgentIdentityRuntimeAuthorizationCommand(command: AgentIdentityRuntimeAuthorizationCommand): void
+{
+	if (!_Identifier(command.siloId))
+		throw new Error("Agent identity runtime authorization requires a server-provided silo identifier");
+	if (!_Identifier(command.agentIdentityId))
+		throw new Error("Agent identity runtime authorization requires a server-provided identity identifier");
 }
 
 /** Validates one envelope and snapshot before it can contribute to current identity state. */
@@ -59,6 +68,15 @@ export function _AssertAgentIdentityCurrentCoordinates(identity: AgentIdentity, 
 		throw new Error("Agent identity history received an identity for a different agent service");
 	if (_AgentIdentityPrincipalId(identity) !== command.principalId)
 		throw new Error("Agent identity history received an identity for a different principal");
+}
+
+/** Checks the computer-derived stable identity coordinates before actor facts are derived from history. */
+export function _AssertAgentIdentityRuntimeAuthorizationCoordinates(identity: AgentIdentity, command: AgentIdentityRuntimeAuthorizationCommand): void
+{
+	if (identity.siloId !== command.siloId)
+		throw new Error("Agent identity runtime authorization received an identity from a different silo");
+	if (identity.id !== command.agentIdentityId)
+		throw new Error("Agent identity runtime authorization received a different identity");
 }
 
 /** Parses the exact discriminated AgentIdentity shape without granting unknown future kinds authority. */

--- a/libs/backend/server/iam/identity/main/src/agent-identities/agent-identity-history.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/agent-identity-history.ts
@@ -2,8 +2,8 @@ import { AgentIdentityStates, type AgentIdentity } from "@opencrane/contracts";
 import { HistoryExpectedRevisions, type HistoryAppend, type HistoryAppendReceipt, type HistoryStore } from "@opencrane/backend/server/infra/history-store";
 import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 
-import type { AgentIdentityAppendCommand, AgentIdentityCurrentCommand, CurrentAgentIdentity } from "./agent-identity-history.types";
-import { _AgentIdentityPrincipalId, _AgentIdentityStreamName, _AssertAgentIdentityCurrentCoordinates, _SameAgentIdentityCoordinates, _ValidatedAgentIdentity, _ValidatedAgentIdentityStreamEvent, _ValidateCurrentAgentIdentityCommand } from "./agent-identity-history-validation";
+import type { ActiveAgentIdentityAuthorization, AgentIdentityAppendCommand, AgentIdentityCurrentCommand, AgentIdentityRuntimeAuthorizationCommand, CurrentAgentIdentity } from "./agent-identity-history.types";
+import { _AgentIdentityPrincipalId, _AgentIdentityStreamName, _AssertAgentIdentityCurrentCoordinates, _AssertAgentIdentityRuntimeAuthorizationCoordinates, _SameAgentIdentityCoordinates, _ValidatedAgentIdentity, _ValidatedAgentIdentityStreamEvent, _ValidateAgentIdentityRuntimeAuthorizationCommand, _ValidateCurrentAgentIdentityCommand } from "./agent-identity-history-validation";
 /** Recognizes UUID event identifiers without treating an ordinary identity coordinate as an idempotency key. */
 const _UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -139,6 +139,37 @@ export class AgentIdentityHistory
 		if (current.identity.state !== AgentIdentityStates.Active)
 			throw new Error("Agent identity history cannot authorize a non-active identity");
 		return current;
+	}
+
+	/**
+	 * Resolves the authorization actor for a computer-selected active identity.
+	 *
+	 * A ConversationComputer owns only its silo and immutable AgentIdentity coordinate. This method
+	 * derives the service, Principal, and actor class from the validated active snapshot, so a
+	 * runtime command cannot substitute another Principal or make a managed identity act as a user.
+	 *
+	 * @param command - Supplies only the computer-selected silo and AgentIdentity coordinates.
+	 * @returns The active checked identity plus its internally derived authorization actor.
+	 * @throws {Error} Rejects missing, stale, inactive, foreign, or unlinked identities.
+	 */
+	public async loadActiveAuthorization(command: AgentIdentityRuntimeAuthorizationCommand): Promise<ActiveAgentIdentityAuthorization>
+	{
+		_ValidateAgentIdentityRuntimeAuthorizationCommand(command);
+		const current = await this._ReadCurrent(command.agentIdentityId);
+		if (current === null)
+			throw new Error("Agent identity runtime authorization cannot authorize a missing identity");
+		_AssertAgentIdentityRuntimeAuthorizationCoordinates(current.identity, command);
+		if (current.identity.state !== AgentIdentityStates.Active)
+			throw new Error("Agent identity runtime authorization cannot authorize a non-active identity");
+		const parents = await this._ParentBinding(current.identity, new Set([current.identity.id]));
+		return {
+			...current,
+			expectedIdentityHeads: [current, ...parents].map(identity => ({ streamName: identity.streamName, revision: identity.revision })),
+			agentServiceId: current.identity.agentServiceId,
+			principalId: _AgentIdentityPrincipalId(current.identity),
+			actorKind: current.identity.kind === "proxied" ? "user" : "agent-service",
+			actorId: current.identity.kind === "proxied" ? current.identity.proxiedPrincipalId : current.identity.id,
+		};
 	}
 }
 

--- a/libs/backend/server/iam/identity/main/src/agent-identities/agent-identity-history.types.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/agent-identity-history.types.ts
@@ -1,5 +1,5 @@
 import type { AgentIdentity } from "@opencrane/contracts";
-import type { HistoryExpectedRevisions } from "@opencrane/backend/server/infra/history-store";
+import type { HistoryExpectedHead, HistoryExpectedRevisions } from "@opencrane/backend/server/infra/history-store";
 
 /** Names the immutable coordinates that select one agent identity and its acting principal. */
 export interface AgentIdentityCurrentCommand
@@ -12,6 +12,20 @@ export interface AgentIdentityCurrentCommand
 	readonly agentServiceId: string;
 	/** Identifies the exact principal that this identity is permitted to represent. */
 	readonly principalId: string;
+}
+
+/**
+ * Limits a ConversationComputer to the identity coordinates it may use to resolve a runtime actor.
+ *
+ * The computer must not choose an AgentService or Principal. {@link AgentIdentityHistory} derives
+ * both from the active identity history so a runtime command cannot substitute another actor.
+ */
+export interface AgentIdentityRuntimeAuthorizationCommand
+{
+	/** Identifies the silo that owns the computer-selected identity. */
+	readonly siloId: string;
+	/** Identifies the active computer's immutable agent identity. */
+	readonly agentIdentityId: string;
 }
 
 /** Carries one checked identity snapshot append to its deterministic history stream. */
@@ -36,4 +50,26 @@ export interface CurrentAgentIdentity
 	readonly headDigest: string;
 	/** Carries the validated identity snapshot at the reported revision. */
 	readonly identity: AgentIdentity;
+}
+
+/**
+ * Gives a runtime command the actor derived from a checked active identity.
+ *
+ * A proxied identity acts as its proxied user, while managed identities act through their dedicated
+ * AgentService principal. A later command append must preserve every {@link expectedIdentityHeads}
+ * condition or re-read this result; otherwise a suspended identity or changed parent could authorize
+ * work after the identity history changed.
+ */
+export interface ActiveAgentIdentityAuthorization extends CurrentAgentIdentity
+{
+	/** Lists every active identity and managed-sub-chat parent stream condition to preserve atomically. */
+	readonly expectedIdentityHeads: readonly HistoryExpectedHead[];
+	/** Identifies the AgentService realized by the checked identity. */
+	readonly agentServiceId: string;
+	/** Identifies the current Principal that authorization must evaluate. */
+	readonly principalId: string;
+	/** States whether the checked identity acts through a user or dedicated agent-service principal. */
+	readonly actorKind: "user" | "agent-service";
+	/** Identifies the proxied user or checked managed identity recorded in authorization evidence. */
+	readonly actorId: string;
 }

--- a/libs/backend/server/iam/identity/main/src/agent-identities/index.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/index.ts
@@ -1,2 +1,2 @@
 export { AgentIdentityHistory } from "./agent-identity-history";
-export type { AgentIdentityAppendCommand, AgentIdentityCurrentCommand, CurrentAgentIdentity } from "./agent-identity-history.types";
+export type { ActiveAgentIdentityAuthorization, AgentIdentityAppendCommand, AgentIdentityCurrentCommand, AgentIdentityRuntimeAuthorizationCommand, CurrentAgentIdentity } from "./agent-identity-history.types";


### PR DESCRIPTION
## Summary

- derive a ConversationComputer runtime actor from only its trusted silo and AgentIdentity coordinates
- bind proxied identities to their proxied user Principal and managed identities to their dedicated agent-service Principal
- carry the checked child and managed-subchat parent identity heads into the later atomic command condition
- replay a complete conversation transcript and return a checked KurrentDB head condition for a later append

## Boundary

This checkpoint establishes trusted inputs for the later `ConversationComputerRuntimeInputElicitationAuthority`. It does not admit a command, evaluate `Conversation/Use`, write an elicitation entry, resolve elicitation requests, select participants, create an Agent Sandbox claim, or provide a compatibility or migration path.

## Commits

1. `🔐 derive ConversationComputer identity actors from history`
2. `🧱 fence ConversationComputer input history at its head`

## Validation

- focused AgentIdentity history: 15/15
- conversations: 117/117
- TypeScript checks: identity and conversations packages
- `git diff --check`
- `scripts/agent-style-check.sh --diff ca91b8968`: 0 errors; 7 existing discriminated-union literal warnings

The full identity target still contains seven unrelated Supertest router cases that cannot bind `0.0.0.0` in this sandbox. The focused changed history suite passes.

## Review

- post-diff architecture gate: PASS
- independent review: no critical, high, medium, or low findings
- residue gate retained these intentionally package-private preparatory ports because the next authority checkpoint is their first production consumer
- final comments and package-documentation gate: PASS

## Review order

1. #766
2. #767
3. #769
4. #770
5. #771
6. #772
7. #773
8. #774
9. #776