### PR TITLE
🔁 cut over conversation creation to immutable history

### DIFF
--- a/apps/opencrane/src/app/conversation-history-creation-composition.ts
+++ b/apps/opencrane/src/app/conversation-history-creation-composition.ts
@@ -1,0 +1,90 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { ManagedAgentIdentityHistoryProvisioner, ProxiedAgentIdentityHistoryProvisioner, AgentIdentityHistory } from "@opencrane/backend/server/iam/identity";
+import { MANAGED_AGENT_SERVICE_PRINCIPAL_ISSUER, __ManagedAgentServicePrincipal } from "@opencrane/backend/server/agents/agent-services";
+import { ConversationAgentBindingResolver, ConversationComputerAgentServiceKinds, ConversationCreationAnchorVerifier, ConversationHistoryAuthority, ConversationHistoryReader, HistoryAnchoredConversationCreationAuthority, HistoryAnchoredConversationCreationService, PrismaConversationAgentBindingUnitOfWork, PrismaConversationCreationCompilerUnitOfWork, PrismaConversationCreationProjectionUnitOfWork, PrismaConversationCreationReservationUnitOfWork, type ConversationAgentIdentitySelector, type ConversationComputerProfileSelector, type ConversationCreationAuthority, type ConversationManagedAgentPrincipalValidator } from "@opencrane/backend/server/conversations";
+import type { HistoryStore } from "@opencrane/backend/server/infra/history-store";
+
+
+/**
+ * Builds the creation authority shared by the authenticated HTTP router and socket transport.
+ *
+ * Each request supplies its own {@link ConversationCaller}, so the factory below can bind every
+ * reservation lookup to that caller before it reaches immutable history. Agent-session creation
+ * currently has no selected computer profile and therefore denies at the binding boundary; direct
+ * and group creation do not select a profile.
+ *
+ * Called by: {@link _Main} in index.ts.
+ * @param prisma - Opens the short reservation and projection transactions.
+ * @param historyStore - Owns immutable conversation anchors and AgentIdentity streams.
+ * @param siloId - Passed by app startup; this composition does not yet consume it.
+ * @returns The request-time authority mounted by both conversation transports.
+ */
+export function _CreateHistoryAnchoredConversationCreationAuthority(prisma: PrismaClient, historyStore: HistoryStore): ConversationCreationAuthority
+{
+	const profiles = _UnavailableProfiles();
+	const identities = _CreateAgentIdentitySelector(historyStore);
+	const verifier = new PrismaConversationAgentBindingUnitOfWork(prisma, _ManagedPrincipalValidator);
+	const bindings = new ConversationAgentBindingResolver(verifier, { profiles, identities });
+	const compiler = new PrismaConversationCreationCompilerUnitOfWork(prisma);
+	const history = { create(caller: { readonly principalId: string; readonly subjectId: string; readonly issuer: string; readonly siloId: string })
+	{
+		const reservations = new PrismaConversationCreationReservationUnitOfWork(prisma, caller);
+		const anchors = new ConversationHistoryAuthority(historyStore);
+		const verifier = new ConversationCreationAnchorVerifier(historyStore);
+		const projectionReader = new ConversationHistoryReader(historyStore);
+		const projection = new PrismaConversationCreationProjectionUnitOfWork(prisma, projectionReader);
+		return new HistoryAnchoredConversationCreationAuthority(reservations, anchors, verifier, projection);
+	} };
+	return new HistoryAnchoredConversationCreationService({ compiler, agentBindings: bindings, history, clock: { now: function _Now() { return new Date(); } } });
+}
+
+/**
+ * Returns no computer profile for any AgentService.
+ *
+ * {@link ConversationAgentBindingResolver} maps this `null` result to `ProfileUnavailable` before
+ * it provisions an AgentIdentity, so Agent-session creation fails closed while direct and group
+ * creation bypass profile selection.
+ */
+function _UnavailableProfiles(): ConversationComputerProfileSelector
+{
+	return { async select() { return null; } };
+}
+
+/**
+ * Builds the identity selector that runs after AgentService verification has closed its SQL transaction.
+ *
+ * {@link ConversationAgentBindingResolver} supplies database-verified service facts to this selector,
+ * so the identity provisioners never receive a browser-chosen identity or extend that transaction
+ * while writing their history streams.
+ */
+function _CreateAgentIdentitySelector(historyStore: HistoryStore): ConversationAgentIdentitySelector
+{
+	const history = new AgentIdentityHistory(historyStore);
+	const managed = new ManagedAgentIdentityHistoryProvisioner(history, { now: function _Now() { return new Date(); } });
+	const proxied = new ProxiedAgentIdentityHistoryProvisioner(history, { now: function _Now() { return new Date(); } });
+	return {
+		async ensure(command)
+		{
+			if (command.agentServiceKind === ConversationComputerAgentServiceKinds.Managed)
+				return managed.ensure(command);
+			return proxied.ensure({ siloId: command.siloId, agentServiceId: command.agentServiceId, proxiedPrincipalId: command.principalId, delegationPolicyId: command.delegationPolicyId, agentServiceName: command.agentServiceName });
+		},
+	};
+}
+
+/**
+ * Checks that a managed AgentService names the internal Principal derived from its service id.
+ *
+ * The binding verifier rejects any other issuer, subject, origin, or identifier before profile and
+ * identity authorities receive the service facts.
+ */
+const _ManagedPrincipalValidator: ConversationManagedAgentPrincipalValidator = {
+	validate(command)
+	{
+		return command.principalId === __ManagedAgentServicePrincipal(command.agentServiceId)
+			&& command.issuer === MANAGED_AGENT_SERVICE_PRINCIPAL_ISSUER
+			&& command.provenance === "internal"
+			&& command.subject === command.agentServiceId;
+	},
+};

--- a/apps/opencrane/src/app/public-app.ts
+++ b/apps/opencrane/src/app/public-app.ts
@@ -20,6 +20,7 @@ import { _RegisterRoutes } from "./routes";
 import { _CreateHttpRequestLogger } from "./telemetry";
 import type { McpRuntimeComposition } from "./mcp-runtime-composition.types";
 import type { ProviderEffectCommandExecutor } from "@opencrane/backend/server/gateways/providers";
+import type { ConversationCreationAuthority } from "@opencrane/backend/server/conversations";
 
 /**
  * Build the audit-log appender for the standalone first-owner claim, or null when that claim is not configured.
@@ -48,13 +49,14 @@ export function _CreatePublicAuthentication(prisma: PrismaClient, customApi: k8s
  * @param personalRunAdmission - Browser-session personal run admission port.
  * @param runCancellation - Shared attempt-fenced cancellation authority.
  * @param retryInputCompiler - Compiles the fresh snapshot required for participant run retries.
+ * @param creation - Creates conversations through the history-anchored authority shared with sockets.
  * @param authentication - One browser-session composition shared with the internal resolver.
  * @param artifactScannerEnabled - Whether newly quarantined conversation files can be consumed.
  * @param health - Cached public service report reader with no topology or error details.
  * @param mcpWorkflows - Shared transaction and worker authority for saved MCP jobs.
  * @returns The public Express listener before the lifecycle starts it.
  */
-export function _CreatePublicApp(prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, personalRunAdmission: PersonalRunAdmissionPort, runCancellation: RunCancellationRepository & SelfRunCancellationRepository, retryInputCompiler: RetryRunInputCompiler, authentication: PublicAuthenticationComposition, artifactScannerEnabled: boolean, health: PublicHealthReportReader, mcpWorkflows: McpWorkflowComposition, mcpRuntime: McpRuntimeComposition, providerEffects: ProviderEffectCommandExecutor): Express
+export function _CreatePublicApp(prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, personalRunAdmission: PersonalRunAdmissionPort, runCancellation: RunCancellationRepository & SelfRunCancellationRepository, retryInputCompiler: RetryRunInputCompiler, creation: ConversationCreationAuthority, authentication: PublicAuthenticationComposition, artifactScannerEnabled: boolean, health: PublicHealthReportReader, mcpWorkflows: McpWorkflowComposition, mcpRuntime: McpRuntimeComposition, providerEffects: ProviderEffectCommandExecutor): Express
 {
 	const app = express();
 
@@ -81,7 +83,7 @@ export function _CreatePublicApp(prisma: PrismaClient, runAdmission: ManagedRunA
 		app.use(organizationMembers.productAccess);
 
 	// 5. Mount authenticated product routes, then terminate failures through one structured handler.
-	_RegisterRoutes(app, prisma, runAdmission, personalRunAdmission, runCancellation, retryInputCompiler, artifactScannerEnabled, organizationMembers.router, mcpWorkflows, mcpRuntime, providerEffects);
+	_RegisterRoutes(app, prisma, runAdmission, personalRunAdmission, runCancellation, retryInputCompiler, creation, artifactScannerEnabled, organizationMembers.router, mcpWorkflows, mcpRuntime, providerEffects);
 	app.use(_ErrorHandler(_log));
 	return app;
 }

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -19,7 +19,7 @@ import { _CreatePersonaOnboardingRouter } from "@opencrane/backend/agents/person
 import { type UserOnboardingOwnerResolver } from "@opencrane/backend/server/agents/onboarding";
 import { _CreatePersonalArtifactCatalogueRouter } from "@opencrane/backend/server/agents/artifacts";
 import { _CreatePersonalConfigurationRouter } from "@opencrane/backend/agents/personal/configuration";
-import { _CreateSelfConversationsRouter } from "@opencrane/backend/server/conversations";
+import { _CreateSelfConversationsRouter, type ConversationCreationAuthority } from "@opencrane/backend/server/conversations";
 import { _CreateConversationAttachmentAdmission, __CreateConversationAssetRouter } from "@opencrane/backend/server/conversation-assets";
 import { _CreateSelfRunCancellationRouter, _CreateSelfRunStatusRouter, type RetryRunInputCompiler, type RunCancellationRepository, type SelfRunCancellationRepository } from "@opencrane/backend/agents/execution/runs";
 import type { PersonalRunAdmissionPort } from "@opencrane/backend/agents/execution/admission";
@@ -51,12 +51,13 @@ import type { McpRuntimeComposition } from "./mcp-runtime-composition.types";
  * @param personalRunAdmission - Shared personal browser-run admission port.
  * @param runCancellation - Shared attempt-fenced cancellation authority.
  * @param retryInputCompiler - Compiles fresh lease-bound snapshots within the run-owned retry transaction.
+ * @param creation - Creates participant conversations through reservation, immutable history, and projection.
  * @param artifactScannerEnabled - Whether upload admission has a live scanner consumer.
  * @param organizationMembersRouter - Startup-selected standalone or Fleet member authority.
  * @param mcpWorkflows - Shared guarded workflow engine plus saved MCP task authorities.
  * @returns The configured public listener.
  */
-export function _RegisterRoutes(app: Express, prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, personalRunAdmission: PersonalRunAdmissionPort, runCancellation: RunCancellationRepository & SelfRunCancellationRepository, retryInputCompiler: RetryRunInputCompiler, artifactScannerEnabled: boolean, organizationMembersRouter: Router, mcpWorkflows: McpWorkflowComposition, mcpRuntime: McpRuntimeComposition, providerEffects: ProviderEffectCommandExecutor): Express
+export function _RegisterRoutes(app: Express, prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, personalRunAdmission: PersonalRunAdmissionPort, runCancellation: RunCancellationRepository & SelfRunCancellationRepository, retryInputCompiler: RetryRunInputCompiler, creation: ConversationCreationAuthority, artifactScannerEnabled: boolean, organizationMembersRouter: Router, mcpWorkflows: McpWorkflowComposition, mcpRuntime: McpRuntimeComposition, providerEffects: ProviderEffectCommandExecutor): Express
 {
 	const onboarding = _CreateUserOnboardingComposition(prisma, _log, _ResolveUserOnboardingOwner);
 	const principalDirectory = new PrismaAuthenticatedPrincipalDirectoryUnitOfWork(prisma);
@@ -79,7 +80,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, runAdmission
 		{ method: "use", path: "/api/v1/me/runs", handler: _CreateSelfRunStatusRouter(prisma, _log) },
 		{ method: "use", path: "/api/v1/me/runs", handler: _CreateSelfRunCancellationRouter(runCancellation, _log) },
 		{ method: "use", path: "/api/v1/me/configuration", handler: _CreatePersonalConfigurationRouter(prisma, _log) },
-		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfConversationsRouter(prisma, personalRunAdmission, mcpWorkflows.execution, retryInputCompiler, _CreateConversationAttachmentAdmission, _log) },
+		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfConversationsRouter(prisma, personalRunAdmission, mcpWorkflows.execution, retryInputCompiler, _CreateConversationAttachmentAdmission, creation, _log) },
 		{ method: "use", path: "/api/v1/me/conversations", handler: __CreateConversationAssetRouter({ resolveCaller: _ResolveConversationAssetCaller, authority: _CreateConversationAssetAuthority(prisma, process.env, artifactScannerEnabled), logger: _log }) },
 		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfElicitationRouter(prisma, _log) },
 		{ method: "use", path: "/api/v1/me/activity", handler: _CreateSelfElicitationActivityRouter(prisma, _log) },

--- a/apps/opencrane/src/index.ts
+++ b/apps/opencrane/src/index.ts
@@ -13,6 +13,7 @@ import { ___BindConsole } from "@opencrane/backend/observability";
 
 import { _ReadProcessConfig } from "./app/config";
 import { _CreateConversationComputerActivationProfileResolver, _StartConversationComputerActivationWorker } from "./app/conversation-computer-activation-composition";
+import { _CreateHistoryAnchoredConversationCreationAuthority } from "./app/conversation-history-creation-composition";
 import type { OpenCraneConversationComputerActivationWorker } from "./app/conversation-computer-activation-composition.types";
 import { _StartConversationComputerSandboxReconciliationWorker } from "./app/conversation-computer-sandbox-reconciliation-composition";
 import type { OpenCraneConversationComputerSandboxReconciliationWorker } from "./app/conversation-computer-sandbox-reconciliation-composition.types";
@@ -60,6 +61,7 @@ async function _Main(): Promise<void>
 	const managedRunAdmission = __CreateManagedRunAdmissionPort(prisma, workflows.execution, runAdmissionCapacityGate, executionSubjects.admissionAuthority);
 	const personalRunAdmission = __CreatePersonalRunAdmissionPort(prisma, workflows.execution, runAdmissionCapacityGate, executionSubjects.admissionAuthority);
 	const runCancellation = _CreateRunCancellationAuthority(prisma);
+	const conversationCreation = _CreateHistoryAnchoredConversationCreationAuthority(prisma, historyStore.historyStore);
 
 	// 4. Compose the class-specific MCP authority before the generic external-action worker.
 	const channelTargetRoutes = _StartChannelTargetRouteReconciler(prisma, config.runtime.channelTargets);
@@ -91,10 +93,10 @@ async function _Main(): Promise<void>
 	// 5. Build separate HTTP listeners; only the internal app receives workload-only routes.
 	const authentication = _CreatePublicAuthentication(prisma, kubernetes.customApi, config.standaloneFirstUserAdmission);
 	const publicHealth = ___CreatePublicHealthReportReader(prisma, config, _log);
-	const publicApp = _CreatePublicApp(prisma, managedRunAdmission, personalRunAdmission, runCancellation, executionSubjects.retryInputCompiler, authentication, config.runtime.artifactScannerEnabled, publicHealth, workflows, mcpRuntime, providerEffects);
+	const publicApp = _CreatePublicApp(prisma, managedRunAdmission, personalRunAdmission, runCancellation, executionSubjects.retryInputCompiler, conversationCreation, authentication, config.runtime.artifactScannerEnabled, publicHealth, workflows, mcpRuntime, providerEffects);
 	publicApp.locals.artifactUploadGateway = _CreateArtifactUploadGateway(prisma, workflows.execution);
 	const internalApp = _CreateInternalApp(prisma, kubernetes.authApi, config.runtime, authentication.sessionMiddleware, mcpRuntime, workflows.execution, historyStore.historyStore);
-	const conversationSockets = _CreatePrismaSelfConversationSocketServer(prisma, personalRunAdmission, workflows.execution, executionSubjects.retryInputCompiler, _CreateConversationAttachmentAdmission, _log, _CreateConversationSocketAuthenticator(authentication.sessionMiddleware, authentication.authMiddleware), { interrupts: _CreateElicitationInterruptReader(prisma), shutdownSignal: _ProcessShutdownSignal });
+	const conversationSockets = _CreatePrismaSelfConversationSocketServer(prisma, personalRunAdmission, workflows.execution, executionSubjects.retryInputCompiler, _CreateConversationAttachmentAdmission, conversationCreation, _log, _CreateConversationSocketAuthenticator(authentication.sessionMiddleware, authentication.authMiddleware), { interrupts: _CreateElicitationInterruptReader(prisma), shutdownSignal: _ProcessShutdownSignal });
 	const conversationComputerActivation: OpenCraneConversationComputerActivationWorker | null = conversationComputerActivationAuthority === null
 		? null
 		: await _StartConversationComputerActivationWorker(historyStore.historyStore, conversationComputerActivationAuthority, config.runtime.siloId);

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -2300,6 +2300,7 @@
 			"libs/backend/server/gateways/providers/main/src/provider-byok-composition.ts",
 			"libs/backend/server/agents/agent-services/main/src/db/prisma-managed-agent-service-principal.factory.ts",
 			"apps/opencrane/src/index.ts",
+			"apps/opencrane/src/app/conversation-history-creation-composition.ts",
 			"libs/backend/server/agents/agent-services/main/src/prisma-agent-services.router.ts",
 			"apps/opencrane/src/app/routes.ts",
 			"libs/backend/server/iam/groups/main/src/routes/groups.ts",

--- a/libs/backend/server/conversations/main/src/__tests__/conversation-creation-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/conversation-creation-authority.test.ts
@@ -9,10 +9,13 @@ import { ConversationWriteDenialReasons } from "../types/conversation-authority-
 const _CALLER = { siloId: "silo-1", principalId: "principal-1", subjectId: "user-1", issuer: "https://issuer.test" };
 
 /** Builds the authority with a programmable compiler, binding resolver, and history factory. */
-function _Authority(overrides: { readonly compiled?: { readonly participantUserIds: readonly string[]; readonly agentServiceId: string | null } | null; readonly binding?: { readonly outcome: "bound"; readonly value: { readonly agentServiceId: string; readonly agentRevisionId: string; readonly agentIdentityId: string; readonly profileRevisionId: string } } | { readonly outcome: "denied"; readonly reason: "service_unavailable" }; readonly historyResult?: { readonly outcome: "projection_needed"; readonly reservation: { readonly conversationId: string } } | { readonly outcome: "projected"; readonly reservation: { readonly conversationId: string } } | { readonly outcome: "denied" } | { readonly outcome: "idempotency_conflict" } } = {})
+function _Authority(overrides: { readonly compiled?: { readonly participantUserIds: readonly string[]; readonly agentServiceId: string | null } | null; readonly binding?: { readonly outcome: "bound"; readonly value: { readonly agentServiceId: string; readonly agentRevisionId: string; readonly agentIdentityId: string; readonly profileRevisionId: string } } | { readonly outcome: "denied"; readonly reason: "service_unavailable" }; readonly historyResult?: { readonly outcome: "projection_needed"; readonly reservation: { readonly conversationId: string } } | { readonly outcome: "projected"; readonly reservation: { readonly conversationId: string } } | { readonly outcome: "denied" } | { readonly outcome: "idempotency_conflict" }; readonly recovered?: { readonly outcome: "projection_needed"; readonly reservation: { readonly conversationId: string } } | { readonly outcome: "projected"; readonly reservation: { readonly conversationId: string } } | { readonly outcome: "denied" } | { readonly outcome: "idempotency_conflict" } | null } = {})
 {
 	const create = vi.fn().mockResolvedValue(overrides.historyResult ?? { outcome: "projection_needed", reservation: { conversationId: "conversation-1" } });
-	return { subject: new HistoryAnchoredConversationCreationService({ compiler: { compile: vi.fn().mockResolvedValue(overrides.compiled ?? { participantUserIds: ["user-1", "user-2"], agentServiceId: null }) }, agentBindings: { bind: vi.fn().mockResolvedValue(overrides.binding ?? { outcome: "bound", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1" } }) }, history: { create: vi.fn().mockReturnValue({ create }) }, clock: { now: function _Now() { return new Date("2026-09-02T00:00:00.000Z"); } } }), create };
+	const resume = vi.fn().mockResolvedValue(overrides.recovered ?? null);
+	const compile = vi.fn().mockResolvedValue(overrides.compiled ?? { participantUserIds: ["user-1", "user-2"], agentServiceId: null });
+	const bind = vi.fn().mockResolvedValue(overrides.binding ?? { outcome: "bound", value: { agentServiceId: "service-1", agentRevisionId: "revision-1", agentIdentityId: "identity-1", profileRevisionId: "profile-1" } });
+	return { subject: new HistoryAnchoredConversationCreationService({ compiler: { compile }, agentBindings: { bind }, history: { create: vi.fn().mockReturnValue({ create, resume }) }, clock: { now: function _Now() { return new Date("2026-09-02T00:00:00.000Z"); } } }), create, resume, compile, bind };
 }
 
 describe("HistoryAnchoredConversationCreationService", function _Suite()
@@ -35,5 +38,15 @@ describe("HistoryAnchoredConversationCreationService", function _Suite()
 	{
 		const authority = _Authority({ historyResult: { outcome: "idempotency_conflict" } });
 		await expect(authority.subject.create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000003", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).resolves.toEqual({ outcome: "denied", reason: ConversationWriteDenialReasons.IdempotencyConflict });
+	});
+
+	it("resumes an anchored request before mutable participant or Agent facts are compiled again", async function _ResumesBeforeCompilation()
+	{
+		const authority = _Authority({ compiled: null, recovered: { outcome: "projection_needed", reservation: { conversationId: "conversation-recovered" } } });
+		await expect(authority.subject.create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000004", mode: ConversationModes.AgentSession, personalAgentRef: "service-removed" })).resolves.toEqual({ outcome: "created", conversationId: "conversation-recovered" });
+		expect(authority.resume).toHaveBeenCalledOnce();
+		expect(authority.compile).not.toHaveBeenCalled();
+		expect(authority.bind).not.toHaveBeenCalled();
+		expect(authority.create).not.toHaveBeenCalled();
 	});
 });

--- a/libs/backend/server/conversations/main/src/__tests__/history-anchored-conversation-creation-authority.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/history-anchored-conversation-creation-authority.test.ts
@@ -53,6 +53,7 @@ function _Ports(reservation: ReservedConversationCreation = _Reservation())
 	const phases: string[] = [];
 	const reservations: ConversationCreationReservationUnitOfWork = {
 		reserve: vi.fn(async function _Reserve() { phases.push("reserve"); return { outcome: ConversationCreationReservationOutcomes.Reserved, value: reservation } as const; }),
+		recover: vi.fn(async function _Recover() { phases.push("recover"); return { outcome: ConversationCreationReservationOutcomes.Idempotent, value: reservation } as const; }),
 		markHistoryAnchored: vi.fn(async function _Mark() { phases.push("mark"); return { ...reservation, state: ConversationCreationReservationStates.HistoryAnchored }; }),
 	};
 	const historyCreate = vi.fn(async function _Create(): Promise<HistoryAppendReceipt> { phases.push("history"); return { streamName: `conversation-${_CONVERSATION_ID}`, revision: 0n }; });
@@ -114,6 +115,17 @@ describe("HistoryAnchoredConversationCreationAuthority", function _Suite()
 		await expect(authority.create({ reservation: _Command() })).resolves.toMatchObject({ outcome: HistoryAnchoredConversationCreationOutcomes.ProjectionNeeded });
 		expect(ports.history.create).not.toHaveBeenCalled();
 		expect(ports.phases).toEqual(["reserve", "mark", "projection"]);
+	});
+
+	it("recovers the stored reservation without creating a fresh command", async function _RecoversBeforeCreate()
+	{
+		const anchored = _Reservation({ state: ConversationCreationReservationStates.HistoryAnchored });
+		const ports = _Ports(anchored);
+		const authority = new HistoryAnchoredConversationCreationAuthority(ports.reservations, ports.history, ports.anchorVerifier, ports.projection);
+		await expect(authority.resume({ requestId: _REQUEST_ID, requestDigest: _Command().requestDigest })).resolves.toMatchObject({ outcome: HistoryAnchoredConversationCreationOutcomes.ProjectionNeeded, reservation: { conversationId: _CONVERSATION_ID } });
+		expect(ports.reservations.reserve).not.toHaveBeenCalled();
+		expect(ports.history.create).not.toHaveBeenCalled();
+		expect(ports.phases).toEqual(["recover", "mark", "projection"]);
 	});
 
 	it("recovers an Agent anchor with its originally frozen binding after the progress transaction fails", async function _RecoversAgentAnchor()

--- a/libs/backend/server/conversations/main/src/__tests__/prisma-conversation-unit-of-work.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/prisma-conversation-unit-of-work.test.ts
@@ -7,6 +7,7 @@ import { __DecodeConversationProjectionCursor } from "@opencrane/backend/convers
 
 import { PrismaConversationUnitOfWork } from "../db/prisma-conversation-unit-of-work";
 import type { ConversationMessageAdmissionUnitOfWork } from "../conversation-message-admission.types";
+import type { ConversationCreationAuthority } from "../conversation-creation-authority.types";
 import type { SubmitConversationMessageRequest } from "../types/conversation-request.types";
 
 const _channelProjection = vi.hoisted(function _CreateChannelProjectionState()
@@ -73,9 +74,9 @@ function _Participant(lifecycle: ConversationLifecycle = ConversationLifecycle.O
 }
 
 /** Creates the aggregate authority with replaceable message-admission and retry collaborators. */
-function _Authority(prisma: object, messageAdmission: Partial<ConversationMessageAdmissionUnitOfWork> = {}, runRetry: RunRetryAuthority = { retry: vi.fn().mockResolvedValue({ outcome: "denied", reason: "run_not_found" }) }): PrismaConversationUnitOfWork
+function _Authority(prisma: object, messageAdmission: Partial<ConversationMessageAdmissionUnitOfWork> = {}, runRetry: RunRetryAuthority = { retry: vi.fn().mockResolvedValue({ outcome: "denied", reason: "run_not_found" }) }, creation: ConversationCreationAuthority = { create: vi.fn().mockResolvedValue({ outcome: "created", conversationId: "conversation-1" }) }): PrismaConversationUnitOfWork
 {
-	return new PrismaConversationUnitOfWork(prisma as never, messageAdmission as ConversationMessageAdmissionUnitOfWork, runRetry);
+	return new PrismaConversationUnitOfWork(prisma as never, messageAdmission as ConversationMessageAdmissionUnitOfWork, runRetry, creation);
 }
 
 describe("PrismaConversationUnitOfWork", function _Suite()
@@ -313,41 +314,22 @@ describe("PrismaConversationUnitOfWork", function _Suite()
 		expect(updateConversation).not.toHaveBeenCalled();
 	});
 
-	it("creates a direct conversation and projects it in one serializable unit of work", async function _CreatesConversation()
+	it("returns the history-anchored creation projection through one repeatable-read query", async function _ReadsCreatedProjection()
 	{
-		const createConversation = vi.fn().mockResolvedValue({});
-		const createParticipant = vi.fn().mockResolvedValue({});
 		const transaction = {
 			orgMembership: _ActiveMembership(),
-			conversation: { create: createConversation },
 			principal: { findMany: vi.fn().mockResolvedValue([{ id: "principal-1", subject: "user-1" }, { id: "principal-2", subject: "user-2" }]) },
-			conversationParticipant: { create: createParticipant, findFirst: vi.fn().mockResolvedValue(_Participant()) },
+			conversationParticipant: { findFirst: vi.fn().mockResolvedValue(_Participant()) },
 			conversationTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
 		};
 		const prisma = _Prisma(transaction) as { readonly $transaction: ReturnType<typeof vi.fn> };
+		const creation: ConversationCreationAuthority = { create: vi.fn().mockResolvedValue({ outcome: "created", conversationId: "conversation-1" }) };
 
-		await expect(_Authority(prisma).create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000001", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).resolves.toEqual(expect.objectContaining({ outcome: "created", conversation: expect.objectContaining({ id: "conversation-1", mode: ConversationModes.Direct, participantRefs: ["member-1", "member-2"] }) }));
+		await expect(_Authority(prisma, {}, undefined, creation).create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000001", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).resolves.toEqual(expect.objectContaining({ outcome: "created", conversation: expect.objectContaining({ id: "conversation-1", mode: ConversationModes.Direct, participantRefs: ["member-1", "member-2"] }) }));
+		expect(creation.create).toHaveBeenCalledWith(_CALLER, { requestId: "00000000-0000-4000-8000-000000000001", mode: ConversationModes.Direct, participantRefs: ["member-2"] });
 		expect(prisma.$transaction).toHaveBeenCalledTimes(1);
-		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), { isolationLevel: "Serializable" });
-		expect(createConversation).toHaveBeenCalledWith({ data: expect.objectContaining({ siloId: "silo-1", mode: ConversationMode.Direct, agentServiceId: null }) });
-		expect(createParticipant).toHaveBeenCalledTimes(2);
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ isolationLevel: "RepeatableRead" }));
 		expect(_channelProjection.reconcileConversation).not.toHaveBeenCalled();
-	});
-
-	it("projects exact ChannelTarget grants with a new Agent-session participant relation", async function _ProjectsAgentSessionTarget()
-	{
-		const transaction = {
-			orgMembership: _ActiveMembership(),
-			personaProfile: { findUnique: vi.fn().mockResolvedValue({ id: "persona-profile-1", activeRevisionId: "persona-revision-1" }) },
-			agentService: { findMany: vi.fn().mockResolvedValue([{ id: "service-1" }]) },
-			conversation: { create: vi.fn().mockResolvedValue({}) },
-			principal: { findMany: vi.fn().mockResolvedValue([{ id: "principal-1", subject: "user-1" }]) },
-			conversationParticipant: { create: vi.fn().mockResolvedValue({}), findFirst: vi.fn().mockResolvedValue({ ..._Participant(), conversation: { ...(_Participant() as { readonly conversation: object }).conversation, mode: ConversationMode.AgentSession, agentServiceId: "service-1", participants: [{ userId: "user-1" }] } }) },
-			conversationTimelineEntry: { findMany: vi.fn().mockResolvedValue([]) },
-		};
-
-		await expect(_Authority(_Prisma(transaction)).create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000002", mode: ConversationModes.AgentSession, personalAgentRef: "service-1" })).resolves.toMatchObject({ outcome: "created" });
-		expect(_channelProjection.reconcileConversation).toHaveBeenCalledWith(expect.any(String), "silo-1", expect.any(Date));
 	});
 
 	it("archives a participant and projects the result in one serializable unit of work", async function _ArchivesConversation()
@@ -394,7 +376,7 @@ describe("PrismaConversationUnitOfWork", function _Suite()
 		expect(_channelProjection.reconcileConversation).toHaveBeenCalledWith("conversation-1", "silo-1", expect.any(Date));
 	});
 
-	it("rolls back by throwing when a written conversation cannot be projected", async function _RejectsMissingWriteProjection()
+	it("throws when a confirmed history anchor has no relational projection", async function _RejectsMissingHistoryProjection()
 	{
 		const transaction = {
 			orgMembership: _ActiveMembership(),
@@ -403,6 +385,6 @@ describe("PrismaConversationUnitOfWork", function _Suite()
 			conversationParticipant: { create: vi.fn().mockResolvedValue({}), findFirst: vi.fn().mockResolvedValue(null) },
 		};
 
-		await expect(_Authority(_Prisma(transaction)).create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000003", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).rejects.toThrow("Written conversation projection unavailable");
+		await expect(_Authority(_Prisma(transaction)).create(_CALLER, { requestId: "00000000-0000-4000-8000-000000000003", mode: ConversationModes.Direct, participantRefs: ["member-2"] })).rejects.toThrow("History-anchored conversation projection unavailable");
 	});
 });

--- a/libs/backend/server/conversations/main/src/conversation-creation-authority.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-authority.ts
@@ -3,9 +3,10 @@ import { randomUUID } from "node:crypto";
 import { ConversationModes } from "@opencrane/models/conversations";
 import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 
-import { ConversationCreationReservationOutcomes, type ReserveConversationCreationCommand } from "./conversation-creation-reservation.types";
-import { HistoryAnchoredConversationCreationOutcomes } from "./history-anchored-conversation-creation-authority.types";
+import type { ReserveConversationCreationCommand } from "./conversation-creation-reservation.types";
+import { HistoryAnchoredConversationCreationOutcomes, type HistoryAnchoredConversationCreationResult } from "./history-anchored-conversation-creation-authority.types";
 import { ConversationWriteDenialReasons } from "./types/conversation-authority-result.types";
+import type { ConversationAgentBindingResult } from "./conversation-agent-binding.types";
 import type { ConversationCaller } from "./types/conversation-caller.types";
 import type { CreateConversationRequest } from "./types/conversation-request.types";
 import type { ConversationCreationAuthority, ConversationCreationAuthorityDependencies, ConversationCreationAuthorityResult } from "./conversation-creation-authority.types";
@@ -19,32 +20,48 @@ export class HistoryAnchoredConversationCreationService implements ConversationC
 	/** @inheritdoc */
 	public async create(caller: ConversationCaller, request: CreateConversationRequest): Promise<ConversationCreationAuthorityResult>
 	{
-		// 1. Resolve opaque browser references while their membership and resource access are current.
+		const requestDigest = ___DigestCanonicalJson(request as unknown as JsonValue);
+		const history = this.dependencies.history.create(caller);
+		// 1. Resume a known command before mutable references or Agent policy can strand its anchor.
+		const recovered = await history.resume({ requestId: request.requestId, requestDigest });
+		if (recovered !== null)
+			return _Result(recovered, request);
+		// 2. Resolve opaque browser references while their membership and resource access are current.
 		const compiled = await this.dependencies.compiler.compile(caller, request);
 		if (compiled === null)
 			return _Denied(request);
-
-		// 2. Freeze an Agent-only binding before a reservation may carry computer coordinates.
-		const binding = request.mode === ConversationModes.AgentSession
-			? await this.dependencies.agentBindings.bind({ siloId: caller.siloId, agentServiceId: compiled.agentServiceId!, callerPrincipalId: caller.principalId, callerSubjectId: caller.subjectId })
-			: null;
+		// 3. Freeze an Agent-only binding before a reservation may carry computer coordinates.
+		let binding: ConversationAgentBindingResult | null = null;
+		if (request.mode === ConversationModes.AgentSession)
+		{
+			const agentServiceId = compiled.agentServiceId;
+			if (agentServiceId === null)
+				return _Denied(request);
+			binding = await this.dependencies.agentBindings.bind({ siloId: caller.siloId, agentServiceId, callerPrincipalId: caller.principalId, callerSubjectId: caller.subjectId });
+		}
 		if (binding !== null && !("value" in binding))
 			return { outcome: "denied", reason: ConversationWriteDenialReasons.AgentServiceUnavailable };
 
-		// 3. Reserve, anchor, confirm, and project through a caller-bound authority without direct row creation.
+		// 4. Reserve, anchor, confirm, and project through a caller-bound authority without direct row creation.
 		const boundAgent = binding === null || !("value" in binding) ? null : binding.value;
-		const command = _Command(caller, request, compiled.participantUserIds, boundAgent, this.dependencies.clock.now());
-		const result = await this.dependencies.history.create(caller).create({ reservation: command });
+		const command = _Command(caller, request, requestDigest, compiled.participantUserIds, boundAgent, this.dependencies.clock.now());
+		const result = await history.create({ reservation: command });
+		return _Result(result, request);
+	}
+}
+
+/** Maps durable authority outcomes to the route's narrow create result. */
+function _Result(result: HistoryAnchoredConversationCreationResult, request: CreateConversationRequest): ConversationCreationAuthorityResult
+{
 		if (result.outcome === HistoryAnchoredConversationCreationOutcomes.Denied)
 			return _Denied(request);
 		if (result.outcome === HistoryAnchoredConversationCreationOutcomes.IdempotencyConflict)
 			return { outcome: "denied", reason: ConversationWriteDenialReasons.IdempotencyConflict };
 		return { outcome: "created", conversationId: result.reservation.conversationId };
-	}
 }
 
 /** Builds a complete server-resolved durable creation command from checked references and Agent facts. */
-function _Command(caller: ConversationCaller, request: CreateConversationRequest, participantUserIds: readonly string[], binding: { readonly agentServiceId: string; readonly agentRevisionId: string; readonly agentIdentityId: string; readonly profileRevisionId: string } | null, createdAt: Date): ReserveConversationCreationCommand
+function _Command(caller: ConversationCaller, request: CreateConversationRequest, requestDigest: `sha256:${string}`, participantUserIds: readonly string[], binding: { readonly agentServiceId: string; readonly agentRevisionId: string; readonly agentIdentityId: string; readonly profileRevisionId: string } | null, createdAt: Date): ReserveConversationCreationCommand
 {
 	const agent = binding === null
 		? null
@@ -53,7 +70,7 @@ function _Command(caller: ConversationCaller, request: CreateConversationRequest
 		siloId: caller.siloId,
 		principalId: caller.principalId,
 		requestId: request.requestId,
-		requestDigest: ___DigestCanonicalJson(request as unknown as JsonValue),
+		requestDigest,
 		conversationId: randomUUID(),
 		historyEventId: randomUUID(),
 		mode: request.mode,

--- a/libs/backend/server/conversations/main/src/conversation-creation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-authority.types.ts
@@ -12,14 +12,26 @@ export interface ConversationCreationClock
 	now(): Date;
 }
 
-/** Creates a caller-bound history authority without exposing its reservation adapter to the transport. */
+/**
+ * Creates the history authority for one session-derived caller.
+ *
+ * The factory keeps reservation recovery scoped to the authenticated caller instead of letting a
+ * process-wide authority reuse another caller's authorization evidence. Called by:
+ * {@link HistoryAnchoredConversationCreationService} before it resumes or reserves a command.
+ */
 export interface HistoryAnchoredConversationCreationAuthorityFactory
 {
 	/** Builds the authority whose reservation operations are bound to this authenticated caller. */
 	create(caller: ConversationCaller): HistoryAnchoredConversationCreationAuthority;
 }
 
-/** Holds the trusted seams needed to create a history-anchored conversation. */
+/**
+ * Supplies the ordered authority boundaries for history-anchored conversation creation.
+ *
+ * The service resumes an existing reservation before it reads mutable references, then uses these
+ * ports to compile current access, freeze Agent facts, and write the immutable anchor. An
+ * implementation must keep those responsibilities separate so no browser payload becomes history.
+ */
 export interface ConversationCreationAuthorityDependencies
 {
 	/** Resolves opaque browser references against a current serializable authority snapshot. */
@@ -32,14 +44,32 @@ export interface ConversationCreationAuthorityDependencies
 	readonly clock: ConversationCreationClock;
 }
 
-/** Reports whether the immutable anchor and projection made one conversation available. */
+/**
+ * Tells a transport whether its request produced a readable conversation projection.
+ *
+ * `created` supplies the projection id after the creation authority has accepted the immutable
+ * anchor and its relational rebuild. `denied` preserves the existing non-disclosing reason, so a
+ * transport must not infer whether a participant or AgentService exists from that result.
+ */
 export type ConversationCreationAuthorityResult
 	= { readonly outcome: "created"; readonly conversationId: string }
 	| { readonly outcome: "denied"; readonly reason: ConversationWriteDenial };
 
-/** Creates one history-anchored conversation from a session-derived caller and parsed browser request. */
+/**
+ * Creates or resumes one conversation from a session-derived caller and parsed browser request.
+ *
+ * The implementation must recover a matching request id before it recompiles mutable participant
+ * or Agent facts; otherwise a lost response could create a second anchor or strand the original.
+ * Called by: {@link PrismaConversationUnitOfWork.create}.
+ */
 export interface ConversationCreationAuthority
 {
-	/** Resolves, reserves, anchors, and projects one creation request without direct relational creation. */
+	/**
+	 * Resolves, reserves, anchors, and projects one creation request without direct relational creation.
+	 * @param caller - Identifies the authenticated user whose access evidence the reservation records.
+	 * @param request - Carries the parsed request id, mode, and opaque participant references.
+	 * @returns `created` with a readable projection id, or `denied` without disclosing unavailable coordinates.
+	 * @throws {Error} When immutable history or projection cannot confirm the admitted reservation.
+	 */
 	create(caller: ConversationCaller, request: CreateConversationRequest): Promise<ConversationCreationAuthorityResult>;
 }

--- a/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
+++ b/libs/backend/server/conversations/main/src/conversation-creation-reservation.types.ts
@@ -83,6 +83,15 @@ export interface AnchorConversationCreationReservationCommand
 	readonly reservationId: string;
 }
 
+/** Names one parsed browser retry while its existing reservation is recovered before mutable compilation. */
+export interface RecoverConversationCreationReservationCommand
+{
+	/** Identifies the caller-scoped browser retry key. */
+	readonly requestId: string;
+	/** Binds recovery to the same parsed request body that created the reservation. */
+	readonly requestDigest: `sha256:${string}`;
+}
+
 /**
  * Requests the `Projected` transition after the directory has applied a confirmed revision-zero
  * Kurrent anchor.
@@ -172,6 +181,14 @@ export interface ConversationCreationReservationRepository
 	 * @returns The persisted command, a retry conflict, or an authorization denial.
 	 */
 	reserve(command: ReserveConversationCreationCommand): Promise<ReserveConversationCreationResult>;
+	/**
+	 * Recovers the exact reservation before mutable participant or Agent facts are compiled again.
+	 *
+	 * The repository scopes the lookup to the authenticated caller. A matching digest returns frozen
+	 * coordinates for history/projection recovery; a changed body returns a conflict; an absent key
+	 * lets the creation authority perform a fresh authorization and compilation.
+	 */
+	recover(command: RecoverConversationCreationReservationCommand): Promise<ReserveConversationCreationResult | null>;
 	/**
 	 * Advances one reservation only after its exact revision-zero anchor is present in KurrentDB.
 	 *

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-repository.ts
@@ -3,7 +3,7 @@ import { ConversationCreationReservationState, ConversationMode, type Prisma } f
 import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
 import { ConversationModes } from "@opencrane/models/conversations";
 
-import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type AnchorConversationCreationReservationCommand, type ConversationCreationReservationRepository, type ProjectConversationCreationReservationCommand, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
+import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type AnchorConversationCreationReservationCommand, type ConversationCreationReservationRepository, type ProjectConversationCreationReservationCommand, type RecoverConversationCreationReservationCommand, type ReserveConversationCreationCommand, type ReserveConversationCreationResult, type ReservedConversationCreation } from "../conversation-creation-reservation.types";
 import { __ConversationCreationReservationAuthorizationArguments, __ValidateConversationCreationReservation } from "../conversation-creation-reservation.validation";
 import type { ConversationCaller } from "../types/conversation-caller.types";
 import { PrismaConversationProductAuthorizationRepository } from "./conversation-product-authorization";
@@ -54,6 +54,21 @@ export class PrismaConversationCreationReservationRepository implements Conversa
 			include: { participants: { orderBy: { ordinal: "asc" } } },
 		});
 		return { outcome: ConversationCreationReservationOutcomes.Reserved, value: _Reserved(created) };
+	}
+
+	/** @inheritdoc */
+	public async recover(command: RecoverConversationCreationReservationCommand): Promise<ReserveConversationCreationResult | null>
+	{
+		_ValidateRecoveryCommand(command);
+		const prior = await this.transaction.conversationCreationReservation.findUnique({
+			where: { siloId_principalId_requestId: { siloId: this.caller.siloId, principalId: this.caller.principalId, requestId: command.requestId } },
+			include: { participants: { orderBy: { ordinal: "asc" } } },
+		});
+		if (prior === null)
+			return null;
+		return prior.requestDigest === command.requestDigest
+			? { outcome: ConversationCreationReservationOutcomes.Idempotent, value: _Reserved(prior) }
+			: { outcome: ConversationCreationReservationOutcomes.IdempotencyConflict };
 	}
 
 	/** @inheritdoc */
@@ -158,6 +173,15 @@ function _ValidateAnchorCommand(command: AnchorConversationCreationReservationCo
 {
 	if (command.reservationId.trim().length === 0 || command.reservationId !== command.reservationId.trim())
 		throw new Error("Conversation creation history anchoring requires a reservation identifier");
+}
+
+/** Refuses malformed caller retry coordinates before a recovery lookup reaches PostgreSQL. */
+function _ValidateRecoveryCommand(command: RecoverConversationCreationReservationCommand): void
+{
+	if (command.requestId.trim().length === 0 || command.requestId !== command.requestId.trim())
+		throw new Error("Conversation creation recovery requires a request identifier");
+	if (!/^sha256:[a-f0-9]{64}$/u.test(command.requestDigest))
+		throw new Error("Conversation creation recovery requires a request digest");
 }
 
 /** Refuses an empty projection coordinate before it reaches the durable state machine. */

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-creation-reservation-unit-of-work.ts
@@ -2,7 +2,7 @@ import type { PrismaClient } from "@prisma/client";
 
 import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
 
-import type { AnchorConversationCreationReservationCommand, ReserveConversationCreationCommand, ReserveConversationCreationResult, ReservedConversationCreation } from "../conversation-creation-reservation.types";
+import type { AnchorConversationCreationReservationCommand, RecoverConversationCreationReservationCommand, ReserveConversationCreationCommand, ReserveConversationCreationResult, ReservedConversationCreation } from "../conversation-creation-reservation.types";
 import type { ConversationCreationReservationUnitOfWork } from "../history-anchored-conversation-creation-authority.types";
 import type { ConversationCaller } from "../types/conversation-caller.types";
 import { PrismaConversationCreationReservationRepository } from "./prisma-conversation-creation-reservation-repository";
@@ -17,6 +17,12 @@ export class PrismaConversationCreationReservationUnitOfWork implements Conversa
 	public async reserve(command: ReserveConversationCreationCommand): Promise<ReserveConversationCreationResult>
 	{
 		return this._Run(function _Reserve(repository): Promise<ReserveConversationCreationResult> { return repository.reserve(command); }, "conversation creation reservation");
+	}
+
+	/** @inheritdoc */
+	public async recover(command: RecoverConversationCreationReservationCommand): Promise<ReserveConversationCreationResult | null>
+	{
+		return this._Run(function _Recover(repository): Promise<ReserveConversationCreationResult | null> { return repository.recover(command); }, "conversation creation recovery");
 	}
 
 	/** @inheritdoc */

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-query-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-query-repository.ts
@@ -59,8 +59,8 @@ const _STATE_BY_PERSISTED_STATE: Readonly<Record<ConversationMessageState, Messa
  * it is handed, which is how the same reads serve both a read-only query and a write that has to
  * check its own preconditions. {@link PrismaConversationUnitOfWork} builds it inside `_read`
  * (repeatable read) and `PrismaConversationMessageAdmissionUnitOfWork` does the same;
- * {@link PrismaConversationMutationRepository} builds it over its own serializable write
- * transaction, so a check made here and the write that follows see the same snapshot.
+ * {@link PrismaConversationMutationRepository} builds it over its own serializable mutation
+ * transaction, so a check made here and the remaining mutation that follows see the same snapshot.
  *
  * Two rules hold across every method. Organisation membership is re-read on each call rather than
  * trusted from the session, so a removed user immediately stops being able to read. And nothing
@@ -71,7 +71,7 @@ const _STATE_BY_PERSISTED_STATE: Readonly<Record<ConversationMessageState, Messa
  * caller cannot probe for other people's conversations.
  *
  * Called by: `PrismaConversationUnitOfWork._read`, `PrismaConversationMessageAdmissionUnitOfWork`,
- * and `PrismaConversationMutationRepository` (as its `query` collaborator).
+ * and `PrismaConversationMutationRepository` for surviving message and lifecycle mutations.
  *
  * @see ConversationQueryRepository for the port this implements.
  */
@@ -100,8 +100,8 @@ export class PrismaConversationQueryRepository implements ConversationQueryRepos
 	 *
 	 * This exists so the browser never has to hold a login identity. Each member is returned as an
 	 * opaque OrgMembership reference, and those references are the only participant values creation
-	 * accepts — see `_creationAuthority` in prisma-conversation-mutation-repository.ts, which resolves
-	 * them again at write time. `openapi.test.ts` asserts the published response schema mentions
+ * accepts — the history-anchored creation compiler resolves them before it reserves the immutable
+ * creation command. `openapi.test.ts` asserts the published response schema mentions
 	 * neither `subject` nor `email`, and the router test asserts the response body does not contain
 	 * the caller's own subject.
 	 *

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-unit-of-work.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-
 import type { PrismaClient } from "@prisma/client";
 
 import { ___DoWithTrace } from "@opencrane/backend/observability";
@@ -7,7 +5,8 @@ import type { RunRetryAuthority } from "@opencrane/backend/agents/execution/runs
 import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
 
 import type { AgentThreadSnapshotView } from "../types/agent-thread-view.types";
-import type { CreateConversationResult, MarkAgentThreadReadResult, MutateConversationResult, RetryConversationRunResult, SubmitConversationMessageResult } from "../types/conversation-authority-result.types";
+import { ConversationAuthorityOutcomes, type CreateConversationResult, type MarkAgentThreadReadResult, type MutateConversationResult, type RetryConversationRunResult, type SubmitConversationMessageResult } from "../types/conversation-authority-result.types";
+import type { ConversationCreationAuthority } from "../conversation-creation-authority.types";
 import type { ConversationCaller } from "../types/conversation-caller.types";
 import type { ConversationCreationDirectory } from "../types/conversation-directory.types";
 import type { CreateConversationRequest, RetryConversationRunRequest, SubmitConversationMessageRequest } from "../types/conversation-request.types";
@@ -28,9 +27,9 @@ import type { ConversationQueryRepository } from "./prisma-conversation-query-re
  * docs/agents/prisma-boundary-policy.json. Two isolation levels are used on purpose. Reads run
  * through `_read` at repeatable read, so a method that makes
  * several queries — membership, then participant rows, then messages — cannot see the picture change
- * halfway. Writes run through `_mutate` at serializable, so a check made inside the transaction still
- * holds when the write commits; closing a conversation while a run is starting is the case that needs
- * it.
+ * halfway. Remaining relational mutations run through `_mutate` at serializable, so a check made
+ * inside the transaction still holds when the write commits; closing a conversation while a run is
+ * starting is the case that needs it. Creation instead delegates to its history-anchored authority.
  *
  * Two methods do not follow that pattern. `submitMessage` hands over to the message-admission
  * authority, which has to open an agent run and write the message in one transaction of its own, and
@@ -51,13 +50,16 @@ export class PrismaConversationUnitOfWork implements ConversationUnitOfWork
 	private readonly messageAdmission: ConversationMessageAdmissionUnitOfWork;
 	/** Run-owned authority that validates and persists participant retry requests. */
 	private readonly runRetry: RunRetryAuthority;
+	/** Delegates creation to the authority that reserves, anchors, and projects immutable history. */
+	private readonly creation: ConversationCreationAuthority;
 
-	/** Creates the aggregate authority with its message-admission and run-retry collaborators. */
-	constructor(prisma: PrismaClient, messageAdmission: ConversationMessageAdmissionUnitOfWork, runRetry: RunRetryAuthority)
+	/** Creates the aggregate authority with its message, retry, and history-anchored creation collaborators. */
+	constructor(prisma: PrismaClient, messageAdmission: ConversationMessageAdmissionUnitOfWork, runRetry: RunRetryAuthority, creation: ConversationCreationAuthority)
 	{
 		this.prisma = prisma;
 		this.messageAdmission = messageAdmission;
 		this.runRetry = runRetry;
+		this.creation = creation;
 	}
 
 	/**
@@ -132,13 +134,26 @@ export class PrismaConversationUnitOfWork implements ConversationUnitOfWork
 		});
 	}
 
-	/** Writes the conversation and participant rows atomically; the selected mode can never change. */
+	/**
+	 * Creates immutable conversation history first, then reads its reconstructed relational projection.
+	 *
+	 * The creation authority owns request-id recovery and refuses direct row creation. This adapter
+	 * re-reads the projection through the caller's participant coordinate, so an accepted creation
+	 * cannot return a conversation the caller is no longer allowed to open.
+	 * @returns `Created` with the readable projection, or `Denied` with the authority's existing reason.
+	 * @throws {Error} When history accepted the reservation but projection is not readable yet.
+	 */
 	async create(caller: ConversationCaller, request: CreateConversationRequest): Promise<CreateConversationResult>
 	{
 		return ___DoWithTrace("conversation.create", { siloId: caller.siloId, mode: request.mode }, async () =>
 		{
-			const conversationId = randomUUID();
-			return this._mutate(function _Create(repository) { return repository.create(caller, conversationId, request); });
+			const created = await this.creation.create(caller, request);
+			if ("reason" in created)
+				return { outcome: ConversationAuthorityOutcomes.Denied, reason: created.reason };
+			const conversation = await this._read(function _ReadCreated(query) { return query.open(caller, created.conversationId); });
+			if (conversation === null)
+				throw new Error("History-anchored conversation projection unavailable");
+			return { outcome: ConversationAuthorityOutcomes.Created, conversation };
 		});
 	}
 

--- a/libs/backend/server/conversations/main/src/db/prisma-self-conversations.router.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-self-conversations.router.ts
@@ -17,6 +17,7 @@ import { __CreateSelfConversationSocketServer } from "../self-conversation-socke
 import type { SelfConversationSocketAuthenticator, SelfConversationSocketServer } from "../self-conversation-socket.types";
 import type { ConversationCaller } from "../types/conversation-caller.types";
 import type { ConversationAttachmentAdmissionFactory } from "../conversation-message-admission.types";
+import type { ConversationCreationAuthority } from "../conversation-creation-authority.types";
 
 /** Maps authenticated request facts to the caller contract owned by conversations. */
 function _resolveCaller(request: Parameters<typeof _ResolveRequestPrincipal>[0]): ConversationCaller | null
@@ -45,23 +46,40 @@ function _createMutationRepository(transaction: RunAdmissionTransaction): Prisma
  *   triggered it.
  * @param workflow - Guarded engine that saves a retry task in the retry transaction.
  * @param retryInputCompiler - Inputs authority that compiles the exact new retry subject and snapshot.
+ * @param createAttachmentAdmission - Admits upload references before a message transaction uses them.
+ * @param creation - Creates conversations through reservation, immutable history, and projection.
  * @param logger - Used only for unexpected failures; never receives message content.
  * @returns An Express router ready to mount.
  */
-export function _CreateSelfConversationsRouter(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, workflow: Pick<IWorkflowEngine, "spawn">, retryInputCompiler: RetryRunInputCompiler, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, logger: Logger): Router
+export function _CreateSelfConversationsRouter(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, workflow: Pick<IWorkflowEngine, "spawn">, retryInputCompiler: RetryRunInputCompiler, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, creation: ConversationCreationAuthority, logger: Logger): Router
 {
 	const messageAdmission = new PrismaConversationMessageAdmissionUnitOfWork(prisma, runAdmission, _createMutationRepository, createAttachmentAdmission);
 	const runRetry = new PrismaAgentRunRetryUnitOfWork(prisma, workflow, retryInputCompiler);
-	const authority = new PrismaConversationUnitOfWork(prisma, messageAdmission, runRetry);
+	const authority = new PrismaConversationUnitOfWork(prisma, messageAdmission, runRetry, creation);
 	return __CreateSelfConversationsRouter({ resolveCaller: _resolveCaller, authority, logger });
 }
 
-/** Build the socket endpoint over the same Prisma authorities as the participant HTTP router. */
-export function _CreatePrismaSelfConversationSocketServer(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, workflow: Pick<IWorkflowEngine, "spawn">, retryInputCompiler: RetryRunInputCompiler, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, logger: Logger, authenticator: SelfConversationSocketAuthenticator, options: { readonly interrupts?: ConversationOpenInterruptReader; readonly shutdownSignal?: AbortSignal } = {}): SelfConversationSocketServer
+/**
+ * Builds the participant socket endpoint over the same authorities as the HTTP router.
+ *
+ * Sharing `creation` keeps a socket-triggered create subject to the same caller-bound reservation
+ * and history projection as an HTTP create. Called by: {@link _Main} in apps/opencrane/src/index.ts.
+ * @param prisma - Opens read and remaining mutation transactions.
+ * @param runAdmission - Admits personal agent runs started by participant messages.
+ * @param workflow - Saves retries from participant-owned run commands.
+ * @param retryInputCompiler - Compiles the fresh retry snapshot.
+ * @param createAttachmentAdmission - Admits attachments before a message transaction uses them.
+ * @param creation - Reserves, anchors, and projects a conversation creation request.
+ * @param logger - Records unexpected transport failures without message content.
+ * @param authenticator - Resolves the socket session to its conversation caller.
+ * @param options - Supplies optional interruption reads and process shutdown handling.
+ * @returns A socket server that shares the participant conversation authority.
+ */
+export function _CreatePrismaSelfConversationSocketServer(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, workflow: Pick<IWorkflowEngine, "spawn">, retryInputCompiler: RetryRunInputCompiler, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, creation: ConversationCreationAuthority, logger: Logger, authenticator: SelfConversationSocketAuthenticator, options: { readonly interrupts?: ConversationOpenInterruptReader; readonly shutdownSignal?: AbortSignal } = {}): SelfConversationSocketServer
 {
 	const messageAdmission = new PrismaConversationMessageAdmissionUnitOfWork(prisma, runAdmission, _createMutationRepository, createAttachmentAdmission);
 	const runRetry = new PrismaAgentRunRetryUnitOfWork(prisma, workflow, retryInputCompiler);
-	const authority = new PrismaConversationUnitOfWork(prisma, messageAdmission, runRetry);
+	const authority = new PrismaConversationUnitOfWork(prisma, messageAdmission, runRetry, creation);
 	const interruptOptions = options.interrupts === undefined ? {} : { interrupts: options.interrupts };
 	const shutdownOptions = options.shutdownSignal === undefined ? {} : { shutdownSignal: options.shutdownSignal };
 	return __CreateSelfConversationSocketServer({ authenticator, authority, repository: _CreateConversationReplayRepository(prisma), clock: CONVERSATION_PROJECTION_CLOCK, limits: CONVERSATION_PROJECTION_LIMITS, ...interruptOptions, ...shutdownOptions, logger });

--- a/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.ts
+++ b/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.ts
@@ -3,7 +3,7 @@ import { ConversationModes } from "@opencrane/models/conversations";
 
 import { ConversationCreationAnchorVerifier } from "./conversation-creation-anchor-verifier";
 import { ConversationCreationAnchorConfirmationOutcomes } from "./conversation-creation-anchor-verifier.types";
-import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type ReservedConversationCreation } from "./conversation-creation-reservation.types";
+import { ConversationCreationReservationOutcomes, ConversationCreationReservationStates, type RecoverConversationCreationReservationCommand, type ReservedConversationCreation } from "./conversation-creation-reservation.types";
 import { ConversationHistoryAuthority } from "./conversation-history-authority";
 import { HistoryAnchoredConversationCreationOutcomes, type ConversationCreationProjectionCommand, type ConversationCreationProjectionPort, type ConversationCreationReservationUnitOfWork, type CreateHistoryAnchoredConversationCommand, type HistoryAnchoredConversationCreationResult } from "./history-anchored-conversation-creation-authority.types";
 
@@ -37,7 +37,25 @@ export class HistoryAnchoredConversationCreationAuthority
 			return { outcome: HistoryAnchoredConversationCreationOutcomes.Denied };
 		if (reservedResult.outcome === ConversationCreationReservationOutcomes.IdempotencyConflict)
 			return { outcome: HistoryAnchoredConversationCreationOutcomes.IdempotencyConflict };
-		const reservation = reservedResult.value;
+		return this._Continue(reservedResult.value);
+	}
+
+	/** Recovers an exact admitted command without recompiling mutable participants or Agent bindings. */
+	public async resume(command: RecoverConversationCreationReservationCommand): Promise<HistoryAnchoredConversationCreationResult | null>
+	{
+		const recovered = await this.reservations.recover(command);
+		if (recovered === null)
+			return null;
+		if (recovered.outcome === ConversationCreationReservationOutcomes.IdempotencyConflict)
+			return { outcome: HistoryAnchoredConversationCreationOutcomes.IdempotencyConflict };
+		if (recovered.outcome !== ConversationCreationReservationOutcomes.Idempotent)
+			throw new Error("Conversation creation recovery returned an unadmitted reservation");
+		return this._Continue(recovered.value);
+	}
+
+	/** Progresses a stored command through anchor confirmation and its replayable projection handoff. */
+	private async _Continue(reservation: ReservedConversationCreation): Promise<HistoryAnchoredConversationCreationResult>
+	{
 		const created = _Created(reservation);
 		if (reservation.state === ConversationCreationReservationStates.Projected)
 			return { outcome: HistoryAnchoredConversationCreationOutcomes.Projected, reservation, created };

--- a/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.types.ts
+++ b/libs/backend/server/conversations/main/src/history-anchored-conversation-creation-authority.types.ts
@@ -1,6 +1,6 @@
 import type { ConversationCreated } from "@opencrane/contracts";
 
-import type { AnchorConversationCreationReservationCommand, ConversationCreationReservationStates, ReserveConversationCreationCommand, ReserveConversationCreationResult, ReservedConversationCreation } from "./conversation-creation-reservation.types";
+import type { AnchorConversationCreationReservationCommand, ConversationCreationReservationStates, RecoverConversationCreationReservationCommand, ReserveConversationCreationCommand, ReserveConversationCreationResult, ReservedConversationCreation } from "./conversation-creation-reservation.types";
 
 /**
  * States how the creation authority handled a server-resolved create command.
@@ -97,6 +97,13 @@ export interface ConversationCreationReservationUnitOfWork
 	 * @returns The admitted command, a conflicting retry key, or an authorization denial.
 	 */
 	reserve(command: ReserveConversationCreationCommand): Promise<ReserveConversationCreationResult>;
+	/**
+	 * Recovers one caller-scoped reservation before fresh request compilation consults mutable facts.
+	 *
+	 * Called by: {@link HistoryAnchoredConversationCreationAuthority.resume}. It never opens a
+	 * history transaction and returns `null` only when this retry key has not been admitted before.
+	 */
+	recover(command: RecoverConversationCreationReservationCommand): Promise<ReserveConversationCreationResult | null>;
 	/**
 	 * Advances an already-proven history anchor in a new serializable PostgreSQL operation.
 	 *

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -44,6 +44,14 @@ export { PrismaConversationAgentBindingUnitOfWork } from "./db/prisma-conversati
 export { ConversationAgentBindingResolver } from "./conversation-agent-binding-authority";
 export type { ConversationAgentBinding, ConversationAgentBindingAuthority as ConversationAgentBindingAuthorityPort, ConversationAgentBindingAuthorityDependencies, ConversationAgentBindingCommand, ConversationAgentBindingResult, ConversationAgentIdentitySelectionCommand, ConversationAgentIdentitySelector, ConversationManagedAgentPrincipalValidator } from "./conversation-agent-binding.types";
 export { ConversationAgentBindingDenialReasons } from "./conversation-agent-binding.types";
+export { HistoryAnchoredConversationCreationService } from "./conversation-creation-authority";
+export type { ConversationCreationAuthority, ConversationCreationAuthorityDependencies, ConversationCreationAuthorityResult, ConversationCreationClock, HistoryAnchoredConversationCreationAuthorityFactory } from "./conversation-creation-authority.types";
+export { PrismaConversationCreationCompilerUnitOfWork } from "./db/prisma-conversation-creation-compiler-unit-of-work";
+export { PrismaConversationCreationProjectionUnitOfWork } from "./db/prisma-conversation-creation-projection-unit-of-work";
+export { PrismaConversationCreationReservationUnitOfWork } from "./db/prisma-conversation-creation-reservation-unit-of-work";
+export { ConversationCreationAnchorVerifier } from "./conversation-creation-anchor-verifier";
+export { ConversationHistoryAuthority } from "./conversation-history-authority";
+export { HistoryAnchoredConversationCreationAuthority } from "./history-anchored-conversation-creation-authority";
 export { ConversationComputerSandboxReconciliationAuthority } from "./conversation-computer-sandbox-reconciliation-authority";
 export { ConversationComputerSandboxReconciliationOutcomes } from "./conversation-computer-sandbox-reconciliation-authority.types";
 export type { ConversationComputerSandboxReconciliationAuthorityDependencies, ConversationComputerSandboxReconciliationOutcome } from "./conversation-computer-sandbox-reconciliation-authority.types";

--- a/libs/backend/server/conversations/main/src/validators/conversation-creation.validator.ts
+++ b/libs/backend/server/conversations/main/src/validators/conversation-creation.validator.ts
@@ -16,12 +16,11 @@
  * `__tests__/self-conversations.router.test.ts`.
  *
  * The references themselves are still unproven after this file. They are resolved against current
- * membership and personal-Agent ownership inside the write transaction, in
- * `PrismaConversationMutationRepository._creationAuthority`, which is also where a duplicate
- * reference and the caller's own reference are refused. Nothing here can tell whether a reference
- * exists, and it deliberately does not try.
+ * membership and personal-Agent ownership inside the history-anchored creation compiler before its
+ * reservation transaction. That compiler also refuses a duplicate reference and the caller's own
+ * reference. Nothing here can tell whether a reference exists, and it deliberately does not try.
  *
- * @see PrismaConversationMutationRepository — resolves these references to real subjects.
+ * @see PrismaConversationCreationCompilerUnitOfWork — resolves these references to real subjects.
  * @see ___ConversationCreationRequestSchema in `@opencrane/models/conversations` — the same
  * per-mode participant rules over internal user ids, for values already inside the server.
  */
@@ -42,7 +41,7 @@ const _ReferenceSchema = z.string().trim().min(1).max(128);
 /**
  * Agent-session creation names the caller's own personal Agent and no participants.
  *
- * The reference is checked in the write transaction against the single Active personal
+ * The reference is checked by the server-side creation compiler against the single Active personal
  * AgentService built from the caller's approved persona revision, so naming somebody else's Agent
  * here is refused there rather than here.
  */

--- a/libs/frontend/state/conversation/workspace/src/lib/__tests__/conversation-workspace.store.spec.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/__tests__/conversation-workspace.store.spec.ts
@@ -217,6 +217,21 @@ describe("ConversationWorkspaceStore", function _ConversationWorkspaceStore()
 		expect(store.selected()?.id).toBe("conversation-1");
 	});
 
+	it("reuses the exact creation UUID after an ambiguous gateway failure", async function _RetriesCreate()
+	{
+		const [store, gateway] = _CreateStore();
+		gateway.historyResult = { status: ConversationOnboardingHistoryStatuses.NotRecorded, history: null };
+		await store.load();
+		store.selectCreationMode(ConversationModes.Direct);
+		store.toggleParticipant("other-ref");
+		gateway.createResult = Promise.reject(new Error("response lost"));
+		await expect(store.create()).resolves.toBeNull();
+		gateway.createResult = null;
+		await expect(store.create()).resolves.toEqual({ conversationId: "created-1" });
+		expect(gateway.created).toHaveLength(2);
+		expect(gateway.created[1]?.requestId).toBe(gateway.created[0]?.requestId);
+	});
+
 	it("does not navigate to a created conversation after the participant selects another row", async function _StaleCreate()
 	{
 		const [store, gateway] = _CreateStore();

--- a/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.store.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.store.ts
@@ -48,6 +48,8 @@ export class ConversationWorkspaceStore
 	private readonly _sending = signal(false);
 	/** Exact command retained after an ambiguous response so retry cannot duplicate the message. */
 	private _pendingMessage: SubmitConversationMessageCommand | null = null;
+	/** Retains the failed creation command so retry sends the same request id and cannot create another conversation. */
+	private _pendingCreation: CreateConversationCommand | null = null;
 	/** Whether a conversation command is active. */
 	private readonly _conversationCommandBusy = signal(false);
 	/** Browser-safe error for the latest failed operation. */
@@ -186,6 +188,7 @@ export class ConversationWorkspaceStore
 	{
 		this._creationMode.set(mode);
 		this._selectedParticipantRefs.set(new Set());
+		this._pendingCreation = null;
 		this._creationState.set(ConversationCreationStates.Idle);
 		this._error.set(null);
 	}
@@ -201,12 +204,20 @@ export class ConversationWorkspaceStore
 		else selected.add(participantRef);
 		if (this._creationMode() === ConversationModes.Direct && selected.size > 1) this._selectedParticipantRefs.set(new Set([participantRef]));
 		else this._selectedParticipantRefs.set(selected);
+		this._pendingCreation = null;
 	}
 
-	/** Create the exact selected immutable mode and adopt its returned snapshot. */
+	/**
+	 * Creates the selected mode and returns the server's conversation id for navigation.
+	 *
+	 * A gateway failure retains the complete command, including its request id, until the participant
+	 * changes the mode or selected coordinates. Retrying then lets the server resume the original
+	 * reservation instead of admitting another conversation.
+	 * @returns A navigation target after success, or `null` while the command is invalid, active, or failed.
+	 */
 	public async create(): Promise<ConversationWorkspaceNavigationIntent | null>
 	{
-		const command = this._CreateCommand();
+		const command = this._pendingCreation ?? this._CreateCommand();
 		if (command === null || this._creationState() === ConversationCreationStates.Creating) return null;
 		const generation = this._generation;
 		this._creationState.set(ConversationCreationStates.Creating);
@@ -215,12 +226,14 @@ export class ConversationWorkspaceStore
 		{
 			const detail = await this._gateway.create(command);
 			this._conversations.update(current => [detail, ...current.filter(candidate => candidate.id !== detail.id)]);
+			this._pendingCreation = null;
 			this._creationState.set(ConversationCreationStates.Idle);
 			if (generation !== this._generation) return null;
 			return { conversationId: detail.id };
 		}
 		catch (error)
 		{
+			this._pendingCreation = command;
 			this._creationState.set(ConversationCreationStates.Failed);
 			this._error.set(_Message(error, "OpenCrane could not create this conversation."));
 			return null;


### PR DESCRIPTION
## Summary

- mount one history-anchored creation authority into the public HTTP route and conversation socket composition
- make the signed-in conversation unit delegate creation to reservation, KurrentDB anchor confirmation, projection, and re-read rather than the direct Prisma create writer
- recover an existing caller-scoped request id and digest before compiling mutable participants or Agent facts
- retain the exact frontend request UUID after an ambiguous gateway failure

## Checkpoint boundary

- Direct and group conversation creation now uses the authoritative history path.
- Agent-session creation fails closed in this layer. The immediate child stack will provision the reservation-frozen `ConversationComputer` and publish its durable activation request before enabling the configured Agent profile selector. This avoids recording Agent conversations that have no runnable computer.
- The superseded direct relational create writer has no live caller; the immediate deletion child removes it and its creation-only port/import/test residue. Remaining message and lifecycle mutations continue to use that repository.

## Validation

- `npx nx run backend-server-conversations:test --skipNxCache` — 36 files, 241 tests
- `npx nx run opencrane:lint --skipNxCache`
- `npx nx run frontend-conversation-workspace-state:test --skipNxCache -- src/lib/__tests__/conversation-workspace.store.spec.ts` — 20 tests
- `npm run lint:boundaries`
- `npm run check:prisma-boundaries -- --diff feat/issue-759-mount-authoritative-creation`
- `scripts/agent-style-check.sh` and `git diff --check`

## Review

- independent correctness/security/residue review: no findings after the explicit Agent-session fail-closed boundary and retry-recovery fix
- post-change reaper retained only the direct creation writer for the explicitly sequenced deletion child
- documentation gate updated comments for the new transport, reservation-recovery, and projection boundaries

## Stack

- Base: #814 `feat/issue-759-mount-authoritative-creation`
- This PR: live transport cutover and durable retry recovery
- Next: provision the frozen ConversationComputer and durable activation before enabling Agent sessions, then delete the superseded direct create writer

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807 → #808 → #810 → #811 → #812 → #813 → #814 → #815