### PR TITLE
🪪 provision proxied personal agent identities

### DIFF
--- a/libs/backend/server/iam/identity/main/src/agent-identities/__tests__/proxied-agent-identity-provisioner.test.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/__tests__/proxied-agent-identity-provisioner.test.ts
@@ -1,0 +1,56 @@
+import { AgentIdentityStates, type ProxiedAgentIdentity } from "@opencrane/contracts";
+import { HistoryExpectedRevisions } from "@opencrane/backend/server/infra/history-store";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CurrentAgentIdentity } from "../agent-identity-history.types";
+import { __ProxiedAgentIdentityId, ProxiedAgentIdentityHistoryProvisioner } from "../proxied-agent-identity-provisioner";
+
+/** Builds trusted personal-agent facts after the caller and active revision were checked. */
+function _Command(overrides: Partial<{ readonly siloId: string; readonly agentServiceId: string; readonly proxiedPrincipalId: string; readonly delegationPolicyId: string; readonly agentServiceName: string }> = {})
+{
+	return { siloId: "silo-1", agentServiceId: "service-1", proxiedPrincipalId: "principal-1", delegationPolicyId: "agent-revision:revision-1", agentServiceName: "Personal assistant", ...overrides };
+}
+
+/** Builds the exact active identity a personal service may hold for one user. */
+function _Current(overrides: Partial<ProxiedAgentIdentity> = {}): CurrentAgentIdentity
+{
+	const identity: ProxiedAgentIdentity = { schemaVersion: 1, id: __ProxiedAgentIdentityId("service-1", "principal-1"), siloId: "silo-1", agentServiceId: "service-1", name: "Personal assistant", avatarArtifactRevisionId: null, state: AgentIdentityStates.Active, createdByPrincipalId: "principal-1", createdAt: "2026-09-02T00:00:00.000Z", kind: "proxied", proxiedPrincipalId: "principal-1", delegationPolicyId: "agent-revision:revision-1", ...overrides };
+	return { streamName: `agent-identity-${identity.id}`, revision: 0n, headDigest: `sha256:${"a".repeat(64)}`, identity };
+}
+
+/** Builds the provisioner over a narrow identity history fake. */
+function _Provisioner(load = vi.fn(), append = vi.fn())
+{
+	return { subject: new ProxiedAgentIdentityHistoryProvisioner({ load, append } as never, { now: () => new Date("2026-09-02T00:00:00.000Z") }), load, append };
+}
+
+describe("ProxiedAgentIdentityHistoryProvisioner", function _ProxiedAgentIdentityHistoryProvisionerSuite()
+{
+	it("derives different opaque keys for service and principal tuples that contain separators", function _SeparatesOpaqueCoordinates()
+	{
+		expect(__ProxiedAgentIdentityId("service:alice", "bob")).not.toEqual(__ProxiedAgentIdentityId("service", "alice:bob"));
+	});
+
+	it("anchors one deterministic personal-agent identity for its exact proxied user", async function _ProvisionsIdentity()
+	{
+		const { subject, load, append } = _Provisioner(vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(_Current()), vi.fn().mockResolvedValue({ streamName: `agent-identity-${__ProxiedAgentIdentityId("service-1", "principal-1")}`, revision: 0n }));
+		await expect(subject.ensure(_Command())).resolves.toEqual({ agentIdentityId: __ProxiedAgentIdentityId("service-1", "principal-1") });
+		expect(append).toHaveBeenCalledWith(expect.objectContaining({ expectedRevision: HistoryExpectedRevisions.NoStream, identity: expect.objectContaining({ kind: "proxied", proxiedPrincipalId: "principal-1", delegationPolicyId: "agent-revision:revision-1" }) }));
+		expect(load).toHaveBeenCalledTimes(2);
+	});
+
+	it("reuses only the matching active identity and recovers an append race", async function _ReusesOrRecovers()
+	{
+		const existing = _Provisioner(vi.fn().mockResolvedValue(_Current()));
+		await expect(existing.subject.ensure(_Command())).resolves.toEqual({ agentIdentityId: __ProxiedAgentIdentityId("service-1", "principal-1") });
+		expect(existing.append).not.toHaveBeenCalled();
+		const race = _Provisioner(vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(_Current()), vi.fn().mockRejectedValue(new Error("stale expected revision")));
+		await expect(race.subject.ensure(_Command())).resolves.toEqual({ agentIdentityId: __ProxiedAgentIdentityId("service-1", "principal-1") });
+	});
+
+	it("fails closed for a different proxied user, policy, identity kind, or inactive stream", async function _RejectsConflicts()
+	{
+		for (const identity of [_Current({ proxiedPrincipalId: "principal-2" }), _Current({ delegationPolicyId: "agent-revision:revision-2" }), _Current({ kind: "managed" } as never), _Current({ state: AgentIdentityStates.Suspended })])
+			await expect(_Provisioner(vi.fn().mockResolvedValue(identity)).subject.ensure(_Command())).rejects.toThrow("conflicting identity stream");
+	});
+});

--- a/libs/backend/server/iam/identity/main/src/agent-identities/index.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/index.ts
@@ -2,3 +2,5 @@ export { AgentIdentityHistory } from "./agent-identity-history";
 export type { ActiveAgentIdentityAuthorization, AgentIdentityAppendCommand, AgentIdentityCurrentCommand, AgentIdentityRuntimeAuthorizationCommand, CurrentAgentIdentity } from "./agent-identity-history.types";
 export { __ManagedAgentIdentityId, ManagedAgentIdentityHistoryProvisioner } from "./managed-agent-identity-provisioner";
 export type { ManagedAgentIdentityProvisionCommand, ManagedAgentIdentityProvisioner, ManagedAgentIdentityProvisionerClock } from "./managed-agent-identity-provisioner.types";
+export { __ProxiedAgentIdentityId, ProxiedAgentIdentityHistoryProvisioner } from "./proxied-agent-identity-provisioner";
+export type { ProxiedAgentIdentityProvisionCommand, ProxiedAgentIdentityProvisioner, ProxiedAgentIdentityProvisionerClock } from "./proxied-agent-identity-provisioner.types";

--- a/libs/backend/server/iam/identity/main/src/agent-identities/proxied-agent-identity-provisioner.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/proxied-agent-identity-provisioner.ts
@@ -1,0 +1,79 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import { AgentIdentityStates, type ProxiedAgentIdentity } from "@opencrane/contracts";
+import { HistoryExpectedRevisions } from "@opencrane/backend/server/infra/history-store";
+
+import { AgentIdentityHistory } from "./agent-identity-history";
+import type { CurrentAgentIdentity } from "./agent-identity-history.types";
+import type { ProxiedAgentIdentityProvisionCommand, ProxiedAgentIdentityProvisioner, ProxiedAgentIdentityProvisionerClock } from "./proxied-agent-identity-provisioner.types";
+
+/** Names the sole discriminated identity variant this provisioner may create or accept. */
+const _PROXIED_IDENTITY_KIND: ProxiedAgentIdentity["kind"] = "proxied";
+
+/** Derives the deterministic identity coordinate for one personal service acting for one user. */
+export function __ProxiedAgentIdentityId(agentServiceId: string, proxiedPrincipalId: string): string
+{
+	if (!_Identifier(agentServiceId) || !_Identifier(proxiedPrincipalId))
+		throw new Error("Proxied agent identity provision requires server-provided service and principal identifiers");
+	return `proxied-agent-identity:${createHash("sha256").update(JSON.stringify([agentServiceId, proxiedPrincipalId])).digest("hex")}`;
+}
+
+/** Establishes or reuses the immutable identity after the binding authority verified its coordinates. */
+export class ProxiedAgentIdentityHistoryProvisioner implements ProxiedAgentIdentityProvisioner
+{
+	/** Uses identity history for durable state and reads the clock only for a missing stream. */
+	public constructor(private readonly history: AgentIdentityHistory, private readonly clock: ProxiedAgentIdentityProvisionerClock) {}
+
+	/** @inheritdoc */
+	public async ensure(command: ProxiedAgentIdentityProvisionCommand): Promise<{ readonly agentIdentityId: string }>
+	{
+		_ValidateCommand(command);
+		const agentIdentityId = __ProxiedAgentIdentityId(command.agentServiceId, command.proxiedPrincipalId);
+		const current = await this.history.load({ siloId: command.siloId, agentIdentityId, agentServiceId: command.agentServiceId, principalId: command.proxiedPrincipalId });
+		if (current !== null)
+			return _ProxiedIdentityResult(current, command, agentIdentityId);
+		try
+		{
+			await this.history.append({ expectedRevision: HistoryExpectedRevisions.NoStream, eventId: randomUUID(), identity: _ProxiedIdentity(command, agentIdentityId, this.clock.now()) });
+		}
+		catch (error)
+		{
+			const raced = await this.history.load({ siloId: command.siloId, agentIdentityId, agentServiceId: command.agentServiceId, principalId: command.proxiedPrincipalId });
+			if (raced === null)
+				throw error;
+			return _ProxiedIdentityResult(raced, command, agentIdentityId);
+		}
+		const provisioned = await this.history.load({ siloId: command.siloId, agentIdentityId, agentServiceId: command.agentServiceId, principalId: command.proxiedPrincipalId });
+		if (provisioned === null)
+			throw new Error("Proxied agent identity provision did not persist its identity stream");
+		return _ProxiedIdentityResult(provisioned, command, agentIdentityId);
+	}
+}
+
+/** Builds the revision-zero snapshot; later authorization reads the current proxied principal. */
+function _ProxiedIdentity(command: ProxiedAgentIdentityProvisionCommand, agentIdentityId: string, createdAt: Date): ProxiedAgentIdentity
+{
+	return { schemaVersion: 1, id: agentIdentityId, siloId: command.siloId, agentServiceId: command.agentServiceId, name: command.agentServiceName, avatarArtifactRevisionId: null, state: AgentIdentityStates.Active, createdByPrincipalId: command.proxiedPrincipalId, createdAt: createdAt.toISOString(), kind: _PROXIED_IDENTITY_KIND, proxiedPrincipalId: command.proxiedPrincipalId, delegationPolicyId: command.delegationPolicyId };
+}
+
+/** Refuses any stream that would realize a different service, user, or delegation ceiling. */
+function _ProxiedIdentityResult(current: CurrentAgentIdentity, command: ProxiedAgentIdentityProvisionCommand, agentIdentityId: string): { readonly agentIdentityId: string }
+{
+	const identity = current.identity;
+	if (identity.kind !== _PROXIED_IDENTITY_KIND || identity.state !== AgentIdentityStates.Active || identity.id !== agentIdentityId || identity.siloId !== command.siloId || identity.agentServiceId !== command.agentServiceId || identity.proxiedPrincipalId !== command.proxiedPrincipalId || identity.delegationPolicyId !== command.delegationPolicyId || identity.createdByPrincipalId !== command.proxiedPrincipalId || identity.avatarArtifactRevisionId !== null)
+		throw new Error("Proxied agent identity provision found a conflicting identity stream");
+	return { agentIdentityId };
+}
+
+/** Rejects missing or normalized coordinates before they derive an identity stream. */
+function _ValidateCommand(command: ProxiedAgentIdentityProvisionCommand): void
+{
+	if (!_Identifier(command.siloId) || !_Identifier(command.agentServiceId) || !_Identifier(command.proxiedPrincipalId) || !_Identifier(command.delegationPolicyId) || !_Identifier(command.agentServiceName))
+		throw new Error("Proxied agent identity provision requires complete server-provided service coordinates");
+}
+
+/** Checks one durable coordinate without silently normalizing it. */
+function _Identifier(value: string): boolean
+{
+	return value.trim().length > 0 && value === value.trim();
+}

--- a/libs/backend/server/iam/identity/main/src/agent-identities/proxied-agent-identity-provisioner.types.ts
+++ b/libs/backend/server/iam/identity/main/src/agent-identities/proxied-agent-identity-provisioner.types.ts
@@ -1,0 +1,28 @@
+/** Supplies the personal-agent and user coordinates a binding authority must verify before provisioning. */
+export interface ProxiedAgentIdentityProvisionCommand
+{
+	/** Identifies the silo that owns the personal service and its identity. */
+	readonly siloId: string;
+	/** Identifies the personal AgentService selected by the caller's binding authority. */
+	readonly agentServiceId: string;
+	/** Identifies the user Principal whose authority the agent may proxy after caller verification. */
+	readonly proxiedPrincipalId: string;
+	/** Identifies the revision-scoped delegation ceiling selected by the caller. */
+	readonly delegationPolicyId: string;
+	/** Supplies the personal-agent display name for the first identity snapshot. */
+	readonly agentServiceName: string;
+}
+
+/** Supplies the trusted server time for an initial proxied identity snapshot. */
+export interface ProxiedAgentIdentityProvisionerClock
+{
+	/** Returns the time recorded if the deterministic identity stream is first created. */
+	now(): Date;
+}
+
+/** Ensures one active identity for an exact personal service, user principal, and delegation policy. */
+export interface ProxiedAgentIdentityProvisioner
+{
+	/** Creates or reloads the matching active proxied identity after a no-stream append race. */
+	ensure(command: ProxiedAgentIdentityProvisionCommand): Promise<{ readonly agentIdentityId: string }>;
+}


### PR DESCRIPTION
## Summary

- add a deterministic Kurrent-backed `ProxiedAgentIdentity` provisioner for one personal AgentService and exact user Principal
- bind the immutable identity to a revision-scoped delegation-policy coordinate while runtime authorization continues to evaluate the proxied principal
- recover no-stream append races only by reloading the exact active identity; reject changed user, policy, kind, state, or tuple identity

## Boundary

- this provisioner owns identity-stream creation and equivalence checking only; its caller must first verify the personal service, active revision, user principal, and selected delegation ceiling
- the tuple key uses a SHA-256 encoding, so opaque IDs containing separators cannot collide

## Validation

- `npx nx run backend-server-identity:test --skip-nx-cache -- src/agent-identities/__tests__/proxied-agent-identity-provisioner.test.ts` (4 passing)
- `npx nx run backend-server-identity:lint`
- `scripts/agent-style-check.sh --diff d99bc95a1`
- `npm run check:module-growth -- --diff d99bc95a1`
- `npm run check:prisma-boundaries -- --diff d99bc95a1`
- `git diff --check`

## Review

- independent review found a delimiter collision in the first tuple key; replaced it with canonical SHA-256 tuple encoding and added the collision proof
- final comments gate passed after clarifying the caller-owned provenance check



## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807