### PR TITLE
🏗️ assemble history-anchored conversation creation

### DIFF
--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -682,6 +682,18 @@
 				]
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-compiler-repository.ts",
+				"adapter": "PrismaConversationCreationCompilerRepository",
+				"contract": "ConversationCreationCompilerRepository",
+				"contractImportPath": "../conversation-creation-compiler.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationProductAuthorizationRepository",
+						"importPath": "./conversation-product-authorization"
+					}
+				]
+			},
+			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-repository.ts",
 				"adapter": "PrismaConversationCreationProjectionRepository",
 				"contract": "ConversationCreationProjectionRepository",
@@ -1832,6 +1844,18 @@
 					{
 						"adapter": "PrismaAgentThreadParentDeliveryRepository",
 						"importPath": "./prisma-agent-thread-parent-delivery-repository"
+					}
+				]
+			},
+			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-compiler-unit-of-work.ts",
+				"adapter": "PrismaConversationCreationCompilerUnitOfWork",
+				"contract": "ConversationCreationCompiler",
+				"contractImportPath": "../conversation-creation-compiler.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationCreationCompilerRepository",
+						"importPath": "./prisma-conversation-creation-compiler-repository"
 					}
 				]
 			},

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-creation-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-creation-authority.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ConversationModes } from "@opencrane/models/conversations";
+
+import { HistoryAnchoredConversationCreationService } from "../conversation-creation-authority";
+import { ConversationWriteDenialReasons } from "../types/conversation-authority-result.types";
+
+/** Fixed session coordinates for every creation authority test. */
+const _CALLER = { siloId: "silo-1", principalId: "principal-1", subjectId: "user-1", issuer: "https://issuer.test" };
+
+/** Builds the authority with a programmable compiler, binding resolver, and history factory. */
+function _Authority(overrides: { readonly compiled?: { readonly participantUserIds: readonly string[]; readonly agentServiceId: string | null } | null; readonly binding?: { readonly outcome: "bound"; readonly value: { readonly agentServiceId: string; readonly agentRevisionId: string; readonly agentIdentityId: string; readonly profileRevisionId: string } } | { readonly outcome: "denied"; readonly reason: "service_unavailable" }; readonly historyResult?: { readonly outcome: "projection_needed"; readonly reservation: { readonly conversationId: string } } | { readonly outcome: "projected"; readonly reservation: { readonly conversationId: string } } | { readonly outcome: "denied" } | { readonly outcome: "idempotency_conflict" } } = {})
+{
+	const create = vi.fn().mockResolvedValue(overrides.historyResult ?? { outcome: "projection_needed", reservation: { conversationId: "conversation-1" } });
+	return { subject: new HistoryAnchoredConversationCreationService({ compiler: { compile: vi.fn().mockResolvedValue(overrides.compiled ?? { participantUserIds: ["user-1", "user-2"], agentServiceId: null }) }, agentBindings: { bind: vi.fn().mockResolvedValue(overrides.binding ?? { outcome: "bound", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1" } }) }, history: { create: vi.fn().mockReturnValue({ create }) }, clock: { now: function _Now() { return new Date("2026-09-02T00:00:00.000Z"); } } }), create };
+}
+
+describe("HistoryAnchoredConversationCreationService", function _Suite()
+{
+	it("anchors and projects server-resolved direct participants", async function _CreatesDirect()
+	{
+		const authority = _Authority();
+		await expect(authority.subject.create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000001", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).resolves.toEqual({ outcome: "created", conversationId: "conversation-1" });
+		expect(authority.create).toHaveBeenCalledWith(expect.objectContaining({ reservation: expect.objectContaining({ mode: ConversationModes.Direct, participants: [{ userId: "user-1", visibleFromPosition: "1", joinedAt: "2026-09-02T00:00:00.000Z" }, { userId: "user-2", visibleFromPosition: "2", joinedAt: "2026-09-02T00:00:00.000Z" }], agent: null, agentBinding: null }) }));
+	});
+
+	it("denies an Agent session before history when its frozen binding is unavailable", async function _DeniesUnavailableAgent()
+	{
+		const authority = _Authority({ compiled: { participantUserIds: ["user-1"], agentServiceId: "service-1" }, binding: { outcome: "denied", reason: "service_unavailable" } });
+		await expect(authority.subject.create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000002", mode: ConversationModes.AgentSession, personalAgentRef: "service-1" })).resolves.toEqual({ outcome: "denied", reason: ConversationWriteDenialReasons.AgentServiceUnavailable });
+		expect(authority.create).not.toHaveBeenCalled();
+	});
+
+	it("returns the existing idempotency-conflict denial without pretending the anchor was created", async function _ReportsConflict()
+	{
+		const authority = _Authority({ historyResult: { outcome: "idempotency_conflict" } });
+		await expect(authority.subject.create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000003", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).resolves.toEqual({ outcome: "denied", reason: ConversationWriteDenialReasons.IdempotencyConflict });
+	});
+});

--- a/libs/backend/server/conversations/main/src/__tests__/prisma-conversation-unit-of-work.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/prisma-conversation-unit-of-work.test.ts
@@ -326,7 +326,7 @@ describe("PrismaConversationUnitOfWork", function _Suite()
 		};
 		const prisma = _Prisma(transaction) as { readonly $transaction: ReturnType<typeof vi.fn> };
 
-		await expect(_Authority(prisma).create(_CALLER, { mode: ConversationModes.Direct, participantRefs: ["member-2"] })).resolves.toEqual(expect.objectContaining({ outcome: "created", conversation: expect.objectContaining({ id: "conversation-1", mode: ConversationModes.Direct, participantRefs: ["member-1", "member-2"] }) }));
+		await expect(_Authority(prisma).create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000001", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).resolves.toEqual(expect.objectContaining({ outcome: "created", conversation: expect.objectContaining({ id: "conversation-1", mode: ConversationModes.Direct, participantRefs: ["member-1", "member-2"] }) }));
 		expect(prisma.$transaction).toHaveBeenCalledTimes(1);
 		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), { isolationLevel: "Serializable" });
 		expect(createConversation).toHaveBeenCalledWith({ data: expect.objectContaining({ siloId: "silo-1", mode: ConversationMode.Direct, agentServiceId: null }) });
@@ -346,7 +346,7 @@ describe("PrismaConversationUnitOfWork", function _Suite()
 			conversationTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
 		};
 
-		await expect(_Authority(_Prisma(transaction)).create(_CALLER, { mode: ConversationModes.AgentSession, personalAgentRef: "service-1" })).resolves.toMatchObject({ outcome: "created" });
+		await expect(_Authority(_Prisma(transaction)).create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000002", mode: ConversationModes.AgentSession, personalAgentRef: "service-1" })).resolves.toMatchObject({ outcome: "created" });
 		expect(_channelProjection.reconcileConversation).toHaveBeenCalledWith(expect.any(String), "silo-1", expect.any(Date));
 	});
 
@@ -403,6 +403,6 @@ describe("PrismaConversationUnitOfWork", function _Suite()
 			conversationParticipant: { create: vi.fn().mockResolvedValue({}), findFirst: vi.fn().mockResolvedValue(null) },
 		};
 
-		await expect(_Authority(_Prisma(transaction)).create(_CALLER, { mode: ConversationModes.Direct, participantRefs: ["member-2"] })).rejects.toThrow("Written conversation projection unavailable");
+		await expect(_Authority(_Prisma(transaction)).create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000003", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).rejects.toThrow("Written conversation projection unavailable");
 	});
 });

--- a/libs/backend/server/conversations/main/src/conversation-creation-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-authority.ts
@@ -1,0 +1,70 @@
+import { randomUUID } from "node:crypto";
+
+import { ConversationModes } from "@opencrane/models/conversations";
+import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
+
+import { ConversationCreationReservationOutcomes, type ReserveConversationCreationCommand } from "./conversation-creation-reservation.types";
+import { HistoryAnchoredConversationCreationOutcomes } from "./history-anchored-conversation-creation-authority.types";
+import { ConversationWriteDenialReasons } from "./types/conversation-authority-result.types";
+import type { ConversationCaller } from "./types/conversation-caller.types";
+import type { CreateConversationRequest } from "./types/conversation-request.types";
+import type { ConversationCreationAuthority, ConversationCreationAuthorityDependencies, ConversationCreationAuthorityResult } from "./conversation-creation-authority.types";
+
+/** Turns a parsed browser request into one immutable, history-authoritative conversation. */
+export class HistoryAnchoredConversationCreationService implements ConversationCreationAuthority
+{
+	/** Holds the narrow server-owned authorities needed before an anchor can be written. */
+	public constructor(private readonly dependencies: ConversationCreationAuthorityDependencies) {}
+
+	/** @inheritdoc */
+	public async create(caller: ConversationCaller, request: CreateConversationRequest): Promise<ConversationCreationAuthorityResult>
+	{
+		// 1. Resolve opaque browser references while their membership and resource access are current.
+		const compiled = await this.dependencies.compiler.compile(caller, request);
+		if (compiled === null)
+			return _Denied(request);
+
+		// 2. Freeze an Agent-only binding before a reservation may carry computer coordinates.
+		const binding = request.mode === ConversationModes.AgentSession
+			? await this.dependencies.agentBindings.bind({ siloId: caller.siloId, agentServiceId: compiled.agentServiceId!, callerPrincipalId: caller.principalId, callerSubjectId: caller.subjectId })
+			: null;
+		if (binding !== null && !("value" in binding))
+			return { outcome: "denied", reason: ConversationWriteDenialReasons.AgentServiceUnavailable };
+
+		// 3. Reserve, anchor, confirm, and project through a caller-bound authority without direct row creation.
+		const boundAgent = binding === null || !("value" in binding) ? null : binding.value;
+		const command = _Command(caller, request, compiled.participantUserIds, boundAgent, this.dependencies.clock.now());
+		const result = await this.dependencies.history.create(caller).create({ reservation: command });
+		if (result.outcome === HistoryAnchoredConversationCreationOutcomes.Denied)
+			return _Denied(request);
+		if (result.outcome === HistoryAnchoredConversationCreationOutcomes.IdempotencyConflict)
+			return { outcome: "denied", reason: ConversationWriteDenialReasons.IdempotencyConflict };
+		return { outcome: "created", conversationId: result.reservation.conversationId };
+	}
+}
+
+/** Builds a complete server-resolved durable creation command from checked references and Agent facts. */
+function _Command(caller: ConversationCaller, request: CreateConversationRequest, participantUserIds: readonly string[], binding: { readonly agentServiceId: string; readonly agentRevisionId: string; readonly agentIdentityId: string; readonly profileRevisionId: string } | null, createdAt: Date): ReserveConversationCreationCommand
+{
+	const agent = binding === null
+		? null
+		: { agentServiceId: binding.agentServiceId, agentRevisionId: binding.agentRevisionId, computerId: randomUUID(), computerHistoryEventId: randomUUID() };
+	return {
+		siloId: caller.siloId,
+		principalId: caller.principalId,
+		requestId: request.requestId,
+		requestDigest: ___DigestCanonicalJson(request as unknown as JsonValue),
+		conversationId: randomUUID(),
+		historyEventId: randomUUID(),
+		mode: request.mode,
+		participants: participantUserIds.map(function _Participant(userId, index) { return { userId, visibleFromPosition: (index + 1).toString(), joinedAt: createdAt.toISOString() }; }),
+		agent,
+		agentBinding: binding === null ? null : { agentIdentityId: binding.agentIdentityId, profileRevisionId: binding.profileRevisionId },
+	};
+}
+
+/** Maps failed reference compilation back to the route's existing non-disclosing denial vocabulary. */
+function _Denied(request: CreateConversationRequest): ConversationCreationAuthorityResult
+{
+	return { outcome: "denied", reason: request.mode === ConversationModes.AgentSession ? ConversationWriteDenialReasons.AgentServiceUnavailable : ConversationWriteDenialReasons.ParticipantUnavailable };
+}

--- a/libs/backend/server/conversations/main/src/conversation-creation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-authority.types.ts
@@ -1,0 +1,45 @@
+import type { ConversationAgentBindingAuthority } from "./conversation-agent-binding.types";
+import type { ConversationCreationCompiler } from "./conversation-creation-compiler.types";
+import type { HistoryAnchoredConversationCreationAuthority } from "./history-anchored-conversation-creation-authority";
+import type { ConversationWriteDenial } from "./types/conversation-authority-result.types";
+import type { ConversationCaller } from "./types/conversation-caller.types";
+import type { CreateConversationRequest } from "./types/conversation-request.types";
+
+/** Returns server time for immutable creation participant coordinates. */
+export interface ConversationCreationClock
+{
+	/** Returns the instant recorded in every participant creation coordinate. */
+	now(): Date;
+}
+
+/** Creates a caller-bound history authority without exposing its reservation adapter to the transport. */
+export interface HistoryAnchoredConversationCreationAuthorityFactory
+{
+	/** Builds the authority whose reservation operations are bound to this authenticated caller. */
+	create(caller: ConversationCaller): HistoryAnchoredConversationCreationAuthority;
+}
+
+/** Holds the trusted seams needed to create a history-anchored conversation. */
+export interface ConversationCreationAuthorityDependencies
+{
+	/** Resolves opaque browser references against a current serializable authority snapshot. */
+	readonly compiler: ConversationCreationCompiler;
+	/** Freezes Agent service, revision, profile, and AgentIdentity facts for Agent sessions. */
+	readonly agentBindings: ConversationAgentBindingAuthority;
+	/** Creates the caller-bound reservation, history, confirmation, and projection authority. */
+	readonly history: HistoryAnchoredConversationCreationAuthorityFactory;
+	/** Supplies server time for the immutable creation anchor. */
+	readonly clock: ConversationCreationClock;
+}
+
+/** Reports whether the immutable anchor and projection made one conversation available. */
+export type ConversationCreationAuthorityResult
+	= { readonly outcome: "created"; readonly conversationId: string }
+	| { readonly outcome: "denied"; readonly reason: ConversationWriteDenial };
+
+/** Creates one history-anchored conversation from a session-derived caller and parsed browser request. */
+export interface ConversationCreationAuthority
+{
+	/** Resolves, reserves, anchors, and projects one creation request without direct relational creation. */
+	create(caller: ConversationCaller, request: CreateConversationRequest): Promise<ConversationCreationAuthorityResult>;
+}

--- a/libs/backend/server/conversations/main/src/conversation-creation-compiler.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-compiler.types.ts
@@ -1,0 +1,33 @@
+import { ConversationModes } from "@opencrane/models/conversations";
+
+import type { ConversationCaller } from "./types/conversation-caller.types";
+import type { CreateConversationRequest } from "./types/conversation-request.types";
+
+/** Holds the server-resolved references that a creation reservation may persist. */
+export interface CompiledConversationCreation
+{
+	/** Lists the initial participants in immutable creation order. */
+	readonly participantUserIds: readonly string[];
+	/** Names the checked personal Agent service for an Agent session, or null otherwise. */
+	readonly agentServiceId: string | null;
+}
+
+/** Resolves opaque browser references inside the transaction that checks their current authority. */
+export interface ConversationCreationCompilerRepository
+{
+	/** Returns trusted creation coordinates, or null without distinguishing unavailable references. */
+	compile(caller: ConversationCaller, request: CreateConversationRequest): Promise<CompiledConversationCreation | null>;
+}
+
+/** Opens a short serializable snapshot to resolve one browser create request. */
+export interface ConversationCreationCompiler
+{
+	/** Resolves current memberships and the caller-owned personal Agent before history can be addressed. */
+	compile(caller: ConversationCaller, request: CreateConversationRequest): Promise<CompiledConversationCreation | null>;
+}
+
+/** Returns the denial reason selected by the untrusted request mode. */
+export function __ConversationCreationDenialMode(request: CreateConversationRequest): "agent" | "participants"
+{
+	return request.mode === ConversationModes.AgentSession ? "agent" : "participants";
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-compiler-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-compiler-repository.ts
@@ -1,0 +1,73 @@
+import { AgentServiceKind, AgentServiceState, OrgMemberStatus, type Prisma } from "@prisma/client";
+
+import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
+import { ConversationModes } from "@opencrane/models/conversations";
+
+import type { CompiledConversationCreation, ConversationCreationCompilerRepository } from "../conversation-creation-compiler.types";
+import type { ConversationCaller } from "../types/conversation-caller.types";
+import type { CreateConversationRequest } from "../types/conversation-request.types";
+import { PrismaConversationProductAuthorizationRepository } from "./conversation-product-authorization";
+
+/** Resolves current participant and personal-Agent authority inside the creation transaction. */
+export class PrismaConversationCreationCompilerRepository implements ConversationCreationCompilerRepository
+{
+	/** Holds the caller-scoped serializable transaction. */
+	private readonly transaction: Prisma.TransactionClient;
+	/** Checks the collection and referenced resources against this exact transaction snapshot. */
+	private readonly authorization: PrismaConversationProductAuthorizationRepository;
+
+	/** Binds reference resolution and authorization evidence to the same serializable transaction. */
+	public constructor(transaction: Prisma.TransactionClient)
+	{
+		this.transaction = transaction;
+		this.authorization = new PrismaConversationProductAuthorizationRepository(transaction);
+	}
+
+	/** @inheritdoc */
+	public async compile(caller: ConversationCaller, request: CreateConversationRequest): Promise<CompiledConversationCreation | null>
+	{
+		const callerMembership = await this.transaction.orgMembership.findFirst({ where: { clusterTenant: caller.siloId, subject: caller.subjectId, status: OrgMemberStatus.Active }, select: { id: true } });
+		if (callerMembership === null)
+			return null;
+		if (request.mode === ConversationModes.AgentSession)
+			return this._CompilePersonalAgent(caller, request.personalAgentRef);
+		return this._CompileParticipants(caller, callerMembership.id, request.participantRefs);
+	}
+
+	/** Resolves opaque membership references without exposing which coordinate became unavailable. */
+	private async _CompileParticipants(caller: ConversationCaller, callerMembershipId: string, participantRefs: readonly string[]): Promise<CompiledConversationCreation | null>
+	{
+		const uniqueReferences = [...new Set(participantRefs)];
+		if (uniqueReferences.length !== participantRefs.length || uniqueReferences.includes(callerMembershipId))
+			return null;
+		const memberships = await this.transaction.orgMembership.findMany({ where: { id: { in: uniqueReferences }, clusterTenant: caller.siloId, status: OrgMemberStatus.Active }, select: { subject: true }, orderBy: { id: "asc" } });
+		if (memberships.length !== uniqueReferences.length)
+			return null;
+		const readable = await this.authorization.canReadResources(caller, uniqueReferences.map(function _Membership(id) { return { kind: ProductAuthorizationResourceKinds.OrganizationMembership, id }; }));
+		if (!readable)
+			return null;
+		return { participantUserIds: [caller.subjectId, ...memberships.map(function _Subject(membership) { return membership.subject; })], agentServiceId: null };
+	}
+
+	/** Resolves only the caller-owned active personal Agent and records its use evidence. */
+	private async _CompilePersonalAgent(caller: ConversationCaller, personalAgentRef: string): Promise<CompiledConversationCreation | null>
+	{
+		const profile = await this.transaction.personaProfile.findUnique({ where: { siloId_userId: { siloId: caller.siloId, userId: caller.subjectId } }, select: { id: true, activeRevisionId: true } });
+		if (profile?.activeRevisionId === null || profile?.activeRevisionId === undefined)
+			return null;
+		const services = await this.transaction.agentService.findMany({ where: { siloId: caller.siloId, kind: AgentServiceKind.Personal, state: AgentServiceState.Active, activeRevisionId: { not: null }, activeRevision: { is: { personaRevisionId: profile.activeRevisionId } } }, select: { id: true }, orderBy: { id: "asc" }, take: 2 });
+		const service = services[0];
+		if (services.length !== 1 || service === undefined || service.id !== personalAgentRef)
+			return null;
+		const readable = await this.authorization.canReadResources(caller, [{ kind: ProductAuthorizationResourceKinds.AgentService, id: service.id }]);
+		if (!readable)
+			return null;
+		const invocable = await this.authorization.admit(caller, { kind: ProductAuthorizationResourceKinds.AgentService, id: service.id }, ProductAuthorizationActions.Invoke, { conversationMode: ConversationModes.AgentSession });
+		if (!invocable)
+			return null;
+		const personaUsable = await this.authorization.admit(caller, { kind: ProductAuthorizationResourceKinds.Persona, id: profile.id }, ProductAuthorizationActions.Use, { conversationMode: ConversationModes.AgentSession });
+		if (!personaUsable)
+			return null;
+		return { participantUserIds: [caller.subjectId], agentServiceId: service.id };
+	}
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-compiler-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-compiler-unit-of-work.ts
@@ -1,0 +1,25 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
+
+import type { CompiledConversationCreation, ConversationCreationCompiler } from "../conversation-creation-compiler.types";
+import type { ConversationCaller } from "../types/conversation-caller.types";
+import type { CreateConversationRequest } from "../types/conversation-request.types";
+import { PrismaConversationCreationCompilerRepository } from "./prisma-conversation-creation-compiler-repository";
+
+/** Opens the short serializable authority snapshot that resolves one browser create request. */
+export class PrismaConversationCreationCompilerUnitOfWork implements ConversationCreationCompiler
+{
+	/** Holds the root client used only to open the reviewed transaction envelope. */
+	public constructor(private readonly prisma: PrismaClient) {}
+
+	/** @inheritdoc */
+	public compile(caller: ConversationCaller, request: CreateConversationRequest): Promise<CompiledConversationCreation | null>
+	{
+		return ___RunInPrismaUnitOfWork(this.prisma, async function _Compile(transaction): Promise<CompiledConversationCreation | null>
+		{
+			const repository = new PrismaConversationCreationCompilerRepository(transaction);
+			return repository.compile(caller, request);
+		}, { isolationLevel: "Serializable", attemptLimit: 3, operation: "conversation creation compile" });
+	}
+}

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -41,6 +41,7 @@ export type { ConversationComputerActivationAuthorityDependencies, ConversationC
 export { ConversationComputerAgentServiceKinds } from "./conversation-computer-profile-selection.types";
 export type { ConversationComputerAgentServiceKind, ConversationComputerProfileSelectionCommand, ConversationComputerProfileSelector } from "./conversation-computer-profile-selection.types";
 export { PrismaConversationAgentBindingUnitOfWork } from "./db/prisma-conversation-agent-binding-unit-of-work";
+export { ConversationAgentBindingResolver } from "./conversation-agent-binding-authority";
 export type { ConversationAgentBinding, ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult, ConversationAgentIdentitySelectionCommand, ConversationAgentIdentitySelector, ConversationManagedAgentPrincipalValidator } from "./conversation-agent-binding.types";
 export { ConversationAgentBindingDenialReasons } from "./conversation-agent-binding.types";
 export { ConversationComputerSandboxReconciliationAuthority } from "./conversation-computer-sandbox-reconciliation-authority";

--- a/libs/backend/server/conversations/main/src/openapi.ts
+++ b/libs/backend/server/conversations/main/src/openapi.ts
@@ -183,9 +183,9 @@ export const _SelfConversationsOpenapiPaths = {
 			summary: "Create one immutable-mode conversation",
 			tags: ["Conversations"],
 			requestBody: { required: true, content: { "application/json": { schema: { oneOf: [
-				{ type: "object", additionalProperties: false, required: ["mode", "personalAgentRef"], properties: { mode: { type: "string", enum: [ConversationModes.AgentSession] }, personalAgentRef: { type: "string" } } },
-				{ type: "object", additionalProperties: false, required: ["mode", "participantRefs"], properties: { mode: { type: "string", enum: [ConversationModes.Direct] }, participantRefs: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 1 } } },
-				{ type: "object", additionalProperties: false, required: ["mode", "participantRefs"], properties: { mode: { type: "string", enum: [ConversationModes.Group] }, participantRefs: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 99 } } },
+				{ type: "object", additionalProperties: false, required: ["requestId", "mode", "personalAgentRef"], properties: { requestId: { type: "string", format: "uuid" }, mode: { type: "string", enum: [ConversationModes.AgentSession] }, personalAgentRef: { type: "string" } } },
+				{ type: "object", additionalProperties: false, required: ["requestId", "mode", "participantRefs"], properties: { requestId: { type: "string", format: "uuid" }, mode: { type: "string", enum: [ConversationModes.Direct] }, participantRefs: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 1 } } },
+				{ type: "object", additionalProperties: false, required: ["requestId", "mode", "participantRefs"], properties: { requestId: { type: "string", format: "uuid" }, mode: { type: "string", enum: [ConversationModes.Group] }, participantRefs: { type: "array", items: { type: "string" }, minItems: 1, maxItems: 99 } } },
 			] } } } },
 			responses: { 201: { description: "Conversation created with its bounded canonical history.", content: { "application/json": { schema: _ConversationDetailEnvelopeSchema } } }, 400: { description: "Invalid immutable-mode request." }, 401: { description: "Authentication required." }, 404: { description: "A participant or agent service is unavailable." }, 503: { description: "Conversation authority unavailable." } },
 		},

--- a/libs/backend/server/conversations/main/src/types/conversation-request.types.ts
+++ b/libs/backend/server/conversations/main/src/types/conversation-request.types.ts
@@ -12,8 +12,8 @@ import type { AgentThreadTarget } from "@opencrane/backend/conversations/agent-t
  * cannot drift apart.
  */
 export type CreateConversationRequest =
-	| { readonly mode: ConversationModes.AgentSession; readonly personalAgentRef: string; readonly participantRefs?: never }
-	| { readonly mode: ConversationModes.Direct | ConversationModes.Group; readonly participantRefs: readonly string[]; readonly personalAgentRef?: never };
+	| { readonly requestId: string; readonly mode: ConversationModes.AgentSession; readonly personalAgentRef: string; readonly participantRefs?: never }
+	| { readonly requestId: string; readonly mode: ConversationModes.Direct | ConversationModes.Group; readonly participantRefs: readonly string[]; readonly personalAgentRef?: never };
 
 /**
  * One message a user is trying to post, after the router's size and shape checks passed.

--- a/libs/backend/server/conversations/main/src/validators/conversation-creation.validator.ts
+++ b/libs/backend/server/conversations/main/src/validators/conversation-creation.validator.ts
@@ -46,13 +46,15 @@ const _ReferenceSchema = z.string().trim().min(1).max(128);
  * AgentService built from the caller's approved persona revision, so naming somebody else's Agent
  * here is refused there rather than here.
  */
-const _AgentSessionSchema = z.object({ mode: z.literal(ConversationModes.AgentSession), personalAgentRef: _ReferenceSchema }).strict();
+const _RequestIdSchema = z.string().uuid();
+
+const _AgentSessionSchema = z.object({ requestId: _RequestIdSchema, mode: z.literal(ConversationModes.AgentSession), personalAgentRef: _ReferenceSchema }).strict();
 
 /**
  * Direct creation names exactly one other person. The caller is added by the server and is not
  * listed, so a length of one means a two-person conversation.
  */
-const _DirectSchema = z.object({ mode: z.literal(ConversationModes.Direct), participantRefs: z.array(_ReferenceSchema).length(1) }).strict();
+const _DirectSchema = z.object({ requestId: _RequestIdSchema, mode: z.literal(ConversationModes.Direct), participantRefs: z.array(_ReferenceSchema).length(1) }).strict();
 
 /**
  * Group creation names one to ninety-nine other people, again excluding the caller, giving a
@@ -60,7 +62,7 @@ const _DirectSchema = z.object({ mode: z.literal(ConversationModes.Direct), part
  * by `_GroupCreationSchema` in `libs/models/conversations/main/src/conversation.validator.ts`, so
  * the HTTP boundary and the model agree on the cap.
  */
-const _GroupSchema = z.object({ mode: z.literal(ConversationModes.Group), participantRefs: z.array(_ReferenceSchema).min(1).max(99) }).strict();
+const _GroupSchema = z.object({ requestId: _RequestIdSchema, mode: z.literal(ConversationModes.Group), participantRefs: z.array(_ReferenceSchema).min(1).max(99) }).strict();
 
 /**
  * Checks a create-conversation body and decides which mode it is asking for.

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -6020,14 +6020,20 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": {
+                    /** Format: uuid */
+                    requestId: string;
                     /** @enum {string} */
                     mode: "agent_session";
                     personalAgentRef: string;
                 } | {
+                    /** Format: uuid */
+                    requestId: string;
                     /** @enum {string} */
                     mode: "direct";
                     participantRefs: string[];
                 } | {
+                    /** Format: uuid */
+                    requestId: string;
                     /** @enum {string} */
                     mode: "group";
                     participantRefs: string[];

--- a/libs/frontend/state/conversation/workspace/src/lib/__tests__/conversation-workspace.store.spec.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/__tests__/conversation-workspace.store.spec.ts
@@ -213,7 +213,7 @@ describe("ConversationWorkspaceStore", function _ConversationWorkspaceStore()
 		store.toggleParticipant("other-ref");
 		expect(store.canCreate()).toBe(true);
 		expect(await store.create()).toEqual({ conversationId: "created-1" });
-		expect(gateway.created).toEqual([{ mode: ConversationModes.Direct, participantRefs: ["other-ref"] }]);
+		expect(gateway.created).toEqual([expect.objectContaining({ mode: ConversationModes.Direct, participantRefs: ["other-ref"], requestId: expect.any(String) })]);
 		expect(store.selected()?.id).toBe("conversation-1");
 	});
 

--- a/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.store.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.store.ts
@@ -440,8 +440,11 @@ export class ConversationWorkspaceStore
 		const mode = this._creationMode();
 		const directory = this._directory();
 		if (directory === null) return null;
-		if (mode === ConversationModes.AgentSession && directory.personalAgent !== null) return { mode, personalAgentRef: directory.personalAgent.personalAgentRef };
-		if (mode === ConversationModes.Direct || mode === ConversationModes.Group) return { mode, participantRefs: [...this._selectedParticipantRefs()] };
+		const requestId = globalThis.crypto.randomUUID();
+		if (mode === ConversationModes.AgentSession && directory.personalAgent !== null)
+			return { requestId, mode, personalAgentRef: directory.personalAgent.personalAgentRef };
+		if (mode === ConversationModes.Direct || mode === ConversationModes.Group)
+			return { requestId, mode, participantRefs: [...this._selectedParticipantRefs()] };
 		return null;
 	}
 

--- a/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.types.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.types.ts
@@ -236,9 +236,9 @@ export interface ConversationRun
 
 /** Immutable command for a new conversation. */
 export type CreateConversationCommand =
-	| { readonly mode: ConversationModes.AgentSession; readonly personalAgentRef: string }
-	| { readonly mode: ConversationModes.Direct; readonly participantRefs: readonly string[] }
-	| { readonly mode: ConversationModes.Group; readonly participantRefs: readonly string[] };
+	| { readonly requestId: string; readonly mode: ConversationModes.AgentSession; readonly personalAgentRef: string }
+	| { readonly requestId: string; readonly mode: ConversationModes.Direct; readonly participantRefs: readonly string[] }
+	| { readonly requestId: string; readonly mode: ConversationModes.Group; readonly participantRefs: readonly string[] };
 
 /** One participant-admitted block frozen inside a retry-stable message command. */
 export interface SubmitConversationMessageBlock


### PR DESCRIPTION
## Summary

- expose the verified Agent-binding resolver to the application composition
- compile opaque member and personal-Agent references in a serializable, authorization-checked adapter
- require a browser-generated `requestId` for durable create retries and regenerate the typed API client
- assemble compiler, frozen Agent binding, reservation, KurrentDB anchor confirmation, and relational projection behind one creation authority

## Boundary

This checkpoint builds the direct replacement path but does **not** yet switch the mounted route. The next child PR will compose it into the public app, make the history-backed projection the live response source, and then remove the old direct relational creation writer. No compatibility fallback or dual-write path is introduced.

## Validation

- focused ConversationComputer creation-authority tests (3)
- focused legacy conversation unit-of-work/router tests (36)
- focused workspace-store tests (19)
- `contracts:generate` OpenAPI type regeneration
- `scripts/agent-style-check.sh`
- `npm run check:prisma-boundaries -- --diff feat/issue-759-repair-nx-boundaries`
- `npm run lint:boundaries`
- `git diff --check`

## Stack

Base: #813 `feat/issue-759-repair-nx-boundaries`. This is a native GitHub stack layer. The follow-on route cutover PR will base on this PR.

## Review focus

- opaque browser references become durable coordinates only after current membership, resource read, Agent invocation, and persona-use checks
- an Agent binding is frozen before reservation and history I/O
- the creation UUID is reused on a network retry; a changed body receives the existing 409 conflict
- PostgreSQL reservation transactions remain closed during KurrentDB I/O and the projector reads immutable history before rebuilding relational state

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807 → #808 → #810 → #811 → #812 → #813 → #814