### PR TITLE
🔁 materialize history-anchored conversation creation

### DIFF
--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -682,6 +682,22 @@
 				]
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-repository.ts",
+				"adapter": "PrismaConversationCreationProjectionRepository",
+				"contract": "ConversationCreationProjectionRepository",
+				"contractImportPath": "../history-anchored-conversation-creation-authority.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationProductAuthorizationRepository",
+						"importPath": "./conversation-product-authorization"
+					},
+					{
+						"adapter": "PrismaChannelTargetParticipantGrantProjectionRepository",
+						"importPath": "@opencrane/backend/server/agents/channel-targets"
+					}
+				]
+			},
+			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts",
 				"adapter": "PrismaConversationCreationReservationRepository",
 				"contract": "ConversationCreationReservationRepository",
@@ -1816,6 +1832,18 @@
 					{
 						"adapter": "PrismaAgentThreadParentDeliveryRepository",
 						"importPath": "./prisma-agent-thread-parent-delivery-repository"
+					}
+				]
+			},
+			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-unit-of-work.ts",
+				"adapter": "PrismaConversationCreationProjectionUnitOfWork",
+				"contract": "ConversationCreationProjectionPort",
+				"contractImportPath": "../history-anchored-conversation-creation-authority.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationCreationProjectionRepository",
+						"importPath": "./prisma-conversation-creation-projection-repository"
 					}
 				]
 			},

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -1836,6 +1836,18 @@
 				]
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-unit-of-work.ts",
+				"adapter": "PrismaConversationCreationReservationUnitOfWork",
+				"contract": "ConversationCreationReservationUnitOfWork",
+				"contractImportPath": "../history-anchored-conversation-creation-authority.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationCreationReservationRepository",
+						"importPath": "./prisma-conversation-creation-reservation-repository"
+					}
+				]
+			},
+			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-unit-of-work.ts",
 				"adapter": "PrismaConversationCreationProjectionUnitOfWork",
 				"contract": "ConversationCreationProjectionPort",

--- a/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
@@ -83,6 +83,20 @@ export interface AnchorConversationCreationReservationCommand
 	readonly reservationId: string;
 }
 
+/**
+ * Requests the `Projected` transition after the directory has applied a confirmed revision-zero
+ * Kurrent anchor.
+ *
+ * The command carries no creation data because the projection must preserve that immutable anchor;
+ * retrying it returns the stored `Projected` reservation instead of advancing it again.
+ * @see ConversationCreationReservationStates.Projected
+ */
+export interface ProjectConversationCreationReservationCommand
+{
+	/** Identifies the durable command whose confirmed anchor the directory has projected. */
+	readonly reservationId: string;
+}
+
 /** Names the complete, resolved command that a transaction stores before any history I/O. */
 export interface ReserveConversationCreationCommand
 {
@@ -171,4 +185,15 @@ export interface ConversationCreationReservationRepository
 	 * match its conversation mode.
 	 */
 	markHistoryAnchored(command: AnchorConversationCreationReservationCommand): Promise<ReservedConversationCreation>;
+	/**
+	 * Records that the directory and grant projections have converged from the immutable creation anchor.
+	 *
+	 * The repository accepts an already projected reservation as an idempotent replay, but it never
+	 * advances a reserved command: KurrentDB must be confirmed before relational state can claim to
+	 * represent it.
+	 * @param command The durable reservation whose history-derived projection has completed.
+	 * @returns The projected reservation, including an exact idempotent replay.
+	 * @throws {Error} The reservation is unavailable to this caller or has no confirmed anchor.
+	 */
+	markProjected(command: ProjectConversationCreationReservationCommand): Promise<ReservedConversationCreation>;
 }

--- a/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-projection-repository.test.ts
+++ b/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-projection-repository.test.ts
@@ -1,0 +1,76 @@
+import { ConversationCreationReservationState, ConversationMode } from "@prisma/client";
+import { ConversationLifecycleModes, type ConversationCreated } from "@opencrane/contracts";
+import { describe, expect, it, vi } from "vitest";
+
+import { PrismaConversationCreationProjectionRepository } from "../prisma-conversation-creation-projection-repository";
+
+const _COMMAND = { reservationId: "reservation-1", siloId: "silo-1", conversationId: "conversation-1", historyRevision: 0n } as const;
+
+/** Builds the immutable revision-zero payload accepted by a matching direct reservation. */
+function _Created(overrides: Partial<ConversationCreated> = {}): ConversationCreated
+{
+	return {
+		schemaVersion: 1,
+		conversationId: _COMMAND.conversationId,
+		mode: ConversationLifecycleModes.Direct,
+		participants: [{ userId: "user-1", visibleFromPosition: "1", joinedAt: "2026-09-02T00:00:00.000Z" }, { userId: "user-2", visibleFromPosition: "2", joinedAt: "2026-09-02T00:00:00.000Z" }],
+		agentBinding: null,
+		createdAt: "2026-09-02T00:00:00.000Z",
+		provenance: { principalId: "principal-1", authorizationEvidenceId: "decision-1", requestId: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651" },
+		...overrides,
+	};
+}
+
+/** Builds a history-anchored reservation with the participant order the immutable anchor must retain. */
+function _Reservation(overrides: Record<string, unknown> = {})
+{
+	return {
+		id: _COMMAND.reservationId,
+		siloId: _COMMAND.siloId,
+		conversationId: _COMMAND.conversationId,
+		principalId: "principal-1",
+		mode: ConversationMode.Direct,
+		state: ConversationCreationReservationState.HistoryAnchored,
+		historyRevision: 0n,
+		agentServiceId: null,
+		agentRevisionId: null,
+		agentIdentityId: null,
+		profileRevisionId: null,
+		computerId: null,
+		participants: [{ userId: "user-1", visibleFromPosition: 1n }, { userId: "user-2", visibleFromPosition: 2n }],
+		...overrides,
+	};
+}
+
+/** Builds transaction delegates for an already-materialized direct conversation replay. */
+function _Database(reservation = _Reservation())
+{
+	return {
+		conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(reservation), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+		conversation: { findUnique: vi.fn().mockResolvedValue({ siloId: _COMMAND.siloId, mode: ConversationMode.Direct, agentServiceId: null }), create: vi.fn() },
+		conversationParticipant: { createMany: vi.fn(), findMany: vi.fn().mockResolvedValue(reservation.participants) },
+		principal: { findMany: vi.fn().mockResolvedValue([{ id: "principal-1", subject: "user-1" }, { id: "principal-2", subject: "user-2" }]) },
+		authorizationGrant: { findMany: vi.fn().mockResolvedValue([]), updateMany: vi.fn(), create: vi.fn() },
+		auditEntry: { create: vi.fn() },
+	};
+}
+
+describe("PrismaConversationCreationProjectionRepository", function _Suite()
+{
+	it("materializes an exact immutable direct anchor before advancing the reservation", async function _Projects()
+	{
+		const database = _Database();
+		await new PrismaConversationCreationProjectionRepository(database as never).project(_COMMAND, _Created());
+		expect(database.conversationCreationReservation.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: _COMMAND.reservationId, state: ConversationCreationReservationState.HistoryAnchored } }));
+	});
+
+	it("rejects a mismatched immutable Agent binding before it writes or advances", async function _RejectsMismatchedAgent()
+	{
+		const reservation = _Reservation({ mode: ConversationMode.AgentSession, agentServiceId: "service-1", agentRevisionId: "revision-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1", computerId: "computer-1", participants: [{ userId: "user-1", visibleFromPosition: 1n }] });
+		const database = _Database(reservation);
+		const created = _Created({ mode: ConversationLifecycleModes.Agent, participants: [{ userId: "user-1", visibleFromPosition: "1", joinedAt: "2026-09-02T00:00:00.000Z" }], agentBinding: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentIdentityId: "other-identity", profileRevisionId: "profile-1", computerId: "computer-1" } });
+		await expect(new PrismaConversationCreationProjectionRepository(database as never).project(_COMMAND, created)).rejects.toThrow("agent binding does not match");
+		expect(database.conversation.create).not.toHaveBeenCalled();
+		expect(database.conversationCreationReservation.updateMany).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts
+++ b/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts
@@ -139,6 +139,38 @@ describe("PrismaConversationCreationReservationRepository", function _Suite()
 		expect(database.conversationCreationReservation.update).not.toHaveBeenCalled();
 	});
 
+	it("marks a history-anchored reservation projected only after directory convergence", async function _Projects()
+	{
+		const projected = _Stored({ state: ConversationCreationReservationState.Projected, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z"), projectedAt: new Date("2026-09-02T00:02:00.000Z") });
+		const anchored = _Stored({ state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z") });
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValueOnce(anchored).mockResolvedValueOnce(projected), updateMany: vi.fn().mockResolvedValue({ count: 1 }) } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markProjected({ reservationId: "reservation-1" })).resolves.toMatchObject({ state: "projected" });
+		expect(database.conversationCreationReservation.updateMany).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "reservation-1", state: ConversationCreationReservationState.HistoryAnchored }, data: expect.objectContaining({ state: ConversationCreationReservationState.Projected, projectedAt: expect.any(Date) }) }));
+	});
+
+	it("does not project an unanchored reservation", async function _RejectsUnanchoredProjection()
+	{
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(_Stored()), update: vi.fn() } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markProjected({ reservationId: "reservation-1" })).rejects.toThrow("requires a history-anchored reservation");
+		expect(database.conversationCreationReservation.update).not.toHaveBeenCalled();
+	});
+
+	it("returns a projected reservation without attempting a second transition", async function _RecoversProjected()
+	{
+		const projected = _Stored({ state: ConversationCreationReservationState.Projected, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z"), projectedAt: new Date("2026-09-02T00:02:00.000Z") });
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValue(projected), updateMany: vi.fn() } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markProjected({ reservationId: "reservation-1" })).resolves.toMatchObject({ state: "projected" });
+		expect(database.conversationCreationReservation.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("returns the competing projector's completed transition after a lost compare-and-swap race", async function _RecoversProjectionRace()
+	{
+		const anchored = _Stored({ state: ConversationCreationReservationState.HistoryAnchored, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z") });
+		const projected = _Stored({ state: ConversationCreationReservationState.Projected, historyRevision: 0n, historyAnchoredAt: new Date("2026-09-02T00:01:00.000Z"), projectedAt: new Date("2026-09-02T00:02:00.000Z") });
+		const database = { conversationCreationReservation: { findUnique: vi.fn().mockResolvedValueOnce(anchored).mockResolvedValueOnce(projected), updateMany: vi.fn().mockResolvedValue({ count: 0 }) } };
+		await expect(new PrismaConversationCreationReservationRepository(database as never, _Caller()).markProjected({ reservationId: "reservation-1" })).resolves.toMatchObject({ state: "projected" });
+	});
+
 	it("commits the full Agent binding with its initial reservation before history I/O", async function _ReservesAgent()
 	{
 		const agent = { agentServiceId: "service-1", agentRevisionId: "revision-1", computerId: _CONVERSATION_ID, computerHistoryEventId: _HISTORY_EVENT_ID };

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-repository.ts
@@ -1,0 +1,84 @@
+import { ConversationCreationReservationState, ConversationMode, type Prisma } from "@prisma/client";
+
+import { PrismaChannelTargetParticipantGrantProjectionRepository } from "@opencrane/backend/server/agents/channel-targets";
+import { ConversationLifecycleModes, type ConversationCreated } from "@opencrane/contracts";
+
+import type { ConversationCreationProjectionCommand, ConversationCreationProjectionRepository } from "../history-anchored-conversation-creation-authority.types";
+import { PrismaConversationProductAuthorizationRepository } from "./conversation-product-authorization";
+
+/** Materializes immutable creation state with the serializable transaction supplied by its UoW. */
+export class PrismaConversationCreationProjectionRepository implements ConversationCreationProjectionRepository
+{
+	/** Holds the transaction that owns directory rows, grants, and the final reservation transition. */
+	public constructor(private readonly transaction: Prisma.TransactionClient) {}
+
+	/** Applies one history-derived directory projection, accepting only an exact idempotent replay. */
+	public async project(command: ConversationCreationProjectionCommand, created: ConversationCreated): Promise<void>
+	{
+		const reservation = await this.transaction.conversationCreationReservation.findUnique({ where: { id: command.reservationId }, include: { participants: { orderBy: { ordinal: "asc" } } } });
+		if (reservation === null || reservation.siloId !== command.siloId || reservation.conversationId !== command.conversationId)
+			throw new Error("Conversation creation projection reservation is unavailable");
+		if (reservation.state === ConversationCreationReservationState.Projected)
+			return;
+		if (reservation.state !== ConversationCreationReservationState.HistoryAnchored || reservation.historyRevision !== command.historyRevision)
+			throw new Error("Conversation creation projection requires its confirmed revision-zero anchor");
+		_AssertAnchor(reservation, created);
+		const existing = await this.transaction.conversation.findUnique({ where: { id: command.conversationId } });
+		if (existing === null)
+			await this.transaction.conversation.create({ data: { id: command.conversationId, siloId: command.siloId, mode: _Mode(created.mode), agentServiceId: reservation.agentServiceId, createdAt: new Date(created.createdAt) } });
+		else
+			_AssertDirectory(existing, command, created, reservation.agentServiceId);
+		await this.transaction.conversationParticipant.createMany({ data: created.participants.map(participant => ({ conversationId: command.conversationId, userId: participant.userId, visibleFromPosition: BigInt(participant.visibleFromPosition), joinedAt: new Date(participant.joinedAt) })), skipDuplicates: true });
+		const participants = await this.transaction.conversationParticipant.findMany({ where: { conversationId: command.conversationId }, orderBy: { visibleFromPosition: "asc" } });
+		if (participants.length !== created.participants.length || participants.some((participant, index) => participant.userId !== created.participants[index]?.userId || participant.visibleFromPosition !== BigInt(created.participants[index]?.visibleFromPosition ?? "-1")))
+			throw new Error("Conversation creation projection participants do not match immutable history");
+		const authorization = new PrismaConversationProductAuthorizationRepository(this.transaction);
+		await authorization.reconcileParticipants(command.siloId, command.conversationId, created.participants.map(participant => participant.userId), created.provenance.principalId, new Date(created.createdAt));
+		await authorization.reconcileCreator(command.siloId, command.conversationId, created.provenance.principalId, new Date(created.createdAt));
+		if (created.mode === ConversationLifecycleModes.Agent)
+			await new PrismaChannelTargetParticipantGrantProjectionRepository(this.transaction).reconcileConversation(command.conversationId, command.siloId, new Date(created.createdAt));
+		const advanced = await this.transaction.conversationCreationReservation.updateMany({ where: { id: command.reservationId, state: ConversationCreationReservationState.HistoryAnchored }, data: { state: ConversationCreationReservationState.Projected, projectedAt: new Date() } });
+		if (advanced.count === 0)
+		{
+			const current = await this.transaction.conversationCreationReservation.findUnique({ where: { id: command.reservationId }, select: { state: true } });
+			if (current?.state !== ConversationCreationReservationState.Projected)
+				throw new Error("Conversation creation projection did not converge");
+		}
+	}
+}
+
+/** Rejects a history event whose immutable facts do not match the durable pre-history reservation. */
+function _AssertAnchor(reservation: { readonly mode: ConversationMode; readonly principalId: string; readonly agentServiceId: string | null; readonly agentRevisionId: string | null; readonly agentIdentityId: string | null; readonly profileRevisionId: string | null; readonly computerId: string | null; readonly participants: readonly { readonly userId: string; readonly visibleFromPosition: bigint }[] }, created: ConversationCreated): void
+{
+	if (_Mode(created.mode) !== reservation.mode || created.provenance.principalId !== reservation.principalId)
+		throw new Error("Conversation creation projection anchor does not match its reservation");
+	if (!_MatchesAgentBinding(reservation, created.agentBinding))
+		throw new Error("Conversation creation projection agent binding does not match its reservation");
+	if (reservation.participants.length !== created.participants.length || reservation.participants.some((participant, index) => participant.userId !== created.participants[index]?.userId || participant.visibleFromPosition !== BigInt(created.participants[index]?.visibleFromPosition ?? "-1")))
+		throw new Error("Conversation creation projection anchor participants do not match its reservation");
+}
+
+/** Requires immutable Agent coordinates to retain the exact service, identity, revision, profile, and computer. */
+function _MatchesAgentBinding(reservation: { readonly agentServiceId: string | null; readonly agentRevisionId: string | null; readonly agentIdentityId: string | null; readonly profileRevisionId: string | null; readonly computerId: string | null }, binding: ConversationCreated["agentBinding"]): boolean
+{
+	if (reservation.agentServiceId === null && reservation.agentRevisionId === null && reservation.agentIdentityId === null && reservation.profileRevisionId === null && reservation.computerId === null)
+		return binding === null;
+	return binding !== null && binding.agentServiceId === reservation.agentServiceId && binding.agentRevisionId === reservation.agentRevisionId && binding.agentIdentityId === reservation.agentIdentityId && binding.profileRevisionId === reservation.profileRevisionId && binding.computerId === reservation.computerId;
+}
+
+/** Refuses an existing directory row unless it is the exact idempotent materialization of the anchor. */
+function _AssertDirectory(conversation: { readonly siloId: string; readonly mode: ConversationMode; readonly agentServiceId: string | null }, command: ConversationCreationProjectionCommand, created: ConversationCreated, agentServiceId: string | null): void
+{
+	if (conversation.siloId !== command.siloId || conversation.mode !== _Mode(created.mode) || conversation.agentServiceId !== agentServiceId)
+		throw new Error("Conversation creation projection directory does not match immutable history");
+}
+
+/** Maps immutable lifecycle modes to the target database enum without accepting widened strings. */
+function _Mode(mode: ConversationLifecycleModes): ConversationMode
+{
+	if (mode === ConversationLifecycleModes.Agent)
+		return ConversationMode.AgentSession;
+	if (mode === ConversationLifecycleModes.Direct)
+		return ConversationMode.Direct;
+	return ConversationMode.Group;
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-unit-of-work.ts
@@ -1,0 +1,23 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
+import { ConversationHistoryReader } from "../conversation-history-reader";
+import type { ConversationCreationProjectionCommand, ConversationCreationProjectionPort } from "../history-anchored-conversation-creation-authority.types";
+import { PrismaConversationCreationProjectionRepository } from "./prisma-conversation-creation-projection-repository";
+
+/** Materializes a confirmed creation anchor before recording the reservation's final progress state. */
+export class PrismaConversationCreationProjectionUnitOfWork implements ConversationCreationProjectionPort
+{
+	/** Holds the database transaction runner and read-only immutable history authority. */
+	public constructor(private readonly prisma: PrismaClient, private readonly history: Pick<ConversationHistoryReader, "readCreation">) {}
+
+	/** @inheritdoc */
+	public async request(command: ConversationCreationProjectionCommand): Promise<void>
+	{
+		const created = await this.history.readCreation({ siloId: command.siloId, conversationId: command.conversationId });
+		await ___RunInPrismaUnitOfWork(this.prisma, async function _Project(transaction): Promise<void>
+		{
+			return new PrismaConversationCreationProjectionRepository(transaction).project(command, created);
+		}, { isolationLevel: "Serializable", attemptLimit: 3, operation: "conversation creation projection" });
+	}
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
@@ -3,7 +3,7 @@ import { ConversationCreationReservationState, ConversationMode, type Prisma } f
 import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
 import { ConversationModes } from "@opencrane/models/conversations";
 
-import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type AnchorConversationCreationReservationCommand, type ConversationCreationReservationRepository, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
+import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type AnchorConversationCreationReservationCommand, type ConversationCreationReservationRepository, type ProjectConversationCreationReservationCommand, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
 import { __ConversationCreationReservationAuthorizationArguments, __ValidateConversationCreationReservation } from "../conversation-creation-reservation.validation";
 import type { ConversationCaller } from "../types/conversation-caller.types";
 import { PrismaConversationProductAuthorizationRepository } from "./conversation-product-authorization";
@@ -83,6 +83,43 @@ export class PrismaConversationCreationReservationRepository implements Conversa
 		});
 		return _Reserved(updated);
 	}
+
+	/** @inheritdoc */
+	public async markProjected(command: ProjectConversationCreationReservationCommand): Promise<ReservedConversationCreation>
+	{
+		_ValidateProjectionCommand(command);
+		const reservation = await this.transaction.conversationCreationReservation.findUnique({
+			where: { id: command.reservationId },
+			include: { participants: { orderBy: { ordinal: "asc" } } },
+		});
+		if (reservation === null)
+			throw new Error("Conversation creation reservation is unavailable");
+		if (reservation.siloId !== this.caller.siloId || reservation.principalId !== this.caller.principalId)
+			throw new Error("Conversation creation reservation is unavailable");
+		const existing = _Reserved(reservation);
+		if (existing.state === ConversationCreationReservationStates.Projected)
+			return existing;
+		if (existing.state !== ConversationCreationReservationStates.HistoryAnchored)
+			throw new Error("Conversation creation projection requires a history-anchored reservation");
+		// Advance only the anchored row so a concurrent projector cannot overwrite its own completed transition.
+		const transitioned = await this.transaction.conversationCreationReservation.updateMany({
+			where: { id: command.reservationId, state: ConversationCreationReservationState.HistoryAnchored },
+			data: { state: ConversationCreationReservationState.Projected, projectedAt: new Date() },
+		});
+		// Reload the row so a competing projector's completed transition becomes this call's idempotent replay.
+		const current = await this.transaction.conversationCreationReservation.findUnique({
+			where: { id: command.reservationId },
+			include: { participants: { orderBy: { ordinal: "asc" } } },
+		});
+		if (current === null || current.siloId !== this.caller.siloId || current.principalId !== this.caller.principalId)
+			throw new Error("Conversation creation reservation is unavailable");
+		const projected = _Reserved(current);
+		if (projected.state === ConversationCreationReservationStates.Projected)
+			return projected;
+		if (transitioned.count === 0)
+			throw new Error("Conversation creation projection did not converge");
+		throw new Error("Conversation creation projection did not persist");
+	}
 }
 
 /** Maps model-owned mode values to the generated Prisma enum without accepting arbitrary strings. */
@@ -121,6 +158,13 @@ function _ValidateAnchorCommand(command: AnchorConversationCreationReservationCo
 {
 	if (command.reservationId.trim().length === 0 || command.reservationId !== command.reservationId.trim())
 		throw new Error("Conversation creation history anchoring requires a reservation identifier");
+}
+
+/** Refuses an empty projection coordinate before it reaches the durable state machine. */
+function _ValidateProjectionCommand(command: ProjectConversationCreationReservationCommand): void
+{
+	if (command.reservationId.trim().length === 0 || command.reservationId !== command.reservationId.trim())
+		throw new Error("Conversation creation projection requires a reservation identifier");
 }
 
 /** Ensures direct/group never gain agent facts, while Agent reservations retain a complete frozen binding. */

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-unit-of-work.ts
@@ -1,0 +1,37 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
+
+import type { AnchorConversationCreationReservationCommand, ReserveConversationCreationCommand, ReserveConversationCreationResult, ReservedConversationCreation } from "../conversation-creation-reservation.types";
+import type { ConversationCreationReservationUnitOfWork } from "../history-anchored-conversation-creation-authority.types";
+import type { ConversationCaller } from "../types/conversation-caller.types";
+import { PrismaConversationCreationReservationRepository } from "./prisma-conversation-creation-reservation-repository";
+
+/** Opens the short serializable reservation transactions on either side of immutable history I/O. */
+export class PrismaConversationCreationReservationUnitOfWork implements ConversationCreationReservationUnitOfWork
+{
+	/** Holds the request-scoped caller whose authorization evidence each reservation transaction records. */
+	public constructor(private readonly prisma: PrismaClient, private readonly caller: ConversationCaller) {}
+
+	/** @inheritdoc */
+	public async reserve(command: ReserveConversationCreationCommand): Promise<ReserveConversationCreationResult>
+	{
+		return this._Run(function _Reserve(repository): Promise<ReserveConversationCreationResult> { return repository.reserve(command); }, "conversation creation reservation");
+	}
+
+	/** @inheritdoc */
+	public async markHistoryAnchored(command: AnchorConversationCreationReservationCommand): Promise<ReservedConversationCreation>
+	{
+		return this._Run(function _MarkHistoryAnchored(repository): Promise<ReservedConversationCreation> { return repository.markHistoryAnchored(command); }, "conversation creation history anchor");
+	}
+
+	/** Runs one short reservation operation without holding its transaction across immutable history I/O. */
+	private _Run<Result>(operation: (repository: PrismaConversationCreationReservationRepository) => Promise<Result>, name: string): Promise<Result>
+	{
+		const caller = this.caller;
+		return ___RunInPrismaUnitOfWork(this.prisma, async function _Transaction(transaction): Promise<Result>
+		{
+			return operation(new PrismaConversationCreationReservationRepository(transaction, caller));
+		}, { isolationLevel: "Serializable", attemptLimit: 3, operation: name });
+	}
+}

--- a/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.types.ts
@@ -72,6 +72,13 @@ export interface ConversationCreationProjectionPort
 	request(command: ConversationCreationProjectionCommand): Promise<void>;
 }
 
+/** Applies one history record through the transaction that the projection unit of work opened. */
+export interface ConversationCreationProjectionRepository
+{
+	/** Rebuilds directory state and advances the matching durable reservation as one transaction. */
+	project(command: ConversationCreationProjectionCommand, created: ConversationCreated): Promise<void>;
+}
+
 /**
  * Opens separate serializable PostgreSQL operations on either side of KurrentDB history I/O.
  *


### PR DESCRIPTION
## Summary

- make the history-anchored creation reservation transition to `Projected` explicit and one-way
- materialize the confirmed `ConversationCreated` record into the directory, participants, durable grants, and Agent channel targets inside a serializable transaction
- recover a concurrent projector through a guarded compare-and-swap plus reload, without an illegal projected-to-projected write
- cover first projection, unanchored denial, idempotent replay, and a lost-CAS race

## Boundary

- this checkpoint now owns the history-derived directory and grant projector; router composition and legacy-writer deletion follow
- it preserves the 0.11 fresh baseline: no migration, compatibility writer, or relational fallback is added
- concurrent replays retry only proven rolled-back unique or serialization conflicts, then observe the winner

## Validation

- npx nx run backend-server-conversations:test --skipNxCache -- src/db/__tests__/prisma-conversation-creation-reservation-repository.test.ts (13 passing)
- npx nx run backend-server-conversations:lint --skipNxCache
- scripts/agent-style-check.sh --diff HEAD
- npm run check:module-growth -- --diff HEAD
- npm run check:prisma-boundaries -- --diff HEAD
- git diff --check
- second projector commit: `npx nx run backend-server-conversations:lint --skipNxCache`, `npm run check:prisma-boundaries -- --diff HEAD`, `scripts/agent-style-check.sh --diff HEAD`, and `git diff --check`
- npx nx run backend-server-conversations:test --skipNxCache -- src/db/__tests__/prisma-conversation-creation-projection-repository.test.ts (2 passing)
- reservation adapter: `npx nx run backend-server-conversations:lint --skipNxCache`, `npm run check:prisma-boundaries -- --diff HEAD`, `scripts/agent-style-check.sh --diff HEAD`, and `git diff --check`

## Review

- independent correctness review passed after the CAS/reload race fix
- final comments gate passed; it clarified the durable state transition and CAS recovery

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807 → #808 → #810 → #811 → #812