### PR TITLE
🔐 redeem ConversationComputer work packages behind active leases

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -3901,21 +3901,16 @@ ALTER TABLE "oci_image_validations" ADD CONSTRAINT "oci_image_validations_result
     OR ("state" = 'rejected' AND "index_digest" IS NULL AND "image_manifest_digest" IS NULL AND "config_digest" IS NULL AND "registry_reference" IS NULL AND "failure_code" IN ('artifact_mismatch', 'bundle_too_large', 'malformed_zip_package', 'not_oci_image_layout', 'invalid_layout', 'invalid_index', 'invalid_image_manifest', 'validation_failed', 'registry_import_failed') AND "completed_at" IS NOT NULL)
 );
 
--- Null-safe immutable run/snapshot binding. SQL composite FKs alone skip checks when conversation_id is NULL.
-ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_run_digest_fkey"
-    FOREIGN KEY ("run_id", "input_digest", "conversation_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest")
-    REFERENCES "agent_runs"("id", "input_snapshot_digest", "conversation_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest")
-    ON DELETE RESTRICT ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;
-ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_input_snapshot_fkey"
-    FOREIGN KEY ("id", "input_snapshot_digest", "conversation_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest")
-    REFERENCES "run_input_snapshots"("run_id", "input_digest", "conversation_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest")
-    ON DELETE RESTRICT ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED;
+-- Null-safe immutable run/snapshot binding. The generated run/attempt/digest foreign key owns
+-- referential integrity; deferred guards below also compare nullable conversation coordinates and
+-- the serialized execution subject.
 ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_run_input_check" CHECK (
     ("conversation_id" IS NULL OR btrim("conversation_id") <> '')
-    AND btrim("capability_set_digest") <> ''
-    AND "capability_set_digest" ~ '^sha256:[0-9a-f]{64}$'
+    AND btrim("agent_identity_id") <> ''
+    AND btrim("principal_id") <> ''
+    AND jsonb_typeof("execution_subject") = 'object'
     AND jsonb_typeof("memory_facts") = 'array'
-	AND jsonb_typeof("mcp_tools") = 'array'
+    AND jsonb_typeof("mcp_tools") = 'array'
 );
 
 -- Channel-target constraints cannot be represented by Prisma relations/indexes alone.
@@ -4704,11 +4699,12 @@ BEGIN
         OR NEW."agent_revision_id" IS DISTINCT FROM OLD."agent_revision_id"
         OR NEW."conversation_id" IS DISTINCT FROM OLD."conversation_id"
         OR NEW."trigger" IS DISTINCT FROM OLD."trigger"
-        OR NEW."delegated_user_id" IS DISTINCT FROM OLD."delegated_user_id"
+        OR NEW."agent_identity_id" IS DISTINCT FROM OLD."agent_identity_id"
+        OR NEW."principal_id" IS DISTINCT FROM OLD."principal_id"
+        OR NEW."execution_subject" IS DISTINCT FROM OLD."execution_subject"
         OR NEW."request_idempotency_key" IS DISTINCT FROM OLD."request_idempotency_key"
         OR NEW."root_run_id" IS DISTINCT FROM OLD."root_run_id"
         OR NEW."parent_run_id" IS DISTINCT FROM OLD."parent_run_id"
-        OR NEW."effective_contract_digest" IS DISTINCT FROM OLD."effective_contract_digest"
         OR NEW."input_snapshot_digest" IS DISTINCT FROM OLD."input_snapshot_digest" THEN
         RAISE EXCEPTION 'AgentRun identity and accepted inputs are immutable';
     END IF;
@@ -4799,7 +4795,8 @@ BEGIN
         WHERE "run_id" = NEW."run_id" AND "attempt" = NEW."attempt"
           AND "agent_service_id" = NEW."agent_service_id"
           AND "agent_revision_id" = NEW."agent_revision_id"
-          AND "silo_id" = NEW."silo_id" AND "subject_id" = NEW."subject_id"
+          AND "silo_id" = NEW."silo_id" AND "agent_identity_id" = NEW."agent_identity_id"
+          AND "principal_id" = NEW."principal_id"
           AND "audience" = NEW."audience"
           AND "service_account_name" = NEW."service_account_name"
           AND "namespace" = NEW."namespace" AND "workload_kind" = NEW."workload_kind"
@@ -4816,7 +4813,10 @@ BEGIN
         OR NEW."generation" IS DISTINCT FROM OLD."generation"
         OR NEW."agent_service_id" IS DISTINCT FROM OLD."agent_service_id"
         OR NEW."agent_revision_id" IS DISTINCT FROM OLD."agent_revision_id"
-        OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id" OR NEW."subject_id" IS DISTINCT FROM OLD."subject_id"
+        OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id"
+        OR NEW."agent_identity_id" IS DISTINCT FROM OLD."agent_identity_id"
+        OR NEW."principal_id" IS DISTINCT FROM OLD."principal_id"
+        OR NEW."execution_subject" IS DISTINCT FROM OLD."execution_subject"
         OR NEW."audience" IS DISTINCT FROM OLD."audience"
         OR NEW."service_account_name" IS DISTINCT FROM OLD."service_account_name"
         OR NEW."namespace" IS DISTINCT FROM OLD."namespace"
@@ -4914,7 +4914,10 @@ BEGIN
     IF NEW."run_id" IS DISTINCT FROM OLD."run_id" OR NEW."attempt" IS DISTINCT FROM OLD."attempt"
         OR NEW."agent_service_id" IS DISTINCT FROM OLD."agent_service_id"
         OR NEW."agent_revision_id" IS DISTINCT FROM OLD."agent_revision_id"
-        OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id" OR NEW."subject_id" IS DISTINCT FROM OLD."subject_id"
+        OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id"
+        OR NEW."agent_identity_id" IS DISTINCT FROM OLD."agent_identity_id"
+        OR NEW."principal_id" IS DISTINCT FROM OLD."principal_id"
+        OR NEW."execution_subject" IS DISTINCT FROM OLD."execution_subject"
         OR NEW."audience" IS DISTINCT FROM OLD."audience"
         OR NEW."service_account_name" IS DISTINCT FROM OLD."service_account_name"
         OR NEW."namespace" IS DISTINCT FROM OLD."namespace"
@@ -5028,7 +5031,8 @@ BEGIN
         FROM "workload_assignments"
         WHERE "run_id" = NEW."run_id" AND "attempt" = NEW."attempt"
           AND "agent_service_id" = NEW."agent_service_id" AND "agent_revision_id" = NEW."agent_revision_id"
-          AND "silo_id" = NEW."silo_id" AND "subject_id" = NEW."subject_id"
+          AND "silo_id" = NEW."silo_id" AND "agent_identity_id" = NEW."agent_identity_id"
+          AND "principal_id" = NEW."principal_id"
           AND "audience" = NEW."workload_audience" AND "service_account_name" = NEW."service_account_name"
           AND "namespace" = NEW."namespace" AND "workload_kind" = NEW."workload_kind"
           AND "workload_uid" = NEW."workload_uid" AND "pod_uid" = NEW."pod_uid"
@@ -5053,7 +5057,9 @@ BEGIN
         OR NEW."attempt" IS DISTINCT FROM OLD."attempt" OR NEW."agent_revision_id" IS DISTINCT FROM OLD."agent_revision_id"
         OR NEW."agent_service_id" IS DISTINCT FROM OLD."agent_service_id" OR NEW."silo_id" IS DISTINCT FROM OLD."silo_id"
         OR NEW."proof_key_id" IS DISTINCT FROM OLD."proof_key_id" OR NEW."proof_key_thumbprint" IS DISTINCT FROM OLD."proof_key_thumbprint"
-        OR NEW."subject_id" IS DISTINCT FROM OLD."subject_id" OR NEW."workload_audience" IS DISTINCT FROM OLD."workload_audience"
+        OR NEW."agent_identity_id" IS DISTINCT FROM OLD."agent_identity_id"
+        OR NEW."principal_id" IS DISTINCT FROM OLD."principal_id"
+        OR NEW."workload_audience" IS DISTINCT FROM OLD."workload_audience"
         OR NEW."service_account_name" IS DISTINCT FROM OLD."service_account_name" OR NEW."namespace" IS DISTINCT FROM OLD."namespace"
         OR NEW."workload_kind" IS DISTINCT FROM OLD."workload_kind" OR NEW."workload_uid" IS DISTINCT FROM OLD."workload_uid"
         OR NEW."pod_uid" IS DISTINCT FROM OLD."pod_uid" OR NEW."resource_kind" IS DISTINCT FROM OLD."resource_kind"
@@ -5088,7 +5094,8 @@ BEGIN
         FROM "workload_assignments"
         WHERE "run_id" = OLD."run_id" AND "attempt" = OLD."attempt"
           AND "agent_service_id" = OLD."agent_service_id" AND "agent_revision_id" = OLD."agent_revision_id"
-          AND "silo_id" = OLD."silo_id" AND "subject_id" = OLD."subject_id"
+          AND "silo_id" = OLD."silo_id" AND "agent_identity_id" = OLD."agent_identity_id"
+          AND "principal_id" = OLD."principal_id"
           AND "audience" = OLD."workload_audience" AND "service_account_name" = OLD."service_account_name"
           AND "namespace" = OLD."namespace" AND "workload_kind" = OLD."workload_kind"
           AND "workload_uid" = OLD."workload_uid" AND "pod_uid" = OLD."pod_uid"
@@ -5460,7 +5467,7 @@ BEGIN
             RAISE EXCEPTION 'a new RuntimeSteeringRequest must begin pending without consumption evidence';
         END IF;
 
-        SELECT "attempt", "silo_id", "delegated_user_id", "state"
+        SELECT "attempt", "silo_id", "principal_id", "state"
         INTO run_attempt, run_silo_id, run_subject_id, run_state
         FROM "agent_runs"
         WHERE "id" = NEW."run_id"
@@ -6389,7 +6396,7 @@ BEGIN
         IF NOT EXISTS (SELECT 1 FROM "conversation_participants" WHERE "conversation_id" = NEW."source_conversation_id" AND "user_id" = NEW."user_id" AND "access_ended_position" IS NULL) THEN
             RAISE EXCEPTION 'PersonalConfigurationChange source conversation requires the initiating participant with current access';
         END IF;
-        SELECT "silo_id", "conversation_id", "agent_service_id", "delegated_user_id" INTO run_silo, run_conversation, run_service, run_user
+        SELECT "silo_id", "conversation_id", "agent_service_id", "principal_id" INTO run_silo, run_conversation, run_service, run_user
           FROM "agent_runs" WHERE "id" = NEW."source_run_id" FOR UPDATE;
         SELECT "silo_id", "kind", "active_revision_id" INTO service_silo, service_kind, active_agent
           FROM "agent_services" WHERE "id" = NEW."agent_service_id" FOR UPDATE;
@@ -7325,9 +7332,9 @@ ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_attempt_check" CHECK ("attem
 ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_nonempty_check" CHECK (
         btrim("silo_id") <> '' AND btrim("agent_service_id") <> '' AND
         btrim("agent_revision_id") <> '' AND btrim("request_idempotency_key") <> '' AND
-        btrim("root_run_id") <> '' AND btrim("effective_contract_digest") <> '' AND
+        btrim("root_run_id") <> '' AND btrim("agent_identity_id") <> '' AND btrim("principal_id") <> '' AND
         btrim("input_snapshot_digest") <> '' AND
-        "effective_contract_digest" ~ '^sha256:[0-9a-f]{64}$' AND
+        jsonb_typeof("execution_subject") = 'object' AND
         "input_snapshot_digest" ~ '^sha256:[0-9a-f]{64}$'
     );
 ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_terminal_check" CHECK (
@@ -7347,8 +7354,9 @@ ALTER TABLE "agent_runs" ADD CONSTRAINT "agent_runs_cost_check" CHECK (
 ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_version_check" CHECK ("snapshot_version" > 0);
 ALTER TABLE "run_input_snapshots" ADD CONSTRAINT "run_input_snapshots_nonempty_check" CHECK (
         btrim("silo_id") <> '' AND btrim("agent_service_id") <> '' AND btrim("agent_revision_id") <> '' AND
-        btrim("effective_contract_digest") <> '' AND btrim("prompt_compiler_version") <> '' AND btrim("input_digest") <> '' AND
-        "effective_contract_digest" ~ '^sha256:[0-9a-f]{64}$' AND "input_digest" ~ '^sha256:[0-9a-f]{64}$'
+        btrim("agent_identity_id") <> '' AND btrim("principal_id") <> '' AND
+        jsonb_typeof("execution_subject") = 'object' AND btrim("prompt_compiler_version") <> '' AND btrim("input_digest") <> '' AND
+        "input_digest" ~ '^sha256:[0-9a-f]{64}$'
     );
 ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_positive_limits" CHECK (
     "depth" > 0
@@ -7358,7 +7366,8 @@ ALTER TABLE "child_run_reservations" ADD CONSTRAINT "child_run_reservations_posi
 ALTER TABLE "workload_assignments" ADD CONSTRAINT "workload_assignments_attempt_check" CHECK ("attempt" > 0);
 ALTER TABLE "workload_assignments" ADD CONSTRAINT "workload_assignments_nonempty_check" CHECK (
         btrim("agent_service_id") <> '' AND btrim("agent_revision_id") <> '' AND btrim("silo_id") <> '' AND
-        btrim("subject_id") <> '' AND "audience" IN ('opencrane-agent-runtime', 'opencrane-managed-agent-runtime') AND btrim("service_account_name") <> '' AND
+        btrim("agent_identity_id") <> '' AND btrim("principal_id") <> '' AND jsonb_typeof("execution_subject") = 'object' AND
+        "audience" IN ('opencrane-agent-runtime', 'opencrane-managed-agent-runtime') AND btrim("service_account_name") <> '' AND
         btrim("namespace") <> '' AND btrim("workload_uid") <> '' AND btrim("workload_profile") <> ''
     );
 ALTER TABLE "workload_assignments" ADD CONSTRAINT "workload_assignments_expiry_check" CHECK ("expires_at" > "created_at");
@@ -7395,7 +7404,7 @@ ALTER TABLE "capability_catalog_revisions" ADD CONSTRAINT "capability_catalog_re
     );
 ALTER TABLE "approval_requests" ADD CONSTRAINT "approval_requests_exact_check" CHECK (
         "attempt" > 0 AND btrim("agent_revision_id") <> '' AND btrim("agent_service_id") <> '' AND btrim("silo_id") <> '' AND
-        "proof_key_thumbprint" ~ '^[A-Za-z0-9_-]{43}$' AND btrim("subject_id") <> '' AND
+		btrim("agent_identity_id") <> '' AND btrim("principal_id") <> '' AND "proof_key_thumbprint" ~ '^[A-Za-z0-9_-]{43}$' AND
 		btrim("workload_audience") <> '' AND btrim("service_account_name") <> '' AND btrim("namespace") <> '' AND
 		btrim("workload_uid") <> '' AND btrim("pod_uid") <> '' AND
 		btrim("resource_kind") NOT IN ('', '*') AND
@@ -7942,7 +7951,7 @@ BEGIN
         OR request_row."purpose_payload_digest" IS DISTINCT FROM NEW."purpose_digest" OR NOT accepted_response
         OR invocation_row."id" IS NULL OR invocation_row."tool_revision_id" <> 'memory:recall'
         OR invocation_row."run_id" IS DISTINCT FROM NEW."run_id" OR invocation_row."attempt" IS DISTINCT FROM NEW."attempt"
-        OR invocation_row."subject_id" IS DISTINCT FROM NEW."execution_subject_id"
+        OR invocation_row."principal_id" IS DISTINCT FROM NEW."execution_subject_id"
         OR invocation_row."state" <> 'ready' OR invocation_row."revision" IS DISTINCT FROM NEW."tool_invocation_revision"
         OR snapshot_row."run_id" IS NULL OR snapshot_row."input_digest" IS DISTINCT FROM NEW."input_snapshot_digest"
         OR snapshot_row."persona_revision_id" IS DISTINCT FROM NEW."persona_revision_id"
@@ -8075,12 +8084,15 @@ BEGIN
     IF NOT EXISTS (
         SELECT 1 FROM "run_input_snapshots" snapshot
         WHERE snapshot."run_id" = NEW."id"
+          AND snapshot."attempt" = NEW."attempt"
           AND snapshot."input_digest" = NEW."input_snapshot_digest"
           AND snapshot."conversation_id" IS NOT DISTINCT FROM NEW."conversation_id"
           AND snapshot."silo_id" = NEW."silo_id"
           AND snapshot."agent_service_id" = NEW."agent_service_id"
           AND snapshot."agent_revision_id" = NEW."agent_revision_id"
-          AND snapshot."effective_contract_digest" = NEW."effective_contract_digest"
+          AND snapshot."agent_identity_id" = NEW."agent_identity_id"
+          AND snapshot."principal_id" = NEW."principal_id"
+          AND snapshot."execution_subject" = NEW."execution_subject"
     ) THEN
         RAISE EXCEPTION 'AgentRun requires its exact immutable RunInputSnapshot' USING ERRCODE = '23503';
     END IF;
@@ -8089,7 +8101,7 @@ END;
 $$;
 
 CREATE CONSTRAINT TRIGGER agent_runs_input_snapshot_complete
-AFTER INSERT OR UPDATE OF "input_snapshot_digest", "conversation_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest"
+AFTER INSERT OR UPDATE OF "attempt", "input_snapshot_digest", "conversation_id", "silo_id", "agent_service_id", "agent_revision_id", "agent_identity_id", "principal_id", "execution_subject"
 ON "agent_runs" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW
 EXECUTE FUNCTION enforce_agent_run_input_snapshot_completeness();
 
@@ -8100,12 +8112,15 @@ BEGIN
     IF NOT EXISTS (
         SELECT 1 FROM "agent_runs" run
         WHERE run."id" = NEW."run_id"
+          AND run."attempt" = NEW."attempt"
           AND run."input_snapshot_digest" = NEW."input_digest"
           AND run."conversation_id" IS NOT DISTINCT FROM NEW."conversation_id"
           AND run."silo_id" = NEW."silo_id"
           AND run."agent_service_id" = NEW."agent_service_id"
           AND run."agent_revision_id" = NEW."agent_revision_id"
-          AND run."effective_contract_digest" = NEW."effective_contract_digest"
+          AND run."agent_identity_id" = NEW."agent_identity_id"
+          AND run."principal_id" = NEW."principal_id"
+          AND run."execution_subject" = NEW."execution_subject"
     ) THEN
         RAISE EXCEPTION 'RunInputSnapshot must bind the exact AgentRun conversation and authority' USING ERRCODE = '23503';
     END IF;
@@ -8114,7 +8129,7 @@ END;
 $$;
 
 CREATE CONSTRAINT TRIGGER run_input_snapshots_run_binding
-AFTER INSERT OR UPDATE OF "run_id", "input_digest", "conversation_id", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest"
+AFTER INSERT OR UPDATE OF "run_id", "attempt", "input_digest", "conversation_id", "silo_id", "agent_service_id", "agent_revision_id", "agent_identity_id", "principal_id", "execution_subject"
 ON "run_input_snapshots" DEFERRABLE INITIALLY DEFERRED FOR EACH ROW
 EXECUTE FUNCTION enforce_run_input_snapshot_run_binding();
 
@@ -8785,7 +8800,7 @@ BEGIN
         JOIN "persona_revisions" revision ON revision."id" = snapshot."persona_revision_id"
         WHERE run."id" = NEW."first_run_id" AND run."conversation_id" = NEW."child_conversation_id"
           AND run."silo_id" = NEW."silo_id" AND run."agent_service_id" = NEW."agent_service_id"
-          AND run."delegated_user_id" = NEW."initiator_user_id" AND run."state" = 'accepted'
+          AND run."principal_id" = NEW."initiator_user_id" AND run."state" = 'accepted'
           AND snapshot."persona_revision_id" = NEW."persona_revision_id"
           AND revision."persona_profile_id" = NEW."persona_profile_id" AND revision."state" = 'approved'
     ) THEN

--- a/apps/opencrane/prisma/tests/phase-d-authority-integration.sh
+++ b/apps/opencrane/prisma/tests/phase-d-authority-integration.sh
@@ -28,6 +28,21 @@ run_psql < "$SCRIPT_DIR/authorization-active-grant-uniqueness.sql"
 run_psql < "$TEST_FILE"
 run_psql < "$SCRIPT_DIR/run-input-snapshot-admission.sql"
 run_psql < "$SCRIPT_DIR/skill-authoring-validation-authority.sql"
+run_psql <<'SQL'
+CREATE FUNCTION phase_d_execution_subject(scope_silo_id TEXT, scope_agent_identity_id TEXT, scope_principal_id TEXT, scope_run_id TEXT, scope_attempt INTEGER, scope_agent_service_id TEXT, scope_agent_revision_id TEXT, scope_request_idempotency_key TEXT)
+RETURNS JSONB LANGUAGE sql IMMUTABLE AS $$
+  SELECT jsonb_build_object(
+    'schemaVersion', 1, 'siloId', scope_silo_id, 'agentIdentityId', scope_agent_identity_id, 'principalId', scope_principal_id,
+    'identity', jsonb_build_object('agentIdentityId', scope_agent_identity_id, 'principalId', scope_principal_id, 'siloId', scope_silo_id, 'headRevision', '1', 'headDigest', 'sha256:' || repeat('a', 64), 'decisionEvidenceId', 'identity-decision-' || scope_run_id, 'verifiedAt', '2026-09-01T00:00:00.000Z'),
+    'membership', jsonb_build_object('principalId', scope_principal_id, 'siloId', scope_silo_id, 'revision', 1, 'assertionId', 'membership-' || scope_run_id, 'payloadDigest', 'sha256:' || repeat('b', 64), 'decisionEvidenceId', 'membership-decision-' || scope_run_id, 'trustedUntil', '2030-01-01T00:00:00.000Z'),
+    'capability', jsonb_build_object('agentIdentityId', scope_agent_identity_id, 'computerId', 'computer-' || scope_run_id, 'capabilitySetDigest', 'sha256:' || repeat('c', 64), 'effectiveContractDigest', 'sha256:' || repeat('d', 64), 'decisionEvidenceId', 'capability-decision-' || scope_run_id, 'decidedAt', '2026-09-01T00:00:00.000Z'),
+    'runScope', jsonb_build_object('siloId', scope_silo_id, 'runId', scope_run_id, 'attempt', scope_attempt, 'agentServiceId', scope_agent_service_id, 'agentRevisionId', scope_agent_revision_id),
+    'computerScope', jsonb_build_object('siloId', scope_silo_id, 'computerId', 'computer-' || scope_run_id, 'leaseId', 'lease-' || scope_run_id, 'leaseGeneration', 1),
+    'requester', jsonb_build_object('siloId', scope_silo_id, 'requesterPrincipalId', scope_principal_id, 'requestIdempotencyKey', scope_request_idempotency_key, 'authenticatedAt', '2026-09-01T00:00:00.000Z'),
+    'admission', jsonb_build_object('authorizingPrincipalId', scope_principal_id, 'decisionEvidenceId', 'admission-decision-' || scope_run_id, 'admittedAt', '2026-09-01T00:00:00.000Z')
+  );
+$$;
+SQL
 
 RACE_DIR="$(mktemp -d)"
 trap 'rm -rf "$RACE_DIR"' EXIT
@@ -393,10 +408,10 @@ wait_for_holder_sleeping 'phase-d-run-rollover'
 SET application_name = 'phase-d-run-after-rollover';
 INSERT INTO "agent_runs" (
   "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-  "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+  "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES (
   'run-race-superseded', 'silo-race', 'svc-race-run-rollover', 'rev-race-run-rollover-1', 'conversation-race-superseded', 'interactive',
-  'request-race-superseded', 'run-race-superseded', 'sha256:' || repeat('9', 64),
+  'agent-service:svc-race-run-rollover', 'svc-race-run-rollover-principal', phase_d_execution_subject('silo-race', 'agent-service:svc-race-run-rollover', 'svc-race-run-rollover-principal', 'run-race-superseded', 1, 'svc-race-run-rollover', 'rev-race-run-rollover-1', 'request-race-superseded'), 'request-race-superseded', 'run-race-superseded',
   'sha256:' || repeat('a', 64)
 );
 SQL
@@ -448,20 +463,20 @@ SET application_name = 'phase-d-run-first';
 BEGIN;
 INSERT INTO "agent_runs" (
   "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-  "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+  "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES (
   'run-race-before-retirement', 'silo-race', 'svc-race-run-first', 'rev-race-run-first', 'conversation-race-before-retirement', 'interactive',
-  'request-race-before-retirement', 'run-race-before-retirement', 'sha256:' || repeat('c', 64),
+  'agent-service:svc-race-run-first', 'svc-race-run-first-principal', phase_d_execution_subject('silo-race', 'agent-service:svc-race-run-first', 'svc-race-run-first-principal', 'run-race-before-retirement', 1, 'svc-race-run-first', 'rev-race-run-first', 'request-race-before-retirement'), 'request-race-before-retirement', 'run-race-before-retirement',
   'sha256:' || repeat('d', 64)
 );
 INSERT INTO "run_input_snapshots" (
-  "id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id",
-  "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route",
-  "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest"
+  "id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id",
+  "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route",
+  "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest"
 ) VALUES (
-  'run-race-before-retirement-input', 'run-race-before-retirement', 1, 'silo-race', 'svc-race-run-first', 'rev-race-run-first',
-  'sha256:' || repeat('c', 64), 'conversation-race-before-retirement', '[]', '{}', '{}', '[]', '{}', '{}',
-  'sha256:' || repeat('e', 64), 'prompt-v1', 'sha256:' || repeat('d', 64)
+  'run-race-before-retirement-input', 'run-race-before-retirement', 1, 1, 'silo-race', 'svc-race-run-first', 'rev-race-run-first',
+  'agent-service:svc-race-run-first', 'svc-race-run-first-principal', phase_d_execution_subject('silo-race', 'agent-service:svc-race-run-first', 'svc-race-run-first-principal', 'run-race-before-retirement', 1, 'svc-race-run-first', 'rev-race-run-first', 'request-race-before-retirement'), 'conversation-race-before-retirement', '[]', '{}', '[]', '{}', '{}',
+  'prompt-v1', 'sha256:' || repeat('d', 64)
 );
 SELECT pg_sleep(3);
 COMMIT;
@@ -635,30 +650,29 @@ WHERE "id" = 'svc-race-cancel-proof';
 BEGIN;
 INSERT INTO "agent_runs" (
   "id", "silo_id", "agent_service_id", "agent_revision_id", "trigger",
-  "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+  "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES (
   'run-race-cancel-proof', 'silo-race-cancel-proof', 'svc-race-cancel-proof',
-  'rev-race-cancel-proof', 'interactive', 'request-race-cancel-proof', 'run-race-cancel-proof',
-  'sha256:' || repeat('a', 64), 'sha256:' || repeat('b', 64)
+  'rev-race-cancel-proof', 'interactive', 'agent-service:svc-race-cancel-proof', 'svc-race-cancel-proof-principal', phase_d_execution_subject('silo-race-cancel-proof', 'agent-service:svc-race-cancel-proof', 'svc-race-cancel-proof-principal', 'run-race-cancel-proof', 1, 'svc-race-cancel-proof', 'rev-race-cancel-proof', 'request-race-cancel-proof'), 'request-race-cancel-proof', 'run-race-cancel-proof',
+  'sha256:' || repeat('b', 64)
 );
 INSERT INTO "run_input_snapshots" (
-  "id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id",
-  "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route",
-  "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest"
+  "id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id",
+  "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route",
+  "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest"
 ) VALUES (
-  'run-race-cancel-proof-input', 'run-race-cancel-proof', 1, 'silo-race-cancel-proof',
-  'svc-race-cancel-proof', 'rev-race-cancel-proof', 'sha256:' || repeat('a', 64), NULL,
-  '[]', '{}', '{}', '[]', '{}', '{}', 'sha256:' || repeat('d', 64), 'prompt-v1',
-  'sha256:' || repeat('b', 64)
+  'run-race-cancel-proof-input', 'run-race-cancel-proof', 1, 1, 'silo-race-cancel-proof',
+  'svc-race-cancel-proof', 'rev-race-cancel-proof', 'agent-service:svc-race-cancel-proof', 'svc-race-cancel-proof-principal', phase_d_execution_subject('silo-race-cancel-proof', 'agent-service:svc-race-cancel-proof', 'svc-race-cancel-proof-principal', 'run-race-cancel-proof', 1, 'svc-race-cancel-proof', 'rev-race-cancel-proof', 'request-race-cancel-proof'), NULL,
+  '[]', '{}', '[]', '{}', '{}', 'prompt-v1', 'sha256:' || repeat('b', 64)
 );
 UPDATE "agent_runs" SET "state" = 'queued' WHERE "id" = 'run-race-cancel-proof';
 INSERT INTO "workload_assignments" (
-  "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+  "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
   "audience", "service_account_name", "namespace", "workload_kind", "workload_uid",
   "workload_profile", "pod_uid", "expires_at"
 ) VALUES (
   'run-race-cancel-proof', 1, 'svc-race-cancel-proof', 'rev-race-cancel-proof',
-  'silo-race-cancel-proof', 'agent-service:svc-race-cancel-proof',
+  'silo-race-cancel-proof', 'agent-service:svc-race-cancel-proof', 'svc-race-cancel-proof-principal', phase_d_execution_subject('silo-race-cancel-proof', 'agent-service:svc-race-cancel-proof', 'svc-race-cancel-proof-principal', 'run-race-cancel-proof', 1, 'svc-race-cancel-proof', 'rev-race-cancel-proof', 'request-race-cancel-proof'),
   'opencrane-managed-agent-runtime', 'runtime', 'managed-race-cancel-proof', 'deployment',
   'pod-race-cancel-proof', 'standard', 'pod-race-cancel-proof',
   clock_timestamp() + interval '1 hour'
@@ -675,12 +689,12 @@ INSERT INTO "warm_runtime_reservations" (
   clock_timestamp() + interval '30 minutes'
 );
 INSERT INTO "workload_bootstraps" (
-  "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+  "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
   "audience", "service_account_name", "namespace", "workload_kind", "workload_uid",
   "claim_digest", "expires_at"
 ) VALUES (
   'bootstrap-race-cancel-proof', 'run-race-cancel-proof', 1, 'svc-race-cancel-proof',
-  'rev-race-cancel-proof', 'silo-race-cancel-proof', 'agent-service:svc-race-cancel-proof',
+  'rev-race-cancel-proof', 'silo-race-cancel-proof', 'agent-service:svc-race-cancel-proof', 'svc-race-cancel-proof-principal', phase_d_execution_subject('silo-race-cancel-proof', 'agent-service:svc-race-cancel-proof', 'svc-race-cancel-proof-principal', 'run-race-cancel-proof', 1, 'svc-race-cancel-proof', 'rev-race-cancel-proof', 'request-race-cancel-proof'),
   'opencrane-managed-agent-runtime', 'runtime', 'managed-race-cancel-proof', 'deployment',
   'pod-race-cancel-proof', 'sha256:' || repeat('c', 64), clock_timestamp() + interval '30 minutes'
 );
@@ -757,20 +771,20 @@ INSERT INTO "conversations" (
 INSERT INTO "agent_runs" (
   "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
   "request_idempotency_key", "root_run_id", "parent_run_id", "attempt", "state",
-  "effective_contract_digest", "input_snapshot_digest", "started_at", "finished_at", "terminal_reason"
+  "agent_identity_id", "principal_id", "execution_subject", "input_snapshot_digest", "started_at", "finished_at", "terminal_reason"
 ) VALUES
   (
     'phase-d-child-attempt-parent', 'phase-d-attempt-proof-silo', 'phase-d-attempt-proof-service',
     'phase-d-attempt-proof-revision',
     'phase-d-child-attempt-conversation', 'interactive', 'phase-d-child-attempt-parent-request',
-    'phase-d-child-attempt-parent', NULL, 1, 'running', 'sha256:' || repeat('1', 64),
+    'phase-d-child-attempt-parent', NULL, 1, 'running', 'agent-identity:phase-d-attempt-proof', 'principal:phase-d-attempt-proof', phase_d_execution_subject('phase-d-attempt-proof-silo', 'agent-identity:phase-d-attempt-proof', 'principal:phase-d-attempt-proof', 'phase-d-child-attempt-parent', 1, 'phase-d-attempt-proof-service', 'phase-d-attempt-proof-revision', 'phase-d-child-attempt-parent-request'),
     'sha256:' || repeat('2', 64), clock_timestamp(), NULL, NULL
   ),
   (
     'phase-d-child-attempt-child', 'phase-d-attempt-proof-silo', 'phase-d-attempt-proof-service',
     'phase-d-attempt-proof-revision', NULL, 'managed_invocation',
     'phase-d-child-attempt-child-request', 'phase-d-child-attempt-parent',
-    'phase-d-child-attempt-parent', 1, 'failed', 'sha256:' || repeat('3', 64),
+    'phase-d-child-attempt-parent', 1, 'failed', 'agent-identity:phase-d-attempt-proof', 'principal:phase-d-attempt-proof', phase_d_execution_subject('phase-d-attempt-proof-silo', 'agent-identity:phase-d-attempt-proof', 'principal:phase-d-attempt-proof', 'phase-d-child-attempt-child', 1, 'phase-d-attempt-proof-service', 'phase-d-attempt-proof-revision', 'phase-d-child-attempt-child-request'),
     'sha256:' || repeat('4', 64), clock_timestamp(), clock_timestamp(), 'runtime_failure'
   );
 INSERT INTO "child_run_reservations" (
@@ -861,20 +875,20 @@ INSERT INTO "conversations" (
 INSERT INTO "agent_runs" (
   "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
   "request_idempotency_key", "root_run_id", "parent_run_id", "attempt", "state",
-  "effective_contract_digest", "input_snapshot_digest", "started_at", "finished_at", "terminal_reason"
+  "agent_identity_id", "principal_id", "execution_subject", "input_snapshot_digest", "started_at", "finished_at", "terminal_reason"
 ) VALUES
   (
     'phase-d-parent-attempt-parent', 'phase-d-attempt-proof-silo', 'phase-d-attempt-proof-service',
     'phase-d-attempt-proof-revision',
     'phase-d-parent-attempt-conversation', 'interactive', 'phase-d-parent-attempt-parent-request',
-    'phase-d-parent-attempt-parent', NULL, 1, 'failed', 'sha256:' || repeat('5', 64),
+    'phase-d-parent-attempt-parent', NULL, 1, 'failed', 'agent-identity:phase-d-attempt-proof', 'principal:phase-d-attempt-proof', phase_d_execution_subject('phase-d-attempt-proof-silo', 'agent-identity:phase-d-attempt-proof', 'principal:phase-d-attempt-proof', 'phase-d-parent-attempt-parent', 1, 'phase-d-attempt-proof-service', 'phase-d-attempt-proof-revision', 'phase-d-parent-attempt-parent-request'),
     'sha256:' || repeat('6', 64), clock_timestamp(), clock_timestamp(), 'runtime_failure'
   ),
   (
     'phase-d-parent-attempt-child', 'phase-d-attempt-proof-silo', 'phase-d-attempt-proof-service',
     'phase-d-attempt-proof-revision', NULL, 'managed_invocation',
     'phase-d-parent-attempt-child-request', 'phase-d-parent-attempt-parent',
-    'phase-d-parent-attempt-parent', 1, 'completed', 'sha256:' || repeat('7', 64),
+    'phase-d-parent-attempt-parent', 1, 'completed', 'agent-identity:phase-d-attempt-proof', 'principal:phase-d-attempt-proof', phase_d_execution_subject('phase-d-attempt-proof-silo', 'agent-identity:phase-d-attempt-proof', 'principal:phase-d-attempt-proof', 'phase-d-parent-attempt-child', 1, 'phase-d-attempt-proof-service', 'phase-d-attempt-proof-revision', 'phase-d-parent-attempt-child-request'),
     'sha256:' || repeat('8', 64), clock_timestamp(), clock_timestamp(), 'success'
   );
 INSERT INTO "child_run_reservations" (
@@ -987,3 +1001,5 @@ if [[ "$(<"$RACE_DIR/child-delivery-duplicate.status")" == "0" ]] \
   exit 1
 fi
 echo 'PASS: partial uniqueness rejects a duplicate delivered child attempt'
+
+run_psql --command='DROP FUNCTION phase_d_execution_subject(TEXT, TEXT, TEXT, TEXT, INTEGER, TEXT, TEXT, TEXT);'

--- a/apps/opencrane/prisma/tests/phase-d-authority-integration.sql
+++ b/apps/opencrane/prisma/tests/phase-d-authority-integration.sql
@@ -43,6 +43,35 @@ BEGIN
 END;
 $$;
 
+CREATE FUNCTION pg_temp.execution_subject(
+    scope_silo_id TEXT,
+    scope_agent_identity_id TEXT,
+    scope_principal_id TEXT,
+    scope_run_id TEXT,
+    scope_attempt INTEGER,
+    scope_agent_service_id TEXT,
+    scope_agent_revision_id TEXT,
+    scope_request_idempotency_key TEXT
+)
+RETURNS JSONB
+LANGUAGE sql
+IMMUTABLE
+AS $$
+    SELECT jsonb_build_object(
+        'schemaVersion', 1,
+        'siloId', scope_silo_id,
+        'agentIdentityId', scope_agent_identity_id,
+        'principalId', scope_principal_id,
+        'identity', jsonb_build_object('agentIdentityId', scope_agent_identity_id, 'principalId', scope_principal_id, 'siloId', scope_silo_id, 'headRevision', '1', 'headDigest', 'sha256:' || repeat('a', 64), 'decisionEvidenceId', 'identity-decision-' || scope_run_id, 'verifiedAt', '2026-09-01T00:00:00.000Z'),
+        'membership', jsonb_build_object('principalId', scope_principal_id, 'siloId', scope_silo_id, 'revision', 1, 'assertionId', 'membership-' || scope_run_id, 'payloadDigest', 'sha256:' || repeat('b', 64), 'decisionEvidenceId', 'membership-decision-' || scope_run_id, 'trustedUntil', '2030-01-01T00:00:00.000Z'),
+        'capability', jsonb_build_object('agentIdentityId', scope_agent_identity_id, 'computerId', 'computer-' || scope_run_id, 'capabilitySetDigest', 'sha256:' || repeat('c', 64), 'effectiveContractDigest', 'sha256:' || repeat('d', 64), 'decisionEvidenceId', 'capability-decision-' || scope_run_id, 'decidedAt', '2026-09-01T00:00:00.000Z'),
+        'runScope', jsonb_build_object('siloId', scope_silo_id, 'runId', scope_run_id, 'attempt', scope_attempt, 'agentServiceId', scope_agent_service_id, 'agentRevisionId', scope_agent_revision_id),
+        'computerScope', jsonb_build_object('siloId', scope_silo_id, 'computerId', 'computer-' || scope_run_id, 'leaseId', 'lease-' || scope_run_id, 'leaseGeneration', 1),
+        'requester', jsonb_build_object('siloId', scope_silo_id, 'requesterPrincipalId', scope_principal_id, 'requestIdempotencyKey', scope_request_idempotency_key, 'authenticatedAt', '2026-09-01T00:00:00.000Z'),
+        'admission', jsonb_build_object('authorizingPrincipalId', scope_principal_id, 'decisionEvidenceId', 'admission-decision-' || scope_run_id, 'admittedAt', '2026-09-01T00:00:00.000Z')
+    );
+$$;
+
 INSERT INTO "agent_services" (
     "id", "silo_id", "kind", "name",
     "state", "workload_profile", "principal_id", "created_at", "updated_at"
@@ -129,10 +158,10 @@ SELECT pg_temp.expect_failure(
     $statement$
         INSERT INTO "agent_runs" (
             "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-            "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+            "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
         ) VALUES (
             'run-wrong-silo', 'silo-other', 'svc-main', 'rev-published', NULL, 'interactive',
-            'request-wrong-silo', 'run-wrong-silo', 'sha256:' || repeat('e', 64), 'sha256:' || repeat('f', 64)
+            'agent-service:svc-main', 'svc-main-principal', pg_temp.execution_subject('silo-other', 'agent-service:svc-main', 'svc-main-principal', 'run-wrong-silo', 1, 'svc-main', 'rev-published', 'request-wrong-silo'), 'request-wrong-silo', 'run-wrong-silo', 'sha256:' || repeat('f', 64)
         )
     $statement$,
     'requires the exact silo and active revision'
@@ -153,11 +182,11 @@ SELECT pg_temp.expect_failure(
     $statement$
         INSERT INTO "agent_runs" (
             "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-            "request_idempotency_key", "root_run_id", "effective_contract_digest",
+            "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id",
             "input_snapshot_digest"
         ) VALUES (
             'run-unpublished', 'silo-1', 'svc-main', 'rev-draft', NULL, 'interactive',
-            'request-unpublished', 'run-unpublished', 'sha256:' || repeat('c', 64),
+            'agent-service:svc-main', 'svc-main-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'svc-main-principal', 'run-unpublished', 1, 'svc-main', 'rev-draft', 'request-unpublished'), 'request-unpublished', 'run-unpublished',
             'sha256:' || repeat('d', 64)
         )
     $statement$,
@@ -170,11 +199,11 @@ SELECT pg_temp.expect_failure(
         INSERT INTO "agent_runs" (
             "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
             "request_idempotency_key", "root_run_id", "attempt", "state",
-            "effective_contract_digest", "input_snapshot_digest", "finished_at", "terminal_reason"
+            "agent_identity_id", "principal_id", "execution_subject", "input_snapshot_digest", "finished_at", "terminal_reason"
         ) VALUES (
             'run-terminal-insert', 'silo-1', 'svc-main', 'rev-published', NULL, 'interactive',
             'request-terminal-insert', 'run-terminal-insert', 1, 'completed',
-            'sha256:' || repeat('c', 64), 'sha256:' || repeat('d', 64), clock_timestamp(), 'success'
+            'agent-service:svc-main', 'svc-main-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'svc-main-principal', 'run-terminal-insert', 1, 'svc-main', 'rev-published', 'request-terminal-insert'), 'sha256:' || repeat('d', 64), clock_timestamp(), 'success'
         )
     $statement$,
     'must begin as accepted attempt 1'
@@ -244,11 +273,11 @@ INSERT INTO "conversations" ("id", "silo_id", "agent_service_id", "mode", "updat
 VALUES ('conversation-retry-retirement', 'silo-1', 'svc-run-retirement', 'agent_session', clock_timestamp());
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest",
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id",
     "input_snapshot_digest"
 ) VALUES (
     'run-retry-retirement', 'silo-1', 'svc-run-retirement', 'rev-run-retirement', 'conversation-retry-retirement', 'interactive',
-    'request-retry-retirement', 'run-retry-retirement', 'sha256:' || repeat('1', 64),
+    'agent-service:svc-run-retirement', 'svc-run-retirement-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-run-retirement', 'svc-run-retirement-principal', 'run-retry-retirement', 1, 'svc-run-retirement', 'rev-run-retirement', 'request-retry-retirement'), 'request-retry-retirement', 'run-retry-retirement',
     'sha256:' || repeat('2', 64)
 );
 UPDATE "agent_runs"
@@ -263,11 +292,11 @@ SELECT pg_temp.expect_failure(
     $statement$
         INSERT INTO "agent_runs" (
             "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-            "request_idempotency_key", "root_run_id", "effective_contract_digest",
+            "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id",
             "input_snapshot_digest"
         ) VALUES (
             'run-after-retirement', 'silo-1', 'svc-run-retirement', 'rev-run-retirement', NULL, 'interactive',
-            'request-after-retirement', 'run-after-retirement', 'sha256:' || repeat('3', 64),
+            'agent-service:svc-run-retirement', 'svc-run-retirement-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-run-retirement', 'svc-run-retirement-principal', 'run-after-retirement', 1, 'svc-run-retirement', 'rev-run-retirement', 'request-after-retirement'), 'request-after-retirement', 'run-after-retirement',
             'sha256:' || repeat('4', 64)
         )
     $statement$,
@@ -308,11 +337,11 @@ INSERT INTO "conversations" ("id", "silo_id", "agent_service_id", "mode", "updat
 VALUES ('conversation-retry-rollover', 'silo-1', 'svc-run-rollover', 'agent_session', clock_timestamp());
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest",
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id",
     "input_snapshot_digest"
 ) VALUES (
     'run-retry-rollover', 'silo-1', 'svc-run-rollover', 'rev-run-rollover-1', 'conversation-retry-rollover', 'interactive',
-    'request-retry-rollover', 'run-retry-rollover', 'sha256:' || repeat('5', 64),
+    'agent-service:svc-run-rollover', 'svc-run-rollover-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-run-rollover', 'svc-run-rollover-principal', 'run-retry-rollover', 1, 'svc-run-rollover', 'rev-run-rollover-1', 'request-retry-rollover'), 'request-retry-rollover', 'run-retry-rollover',
     'sha256:' || repeat('6', 64)
 );
 UPDATE "agent_runs"
@@ -327,11 +356,11 @@ SELECT pg_temp.expect_failure(
     $statement$
         INSERT INTO "agent_runs" (
             "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-            "request_idempotency_key", "root_run_id", "effective_contract_digest",
+            "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id",
             "input_snapshot_digest"
         ) VALUES (
             'run-superseded-revision', 'silo-1', 'svc-run-rollover', 'rev-run-rollover-1', NULL, 'interactive',
-            'request-superseded-revision', 'run-superseded-revision', 'sha256:' || repeat('7', 64),
+            'agent-service:svc-run-rollover', 'svc-run-rollover-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-run-rollover', 'svc-run-rollover-principal', 'run-superseded-revision', 1, 'svc-run-rollover', 'rev-run-rollover-1', 'request-superseded-revision'), 'request-superseded-revision', 'run-superseded-revision',
             'sha256:' || repeat('8', 64)
         )
     $statement$,
@@ -355,11 +384,11 @@ INSERT INTO "conversations" ("id", "silo_id", "agent_service_id", "mode", "updat
     ('conversation-run-action', 'silo-1', 'svc-main', 'agent_session', clock_timestamp());
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest",
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id",
     "input_snapshot_digest"
 ) VALUES (
     'run-state', 'silo-1', 'svc-main', 'rev-published', 'conversation-run-state', 'interactive',
-    'request-state', 'run-state', 'sha256:' || repeat('1', 64),
+    'agent-service:svc-main', 'svc-main-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'svc-main-principal', 'run-state', 1, 'svc-main', 'rev-published', 'request-state'), 'request-state', 'run-state',
     'sha256:' || repeat('a', 64)
 );
 
@@ -473,18 +502,18 @@ SELECT pg_temp.expect_failure(
 
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES
     ('run-cancel-accepted', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-     'request-cancel-accepted', 'run-cancel-accepted', 'sha256:' || repeat('1', 64), 'sha256:' || repeat('1', 64)),
+     'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-accepted', 1, 'svc-main', 'rev-published', 'request-cancel-accepted'), 'request-cancel-accepted', 'run-cancel-accepted', 'sha256:' || repeat('1', 64)),
     ('run-cancel-queued', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-     'request-cancel-queued', 'run-cancel-queued', 'sha256:' || repeat('2', 64), 'sha256:' || repeat('c2', 32)),
+     'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-queued', 1, 'svc-main', 'rev-published', 'request-cancel-queued'), 'request-cancel-queued', 'run-cancel-queued', 'sha256:' || repeat('c2', 32)),
     ('run-cancel-assigned', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-     'request-cancel-assigned', 'run-cancel-assigned', 'sha256:' || repeat('3', 64), 'sha256:' || repeat('3', 64)),
+     'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-assigned', 1, 'svc-main', 'rev-published', 'request-cancel-assigned'), 'request-cancel-assigned', 'run-cancel-assigned', 'sha256:' || repeat('3', 64)),
     ('run-cancel-running', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-     'request-cancel-running', 'run-cancel-running', 'sha256:' || repeat('4', 64), 'sha256:' || repeat('4', 64)),
+     'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-running', 1, 'svc-main', 'rev-published', 'request-cancel-running'), 'request-cancel-running', 'run-cancel-running', 'sha256:' || repeat('4', 64)),
     ('run-cancel-waiting', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-     'request-cancel-waiting', 'run-cancel-waiting', 'sha256:' || repeat('5', 64), 'sha256:' || repeat('5', 64));
+     'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-waiting', 1, 'svc-main', 'rev-published', 'request-cancel-waiting'), 'request-cancel-waiting', 'run-cancel-waiting', 'sha256:' || repeat('5', 64));
 
 UPDATE "agent_runs" SET "state" = 'queued'
 WHERE "id" IN ('run-cancel-queued', 'run-cancel-assigned', 'run-cancel-running', 'run-cancel-waiting');
@@ -552,10 +581,10 @@ INSERT INTO "conversations" ("id", "silo_id", "agent_service_id", "mode", "updat
 VALUES ('conversation-cancel-event', 'silo-1', 'svc-main', 'agent_session', clock_timestamp());
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES (
     'run-cancel-event', 'silo-1', 'svc-main', 'rev-published', 'conversation-cancel-event', 'interactive',
-    'request-cancel-event', 'run-cancel-event', 'sha256:' || repeat('6', 64), 'sha256:' || repeat('c6', 32)
+    'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-event', 1, 'svc-main', 'rev-published', 'request-cancel-event'), 'request-cancel-event', 'run-cancel-event', 'sha256:' || repeat('c6', 32)
 );
 UPDATE "agent_runs" SET "state" = 'cancelling' WHERE "id" = 'run-cancel-event';
 
@@ -576,21 +605,21 @@ VALUES ('conversation-cancel-event', 'run-cancel-event', 1, 1, 'run.cancelled', 
 
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES
     ('run-cancel-bootstrap', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-     'request-cancel-bootstrap', 'run-cancel-bootstrap', 'sha256:' || repeat('7', 64), 'sha256:' || repeat('7', 64)),
+     'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-bootstrap', 1, 'svc-main', 'rev-published', 'request-cancel-bootstrap'), 'request-cancel-bootstrap', 'run-cancel-bootstrap', 'sha256:' || repeat('7', 64)),
     ('run-cancel-proof', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-     'request-cancel-proof', 'run-cancel-proof', 'sha256:' || repeat('8', 64), 'sha256:' || repeat('8', 64));
+     'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-proof', 1, 'svc-main', 'rev-published', 'request-cancel-proof'), 'request-cancel-proof', 'run-cancel-proof', 'sha256:' || repeat('8', 64));
 UPDATE "agent_runs" SET "state" = 'queued' WHERE "id" IN ('run-cancel-bootstrap', 'run-cancel-proof');
 
 INSERT INTO "workload_assignments" (
-    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "workload_profile", "expires_at"
 ) VALUES
-    ('run-cancel-bootstrap', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    ('run-cancel-bootstrap', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-bootstrap', 1, 'svc-main', 'rev-published', 'request-cancel-bootstrap'),
      'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-cancel-bootstrap', 'personal-small', clock_timestamp() + interval '1 hour'),
-    ('run-cancel-proof', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    ('run-cancel-proof', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-proof', 1, 'svc-main', 'rev-published', 'request-cancel-proof'),
      'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-cancel-proof', 'personal-small', clock_timestamp() + interval '1 hour');
 UPDATE "agent_runs" SET "state" = 'assigned' WHERE "id" IN ('run-cancel-bootstrap', 'run-cancel-proof');
 
@@ -607,13 +636,13 @@ INSERT INTO "warm_runtime_reservations" (
      'generic', 'personal-small', 'runtime', 'reserved', clock_timestamp() + interval '30 minutes');
 
 INSERT INTO "workload_bootstraps" (
-    "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "claim_digest", "expires_at"
 ) VALUES
-    ('bootstrap-cancel-bootstrap', 'run-cancel-bootstrap', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    ('bootstrap-cancel-bootstrap', 'run-cancel-bootstrap', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-bootstrap', 1, 'svc-main', 'rev-published', 'request-cancel-bootstrap'),
      'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-cancel-bootstrap',
      'sha256:' || repeat('9', 64), clock_timestamp() + interval '30 minutes'),
-    ('bootstrap-cancel-proof', 'run-cancel-proof', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    ('bootstrap-cancel-proof', 'run-cancel-proof', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-proof', 1, 'svc-main', 'rev-published', 'request-cancel-proof'),
      'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-cancel-proof',
      'sha256:' || repeat('a', 64), clock_timestamp() + interval '30 minutes');
 
@@ -778,19 +807,19 @@ SELECT pg_temp.expect_failure(
 -- WorkloadAssignment is revoked.
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES (
     'run-cancel-invariant-proofkey', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-    'request-cancel-invariant-proofkey', 'run-cancel-invariant-proofkey',
-    'sha256:' || repeat('d3', 32), 'sha256:' || repeat('d3', 32)
+    'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-invariant-proofkey', 1, 'svc-main', 'rev-published', 'request-cancel-invariant-proofkey'), 'request-cancel-invariant-proofkey', 'run-cancel-invariant-proofkey',
+    'sha256:' || repeat('d3', 32)
 );
 UPDATE "agent_runs" SET "state" = 'queued' WHERE "id" = 'run-cancel-invariant-proofkey';
 
 INSERT INTO "workload_assignments" (
-    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "workload_profile", "expires_at"
 ) VALUES (
-    'run-cancel-invariant-proofkey', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    'run-cancel-invariant-proofkey', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-invariant-proofkey', 1, 'svc-main', 'rev-published', 'request-cancel-invariant-proofkey'),
     'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-cancel-invariant-proofkey', 'personal-small',
     clock_timestamp() + interval '1 hour'
 );
@@ -808,10 +837,10 @@ INSERT INTO "warm_runtime_reservations" (
 );
 
 INSERT INTO "workload_bootstraps" (
-    "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "claim_digest", "expires_at"
 ) VALUES (
-    'bootstrap-cancel-invariant-proofkey', 'run-cancel-invariant-proofkey', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    'bootstrap-cancel-invariant-proofkey', 'run-cancel-invariant-proofkey', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-invariant-proofkey', 1, 'svc-main', 'rev-published', 'request-cancel-invariant-proofkey'),
     'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-cancel-invariant-proofkey',
     'sha256:' || repeat('d4', 32), clock_timestamp() + interval '30 minutes'
 );
@@ -866,21 +895,21 @@ SELECT pg_temp.assert_true(
 -- A bound workflow task must record exact warm runtime deletion before cancellation finalises.
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES (
     'run-cancel-workflow-task', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-    'request-cancel-workflow-task', 'run-cancel-workflow-task',
-    'sha256:' || repeat('d2', 32), 'sha256:' || repeat('d2', 32)
+    'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-workflow-task', 1, 'svc-main', 'rev-published', 'request-cancel-workflow-task'), 'request-cancel-workflow-task', 'run-cancel-workflow-task',
+    'sha256:' || repeat('d2', 32)
 );
 
 UPDATE "agent_runs" SET "state" = 'queued' WHERE "id" = 'run-cancel-workflow-task';
 
 INSERT INTO "workload_assignments" (
-    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "workload_profile",
     "pod_uid", "expires_at"
 ) VALUES (
-    'run-cancel-workflow-task', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    'run-cancel-workflow-task', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-cancel-workflow-task', 1, 'svc-main', 'rev-published', 'request-cancel-workflow-task'),
     'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'deployment', 'pod-uid-cancel-workflow', 'personal-small',
     'pod-uid-cancel-workflow', clock_timestamp() + interval '1 hour'
 );
@@ -967,11 +996,11 @@ SELECT pg_temp.assert_true(
 
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest",
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id",
     "input_snapshot_digest"
 ) VALUES (
     'run-action', 'silo-1', 'svc-main', 'rev-published', 'conversation-run-action', 'interactive',
-    'request-action', 'run-action', 'sha256:' || repeat('3', 64),
+    'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-action', 1, 'svc-main', 'rev-published', 'request-action'), 'request-action', 'run-action',
     'sha256:' || repeat('b', 64)
 );
 
@@ -981,11 +1010,11 @@ SELECT pg_temp.expect_failure(
     'new WorkloadAssignment cannot begin registered',
     $statement$
         INSERT INTO "workload_assignments" (
-            "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+            "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
             "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "workload_profile",
             "pod_uid", "state", "expires_at", "registered_at"
         ) VALUES (
-            'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+            'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-action', 1, 'svc-main', 'rev-published', 'request-action'),
             'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-invalid', 'personal-small',
             'pod-uid-invalid', 'registered', clock_timestamp() + interval '1 hour', clock_timestamp()
         )
@@ -994,10 +1023,10 @@ SELECT pg_temp.expect_failure(
 );
 
 INSERT INTO "workload_assignments" (
-    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "workload_profile", "expires_at"
 ) VALUES (
-    'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-action', 1, 'svc-main', 'rev-published', 'request-action'),
     'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-1', 'personal-small', clock_timestamp() + interval '1 hour'
 );
 
@@ -1015,11 +1044,11 @@ SELECT pg_temp.expect_failure(
     'WorkloadBootstrap cannot be created before the run is Assigned',
     $statement$
         INSERT INTO "workload_bootstraps" (
-            "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+            "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
             "audience", "service_account_name", "namespace", "workload_kind", "workload_uid",
             "claim_digest", "expires_at"
         ) VALUES (
-            'bootstrap-too-early', 'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+            'bootstrap-too-early', 'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-action', 1, 'svc-main', 'rev-published', 'request-action'),
             'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-1',
             'sha256:' || repeat('0', 64), clock_timestamp() + interval '30 minutes'
         )
@@ -1043,11 +1072,11 @@ SELECT pg_temp.expect_failure(
     'new WorkloadBootstrap cannot begin consumed',
     $statement$
         INSERT INTO "workload_bootstraps" (
-            "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+            "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
             "audience", "service_account_name", "namespace", "workload_kind", "workload_uid",
             "claim_digest", "expires_at", "consumed_at", "consumed_by_pod_uid", "receipt_id"
         ) VALUES (
-            'bootstrap-consumed', 'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+            'bootstrap-consumed', 'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-action', 1, 'svc-main', 'rev-published', 'request-action'),
             'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-1',
             'sha256:' || repeat('f', 64), clock_timestamp() + interval '30 minutes',
             clock_timestamp(), 'pod-uid-1', 'receipt-invalid'
@@ -1057,11 +1086,11 @@ SELECT pg_temp.expect_failure(
 );
 
 INSERT INTO "workload_bootstraps" (
-    "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "id", "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid",
     "claim_digest", "expires_at"
 ) VALUES (
-    'bootstrap-1', 'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'user-1',
+    'bootstrap-1', 'run-action', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'user-1', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'user-1', 'run-action', 1, 'svc-main', 'rev-published', 'request-action'),
     'opencrane-agent-runtime', 'runtime', 'tenant-silo-1', 'job', 'job-uid-1',
     'sha256:' || repeat('5', 64), clock_timestamp() + interval '30 minutes'
 );
@@ -1117,20 +1146,20 @@ INSERT INTO "run_proof_keys" (
 -- A managed runtime uses the same generation-bound chain with its distinct projected-token audience.
 INSERT INTO "agent_runs" (
     "id", "silo_id", "agent_service_id", "agent_revision_id", "trigger",
-    "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest"
+    "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "input_snapshot_digest"
 ) VALUES (
     'run-managed-bootstrap', 'silo-1', 'svc-main', 'rev-published', 'interactive',
-    'request-managed-bootstrap', 'run-managed-bootstrap', 'sha256:' || repeat('e', 64),
+    'agent-service:svc-main', 'svc-main-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'svc-main-principal', 'run-managed-bootstrap', 1, 'svc-main', 'rev-published', 'request-managed-bootstrap'), 'request-managed-bootstrap', 'run-managed-bootstrap',
     'sha256:' || repeat('f', 64)
 );
 UPDATE "agent_runs" SET "state" = 'queued' WHERE "id" = 'run-managed-bootstrap';
 
 INSERT INTO "workload_assignments" (
-    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "run_id", "attempt", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "workload_profile",
     "pod_uid", "expires_at"
 ) VALUES (
-    'run-managed-bootstrap', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main',
+    'run-managed-bootstrap', 1, 'svc-main', 'rev-published', 'silo-1', 'agent-service:svc-main', 'svc-main-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'svc-main-principal', 'run-managed-bootstrap', 1, 'svc-main', 'rev-published', 'request-managed-bootstrap'),
     'opencrane-managed-agent-runtime', 'runtime', 'managed-runtime', 'deployment',
     'pod-uid-managed-bootstrap', 'standard', 'pod-uid-managed-bootstrap', clock_timestamp() + interval '1 hour'
 );
@@ -1147,11 +1176,11 @@ INSERT INTO "warm_runtime_reservations" (
 );
 
 INSERT INTO "workload_bootstraps" (
-    "id", "run_id", "attempt", "generation", "agent_service_id", "agent_revision_id", "silo_id", "subject_id",
+    "id", "run_id", "attempt", "generation", "agent_service_id", "agent_revision_id", "silo_id", "agent_identity_id", "principal_id", "execution_subject",
     "audience", "service_account_name", "namespace", "workload_kind", "workload_uid", "claim_digest", "expires_at"
 ) VALUES (
     'bootstrap-managed', 'run-managed-bootstrap', 1, 1, 'svc-main', 'rev-published', 'silo-1',
-    'agent-service:svc-main', 'opencrane-managed-agent-runtime', 'runtime', 'managed-runtime', 'deployment',
+    'agent-service:svc-main', 'svc-main-principal', pg_temp.execution_subject('silo-1', 'agent-service:svc-main', 'svc-main-principal', 'run-managed-bootstrap', 1, 'svc-main', 'rev-published', 'request-managed-bootstrap'), 'opencrane-managed-agent-runtime', 'runtime', 'managed-runtime', 'deployment',
     'pod-uid-managed-bootstrap', 'sha256:' || repeat('e', 64), clock_timestamp() + interval '30 minutes'
 );
 
@@ -1399,13 +1428,13 @@ INSERT INTO "conversation_run_events" ("conversation_id", "run_id", "attempt", "
     ('conversation-retry-rollover', 'run-retry-rollover', 1, 1, 'run.failed', '{}', clock_timestamp());
 
 INSERT INTO "run_input_snapshots" (
-    "id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id",
-    "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route",
-    "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest"
+    "id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id",
+    "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route",
+    "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest"
 )
 SELECT
-    'snapshot-' || "id", "id", 1, "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest",
-    "conversation_id", '[]', '{}', '{}', '[]', '{}', '{}', 'sha256:' || repeat('0', 64), 'prompt-v1', "input_snapshot_digest"
+    'snapshot-' || "id", "id", "attempt", 1, "silo_id", "agent_service_id", "agent_revision_id",
+    "agent_identity_id", "principal_id", "execution_subject", "conversation_id", '[]', '{}', '[]', '{}', '{}', 'prompt-v1', "input_snapshot_digest"
 FROM "agent_runs"
 WHERE "id" IN (
     'run-retry-retirement', 'run-retry-rollover', 'run-state', 'run-action', 'run-managed-bootstrap',

--- a/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
+++ b/apps/opencrane/prisma/tests/run-input-snapshot-admission.sql
@@ -16,14 +16,14 @@ INSERT INTO "conversations" ("id", "silo_id", "agent_service_id", "mode", "updat
     ('missing-conversation', 'silo-snapshot', 'snapshot-service', 'agent_session', clock_timestamp()),
     ('run-conversation', 'silo-snapshot', 'snapshot-service', 'agent_session', clock_timestamp());
 
-INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
-VALUES ('snapshot-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-conversation', 'interactive', 'snapshot-request', 'snapshot-run', 'sha256:' || repeat('b', 64), 'sha256:' || repeat('c', 64));
-INSERT INTO "run_input_snapshots" ("id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
-VALUES ('snapshot-run-input', 'snapshot-run', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('b', 64), 'snapshot-conversation', '[]', '{}', '{}', '[]', '{}', '{}', 'sha256:' || repeat('d', 64), 'prompt-v1', 'sha256:' || repeat('c', 64));
-INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
-VALUES ('snapshot-scheduled-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-scheduled-request', 'snapshot-scheduled-run', 'sha256:' || repeat('e', 64), 'sha256:' || repeat('f', 64));
-INSERT INTO "run_input_snapshots" ("id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
-VALUES ('snapshot-scheduled-run-input', 'snapshot-scheduled-run', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('e', 64), NULL, '[]', '{}', '{}', '[]', '{}', '{}', 'sha256:' || repeat('1', 64), 'prompt-v1', 'sha256:' || repeat('f', 64));
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "attempt", "input_snapshot_digest")
+VALUES ('snapshot-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-conversation', 'interactive', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-request', 'snapshot-run', 1, 'sha256:' || repeat('c', 64));
+INSERT INTO "run_input_snapshots" ("id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-run-input', 'snapshot-run', 1, 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-conversation', '[]', '{}', '[]', '{}', '{}', 'prompt-v1', 'sha256:' || repeat('c', 64));
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "attempt", "input_snapshot_digest")
+VALUES ('snapshot-scheduled-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-scheduled-request', 'snapshot-scheduled-run', 1, 'sha256:' || repeat('f', 64));
+INSERT INTO "run_input_snapshots" ("id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-scheduled-run-input', 'snapshot-scheduled-run', 1, 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-identity', 'snapshot-service-principal', '{}', NULL, '[]', '{}', '[]', '{}', '{}', 'prompt-v1', 'sha256:' || repeat('f', 64));
 SET CONSTRAINTS ALL IMMEDIATE;
 DO $$
 BEGIN
@@ -39,8 +39,8 @@ DECLARE
     actual_message TEXT;
 BEGIN
     BEGIN
-        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
-        VALUES ('snapshot-missing', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'missing-conversation', 'interactive', 'snapshot-missing-request', 'snapshot-missing', 'sha256:' || repeat('e', 64), 'sha256:' || repeat('f', 64));
+        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "attempt", "input_snapshot_digest")
+        VALUES ('snapshot-missing', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'missing-conversation', 'interactive', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-missing-request', 'snapshot-missing', 1, 'sha256:' || repeat('f', 64));
         SET CONSTRAINTS agent_runs_input_snapshot_complete IMMEDIATE;
     EXCEPTION WHEN foreign_key_violation THEN
         GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
@@ -58,14 +58,14 @@ DECLARE
     actual_message TEXT;
 BEGIN
     BEGIN
-        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
-        VALUES ('snapshot-mismatch', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'run-conversation', 'interactive', 'snapshot-mismatch-request', 'snapshot-mismatch', 'sha256:' || repeat('1', 64), 'sha256:' || repeat('2', 64));
-        INSERT INTO "run_input_snapshots" ("id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
-        VALUES ('snapshot-mismatch-input', 'snapshot-mismatch', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('1', 64), 'snapshot-conversation', '[]', '{}', '{}', '[]', '{}', '{}', 'sha256:' || repeat('3', 64), 'prompt-v1', 'sha256:' || repeat('2', 64));
+        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "attempt", "input_snapshot_digest")
+        VALUES ('snapshot-mismatch', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'run-conversation', 'interactive', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-mismatch-request', 'snapshot-mismatch', 1, 'sha256:' || repeat('2', 64));
+        INSERT INTO "run_input_snapshots" ("id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest")
+        VALUES ('snapshot-mismatch-input', 'snapshot-mismatch', 1, 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-conversation', '[]', '{}', '[]', '{}', '{}', 'prompt-v1', 'sha256:' || repeat('2', 64));
         SET CONSTRAINTS run_input_snapshots_run_binding IMMEDIATE;
     EXCEPTION WHEN foreign_key_violation THEN
         GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
-        IF strpos(actual_message, 'run_input_snapshots_run_id_input_digest_conversation_id_si_fkey') = 0 THEN RAISE EXCEPTION 'FAIL: expected snapshot run-binding rejection, got %', actual_message; END IF;
+        IF strpos(actual_message, 'RunInputSnapshot must bind the exact AgentRun conversation and authority') = 0 THEN RAISE EXCEPTION 'FAIL: expected snapshot run-binding rejection, got %', actual_message; END IF;
         RAISE NOTICE 'PASS: an input snapshot must bind the exact admitted run conversation';
         SET CONSTRAINTS ALL DEFERRED;
         RETURN;
@@ -79,14 +79,14 @@ DECLARE
     actual_message TEXT;
 BEGIN
     BEGIN
-        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "request_idempotency_key", "root_run_id", "effective_contract_digest", "input_snapshot_digest")
-        VALUES ('snapshot-null-mismatch', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-null-mismatch-request', 'snapshot-null-mismatch', 'sha256:' || repeat('e', 64), 'sha256:' || repeat('7', 64));
-        INSERT INTO "run_input_snapshots" ("id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
-        VALUES ('snapshot-null-mismatch-input', 'snapshot-null-mismatch', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('e', 64), 'snapshot-conversation', '[]', '{}', '{}', '[]', '{}', '{}', 'sha256:' || repeat('8', 64), 'prompt-v1', 'sha256:' || repeat('7', 64));
+        INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "attempt", "input_snapshot_digest")
+        VALUES ('snapshot-null-mismatch', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-null-mismatch-request', 'snapshot-null-mismatch', 1, 'sha256:' || repeat('7', 64));
+        INSERT INTO "run_input_snapshots" ("id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest")
+        VALUES ('snapshot-null-mismatch-input', 'snapshot-null-mismatch', 1, 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-conversation', '[]', '{}', '[]', '{}', '{}', 'prompt-v1', 'sha256:' || repeat('7', 64));
         SET CONSTRAINTS run_input_snapshots_run_binding IMMEDIATE;
     EXCEPTION WHEN foreign_key_violation THEN
         GET STACKED DIAGNOSTICS actual_message = MESSAGE_TEXT;
-        IF strpos(actual_message, 'run_input_snapshots_run_id_input_digest_conversation_id_si_fkey') = 0 THEN RAISE EXCEPTION 'FAIL: expected null-safe snapshot run-binding rejection, got %', actual_message; END IF;
+        IF strpos(actual_message, 'RunInputSnapshot must bind the exact AgentRun conversation and authority') = 0 THEN RAISE EXCEPTION 'FAIL: expected null-safe snapshot run-binding rejection, got %', actual_message; END IF;
         RAISE NOTICE 'PASS: a null-conversation run cannot bind a conversationed snapshot';
         SET CONSTRAINTS ALL DEFERRED;
         RETURN;
@@ -95,10 +95,10 @@ BEGIN
 END;
 $$;
 
-INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "request_idempotency_key", "root_run_id", "parent_run_id", "effective_contract_digest", "input_snapshot_digest")
-VALUES ('snapshot-scheduled-child', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-scheduled-child-request', 'snapshot-run', 'snapshot-run', 'sha256:' || repeat('b', 64), 'sha256:' || repeat('4', 64));
-INSERT INTO "run_input_snapshots" ("id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
-VALUES ('snapshot-scheduled-child-input', 'snapshot-scheduled-child', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('b', 64), NULL, '[]', '{}', '{}', '[]', '{}', '{}', 'sha256:' || repeat('d', 64), 'prompt-v1', 'sha256:' || repeat('4', 64));
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "parent_run_id", "attempt", "input_snapshot_digest")
+VALUES ('snapshot-scheduled-child', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'schedule', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-scheduled-child-request', 'snapshot-run', 'snapshot-run', 1, 'sha256:' || repeat('4', 64));
+INSERT INTO "run_input_snapshots" ("id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-scheduled-child-input', 'snapshot-scheduled-child', 1, 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-identity', 'snapshot-service-principal', '{}', NULL, '[]', '{}', '[]', '{}', '{}', 'prompt-v1', 'sha256:' || repeat('4', 64));
 DO $$
 DECLARE
     actual_message TEXT;
@@ -116,10 +116,10 @@ BEGIN
 END;
 $$;
 
-INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "request_idempotency_key", "root_run_id", "parent_run_id", "effective_contract_digest", "input_snapshot_digest")
-VALUES ('snapshot-child-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'managed_invocation', 'snapshot-child-request', 'snapshot-run', 'snapshot-run', 'sha256:' || repeat('9', 64), 'sha256:' || repeat('0', 64));
-INSERT INTO "run_input_snapshots" ("id", "run_id", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "effective_contract_digest", "conversation_id", "memory_facts", "identity_snapshot", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "capability_set_digest", "prompt_compiler_version", "input_digest")
-VALUES ('snapshot-child-run-input', 'snapshot-child-run', 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'sha256:' || repeat('9', 64), NULL, '[]', '{}', '{}', '[]', '{}', '{}', 'sha256:' || repeat('a', 64), 'prompt-v1', 'sha256:' || repeat('0', 64));
+INSERT INTO "agent_runs" ("id", "silo_id", "agent_service_id", "agent_revision_id", "conversation_id", "trigger", "agent_identity_id", "principal_id", "execution_subject", "request_idempotency_key", "root_run_id", "parent_run_id", "attempt", "input_snapshot_digest")
+VALUES ('snapshot-child-run', 'silo-snapshot', 'snapshot-service', 'snapshot-revision', NULL, 'managed_invocation', 'snapshot-identity', 'snapshot-service-principal', '{}', 'snapshot-child-request', 'snapshot-run', 'snapshot-run', 1, 'sha256:' || repeat('0', 64));
+INSERT INTO "run_input_snapshots" ("id", "run_id", "attempt", "snapshot_version", "silo_id", "agent_service_id", "agent_revision_id", "agent_identity_id", "principal_id", "execution_subject", "conversation_id", "memory_facts", "model_route", "mcp_tools", "memory_query_policy", "budget_policy", "prompt_compiler_version", "input_digest")
+VALUES ('snapshot-child-run-input', 'snapshot-child-run', 1, 1, 'silo-snapshot', 'snapshot-service', 'snapshot-revision', 'snapshot-identity', 'snapshot-service-principal', '{}', NULL, '[]', '{}', '[]', '{}', '{}', 'prompt-v1', 'sha256:' || repeat('0', 64));
 INSERT INTO "child_run_reservations" ("child_run_id", "parent_run_id", "root_run_id", "depth", "max_tokens", "max_cost_usd_micros")
 VALUES ('snapshot-child-run', 'snapshot-run', 'snapshot-run', 1, 100, 1000000);
 SET CONSTRAINTS ALL IMMEDIATE;

--- a/apps/opencrane/src/app/runtime-composition.ts
+++ b/apps/opencrane/src/app/runtime-composition.ts
@@ -280,6 +280,9 @@ export function _CreateInternalRuntimeComposition(prisma: PrismaClient, authApi:
 	const conversationComputerRuntimeCommandsAuthority = sandboxConfig === null
 		? null
 		: new ConversationComputerRuntimeCommandAuthority({ history: historyStore!, computers: conversationComputerHistory!, clock: conversationComputerRuntimeClock });
+	const conversationComputerRuntimePayloads = sandboxConfig === null
+		? null
+		: new PrismaConversationPrivatePayloadStoreUnitOfWork(prisma, new MountedConversationPayloadCipher(config.conversationPayloadKeyringPath!));
 	const conversationComputerRuntimeBootstrap = sandboxConfig === null
 		? null
 		: __CreateConversationComputerRuntimeBootstrapRouter({ history: conversationComputerHistory!, tokenReviewer: conversationComputerRuntimeTokenReviewer!, siloId: config.siloId, clock: conversationComputerRuntimeClock, logger: _log });
@@ -289,6 +292,7 @@ export function _CreateInternalRuntimeComposition(prisma: PrismaClient, authApi:
 			history: conversationComputerHistory!,
 			tokenReviewer: conversationComputerRuntimeTokenReviewer!,
 			authority: conversationComputerRuntimeCommandsAuthority!,
+			payloads: conversationComputerRuntimePayloads!,
 			siloId: config.siloId,
 			clock: conversationComputerRuntimeClock,
 			logger: _log,
@@ -304,7 +308,7 @@ export function _CreateInternalRuntimeComposition(prisma: PrismaClient, authApi:
 				identities: new AgentIdentityHistory(historyStore!),
 				conversations: new ConversationHistoryReader(historyStore!),
 				claims: conversationComputerRuntimeCommandsAuthority!,
-				payloads: new PrismaConversationPrivatePayloadStoreUnitOfWork(prisma, new MountedConversationPayloadCipher(config.conversationPayloadKeyringPath!)),
+				payloads: conversationComputerRuntimePayloads!,
 				clock: conversationComputerRuntimeClock,
 			}),
 			siloId: config.siloId,

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -169,10 +169,11 @@ transport for workloads; it is not a browser fallback.
   fails closed. It commits or rolls back before the output authority appends to KurrentDB, so no
   PostgreSQL transaction spans external history I/O.
 - `__CreateConversationComputerRuntimeCommandRouter` gives a reviewed Sandbox Pod the narrow
-  `commands/next` and `commands/complete` transport. It derives the computer execution from history
-  again on every request and compares the Pod UID, namespace, and service account with the active
-  lease before it delegates to the command authority. It never accepts runtime output, a selected
-  conversation, or an AgentRun coordinate.
+  `commands/next` and `commands/complete` transport. After it derives the computer execution from
+  history and compares Pod UID, namespace, and service account with the active lease, `next` redeems
+  the one oldest command's encrypted input inside the server and returns a strict work package. The
+  Sandbox never receives an arbitrary payload reader or a private storage reference, and the route
+  never accepts runtime output, a selected conversation, or an AgentRun coordinate.
 - `__CreateConversationComputerRuntimeOutputRouter` accepts only a command id, computer id, and
   bounded text from a reviewed Sandbox Pod. It repeats active-lease admission, derives the silo,
   conversation, execution, lease generation, profile revision, and author path in the server, then

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-computer-runtime-command.router.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-computer-runtime-command.router.test.ts
@@ -11,7 +11,7 @@ const _IDENTITY = { namespace: "conversation-computers", serviceAccountName: "ag
 /** Supplies the active execution whose coordinates a runtime route must derive. */
 const _ACTIVE = { computer: { id: "computer-1", conversationId: "conversation-1" }, execution: { id: "11c1f1dc-0010-4f13-9c2f-d3841ffd6651" }, lease: { generation: 2, runtimePod: _IDENTITY } } as never;
 /** Supplies one durable head command returned to the reviewed Sandbox. */
-const _COMMAND = { protocolVersion: CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION, commandId: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651", sequence: 1, computerId: "computer-1", executionId: "11c1f1dc-0010-4f13-9c2f-d3841ffd6651", leaseGeneration: 2, issuedAt: "2026-09-01T00:00:00.000Z", expiresAt: "2026-09-01T00:05:00.000Z", kind: ConversationComputerRuntimeCommandKinds.StartTurn, payload: { inputEntryId: "input-1", inputPayloadRef: "payload://input-1", inputPayloadDigest: `sha256:${"a".repeat(64)}` } } as const satisfies ConversationComputerRuntimeCommandEnvelope;
+const _COMMAND = { protocolVersion: CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION, commandId: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651", sequence: 1, computerId: "computer-1", executionId: "11c1f1dc-0010-4f13-9c2f-d3841ffd6651", leaseGeneration: 2, issuedAt: "2026-09-01T00:00:00.000Z", expiresAt: "2026-09-01T00:05:00.000Z", kind: ConversationComputerRuntimeCommandKinds.StartTurn, payload: { inputEntryId: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651", inputPayloadRef: "payload://31c1f1dc-0010-4f13-9c2f-d3841ffd6651", inputPayloadDigest: `sha256:${"a".repeat(64)}` } } as const satisfies ConversationComputerRuntimeCommandEnvelope;
 
 /** Builds one internal router with controlled identity, history, and queue ports. */
 function _App(overrides: Partial<ConversationComputerRuntimeCommandRouterDependencies> = {})
@@ -56,6 +56,8 @@ describe("ConversationComputer runtime command router", function _ConversationCo
 		expect(response.body).toEqual({ work: { command: { protocolVersion: _COMMAND.protocolVersion, commandId: _COMMAND.commandId, sequence: _COMMAND.sequence, computerId: _COMMAND.computerId, executionId: _COMMAND.executionId, leaseGeneration: _COMMAND.leaseGeneration, issuedAt: _COMMAND.issuedAt, expiresAt: _COMMAND.expiresAt, kind: _COMMAND.kind }, inputEntryId: _COMMAND.payload.inputEntryId, inputText: "Private participant input" } });
 		expect(dependencies.authority.poll).toHaveBeenCalledWith({ siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1" });
 		expect(dependencies.payloads.readText).toHaveBeenCalledWith({ siloId: "testv5", conversationId: "conversation-1", idempotencyKey: _COMMAND.payload.inputEntryId, payloadRef: _COMMAND.payload.inputPayloadRef, ciphertextDigest: _COMMAND.payload.inputPayloadDigest });
+		expect(dependencies.authority.poll).toHaveBeenCalledTimes(2);
+		expect(dependencies.history.loadActiveExecutionForBootstrap).toHaveBeenCalledTimes(2);
 	});
 
 	it("refuses an unreviewed caller before it reads active computer history", async function _RefusesUnreviewedCaller()
@@ -96,6 +98,20 @@ describe("ConversationComputer runtime command router", function _ConversationCo
 
 		expect(response.status).toBe(403);
 		expect(response.body).toEqual({ error: "runtime_denied" });
+	});
+
+	it("withholds plaintext when the lease changes during payload redemption", async function _WithholdsPayloadAfterLeaseChange()
+	{
+		const replacement = { computer: { id: "computer-1", conversationId: "conversation-1" }, execution: { id: "11c1f1dc-0010-4f13-9c2f-d3841ffd6651" }, lease: { generation: 3, runtimePod: { ..._IDENTITY, podUid: "pod-uid-2" } } } as never;
+		const history = { loadActiveExecutionForBootstrap: vi.fn().mockResolvedValueOnce(_ACTIVE).mockResolvedValueOnce(replacement) };
+		const { app, dependencies } = _App({ history });
+
+		const response = await request(app).get("/commands/next?computerId=computer-1").set(_Bearer());
+
+		expect(response.status).toBe(403);
+		expect(response.body).toEqual({ error: "runtime_denied" });
+		expect(dependencies.payloads.readText).toHaveBeenCalledTimes(1);
+		expect(dependencies.authority.poll).toHaveBeenCalledTimes(2);
 	});
 
 	it("completes only a strict terminal report against server-derived active coordinates", async function _CompletesHeadCommand()

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-computer-runtime-command.router.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-computer-runtime-command.router.test.ts
@@ -20,6 +20,7 @@ function _App(overrides: Partial<ConversationComputerRuntimeCommandRouterDepende
 		tokenReviewer: { __Review: vi.fn().mockResolvedValue(_IDENTITY) },
 		history: { loadActiveExecutionForBootstrap: vi.fn().mockResolvedValue(_ACTIVE) },
 		authority: { poll: vi.fn().mockResolvedValue({ command: _COMMAND }), complete: vi.fn().mockResolvedValue(undefined) },
+		payloads: { readText: vi.fn().mockResolvedValue("Private participant input") },
 		siloId: "testv5",
 		clock: { now: function _Now() { return new Date("2026-09-01T00:00:00.000Z"); } },
 		logger: { warn: vi.fn(), error: vi.fn() } as never,
@@ -45,15 +46,16 @@ function _Report()
 
 describe("ConversationComputer runtime command router", function _ConversationComputerRuntimeCommandRouter()
 {
-	it("returns the oldest durable command only after the reviewed Pod matches its active lease", async function _ReturnsHeadCommand()
+	it("returns the oldest durable work package only after the reviewed Pod matches its active lease", async function _ReturnsHeadCommand()
 	{
 		const { app, dependencies } = _App();
 
 		const response = await request(app).get("/commands/next?computerId=computer-1").set(_Bearer());
 
 		expect(response.status).toBe(200);
-		expect(response.body).toEqual({ command: _COMMAND });
+		expect(response.body).toEqual({ work: { command: { protocolVersion: _COMMAND.protocolVersion, commandId: _COMMAND.commandId, sequence: _COMMAND.sequence, computerId: _COMMAND.computerId, executionId: _COMMAND.executionId, leaseGeneration: _COMMAND.leaseGeneration, issuedAt: _COMMAND.issuedAt, expiresAt: _COMMAND.expiresAt, kind: _COMMAND.kind }, inputEntryId: _COMMAND.payload.inputEntryId, inputText: "Private participant input" } });
 		expect(dependencies.authority.poll).toHaveBeenCalledWith({ siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1" });
+		expect(dependencies.payloads.readText).toHaveBeenCalledWith({ siloId: "testv5", conversationId: "conversation-1", idempotencyKey: _COMMAND.payload.inputEntryId, payloadRef: _COMMAND.payload.inputPayloadRef, ciphertextDigest: _COMMAND.payload.inputPayloadDigest });
 	});
 
 	it("refuses an unreviewed caller before it reads active computer history", async function _RefusesUnreviewedCaller()
@@ -84,6 +86,16 @@ describe("ConversationComputer runtime command router", function _ConversationCo
 		const response = await request(app).get("/commands/next?computerId=computer-1").set(_Bearer());
 
 		expect(response.status).toBe(204);
+	});
+
+	it("denies payload redemption failure without exposing the command's private reference", async function _DeniesUnreadablePayload()
+	{
+		const { app } = _App({ payloads: { readText: vi.fn().mockRejectedValue(new Error("payload mismatch")) } });
+
+		const response = await request(app).get("/commands/next?computerId=computer-1").set(_Bearer());
+
+		expect(response.status).toBe(403);
+		expect(response.body).toEqual({ error: "runtime_denied" });
 	});
 
 	it("completes only a strict terminal report against server-derived active coordinates", async function _CompletesHeadCommand()

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-private-payload-store.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-private-payload-store.test.ts
@@ -11,6 +11,8 @@ class _Cipher implements ConversationPayloadCipher
 	public sealCalls = 0;
 	/** Captures the exact ownership coordinates authenticated with the ciphertext. */
 	public associatedData: ConversationPayloadAssociatedData | null = null;
+	/** Captures the exact ownership coordinates used for a protected read. */
+	public openedAssociatedData: ConversationPayloadAssociatedData | null = null;
 
 	/** Seals deterministic test bytes after recording the caller's associated data. */
 	async seal(_plaintext: Uint8Array, associatedData: ConversationPayloadAssociatedData): Promise<SealedConversationPayload>
@@ -20,10 +22,11 @@ class _Cipher implements ConversationPayloadCipher
 		return { keyId: "key-1", ciphertext: Uint8Array.of(1, 2, 3), nonce: Uint8Array.of(4), authenticationTag: Uint8Array.of(5) };
 	}
 
-	/** Satisfies the cipher port; this store-only suite never reads ciphertext. */
-	async open(_sealed: SealedConversationPayload, _associatedData: ConversationPayloadAssociatedData): Promise<Uint8Array>
+	/** Returns the fixture body after recording the server-derived decryption coordinates. */
+	async open(_sealed: SealedConversationPayload, associatedData: ConversationPayloadAssociatedData): Promise<Uint8Array>
 	{
-		return new Uint8Array();
+		this.openedAssociatedData = associatedData;
+		return Buffer.from("Private agent reply", "utf8");
 	}
 }
 
@@ -37,6 +40,12 @@ class _Repository implements ConversationPrivatePayloadRepository
 	async find(command: Pick<ConversationPrivatePayloadStoreCommand, "siloId" | "conversationId" | "idempotencyKey">): Promise<ConversationPrivatePayloadRecord | null>
 	{
 		return this.records.get(_Key(command)) ?? null;
+	}
+
+	/** Finds the one record whose opaque reference would carry this generated UUID. */
+	async findById(id: string): Promise<ConversationPrivatePayloadRecord | null>
+	{
+		return Array.from(this.records.values()).find(record => record.id === id) ?? null;
 	}
 
 	/** Inserts only the first record for one exact durable owner key. */
@@ -87,5 +96,25 @@ describe("ConversationPrivatePayloadStore", function _ConversationPrivatePayload
 		await store.storeText(_Command());
 		await expect(store.storeText(_Command("Changed agent reply"))).rejects.toThrow("Conversation private payload idempotency key already owns different text");
 		expect(cipher.sealCalls).toBe(1);
+	});
+
+	it("redeems only a row whose opaque reference, owner key, and ciphertext digest all match", async function _RedeemsExactPayload()
+	{
+		const cipher = new _Cipher();
+		const store = new ConversationPrivatePayloadStore(new _Repository(), cipher);
+		const stored = await store.storeText(_Command());
+
+		await expect(store.readText({ siloId: "silo-1", conversationId: "conversation-1", idempotencyKey: "command-1", payloadRef: stored.payloadRef, ciphertextDigest: stored.ciphertextDigest })).resolves.toBe("Private agent reply");
+		expect(cipher.openedAssociatedData).toMatchObject({ siloId: "silo-1", conversationId: "conversation-1", idempotencyKey: "command-1" });
+	});
+
+	it("refuses a copied payload reference before decrypting its body", async function _RefusesCopiedPayload()
+	{
+		const cipher = new _Cipher();
+		const store = new ConversationPrivatePayloadStore(new _Repository(), cipher);
+		const stored = await store.storeText(_Command());
+
+		await expect(store.readText({ siloId: "silo-1", conversationId: "conversation-2", idempotencyKey: "command-1", payloadRef: stored.payloadRef, ciphertextDigest: stored.ciphertextDigest })).rejects.toThrow("Conversation private payload does not match its command");
+		expect(cipher.openedAssociatedData).toBeNull();
 	});
 });

--- a/libs/backend/server/conversations/main/src/conversation-computer-runtime-command.router.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computer-runtime-command.router.ts
@@ -1,8 +1,8 @@
-import { CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION, ConversationComputerRuntimeTerminalStates, type ConversationComputerRuntimeTerminalReport } from "@opencrane/contracts";
+import { CONVERSATION_COMPUTER_RUNTIME_PROTOCOL_VERSION, ConversationComputerRuntimeCommandKinds, ConversationComputerRuntimeTerminalStates, type ConversationComputerRuntimeCommandEnvelope, type ConversationComputerRuntimeTerminalReport } from "@opencrane/contracts";
 import { Router, type Request, type Response } from "express";
 
 import { _AdmitConversationComputerRuntime, _ReviewConversationComputerRuntimeIdentity } from "./conversation-computer-runtime-admission";
-import type { ConversationComputerRuntimeCommandRouterDependencies } from "./conversation-computer-runtime-command.router.types";
+import type { ConversationComputerRuntimeCommandRouterDependencies, ConversationComputerRuntimeWorkPackage } from "./conversation-computer-runtime-command.router.types";
 
 /** Recognizes the UUID runtime coordinates that the durable command authority accepts. */
 const _UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
@@ -41,7 +41,9 @@ export function __CreateConversationComputerRuntimeCommandRouter(dependencies: C
 				response.status(204).end();
 				return;
 			}
-			response.status(200).json({ command: result.command });
+			// 5. Redeem only the selected oldest input, after the active lease has fenced the caller.
+			const work = await _WorkPackage(result.command, dependencies, active.computer.conversationId);
+			response.status(200).json({ work });
 		}
 		catch (err)
 		{
@@ -81,6 +83,22 @@ export function __CreateConversationComputerRuntimeCommandRouter(dependencies: C
 		}
 	});
 	return router;
+}
+
+/** Builds one runtime work package without returning the command's private storage reference. */
+async function _WorkPackage(command: ConversationComputerRuntimeCommandEnvelope, dependencies: ConversationComputerRuntimeCommandRouterDependencies, conversationId: string): Promise<ConversationComputerRuntimeWorkPackage>
+{
+	if (command.kind !== ConversationComputerRuntimeCommandKinds.StartTurn)
+		throw new Error("ConversationComputer runtime command kind is unsupported");
+	const inputText = await dependencies.payloads.readText({
+		siloId: dependencies.siloId,
+		conversationId,
+		idempotencyKey: command.payload.inputEntryId,
+		payloadRef: command.payload.inputPayloadRef as `payload://${string}`,
+		ciphertextDigest: command.payload.inputPayloadDigest,
+	});
+	const { payload: _payload, ...commandFence } = command;
+	return { command: commandFence, inputEntryId: command.payload.inputEntryId, inputText };
 }
 
 /** Reads one strict query or body computer selector without extra execution coordinates. */

--- a/libs/backend/server/conversations/main/src/conversation-computer-runtime-command.router.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computer-runtime-command.router.ts
@@ -43,6 +43,13 @@ export function __CreateConversationComputerRuntimeCommandRouter(dependencies: C
 			}
 			// 5. Redeem only the selected oldest input, after the active lease has fenced the caller.
 			const work = await _WorkPackage(result.command, dependencies, active.computer.conversationId);
+			// 6. Recheck the command head and lease after decryption so a replaced Pod never receives plaintext.
+			const current = await dependencies.authority.poll({ siloId: dependencies.siloId, computerId: active.computer.id, conversationId: active.computer.conversationId });
+			if (!_IsSameCommand(current.command, result.command))
+				throw new Error("ConversationComputer runtime command changed during payload redemption");
+			const finalAdmission = await _AdmitConversationComputerRuntime(computerId, identity, response, dependencies);
+			if (finalAdmission === null)
+				return;
 			response.status(200).json({ work });
 		}
 		catch (err)
@@ -85,6 +92,15 @@ export function __CreateConversationComputerRuntimeCommandRouter(dependencies: C
 	return router;
 }
 
+/** Confirms that the oldest pending command did not change while its private input was redeemed. */
+function _IsSameCommand(current: ConversationComputerRuntimeCommandEnvelope | null, selected: ConversationComputerRuntimeCommandEnvelope): boolean
+{
+	return current !== null
+		&& current.commandId === selected.commandId
+		&& current.executionId === selected.executionId
+		&& current.leaseGeneration === selected.leaseGeneration;
+}
+
 /** Builds one runtime work package without returning the command's private storage reference. */
 async function _WorkPackage(command: ConversationComputerRuntimeCommandEnvelope, dependencies: ConversationComputerRuntimeCommandRouterDependencies, conversationId: string): Promise<ConversationComputerRuntimeWorkPackage>
 {
@@ -94,7 +110,7 @@ async function _WorkPackage(command: ConversationComputerRuntimeCommandEnvelope,
 		siloId: dependencies.siloId,
 		conversationId,
 		idempotencyKey: command.payload.inputEntryId,
-		payloadRef: command.payload.inputPayloadRef as `payload://${string}`,
+		payloadRef: command.payload.inputPayloadRef,
 		ciphertextDigest: command.payload.inputPayloadDigest,
 	});
 	const { payload: _payload, ...commandFence } = command;

--- a/libs/backend/server/conversations/main/src/conversation-computer-runtime-command.router.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computer-runtime-command.router.types.ts
@@ -12,9 +12,29 @@ export interface ConversationComputerRuntimeCommandAuthorityPort
 	complete(command: ConversationComputerRuntimeCommandPollCommand & { readonly report: ConversationComputerRuntimeTerminalReport }): Promise<void>;
 }
 
+/** Redeems one server-selected encrypted input body after command queue admission. */
+export interface ConversationComputerRuntimeCommandPayloadReader
+{
+	/** Returns plaintext only when the durable reference and its server-derived ownership coordinates match. */
+	readText(command: { readonly siloId: string; readonly conversationId: string; readonly idempotencyKey: string; readonly payloadRef: `payload://${string}`; readonly ciphertextDigest: `sha256:${string}` }): Promise<string>;
+}
+
+/** Gives the Sandbox the sole runnable command plus its server-redeemed input text. */
+export interface ConversationComputerRuntimeWorkPackage
+{
+	/** Carries the command fences that must accompany every output and terminal report. */
+	readonly command: Omit<ConversationComputerRuntimeCommandEnvelope, "payload">;
+	/** Names the participant entry that caused this turn. */
+	readonly inputEntryId: string;
+	/** Carries the protected plaintext after server-side payload redemption. */
+	readonly inputText: string;
+}
+
 /** Binds the internal runtime command route to identity, history, and durable command authority. */
 export interface ConversationComputerRuntimeCommandRouterDependencies extends ConversationComputerRuntimeAdmissionDependencies
 {
 	/** Selects and completes the execution-fenced command queue. */
 	readonly authority: ConversationComputerRuntimeCommandAuthorityPort;
+	/** Redeems the oldest admitted command's input without exposing a general payload reader. */
+	readonly payloads: ConversationComputerRuntimeCommandPayloadReader;
 }

--- a/libs/backend/server/conversations/main/src/conversation-computers/__tests__/conversation-computer-runtime-command-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/__tests__/conversation-computer-runtime-command-authority.test.ts
@@ -3,6 +3,7 @@ import { HistoryExpectedRevisions, type HistoryRecordedEvent, type HistoryStore 
 import { describe, expect, it, vi } from "vitest";
 
 import { ConversationComputerRuntimeCommandAuthority } from "../conversation-computer-runtime-command-authority";
+import type { ConversationComputerRuntimeStartTurnIssueCommand } from "../conversation-computer-runtime-command-authority.types";
 
 /** Reuses a valid participant-input UUID as the target command idempotency key. */
 const _COMMAND_ID = "31c1f1dc-0010-4f13-9c2f-d3841ffd6651";
@@ -44,7 +45,7 @@ function _Command(sequence = 1, commandId = _COMMAND_ID): ConversationComputerRu
 		issuedAt: _NOW.toISOString(),
 		expiresAt: "2026-09-01T00:15:00.000Z",
 		kind: ConversationComputerRuntimeCommandKinds.StartTurn,
-		payload: { inputEntryId: commandId, inputPayloadRef: `payload://input-${sequence}`, inputPayloadDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+		payload: { inputEntryId: commandId, inputPayloadRef: "payload://31c1f1dc-0010-4f13-9c2f-d3841ffd6651", inputPayloadDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
 	};
 }
 
@@ -88,9 +89,9 @@ function _Subject(events: readonly HistoryRecordedEvent[] = [])
 }
 
 /** Builds the trusted server-selected input that may issue one target start command. */
-function _Issue(overrides: Record<string, unknown> = {})
+function _Issue(overrides: Record<string, unknown> = {}): ConversationComputerRuntimeStartTurnIssueCommand
 {
-	return { siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1", inputEntryId: _COMMAND_ID, inputPayloadRef: "payload://input-1", inputPayloadDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const, ...overrides };
+	return { siloId: "testv5", computerId: "computer-1", conversationId: "conversation-1", inputEntryId: _COMMAND_ID, inputPayloadRef: "payload://31c1f1dc-0010-4f13-9c2f-d3841ffd6651", inputPayloadDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const, ...overrides };
 }
 
 describe("ConversationComputerRuntimeCommandAuthority", function _CommandAuthoritySuite()

--- a/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-runtime-command-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-runtime-command-authority.ts
@@ -16,7 +16,7 @@ const _COMMAND_OUTPUT_RECORDED_EVENT_TYPE = "opencrane.conversation-computer-run
 /** Recognizes UUID event identifiers used for command idempotency and completion records. */
 const _UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 /** Recognizes opaque protected payload references without accepting a path or network address. */
-const _PAYLOAD_REFERENCE_PATTERN = /^payload:\/\/[A-Za-z0-9][A-Za-z0-9._-]*$/u;
+const _PAYLOAD_REFERENCE_PATTERN = /^payload:\/\/[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 /** Recognizes the fixed digest format used to bind protected payload references. */
 const _DIGEST_PATTERN = /^sha256:[a-f0-9]{64}$/u;
 
@@ -462,7 +462,7 @@ function _Uuid(value: unknown): value is string
 }
 
 /** Checks a protected payload reference without allowing a filesystem path or network address. */
-function _PayloadReference(value: unknown): value is string
+function _PayloadReference(value: unknown): value is `payload://${string}-${string}-${string}-${string}-${string}`
 {
 	return typeof value === "string" && _PAYLOAD_REFERENCE_PATTERN.test(value);
 }

--- a/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-runtime-command-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-runtime-command-authority.types.ts
@@ -1,4 +1,4 @@
-import type { ConversationComputerRuntimeCommandEnvelope, ConversationComputerRuntimeTerminalReport } from "@opencrane/contracts";
+import type { ConversationComputerRuntimeCommandEnvelope, ConversationComputerRuntimePrivatePayloadReference, ConversationComputerRuntimeTerminalReport } from "@opencrane/contracts";
 import type { HistoryAppend, HistoryExpectedHead, HistoryStore } from "@opencrane/backend/server/infra/history-store";
 
 import type { ConversationComputerHistory } from "./conversation-computer-history";
@@ -38,7 +38,7 @@ export interface ConversationComputerRuntimeStartTurnIssueCommand extends Conver
 	/** Supplies the UUID conversation entry identifier that makes this command retry idempotent. */
 	readonly inputEntryId: string;
 	/** References the protected input without storing its plaintext in the command stream. */
-	readonly inputPayloadRef: string;
+	readonly inputPayloadRef: ConversationComputerRuntimePrivatePayloadReference;
 	/** Binds the protected input reference to its canonical content digest. */
 	readonly inputPayloadDigest: `sha256:${string}`;
 }

--- a/libs/backend/server/conversations/main/src/conversation-private-payload-store.ts
+++ b/libs/backend/server/conversations/main/src/conversation-private-payload-store.ts
@@ -87,7 +87,12 @@ export class ConversationPrivatePayloadStore implements ConversationPrivatePaylo
 		return _Stored(stored, plaintextDigest);
 	}
 
-	/** Redeems one authenticated stored body for an already-admitted runtime command. */
+	/**
+	 * Redeems one authenticated stored body for an already-admitted runtime command.
+	 *
+	 * It compares the stored row with every command coordinate before decrypting, then verifies the
+	 * plaintext digest because successful AES-GCM decryption alone does not prove the expected body.
+	 */
 	async readText(command: ConversationPrivatePayloadReadCommand): Promise<string>
 	{
 		_ValidateRead(command);

--- a/libs/backend/server/conversations/main/src/conversation-private-payload-store.ts
+++ b/libs/backend/server/conversations/main/src/conversation-private-payload-store.ts
@@ -2,10 +2,12 @@ import { createHash, randomUUID } from "node:crypto";
 
 import type { ConversationPayloadCipher } from "@opencrane/backend/server/infra/conversation-payloads";
 
-import type { ConversationPrivatePayloadRecord, ConversationPrivatePayloadRepository, ConversationPrivatePayloadStore as ConversationPrivatePayloadStorePort, ConversationPrivatePayloadStoreCommand, StoredConversationPrivatePayload } from "./conversation-private-payload-store.types";
+import type { ConversationPrivatePayloadReadCommand, ConversationPrivatePayloadRecord, ConversationPrivatePayloadRepository, ConversationPrivatePayloadStore as ConversationPrivatePayloadStorePort, ConversationPrivatePayloadStoreCommand, StoredConversationPrivatePayload } from "./conversation-private-payload-store.types";
 
 /** Limits a body before the store allocates ciphertext for it. */
 const _MaximumTextBytes = 64 * 1024;
+/** Recognizes the complete digest form that immutable command envelopes retain. */
+const _DigestPattern = /^sha256:[0-9a-f]{64}$/iu;
 
 /**
  * Stores ConversationComputer text under one authorization-owned idempotency key.
@@ -84,6 +86,30 @@ export class ConversationPrivatePayloadStore implements ConversationPrivatePaylo
 			throw new Error("Conversation private payload store lost its inserted record");
 		return _Stored(stored, plaintextDigest);
 	}
+
+	/** Redeems one authenticated stored body for an already-admitted runtime command. */
+	async readText(command: ConversationPrivatePayloadReadCommand): Promise<string>
+	{
+		_ValidateRead(command);
+		const payloadId = _PayloadId(command.payloadRef);
+		const stored = await this.repository.findById(payloadId);
+		if (stored === null)
+			throw new Error("Conversation private payload is unavailable");
+		if (stored.siloId !== command.siloId || stored.conversationId !== command.conversationId || stored.idempotencyKey !== command.idempotencyKey || stored.ciphertextDigest !== command.ciphertextDigest)
+			throw new Error("Conversation private payload does not match its command");
+		const plaintext = await this.cipher.open({ keyId: stored.keyId, ciphertext: stored.ciphertext, nonce: stored.nonce, authenticationTag: stored.authenticationTag }, {
+			formatVersion: "conversation-payload/v1",
+			siloId: command.siloId,
+			conversationId: command.conversationId,
+			idempotencyKey: command.idempotencyKey,
+			plaintextDigest: stored.plaintextDigest,
+		});
+		if (_Digest(plaintext) !== stored.plaintextDigest)
+			throw new Error("Conversation private payload plaintext digest is invalid");
+		const text = new TextDecoder("utf-8", { fatal: true }).decode(plaintext);
+		_Validate({ siloId: command.siloId, conversationId: command.conversationId, idempotencyKey: command.idempotencyKey, text });
+		return text;
+	}
 }
 
 /** Creates the `sha256:` value stored as a plaintext or ciphertext digest. */
@@ -99,6 +125,23 @@ function _Validate(command: ConversationPrivatePayloadStoreCommand): void
 		throw new Error("Conversation private payload store requires non-blank ownership coordinates");
 	if (command.text.trim().length === 0 || Buffer.byteLength(command.text, "utf8") > _MaximumTextBytes)
 		throw new Error("Conversation private payload store requires bounded non-blank text");
+}
+
+/** Rejects a malformed durable reference before it can select a private-payload row. */
+function _ValidateRead(command: ConversationPrivatePayloadReadCommand): void
+{
+	if (!_Identifier(command.siloId) || !_Identifier(command.conversationId) || !_Identifier(command.idempotencyKey) || !_DigestPattern.test(command.ciphertextDigest))
+		throw new Error("Conversation private payload read requires valid ownership coordinates");
+	_PayloadId(command.payloadRef);
+}
+
+/** Parses only the opaque UUID reference generated when the payload row was first stored. */
+function _PayloadId(payloadRef: string): string
+{
+	const match = /^payload:\/\/([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/iu.exec(payloadRef);
+	if (match === null)
+		throw new Error("Conversation private payload reference is invalid");
+	return match[1];
 }
 
 /** Allows any non-blank identifier within the database guard's maximum length. */

--- a/libs/backend/server/conversations/main/src/conversation-private-payload-store.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-private-payload-store.types.ts
@@ -32,7 +32,12 @@ export interface StoredConversationPrivatePayload
 	readonly ciphertextDigest: `sha256:${string}`;
 }
 
-/** Carries the server-derived coordinates required to redeem one runtime input body. */
+/**
+ * Carries the server-derived coordinates required to redeem one runtime input body.
+ *
+ * The store checks the row identifier, owner key, and ciphertext digest before it decrypts. A
+ * caller cannot use this command to swap in another conversation's body or a changed ciphertext.
+ */
 export interface ConversationPrivatePayloadReadCommand
 {
 	/** Names the tenant that owns the payload and its authenticated ciphertext coordinates. */
@@ -92,7 +97,7 @@ export interface ConversationPrivatePayloadRepository
 	 * @returns The stored row, or `null` when no write owns the key yet.
 	 */
 	find(command: Pick<ConversationPrivatePayloadStoreCommand, "siloId" | "conversationId" | "idempotencyKey">): Promise<ConversationPrivatePayloadRecord | null>;
-	/** Loads one payload row by its opaque server-generated identifier. */
+	/** Loads one payload row by its opaque server-generated identifier for the store's ownership check. */
 	findById(id: string): Promise<ConversationPrivatePayloadRecord | null>;
 	/**
 	 * Attempts to store a candidate without replacing an existing row.
@@ -121,8 +126,9 @@ export interface ConversationPrivatePayloadStore
 	/**
 	 * Decrypts one exact server-selected payload after the runtime command authority admitted it.
 	 *
-	 * @returns The original bounded UTF-8 text only when the durable reference, owner key, digest,
-	 * and AES-GCM associated data all agree.
+	 * The store verifies the durable reference, owner key, digest, AES-GCM associated data, and
+	 * plaintext digest before returning bounded UTF-8 text. Every mismatch rejects rather than
+	 * making ciphertext from a different command readable.
 	 */
 	readText(command: ConversationPrivatePayloadReadCommand): Promise<string>;
 }

--- a/libs/backend/server/conversations/main/src/conversation-private-payload-store.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-private-payload-store.types.ts
@@ -32,6 +32,21 @@ export interface StoredConversationPrivatePayload
 	readonly ciphertextDigest: `sha256:${string}`;
 }
 
+/** Carries the server-derived coordinates required to redeem one runtime input body. */
+export interface ConversationPrivatePayloadReadCommand
+{
+	/** Names the tenant that owns the payload and its authenticated ciphertext coordinates. */
+	readonly siloId: string;
+	/** Names the one conversation whose command stream selected the payload. */
+	readonly conversationId: string;
+	/** Names the server-issued input command that owns the private-payload row. */
+	readonly idempotencyKey: string;
+	/** Names the opaque row reference retained in the durable command envelope. */
+	readonly payloadRef: `payload://${string}`;
+	/** Binds the durable command reference to the exact stored ciphertext. */
+	readonly ciphertextDigest: `sha256:${string}`;
+}
+
 /**
  * Represents one encrypted private-payload row between the store and its persistence adapter.
  *
@@ -77,6 +92,8 @@ export interface ConversationPrivatePayloadRepository
 	 * @returns The stored row, or `null` when no write owns the key yet.
 	 */
 	find(command: Pick<ConversationPrivatePayloadStoreCommand, "siloId" | "conversationId" | "idempotencyKey">): Promise<ConversationPrivatePayloadRecord | null>;
+	/** Loads one payload row by its opaque server-generated identifier. */
+	findById(id: string): Promise<ConversationPrivatePayloadRecord | null>;
 	/**
 	 * Attempts to store a candidate without replacing an existing row.
 	 *
@@ -101,4 +118,11 @@ export interface ConversationPrivatePayloadStore
 	 * @throws Error when the command is invalid, the existing row has different text, or storage loses the inserted row.
 	 */
 	storeText(command: ConversationPrivatePayloadStoreCommand): Promise<StoredConversationPrivatePayload>;
+	/**
+	 * Decrypts one exact server-selected payload after the runtime command authority admitted it.
+	 *
+	 * @returns The original bounded UTF-8 text only when the durable reference, owner key, digest,
+	 * and AES-GCM associated data all agree.
+	 */
+	readText(command: ConversationPrivatePayloadReadCommand): Promise<string>;
 }

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-private-payload-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-private-payload-repository.ts
@@ -38,6 +38,13 @@ export class PrismaConversationPrivatePayloadRepository implements ConversationP
 		return record === null ? null : _Record(record);
 	}
 
+	/** Loads one payload record by the UUID carried in a protected command reference. */
+	async findById(id: string): Promise<ConversationPrivatePayloadRecord | null>
+	{
+		const record = await this.transaction.conversationPrivatePayload.findUnique({ where: { id } });
+		return record === null ? null : _Record(record);
+	}
+
 	/**
 	 * Inserts a candidate without replacing the row that already owns its key.
 	 *

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-private-payload-store-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-private-payload-store-unit-of-work.ts
@@ -3,7 +3,7 @@ import { type PrismaClient } from "@prisma/client";
 import type { ConversationPayloadCipher } from "@opencrane/backend/server/infra/conversation-payloads";
 
 import { ConversationPrivatePayloadStore } from "../conversation-private-payload-store";
-import type { ConversationPrivatePayloadStore as ConversationPrivatePayloadStorePort, ConversationPrivatePayloadStoreCommand, StoredConversationPrivatePayload } from "../conversation-private-payload-store.types";
+import type { ConversationPrivatePayloadReadCommand, ConversationPrivatePayloadStore as ConversationPrivatePayloadStorePort, ConversationPrivatePayloadStoreCommand, StoredConversationPrivatePayload } from "../conversation-private-payload-store.types";
 import { PrismaConversationPrivatePayloadRepository } from "./prisma-conversation-private-payload-repository";
 
 /**
@@ -30,12 +30,30 @@ export class PrismaConversationPrivatePayloadStoreUnitOfWork implements Conversa
 	/** Stores one encrypted payload and releases the database transaction before history can append. */
 	async storeText(command: ConversationPrivatePayloadStoreCommand): Promise<StoredConversationPrivatePayload>
 	{
+		return this._UseStore(function _Store(store): Promise<StoredConversationPrivatePayload>
+		{
+			return store.storeText(command);
+		});
+	}
+
+	/** Reads and decrypts one payload in a short transaction before returning plaintext to a lease-fenced Sandbox. */
+	async readText(command: ConversationPrivatePayloadReadCommand): Promise<string>
+	{
+		return this._UseStore(function _Read(store): Promise<string>
+		{
+			return store.readText(command);
+		});
+	}
+
+	/** Opens one short transaction around any payload cipher operation without spanning history I/O. */
+	private async _UseStore<T>(operation: (store: ConversationPrivatePayloadStore) => Promise<T>): Promise<T>
+	{
 		const unit = this;
-		return unit.prisma.$transaction(async function _Store(transaction): Promise<StoredConversationPrivatePayload>
+		return unit.prisma.$transaction(async function _Use(transaction): Promise<T>
 		{
 			const repository = new PrismaConversationPrivatePayloadRepository(transaction);
 			const store = new ConversationPrivatePayloadStore(repository, unit.cipher);
-			return store.storeText(command);
+			return operation(store);
 		});
 	}
 }

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -18,7 +18,7 @@ export { __CreateConversationReplayRouter } from "./conversation-replay.router";
 export { __CreateConversationComputerRuntimeBootstrapRouter } from "./conversation-computer-runtime-bootstrap.router";
 export type { ConversationComputerRuntimeBootstrapResponse } from "./conversation-computer-runtime-bootstrap.router.types";
 export { __CreateConversationComputerRuntimeCommandRouter } from "./conversation-computer-runtime-command.router";
-export type { ConversationComputerRuntimeCommandAuthorityPort, ConversationComputerRuntimeCommandPayloadReader, ConversationComputerRuntimeCommandRouterDependencies, ConversationComputerRuntimeWorkPackage } from "./conversation-computer-runtime-command.router.types";
+export type { ConversationComputerRuntimeCommandRouterDependencies } from "./conversation-computer-runtime-command.router.types";
 export { __CreateConversationComputerRuntimeOutputRouter } from "./conversation-computer-runtime-output.router";
 export type { ConversationComputerRuntimeOutputAuthorityPort, ConversationComputerRuntimeOutputRouterDependencies } from "./conversation-computer-runtime-output.router.types";
 export { __CreateSelfConversationSocketServer } from "./self-conversation-socket";

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -18,7 +18,7 @@ export { __CreateConversationReplayRouter } from "./conversation-replay.router";
 export { __CreateConversationComputerRuntimeBootstrapRouter } from "./conversation-computer-runtime-bootstrap.router";
 export type { ConversationComputerRuntimeBootstrapResponse } from "./conversation-computer-runtime-bootstrap.router.types";
 export { __CreateConversationComputerRuntimeCommandRouter } from "./conversation-computer-runtime-command.router";
-export type { ConversationComputerRuntimeCommandAuthorityPort, ConversationComputerRuntimeCommandRouterDependencies } from "./conversation-computer-runtime-command.router.types";
+export type { ConversationComputerRuntimeCommandAuthorityPort, ConversationComputerRuntimeCommandPayloadReader, ConversationComputerRuntimeCommandRouterDependencies, ConversationComputerRuntimeWorkPackage } from "./conversation-computer-runtime-command.router.types";
 export { __CreateConversationComputerRuntimeOutputRouter } from "./conversation-computer-runtime-output.router";
 export type { ConversationComputerRuntimeOutputAuthorityPort, ConversationComputerRuntimeOutputRouterDependencies } from "./conversation-computer-runtime-output.router.types";
 export { __CreateSelfConversationSocketServer } from "./self-conversation-socket";

--- a/libs/contracts/src/__tests__/conversation-computer-runtime-protocol.types.test.ts
+++ b/libs/contracts/src/__tests__/conversation-computer-runtime-protocol.types.test.ts
@@ -17,7 +17,7 @@ describe("ConversationComputer runtime protocol contracts", function ()
 			issuedAt: "2026-09-01T00:00:00.000Z",
 			expiresAt: "2026-09-01T00:05:00.000Z",
 			kind: ConversationComputerRuntimeCommandKinds.StartTurn,
-			payload: { inputEntryId: "entry-1", inputPayloadRef: "payload://input-1", inputPayloadDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+			payload: { inputEntryId: "entry-1", inputPayloadRef: "payload://31c1f1dc-0010-4f13-9c2f-d3841ffd6651", inputPayloadDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
 		};
 		const terminal: ConversationComputerRuntimeTerminalReport = {
 			protocolVersion: command.protocolVersion,

--- a/libs/contracts/src/conversation-computer-runtime-protocol.types.ts
+++ b/libs/contracts/src/conversation-computer-runtime-protocol.types.ts
@@ -61,7 +61,7 @@ export enum ConversationComputerRuntimeStopReasons
  */
 export interface ConversationComputerRuntimeCommandCoordinates
 {
-	/** Names the protocol revision that both the server router and Sandbox adapter must validate. */
+	/** Names the protocol revision retained by the durable server command and echoed by the Sandbox work package. */
 	readonly protocolVersion: ConversationComputerRuntimeProtocolVersion;
 	/** Identifies the durable command so retries cannot select a second command effect. */
 	readonly commandId: string;
@@ -80,6 +80,14 @@ export interface ConversationComputerRuntimeCommandCoordinates
 }
 
 /**
+ * Names the opaque reference shape produced by the ConversationComputer private-payload store.
+ *
+ * The durable envelope carries no plaintext. Server validation resolves this shape to the generated
+ * UUID row before a lease-admitted command can redeem it.
+ */
+export type ConversationComputerRuntimePrivatePayloadReference = `payload://${string}-${string}-${string}-${string}-${string}`;
+
+/**
  * Delivers the server-selected input that begins a target loop turn.
  *
  * It carries an immutable entry and protected-payload coordinates rather than plaintext.
@@ -88,9 +96,9 @@ export interface ConversationComputerRuntimeStartTurnCommand
 {
 	/** Identifies the immutable conversation entry whose admission caused this turn. */
 	readonly inputEntryId: string;
-	/** References the protected input payload without putting plaintext on the durable command queue. */
-	readonly inputPayloadRef: string;
-	/** Binds the protected input payload that the runtime reads through its later narrow reader route. */
+	/** References the protected input payload UUID without putting plaintext on the durable command queue. */
+	readonly inputPayloadRef: ConversationComputerRuntimePrivatePayloadReference;
+	/** Binds the protected input payload that the server redeems only after active-lease admission. */
 	readonly inputPayloadDigest: `sha256:${string}`;
 }
 

--- a/releases/0.11.0.json
+++ b/releases/0.11.0.json
@@ -4,7 +4,7 @@
   "database": {
     "schemaVersion": "0.11.0",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "92e80d9a8ab2f873ca1feb6c8004a35040e888c6d2cbbbc515bd7cba4bd470ea",
+    "baselineSha256": "895850ec8a2a2d0c2cf42c89e59294bb992dbb299c4fe28484bb045e890aade8",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {

--- a/scripts/config-docs-contract.json
+++ b/scripts/config-docs-contract.json
@@ -13,7 +13,9 @@
         { "path": "certManager", "documentation": "website/operators/deployment-configuration.md" },
         { "path": "networkPolicy", "documentation": "website/operators/deployment-configuration.md" },
         { "path": "externalSecrets", "documentation": "website/operators/deployment-configuration.md" },
-        { "path": "observability", "documentation": "website/operators/deployment-configuration.md" }
+        { "path": "observability", "documentation": "website/operators/deployment-configuration.md" },
+        { "path": "historyStore", "documentation": "website/operators/deployment-configuration.md" },
+        { "path": "agentSandbox", "documentation": "website/operators/deployment-configuration.md" }
       ],
       "forwardedKeys": [
         { "path": "channelProxy", "owner": "apps/channel-proxy/helm" },

--- a/website/operators/deployment-configuration.md
+++ b/website/operators/deployment-configuration.md
@@ -47,6 +47,8 @@ These are the public configuration roots owned by the silo umbrella chart.
 | `networkPolicy` | Tune the release's default-deny and narrowly admitted network paths. |
 | `externalSecrets` | Connect an External Secrets Operator store when that controller is already installed. |
 | `observability` | Enable OpenTelemetry export and choose its logging detail. |
+| `historyStore` | Configure the private KurrentDB event ledger, including immutable images and pre-created TLS, administrator, operations, and service credential Secrets. |
+| `agentSandbox` | Configure release-scoped Sandbox profiles and their claim-admission contract; the cluster operator installs the controller and CRDs separately. |
 
 ::: warning
 Do not copy a child chart's entire value tree into a platform overlay just because it appears in the
@@ -54,6 +56,18 @@ umbrella `values.yaml`. `channelProxy`, `agentController`, `clustertenantManager
 vendored services are forwarded to their app owners. Change them only with the app's documented
 deployment contract and review their trust boundary first.
 :::
+
+## ConversationComputer substrate
+
+`historyStore.kurrentdb` is disabled by default. Enable it only after supplying immutable KurrentDB
+and bootstrap image digests plus existing TLS, administrator, operations, and HistoryStore-service
+Secrets. The chart owns the namespaced ledger workload and its bootstrap boundary; it never creates
+or rotates those credentials.
+
+`agentSandbox` similarly creates only release-scoped `SandboxTemplate`, `SandboxWarmPool`, and
+claim-admission resources. The Agent Sandbox controller and its `v1beta1` CRDs are cluster-wide
+prerequisites. A profile must name the target namespace, verified RuntimeClass, zero-RBAC service
+account, and immutable runtime image before a ConversationComputer may claim it.
 
 ## MCP image registry
 


### PR DESCRIPTION
## Summary

- add server-only private-payload redemption that verifies opaque UUID reference, owner coordinates, ciphertext digest, AES-GCM associated data, and plaintext digest
- change the Sandbox `commands/next` response from a durable envelope with a payload reference to a strict work package with server-redeemed input text and command fences
- re-poll the FIFO command head and re-admit the exact Pod UID, service account, namespace, and lease immediately before plaintext delivery; a lease replacement now receives no work package
- tighten durable start-turn payload references to the UUID shape generated by the private-payload store, and share one composed payload unit of work with output persistence

## Security boundary

The Sandbox can obtain plaintext only for the oldest pending command of its currently active lease. It never receives a general payload reader, payload storage reference, conversation selector, execution selector, AgentRun coordinate, or payload encryption key. Every stale, foreign, changed, completed, malformed, or replacement-lease condition fails closed.

## Validation

- `npx nx run backend-server-conversations:lint --skipNxCache`
- `npx nx run backend-server-conversations:test --skipNxCache` — passed twice with 210 tests; a final rerun hit the known local sandbox `listen EPERM` restriction in 44 Supertest/socket cases, including unrelated existing routes
- `npx nx run contracts:lint --skipNxCache`
- `npx nx run contracts:test --skipNxCache` — 49 tests
- `npx nx run opencrane:lint --skipNxCache`
- `scripts/agent-style-check.sh --diff 40155a8bf`
- `npm run check:prisma-boundaries -- --diff 40155a8bf`
- `npm run check:module-growth -- --diff 40155a8bf`
- `npm run check:release-versioning`
- `npm run check:pr-stack-integrity -- --current-branch feat/issue-759-conversation-computer-runtime-loop`

## Review

- post-diff architecture gate: PASS
- independent review: PASS after resolving the lease-replacement TOCTOU and UUID-reference contract mismatch
- reaper removed internal-only command assembly type exports and updated stale protected-payload documentation
- documentation gate: PASS

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797