### PR TITLE
🔐 bootstrap the fenced ConversationComputer runtime

### DIFF
--- a/apps/agent-runtime/src/README.md
+++ b/apps/agent-runtime/src/README.md
@@ -12,6 +12,7 @@ results and therefore cannot repeat a provider action after reconnecting.
 
 ```text
 runtime.py  warm binding, process lifecycle, and bounded reconnects
+conversation_computer/  mounted Sandbox bootstrap contract and fenced execution exchange
 │
 ├── bootstrap/ ───────────────────────┐
 │   proof evidence + one-use binding  │

--- a/apps/agent-runtime/src/conversation_computer/README.md
+++ b/apps/agent-runtime/src/conversation_computer/README.md
@@ -1,0 +1,39 @@
+# ConversationComputer bootstrap client
+
+> [agent-runtime](../../README.md) › conversation-computer
+
+## What it owns
+
+This package reads the immutable Agent Sandbox bootstrap files and exchanges the Pod's projected
+Kubernetes token for server-derived ConversationComputer execution coordinates. It gives the later
+agent loop no way to select its own conversation, execution, or lease generation.
+
+```
+immutable ConfigMap + Downward label + projected token
+                         │
+                         ▼
+        conversation-computer bootstrap client ◄── HERE
+                         │ checked Pod identity
+                         ▼
+          server-derived computer execution
+```
+
+**In this flow:** [agent runtime](../../README.md) · [Agent Sandbox chart](../../../_infra/agent-sandbox/README.md)
+
+The client denies malformed mounted contracts, denied tokens, and malformed responses. It preserves
+no credential or lease state, and it neither starts a model loop nor authorises a product action.
+
+## Public surface
+
+- `read_bootstrap_settings` validates the three mounted bootstrap inputs.
+- `bootstrap_execution` requests and validates the single fenced execution response.
+
+## Boundary
+
+The server remains the execution authority. This client does not open a command stream, read
+conversation history, or execute an external tool.
+
+## See also
+
+- Parent: [agent runtime](../../README.md)
+- Release contract: [Agent Sandbox chart](../../../_infra/agent-sandbox/README.md)

--- a/apps/agent-runtime/src/conversation_computer/README.md
+++ b/apps/agent-runtime/src/conversation_computer/README.md
@@ -27,6 +27,8 @@ no credential or lease state, and it neither starts a model loop nor authorises 
 
 - `read_bootstrap_settings` validates the three mounted bootstrap inputs.
 - `bootstrap_execution` requests and validates the single fenced execution response.
+- `run` retries only unavailable bootstrap transport, then hands the checked execution once to a
+  separately composed product-loop adapter.
 
 ## Boundary
 

--- a/apps/agent-runtime/src/conversation_computer/__init__.py
+++ b/apps/agent-runtime/src/conversation_computer/__init__.py
@@ -1,0 +1,1 @@
+"""Expose the ConversationComputer bootstrap client without starting an agent loop."""

--- a/apps/agent-runtime/src/conversation_computer/bootstrap.py
+++ b/apps/agent-runtime/src/conversation_computer/bootstrap.py
@@ -11,6 +11,7 @@ import os
 from dataclasses import dataclass
 from collections.abc import Callable
 from urllib.error import HTTPError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 _CONFIG_DIRECTORY = "/var/run/opencrane/conversation-computer"
@@ -57,7 +58,8 @@ def read_bootstrap_settings(
     endpoint = read(f"{_CONFIG_DIRECTORY}/endpoint").strip()
     protocol_version = read(f"{_CONFIG_DIRECTORY}/protocol-version").strip()
     token_audience = read(f"{_CONFIG_DIRECTORY}/token-audience").strip()
-    if not endpoint.startswith(("http://", "https://")) or protocol_version != _PROTOCOL_VERSION or token_audience != _TOKEN_AUDIENCE:
+    parsed_endpoint = urlparse(endpoint)
+    if parsed_endpoint.scheme not in ("http", "https") or not parsed_endpoint.netloc or parsed_endpoint.params or parsed_endpoint.query or parsed_endpoint.fragment or protocol_version != _PROTOCOL_VERSION or token_audience != _TOKEN_AUDIENCE:
         raise ConversationComputerBootstrapDeniedError("ConversationComputer runtime bootstrap contract is invalid")
     # 2. Require the identity label admission policy stamped onto this exact Pod.
     computer_id = (get_environment("OPENCRANE_CONVERSATION_COMPUTER_ID") or "").strip()

--- a/apps/agent-runtime/src/conversation_computer/bootstrap.py
+++ b/apps/agent-runtime/src/conversation_computer/bootstrap.py
@@ -1,0 +1,127 @@
+"""Read one fixed Sandbox bootstrap contract and exchange it for fenced execution coordinates.
+
+The Agent Sandbox Pod receives its endpoint and protocol revision from an immutable ConfigMap, its
+computer identifier from the Downward API, and a short-lived token from a projected volume. This
+module joins those three independently owned inputs without accepting a caller-selected execution
+or preserving the token after a request completes.
+"""
+
+import json
+import os
+from dataclasses import dataclass
+from collections.abc import Callable
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+_CONFIG_DIRECTORY = "/var/run/opencrane/conversation-computer"
+_TOKEN_PATH = "/var/run/secrets/opencrane/conversation-computer/token"
+_PROTOCOL_VERSION = "conversation-computer-runtime.v1"
+_TOKEN_AUDIENCE = "opencrane-conversation-computer-runtime"
+
+
+class ConversationComputerBootstrapDeniedError(RuntimeError):
+    """Signal a permanent refusal to bootstrap this Sandbox Pod's admitted computer."""
+
+
+@dataclass(frozen=True)
+class ConversationComputerBootstrapSettings:
+    """Hold the fixed runtime contract mounted into one Agent Sandbox Pod."""
+
+    endpoint: str
+    computer_id: str
+    token_path: str
+
+
+@dataclass(frozen=True)
+class ConversationComputerExecution:
+    """Hold the server-derived execution coordinates released after Pod identity verification."""
+
+    computer_id: str
+    conversation_id: str
+    execution_id: str
+    lease_generation: int
+
+
+def read_bootstrap_settings(
+    read_file: Callable[[str], str] | None = None,
+    environment: Callable[[str], str | None] | None = None,
+) -> ConversationComputerBootstrapSettings:
+    """Read and validate the immutable ConfigMap, Downward API, and projected-token locations.
+
+    The protocol and audience files are checked locally before any outbound request. A substituted
+    ConfigMap therefore fails closed instead of making the runtime negotiate an older protocol.
+    """
+    read = read_file or _read_file
+    get_environment = environment or os.environ.get
+    # 1. Accept only the endpoint released by the mounted protocol revision.
+    endpoint = read(f"{_CONFIG_DIRECTORY}/endpoint").strip()
+    protocol_version = read(f"{_CONFIG_DIRECTORY}/protocol-version").strip()
+    token_audience = read(f"{_CONFIG_DIRECTORY}/token-audience").strip()
+    if not endpoint.startswith(("http://", "https://")) or protocol_version != _PROTOCOL_VERSION or token_audience != _TOKEN_AUDIENCE:
+        raise ConversationComputerBootstrapDeniedError("ConversationComputer runtime bootstrap contract is invalid")
+    # 2. Require the identity label admission policy stamped onto this exact Pod.
+    computer_id = (get_environment("OPENCRANE_CONVERSATION_COMPUTER_ID") or "").strip()
+    if not computer_id or len(computer_id) > 128:
+        raise ConversationComputerBootstrapDeniedError("ConversationComputer runtime computer identity is invalid")
+    # 3. Retain only the token location so kubelet rotation is observed at request time.
+    return ConversationComputerBootstrapSettings(endpoint=endpoint.rstrip("/"), computer_id=computer_id, token_path=_TOKEN_PATH)
+
+
+def bootstrap_execution(
+    settings: ConversationComputerBootstrapSettings,
+    read_file: Callable[[str], str] | None = None,
+    open_request: Callable[[Request], object] | None = None,
+) -> ConversationComputerExecution:
+    """Exchange the projected Pod token for one server-derived active computer execution.
+
+    A 401, 403, or malformed successful response is permanent because retrying cannot change the
+    Pod identity or its admitted lease. Transport and server availability failures propagate for
+    the process supervisor to retry with a freshly projected token.
+    """
+    read = read_file or _read_file
+    token = read(settings.token_path).strip()
+    if not token:
+        raise ConversationComputerBootstrapDeniedError("ConversationComputer runtime token is empty")
+    request = Request(
+        f"{settings.endpoint}/bootstrap",
+        data=json.dumps({"computerId": settings.computer_id}, separators=(",", ":")).encode("utf-8"),
+        headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with (open_request or _open_request)(request) as response:
+            if getattr(response, "status", None) != 200:
+                raise RuntimeError("ConversationComputer bootstrap returned an unexpected status")
+            return _read_execution(response.read(), settings.computer_id)
+    except HTTPError as error:
+        if error.code in (401, 403, 400):
+            raise ConversationComputerBootstrapDeniedError("ConversationComputer runtime bootstrap was denied") from error
+        raise
+
+
+def _read_execution(value: bytes, expected_computer_id: str) -> ConversationComputerExecution:
+    """Validate the complete response before coordinates can enter a future runtime command loop."""
+    try:
+        response = json.loads(value.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ConversationComputerBootstrapDeniedError("ConversationComputer bootstrap returned invalid JSON") from error
+    if not isinstance(response, dict) or set(response) != {"computerId", "conversationId", "executionId", "leaseGeneration"}:
+        raise ConversationComputerBootstrapDeniedError("ConversationComputer bootstrap returned invalid coordinates")
+    computer_id = response["computerId"]
+    conversation_id = response["conversationId"]
+    execution_id = response["executionId"]
+    lease_generation = response["leaseGeneration"]
+    if computer_id != expected_computer_id or not all(isinstance(identifier, str) and 0 < len(identifier) <= 128 for identifier in (computer_id, conversation_id, execution_id)) or not isinstance(lease_generation, int) or isinstance(lease_generation, bool) or lease_generation < 1:
+        raise ConversationComputerBootstrapDeniedError("ConversationComputer bootstrap returned mismatched coordinates")
+    return ConversationComputerExecution(computer_id=computer_id, conversation_id=conversation_id, execution_id=execution_id, lease_generation=lease_generation)
+
+
+def _read_file(path: str) -> str:
+    """Read one mounted ConfigMap or projected-token file without caching its contents."""
+    with open(path, "r", encoding="utf-8") as file:
+        return file.read()
+
+
+def _open_request(request: Request) -> object:
+    """Open one bounded bootstrap request through Python's standard HTTPS transport."""
+    return urlopen(request, timeout=10)

--- a/apps/agent-runtime/src/conversation_computer/supervisor.py
+++ b/apps/agent-runtime/src/conversation_computer/supervisor.py
@@ -1,0 +1,61 @@
+"""Supervise the one fenced bootstrap exchange before a ConversationComputer loop begins.
+
+This module owns only retry policy. The later command-loop adapter receives already checked
+execution coordinates and remains responsible for model work, interruption, elicitation, and
+terminal behaviour. Keeping that split prevents a retrying transport concern from becoming a
+second product-loop authority.
+"""
+
+import random
+import time
+from collections.abc import Callable
+from urllib.error import HTTPError, URLError
+
+from ..observability import log
+from .bootstrap import (
+    ConversationComputerBootstrapDeniedError,
+    ConversationComputerBootstrapSettings,
+    ConversationComputerExecution,
+    bootstrap_execution as _bootstrap_execution,
+)
+
+
+def retry_delay(attempt: int) -> float:
+    """Return a bounded jittered delay after a retryable bootstrap failure."""
+    return min(30.0, (2 ** min(attempt, 5)) + random.uniform(0.0, 1.0))
+
+
+def run(
+    settings: ConversationComputerBootstrapSettings,
+    bootstrap: Callable[[ConversationComputerBootstrapSettings], ConversationComputerExecution] = _bootstrap_execution,
+    start_loop: Callable[[ConversationComputerExecution], None] | None = None,
+    wait: Callable[[float], None] = time.sleep,
+) -> None:
+    """Bootstrap one admitted computer, then hand it once to the future product-loop adapter.
+
+    A permanent denial exits the Pod because its Pod identity and immutable contract cannot change.
+    Availability failures retry with a freshly read projected token inside ``bootstrap``. A returned
+    execution is passed once to the loop adapter; this supervisor never starts, replaces, or resumes
+    an execution itself.
+    """
+    if start_loop is None:
+        raise RuntimeError("ConversationComputer loop adapter must be composed before runtime startup")
+    attempts = 0
+    while True:
+        try:
+            # Bootstrap rereads the projected token so retrying an unavailable server never caches
+            # a credential beyond the request that used it.
+            execution = bootstrap(settings)
+            break
+        except ConversationComputerBootstrapDeniedError as error:
+            # A denied identity, contract, or lease has no Pod-local recovery path.
+            log("conversation_computer_bootstrap_denied", computerId=settings.computer_id, errorType=type(error).__name__)
+            return
+        except (HTTPError, URLError, OSError, RuntimeError) as error:
+            # Transport and control-plane availability may change without changing execution trust.
+            attempts += 1
+            delay_seconds = retry_delay(attempts)
+            log("conversation_computer_bootstrap_retry", computerId=settings.computer_id, errorType=type(error).__name__, retryInSeconds=round(delay_seconds, 2))
+            wait(delay_seconds)
+    # The server-derived execution is now the only input the product-loop adapter receives.
+    start_loop(execution)

--- a/apps/agent-runtime/tests/test_conversation_computer_bootstrap.py
+++ b/apps/agent-runtime/tests/test_conversation_computer_bootstrap.py
@@ -57,6 +57,17 @@ class ConversationComputerBootstrapTests(unittest.TestCase):
         with self.assertRaises(ConversationComputerBootstrapDeniedError):
             read_bootstrap_settings(files.__getitem__, lambda _name: "computer-1")
 
+    def test_rejects_a_mount_endpoint_without_a_network_authority(self) -> None:
+        """A malformed immutable endpoint cannot become a retryable request failure."""
+        files = {
+            "/var/run/opencrane/conversation-computer/endpoint": "http:",
+            "/var/run/opencrane/conversation-computer/protocol-version": "conversation-computer-runtime.v1",
+            "/var/run/opencrane/conversation-computer/token-audience": "opencrane-conversation-computer-runtime",
+        }
+
+        with self.assertRaises(ConversationComputerBootstrapDeniedError):
+            read_bootstrap_settings(files.__getitem__, lambda _name: "computer-1")
+
     def test_accepts_only_the_matching_server_execution(self) -> None:
         """The bootstrap request sends only the Downward-API computer id and verifies its echo."""
         settings = ConversationComputerBootstrapSettings("http://server/runtime", "computer-1", "/token")

--- a/apps/agent-runtime/tests/test_conversation_computer_bootstrap.py
+++ b/apps/agent-runtime/tests/test_conversation_computer_bootstrap.py
@@ -1,0 +1,93 @@
+"""Test the fixed ConversationComputer Sandbox bootstrap exchange without a cluster."""
+
+import json
+import io
+import unittest
+from urllib.error import HTTPError
+
+from src.conversation_computer.bootstrap import (
+    ConversationComputerBootstrapDeniedError,
+    ConversationComputerBootstrapSettings,
+    bootstrap_execution,
+    read_bootstrap_settings,
+)
+
+
+class _Response:
+    """Provide the minimal successful HTTP response shape used by the bootstrap client."""
+
+    status = 200
+
+    def __init__(self, body: object) -> None:
+        self._body = json.dumps(body).encode("utf-8")
+
+    def __enter__(self) -> "_Response":
+        return self
+
+    def __exit__(self, *_arguments: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._body
+
+
+class ConversationComputerBootstrapTests(unittest.TestCase):
+    """Prove that the runtime accepts only the exact mounted and server-derived contract."""
+
+    def test_reads_the_fixed_mount_contract(self) -> None:
+        """The runtime obtains its computer identity only from the admission-stamped Pod label."""
+        files = {
+            "/var/run/opencrane/conversation-computer/endpoint": "http://server/runtime\n",
+            "/var/run/opencrane/conversation-computer/protocol-version": "conversation-computer-runtime.v1\n",
+            "/var/run/opencrane/conversation-computer/token-audience": "opencrane-conversation-computer-runtime\n",
+        }
+
+        settings = read_bootstrap_settings(files.__getitem__, lambda name: "computer-1" if name == "OPENCRANE_CONVERSATION_COMPUTER_ID" else None)
+
+        self.assertEqual(settings, ConversationComputerBootstrapSettings(endpoint="http://server/runtime", computer_id="computer-1", token_path="/var/run/secrets/opencrane/conversation-computer/token"))
+
+    def test_rejects_a_substituted_protocol_contract(self) -> None:
+        """A mounted protocol downgrade ends the runtime before it can send its token."""
+        files = {
+            "/var/run/opencrane/conversation-computer/endpoint": "http://server/runtime",
+            "/var/run/opencrane/conversation-computer/protocol-version": "conversation-computer-runtime.v0",
+            "/var/run/opencrane/conversation-computer/token-audience": "opencrane-conversation-computer-runtime",
+        }
+
+        with self.assertRaises(ConversationComputerBootstrapDeniedError):
+            read_bootstrap_settings(files.__getitem__, lambda _name: "computer-1")
+
+    def test_accepts_only_the_matching_server_execution(self) -> None:
+        """The bootstrap request sends only the Downward-API computer id and verifies its echo."""
+        settings = ConversationComputerBootstrapSettings("http://server/runtime", "computer-1", "/token")
+        captured: list[object] = []
+
+        def _open(request: object) -> _Response:
+            captured.append(request)
+            return _Response({"computerId": "computer-1", "conversationId": "conversation-1", "executionId": "execution-1", "leaseGeneration": 2})
+
+        execution = bootstrap_execution(settings, lambda _path: "token-value", _open)
+
+        self.assertEqual(execution.execution_id, "execution-1")
+        self.assertEqual(json.loads(captured[0].data.decode("utf-8")), {"computerId": "computer-1"})
+
+    def test_rejects_a_foreign_computer_response(self) -> None:
+        """A server response cannot move this Pod onto another admitted computer execution."""
+        settings = ConversationComputerBootstrapSettings("http://server/runtime", "computer-1", "/token")
+
+        with self.assertRaises(ConversationComputerBootstrapDeniedError):
+            bootstrap_execution(settings, lambda _path: "token-value", lambda _request: _Response({"computerId": "computer-2", "conversationId": "conversation-1", "executionId": "execution-1", "leaseGeneration": 2}))
+
+    def test_treats_an_identity_refusal_as_permanent(self) -> None:
+        """Retrying a denied Pod cannot create a new lease or recover a revoked identity."""
+        settings = ConversationComputerBootstrapSettings("http://server/runtime", "computer-1", "/token")
+
+        def _deny(_request: object) -> object:
+            raise HTTPError("http://server/runtime/bootstrap", 403, "denied", {}, io.BytesIO())
+
+        with self.assertRaises(ConversationComputerBootstrapDeniedError):
+            bootstrap_execution(settings, lambda _path: "token-value", _deny)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/agent-runtime/tests/test_conversation_computer_supervisor.py
+++ b/apps/agent-runtime/tests/test_conversation_computer_supervisor.py
@@ -1,0 +1,57 @@
+"""Test ConversationComputer bootstrap retry policy without a server or model loop."""
+
+import unittest
+from urllib.error import URLError
+
+from src.conversation_computer.bootstrap import (
+    ConversationComputerBootstrapDeniedError,
+    ConversationComputerBootstrapSettings,
+    ConversationComputerExecution,
+)
+from src.conversation_computer.supervisor import run
+
+
+class ConversationComputerSupervisorTests(unittest.TestCase):
+    """Prove bootstrap retries cannot become a local execution-selection mechanism."""
+
+    _SETTINGS = ConversationComputerBootstrapSettings("http://server/runtime", "computer-1", "/token")
+    _EXECUTION = ConversationComputerExecution("computer-1", "conversation-1", "execution-1", 2)
+
+    def test_denial_never_starts_the_loop(self) -> None:
+        """A denied Pod exits instead of retrying or borrowing another computer execution."""
+        started: list[ConversationComputerExecution] = []
+
+        def _deny(_settings: ConversationComputerBootstrapSettings) -> ConversationComputerExecution:
+            raise ConversationComputerBootstrapDeniedError("denied")
+
+        run(self._SETTINGS, _deny, started.append)
+
+        self.assertEqual(started, [])
+
+    def test_unavailable_bootstrap_retries_then_hands_off_once(self) -> None:
+        """A transient failure rereads bootstrap state before one server-derived loop handoff."""
+        attempts = 0
+        waits: list[float] = []
+        started: list[ConversationComputerExecution] = []
+
+        def _bootstrap(_settings: ConversationComputerBootstrapSettings) -> ConversationComputerExecution:
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                raise URLError("temporarily unavailable")
+            return self._EXECUTION
+
+        run(self._SETTINGS, _bootstrap, started.append, waits.append)
+
+        self.assertEqual(attempts, 2)
+        self.assertEqual(started, [self._EXECUTION])
+        self.assertEqual(len(waits), 1)
+
+    def test_missing_loop_adapter_refuses_runtime_startup(self) -> None:
+        """Bootstrap coordinates cannot be logged or abandoned when no product loop owns them."""
+        with self.assertRaisesRegex(RuntimeError, "loop adapter"):
+            run(self._SETTINGS, lambda _settings: self._EXECUTION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/opencrane/README.md
+++ b/apps/opencrane/README.md
@@ -92,7 +92,8 @@ its resources to the lifecycle owner.
 - `src/app/conversation-computer-sandbox-reconciliation-composition.ts` replays the same durable
   activation history and keeps only outstanding computer generations in a bounded status-polling
   set. It rechecks history and reads each exact Agent Sandbox claim until the controller makes it
-  ready or its durable lease expires; it never lists, watches, or controls Pods.
+  ready or its durable lease expires. After it records the checked active Pod, the server appends
+  the sole fenced computer execution; it never lists, watches, or controls Pods.
 - `src/app/kubernetes-clients.ts` constructs the exact Kubernetes clients the process needs.
 - `src/app/public-app.ts` builds the browser-session-authenticated API.
 - The neutral [membership](../../libs/backend/server/iam/membership/main/README.md) package owns

--- a/apps/opencrane/src/app/__tests__/conversation-computer-sandbox-reconciliation-composition.test.ts
+++ b/apps/opencrane/src/app/__tests__/conversation-computer-sandbox-reconciliation-composition.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { HistoryStore } from "@opencrane/backend/server/infra/history-store";
-import { ConversationComputerSandboxReconciliationOutcomes } from "@opencrane/backend/server/conversations";
+import { ConversationComputerExecutionStartOutcomes, ConversationComputerSandboxReconciliationOutcomes } from "@opencrane/backend/server/conversations";
 
 import { _StartConversationComputerSandboxReconciliationWorker } from "../conversation-computer-sandbox-reconciliation-composition";
 
@@ -21,8 +21,14 @@ const _stream = vi.hoisted(function _Stream()
 
 vi.mock("../log", function _Log()
 {
-	return { _log: { error: vi.fn(), fatal: vi.fn() } };
+	return { _log: { error: vi.fn(), fatal: vi.fn(), warn: vi.fn() } };
 });
+
+/** Builds a server-owned execution-start port that never lets the worker choose execution facts. */
+function _Executions()
+{
+	return { start: vi.fn().mockResolvedValue({ outcome: ConversationComputerExecutionStartOutcomes.Started, execution: { id: "execution-1" } }) };
+}
 
 describe("ConversationComputer sandbox reconciliation composition", function _ReconciliationCompositionSuite()
 {
@@ -38,11 +44,13 @@ describe("ConversationComputer sandbox reconciliation composition", function _Re
 		const subscription = { events: _stream.events, close: vi.fn(async function _Close() { _stream.close(); }) };
 		const subscribe = vi.fn().mockResolvedValue(subscription);
 		const authority = { reconcile: vi.fn().mockResolvedValue("warmed") };
-		const worker = await _StartConversationComputerSandboxReconciliationWorker({ subscribe } as unknown as HistoryStore, authority as never, "testv5");
+		const executions = _Executions();
+		const worker = await _StartConversationComputerSandboxReconciliationWorker({ subscribe } as unknown as HistoryStore, authority as never, executions as never, "testv5");
 
 		expect(subscribe).toHaveBeenCalledWith({ streamName: "computer-activations-testv5", fromRevision: 0n });
 		await vi.advanceTimersByTimeAsync(1_000);
 		expect(authority.reconcile).toHaveBeenCalledWith({ siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1", generation: 2 });
+		expect(executions.start).toHaveBeenCalledWith({ siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1", generation: 2 });
 
 		await worker.stop();
 		expect(subscription.close).toHaveBeenCalledOnce();
@@ -61,7 +69,7 @@ describe("ConversationComputer sandbox reconciliation composition", function _Re
 		})();
 		const subscription = { events, close: vi.fn(async function _Close() { resolveStream(); }) };
 		const authority = { reconcile: vi.fn().mockImplementation(async function _Reconcile() { await new Promise<void>(function _Wait(resolve) { resolvePass = resolve; }); return "pending"; }) };
-		const worker = await _StartConversationComputerSandboxReconciliationWorker({ subscribe: vi.fn().mockResolvedValue(subscription) } as unknown as HistoryStore, authority as never, "testv5");
+		const worker = await _StartConversationComputerSandboxReconciliationWorker({ subscribe: vi.fn().mockResolvedValue(subscription) } as unknown as HistoryStore, authority as never, _Executions() as never, "testv5");
 
 		await vi.advanceTimersByTimeAsync(1_000);
 		const stopping = worker.stop();
@@ -87,12 +95,14 @@ describe("ConversationComputer sandbox reconciliation composition", function _Re
 		})();
 		const subscription = { events, close: vi.fn(async function _Close() { resolveStream(); }) };
 		const authority = { reconcile: vi.fn(async function _Reconcile(command: { readonly computerId: string }) { return command.computerId === "computer-9" ? ConversationComputerSandboxReconciliationOutcomes.Warmed : ConversationComputerSandboxReconciliationOutcomes.Pending; }) };
-		const worker = await _StartConversationComputerSandboxReconciliationWorker({ subscribe: vi.fn().mockResolvedValue(subscription) } as unknown as HistoryStore, authority as never, "testv5");
+		const executions = _Executions();
+		const worker = await _StartConversationComputerSandboxReconciliationWorker({ subscribe: vi.fn().mockResolvedValue(subscription) } as unknown as HistoryStore, authority as never, executions as never, "testv5");
 
 		await vi.advanceTimersByTimeAsync(1_000);
 		expect(authority.reconcile).not.toHaveBeenCalledWith(expect.objectContaining({ computerId: "computer-9" }));
 		await vi.advanceTimersByTimeAsync(1_000);
 		expect(authority.reconcile).toHaveBeenCalledWith(expect.objectContaining({ computerId: "computer-9" }));
+		expect(executions.start).toHaveBeenCalledWith(expect.objectContaining({ computerId: "computer-9" }));
 
 		await worker.stop();
 	});

--- a/apps/opencrane/src/app/__tests__/conversation-computer-sandbox-reconciliation-composition.test.ts
+++ b/apps/opencrane/src/app/__tests__/conversation-computer-sandbox-reconciliation-composition.test.ts
@@ -56,6 +56,49 @@ describe("ConversationComputer sandbox reconciliation composition", function _Re
 		expect(subscription.close).toHaveBeenCalledOnce();
 	});
 
+	it("recovers execution admission from an already warm exact generation after a restart", async function _RecoversWarmExecutionAdmission()
+	{
+		vi.useFakeTimers();
+		let resolveStream: () => void;
+		const streamClosed = new Promise<void>(function _CreateStreamClose(resolve) { resolveStream = resolve; });
+		const events = (async function* _Events()
+		{
+			yield { id: "activation-recovery", streamName: "computer-activations-testv5", type: "opencrane.computer.activation-requested.v1", data: { siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1", generation: 2 }, metadata: {}, revision: 1n, recordedAt: new Date("2026-09-01T00:00:00.000Z") };
+			await streamClosed;
+		})();
+		const subscription = { events, close: vi.fn(async function _Close() { resolveStream(); }) };
+		const authority = { reconcile: vi.fn().mockResolvedValue(ConversationComputerSandboxReconciliationOutcomes.ExecutionPending) };
+		const executions = _Executions();
+		const worker = await _StartConversationComputerSandboxReconciliationWorker({ subscribe: vi.fn().mockResolvedValue(subscription) } as unknown as HistoryStore, authority as never, executions as never, "testv5");
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(executions.start).toHaveBeenCalledWith({ siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1", generation: 2 });
+
+		await worker.stop();
+	});
+
+	it("retries a transient execution-admission failure against the same warm generation", async function _RetriesExecutionAdmission()
+	{
+		vi.useFakeTimers();
+		let resolveStream: () => void;
+		const streamClosed = new Promise<void>(function _CreateStreamClose(resolve) { resolveStream = resolve; });
+		const events = (async function* _Events()
+		{
+			yield { id: "activation-retry", streamName: "computer-activations-testv5", type: "opencrane.computer.activation-requested.v1", data: { siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1", generation: 2 }, metadata: {}, revision: 1n, recordedAt: new Date("2026-09-01T00:00:00.000Z") };
+			await streamClosed;
+		})();
+		const subscription = { events, close: vi.fn(async function _Close() { resolveStream(); }) };
+		const authority = { reconcile: vi.fn().mockResolvedValueOnce(ConversationComputerSandboxReconciliationOutcomes.Warmed).mockResolvedValueOnce(ConversationComputerSandboxReconciliationOutcomes.ExecutionPending) };
+		const executions = { start: vi.fn().mockRejectedValueOnce(new Error("temporary history error")).mockResolvedValueOnce({ outcome: ConversationComputerExecutionStartOutcomes.Started, execution: { id: "execution-1" } }) };
+		const worker = await _StartConversationComputerSandboxReconciliationWorker({ subscribe: vi.fn().mockResolvedValue(subscription) } as unknown as HistoryStore, authority as never, executions as never, "testv5");
+
+		await vi.advanceTimersByTimeAsync(1_000);
+		await vi.advanceTimersByTimeAsync(1_000);
+		expect(executions.start).toHaveBeenCalledTimes(2);
+
+		await worker.stop();
+	});
+
 	it("waits for an in-flight status pass before its HistoryStore subscription can close", async function _DrainsStatusPass()
 	{
 		vi.useFakeTimers();

--- a/apps/opencrane/src/app/conversation-computer-sandbox-reconciliation-composition.ts
+++ b/apps/opencrane/src/app/conversation-computer-sandbox-reconciliation-composition.ts
@@ -85,7 +85,7 @@ async function _ReadActivationLocators(events: AsyncIterable<HistoryRecordedEven
 	}
 }
 
-/** Reconciles one bounded batch and preserves only claims whose transient result is Pending. */
+/** Reconciles one bounded batch and retains exact warm generations until execution admission converges. */
 async function _ReconcileOutstanding(authority: ConversationComputerSandboxReconciliationAuthority, executions: Pick<ConversationComputerExecutionAuthority, "start">, outstanding: Map<string, ConversationComputerActivationCommand>, cursor: number): Promise<number>
 {
 	const entries = [...outstanding.entries()];
@@ -99,10 +99,14 @@ async function _ReconcileOutstanding(authority: ConversationComputerSandboxRecon
 		{
 			const outcome = await authority.reconcile(command);
 			// 1. Admit an execution only after reconciliation persisted the checked active Sandbox Pod.
-			if (outcome === ConversationComputerSandboxReconciliationOutcomes.Warmed)
+			const executionPending = outcome === ConversationComputerSandboxReconciliationOutcomes.Warmed || outcome === ConversationComputerSandboxReconciliationOutcomes.ExecutionPending;
+			// 2. Retire the polling locator once durable state moved beyond a pending claim or execution admission.
+			if (executionPending)
+			{
 				await _StartExecution(executions, command);
-			// 2. Retire the polling locator once durable state moved beyond a pending claim.
-			if (outcome !== ConversationComputerSandboxReconciliationOutcomes.Pending)
+				outstanding.delete(key);
+			}
+			else if (outcome !== ConversationComputerSandboxReconciliationOutcomes.Pending)
 				outstanding.delete(key);
 			// 3. Surface release contradictions without inventing a replacement claim or lease.
 			if (outcome === ConversationComputerSandboxReconciliationOutcomes.Blocked)

--- a/apps/opencrane/src/app/conversation-computer-sandbox-reconciliation-composition.ts
+++ b/apps/opencrane/src/app/conversation-computer-sandbox-reconciliation-composition.ts
@@ -1,5 +1,5 @@
-import { ConversationComputerSandboxReconciliationOutcomes, type ConversationComputerActivationCommand } from "@opencrane/backend/server/conversations";
-import type { ConversationComputerSandboxReconciliationAuthority } from "@opencrane/backend/server/conversations";
+import { ConversationComputerExecutionStartOutcomes, ConversationComputerSandboxReconciliationOutcomes, type ConversationComputerActivationCommand } from "@opencrane/backend/server/conversations";
+import type { ConversationComputerExecutionAuthority, ConversationComputerSandboxReconciliationAuthority } from "@opencrane/backend/server/conversations";
 import type { HistoryRecordedEvent, HistoryStore } from "@opencrane/backend/server/infra/history-store";
 
 import type { OpenCraneConversationComputerSandboxReconciliationWorker } from "./conversation-computer-sandbox-reconciliation-composition.types";
@@ -27,7 +27,7 @@ const _RECONCILIATION_INTERVAL_MILLISECONDS = 1_000;
  * @returns A worker that stops polling and closes its regular stream before KurrentDB closes.
  * @throws {Error} Propagates a failure to open the regular history subscription.
  */
-export async function _StartConversationComputerSandboxReconciliationWorker(historyStore: HistoryStore, authority: ConversationComputerSandboxReconciliationAuthority, siloId: string): Promise<OpenCraneConversationComputerSandboxReconciliationWorker>
+export async function _StartConversationComputerSandboxReconciliationWorker(historyStore: HistoryStore, authority: ConversationComputerSandboxReconciliationAuthority, executions: Pick<ConversationComputerExecutionAuthority, "start">, siloId: string): Promise<OpenCraneConversationComputerSandboxReconciliationWorker>
 {
 	const streamName = `computer-activations-${siloId}`;
 	const subscription = await historyStore.subscribe({ streamName, fromRevision: 0n });
@@ -49,7 +49,7 @@ export async function _StartConversationComputerSandboxReconciliationWorker(hist
 	{
 		if (reconciliationPass !== null)
 			return;
-		reconciliationPass = _ReconcileOutstanding(authority, outstanding, reconciliationCursor).then(function _AdvanceReconciliationCursor(nextCursor)
+		reconciliationPass = _ReconcileOutstanding(authority, executions, outstanding, reconciliationCursor).then(function _AdvanceReconciliationCursor(nextCursor)
 		{
 			reconciliationCursor = nextCursor;
 		}).catch(function _LogReconciliationFailure(error: unknown)
@@ -86,7 +86,7 @@ async function _ReadActivationLocators(events: AsyncIterable<HistoryRecordedEven
 }
 
 /** Reconciles one bounded batch and preserves only claims whose transient result is Pending. */
-async function _ReconcileOutstanding(authority: ConversationComputerSandboxReconciliationAuthority, outstanding: Map<string, ConversationComputerActivationCommand>, cursor: number): Promise<number>
+async function _ReconcileOutstanding(authority: ConversationComputerSandboxReconciliationAuthority, executions: Pick<ConversationComputerExecutionAuthority, "start">, outstanding: Map<string, ConversationComputerActivationCommand>, cursor: number): Promise<number>
 {
 	const entries = [...outstanding.entries()];
 	if (entries.length === 0)
@@ -98,8 +98,13 @@ async function _ReconcileOutstanding(authority: ConversationComputerSandboxRecon
 		try
 		{
 			const outcome = await authority.reconcile(command);
+			// 1. Admit an execution only after reconciliation persisted the checked active Sandbox Pod.
+			if (outcome === ConversationComputerSandboxReconciliationOutcomes.Warmed)
+				await _StartExecution(executions, command);
+			// 2. Retire the polling locator once durable state moved beyond a pending claim.
 			if (outcome !== ConversationComputerSandboxReconciliationOutcomes.Pending)
 				outstanding.delete(key);
+			// 3. Surface release contradictions without inventing a replacement claim or lease.
 			if (outcome === ConversationComputerSandboxReconciliationOutcomes.Blocked)
 				_log.error({ computerId: command.computerId, generation: command.generation, siloId: command.siloId }, "conversation computer sandbox reconciliation is blocked by release or claim evidence");
 		}
@@ -109,6 +114,14 @@ async function _ReconcileOutstanding(authority: ConversationComputerSandboxRecon
 		}
 	}));
 	return (start + batch.length) % entries.length;
+}
+
+/** Starts the sole server-owned execution after its exact Sandbox-backed lease became warm. */
+async function _StartExecution(executions: Pick<ConversationComputerExecutionAuthority, "start">, command: ConversationComputerActivationCommand): Promise<void>
+{
+	const result = await executions.start(command);
+	if (result.outcome === ConversationComputerExecutionStartOutcomes.Unavailable)
+		_log.warn({ computerId: command.computerId, generation: command.generation, siloId: command.siloId }, "conversation computer became unavailable before execution admission");
 }
 
 /** Validates one status-reconciliation locator without treating arbitrary stream data as a claim target. */

--- a/apps/opencrane/src/index.ts
+++ b/apps/opencrane/src/index.ts
@@ -5,7 +5,7 @@ import "./app/instrument";
 import type { PrismaClient } from "@prisma/client";
 import { __CreateManagedRunAdmissionPort, __CreatePersonalRunAdmissionPort, __ReadRunAdmissionConcurrencyPolicy, _CreateRunAdmissionCapacityGate } from "@opencrane/backend/agents/execution/admission";
 import { _CreateElicitationInterruptReader } from "@opencrane/backend/agents/execution/elicitation";
-import { ConversationComputerActivationClaimAuthority, ConversationComputerHistory, ConversationComputerSandboxReconciliationAuthority, _CreatePrismaSelfConversationSocketServer } from "@opencrane/backend/server/conversations";
+import { ConversationComputerActivationClaimAuthority, ConversationComputerExecutionAuthority, ConversationComputerHistory, ConversationComputerSandboxReconciliationAuthority, _CreatePrismaSelfConversationSocketServer } from "@opencrane/backend/server/conversations";
 import type { ConversationComputerActivationAuthority } from "@opencrane/backend/server/conversations";
 import { _CreateConversationAttachmentAdmission } from "@opencrane/backend/server/conversation-assets";
 import { _KubernetesAgentSandboxClaimAuthority, _KubernetesAgentSandboxClaimObservationReader, _KubernetesAgentSandboxRuntimePodReader } from "@opencrane/backend/server/infra/agent-sandbox-claims";
@@ -68,6 +68,7 @@ async function _Main(): Promise<void>
 	const providerEffects = _CreateProviderEffectCommandExecutor(prisma, kubernetes.coreApi, config.runtime.serverNamespace, _log);
 	let conversationComputerActivationAuthority: ConversationComputerActivationAuthority | null = null;
 	let conversationComputerSandboxReconciliationAuthority: ConversationComputerSandboxReconciliationAuthority | null = null;
+	let conversationComputerExecutionAuthority: ConversationComputerExecutionAuthority | null = null;
 	if (config.runtime.conversationComputerActivation !== null)
 	{
 		const profiles = _CreateConversationComputerActivationProfileResolver(config.runtime.conversationComputerActivation, config.runtime.siloId);
@@ -84,6 +85,7 @@ async function _Main(): Promise<void>
 			runtimePods: new _KubernetesAgentSandboxRuntimePodReader(kubernetes.customApi, kubernetes.coreApi),
 			clock: { now: function _Now() { return new Date(); } },
 		});
+		conversationComputerExecutionAuthority = new ConversationComputerExecutionAuthority(new ConversationComputerHistory(historyStore.historyStore), { now: function _Now() { return new Date(); } });
 	}
 
 	// 5. Build separate HTTP listeners; only the internal app receives workload-only routes.
@@ -97,11 +99,11 @@ async function _Main(): Promise<void>
 		? null
 		: await _StartConversationComputerActivationWorker(historyStore.historyStore, conversationComputerActivationAuthority, config.runtime.siloId);
 	let conversationComputerSandboxReconciliation: OpenCraneConversationComputerSandboxReconciliationWorker | null = null;
-	if (conversationComputerSandboxReconciliationAuthority !== null)
+	if (conversationComputerSandboxReconciliationAuthority !== null && conversationComputerExecutionAuthority !== null)
 	{
 		try
 		{
-			conversationComputerSandboxReconciliation = await _StartConversationComputerSandboxReconciliationWorker(historyStore.historyStore, conversationComputerSandboxReconciliationAuthority, config.runtime.siloId);
+			conversationComputerSandboxReconciliation = await _StartConversationComputerSandboxReconciliationWorker(historyStore.historyStore, conversationComputerSandboxReconciliationAuthority, conversationComputerExecutionAuthority, config.runtime.siloId);
 		}
 		catch (error)
 		{

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -63,7 +63,7 @@ cross-coordinate snapshot fails closed. This history authority does not create a
 activate a sandbox, use PostgreSQL, or receive a direct KurrentDB client.
 
 `ConversationComputerExecutionAuthority` is the next boundary after a sandbox claim becomes ready.
-It starts the loop only by appending one server-generated execution to the computer's warm active
+The server's Sandbox reconciliation worker starts the loop only by appending one server-generated execution to the computer's warm active
 lease. If a caller loses the response while another server process wins the append race, it reloads
 and returns that stored execution instead of starting another one. A sandbox never creates or picks
 this execution: it must remain unavailable whenever the computer is cold, cooling, expired, replaced,

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-computer-sandbox-reconciliation-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-computer-sandbox-reconciliation-authority.test.ts
@@ -102,9 +102,17 @@ describe("ConversationComputerSandboxReconciliationAuthority", function _Reconci
 		expect(fixture.history.append).toHaveBeenCalledWith(expect.objectContaining({ computer: expect.objectContaining({ state: ConversationComputerStates.RecoveryRequired }), lease: expect.objectContaining({ state: ComputerLeaseStates.Lost }) }));
 	});
 
-	it("ignores a stale or already-converged activation locator", async function _IgnoresStaleLocator()
+	it("retains one current warm generation for restart-safe execution admission", async function _RetainsWarmGeneration()
 	{
 		const fixture = _Authority(_Current({ computer: { ..._Current().computer, state: ConversationComputerStates.Warm }, lease: { ..._Current().lease, state: ComputerLeaseStates.Active, sandboxId: "sandbox-1", runtimePod: { namespace: "testv5", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-1" } } }));
+
+		await expect(fixture.authority.reconcile(_Command)).resolves.toBe(ConversationComputerSandboxReconciliationOutcomes.ExecutionPending);
+		expect(fixture.observations.observe).not.toHaveBeenCalled();
+	});
+
+	it("ignores a stale or terminal activation locator", async function _IgnoresStaleLocator()
+	{
+		const fixture = _Authority(_Current({ computer: { ..._Current().computer, state: ConversationComputerStates.Warm }, lease: { ..._Current().lease, state: ComputerLeaseStates.Active, sandboxId: "sandbox-1", runtimePod: { namespace: "testv5", serviceAccountName: "agent-sandbox-runtime", podUid: "pod-uid-1" }, expiresAt: "2026-09-01T00:09:00.000Z" } }));
 
 		await expect(fixture.authority.reconcile(_Command)).resolves.toBe(ConversationComputerSandboxReconciliationOutcomes.Ignored);
 		expect(fixture.observations.observe).not.toHaveBeenCalled();

--- a/libs/backend/server/conversations/main/src/conversation-computer-sandbox-reconciliation-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computer-sandbox-reconciliation-authority.ts
@@ -35,6 +35,8 @@ export class ConversationComputerSandboxReconciliationAuthority
 		const current = await this._LoadCurrentComputer(command);
 		if (_IsCurrentPendingGeneration(current, command))
 			return this._ReconcilePendingDispatch(current, command);
+		if (_IsCurrentWarmGeneration(current, command, this.dependencies.clock.now()))
+			return ConversationComputerSandboxReconciliationOutcomes.ExecutionPending;
 		if (!_IsCurrentDispatchedGeneration(current, command))
 			return ConversationComputerSandboxReconciliationOutcomes.Ignored;
 		const profile = await this.dependencies.profiles.resolve({ siloId: command.siloId, profileRevisionId: current.computer.profileRevisionId });
@@ -126,4 +128,16 @@ function _IsCurrentPendingGeneration(current: CurrentConversationComputer | null
 		&& current.lease !== null
 		&& current.lease.state === ComputerLeaseStates.Claimed
 		&& current.lease.generation === command.generation;
+}
+
+/** Retains one exact warm lease until the separate server-owned execution admission has converged. */
+function _IsCurrentWarmGeneration(current: CurrentConversationComputer | null, command: ConversationComputerActivationCommand, now: Date): current is CurrentConversationComputer & { readonly lease: NonNullable<CurrentConversationComputer["lease"]> }
+{
+	return current !== null
+		&& current.computer.state === ConversationComputerStates.Warm
+		&& current.computer.leaseGeneration === command.generation
+		&& current.lease !== null
+		&& current.lease.state === ComputerLeaseStates.Active
+		&& current.lease.generation === command.generation
+		&& Date.parse(current.lease.expiresAt) > now.getTime();
 }

--- a/libs/backend/server/conversations/main/src/conversation-computer-sandbox-reconciliation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computer-sandbox-reconciliation-authority.types.ts
@@ -7,16 +7,18 @@ import type { ConversationComputerHistory } from "./conversation-computers";
  * States the transient result of one exact Agent Sandbox status reconciliation pass.
  *
  * The worker uses this closed set to decide whether an in-memory polling locator stays in its next
- * pass. These values are never persisted: `Warmed` and `Compensated` report that this authority
- * appended the separately persisted computer and lease state, while the other outcomes append
- * nothing. An unknown result must not keep polling a claim.
+ * pass. These values are never persisted: `Warmed` reports an appended warm lease,
+ * `ExecutionPending` reports a current warm lease, and `Compensated` reports an appended recovery.
+ * The other outcomes append nothing. An unknown result must not keep polling a claim.
  */
 export enum ConversationComputerSandboxReconciliationOutcomes
 {
 	/** The claim has not published a current ready assignment, so the worker must retain the locator. */
 	Pending = "pending",
-	/** This pass appended Warm and an active lease from one current controller assignment, so polling stops. */
+	/** This pass appended Warm and an active lease from one current controller assignment, so execution admission runs. */
 	Warmed = "warmed",
+	/** The exact generation already has an unexpired warm lease, so the worker must recover execution admission. */
+	ExecutionPending = "execution-pending",
 	/** This pass appended RecoveryRequired and a lost lease after the dispatch expired, so polling stops. */
 	Compensated = "compensated",
 	/** Current history no longer names this generation as pending or dispatched, so polling stops. */


### PR DESCRIPTION
## Summary

- add the authenticated, lease-fenced runtime bootstrap client for a ConversationComputer Sandbox Pod
- derive the active execution from server history and start it only after the admitted Sandbox workload is warm
- supervise bootstrap failures and replay an in-flight execution admission without creating a second execution
- reject malformed bootstrap endpoints and untrusted runtime responses before they become execution state

## Why this checkpoint exists

This is the first runtime-side layer in the #759 replacement. It does not move the agentic loop into Agent Sandbox: Agent Sandbox supplies isolated compute, while OpenCrane remains the authority for history, commands, interruption, and elicitation.

## Validation

- focused ConversationComputer bootstrap and execution-admission tests
- TypeScript compilation and repository policy checks for the changed boundary

## Stack and review order

1. #787 supplies the fenced ConversationComputer-to-Sandbox identity projection.
2. This PR bootstraps the admitted runtime client.
3. #789 defines the protocol consumed by that client.
4. #790 adds server-owned durable command authority on top of the protocol.

## Review order

#783 → #784 → #785 → #786 → #787 → #788