### PR TITLE
🔒 bind ConversationComputer creation to active managed agents

### DIFF
--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -702,6 +702,13 @@
 				]
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts",
+				"adapter": "PrismaConversationAgentBindingRepository",
+				"contract": "ConversationAgentBindingRepository",
+				"contractImportPath": "../conversation-agent-binding.types",
+				"constructs": []
+			},
+			{
 				"path": "libs/backend/server/agents/onboarding/main/src/prisma-user-onboarding-repository.ts",
 				"adapter": "PrismaUserOnboardingRepository",
 				"contract": "UserOnboardingRepository",
@@ -1813,6 +1820,18 @@
 					{
 						"adapter": "PrismaConversationQueryRepository",
 						"importPath": "./prisma-conversation-query-repository"
+					}
+				]
+			},
+			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts",
+				"adapter": "PrismaConversationAgentBindingUnitOfWork",
+				"contract": "ConversationAgentBindingAuthority",
+				"contractImportPath": "../conversation-agent-binding.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationAgentBindingRepository",
+						"importPath": "./prisma-conversation-agent-binding-repository"
 					}
 				]
 			},

--- a/libs/backend/server/agents/agent-services/main/src/index.ts
+++ b/libs/backend/server/agents/agent-services/main/src/index.ts
@@ -21,6 +21,6 @@ export type { AgentServicesRouterDependencies, ManagementCaller, ManagementClock
 export { _AgentServicesOpenapiPaths } from "./openapi";
 export { __CreateAgentSchedule, __UpdateAgentSchedule } from "./agent-schedule";
 export { AgentScheduleOverlapPolicies, type AgentScheduleDeletionResult, type AgentScheduleDenial, type AgentScheduleMutationResult, type AgentScheduleOverlapPolicy, type AgentScheduleRepository, type AgentServiceScheduleRecord, type CreateAgentScheduleCommand, type UpdateAgentScheduleCommand } from "./agent-schedule.types";
-export { __ManagedAgentServicePrincipal } from "./managed-agent-service-principal";
+export { __ManagedAgentServicePrincipal, MANAGED_AGENT_SERVICE_PRINCIPAL_ISSUER } from "./managed-agent-service-principal";
 export { _CreateManagedExecutionEvidenceAuthority } from "./managed-execution-evidence.factory";
 export type { ManagedExecutionCapabilityEvidence, ManagedExecutionEvidence, ManagedExecutionEvidenceAuthority, ManagedExecutionEvidenceCommand, ManagedExecutionEvidenceConfig, ManagedExecutionEvidenceResult, ManagedExecutionEvidenceTransaction, ManagedExecutionIdentityCoordinates, ManagedExecutionMembershipEvidence } from "./managed-execution-evidence.types";

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -72,8 +72,9 @@ or already terminal.
 
 `PrismaConversationAgentBindingUnitOfWork` supplies the pre-creation binding an eventual
 history-anchored agent-session creation command needs. In one serializable snapshot it accepts only
-an active service in the selected silo whose exact active revision is published, verifies a managed
-service's deterministic internal Principal, selects the release-owned computer profile, and asks a
+an active service in the selected silo whose exact active revision is published, asks the separately
+owned AgentService contract to verify a managed service's deterministic internal Principal, selects
+the release-owned computer profile, and asks a
 separate identity authority for the stable `AgentIdentity`. Any missing or malformed coordinate
 denies without returning a partial binding. Personal services are explicitly unavailable here until
 their owned delegation policy can provide a proxied identity; this boundary never invents an

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -70,6 +70,15 @@ and returns that stored execution instead of starting another one. A sandbox nev
 this execution: it must remain unavailable whenever the computer is cold, cooling, expired, replaced,
 or already terminal.
 
+`PrismaConversationAgentBindingUnitOfWork` supplies the pre-creation binding an eventual
+history-anchored agent-session creation command needs. In one serializable snapshot it accepts only
+an active service in the selected silo whose exact active revision is published, verifies a managed
+service's deterministic internal Principal, selects the release-owned computer profile, and asks a
+separate identity authority for the stable `AgentIdentity`. Any missing or malformed coordinate
+denies without returning a partial binding. Personal services are explicitly unavailable here until
+their owned delegation policy can provide a proxied identity; this boundary never invents an
+identity or falls back to the legacy personal-service lookup.
+
 Before creation, the directory returns active organisation members as opaque membership references.
 It never returns login subjects, email addresses, roles, or personal-memory identity. It also
 projects the caller's active personal Agent only when exactly one service matches their approved
@@ -147,6 +156,10 @@ transport for workloads; it is not a browser fallback.
   claim. The claim stamps the release selectors and checked computer identifier required by the
   runtime Pod, and the authority parks a profile, lease, or receipt mismatch before that mismatch can become a second
   computer realization; it does not authorize an agent.
+- `PrismaConversationAgentBindingUnitOfWork` exposes the transactional port an app composition
+  needs to bind an agent-session creation command to one active managed `AgentService`, its
+  published revision, deterministic Principal, release-owned profile, and identity selected by an
+  injected catalog. Its repository and policy implementation remain package-private.
 - `ConversationComputerSandboxReconciliationAuthority` replays an activation locator against
   current computer history and the exact immutable claim status. `Ready=True` becomes the active
   lease; an expired dispatch becomes `RecoveryRequired` with a lost lease. It never manages a Pod,

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { ConversationAgentBindingAuthority } from "../conversation-agent-binding-authority";
+import { ConversationAgentBindingResolver } from "../conversation-agent-binding-authority";
 import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCandidate } from "../conversation-agent-binding.types";
 import { PrismaConversationAgentBindingRepository } from "../db/prisma-conversation-agent-binding-repository";
 import { PrismaConversationAgentBindingUnitOfWork } from "../db/prisma-conversation-agent-binding-unit-of-work";
@@ -21,13 +21,13 @@ function _Dependencies(): ConversationAgentBindingAuthorityDependencies
 	};
 }
 
-describe("ConversationAgentBindingAuthority", function _ConversationAgentBindingAuthoritySuite()
+describe("ConversationAgentBindingResolver", function _ConversationAgentBindingResolverSuite()
 {
 	it("binds only one active managed service to its revision, principal, selected identity, and release profile", async function _BindsManagedService()
 	{
 		const load = vi.fn().mockResolvedValue(_ManagedCandidate());
 		const dependencies = _Dependencies();
-		const result = await new ConversationAgentBindingAuthority({ load }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" });
+		const result = await new ConversationAgentBindingResolver({ load }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" });
 
 		expect(result).toEqual({ outcome: "bound", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentServiceKind: "managed", principalId: "managed-principal:service-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1" } });
 		expect(dependencies.profiles.select).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceKind: "managed" });
@@ -37,18 +37,18 @@ describe("ConversationAgentBindingAuthority", function _ConversationAgentBinding
 	it("fails closed for a missing service, malformed managed Principal, missing release profile, and missing identity", async function _RejectsIncompleteCoordinates()
 	{
 		const dependencies = _Dependencies();
-		await expect(new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(null) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable });
-		await expect(new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(_ManagedCandidate({ principalId: "forged" })) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ManagedPrincipalUnavailable });
+		await expect(new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(null) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable });
+		await expect(new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(_ManagedCandidate({ principalId: "forged" })) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ManagedPrincipalUnavailable });
 		(dependencies.profiles.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
-		await expect(new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(_ManagedCandidate()) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ProfileUnavailable });
+		await expect(new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(_ManagedCandidate()) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ProfileUnavailable });
 		(dependencies.identities.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
-		await expect(new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(_ManagedCandidate()) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.IdentityUnavailable });
+		await expect(new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(_ManagedCandidate()) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.IdentityUnavailable });
 	});
 
 	it("refuses a personal service until a real owned-personal delegation policy can create its proxied identity", async function _RejectsPersonalService()
 	{
 		const dependencies = _Dependencies();
-		const result = await new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(_ManagedCandidate({ agentServiceKind: "personal", principalId: null, principal: null })) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" });
+		const result = await new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(_ManagedCandidate({ agentServiceKind: "personal", principalId: null, principal: null })) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" });
 
 		expect(result).toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable });
 		expect(dependencies.profiles.select).not.toHaveBeenCalled();

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
@@ -1,0 +1,80 @@
+import { Prisma } from "@prisma/client";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConversationAgentBindingAuthority } from "../conversation-agent-binding-authority";
+import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCandidate } from "../conversation-agent-binding.types";
+import { PrismaConversationAgentBindingRepository } from "../db/prisma-conversation-agent-binding-repository";
+import { PrismaConversationAgentBindingUnitOfWork } from "../db/prisma-conversation-agent-binding-unit-of-work";
+
+/** Builds one checked managed service candidate with its deterministic Principal contract. */
+function _ManagedCandidate(overrides: Partial<ConversationAgentBindingCandidate> = {}): ConversationAgentBindingCandidate
+{
+	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentServiceKind: "managed", principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "internal", subject: "service-1" }, ...overrides };
+}
+
+/** Builds the deployment and identity selection ports without introducing a database fallback. */
+function _Dependencies(): ConversationAgentBindingAuthorityDependencies
+{
+	return {
+		profiles: { select: vi.fn().mockResolvedValue({ profileRevisionId: "profile-1" }) },
+		identities: { select: vi.fn().mockResolvedValue({ agentIdentityId: "identity-1" }) },
+	};
+}
+
+describe("ConversationAgentBindingAuthority", function _ConversationAgentBindingAuthoritySuite()
+{
+	it("binds only one active managed service to its revision, principal, selected identity, and release profile", async function _BindsManagedService()
+	{
+		const load = vi.fn().mockResolvedValue(_ManagedCandidate());
+		const dependencies = _Dependencies();
+		const result = await new ConversationAgentBindingAuthority({ load }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" });
+
+		expect(result).toEqual({ outcome: "bound", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentServiceKind: "managed", principalId: "managed-principal:service-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1" } });
+		expect(dependencies.profiles.select).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceKind: "managed" });
+		expect(dependencies.identities.select).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceId: "service-1", principalId: "managed-principal:service-1" });
+	});
+
+	it("fails closed for a missing service, malformed managed Principal, missing release profile, and missing identity", async function _RejectsIncompleteCoordinates()
+	{
+		const dependencies = _Dependencies();
+		await expect(new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(null) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable });
+		await expect(new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(_ManagedCandidate({ principalId: "forged" })) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ManagedPrincipalUnavailable });
+		(dependencies.profiles.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+		await expect(new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(_ManagedCandidate()) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ProfileUnavailable });
+		(dependencies.identities.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+		await expect(new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(_ManagedCandidate()) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.IdentityUnavailable });
+	});
+
+	it("refuses a personal service until a real owned-personal delegation policy can create its proxied identity", async function _RejectsPersonalService()
+	{
+		const dependencies = _Dependencies();
+		const result = await new ConversationAgentBindingAuthority({ load: vi.fn().mockResolvedValue(_ManagedCandidate({ agentServiceKind: "personal", principalId: null, principal: null })) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" });
+
+		expect(result).toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable });
+		expect(dependencies.profiles.select).not.toHaveBeenCalled();
+		expect(dependencies.identities.select).not.toHaveBeenCalled();
+	});
+});
+
+describe("PrismaConversationAgentBindingRepository", function _PrismaConversationAgentBindingRepositorySuite()
+{
+	it("queries an active service only through its matching published active revision", async function _LoadsPublishedActiveRevision()
+	{
+		const findFirst = vi.fn().mockResolvedValue({ id: "service-1", kind: "Managed", activeRevisionId: "revision-1", activeRevision: { id: "revision-1" }, principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "Internal", subject: "service-1" } });
+		const result = await new PrismaConversationAgentBindingRepository({ agentService: { findFirst } } as never).load({ siloId: "silo-1", agentServiceId: "service-1" });
+
+		expect(result).toEqual(_ManagedCandidate());
+		expect(findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ id: "service-1", siloId: "silo-1", state: "Active", activeRevision: { is: { siloId: "silo-1", state: "Published" } } }) }));
+	});
+
+	it("uses a serializable transaction for the final binding snapshot", async function _UsesSerializableTransaction()
+	{
+		const transaction = { agentService: { findFirst: vi.fn().mockResolvedValue({ id: "service-1", kind: "Managed", activeRevisionId: "revision-1", activeRevision: { id: "revision-1" }, principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "Internal", subject: "service-1" } }) } };
+		const $transaction = vi.fn(async function _Transaction(work, options)
+		{
+			expect(options).toEqual({ isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+			return work(transaction);
+		});
+		await expect(new PrismaConversationAgentBindingUnitOfWork({ $transaction } as never, _Dependencies()).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toMatchObject({ outcome: "bound" });
+	});
+});

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
@@ -17,6 +17,9 @@ function _Dependencies(): ConversationAgentBindingAuthorityDependencies
 {
 	return {
 		profiles: { select: vi.fn().mockResolvedValue({ profileRevisionId: "profile-1" }) },
+		managedPrincipalValidator: {
+			validate: vi.fn().mockImplementation(command => command.principalId === `managed-principal:${command.agentServiceId}` && command.issuer === "urn:opencrane:managed-agent" && command.provenance === "internal" && command.subject === command.agentServiceId),
+		},
 		identities: { select: vi.fn().mockResolvedValue({ agentIdentityId: "identity-1" }) },
 	};
 }
@@ -31,6 +34,7 @@ describe("ConversationAgentBindingResolver", function _ConversationAgentBindingR
 
 		expect(result).toEqual({ outcome: "bound", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentServiceKind: "managed", principalId: "managed-principal:service-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1" } });
 		expect(dependencies.profiles.select).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceKind: "managed" });
+		expect(dependencies.managedPrincipalValidator.validate).toHaveBeenCalledWith({ agentServiceId: "service-1", principalId: "managed-principal:service-1", issuer: "urn:opencrane:managed-agent", provenance: "internal", subject: "service-1" });
 		expect(dependencies.identities.select).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceId: "service-1", principalId: "managed-principal:service-1" });
 	});
 

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -1,12 +1,26 @@
 import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCommand, type ConversationAgentBindingRepository, type ConversationAgentBindingResult } from "./conversation-agent-binding.types";
 
-/** Resolves exact managed-agent facts for a later history-anchored conversation creation command. */
+/**
+ * Resolves the complete managed-agent binding required before conversation history is created.
+ *
+ * The resolver accepts a service candidate only after the AgentService Principal validator, release
+ * profile selector, and identity selector each return their owned coordinate. A missing coordinate
+ * becomes a denial, which prevents a later creation flow from persisting a partial agent binding.
+ * @implements ConversationAgentBindingAuthority
+ */
 export class ConversationAgentBindingResolver implements ConversationAgentBindingAuthorityPort
 {
-	/** Reads transactional service facts and uses only deployment- and identity-owned selection ports. */
+	/** Holds the transaction-scoped candidate reader and the three authorities that complete it. */
 	public constructor(private readonly repository: ConversationAgentBindingRepository, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}
 
-	/** Returns a complete binding only after every durable coordinate is current and independently owned. */
+	/**
+	 * Returns a complete managed binding or the first reason this checkpoint must deny it.
+	 *
+	 * An empty command denies before any lookup; a personal candidate denies before profile or identity
+	 * selection. The remaining checks run in ownership order so no selector sees a Principal that the
+	 * AgentService boundary rejected.
+	 * @returns `bound` with all creation coordinates, or `denied` without a partial binding.
+	 */
 	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
 	{
 		if (!_Present(command.siloId) || !_Present(command.agentServiceId))
@@ -30,13 +44,13 @@ export class ConversationAgentBindingResolver implements ConversationAgentBindin
 	}
 }
 
-/** Hides partial database and deployment facts behind one closed binding denial. */
+/** Builds a denial result so no branch returns the candidate facts it rejected. */
 function _Denied(reason: ConversationAgentBindingDenialReasons): ConversationAgentBindingResult
 {
 	return { outcome: "denied", reason };
 }
 
-/** Rejects empty server-owned coordinates before a repository or selector sees them. */
+/** Checks an input coordinate before a repository or selector receives it. */
 function _Present(value: string): boolean
 {
 	return value.trim().length > 0;

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -1,5 +1,3 @@
-import { __ManagedAgentServicePrincipal, MANAGED_AGENT_SERVICE_PRINCIPAL_ISSUER } from "@opencrane/backend/server/agents/agent-services";
-
 import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCommand, type ConversationAgentBindingRepository, type ConversationAgentBindingResult } from "./conversation-agent-binding.types";
 
 /** Resolves exact managed-agent facts for a later history-anchored conversation creation command. */
@@ -19,12 +17,8 @@ export class ConversationAgentBindingResolver implements ConversationAgentBindin
 		if (candidate.agentServiceKind === "personal")
 			return _Denied(ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable);
 		const principalId = candidate.principalId;
-		if (principalId === null
-			|| principalId !== __ManagedAgentServicePrincipal(candidate.agentServiceId)
-			|| candidate.principal === null
-			|| candidate.principal.provenance !== "internal"
-			|| candidate.principal.issuer !== MANAGED_AGENT_SERVICE_PRINCIPAL_ISSUER
-			|| candidate.principal.subject !== candidate.agentServiceId)
+		if (principalId === null || candidate.principal === null
+			|| !this.dependencies.managedPrincipalValidator.validate({ agentServiceId: candidate.agentServiceId, principalId, ...candidate.principal }))
 			return _Denied(ConversationAgentBindingDenialReasons.ManagedPrincipalUnavailable);
 		const profile = await this.dependencies.profiles.select({ siloId: command.siloId, agentServiceKind: candidate.agentServiceKind });
 		if (profile === null)

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -1,0 +1,49 @@
+import { __ManagedAgentServicePrincipal, MANAGED_AGENT_SERVICE_PRINCIPAL_ISSUER } from "@opencrane/backend/server/agents/agent-services";
+
+import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCommand, type ConversationAgentBindingRepository, type ConversationAgentBindingResult } from "./conversation-agent-binding.types";
+
+/** Resolves exact managed-agent facts for a later history-anchored conversation creation command. */
+export class ConversationAgentBindingAuthority implements ConversationAgentBindingAuthorityPort
+{
+	/** Reads transactional service facts and uses only deployment- and identity-owned selection ports. */
+	public constructor(private readonly repository: ConversationAgentBindingRepository, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}
+
+	/** Returns a complete binding only after every durable coordinate is current and independently owned. */
+	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
+	{
+		if (!_Present(command.siloId) || !_Present(command.agentServiceId))
+			return _Denied(ConversationAgentBindingDenialReasons.InvalidCommand);
+		const candidate = await this.repository.load(command);
+		if (candidate === null)
+			return _Denied(ConversationAgentBindingDenialReasons.ServiceUnavailable);
+		if (candidate.agentServiceKind === "personal")
+			return _Denied(ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable);
+		const principalId = candidate.principalId;
+		if (principalId === null
+			|| principalId !== __ManagedAgentServicePrincipal(candidate.agentServiceId)
+			|| candidate.principal === null
+			|| candidate.principal.provenance !== "internal"
+			|| candidate.principal.issuer !== MANAGED_AGENT_SERVICE_PRINCIPAL_ISSUER
+			|| candidate.principal.subject !== candidate.agentServiceId)
+			return _Denied(ConversationAgentBindingDenialReasons.ManagedPrincipalUnavailable);
+		const profile = await this.dependencies.profiles.select({ siloId: command.siloId, agentServiceKind: candidate.agentServiceKind });
+		if (profile === null)
+			return _Denied(ConversationAgentBindingDenialReasons.ProfileUnavailable);
+		const identity = await this.dependencies.identities.select({ siloId: command.siloId, agentServiceId: candidate.agentServiceId, principalId });
+		if (identity === null || !_Present(identity.agentIdentityId))
+			return _Denied(ConversationAgentBindingDenialReasons.IdentityUnavailable);
+		return { outcome: "bound", value: { agentServiceId: candidate.agentServiceId, agentRevisionId: candidate.agentRevisionId, agentServiceKind: "managed", principalId, agentIdentityId: identity.agentIdentityId, profileRevisionId: profile.profileRevisionId } };
+	}
+}
+
+/** Hides partial database and deployment facts behind one closed binding denial. */
+function _Denied(reason: ConversationAgentBindingDenialReasons): ConversationAgentBindingResult
+{
+	return { outcome: "denied", reason };
+}
+
+/** Rejects empty server-owned coordinates before a repository or selector sees them. */
+function _Present(value: string): boolean
+{
+	return value.trim().length > 0;
+}

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -3,7 +3,7 @@ import { __ManagedAgentServicePrincipal, MANAGED_AGENT_SERVICE_PRINCIPAL_ISSUER 
 import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCommand, type ConversationAgentBindingRepository, type ConversationAgentBindingResult } from "./conversation-agent-binding.types";
 
 /** Resolves exact managed-agent facts for a later history-anchored conversation creation command. */
-export class ConversationAgentBindingAuthority implements ConversationAgentBindingAuthorityPort
+export class ConversationAgentBindingResolver implements ConversationAgentBindingAuthorityPort
 {
 	/** Reads transactional service facts and uses only deployment- and identity-owned selection ports. */
 	public constructor(private readonly repository: ConversationAgentBindingRepository, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
@@ -1,23 +1,27 @@
 import type { ConversationComputerAgentServiceKind, ConversationComputerProfileSelector } from "./conversation-computer-profile-selection.types";
 
-/** Lists the closed reasons a conversation creation flow cannot bind its requested agent. */
+/**
+ * Explains why the pre-creation authority did not return an AgentService binding.
+ *
+ * Each reason means the future history-anchored creation flow has no complete binding to persist.
+ */
 export enum ConversationAgentBindingDenialReasons
 {
-	/** The requested service is absent, foreign, inactive, or has no active published revision. */
+	/** The requested service is absent, belongs to another silo, is inactive, or lacks a published active revision. */
 	ServiceUnavailable = "service_unavailable",
-	/** A managed service's durable Principal does not match its deterministic identity contract. */
+	/** The stored Principal does not meet the managed service's issuer, subject, and identity contract. */
 	ManagedPrincipalUnavailable = "managed_principal_unavailable",
-	/** A personal service cannot act until an explicit owned-personal delegation policy is selected. */
+	/** A personal service has no selected delegation policy or proxied identity in this checkpoint. */
 	PersonalDelegationUnavailable = "personal_delegation_unavailable",
 	/** The local release does not admit a computer profile for the resolved service kind. */
 	ProfileUnavailable = "profile_unavailable",
-	/** The identity catalog cannot provide the stable identity that the computer stream must bind. */
+	/** The identity authority did not provide the stored AgentIdentity needed by the computer stream. */
 	IdentityUnavailable = "identity_unavailable",
-	/** The command did not carry server-owned nonempty coordinates. */
+	/** The caller supplied an empty silo or service coordinate, so no repository lookup ran. */
 	InvalidCommand = "invalid_command",
 }
 
-/** Carries the trusted service coordinate for an eventual ConversationCreated command. */
+/** Carries the silo and service that an already-authorized creation flow resolved. */
 export interface ConversationAgentBindingCommand
 {
 	/** Identifies the silo containing the active service and immutable revision. */
@@ -26,7 +30,7 @@ export interface ConversationAgentBindingCommand
 	readonly agentServiceId: string;
 }
 
-/** Represents one exact active service and revision loaded in the binding transaction. */
+/** Holds service facts before their Principal, profile, and AgentIdentity checks complete. */
 export interface ConversationAgentBindingCandidate
 {
 	/** Identifies the active service in the command silo. */
@@ -41,13 +45,17 @@ export interface ConversationAgentBindingCandidate
 	readonly principal: { readonly issuer: string; readonly provenance: "internal" | "external"; readonly subject: string } | null;
 }
 
-/** Loads an exact active service and published revision inside the caller-owned transaction. */
+/**
+ * Loads an active service and the published revision named by its active pointer.
+ *
+ * `null` denies creation rather than allowing a stale service fact to proceed.
+ */
 export interface ConversationAgentBindingRepository
 {
 	load(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingCandidate | null>;
 }
 
-/** Carries the immutable coordinates used to retrieve a server-owned AgentIdentity. */
+/** Carries checked service and Principal coordinates for an existing AgentIdentity lookup. */
 export interface ConversationAgentIdentitySelectionCommand
 {
 	/** Identifies the silo where the identity stream must be owned. */
@@ -58,19 +66,33 @@ export interface ConversationAgentIdentitySelectionCommand
 	readonly principalId: string;
 }
 
-/** Supplies a stable AgentIdentity id only from a trusted catalog or identity-provisioning authority. */
+/**
+ * Selects an existing AgentIdentity from its owning authority.
+ *
+ * `null` denies the binding; this checkpoint has no AgentService-to-AgentIdentity producer and no
+ * fallback identity creation.
+ */
 export interface ConversationAgentIdentitySelector
 {
 	select(command: ConversationAgentIdentitySelectionCommand): Promise<{ readonly agentIdentityId: string } | null>;
 }
 
-/** Verifies that service Principal facts satisfy the managed-Agent issuer and subject contract. */
+/**
+ * Checks the Principal facts that identify a managed AgentService.
+ *
+ * The AgentService boundary owns the rule, so a false result denies before profile or identity
+ * selection can use the service.
+ */
 export interface ConversationManagedAgentPrincipalValidator
 {
 	validate(command: { readonly agentServiceId: string; readonly principalId: string; readonly issuer: string; readonly provenance: "internal" | "external"; readonly subject: string }): boolean;
 }
 
-/** Represents the complete immutable agent binding later persisted with conversation and computer history anchors. */
+/**
+ * Represents every managed-agent coordinate that a later creation command must persist together.
+ *
+ * Personal services deny until their delegation policy can supply an identity.
+ */
 export interface ConversationAgentBinding
 {
 	/** Identifies the active service. */
@@ -87,18 +109,23 @@ export interface ConversationAgentBinding
 	readonly profileRevisionId: string;
 }
 
-/** Returns one complete binding or one closed denial that must not reveal a partial agent state. */
+/** Returns complete creation coordinates or a denial with no partial binding to persist. */
 export type ConversationAgentBindingResult
 	= { readonly outcome: "bound"; readonly value: ConversationAgentBinding }
 	| { readonly outcome: "denied"; readonly reason: ConversationAgentBindingDenialReasons };
 
-/** Resolves the agent facts an eventual history-anchored conversation creation command requires. */
+/**
+ * Resolves the service, revision, Principal, profile, and AgentIdentity that pre-creation needs.
+ *
+ * It denies when any owned boundary cannot supply its coordinate; it never creates an identity or
+ * falls back to the older personal-service lookup.
+ */
 export interface ConversationAgentBindingAuthority
 {
 	bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>;
 }
 
-/** Lists the dependencies that keep profile and identity selection out of browser- and database-controlled data. */
+/** Lists the separately owned policy ports that complete a repository candidate. */
 export interface ConversationAgentBindingAuthorityDependencies
 {
 	/** Selects one release-owned profile after the authority resolves the trusted service kind. */

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
@@ -64,6 +64,12 @@ export interface ConversationAgentIdentitySelector
 	select(command: ConversationAgentIdentitySelectionCommand): Promise<{ readonly agentIdentityId: string } | null>;
 }
 
+/** Verifies that service Principal facts satisfy the managed-Agent issuer and subject contract. */
+export interface ConversationManagedAgentPrincipalValidator
+{
+	validate(command: { readonly agentServiceId: string; readonly principalId: string; readonly issuer: string; readonly provenance: "internal" | "external"; readonly subject: string }): boolean;
+}
+
 /** Represents the complete immutable agent binding later persisted with conversation and computer history anchors. */
 export interface ConversationAgentBinding
 {
@@ -97,6 +103,8 @@ export interface ConversationAgentBindingAuthorityDependencies
 {
 	/** Selects one release-owned profile after the authority resolves the trusted service kind. */
 	readonly profiles: ConversationComputerProfileSelector;
+	/** Verifies managed Principal facts through the independently-owned AgentService contract. */
+	readonly managedPrincipalValidator: ConversationManagedAgentPrincipalValidator;
 	/** Resolves an existing server-owned identity; this authority never manufactures an identity id. */
 	readonly identities: ConversationAgentIdentitySelector;
 }

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
@@ -1,0 +1,102 @@
+import type { ConversationComputerAgentServiceKind, ConversationComputerProfileSelector } from "./conversation-computer-profile-selection.types";
+
+/** Lists the closed reasons a conversation creation flow cannot bind its requested agent. */
+export enum ConversationAgentBindingDenialReasons
+{
+	/** The requested service is absent, foreign, inactive, or has no active published revision. */
+	ServiceUnavailable = "service_unavailable",
+	/** A managed service's durable Principal does not match its deterministic identity contract. */
+	ManagedPrincipalUnavailable = "managed_principal_unavailable",
+	/** A personal service cannot act until an explicit owned-personal delegation policy is selected. */
+	PersonalDelegationUnavailable = "personal_delegation_unavailable",
+	/** The local release does not admit a computer profile for the resolved service kind. */
+	ProfileUnavailable = "profile_unavailable",
+	/** The identity catalog cannot provide the stable identity that the computer stream must bind. */
+	IdentityUnavailable = "identity_unavailable",
+	/** The command did not carry server-owned nonempty coordinates. */
+	InvalidCommand = "invalid_command",
+}
+
+/** Carries the trusted service coordinate for an eventual ConversationCreated command. */
+export interface ConversationAgentBindingCommand
+{
+	/** Identifies the silo containing the active service and immutable revision. */
+	readonly siloId: string;
+	/** Identifies the AgentService selected by an already-authorized creation flow. */
+	readonly agentServiceId: string;
+}
+
+/** Represents one exact active service and revision loaded in the binding transaction. */
+export interface ConversationAgentBindingCandidate
+{
+	/** Identifies the active service in the command silo. */
+	readonly agentServiceId: string;
+	/** Identifies the published revision selected by the service's current pointer. */
+	readonly agentRevisionId: string;
+	/** States which principal and delegation rules apply to the service. */
+	readonly agentServiceKind: ConversationComputerAgentServiceKind;
+	/** Identifies the service principal when the service is managed, otherwise null. */
+	readonly principalId: string | null;
+	/** Gives the durable Principal facts that prove the managed-service identity, otherwise null. */
+	readonly principal: { readonly issuer: string; readonly provenance: "internal" | "external"; readonly subject: string } | null;
+}
+
+/** Loads an exact active service and published revision inside the caller-owned transaction. */
+export interface ConversationAgentBindingRepository
+{
+	load(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingCandidate | null>;
+}
+
+/** Carries the immutable coordinates used to retrieve a server-owned AgentIdentity. */
+export interface ConversationAgentIdentitySelectionCommand
+{
+	/** Identifies the silo where the identity stream must be owned. */
+	readonly siloId: string;
+	/** Identifies the already-validated service the identity must realize. */
+	readonly agentServiceId: string;
+	/** Identifies the exact principal the identity must represent. */
+	readonly principalId: string;
+}
+
+/** Supplies a stable AgentIdentity id only from a trusted catalog or identity-provisioning authority. */
+export interface ConversationAgentIdentitySelector
+{
+	select(command: ConversationAgentIdentitySelectionCommand): Promise<{ readonly agentIdentityId: string } | null>;
+}
+
+/** Represents the complete immutable agent binding later persisted with conversation and computer history anchors. */
+export interface ConversationAgentBinding
+{
+	/** Identifies the active service. */
+	readonly agentServiceId: string;
+	/** Identifies the active published revision. */
+	readonly agentRevisionId: string;
+	/** Identifies the managed service kind. */
+	readonly agentServiceKind: "managed";
+	/** Identifies the service's verified dedicated Principal. */
+	readonly principalId: string;
+	/** Identifies the stable AgentIdentity selected by the trusted identity authority. */
+	readonly agentIdentityId: string;
+	/** Identifies the immutable release-owned computer profile revision. */
+	readonly profileRevisionId: string;
+}
+
+/** Returns one complete binding or one closed denial that must not reveal a partial agent state. */
+export type ConversationAgentBindingResult
+	= { readonly outcome: "bound"; readonly value: ConversationAgentBinding }
+	| { readonly outcome: "denied"; readonly reason: ConversationAgentBindingDenialReasons };
+
+/** Resolves the agent facts an eventual history-anchored conversation creation command requires. */
+export interface ConversationAgentBindingAuthority
+{
+	bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>;
+}
+
+/** Lists the dependencies that keep profile and identity selection out of browser- and database-controlled data. */
+export interface ConversationAgentBindingAuthorityDependencies
+{
+	/** Selects one release-owned profile after the authority resolves the trusted service kind. */
+	readonly profiles: ConversationComputerProfileSelector;
+	/** Resolves an existing server-owned identity; this authority never manufactures an identity id. */
+	readonly identities: ConversationAgentIdentitySelector;
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
@@ -33,9 +33,27 @@ export class PrismaConversationAgentBindingRepository implements ConversationAge
 		return {
 			agentServiceId: service.id,
 			agentRevisionId: service.activeRevision.id,
-			agentServiceKind: service.kind === AgentServiceKind.Managed ? "managed" : "personal",
+			agentServiceKind: _ConversationComputerAgentServiceKind(service.kind),
 			principalId: service.principalId,
-			principal: service.principal === null ? null : { issuer: service.principal.issuer, provenance: service.principal.provenance === "Internal" ? "internal" : "external", subject: service.principal.subject },
+			principal: _Principal(service.principal),
 		};
 	}
+}
+
+/** Converts the database enum to the closed set accepted by computer profile selection. */
+function _ConversationComputerAgentServiceKind(kind: AgentServiceKind): ConversationAgentBindingCandidate["agentServiceKind"]
+{
+	return kind === AgentServiceKind.Managed ? "managed" : "personal";
+}
+
+/** Maps optional persistent Principal facts without broadening their provenance vocabulary. */
+function _Principal(principal: { readonly issuer: string; readonly provenance: string; readonly subject: string } | null): ConversationAgentBindingCandidate["principal"]
+{
+	if (principal === null)
+		return null;
+	return {
+		issuer: principal.issuer,
+		provenance: principal.provenance === "Internal" ? "internal" : "external",
+		subject: principal.subject,
+	};
 }

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
@@ -2,13 +2,28 @@ import { AgentRevisionState, AgentServiceKind, AgentServiceState, type Prisma } 
 
 import type { ConversationAgentBindingCandidate, ConversationAgentBindingCommand, ConversationAgentBindingRepository } from "../conversation-agent-binding.types";
 
-/** Loads active AgentService state and its published revision from one caller-owned Prisma transaction. */
+/**
+ * Loads an active AgentService and its current published revision from the transaction supplied by
+ * {@link PrismaConversationAgentBindingUnitOfWork}.
+ *
+ * The query keeps the service, silo, and active-revision requirements together. It returns a
+ * candidate rather than accepting a Principal, profile, or AgentIdentity; those checks belong to
+ * the resolver's injected authorities.
+ * @implements ConversationAgentBindingRepository
+ */
 export class PrismaConversationAgentBindingRepository implements ConversationAgentBindingRepository
 {
-	/** Captures the serializable transaction that must see service, revision, and Principal together. */
+	/** Holds the transaction that reads the service, revision, and Principal as one snapshot. */
 	public constructor(private readonly transaction: Prisma.TransactionClient) {}
 
-	/** Returns only a service whose active pointer still names its current published revision. */
+/**
+ * Returns the matching active service only when its active pointer still identifies a published
+ * revision in the requested silo.
+ *
+ * `null` tells the resolver to deny the command. The post-query pointer check defends the mapping
+ * from a partial relation result before any later authority sees it.
+ * @returns A candidate for further validation, or `null` when the active service/revision pair is unavailable.
+ */
 	public async load(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingCandidate | null>
 	{
 		const service = await this.transaction.agentService.findFirst({
@@ -40,13 +55,13 @@ export class PrismaConversationAgentBindingRepository implements ConversationAge
 	}
 }
 
-/** Converts the database enum to the closed set accepted by computer profile selection. */
+/** Converts the database enum to the two kinds accepted by computer-profile selection. */
 function _ConversationComputerAgentServiceKind(kind: AgentServiceKind): ConversationAgentBindingCandidate["agentServiceKind"]
 {
 	return kind === AgentServiceKind.Managed ? "managed" : "personal";
 }
 
-/** Maps optional persistent Principal facts without broadening their provenance vocabulary. */
+/** Maps optional stored Principal facts into the two source values accepted by the binding port. */
 function _Principal(principal: { readonly issuer: string; readonly provenance: string; readonly subject: string } | null): ConversationAgentBindingCandidate["principal"]
 {
 	if (principal === null)

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
@@ -1,0 +1,41 @@
+import { AgentRevisionState, AgentServiceKind, AgentServiceState, type Prisma } from "@prisma/client";
+
+import type { ConversationAgentBindingCandidate, ConversationAgentBindingCommand, ConversationAgentBindingRepository } from "../conversation-agent-binding.types";
+
+/** Loads active AgentService state and its published revision from one caller-owned Prisma transaction. */
+export class PrismaConversationAgentBindingRepository implements ConversationAgentBindingRepository
+{
+	/** Captures the serializable transaction that must see service, revision, and Principal together. */
+	public constructor(private readonly transaction: Prisma.TransactionClient) {}
+
+	/** Returns only a service whose active pointer still names its current published revision. */
+	public async load(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingCandidate | null>
+	{
+		const service = await this.transaction.agentService.findFirst({
+			where: {
+				id: command.agentServiceId,
+				siloId: command.siloId,
+				state: AgentServiceState.Active,
+				activeRevisionId: { not: null },
+				activeRevision: { is: { siloId: command.siloId, state: AgentRevisionState.Published } },
+			},
+			select: {
+				id: true,
+				kind: true,
+				activeRevisionId: true,
+				principalId: true,
+				activeRevision: { select: { id: true } },
+				principal: { select: { issuer: true, provenance: true, subject: true } },
+			},
+		});
+		if (service === null || service.activeRevision === null || service.activeRevisionId === null || service.activeRevision.id !== service.activeRevisionId)
+			return null;
+		return {
+			agentServiceId: service.id,
+			agentRevisionId: service.activeRevision.id,
+			agentServiceKind: service.kind === AgentServiceKind.Managed ? "managed" : "personal",
+			principalId: service.principalId,
+			principal: service.principal === null ? null : { issuer: service.principal.issuer, provenance: service.principal.provenance === "Internal" ? "internal" : "external", subject: service.principal.subject },
+		};
+	}
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
@@ -1,6 +1,6 @@
 import { Prisma, type PrismaClient } from "@prisma/client";
 
-import { ConversationAgentBindingAuthority } from "../conversation-agent-binding-authority";
+import { ConversationAgentBindingResolver } from "../conversation-agent-binding-authority";
 import type { ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult } from "../conversation-agent-binding.types";
 import { PrismaConversationAgentBindingRepository } from "./prisma-conversation-agent-binding-repository";
 
@@ -13,6 +13,12 @@ export class PrismaConversationAgentBindingUnitOfWork implements ConversationAge
 	/** Resolves the binding inside one serializable snapshot before later creation persists its history anchors. */
 	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
 	{
-		return this.prisma.$transaction(async transaction => new ConversationAgentBindingAuthority(new PrismaConversationAgentBindingRepository(transaction), this.dependencies).bind(command), { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+		const dependencies = this.dependencies;
+		return this.prisma.$transaction(async function _BindConversationAgent(transaction)
+		{
+			const repository = new PrismaConversationAgentBindingRepository(transaction);
+			const authority = new ConversationAgentBindingResolver(repository, dependencies);
+			return authority.bind(command);
+		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
 	}
 }

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
@@ -4,13 +4,27 @@ import { ConversationAgentBindingResolver } from "../conversation-agent-binding-
 import type { ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult } from "../conversation-agent-binding.types";
 import { PrismaConversationAgentBindingRepository } from "./prisma-conversation-agent-binding-repository";
 
-/** Opens the serializable snapshot that binds one active service, revision, and managed Principal. */
+/**
+ * Runs binding resolution in the serializable transaction that owns its service snapshot.
+ *
+ * A later creation composition can use this public authority port without constructing the
+ * repository against the root Prisma client. The transaction contains the service, revision, and
+ * Principal read; profile and identity selectors remain injected policy ports because this
+ * checkpoint does not own their data.
+ * @implements ConversationAgentBindingAuthority
+ */
 export class PrismaConversationAgentBindingUnitOfWork implements ConversationAgentBindingAuthorityPort
 {
-	/** Opens the authority transaction over the OpenCrane product database. */
+	/** Holds the product database client and the non-database authorities used by the resolver. */
 	public constructor(private readonly prisma: PrismaClient, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}
 
-	/** Resolves the binding inside one serializable snapshot before later creation persists its history anchors. */
+/**
+ * Resolves a binding against one serializable database snapshot.
+ *
+ * The unit of work builds its repository inside the transaction so the service and active revision
+ * cannot be read separately. A returned denial leaves no creation history to persist.
+ * @returns A complete binding or the reason the later creation flow must not continue.
+ */
 	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
 	{
 		const dependencies = this.dependencies;

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
@@ -1,0 +1,18 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+import { ConversationAgentBindingAuthority } from "../conversation-agent-binding-authority";
+import type { ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult } from "../conversation-agent-binding.types";
+import { PrismaConversationAgentBindingRepository } from "./prisma-conversation-agent-binding-repository";
+
+/** Opens the serializable snapshot that binds one active service, revision, and managed Principal. */
+export class PrismaConversationAgentBindingUnitOfWork implements ConversationAgentBindingAuthorityPort
+{
+	/** Opens the authority transaction over the OpenCrane product database. */
+	public constructor(private readonly prisma: PrismaClient, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}
+
+	/** Resolves the binding inside one serializable snapshot before later creation persists its history anchors. */
+	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
+	{
+		return this.prisma.$transaction(async transaction => new ConversationAgentBindingAuthority(new PrismaConversationAgentBindingRepository(transaction), this.dependencies).bind(command), { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+	}
+}

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -40,9 +40,8 @@ export { ConversationComputerActivationClaimAuthority } from "./conversation-com
 export type { ConversationComputerActivationAuthorityDependencies, ConversationComputerActivationClock, ConversationComputerActivationProfile, ConversationComputerActivationProfileCommand, ConversationComputerActivationProfileResolver } from "./conversation-computer-activation-authority.types";
 export { ConversationComputerAgentServiceKinds } from "./conversation-computer-profile-selection.types";
 export type { ConversationComputerAgentServiceKind, ConversationComputerProfileSelectionCommand, ConversationComputerProfileSelector } from "./conversation-computer-profile-selection.types";
-export { ConversationAgentBindingAuthority } from "./conversation-agent-binding-authority";
 export { PrismaConversationAgentBindingUnitOfWork } from "./db/prisma-conversation-agent-binding-unit-of-work";
-export type { ConversationAgentBinding, ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCandidate, ConversationAgentBindingCommand, ConversationAgentBindingRepository, ConversationAgentBindingResult, ConversationAgentIdentitySelectionCommand, ConversationAgentIdentitySelector } from "./conversation-agent-binding.types";
+export type { ConversationAgentBinding, ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult, ConversationAgentIdentitySelectionCommand, ConversationAgentIdentitySelector } from "./conversation-agent-binding.types";
 export { ConversationAgentBindingDenialReasons } from "./conversation-agent-binding.types";
 export { ConversationComputerSandboxReconciliationAuthority } from "./conversation-computer-sandbox-reconciliation-authority";
 export { ConversationComputerSandboxReconciliationOutcomes } from "./conversation-computer-sandbox-reconciliation-authority.types";

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -41,7 +41,7 @@ export type { ConversationComputerActivationAuthorityDependencies, ConversationC
 export { ConversationComputerAgentServiceKinds } from "./conversation-computer-profile-selection.types";
 export type { ConversationComputerAgentServiceKind, ConversationComputerProfileSelectionCommand, ConversationComputerProfileSelector } from "./conversation-computer-profile-selection.types";
 export { PrismaConversationAgentBindingUnitOfWork } from "./db/prisma-conversation-agent-binding-unit-of-work";
-export type { ConversationAgentBinding, ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult, ConversationAgentIdentitySelectionCommand, ConversationAgentIdentitySelector } from "./conversation-agent-binding.types";
+export type { ConversationAgentBinding, ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult, ConversationAgentIdentitySelectionCommand, ConversationAgentIdentitySelector, ConversationManagedAgentPrincipalValidator } from "./conversation-agent-binding.types";
 export { ConversationAgentBindingDenialReasons } from "./conversation-agent-binding.types";
 export { ConversationComputerSandboxReconciliationAuthority } from "./conversation-computer-sandbox-reconciliation-authority";
 export { ConversationComputerSandboxReconciliationOutcomes } from "./conversation-computer-sandbox-reconciliation-authority.types";

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -40,6 +40,10 @@ export { ConversationComputerActivationClaimAuthority } from "./conversation-com
 export type { ConversationComputerActivationAuthorityDependencies, ConversationComputerActivationClock, ConversationComputerActivationProfile, ConversationComputerActivationProfileCommand, ConversationComputerActivationProfileResolver } from "./conversation-computer-activation-authority.types";
 export { ConversationComputerAgentServiceKinds } from "./conversation-computer-profile-selection.types";
 export type { ConversationComputerAgentServiceKind, ConversationComputerProfileSelectionCommand, ConversationComputerProfileSelector } from "./conversation-computer-profile-selection.types";
+export { ConversationAgentBindingAuthority } from "./conversation-agent-binding-authority";
+export { PrismaConversationAgentBindingUnitOfWork } from "./db/prisma-conversation-agent-binding-unit-of-work";
+export type { ConversationAgentBinding, ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCandidate, ConversationAgentBindingCommand, ConversationAgentBindingRepository, ConversationAgentBindingResult, ConversationAgentIdentitySelectionCommand, ConversationAgentIdentitySelector } from "./conversation-agent-binding.types";
+export { ConversationAgentBindingDenialReasons } from "./conversation-agent-binding.types";
 export { ConversationComputerSandboxReconciliationAuthority } from "./conversation-computer-sandbox-reconciliation-authority";
 export { ConversationComputerSandboxReconciliationOutcomes } from "./conversation-computer-sandbox-reconciliation-authority.types";
 export type { ConversationComputerSandboxReconciliationAuthorityDependencies, ConversationComputerSandboxReconciliationOutcome } from "./conversation-computer-sandbox-reconciliation-authority.types";


### PR DESCRIPTION
## Summary

- resolve one active managed AgentService, its exact published revision, deterministic Principal, release-owned profile, and separately selected AgentIdentity in a Serializable snapshot
- fail closed for missing or foreign services, malformed managed Principals, absent profiles or identities, and all personal services pending an explicit delegation policy
- expose only the composition-facing unit of work and ports; keep the resolver and Prisma repository package-private

## Boundary

- does not create or catalogue AgentIdentity records; the injected identity selector must supply an existing owned identity
- does not alter the legacy creation or group-thread paths; their direct replacement follows once the canonical identity producer and history-anchored creation composition exist
- receives managed-Principal verification through an injected AgentService-owned port, preserving the enforced conversations dependency boundary

## Validation

- focused ConversationAgentBindingResolver Vitest suite: 5 tests
- backend-server-conversations TypeScript lint
- exact ESLint Nx dependency-boundary check
- Prisma boundary, agent-style, module-growth, and diff checks
- backend-server-agent-services lint and 61-test suite

## Review

- independent review found the initial forbidden conversations-to-agent-services import; the final commit replaces it with a narrow injected validation port and the reviewer confirmed the repair
- post-implementation reaper retained no premature identity catalog or legacy creation change and removed accidental public implementation exports
- final comments gate documented ownership, denial, and Serializable-snapshot semantics

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800