### PR TITLE
🏗️ provision deterministic managed AgentIdentity history

### DIFF
--- a/libs/backend/server/iam/identity/main/README.md
+++ b/libs/backend/server/iam/identity/main/README.md
@@ -77,6 +77,12 @@ acceptance route can establish membership; it gains no Owner or administrator fa
   loader accepts only a ConversationComputer's silo and identity, then derives the active service,
   Principal, actor class, and every checked child/parent stream-head condition from the identity
   history. A later command append must preserve every returned condition atomically.
+- `ManagedAgentIdentityHistoryProvisioner` — ensures the deterministic revision-zero, active
+  `managed-agent-identity:<AgentService.id>` stream for already-verified managed service facts.
+  It writes only at `NoStream`, then reloads and verifies the exact active identity after creation
+  or an append race. It never queries AgentService persistence, accepts a browser identity id, or
+  creates a relational catalog; the caller supplies the service, silo, and dedicated Principal that
+  its own authority has already checked.
 
 The OIDC service keeps login group projection and standalone first-owner admission as internal
 steps. They are not package entry points because the login flow coordinates their verified inputs,

--- a/libs/backend/server/iam/identity/main/src/agent-identities/__tests__/managed-agent-identity-provisioner.test.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/__tests__/managed-agent-identity-provisioner.test.ts
@@ -1,0 +1,68 @@
+import { AgentIdentityStates, type ManagedAgentIdentity } from "@opencrane/contracts";
+import { HistoryExpectedRevisions } from "@opencrane/backend/server/infra/history-store";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CurrentAgentIdentity } from "../agent-identity-history.types";
+import { __ManagedAgentIdentityId, ManagedAgentIdentityHistoryProvisioner } from "../managed-agent-identity-provisioner";
+
+/** Builds service facts already verified by the AgentService and conversation binding authorities. */
+function _Command(overrides: Partial<{ readonly siloId: string; readonly agentServiceId: string; readonly principalId: string; readonly agentServiceName: string }> = {})
+{
+	return { siloId: "silo-1", agentServiceId: "service-1", principalId: "managed-principal:service-1", agentServiceName: "Research assistant", ...overrides };
+}
+
+/** Builds the exact active identity this service may own. */
+function _Current(overrides: Partial<ManagedAgentIdentity> = {}): CurrentAgentIdentity
+{
+	const identity: ManagedAgentIdentity = {
+		schemaVersion: 1,
+		id: __ManagedAgentIdentityId("service-1"),
+		siloId: "silo-1",
+		agentServiceId: "service-1",
+		name: "Research assistant",
+		avatarArtifactRevisionId: null,
+		state: AgentIdentityStates.Active,
+		createdByPrincipalId: "managed-principal:service-1",
+		createdAt: "2026-09-02T00:00:00.000Z",
+		kind: "managed",
+		principalId: "managed-principal:service-1",
+		...overrides,
+	};
+	return { streamName: `agent-identity-${identity.id}`, revision: 0n, headDigest: `sha256:${"a".repeat(64)}`, identity };
+}
+
+/** Builds the provisioner over a narrow history fake; the history authority owns stream validation. */
+function _Provisioner(load = vi.fn(), append = vi.fn())
+{
+	return { subject: new ManagedAgentIdentityHistoryProvisioner({ load, append } as never, { now: () => new Date("2026-09-02T00:00:00.000Z") }), load, append };
+}
+
+describe("ManagedAgentIdentityHistoryProvisioner", function _ManagedAgentIdentityHistoryProvisionerSuite()
+{
+	it("anchors one deterministic active managed identity at revision zero when the stream is absent", async function _ProvisionsIdentity()
+	{
+		const { subject, load, append } = _Provisioner(vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(_Current()), vi.fn().mockResolvedValue({ streamName: `agent-identity-${__ManagedAgentIdentityId("service-1")}`, revision: 0n }));
+
+		await expect(subject.ensure(_Command())).resolves.toEqual({ agentIdentityId: __ManagedAgentIdentityId("service-1") });
+		expect(append).toHaveBeenCalledWith(expect.objectContaining({ expectedRevision: HistoryExpectedRevisions.NoStream, identity: expect.objectContaining({ id: __ManagedAgentIdentityId("service-1"), kind: "managed", state: AgentIdentityStates.Active, principalId: "managed-principal:service-1", createdByPrincipalId: "managed-principal:service-1", avatarArtifactRevisionId: null }) }));
+		expect(load).toHaveBeenCalledTimes(2);
+	});
+
+	it("reuses only a matching existing active managed stream and reloads one append race", async function _ReusesOrReloads()
+	{
+		const existing = _Provisioner(vi.fn().mockResolvedValue(_Current()));
+		await expect(existing.subject.ensure(_Command())).resolves.toEqual({ agentIdentityId: __ManagedAgentIdentityId("service-1") });
+		expect(existing.append).not.toHaveBeenCalled();
+
+		const race = _Provisioner(vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(_Current()), vi.fn().mockRejectedValue(new Error("stale expected revision")));
+		await expect(race.subject.ensure(_Command())).resolves.toEqual({ agentIdentityId: __ManagedAgentIdentityId("service-1") });
+	});
+
+	it("rejects missing post-append history and a non-managed, suspended, or conflicting stream", async function _RejectsConflictingIdentity()
+	{
+		const missing = _Provisioner(vi.fn().mockResolvedValue(null), vi.fn().mockResolvedValue({ streamName: "agent-identity-any", revision: 0n }));
+		await expect(missing.subject.ensure(_Command())).rejects.toThrow("did not persist");
+		for (const identity of [_Current({ kind: "managed_subchat" } as never), _Current({ state: AgentIdentityStates.Suspended }), _Current({ principalId: "managed-principal:other" })])
+			await expect(_Provisioner(vi.fn().mockResolvedValue(identity)).subject.ensure(_Command())).rejects.toThrow();
+	});
+});

--- a/libs/backend/server/iam/identity/main/src/agent-identities/index.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/index.ts
@@ -1,2 +1,4 @@
 export { AgentIdentityHistory } from "./agent-identity-history";
 export type { ActiveAgentIdentityAuthorization, AgentIdentityAppendCommand, AgentIdentityCurrentCommand, AgentIdentityRuntimeAuthorizationCommand, CurrentAgentIdentity } from "./agent-identity-history.types";
+export { __ManagedAgentIdentityId, ManagedAgentIdentityHistoryProvisioner } from "./managed-agent-identity-provisioner";
+export type { ManagedAgentIdentityProvisionCommand, ManagedAgentIdentityProvisioner, ManagedAgentIdentityProvisionerClock } from "./managed-agent-identity-provisioner.types";

--- a/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.ts
@@ -1,0 +1,91 @@
+import { randomUUID } from "node:crypto";
+
+import { AgentIdentityStates, type ManagedAgentIdentity } from "@opencrane/contracts";
+import { HistoryExpectedRevisions } from "@opencrane/backend/server/infra/history-store";
+
+import { AgentIdentityHistory } from "./agent-identity-history";
+import type { CurrentAgentIdentity } from "./agent-identity-history.types";
+import type { ManagedAgentIdentityProvisionCommand, ManagedAgentIdentityProvisioner, ManagedAgentIdentityProvisionerClock } from "./managed-agent-identity-provisioner.types";
+
+/** Derives the sole AgentIdentity coordinate a managed AgentService may realize. */
+export function __ManagedAgentIdentityId(agentServiceId: string): string
+{
+	if (!_Identifier(agentServiceId))
+		throw new Error("Managed agent identity provision requires a server-provided agent service identifier");
+	return `managed-agent-identity:${agentServiceId}`;
+}
+
+/** Ensures one active managed identity history stream from already-verified managed service facts. */
+export class ManagedAgentIdentityHistoryProvisioner implements ManagedAgentIdentityProvisioner
+{
+	/** Uses identity history for durable state and a server clock only when the stream is new. */
+	public constructor(private readonly history: AgentIdentityHistory, private readonly clock: ManagedAgentIdentityProvisionerClock) {}
+
+	/** Returns the exact active managed identity after first append or a concurrent stream creator. */
+	public async ensure(command: ManagedAgentIdentityProvisionCommand): Promise<{ readonly agentIdentityId: string }>
+	{
+		_ValidateCommand(command);
+		const agentIdentityId = __ManagedAgentIdentityId(command.agentServiceId);
+		const current = await this.history.load({ siloId: command.siloId, agentIdentityId, agentServiceId: command.agentServiceId, principalId: command.principalId });
+		if (current !== null)
+			return _ManagedIdentityResult(current, command, agentIdentityId);
+		try
+		{
+			await this.history.append({ expectedRevision: HistoryExpectedRevisions.NoStream, eventId: randomUUID(), identity: _ManagedIdentity(command, agentIdentityId, this.clock.now()) });
+		}
+		catch (error)
+		{
+			const raced = await this.history.load({ siloId: command.siloId, agentIdentityId, agentServiceId: command.agentServiceId, principalId: command.principalId });
+			if (raced === null)
+				throw error;
+			return _ManagedIdentityResult(raced, command, agentIdentityId);
+		}
+		const provisioned = await this.history.load({ siloId: command.siloId, agentIdentityId, agentServiceId: command.agentServiceId, principalId: command.principalId });
+		if (provisioned === null)
+			throw new Error("Managed agent identity provision did not persist its identity stream");
+		return _ManagedIdentityResult(provisioned, command, agentIdentityId);
+	}
+}
+
+/** Builds the first immutable snapshot for one managed service's deterministic identity stream. */
+function _ManagedIdentity(command: ManagedAgentIdentityProvisionCommand, agentIdentityId: string, createdAt: Date): ManagedAgentIdentity
+{
+	return {
+		schemaVersion: 1,
+		id: agentIdentityId,
+		siloId: command.siloId,
+		agentServiceId: command.agentServiceId,
+		name: command.agentServiceName,
+		avatarArtifactRevisionId: null,
+		state: AgentIdentityStates.Active,
+		createdByPrincipalId: command.principalId,
+		createdAt: createdAt.toISOString(),
+		kind: "managed",
+		principalId: command.principalId,
+	};
+}
+
+/** Rejects a stream that does not remain the exact active managed realization of this service. */
+function _ManagedIdentityResult(current: CurrentAgentIdentity, command: ManagedAgentIdentityProvisionCommand, agentIdentityId: string): { readonly agentIdentityId: string }
+{
+	const identity = current.identity;
+	if (identity.kind !== "managed" || identity.state !== AgentIdentityStates.Active
+		|| identity.id !== agentIdentityId || identity.siloId !== command.siloId
+		|| identity.agentServiceId !== command.agentServiceId || identity.principalId !== command.principalId
+		|| identity.createdByPrincipalId !== command.principalId || identity.avatarArtifactRevisionId !== null)
+		throw new Error("Managed agent identity provision found a conflicting identity stream");
+	return { agentIdentityId };
+}
+
+/** Rejects untrusted empty managed-service coordinates before they select an identity stream. */
+function _ValidateCommand(command: ManagedAgentIdentityProvisionCommand): void
+{
+	if (!_Identifier(command.siloId) || !_Identifier(command.agentServiceId) || !_Identifier(command.principalId) || !_Identifier(command.agentServiceName))
+		throw new Error("Managed agent identity provision requires complete server-provided service coordinates");
+}
+
+/** Checks one durable coordinate without silently normalizing it. */
+function _Identifier(value: string): boolean
+{
+	return value.trim().length > 0 && value === value.trim();
+}

--- a/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.ts
@@ -10,7 +10,15 @@ import type { ManagedAgentIdentityProvisionCommand, ManagedAgentIdentityProvisio
 /** Names the one discriminated identity variant this provisioner may create or accept. */
 const _MANAGED_IDENTITY_KIND: ManagedAgentIdentity["kind"] = "managed";
 
-/** Derives the sole AgentIdentity coordinate a managed AgentService may realize. */
+/**
+ * Derives the deterministic AgentIdentity coordinate for one managed AgentService.
+ *
+ * Creation and reuse must address this same stream. The function therefore rejects an empty or
+ * normalized service coordinate instead of deriving an identity from a browser-supplied id.
+ * @param agentServiceId - Supplies the verified managed AgentService identifier.
+ * @returns The stable identity id used by this provisioner's history stream.
+ * @throws {Error} When the service identifier is blank or has surrounding whitespace.
+ */
 export function __ManagedAgentIdentityId(agentServiceId: string): string
 {
 	if (!_Identifier(agentServiceId))
@@ -18,13 +26,29 @@ export function __ManagedAgentIdentityId(agentServiceId: string): string
 	return `managed-agent-identity:${agentServiceId}`;
 }
 
-/** Ensures one active managed identity history stream from already-verified managed service facts. */
+/**
+ * Establishes the active managed AgentIdentity history for already-verified service facts.
+ *
+ * The authority appends only at {@link HistoryExpectedRevisions.NoStream}, then reloads the active
+ * snapshot. A concurrent creator is accepted only when that reload realizes the same managed
+ * service, silo, and Principal; treating any successful append race as interchangeable could bind
+ * the service to a different actor. This boundary owns history creation, not AgentService lookup or
+ * a relational identity catalog.
+ * @see ManagedAgentIdentityProvisioner for the contract callers receive.
+ */
 export class ManagedAgentIdentityHistoryProvisioner implements ManagedAgentIdentityProvisioner
 {
 	/** Uses identity history for durable state and a server clock only when the stream is new. */
 	public constructor(private readonly history: AgentIdentityHistory, private readonly clock: ManagedAgentIdentityProvisionerClock) {}
 
-	/** Returns the exact active managed identity after first append or a concurrent stream creator. */
+	/**
+	 * Creates or reuses this service's deterministic managed identity stream.
+	 *
+	 * @param command - Supplies service facts that the upstream binding authority already verified.
+	 * @returns The managed identity id after a matching active history snapshot is loaded.
+	 * @throws {Error} When inputs are incomplete, persistence did not produce a stream, or the loaded
+	 * stream realizes a different, inactive, or non-managed identity.
+	 */
 	public async ensure(command: ManagedAgentIdentityProvisionCommand): Promise<{ readonly agentIdentityId: string }>
 	{
 		_ValidateCommand(command);

--- a/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.ts
@@ -7,6 +7,9 @@ import { AgentIdentityHistory } from "./agent-identity-history";
 import type { CurrentAgentIdentity } from "./agent-identity-history.types";
 import type { ManagedAgentIdentityProvisionCommand, ManagedAgentIdentityProvisioner, ManagedAgentIdentityProvisionerClock } from "./managed-agent-identity-provisioner.types";
 
+/** Names the one discriminated identity variant this provisioner may create or accept. */
+const _MANAGED_IDENTITY_KIND: ManagedAgentIdentity["kind"] = "managed";
+
 /** Derives the sole AgentIdentity coordinate a managed AgentService may realize. */
 export function __ManagedAgentIdentityId(agentServiceId: string): string
 {
@@ -60,7 +63,7 @@ function _ManagedIdentity(command: ManagedAgentIdentityProvisionCommand, agentId
 		state: AgentIdentityStates.Active,
 		createdByPrincipalId: command.principalId,
 		createdAt: createdAt.toISOString(),
-		kind: "managed",
+		kind: _MANAGED_IDENTITY_KIND,
 		principalId: command.principalId,
 	};
 }
@@ -69,7 +72,7 @@ function _ManagedIdentity(command: ManagedAgentIdentityProvisionCommand, agentId
 function _ManagedIdentityResult(current: CurrentAgentIdentity, command: ManagedAgentIdentityProvisionCommand, agentIdentityId: string): { readonly agentIdentityId: string }
 {
 	const identity = current.identity;
-	if (identity.kind !== "managed" || identity.state !== AgentIdentityStates.Active
+	if (identity.kind !== _MANAGED_IDENTITY_KIND || identity.state !== AgentIdentityStates.Active
 		|| identity.id !== agentIdentityId || identity.siloId !== command.siloId
 		|| identity.agentServiceId !== command.agentServiceId || identity.principalId !== command.principalId
 		|| identity.createdByPrincipalId !== command.principalId || identity.avatarArtifactRevisionId !== null)

--- a/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.types.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.types.ts
@@ -1,0 +1,26 @@
+/** Carries the verified managed-service facts required to ensure its durable AgentIdentity. */
+export interface ManagedAgentIdentityProvisionCommand
+{
+	/** Identifies the silo that owns the managed service and its identity stream. */
+	readonly siloId: string;
+	/** Identifies the managed AgentService that deterministically owns the identity. */
+	readonly agentServiceId: string;
+	/** Identifies the managed service's already-verified dedicated Principal. */
+	readonly principalId: string;
+	/** Supplies the trusted service display name captured for the first identity snapshot. */
+	readonly agentServiceName: string;
+}
+
+/** Gives the provisioner a testable server clock for immutable revision-zero timestamps. */
+export interface ManagedAgentIdentityProvisionerClock
+{
+	/** Returns the time recorded when this authority first creates an identity snapshot. */
+	now(): Date;
+}
+
+/** Returns the deterministic identity coordinate only after its active managed history is checked. */
+export interface ManagedAgentIdentityProvisioner
+{
+	/** Ensures the exact managed identity stream exists and returns its trusted identity id. */
+	ensure(command: ManagedAgentIdentityProvisionCommand): Promise<{ readonly agentIdentityId: string }>;
+}

--- a/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.types.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/managed-agent-identity-provisioner.types.ts
@@ -1,4 +1,11 @@
-/** Carries the verified managed-service facts required to ensure its durable AgentIdentity. */
+/**
+ * Supplies the managed-service facts needed to establish its AgentIdentity history.
+ *
+ * The provisioner intentionally does not read AgentService persistence: its caller must first
+ * verify this service, its dedicated Principal, and its silo. It uses this tuple to select a
+ * deterministic stream, then rejects a stream whose active snapshot realizes anything else.
+ * @see ManagedAgentIdentityProvisioner for the checked creation or reuse outcome.
+ */
 export interface ManagedAgentIdentityProvisionCommand
 {
 	/** Identifies the silo that owns the managed service and its identity stream. */
@@ -11,16 +18,35 @@ export interface ManagedAgentIdentityProvisionCommand
 	readonly agentServiceName: string;
 }
 
-/** Gives the provisioner a testable server clock for immutable revision-zero timestamps. */
+/**
+ * Supplies the server time used for an immutable revision-zero identity snapshot.
+ *
+ * The clock is read only when a missing stream is first appended; reused streams retain their
+ * recorded timestamp, so callers can make first-creation time deterministic in tests.
+ */
 export interface ManagedAgentIdentityProvisionerClock
 {
 	/** Returns the time recorded when this authority first creates an identity snapshot. */
 	now(): Date;
 }
 
-/** Returns the deterministic identity coordinate only after its active managed history is checked. */
+/**
+ * Ensures that one managed service has exactly one active, matching AgentIdentity stream.
+ *
+ * Implementations may create the revision-zero stream or accept another creator's winning append,
+ * but they must return only after loading and checking the active snapshot against the supplied
+ * service, silo, and Principal. A conflict, inactive identity, or different identity kind is a
+ * failure rather than an alternate identity selection.
+ */
 export interface ManagedAgentIdentityProvisioner
 {
-	/** Ensures the exact managed identity stream exists and returns its trusted identity id. */
+	/**
+	 * Creates or reuses the deterministic identity stream for verified service facts.
+	 *
+	 * @param command - Supplies the trusted service coordinates that must match the active snapshot.
+	 * @returns The identity id after the matching active history has been checked.
+	 * @throws {Error} When the command is incomplete or the stream is absent, inactive, or bound to
+	 * another identity realization after creation or an append race.
+	 */
 	ensure(command: ManagedAgentIdentityProvisionCommand): Promise<{ readonly agentIdentityId: string }>;
 }


### PR DESCRIPTION
## Summary

- ensure exactly one deterministic managed AgentIdentity stream for each already-verified managed AgentService
- append the active revision-zero managed snapshot only at NoStream, then reload and validate it after an append race
- keep identity history in IAM: no AgentService database lookup, browser-selected identity id, relational catalog, or cross-store transaction

## Boundary

- consumes already-verified silo, service, Principal, and display-name facts; the later composition must recheck active service lifecycle before invoking it
- rejects missing, suspended, non-managed, foreign, and principal-conflicting identity streams
- does not yet call this Kurrent-backed ensure operation from the #800 Prisma transaction; that refactor is required before live creation cutover

## Validation

- focused managed identity provisioner Vitest suite: 3 tests
- full backend-server-identity suite: 59 tests
- backend-server-identity TypeScript lint
- agent-style, Prisma-boundary, module-growth, and diff checks

## Review

- architecture preflight located the authority in IAM identity and required an injected composition seam
- reaper confirmed no previous producer, catalog, or writer exists to delete
- independent review found no implementation blocker and requested the public package-surface documentation now included
- final comments gate passed after ownership and failure semantics were documented

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801