### PR TITLE
🏗️ anchor and recover ConversationComputer creation

### DIFF
--- a/apps/opencrane/prisma/bootstrap/target-baseline.sql
+++ b/apps/opencrane/prisma/bootstrap/target-baseline.sql
@@ -4094,10 +4094,11 @@ ALTER TABLE "conversation_creation_reservations" ADD CONSTRAINT "conversation_cr
       "agent_identity_id" IS NULL AND "profile_revision_id" IS NULL AND "computer_id" IS NULL AND "computer_history_event_id" IS NULL) OR
      ("mode" = 'agent_session' AND "agent_service_id" IS NOT NULL AND btrim("agent_service_id") <> '' AND
       "agent_revision_id" IS NOT NULL AND btrim("agent_revision_id") <> '' AND
+	  "agent_identity_id" IS NOT NULL AND btrim("agent_identity_id") <> '' AND
+	  "profile_revision_id" IS NOT NULL AND btrim("profile_revision_id") <> '' AND
       "computer_id" IS NOT NULL AND "computer_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' AND
       "computer_history_event_id" IS NOT NULL AND "computer_history_event_id" ~ '^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$')) AND
-    (("state" = 'reserved' AND "history_revision" IS NULL AND "history_anchored_at" IS NULL AND "projected_at" IS NULL AND
-      "agent_identity_id" IS NULL AND "profile_revision_id" IS NULL) OR
+	(("state" = 'reserved' AND "history_revision" IS NULL AND "history_anchored_at" IS NULL AND "projected_at" IS NULL) OR
      ("state" = 'history_anchored' AND "history_revision" = 0 AND "history_anchored_at" IS NOT NULL AND "projected_at" IS NULL AND
       (("mode" = 'agent_session' AND "agent_identity_id" IS NOT NULL AND btrim("agent_identity_id") <> '' AND
         "profile_revision_id" IS NOT NULL AND btrim("profile_revision_id") <> '') OR
@@ -4122,7 +4123,8 @@ BEGIN
         OR OLD."authorization_policy_revision_hash" IS DISTINCT FROM NEW."authorization_policy_revision_hash"
         OR OLD."effective_authorization_digest" IS DISTINCT FROM NEW."effective_authorization_digest"
         OR OLD."mode" IS DISTINCT FROM NEW."mode" OR OLD."agent_service_id" IS DISTINCT FROM NEW."agent_service_id"
-        OR OLD."agent_revision_id" IS DISTINCT FROM NEW."agent_revision_id" OR OLD."computer_id" IS DISTINCT FROM NEW."computer_id"
+		OR OLD."agent_revision_id" IS DISTINCT FROM NEW."agent_revision_id" OR OLD."agent_identity_id" IS DISTINCT FROM NEW."agent_identity_id"
+		OR OLD."profile_revision_id" IS DISTINCT FROM NEW."profile_revision_id" OR OLD."computer_id" IS DISTINCT FROM NEW."computer_id"
         OR OLD."computer_history_event_id" IS DISTINCT FROM NEW."computer_history_event_id" OR OLD."reserved_at" IS DISTINCT FROM NEW."reserved_at" THEN
         RAISE EXCEPTION 'ConversationCreationReservation command coordinates are immutable';
     END IF;

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-history-reader.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-history-reader.test.ts
@@ -3,7 +3,7 @@ import { HistoryExpectedRevisions, type HistoryRecordedEvent } from "@opencrane/
 import { describe, expect, it, vi } from "vitest";
 
 import { ConversationHistoryReader } from "../conversation-history-reader";
-import type { ConversationHistoryReadCommand } from "../conversation-history-reader.types";
+import type { ConversationCreationReadCommand, ConversationHistoryReadCommand } from "../conversation-history-reader.types";
 
 /** Reuses a valid UUID for the first immutable participant-visible entry. */
 const _FIRST_ENTRY_ID = "31c1f1dc-0010-4f13-9c2f-d3841ffd6651";
@@ -12,6 +12,12 @@ const _SECOND_ENTRY_ID = "e97a2af7-81a2-4f48-96b8-cf2ea37f3d5f";
 
 /** Builds trusted command coordinates so each test changes only the integrity condition under test. */
 function _Command(overrides: Partial<ConversationHistoryReadCommand> = {}): ConversationHistoryReadCommand
+{
+	return { siloId: "silo-1", conversationId: "conversation-1", ...overrides };
+}
+
+/** Builds creation-only coordinates so the projector cannot request a participant-entry range. */
+function _CreationCommand(overrides: Partial<ConversationCreationReadCommand> = {}): ConversationCreationReadCommand
 {
 	return { siloId: "silo-1", conversationId: "conversation-1", ...overrides };
 }
@@ -125,6 +131,26 @@ describe("ConversationHistoryReader", function ()
 
 		await expect(reader.readCurrent(_Command())).resolves.toEqual(expect.objectContaining({ streamName: "conversation-conversation-1", expectedRevision: 2n, entries: expect.arrayContaining([expect.objectContaining({ position: "1" }), expect.objectContaining({ position: "2" })]) }));
 		expect(readHead).toHaveBeenCalledWith("conversation-conversation-1");
+	});
+
+	it("returns the revision-zero creation record only after it validates the complete stream", async function _ReadsCreation()
+	{
+		const created = _CreatedEvent().data.created;
+		const reader = new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events(_History([_Event(1n)]))), readHead: vi.fn() });
+
+		await expect(reader.readCreation(_CreationCommand())).resolves.toEqual(created);
+	});
+
+	it("fails closed when the creation stream is absent or malformed", async function _RejectsInvalidCreation()
+	{
+		const malformedCreation = { ..._CreatedEvent(), data: { created: { ..._CreatedEvent().data.created as object, mode: "unknown" } } };
+		const absent = new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([])), readHead: vi.fn() });
+		const malformedAnchor = new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events([malformedCreation])), readHead: vi.fn() });
+		const malformedTail = new ConversationHistoryReader({ readStream: vi.fn().mockReturnValue(_Events(_History([_Event(2n)]))), readHead: vi.fn() });
+
+		await expect(absent.readCreation(_CreationCommand())).rejects.toThrow("requires a creation event");
+		await expect(malformedAnchor.readCreation(_CreationCommand())).rejects.toThrow("invalid creation event");
+		await expect(malformedTail.readCreation(_CreationCommand())).rejects.toThrow("noncontiguous");
 	});
 
 	it("preserves the no-stream condition and fails closed when the current head moves or a partial range is requested", async function ()

--- a/libs/backend/server/conversations/main/src/__tests__/history-anchored-conversation-creation-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/history-anchored-conversation-creation-authority.test.ts
@@ -1,0 +1,139 @@
+import { ConversationModes } from "@opencrane/models/conversations";
+import type { HistoryAppendReceipt } from "@opencrane/backend/server/infra/history-store";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type ReserveConversationCreationCommand, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
+import { HistoryAnchoredConversationCreationAuthority } from "../history-anchored-conversation-creation-authority";
+import { HistoryAnchoredConversationCreationOutcomes, type ConversationCreationProjectionPort, type ConversationCreationReservationUnitOfWork } from "../history-anchored-conversation-creation-authority.types";
+import type { ConversationHistoryAuthority } from "../conversation-history-authority";
+import type { ConversationCreationAnchorVerifier } from "../conversation-creation-anchor-verifier";
+import { ConversationCreationAnchorConfirmationOutcomes, type ConversationCreationAnchorConfirmation } from "../conversation-creation-anchor-verifier.types";
+
+/** Supplies the stable server-generated request UUID used by a browser retry. */
+const _REQUEST_ID = "31c1f1dc-0010-4f13-9c2f-d3841ffd6651";
+/** Supplies the stable server-generated conversation UUID used by immutable history. */
+const _CONVERSATION_ID = "31c1f1dc-0011-4f13-9c2f-d3841ffd6651";
+/** Supplies the revision-zero event UUID reserved before the history append. */
+const _EVENT_ID = "31c1f1dc-0012-4f13-9c2f-d3841ffd6651";
+
+/** Builds one direct command that a caller already resolved without a browser-selected history record. */
+function _Command(overrides: Partial<ReserveConversationCreationCommand> = {}): ReserveConversationCreationCommand
+{
+	return {
+		siloId: "silo-1",
+		principalId: "principal-1",
+		requestId: _REQUEST_ID,
+		requestDigest: `sha256:${"a".repeat(64)}`,
+		conversationId: _CONVERSATION_ID,
+		historyEventId: _EVENT_ID,
+		mode: ConversationModes.Direct,
+		participants: [{ userId: "user-1", visibleFromPosition: "1", joinedAt: "2026-09-02T00:00:00.000Z" }, { userId: "user-2", visibleFromPosition: "2", joinedAt: "2026-09-02T00:00:00.000Z" }],
+		agent: null,
+		agentBinding: null,
+		...overrides,
+	};
+}
+
+/** Builds the durable reservation returned by either serializable reservation operation. */
+function _Reservation(overrides: Partial<ReservedConversationCreation> = {}): ReservedConversationCreation
+{
+	return {
+		reservationId: "reservation-1",
+		createdAt: "2026-09-02T00:00:00.000Z",
+		..._Command(),
+		authorizationEvidenceId: "decision-1",
+		state: ConversationCreationReservationStates.Reserved,
+		...overrides,
+	};
+}
+
+/** Creates test ports whose calls expose the order across PostgreSQL, history, and projection ownership. */
+function _Ports(reservation: ReservedConversationCreation = _Reservation())
+{
+	const phases: string[] = [];
+	const reservations: ConversationCreationReservationUnitOfWork = {
+		reserve: vi.fn(async function _Reserve() { phases.push("reserve"); return { outcome: ConversationCreationReservationOutcomes.Reserved, value: reservation } as const; }),
+		markHistoryAnchored: vi.fn(async function _Mark() { phases.push("mark"); return { ...reservation, state: ConversationCreationReservationStates.HistoryAnchored }; }),
+	};
+	const historyCreate = vi.fn(async function _Create(): Promise<HistoryAppendReceipt> { phases.push("history"); return { streamName: `conversation-${_CONVERSATION_ID}`, revision: 0n }; });
+	const history: Pick<ConversationHistoryAuthority, "create"> = { create: historyCreate };
+	const anchorConfirm = vi.fn(async function _Confirm(): Promise<ConversationCreationAnchorConfirmation> { phases.push("confirm"); return { outcome: ConversationCreationAnchorConfirmationOutcomes.Confirmed, revision: 0n }; });
+	const anchorVerifier: Pick<ConversationCreationAnchorVerifier, "confirm"> = { confirm: anchorConfirm };
+	const projection: ConversationCreationProjectionPort = { request: vi.fn(async function _Request() { phases.push("projection"); }) };
+	return { phases, reservations, history, historyCreate, anchorVerifier, anchorConfirm, projection };
+}
+
+describe("HistoryAnchoredConversationCreationAuthority", function _Suite()
+{
+	it("reserves before history, marks the exact anchor, and requests a projection", async function _Creates()
+	{
+		const ports = _Ports();
+		const authority = new HistoryAnchoredConversationCreationAuthority(ports.reservations, ports.history, ports.anchorVerifier, ports.projection);
+		const result = await authority.create({ reservation: _Command() });
+		expect(result).toMatchObject({ outcome: HistoryAnchoredConversationCreationOutcomes.ProjectionNeeded, created: { conversationId: _CONVERSATION_ID, createdAt: "2026-09-02T00:00:00.000Z", agentBinding: null }, projection: { historyRevision: 0n } });
+		expect(ports.phases).toEqual(["reserve", "history", "mark", "projection"]);
+		expect(ports.history.create).toHaveBeenCalledWith(expect.objectContaining({ eventId: _EVENT_ID, created: expect.objectContaining({ provenance: { principalId: "principal-1", authorizationEvidenceId: "decision-1", requestId: _REQUEST_ID } }) }));
+		expect(ports.reservations.markHistoryAnchored).toHaveBeenCalledWith({ reservationId: "reservation-1" });
+	});
+
+	it("does not touch history or projection after a product authorization denial", async function _Denies()
+	{
+		const ports = _Ports();
+		ports.reservations.reserve = vi.fn(async function _Deny() { return { outcome: ConversationCreationReservationOutcomes.Denied } as const; });
+		const authority = new HistoryAnchoredConversationCreationAuthority(ports.reservations, ports.history, ports.anchorVerifier, ports.projection);
+		await expect(authority.create({ reservation: _Command() })).resolves.toEqual({ outcome: HistoryAnchoredConversationCreationOutcomes.Denied });
+		expect(ports.history.create).not.toHaveBeenCalled();
+		expect(ports.projection.request).not.toHaveBeenCalled();
+	});
+
+	it("confirms the exact anchor after an ambiguous append response before it marks the reservation", async function _RecoversAmbiguousAppend()
+	{
+		const ports = _Ports();
+		ports.historyCreate.mockImplementationOnce(async function _LostResponse() { ports.phases.push("history"); throw new Error("response lost"); });
+		const authority = new HistoryAnchoredConversationCreationAuthority(ports.reservations, ports.history, ports.anchorVerifier, ports.projection);
+		await expect(authority.create({ reservation: _Command() })).resolves.toMatchObject({ outcome: HistoryAnchoredConversationCreationOutcomes.ProjectionNeeded });
+		expect(ports.phases).toEqual(["reserve", "history", "confirm", "mark", "projection"]);
+		expect(ports.anchorVerifier.confirm).toHaveBeenCalledWith(expect.objectContaining({ eventId: _EVENT_ID, created: expect.objectContaining({ createdAt: "2026-09-02T00:00:00.000Z" }) }));
+	});
+
+	it("retries one absent stream only after the verifier declines to invent a committed append", async function _RetriesAbsentAnchor()
+	{
+		const ports = _Ports();
+		ports.historyCreate.mockImplementationOnce(async function _LostResponse() { ports.phases.push("history"); throw new Error("response lost"); });
+		ports.anchorConfirm.mockImplementationOnce(async function _Absent(): Promise<ConversationCreationAnchorConfirmation> { ports.phases.push("confirm"); return { outcome: ConversationCreationAnchorConfirmationOutcomes.Absent }; });
+		const authority = new HistoryAnchoredConversationCreationAuthority(ports.reservations, ports.history, ports.anchorVerifier, ports.projection);
+		await expect(authority.create({ reservation: _Command() })).resolves.toMatchObject({ outcome: HistoryAnchoredConversationCreationOutcomes.ProjectionNeeded });
+		expect(ports.phases).toEqual(["reserve", "history", "confirm", "history", "mark", "projection"]);
+	});
+
+	it("replays an anchored reservation without a second history append", async function _ResumesAnchored()
+	{
+		const anchored = _Reservation({ state: ConversationCreationReservationStates.HistoryAnchored });
+		const ports = _Ports(anchored);
+		const authority = new HistoryAnchoredConversationCreationAuthority(ports.reservations, ports.history, ports.anchorVerifier, ports.projection);
+		await expect(authority.create({ reservation: _Command() })).resolves.toMatchObject({ outcome: HistoryAnchoredConversationCreationOutcomes.ProjectionNeeded });
+		expect(ports.history.create).not.toHaveBeenCalled();
+		expect(ports.phases).toEqual(["reserve", "mark", "projection"]);
+	});
+
+	it("recovers an Agent anchor with its originally frozen binding after the progress transaction fails", async function _RecoversAgentAnchor()
+	{
+		const frozenBinding = { agentIdentityId: "identity-1", profileRevisionId: "profile-1" };
+		const agentReservation = _Reservation({ mode: ConversationModes.AgentSession, participants: [_Command().participants[0]], agent: { agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _EVENT_ID }, agentBinding: frozenBinding });
+		const ports = _Ports(agentReservation);
+		let markAttempts = 0;
+		ports.reservations.markHistoryAnchored = vi.fn(async function _FailThenAdvance()
+		{
+			markAttempts += 1;
+			if (markAttempts === 1)
+				throw new Error("transaction lost");
+			return { ...agentReservation, state: ConversationCreationReservationStates.HistoryAnchored };
+		});
+		ports.historyCreate.mockImplementationOnce(async function _FirstAppend() { ports.phases.push("history"); return { streamName: `conversation-${_CONVERSATION_ID}`, revision: 0n }; });
+		ports.historyCreate.mockImplementationOnce(async function _ExistingAnchor() { ports.phases.push("history"); throw new Error("already created"); });
+		const authority = new HistoryAnchoredConversationCreationAuthority(ports.reservations, ports.history, ports.anchorVerifier, ports.projection);
+		await expect(authority.create({ reservation: _Command({ mode: ConversationModes.AgentSession, participants: [_Command().participants[0]], agent: agentReservation.agent, agentBinding: frozenBinding }) })).rejects.toThrow("transaction lost");
+		await expect(authority.create({ reservation: _Command({ mode: ConversationModes.AgentSession, participants: [_Command().participants[0]], agent: agentReservation.agent, agentBinding: { agentIdentityId: "identity-2", profileRevisionId: "profile-2" } }) })).resolves.toMatchObject({ created: { agentBinding: expect.objectContaining(frozenBinding) } });
+		expect(ports.anchorVerifier.confirm).toHaveBeenCalledWith(expect.objectContaining({ created: expect.objectContaining({ agentBinding: expect.objectContaining(frozenBinding) }) }));
+	});
+});

--- a/libs/backend/server/conversations/main/src/conversation-computers/__tests__/conversation-computer-provision-recovery.test.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/__tests__/conversation-computer-provision-recovery.test.ts
@@ -1,0 +1,87 @@
+import { ConversationComputerStates, type ConversationComputer } from "@opencrane/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { _ConversationComputerProvisionRecovery } from "../conversation-computer-provision-recovery";
+import { _ConversationComputerProvisionRecoveryOutcomes } from "../conversation-computer-provision-recovery.types";
+
+/** Reuses the event identifier that the creation reservation assigns to one computer provision. */
+const _EVENT_ID = "31c1f1dc-0010-4f13-9c2f-d3841ffd6651";
+
+/** Builds the only cold snapshot that can establish a computer history stream. */
+function _ColdComputer(overrides: Partial<ConversationComputer> = {}): ConversationComputer
+{
+	return {
+		schemaVersion: 1,
+		id: "computer-1",
+		siloId: "silo-1",
+		conversationId: "conversation-1",
+		agentIdentityId: "identity-1",
+		profileRevisionId: "profile-1",
+		state: ConversationComputerStates.Cold,
+		leaseGeneration: 0,
+		workspaceCheckpoint: null,
+		activeExecution: null,
+		createdAt: "2026-09-02T00:00:00.000Z",
+		updatedAt: "2026-09-02T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+/** Builds a revision-zero, lease-free snapshot for cold-provision recovery tests. */
+function _Current(computer: ConversationComputer = _ColdComputer(), revision = 0n)
+{
+	return {
+		streamName: `computer-${computer.id}`,
+		revision,
+		computer,
+		lease: null,
+	};
+}
+
+/** Creates the narrow computer-history fake used to observe provision and reload behavior. */
+function _Subject(overrides: { readonly provisionError?: Error; readonly current?: ReturnType<typeof _Current> | null } = {})
+{
+	const provision = vi.fn();
+	if (overrides.provisionError !== undefined)
+		provision.mockRejectedValue(overrides.provisionError);
+	const load = vi.fn().mockResolvedValue(overrides.current ?? null);
+	const authority = new _ConversationComputerProvisionRecovery({ provision, load } as never);
+	return { authority, provision, load };
+}
+
+describe("_ConversationComputerProvisionRecovery", function _DescribeConversationComputerProvisionRecovery()
+{
+	it("provisions a frozen cold computer without reading history when the append acknowledges", async function _ProvisionsColdComputer()
+	{
+		const subject = _Subject();
+		const computer = _ColdComputer();
+
+		await expect(subject.authority.provision({ eventId: _EVENT_ID, computer })).resolves.toEqual({ outcome: _ConversationComputerProvisionRecoveryOutcomes.Provisioned });
+		expect(subject.provision).toHaveBeenCalledWith({ eventId: _EVENT_ID, computer });
+		expect(subject.load).not.toHaveBeenCalled();
+	});
+
+	it("recovers a duplicate or response-lost append only from the same cold revision-zero snapshot", async function _RecoversExactColdComputer()
+	{
+		const computer = _ColdComputer();
+		const subject = _Subject({ provisionError: new Error("expected no stream"), current: _Current(computer) });
+
+		await expect(subject.authority.provision({ eventId: _EVENT_ID, computer })).resolves.toEqual({ outcome: _ConversationComputerProvisionRecoveryOutcomes.Recovered });
+		expect(subject.load).toHaveBeenCalledWith({ siloId: "silo-1", computerId: "computer-1", conversationId: "conversation-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1" });
+	});
+
+	it("keeps a missing, foreign, changed, or later computer stream as the original provision failure", async function _RejectsNonExactRecovery()
+	{
+		const error = new Error("expected no stream");
+		const computer = _ColdComputer();
+		const missing = _Subject({ provisionError: error });
+		const foreign = _Subject({ provisionError: error, current: _Current(_ColdComputer({ id: "computer-foreign" })) });
+		const changed = _Subject({ provisionError: error, current: _Current(_ColdComputer({ createdAt: "2026-09-02T00:00:01.000Z", updatedAt: "2026-09-02T00:00:01.000Z" })) });
+		const later = _Subject({ provisionError: error, current: _Current(computer, 1n) });
+
+		await expect(missing.authority.provision({ eventId: _EVENT_ID, computer })).rejects.toThrow(error);
+		await expect(foreign.authority.provision({ eventId: _EVENT_ID, computer })).rejects.toThrow(error);
+		await expect(changed.authority.provision({ eventId: _EVENT_ID, computer })).rejects.toThrow(error);
+		await expect(later.authority.provision({ eventId: _EVENT_ID, computer })).rejects.toThrow(error);
+	});
+});

--- a/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-provision-recovery.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-provision-recovery.ts
@@ -1,0 +1,69 @@
+import type { ConversationComputer } from "@opencrane/contracts";
+import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
+
+import { ConversationComputerHistory } from "./conversation-computer-history";
+import type { CurrentConversationComputer } from "./conversation-computer-history.types";
+import { _ConversationComputerProvisionRecoveryOutcomes, type _ConversationComputerProvisionRecoveryCommand, type _ConversationComputerProvisionRecoveryResult } from "./conversation-computer-provision-recovery.types";
+
+/**
+ * Recovers a cold-computer provision when KurrentDB may have committed it without acknowledging it.
+ *
+ * A future history-anchored creation projector calls this after its reservation freezes the computer
+ * and event identifier. A duplicate or a lost response can leave the provision append ambiguous, so
+ * this authority reloads the computer through those frozen coordinates. It reports recovery only for
+ * revision zero, no lease, and the same canonical JSON snapshot; every other stream rethrows the
+ * original provision failure.
+ *
+ * @see ConversationComputerHistory.provision
+ */
+export class _ConversationComputerProvisionRecovery
+{
+	/** Connects provision recovery to the narrow computer-history operations it needs. */
+	public constructor(private readonly history: Pick<ConversationComputerHistory, "load" | "provision">)
+	{
+	}
+
+	/**
+	 * Provisions one cold computer and recovers only when history proves the same revision-zero record.
+	 *
+	 * @param command - Supplies the event key and cold snapshot frozen in the creation reservation.
+	 * @returns Whether KurrentDB acknowledged the provision or history recovered its cold revision-zero record.
+	 * @throws {Error} Rethrows the provision failure unless history proves the exact cold revision-zero record.
+	 */
+	public async provision(command: _ConversationComputerProvisionRecoveryCommand): Promise<_ConversationComputerProvisionRecoveryResult>
+	{
+		try
+		{
+			await this.history.provision(command);
+			return { outcome: _ConversationComputerProvisionRecoveryOutcomes.Provisioned };
+		}
+		catch (error: unknown)
+		{
+			const current = await this.history.load(_CurrentCommand(command.computer));
+			if (_IsExactColdProvision(current, command.computer))
+				return { outcome: _ConversationComputerProvisionRecoveryOutcomes.Recovered };
+			throw error;
+		}
+	}
+}
+
+/** Builds the history locator from the coordinates that the creation reservation froze. */
+function _CurrentCommand(computer: ConversationComputer)
+{
+	return {
+		siloId: computer.siloId,
+		computerId: computer.id,
+		conversationId: computer.conversationId,
+		agentIdentityId: computer.agentIdentityId,
+		profileRevisionId: computer.profileRevisionId,
+	};
+}
+
+/** Checks that the reloaded snapshot is the same cold provision that this call requested. */
+function _IsExactColdProvision(current: CurrentConversationComputer | null, computer: ConversationComputer): boolean
+{
+	return current !== null
+		&& current.revision === 0n
+		&& current.lease === null
+		&& ___DigestCanonicalJson(current.computer as unknown as JsonValue) === ___DigestCanonicalJson(computer as unknown as JsonValue);
+}

--- a/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-provision-recovery.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-computers/conversation-computer-provision-recovery.types.ts
@@ -1,0 +1,26 @@
+import type { ConversationComputer } from "@opencrane/contracts";
+
+/** States whether KurrentDB acknowledged a cold provision or history recovered it after an ambiguous append. */
+export enum _ConversationComputerProvisionRecoveryOutcomes
+{
+	/** KurrentDB acknowledged the append that established the cold computer stream. */
+	Provisioned = "provisioned",
+	/** History confirmed the same cold revision-zero stream after the append response was lost or rejected as a duplicate. */
+	Recovered = "recovered",
+}
+
+/** Carries the event identifier and cold snapshot that the creation reservation froze before history I/O. */
+export interface _ConversationComputerProvisionRecoveryCommand
+{
+	/** Supplies the UUID that the creation reservation assigned to this provision event. */
+	readonly eventId: string;
+	/** Supplies the server-resolved cold computer snapshot that history must match. */
+	readonly computer: ConversationComputer;
+}
+
+/** Reports whether the cold computer provision append completed or history recovered its record. */
+export interface _ConversationComputerProvisionRecoveryResult
+{
+	/** States whether KurrentDB acknowledged the append or history proved recovery. */
+	readonly outcome: _ConversationComputerProvisionRecoveryOutcomes;
+}

--- a/libs/backend/server/conversations/main/src/conversation-creation-anchor-verifier.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-anchor-verifier.ts
@@ -2,7 +2,7 @@ import { ___ConversationCreatedSchema } from "@opencrane/contracts";
 import type { HistoryRecordedEvent, HistoryStore } from "@opencrane/backend/server/infra/history-store";
 import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 
-import type { ConfirmConversationCreationAnchorCommand, ConversationCreationAnchorConfirmation } from "./conversation-creation-anchor-verifier.types";
+import { ConversationCreationAnchorConfirmationOutcomes, type ConfirmConversationCreationAnchorCommand, type ConversationCreationAnchorConfirmation } from "./conversation-creation-anchor-verifier.types";
 
 /** Names the only revision-zero event that can prove a durable conversation creation reservation. */
 const _CONVERSATION_CREATED_EVENT_TYPE = "opencrane.conversation-created.v1";
@@ -34,9 +34,9 @@ export class ConversationCreationAnchorVerifier
 		for await (const event of this.historyStore.readStream({ streamName }))
 		{
 			_AssertAnchor(event, command, streamName);
-			return { outcome: "confirmed", revision: 0n };
+			return { outcome: ConversationCreationAnchorConfirmationOutcomes.Confirmed, revision: 0n };
 		}
-		return { outcome: "absent" };
+		return { outcome: ConversationCreationAnchorConfirmationOutcomes.Absent };
 	}
 }
 

--- a/libs/backend/server/conversations/main/src/conversation-creation-anchor-verifier.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-anchor-verifier.types.ts
@@ -1,5 +1,14 @@
 import type { ConversationCreated } from "@opencrane/contracts";
 
+/** States whether a read-only recovery check proved the exact reserved creation anchor. */
+export enum ConversationCreationAnchorConfirmationOutcomes
+{
+	/** The conversation stream has no first event, so one append retry remains permissible. */
+	Absent = "absent",
+	/** Revision zero contains the exact reserved creation envelope and payload. */
+	Confirmed = "confirmed",
+}
+
 /** Carries the fixed creation record that a response-lost history retry must prove already exists. */
 export interface ConfirmConversationCreationAnchorCommand
 {
@@ -13,5 +22,5 @@ export interface ConfirmConversationCreationAnchorCommand
 
 /** Separates an absent stream from a proven reservation match without treating a foreign stream as recoverable. */
 export type ConversationCreationAnchorConfirmation
-	= { readonly outcome: "absent" }
-	| { readonly outcome: "confirmed"; readonly revision: 0n };
+	= { readonly outcome: ConversationCreationAnchorConfirmationOutcomes.Absent }
+	| { readonly outcome: ConversationCreationAnchorConfirmationOutcomes.Confirmed; readonly revision: 0n };

--- a/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
@@ -17,6 +17,24 @@ export enum ConversationCreationReservationStates
 	Projected = "projected",
 }
 
+/**
+ * States the outcome of reserving one server-resolved conversation creation command.
+ *
+ * The values cross the reservation port and determine whether history I/O may begin; only a new
+ * or exact-idempotent reservation permits the history-anchored creation authority to continue.
+ */
+export enum ConversationCreationReservationOutcomes
+{
+	/** A new command and its authorization evidence committed in the reservation transaction. */
+	Reserved = "reserved",
+	/** The same principal, retry key, and request digest already identify a durable command. */
+	Idempotent = "idempotent",
+	/** The retry key identifies another request digest, so no replacement command may be stored. */
+	IdempotencyConflict = "idempotency_conflict",
+	/** Product authorization denied the command before a reservation or history append occurred. */
+	Denied = "denied",
+}
+
 /** Carries one resolved participant coordinate that the immutable creation anchor must replay exactly. */
 export interface ConversationCreationReservationParticipant
 {
@@ -42,9 +60,9 @@ export interface ConversationCreationReservationAgentCoordinates
 }
 
 /**
- * Carries the Agent identity and profile revision recorded when an agent conversation reaches its
+ * Carries the Agent identity and profile revision frozen before an agent conversation reaches its
  * history anchor. Direct and group conversations carry no binding, while an agent conversation
- * must carry both values so a retry can compare the persisted pair without changing it.
+ * must carry both values so a retry rebuilds the same creation payload after an ambiguous append.
  */
 export interface ConversationCreationReservationAgentBinding
 {
@@ -56,15 +74,13 @@ export interface ConversationCreationReservationAgentBinding
 
 /**
  * Requests the reservation transition after KurrentDB has confirmed its revision-zero creation
- * anchor. Callers use `null` for direct and group conversations; agent conversations supply the
- * resolved {@link ConversationCreationReservationAgentBinding} that is persisted with the anchor.
+ * anchor. The reservation already carries its immutable Agent binding, so callers cannot alter
+ * identity or profile facts after history I/O begins.
  */
 export interface AnchorConversationCreationReservationCommand
 {
 	/** Identifies the durable command whose Kurrent creation anchor has been verified. */
 	readonly reservationId: string;
-	/** Supplies Agent-only identity/profile facts, or null for direct and group conversations. */
-	readonly agentBinding: ConversationCreationReservationAgentBinding | null;
 }
 
 /** Names the complete, resolved command that a transaction stores before any history I/O. */
@@ -88,6 +104,8 @@ export interface ReserveConversationCreationCommand
 	readonly participants: readonly ConversationCreationReservationParticipant[];
 	/** Carries agent-only server coordinates, or null for direct and group conversations. */
 	readonly agent: ConversationCreationReservationAgentCoordinates | null;
+	/** Carries the Agent-only identity/profile pair frozen into the initial reservation, or null otherwise. */
+	readonly agentBinding: ConversationCreationReservationAgentBinding | null;
 }
 
 /** Gives callers the fixed durable command after reservation or idempotent recovery. */
@@ -95,10 +113,15 @@ export interface ReservedConversationCreation extends ReserveConversationCreatio
 {
 	/** Identifies the durable reservation row. */
 	readonly reservationId: string;
+	/**
+	 * Records the server-owned instant at which PostgreSQL admitted the creation command.
+	 *
+	 * The history anchor reuses this exact value as `ConversationCreated.createdAt`, so a retry
+	 * rebuilds byte-identical revision-zero payload without trusting a new request timestamp.
+	 */
+	readonly createdAt: string;
 	/** Identifies the same-transaction authorization decision that admitted the reservation. */
 	readonly authorizationEvidenceId: string;
-	/** Carries the persisted agent identity/profile pair after history anchoring, or null when no agent owns the conversation. */
-	readonly resolvedAgentBinding: ConversationCreationReservationAgentBinding | null;
 	/** States whether the command has been anchored and projected. */
 	readonly state: ConversationCreationReservationStates;
 }
@@ -111,10 +134,10 @@ export interface ReservedConversationCreation extends ReserveConversationCreatio
  * and must not append history after `denied`.
  */
 export type ReserveConversationCreationResult
-	= { readonly outcome: "reserved"; readonly value: ReservedConversationCreation }
-	| { readonly outcome: "idempotent"; readonly value: ReservedConversationCreation }
-	| { readonly outcome: "idempotency_conflict" }
-	| { readonly outcome: "denied" };
+	= { readonly outcome: ConversationCreationReservationOutcomes.Reserved; readonly value: ReservedConversationCreation }
+	| { readonly outcome: ConversationCreationReservationOutcomes.Idempotent; readonly value: ReservedConversationCreation }
+	| { readonly outcome: ConversationCreationReservationOutcomes.IdempotencyConflict }
+	| { readonly outcome: ConversationCreationReservationOutcomes.Denied };
 
 /**
  * Persists and reloads creation commands inside the caller's serializable PostgreSQL transaction.
@@ -138,13 +161,14 @@ export interface ConversationCreationReservationRepository
 	/**
 	 * Advances one reservation only after its exact revision-zero anchor is present in KurrentDB.
 	 *
-	 * The repository accepts a direct/group null binding or the full Agent identity/profile pair and
-	 * returns the already-advanced command for an exact retry. It never accepts a partial binding.
-	 * @param command The reservation and, when applicable, the Agent identity/profile pair to persist.
-	 * @returns The anchored reservation, including the persisted binding. Matching anchored retries
-	 * return the stored reservation without another update.
-	 * @throws {Error} The reservation is unavailable, its binding does not match its conversation
-	 * mode or stored retry value, or an agent binding is incomplete.
+	 * The repository validates the immutable binding fixed in the reservation and returns the
+	 * already-advanced command for an exact retry. It never accepts replacement identity or profile
+	 * facts after history I/O begins.
+	 * @param command The durable reservation whose exact history anchor has been confirmed.
+	 * @returns The anchored reservation. Matching anchored retries return the stored reservation
+	 * without another update.
+	 * @throws {Error} The reservation is unavailable to this caller, or its stored binding does not
+	 * match its conversation mode.
 	 */
 	markHistoryAnchored(command: AnchorConversationCreationReservationCommand): Promise<ReservedConversationCreation>;
 }

--- a/libs/backend/server/conversations/main/src/conversation-creation-reservation.validation.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-reservation.validation.ts
@@ -21,18 +21,20 @@ export function __ValidateConversationCreationReservation(command: ReserveConver
 		throw new Error("Direct conversation reservation requires two participants");
 	if (command.mode === ConversationModes.Group && command.participants.length < 2)
 		throw new Error("Group conversation reservation requires at least two participants");
-	if (command.mode === ConversationModes.AgentSession && (command.participants.length !== 1 || command.agent === null))
-		throw new Error("Agent conversation reservation requires one participant and server agent coordinates");
-	if (command.mode !== ConversationModes.AgentSession && command.agent !== null)
-		throw new Error("Direct and group conversation reservation must not carry agent coordinates");
+	if (command.mode === ConversationModes.AgentSession && (command.participants.length !== 1 || command.agent === null || command.agentBinding === null))
+		throw new Error("Agent conversation reservation requires one participant, server agent coordinates, and a frozen binding");
+	if (command.mode !== ConversationModes.AgentSession && (command.agent !== null || command.agentBinding !== null))
+		throw new Error("Direct and group conversation reservation must not carry agent coordinates or a binding");
 	if (command.agent !== null && (!_Identifier(command.agent.agentServiceId) || !_Identifier(command.agent.agentRevisionId) || !_Uuid(command.agent.computerId) || !_Uuid(command.agent.computerHistoryEventId)))
 		throw new Error("Agent conversation reservation requires complete server agent coordinates");
+	if (command.agentBinding !== null && (!_Identifier(command.agentBinding.agentIdentityId) || !_Identifier(command.agentBinding.profileRevisionId)))
+		throw new Error("Agent conversation reservation requires a complete frozen binding");
 }
 
 /** Builds the canonical authorization arguments that bind a decision to this exact durable command. */
 export function __ConversationCreationReservationAuthorizationArguments(command: ReserveConversationCreationCommand): JsonValue
 {
-	return { requestId: command.requestId, requestDigest: command.requestDigest, conversationId: command.conversationId, historyEventId: command.historyEventId, mode: command.mode, participants: command.participants, agent: command.agent } as unknown as JsonValue;
+	return { requestId: command.requestId, requestDigest: command.requestDigest, conversationId: command.conversationId, historyEventId: command.historyEventId, mode: command.mode, participants: command.participants, agent: command.agent, agentBinding: command.agentBinding } as unknown as JsonValue;
 }
 
 /** Checks an opaque server identifier without changing the durable coordinate. */

--- a/libs/backend/server/conversations/main/src/conversation-history-reader.ts
+++ b/libs/backend/server/conversations/main/src/conversation-history-reader.ts
@@ -1,7 +1,7 @@
-import { ___ConversationCreatedSchema, ___ConversationEntrySchema, type ConversationEntry } from "@opencrane/contracts";
+import { ___ConversationCreatedSchema, ___ConversationEntrySchema, type ConversationCreated, type ConversationEntry } from "@opencrane/contracts";
 import { HistoryExpectedRevisions, type HistoryRecordedEvent, type HistoryStore } from "@opencrane/backend/server/infra/history-store";
 
-import type { ConversationHistoryReadCommand, ConversationHistoryReadResult, CurrentConversationHistory } from "./conversation-history-reader.types";
+import type { ConversationCreationReadCommand, ConversationHistoryReadCommand, ConversationHistoryReadResult, CurrentConversationHistory } from "./conversation-history-reader.types";
 
 /** Names the sole versioned event that this reader exposes as a participant-visible entry. */
 const _CONVERSATION_ENTRY_EVENT_TYPE = "opencrane.conversation-entry.v1";
@@ -45,14 +45,48 @@ export class ConversationHistoryReader
 		// 2. Check every immutable envelope before exposing its entry to a participant transport.
 		for await (const event of this.historyStore.readStream(request))
 		{
-			const entry = _ValidatedEvent(event, command, streamName, expectedRevision);
-			if (entry !== null && (command.fromRevision === undefined || event.revision >= command.fromRevision))
-				entries.push(entry);
+			const validated = _ValidatedEvent(event, command, streamName, expectedRevision);
+			if (validated.entry !== null && (command.fromRevision === undefined || event.revision >= command.fromRevision))
+				entries.push(validated.entry);
 			expectedRevision += 1n;
 		}
 
 		// 3. Return the finite ordered stream result without constructing a relational or projection fallback.
 		return { streamName, revision: expectedRevision === 0n ? null : expectedRevision - 1n, entries };
+	}
+
+	/**
+	 * Reads the immutable revision-zero creation record after validating the complete stream.
+	 *
+	 * A history projector must call this before it writes relational conversation rows, participants,
+	 * or grants. Reading every event makes a damaged tail an integrity failure rather than allowing
+	 * a projection to use an anchor from a stream whose later records cannot be trusted.
+	 *
+	 * @param command - Supplies server-derived silo and conversation coordinates for the creation anchor.
+	 * @returns The validated `ConversationCreated@0` payload for this conversation.
+	 * @throws {Error} Rejects an absent stream, an invalid creation record, or any malformed stream event.
+	 */
+	public async readCreation(command: ConversationCreationReadCommand): Promise<ConversationCreated>
+	{
+		// 1. Derive one stream before reading so a projection cannot widen its history scope.
+		const streamName = _StreamName(command);
+		const request = { streamName };
+		let expectedRevision = 0n;
+		let created: ConversationCreated | null = null;
+
+		// 2. Validate the complete stream before returning its revision-zero creation record.
+		for await (const event of this.historyStore.readStream(request))
+		{
+			const validated = _ValidatedEvent(event, command, streamName, expectedRevision);
+			if (validated.created !== null)
+				created = validated.created;
+			expectedRevision += 1n;
+		}
+
+		// 3. Reject an absent stream so a projection cannot invent relational state without history.
+		if (created === null)
+			throw new Error("Conversation history creation read requires a creation event at revision zero");
+		return created;
 	}
 
 	/**
@@ -82,19 +116,19 @@ export class ConversationHistoryReader
 }
 
 /** Validates trusted command coordinates and derives the only stream that this reader may request. */
-function _StreamName(command: ConversationHistoryReadCommand): string
+function _StreamName(command: ConversationCreationReadCommand | ConversationHistoryReadCommand): string
 {
 	if (!_Identifier(command.siloId))
 		throw new Error("Conversation history read requires a server-provided silo identifier");
 	if (!_Identifier(command.conversationId))
 		throw new Error("Conversation history read requires a server-provided conversation identifier");
-	if (command.fromRevision !== undefined && command.fromRevision < 0n)
+	if ("fromRevision" in command && command.fromRevision !== undefined && command.fromRevision < 0n)
 		throw new Error("Conversation history read requires a nonnegative starting revision");
 	return `conversation-${command.conversationId}`;
 }
 
 /** Validates one recorded event before the reader returns its participant-visible entry. */
-function _ValidatedEvent(event: HistoryRecordedEvent, command: ConversationHistoryReadCommand, streamName: string, expectedRevision: bigint): ConversationEntry | null
+function _ValidatedEvent(event: HistoryRecordedEvent, command: ConversationCreationReadCommand | ConversationHistoryReadCommand, streamName: string, expectedRevision: bigint): { readonly created: ConversationCreated | null; readonly entry: ConversationEntry | null }
 {
 	if (event.streamName !== streamName)
 		throw new Error("Conversation history read received an event from a different stream");
@@ -105,7 +139,7 @@ function _ValidatedEvent(event: HistoryRecordedEvent, command: ConversationHisto
 	if (event.metadata.conversationId !== command.conversationId)
 		throw new Error("Conversation history read received an event for a different conversation");
 	if (event.revision === 0n)
-		return _ValidatedCreation(event, command);
+		return { created: _ValidatedCreation(event, command), entry: null };
 	if (event.type !== _CONVERSATION_ENTRY_EVENT_TYPE)
 		throw new Error("Conversation history read received an unsupported event type");
 	const entry = ___ConversationEntrySchema.safeParse(event.data.entry);
@@ -119,11 +153,11 @@ function _ValidatedEvent(event: HistoryRecordedEvent, command: ConversationHisto
 		throw new Error("Conversation history read received an entry with an invalid idempotency key");
 	if (event.id !== entry.data.id || event.metadata.causationId !== entry.data.causationId || event.metadata.correlationId !== entry.data.correlationId || event.metadata.idempotencyKey !== entry.data.idempotencyKey)
 		throw new Error("Conversation history read received an entry that does not match its envelope");
-	return entry.data;
+	return { created: null, entry: entry.data };
 }
 
 /** Validates the required immutable revision-zero creation record without exposing it as a participant entry. */
-function _ValidatedCreation(event: HistoryRecordedEvent, command: ConversationHistoryReadCommand): null
+function _ValidatedCreation(event: HistoryRecordedEvent, command: ConversationCreationReadCommand | ConversationHistoryReadCommand): ConversationCreated
 {
 	if (event.type !== _CONVERSATION_CREATED_EVENT_TYPE)
 		throw new Error("Conversation history read requires a creation event at revision zero");
@@ -134,7 +168,7 @@ function _ValidatedCreation(event: HistoryRecordedEvent, command: ConversationHi
 		throw new Error("Conversation history creation belongs to a different conversation");
 	if (event.metadata.idempotencyKey !== event.id || !_UUID_PATTERN.test(event.id))
 		throw new Error("Conversation history read received a creation event with an invalid idempotency key");
-	return null;
+	return created.data;
 }
 
 /** Checks a trusted identifier without altering the coordinate used to derive a stream name. */

--- a/libs/backend/server/conversations/main/src/conversation-history-reader.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-history-reader.types.ts
@@ -2,6 +2,21 @@ import type { ConversationEntry } from "@opencrane/contracts";
 import type { HistoryExpectedRevisions } from "@opencrane/backend/server/infra/history-store";
 
 /**
+ * Identifies the immutable creation record that a history-backed projection may read.
+ *
+ * The projection supplies server-derived coordinates and receives the validated revision-zero
+ * record. It cannot select a later range because every conversation projection starts from its
+ * creation anchor.
+ */
+export interface ConversationCreationReadCommand
+{
+	/** Names the silo whose envelope metadata must own the creation record. */
+	readonly siloId: string;
+	/** Names the sole conversation stream whose revision-zero record may be read. */
+	readonly conversationId: string;
+}
+
+/**
  * Identifies a finite read that an authorized conversation transport may make from a KurrentDB stream.
  *
  * The transport supplies server-derived coordinates after it checks current PostgreSQL membership

--- a/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts
+++ b/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PrismaConversationCreationReservationRepository } from "../prisma-conversation-creation-reservation-repository";
 import { PrismaConversationProductAuthorizationRepository } from "../conversation-product-authorization";
+import { ConversationCreationReservationOutcomes } from "../../conversation-creation-reservation.types";
 
 const _SILO_ID = "silo-1";
 const _PRINCIPAL_ID = "principal-1";
@@ -29,6 +30,7 @@ function _Command(overrides: Record<string, unknown> = {})
 			{ userId: "user-2", visibleFromPosition: "2", joinedAt: "2026-09-02T00:00:00.000Z" },
 		],
 		agent: null,
+		agentBinding: null,
 		...overrides,
 	} as const;
 }
@@ -51,6 +53,7 @@ function _Stored(overrides: Record<string, unknown> = {})
 		profileRevisionId: null,
 		computerId: null,
 		computerHistoryEventId: null,
+		reservedAt: new Date("2026-09-02T00:00:00.000Z"),
 		state: ConversationCreationReservationState.Reserved,
 		participants: [
 			{ userId: "user-1", visibleFromPosition: 1n, joinedAt: new Date("2026-09-02T00:00:00.000Z") },
@@ -77,7 +80,7 @@ describe("PrismaConversationCreationReservationRepository", function _Suite()
 		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue(_Stored()) } };
 		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
 		const result = await new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command());
-		expect(result).toMatchObject({ outcome: "reserved", value: { authorizationEvidenceId: "decision-1", participants: [{ visibleFromPosition: "1" }, { visibleFromPosition: "2" }], agent: null } });
+		expect(result).toMatchObject({ outcome: ConversationCreationReservationOutcomes.Reserved, value: { authorizationEvidenceId: "decision-1", createdAt: "2026-09-02T00:00:00.000Z", participants: [{ visibleFromPosition: "1" }, { visibleFromPosition: "2" }], agent: null } });
 		expect(admission).toHaveBeenCalledWith(expect.objectContaining({ principalId: _PRINCIPAL_ID }), expect.anything(), ProductAuthorizationActions.Create, expect.objectContaining({ requestId: _REQUEST_ID, conversationId: _CONVERSATION_ID }));
 		expect(database.conversationCreationReservation.create).toHaveBeenCalledWith(expect.objectContaining({
 			data: expect.objectContaining({
@@ -92,7 +95,7 @@ describe("PrismaConversationCreationReservationRepository", function _Suite()
 	{
 		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored()), create: vi.fn() } };
 		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command())).resolves.toMatchObject({ outcome: "idempotent", value: { reservationId: "reservation-1" } });
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command())).resolves.toMatchObject({ outcome: ConversationCreationReservationOutcomes.Idempotent, value: { reservationId: "reservation-1" } });
 		expect(admission).not.toHaveBeenCalled();
 		expect(database.conversationCreationReservation.create).not.toHaveBeenCalled();
 	});
@@ -101,7 +104,7 @@ describe("PrismaConversationCreationReservationRepository", function _Suite()
 	{
 		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored()), create: vi.fn() } };
 		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command({ requestDigest: `sha256:${"e".repeat(64)}` }))).resolves.toEqual({ outcome: "idempotency_conflict" });
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command({ requestDigest: `sha256:${"e".repeat(64)}` }))).resolves.toEqual({ outcome: ConversationCreationReservationOutcomes.IdempotencyConflict });
 		expect(admission).not.toHaveBeenCalled();
 	});
 
@@ -109,7 +112,7 @@ describe("PrismaConversationCreationReservationRepository", function _Suite()
 	{
 		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn() } };
 		vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(null);
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command())).resolves.toEqual({ outcome: "denied" });
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command())).resolves.toEqual({ outcome: ConversationCreationReservationOutcomes.Denied });
 		expect(database.conversationCreationReservation.create).not.toHaveBeenCalled();
 	});
 
@@ -117,7 +120,7 @@ describe("PrismaConversationCreationReservationRepository", function _Suite()
 	{
 		const database = { conversationCreationReservation: { findUnique: vi.fn(), create: vi.fn() } };
 		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command({ mode: ConversationModes.AgentSession, participants: [_Command().participants[0]], agent: null }))).rejects.toThrow("one participant and server agent coordinates");
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command({ mode: ConversationModes.AgentSession, participants: [_Command().participants[0]], agent: null }))).rejects.toThrow("server agent coordinates, and a frozen binding");
 		expect(admission).not.toHaveBeenCalled();
 	});
 
@@ -125,31 +128,33 @@ describe("PrismaConversationCreationReservationRepository", function _Suite()
 	{
 		const anchored = _Stored({ state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z") });
 		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored()), update: vi.fn().mockResolvedValue(anchored) } };
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: null })).resolves.toMatchObject({ state: "history_anchored", resolvedAgentBinding: null });
-		expect(database.conversationCreationReservation.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, agentIdentityId: null, profileRevisionId: null }) }));
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1" })).resolves.toMatchObject({ state: "history_anchored", agentBinding: null });
+		expect(database.conversationCreationReservation.update).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n }) }));
 	});
 
-	it("refuses to anchor an agent reservation before its identity and profile are resolved", async function _RejectsIncompleteAnchoredAgent()
+	it("does not advance another caller's reservation by its identifier", async function _ScopesAnchorAdvance()
 	{
-		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored({ mode: ConversationMode.AgentSession, agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _HISTORY_EVENT_ID })), update: vi.fn() } };
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: null })).rejects.toThrow("require an agent binding");
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored({ principalId: "principal-2" })), update: vi.fn() } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1" })).rejects.toThrow("reservation is unavailable");
 		expect(database.conversationCreationReservation.update).not.toHaveBeenCalled();
 	});
 
-	it("records the full resolved Agent binding with an agent conversation history anchor", async function _AnchorsAgent()
+	it("commits the full Agent binding with its initial reservation before history I/O", async function _ReservesAgent()
 	{
-		const reserved = _Stored({ mode: ConversationMode.AgentSession, agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _HISTORY_EVENT_ID });
-		const anchored = { ...reserved, state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z"), agentIdentityId: "identity-1", profileRevisionId: "profile-1" };
-		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(reserved), update: vi.fn().mockResolvedValue(anchored) } };
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: { agentIdentityId: "identity-1", profileRevisionId: "profile-1" } })).resolves.toMatchObject({ state: "history_anchored", resolvedAgentBinding: { agentIdentityId: "identity-1", profileRevisionId: "profile-1" } });
+		const agent = { agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _HISTORY_EVENT_ID };
+		const agentBinding = { agentIdentityId: "identity-1", profileRevisionId: "profile-1" };
+		const stored = _Stored({ mode: ConversationMode.AgentSession, participants: [_Stored().participants[0]], ...agent, ...agentBinding });
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue(stored) } };
+		vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admitEvidence").mockResolvedValue(_EVIDENCE);
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).reserve(_Command({ mode: ConversationModes.AgentSession, participants: [_Command().participants[0]], agent, agentBinding }))).resolves.toMatchObject({ value: { agentBinding } });
+		expect(database.conversationCreationReservation.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining(agentBinding) }));
 	});
 
-	it("returns an exact anchored retry without rewriting its Agent binding", async function _RecoversAnchoredAgent()
+	it("returns an exact anchored retry without rewriting its frozen Agent binding", async function _RecoversAnchoredAgent()
 	{
 		const anchored = _Stored({ mode: ConversationMode.AgentSession, agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _HISTORY_EVENT_ID, state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z"), agentIdentityId: "identity-1", profileRevisionId: "profile-1" });
 		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(anchored), update: vi.fn() } };
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: { agentIdentityId: "identity-1", profileRevisionId: "profile-1" } })).resolves.toMatchObject({ resolvedAgentBinding: { agentIdentityId: "identity-1" } });
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1" })).resolves.toMatchObject({ agentBinding: { agentIdentityId: "identity-1" } });
 		expect(database.conversationCreationReservation.update).not.toHaveBeenCalled();
-		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markHistoryAnchored({ reservationId: "reservation-1", agentBinding: { agentIdentityId: "identity-2", profileRevisionId: "profile-1" } })).rejects.toThrow("conflicting agent binding");
 	});
 });

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
@@ -3,7 +3,7 @@ import { ConversationCreationReservationState, ConversationMode, type Prisma } f
 import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
 import { ConversationModes } from "@opencrane/models/conversations";
 
-import { ConversationCreationReservationStates, type AnchorConversationCreationReservationCommand, type ConversationCreationReservationRepository, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
+import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type AnchorConversationCreationReservationCommand, type ConversationCreationReservationRepository, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
 import { __ConversationCreationReservationAuthorizationArguments, __ValidateConversationCreationReservation } from "../conversation-creation-reservation.validation";
 import type { ConversationCaller } from "../types/conversation-caller.types";
 import { PrismaConversationProductAuthorizationRepository } from "./conversation-product-authorization";
@@ -23,12 +23,12 @@ export class PrismaConversationCreationReservationRepository implements Conversa
 			include: { participants: { orderBy: { ordinal: "asc" } } },
 		});
 		if (prior !== null)
-			return prior.requestDigest === command.requestDigest ? { outcome: "idempotent", value: _Reserved(prior) } : { outcome: "idempotency_conflict" };
+			return prior.requestDigest === command.requestDigest ? { outcome: ConversationCreationReservationOutcomes.Idempotent, value: _Reserved(prior) } : { outcome: ConversationCreationReservationOutcomes.IdempotencyConflict };
 
 		const authorization = new PrismaConversationProductAuthorizationRepository(this.transaction);
 		const evidence = await authorization.admitEvidence(this.caller, { kind: ProductAuthorizationResourceKinds.ConversationCollection, id: command.siloId }, ProductAuthorizationActions.Create, __ConversationCreationReservationAuthorizationArguments(command));
 		if (evidence === null)
-			return { outcome: "denied" };
+			return { outcome: ConversationCreationReservationOutcomes.Denied };
 
 		const created = await this.transaction.conversationCreationReservation.create({
 			data: {
@@ -47,11 +47,13 @@ export class PrismaConversationCreationReservationRepository implements Conversa
 				agentRevisionId: command.agent?.agentRevisionId ?? null,
 				computerId: command.agent?.computerId ?? null,
 				computerHistoryEventId: command.agent?.computerHistoryEventId ?? null,
+				agentIdentityId: command.agentBinding?.agentIdentityId ?? null,
+				profileRevisionId: command.agentBinding?.profileRevisionId ?? null,
 				participants: { create: command.participants.map(function _Participant(participant, index) { return { ordinal: index + 1, userId: participant.userId, visibleFromPosition: BigInt(participant.visibleFromPosition), joinedAt: new Date(participant.joinedAt) }; }) },
 			},
 			include: { participants: { orderBy: { ordinal: "asc" } } },
 		});
-		return { outcome: "reserved", value: _Reserved(created) };
+		return { outcome: ConversationCreationReservationOutcomes.Reserved, value: _Reserved(created) };
 	}
 
 	/** @inheritdoc */
@@ -64,8 +66,10 @@ export class PrismaConversationCreationReservationRepository implements Conversa
 		});
 		if (reservation === null)
 			throw new Error("Conversation creation reservation is unavailable");
+		if (reservation.siloId !== this.caller.siloId || reservation.principalId !== this.caller.principalId)
+			throw new Error("Conversation creation reservation is unavailable");
 		const existing = _Reserved(reservation);
-		_AssertAnchorBinding(existing, command.agentBinding);
+		_AssertAnchorBinding(existing);
 		if (existing.state !== ConversationCreationReservationStates.Reserved)
 			return existing;
 		const updated = await this.transaction.conversationCreationReservation.update({
@@ -74,8 +78,6 @@ export class PrismaConversationCreationReservationRepository implements Conversa
 				state: ConversationCreationReservationState.HistoryAnchored,
 				historyRevision: 0n,
 				historyAnchoredAt: new Date(),
-				agentIdentityId: command.agentBinding?.agentIdentityId ?? null,
-				profileRevisionId: command.agentBinding?.profileRevisionId ?? null,
 			},
 			include: { participants: { orderBy: { ordinal: "asc" } } },
 		});
@@ -94,10 +96,11 @@ function _Mode(mode: ConversationModes): ConversationMode
 }
 
 /** Converts a fully persisted row to the domain port without exposing Prisma records. */
-function _Reserved(reservation: { readonly id: string; readonly siloId: string; readonly principalId: string; readonly requestId: string; readonly requestDigest: string; readonly conversationId: string; readonly historyEventId: string; readonly authorizationDecisionEvidenceId: string; readonly mode: ConversationMode; readonly agentServiceId: string | null; readonly agentRevisionId: string | null; readonly agentIdentityId: string | null; readonly profileRevisionId: string | null; readonly computerId: string | null; readonly computerHistoryEventId: string | null; readonly state: ConversationCreationReservationState; readonly participants: readonly { readonly userId: string; readonly visibleFromPosition: bigint; readonly joinedAt: Date }[] }): ReservedConversationCreation
+function _Reserved(reservation: { readonly id: string; readonly siloId: string; readonly principalId: string; readonly requestId: string; readonly requestDigest: string; readonly conversationId: string; readonly historyEventId: string; readonly authorizationDecisionEvidenceId: string; readonly mode: ConversationMode; readonly agentServiceId: string | null; readonly agentRevisionId: string | null; readonly agentIdentityId: string | null; readonly profileRevisionId: string | null; readonly computerId: string | null; readonly computerHistoryEventId: string | null; readonly reservedAt: Date; readonly state: ConversationCreationReservationState; readonly participants: readonly { readonly userId: string; readonly visibleFromPosition: bigint; readonly joinedAt: Date }[] }): ReservedConversationCreation
 {
 	return {
 		reservationId: reservation.id,
+		createdAt: reservation.reservedAt.toISOString(),
 		siloId: reservation.siloId,
 		principalId: reservation.principalId,
 		requestId: reservation.requestId,
@@ -107,7 +110,7 @@ function _Reserved(reservation: { readonly id: string; readonly siloId: string; 
 		mode: _ConversationMode(reservation.mode),
 		participants: reservation.participants.map(function _Participant(participant) { return { userId: participant.userId, visibleFromPosition: participant.visibleFromPosition.toString(), joinedAt: participant.joinedAt.toISOString() }; }),
 		agent: _Agent(reservation),
-		resolvedAgentBinding: _ResolvedAgentBinding(reservation),
+		agentBinding: _ResolvedAgentBinding(reservation),
 		authorizationEvidenceId: reservation.authorizationDecisionEvidenceId,
 		state: _State(reservation.state),
 	};
@@ -118,19 +121,15 @@ function _ValidateAnchorCommand(command: AnchorConversationCreationReservationCo
 {
 	if (command.reservationId.trim().length === 0 || command.reservationId !== command.reservationId.trim())
 		throw new Error("Conversation creation history anchoring requires a reservation identifier");
-	if (command.agentBinding !== null && (command.agentBinding.agentIdentityId.trim().length === 0 || command.agentBinding.agentIdentityId !== command.agentBinding.agentIdentityId.trim() || command.agentBinding.profileRevisionId.trim().length === 0 || command.agentBinding.profileRevisionId !== command.agentBinding.profileRevisionId.trim()))
-		throw new Error("Conversation creation history anchoring requires complete agent identity and profile coordinates");
 }
 
-/** Ensures direct/group never gain agent facts, while Agent reservations cannot advance without them. */
-function _AssertAnchorBinding(reservation: ReservedConversationCreation, binding: AnchorConversationCreationReservationCommand["agentBinding"]): void
+/** Ensures direct/group never gain agent facts, while Agent reservations retain a complete frozen binding. */
+function _AssertAnchorBinding(reservation: ReservedConversationCreation): void
 {
-	if (reservation.agent === null && binding !== null)
-		throw new Error("Direct and group conversation reservations cannot receive an agent binding");
-	if (reservation.agent !== null && binding === null)
-		throw new Error("Agent conversation reservations require an agent binding");
-	if (reservation.resolvedAgentBinding !== null && (binding === null || reservation.resolvedAgentBinding.agentIdentityId !== binding.agentIdentityId || reservation.resolvedAgentBinding.profileRevisionId !== binding.profileRevisionId))
-		throw new Error("Conversation creation reservation has a conflicting agent binding");
+	if (reservation.agent === null && reservation.agentBinding !== null)
+		throw new Error("Direct and group conversation reservations cannot retain an agent binding");
+	if (reservation.agent !== null && reservation.agentBinding === null)
+		throw new Error("Agent conversation reservations require a frozen binding");
 }
 
 /** Restores agent coordinates only from the all-or-nothing reserved database columns. */
@@ -143,8 +142,8 @@ function _Agent(reservation: { readonly agentServiceId: string | null; readonly 
 	return { agentServiceId: reservation.agentServiceId, agentRevisionId: reservation.agentRevisionId, computerId: reservation.computerId, computerHistoryEventId: reservation.computerHistoryEventId };
 }
 
-/** Restores the all-or-nothing post-history Agent binding without exposing Prisma records. */
-function _ResolvedAgentBinding(reservation: { readonly agentIdentityId: string | null; readonly profileRevisionId: string | null }): ReservedConversationCreation["resolvedAgentBinding"]
+/** Restores the all-or-nothing Agent binding frozen with the reservation without exposing Prisma records. */
+function _ResolvedAgentBinding(reservation: { readonly agentIdentityId: string | null; readonly profileRevisionId: string | null }): ReservedConversationCreation["agentBinding"]
 {
 	if (reservation.agentIdentityId === null && reservation.profileRevisionId === null)
 		return null;

--- a/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.ts
+++ b/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.ts
@@ -1,0 +1,136 @@
+import { ConversationLifecycleModes, type ConversationCreated } from "@opencrane/contracts";
+import { ConversationModes } from "@opencrane/models/conversations";
+
+import { ConversationCreationAnchorVerifier } from "./conversation-creation-anchor-verifier";
+import { ConversationCreationAnchorConfirmationOutcomes } from "./conversation-creation-anchor-verifier.types";
+import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type ReservedConversationCreation } from "./conversation-creation-reservation.types";
+import { ConversationHistoryAuthority } from "./conversation-history-authority";
+import { HistoryAnchoredConversationCreationOutcomes, type ConversationCreationProjectionCommand, type ConversationCreationProjectionPort, type ConversationCreationReservationUnitOfWork, type CreateHistoryAnchoredConversationCommand, type HistoryAnchoredConversationCreationResult } from "./history-anchored-conversation-creation-authority.types";
+
+/**
+ * Establishes a revision-zero conversation anchor from a durable, authorization-evidenced reservation.
+ *
+ * This authority deliberately stops at a projection request. PostgreSQL reservation and anchoring
+ * protect retry semantics, KurrentDB owns immutable participant history, and a separate projector
+ * rebuilds directory rows and grants from the confirmed record.
+ */
+export class HistoryAnchoredConversationCreationAuthority
+{
+	/** Holds the durable reservation UoW, immutable history, recovery reader, and projection handoff ports. */
+	public constructor(private readonly reservations: ConversationCreationReservationUnitOfWork, private readonly history: Pick<ConversationHistoryAuthority, "create">, private readonly anchorVerifier: Pick<ConversationCreationAnchorVerifier, "confirm">, private readonly projection: ConversationCreationProjectionPort) {}
+
+	/**
+	 * Reserves, anchors, confirms, and hands off one new conversation without accepting a caller payload.
+	 *
+	 * A retry always reloads the reservation before history is touched. A lost append response is
+	 * recovered only when the verifier proves the exact reserved revision-zero event; an absent stream
+	 * permits one retry of the append, while a mismatched stream remains a corruption error.
+	 * @param command - Contains server-resolved command coordinates and trusted Agent-only binding facts.
+	 * @returns A denial, retry conflict, projected replay, or the confirmed projection handoff.
+	 * @throws {Error} When KurrentDB cannot create or prove the reserved anchor, or projection handoff fails.
+	 */
+	public async create(command: CreateHistoryAnchoredConversationCommand): Promise<HistoryAnchoredConversationCreationResult>
+	{
+		// 1. Reservation — commits idempotency and authorization evidence before any history I/O occurs.
+		const reservedResult = await this.reservations.reserve(command.reservation);
+		if (reservedResult.outcome === ConversationCreationReservationOutcomes.Denied)
+			return { outcome: HistoryAnchoredConversationCreationOutcomes.Denied };
+		if (reservedResult.outcome === ConversationCreationReservationOutcomes.IdempotencyConflict)
+			return { outcome: HistoryAnchoredConversationCreationOutcomes.IdempotencyConflict };
+		const reservation = reservedResult.value;
+		const created = _Created(reservation);
+		if (reservation.state === ConversationCreationReservationStates.Projected)
+			return { outcome: HistoryAnchoredConversationCreationOutcomes.Projected, reservation, created };
+
+		// 2. History — writes only the reserved revision-zero envelope, with exact-anchor recovery for ambiguity.
+		if (reservation.state === ConversationCreationReservationStates.Reserved)
+			await this._CreateOrConfirm(reservation, created);
+
+		// 3. Progress — persists the confirmed anchor before the projector can rebuild relational state.
+		const anchored = await this.reservations.markHistoryAnchored({ reservationId: reservation.reservationId });
+		const projection = _Projection(anchored);
+		await this.projection.request(projection);
+		return { outcome: HistoryAnchoredConversationCreationOutcomes.ProjectionNeeded, reservation: anchored, created: _Created(anchored), projection };
+	}
+
+	/** Creates the anchor, then proves exactly what KurrentDB retained when an append response is ambiguous. */
+	private async _CreateOrConfirm(reservation: ReservedConversationCreation, created: ConversationCreated): Promise<void>
+	{
+		// 1. Initial append — requests the one server-reserved event id at the no-stream head.
+		try
+		{
+			await this.history.create({ siloId: reservation.siloId, eventId: reservation.historyEventId, created });
+			return;
+		}
+		catch (error)
+		{
+			// 2. Confirmation — accepts only the exact anchor when the first response may have been lost.
+			const confirmation = await this.anchorVerifier.confirm({ siloId: reservation.siloId, eventId: reservation.historyEventId, created });
+			if (confirmation.outcome === ConversationCreationAnchorConfirmationOutcomes.Confirmed)
+				return;
+			// 3. Retry — an absent stream permits one fresh append; a second error remains visible to the caller.
+			try
+			{
+				await this.history.create({ siloId: reservation.siloId, eventId: reservation.historyEventId, created });
+				return;
+			}
+			catch
+			{
+				const retriedConfirmation = await this.anchorVerifier.confirm({ siloId: reservation.siloId, eventId: reservation.historyEventId, created });
+				if (retriedConfirmation.outcome === ConversationCreationAnchorConfirmationOutcomes.Confirmed)
+					return;
+				throw error;
+			}
+		}
+	}
+}
+
+/** Rebuilds the only valid revision-zero payload from durable reservation coordinates. */
+function _Created(reservation: ReservedConversationCreation): ConversationCreated
+{
+	const agentBinding = _CreatedAgentBinding(reservation);
+	return {
+		schemaVersion: 1,
+		conversationId: reservation.conversationId,
+		mode: _LifecycleMode(reservation.mode),
+		participants: reservation.participants,
+		agentBinding,
+		createdAt: reservation.createdAt,
+		provenance: { principalId: reservation.principalId, authorizationEvidenceId: reservation.authorizationEvidenceId, requestId: reservation.requestId },
+	};
+}
+
+/** Selects the stored agent binding on recovery or checks the trusted input required before first anchoring. */
+function _CreatedAgentBinding(reservation: ReservedConversationCreation): ConversationCreated["agentBinding"]
+{
+	if (reservation.mode !== ConversationModes.AgentSession)
+	{
+		if (reservation.agentBinding !== null)
+			throw new Error("Direct and group conversation creation cannot carry an agent binding");
+		return null;
+	}
+	if (reservation.agent === null)
+		throw new Error("Agent conversation creation requires reserved agent coordinates");
+	if (reservation.agentBinding === null)
+		throw new Error("Agent conversation creation requires a frozen binding");
+	const binding = reservation.agentBinding;
+	return { agentServiceId: reservation.agent.agentServiceId, agentRevisionId: reservation.agent.agentRevisionId, agentIdentityId: binding.agentIdentityId, profileRevisionId: binding.profileRevisionId, computerId: reservation.agent.computerId };
+}
+
+/** Maps the durable mode to the lifecycle mode serialized in immutable history. */
+function _LifecycleMode(mode: ConversationModes): ConversationLifecycleModes
+{
+	if (mode === ConversationModes.AgentSession)
+		return ConversationLifecycleModes.Agent;
+	if (mode === ConversationModes.Direct)
+		return ConversationLifecycleModes.Direct;
+	return ConversationLifecycleModes.Group;
+}
+
+/** Gives the projection owner only the durable anchor coordinate it must read and materialize. */
+function _Projection(reservation: ReservedConversationCreation): ConversationCreationProjectionCommand
+{
+	if (reservation.state === ConversationCreationReservationStates.Reserved)
+		throw new Error("Conversation projection requires a history-anchored reservation");
+	return { reservationId: reservation.reservationId, siloId: reservation.siloId, conversationId: reservation.conversationId, historyRevision: 0n };
+}

--- a/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.types.ts
@@ -1,0 +1,116 @@
+import type { ConversationCreated } from "@opencrane/contracts";
+
+import type { AnchorConversationCreationReservationCommand, ConversationCreationReservationStates, ReserveConversationCreationCommand, ReserveConversationCreationResult, ReservedConversationCreation } from "./conversation-creation-reservation.types";
+
+/**
+ * States how the creation authority handled a server-resolved create command.
+ *
+ * {@link HistoryAnchoredConversationCreationResult} returns these values so its caller can either
+ * stop without history I/O, reject a changed retry body, or hand the confirmed anchor to the
+ * projection owner. The authority never converts a denial or retry conflict into a history append.
+ */
+export enum HistoryAnchoredConversationCreationOutcomes
+{
+	/** The PostgreSQL collection policy denied the creation command before history I/O. */
+	Denied = "denied",
+	/** The retry key already names a different request body, so the authority did not change history. */
+	IdempotencyConflict = "idempotency_conflict",
+	/** A confirmed revision-zero anchor awaits its separately owned PostgreSQL projection. */
+	ProjectionNeeded = "projection_needed",
+	/** The reservation and its durable projection had already converged before this retry arrived. */
+	Projected = "projected",
+}
+
+/**
+ * Requests creation from a server-resolved command without accepting a browser-created history payload.
+ *
+ * The reservation carries every fact that becomes part of {@link ConversationCreated}, so retry
+ * recovery can reproduce revision zero without trusting another request body.
+ */
+export interface CreateHistoryAnchoredConversationCommand
+{
+	/**
+	 * Supplies the command that the reservation repository must persist before KurrentDB I/O.
+	 *
+	 * Agent creation carries the verified identity/profile pair in `reservation.agentBinding`, which
+	 * the reservation freezes with the service and revision before history I/O starts.
+	 */
+	readonly reservation: ReserveConversationCreationCommand;
+}
+
+/** Names the revision-zero anchor that the projection owner must rebuild from history. */
+export interface ConversationCreationProjectionCommand
+{
+	/** Identifies the durable reservation whose state remains `HistoryAnchored` until projection converges. */
+	readonly reservationId: string;
+	/** Identifies the silo that owns the projection and its history stream. */
+	readonly siloId: string;
+	/** Identifies the conversation whose revision-zero anchor the projector must read. */
+	readonly conversationId: string;
+	/** Records the only history revision that can establish a conversation projection. */
+	readonly historyRevision: 0n;
+}
+
+/**
+	 * Requests an idempotent projection after immutable history is confirmed.
+	 *
+	 * The projection owner reads the revision-zero anchor itself; this creation authority never writes
+	 * the relational directory, participants, or grants directly.
+	 */
+export interface ConversationCreationProjectionPort
+{
+	/**
+	 * Records or runs projection work for one confirmed conversation anchor.
+	 *
+	 * The implementation must tolerate the same command again because a `HistoryAnchored`
+	 * reservation replays this handoff after an interrupted response. It receives anchor coordinates,
+	 * not directory rows or grants, so it must read revision zero before rebuilding relational state.
+	 * Called by: {@link HistoryAnchoredConversationCreationAuthority.create}.
+	 * @param command Identifies the reservation and its revision-zero history record.
+	 * @returns Resolves after the implementation has accepted the projection work.
+	 */
+	request(command: ConversationCreationProjectionCommand): Promise<void>;
+}
+
+/**
+ * Opens separate serializable PostgreSQL operations on either side of KurrentDB history I/O.
+ *
+ * The concrete adapter builds the existing transaction-scoped reservation repository inside each
+ * operation. It must never retain a Prisma transaction while this authority appends or reads
+ * immutable history.
+ */
+export interface ConversationCreationReservationUnitOfWork
+{
+	/**
+	 * Persists or reloads the idempotent authorization-evidenced command before history I/O.
+	 *
+	 * This operation finishes its PostgreSQL transaction before the authority can append to KurrentDB.
+	 * Called by: {@link HistoryAnchoredConversationCreationAuthority.create}.
+	 * @param command Carries server-resolved coordinates and authorization inputs to reserve.
+	 * @returns The admitted command, a conflicting retry key, or an authorization denial.
+	 */
+	reserve(command: ReserveConversationCreationCommand): Promise<ReserveConversationCreationResult>;
+	/**
+	 * Advances an already-proven history anchor in a new serializable PostgreSQL operation.
+	 *
+	 * This operation runs after KurrentDB confirms revision zero, so it cannot keep a Prisma
+	 * transaction open across history I/O. Called by: {@link HistoryAnchoredConversationCreationAuthority.create}.
+	 * @param command Identifies the reservation whose exact creation anchor was confirmed.
+	 * @returns The reservation at its stored progress state.
+	 */
+	markHistoryAnchored(command: AnchorConversationCreationReservationCommand): Promise<ReservedConversationCreation>;
+}
+
+/** Reports a denial, retry conflict, or the durable anchor available to the projection owner. */
+export type HistoryAnchoredConversationCreationResult
+	= { readonly outcome: HistoryAnchoredConversationCreationOutcomes.Denied }
+	| { readonly outcome: HistoryAnchoredConversationCreationOutcomes.IdempotencyConflict }
+	| { readonly outcome: HistoryAnchoredConversationCreationOutcomes.ProjectionNeeded; readonly reservation: ReservedConversationCreation; readonly created: ConversationCreated; readonly projection: ConversationCreationProjectionCommand }
+	| { readonly outcome: HistoryAnchoredConversationCreationOutcomes.Projected; readonly reservation: ReservedConversationCreation; readonly created: ConversationCreated };
+
+/** Carries the durable state used by helper functions that reconstruct the creation record. */
+export interface HistoryAnchoredConversationCreationReservation extends ReservedConversationCreation
+{
+	/** Narrows the durable reservation state for helpers that reject unknown future values. */
+	readonly state: ConversationCreationReservationStates;
+}

--- a/releases/0.11.0.json
+++ b/releases/0.11.0.json
@@ -4,7 +4,7 @@
   "database": {
     "schemaVersion": "0.11.0",
     "baselinePath": "apps/opencrane/prisma/bootstrap/target-baseline.sql",
-    "baselineSha256": "cc206997fc133b180b8d5aa439963502335d79e3f74c5ab09be7074b61b15b16",
+    "baselineSha256": "abe6cae2a2b2e6fcd6398d6980b8a0e724690f0543e1e13663f05f20d5b7527b",
     "operandImage": "ghcr.io/elewa-git/opencrane-postgres:17.5-sha-be461113253b9cd6d51532cf007775ec8385bfe7@sha256:9c27816e67b9f0b23e771a4c8a8a4c8eb4c84abeefead14f727747d21d7d70c7"
   },
   "projects": {


### PR DESCRIPTION
## Summary

- freeze the exact Agent identity, profile, and server timestamp before a retryable creation reservation can be appended
- anchor `ConversationCreated@0` from that durable reservation, including exact ambiguous-write recovery before projection handoff
- add a strict creation-anchor reader and conservative recovery for ambiguous cold `ConversationComputer` provisioning

## Boundary

- this checkpoint establishes the durable history and computer prerequisites only; it does not yet mount the browser creation route or delete the legacy relational writer
- KurrentDB writes remain outside Prisma transactions, and no compatibility or migration path is introduced for the 0.11.0 baseline

## Validation

- `npx nx run backend-server-conversations:test --skip-nx-cache -- src/conversation-computers/__tests__/conversation-computer-provision-recovery.test.ts` (3 passing)
- `npx nx run backend-server-conversations:lint --skip-nx-cache`
- `scripts/agent-style-check.sh --diff HEAD`
- `npm run check:module-growth -- --diff HEAD`
- `git diff --check`
- `npm run check:pr-stack-integrity -- --current-branch feat/issue-759-mount-history-anchored-creation`

## Review

- independent review found no correctness or security findings; exact revision-zero, no-lease, canonical-snapshot recovery is covered
- the JSDoc contract is mechanically checked; the final cross-worktree comments pass remains outstanding before merge



## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807 → #808 → #810