### PR TITLE
🧾 reserve retry-safe conversation creation commands

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -92,6 +92,9 @@ CREATE TYPE "ConversationMode" AS ENUM ('agent_session', 'direct', 'group');
 CREATE TYPE "ConversationLifecycle" AS ENUM ('open', 'closed');
 
 -- CreateEnum
+CREATE TYPE "ConversationCreationReservationState" AS ENUM ('reserved', 'history_anchored', 'projected');
+
+-- CreateEnum
 CREATE TYPE "ConversationMessageRole" AS ENUM ('user', 'assistant', 'tool', 'system');
 
 -- CreateEnum
@@ -797,6 +800,46 @@ CREATE TABLE "conversations" (
     "activity_sequence" BIGINT GENERATED ALWAYS AS IDENTITY NOT NULL,
 
     CONSTRAINT "conversations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "conversation_creation_reservations" (
+    "id" TEXT NOT NULL,
+    "silo_id" TEXT NOT NULL,
+    "principal_id" TEXT NOT NULL,
+    "request_id" TEXT NOT NULL,
+    "request_digest" TEXT NOT NULL,
+    "conversation_id" TEXT NOT NULL,
+    "history_event_id" TEXT NOT NULL,
+    "authorization_decision_evidence_id" TEXT NOT NULL,
+    "authorization_decision_digest" TEXT NOT NULL,
+    "authorization_policy_revision_hash" TEXT NOT NULL,
+    "effective_authorization_digest" TEXT NOT NULL,
+    "mode" "ConversationMode" NOT NULL,
+    "agent_service_id" TEXT,
+    "agent_revision_id" TEXT,
+    "agent_identity_id" TEXT,
+    "profile_revision_id" TEXT,
+    "computer_id" TEXT,
+    "computer_history_event_id" TEXT,
+    "state" "ConversationCreationReservationState" NOT NULL DEFAULT 'reserved',
+    "history_revision" BIGINT,
+    "reserved_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "history_anchored_at" TIMESTAMP(3),
+    "projected_at" TIMESTAMP(3),
+
+    CONSTRAINT "conversation_creation_reservations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "conversation_creation_reservation_participants" (
+    "reservation_id" TEXT NOT NULL,
+    "ordinal" INTEGER NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "visible_from_position" BIGINT NOT NULL,
+    "joined_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "conversation_creation_reservation_participants_pkey" PRIMARY KEY ("reservation_id","ordinal")
 );
 
 -- CreateTable
@@ -2611,6 +2654,27 @@ CREATE UNIQUE INDEX "conversations_exact_service_key" ON "conversations"("id", "
 CREATE UNIQUE INDEX "conversations_id_context_revision_id_key" ON "conversations"("id", "context_revision_id");
 
 -- CreateIndex
+CREATE UNIQUE INDEX "conversation_creation_reservations_conversation_id_key" ON "conversation_creation_reservations"("conversation_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversation_creation_reservations_history_event_id_key" ON "conversation_creation_reservations"("history_event_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversation_creation_reservations_computer_history_event_i_key" ON "conversation_creation_reservations"("computer_history_event_id");
+
+-- CreateIndex
+CREATE INDEX "conversation_creation_reservations_silo_id_state_reserved_a_idx" ON "conversation_creation_reservations"("silo_id", "state", "reserved_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversation_creation_reservations_silo_id_principal_id_req_key" ON "conversation_creation_reservations"("silo_id", "principal_id", "request_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversation_creation_reservation_participant_user_key" ON "conversation_creation_reservation_participants"("reservation_id", "user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "conversation_creation_reservation_participant_position_key" ON "conversation_creation_reservation_participants"("reservation_id", "visible_from_position");
+
+-- CreateIndex
 CREATE INDEX "conversation_participants_user_id_archived_at_conversation__idx" ON "conversation_participants"("user_id", "archived_at", "conversation_id");
 
 -- CreateIndex
@@ -3530,6 +3594,9 @@ ALTER TABLE "conversations" ADD CONSTRAINT "conversations_id_context_revision_id
 ALTER TABLE "conversations" ADD CONSTRAINT "conversations_agent_service_id_silo_id_fkey" FOREIGN KEY ("agent_service_id", "silo_id") REFERENCES "agent_services"("id", "silo_id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
+ALTER TABLE "conversation_creation_reservation_participants" ADD CONSTRAINT "conversation_creation_reservation_participants_reservation_fkey" FOREIGN KEY ("reservation_id") REFERENCES "conversation_creation_reservations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "conversation_participants" ADD CONSTRAINT "conversation_participants_conversation_id_fkey" FOREIGN KEY ("conversation_id") REFERENCES "conversations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
@@ -4013,6 +4080,75 @@ CREATE TRIGGER "org_memberships_last_owner_guard"
     FOR EACH ROW EXECUTE FUNCTION "protect_org_membership_last_owner"();
 
 -- Database-native authority guards omitted by Prisma schema diff.
+ALTER TABLE "conversation_creation_reservations" ADD CONSTRAINT "conversation_creation_reservations_exact_check" CHECK (
+    btrim("silo_id") <> '' AND btrim("principal_id") <> '' AND
+    "request_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' AND
+    "request_digest" ~ '^sha256:[0-9a-f]{64}$' AND
+    "conversation_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' AND
+    "history_event_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' AND
+    btrim("authorization_decision_evidence_id") <> '' AND
+    "authorization_decision_digest" ~ '^sha256:[0-9a-f]{64}$' AND
+    "authorization_policy_revision_hash" ~ '^sha256:[0-9a-f]{64}$' AND
+    "effective_authorization_digest" ~ '^sha256:[0-9a-f]{64}$' AND
+    (("mode" IN ('direct', 'group') AND "agent_service_id" IS NULL AND "agent_revision_id" IS NULL AND
+      "agent_identity_id" IS NULL AND "profile_revision_id" IS NULL AND "computer_id" IS NULL AND "computer_history_event_id" IS NULL) OR
+     ("mode" = 'agent_session' AND "agent_service_id" IS NOT NULL AND btrim("agent_service_id") <> '' AND
+      "agent_revision_id" IS NOT NULL AND btrim("agent_revision_id") <> '' AND
+      "computer_id" IS NOT NULL AND "computer_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' AND
+      "computer_history_event_id" IS NOT NULL AND "computer_history_event_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')) AND
+    (("state" = 'reserved' AND "history_revision" IS NULL AND "history_anchored_at" IS NULL AND "projected_at" IS NULL AND
+      "agent_identity_id" IS NULL AND "profile_revision_id" IS NULL) OR
+     ("state" = 'history_anchored' AND "history_revision" = 0 AND "history_anchored_at" IS NOT NULL AND "projected_at" IS NULL AND
+      (("mode" = 'agent_session' AND "agent_identity_id" IS NOT NULL AND btrim("agent_identity_id") <> '' AND
+        "profile_revision_id" IS NOT NULL AND btrim("profile_revision_id") <> '') OR
+       ("mode" IN ('direct', 'group') AND "agent_identity_id" IS NULL AND "profile_revision_id" IS NULL))) OR
+     ("state" = 'projected' AND "history_revision" = 0 AND "history_anchored_at" IS NOT NULL AND "projected_at" IS NOT NULL AND
+      (("mode" = 'agent_session' AND "agent_identity_id" IS NOT NULL AND btrim("agent_identity_id") <> '' AND
+        "profile_revision_id" IS NOT NULL AND btrim("profile_revision_id") <> '') OR
+       ("mode" IN ('direct', 'group') AND "agent_identity_id" IS NULL AND "profile_revision_id" IS NULL))))
+);
+ALTER TABLE "conversation_creation_reservation_participants" ADD CONSTRAINT "conversation_creation_reservation_participants_exact_check" CHECK (
+    "ordinal" > 0 AND "visible_from_position" = "ordinal" AND btrim("user_id") <> ''
+);
+CREATE FUNCTION "enforce_conversation_creation_reservation"() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'ConversationCreationReservation rows cannot be deleted'; END IF;
+    IF TG_OP = 'INSERT' THEN RETURN NEW; END IF;
+    IF OLD."silo_id" IS DISTINCT FROM NEW."silo_id" OR OLD."principal_id" IS DISTINCT FROM NEW."principal_id"
+        OR OLD."request_id" IS DISTINCT FROM NEW."request_id" OR OLD."request_digest" IS DISTINCT FROM NEW."request_digest"
+        OR OLD."conversation_id" IS DISTINCT FROM NEW."conversation_id" OR OLD."history_event_id" IS DISTINCT FROM NEW."history_event_id"
+        OR OLD."authorization_decision_evidence_id" IS DISTINCT FROM NEW."authorization_decision_evidence_id"
+        OR OLD."authorization_decision_digest" IS DISTINCT FROM NEW."authorization_decision_digest"
+        OR OLD."authorization_policy_revision_hash" IS DISTINCT FROM NEW."authorization_policy_revision_hash"
+        OR OLD."effective_authorization_digest" IS DISTINCT FROM NEW."effective_authorization_digest"
+        OR OLD."mode" IS DISTINCT FROM NEW."mode" OR OLD."agent_service_id" IS DISTINCT FROM NEW."agent_service_id"
+        OR OLD."agent_revision_id" IS DISTINCT FROM NEW."agent_revision_id" OR OLD."computer_id" IS DISTINCT FROM NEW."computer_id"
+        OR OLD."computer_history_event_id" IS DISTINCT FROM NEW."computer_history_event_id" OR OLD."reserved_at" IS DISTINCT FROM NEW."reserved_at" THEN
+        RAISE EXCEPTION 'ConversationCreationReservation command coordinates are immutable';
+    END IF;
+    IF OLD."state" = 'reserved' AND NEW."state" = 'history_anchored' THEN RETURN NEW; END IF;
+    IF OLD."state" = 'history_anchored' AND NEW."state" = 'projected'
+        AND OLD."agent_identity_id" IS NOT DISTINCT FROM NEW."agent_identity_id"
+        AND OLD."profile_revision_id" IS NOT DISTINCT FROM NEW."profile_revision_id"
+        AND OLD."history_revision" IS NOT DISTINCT FROM NEW."history_revision"
+        AND OLD."history_anchored_at" IS NOT DISTINCT FROM NEW."history_anchored_at" THEN RETURN NEW; END IF;
+    RAISE EXCEPTION 'ConversationCreationReservation must progress from reserved to history anchored to projected';
+END;
+$$;
+CREATE FUNCTION "enforce_conversation_creation_reservation_participant"() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE reservation_state "ConversationCreationReservationState";
+BEGIN
+    IF TG_OP <> 'INSERT' THEN RAISE EXCEPTION 'ConversationCreationReservationParticipant rows are immutable'; END IF;
+    SELECT "state" INTO reservation_state FROM "conversation_creation_reservations" WHERE "id" = NEW."reservation_id" FOR UPDATE;
+    IF reservation_state IS DISTINCT FROM 'reserved' THEN RAISE EXCEPTION 'ConversationCreationReservationParticipant requires a reserved command'; END IF;
+    RETURN NEW;
+END;
+$$;
+CREATE TRIGGER "conversation_creation_reservations_progression" BEFORE INSERT OR UPDATE OR DELETE ON "conversation_creation_reservations"
+FOR EACH ROW EXECUTE FUNCTION "enforce_conversation_creation_reservation"();
+CREATE TRIGGER "conversation_creation_reservation_participants_immutable" BEFORE INSERT OR UPDATE OR DELETE ON "conversation_creation_reservation_participants"
+FOR EACH ROW EXECUTE FUNCTION "enforce_conversation_creation_reservation_participant"();
+
 ALTER TABLE "provider_effect_commands" ADD CONSTRAINT "provider_effect_commands_identity_check" CHECK (
     btrim("id") <> ''
     AND btrim("silo_id") <> ''

--- a/apps/opencrane/prisma/schema/conversations.prisma
+++ b/apps/opencrane/prisma/schema/conversations.prisma
@@ -9,6 +9,12 @@ enum ConversationLifecycle {
   Closed @map("closed")
 }
 
+enum ConversationCreationReservationState {
+  Reserved        @map("reserved")
+  HistoryAnchored @map("history_anchored")
+  Projected       @map("projected")
+}
+
 enum ConversationMessageRole {
   User      @map("user")
   Assistant @map("assistant")
@@ -78,6 +84,57 @@ model Conversation {
   @@index([siloId, mode, lifecycle, activitySequence])
   @@index([siloId, agentServiceId, lifecycle])
   @@map("conversations")
+}
+
+/// Durable, server-owned recovery command for one history-anchored conversation creation.
+///
+/// The reservation exists before a Kurrent append, so a response-lost retry must resume the
+/// exact command rather than create another conversation. Audit evidence is deliberately a soft
+/// identifier: an authorized product deletion must not erase the decision that admitted it.
+model ConversationCreationReservation {
+  id                              String                               @id @default(cuid())
+  siloId                          String                               @map("silo_id")
+  principalId                     String                               @map("principal_id")
+  requestId                       String                               @map("request_id")
+  requestDigest                   String                               @map("request_digest")
+  conversationId                  String                               @unique @map("conversation_id")
+  historyEventId                  String                               @unique @map("history_event_id")
+  authorizationDecisionEvidenceId String                               @map("authorization_decision_evidence_id")
+  authorizationDecisionDigest     String                               @map("authorization_decision_digest")
+  authorizationPolicyRevisionHash String                               @map("authorization_policy_revision_hash")
+  effectiveAuthorizationDigest    String                               @map("effective_authorization_digest")
+  mode                            ConversationMode
+  agentServiceId                  String?                              @map("agent_service_id")
+  agentRevisionId                 String?                              @map("agent_revision_id")
+  agentIdentityId                 String?                              @map("agent_identity_id")
+  profileRevisionId               String?                              @map("profile_revision_id")
+  computerId                      String?                              @map("computer_id")
+  computerHistoryEventId          String?                              @unique @map("computer_history_event_id")
+  state                           ConversationCreationReservationState @default(Reserved)
+  historyRevision                 BigInt?                              @map("history_revision")
+  reservedAt                      DateTime                             @default(now()) @map("reserved_at")
+  historyAnchoredAt               DateTime?                            @map("history_anchored_at")
+  projectedAt                     DateTime?                            @map("projected_at")
+  participants                    ConversationCreationReservationParticipant[]
+
+  @@unique([siloId, principalId, requestId])
+  @@index([siloId, state, reservedAt])
+  @@map("conversation_creation_reservations")
+}
+
+/// Stores one replayable initial participant coordinate outside the legacy conversation projection.
+model ConversationCreationReservationParticipant {
+  reservationId       String                         @map("reservation_id")
+  ordinal             Int
+  userId              String                         @map("user_id")
+  visibleFromPosition BigInt                          @map("visible_from_position")
+  joinedAt            DateTime                        @map("joined_at")
+  reservation         ConversationCreationReservation @relation(fields: [reservationId], references: [id], onDelete: Restrict)
+
+  @@id([reservationId, ordinal])
+  @@unique([reservationId, userId], map: "conversation_creation_reservation_participant_user_key")
+  @@unique([reservationId, visibleFromPosition], map: "conversation_creation_reservation_participant_position_key")
+  @@map("conversation_creation_reservation_participants")
 }
 
 model ConversationParticipant {

--- a/apps/opencrane/prisma/tests/phase-d-authority-integration.sql
+++ b/apps/opencrane/prisma/tests/phase-d-authority-integration.sql
@@ -72,6 +72,22 @@ AS $$
     );
 $$;
 
+SELECT pg_temp.expect_failure(
+    'agent creation reservation requires non-null server agent coordinates',
+    $statement$
+        INSERT INTO "conversation_creation_reservations" (
+            "id", "silo_id", "principal_id", "request_id", "request_digest", "conversation_id", "history_event_id",
+            "authorization_decision_evidence_id", "authorization_decision_digest", "authorization_policy_revision_hash",
+            "effective_authorization_digest", "mode"
+        ) VALUES (
+            'reservation-agent-missing-coordinates', 'silo-1', 'user-1', '31c1f1dc-0010-4f13-9c2f-d3841ffd6651',
+            'sha256:' || repeat('a', 64), '31c1f1dc-0011-4f13-9c2f-d3841ffd6651', '31c1f1dc-0012-4f13-9c2f-d3841ffd6651',
+            'decision-1', 'sha256:' || repeat('b', 64), 'sha256:' || repeat('c', 64), 'sha256:' || repeat('d', 64), 'agent_session'
+        )
+    $statement$,
+    'conversation_creation_reservations_exact_check'
+);
+
 INSERT INTO "agent_services" (
     "id", "silo_id", "kind", "name",
     "state", "workload_profile", "principal_id", "created_at", "updated_at"

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -682,6 +682,18 @@
 				]
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts",
+				"adapter": "PrismaConversationCreationReservationRepository",
+				"contract": "ConversationCreationReservationRepository",
+				"contractImportPath": "../conversation-creation-reservation.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationProductAuthorizationRepository",
+						"importPath": "./conversation-product-authorization"
+					}
+				]
+			},
+			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-mutation-repository.ts",
 				"adapter": "PrismaConversationMutationRepository",
 				"contract": "ConversationMutationRepository",

--- a/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
@@ -1,0 +1,110 @@
+import { ConversationModes } from "@opencrane/models/conversations";
+
+/**
+ * States how far a stored creation command has progressed after its PostgreSQL reservation.
+ *
+ * The database persists these values, and the creation orchestrator must resume from the recorded
+ * state after a lost response instead of issuing a second history append. `Projected` means the
+ * history anchor and the PostgreSQL projection now agree; it does not authorize another create.
+ */
+export enum ConversationCreationReservationStates
+{
+	/** The command committed with authorization evidence but has no confirmed Kurrent anchor. */
+	Reserved = "reserved",
+	/** The immutable revision-zero anchor matches the reservation and may now rebuild the projection. */
+	HistoryAnchored = "history_anchored",
+	/** The PostgreSQL directory projection and durable grants converge from the confirmed history anchor. */
+	Projected = "projected",
+}
+
+/** Carries one resolved participant coordinate that the immutable creation anchor must replay exactly. */
+export interface ConversationCreationReservationParticipant
+{
+	/** Names the participant's durable user subject, resolved inside the reservation transaction. */
+	readonly userId: string;
+	/** Gives the one-based creation order shared by history and the fresh 0.11 projection. */
+	readonly visibleFromPosition: string;
+	/** Records the server time at which the participant became visible. */
+	readonly joinedAt: string;
+}
+
+/** Carries the server-owned agent coordinates known before history receives a computer provision. */
+export interface ConversationCreationReservationAgentCoordinates
+{
+	/** Identifies the active AgentService selected inside the reservation transaction. */
+	readonly agentServiceId: string;
+	/** Identifies the published revision selected by the checked service pointer. */
+	readonly agentRevisionId: string;
+	/** Names the server-generated logical computer that only the future agent anchor may provision. */
+	readonly computerId: string;
+	/** Supplies the server-generated event id for the computer's retriable revision-zero provision. */
+	readonly computerHistoryEventId: string;
+}
+
+/** Names the complete, resolved command that a transaction stores before any history I/O. */
+export interface ReserveConversationCreationCommand
+{
+	/** Identifies the silo derived from the authenticated request. */
+	readonly siloId: string;
+	/** Identifies the caller Principal that owns this idempotency namespace. */
+	readonly principalId: string;
+	/** Carries the browser-provided UUID that identifies one retryable create request. */
+	readonly requestId: string;
+	/** Carries the digest of the exact untrusted create body after canonical server parsing. */
+	readonly requestDigest: `sha256:${string}`;
+	/** Supplies the server-generated conversation id that no browser may select. */
+	readonly conversationId: string;
+	/** Supplies the server-generated revision-zero event id for the conversation stream. */
+	readonly historyEventId: string;
+	/** Selects the immutable conversation kind after the server has resolved request references. */
+	readonly mode: ConversationModes;
+	/** Lists exact initial participant coordinates in immutable replay order. */
+	readonly participants: readonly ConversationCreationReservationParticipant[];
+	/** Carries agent-only server coordinates, or null for direct and group conversations. */
+	readonly agent: ConversationCreationReservationAgentCoordinates | null;
+}
+
+/** Gives callers the fixed durable command after reservation or idempotent recovery. */
+export interface ReservedConversationCreation extends ReserveConversationCreationCommand
+{
+	/** Identifies the durable reservation row. */
+	readonly reservationId: string;
+	/** Identifies the same-transaction authorization decision that admitted the reservation. */
+	readonly authorizationEvidenceId: string;
+	/** States whether the command has been anchored and projected. */
+	readonly state: ConversationCreationReservationStates;
+}
+
+/**
+ * Describes what a reservation attempt found for the caller's retry key.
+ *
+ * `reserved` gives the newly admitted command to anchor, while `idempotent` gives the earlier
+ * command to resume. Callers must reject `idempotency_conflict` rather than substitute its body,
+ * and must not append history after `denied`.
+ */
+export type ReserveConversationCreationResult
+	= { readonly outcome: "reserved"; readonly value: ReservedConversationCreation }
+	| { readonly outcome: "idempotent"; readonly value: ReservedConversationCreation }
+	| { readonly outcome: "idempotency_conflict" }
+	| { readonly outcome: "denied" };
+
+/**
+ * Persists and reloads creation commands inside the caller's serializable PostgreSQL transaction.
+ *
+ * A caller supplies server-resolved coordinates and receives either the command it may continue,
+ * an idempotency conflict, or a denial. The command exists before Kurrent I/O so a retry cannot
+ * create a second conversation from the same request key.
+ */
+export interface ConversationCreationReservationRepository
+{
+	/**
+	 * Returns the prior command for a matching retry key or commits a newly admitted reservation.
+	 *
+	 * A changed digest under the key returns `idempotency_conflict`; a denied authorization decision
+	 * returns `denied` without a command. The caller must continue history work only for the returned
+	 * `reserved` or `idempotent` value.
+	 * @param command Server-resolved retry, history, participant, and agent coordinates.
+	 * @returns The persisted command, a retry conflict, or an authorization denial.
+	 */
+	reserve(command: ReserveConversationCreationCommand): Promise<ReserveConversationCreationResult>;
+}

--- a/libs/backend/server/conversations/main/src/conversation-creation-reservation.validation.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-reservation.validation.ts
@@ -1,0 +1,48 @@
+import { ConversationModes } from "@opencrane/models/conversations";
+import type { JsonValue } from "@opencrane/util";
+
+import type { ReserveConversationCreationCommand } from "./conversation-creation-reservation.types";
+import type { ConversationCaller } from "./types/conversation-caller.types";
+
+/** Rejects non-replayable commands before their authorization evidence and reservation can commit. */
+export function __ValidateConversationCreationReservation(command: ReserveConversationCreationCommand, caller: ConversationCaller): void
+{
+	if (command.siloId !== caller.siloId || command.principalId !== caller.principalId)
+		throw new Error("Conversation creation reservation caller coordinates must be session-derived");
+	if (!_Uuid(command.requestId) || !_Uuid(command.conversationId) || !_Uuid(command.historyEventId))
+		throw new Error("Conversation creation reservation requires UUID retry and history coordinates");
+	if (!/^sha256:[0-9a-f]{64}$/u.test(command.requestDigest))
+		throw new Error("Conversation creation reservation requires a SHA-256 request digest");
+	if (command.participants.length === 0 || command.participants.some(function _InvalidParticipant(participant, index) { return participant.userId.trim().length === 0 || participant.visibleFromPosition !== (index + 1).toString() || Number.isNaN(Date.parse(participant.joinedAt)); }))
+		throw new Error("Conversation creation reservation requires sequential participant coordinates");
+	if (new Set(command.participants.map(function _UserId(participant) { return participant.userId; })).size !== command.participants.length)
+		throw new Error("Conversation creation reservation requires distinct participants");
+	if (command.mode === ConversationModes.Direct && command.participants.length !== 2)
+		throw new Error("Direct conversation reservation requires two participants");
+	if (command.mode === ConversationModes.Group && command.participants.length < 2)
+		throw new Error("Group conversation reservation requires at least two participants");
+	if (command.mode === ConversationModes.AgentSession && (command.participants.length !== 1 || command.agent === null))
+		throw new Error("Agent conversation reservation requires one participant and server agent coordinates");
+	if (command.mode !== ConversationModes.AgentSession && command.agent !== null)
+		throw new Error("Direct and group conversation reservation must not carry agent coordinates");
+	if (command.agent !== null && (!_Identifier(command.agent.agentServiceId) || !_Identifier(command.agent.agentRevisionId) || !_Uuid(command.agent.computerId) || !_Uuid(command.agent.computerHistoryEventId)))
+		throw new Error("Agent conversation reservation requires complete server agent coordinates");
+}
+
+/** Builds the canonical authorization arguments that bind a decision to this exact durable command. */
+export function __ConversationCreationReservationAuthorizationArguments(command: ReserveConversationCreationCommand): JsonValue
+{
+	return { requestId: command.requestId, requestDigest: command.requestDigest, conversationId: command.conversationId, historyEventId: command.historyEventId, mode: command.mode, participants: command.participants, agent: command.agent } as unknown as JsonValue;
+}
+
+/** Checks an opaque server identifier without changing the durable coordinate. */
+function _Identifier(value: string): boolean
+{
+	return value.trim().length > 0 && value === value.trim();
+}
+
+/** Recognizes the UUID form accepted for server-generated history and retry identifiers. */
+function _Uuid(value: string): boolean
+{
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(value);
+}

--- a/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts
+++ b/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts
@@ -1,0 +1,121 @@
+import { ConversationCreationReservationState, ConversationMode } from "@prisma/client";
+import { ProductAuthorizationActions } from "@opencrane/models/authorization";
+import { ConversationModes } from "@opencrane/models/conversations";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PrismaConversationCreationReservationRepository } from "../prisma-conversation-creation-reservation-repository";
+import { PrismaConversationProductAuthorizationRepository } from "../conversation-product-authorization";
+
+const _SILO_ID = "silo-1";
+const _PRINCIPAL_ID = "principal-1";
+const _REQUEST_ID = "31c1f1dc-0010-4f13-9c2f-d3841ffd6651";
+const _CONVERSATION_ID = "31c1f1dc-0011-4f13-9c2f-d3841ffd6651";
+const _HISTORY_EVENT_ID = "31c1f1dc-0012-4f13-9c2f-d3841ffd6651";
+const _DIGEST = `sha256:${"a".repeat(64)}` as const;
+const _EVIDENCE = { decisionEvidenceId: "decision-1", decisionDigest: `sha256:${"b".repeat(64)}` as const, policyRevisionHash: `sha256:${"c".repeat(64)}` as const, effectiveAuthorizationDigest: `sha256:${"d".repeat(64)}` as const };
+
+function _Command(overrides: Record<string, unknown> = {})
+{
+	return {
+		siloId: _SILO_ID,
+		principalId: _PRINCIPAL_ID,
+		requestId: _REQUEST_ID,
+		requestDigest: _DIGEST,
+		conversationId: _CONVERSATION_ID,
+		historyEventId: _HISTORY_EVENT_ID,
+		mode: ConversationModes.Direct,
+		participants: [
+			{ userId: "user-1", visibleFromPosition: "1", joinedAt: "2026-09-02T00:00:00.000Z" },
+			{ userId: "user-2", visibleFromPosition: "2", joinedAt: "2026-09-02T00:00:00.000Z" },
+		],
+		agent: null,
+		...overrides,
+	} as const;
+}
+
+function _Stored(overrides: Record<string, unknown> = {})
+{
+	return {
+		id: "reservation-1",
+		siloId: _SILO_ID,
+		principalId: _PRINCIPAL_ID,
+		requestId: _REQUEST_ID,
+		requestDigest: _DIGEST,
+		conversationId: _CONVERSATION_ID,
+		historyEventId: _HISTORY_EVENT_ID,
+		authorizationDecisionEvidenceId: _EVIDENCE.decisionEvidenceId,
+		mode: ConversationMode.Direct,
+		agentServiceId: null,
+		agentRevisionId: null,
+		computerId: null,
+		computerHistoryEventId: null,
+		state: ConversationCreationReservationState.Reserved,
+		participants: [
+			{ userId: "user-1", visibleFromPosition: 1n, joinedAt: new Date("2026-09-02T00:00:00.000Z") },
+			{ userId: "user-2", visibleFromPosition: 2n, joinedAt: new Date("2026-09-02T00:00:00.000Z") },
+		],
+		...overrides,
+	};
+}
+
+function _Caller()
+{
+	return { siloId: _SILO_ID, principalId: _PRINCIPAL_ID, subjectId: "user-1", issuer: "https://issuer.example.test" };
+}
+
+describe("PrismaConversationCreationReservationRepository", function _Suite()
+{
+	beforeEach(function _Reset()
+	{
+		vi.restoreAllMocks();
+	});
+
+	it("commits one authorization-evidenced direct command with replayable coordinates", async function _Reserves()
+	{
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue(_Stored()) } };
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
+		const result = await new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command());
+		expect(result).toMatchObject({ outcome: "reserved", value: { authorizationEvidenceId: "decision-1", participants: [{ visibleFromPosition: "1" }, { visibleFromPosition: "2" }], agent: null } });
+		expect(admission).toHaveBeenCalledWith(expect.objectContaining({ principalId: _PRINCIPAL_ID }), expect.anything(), ProductAuthorizationActions.Create, expect.objectContaining({ requestId: _REQUEST_ID, conversationId: _CONVERSATION_ID }));
+		expect(database.conversationCreationReservation.create).toHaveBeenCalledWith(expect.objectContaining({
+			data: expect.objectContaining({
+				historyEventId: _HISTORY_EVENT_ID,
+				authorizationDecisionEvidenceId: "decision-1",
+				participants: { create: expect.arrayContaining([expect.objectContaining({ ordinal: 1, visibleFromPosition: 1n }), expect.objectContaining({ ordinal: 2, visibleFromPosition: 2n })]) },
+			}),
+		}));
+	});
+
+	it("returns the exact prior command without a second authorization decision", async function _Recovers()
+	{
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored()), create: vi.fn() } };
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command())).resolves.toMatchObject({ outcome: "idempotent", value: { reservationId: "reservation-1" } });
+		expect(admission).not.toHaveBeenCalled();
+		expect(database.conversationCreationReservation.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects a changed body under an existing retry key before authorization", async function _RejectsChangedRetry()
+	{
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored()), create: vi.fn() } };
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command({ requestDigest: `sha256:${"e".repeat(64)}` }))).resolves.toEqual({ outcome: "idempotency_conflict" });
+		expect(admission).not.toHaveBeenCalled();
+	});
+
+	it("leaves no reservation when collection creation is denied", async function _Denies()
+	{
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn() } };
+		vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(null);
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command())).resolves.toEqual({ outcome: "denied" });
+		expect(database.conversationCreationReservation.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects an agent command without server-owned agent coordinates before audit evidence", async function _RejectsIncompleteAgent()
+	{
+		const database = { conversationCreationReservation: { findUnique: vi.fn(), create: vi.fn() } };
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command({ mode: ConversationModes.AgentSession, participants: [_Command().participants[0]], agent: null }))).rejects.toThrow("one participant and server agent coordinates");
+		expect(admission).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/conversations/main/src/db/conversation-product-authorization.ts
+++ b/libs/backend/server/conversations/main/src/db/conversation-product-authorization.ts
@@ -1,6 +1,6 @@
 import type { Prisma } from "@prisma/client";
 
-import { PrismaAuthorizationAuthority, PrismaManagedAuthorizationGrantRepository } from "@opencrane/backend/server/iam/authorization";
+import { PrismaAuthorizationAuthority, PrismaManagedAuthorizationGrantRepository, type ProductAuthorizationAdmissionEvidence } from "@opencrane/backend/server/iam/authorization";
 import { AuthorizationBoundaryCoverages, AuthorizationBoundaryKinds, AuthorizationDecisionOutcomes, AuthorizationSubjectKinds, ProductAuthorizationActions, ProductAuthorizationResourceKinds, __ProductAuthorizationCapability, type ProductAuthorizationResourceLocator } from "@opencrane/models/authorization";
 import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 
@@ -31,8 +31,14 @@ export class PrismaConversationProductAuthorizationRepository implements Convers
 	/** Records an exact conversation or collection mutation/effect before its protected write. */
 	async admit(caller: ConversationCaller, resource: ProductAuthorizationResourceLocator, action: ProductAuthorizationActions, argumentsValue: JsonValue): Promise<boolean>
 	{
+		return (await this.admitEvidence(caller, resource, action, argumentsValue)) !== null;
+	}
+
+	/** Records an allowed mutation and returns the same-transaction decision evidence it produced. */
+	async admitEvidence(caller: ConversationCaller, resource: ProductAuthorizationResourceLocator, action: ProductAuthorizationActions, argumentsValue: JsonValue): Promise<ProductAuthorizationAdmissionEvidence | null>
+	{
 		const result = await this.authority.admitPrincipal({ siloId: caller.siloId, principalId: caller.principalId, actorKind: "user", actorId: caller.principalId, resource, action, argumentsDigest: ___DigestCanonicalJson(argumentsValue), nowEpochMs: Date.now() });
-		return result.outcome === AuthorizationDecisionOutcomes.Allow;
+		return result.outcome === AuthorizationDecisionOutcomes.Allow ? result.evidence : null;
 	}
 
 	/** Filters exact conversation ids through one transaction-bound catalogue decision. */

--- a/libs/backend/server/conversations/main/src/db/conversation-product-authorization.types.ts
+++ b/libs/backend/server/conversations/main/src/db/conversation-product-authorization.types.ts
@@ -1,4 +1,5 @@
 import type { ProductAuthorizationActions, ProductAuthorizationResourceLocator } from "@opencrane/models/authorization";
+import type { ProductAuthorizationAdmissionEvidence } from "@opencrane/backend/server/iam/authorization";
 import type { JsonValue } from "@opencrane/util";
 
 import type { ConversationCaller } from "../types/conversation-caller.types";
@@ -8,6 +9,7 @@ export interface ConversationProductAuthorizationRepository
 {
 	canAccess(caller: ConversationCaller, conversationId: string, action: ProductAuthorizationActions): Promise<boolean>;
 	admit(caller: ConversationCaller, resource: ProductAuthorizationResourceLocator, action: ProductAuthorizationActions, argumentsValue: JsonValue): Promise<boolean>;
+	admitEvidence(caller: ConversationCaller, resource: ProductAuthorizationResourceLocator, action: ProductAuthorizationActions, argumentsValue: JsonValue): Promise<ProductAuthorizationAdmissionEvidence | null>;
 	entitledIds(caller: ConversationCaller, conversationIds: readonly string[], action: ProductAuthorizationActions): Promise<ReadonlySet<string>>;
 	canReadResources(caller: ConversationCaller, resources: readonly ProductAuthorizationResourceLocator[]): Promise<boolean>;
 	reconcileParticipants(siloId: string, conversationId: string, participantUserIds: readonly string[], createdByPrincipalId: string, now: Date): Promise<void>;

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
@@ -1,0 +1,115 @@
+import { ConversationCreationReservationState, ConversationMode, type Prisma } from "@prisma/client";
+
+import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
+import { ConversationModes } from "@opencrane/models/conversations";
+
+import { ConversationCreationReservationStates, type ConversationCreationReservationRepository, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
+import { __ConversationCreationReservationAuthorizationArguments, __ValidateConversationCreationReservation } from "../conversation-creation-reservation.validation";
+import type { ConversationCaller } from "../types/conversation-caller.types";
+import { PrismaConversationProductAuthorizationRepository } from "./conversation-product-authorization";
+
+/** Writes and recovers one authorization-evidenced creation command before any history I/O begins. */
+export class PrismaConversationCreationReservationRepository implements ConversationCreationReservationRepository
+{
+	/** Holds the serializable transaction that commits the command and its audit decision together. */
+	public constructor(private readonly transaction: Prisma.TransactionClient, private readonly caller: ConversationCaller) {}
+
+	/** @inheritdoc */
+	public async reserve(command: ReserveConversationCreationCommand): Promise<ReserveConversationCreationResult>
+	{
+		__ValidateConversationCreationReservation(command, this.caller);
+		const prior = await this.transaction.conversationCreationReservation.findUnique({
+			where: { siloId_principalId_requestId: { siloId: command.siloId, principalId: command.principalId, requestId: command.requestId } },
+			include: { participants: { orderBy: { ordinal: "asc" } } },
+		});
+		if (prior !== null)
+			return prior.requestDigest === command.requestDigest ? { outcome: "idempotent", value: _Reserved(prior) } : { outcome: "idempotency_conflict" };
+
+		const authorization = new PrismaConversationProductAuthorizationRepository(this.transaction);
+		const evidence = await authorization.admitEvidence(this.caller, { kind: ProductAuthorizationResourceKinds.ConversationCollection, id: command.siloId }, ProductAuthorizationActions.Create, __ConversationCreationReservationAuthorizationArguments(command));
+		if (evidence === null)
+			return { outcome: "denied" };
+
+		const created = await this.transaction.conversationCreationReservation.create({
+			data: {
+				siloId: command.siloId,
+				principalId: command.principalId,
+				requestId: command.requestId,
+				requestDigest: command.requestDigest,
+				conversationId: command.conversationId,
+				historyEventId: command.historyEventId,
+				authorizationDecisionEvidenceId: evidence.decisionEvidenceId,
+				authorizationDecisionDigest: evidence.decisionDigest,
+				authorizationPolicyRevisionHash: evidence.policyRevisionHash,
+				effectiveAuthorizationDigest: evidence.effectiveAuthorizationDigest,
+				mode: _Mode(command.mode),
+				agentServiceId: command.agent?.agentServiceId ?? null,
+				agentRevisionId: command.agent?.agentRevisionId ?? null,
+				computerId: command.agent?.computerId ?? null,
+				computerHistoryEventId: command.agent?.computerHistoryEventId ?? null,
+				participants: { create: command.participants.map(function _Participant(participant, index) { return { ordinal: index + 1, userId: participant.userId, visibleFromPosition: BigInt(participant.visibleFromPosition), joinedAt: new Date(participant.joinedAt) }; }) },
+			},
+			include: { participants: { orderBy: { ordinal: "asc" } } },
+		});
+		return { outcome: "reserved", value: _Reserved(created) };
+	}
+}
+
+/** Maps model-owned mode values to the generated Prisma enum without accepting arbitrary strings. */
+function _Mode(mode: ConversationModes): ConversationMode
+{
+	if (mode === ConversationModes.AgentSession)
+		return ConversationMode.AgentSession;
+	if (mode === ConversationModes.Direct)
+		return ConversationMode.Direct;
+	return ConversationMode.Group;
+}
+
+/** Converts a fully persisted row to the domain port without exposing Prisma records. */
+function _Reserved(reservation: { readonly id: string; readonly siloId: string; readonly principalId: string; readonly requestId: string; readonly requestDigest: string; readonly conversationId: string; readonly historyEventId: string; readonly authorizationDecisionEvidenceId: string; readonly mode: ConversationMode; readonly agentServiceId: string | null; readonly agentRevisionId: string | null; readonly computerId: string | null; readonly computerHistoryEventId: string | null; readonly state: ConversationCreationReservationState; readonly participants: readonly { readonly userId: string; readonly visibleFromPosition: bigint; readonly joinedAt: Date }[] }): ReservedConversationCreation
+{
+	return {
+		reservationId: reservation.id,
+		siloId: reservation.siloId,
+		principalId: reservation.principalId,
+		requestId: reservation.requestId,
+		requestDigest: reservation.requestDigest as `sha256:${string}`,
+		conversationId: reservation.conversationId,
+		historyEventId: reservation.historyEventId,
+		mode: _ConversationMode(reservation.mode),
+		participants: reservation.participants.map(function _Participant(participant) { return { userId: participant.userId, visibleFromPosition: participant.visibleFromPosition.toString(), joinedAt: participant.joinedAt.toISOString() }; }),
+		agent: _Agent(reservation),
+		authorizationEvidenceId: reservation.authorizationDecisionEvidenceId,
+		state: _State(reservation.state),
+	};
+}
+
+/** Restores agent coordinates only from the all-or-nothing reserved database columns. */
+function _Agent(reservation: { readonly agentServiceId: string | null; readonly agentRevisionId: string | null; readonly computerId: string | null; readonly computerHistoryEventId: string | null }): ReservedConversationCreation["agent"]
+{
+	if (reservation.agentServiceId === null && reservation.agentRevisionId === null && reservation.computerId === null && reservation.computerHistoryEventId === null)
+		return null;
+	if (reservation.agentServiceId === null || reservation.agentRevisionId === null || reservation.computerId === null || reservation.computerHistoryEventId === null)
+		throw new Error("Conversation creation reservation has incomplete agent coordinates");
+	return { agentServiceId: reservation.agentServiceId, agentRevisionId: reservation.agentRevisionId, computerId: reservation.computerId, computerHistoryEventId: reservation.computerHistoryEventId };
+}
+
+/** Maps the generated progress enum to the public state without widening it to a string. */
+function _State(state: ConversationCreationReservationState): ConversationCreationReservationStates
+{
+	if (state === ConversationCreationReservationState.Reserved)
+		return ConversationCreationReservationStates.Reserved;
+	if (state === ConversationCreationReservationState.HistoryAnchored)
+		return ConversationCreationReservationStates.HistoryAnchored;
+	return ConversationCreationReservationStates.Projected;
+}
+
+/** Restores the model-owned create mode from the persisted enum. */
+function _ConversationMode(mode: ConversationMode): ConversationModes
+{
+	if (mode === ConversationMode.AgentSession)
+		return ConversationModes.AgentSession;
+	if (mode === ConversationMode.Direct)
+		return ConversationModes.Direct;
+	return ConversationModes.Group;
+}

--- a/releases/0.11.0.json
+++ b/releases/0.11.0.json
@@ -4,7 +4,7 @@
   "database": {
     "schemaVersion": "0.11.0",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "895850ec8a2a2d0c2cf42c89e59294bb992dbb299c4fe28484bb045e890aade8",
+    "baselineSha256": "cc206997fc133b180b8d5aa439963502335d79e3f74c5ab09be7074b61b15b16",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {


### PR DESCRIPTION
## Summary

- persist one server-owned creation command per silo, Principal, and browser retry UUID before any KurrentDB operation
- bind that command to exact request, authorization, conversation-history, initial-participant, and agent-computer coordinates
- return the existing command for an exact retry, reject a changed payload under the same key, and never issue a second authorization decision for recovery
- add a fresh 0.11 baseline state machine: `reserved → history_anchored → projected`, with immutable participant rows and fail-closed agent coordinates

## Boundary

- this PR deliberately does not mount a new route or create a legacy `Conversation` projection
- direct and group reservations cannot carry a computer; agent reservations carry only server-generated service/revision/computer coordinates until their later verified history anchor
- the later cutover owns Kurrent anchor confirmation, AgentIdentity/profile completion, projection convergence, and deletion of the legacy writer

## Validation

- focused reservation repository tests: 5 passing (new reservation, exact retry, changed-key rejection, authorization deny, incomplete agent denial)
- `backend-server-conversations` TypeScript lint
- Prisma-boundary, module-growth, release-versioning, baseline-authority, agent-style, and diff checks
- added a negative PostgreSQL authority test for NULL agent coordinates; execution needs the target-baseline PostgreSQL test environment

## Review

- independent correctness review found one medium PostgreSQL NULL-semantics gap; explicit `IS NOT NULL` predicates and the negative SQL test now close it
- independent re-check confirmed that fix
- final comments gate passed

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804