### PR TITLE
📜 define the ConversationComputer runtime protocol

### DIFF
--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -113,6 +113,10 @@ runtime from silently interpreting a frozen snapshot with different assembly rul
   workload class cannot borrow the other's transport identity.
 - `RuntimeCommandKinds` and `RuntimeCandidateKinds` — documented string-backed discriminants that
   keep workload command and candidate control flow exhaustive while preserving protocol bytes.
+- `CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION`, `ConversationComputerRuntimeCommandEnvelope`,
+  and `ConversationComputerRuntimeTerminalReport` — the target Sandbox protocol for one
+  ConversationComputer execution. Its command and terminal coordinates fence one computer,
+  execution, and lease generation; it carries no `AgentRun`, attempt, or legacy runtime candidate.
 - `AGENT_CONTROLLER_PROJECTED_TOKEN_AUDIENCE`, `AGENT_CONTROLLER_SERVICE_ACCOUNT_NAME`, and
   `AgentControllerRunAttempt*` — the private controller handshake for claiming one authorised run,
   reporting the Kubernetes-issued Job identity, and committing that identity under the same database

--- a/libs/contracts/src/__tests__/conversation-computer-runtime-protocol.types.test.ts
+++ b/libs/contracts/src/__tests__/conversation-computer-runtime-protocol.types.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION, ConversationComputerRuntimeCommandKinds, ConversationComputerRuntimeTerminalStates } from "../index";
+import type { ConversationComputerRuntimeCommandEnvelope, ConversationComputerRuntimeTerminalReport } from "../index";
+
+describe("ConversationComputer runtime protocol contracts", function ()
+{
+	it("binds a target command and terminal report to one execution generation without AgentRun coordinates", function ()
+	{
+		const command: ConversationComputerRuntimeCommandEnvelope = {
+			protocolVersion: CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION,
+			commandId: "command-1",
+			sequence: 1,
+			computerId: "computer-1",
+			executionId: "execution-1",
+			leaseGeneration: 2,
+			issuedAt: "2026-09-01T00:00:00.000Z",
+			expiresAt: "2026-09-01T00:05:00.000Z",
+			kind: ConversationComputerRuntimeCommandKinds.StartTurn,
+			payload: { inputEntryId: "entry-1", inputPayloadRef: "payload://input-1", inputPayloadDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+		};
+		const terminal: ConversationComputerRuntimeTerminalReport = {
+			protocolVersion: command.protocolVersion,
+			commandId: command.commandId,
+			computerId: command.computerId,
+			executionId: command.executionId,
+			leaseGeneration: command.leaseGeneration,
+			state: ConversationComputerRuntimeTerminalStates.Completed,
+		};
+
+		expect(command.executionId).toBe(terminal.executionId);
+		expect(command.leaseGeneration).toBe(terminal.leaseGeneration);
+		expect(command.kind).not.toContain("attempt");
+	});
+});

--- a/libs/contracts/src/conversation-computer-runtime-protocol.types.ts
+++ b/libs/contracts/src/conversation-computer-runtime-protocol.types.ts
@@ -1,0 +1,170 @@
+/** Pins the revision carried by every frame between a ConversationComputer Sandbox and the server. */
+export const CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION = "opencrane.conversation-computer-runtime/v1";
+
+/** Gives each command and terminal report the same private protocol revision. */
+export type ConversationComputerRuntimeProtocolVersion = typeof CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION;
+
+/**
+ * Names the work the server may ask a ConversationComputer Sandbox to perform.
+ *
+ * Each member selects a different payload in {@link ConversationComputerRuntimeCommand}; the
+ * Sandbox receives the selected command rather than choosing work from ConversationComputer history.
+ */
+export enum ConversationComputerRuntimeCommandKinds
+{
+	/** Begins one newly admitted conversation turn from server-selected input. */
+	StartTurn = "start_turn",
+	/** Delivers one server-accepted participant response to the suspended loop. */
+	ResumeAfterInput = "resume_after_input",
+	/** Requests that the loop reach a safe interruption boundary before later work is selected. */
+	Interrupt = "interrupt",
+	/** Ends the active execution because the server has selected a terminal lifecycle transition. */
+	Stop = "stop",
+}
+
+/**
+ * Names the outcome a Sandbox reports after it finishes a command.
+ *
+ * A report records the loop's result but does not itself select a durable lifecycle transition.
+ */
+export enum ConversationComputerRuntimeTerminalStates
+{
+	/** Records that the target loop completed its selected work without a replacement command. */
+	Completed = "completed",
+	/** Records that the target loop observed the server-owned interruption or stop boundary. */
+	Interrupted = "interrupted",
+	/** Records a failure category without accepting provider or exception text as history. */
+	Failed = "failed",
+}
+
+/**
+ * Names the lifecycle decisions the server can deliver as a stop command.
+ *
+ * A stop command tells the Sandbox why to stop; a terminal report tells the server how the loop ended.
+ */
+export enum ConversationComputerRuntimeStopReasons
+{
+	/** Ends the loop because its exact active lease reached its server-owned expiry. */
+	LeaseExpired = "lease_expired",
+	/** Ends the loop because the computer entered its checked cooling lifecycle. */
+	ComputerCooling = "computer_cooling",
+	/** Ends the loop because the computer was permanently retired by the server. */
+	ComputerRetired = "computer_retired",
+	/** Ends the loop because current authorization no longer permits the execution. */
+	AuthorizationRevoked = "authorization_revoked",
+}
+
+/**
+ * Carries the protocol, identity, lease, and delivery fields for one server-issued command.
+ *
+ * The terminal report echoes the computer, execution, and lease-generation coordinates from this command.
+ */
+export interface ConversationComputerRuntimeCommandCoordinates
+{
+	/** Names the protocol revision that both the server router and Sandbox adapter must validate. */
+	readonly protocolVersion: ConversationComputerRuntimeProtocolVersion;
+	/** Identifies the durable command so retries cannot select a second command effect. */
+	readonly commandId: string;
+	/** Orders commands monotonically within this exact execution. */
+	readonly sequence: number;
+	/** Names the logical computer whose current lease the command must revalidate. */
+	readonly computerId: string;
+	/** Names the server-created execution that owns the command. */
+	readonly executionId: string;
+	/** Fences the command to one Sandbox lease generation. */
+	readonly leaseGeneration: number;
+	/** Records the server instant at which this command became eligible for delivery. */
+	readonly issuedAt: string;
+	/** Rejects delayed delivery after the server-owned command deadline. */
+	readonly expiresAt: string;
+}
+
+/**
+ * Delivers the server-selected input that begins a target loop turn.
+ *
+ * It carries an immutable entry and protected-payload coordinates rather than plaintext.
+ */
+export interface ConversationComputerRuntimeStartTurnCommand
+{
+	/** Identifies the immutable conversation entry whose admission caused this turn. */
+	readonly inputEntryId: string;
+	/** References the protected input payload without putting plaintext on the durable command queue. */
+	readonly inputPayloadRef: string;
+	/** Binds the protected input payload that the runtime reads through its later narrow reader route. */
+	readonly inputPayloadDigest: `sha256:${string}`;
+}
+
+/**
+ * Delivers a server-accepted elicitation resolution to a loop waiting for participant input.
+ *
+ * Response coordinates stay nullable because an accepted resolution may not contain a response payload.
+ */
+export interface ConversationComputerRuntimeResumeAfterInputCommand
+{
+	/** Identifies the logical elicitation whose terminal resolution this command carries. */
+	readonly elicitationId: string;
+	/** Identifies the immutable resolution entry the server accepted for that elicitation. */
+	readonly resolutionEntryId: string;
+	/** References the protected response payload when a participant supplied one. */
+	readonly responsePayloadRef: string | null;
+	/** Binds the protected response payload when a participant supplied one. */
+	readonly responsePayloadDigest: `sha256:${string}` | null;
+}
+
+/** Delivers the history entry that tells an active target loop to reach an interruption boundary. */
+export interface ConversationComputerRuntimeInterruptCommand
+{
+	/** Identifies the server-admitted conversation entry that superseded the active work. */
+	readonly interruptionEntryId: string;
+}
+
+/** Delivers the server-owned reason that closes an active ConversationComputer execution. */
+export interface ConversationComputerRuntimeStopCommand
+{
+	/** Names the terminal reason without importing legacy run lifecycle categories. */
+	readonly reason: ConversationComputerRuntimeStopReasons;
+}
+
+/**
+ * Describes one target-loop command without carrying an AgentRun, attempt, or legacy candidate shape.
+ *
+ * The `kind` and `payload` stay paired, so a Sandbox cannot apply an interruption payload as start-turn input.
+ */
+export type ConversationComputerRuntimeCommand =
+	| { readonly kind: ConversationComputerRuntimeCommandKinds.StartTurn; readonly payload: ConversationComputerRuntimeStartTurnCommand }
+	| { readonly kind: ConversationComputerRuntimeCommandKinds.ResumeAfterInput; readonly payload: ConversationComputerRuntimeResumeAfterInputCommand }
+	| { readonly kind: ConversationComputerRuntimeCommandKinds.Interrupt; readonly payload: ConversationComputerRuntimeInterruptCommand }
+	| { readonly kind: ConversationComputerRuntimeCommandKinds.Stop; readonly payload: ConversationComputerRuntimeStopCommand };
+
+/** Combines the server-issued delivery coordinates with one target-loop command. */
+export type ConversationComputerRuntimeCommandEnvelope = ConversationComputerRuntimeCommandCoordinates & ConversationComputerRuntimeCommand;
+
+/**
+ * Carries the command identity and lease fields a Sandbox echoes in a terminal report.
+ *
+ * A terminal state alone does not identify the execution that reported it.
+ */
+export interface ConversationComputerRuntimeTerminalCoordinates
+{
+	/** Names the protocol revision that the runtime router validates before any durable terminal write. */
+	readonly protocolVersion: ConversationComputerRuntimeProtocolVersion;
+	/** Identifies the server-issued command that reached a terminal result. */
+	readonly commandId: string;
+	/** Names the logical computer that owns the reporting Sandbox. */
+	readonly computerId: string;
+	/** Names the active server-created execution that may accept this report. */
+	readonly executionId: string;
+	/** Fences the report to the admitted Sandbox lease generation. */
+	readonly leaseGeneration: number;
+}
+
+/**
+ * Reports one terminal target-loop outcome without claiming a durable lifecycle transition.
+ *
+ * Callers use the echoed coordinates to select the active execution before translating {@link state} into history.
+ */
+export interface ConversationComputerRuntimeTerminalReport extends ConversationComputerRuntimeTerminalCoordinates
+{
+	/** States the bounded outcome that the server terminal authority may translate into history. */
+	readonly state: ConversationComputerRuntimeTerminalStates;
+}

--- a/libs/contracts/src/index.ts
+++ b/libs/contracts/src/index.ts
@@ -36,6 +36,7 @@ export * from "./agent-controller-identity.types";
 export * from "./agent-identity.types";
 export * from "./agent-capability-grant.types";
 export * from "./conversation-computer.types";
+export * from "./conversation-computer-runtime-protocol.types";
 export * from "./conversation-entry.types";
 export * from "./conversation-entry.validator";
 // Keep sibling-only `_...` wire schemas and parsers out of the cross-package public surface.


### PR DESCRIPTION
## Summary

- define the versioned ConversationComputer runtime command and terminal-report protocol in shared contracts
- fence every command and terminal report to the computer, execution, and lease generation
- represent start, resume-after-input, interruption, and stop commands without carrying arbitrary runtime output
- add contract tests and package documentation for the protocol boundary

## Why this checkpoint exists

The runtime can request isolated compute from Agent Sandbox, but it cannot own conversation state. This protocol lets the OpenCrane-owned ConversationComputer loop issue commands and accept narrowly scoped terminal reports while preserving interruption and elicitation in canonical history.

## Validation

- `npx nx run contracts:test --skipNxCache`
- `npx nx run contracts:lint --skipNxCache`

## Stack and review order

1. #788 establishes the fenced bootstrap client.
2. This PR defines its stable command/report vocabulary.
3. #790 persists and selects those commands from server-owned history.

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789