### PR TITLE
🔒 bind computer input to current PostgreSQL authority

### DIFF
--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -1860,6 +1860,18 @@
 				]
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-computer-participant-input-authorizer-unit-of-work.ts",
+				"adapter": "PrismaConversationComputerParticipantInputAuthorizerUnitOfWork",
+				"contract": "ConversationComputerParticipantInputAuthorizer",
+				"contractImportPath": "../conversation-computers/conversation-computer-participant-input-admission.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationComputerParticipantInputAuthorizationAuthority",
+						"importPath": "./prisma-conversation-computer-participant-input-authorizer"
+					}
+				]
+			},
+			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-compiler-unit-of-work.ts",
 				"adapter": "PrismaConversationCreationCompilerUnitOfWork",
 				"contract": "ConversationCreationCompiler",

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -694,6 +694,18 @@
 				]
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-computer-participant-input-authorizer.ts",
+				"adapter": "PrismaConversationComputerParticipantInputAuthorizationAuthority",
+				"contract": "ConversationComputerParticipantInputAuthorizer",
+				"contractImportPath": "../conversation-computers/conversation-computer-participant-input-admission.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationProductAuthorizationRepository",
+						"importPath": "./conversation-product-authorization"
+					}
+				]
+			},
+			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-repository.ts",
 				"adapter": "PrismaConversationCreationProjectionRepository",
 				"contract": "ConversationCreationProjectionRepository",

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -198,6 +198,12 @@ transport for workloads; it is not a browser fallback.
   append and `idempotent` for an exact response-lost retry. A later command worker may issue work
   from that entry only after the computer has an active execution; cold-start inputs therefore do
   not need an AgentRun.
+- `PrismaConversationComputerParticipantInputAuthorizerUnitOfWork` is the transaction-bound adapter
+  that checks current participant-input authority. It requires active organisation membership, continuing
+  participant access to an open Agent session, and the matching projected creation reservation
+  before it records `Conversation/Use`. The audit arguments retain the UUID input id and a text
+  digest, never plaintext; it returns only the creation-bound computer and server-derived human
+  display coordinates.
 - `ConversationComputerParticipantInputDispatchAuthority` replays those retained start entries when
   Sandbox reconciliation has admitted an execution and on each later bounded reconciliation pass.
   Each entry is narrowed to its text payload and passed in transcript order to the command authority,

--- a/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-computer-participant-input-authorizer.test.ts
+++ b/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-computer-participant-input-authorizer.test.ts
@@ -1,0 +1,97 @@
+import { createHash } from "node:crypto";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PrismaConversationComputerParticipantInputAuthorizationAuthority } from "../prisma-conversation-computer-participant-input-authorizer";
+import { PrismaConversationProductAuthorizationRepository } from "../conversation-product-authorization";
+import type { ConversationCaller } from "../../types/conversation-caller.types";
+
+/** Fixes the session-derived caller used by every current-authority test. */
+const _CALLER: ConversationCaller = { siloId: "testv5", principalId: "principal-1", subjectId: "subject-1", issuer: "https://issuer.example" };
+/** Fixes the immutable input id whose text never enters authorization arguments. */
+const _INPUT_ID = "31c1f1dc-0010-4f13-9c2f-d3841ffd6651";
+
+/** Builds transaction doubles whose reads retain the current target binding. */
+function _Database(overrides: { readonly membership?: { readonly displayName: string | null } | null; readonly conversation?: { readonly agentServiceId: string | null } | null; readonly reservation?: { readonly computerId: string | null; readonly agentServiceId: string | null } | null } = {})
+{
+	return {
+		orgMembership: { findFirst: vi.fn().mockResolvedValue(overrides.membership === undefined ? { displayName: "Jente" } : overrides.membership) },
+		conversation: { findFirst: vi.fn().mockResolvedValue(overrides.conversation === undefined ? { agentServiceId: "service-1" } : overrides.conversation) },
+		conversationCreationReservation: { findFirst: vi.fn().mockResolvedValue(overrides.reservation === undefined ? { computerId: "computer-1", agentServiceId: "service-1" } : overrides.reservation) },
+	};
+}
+
+/** Restores authorization seams so one denial case cannot influence another. */
+afterEach(function _RestoreMocks()
+{
+	vi.restoreAllMocks();
+});
+
+describe("PrismaConversationComputerParticipantInputAuthorizationAuthority", function _PrismaConversationComputerParticipantInputAuthorizationAuthoritySuite()
+{
+	it("returns only current server-derived computer and author coordinates after recording Use evidence", async function _AuthorizesCurrentParticipant()
+	{
+		const database = _Database();
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admit").mockResolvedValue(true);
+		const authorizer = new PrismaConversationComputerParticipantInputAuthorizationAuthority(database as never);
+
+		await expect(authorizer.authorize(_CALLER, "conversation-1", { inputId: _INPUT_ID, text: "Please prepare the release notes." })).resolves.toEqual({ computerId: "computer-1", author: { principalId: "principal-1", participantId: "subject-1", name: "Jente", avatarArtifactRevisionId: null } });
+
+		expect(admission).toHaveBeenCalledWith(_CALLER, { kind: "conversation", id: "conversation-1" }, "use", { inputId: _INPUT_ID, textDigest: `sha256:${createHash("sha256").update("Please prepare the release notes.", "utf8").digest("hex")}` });
+	});
+
+	it("does not record authorization evidence when current membership is unavailable", async function _DeniesInactiveMembership()
+	{
+		const database = _Database({ membership: null });
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admit");
+		const authorizer = new PrismaConversationComputerParticipantInputAuthorizationAuthority(database as never);
+
+		await expect(authorizer.authorize(_CALLER, "conversation-1", { inputId: _INPUT_ID, text: "Please prepare the release notes." })).resolves.toBeNull();
+
+		expect(database.conversation.findFirst).not.toHaveBeenCalled();
+		expect(admission).not.toHaveBeenCalled();
+	});
+
+	it("rejects a malformed input before it records a protected-action decision", async function _RejectsMalformedInput()
+	{
+		const database = _Database();
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admit");
+		const authorizer = new PrismaConversationComputerParticipantInputAuthorizationAuthority(database as never);
+
+		await expect(authorizer.authorize(_CALLER, "conversation-1", { inputId: "not-a-uuid", text: "Please prepare the release notes." })).resolves.toBeNull();
+
+		expect(database.orgMembership.findFirst).not.toHaveBeenCalled();
+		expect(admission).not.toHaveBeenCalled();
+	});
+
+	it("rejects a projected computer whose Agent service no longer matches the open conversation", async function _DeniesMismatchedBinding()
+	{
+		const database = _Database({ reservation: { computerId: "computer-1", agentServiceId: "service-2" } });
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admit");
+		const authorizer = new PrismaConversationComputerParticipantInputAuthorizationAuthority(database as never);
+
+		await expect(authorizer.authorize(_CALLER, "conversation-1", { inputId: _INPUT_ID, text: "Please prepare the release notes." })).resolves.toBeNull();
+
+		expect(admission).not.toHaveBeenCalled();
+	});
+
+	it("denies input when the current Conversation Use decision is refused", async function _DeniesRefusedUse()
+	{
+		const database = _Database();
+		const admission = vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admit").mockResolvedValue(false);
+		const authorizer = new PrismaConversationComputerParticipantInputAuthorizationAuthority(database as never);
+
+		await expect(authorizer.authorize(_CALLER, "conversation-1", { inputId: _INPUT_ID, text: "Please prepare the release notes." })).resolves.toBeNull();
+
+		expect(admission).toHaveBeenCalledOnce();
+	});
+
+	it("uses the authenticated subject when membership has no peer-visible display name", async function _UsesSubjectFallback()
+	{
+		const database = _Database({ membership: { displayName: "  " } });
+		vi.spyOn(PrismaConversationProductAuthorizationRepository.prototype, "admit").mockResolvedValue(true);
+		const authorizer = new PrismaConversationComputerParticipantInputAuthorizationAuthority(database as never);
+
+		await expect(authorizer.authorize(_CALLER, "conversation-1", { inputId: _INPUT_ID, text: "Please prepare the release notes." })).resolves.toMatchObject({ author: { name: "subject-1" } });
+	});
+});

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-computer-participant-input-authorizer-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-computer-participant-input-authorizer-unit-of-work.ts
@@ -1,0 +1,47 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
+
+import type { AuthorizedConversationComputerParticipantInput, ConversationComputerParticipantInputAuthorizer, ConversationComputerParticipantInputRequest } from "../conversation-computers/conversation-computer-participant-input-admission.types";
+import type { ConversationCaller } from "../types/conversation-caller.types";
+import { PrismaConversationComputerParticipantInputAuthorizationAuthority } from "./prisma-conversation-computer-participant-input-authorizer";
+
+/**
+ * Runs participant-input authorization in a serializable PostgreSQL transaction.
+ *
+ * Current membership, participant access, the open Agent session, its creation reservation, and the
+ * `Conversation/Use` evidence must describe the same decision. Retrying serialization conflicts
+ * avoids accepting an input from an earlier view; callers receive either a `null` refusal that does
+ * not disclose its cause or the coordinates allowed to enter immutable history.
+ *
+ * @implements {ConversationComputerParticipantInputAuthorizer}
+ * @see ConversationComputerParticipantInputAuthorizer for the public admission contract.
+ */
+export class PrismaConversationComputerParticipantInputAuthorizerUnitOfWork implements ConversationComputerParticipantInputAuthorizer
+{
+	/** Holds the root client that opens the serializable authorization transaction. */
+	public constructor(private readonly prisma: PrismaClient)
+	{
+	}
+
+	/**
+	 * Rechecks one input in the serializable snapshot before immutable history may append it.
+	 *
+	 * A non-null result carries the computer and author metadata for the append. A `null` result does
+	 * not disclose whether membership, participant access, the creation binding, or `Conversation/Use`
+	 * refused the request.
+	 *
+	 * @param caller - Identifies the authenticated principal and subject in the requesting silo.
+	 * @param conversationId - Names the conversation that the current PostgreSQL facts must authorize.
+	 * @param request - Supplies the UUID retry key and plaintext that is digested before audit storage.
+	 * @returns Append coordinates, or `null` when the current authorization check refused the input.
+	 */
+	public async authorize(caller: ConversationCaller, conversationId: string, request: ConversationComputerParticipantInputRequest): Promise<AuthorizedConversationComputerParticipantInput | null>
+	{
+		return ___RunInPrismaUnitOfWork(this.prisma, async function _Authorize(transaction): Promise<AuthorizedConversationComputerParticipantInput | null>
+		{
+			const authorizer = new PrismaConversationComputerParticipantInputAuthorizationAuthority(transaction);
+			return authorizer.authorize(caller, conversationId, request);
+		}, { isolationLevel: "Serializable", attemptLimit: 3, operation: "conversation computer participant input authorization" });
+	}
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-computer-participant-input-authorizer.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-computer-participant-input-authorizer.ts
@@ -1,0 +1,95 @@
+import { createHash } from "node:crypto";
+
+import { ConversationCreationReservationState, ConversationLifecycle, ConversationMode, OrgMemberStatus, type Prisma } from "@prisma/client";
+
+import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
+
+import type { AuthorizedConversationComputerParticipantInput, ConversationComputerParticipantInputAuthorizer, ConversationComputerParticipantInputRequest } from "../conversation-computers/conversation-computer-participant-input-admission.types";
+import type { ConversationCaller } from "../types/conversation-caller.types";
+import { PrismaConversationProductAuthorizationRepository } from "./conversation-product-authorization";
+
+/** Recognizes the UUID input identifiers that immutable conversation history accepts. */
+const _UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+/**
+ * Rechecks current PostgreSQL facts before participant input reaches immutable history.
+ *
+ * The caller uses this while its serializable transaction is open, so a membership, participant,
+ * conversation, or creation-reservation change cannot be accepted from an earlier read. It returns
+ * the creation-bound computer and server-owned author facts after it records `Conversation/Use`; it
+ * returns `null` without saying which current condition prevented the append.
+ *
+ * Called by: {@link PrismaConversationComputerParticipantInputAuthorizerUnitOfWork}.
+ * @implements {ConversationComputerParticipantInputAuthorizer}
+ * @see ConversationComputerParticipantInputAuthorizer for the public admission contract.
+ */
+export class PrismaConversationComputerParticipantInputAuthorizationAuthority implements ConversationComputerParticipantInputAuthorizer
+{
+	/** Holds the serializable transaction that binds membership and decision evidence together. */
+	public constructor(private readonly transaction: Prisma.TransactionClient)
+	{
+	}
+
+	/**
+	 * Checks a participant input against the current conversation and returns its append coordinates.
+	 *
+	 * `null` keeps the refusal private; a non-null result is the creation-bound computer and the
+	 * server-derived author metadata that immutable history may retain.
+	 *
+	 * @param caller - Identifies the authenticated principal and subject in the requesting silo.
+	 * @param conversationId - Names the conversation whose current access and creation binding must match.
+	 * @param request - Supplies the UUID retry key and plaintext that is digested before audit storage.
+	 * @returns The history append coordinates after `Conversation/Use` is recorded, or `null` on refusal.
+	 */
+	public async authorize(caller: ConversationCaller, conversationId: string, request: ConversationComputerParticipantInputRequest): Promise<AuthorizedConversationComputerParticipantInput | null>
+	{
+		if (!_ValidRequest(request))
+			return null;
+
+		// 1. Require current organisation membership before exposing a conversation's creation binding.
+		const membership = await this.transaction.orgMembership.findFirst({ where: { clusterTenant: caller.siloId, subject: caller.subjectId, status: OrgMemberStatus.Active }, select: { displayName: true } });
+		if (membership === null)
+			return null;
+
+		// 2. Bind the open Agent conversation to its projected creation reservation and continuing participant.
+		const conversation = await this.transaction.conversation.findFirst({
+			where: { id: conversationId, siloId: caller.siloId, mode: ConversationMode.AgentSession, lifecycle: ConversationLifecycle.Open, participants: { some: { userId: caller.subjectId, accessEndedPosition: null } } },
+			select: { agentServiceId: true },
+		});
+		if (conversation === null)
+			return null;
+		const reservation = await this.transaction.conversationCreationReservation.findFirst({
+			where: { siloId: caller.siloId, conversationId, state: ConversationCreationReservationState.Projected, mode: ConversationMode.AgentSession, computerId: { not: null } },
+			select: { computerId: true, agentServiceId: true },
+		});
+		if (reservation?.computerId === null || reservation?.computerId === undefined || reservation.agentServiceId !== conversation.agentServiceId)
+			return null;
+
+		// 3. Commit current `Use` evidence without retaining the participant's plaintext in the audit log.
+		const authorization = new PrismaConversationProductAuthorizationRepository(this.transaction);
+		const admitted = await authorization.admit(caller, { kind: ProductAuthorizationResourceKinds.Conversation, id: conversationId }, ProductAuthorizationActions.Use, _Arguments(request));
+		if (!admitted)
+			return null;
+		return { computerId: reservation.computerId, author: { principalId: caller.principalId, participantId: caller.subjectId, name: _DisplayName(membership.displayName, caller.subjectId), avatarArtifactRevisionId: null } };
+	}
+}
+
+/** Builds non-plaintext protected-action arguments for the authorization audit decision. */
+function _Arguments(request: ConversationComputerParticipantInputRequest): { readonly inputId: string; readonly textDigest: `sha256:${string}` }
+{
+	return { inputId: request.inputId, textDigest: `sha256:${createHash("sha256").update(request.text, "utf8").digest("hex")}` };
+}
+
+/** Returns a peer-visible author name without depending on an optional profile field. */
+function _DisplayName(displayName: string | null, subjectId: string): string
+{
+	if (displayName !== null && displayName.trim().length > 0)
+		return displayName.trim();
+	return subjectId;
+}
+
+/** Rejects malformed input before a protected-action decision can reach the audit log. */
+function _ValidRequest(request: ConversationComputerParticipantInputRequest): boolean
+{
+	return _UUID_PATTERN.test(request.inputId) && request.text.trim().length > 0 && Buffer.byteLength(request.text, "utf8") <= 64 * 1024;
+}

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -33,6 +33,7 @@ export { __CreateAgentThreadParentDeliveryRouter } from "./agent-thread-parent-d
 export { BoundConversationWriter } from "./bound-conversation-writer";
 export type { BoundConversationWriterAppend, BoundConversationWriterBinding, BoundConversationWriterClock, BoundConversationWriterLeaseFence, BoundConversationWriterRateLimiter, BoundConversationWriterVisibilityPolicy, ComputerConversationEntryDraft } from "./bound-conversation-writer.types";
 export { PrismaConversationPrivatePayloadStoreUnitOfWork } from "./db/prisma-conversation-private-payload-store-unit-of-work";
+export { PrismaConversationComputerParticipantInputAuthorizerUnitOfWork } from "./db/prisma-conversation-computer-participant-input-authorizer-unit-of-work";
 export { ConversationHistoryReader } from "./conversation-history-reader";
 export { __RunConversationComputerActivationListener } from "./conversation-computer-activation";
 export type { ConversationComputerActivationAuthority, ConversationComputerActivationCommand, ConversationComputerActivationOutcome, ConversationComputerActivationParked } from "./conversation-computer-activation.types";


### PR DESCRIPTION
## Summary

- add a transaction-local authority that rechecks active organisation membership, continuing participant access, an open Agent session, and the matching projected creation reservation before a participant input may enter ConversationComputer history
- bind the accepted append to the server-derived computer and author coordinates; invalid, stale, mismatched, or refused requests return a private `null` result
- record `Conversation/Use` audit evidence with the retry UUID and SHA-256 text digest only; plaintext input never enters the audit arguments
- expose the authority through a serializable, retrying unit of work and register the Prisma boundary contract

## Authority boundary

This layer is the PostgreSQL current-state decision immediately before the existing immutable-history authority. It does not persist a relational message copy or provide an AgentRun fallback. The downstream history authority remains responsible for immutable append, encryption, idempotency, and creation-binding replay checks.

## Validation

- `npx vitest run` from `libs/backend/server/conversations/main`: 3 focused files, 13 tests passed
- `npx nx run backend-server-conversations:lint --skipNxCache`
- `scripts/agent-style-check.sh`
- `npm run check:prisma-boundaries -- --diff feat/issue-759-project-computer-input`
- `npm run check:module-growth -- --diff feat/issue-759-project-computer-input`
- `npm run check:release-versioning`
- `npm run check:pr-stack-integrity -- --current-branch feat/issue-759-prisma-computer-input-authorizer`

## Review

- independent correctness and authority review: PASS
- documentation/comment gate: PASS
- this PR contains two cohesive commits: the authority plus denial coverage, then the serializable public unit of work and documentation

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807 → #808 → #810 → #811 → #812 → #813 → #814 → #815 → #816 → #817 → #818 → #819 → #821