### PR TITLE
🔎 confirm reserved conversation creation anchors

### DIFF
--- a/libs/backend/server/conversations/main/src/__tests__/conversation-creation-anchor-verifier.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-creation-anchor-verifier.test.ts
@@ -1,0 +1,53 @@
+import { ConversationLifecycleModes, type ConversationCreated } from "@opencrane/contracts";
+import type { HistoryRecordedEvent } from "@opencrane/backend/server/infra/history-store";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConversationCreationAnchorVerifier } from "../conversation-creation-anchor-verifier";
+
+const _EVENT_ID = "31c1f1dc-0010-4f13-9c2f-d3841ffd6651";
+
+function _Created(): ConversationCreated
+{
+	return { schemaVersion: 1, conversationId: "conversation-1", mode: ConversationLifecycleModes.Agent, participants: [{ userId: "user-1", visibleFromPosition: "1", joinedAt: "2026-09-01T00:00:00.000Z" }], agentBinding: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1", computerId: "computer-1" }, createdAt: "2026-09-01T00:00:00.000Z", provenance: { principalId: "principal-1", authorizationEvidenceId: "evidence-1", requestId: _EVENT_ID } };
+}
+
+function _Event(overrides: Record<string, unknown> = {}): HistoryRecordedEvent
+{
+	const created = _Created();
+	return { streamName: "conversation-conversation-1", id: _EVENT_ID, type: "opencrane.conversation-created.v1", data: { created }, metadata: { siloId: "silo-1", conversationId: created.conversationId, idempotencyKey: _EVENT_ID }, revision: 0n, recordedAt: new Date("2026-09-01T00:00:00.000Z"), ...overrides } as HistoryRecordedEvent;
+}
+
+async function *_Events(events: readonly HistoryRecordedEvent[]): AsyncIterable<HistoryRecordedEvent>
+{
+	for (const event of events)
+		yield event;
+}
+
+describe("ConversationCreationAnchorVerifier", function _Suite()
+{
+	it("confirms the exact reserved revision-zero creation envelope", async function _Confirms()
+	{
+		const readStream = vi.fn().mockReturnValue(_Events([_Event()]));
+		await expect(new ConversationCreationAnchorVerifier({ readStream }).confirm({ siloId: "silo-1", created: _Created(), eventId: _EVENT_ID })).resolves.toEqual({ outcome: "confirmed", revision: 0n });
+		expect(readStream).toHaveBeenCalledWith({ streamName: "conversation-conversation-1" });
+	});
+
+	it("reports an absent stream without inventing a successful recovery", async function _Absent()
+	{
+		await expect(new ConversationCreationAnchorVerifier({ readStream: vi.fn().mockReturnValue(_Events([])) }).confirm({ siloId: "silo-1", created: _Created(), eventId: _EVENT_ID })).resolves.toEqual({ outcome: "absent" });
+	});
+
+	it("fails closed when an existing first event has a different envelope or payload", async function _RejectsMismatch()
+	{
+		const foreignStream = _Event({ streamName: "conversation-foreign" });
+		const nonzero = _Event({ revision: 1n });
+		const wrongType = _Event({ type: "opencrane.conversation-entry.v1" });
+		const foreignEnvelope = _Event({ id: "e97a2af7-81a2-4f48-96b8-cf2ea37f3d5f", metadata: { siloId: "silo-1", conversationId: "conversation-1", idempotencyKey: "e97a2af7-81a2-4f48-96b8-cf2ea37f3d5f" } });
+		const foreignPayload = _Event({ data: { created: { ..._Created(), createdAt: "2026-09-02T00:00:00.000Z" } } });
+		await expect(new ConversationCreationAnchorVerifier({ readStream: vi.fn().mockReturnValue(_Events([foreignStream])) }).confirm({ siloId: "silo-1", created: _Created(), eventId: _EVENT_ID })).rejects.toThrow("foreign or nonzero");
+		await expect(new ConversationCreationAnchorVerifier({ readStream: vi.fn().mockReturnValue(_Events([nonzero])) }).confirm({ siloId: "silo-1", created: _Created(), eventId: _EVENT_ID })).rejects.toThrow("foreign or nonzero");
+		await expect(new ConversationCreationAnchorVerifier({ readStream: vi.fn().mockReturnValue(_Events([wrongType])) }).confirm({ siloId: "silo-1", created: _Created(), eventId: _EVENT_ID })).rejects.toThrow("reserved envelope");
+		await expect(new ConversationCreationAnchorVerifier({ readStream: vi.fn().mockReturnValue(_Events([foreignEnvelope])) }).confirm({ siloId: "silo-1", created: _Created(), eventId: _EVENT_ID })).rejects.toThrow("reserved envelope");
+		await expect(new ConversationCreationAnchorVerifier({ readStream: vi.fn().mockReturnValue(_Events([foreignPayload])) }).confirm({ siloId: "silo-1", created: _Created(), eventId: _EVENT_ID })).rejects.toThrow("reserved payload");
+	});
+});

--- a/libs/backend/server/conversations/main/src/conversation-creation-anchor-verifier.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-anchor-verifier.ts
@@ -1,0 +1,75 @@
+import { ___ConversationCreatedSchema } from "@opencrane/contracts";
+import type { HistoryRecordedEvent, HistoryStore } from "@opencrane/backend/server/infra/history-store";
+import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
+
+import type { ConfirmConversationCreationAnchorCommand, ConversationCreationAnchorConfirmation } from "./conversation-creation-anchor-verifier.types";
+
+/** Names the only revision-zero event that can prove a durable conversation creation reservation. */
+const _CONVERSATION_CREATED_EVENT_TYPE = "opencrane.conversation-created.v1";
+
+/**
+ * Reads a conversation stream after an ambiguous creation append and checks whether it holds the reserved anchor.
+ *
+ * The verifier receives no append capability, so it cannot turn an uncertain write into a successful recovery.
+ * A later creation authority must append again only after {@link confirm} reports `absent`.
+ */
+export class ConversationCreationAnchorVerifier
+{
+	/** Reads one conversation stream without receiving history append authority. */
+	public constructor(private readonly historyStore: Pick<HistoryStore, "readStream">) {}
+
+	/**
+	 * Confirms only an exact revision-zero match after a creation append became ambiguous.
+	 *
+	 * `confirmed` proves the reserved record already occupies revision zero; `absent` leaves the
+	 * append decision to the caller. A mismatched first event cannot prove idempotency, so this
+	 * method throws rather than allowing another create.
+	 * @param command The server-reserved stream coordinates, event identifier, and creation payload.
+	 * @returns A proof of the reservation, or `absent` when the stream has no event.
+	 * @throws {Error} When the stream's first event is not the reserved creation record.
+	 */
+	public async confirm(command: ConfirmConversationCreationAnchorCommand): Promise<ConversationCreationAnchorConfirmation>
+	{
+		const streamName = _StreamName(command);
+		for await (const event of this.historyStore.readStream({ streamName }))
+		{
+			_AssertAnchor(event, command, streamName);
+			return { outcome: "confirmed", revision: 0n };
+		}
+		return { outcome: "absent" };
+	}
+}
+
+/** Derives the conversation stream that the reservation may recover. */
+function _StreamName(command: ConfirmConversationCreationAnchorCommand): string
+{
+	if (!_Identifier(command.siloId) || !_Identifier(command.created.conversationId))
+		throw new Error("Conversation creation anchor confirmation requires server-provided silo and conversation coordinates");
+	if (!_Uuid(command.eventId))
+		throw new Error("Conversation creation anchor confirmation requires a reserved UUID event identifier");
+	return `conversation-${command.created.conversationId}`;
+}
+
+/** Checks that revision zero carries the envelope and payload the server reserved. */
+function _AssertAnchor(event: HistoryRecordedEvent, command: ConfirmConversationCreationAnchorCommand, streamName: string): void
+{
+	if (event.streamName !== streamName || event.revision !== 0n)
+		throw new Error("Conversation creation anchor confirmation received a foreign or nonzero first event");
+	if (event.type !== _CONVERSATION_CREATED_EVENT_TYPE || event.id !== command.eventId || event.metadata.siloId !== command.siloId || event.metadata.conversationId !== command.created.conversationId || event.metadata.idempotencyKey !== command.eventId)
+		throw new Error("Conversation creation anchor does not match its reserved envelope");
+	const created = ___ConversationCreatedSchema.safeParse(event.data.created);
+	if (!created.success || ___DigestCanonicalJson(created.data as unknown as JsonValue) !== ___DigestCanonicalJson(command.created as unknown as JsonValue))
+		throw new Error("Conversation creation anchor does not match its reserved payload");
+}
+
+/** Checks an opaque server coordinate without rewriting it before it names the history stream. */
+function _Identifier(value: string): boolean
+{
+	return value.trim().length > 0 && value === value.trim();
+}
+
+/** Recognizes the UUID form used for a reservation's immutable KurrentDB event id. */
+function _Uuid(value: string): boolean
+{
+	return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu.test(value);
+}

--- a/libs/backend/server/conversations/main/src/conversation-creation-anchor-verifier.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-anchor-verifier.types.ts
@@ -1,0 +1,17 @@
+import type { ConversationCreated } from "@opencrane/contracts";
+
+/** Carries the fixed creation record that a response-lost history retry must prove already exists. */
+export interface ConfirmConversationCreationAnchorCommand
+{
+	/** Identifies the silo that must match the stored history envelope. */
+	readonly siloId: string;
+	/** Supplies the complete immutable creation payload reserved before the history append. */
+	readonly created: ConversationCreated;
+	/** Supplies the reserved UUID that must be the revision-zero event and idempotency key. */
+	readonly eventId: string;
+}
+
+/** Separates an absent stream from a proven reservation match without treating a foreign stream as recoverable. */
+export type ConversationCreationAnchorConfirmation
+	= { readonly outcome: "absent" }
+	| { readonly outcome: "confirmed"; readonly revision: 0n };


### PR DESCRIPTION
## Summary

- add a read-only verifier for a reserved `ConversationCreated` anchor after an ambiguous history append
- accept recovery only when stream, revision zero, event id, envelope coordinates, and canonical creation payload exactly match the reservation
- distinguish an absent stream from an invalid existing first event; invalid history fails closed

## Boundary

- this checkpoint does not write Kurrent history or PostgreSQL projection state
- the later mounted creation authority owns the append, calls this verifier only after an ambiguous result, and converges the reservation projection

## Validation

- `npx nx run backend-server-conversations:test --skip-nx-cache -- src/__tests__/conversation-creation-anchor-verifier.test.ts` (3 passing)
- `npx nx run backend-server-conversations:lint`
- `scripts/agent-style-check.sh --diff cf465a74d`
- `npm run check:module-growth -- --diff cf465a74d`
- `npm run check:prisma-boundaries -- --diff cf465a74d`
- `git diff --check`

## Review

- independent review found one medium test-coverage gap for foreign streams, nonzero revisions, and wrong event types; the tests now prove each rejection
- final comments gate passed



## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805