### PR TITLE
🔐 verify proxied personal agent binding

### DIFF
--- a/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
@@ -32,7 +32,7 @@ describe("ConversationAgentBindingResolver", function _Suite()
 		const dependencies = _Dependencies();
 		const verifier = { verify: vi.fn().mockResolvedValue({ outcome: "verified", value: _Candidate() }) };
 		await expect(new ConversationAgentBindingResolver(verifier, dependencies).bind(_Command())).resolves.toMatchObject({ outcome: "bound" });
-		expect(dependencies.identities.ensure).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceId: "service-1", principalId: "managed-principal:service-1", agentServiceName: "Research" });
+		expect(dependencies.identities.ensure).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceId: "service-1", principalId: "managed-principal:service-1", agentServiceName: "Research", agentServiceKind: "managed" });
 	});
 
 	it("does not invoke external selectors after a verifier denial", async function _Denies()
@@ -47,6 +47,14 @@ describe("ConversationAgentBindingResolver", function _Suite()
 	{
 		const verifier = new ConversationAgentBindingVerificationResolver({ load: vi.fn().mockResolvedValue(_Candidate({ agentServiceKind: "personal", principalId: null, principal: null })) }, _Validator());
 		await expect(verifier.verify(_Command())).resolves.toMatchObject({ outcome: "verified", value: { agentServiceKind: "personal", principalId: "principal-1", delegationPolicyId: "agent-revision:revision-1" } });
+	});
+
+	it("passes only verified personal identity coordinates to the proxied selector", async function _SelectsProxiedIdentity()
+	{
+		const dependencies = _Dependencies();
+		const verifier = { verify: vi.fn().mockResolvedValue({ outcome: "verified", value: { ..._Candidate({ agentServiceKind: "personal", principalId: "principal-1", principal: null }), delegationPolicyId: "agent-revision:revision-1" } }) };
+		await expect(new ConversationAgentBindingResolver(verifier, dependencies).bind(_Command())).resolves.toMatchObject({ outcome: "bound", value: { agentServiceKind: "personal", principalId: "principal-1" } });
+		expect(dependencies.identities.ensure).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceId: "service-1", principalId: "principal-1", agentServiceName: "Research", agentServiceKind: "personal", delegationPolicyId: "agent-revision:revision-1" });
 	});
 
 	it("resolves external profile and identity after the serializable SQL transaction closes", async function _ResolvesAfterTransaction()

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-agent-binding-authority.test.ts
@@ -15,6 +15,11 @@ function _Validator(): ConversationManagedAgentPrincipalValidator
 	return { validate: vi.fn(command => command.principalId === `managed-principal:${command.agentServiceId}` && command.issuer === "urn:opencrane:managed-agent" && command.provenance === "internal" && command.subject === command.agentServiceId) };
 }
 
+function _Command(overrides: Record<string, string> = {})
+{
+	return { siloId: "silo-1", agentServiceId: "service-1", callerPrincipalId: "principal-1", callerSubjectId: "user-1", ...overrides };
+}
+
 function _Dependencies(): ConversationAgentBindingAuthorityDependencies
 {
 	return { profiles: { select: vi.fn().mockResolvedValue({ profileRevisionId: "profile-1" }) }, identities: { ensure: vi.fn().mockResolvedValue({ agentIdentityId: "identity-1" }) } };
@@ -26,22 +31,22 @@ describe("ConversationAgentBindingResolver", function _Suite()
 	{
 		const dependencies = _Dependencies();
 		const verifier = { verify: vi.fn().mockResolvedValue({ outcome: "verified", value: _Candidate() }) };
-		await expect(new ConversationAgentBindingResolver(verifier, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toMatchObject({ outcome: "bound" });
+		await expect(new ConversationAgentBindingResolver(verifier, dependencies).bind(_Command())).resolves.toMatchObject({ outcome: "bound" });
 		expect(dependencies.identities.ensure).toHaveBeenCalledWith({ siloId: "silo-1", agentServiceId: "service-1", principalId: "managed-principal:service-1", agentServiceName: "Research" });
 	});
 
 	it("does not invoke external selectors after a verifier denial", async function _Denies()
 	{
 		const dependencies = _Dependencies();
-		await expect(new ConversationAgentBindingResolver({ verify: vi.fn().mockResolvedValue({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable }) }, dependencies).bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable });
+		await expect(new ConversationAgentBindingResolver({ verify: vi.fn().mockResolvedValue({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable }) }, dependencies).bind(_Command())).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.ServiceUnavailable });
 		expect(dependencies.profiles.select).not.toHaveBeenCalled();
 		expect(dependencies.identities.ensure).not.toHaveBeenCalled();
 	});
 
-	it("verifies a personal service before external resolution", async function _Verifies()
+	it("binds a verified personal service to the caller principal and active revision ceiling", async function _Verifies()
 	{
 		const verifier = new ConversationAgentBindingVerificationResolver({ load: vi.fn().mockResolvedValue(_Candidate({ agentServiceKind: "personal", principalId: null, principal: null })) }, _Validator());
-		await expect(verifier.verify({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable });
+		await expect(verifier.verify(_Command())).resolves.toMatchObject({ outcome: "verified", value: { agentServiceKind: "personal", principalId: "principal-1", delegationPolicyId: "agent-revision:revision-1" } });
 	});
 
 	it("resolves external profile and identity after the serializable SQL transaction closes", async function _ResolvesAfterTransaction()
@@ -64,7 +69,7 @@ describe("ConversationAgentBindingResolver", function _Suite()
 		});
 		const verifier = new PrismaConversationAgentBindingUnitOfWork({ $transaction } as never, _Validator());
 		const resolver = new ConversationAgentBindingResolver(verifier, dependencies);
-		await expect(resolver.bind({ siloId: "silo-1", agentServiceId: "service-1" })).resolves.toMatchObject({ outcome: "bound" });
+		await expect(resolver.bind(_Command())).resolves.toMatchObject({ outcome: "bound" });
 		expect(phases).toEqual(["opened", "closed", "profile", "identity"]);
 	});
 });

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -66,7 +66,9 @@ export class ConversationAgentBindingResolver implements ConversationAgentBindin
 		const profile = await this.dependencies.profiles.select({ siloId: command.siloId, agentServiceKind: candidate.agentServiceKind });
 		if (profile === null)
 			return _Denied(ConversationAgentBindingDenialReasons.ProfileUnavailable);
-		const identity = await this.dependencies.identities.ensure({ siloId: command.siloId, agentServiceId: candidate.agentServiceId, principalId: candidate.principalId, agentServiceName: candidate.agentServiceName });
+		const identity = await this.dependencies.identities.ensure(candidate.agentServiceKind === "managed"
+			? { siloId: command.siloId, agentServiceId: candidate.agentServiceId, principalId: candidate.principalId, agentServiceName: candidate.agentServiceName, agentServiceKind: "managed" }
+			: { siloId: command.siloId, agentServiceId: candidate.agentServiceId, principalId: candidate.principalId, agentServiceName: candidate.agentServiceName, agentServiceKind: "personal", delegationPolicyId: candidate.delegationPolicyId });
 		if (identity === null || !_Present(identity.agentIdentityId))
 			return _Denied(ConversationAgentBindingDenialReasons.IdentityUnavailable);
 		return { outcome: "bound", value: { agentServiceId: candidate.agentServiceId, agentRevisionId: candidate.agentRevisionId, agentServiceKind: candidate.agentServiceKind, principalId: candidate.principalId, agentIdentityId: identity.agentIdentityId, profileRevisionId: profile.profileRevisionId } };

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding-authority.ts
@@ -23,13 +23,13 @@ export class ConversationAgentBindingVerificationResolver
 	 */
 	public async verify(command: ConversationAgentBindingCommand): Promise<ConversationAgentBindingVerificationResult>
 	{
-		if (!_Present(command.siloId) || !_Present(command.agentServiceId))
+		if (!_Present(command.siloId) || !_Present(command.agentServiceId) || !_Present(command.callerPrincipalId) || !_Present(command.callerSubjectId))
 			return _VerificationDenied(ConversationAgentBindingDenialReasons.InvalidCommand);
 		const candidate = await this.repository.load(command);
 		if (candidate === null)
 			return _VerificationDenied(ConversationAgentBindingDenialReasons.ServiceUnavailable);
 		if (candidate.agentServiceKind === "personal")
-			return _VerificationDenied(ConversationAgentBindingDenialReasons.PersonalDelegationUnavailable);
+			return { outcome: "verified", value: { ...candidate, agentServiceKind: "personal", principalId: command.callerPrincipalId, delegationPolicyId: `agent-revision:${candidate.agentRevisionId}` } };
 		const principalId = candidate.principalId;
 		if (principalId === null || candidate.principal === null
 			|| !this.managedPrincipalValidator.validate({ agentServiceId: candidate.agentServiceId, principalId, ...candidate.principal }))
@@ -69,7 +69,7 @@ export class ConversationAgentBindingResolver implements ConversationAgentBindin
 		const identity = await this.dependencies.identities.ensure({ siloId: command.siloId, agentServiceId: candidate.agentServiceId, principalId: candidate.principalId, agentServiceName: candidate.agentServiceName });
 		if (identity === null || !_Present(identity.agentIdentityId))
 			return _Denied(ConversationAgentBindingDenialReasons.IdentityUnavailable);
-		return { outcome: "bound", value: { agentServiceId: candidate.agentServiceId, agentRevisionId: candidate.agentRevisionId, agentServiceKind: "managed", principalId: candidate.principalId, agentIdentityId: identity.agentIdentityId, profileRevisionId: profile.profileRevisionId } };
+		return { outcome: "bound", value: { agentServiceId: candidate.agentServiceId, agentRevisionId: candidate.agentRevisionId, agentServiceKind: candidate.agentServiceKind, principalId: candidate.principalId, agentIdentityId: identity.agentIdentityId, profileRevisionId: profile.profileRevisionId } };
 	}
 }
 

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
@@ -28,6 +28,10 @@ export interface ConversationAgentBindingCommand
 	readonly siloId: string;
 	/** Identifies the AgentService selected by an already-authorized creation flow. */
 	readonly agentServiceId: string;
+	/** Identifies the authenticated Principal that a personal service may proxy. */
+	readonly callerPrincipalId: string;
+	/** Identifies the authenticated user whose active persona owns a personal service. */
+	readonly callerSubjectId: string;
 }
 
 /** Holds service facts before their Principal, profile, and AgentIdentity checks complete. */
@@ -105,8 +109,8 @@ export interface ConversationAgentBinding
 	readonly agentServiceId: string;
 	/** Identifies the active published revision. */
 	readonly agentRevisionId: string;
-	/** Identifies the managed service kind. */
-	readonly agentServiceKind: "managed";
+	/** Identifies the managed or proxied personal service kind. */
+	readonly agentServiceKind: ConversationComputerAgentServiceKind;
 	/** Identifies the service's verified dedicated Principal. */
 	readonly principalId: string;
 	/** Identifies the stable AgentIdentity selected by the trusted identity authority. */
@@ -153,6 +157,7 @@ export interface ConversationAgentBindingVerifier
  */
 export type ConversationAgentBindingVerificationResult
 	= { readonly outcome: "verified"; readonly value: ConversationAgentBindingCandidate & { readonly agentServiceKind: "managed"; readonly principalId: string; readonly principal: { readonly issuer: string; readonly provenance: "internal" | "external"; readonly subject: string } } }
+	| { readonly outcome: "verified"; readonly value: ConversationAgentBindingCandidate & { readonly agentServiceKind: "personal"; readonly principalId: string; readonly delegationPolicyId: string } }
 	| { readonly outcome: "denied"; readonly reason: ConversationAgentBindingDenialReasons };
 
 /** Lists the separately owned policy ports that complete a repository candidate. */

--- a/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-agent-binding.types.ts
@@ -62,8 +62,8 @@ export interface ConversationAgentBindingRepository
 }
 
 /** Carries checked service and Principal coordinates for an existing AgentIdentity lookup. */
-export interface ConversationAgentIdentitySelectionCommand
-{
+export type ConversationAgentIdentitySelectionCommand
+	= {
 	/** Identifies the silo where the identity stream must be owned. */
 	readonly siloId: string;
 	/** Identifies the already-validated service the identity must realize. */
@@ -72,7 +72,23 @@ export interface ConversationAgentIdentitySelectionCommand
 	readonly principalId: string;
 	/** Carries the database-selected service name when provisioning the first AgentIdentity history event. */
 	readonly agentServiceName: string;
+	/** Selects the managed identity provisioner. */
+	readonly agentServiceKind: "managed";
 }
+	| {
+		/** Identifies the silo where the identity stream must be owned. */
+		readonly siloId: string;
+		/** Identifies the personal AgentService that the caller verified. */
+		readonly agentServiceId: string;
+		/** Identifies the user Principal whose current authority the personal agent may proxy. */
+		readonly principalId: string;
+		/** Carries the personal-agent display name for the immutable identity snapshot. */
+		readonly agentServiceName: string;
+		/** Selects the proxied identity provisioner. */
+		readonly agentServiceKind: "personal";
+		/** Pins the active revision policy as the personal delegation ceiling. */
+		readonly delegationPolicyId: string;
+	};
 
 /**
  * Returns or provisions the deterministic AgentIdentity from its owning authority.

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-agent-binding-repository.ts
@@ -40,12 +40,18 @@ export class PrismaConversationAgentBindingRepository implements ConversationAge
 				kind: true,
 				activeRevisionId: true,
 				principalId: true,
-				activeRevision: { select: { id: true } },
+				activeRevision: { select: { id: true, personaRevisionId: true } },
 				principal: { select: { issuer: true, provenance: true, subject: true } },
 			},
 		});
 		if (service === null || service.activeRevision === null || service.activeRevisionId === null || service.activeRevision.id !== service.activeRevisionId)
 			return null;
+		if (service.kind === AgentServiceKind.Personal)
+		{
+			const profile = await this.transaction.personaProfile.findUnique({ where: { siloId_userId: { siloId: command.siloId, userId: command.callerSubjectId } }, select: { activeRevisionId: true } });
+			if (profile?.activeRevisionId === null || profile?.activeRevisionId === undefined || service.activeRevision.personaRevisionId !== profile.activeRevisionId)
+				return null;
+		}
 		return {
 			agentServiceName: service.name,
 			agentServiceId: service.id,


### PR DESCRIPTION
## Summary

- require authenticated caller principal and user coordinates for every agent-conversation binding
- verify a personal service against the caller’s active persona revision inside the serializable service snapshot
- replace the personal hard denial with the caller’s proxied principal and a revision-scoped delegation ceiling

## Boundary

- this PR verifies binding facts only; the next layer invokes the managed or proxied identity provisioner from those verified facts
- no browser-supplied user, Principal, persona, or delegation coordinate is accepted

## Validation

- `npx nx run backend-server-conversations:test --skip-nx-cache -- src/__tests__/conversation-agent-binding-authority.test.ts` (4 passing)
- `npx nx run backend-server-conversations:lint`
- `git diff --check`



## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807 → #808