### PR TITLE
🪢 bind ConversationComputer leases to exact Sandbox Pods

### DIFF
--- a/apps/_infra/agent-sandbox/README.md
+++ b/apps/_infra/agent-sandbox/README.md
@@ -28,7 +28,9 @@ internal endpoint, one protocol revision, and a 10-minute projected Kubernetes s
 for that runtime route. The claim policy permits only the OpenCrane server identity to create the fixed
 v1beta1 claim shape, and forbids claim environment variables, volume claims, additional Pod metadata
 and every spec update. A mistake therefore denies a computer activation instead of widening its Pod
-profile.
+profile. The server performs only claim-derived, name-bound reads of the assigned `Sandbox` and
+backing `Pod`, so it can persist the controller-owned Pod UID on the durable computer lease; its
+Role cannot list, watch, or mutate sandbox resources.
 
 ## Public surface
 

--- a/apps/_infra/agent-sandbox/helm/templates/_resources.tpl
+++ b/apps/_infra/agent-sandbox/helm/templates/_resources.tpl
@@ -80,6 +80,12 @@ rules:
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxclaims"]
     verbs: ["create", "get"]
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/apps/_infra/agent-sandbox/tests/helm-contract.sh
+++ b/apps/_infra/agent-sandbox/tests/helm-contract.sh
@@ -61,8 +61,12 @@ grep -Fq 'name: opencrane-testv5-developer-template' <<<"$pool"
 grep -Fq 'apiGroups: ["extensions.agents.x-k8s.io"]' <<<"$role"
 grep -Fq 'resources: ["sandboxclaims"]' <<<"$role"
 grep -Fq 'verbs: ["create", "get"]' <<<"$role"
-if grep -Eq '"(delete|list|watch|patch|update)"' <<<"$role"; then
-  echo "Agent Sandbox server Role is broader than create/get" >&2
+grep -Fq 'apiGroups: ["agents.x-k8s.io"]' <<<"$role"
+grep -Fq 'resources: ["sandboxes"]' <<<"$role"
+grep -Fq 'apiGroups: [""]' <<<"$role"
+grep -Fq 'resources: ["pods"]' <<<"$role"
+if [[ "$(grep -Fc 'verbs: ["get"]' <<<"$role")" -ne 2 ]] || grep -Eq '"(delete|list|watch|patch|update)"' <<<"$role"; then
+  echo "Agent Sandbox server Role exceeds claim, Sandbox, and Pod read-only access" >&2
   exit 1
 fi
 grep -Fq 'apiVersions: ["v1beta1"]' <<<"$policy"
@@ -81,6 +85,7 @@ grep -Fq 'validationActions: [Deny]' <<<"$binding"
 grep -Fq 'immutable: true' <<<"$profile_config"
 grep -Fq '\"profileRevisionId\":\"profile-revision-developer-v1\"' <<<"$profile_config"
 grep -Fq '\"namespace\":\"opencrane-testv5\"' <<<"$profile_config"
+grep -Fq '\"serviceAccountName\":\"agent-sandbox-runtime\"' <<<"$profile_config"
 grep -Fq '\"sandboxProfile\":\"developer\"' <<<"$profile_config"
 grep -Fq '\"warmPoolName\":\"developer-pool\"' <<<"$profile_config"
 grep -Fq 'immutable: true' <<<"$runtime_bootstrap"

--- a/apps/opencrane/helm/templates/_conversation-computer-activation-config.tpl
+++ b/apps/opencrane/helm/templates/_conversation-computer-activation-config.tpl
@@ -3,7 +3,7 @@
 {{- if $sandbox.enabled -}}
 {{- $profiles := list -}}
 {{- range $profile := $sandbox.profiles -}}
-{{- $profiles = append $profiles (dict "profileRevisionId" $profile.profileRevisionId "namespace" $sandbox.namespace "sandboxProfile" $profile.name "warmPoolName" $profile.poolName) -}}
+{{- $profiles = append $profiles (dict "profileRevisionId" $profile.profileRevisionId "namespace" $sandbox.namespace "serviceAccountName" $sandbox.serviceAccountName "sandboxProfile" $profile.name "warmPoolName" $profile.poolName) -}}
 {{- end -}}
 apiVersion: v1
 kind: ConfigMap

--- a/apps/opencrane/src/app/__tests__/config.test.ts
+++ b/apps/opencrane/src/app/__tests__/config.test.ts
@@ -114,11 +114,11 @@ describe("opencrane process config", function _ProcessConfigSuite()
 	it("reads only a unique release-owned ConversationComputer profile map", function _ReadConversationComputerProfiles()
 	{
 		vi.stubEnv("OPENCRANE_CONVERSATION_COMPUTER_PROFILE_CONFIG_PATH", _createConversationComputerProfileConfig([
-			{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", sandboxProfile: "developer", warmPoolName: "developer-pool" },
+			{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", serviceAccountName: "agent-sandbox-runtime", sandboxProfile: "developer", warmPoolName: "developer-pool" },
 		]));
 
 		expect(_ReadProcessConfig().runtime.conversationComputerActivation).toEqual({
-			profiles: [{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", sandboxProfile: "developer", warmPoolName: "developer-pool" }],
+			profiles: [{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", serviceAccountName: "agent-sandbox-runtime", sandboxProfile: "developer", warmPoolName: "developer-pool" }],
 		});
 	});
 
@@ -128,13 +128,13 @@ describe("opencrane process config", function _ProcessConfigSuite()
 		expect(function _readEmptyProfileMap() { _ReadProcessConfig(); }).toThrow(/one or more profiles/);
 
 		vi.stubEnv("OPENCRANE_CONVERSATION_COMPUTER_PROFILE_CONFIG_PATH", _createConversationComputerProfileConfig([
-			{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", sandboxProfile: "developer", warmPoolName: "developer-pool" },
-			{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", sandboxProfile: "analyst", warmPoolName: "analyst-pool" },
+			{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", serviceAccountName: "agent-sandbox-runtime", sandboxProfile: "developer", warmPoolName: "developer-pool" },
+			{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", serviceAccountName: "agent-sandbox-runtime", sandboxProfile: "analyst", warmPoolName: "analyst-pool" },
 		]));
 		expect(function _readDuplicateProfileRevision() { _ReadProcessConfig(); }).toThrow(/unique revision ids/);
 
 		vi.stubEnv("OPENCRANE_CONVERSATION_COMPUTER_PROFILE_CONFIG_PATH", _createConversationComputerProfileConfig([
-			{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", sandboxProfile: "developer", warmPoolName: "a".repeat(64) },
+			{ profileRevisionId: "profile-revision-developer-v1", namespace: "opencrane-testv5", serviceAccountName: "agent-sandbox-runtime", sandboxProfile: "developer", warmPoolName: "a".repeat(64) },
 		]));
 		expect(function _readLongWarmPoolName() { _ReadProcessConfig(); }).toThrow(/DNS-label/);
 	});

--- a/apps/opencrane/src/app/__tests__/conversation-computer-activation-composition.test.ts
+++ b/apps/opencrane/src/app/__tests__/conversation-computer-activation-composition.test.ts
@@ -32,7 +32,7 @@ vi.mock("../log", function _Log()
 function _ActivationConfig(): ConversationComputerActivationConfig
 {
 	return {
-		profiles: [{ profileRevisionId: "profile-revision-developer-v1", namespace: "agent-sandbox", sandboxProfile: "developer", warmPoolName: "developer-warm" }],
+		profiles: [{ profileRevisionId: "profile-revision-developer-v1", namespace: "agent-sandbox", serviceAccountName: "agent-sandbox-runtime", sandboxProfile: "developer", warmPoolName: "developer-warm" }],
 	};
 }
 
@@ -51,7 +51,7 @@ describe("ConversationComputer activation composition", function _ActivationComp
 		const worker = await _StartConversationComputerActivationWorker({ subscribePersistent } as unknown as HistoryStore, { activate: vi.fn() }, "testv5");
 
 		expect(subscribePersistent).toHaveBeenCalledWith({ streamName: "computer-activations-testv5", groupName: "opencrane-conversation-computer-activation" });
-		expect(await profiles.resolve({ siloId: "testv5", profileRevisionId: "profile-revision-developer-v1" })).toEqual({ namespace: "agent-sandbox", sandboxProfile: "developer", warmPoolName: "developer-warm" });
+		expect(await profiles.resolve({ siloId: "testv5", profileRevisionId: "profile-revision-developer-v1" })).toEqual({ namespace: "agent-sandbox", serviceAccountName: "agent-sandbox-runtime", sandboxProfile: "developer", warmPoolName: "developer-warm" });
 		expect(await profiles.resolve({ siloId: "untrusted-silo", profileRevisionId: "profile-revision-developer-v1" })).toBeNull();
 		expect(await profiles.resolve({ siloId: "testv5", profileRevisionId: "unknown-profile" })).toBeNull();
 

--- a/apps/opencrane/src/app/config.ts
+++ b/apps/opencrane/src/app/config.ts
@@ -118,16 +118,17 @@ function _readConversationComputerActivationConfig(): ConversationComputerActiva
 			throw new Error("OPENCRANE_CONVERSATION_COMPUTER_PROFILE_CONFIG_PATH profiles must be objects");
 		const profileRevisionId = typeof value.profileRevisionId === "string" ? value.profileRevisionId : "";
 		const namespace = typeof value.namespace === "string" ? value.namespace : "";
+		const serviceAccountName = typeof value.serviceAccountName === "string" ? value.serviceAccountName : "";
 		const sandboxProfile = typeof value.sandboxProfile === "string" ? value.sandboxProfile : "";
 		const warmPoolName = typeof value.warmPoolName === "string" ? value.warmPoolName : "";
-		if (!profileRevisionId || !_isDnsLabel(namespace) || !_isDnsLabel(sandboxProfile) || !_isDnsLabel(warmPoolName))
-			throw new Error("OPENCRANE_CONVERSATION_COMPUTER_PROFILE_CONFIG_PATH profiles must have one revision id and DNS-label namespace, sandboxProfile, and warmPoolName");
+		if (!profileRevisionId || !_isDnsLabel(namespace) || !_isDnsLabel(serviceAccountName) || !_isDnsLabel(sandboxProfile) || !_isDnsLabel(warmPoolName))
+			throw new Error("OPENCRANE_CONVERSATION_COMPUTER_PROFILE_CONFIG_PATH profiles must have one revision id and DNS-label namespace, serviceAccountName, sandboxProfile, and warmPoolName");
 		if (profileRevisionIds.has(profileRevisionId) || sandboxProfiles.has(sandboxProfile) || warmPools.has(warmPoolName))
 			throw new Error("OPENCRANE_CONVERSATION_COMPUTER_PROFILE_CONFIG_PATH profiles must have unique revision ids, sandbox profiles, and warm pools");
 		profileRevisionIds.add(profileRevisionId);
 		sandboxProfiles.add(sandboxProfile);
 		warmPools.add(warmPoolName);
-		profiles.push({ profileRevisionId, namespace, sandboxProfile, warmPoolName });
+		profiles.push({ profileRevisionId, namespace, serviceAccountName, sandboxProfile, warmPoolName });
 	}
 	return { profiles };
 }

--- a/apps/opencrane/src/app/config.types.ts
+++ b/apps/opencrane/src/app/config.types.ts
@@ -47,6 +47,8 @@ export interface ConversationComputerActivationProfileConfig
 	readonly profileRevisionId: string;
 	/** Names the namespace containing the release-owned Agent Sandbox resources. */
 	readonly namespace: string;
+	/** Names the ServiceAccount fixed by each admitted Agent SandboxTemplate. */
+	readonly serviceAccountName: string;
 	/** Names the Agent Sandbox profile admitted for this immutable revision. */
 	readonly sandboxProfile: string;
 	/** Names the release-owned warm pool paired with the sandbox profile. */

--- a/apps/opencrane/src/app/conversation-computer-activation-composition.ts
+++ b/apps/opencrane/src/app/conversation-computer-activation-composition.ts
@@ -90,13 +90,13 @@ class _ReleaseConversationComputerActivationProfileResolver
 	}
 
 	/** Returns the release-approved resources for a profile in this silo, or null when this release did not admit it. */
-	public async resolve(command: { readonly siloId: string; readonly profileRevisionId: string }): Promise<{ readonly namespace: string; readonly sandboxProfile: string; readonly warmPoolName: string } | null>
+	public async resolve(command: { readonly siloId: string; readonly profileRevisionId: string }): Promise<{ readonly namespace: string; readonly serviceAccountName: string; readonly sandboxProfile: string; readonly warmPoolName: string } | null>
 	{
 		if (command.siloId !== this.siloId)
 			return null;
 		const profile = this.profiles.get(command.profileRevisionId);
 		if (profile === undefined)
 			return null;
-		return { namespace: profile.namespace, sandboxProfile: profile.sandboxProfile, warmPoolName: profile.warmPoolName };
+		return { namespace: profile.namespace, serviceAccountName: profile.serviceAccountName, sandboxProfile: profile.sandboxProfile, warmPoolName: profile.warmPoolName };
 	}
 }

--- a/apps/opencrane/src/index.ts
+++ b/apps/opencrane/src/index.ts
@@ -8,7 +8,7 @@ import { _CreateElicitationInterruptReader } from "@opencrane/backend/agents/exe
 import { ConversationComputerActivationClaimAuthority, ConversationComputerHistory, ConversationComputerSandboxReconciliationAuthority, _CreatePrismaSelfConversationSocketServer } from "@opencrane/backend/server/conversations";
 import type { ConversationComputerActivationAuthority } from "@opencrane/backend/server/conversations";
 import { _CreateConversationAttachmentAdmission } from "@opencrane/backend/server/conversation-assets";
-import { _KubernetesAgentSandboxClaimAuthority, _KubernetesAgentSandboxClaimObservationReader } from "@opencrane/backend/server/infra/agent-sandbox-claims";
+import { _KubernetesAgentSandboxClaimAuthority, _KubernetesAgentSandboxClaimObservationReader, _KubernetesAgentSandboxRuntimePodReader } from "@opencrane/backend/server/infra/agent-sandbox-claims";
 import { ___BindConsole } from "@opencrane/backend/observability";
 
 import { _ReadProcessConfig } from "./app/config";
@@ -81,6 +81,7 @@ async function _Main(): Promise<void>
 			history: new ConversationComputerHistory(historyStore.historyStore),
 			profiles,
 			observations: new _KubernetesAgentSandboxClaimObservationReader(kubernetes.customApi),
+			runtimePods: new _KubernetesAgentSandboxRuntimePodReader(kubernetes.customApi, kubernetes.coreApi),
 			clock: { now: function _Now() { return new Date(); } },
 		});
 	}

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-computer-activation-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-computer-activation-authority.test.ts
@@ -33,6 +33,7 @@ function _PendingCurrent(overrides: Partial<CurrentConversationComputer> = {}): 
 			generation: 2,
 			sandboxClaimId: "computer-1-g2",
 			sandboxId: null,
+			runtimePod: null,
 			state: ComputerLeaseStates.Claimed,
 			claimedAt: "2026-09-01T00:01:00.000Z",
 			expiresAt: "2026-09-01T00:20:00.000Z",
@@ -95,7 +96,7 @@ describe("ConversationComputerActivationClaimAuthority", function _DescribeConve
 		await expect(expired.authority.activate({ siloId: "silo-1", computerId: "computer-1", conversationId: "conversation-1", generation: 2 })).resolves.toBe("denied");
 		const warm = _PendingCurrent({
 			computer: { ..._PendingCurrent().computer, state: ConversationComputerStates.Warm },
-			lease: { ..._PendingCurrent().lease!, sandboxId: "sandbox-1", state: ComputerLeaseStates.Active },
+			lease: { ..._PendingCurrent().lease!, sandboxId: "sandbox-1", runtimePod: { namespace: "sandbox-system", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-1" }, state: ComputerLeaseStates.Active },
 		});
 		const idempotent = _Authority(warm);
 		await expect(idempotent.authority.activate({ siloId: "silo-1", computerId: "computer-1", conversationId: "conversation-1", generation: 2 })).resolves.toBe("idempotent");

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-computer-sandbox-reconciliation-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-computer-sandbox-reconciliation-authority.test.ts
@@ -12,7 +12,7 @@ function _Current(overrides: Record<string, unknown> = {})
 		streamName: "conversation-computer-computer-1",
 		revision: 4n,
 		computer: { schemaVersion: 1, id: "computer-1", siloId: "testv5", conversationId: "conversation-1", agentIdentityId: "agent-1", profileRevisionId: "profile-1", state: ConversationComputerStates.ClaimDispatched, leaseGeneration: 2, workspaceCheckpoint: null, activeExecution: null, createdAt: "2026-09-01T00:00:00.000Z", updatedAt: "2026-09-01T00:01:00.000Z" },
-		lease: { schemaVersion: 1, id: "lease-1", computerId: "computer-1", generation: 2, sandboxClaimId: "computer-1-g2", sandboxId: null, state: ComputerLeaseStates.Claimed, claimedAt: "2026-09-01T00:00:00.000Z", expiresAt: "2026-09-01T00:20:00.000Z", releasedAt: null },
+		lease: { schemaVersion: 1, id: "lease-1", computerId: "computer-1", generation: 2, sandboxClaimId: "computer-1-g2", sandboxId: null, runtimePod: null, state: ComputerLeaseStates.Claimed, claimedAt: "2026-09-01T00:00:00.000Z", expiresAt: "2026-09-01T00:20:00.000Z", releasedAt: null },
 		...overrides,
 	};
 }
@@ -20,9 +20,10 @@ function _Current(overrides: Record<string, unknown> = {})
 function _Authority(current = _Current(), now = new Date("2026-09-01T00:10:00.000Z"))
 {
 	const history = { loadForActivation: vi.fn().mockResolvedValue(current), append: vi.fn().mockResolvedValue(undefined) };
-	const profiles = { resolve: vi.fn().mockResolvedValue({ namespace: "testv5", sandboxProfile: "developer", warmPoolName: "developer-pool" }) };
+	const profiles = { resolve: vi.fn().mockResolvedValue({ namespace: "testv5", serviceAccountName: "agent-sandbox-runtime", sandboxProfile: "developer", warmPoolName: "developer-pool" }) };
 	const observations = { observe: vi.fn().mockResolvedValue({ state: AgentSandboxClaimObservationStates.Ready, sandboxId: "sandbox-1" }) };
-	return { authority: new ConversationComputerSandboxReconciliationAuthority({ history, profiles, observations, clock: { now: vi.fn().mockReturnValue(now) } }), history, profiles, observations };
+	const runtimePods = { read: vi.fn().mockResolvedValue({ namespace: "testv5", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-1" }) };
+	return { authority: new ConversationComputerSandboxReconciliationAuthority({ history, profiles, observations, runtimePods, clock: { now: vi.fn().mockReturnValue(now) } }), history, profiles, observations, runtimePods };
 }
 
 const _Command = { siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1", generation: 2 };
@@ -35,13 +36,23 @@ describe("ConversationComputerSandboxReconciliationAuthority", function _Reconci
 
 		await expect(fixture.authority.reconcile(_Command)).resolves.toBe(ConversationComputerSandboxReconciliationOutcomes.Warmed);
 		expect(fixture.observations.observe).toHaveBeenCalledWith(expect.objectContaining({ namespace: "testv5", computerId: "computer-1", generation: 2, profile: "developer", warmPoolName: "developer-pool" }));
-		expect(fixture.history.append).toHaveBeenCalledWith(expect.objectContaining({ expectedRevision: 4n, computer: expect.objectContaining({ state: ConversationComputerStates.Warm }), lease: expect.objectContaining({ state: ComputerLeaseStates.Active, sandboxId: "sandbox-1" }) }));
+		expect(fixture.runtimePods.read).toHaveBeenCalledWith({ namespace: "testv5", sandboxId: "sandbox-1", serviceAccountName: "agent-sandbox-runtime" });
+		expect(fixture.history.append).toHaveBeenCalledWith(expect.objectContaining({ expectedRevision: 4n, computer: expect.objectContaining({ state: ConversationComputerStates.Warm }), lease: expect.objectContaining({ state: ComputerLeaseStates.Active, sandboxId: "sandbox-1", runtimePod: { namespace: "testv5", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-1" } }) }));
 	});
 
 	it("keeps unready status pending and never turns a false condition into a terminal lease", async function _KeepsPending()
 	{
 		const fixture = _Authority();
 		fixture.observations.observe.mockResolvedValue({ state: AgentSandboxClaimObservationStates.Pending });
+
+		await expect(fixture.authority.reconcile(_Command)).resolves.toBe(ConversationComputerSandboxReconciliationOutcomes.Pending);
+		expect(fixture.history.append).not.toHaveBeenCalled();
+	});
+
+	it("keeps a ready claim pending until its assigned Sandbox has one exact backing Pod", async function _WaitsForBackingPod()
+	{
+		const fixture = _Authority();
+		fixture.runtimePods.read.mockResolvedValue(null);
 
 		await expect(fixture.authority.reconcile(_Command)).resolves.toBe(ConversationComputerSandboxReconciliationOutcomes.Pending);
 		expect(fixture.history.append).not.toHaveBeenCalled();
@@ -83,6 +94,7 @@ describe("ConversationComputerSandboxReconciliationAuthority", function _Reconci
 			history: fixture.history,
 			profiles: fixture.profiles,
 			observations: fixture.observations,
+			runtimePods: fixture.runtimePods,
 			clock: { now: vi.fn().mockReturnValueOnce(new Date("2026-09-01T00:19:59.000Z")).mockReturnValueOnce(new Date("2026-09-01T00:20:00.000Z")) },
 		});
 
@@ -92,7 +104,7 @@ describe("ConversationComputerSandboxReconciliationAuthority", function _Reconci
 
 	it("ignores a stale or already-converged activation locator", async function _IgnoresStaleLocator()
 	{
-		const fixture = _Authority(_Current({ computer: { ..._Current().computer, state: ConversationComputerStates.Warm }, lease: { ..._Current().lease, state: ComputerLeaseStates.Active, sandboxId: "sandbox-1" } }));
+		const fixture = _Authority(_Current({ computer: { ..._Current().computer, state: ConversationComputerStates.Warm }, lease: { ..._Current().lease, state: ComputerLeaseStates.Active, sandboxId: "sandbox-1", runtimePod: { namespace: "testv5", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-1" } } }));
 
 		await expect(fixture.authority.reconcile(_Command)).resolves.toBe(ConversationComputerSandboxReconciliationOutcomes.Ignored);
 		expect(fixture.observations.observe).not.toHaveBeenCalled();

--- a/libs/backend/server/conversations/main/src/conversation-computer-activation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computer-activation-authority.types.ts
@@ -45,6 +45,8 @@ export interface ConversationComputerActivationProfile
 {
 	/** Names the namespace containing this release's Agent Sandbox claims and warm pools. */
 	readonly namespace: string;
+	/** Names the ServiceAccount fixed by this profile's immutable SandboxTemplate. */
+	readonly serviceAccountName: string;
 	/** Names the admission-policy-approved SandboxTemplate profile. */
 	readonly sandboxProfile: string;
 	/** Names the release-owned zero-replica warm pool for the sandbox profile. */

--- a/libs/backend/server/conversations/main/src/conversation-computer-sandbox-reconciliation-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computer-sandbox-reconciliation-authority.ts
@@ -58,6 +58,13 @@ export class ConversationComputerSandboxReconciliationAuthority
 		});
 		if (observation.state !== AgentSandboxClaimObservationStates.Ready)
 			return ConversationComputerSandboxReconciliationOutcomes.Pending;
+		const runtimePod = await this.dependencies.runtimePods.read({
+			namespace: profile.namespace,
+			sandboxId: observation.sandboxId,
+			serviceAccountName: profile.serviceAccountName,
+		});
+		if (runtimePod === null)
+			return ConversationComputerSandboxReconciliationOutcomes.Pending;
 		const warmedAt = this.dependencies.clock.now();
 		if (Date.parse(current.lease.expiresAt) <= warmedAt.getTime())
 			return this._CompensateExpiredDispatch(current, warmedAt);
@@ -65,7 +72,7 @@ export class ConversationComputerSandboxReconciliationAuthority
 			expectedRevision: current.revision,
 			eventId: randomUUID(),
 			computer: { ...current.computer, state: ConversationComputerStates.Warm, updatedAt: warmedAt.toISOString() },
-			lease: { ...current.lease, state: ComputerLeaseStates.Active, sandboxId: observation.sandboxId },
+			lease: { ...current.lease, state: ComputerLeaseStates.Active, sandboxId: observation.sandboxId, runtimePod },
 		});
 		return ConversationComputerSandboxReconciliationOutcomes.Warmed;
 	}

--- a/libs/backend/server/conversations/main/src/conversation-computer-sandbox-reconciliation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computer-sandbox-reconciliation-authority.types.ts
@@ -1,4 +1,4 @@
-import type { AgentSandboxClaimObservationReader } from "@opencrane/backend/server/infra/agent-sandbox-claims";
+import type { AgentSandboxClaimObservationReader, AgentSandboxRuntimePodReader } from "@opencrane/backend/server/infra/agent-sandbox-claims";
 
 import type { ConversationComputerActivationClock, ConversationComputerActivationProfileResolver } from "./conversation-computer-activation-authority.types";
 import type { ConversationComputerHistory } from "./conversation-computers";
@@ -32,8 +32,8 @@ export type ConversationComputerSandboxReconciliationOutcome = ConversationCompu
  * Supplies the checked ports that reconcile one already-dispatched computer claim.
  *
  * History owns the persisted computer lifecycle, profile resolution admits release-owned claim
- * coordinates, and observation reads controller status without acting on Pods. Separating those
- * ports prevents a status pass from selecting a claim, profile, or lease deadline.
+ * coordinates, and read-only observations verify controller status and Pod ownership. Separating
+ * those ports prevents a status pass from selecting a claim, profile, Pod, or lease deadline.
  */
 export interface ConversationComputerSandboxReconciliationAuthorityDependencies
 {
@@ -43,6 +43,8 @@ export interface ConversationComputerSandboxReconciliationAuthorityDependencies
 	readonly profiles: ConversationComputerActivationProfileResolver;
 	/** Reads only the exact immutable SandboxClaim that the checked lease recorded. */
 	readonly observations: AgentSandboxClaimObservationReader;
+	/** Reads only the exact controller-owned Pod that a ready assigned Sandbox identifies. */
+	readonly runtimePods: AgentSandboxRuntimePodReader;
 	/** Supplies the server-owned instant that determines whether a pending lease has expired. */
 	readonly clock: ConversationComputerActivationClock;
 }

--- a/libs/backend/server/conversations/main/src/conversation-computers/__tests__/conversation-computer-execution-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/__tests__/conversation-computer-execution-authority.test.ts
@@ -24,6 +24,7 @@ function _Lease(overrides: Partial<ComputerLease> = {}): ComputerLease
 		generation: 1,
 		sandboxClaimId: "claim-1",
 		sandboxId: "sandbox-1",
+		runtimePod: { namespace: "sandbox", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-1" },
 		state: ComputerLeaseStates.Active,
 		claimedAt: "2026-09-01T00:00:00.000Z",
 		expiresAt: "2026-09-01T00:20:00.000Z",

--- a/libs/backend/server/conversations/main/src/conversation-computers/__tests__/conversation-computer-history.test.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/__tests__/conversation-computer-history.test.ts
@@ -44,6 +44,7 @@ function _Lease(overrides: Partial<ComputerLease> = {}): ComputerLease
 		generation: 1,
 		sandboxClaimId: "claim-1",
 		sandboxId: "sandbox-1",
+		runtimePod: { namespace: "sandbox", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-1" },
 		state: ComputerLeaseStates.Active,
 		claimedAt: "2026-09-01T00:00:00.000Z",
 		expiresAt: "2026-09-01T00:20:00.000Z",
@@ -87,6 +88,9 @@ function _Event(revision: bigint, computer: ConversationComputer = _Computer(), 
 			leaseId: lease?.id ?? null,
 			leaseGeneration: lease?.generation ?? null,
 			leaseState: lease?.state ?? null,
+			runtimePodNamespace: lease?.runtimePod?.namespace ?? null,
+			runtimePodServiceAccountName: lease?.runtimePod?.serviceAccountName ?? null,
+			runtimePodUid: lease?.runtimePod?.podUid ?? null,
 			executionId: computer.activeExecution?.id ?? null,
 			executionLeaseId: computer.activeExecution?.leaseId ?? null,
 			executionLeaseGeneration: computer.activeExecution?.leaseGeneration ?? null,
@@ -139,7 +143,7 @@ describe("ConversationComputerHistory", function ()
 				id: _EVENT_ID,
 				type: "opencrane.conversation-computer.v1",
 				data: { computer: _Computer(), lease: _Lease() },
-				metadata: { siloId: "silo-1", computerId: "computer-1", conversationId: "conversation-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1", leaseId: "lease-1", leaseGeneration: 1, leaseState: ComputerLeaseStates.Active, executionId: "execution-1", executionLeaseId: "lease-1", executionLeaseGeneration: 1, executionEndedAt: null },
+				metadata: { siloId: "silo-1", computerId: "computer-1", conversationId: "conversation-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1", leaseId: "lease-1", leaseGeneration: 1, leaseState: ComputerLeaseStates.Active, runtimePodNamespace: "sandbox", runtimePodServiceAccountName: "agent-sandbox-runtime", runtimePodUid: "pod-uid-1", executionId: "execution-1", executionLeaseId: "lease-1", executionLeaseGeneration: 1, executionEndedAt: null },
 			}],
 		});
 		await expect(history.append(_AppendCommand({ expectedRevision: HistoryExpectedRevisions.NoStream }))).rejects.toThrow("stale expected revision");
@@ -176,10 +180,10 @@ describe("ConversationComputerHistory", function ()
 		const releasedComputer = _Computer({ state: ConversationComputerStates.Cold, activeExecution: _Execution({ endedAt: "2026-09-01T00:05:00.000Z" }), updatedAt: "2026-09-01T00:05:00.000Z" });
 		const releasedLease = _Lease({ state: ComputerLeaseStates.Released, releasedAt: "2026-09-01T00:05:00.000Z" });
 		const claimedComputer = _Computer({ state: ConversationComputerStates.ClaimPending, leaseGeneration: 2, activeExecution: null, updatedAt: "2026-09-01T00:06:00.000Z" });
-		const claimedLease = _Lease({ id: "lease-2", generation: 2, sandboxClaimId: "claim-2", sandboxId: null, state: ComputerLeaseStates.Claimed, expiresAt: "2026-09-01T00:26:00.000Z" });
+		const claimedLease = _Lease({ id: "lease-2", generation: 2, sandboxClaimId: "claim-2", sandboxId: null, runtimePod: null, state: ComputerLeaseStates.Claimed, expiresAt: "2026-09-01T00:26:00.000Z" });
 		const dispatchedComputer = _Computer({ state: ConversationComputerStates.ClaimDispatched, leaseGeneration: 2, activeExecution: null, updatedAt: "2026-09-01T00:06:30.000Z" });
 		const replacementComputer = _Computer({ state: ConversationComputerStates.Warm, leaseGeneration: 2, activeExecution: _Execution({ id: "execution-2", leaseId: "lease-2", leaseGeneration: 2, startedAt: "2026-09-01T00:07:00.000Z" }), updatedAt: "2026-09-01T00:07:00.000Z" });
-		const replacementLease = _Lease({ id: "lease-2", generation: 2, sandboxClaimId: "claim-2", sandboxId: "sandbox-2", expiresAt: "2026-09-01T00:26:00.000Z" });
+		const replacementLease = _Lease({ id: "lease-2", generation: 2, sandboxClaimId: "claim-2", sandboxId: "sandbox-2", runtimePod: { namespace: "sandbox", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-2" }, expiresAt: "2026-09-01T00:26:00.000Z" });
 		const valid = new ConversationComputerHistory(_Store({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n), _Event(1n, releasedComputer, releasedLease), _Event(2n, claimedComputer, claimedLease), _Event(3n, dispatchedComputer, claimedLease), _Event(4n, replacementComputer, replacementLease)])), readHead: vi.fn().mockResolvedValue({ streamName: "conversation-computer-computer-1", revision: 4n }) }));
 		const directReplacement = new ConversationComputerHistory(_Store({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n), _Event(1n, replacementComputer, replacementLease)])), readHead: vi.fn().mockResolvedValue({ streamName: "conversation-computer-computer-1", revision: 1n }) }));
 
@@ -190,9 +194,9 @@ describe("ConversationComputerHistory", function ()
 	it("refuses a terminal transition while one durable claim dispatch still owns the lease", async function _RejectsTerminalDispatchRace()
 	{
 		const dispatchedComputer = _Computer({ state: ConversationComputerStates.ClaimDispatched, activeExecution: null, updatedAt: "2026-09-01T00:01:00.000Z" });
-		const dispatchedLease = _Lease({ sandboxId: null, state: ComputerLeaseStates.Claimed });
+		const dispatchedLease = _Lease({ sandboxId: null, runtimePod: null, state: ComputerLeaseStates.Claimed });
 		const releasedComputer = _Computer({ state: ConversationComputerStates.Cold, activeExecution: null, updatedAt: "2026-09-01T00:02:00.000Z" });
-		const releasedLease = _Lease({ sandboxId: null, state: ComputerLeaseStates.Released, releasedAt: "2026-09-01T00:02:00.000Z" });
+		const releasedLease = _Lease({ sandboxId: null, runtimePod: null, state: ComputerLeaseStates.Released, releasedAt: "2026-09-01T00:02:00.000Z" });
 		const history = new ConversationComputerHistory(_Store({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n, dispatchedComputer, dispatchedLease), _Event(1n, releasedComputer, releasedLease)])), readHead: vi.fn().mockResolvedValue({ streamName: "conversation-computer-computer-1", revision: 1n }) }));
 
 		await expect(history.load(_CurrentCommand())).rejects.toThrow("requires claim dispatch to converge");
@@ -201,9 +205,9 @@ describe("ConversationComputerHistory", function ()
 	it("permits only expired-claim compensation from a durable dispatch fence", async function _AllowsLostDispatchCompensation()
 	{
 		const dispatchedComputer = _Computer({ state: ConversationComputerStates.ClaimDispatched, activeExecution: null, updatedAt: "2026-09-01T00:01:00.000Z" });
-		const dispatchedLease = _Lease({ sandboxId: null, state: ComputerLeaseStates.Claimed });
+		const dispatchedLease = _Lease({ sandboxId: null, runtimePod: null, state: ComputerLeaseStates.Claimed });
 		const recoveredComputer = _Computer({ state: ConversationComputerStates.RecoveryRequired, activeExecution: null, updatedAt: "2026-09-01T00:02:00.000Z" });
-		const lostLease = _Lease({ sandboxId: null, state: ComputerLeaseStates.Lost, releasedAt: "2026-09-01T00:02:00.000Z" });
+		const lostLease = _Lease({ sandboxId: null, runtimePod: null, state: ComputerLeaseStates.Lost, releasedAt: "2026-09-01T00:02:00.000Z" });
 		const history = new ConversationComputerHistory(_Store({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n, dispatchedComputer, dispatchedLease), _Event(1n, recoveredComputer, lostLease)])), readHead: vi.fn().mockResolvedValue({ streamName: "conversation-computer-computer-1", revision: 1n }) }));
 
 		await expect(history.load(_CurrentCommand())).resolves.toEqual(expect.objectContaining({ computer: recoveredComputer, lease: lostLease }));
@@ -223,6 +227,17 @@ describe("ConversationComputerHistory", function ()
 
 		await expect(history.loadActiveExecution(_ActiveCommand())).resolves.toEqual(expect.objectContaining({ execution: _Execution() }));
 		await expect(terminal.loadActiveExecution(_ActiveCommand())).rejects.toThrow("missing or terminal execution");
+	});
+
+	it("requires Pod provenance for every active lease and never permits a same-name Pod replacement", async function _FencesActivePodIdentity()
+	{
+		const missingPod = _Lease({ runtimePod: null });
+		const replacement = _Lease({ runtimePod: { namespace: "sandbox", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-2" } });
+		const invalidActiveLease = new ConversationComputerHistory(_Store({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n, _Computer(), missingPod)])), readHead: vi.fn().mockResolvedValue({ streamName: "conversation-computer-computer-1", revision: 0n }) }));
+		const replacedPod = new ConversationComputerHistory(_Store({ readStream: vi.fn().mockReturnValue(_Events([_Event(0n), _Event(1n, _Computer(), replacement)])), readHead: vi.fn().mockResolvedValue({ streamName: "conversation-computer-computer-1", revision: 1n }) }));
+
+		await expect(invalidActiveLease.load(_CurrentCommand())).rejects.toThrow("active lease for a warm or cooling computer");
+		await expect(replacedPod.load(_CurrentCommand())).rejects.toThrow("changed an active sandbox Pod identity");
 	});
 
 	it("derives the runtime identity from the checked computer stream instead of accepting it from command input", async function ()

--- a/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-history-validation.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-history-validation.ts
@@ -1,4 +1,4 @@
-import { ComputerLeaseStates, ConversationComputerStates, type ComputerLease, type ConversationComputer, type ConversationComputerExecution } from "@opencrane/contracts";
+import { ComputerLeaseStates, ConversationComputerStates, type ComputerLease, type ComputerLeaseRuntimePod, type ConversationComputer, type ConversationComputerExecution } from "@opencrane/contracts";
 import type { HistoryRecordedEvent } from "@opencrane/backend/server/infra/history-store";
 
 import type { ConversationComputerActivationCurrentCommand, ConversationComputerCurrentCommand, ConversationComputerHistorySnapshot, ConversationComputerRuntimeCurrentCommand } from "./conversation-computer-history.types";
@@ -57,7 +57,7 @@ export function _ValidatedConversationComputerEvent(event: HistoryRecordedEvent,
 	if (!_UUID_PATTERN.test(event.id))
 		throw new Error("Conversation computer history received an event with an invalid identifier");
 	const snapshot = _ValidatedConversationComputerSnapshot(event.data);
-	if (event.metadata.siloId !== snapshot.computer.siloId || event.metadata.computerId !== snapshot.computer.id || event.metadata.conversationId !== snapshot.computer.conversationId || event.metadata.agentIdentityId !== snapshot.computer.agentIdentityId || event.metadata.profileRevisionId !== snapshot.computer.profileRevisionId || event.metadata.leaseId !== (snapshot.lease?.id ?? null) || event.metadata.leaseGeneration !== (snapshot.lease?.generation ?? null) || event.metadata.leaseState !== (snapshot.lease?.state ?? null) || event.metadata.executionId !== (snapshot.computer.activeExecution?.id ?? null) || event.metadata.executionLeaseId !== (snapshot.computer.activeExecution?.leaseId ?? null) || event.metadata.executionLeaseGeneration !== (snapshot.computer.activeExecution?.leaseGeneration ?? null) || event.metadata.executionEndedAt !== (snapshot.computer.activeExecution?.endedAt ?? null))
+	if (event.metadata.siloId !== snapshot.computer.siloId || event.metadata.computerId !== snapshot.computer.id || event.metadata.conversationId !== snapshot.computer.conversationId || event.metadata.agentIdentityId !== snapshot.computer.agentIdentityId || event.metadata.profileRevisionId !== snapshot.computer.profileRevisionId || event.metadata.leaseId !== (snapshot.lease?.id ?? null) || event.metadata.leaseGeneration !== (snapshot.lease?.generation ?? null) || event.metadata.leaseState !== (snapshot.lease?.state ?? null) || event.metadata.runtimePodNamespace !== (snapshot.lease?.runtimePod?.namespace ?? null) || event.metadata.runtimePodServiceAccountName !== (snapshot.lease?.runtimePod?.serviceAccountName ?? null) || event.metadata.runtimePodUid !== (snapshot.lease?.runtimePod?.podUid ?? null) || event.metadata.executionId !== (snapshot.computer.activeExecution?.id ?? null) || event.metadata.executionLeaseId !== (snapshot.computer.activeExecution?.leaseId ?? null) || event.metadata.executionLeaseGeneration !== (snapshot.computer.activeExecution?.leaseGeneration ?? null) || event.metadata.executionEndedAt !== (snapshot.computer.activeExecution?.endedAt ?? null))
 		throw new Error("Conversation computer history received an event that does not match its envelope");
 	if (snapshot.computer.siloId !== command.siloId)
 		throw new Error("Conversation computer history received a computer from a different silo");
@@ -121,15 +121,21 @@ function _ValidatedConversationComputerExecution(value: unknown): ConversationCo
 /** Parses the exact closed ComputerLease contract at a history boundary. */
 export function _ValidatedComputerLease(value: unknown): ComputerLease
 {
-	if (!_Record(value) || !_ExactKeys(value, ["schemaVersion", "id", "computerId", "generation", "sandboxClaimId", "sandboxId", "state", "claimedAt", "expiresAt", "releasedAt"]))
+	if (!_Record(value) || !_ExactKeys(value, ["schemaVersion", "id", "computerId", "generation", "sandboxClaimId", "sandboxId", "runtimePod", "state", "claimedAt", "expiresAt", "releasedAt"]))
 		throw new Error("Conversation computer history requires a valid lease snapshot");
-	if (value.schemaVersion !== 1 || !_Identifier(value.id) || !_Identifier(value.computerId) || !_PositiveInteger(value.generation) || !_Identifier(value.sandboxClaimId) || (value.sandboxId !== null && !_Identifier(value.sandboxId)) || !_LeaseState(value.state) || !_IsoTimestamp(value.claimedAt) || !_IsoTimestamp(value.expiresAt) || (value.releasedAt !== null && !_IsoTimestamp(value.releasedAt)))
+	if (value.schemaVersion !== 1 || !_Identifier(value.id) || !_Identifier(value.computerId) || !_PositiveInteger(value.generation) || !_Identifier(value.sandboxClaimId) || (value.sandboxId !== null && !_Identifier(value.sandboxId)) || (value.runtimePod !== null && !_ValidatedComputerLeaseRuntimePod(value.runtimePod)) || !_LeaseState(value.state) || !_IsoTimestamp(value.claimedAt) || !_IsoTimestamp(value.expiresAt) || (value.releasedAt !== null && !_IsoTimestamp(value.releasedAt)))
 		throw new Error("Conversation computer history requires valid lease coordinates");
 	if (Date.parse(value.expiresAt) <= Date.parse(value.claimedAt))
 		throw new Error("Conversation computer history requires a lease expiry after its claim");
 	if (value.releasedAt !== null && Date.parse(value.releasedAt) < Date.parse(value.claimedAt))
 		throw new Error("Conversation computer history requires a lease release after its claim");
 	return value as unknown as ComputerLease;
+}
+
+/** Validates the durable Pod identity that a later TokenReview must match exactly. */
+function _ValidatedComputerLeaseRuntimePod(value: unknown): value is ComputerLeaseRuntimePod
+{
+	return _Record(value) && _ExactKeys(value, ["namespace", "serviceAccountName", "podUid"]) && _DnsLabel(value.namespace) && _DnsLabel(value.serviceAccountName) && _Identifier(value.podUid);
 }
 
 /** Checks whether one snapshot has zero or one lease consistent with the computer's lifecycle. */
@@ -146,13 +152,13 @@ function _ValidateCurrentLease(computer: ConversationComputer, lease: ComputerLe
 		throw new Error("Conversation computer history requires the lease to match its computer generation");
 	if (lease.state === ComputerLeaseStates.Claimed)
 	{
-		if ((computer.state !== ConversationComputerStates.ClaimPending && computer.state !== ConversationComputerStates.ClaimDispatched) || lease.sandboxId !== null || lease.releasedAt !== null)
+		if ((computer.state !== ConversationComputerStates.ClaimPending && computer.state !== ConversationComputerStates.ClaimDispatched) || lease.sandboxId !== null || lease.runtimePod !== null || lease.releasedAt !== null)
 			throw new Error("Conversation computer history requires a pending claim without a sandbox");
 		return;
 	}
 	if (lease.state === ComputerLeaseStates.Active)
 	{
-		if ((computer.state !== ConversationComputerStates.Warm && computer.state !== ConversationComputerStates.Cooling) || lease.sandboxId === null || lease.releasedAt !== null)
+		if ((computer.state !== ConversationComputerStates.Warm && computer.state !== ConversationComputerStates.Cooling) || lease.sandboxId === null || lease.runtimePod === null || lease.releasedAt !== null)
 			throw new Error("Conversation computer history requires an active lease for a warm or cooling computer");
 		return;
 	}
@@ -240,10 +246,18 @@ function _ValidateSameLeaseTransition(previous: ComputerLease, current: Computer
 		throw new Error("Conversation computer history changed stable lease coordinates");
 	if (previous.sandboxId !== null && previous.sandboxId !== current.sandboxId)
 		throw new Error("Conversation computer history changed an assigned sandbox");
+	if (previous.runtimePod !== null && !_SameRuntimePod(previous.runtimePod, current.runtimePod))
+		throw new Error("Conversation computer history changed an active sandbox Pod identity");
 	if ((previous.state === ComputerLeaseStates.Released || previous.state === ComputerLeaseStates.Lost) && previous.state !== current.state)
 		throw new Error("Conversation computer history reactivated a terminal lease");
 	if (previous.state === ComputerLeaseStates.Active && current.state === ComputerLeaseStates.Claimed)
 		throw new Error("Conversation computer history moved an active lease back to claimed");
+}
+
+/** Compares an immutable verified Pod identity without permitting a same-name replacement. */
+function _SameRuntimePod(previous: ComputerLeaseRuntimePod, current: ComputerLeaseRuntimePod | null): boolean
+{
+	return current !== null && previous.namespace === current.namespace && previous.serviceAccountName === current.serviceAccountName && previous.podUid === current.podUid;
 }
 
 /** Validates the nested immutable workspace checkpoint when one is present. */
@@ -264,6 +278,12 @@ function _ExactKeys(value: Record<string, unknown>, keys: readonly string[]): bo
 function _Identifier(value: unknown): value is string
 {
 	return typeof value === "string" && value.trim().length > 0 && value === value.trim();
+}
+
+/** Checks one Kubernetes DNS label used by the release-owned namespace and ServiceAccount. */
+function _DnsLabel(value: unknown): value is string
+{
+	return typeof value === "string" && value.length <= 63 && /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(value);
 }
 
 /** Checks one nonnegative safe integer stored as the computer's durable generation. */

--- a/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-history.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-history.ts
@@ -66,6 +66,9 @@ export class ConversationComputerHistory
 					leaseId: snapshot.lease?.id ?? null,
 					leaseGeneration: snapshot.lease?.generation ?? null,
 					leaseState: snapshot.lease?.state ?? null,
+					runtimePodNamespace: snapshot.lease?.runtimePod?.namespace ?? null,
+					runtimePodServiceAccountName: snapshot.lease?.runtimePod?.serviceAccountName ?? null,
+					runtimePodUid: snapshot.lease?.runtimePod?.podUid ?? null,
 					executionId: snapshot.computer.activeExecution?.id ?? null,
 					executionLeaseId: snapshot.computer.activeExecution?.leaseId ?? null,
 					executionLeaseGeneration: snapshot.computer.activeExecution?.leaseGeneration ?? null,
@@ -172,7 +175,7 @@ export class ConversationComputerHistory
 	public async loadActiveExecutionForRuntime(command: ActiveConversationComputerRuntimeCommand): Promise<ActiveConversationComputerExecution>
 	{
 		const current = await this.loadForRuntime(command);
-		if (current === null || current.computer.state !== ConversationComputerStates.Warm || current.lease === null || current.lease.state !== ComputerLeaseStates.Active || !Number.isSafeInteger(command.nowEpochMilliseconds) || Date.parse(current.lease.expiresAt) <= command.nowEpochMilliseconds || current.computer.activeExecution === null || current.computer.activeExecution.endedAt !== null)
+		if (current === null || current.computer.state !== ConversationComputerStates.Warm || current.lease === null || current.lease.state !== ComputerLeaseStates.Active || current.lease.runtimePod === null || !Number.isSafeInteger(command.nowEpochMilliseconds) || Date.parse(current.lease.expiresAt) <= command.nowEpochMilliseconds || current.computer.activeExecution === null || current.computer.activeExecution.endedAt !== null)
 			throw new Error("Conversation computer history cannot use an inactive runtime execution");
 		return { ...current, lease: current.lease, execution: current.computer.activeExecution };
 	}

--- a/libs/backend/server/infra/agent-sandbox-claims/README.md
+++ b/libs/backend/server/infra/agent-sandbox-claims/README.md
@@ -15,7 +15,7 @@ already-existing claim as idempotent only when every immutable lease field match
  ┌─────────────────────────────────┐
  │ agent-sandbox-claims  ◄── HERE   │
  └──────────────┬──────────────────┘
-                │ create / exact get on 409 / status get
+                │ create / exact claim, Sandbox, and Pod get
                 ▼
        Agent Sandbox SandboxClaim
 ```
@@ -29,14 +29,18 @@ cannot point at a second claim name.
 - `AgentSandboxClaimAuthority` exposes `ensure` as the sole claim-creation operation.
 - `_KubernetesAgentSandboxClaimAuthority` calls only namespaced custom-object `create` and `get`.
 - `AgentSandboxClaimObservationReader` separately reads one exact claim status and exposes a
-  sandbox id only when its immutable lease fields and current `Ready=True` condition match.
+  Sandbox id only when its immutable lease fields and current `Ready=True` condition match.
+- `AgentSandboxRuntimePodReader` resolves the assigned Sandbox's v1 name-matched backing Pod, then
+  accepts it only when its namespace, ServiceAccount, controller owner reference, and immutable UID
+  all match the release-bound realization.
 - `AgentSandboxClaimReason` restricts claims to activation or recovery.
 
 ## Boundary
 
 The caller must authorise the computer action, fence its generation, choose an admitted profile,
 and persist durable intent before calling this adapter. This adapter neither authorises a caller,
-selects a profile, reads Pods or Sandboxes, patches claims, nor implements a Pod controller. The cluster-wide
+selects a profile, patches claims, or implements a Pod controller. It reads the one
+claim-assigned Sandbox and backing Pod only to preserve a durable lease fence; the cluster-wide
 Agent Sandbox controller remains the sole reconciler for sandbox resources.
 
 ## Dependency direction
@@ -47,10 +51,11 @@ or an app entrypoint.
 
 ## Runtime & config
 
-The composing server supplies its own Kubernetes `CustomObjectsApi`. The server's release-scoped
-Role admits only `create` and `get` on `sandboxclaims`; the reader uses the same name-bound `get`
-permission and never lists or watches resources. The Kubernetes admission policy rejects any resource
-body outside the generated immutable shape.
+The composing server supplies its own Kubernetes `CustomObjectsApi` and `CoreV1Api`. The server's
+release-scoped Role allows `create`/`get` on `sandboxclaims` and `get` on `sandboxes` and `pods`.
+The server performs only claim-derived, name-bound reads and never lists, watches, or mutates those
+resources. The Kubernetes admission policy rejects any resource body outside the generated immutable
+claim shape.
 
 ## See also
 

--- a/libs/backend/server/infra/agent-sandbox-claims/src/__tests__/kubernetes-agent-sandbox-runtime-pod-reader.test.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/src/__tests__/kubernetes-agent-sandbox-runtime-pod-reader.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentSandboxClaimCustomObjectsApi, AgentSandboxCoreApi, AgentSandboxRuntimePodCommand } from "../agent-sandbox-claims.types";
+import { _KubernetesAgentSandboxRuntimePodReader } from "../kubernetes-agent-sandbox-runtime-pod-reader";
+
+/** Builds the trusted controller and template coordinates for one assigned Sandbox. */
+function _Command(overrides: Partial<AgentSandboxRuntimePodCommand> = {}): AgentSandboxRuntimePodCommand
+{
+	return { namespace: "testv5", sandboxId: "sandbox-41", serviceAccountName: "agent-sandbox-runtime", ...overrides };
+}
+
+/** Builds the v1 Sandbox resource whose name selects its backing Pod. */
+function _Sandbox(command: AgentSandboxRuntimePodCommand, overrides: Record<string, unknown> = {}): Record<string, unknown>
+{
+	return {
+		apiVersion: "agents.x-k8s.io/v1beta1",
+		kind: "Sandbox",
+		metadata: { name: command.sandboxId, namespace: command.namespace, uid: "sandbox-uid-41" },
+		...overrides,
+	};
+}
+
+/** Builds one backing Pod with the controller-owned Sandbox owner reference and exact template identity. */
+function _Pod(command: AgentSandboxRuntimePodCommand, overrides: Record<string, unknown> = {}): Record<string, unknown>
+{
+	return {
+		metadata: {
+			name: command.sandboxId,
+			namespace: command.namespace,
+			uid: "pod-uid-41",
+			ownerReferences: [{ apiVersion: "agents.x-k8s.io/v1beta1", kind: "Sandbox", name: command.sandboxId, uid: "sandbox-uid-41", controller: true }],
+		},
+		spec: { serviceAccountName: command.serviceAccountName },
+		...overrides,
+	};
+}
+
+/** Builds the narrow custom-resource and Pod-read ports with independently controlled results. */
+function _Apis(sandbox: unknown, pod: unknown): { readonly customApi: AgentSandboxClaimCustomObjectsApi; readonly coreApi: AgentSandboxCoreApi; readonly getSandbox: ReturnType<typeof vi.fn>; readonly getPod: ReturnType<typeof vi.fn> }
+{
+	const getSandbox = vi.fn().mockResolvedValue(sandbox);
+	const getPod = vi.fn().mockResolvedValue(pod);
+	return { customApi: { createNamespacedCustomObject: vi.fn(), getNamespacedCustomObject: getSandbox }, coreApi: { readNamespacedPod: getPod }, getSandbox, getPod };
+}
+
+describe("_KubernetesAgentSandboxRuntimePodReader", function _RuntimePodReaderSuite()
+{
+	it("binds one ready Sandbox to its exact controller-owned Pod UID", async function _ReadsOwnedPod()
+	{
+		const command = _Command();
+		const fixture = _Apis(_Sandbox(command), _Pod(command));
+
+		await expect(new _KubernetesAgentSandboxRuntimePodReader(fixture.customApi, fixture.coreApi).read(command)).resolves.toEqual({ namespace: "testv5", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-41" });
+		expect(fixture.getSandbox).toHaveBeenCalledWith({ group: "agents.x-k8s.io", version: "v1beta1", namespace: "testv5", plural: "sandboxes", name: "sandbox-41" });
+		expect(fixture.getPod).toHaveBeenCalledWith({ namespace: "testv5", name: "sandbox-41" });
+	});
+
+	it("keeps reconciliation pending while the assigned Sandbox or backing Pod is absent", async function _KeepsPendingForMissingResource()
+	{
+		const command = _Command();
+		const missingSandbox = _Apis(null, _Pod(command));
+		missingSandbox.getSandbox.mockRejectedValue(Object.assign(new Error("missing Sandbox"), { statusCode: 404 }));
+		const missingPod = _Apis(_Sandbox(command), null);
+		missingPod.getPod.mockRejectedValue(Object.assign(new Error("missing Pod"), { statusCode: 404 }));
+
+		await expect(new _KubernetesAgentSandboxRuntimePodReader(missingSandbox.customApi, missingSandbox.coreApi).read(command)).resolves.toBeNull();
+		await expect(new _KubernetesAgentSandboxRuntimePodReader(missingPod.customApi, missingPod.coreApi).read(command)).resolves.toBeNull();
+	});
+
+	it("rejects a same-name Pod that lacks the assigned Sandbox controller and template identity", async function _RejectsForeignPod()
+	{
+		const command = _Command();
+		const foreignOwner = _Pod(command, { metadata: { name: "sandbox-41", namespace: "testv5", uid: "pod-uid-41", ownerReferences: [{ apiVersion: "agents.x-k8s.io/v1beta1", kind: "Sandbox", name: "sandbox-41", uid: "sandbox-uid-replacement", controller: true }] } });
+		const wrongServiceAccount = _Pod(command, { spec: { serviceAccountName: "foreign-runtime" } });
+		const foreignOwnerApis = _Apis(_Sandbox(command), foreignOwner);
+		const wrongServiceAccountApis = _Apis(_Sandbox(command), wrongServiceAccount);
+		const foreignOwnerReader = new _KubernetesAgentSandboxRuntimePodReader(foreignOwnerApis.customApi, foreignOwnerApis.coreApi);
+		const wrongServiceAccountReader = new _KubernetesAgentSandboxRuntimePodReader(wrongServiceAccountApis.customApi, wrongServiceAccountApis.coreApi);
+
+		await expect(foreignOwnerReader.read(command)).rejects.toThrow("does not match its assigned Sandbox identity");
+		await expect(wrongServiceAccountReader.read(command)).rejects.toThrow("does not match its assigned Sandbox identity");
+	});
+});

--- a/libs/backend/server/infra/agent-sandbox-claims/src/agent-sandbox-claims.types.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/src/agent-sandbox-claims.types.ts
@@ -104,11 +104,59 @@ export type AgentSandboxClaimObservation =
 	| { readonly state: AgentSandboxClaimObservationStates.Ready; readonly sandboxId: string };
 
 /**
+ * Supplies the server-derived coordinates used to inspect one assigned Sandbox realization.
+ *
+ * The exact claim reader supplies `sandboxId`; the release profile supplies namespace and
+ * ServiceAccount. No caller may select a Pod name or any Kubernetes identity coordinate.
+ */
+export interface AgentSandboxRuntimePodCommand
+{
+	/** Names the release-owned namespace containing the Sandbox and backing Pod. */
+	readonly namespace: string;
+	/** Names the controller-published Sandbox assigned to the exact ready claim. */
+	readonly sandboxId: string;
+	/** Names the ServiceAccount fixed by the admitted SandboxTemplate. */
+	readonly serviceAccountName: string;
+}
+
+/** Identifies an exact current Pod realization of one controller-owned Sandbox. */
+export interface AgentSandboxRuntimePod
+{
+	/** Names the release-owned namespace containing this Pod. */
+	readonly namespace: string;
+	/** Names the ServiceAccount attached to this Pod by the SandboxTemplate. */
+	readonly serviceAccountName: string;
+	/** Identifies the exact Kubernetes Pod instance, including replacement fencing. */
+	readonly podUid: string;
+}
+
+/**
+ * Reads the backing Pod identity for the Sandbox assigned by one ready claim.
+ *
+ * A ready claim supplies a Sandbox name, not authority over a Pod. The reconciliation authority
+ * treats a null result as pending and persists an identity only after this reader verifies the
+ * release namespace, template ServiceAccount, controller owner reference, and Pod UID.
+ *
+ * Called by: `ConversationComputerSandboxReconciliationAuthority`.
+ */
+export interface AgentSandboxRuntimePodReader
+{
+	/**
+	 * Returns the exact ready Pod identity or null while the controller has not published a safe realization.
+	 *
+	 * @param command - Supplies claim- and profile-derived Sandbox coordinates.
+	 * @returns The immutable Pod identity only after Sandbox ownership, namespace, and ServiceAccount checks pass.
+	 * @throws {Error} When Kubernetes is unavailable or a found resource is malformed or foreign.
+	 */
+	read(command: AgentSandboxRuntimePodCommand): Promise<AgentSandboxRuntimePod | null>;
+}
+
+/**
  * Reads a deterministic Agent Sandbox claim without taking any lifecycle action.
  *
  * The port is deliberately distinct from claim creation: reconciliation may observe only the
- * exact, immutable claim that checked history already dispatched. It does not list or watch
- * resources, read Pods or Sandboxes, or mutate an upstream status.
+ * exact, immutable claim that checked history already dispatched. It does not list, watch, or
+ * mutate resources; the separate runtime-Pod reader owns assigned Sandbox and Pod verification.
  */
 export interface AgentSandboxClaimObservationReader
 {
@@ -123,10 +171,10 @@ export interface AgentSandboxClaimObservationReader
 }
 
 /**
- * Limits a Kubernetes client to the two namespaced SandboxClaim calls this adapter needs.
+ * Limits a Kubernetes custom-resource client to the namespaced reads and writes this package needs.
  *
- * The release Role grants the same create-and-get pair. Keeping the port equally narrow prevents
- * this infrastructure adapter from growing its own claim lifecycle or Pod-controller authority.
+ * The release Role grants only claim create/get plus Sandbox get. Keeping the port equally narrow
+ * prevents this infrastructure adapter from growing its own lifecycle or Pod-controller authority.
  */
 export interface AgentSandboxClaimCustomObjectsApi
 {
@@ -144,10 +192,10 @@ export interface AgentSandboxClaimCustomObjectsApi
 		readonly body: Record<string, unknown>;
 	}): Promise<unknown>;
 	/**
-	 * Reads one namespaced custom object by its deterministic name after a create conflict.
+	 * Reads one namespaced custom object by its trusted deterministic resource name.
 	 *
-	 * @param request - The Agent Sandbox API coordinates and deterministic claim name.
-	 * @returns The untrusted Kubernetes response for exact immutable-field comparison.
+	 * @param request - The Agent Sandbox API coordinates and checked resource name.
+	 * @returns The untrusted Kubernetes response for immutable-field or ownership comparison.
 	 */
 	getNamespacedCustomObject(request: {
 		readonly group: string;
@@ -156,4 +204,21 @@ export interface AgentSandboxClaimCustomObjectsApi
 		readonly plural: string;
 		readonly name: string;
 	}): Promise<unknown>;
+}
+
+/**
+ * Limits the Core client to the namespaced backing-Pod read required for lease identity.
+ *
+ * The release Role grants `get` on Pods in the Agent Sandbox namespace, rather than discovery or
+ * mutation permissions, so this adapter cannot select or change another workload.
+ */
+export interface AgentSandboxCoreApi
+{
+	/**
+	 * Reads one named Pod in the assigned Sandbox namespace.
+	 *
+	 * @param request - Supplies the controller-published Pod name and release-owned namespace.
+	 * @returns The untrusted Kubernetes Pod resource.
+	 */
+	readNamespacedPod(request: { readonly namespace: string; readonly name: string }): Promise<unknown>;
 }

--- a/libs/backend/server/infra/agent-sandbox-claims/src/index.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/src/index.ts
@@ -1,4 +1,5 @@
 export { AgentSandboxClaimObservationStates, AgentSandboxClaimReason } from "./agent-sandbox-claims.types";
-export type { AgentSandboxClaimAuthority, AgentSandboxClaimCommand, AgentSandboxClaimCustomObjectsApi, AgentSandboxClaimObservation, AgentSandboxClaimObservationCommand, AgentSandboxClaimObservationReader, AgentSandboxClaimReceipt } from "./agent-sandbox-claims.types";
+export type { AgentSandboxClaimAuthority, AgentSandboxClaimCommand, AgentSandboxClaimCustomObjectsApi, AgentSandboxClaimObservation, AgentSandboxClaimObservationCommand, AgentSandboxClaimObservationReader, AgentSandboxClaimReceipt, AgentSandboxCoreApi, AgentSandboxRuntimePod, AgentSandboxRuntimePodCommand, AgentSandboxRuntimePodReader } from "./agent-sandbox-claims.types";
 export { __AgentSandboxClaimName, _KubernetesAgentSandboxClaimAuthority } from "./kubernetes-agent-sandbox-claim-authority";
 export { _KubernetesAgentSandboxClaimObservationReader } from "./kubernetes-agent-sandbox-claim-observation-reader";
+export { _KubernetesAgentSandboxRuntimePodReader } from "./kubernetes-agent-sandbox-runtime-pod-reader";

--- a/libs/backend/server/infra/agent-sandbox-claims/src/kubernetes-agent-sandbox-runtime-pod-reader.ts
+++ b/libs/backend/server/infra/agent-sandbox-claims/src/kubernetes-agent-sandbox-runtime-pod-reader.ts
@@ -1,0 +1,134 @@
+import { _IsK8sNotFound } from "@opencrane/backend/server/infra/api";
+
+import type { AgentSandboxClaimCustomObjectsApi, AgentSandboxCoreApi, AgentSandboxRuntimePod, AgentSandboxRuntimePodCommand, AgentSandboxRuntimePodReader } from "./agent-sandbox-claims.types";
+
+/** Names the Agent Sandbox API that owns Sandbox resources. */
+const _AGENT_SANDBOX_API_GROUP = "agents.x-k8s.io";
+/** Names the installed Agent Sandbox Sandbox resource version. */
+const _AGENT_SANDBOX_API_VERSION = "v1beta1";
+/** Names the namespaced Sandbox collection. */
+const _AGENT_SANDBOX_PLURAL = "sandboxes";
+
+/** Couples the v1 Sandbox-name Pod convention to the exact Sandbox object that owns it. */
+interface _SandboxBackingPod
+{
+	/** Names the backing Pod, which Agent Sandbox v1 fixes to the Sandbox name. */
+	readonly podName: string;
+	/** Identifies the exact current Sandbox object that must control the Pod. */
+	readonly sandboxUid: string;
+}
+
+/**
+ * Resolves one ready Sandbox assignment into its exact controller-owned Pod identity.
+ *
+ * A claim reports a Sandbox resource, not durable Pod authority. This adapter requires that
+ * resource's v1 fixed backing-Pod name and the Pod's exact owner reference before it returns a UID,
+ * so a same-name Sandbox replacement cannot silently retain the prior computer lease.
+ */
+export class _KubernetesAgentSandboxRuntimePodReader implements AgentSandboxRuntimePodReader
+{
+	/** Connects the narrow Sandbox custom-resource and Core Pod read ports. */
+	public constructor(private readonly customApi: AgentSandboxClaimCustomObjectsApi, private readonly coreApi: AgentSandboxCoreApi) {}
+
+	/**
+	 * Reads one assigned Sandbox and verifies its v1 name-matched backing Pod before returning its identity.
+	 *
+	 * @param command - Supplies the trusted Sandbox namespace, id, and expected ServiceAccount.
+	 * @returns The exact Pod UID only while all controller ownership evidence matches.
+	 * @throws {Error} Propagates unavailable Kubernetes reads and rejects malformed controller resources.
+	 */
+	public async read(command: AgentSandboxRuntimePodCommand): Promise<AgentSandboxRuntimePod | null>
+	{
+		// 1. Read the claim-assigned Sandbox because v1 fixes its backing Pod name to this resource name.
+		const sandbox = await this._ReadSandbox(command);
+		if (sandbox === null)
+			return null;
+		// 2. Read the named Pod without broad discovery, so another workload cannot be adopted by selection.
+		const backingPod = _SandboxBackingPod(sandbox, command);
+		const pod = await this._ReadPod(command.namespace, backingPod.podName);
+		if (pod === null)
+			return null;
+		// 3. Retain the immutable UID only after controller ownership and template identity both agree.
+		return _RuntimePod(pod, command, backingPod);
+	}
+
+	/** Reads the claim-assigned Sandbox without accepting a caller-selected custom-resource name. */
+	private async _ReadSandbox(command: AgentSandboxRuntimePodCommand): Promise<unknown | null>
+	{
+		try
+		{
+			return await this.customApi.getNamespacedCustomObject({
+				group: _AGENT_SANDBOX_API_GROUP,
+				version: _AGENT_SANDBOX_API_VERSION,
+				namespace: command.namespace,
+				plural: _AGENT_SANDBOX_PLURAL,
+				name: command.sandboxId,
+			});
+		}
+		catch (error)
+		{
+			if (_IsK8sNotFound(error))
+				return null;
+			throw error;
+		}
+	}
+
+	/** Reads the one controller-published backing Pod without list or watch authority. */
+	private async _ReadPod(namespace: string, name: string): Promise<unknown | null>
+	{
+		try
+		{
+			return await this.coreApi.readNamespacedPod({ namespace, name });
+		}
+		catch (error)
+		{
+			if (_IsK8sNotFound(error))
+				return null;
+			throw error;
+		}
+	}
+}
+
+/** Derives the v1 name-matched backing Pod and exact Sandbox UID from one assigned resource. */
+function _SandboxBackingPod(value: unknown, command: AgentSandboxRuntimePodCommand): _SandboxBackingPod
+{
+	if (!_Record(value) || value.apiVersion !== `${_AGENT_SANDBOX_API_GROUP}/${_AGENT_SANDBOX_API_VERSION}` || value.kind !== "Sandbox")
+		throw new Error(`Agent Sandbox '${command.sandboxId}' has an unexpected resource identity`);
+	const metadata = value.metadata;
+	if (!_Record(metadata) || metadata.name !== command.sandboxId || metadata.namespace !== command.namespace || !_Identifier(metadata.uid))
+		throw new Error(`Agent Sandbox '${command.sandboxId}' has unexpected coordinates`);
+	return { podName: command.sandboxId, sandboxUid: metadata.uid };
+}
+
+/** Verifies the exact Pod instance, template ServiceAccount, and controlling Sandbox reference. */
+function _RuntimePod(value: unknown, command: AgentSandboxRuntimePodCommand, backingPod: _SandboxBackingPod): AgentSandboxRuntimePod
+{
+	if (!_Record(value))
+		throw new Error(`Agent Sandbox Pod '${backingPod.podName}' has an invalid resource shape`);
+	const metadata = value.metadata;
+	const spec = value.spec;
+	if (!_Record(metadata) || !_Record(spec) || metadata.name !== backingPod.podName || metadata.namespace !== command.namespace || !_Identifier(metadata.uid) || spec.serviceAccountName !== command.serviceAccountName || !_HasSandboxOwner(metadata.ownerReferences, command.sandboxId, backingPod.sandboxUid))
+		throw new Error(`Agent Sandbox Pod '${backingPod.podName}' does not match its assigned Sandbox identity`);
+	return { namespace: command.namespace, serviceAccountName: command.serviceAccountName, podUid: metadata.uid };
+}
+
+/** Requires a controller-owned current-version Sandbox owner reference on the backing Pod. */
+function _HasSandboxOwner(value: unknown, sandboxId: string, sandboxUid: string): boolean
+{
+	return Array.isArray(value) && value.some(function _MatchesSandboxOwner(owner: unknown): boolean
+	{
+		return _Record(owner) && owner.apiVersion === `${_AGENT_SANDBOX_API_GROUP}/${_AGENT_SANDBOX_API_VERSION}` && owner.kind === "Sandbox" && owner.name === sandboxId && owner.uid === sandboxUid && owner.controller === true;
+	});
+}
+
+/** Narrows untrusted Kubernetes data without accepting arrays as resource records. */
+function _Record(value: unknown): value is Record<string, unknown>
+{
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Checks a nonempty Kubernetes UID without normalizing the controller-owned value. */
+function _Identifier(value: unknown): value is string
+{
+	return typeof value === "string" && value.trim().length > 0 && value === value.trim();
+}

--- a/libs/contracts/src/__tests__/conversation-computer.types.test.ts
+++ b/libs/contracts/src/__tests__/conversation-computer.types.test.ts
@@ -42,6 +42,7 @@ describe("conversation computer contracts", function ()
 			generation: computer.leaseGeneration,
 			sandboxClaimId: "claim-3",
 			sandboxId: "sandbox-3",
+			runtimePod: { namespace: "sandbox", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-3" },
 			state: ComputerLeaseStates.Active,
 			claimedAt: "2026-08-31T20:01:00.000Z",
 			expiresAt: "2026-08-31T20:06:00.000Z",

--- a/libs/contracts/src/conversation-computer.types.ts
+++ b/libs/contracts/src/conversation-computer.types.ts
@@ -207,6 +207,23 @@ export interface ConversationComputer
 }
 
 /**
+ * Identifies the exact controller-owned Pod that realizes one active sandbox lease.
+ *
+ * The lease retains this immutable Kubernetes identity after the server verifies the ready claim,
+ * Sandbox owner reference, ServiceAccount, and Pod UID together. A later runtime TokenReview must match
+ * all three coordinates before it can act for this computer generation.
+ */
+export interface ComputerLeaseRuntimePod
+{
+	/** Names the release-owned namespace containing the Sandbox Pod. */
+	readonly namespace: string;
+	/** Names the ServiceAccount fixed by the admitted SandboxTemplate. */
+	readonly serviceAccountName: string;
+	/** Identifies the one Kubernetes Pod instance rather than its reusable name. */
+	readonly podUid: string;
+}
+
+/**
  * Represents one fenced live sandbox realization of a conversation computer.
  *
  * Its generation prevents a replaced or stale Pod from acting as the current computer. A logical
@@ -226,6 +243,8 @@ export interface ComputerLease
 	readonly sandboxClaimId: string;
 	/** Identifies the upstream sandbox after assignment. */
 	readonly sandboxId: string | null;
+	/** Records the exact backing Pod after a ready Sandbox assignment is verified. */
+	readonly runtimePod: ComputerLeaseRuntimePod | null;
 	/** States whether this realization may process work. */
 	readonly state: ComputerLeaseStates;
 	/** Records when this lease was claimed. */


### PR DESCRIPTION
## Summary

- persist the exact Sandbox Pod namespace, ServiceAccount, and UID on every active ConversationComputer lease
- verify the pinned Agent Sandbox v1.0.0 claim-to-Sandbox-to-Pod path before a lease becomes Warm
- derive the expected ServiceAccount from immutable release configuration and grant only namespaced read access required for verification

## Checkpoint

This checkpoint establishes durable compute provenance. It intentionally does not expose the runtime endpoint or add Sandbox-to-server NetworkPolicy traffic; the next checkpoint will bind TokenReview to this stored Pod identity.

## Security

- a ready SandboxClaim alone never activates a lease
- the server verifies the claim-assigned Sandbox, its current UID, the v1 name-matched backing Pod, that Pod's controller owner UID, its fixed ServiceAccount, and its unique Pod UID
- history envelopes and transitions retain this evidence and reject a same-generation Pod replacement
- the release Role allows claim create/get plus namespaced Sandbox and Pod get only: no list, watch, or mutation

## Validation

- `backend-server-infra-agent-sandbox-claims:test` — 12 passing
- `backend-server-conversations:test` — 167 passing
- `opencrane:test` — 97 passing
- `agent-sandbox:test` Helm contract — passing
- targeted TypeScript lint, style, module-growth, Prisma-boundary, release-versioning, and diff checks — passing

## Review

- architecture gate passed after verifying the v1.0.0 Sandbox-name Pod convention and exact Sandbox UID owner reference
- independent review caught the obsolete annotation assumption; this PR fixes it and adds the no-annotation regression fixture
- reaper found no deletions; its fixture and RBAC-documentation corrections are included
- documentation gate passed

## Stack

Base: #784 (`feat/issue-759-conversation-computer-runtime-profile`). This PR contains three reviewable commits: durable history contract, reconciliation adapter/composition, and chart RBAC/configuration.

## Review order

#783 → #784 → #785