### PR TITLE
🧭 advance anchored conversation creation reservations

### DIFF
--- a/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
@@ -41,6 +41,32 @@ export interface ConversationCreationReservationAgentCoordinates
 	readonly computerHistoryEventId: string;
 }
 
+/**
+ * Carries the Agent identity and profile revision recorded when an agent conversation reaches its
+ * history anchor. Direct and group conversations carry no binding, while an agent conversation
+ * must carry both values so a retry can compare the persisted pair without changing it.
+ */
+export interface ConversationCreationReservationAgentBinding
+{
+	/** Identifies the stable AgentIdentity that owns the conversation computer. */
+	readonly agentIdentityId: string;
+	/** Identifies the release-owned profile revision used to provision that computer. */
+	readonly profileRevisionId: string;
+}
+
+/**
+ * Requests the reservation transition after KurrentDB has confirmed its revision-zero creation
+ * anchor. Callers use `null` for direct and group conversations; agent conversations supply the
+ * resolved {@link ConversationCreationReservationAgentBinding} that is persisted with the anchor.
+ */
+export interface AnchorConversationCreationReservationCommand
+{
+	/** Identifies the durable command whose Kurrent creation anchor has been verified. */
+	readonly reservationId: string;
+	/** Supplies Agent-only identity/profile facts, or null for direct and group conversations. */
+	readonly agentBinding: ConversationCreationReservationAgentBinding | null;
+}
+
 /** Names the complete, resolved command that a transaction stores before any history I/O. */
 export interface ReserveConversationCreationCommand
 {
@@ -71,6 +97,8 @@ export interface ReservedConversationCreation extends ReserveConversationCreatio
 	readonly reservationId: string;
 	/** Identifies the same-transaction authorization decision that admitted the reservation. */
 	readonly authorizationEvidenceId: string;
+	/** Carries the persisted agent identity/profile pair after history anchoring, or null when no agent owns the conversation. */
+	readonly resolvedAgentBinding: ConversationCreationReservationAgentBinding | null;
 	/** States whether the command has been anchored and projected. */
 	readonly state: ConversationCreationReservationStates;
 }
@@ -107,4 +135,16 @@ export interface ConversationCreationReservationRepository
 	 * @returns The persisted command, a retry conflict, or an authorization denial.
 	 */
 	reserve(command: ReserveConversationCreationCommand): Promise<ReserveConversationCreationResult>;
+	/**
+	 * Advances one reservation only after its exact revision-zero anchor is present in KurrentDB.
+	 *
+	 * The repository accepts a direct/group null binding or the full Agent identity/profile pair and
+	 * returns the already-advanced command for an exact retry. It never accepts a partial binding.
+	 * @param command The reservation and, when applicable, the Agent identity/profile pair to persist.
+	 * @returns The anchored reservation, including the persisted binding. Matching anchored retries
+	 * return the stored reservation without another update.
+	 * @throws {Error} The reservation is unavailable, its binding does not match its conversation
+	 * mode or stored retry value, or an agent binding is incomplete.
+	 */
+	markHistoryAnchored(command: AnchorConversationCreationReservationCommand): Promise<ReservedConversationCreation>;
 }

--- a/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts
+++ b/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts
@@ -47,6 +47,8 @@ function _Stored(overrides: Record<string, unknown> = {})
 		mode: ConversationMode.Direct,
 		agentServiceId: null,
 		agentRevisionId: null,
+		agentIdentityId: null,
+		profileRevisionId: null,
 		computerId: null,
 		computerHistoryEventId: null,
 		state: ConversationCreationReservationState.Reserved,
@@ -117,5 +119,37 @@ describe("PrismaConversationCreationReservationRepository", function _Suite()
 		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
 		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command({ mode: ConversationModes.AgentSession, participants: [_Command().participants[0]], agent: null }))).rejects.toThrow("one participant and server agent coordinates");
 		expect(admission).not.toHaveBeenCalled();
+	});
+
+	it("advances a direct reservation only after its history anchor and keeps its projection facts agent-free", async function _AnchorsDirect()
+	{
+		const anchored = _Stored({ state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z") });
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored()), update: vi.fn().mockResolvedValue(anchored) } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: null })).resolves.toMatchObject({ state: "history_anchored", resolvedAgentBinding: null });
+		expect(database.conversationCreationReservation.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, agentIdentityId: null, profileRevisionId: null }) }));
+	});
+
+	it("refuses to anchor an agent reservation before its identity and profile are resolved", async function _RejectsIncompleteAnchoredAgent()
+	{
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored({ mode: ConversationMode.AgentSession, agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _HISTORY_EVENT_ID })), update: vi.fn() } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: null })).rejects.toThrow("require an agent binding");
+		expect(database.conversationCreationReservation.update).not.toHaveBeenCalled();
+	});
+
+	it("records the full resolved Agent binding with an agent conversation history anchor", async function _AnchorsAgent()
+	{
+		const reserved = _Stored({ mode: ConversationMode.AgentSession, agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _HISTORY_EVENT_ID });
+		const anchored = { ...reserved, state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z"), agentIdentityId: "identity-1", profileRevisionId: "profile-1" };
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(reserved), update: vi.fn().mockResolvedValue(anchored) } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: { agentIdentityId: "identity-1", profileRevisionId: "profile-1" } })).resolves.toMatchObject({ state: "history_anchored", resolvedAgentBinding: { agentIdentityId: "identity-1", profileRevisionId: "profile-1" } });
+	});
+
+	it("returns an exact anchored retry without rewriting its Agent binding", async function _RecoversAnchoredAgent()
+	{
+		const anchored = _Stored({ mode: ConversationMode.AgentSession, agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _HISTORY_EVENT_ID, state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z"), agentIdentityId: "identity-1", profileRevisionId: "profile-1" });
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(anchored), update: vi.fn() } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: { agentIdentityId: "identity-1", profileRevisionId: "profile-1" } })).resolves.toMatchObject({ resolvedAgentBinding: { agentIdentityId: "identity-1" } });
+		expect(database.conversationCreationReservation.update).not.toHaveBeenCalled();
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: { agentIdentityId: "identity-2", profileRevisionId: "profile-1" } })).rejects.toThrow("conflicting agent binding");
 	});
 });

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
@@ -3,7 +3,7 @@ import { ConversationCreationReservationState, ConversationMode, type Prisma } f
 import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
 import { ConversationModes } from "@opencrane/models/conversations";
 
-import { ConversationCreationReservationStates, type ConversationCreationReservationRepository, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
+import { ConversationCreationReservationStates, type AnchorConversationCreationReservationCommand, type ConversationCreationReservationRepository, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
 import { __ConversationCreationReservationAuthorizationArguments, __ValidateConversationCreationReservation } from "../conversation-creation-reservation.validation";
 import type { ConversationCaller } from "../types/conversation-caller.types";
 import { PrismaConversationProductAuthorizationRepository } from "./conversation-product-authorization";
@@ -53,6 +53,34 @@ export class PrismaConversationCreationReservationRepository implements Conversa
 		});
 		return { outcome: "reserved", value: _Reserved(created) };
 	}
+
+	/** @inheritdoc */
+	public async markHistoryAnchored(command: AnchorConversationCreationReservationCommand): Promise<ReservedConversationCreation>
+	{
+		_ValidateAnchorCommand(command);
+		const reservation = await this.transaction.conversationCreationReservation.findUnique({
+			where: { id: command.reservationId },
+			include: { participants: { orderBy: { ordinal: "asc" } } },
+		});
+		if (reservation === null)
+			throw new Error("Conversation creation reservation is unavailable");
+		const existing = _Reserved(reservation);
+		_AssertAnchorBinding(existing, command.agentBinding);
+		if (existing.state !== ConversationCreationReservationStates.Reserved)
+			return existing;
+		const updated = await this.transaction.conversationCreationReservation.update({
+			where: { id: command.reservationId },
+			data: {
+				state: ConversationCreationReservationState.HistoryAnchored,
+				historyRevision: 0n,
+				historyAnchoredAt: new Date(),
+				agentIdentityId: command.agentBinding?.agentIdentityId ?? null,
+				profileRevisionId: command.agentBinding?.profileRevisionId ?? null,
+			},
+			include: { participants: { orderBy: { ordinal: "asc" } } },
+		});
+		return _Reserved(updated);
+	}
 }
 
 /** Maps model-owned mode values to the generated Prisma enum without accepting arbitrary strings. */
@@ -66,7 +94,7 @@ function _Mode(mode: ConversationModes): ConversationMode
 }
 
 /** Converts a fully persisted row to the domain port without exposing Prisma records. */
-function _Reserved(reservation: { readonly id: string; readonly siloId: string; readonly principalId: string; readonly requestId: string; readonly requestDigest: string; readonly conversationId: string; readonly historyEventId: string; readonly authorizationDecisionEvidenceId: string; readonly mode: ConversationMode; readonly agentServiceId: string | null; readonly agentRevisionId: string | null; readonly computerId: string | null; readonly computerHistoryEventId: string | null; readonly state: ConversationCreationReservationState; readonly participants: readonly { readonly userId: string; readonly visibleFromPosition: bigint; readonly joinedAt: Date }[] }): ReservedConversationCreation
+function _Reserved(reservation: { readonly id: string; readonly siloId: string; readonly principalId: string; readonly requestId: string; readonly requestDigest: string; readonly conversationId: string; readonly historyEventId: string; readonly authorizationDecisionEvidenceId: string; readonly mode: ConversationMode; readonly agentServiceId: string | null; readonly agentRevisionId: string | null; readonly agentIdentityId: string | null; readonly profileRevisionId: string | null; readonly computerId: string | null; readonly computerHistoryEventId: string | null; readonly state: ConversationCreationReservationState; readonly participants: readonly { readonly userId: string; readonly visibleFromPosition: bigint; readonly joinedAt: Date }[] }): ReservedConversationCreation
 {
 	return {
 		reservationId: reservation.id,
@@ -79,9 +107,30 @@ function _Reserved(reservation: { readonly id: string; readonly siloId: string; 
 		mode: _ConversationMode(reservation.mode),
 		participants: reservation.participants.map(function _Participant(participant) { return { userId: participant.userId, visibleFromPosition: participant.visibleFromPosition.toString(), joinedAt: participant.joinedAt.toISOString() }; }),
 		agent: _Agent(reservation),
+		resolvedAgentBinding: _ResolvedAgentBinding(reservation),
 		authorizationEvidenceId: reservation.authorizationDecisionEvidenceId,
 		state: _State(reservation.state),
 	};
+}
+
+/** Refuses malformed post-history coordinates before they can advance a durable reservation. */
+function _ValidateAnchorCommand(command: AnchorConversationCreationReservationCommand): void
+{
+	if (command.reservationId.trim().length === 0 || command.reservationId !== command.reservationId.trim())
+		throw new Error("Conversation creation history anchoring requires a reservation identifier");
+	if (command.agentBinding !== null && (command.agentBinding.agentIdentityId.trim().length === 0 || command.agentBinding.agentIdentityId !== command.agentBinding.agentIdentityId.trim() || command.agentBinding.profileRevisionId.trim().length === 0 || command.agentBinding.profileRevisionId !== command.agentBinding.profileRevisionId.trim()))
+		throw new Error("Conversation creation history anchoring requires complete agent identity and profile coordinates");
+}
+
+/** Ensures direct/group never gain agent facts, while Agent reservations cannot advance without them. */
+function _AssertAnchorBinding(reservation: ReservedConversationCreation, binding: AnchorConversationCreationReservationCommand["agentBinding"]): void
+{
+	if (reservation.agent === null && binding !== null)
+		throw new Error("Direct and group conversation reservations cannot receive an agent binding");
+	if (reservation.agent !== null && binding === null)
+		throw new Error("Agent conversation reservations require an agent binding");
+	if (reservation.resolvedAgentBinding !== null && (binding === null || reservation.resolvedAgentBinding.agentIdentityId !== binding.agentIdentityId || reservation.resolvedAgentBinding.profileRevisionId !== binding.profileRevisionId))
+		throw new Error("Conversation creation reservation has a conflicting agent binding");
 }
 
 /** Restores agent coordinates only from the all-or-nothing reserved database columns. */
@@ -92,6 +141,16 @@ function _Agent(reservation: { readonly agentServiceId: string | null; readonly 
 	if (reservation.agentServiceId === null || reservation.agentRevisionId === null || reservation.computerId === null || reservation.computerHistoryEventId === null)
 		throw new Error("Conversation creation reservation has incomplete agent coordinates");
 	return { agentServiceId: reservation.agentServiceId, agentRevisionId: reservation.agentRevisionId, computerId: reservation.computerId, computerHistoryEventId: reservation.computerHistoryEventId };
+}
+
+/** Restores the all-or-nothing post-history Agent binding without exposing Prisma records. */
+function _ResolvedAgentBinding(reservation: { readonly agentIdentityId: string | null; readonly profileRevisionId: string | null }): ReservedConversationCreation["resolvedAgentBinding"]
+{
+	if (reservation.agentIdentityId === null && reservation.profileRevisionId === null)
+		return null;
+	if (reservation.agentIdentityId === null || reservation.profileRevisionId === null)
+		throw new Error("Conversation creation reservation has incomplete resolved agent coordinates");
+	return { agentIdentityId: reservation.agentIdentityId, profileRevisionId: reservation.profileRevisionId };
 }
 
 /** Maps the generated progress enum to the public state without widening it to a string. */


### PR DESCRIPTION
## Summary

- expose the durable post-history Agent identity and profile binding on a creation reservation
- add an explicit `Reserved -> HistoryAnchored` repository transition that records revision zero and refuses partial, foreign, or conflicting agent facts
- make anchored retries return their saved command without rewriting its resolved binding

## Boundary

- KurrentDB anchor verification remains outside this PostgreSQL repository; the next mounted creation authority calls this transition only after it has appended or exactly confirmed the reserved `ConversationCreated` event
- direct and group reservations remain agent-free; agent reservations cannot progress until both their identity and release profile are resolved

## Validation

- `npx nx run backend-server-conversations:test --skip-nx-cache -- src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts` (9 passing)
- `npx nx run backend-server-conversations:lint`
- `scripts/agent-style-check.sh --diff 9ed0ea637`
- `npm run check:module-growth -- --diff 9ed0ea637`
- `npm run check:prisma-boundaries -- --diff 9ed0ea637`
- `git diff --check`

## Review

- independent correctness review passed; it requested agent-success and matching/conflicting retry coverage, which this PR adds
- final comments gate passed



## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806