### PR TITLE
📜 replay ConversationComputer input from immutable history

### DIFF
--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -706,6 +706,13 @@
 				]
 			},
 			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay-authorization-repository.ts",
+				"adapter": "PrismaConversationHistoryReplayAuthorizationRepository",
+				"contract": "ConversationHistoryReplayAuthorizationRepository",
+				"contractImportPath": "../replay-reader.types",
+				"constructs": []
+			},
+			{
 				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-creation-projection-repository.ts",
 				"adapter": "PrismaConversationCreationProjectionRepository",
 				"contract": "ConversationCreationProjectionRepository",
@@ -1868,6 +1875,18 @@
 					{
 						"adapter": "PrismaConversationComputerParticipantInputAuthorizationAuthority",
 						"importPath": "./prisma-conversation-computer-participant-input-authorizer"
+					}
+				]
+			},
+			{
+				"path": "libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay-unit-of-work.ts",
+				"adapter": "PrismaConversationHistoryReplayUnitOfWork",
+				"contract": "ConversationReplayUnitOfWork",
+				"contractImportPath": "../replay-reader.types",
+				"constructs": [
+					{
+						"adapter": "PrismaConversationHistoryReplayAuthorizationRepository",
+						"importPath": "./prisma-conversation-history-replay-authorization-repository"
 					}
 				]
 			},

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -2375,6 +2375,7 @@
 			"libs/backend/server/agents/artifacts/main/src/prisma-artifact-authority.composition.ts",
 			"libs/backend/server/conversation-assets/main/src/prisma-conversation-asset.composition.ts",
 			"libs/backend/server/conversations/main/src/db/prisma-conversation-replay.composition.ts",
+			"libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay.composition.ts",
 			"libs/backend/server/conversations/main/src/db/prisma-self-conversations.router.ts",
 			"libs/backend/agents/execution/elicitation/main/src/prisma-self-elicitation.router.ts",
 			"libs/backend/agents/execution/elicitation/main/src/prisma-elicitation-interrupt-reader.ts",

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -204,6 +204,10 @@ transport for workloads; it is not a browser fallback.
   before it records `Conversation/Use`. The audit arguments retain the UUID input id and a text
   digest, never plaintext; it returns only the creation-bound computer and server-derived human
   display coordinates.
+- `_CreateConversationHistoryReplayRepository` rechecks active membership and the participant's
+  visibility bounds before and after it reads `conversation-{id}`. It discards the immutable page
+  if access changed during the read, then decrypts only the selected text references for the
+  still-authorized participant; it never returns relational message or timeline rows.
 - `ConversationComputerParticipantInputDispatchAuthority` replays those retained start entries when
   Sandbox reconciliation has admitted an execution and on each later bounded reconciliation pass.
   Each entry is narrowed to its text payload and passed in transcript order to the command authority,

--- a/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-history-replay-unit-of-work.test.ts
+++ b/libs/backend/server/conversations/main/src/db/__tests__/prisma-conversation-history-replay-unit-of-work.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ConversationEntry } from "@opencrane/contracts";
+import { ConversationProjectionReadStatuses } from "@opencrane/backend/conversations/projection";
+
+import { PrismaConversationHistoryReplayUnitOfWork } from "../prisma-conversation-history-replay-unit-of-work";
+
+/** Fixes the current participant and conversation coordinates used by every replay command. */
+const _COMMAND = { conversationId: "conversation-1", siloId: "testv5", subjectId: "subject-1", cursor: null, limit: 20 };
+
+/** Builds the immutable human-authored input shape accepted by the history reader. */
+function _Entry(): ConversationEntry
+{
+	return {
+		schemaVersion: 1,
+		id: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651",
+		conversationId: "conversation-1",
+		position: "1",
+		author: { kind: "human", principalId: "principal-1", participantId: "subject-1", name: "Jente", avatarArtifactRevisionId: null },
+		provenance: "human-authored",
+		visibility: { audience: "conversation" },
+		runId: null,
+		causationId: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651",
+		correlationId: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651",
+		idempotencyKey: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651",
+		occurredAt: "2026-09-02T14:00:00.000Z",
+		attestation: null,
+		kind: "message",
+		state: "completed",
+		blocks: [{ id: "text", kind: "text", payloadRef: "payload://payload-1", ciphertextDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }],
+		replyToEntryId: null,
+		addressedAgentIdentityId: null,
+		activation: "start",
+	} as ConversationEntry;
+}
+
+/** Builds the next immutable message without reusing the first entry's idempotency coordinate. */
+function _NextEntry(): ConversationEntry
+{
+	const first = _Entry();
+	const id = "c1f1dc31-0010-4f13-9c2f-d3841ffd6651";
+	return { ...first, id, position: "2", causationId: id, correlationId: id, idempotencyKey: id };
+}
+
+/** Creates transaction doubles that can change the access decision between history reads. */
+function _Subject(memberships: readonly ({ readonly clusterTenant: string } | null)[] = [{ clusterTenant: "testv5" }, { clusterTenant: "testv5" }])
+{
+	const transaction = {
+		orgMembership: { findFirst: vi.fn().mockResolvedValueOnce(memberships[0]).mockResolvedValueOnce(memberships.length > 1 ? memberships[1] : memberships[0]) },
+		conversationParticipant: { findFirst: vi.fn().mockResolvedValue({ visibleFromPosition: 1n, accessEndedPosition: null }) },
+	};
+	const prisma = { $transaction: vi.fn(async function _Transaction(operation) { return operation(transaction); }) };
+	const conversations = { read: vi.fn().mockResolvedValue({ entries: [_Entry()] }) };
+	const payloads = { readText: vi.fn().mockResolvedValue("Hello from immutable history.") };
+	return { transaction, prisma, conversations, payloads, authority: new PrismaConversationHistoryReplayUnitOfWork(prisma as never, conversations as never, payloads) };
+}
+
+/** Restores test seams so a post-history revocation cannot affect another test. */
+afterEach(function _RestoreMocks()
+{
+	vi.restoreAllMocks();
+});
+
+describe("PrismaConversationHistoryReplayUnitOfWork", function _PrismaConversationHistoryReplayUnitOfWorkSuite()
+{
+	it("reads only current-authorized history and resolves the selected encrypted text reference", async function _ReplaysAuthorizedHistory()
+	{
+		const subject = _Subject();
+
+		await expect(subject.authority.readAuthorized(_COMMAND)).resolves.toEqual({
+			status: ConversationProjectionReadStatuses.Authorized,
+			rows: [expect.objectContaining({ conversationId: "conversation-1", position: "1", runId: null, type: "conversation.message", payload: { messageId: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651", role: "user", state: "completed", blocks: [{ id: "text", kind: "text", value: "Hello from immutable history." }] } })],
+		});
+
+		expect(subject.prisma.$transaction).toHaveBeenCalledTimes(2);
+		expect(subject.conversations.read).toHaveBeenCalledWith({ siloId: "testv5", conversationId: "conversation-1" });
+		expect(subject.payloads.readText).toHaveBeenCalledWith({ siloId: "testv5", conversationId: "conversation-1", idempotencyKey: "31c1f1dc-0010-4f13-9c2f-d3841ffd6651", payloadRef: "payload://payload-1", ciphertextDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+	});
+
+	it("does not read immutable history when current membership is unavailable", async function _RejectsMissingMembership()
+	{
+		const subject = _Subject([null]);
+
+		await expect(subject.authority.readAuthorized(_COMMAND)).resolves.toEqual({ status: ConversationProjectionReadStatuses.RevokedOrMissing, rows: [] });
+
+		expect(subject.conversations.read).not.toHaveBeenCalled();
+		expect(subject.payloads.readText).not.toHaveBeenCalled();
+	});
+
+	it("discards the immutable page when access is revoked during its read", async function _RejectsPostHistoryRevocation()
+	{
+		const subject = _Subject([{ clusterTenant: "testv5" }, null]);
+
+		await expect(subject.authority.readAuthorized(_COMMAND)).resolves.toEqual({ status: ConversationProjectionReadStatuses.RevokedOrMissing, rows: [] });
+
+		expect(subject.conversations.read).toHaveBeenCalledOnce();
+		expect(subject.payloads.readText).not.toHaveBeenCalled();
+	});
+
+	it("starts after a legacy cursor that has no AG-UI subframe", async function _SkipsCompletedLegacyCursor()
+	{
+		const subject = _Subject();
+		subject.conversations.read.mockResolvedValue({ entries: [_Entry(), _NextEntry()] });
+
+		const result = await subject.authority.readAuthorized({ ..._COMMAND, cursor: { conversationId: "conversation-1", position: "1" }, limit: 1 });
+
+		expect(result.rows).toEqual([expect.objectContaining({ position: "2" })]);
+	});
+
+	it("keeps a subframe-resume row without allowing it to consume the next history page", async function _CarriesSubframeResumeAndNewerRows()
+	{
+		const subject = _Subject();
+		subject.conversations.read.mockResolvedValue({ entries: [_Entry(), _NextEntry()] });
+
+		const result = await subject.authority.readAuthorized({ ..._COMMAND, cursor: { conversationId: "conversation-1", position: "1", subframe: 0 }, limit: 1 });
+
+		expect(result.rows).toEqual([expect.objectContaining({ position: "1" }), expect.objectContaining({ position: "2" })]);
+	});
+});

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay-authorization-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay-authorization-repository.ts
@@ -1,0 +1,41 @@
+import { OrgMemberStatus, type Prisma } from "@prisma/client";
+
+import type { ReadConversationProjectionCommand } from "@opencrane/backend/conversations/projection";
+
+import type { ConversationHistoryReplayAccess, ConversationHistoryReplayAuthorizationRepository as ConversationHistoryReplayAuthorizationRepositoryPort } from "../replay-reader.types";
+
+/** Reads current PostgreSQL access facts that bound a later immutable-history replay. */
+export class PrismaConversationHistoryReplayAuthorizationRepository implements ConversationHistoryReplayAuthorizationRepositoryPort
+{
+	/** Holds the transaction whose membership and participant facts form one access decision. */
+	public constructor(private readonly transaction: Prisma.TransactionClient)
+	{
+	}
+
+	/** Returns current visibility bounds without loading relational messages or timeline rows. */
+	public async readAccess(command: ReadConversationProjectionCommand): Promise<ConversationHistoryReplayAccess | null>
+	{
+		if (command.cursor !== null && command.cursor.conversationId !== command.conversationId)
+			return null;
+		const membership = await this.transaction.orgMembership.findFirst({ where: { clusterTenant: command.siloId, subject: command.subjectId, status: OrgMemberStatus.Active }, select: { clusterTenant: true } });
+		if (membership === null)
+			return null;
+		const participant = await this.transaction.conversationParticipant.findFirst({
+			where: { conversationId: command.conversationId, userId: command.subjectId, conversation: _ConversationAccess(command) },
+			select: { visibleFromPosition: true, accessEndedPosition: true },
+		});
+		return participant === null ? null : { visibleFromPosition: participant.visibleFromPosition, accessEndedPosition: participant.accessEndedPosition };
+	}
+}
+
+/** Requires child-thread viewers to retain current access to their immediate parent conversation. */
+function _ConversationAccess(command: ReadConversationProjectionCommand): Prisma.ConversationWhereInput
+{
+	return {
+		siloId: command.siloId,
+		OR: [
+			{ originAgentThread: { is: null } },
+			{ originAgentThread: { is: { parentConversation: { participants: { some: { userId: command.subjectId, accessEndedPosition: null } } } } } },
+		],
+	};
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay-unit-of-work.ts
@@ -1,0 +1,152 @@
+import { Prisma, type PrismaClient } from "@prisma/client";
+
+import { ConversationEntryKinds, type ConversationEntry } from "@opencrane/contracts";
+import { __EncodeConversationProjectionCursor, ConversationProjectionReadStatuses, type ConversationProjectionEventRow, type ConversationProjectionReadResult, type ReadConversationProjectionCommand } from "@opencrane/backend/conversations/projection";
+
+import { ConversationHistoryReader } from "../conversation-history-reader";
+import type { ConversationPrivatePayloadStore } from "../conversation-private-payload-store.types";
+import type { ConversationHistoryReplayAccess, ConversationReplayUnitOfWork } from "../replay-reader.types";
+import { PrismaConversationHistoryReplayAuthorizationRepository } from "./prisma-conversation-history-replay-authorization-repository";
+
+/** Names the human author class that maps to a participant-visible user message. */
+const _HUMAN_AUTHOR_KIND = "human";
+/** Names the agent author class that maps to a participant-visible assistant message. */
+const _AGENT_AUTHOR_KIND = "agent";
+/** Names the opaque text reference block that the protected payload store may redeem. */
+const _TEXT_BLOCK_KIND = "text";
+
+/** Replays authorized immutable conversation history after checking current PostgreSQL visibility twice. */
+export class PrismaConversationHistoryReplayUnitOfWork implements ConversationReplayUnitOfWork
+{
+	/** Holds the services that make access, immutable history, and protected bodies explicit. */
+	public constructor(private readonly prisma: PrismaClient, private readonly conversations: Pick<ConversationHistoryReader, "read">, private readonly payloads: Pick<ConversationPrivatePayloadStore, "readText">)
+	{
+	}
+
+	/** Returns a bounded history page only when current access still agrees after the immutable read. */
+	public async readAuthorized(command: ReadConversationProjectionCommand): Promise<ConversationProjectionReadResult>
+	{
+		const initial = await this._ReadAccess(command);
+		if (initial === null)
+			return _Revoked();
+		const history = await this.conversations.read({ siloId: command.siloId, conversationId: command.conversationId });
+		const final = await this._ReadAccess(command);
+		if (final === null)
+			return _Revoked();
+		return { status: ConversationProjectionReadStatuses.Authorized, rows: await this._Rows(command, history.entries, initial, final) };
+	}
+
+	/** Reads one current membership and participant visibility decision without spanning HistoryStore I/O. */
+	private async _ReadAccess(command: ReadConversationProjectionCommand): Promise<ConversationHistoryReplayAccess | null>
+	{
+		return this.prisma.$transaction(async function _Read(transaction): Promise<ConversationHistoryReplayAccess | null>
+		{
+			return new PrismaConversationHistoryReplayAuthorizationRepository(transaction).readAccess(command);
+		}, { isolationLevel: Prisma.TransactionIsolationLevel.RepeatableRead });
+	}
+
+	/** Filters current history to the overlap of both authorization snapshots and projects each safe row. */
+	private async _Rows(command: ReadConversationProjectionCommand, entries: readonly ConversationEntry[], initial: ConversationHistoryReplayAccess, final: ConversationHistoryReplayAccess): Promise<readonly ConversationProjectionEventRow[]>
+	{
+		const lowerBound = _Maximum(initial.visibleFromPosition, final.visibleFromPosition);
+		const upperBound = _Minimum(initial.accessEndedPosition, final.accessEndedPosition);
+		const cursorPosition = command.cursor === null ? lowerBound - 1n : _Position(command.cursor.position);
+		if (cursorPosition < lowerBound - 1n || (upperBound !== null && cursorPosition > upperBound))
+			return [];
+		const visible = entries.filter(function _Visible(entry)
+		{
+			const position = _Position(entry.position);
+			return position >= lowerBound && (upperBound === null || position <= upperBound);
+		});
+		const resumed = command.cursor?.subframe === undefined
+			? []
+			: visible.filter(function _Resumed(entry) { return _Position(entry.position) === cursorPosition; });
+		const newer = visible.filter(function _Newer(entry) { return _Position(entry.position) > cursorPosition; }).slice(0, command.limit);
+		const selected = command.cursor === null ? visible.slice(0, command.limit) : [...resumed, ...newer];
+		const unit = this;
+		return Promise.all(selected.map(function _Project(entry): Promise<ConversationProjectionEventRow>
+		{
+			return unit._Row(command, entry);
+		}));
+	}
+
+	/** Decrypts only text blocks selected from an already-authorized immutable message entry. */
+	private async _Row(command: ReadConversationProjectionCommand, entry: ConversationEntry): Promise<ConversationProjectionEventRow>
+	{
+		if (entry.kind !== ConversationEntryKinds.Message)
+			return _UnknownRow(command.conversationId, entry);
+		const text = await _Text(entry, command.siloId, this.payloads);
+		return {
+			cursor: __EncodeConversationProjectionCursor({ conversationId: command.conversationId, position: entry.position }),
+			conversationId: command.conversationId,
+			position: entry.position,
+			runId: entry.runId,
+			type: "conversation.message",
+			payload: { messageId: entry.id, role: _Role(entry), state: entry.state, blocks: text === null ? [] : [{ id: "text", kind: "text", value: text }] },
+			occurredAt: entry.occurredAt,
+		};
+	}
+}
+
+/** Returns a private revoked result without distinguishing a missing conversation from lost access. */
+function _Revoked(): ConversationProjectionReadResult
+{
+	return { status: ConversationProjectionReadStatuses.RevokedOrMissing, rows: [] };
+}
+
+/** Converts a known history entry position to a nonnegative bigint before range comparison. */
+function _Position(position: string): bigint
+{
+	if (!/^[1-9][0-9]*$/u.test(position))
+		throw new Error("Conversation history replay requires positive stream positions");
+	return BigInt(position);
+}
+
+/** Keeps the stricter lower visibility boundary observed before or after the immutable read. */
+function _Maximum(left: bigint, right: bigint): bigint
+{
+	return left > right ? left : right;
+}
+
+/** Keeps the stricter access end observed before or after the immutable read. */
+function _Minimum(left: bigint | null, right: bigint | null): bigint | null
+{
+	if (left === null)
+		return right;
+	if (right === null)
+		return left;
+	return left < right ? left : right;
+}
+
+/** Turns non-message history entries into opaque public events while preserving their cursor order. */
+function _UnknownRow(conversationId: string, entry: ConversationEntry): ConversationProjectionEventRow
+{
+	return { cursor: __EncodeConversationProjectionCursor({ conversationId, position: entry.position }), conversationId, position: entry.position, runId: _RunId(entry), type: `conversation.${entry.kind}`, payload: {}, occurredAt: entry.occurredAt };
+}
+
+/** Selects a run coordinate only from entry kinds that retain one. */
+function _RunId(entry: ConversationEntry): string | null
+{
+	return "runId" in entry && typeof entry.runId === "string" ? entry.runId : null;
+}
+
+/** Maps only server-stamped author classes onto the legacy public message vocabulary. */
+function _Role(entry: Extract<ConversationEntry, { readonly kind: "message" }>): "assistant" | "user" | "system"
+{
+	if (entry.author.kind === _HUMAN_AUTHOR_KIND)
+		return "user";
+	if (entry.author.kind === _AGENT_AUTHOR_KIND)
+		return "assistant";
+	return "system";
+}
+
+/** Redeems one immutable text reference only after replay selected its exact entry. */
+async function _Text(entry: Extract<ConversationEntry, { readonly kind: "message" }>, siloId: string, payloads: Pick<ConversationPrivatePayloadStore, "readText">): Promise<string | null>
+{
+	const block = entry.blocks.find(function _TextBlock(candidate) { return candidate.kind === _TEXT_BLOCK_KIND; });
+	if (block === undefined || block.kind !== _TEXT_BLOCK_KIND)
+		return null;
+	if (!block.payloadRef.startsWith("payload://") || !/^sha256:[0-9a-f]{64}$/iu.test(block.ciphertextDigest))
+		throw new Error("Conversation history replay requires a valid protected text reference");
+	return payloads.readText({ siloId, conversationId: entry.conversationId, idempotencyKey: entry.id, payloadRef: block.payloadRef as `payload://${string}`, ciphertextDigest: block.ciphertextDigest as `sha256:${string}` });
+}

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay.composition.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-history-replay.composition.ts
@@ -1,0 +1,14 @@
+import type { PrismaClient } from "@prisma/client";
+
+import type { HistoryStore } from "@opencrane/backend/server/infra/history-store";
+
+import { ConversationHistoryReader } from "../conversation-history-reader";
+import type { ConversationPrivatePayloadStore } from "../conversation-private-payload-store.types";
+import type { ConversationReplayUnitOfWork } from "../replay-reader.types";
+import { PrismaConversationHistoryReplayUnitOfWork } from "./prisma-conversation-history-replay-unit-of-work";
+
+/** Builds the history-backed replay port that public transports use after the AgentSession cutover. */
+export function _CreateConversationHistoryReplayRepository(prisma: PrismaClient, historyStore: Pick<HistoryStore, "readHead" | "readStream">, payloads: Pick<ConversationPrivatePayloadStore, "readText">): ConversationReplayUnitOfWork
+{
+	return new PrismaConversationHistoryReplayUnitOfWork(prisma, new ConversationHistoryReader(historyStore), payloads);
+}

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -34,6 +34,8 @@ export { BoundConversationWriter } from "./bound-conversation-writer";
 export type { BoundConversationWriterAppend, BoundConversationWriterBinding, BoundConversationWriterClock, BoundConversationWriterLeaseFence, BoundConversationWriterRateLimiter, BoundConversationWriterVisibilityPolicy, ComputerConversationEntryDraft } from "./bound-conversation-writer.types";
 export { PrismaConversationPrivatePayloadStoreUnitOfWork } from "./db/prisma-conversation-private-payload-store-unit-of-work";
 export { PrismaConversationComputerParticipantInputAuthorizerUnitOfWork } from "./db/prisma-conversation-computer-participant-input-authorizer-unit-of-work";
+export { PrismaConversationHistoryReplayUnitOfWork } from "./db/prisma-conversation-history-replay-unit-of-work";
+export { _CreateConversationHistoryReplayRepository } from "./db/prisma-conversation-history-replay.composition";
 export { ConversationHistoryReader } from "./conversation-history-reader";
 export { __RunConversationComputerActivationListener } from "./conversation-computer-activation";
 export type { ConversationComputerActivationAuthority, ConversationComputerActivationCommand, ConversationComputerActivationOutcome, ConversationComputerActivationParked } from "./conversation-computer-activation.types";

--- a/libs/backend/server/conversations/main/src/replay-reader.types.ts
+++ b/libs/backend/server/conversations/main/src/replay-reader.types.ts
@@ -1,5 +1,21 @@
 import type { ConversationProjectionReadResult, ReadConversationProjectionCommand } from "@opencrane/backend/conversations/projection";
 
+/** Holds the immutable bounds an authorized participant may read from one conversation history. */
+export interface ConversationHistoryReplayAccess
+{
+	/** Opens the participant-visible range at this stream position. */
+	readonly visibleFromPosition: bigint;
+	/** Closes the participant-visible range at this stream position, or leaves it open. */
+	readonly accessEndedPosition: bigint | null;
+}
+
+/** Rechecks current membership and participant visibility before immutable history is read or emitted. */
+export interface ConversationHistoryReplayAuthorizationRepository
+{
+	/** Returns the current participant-visible bounds, or `null` when the caller has no access. */
+	readAccess(command: ReadConversationProjectionCommand): Promise<ConversationHistoryReplayAccess | null>;
+}
+
 /** Read-only transaction boundary exposed to replay transport and projection orchestration. */
 export interface ConversationReplayUnitOfWork
 {


### PR DESCRIPTION
## Summary

- add the history-backed conversation replay unit that checks active membership and participant visibility in PostgreSQL before and after reading `conversation-{id}` from KurrentDB
- apply the overlap of both access snapshots before projecting any row, so a participant revoked during replay receives no page and no protected payload is decrypted
- redeem only server-selected opaque text references through the private-payload store; the adapter never reads relational `ConversationMessage` or `ConversationTimelineEntry` rows
- preserve WebSocket cursor semantics: a subframe-resume row is retained without consuming the next page, while a legacy cursor starts strictly after its acknowledged position

## Boundary

This is the replay prerequisite for the public AgentSession input cutover. It supplies the transcript source that matches the history-first input writer from #819–#821. It is not mounted yet: the following checkpoint will switch both HTTP and WebSocket transport together and delete the AgentSession `PersonalRunAdmissionPort.admitPersonalRun` branch, with no dual-path fallback.

## Validation

- focused Vitest: history replay plus participant-input admission/authorizer — 13 tests passed
- `npx nx run backend-server-conversations:lint --skipNxCache`
- `npm run check:prisma-boundaries -- --diff feat/issue-759-prisma-computer-input-authorizer`
- `scripts/agent-style-check.sh --diff feat/issue-759-prisma-computer-input-authorizer`
- `npm run check:module-growth -- --diff feat/issue-759-prisma-computer-input-authorizer`
- `npm run check:release-versioning`
- `npm run check:pr-stack-integrity -- --current-branch feat/issue-759-mount-computer-input`

## Review

- independent correctness review caught and verified the `limit: 1` cursor-resumption regression
- focused maintainability review: PASS
- documentation/comment gate: PASS
- two cohesive commits: replay authority and regressions, then reusable composition/export

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807 → #808 → #810 → #811 → #812 → #813 → #814 → #815 → #816 → #817 → #818 → #819 → #821 → #822