### PR TITLE
🔒 keep ConversationComputer identity provisioning outside SQL

### DIFF
--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -1826,7 +1826,7 @@
 			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts",
 				"adapter": "PrismaConversationAgentBindingUnitOfWork",
-				"contract": "ConversationAgentBindingAuthority",
+				"contract": "ConversationAgentBindingVerifier",
 				"contractImportPath": "../conversation-agent-binding.types",
 				"constructs": [
 					{

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -73,12 +73,13 @@ or already terminal.
 `PrismaConversationAgentBindingUnitOfWork` supplies the pre-creation binding an eventual
 history-anchored agent-session creation command needs. In one serializable snapshot it accepts only
 an active service in the selected silo whose exact active revision is published, asks the separately
-owned AgentService contract to verify a managed service's deterministic internal Principal, selects
-the release-owned computer profile, and asks a
-separate identity authority for the stable `AgentIdentity`. Any missing or malformed coordinate
-denies without returning a partial binding. Personal services are explicitly unavailable here until
-their owned delegation policy can provide a proxied identity; this boundary never invents an
-identity or falls back to the legacy personal-service lookup.
+owned AgentService contract to verify a managed service's deterministic internal Principal, then
+closes that transaction. The outer binding authority selects the release-owned computer profile and
+asks a separate identity authority for the stable `AgentIdentity` only from the verified snapshot.
+This keeps KurrentDB identity history outside the PostgreSQL transaction. Any missing or malformed
+coordinate denies without returning a partial binding. Personal services are explicitly unavailable
+here until their owned delegation policy can provide a proxied identity; this boundary never invents
+an identity or falls back to the legacy personal-service lookup.
 
 Before creation, the directory returns active organisation members as opaque membership references.
 It never returns login subjects, email addresses, roles, or personal-memory identity. It also

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
@@ -44,13 +44,27 @@ describe("ConversationAgentBindingResolver", function _Suite()
 		await expect(verifier.verify({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable });
 	});
 
-	it("closes the serializable SQL transaction before the outer resolver is invoked", async function _ClosesTransaction()
+	it("resolves external profile and identity after the serializable SQL transaction closes", async function _ResolvesAfterTransaction()
 	{
 		const phases: string[] = [];
 		const transaction = { agentService: { findFirst: vi.fn().mockResolvedValue({ id: "service-1", name: "Research", kind: "Managed", activeRevisionId: "revision-1", activeRevision: { id: "revision-1" }, principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "Internal", subject: "service-1" } }) } };
 		const $transaction = vi.fn(async function _Transaction(work, options) { expect(options).toEqual({ isolationLevel: Prisma.TransactionIsolationLevel.Serializable }); phases.push("opened"); const result = await work(transaction); phases.push("closed"); return result; });
-		const verified = await new PrismaConversationAgentBindingUnitOfWork({ $transaction } as never, _Validator()).verify({ siloId: "silo-1", agentServiceId: "service-1" });
-		expect(phases).toEqual(["opened", "closed"]);
-		expect(verified).toMatchObject({ outcome: "verified" });
+		const dependencies = _Dependencies();
+		const profiles = dependencies.profiles.select as ReturnType<typeof vi.fn>;
+		const identities = dependencies.identities.ensure as ReturnType<typeof vi.fn>;
+		profiles.mockImplementation(async function _SelectProfile()
+		{
+			phases.push("profile");
+			return { profileRevisionId: "profile-1" };
+		});
+		identities.mockImplementation(async function _EnsureIdentity()
+		{
+			phases.push("identity");
+			return { agentIdentityId: "identity-1" };
+		});
+		const verifier = new PrismaConversationAgentBindingUnitOfWork({ $transaction } as never, _Validator());
+		const resolver = new ConversationAgentBindingResolver(verifier, dependencies);
+		await expect(resolver.bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toMatchObject({ outcome: "bound" });
+		expect(phases).toEqual(["opened", "closed", "profile", "identity"]);
 	});
 });

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
@@ -1,84 +1,56 @@
 import { Prisma } from "@prisma/client";
 import { describe, expect, it, vi } from "vitest";
 
-import { ConversationAgentBindingResolver } from "../conversation-agent-binding-authority";
-import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCandidate } from "../conversation-agent-binding.types";
-import { PrismaConversationAgentBindingRepository } from "../db/prisma-conversation-agent-binding-repository";
+import { ConversationAgentBindingResolver, ConversationAgentBindingVerificationResolver } from "../conversation-agent-binding-authority";
+import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCandidate, type ConversationManagedAgentPrincipalValidator } from "../conversation-agent-binding.types";
 import { PrismaConversationAgentBindingUnitOfWork } from "../db/prisma-conversation-agent-binding-unit-of-work";
 
-/** Builds one checked managed service candidate with its deterministic Principal contract. */
-function _ManagedCandidate(overrides: Partial<ConversationAgentBindingCandidate> = {}): ConversationAgentBindingCandidate
+function _Candidate(overrides: Partial<ConversationAgentBindingCandidate> = {}): ConversationAgentBindingCandidate
 {
-	return { agentServiceId: "service-1", agentRevisionId: "revision-1", agentServiceKind: "managed", principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "internal", subject: "service-1" }, ...overrides };
+	return { agentServiceName: "Research", agentServiceId: "service-1", agentRevisionId: "revision-1", agentServiceKind: "managed", principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "internal", subject: "service-1" }, ...overrides };
 }
 
-/** Builds the deployment and identity selection ports without introducing a database fallback. */
+function _Validator(): ConversationManagedAgentPrincipalValidator
+{
+	return { validate: vi.fn(command => command.principalId === `managed-principal:${command.agentServiceId}` && command.issuer === "urn:opencrane:managed-agent" && command.provenance === "internal" && command.subject === command.agentServiceId) };
+}
+
 function _Dependencies(): ConversationAgentBindingAuthorityDependencies
 {
-	return {
-		profiles: { select: vi.fn().mockResolvedValue({ profileRevisionId: "profile-1" }) },
-		managedPrincipalValidator: {
-			validate: vi.fn().mockImplementation(command => command.principalId === `managed-principal:${command.agentServiceId}` && command.issuer === "urn:opencrane:managed-agent" && command.provenance === "internal" && command.subject === command.agentServiceId),
-		},
-		identities: { select: vi.fn().mockResolvedValue({ agentIdentityId: "identity-1" }) },
-	};
+	return { profiles: { select: vi.fn().mockResolvedValue({ profileRevisionId: "profile-1" }) }, identities: { ensure: vi.fn().mockResolvedValue({ agentIdentityId: "identity-1" }) } };
 }
 
-describe("ConversationAgentBindingResolver", function _ConversationAgentBindingResolverSuite()
+describe("ConversationAgentBindingResolver", function _Suite()
 {
-	it("binds only one active managed service to its revision, principal, selected identity, and release profile", async function _BindsManagedService()
+	it("resolves external profile and identity only from a verified managed snapshot", async function _Resolves()
 	{
-		const load = vi.fn().mockResolvedValue(_ManagedCandidate());
 		const dependencies = _Dependencies();
-		const result = await new ConversationAgentBindingResolver({ load }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" });
-
-		expect(result).toEqual({ outcome: "bound", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentServiceKind: "managed", principalId: "managed-principal:service-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1" } });
-		expect(dependencies.profiles.select).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceKind: "managed" });
-		expect(dependencies.managedPrincipalValidator.validate).toHaveBeenCalledWith({ agentServiceId: "service-1", principalId: "managed-principal:service-1", issuer: "urn:opencrane:managed-agent", provenance: "internal", subject: "service-1" });
-		expect(dependencies.identities.select).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceId: "service-1", principalId: "managed-principal:service-1" });
+		const verifier = { verify: vi.fn().mockResolvedValue({ outcome: "verified", value: _Candidate() }) };
+		await expect(new ConversationAgentBindingResolver(verifier, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toMatchObject({ outcome: "bound" });
+		expect(dependencies.identities.ensure).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceId: "service-1", principalId: "managed-principal:service-1", agentServiceName: "Research" });
 	});
 
-	it("fails closed for a missing service, malformed managed Principal, missing release profile, and missing identity", async function _RejectsIncompleteCoordinates()
+	it("does not invoke external selectors after a verifier denial", async function _Denies()
 	{
 		const dependencies = _Dependencies();
-		await expect(new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(null) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable });
-		await expect(new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(_ManagedCandidate({ principalId: "forged" })) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ManagedPrincipalUnavailable });
-		(dependencies.profiles.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
-		await expect(new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(_ManagedCandidate()) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ProfileUnavailable });
-		(dependencies.identities.select as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
-		await expect(new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(_ManagedCandidate()) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.IdentityUnavailable });
-	});
-
-	it("refuses a personal service until a real owned-personal delegation policy can create its proxied identity", async function _RejectsPersonalService()
-	{
-		const dependencies = _Dependencies();
-		const result = await new ConversationAgentBindingResolver({ load: vi.fn().mockResolvedValue(_ManagedCandidate({ agentServiceKind: "personal", principalId: null, principal: null })) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" });
-
-		expect(result).toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable });
+		await expect(new ConversationAgentBindingResolver({ verify: vi.fn().mockResolvedValue({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable }) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable });
 		expect(dependencies.profiles.select).not.toHaveBeenCalled();
-		expect(dependencies.identities.select).not.toHaveBeenCalled();
-	});
-});
-
-describe("PrismaConversationAgentBindingRepository", function _PrismaConversationAgentBindingRepositorySuite()
-{
-	it("queries an active service only through its matching published active revision", async function _LoadsPublishedActiveRevision()
-	{
-		const findFirst = vi.fn().mockResolvedValue({ id: "service-1", kind: "Managed", activeRevisionId: "revision-1", activeRevision: { id: "revision-1" }, principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "Internal", subject: "service-1" } });
-		const result = await new PrismaConversationAgentBindingRepository({ agentService: { findFirst } } as never).load({ siloId: "silo-1", agentServiceId: "service-1" });
-
-		expect(result).toEqual(_ManagedCandidate());
-		expect(findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ id: "service-1", siloId: "silo-1", state: "Active", activeRevision: { is: { siloId: "silo-1", state: "Published" } } }) }));
+		expect(dependencies.identities.ensure).not.toHaveBeenCalled();
 	});
 
-	it("uses a serializable transaction for the final binding snapshot", async function _UsesSerializableTransaction()
+	it("verifies a personal service before external resolution", async function _Verifies()
 	{
-		const transaction = { agentService: { findFirst: vi.fn().mockResolvedValue({ id: "service-1", kind: "Managed", activeRevisionId: "revision-1", activeRevision: { id: "revision-1" }, principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "Internal", subject: "service-1" } }) } };
-		const $transaction = vi.fn(async function _Transaction(work, options)
-		{
-			expect(options).toEqual({ isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
-			return work(transaction);
-		});
-		await expect(new PrismaConversationAgentBindingUnitOfWork({ $transaction } as never, _Dependencies()).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toMatchObject({ outcome: "bound" });
+		const verifier = new ConversationAgentBindingVerificationResolver({ load: vi.fn().mockResolvedValue(_Candidate({ agentServiceKind: "personal", principalId: null, principal: null })) }, _Validator());
+		await expect(verifier.verify({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable });
+	});
+
+	it("closes the serializable SQL transaction before the outer resolver is invoked", async function _ClosesTransaction()
+	{
+		const phases: string[] = [];
+		const transaction = { agentService: { findFirst: vi.fn().mockResolvedValue({ id: "service-1", name: "Research", kind: "Managed", activeRevisionId: "revision-1", activeRevision: { id: "revision-1" }, principalId: "managed-principal:service-1", principal: { issuer: "urn:opencrane:managed-agent", provenance: "Internal", subject: "service-1" } }) } };
+		const $transaction = vi.fn(async function _Transaction(work, options) { expect(options).toEqual({ isolationLevel: Prisma.TransactionIsolationLevel.Serializable }); phases.push("opened"); const result = await work(transaction); phases.push("closed"); return result; });
+		const verified = await new PrismaConversationAgentBindingUnitOfWork({ $transaction } as never, _Validator()).verify({ siloId: "silo-1", agentServiceId: "service-1" });
+		expect(phases).toEqual(["opened", "closed"]);
+		expect(verified).toMatchObject({ outcome: "verified" });
 	});
 });

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -1,25 +1,25 @@
 import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCandidate, type ConversationAgentBindingCommand, type ConversationAgentBindingRepository, type ConversationAgentBindingResult, type ConversationAgentBindingVerificationResult, type ConversationAgentBindingVerifier, type ConversationManagedAgentPrincipalValidator } from "./conversation-agent-binding.types";
 
 /**
- * Resolves the complete managed-agent binding required before conversation history is created.
+ * Verifies the managed-service snapshot required before external binding work begins.
  *
- * The resolver accepts a service candidate only after the AgentService Principal validator, release
- * profile selector, and identity selector each return their owned coordinate. A missing coordinate
- * becomes a denial, which prevents a later creation flow from persisting a partial agent binding.
- * @implements ConversationAgentBindingAuthority
+ * The resolver rejects an absent, personal, or invalid-principal candidate before profile selection
+ * or identity provisioning sees it. It returns only checked service facts, so the outer binding
+ * authority can resolve those separately owned coordinates after the SQL transaction has closed.
+ * @implements ConversationAgentBindingVerifier
  */
 export class ConversationAgentBindingVerificationResolver
 {
-	/** Holds the transaction-scoped reader and the AgentService-owned Principal validator. */
+	/** Holds the candidate reader and the AgentService-owned Principal validator. */
 	public constructor(private readonly repository: ConversationAgentBindingRepository, private readonly managedPrincipalValidator: ConversationManagedAgentPrincipalValidator) {}
 
 	/**
-	 * Returns a complete managed binding or the first reason this checkpoint must deny it.
+	 * Returns a verified managed snapshot or the first reason this checkpoint must deny it.
 	 *
-	 * An empty command denies before any lookup; a personal candidate denies before profile or identity
-	 * selection. The remaining checks run in ownership order so no selector sees a Principal that the
-	 * AgentService boundary rejected.
-	 * @returns `bound` with all creation coordinates, or `denied` without a partial binding.
+	 * An empty command denies before any lookup. A personal candidate denies before the profile or
+	 * identity authority can receive its Principal. The remaining checks run in ownership order so no
+	 * external authority sees a Principal that the AgentService boundary rejected.
+	 * @returns `verified` with checked service coordinates, or `denied` without partial facts.
 	 */
 	public async verify(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingVerificationResult>
 	{
@@ -38,13 +38,25 @@ export class ConversationAgentBindingVerificationResolver
 	}
 }
 
-/** Resolves external profile and identity coordinates only after SQL verification has completed. */
+/**
+ * Completes a verified service snapshot with its profile and AgentIdentity after SQL has closed.
+ *
+ * Keeping these separately owned ports outside the serializable unit of work prevents their history
+ * work from extending that PostgreSQL transaction. A verifier denial returns unchanged; missing
+ * profile or identity coordinates deny the binding.
+ * @implements ConversationAgentBindingAuthority
+ */
 export class ConversationAgentBindingResolver implements ConversationAgentBindingAuthorityPort
 {
 	/** Holds the serializable verifier plus external profile and identity authorities. */
 	public constructor(private readonly verifier: ConversationAgentBindingVerifier, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}
 
-	/** Returns a complete binding after the verifier has closed its SQL transaction. */
+	/**
+	 * Returns a complete binding after the verifier has closed its SQL transaction.
+	 *
+	 * The method preserves a verifier denial without calling profile or identity ports. It denies when
+	 * either later port cannot provide its coordinate.
+	 */
 	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
 	{
 		const verification = await this.verifier.verify(command);

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -48,7 +48,7 @@ export class ConversationAgentBindingResolver implements ConversationAgentBindin
 	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
 	{
 		const verification = await this.verifier.verify(command);
-		if (verification.outcome === "denied")
+		if (!("value" in verification))
 			return verification;
 		const candidate = verification.value;
 		const profile = await this.dependencies.profiles.select({ siloId: command.siloId, agentServiceKind: candidate.agentServiceKind });

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -1,4 +1,4 @@
-import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCommand, type ConversationAgentBindingRepository, type ConversationAgentBindingResult } from "./conversation-agent-binding.types";
+import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, type ConversationAgentBindingAuthorityDependencies, type ConversationAgentBindingCandidate, type ConversationAgentBindingCommand, type ConversationAgentBindingRepository, type ConversationAgentBindingResult, type ConversationAgentBindingVerificationResult, type ConversationAgentBindingVerifier, type ConversationManagedAgentPrincipalValidator } from "./conversation-agent-binding.types";
 
 /**
  * Resolves the complete managed-agent binding required before conversation history is created.
@@ -8,10 +8,10 @@ import { ConversationAgentBindingDenialReasons, type ConversationAgentBindingAut
  * becomes a denial, which prevents a later creation flow from persisting a partial agent binding.
  * @implements ConversationAgentBindingAuthority
  */
-export class ConversationAgentBindingResolver implements ConversationAgentBindingAuthorityPort
+export class ConversationAgentBindingVerificationResolver
 {
-	/** Holds the transaction-scoped candidate reader and the three authorities that complete it. */
-	public constructor(private readonly repository: ConversationAgentBindingRepository, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}
+	/** Holds the transaction-scoped reader and the AgentService-owned Principal validator. */
+	public constructor(private readonly repository: ConversationAgentBindingRepository, private readonly managedPrincipalValidator: ConversationManagedAgentPrincipalValidator) {}
 
 	/**
 	 * Returns a complete managed binding or the first reason this checkpoint must deny it.
@@ -21,31 +21,54 @@ export class ConversationAgentBindingResolver implements ConversationAgentBindin
 	 * AgentService boundary rejected.
 	 * @returns `bound` with all creation coordinates, or `denied` without a partial binding.
 	 */
-	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
+	public async verify(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingVerificationResult>
 	{
 		if (!_Present(command.siloId) || !_Present(command.agentServiceId))
-			return _Denied(ConversationAgentBindingDenialReasons.InvalidCommand);
+			return _VerificationDenied(ConversationAgentBindingDenialReasons.InvalidCommand);
 		const candidate = await this.repository.load(command);
 		if (candidate === null)
-			return _Denied(ConversationAgentBindingDenialReasons.ServiceUnavailable);
+			return _VerificationDenied(ConversationAgentBindingDenialReasons.ServiceUnavailable);
 		if (candidate.agentServiceKind === "personal")
-			return _Denied(ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable);
+			return _VerificationDenied(ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable);
 		const principalId = candidate.principalId;
 		if (principalId === null || candidate.principal === null
-			|| !this.dependencies.managedPrincipalValidator.validate({ agentServiceId: candidate.agentServiceId, principalId, ...candidate.principal }))
-			return _Denied(ConversationAgentBindingDenialReasons.ManagedPrincipalUnavailable);
+			|| !this.managedPrincipalValidator.validate({ agentServiceId: candidate.agentServiceId, principalId, ...candidate.principal }))
+			return _VerificationDenied(ConversationAgentBindingDenialReasons.ManagedPrincipalUnavailable);
+		return { outcome: "verified", value: { ...candidate, agentServiceKind: "managed", principalId, principal: candidate.principal } };
+	}
+}
+
+/** Resolves external profile and identity coordinates only after SQL verification has completed. */
+export class ConversationAgentBindingResolver implements ConversationAgentBindingAuthorityPort
+{
+	/** Holds the serializable verifier plus external profile and identity authorities. */
+	public constructor(private readonly verifier: ConversationAgentBindingVerifier, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}
+
+	/** Returns a complete binding after the verifier has closed its SQL transaction. */
+	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
+	{
+		const verification = await this.verifier.verify(command);
+		if (verification.outcome === "denied")
+			return verification;
+		const candidate = verification.value;
 		const profile = await this.dependencies.profiles.select({ siloId: command.siloId, agentServiceKind: candidate.agentServiceKind });
 		if (profile === null)
 			return _Denied(ConversationAgentBindingDenialReasons.ProfileUnavailable);
-		const identity = await this.dependencies.identities.select({ siloId: command.siloId, agentServiceId: candidate.agentServiceId, principalId });
+		const identity = await this.dependencies.identities.ensure({ siloId: command.siloId, agentServiceId: candidate.agentServiceId, principalId: candidate.principalId, agentServiceName: candidate.agentServiceName });
 		if (identity === null || !_Present(identity.agentIdentityId))
 			return _Denied(ConversationAgentBindingDenialReasons.IdentityUnavailable);
-		return { outcome: "bound", value: { agentServiceId: candidate.agentServiceId, agentRevisionId: candidate.agentRevisionId, agentServiceKind: "managed", principalId, agentIdentityId: identity.agentIdentityId, profileRevisionId: profile.profileRevisionId } };
+		return { outcome: "bound", value: { agentServiceId: candidate.agentServiceId, agentRevisionId: candidate.agentRevisionId, agentServiceKind: "managed", principalId: candidate.principalId, agentIdentityId: identity.agentIdentityId, profileRevisionId: profile.profileRevisionId } };
 	}
 }
 
 /** Builds a denial result so no branch returns the candidate facts it rejected. */
 function _Denied(reason: ConversationAgentBindingDenialReasons): ConversationAgentBindingResult
+{
+	return { outcome: "denied", reason };
+}
+
+/** Builds a verifier denial without pretending it is a complete externally resolved binding. */
+function _VerificationDenied(reason: ConversationAgentBindingDenialReasons): ConversationAgentBindingVerificationResult
 {
 	return { outcome: "denied", reason };
 }

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
@@ -33,6 +33,8 @@ export interface ConversationAgentBindingCommand
 /** Holds service facts before their Principal, profile, and AgentIdentity checks complete. */
 export interface ConversationAgentBindingCandidate
 {
+	/** Supplies the trusted service name for an initial deterministic AgentIdentity snapshot. */
+	readonly agentServiceName: string;
 	/** Identifies the active service in the command silo. */
 	readonly agentServiceId: string;
 	/** Identifies the published revision selected by the service's current pointer. */
@@ -64,6 +66,8 @@ export interface ConversationAgentIdentitySelectionCommand
 	readonly agentServiceId: string;
 	/** Identifies the exact principal the identity must represent. */
 	readonly principalId: string;
+	/** Supplies the checked service name for a first deterministic identity-history append. */
+	readonly agentServiceName: string;
 }
 
 /**
@@ -74,7 +78,7 @@ export interface ConversationAgentIdentitySelectionCommand
  */
 export interface ConversationAgentIdentitySelector
 {
-	select(command: ConversationAgentIdentitySelectionCommand): Promise<{ readonly agentIdentityId: string } | null>;
+	ensure(command: ConversationAgentIdentitySelectionCommand): Promise<{ readonly agentIdentityId: string } | null>;
 }
 
 /**
@@ -125,13 +129,22 @@ export interface ConversationAgentBindingAuthority
 	bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>;
 }
 
+/** Returns a verified managed service snapshot without selecting an external profile or identity. */
+export interface ConversationAgentBindingVerifier
+{
+	verify(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingVerificationResult>;
+}
+
+/** Carries only the SQL-backed facts a later external resolution phase may consume. */
+export type ConversationAgentBindingVerificationResult
+	= { readonly outcome: "verified"; readonly value: ConversationAgentBindingCandidate & { readonly agentServiceKind: "managed"; readonly principalId: string; readonly principal: { readonly issuer: string; readonly provenance: "internal" | "external"; readonly subject: string } } }
+	| { readonly outcome: "denied"; readonly reason: ConversationAgentBindingDenialReasons };
+
 /** Lists the separately owned policy ports that complete a repository candidate. */
 export interface ConversationAgentBindingAuthorityDependencies
 {
 	/** Selects one release-owned profile after the authority resolves the trusted service kind. */
 	readonly profiles: ConversationComputerProfileSelector;
-	/** Verifies managed Principal facts through the independently-owned AgentService contract. */
-	readonly managedPrincipalValidator: ConversationManagedAgentPrincipalValidator;
-	/** Resolves an existing server-owned identity; this authority never manufactures an identity id. */
+	/** Ensures the server-owned identity; this authority never accepts a browser identity id. */
 	readonly identities: ConversationAgentIdentitySelector;
 }

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
@@ -33,7 +33,7 @@ export interface ConversationAgentBindingCommand
 /** Holds service facts before their Principal, profile, and AgentIdentity checks complete. */
 export interface ConversationAgentBindingCandidate
 {
-	/** Supplies the trusted service name for an initial deterministic AgentIdentity snapshot. */
+	/** Carries the service name read with the snapshot so identity provisioning can seed its deterministic history. */
 	readonly agentServiceName: string;
 	/** Identifies the active service in the command silo. */
 	readonly agentServiceId: string;
@@ -66,18 +66,20 @@ export interface ConversationAgentIdentitySelectionCommand
 	readonly agentServiceId: string;
 	/** Identifies the exact principal the identity must represent. */
 	readonly principalId: string;
-	/** Supplies the checked service name for a first deterministic identity-history append. */
+	/** Carries the database-selected service name when provisioning the first AgentIdentity history event. */
 	readonly agentServiceName: string;
 }
 
 /**
- * Selects an existing AgentIdentity from its owning authority.
+ * Returns or provisions the deterministic AgentIdentity from its owning authority.
  *
- * `null` denies the binding; this checkpoint has no AgentService-to-AgentIdentity producer and no
- * fallback identity creation.
+ * The selector receives the database-verified service facts after SQL verification has closed, so
+ * it can create the first identity-history event without a browser-chosen identity. `null` denies
+ * the binding.
  */
 export interface ConversationAgentIdentitySelector
 {
+	/** Returns the existing or newly provisioned identity, or `null` when the binding must deny. */
 	ensure(command: ConversationAgentIdentitySelectionCommand): Promise<{ readonly agentIdentityId: string } | null>;
 }
 
@@ -121,21 +123,34 @@ export type ConversationAgentBindingResult
 /**
  * Resolves the service, revision, Principal, profile, and AgentIdentity that pre-creation needs.
  *
- * It denies when any owned boundary cannot supply its coordinate; it never creates an identity or
- * falls back to the older personal-service lookup.
+ * It verifies the service, revision, and Principal before profile selection and AgentIdentity
+ * provisioning run outside the serializable SQL transaction. It denies when an owned boundary
+ * cannot supply its coordinate and never falls back to the older personal-service lookup.
  */
 export interface ConversationAgentBindingAuthority
 {
+	/** Returns complete creation coordinates, or the denial that prevents the creation flow from continuing. */
 	bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>;
 }
 
-/** Returns a verified managed service snapshot without selecting an external profile or identity. */
+/**
+ * Verifies the database-backed managed-service facts before the outer authority calls external ports.
+ *
+ * A verified outcome lets the caller select a profile and provision an AgentIdentity after SQL has
+ * closed. A denied outcome tells the caller to stop without calling either port.
+ */
 export interface ConversationAgentBindingVerifier
 {
+	/** Returns a verified snapshot, or the denial that prevents profile and identity resolution. */
 	verify(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingVerificationResult>;
 }
 
-/** Carries only the SQL-backed facts a later external resolution phase may consume. */
+/**
+ * Describes the result of checking a service snapshot.
+ *
+ * `verified` carries managed-service facts that later profile and identity resolution may consume.
+ * `denied` preserves the reason without exposing a partial binding.
+ */
 export type ConversationAgentBindingVerificationResult
 	= { readonly outcome: "verified"; readonly value: ConversationAgentBindingCandidate & { readonly agentServiceKind: "managed"; readonly principalId: string; readonly principal: { readonly issuer: string; readonly provenance: "internal" | "external"; readonly subject: string } } }
 	| { readonly outcome: "denied"; readonly reason: ConversationAgentBindingDenialReasons };

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
@@ -36,6 +36,7 @@ export class PrismaConversationAgentBindingRepository implements ConversationAge
 			},
 			select: {
 				id: true,
+				name: true,
 				kind: true,
 				activeRevisionId: true,
 				principalId: true,
@@ -46,6 +47,7 @@ export class PrismaConversationAgentBindingRepository implements ConversationAge
 		if (service === null || service.activeRevision === null || service.activeRevisionId === null || service.activeRevision.id !== service.activeRevisionId)
 			return null;
 		return {
+			agentServiceName: service.name,
 			agentServiceId: service.id,
 			agentRevisionId: service.activeRevision.id,
 			agentServiceKind: _ConversationComputerAgentServiceKind(service.kind),

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
@@ -1,7 +1,7 @@
 import { Prisma, type PrismaClient } from "@prisma/client";
 
-import { ConversationAgentBindingResolver } from "../conversation-agent-binding-authority";
-import type { ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult } from "../conversation-agent-binding.types";
+import { ConversationAgentBindingVerificationResolver } from "../conversation-agent-binding-authority";
+import type { ConversationAgentBindingCommand, ConversationAgentBindingVerificationResult, ConversationAgentBindingVerifier, ConversationManagedAgentPrincipalValidator } from "../conversation-agent-binding.types";
 import { PrismaConversationAgentBindingRepository } from "./prisma-conversation-agent-binding-repository";
 
 /**
@@ -13,10 +13,10 @@ import { PrismaConversationAgentBindingRepository } from "./prisma-conversation-
  * checkpoint does not own their data.
  * @implements ConversationAgentBindingAuthority
  */
-export class PrismaConversationAgentBindingUnitOfWork implements ConversationAgentBindingAuthorityPort
+export class PrismaConversationAgentBindingUnitOfWork implements ConversationAgentBindingVerifier
 {
 	/** Holds the product database client and the non-database authorities used by the resolver. */
-	public constructor(private readonly prisma: PrismaClient, private readonly dependencies: ConversationAgentBindingAuthorityDependencies) {}
+	public constructor(private readonly prisma: PrismaClient, private readonly managedPrincipalValidator: ConversationManagedAgentPrincipalValidator) {}
 
 /**
  * Resolves a binding against one serializable database snapshot.
@@ -25,14 +25,13 @@ export class PrismaConversationAgentBindingUnitOfWork implements ConversationAge
  * cannot be read separately. A returned denial leaves no creation history to persist.
  * @returns A complete binding or the reason the later creation flow must not continue.
  */
-	public async bind(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingResult>
+	public async verify(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingVerificationResult>
 	{
-		const dependencies = this.dependencies;
-		return this.prisma.$transaction(async function _BindConversationAgent(transaction)
+		const candidate = await this.prisma.$transaction(async function _LoadConversationAgentBinding(transaction)
 		{
 			const repository = new PrismaConversationAgentBindingRepository(transaction);
-			const authority = new ConversationAgentBindingResolver(repository, dependencies);
-			return authority.bind(command);
+			return repository.load(command);
 		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+		return new ConversationAgentBindingVerificationResolver({ load: async () => candidate }, this.managedPrincipalValidator).verify(command);
 	}
 }

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-unit-of-work.ts
@@ -5,33 +5,37 @@ import type { ConversationAgentBindingCommand, ConversationAgentBindingVerificat
 import { PrismaConversationAgentBindingRepository } from "./prisma-conversation-agent-binding-repository";
 
 /**
- * Runs binding resolution in the serializable transaction that owns its service snapshot.
+ * Reads a verified managed-service snapshot in the serializable transaction that owns it.
  *
- * A later creation composition can use this public authority port without constructing the
- * repository against the root Prisma client. The transaction contains the service, revision, and
- * Principal read; profile and identity selectors remain injected policy ports because this
- * checkpoint does not own their data.
- * @implements ConversationAgentBindingAuthority
+ * The outer binding resolver uses this verifier without constructing the repository against the root
+ * Prisma client. The transaction contains the service, revision, and Principal read. Profile
+ * selection and identity provisioning occur after that transaction closes because they may use their
+ * own histories and must not extend a PostgreSQL transaction.
+ * @implements ConversationAgentBindingVerifier
  */
 export class PrismaConversationAgentBindingUnitOfWork implements ConversationAgentBindingVerifier
 {
-	/** Holds the product database client and the non-database authorities used by the resolver. */
+	/** Holds the product database client and the AgentService Principal validator. */
 	public constructor(private readonly prisma: PrismaClient, private readonly managedPrincipalValidator: ConversationManagedAgentPrincipalValidator) {}
 
 /**
- * Resolves a binding against one serializable database snapshot.
+ * Verifies service facts against one serializable database snapshot.
  *
  * The unit of work builds its repository inside the transaction so the service and active revision
- * cannot be read separately. A returned denial leaves no creation history to persist.
- * @returns A complete binding or the reason the later creation flow must not continue.
+ * cannot be read separately. It closes the transaction before the verifier returns checked facts.
+ * @returns A verified service snapshot or the reason the later creation flow must not continue.
  */
 	public async verify(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingVerificationResult>
 	{
+		// 1. Snapshot — reads the service and active revision under serializable isolation before later ports run.
 		const candidate = await this.prisma.$transaction(async function _LoadConversationAgentBinding(transaction)
 		{
 			const repository = new PrismaConversationAgentBindingRepository(transaction);
 			return repository.load(command);
 		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
-		return new ConversationAgentBindingVerificationResolver({ load: async () => candidate }, this.managedPrincipalValidator).verify(command);
+		// 2. Closure — creates the verifier after the transaction resolves so Principal validation cannot extend it.
+		const resolver = new ConversationAgentBindingVerificationResolver({ load: async () => candidate }, this.managedPrincipalValidator);
+		// 3. Verification — preserves the checked snapshot for the outer resolver's later profile and identity work.
+		return resolver.verify(command);
 	}
 }


### PR DESCRIPTION
## Summary

- split managed AgentService verification from external profile and AgentIdentity resolution
- keep the active service, published revision, and managed Principal check inside Serializable Prisma
- invoke profile selection and deterministic identity provisioning only after the SQL callback has closed

## Boundary

- prevents KurrentDB identity-history I/O from being held inside a PostgreSQL transaction
- the later history-anchored creation authority must revalidate the verified tuple before its atomic Kurrent append
- does not mount or preserve the legacy relational creation path

## Validation

- focused ConversationAgentBinding tests: 4 passing, including `opened → closed → profile → identity` through the real UOW and outer resolver
- `backend-server-conversations` TypeScript lint
- Prisma-boundary, module-growth, agent-style, and diff checks

## Review

- independent review found no Critical or High findings; its transaction-order test gap and stale split-contract comments were resolved
- final comments gate passed with no further changes

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802