### PR TITLE
🗃️ store ConversationComputer private payloads

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -830,6 +830,23 @@ CREATE TABLE "conversation_messages" (
 );
 
 -- CreateTable
+CREATE TABLE "conversation_private_payloads" (
+    "id" TEXT NOT NULL,
+    "silo_id" TEXT NOT NULL,
+    "conversation_id" TEXT NOT NULL,
+    "idempotency_key" TEXT NOT NULL,
+    "plaintext_digest" TEXT NOT NULL,
+    "ciphertext_digest" TEXT NOT NULL,
+    "key_id" TEXT NOT NULL,
+    "ciphertext" BYTEA NOT NULL,
+    "nonce" BYTEA NOT NULL,
+    "authentication_tag" BYTEA NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "conversation_private_payloads_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
 CREATE TABLE "conversation_run_events" (
     "conversation_id" TEXT NOT NULL,
     "run_id" TEXT NOT NULL,
@@ -2606,6 +2623,12 @@ CREATE UNIQUE INDEX "conversation_messages_conversation_id_id_key" ON "conversat
 CREATE UNIQUE INDEX "conversation_messages_conversation_id_idempotency_key_key" ON "conversation_messages"("conversation_id", "idempotency_key");
 
 -- CreateIndex
+CREATE INDEX "conversation_private_payloads_conversation_id_created_at_idx" ON "conversation_private_payloads"("conversation_id", "created_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversation_private_payloads_silo_id_conversation_id_idemp_key" ON "conversation_private_payloads"("silo_id", "conversation_id", "idempotency_key");
+
+-- CreateIndex
 CREATE INDEX "conversation_run_events_run_id_attempt_message_id_idx" ON "conversation_run_events"("run_id", "attempt", "message_id");
 
 CREATE UNIQUE INDEX "conversation_run_events_one_message_start" ON "conversation_run_events"("run_id", "attempt", "message_id") WHERE "type" = 'message.started';
@@ -3511,6 +3534,9 @@ ALTER TABLE "conversation_participants" ADD CONSTRAINT "conversation_participant
 
 -- AddForeignKey
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_conversation_id_fkey" FOREIGN KEY ("conversation_id") REFERENCES "conversations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "conversation_private_payloads" ADD CONSTRAINT "conversation_private_payloads_conversation_id_silo_id_fkey" FOREIGN KEY ("conversation_id", "silo_id") REFERENCES "conversations"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "conversation_run_events" ADD CONSTRAINT "conversation_run_events_conversation_id_fkey" FOREIGN KEY ("conversation_id") REFERENCES "conversations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
@@ -7482,6 +7508,17 @@ ALTER TABLE "conversation_participants" ADD CONSTRAINT "conversation_participant
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_source_check" CHECK ("source" IN ('user_input', 'model_output', 'tool_result', 'platform'));
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_blocks_check" CHECK (jsonb_typeof("blocks") = 'array');
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_idempotency_key_check" CHECK (length(btrim("idempotency_key")) BETWEEN 1 AND 128);
+ALTER TABLE "conversation_private_payloads" ADD CONSTRAINT "conversation_private_payloads_coordinates_check" CHECK (
+    length(btrim("silo_id")) BETWEEN 1 AND 256 AND
+    length(btrim("conversation_id")) BETWEEN 1 AND 256 AND
+    length(btrim("idempotency_key")) BETWEEN 1 AND 256 AND
+    "plaintext_digest" ~ '^sha256:[0-9a-f]{64}$' AND
+    "ciphertext_digest" ~ '^sha256:[0-9a-f]{64}$' AND
+    length(btrim("key_id")) BETWEEN 1 AND 64 AND
+    octet_length("ciphertext") > 0 AND
+    octet_length("nonce") = 12 AND
+    octet_length("authentication_tag") = 16
+);
 ALTER TABLE "conversation_messages" ADD CONSTRAINT "conversation_messages_provenance_check" CHECK (
         ("source" = 'user_input' AND "role" = 'user' AND "user_id" IS NOT NULL) OR
         ("source" = 'model_output' AND "role" = 'assistant' AND "user_id" IS NULL AND "run_id" IS NOT NULL) OR

--- a/apps/opencrane/prisma/schema/conversations.prisma
+++ b/apps/opencrane/prisma/schema/conversations.prisma
@@ -56,6 +56,7 @@ model Conversation {
   activitySequence              BigInt                          @unique @default(autoincrement()) @map("activity_sequence")
   participants                  ConversationParticipant[]
   messages                      ConversationMessage[]
+  privatePayloads               ConversationPrivatePayload[]
   runEvents                     ConversationRunEvent[]
   timelineEntries               ConversationTimelineEntry[]
   contextRevisions              ConversationContextRevision[]   @relation("ConversationContextRevisions")
@@ -118,6 +119,30 @@ model ConversationMessage {
   @@unique([conversationId, idempotencyKey])
   @@index([runId])
   @@map("conversation_messages")
+}
+
+/// Stores encrypted content for immutable ConversationComputer history entries.
+///
+/// When an authority appends an entry, it records `payload://<id>` and the ciphertext digest rather
+/// than text. The server stores the encrypted bytes under an idempotency key so a retry returns its
+/// original row, while changed text under that key fails before a participant history append.
+model ConversationPrivatePayload {
+  id                String       @id @default(cuid())
+  siloId            String       @map("silo_id")
+  conversationId    String       @map("conversation_id")
+  idempotencyKey    String       @map("idempotency_key")
+  plaintextDigest   String       @map("plaintext_digest")
+  ciphertextDigest  String       @map("ciphertext_digest")
+  keyId             String       @map("key_id")
+  ciphertext        Bytes
+  nonce             Bytes
+  authenticationTag Bytes        @map("authentication_tag")
+  createdAt         DateTime     @default(now()) @map("created_at")
+  conversation      Conversation @relation(fields: [conversationId, siloId], references: [id, siloId], onDelete: Restrict)
+
+  @@unique([siloId, conversationId, idempotencyKey])
+  @@index([conversationId, createdAt])
+  @@map("conversation_private_payloads")
 }
 
 model ConversationRunEvent {

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -640,6 +640,13 @@
 				"constructs": []
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-private-payload-repository.ts",
+				"adapter": "PrismaConversationPrivatePayloadRepository",
+				"contract": "ConversationPrivatePayloadRepository",
+				"contractImportPath": "../conversation-private-payload-store.types",
+				"constructs": []
+			},
+			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-agent-thread-parent-delivery-repository.ts",
 				"adapter": "PrismaAgentThreadParentDeliveryRepository",
 				"contract": "AgentThreadParentDeliveryRepository",

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -163,6 +163,12 @@ transport for workloads; it is not a browser fallback.
   reference; a Sandbox can only receive its oldest command and report that command's terminal state.
   An exact duplicate terminal report is an idempotent no-op; a stale, foreign, expired, skipped, or
   malformed report fails closed.
+- `ConversationPrivatePayloadStore` accepts text and coordinates from an authority that already
+  authorized the operation, encrypts the body under the dedicated ConversationComputer keyring, and
+  persists it against the `(silo, conversation, idempotency)` owner key. It returns only
+  `payload://…` and a ciphertext digest; a retry with the same text returns the original row, while
+  changed text fails closed. It does not authenticate a caller or append history, and remains
+  uncomposed until the ConversationComputer output authority can make its own history append.
 - `__CreateConversationComputerRuntimeCommandRouter` gives a reviewed Sandbox Pod the narrow
   `commands/next` and `commands/complete` transport. It derives the computer execution from history
   again on every request and compares the Pod UID, namespace, and service account with the active

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-private-payload-store.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-private-payload-store.test.ts
@@ -1,0 +1,91 @@
+import type { ConversationPayloadAssociatedData, ConversationPayloadCipher, SealedConversationPayload } from "@opencrane/backend/server/infra/conversation-payloads";
+import { describe, expect, it } from "vitest";
+
+import { ConversationPrivatePayloadStore } from "../conversation-private-payload-store";
+import type { ConversationPrivatePayloadRecord, ConversationPrivatePayloadRepository, ConversationPrivatePayloadStoreCommand } from "../conversation-private-payload-store.types";
+
+/** Records cipher calls while returning deterministic sealed bytes for store assertions. */
+class _Cipher implements ConversationPayloadCipher
+{
+	/** Counts encryption attempts so exact retries cannot silently re-encrypt a payload. */
+	public sealCalls = 0;
+	/** Captures the exact ownership coordinates authenticated with the ciphertext. */
+	public associatedData: ConversationPayloadAssociatedData | null = null;
+
+	/** Seals deterministic test bytes after recording the caller's associated data. */
+	async seal(_plaintext: Uint8Array, associatedData: ConversationPayloadAssociatedData): Promise<SealedConversationPayload>
+	{
+		this.sealCalls += 1;
+		this.associatedData = associatedData;
+		return { keyId: "key-1", ciphertext: Uint8Array.of(1, 2, 3), nonce: Uint8Array.of(4), authenticationTag: Uint8Array.of(5) };
+	}
+
+	/** Satisfies the cipher port; this store-only suite never reads ciphertext. */
+	async open(_sealed: SealedConversationPayload, _associatedData: ConversationPayloadAssociatedData): Promise<Uint8Array>
+	{
+		return new Uint8Array();
+	}
+}
+
+/** Models the database uniqueness key in memory for one storage authority test. */
+class _Repository implements ConversationPrivatePayloadRepository
+{
+	/** Holds the first record accepted for each exact private-payload owner key. */
+	private readonly records = new Map<string, ConversationPrivatePayloadRecord>();
+
+	/** Finds the first record for one exact durable owner key. */
+	async find(command: Pick<ConversationPrivatePayloadStoreCommand, "siloId" | "conversationId" | "idempotencyKey">): Promise<ConversationPrivatePayloadRecord | null>
+	{
+		return this.records.get(_Key(command)) ?? null;
+	}
+
+	/** Inserts only the first record for one exact durable owner key. */
+	async createIfAbsent(record: ConversationPrivatePayloadRecord): Promise<void>
+	{
+		this.records.set(_Key(record), this.records.get(_Key(record)) ?? record);
+	}
+}
+
+/** Derives the in-memory mirror of the database's composite uniqueness coordinates. */
+function _Key(command: Pick<ConversationPrivatePayloadStoreCommand, "siloId" | "conversationId" | "idempotencyKey">): string
+{
+	return `${command.siloId}/${command.conversationId}/${command.idempotencyKey}`;
+}
+
+/** Supplies one server-derived payload request. */
+function _Command(text: string = "Private agent reply"): ConversationPrivatePayloadStoreCommand
+{
+	return { siloId: "silo-1", conversationId: "conversation-1", idempotencyKey: "command-1", text };
+}
+
+describe("ConversationPrivatePayloadStore", function _ConversationPrivatePayloadStore()
+{
+	it("stores one encrypted winner and returns only its opaque history coordinates", async function _StoreWinner()
+	{
+		const cipher = new _Cipher();
+		const store = new ConversationPrivatePayloadStore(new _Repository(), cipher);
+		const stored = await store.storeText(_Command());
+		expect(stored.payloadRef).toMatch(/^payload:\/\/[A-Za-z0-9-]+$/u);
+		expect(stored.ciphertextDigest).toBe("sha256:039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81");
+		expect(cipher.associatedData).toMatchObject({ siloId: "silo-1", conversationId: "conversation-1", idempotencyKey: "command-1" });
+	});
+
+	it("returns the first exact winner without encrypting a retry again", async function _ExactRetry()
+	{
+		const cipher = new _Cipher();
+		const store = new ConversationPrivatePayloadStore(new _Repository(), cipher);
+		const first = await store.storeText(_Command());
+		const retry = await store.storeText(_Command());
+		expect(retry).toEqual(first);
+		expect(cipher.sealCalls).toBe(1);
+	});
+
+	it("rejects changed text reused under an existing durable command key", async function _ChangedRetry()
+	{
+		const cipher = new _Cipher();
+		const store = new ConversationPrivatePayloadStore(new _Repository(), cipher);
+		await store.storeText(_Command());
+		await expect(store.storeText(_Command("Changed agent reply"))).rejects.toThrow("Conversation private payload idempotency key already owns different text");
+		expect(cipher.sealCalls).toBe(1);
+	});
+});

--- a/libs/backend/server/conversations/main/src/__tests__/prisma-conversation-private-payload-repository.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/prisma-conversation-private-payload-repository.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaConversationPrivatePayloadRepository } from "../db/prisma-conversation-private-payload-repository";
+import type { ConversationPrivatePayloadStoreCommand } from "../conversation-private-payload-store.types";
+
+describe("PrismaConversationPrivatePayloadRepository", function _PrismaConversationPrivatePayloadRepository()
+{
+	it("selects only persisted owner coordinates from a broader store command", async function _SelectsOwnerKey()
+	{
+		const findUnique = vi.fn().mockResolvedValue(null);
+		const repository = new PrismaConversationPrivatePayloadRepository({ conversationPrivatePayload: { findUnique } } as never);
+		const command: ConversationPrivatePayloadStoreCommand = { siloId: "silo-1", conversationId: "conversation-1", idempotencyKey: "command-1", text: "Private reply" };
+		await repository.find(command);
+		expect(findUnique).toHaveBeenCalledWith({
+			where: { siloId_conversationId_idempotencyKey: { siloId: "silo-1", conversationId: "conversation-1", idempotencyKey: "command-1" } },
+		});
+	});
+});

--- a/libs/backend/server/conversations/main/src/conversation-private-payload-store.ts
+++ b/libs/backend/server/conversations/main/src/conversation-private-payload-store.ts
@@ -1,0 +1,116 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import type { ConversationPayloadCipher } from "@opencrane/backend/server/infra/conversation-payloads";
+
+import type { ConversationPrivatePayloadRecord, ConversationPrivatePayloadRepository, ConversationPrivatePayloadStore as ConversationPrivatePayloadStorePort, ConversationPrivatePayloadStoreCommand, StoredConversationPrivatePayload } from "./conversation-private-payload-store.types";
+
+/** Limits a body before the store allocates ciphertext for it. */
+const _MaximumTextBytes = 64 * 1024;
+
+/**
+ * Stores ConversationComputer text under one authorization-owned idempotency key.
+ *
+ * A composing authority supplies coordinates it derived after authorization. This class authenticates
+ * them with the ciphertext and returns no plaintext, leaving the caller to append the resulting
+ * reference to history in its own transaction.
+ * @implements ConversationPrivatePayloadStorePort
+ */
+export class ConversationPrivatePayloadStore implements ConversationPrivatePayloadStorePort
+{
+	/** Reads and creates rows keyed by silo, conversation, and idempotency key. */
+	private readonly repository: ConversationPrivatePayloadRepository;
+	/** Encrypts text and authenticates its ownership coordinates. */
+	private readonly cipher: ConversationPayloadCipher;
+
+	/**
+	 * Creates a private-payload store from a persistence adapter and cipher.
+	 *
+	 * @param repository - The adapter that retains the first row for each owner key.
+	 * @param cipher - The cipher that binds the row to its supplied ownership coordinates.
+	 */
+	constructor(repository: ConversationPrivatePayloadRepository, cipher: ConversationPayloadCipher)
+	{
+		this.repository = repository;
+		this.cipher = cipher;
+	}
+
+	/**
+	 * Stores a text body or returns the first row written for the same idempotency key.
+	 *
+	 * The initial lookup avoids encrypting a response-lost retry again. The second lookup makes the
+	 * database's unique row authoritative when two processes tried to write the same key. This method
+	 * does not authenticate callers or append history.
+	 *
+	 * @param command - The authorized text and its server-derived ownership coordinates.
+	 * @returns Opaque reference and digest for the first row that owns the key.
+	 * @throws Error when the command is malformed, the key already owns changed text, or the inserted row is absent.
+	 */
+	async storeText(command: ConversationPrivatePayloadStoreCommand): Promise<StoredConversationPrivatePayload>
+	{
+		_Validate(command);
+		const plaintext = Buffer.from(command.text, "utf8");
+		const plaintextDigest = _Digest(plaintext);
+
+		// 1. Read first so a response-lost retry returns its original row without encrypting again.
+		const existing = await this.repository.find(command);
+		if (existing !== null)
+			return _Stored(existing, plaintextDigest);
+
+		// 2. Encrypt validated text with the coordinates that a later history entry will retain.
+		const sealed = await this.cipher.seal(plaintext, {
+			formatVersion: "conversation-payload/v1",
+			siloId: command.siloId,
+			conversationId: command.conversationId,
+			idempotencyKey: command.idempotencyKey,
+			plaintextDigest,
+		});
+		const candidate: ConversationPrivatePayloadRecord = {
+			id: randomUUID(),
+			siloId: command.siloId,
+			conversationId: command.conversationId,
+			idempotencyKey: command.idempotencyKey,
+			plaintextDigest,
+			ciphertextDigest: _Digest(sealed.ciphertext),
+			keyId: sealed.keyId,
+			ciphertext: sealed.ciphertext,
+			nonce: sealed.nonce,
+			authenticationTag: sealed.authenticationTag,
+		};
+		await this.repository.createIfAbsent(candidate);
+
+		// 3. Read again because another process may have inserted the row while this process encrypted.
+		const stored = await this.repository.find(command);
+		if (stored === null)
+			throw new Error("Conversation private payload store lost its inserted record");
+		return _Stored(stored, plaintextDigest);
+	}
+}
+
+/** Creates the `sha256:` value stored as a plaintext or ciphertext digest. */
+function _Digest(value: Uint8Array): `sha256:${string}`
+{
+	return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+/** Rejects blank ownership coordinates and text that exceeds this store's body limit. */
+function _Validate(command: ConversationPrivatePayloadStoreCommand): void
+{
+	if (!_Identifier(command.siloId) || !_Identifier(command.conversationId) || !_Identifier(command.idempotencyKey))
+		throw new Error("Conversation private payload store requires non-blank ownership coordinates");
+	if (command.text.trim().length === 0 || Buffer.byteLength(command.text, "utf8") > _MaximumTextBytes)
+		throw new Error("Conversation private payload store requires bounded non-blank text");
+}
+
+/** Allows any non-blank identifier within the database guard's maximum length. */
+function _Identifier(value: string): boolean
+{
+	return value.trim().length > 0 && value.length <= 256;
+}
+
+/** Returns history values after confirming that the retained row has the requested plaintext digest. */
+function _Stored(record: ConversationPrivatePayloadRecord, plaintextDigest: `sha256:${string}`): StoredConversationPrivatePayload
+{
+	if (record.plaintextDigest !== plaintextDigest)
+		throw new Error("Conversation private payload idempotency key already owns different text");
+	return { payloadRef: `payload://${record.id}`, ciphertextDigest: record.ciphertextDigest };
+}

--- a/libs/backend/server/conversations/main/src/conversation-private-payload-store.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-private-payload-store.types.ts
@@ -1,0 +1,104 @@
+/**
+ * Carries the text and ownership coordinates for one private-payload write.
+ *
+ * The composing authority must derive the coordinates after it has authorized the operation. The
+ * store authenticates those coordinates with the ciphertext, so a copied row cannot serve another
+ * conversation or idempotency key.
+ * @see ConversationPayloadAssociatedData
+ */
+export interface ConversationPrivatePayloadStoreCommand
+{
+	/** Names the tenant that owns the payload and its encryption coordinates. */
+	readonly siloId: string;
+	/** Names the one conversation whose immutable history may later reference this payload. */
+	readonly conversationId: string;
+	/** Names the server-derived command or resolution key that owns the first stored body. */
+	readonly idempotencyKey: string;
+	/** Supplies one participant-visible text body that never enters immutable history plaintext. */
+	readonly text: string;
+}
+
+/**
+ * Returns the non-plaintext values that a ConversationComputer history entry may retain.
+ *
+ * A caller records these values instead of text. The digest lets a reader detect a substituted
+ * ciphertext before it asks the payload cipher to decrypt it.
+ */
+export interface StoredConversationPrivatePayload
+{
+	/** Names the opaque payload reference; only the server may resolve it to stored ciphertext. */
+	readonly payloadRef: `payload://${string}`;
+	/** Binds the history reference to the stored ciphertext bytes. */
+	readonly ciphertextDigest: `sha256:${string}`;
+}
+
+/**
+ * Represents one encrypted private-payload row between the store and its persistence adapter.
+ *
+ * The store creates `id`, derives both digests, and obtains the encrypted fields from
+ * {@link ConversationPayloadCipher}; callers cannot use this type to choose a different owner key.
+ */
+export interface ConversationPrivatePayloadRecord
+{
+	/** Identifies the server-generated payload record. */
+	readonly id: string;
+	/** Names the silo that owns this record. */
+	readonly siloId: string;
+	/** Names the one conversation that owns this record. */
+	readonly conversationId: string;
+	/** Names the idempotency key that owns the stored body. */
+	readonly idempotencyKey: string;
+	/** Holds the plaintext digest used only for exact retry comparison. */
+	readonly plaintextDigest: `sha256:${string}`;
+	/** Holds the ciphertext digest published in immutable history. */
+	readonly ciphertextDigest: `sha256:${string}`;
+	/** Names the retained encryption key needed for future protected reads. */
+	readonly keyId: string;
+	/** Holds AES-GCM ciphertext only. */
+	readonly ciphertext: Uint8Array;
+	/** Holds the random AES-GCM nonce. */
+	readonly nonce: Uint8Array;
+	/** Holds the AES-GCM authentication tag. */
+	readonly authenticationTag: Uint8Array;
+}
+
+/**
+ * Defines the persistence operations that preserve one body for each owner key.
+ *
+ * An implementation must return the stored row from `find` and leave that row unchanged when
+ * `createIfAbsent` sees the same key. The store reads again after insertion to identify which row
+ * the database retained during an insert race.
+ */
+export interface ConversationPrivatePayloadRepository
+{
+	/**
+	 * Loads the row for one silo, conversation, and idempotency key.
+	 *
+	 * @returns The stored row, or `null` when no write owns the key yet.
+	 */
+	find(command: Pick<ConversationPrivatePayloadStoreCommand, "siloId" | "conversationId" | "idempotencyKey">): Promise<ConversationPrivatePayloadRecord | null>;
+	/**
+	 * Attempts to store a candidate without replacing an existing row.
+	 *
+	 * @returns Nothing; callers must read the owner key again because a concurrent insert may have won.
+	 */
+	createIfAbsent(record: ConversationPrivatePayloadRecord): Promise<void>;
+}
+
+/**
+ * Encrypts an authorized text body and returns the values a history entry can retain.
+ *
+ * A repeat with the same text returns the original payload reference and digest. A repeat with
+ * changed text under the same idempotency key fails, so the caller cannot attach a new body to an
+ * existing command.
+ */
+export interface ConversationPrivatePayloadStore
+{
+	/**
+	 * Stores text for an owner key, or replays the first stored values for the same text.
+	 *
+	 * @returns Opaque history values for the stored row.
+	 * @throws Error when the command is invalid, the existing row has different text, or storage loses the inserted row.
+	 */
+	storeText(command: ConversationPrivatePayloadStoreCommand): Promise<StoredConversationPrivatePayload>;
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-private-payload-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-private-payload-repository.ts
@@ -1,0 +1,80 @@
+import type { Prisma } from "@prisma/client";
+
+import type { ConversationPrivatePayloadRecord, ConversationPrivatePayloadRepository, ConversationPrivatePayloadStoreCommand } from "../conversation-private-payload-store.types";
+
+/**
+ * Implements private-payload persistence with the transaction an authority already holds.
+ *
+ * The adapter never creates its own Prisma client, so the authority can make the payload row and a
+ * related history append part of the transaction it controls.
+ * @implements ConversationPrivatePayloadRepository
+ */
+export class PrismaConversationPrivatePayloadRepository implements ConversationPrivatePayloadRepository
+{
+	/** Executes payload reads and writes in the caller's transaction. */
+	private readonly transaction: Prisma.TransactionClient;
+
+	/**
+	 * Binds this adapter to an existing transaction.
+	 *
+	 * @param transaction - The Prisma transaction that also owns the caller's wider operation.
+	 */
+	constructor(transaction: Prisma.TransactionClient)
+	{
+		this.transaction = transaction;
+	}
+
+	/**
+	 * Finds the row for one owner key.
+	 *
+	 * @param command - The broader store command that supplies the three persisted key fields.
+	 * @returns The row that owns the key, or `null` if the key is unused.
+	 */
+	async find(command: Pick<ConversationPrivatePayloadStoreCommand, "siloId" | "conversationId" | "idempotencyKey">): Promise<ConversationPrivatePayloadRecord | null>
+	{
+		const record = await this.transaction.conversationPrivatePayload.findUnique({
+			where: { siloId_conversationId_idempotencyKey: _OwnerKey(command) },
+		});
+		return record === null ? null : _Record(record);
+	}
+
+	/**
+	 * Inserts a candidate without replacing the row that already owns its key.
+	 *
+	 * @param record - The encrypted row the store prepared after it found no existing row.
+	 * @returns Nothing; the store reads again to discover the retained row.
+	 */
+	async createIfAbsent(record: ConversationPrivatePayloadRecord): Promise<void>
+	{
+		const data = {
+			...record,
+			ciphertext: Buffer.from(record.ciphertext),
+			nonce: Buffer.from(record.nonce),
+			authenticationTag: Buffer.from(record.authenticationTag),
+		};
+		await this.transaction.conversationPrivatePayload.createMany({ data: [data], skipDuplicates: true });
+	}
+}
+
+/** Selects the three fields Prisma uses for the private-payload unique key. */
+function _OwnerKey(command: Pick<ConversationPrivatePayloadStoreCommand, "siloId" | "conversationId" | "idempotencyKey">): { siloId: string; conversationId: string; idempotencyKey: string }
+{
+	return { siloId: command.siloId, conversationId: command.conversationId, idempotencyKey: command.idempotencyKey };
+}
+
+/** Converts Prisma's stored bytes into the record shared with the private-payload store. */
+function _Record(record: Prisma.ConversationPrivatePayloadGetPayload<{}>): ConversationPrivatePayloadRecord
+{
+	return {
+		id: record.id,
+		siloId: record.siloId,
+		conversationId: record.conversationId,
+		idempotencyKey: record.idempotencyKey,
+		plaintextDigest: record.plaintextDigest as `sha256:${string}`,
+		ciphertextDigest: record.ciphertextDigest as `sha256:${string}`,
+		keyId: record.keyId,
+		ciphertext: record.ciphertext,
+		nonce: record.nonce,
+		authenticationTag: record.authenticationTag,
+	};
+}

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -30,6 +30,9 @@ export { PrismaAgentThreadParentDeliveryUnitOfWork } from "./db/prisma-agent-thr
 export { __CreateAgentThreadParentDeliveryRouter } from "./agent-thread-parent-delivery.router";
 export { BoundConversationWriter } from "./bound-conversation-writer";
 export type { BoundConversationWriterAppend, BoundConversationWriterBinding, BoundConversationWriterClock, BoundConversationWriterLeaseFence, BoundConversationWriterRateLimiter, BoundConversationWriterVisibilityPolicy, ComputerConversationEntryDraft } from "./bound-conversation-writer.types";
+export { ConversationPrivatePayloadStore } from "./conversation-private-payload-store";
+export type { ConversationPrivatePayloadRecord, ConversationPrivatePayloadRepository, ConversationPrivatePayloadStoreCommand, StoredConversationPrivatePayload } from "./conversation-private-payload-store.types";
+export { PrismaConversationPrivatePayloadRepository } from "./db/prisma-conversation-private-payload-repository";
 export { __RunConversationComputerActivationListener } from "./conversation-computer-activation";
 export type { ConversationComputerActivationAuthority, ConversationComputerActivationCommand, ConversationComputerActivationOutcome, ConversationComputerActivationParked } from "./conversation-computer-activation.types";
 export { ConversationComputerActivationClaimAuthority } from "./conversation-computer-activation-authority";

--- a/releases/0.11.0.json
+++ b/releases/0.11.0.json
@@ -4,7 +4,7 @@
   "database": {
     "schemaVersion": "0.11.0",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "324bfc588a00f0a3e85027359178e7797a54bd5c28246d96bc1c281eeb9103c5",
+    "baselineSha256": "92e80d9a8ab2f873ca1feb6c8004a35040e888c6d2cbbbc515bd7cba4bd470ea",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {


### PR DESCRIPTION
## Summary

- add the fresh `conversation_private_payloads` authority table, tenant-and-conversation ownership key, and database checks for encrypted payload material
- add `ConversationPrivatePayloadStore`, which encrypts server-authorized text and returns only `payload://…` plus a ciphertext digest for future immutable history entries
- make retries deterministic: the first exact command body wins, while a changed body under the same server-derived key is rejected before history can change
- add a transaction-bound Prisma repository that never opens its own client and strips non-persisted command fields from the compound unique query
- register the new adapter in the Prisma boundary policy and refresh the 0.11.0 fresh-baseline digest

## Why

ConversationComputer output and elicitation need durable, protected bodies without placing plaintext in Kurrent history. This checkpoint establishes that storage seam. It deliberately does not yet compose a runtime output authority, publish an output protocol route, or reuse the retired AgentRun / warm-runtime path.

## Validation

- `npx nx run backend-server-conversations:lint --skipNxCache`
- `npx nx run backend-server-conversations:test --skipNxCache` (27 files, 192 tests)
- `npm run test:authority-baseline -w @opencrane/server`
- `npm run check:release-versioning`
- `npm run check:prisma-boundaries -- --diff HEAD`
- `npm run check:module-growth -- --diff HEAD`
- `scripts/agent-style-check.sh --diff HEAD`
- `git diff --check`

## Review

An independent review found and this PR fixes the compound-key adapter bug where an otherwise-valid store command also carried plaintext `text` into Prisma's three-field unique selector. The regression test asserts that only persisted owner coordinates reach Prisma. The final comment gate reviewed the stable diff before the two commits were created.

## Stack

This is the next layer after #792's dedicated AES-GCM payload cipher. The next checkpoint will compose this store into the ConversationComputer-owned execution/output authority; it remains separate from Agent Sandbox compute and the removed warm runtime.

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793