### PR TITLE
🌐 route AgentSession input through ConversationComputer

### DIFF
--- a/apps/opencrane/src/app/public-app.ts
+++ b/apps/opencrane/src/app/public-app.ts
@@ -20,6 +20,7 @@ import { _RegisterRoutes } from "./routes";
 import { _CreateHttpRequestLogger } from "./telemetry";
 import type { McpRuntimeComposition } from "./mcp-runtime-composition.types";
 import type { ProviderEffectCommandExecutor } from "@opencrane/backend/server/gateways/providers";
+import type { ConversationComputerParticipantInputAdmission } from "@opencrane/backend/server/conversations";
 import type { ConversationCreationAuthority } from "@opencrane/backend/server/conversations";
 
 /**
@@ -56,7 +57,7 @@ export function _CreatePublicAuthentication(prisma: PrismaClient, customApi: k8s
  * @param mcpWorkflows - Shared transaction and worker authority for saved MCP jobs.
  * @returns The public Express listener before the lifecycle starts it.
  */
-export function _CreatePublicApp(prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, personalRunAdmission: PersonalRunAdmissionPort, runCancellation: RunCancellationRepository & SelfRunCancellationRepository, retryInputCompiler: RetryRunInputCompiler, creation: ConversationCreationAuthority, authentication: PublicAuthenticationComposition, artifactScannerEnabled: boolean, health: PublicHealthReportReader, mcpWorkflows: McpWorkflowComposition, mcpRuntime: McpRuntimeComposition, providerEffects: ProviderEffectCommandExecutor): Express
+export function _CreatePublicApp(prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, personalRunAdmission: PersonalRunAdmissionPort, runCancellation: RunCancellationRepository & SelfRunCancellationRepository, retryInputCompiler: RetryRunInputCompiler, creation: ConversationCreationAuthority, computerInputs: Pick<ConversationComputerParticipantInputAdmission, "admit"> | null, authentication: PublicAuthenticationComposition, artifactScannerEnabled: boolean, health: PublicHealthReportReader, mcpWorkflows: McpWorkflowComposition, mcpRuntime: McpRuntimeComposition, providerEffects: ProviderEffectCommandExecutor): Express
 {
 	const app = express();
 
@@ -83,7 +84,7 @@ export function _CreatePublicApp(prisma: PrismaClient, runAdmission: ManagedRunA
 		app.use(organizationMembers.productAccess);
 
 	// 5. Mount authenticated product routes, then terminate failures through one structured handler.
-	_RegisterRoutes(app, prisma, runAdmission, personalRunAdmission, runCancellation, retryInputCompiler, creation, artifactScannerEnabled, organizationMembers.router, mcpWorkflows, mcpRuntime, providerEffects);
+	_RegisterRoutes(app, prisma, runAdmission, personalRunAdmission, runCancellation, retryInputCompiler, creation, computerInputs, artifactScannerEnabled, organizationMembers.router, mcpWorkflows, mcpRuntime, providerEffects);
 	app.use(_ErrorHandler(_log));
 	return app;
 }

--- a/apps/opencrane/src/app/routes.ts
+++ b/apps/opencrane/src/app/routes.ts
@@ -19,7 +19,7 @@ import { _CreatePersonaOnboardingRouter } from "@opencrane/backend/agents/person
 import { type UserOnboardingOwnerResolver } from "@opencrane/backend/server/agents/onboarding";
 import { _CreatePersonalArtifactCatalogueRouter } from "@opencrane/backend/server/agents/artifacts";
 import { _CreatePersonalConfigurationRouter } from "@opencrane/backend/agents/personal/configuration";
-import { _CreateSelfConversationsRouter, type ConversationCreationAuthority } from "@opencrane/backend/server/conversations";
+import { _CreateSelfConversationsRouter, type ConversationComputerParticipantInputAdmission, type ConversationCreationAuthority } from "@opencrane/backend/server/conversations";
 import { _CreateConversationAttachmentAdmission, __CreateConversationAssetRouter } from "@opencrane/backend/server/conversation-assets";
 import { _CreateSelfRunCancellationRouter, _CreateSelfRunStatusRouter, type RetryRunInputCompiler, type RunCancellationRepository, type SelfRunCancellationRepository } from "@opencrane/backend/agents/execution/runs";
 import type { PersonalRunAdmissionPort } from "@opencrane/backend/agents/execution/admission";
@@ -57,7 +57,7 @@ import type { McpRuntimeComposition } from "./mcp-runtime-composition.types";
  * @param mcpWorkflows - Shared guarded workflow engine plus saved MCP task authorities.
  * @returns The configured public listener.
  */
-export function _RegisterRoutes(app: Express, prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, personalRunAdmission: PersonalRunAdmissionPort, runCancellation: RunCancellationRepository & SelfRunCancellationRepository, retryInputCompiler: RetryRunInputCompiler, creation: ConversationCreationAuthority, artifactScannerEnabled: boolean, organizationMembersRouter: Router, mcpWorkflows: McpWorkflowComposition, mcpRuntime: McpRuntimeComposition, providerEffects: ProviderEffectCommandExecutor): Express
+export function _RegisterRoutes(app: Express, prisma: PrismaClient, runAdmission: ManagedRunAdmissionPort, personalRunAdmission: PersonalRunAdmissionPort, runCancellation: RunCancellationRepository & SelfRunCancellationRepository, retryInputCompiler: RetryRunInputCompiler, creation: ConversationCreationAuthority, computerInputs: Pick<ConversationComputerParticipantInputAdmission, "admit"> | null, artifactScannerEnabled: boolean, organizationMembersRouter: Router, mcpWorkflows: McpWorkflowComposition, mcpRuntime: McpRuntimeComposition, providerEffects: ProviderEffectCommandExecutor): Express
 {
 	const onboarding = _CreateUserOnboardingComposition(prisma, _log, _ResolveUserOnboardingOwner);
 	const principalDirectory = new PrismaAuthenticatedPrincipalDirectoryUnitOfWork(prisma);
@@ -80,7 +80,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, runAdmission
 		{ method: "use", path: "/api/v1/me/runs", handler: _CreateSelfRunStatusRouter(prisma, _log) },
 		{ method: "use", path: "/api/v1/me/runs", handler: _CreateSelfRunCancellationRouter(runCancellation, _log) },
 		{ method: "use", path: "/api/v1/me/configuration", handler: _CreatePersonalConfigurationRouter(prisma, _log) },
-		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfConversationsRouter(prisma, personalRunAdmission, mcpWorkflows.execution, retryInputCompiler, _CreateConversationAttachmentAdmission, creation, _log) },
+		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfConversationsRouter(prisma, personalRunAdmission, mcpWorkflows.execution, retryInputCompiler, _CreateConversationAttachmentAdmission, creation, computerInputs, _log) },
 		{ method: "use", path: "/api/v1/me/conversations", handler: __CreateConversationAssetRouter({ resolveCaller: _ResolveConversationAssetCaller, authority: _CreateConversationAssetAuthority(prisma, process.env, artifactScannerEnabled), logger: _log }) },
 		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfElicitationRouter(prisma, _log) },
 		{ method: "use", path: "/api/v1/me/activity", handler: _CreateSelfElicitationActivityRouter(prisma, _log) },

--- a/apps/opencrane/src/index.ts
+++ b/apps/opencrane/src/index.ts
@@ -5,10 +5,11 @@ import "./app/instrument";
 import type { PrismaClient } from "@prisma/client";
 import { __CreateManagedRunAdmissionPort, __CreatePersonalRunAdmissionPort, __ReadRunAdmissionConcurrencyPolicy, _CreateRunAdmissionCapacityGate } from "@opencrane/backend/agents/execution/admission";
 import { _CreateElicitationInterruptReader } from "@opencrane/backend/agents/execution/elicitation";
-import { ConversationComputerActivationClaimAuthority, ConversationComputerExecutionAuthority, ConversationComputerHistory, ConversationComputerParticipantInputDispatchAuthority, ConversationComputerRuntimeCommandAuthority, ConversationComputerSandboxReconciliationAuthority, ConversationHistoryReader, _CreatePrismaSelfConversationSocketServer } from "@opencrane/backend/server/conversations";
+import { ConversationComputerActivationClaimAuthority, ConversationComputerExecutionAuthority, ConversationComputerHistory, ConversationComputerParticipantInputAdmission, ConversationComputerParticipantInputAuthority, ConversationComputerParticipantInputDispatchAuthority, ConversationComputerRuntimeCommandAuthority, ConversationComputerSandboxReconciliationAuthority, ConversationHistoryReader, PrismaConversationComputerParticipantInputAuthorizerUnitOfWork, PrismaConversationPrivatePayloadStoreUnitOfWork, _CreatePrismaSelfConversationSocketServer } from "@opencrane/backend/server/conversations";
 import type { ConversationComputerActivationAuthority } from "@opencrane/backend/server/conversations";
 import { _CreateConversationAttachmentAdmission } from "@opencrane/backend/server/conversation-assets";
 import { _KubernetesAgentSandboxClaimAuthority, _KubernetesAgentSandboxClaimObservationReader, _KubernetesAgentSandboxRuntimePodReader } from "@opencrane/backend/server/infra/agent-sandbox-claims";
+import { MountedConversationPayloadCipher } from "@opencrane/backend/server/infra/conversation-payloads";
 import { ___BindConsole } from "@opencrane/backend/observability";
 
 import { _ReadProcessConfig } from "./app/config";
@@ -72,6 +73,7 @@ async function _Main(): Promise<void>
 	let conversationComputerSandboxReconciliationAuthority: ConversationComputerSandboxReconciliationAuthority | null = null;
 	let conversationComputerExecutionAuthority: ConversationComputerExecutionAuthority | null = null;
 	let conversationComputerParticipantInputDispatchAuthority: ConversationComputerParticipantInputDispatchAuthority | null = null;
+	let conversationComputerParticipantInputs: ConversationComputerParticipantInputAdmission | null = null;
 	if (config.runtime.conversationComputerActivation !== null)
 	{
 		const profiles = _CreateConversationComputerActivationProfileResolver(config.runtime.conversationComputerActivation, config.runtime.siloId);
@@ -89,6 +91,14 @@ async function _Main(): Promise<void>
 			clock: { now: function _Now() { return new Date(); } },
 		});
 		conversationComputerExecutionAuthority = new ConversationComputerExecutionAuthority(new ConversationComputerHistory(historyStore.historyStore), { now: function _Now() { return new Date(); } });
+		const conversationPayloads = new PrismaConversationPrivatePayloadStoreUnitOfWork(prisma, new MountedConversationPayloadCipher(config.runtime.conversationPayloadKeyringPath!));
+		const participantInputs = new ConversationComputerParticipantInputAuthority({
+			history: historyStore.historyStore,
+			conversations: new ConversationHistoryReader(historyStore.historyStore),
+			payloads: conversationPayloads,
+			clock: { now: function _Now() { return new Date(); } },
+		});
+		conversationComputerParticipantInputs = new ConversationComputerParticipantInputAdmission(new PrismaConversationComputerParticipantInputAuthorizerUnitOfWork(prisma), participantInputs);
 		const commands = new ConversationComputerRuntimeCommandAuthority({ history: historyStore.historyStore, computers: new ConversationComputerHistory(historyStore.historyStore), clock: { now: function _Now() { return new Date(); } } });
 		conversationComputerParticipantInputDispatchAuthority = new ConversationComputerParticipantInputDispatchAuthority({ conversations: new ConversationHistoryReader(historyStore.historyStore), commands });
 	}
@@ -96,10 +106,10 @@ async function _Main(): Promise<void>
 	// 5. Build separate HTTP listeners; only the internal app receives workload-only routes.
 	const authentication = _CreatePublicAuthentication(prisma, kubernetes.customApi, config.standaloneFirstUserAdmission);
 	const publicHealth = ___CreatePublicHealthReportReader(prisma, config, _log);
-	const publicApp = _CreatePublicApp(prisma, managedRunAdmission, personalRunAdmission, runCancellation, executionSubjects.retryInputCompiler, conversationCreation, authentication, config.runtime.artifactScannerEnabled, publicHealth, workflows, mcpRuntime, providerEffects);
+	const publicApp = _CreatePublicApp(prisma, managedRunAdmission, personalRunAdmission, runCancellation, executionSubjects.retryInputCompiler, conversationCreation, conversationComputerParticipantInputs, authentication, config.runtime.artifactScannerEnabled, publicHealth, workflows, mcpRuntime, providerEffects);
 	publicApp.locals.artifactUploadGateway = _CreateArtifactUploadGateway(prisma, workflows.execution);
 	const internalApp = _CreateInternalApp(prisma, kubernetes.authApi, config.runtime, authentication.sessionMiddleware, mcpRuntime, workflows.execution, historyStore.historyStore);
-	const conversationSockets = _CreatePrismaSelfConversationSocketServer(prisma, personalRunAdmission, workflows.execution, executionSubjects.retryInputCompiler, _CreateConversationAttachmentAdmission, conversationCreation, _log, _CreateConversationSocketAuthenticator(authentication.sessionMiddleware, authentication.authMiddleware), { interrupts: _CreateElicitationInterruptReader(prisma), shutdownSignal: _ProcessShutdownSignal });
+	const conversationSockets = _CreatePrismaSelfConversationSocketServer(prisma, personalRunAdmission, workflows.execution, executionSubjects.retryInputCompiler, _CreateConversationAttachmentAdmission, conversationCreation, conversationComputerParticipantInputs, _log, _CreateConversationSocketAuthenticator(authentication.sessionMiddleware, authentication.authMiddleware), { interrupts: _CreateElicitationInterruptReader(prisma), shutdownSignal: _ProcessShutdownSignal });
 	const conversationComputerActivation: OpenCraneConversationComputerActivationWorker | null = conversationComputerActivationAuthority === null
 		? null
 		: await _StartConversationComputerActivationWorker(historyStore.historyStore, conversationComputerActivationAuthority, config.runtime.siloId);

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -11,16 +11,16 @@ not bind an agent and their ordinary messages never manufacture runs.
 
 ```
  authenticated participant
-          │ directory · list · create · open · message · retry run · archive · close · replay
+          │ directory · list · create · open · input · message · retry run · archive · close · replay
           ▼
  ┌──────────────────────────────────────────┐
  │ conversations  ◄── HERE                   │
  │ immutable mode · participant coordinates │
  │ atomic admission · authorised event read │
  └──────────────────────────────────────────┘
-          │ agent-session message       │ direct/group message
+          │ AgentSession input           │ direct/group message
           ▼                             ▼
- execution/admission              canonical message only
+ ConversationComputer history     canonical message only
 ```
 
 **In this flow:** [execution admission](../../../agents/execution/admission/main/README.md) ·
@@ -29,15 +29,17 @@ not bind an agent and their ordinary messages never manufacture runs.
 [AG-UI browser state](../../../../frontend/state/conversation/ag-ui/README.md)
 
 Message admission dispatches through the persisted mode strategy. A direct or group message commits
-as a canonical message without an `AgentRun`. An agent-session message enters the internal personal
-run-admission port so the message, immutable input snapshot, run, and first dispatch intent commit in
-one transaction. A single active foreground run blocks another agent-session message. The public API
-does not expose a separate run-start route.
+as a canonical message without an `AgentRun`. An AgentSession rejects that message path. Its dedicated
+`input` contract rechecks current access, encrypts one text body, and appends the opaque reference to
+immutable ConversationComputer history. The reconciliation worker later issues a start-turn command
+when the creation-bound computer has an active execution. The public API does not expose a separate
+run-start route.
 
 The general conversation unit of work owns participant reads and aggregate lifecycle writes. A
-dedicated message-admission unit owns submission routing, retry recovery, denial translation, and
-the handoff into execution admission's authoritative final transaction. Conversation composition
-supplies the route facts and the required execution-inputs compiler. The runs package then checks
+dedicated message-admission unit owns direct and group submission routing, retry recovery, and denial
+translation. ConversationComputer participant-input admission owns the AgentSession write and never
+falls back to message or execution admission. Conversation composition supplies the route facts and
+the required execution-inputs compiler. The runs package then checks
 replay, requester, run, and service authority, requires its compiler to recheck the next attempt's
 AgentIdentity, membership, capability decision, and computer lease, and commits its
 immutable snapshot through the same serializable compare-and-swap. Browser requester coordinates
@@ -131,14 +133,15 @@ the tool, while credentials and provider details are never exposed.
 The server rechecks organisation membership and participant bounds on every page. The public
 browser transport is one same-origin WebSocket: it restores the signed-in cookie session during the
 upgrade, rejects a mismatched origin, replays the canonical timeline as structured frames, and
-accepts only idempotent participant-message commands. Projection pauses when a peer is congested
+accepts direct/group message commands plus the separate AgentSession immutable-input command.
+Projection pauses when a peer is congested
 and rechecks access before every replay page, so revocation closes the socket instead of becoming an
 empty successful stream. The separate internal replay route remains a one-use channel-context
 transport for workloads; it is not a browser fallback.
 
 ## Public surface
 
-- `_CreateSelfConversationsRouter` composes the privacy-safe creation directory, participant-bound list, create, open, message,
+- `_CreateSelfConversationsRouter` composes the privacy-safe creation directory, participant-bound list, create, open, AgentSession input, direct/group message,
   Agent-thread mark-read, failed-run retry, archive, and close API over Prisma and the internal
   execution ports. Retry accepts only the observed terminal attempt; all
   identity and authority coordinates come from the signed-in route and are rechecked transactionally.
@@ -146,7 +149,7 @@ transport for workloads; it is not a browser fallback.
   access-ending races cannot expose later events.
 - `__CreateConversationReplayRouter` mounts internal context-authorized AG-UI snapshot-to-live replay.
 - `_CreatePrismaSelfConversationSocketServer` composes the signed-in participant WebSocket from the
-  same message authority and replay repository as the REST conversation metadata API.
+  direct/group message authority, the AgentSession history-input authority, and the replay repository.
 - `_SelfConversationsOpenapiPaths` contributes the remaining REST metadata and lifecycle APIs to the
   server-owned OpenAPI document.
 - `BoundConversationWriter` is a one-use, stream-bound KurrentDB append boundary for a currently
@@ -267,9 +270,9 @@ transport for workloads; it is not a browser fallback.
 ## Boundary
 
 The self API receives only server-derived session and host identity. It never accepts silo,
-membership, user, agent authority, or run identifiers as browser-selected trust facts. It creates a
-run only by calling the internal execution-admission port for an eligible agent-session message; it
-does not assemble inputs, dispatch workloads, or execute agents. The channel replay route separately
+membership, user, agent authority, or run identifiers as browser-selected trust facts. AgentSession
+input becomes immutable history before the computer command worker can issue work; the browser does
+not assemble inputs, dispatch workloads, or execute agents. The channel replay route separately
 requires a consumed one-use context and the exact controller-selected route identifier.
 
 Missing, foreign, closed, access-ended, wrong-mode, duplicate-body, and active-run writes fail
@@ -292,8 +295,9 @@ import an app, frontend state, or deployment package.
 Owns participant-facing operations over `Conversation`, `ConversationParticipant`,
 `ConversationMessage`, and `ConversationTimelineEntry`. The write authority uses serialisable
 transactions and projects create, archive, and close results from the same authorised write
-snapshot. Message admission separately uses serialisable ordinary-message writes and binds agent
-messages to execution admission's final transaction. The replay adapter is read-only and joins
+snapshot. Message admission separately uses serialisable ordinary-message writes. AgentSession input
+uses its own transaction to recheck current authority before appending immutable history. The replay
+adapter is read-only and joins
 timeline references to canonical messages and `RunEvent`; neither path
 reconstructs order from client or run timestamps. All paths depend on current active `OrgMembership`
 in the caller's host-selected silo; participant rows alone never preserve authority after revocation.

--- a/libs/backend/server/conversations/main/src/__tests__/openapi.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/openapi.test.ts
@@ -65,6 +65,15 @@ describe("participant conversation OpenAPI", function _Suite()
 		} } } });
 	});
 
+	it("publishes immutable ConversationComputer input as a separate AgentSession contract", function _ReturnsComputerInputOutcomes()
+	{
+		const accepted = _SuccessSchema("/me/conversations/{conversationId}/input", "post", 201);
+		const idempotent = _SuccessSchema("/me/conversations/{conversationId}/input", "post", 200);
+
+		expect(accepted).toMatchObject({ additionalProperties: false, required: ["outcome", "inputEntryId"], properties: { outcome: { enum: ["accepted"] }, inputEntryId: { format: "uuid" } } });
+		expect(idempotent).toMatchObject({ additionalProperties: false, required: ["outcome", "inputEntryId"], properties: { outcome: { enum: ["idempotent"] }, inputEntryId: { format: "uuid" } } });
+	});
+
 	it("keeps conversation OpenAPI vocabularies owned by the domain model", function _OwnsConversationVocabularies()
 	{
 		const list = _SuccessSchema("/me/conversations", "get", 200) as { readonly properties: { readonly conversations: { readonly items: { readonly properties: Record<string, { readonly enum: readonly string[] }> } } } };

--- a/libs/backend/server/conversations/main/src/__tests__/prisma-conversation-message-admission-unit-of-work.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/prisma-conversation-message-admission-unit-of-work.test.ts
@@ -82,27 +82,6 @@ describe("PrismaConversationMessageAdmissionUnitOfWork", function _Suite()
 		expect(persistAgentThread).toHaveBeenCalledWith(_CALLER, expect.objectContaining({ firstRunId: "run-1", personaRevisionId: "persona-1" }), "profile-1", expect.any(String), request, expect.objectContaining({ blocks: request.blocks }), expect.any(Object));
 	});
 
-	it("routes agent-session input through run admission and persists the message in its transaction", async function _AdmitsAgentMessage()
-	{
-		const create = vi.fn().mockResolvedValue({});
-		const findFirst = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce(_Entry("run-1"));
-		const admitPersonalRun = vi.fn(async function _Admit(command, commit)
-		{
-			await commit({ prisma: { orgMembership: _ActiveMembership(), conversation: { findFirst: vi.fn().mockResolvedValue({ mode: ConversationMode.AgentSession, lifecycle: ConversationLifecycle.Open, agentServiceId: "service-1", runs: [{ id: "run-1" }] }) }, conversationMessage: { create } } }, { snapshot: { runId: "run-1" } });
-			return { outcome: PersonalRunAdmissionOutcomes.Accepted, runId: "run-1" };
-		});
-		const transaction = {
-			orgMembership: _ActiveMembership(),
-			conversationTimelineEntry: { findFirst },
-			conversation: { findFirst: vi.fn().mockResolvedValue({ mode: ConversationMode.AgentSession, lifecycle: ConversationLifecycle.Open, agentServiceId: "service-1", runs: [] }) },
-		};
-		const admission = _Admission(_Prisma(transaction), { admitPersonalRun } as never);
-
-		await expect(admission.submit(_CALLER, "conversation-1", _REQUEST)).resolves.toEqual(expect.objectContaining({ outcome: "accepted", message: expect.objectContaining({ runId: "run-1", position: "2" }) }));
-		expect(admitPersonalRun).toHaveBeenCalledWith(expect.objectContaining({ siloId: "silo-1", requesterSubjectId: "user-1", requesterIssuer: "https://issuer.test", requesterAuthenticatedAt: expect.any(String), conversationId: "conversation-1", requestIdempotencyKey: "request-1", inputMessageBlocks: _REQUEST.blocks, inputMessageId: expect.any(String) }), expect.any(Function));
-		expect(create).toHaveBeenCalledWith({ data: expect.objectContaining({ conversationId: "conversation-1", runId: "run-1", userId: "user-1", idempotencyKey: "request-1", source: "user_input" }) });
-	});
-
 	it("persists direct input without creating an AgentRun", async function _AdmitsDirectMessage()
 	{
 		const create = vi.fn().mockResolvedValue({});
@@ -110,11 +89,9 @@ describe("PrismaConversationMessageAdmissionUnitOfWork", function _Suite()
 		const context = { mode: ConversationMode.Direct, lifecycle: ConversationLifecycle.Open, agentServiceId: null, runs: [] };
 		const transaction = { orgMembership: _ActiveMembership(), conversation: { findFirst: vi.fn().mockResolvedValue(context) }, conversationMessage: { create } };
 		Object.assign(transaction, { conversationTimelineEntry: { findFirst } });
-		const admitPersonalRun = vi.fn();
 		const prisma = _Prisma(transaction) as { readonly $transaction: ReturnType<typeof vi.fn> };
 
-		await expect(_Admission(prisma, { admitPersonalRun }).submit(_CALLER, "conversation-1", _REQUEST)).resolves.toEqual(expect.objectContaining({ outcome: "accepted", message: expect.objectContaining({ runId: null }) }));
-		expect(admitPersonalRun).not.toHaveBeenCalled();
+		await expect(_Admission(prisma, {}).submit(_CALLER, "conversation-1", _REQUEST)).resolves.toEqual(expect.objectContaining({ outcome: "accepted", message: expect.objectContaining({ runId: null }) }));
 		expect(prisma.$transaction).toHaveBeenNthCalledWith(2, expect.any(Function), { isolationLevel: "Serializable" });
 		expect(create).toHaveBeenCalledWith({ data: expect.objectContaining({ runId: null, role: ConversationMessageRole.User, state: ConversationMessageState.Completed }) });
 	});
@@ -125,10 +102,8 @@ describe("PrismaConversationMessageAdmissionUnitOfWork", function _Suite()
 			orgMembership: _ActiveMembership(),
 			conversationTimelineEntry: { findFirst: vi.fn().mockResolvedValue(_Entry(null)) },
 		};
-		const admitPersonalRun = vi.fn();
 
-		await expect(_Admission(_Prisma(transaction), { admitPersonalRun }).submit(_CALLER, "conversation-1", _REQUEST)).resolves.toEqual(expect.objectContaining({ outcome: "idempotent", message: expect.objectContaining({ id: "message-1" }) }));
-		expect(admitPersonalRun).not.toHaveBeenCalled();
+		await expect(_Admission(_Prisma(transaction), {}).submit(_CALLER, "conversation-1", _REQUEST)).resolves.toEqual(expect.objectContaining({ outcome: "idempotent", message: expect.objectContaining({ id: "message-1" }) }));
 	});
 
 	it("rejects changed-body reuse of a participant-owned idempotency key", async function _RejectsChangedDuplicate()
@@ -142,25 +117,16 @@ describe("PrismaConversationMessageAdmissionUnitOfWork", function _Suite()
 		await expect(_Admission(_Prisma(transaction), {}).submit(_CALLER, "conversation-1", changedRequest)).resolves.toEqual({ outcome: "denied", reason: "idempotency_conflict" });
 	});
 
-	it.each([
-		["conversation_unavailable", "conversation_unavailable"],
-		["authority_conflict", "idempotency_conflict"],
-		["admission_concurrency_limited", "capacity_limited"],
-		["active_run", "active_run"],
-		["run_not_admittable", "agent_service_unavailable"],
-		["revision_unavailable", "agent_service_unavailable"],
-		["persona_unavailable", "agent_service_unavailable"],
-		["future_failure", "persistence_unavailable"],
-	])("maps run-admission refusal %s to %s", async function _MapsAdmissionRefusal(reason, expected)
+
+	it("rejects AgentSession messages so its immutable input authority remains the sole owner", async function _RejectsAgentSessionMessage()
 	{
 		const transaction = {
 			orgMembership: _ActiveMembership(),
 			conversationTimelineEntry: { findFirst: vi.fn().mockResolvedValue(null) },
 			conversation: { findFirst: vi.fn().mockResolvedValue({ mode: ConversationMode.AgentSession, lifecycle: ConversationLifecycle.Open, agentServiceId: "service-1", runs: [] }) },
 		};
-		const runAdmission = { admitPersonalRun: vi.fn().mockResolvedValue({ outcome: PersonalRunAdmissionOutcomes.Denied, reason }) };
 
-		await expect(_Admission(_Prisma(transaction), runAdmission).submit(_CALLER, "conversation-1", _REQUEST)).resolves.toEqual({ outcome: "denied", reason: expected });
+		await expect(_Admission(_Prisma(transaction), {}).submit(_CALLER, "conversation-1", _REQUEST)).resolves.toEqual({ outcome: "denied", reason: "command_not_supported" });
 	});
 
 	it("returns the caller's canonical message after losing a concurrent insert race", async function _RecoversOwnConcurrentInsert()

--- a/libs/backend/server/conversations/main/src/__tests__/self-conversation-socket.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/self-conversation-socket.test.ts
@@ -2,9 +2,10 @@ import { once } from "node:events";
 import { createServer } from "node:http";
 import { connect } from "node:net";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { __CreateSelfConversationSocketServer } from "../self-conversation-socket";
+import { ConversationSocketFrameKinds } from "@opencrane/models/conversations";
+import { __CreateSelfConversationSocketServer, __SubmitSelfConversationSocketCommand } from "../self-conversation-socket";
 import type { SelfConversationSocketDependencies } from "../self-conversation-socket.types";
 
 describe("__CreateSelfConversationSocketServer", function _SelfConversationSocketServer()
@@ -22,6 +23,22 @@ describe("__CreateSelfConversationSocketServer", function _SelfConversationSocke
 		client.write("GET /not-a-conversation HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Version: 13\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\r\n");
 		await expect(_ClosedWithin(client, 250)).resolves.toBe(true);
 		await new Promise<void>(function _Close(resolve) { server.close(function _Closed() { resolve(); }); });
+	});
+
+	it("sends AgentSession input to immutable ConversationComputer admission", async function _AdmitsComputerInput()
+	{
+		const admitted = vi.fn().mockResolvedValue({ outcome: "accepted", inputEntryId: "f8b48e77-9e1c-4dac-8e24-fac21e751ef5" });
+		const send = vi.fn();
+		await __SubmitSelfConversationSocketCommand(
+			{ readyState: 1, send } as never,
+			{ authority: { submitMessage: vi.fn() }, computerInputs: { admit: admitted }, logger: { error: vi.fn() } } as never,
+			{ siloId: "silo-1", principalId: "principal-1", issuer: "https://issuer.test", subjectId: "user-1" },
+			"conversation-1",
+			JSON.stringify({ type: ConversationSocketFrameKinds.ComputerInputSubmit, requestId: "667f1b39-8033-492a-b7c7-4a3c689dbfc8", inputId: "f8b48e77-9e1c-4dac-8e24-fac21e751ef5", text: "Hello" }),
+		);
+
+		expect(JSON.parse(send.mock.calls[0][0])).toEqual({ type: ConversationSocketFrameKinds.ComputerInputAccepted, requestId: "667f1b39-8033-492a-b7c7-4a3c689dbfc8", outcome: "accepted", inputEntryId: "f8b48e77-9e1c-4dac-8e24-fac21e751ef5" });
+		expect(admitted).toHaveBeenCalledWith({ siloId: "silo-1", principalId: "principal-1", issuer: "https://issuer.test", subjectId: "user-1" }, "conversation-1", { inputId: "f8b48e77-9e1c-4dac-8e24-fac21e751ef5", text: "Hello" });
 	});
 });
 

--- a/libs/backend/server/conversations/main/src/__tests__/self-conversations.router.test.ts
+++ b/libs/backend/server/conversations/main/src/__tests__/self-conversations.router.test.ts
@@ -9,7 +9,7 @@ function _App(authority: object, authenticated = true): Express
 {
 	const app = express();
 	app.use(express.json());
-	app.use(__CreateSelfConversationsRouter({ resolveCaller: function _Caller() { return authenticated ? { siloId: "silo-1", principalId: "principal-1", issuer: "https://issuer.test", subjectId: "user-1" } : null; }, authority: authority as never, logger: { error: vi.fn(), warn: vi.fn() } as never }));
+	app.use(__CreateSelfConversationsRouter({ resolveCaller: function _Caller() { return authenticated ? { siloId: "silo-1", principalId: "principal-1", issuer: "https://issuer.test", subjectId: "user-1" } : null; }, authority: authority as never, computerInputs: (authority as { computerInputs?: object }).computerInputs as never ?? null, logger: { error: vi.fn(), warn: vi.fn() } as never }));
 	return app;
 }
 
@@ -66,6 +66,22 @@ describe("self conversations router", function _Suite()
 	{
 		const submitMessage = vi.fn().mockResolvedValue({ outcome: "denied", reason: "capacity_limited" });
 		await request(_App({ submitMessage })).post("/conversation-1/messages").send({ idempotencyKey: "request-1", blocks: [{ id: "block-1", kind: "text", value: "Later" }] }).expect(429, { error: "capacity_limited" });
+	});
+
+	it("admits AgentSession text through the dedicated immutable input route", async function _AdmitsComputerInput()
+	{
+		const admit = vi.fn().mockResolvedValueOnce({ outcome: "accepted", inputEntryId: "input-1" }).mockResolvedValueOnce({ outcome: "idempotent", inputEntryId: "input-1" });
+		const app = _App({ computerInputs: { admit } });
+		const body = { inputId: "f8b48e77-9e1c-4dac-8e24-fac21e751ef5", text: "Hello" };
+
+		await request(app).post("/conversation-1/input").send(body).expect(201, { outcome: "accepted", inputEntryId: "input-1" });
+		await request(app).post("/conversation-1/input").send(body).expect(200, { outcome: "idempotent", inputEntryId: "input-1" });
+		expect(admit).toHaveBeenCalledWith({ siloId: "silo-1", principalId: "principal-1", issuer: "https://issuer.test", subjectId: "user-1" }, "conversation-1", body);
+	});
+
+	it("does not expose a partially composed ConversationComputer input route", async function _FailsClosedWithoutComputerInput()
+	{
+		await request(_App({})).post("/conversation-1/input").send({ inputId: "f8b48e77-9e1c-4dac-8e24-fac21e751ef5", text: "Hello" }).expect(503, { error: "conversation_computer_unavailable" });
 	});
 
 	it("starts and idempotently replays an exact participant run retry", async function _RetriesRun()

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-message-admission-unit-of-work.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-message-admission-unit-of-work.ts
@@ -51,15 +51,9 @@ export class PrismaConversationMessageAdmissionUnitOfWork implements Conversatio
 				? this._admitAgentThreadMessage(caller, conversationId, request)
 				: _denied(ConversationWriteDenialReasons.CommandNotSupported);
 
-			switch (decision.action)
-			{
-				case ConversationCommandActions.AdmitOrdinaryMessage:
-					return this._admitOrdinaryMessage(caller, conversationId, request);
-				case ConversationCommandActions.AdmitAgentRun:
-					return this._admitAgentMessage(caller, conversationId, request);
-				default:
-					return _denied(ConversationWriteDenialReasons.CommandNotSupported);
-			}
+			if (decision.action !== ConversationCommandActions.AdmitOrdinaryMessage)
+				return _denied(ConversationWriteDenialReasons.CommandNotSupported);
+			return this._admitOrdinaryMessage(caller, conversationId, request);
 		});
 	}
 
@@ -87,22 +81,6 @@ export class PrismaConversationMessageAdmissionUnitOfWork implements Conversatio
 		{
 			return this._resolveIdempotencyConflict(error, caller, conversationId, request);
 		}
-	}
-
-	/** Commits a user message inside the run repository's sole final transaction. */
-	private async _admitAgentMessage(caller: ConversationCaller, conversationId: string, request: SubmitConversationMessageRequest): Promise<SubmitConversationMessageResult>
-	{
-		const messageId = randomUUID();
-		const createAttachmentAdmission = this.createAttachmentAdmission;
-		const createMutationRepository = this.createMutationRepository;
-		const result = await this.runAdmission.admitPersonalRun({ siloId: caller.siloId, requesterSubjectId: caller.subjectId, requesterIssuer: caller.issuer, requesterAuthenticatedAt: new Date().toISOString(), conversationId, requestIdempotencyKey: request.idempotencyKey, inputMessageId: messageId, inputMessageBlocks: request.blocks }, async function _PersistMessage(transaction: RunAdmissionTransaction, value: RunAdmissionBuild)
-		{
-			await createMutationRepository(transaction).persistAgentMessage(caller, conversationId, messageId, value.snapshot.runId, request, createAttachmentAdmission(transaction));
-		});
-		if (result.outcome === PersonalRunAdmissionOutcomes.Denied) return _denied(_runAdmissionDenial(result.reason));
-		const message = await this._findOwnMessage(caller, conversationId, request.idempotencyKey);
-		if (message === null) return _denied(ConversationWriteDenialReasons.PersistenceUnavailable);
-		return result.outcome === PersonalRunAdmissionOutcomes.Idempotent ? _duplicateResult(message, request) : _accepted(message);
 	}
 
 	/** Atomically creates the parent root message, child session, first run, and immutable origin. */

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-mutation-repository.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-mutation-repository.ts
@@ -294,35 +294,6 @@ export class PrismaConversationMutationRepository implements ConversationMutatio
 	}
 
 	/**
-	 * Writes the user's message inside the transaction that is already starting an agent run.
-	 *
-	 * Unlike the other methods here it throws instead of returning a denial, because by this point the
-	 * run is staged in the same transaction: the only correct way to refuse is to make the whole
-	 * transaction roll back, taking the run with it. A returned denial would leave a run with no message
-	 * that asked for it.
-	 *
-	 * @param runId - The run staged in this transaction; stored on the message so the two are linked.
-	 * @throws Error when membership, participant access, or the mode decision no longer allows the
-	 *   message — which discards the staged run as well.
-	 */
-	async persistAgentMessage(caller: ConversationCaller, conversationId: string, messageId: string, runId: string, request: SubmitConversationMessageRequest, attachments: ConversationAttachmentAdmissionPort): Promise<void>
-	{
-		// 1. Revalidate current silo membership and participant access inside run admission's final transaction.
-		const context = await this.query.loadCommandContext(caller, conversationId);
-		if (context === null) throw new Error("Conversation authority unavailable");
-
-		// 2. Re-dispatch persisted mode and lifecycle through the exhaustive strategy after the run is staged.
-		const decision = __DecideConversationCommand({ ...context, command: { kind: ConversationCommandKinds.SubmitMessage } });
-		if (!decision.allowed || decision.action !== ConversationCommandActions.AdmitAgentRun) throw new Error("Conversation command unavailable");
-		if (!await this.authorization.admit(caller, { kind: ProductAuthorizationResourceKinds.Conversation, id: conversationId }, ProductAuthorizationActions.Use, { idempotencyKey: request.idempotencyKey, messageId, runId }))
-			throw new Error("Conversation product authorization unavailable");
-
-		// 3. Persist the message only after every caller and immutable-mode fence remains valid.
-		await this.transaction.conversationMessage.create({ data: _messageData(messageId, conversationId, caller.subjectId, request, runId) });
-		await attachments.bindReadyAssets(caller, conversationId, messageId, request.blocks);
-	}
-
-	/**
 	 * Writes the message that asks an Agent something in a group, plus the child conversation the Agent
 	 * will answer in.
 	 *

--- a/libs/backend/server/conversations/main/src/db/prisma-conversation-mutation-repository.types.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-conversation-mutation-repository.types.ts
@@ -14,23 +14,19 @@ export interface ConversationMutationRepository
 	close(caller: ConversationCaller, conversationId: string): Promise<MutateConversationResult>;
 	markAgentThreadRead(caller: ConversationCaller, parentConversationId: string, childConversationId: string, observedPosition: bigint): Promise<MarkAgentThreadReadResult>;
 	admitOrdinaryMessage(caller: ConversationCaller, conversationId: string, messageId: string, request: SubmitConversationMessageRequest, attachments: ConversationAttachmentAdmissionPort): Promise<{ readonly outcome: ConversationAuthorityOutcomes.Accepted } | { readonly outcome: ConversationAuthorityOutcomes.Denied; readonly reason: ConversationWriteDenial }>;
-	persistAgentMessage(caller: ConversationCaller, conversationId: string, messageId: string, runId: string, request: SubmitConversationMessageRequest, attachments: ConversationAttachmentAdmissionPort): Promise<void>;
 	prepareAgentThread(caller: ConversationCaller, parentConversationId: string, parentMessageId: string, childConversationId: string, request: SubmitConversationMessageRequest, attachments: ConversationAttachmentAdmissionPort): Promise<{ readonly personaProfileId: string; readonly personaRevisionId: string }>;
 	persistAgentThread(caller: ConversationCaller, origin: AgentThreadOrigin, personaProfileId: string, childMessageId: string, parentRequest: SubmitConversationMessageRequest, childRequest: SubmitConversationMessageRequest, attachments: ConversationAttachmentAdmissionPort): Promise<void>;
 }
 
 /**
- * Makes a {@link ConversationMutationRepository} bound to a transaction that run admission
- * owns.
+ * Makes a {@link ConversationMutationRepository} bound to the agent-thread run transaction.
  *
- * This exists so the conversation package can write the user's message inside admission's
- * transaction without ever holding a client of its own. Admission calls the factory with its
- * live transaction at the moment the run is being committed, which is what makes "message and
- * run commit together" true rather than merely intended.
+ * Group Agent-thread creation uses this factory while it prepares the child conversation and
+ * commits its first run. The factory never serves AgentSession participant input, which belongs to
+ * immutable ConversationComputer history.
  *
- * Called by: `PrismaConversationUnitOfWork._admitAgentMessage`
- * (prisma-conversation-unit-of-work.ts). Supplied by `_CreateSelfConversationsRouter`
- * (prisma-self-conversations.router.ts).
+ * Called by: `PrismaConversationMessageAdmissionUnitOfWork._admitAgentThreadMessage`.
+ * Supplied by `_CreateSelfConversationsRouter` (prisma-self-conversations.router.ts).
  */
 export interface ConversationMutationRepositoryFactory
 {

--- a/libs/backend/server/conversations/main/src/db/prisma-self-conversations.router.ts
+++ b/libs/backend/server/conversations/main/src/db/prisma-self-conversations.router.ts
@@ -18,6 +18,7 @@ import type { SelfConversationSocketAuthenticator, SelfConversationSocketServer 
 import type { ConversationCaller } from "../types/conversation-caller.types";
 import type { ConversationAttachmentAdmissionFactory } from "../conversation-message-admission.types";
 import type { ConversationCreationAuthority } from "../conversation-creation-authority.types";
+import type { ConversationComputerParticipantInputAdmission } from "../conversation-computers/conversation-computer-participant-input-admission";
 
 /** Maps authenticated request facts to the caller contract owned by conversations. */
 function _resolveCaller(request: Parameters<typeof _ResolveRequestPrincipal>[0]): ConversationCaller | null
@@ -26,7 +27,7 @@ function _resolveCaller(request: Parameters<typeof _ResolveRequestPrincipal>[0])
 	return principal ? { principalId: principal.principalId, subjectId: principal.externalSubject, issuer: principal.externalIssuer, siloId: principal.siloId } : null;
 }
 
-/** Creates a mutation repository over run admission's final transaction. */
+/** Creates a mutation repository for an Agent-thread run admission's final transaction. */
 function _createMutationRepository(transaction: RunAdmissionTransaction): PrismaConversationMutationRepository
 {
 	return new PrismaConversationMutationRepository(transaction.prisma);
@@ -36,27 +37,29 @@ function _createMutationRepository(transaction: RunAdmissionTransaction): Prisma
  * Build the ready-to-mount conversation router for an app.
  *
  * Everything Prisma-shaped is assembled here — the unit of work, the query and mutation
- * repositories, and the factory that lets run admission write the user's message inside its own
- * transaction — so the router itself stays free of database types.
+ * repositories, and the factory that lets Agent-thread run admission create its parent and child
+ * records inside its own transaction — so the router itself stays free of database types.
  *
  * Called by: apps/opencrane/src/app/routes.ts, mounted at `/api/v1/me/conversations`.
  *
  * @param prisma - Product database client.
- * @param runAdmission - Starts an agent run in the same transaction as the message that
- *   triggered it.
+ * @param runAdmission - Starts the first Agent-thread run in the transaction that creates its
+ *   parent and child records. It does not admit AgentSession participant input.
  * @param workflow - Guarded engine that saves a retry task in the retry transaction.
  * @param retryInputCompiler - Inputs authority that compiles the exact new retry subject and snapshot.
  * @param createAttachmentAdmission - Admits upload references before a message transaction uses them.
  * @param creation - Creates conversations through reservation, immutable history, and projection.
+ * @param computerInputs - Rechecks and appends AgentSession text to immutable history, or leaves
+ *   that route unavailable when the computer composition is absent.
  * @param logger - Used only for unexpected failures; never receives message content.
  * @returns An Express router ready to mount.
  */
-export function _CreateSelfConversationsRouter(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, workflow: Pick<IWorkflowEngine, "spawn">, retryInputCompiler: RetryRunInputCompiler, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, creation: ConversationCreationAuthority, logger: Logger): Router
+export function _CreateSelfConversationsRouter(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, workflow: Pick<IWorkflowEngine, "spawn">, retryInputCompiler: RetryRunInputCompiler, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, creation: ConversationCreationAuthority, computerInputs: Pick<ConversationComputerParticipantInputAdmission, "admit"> | null, logger: Logger): Router
 {
 	const messageAdmission = new PrismaConversationMessageAdmissionUnitOfWork(prisma, runAdmission, _createMutationRepository, createAttachmentAdmission);
 	const runRetry = new PrismaAgentRunRetryUnitOfWork(prisma, workflow, retryInputCompiler);
 	const authority = new PrismaConversationUnitOfWork(prisma, messageAdmission, runRetry, creation);
-	return __CreateSelfConversationsRouter({ resolveCaller: _resolveCaller, authority, logger });
+	return __CreateSelfConversationsRouter({ resolveCaller: _resolveCaller, authority, computerInputs, logger });
 }
 
 /**
@@ -65,22 +68,25 @@ export function _CreateSelfConversationsRouter(prisma: PrismaClient, runAdmissio
  * Sharing `creation` keeps a socket-triggered create subject to the same caller-bound reservation
  * and history projection as an HTTP create. Called by: {@link _Main} in apps/opencrane/src/index.ts.
  * @param prisma - Opens read and remaining mutation transactions.
- * @param runAdmission - Admits personal agent runs started by participant messages.
+ * @param runAdmission - Starts first Agent-thread runs for the remaining group-agent workflow;
+ *   it does not admit AgentSession participant input.
  * @param workflow - Saves retries from participant-owned run commands.
  * @param retryInputCompiler - Compiles the fresh retry snapshot.
  * @param createAttachmentAdmission - Admits attachments before a message transaction uses them.
  * @param creation - Reserves, anchors, and projects a conversation creation request.
+ * @param computerInputs - Rechecks and appends AgentSession text to immutable history, or leaves
+ *   that socket command unavailable when the computer composition is absent.
  * @param logger - Records unexpected transport failures without message content.
  * @param authenticator - Resolves the socket session to its conversation caller.
  * @param options - Supplies optional interruption reads and process shutdown handling.
  * @returns A socket server that shares the participant conversation authority.
  */
-export function _CreatePrismaSelfConversationSocketServer(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, workflow: Pick<IWorkflowEngine, "spawn">, retryInputCompiler: RetryRunInputCompiler, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, creation: ConversationCreationAuthority, logger: Logger, authenticator: SelfConversationSocketAuthenticator, options: { readonly interrupts?: ConversationOpenInterruptReader; readonly shutdownSignal?: AbortSignal } = {}): SelfConversationSocketServer
+export function _CreatePrismaSelfConversationSocketServer(prisma: PrismaClient, runAdmission: PersonalRunAdmissionPort, workflow: Pick<IWorkflowEngine, "spawn">, retryInputCompiler: RetryRunInputCompiler, createAttachmentAdmission: ConversationAttachmentAdmissionFactory, creation: ConversationCreationAuthority, computerInputs: Pick<ConversationComputerParticipantInputAdmission, "admit"> | null, logger: Logger, authenticator: SelfConversationSocketAuthenticator, options: { readonly interrupts?: ConversationOpenInterruptReader; readonly shutdownSignal?: AbortSignal } = {}): SelfConversationSocketServer
 {
 	const messageAdmission = new PrismaConversationMessageAdmissionUnitOfWork(prisma, runAdmission, _createMutationRepository, createAttachmentAdmission);
 	const runRetry = new PrismaAgentRunRetryUnitOfWork(prisma, workflow, retryInputCompiler);
 	const authority = new PrismaConversationUnitOfWork(prisma, messageAdmission, runRetry, creation);
 	const interruptOptions = options.interrupts === undefined ? {} : { interrupts: options.interrupts };
 	const shutdownOptions = options.shutdownSignal === undefined ? {} : { shutdownSignal: options.shutdownSignal };
-	return __CreateSelfConversationSocketServer({ authenticator, authority, repository: _CreateConversationReplayRepository(prisma), clock: CONVERSATION_PROJECTION_CLOCK, limits: CONVERSATION_PROJECTION_LIMITS, ...interruptOptions, ...shutdownOptions, logger });
+	return __CreateSelfConversationSocketServer({ authenticator, authority, computerInputs, repository: _CreateConversationReplayRepository(prisma), clock: CONVERSATION_PROJECTION_CLOCK, limits: CONVERSATION_PROJECTION_LIMITS, ...interruptOptions, ...shutdownOptions, logger });
 }

--- a/libs/backend/server/conversations/main/src/openapi.ts
+++ b/libs/backend/server/conversations/main/src/openapi.ts
@@ -2,6 +2,7 @@ import { ConversationLifecycles, ConversationModes, MessageContentBlockKinds, Me
 
 import { ConversationAuthorityOutcomes } from "./types/conversation-authority-result.types";
 import { PersonalAgentDirectoryStatuses } from "./types/conversation-directory.types";
+import { ConversationComputerParticipantInputOutcomes } from "./conversation-computers/conversation-computer-participant-input-authority.types";
 
 /**
  * Shared participant conversation summary schema kept local to the owning OpenAPI fragment.
@@ -223,8 +224,8 @@ export const _SelfConversationsOpenapiPaths = {
 	"/me/conversations/{conversationId}/messages": {
 		post: {
 			operationId: "submitMyConversationMessage",
-			summary: "Submit participant input through the immutable mode strategy",
-			description: "Agent-session input is committed atomically with a governed run. Direct and ordinary group input is committed without creating an AgentRun.",
+			summary: "Submit direct or group participant input",
+			description: "Direct and ordinary group input is committed without creating an AgentRun. Agent-session input uses the separate immutable ConversationComputer input contract.",
 			tags: ["Conversations"],
 			parameters: [{ name: "conversationId", in: "path", required: true, schema: { type: "string" } }],
 			requestBody: {
@@ -255,6 +256,24 @@ export const _SelfConversationsOpenapiPaths = {
 				},
 			},
 			responses: { 201: { description: "Message accepted.", content: { "application/json": { schema: _AcceptedConversationMessageEnvelopeSchema } } }, 200: { description: "Exact idempotent retry returned the canonical message.", content: { "application/json": { schema: _IdempotentConversationMessageEnvelopeSchema } } }, 400: { description: "Invalid message body." }, 401: { description: "Authentication required." }, 404: { description: "Conversation unavailable." }, 409: { description: "Closed, active-run, mode, or idempotency conflict." }, 429: { description: "Conversation admission capacity is currently full; retry later." }, 503: { description: "Admission authority unavailable." } },
+		},
+	},
+	"/me/conversations/{conversationId}/input": {
+		post: {
+			operationId: "submitMyConversationComputerInput",
+			summary: "Append one AgentSession text input to immutable ConversationComputer history",
+			description: "Requires current membership, participant access, an open AgentSession creation binding, and Conversation/Use evidence. The text is encrypted before history receives its opaque payload reference; a retry with the same inputId returns the same entry.",
+			tags: ["Conversations"],
+			parameters: [{ name: "conversationId", in: "path", required: true, schema: { type: "string" } }],
+			requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: false, required: ["inputId", "text"], properties: { inputId: { type: "string", format: "uuid" }, text: { type: "string", minLength: 1, maxLength: 65536 } } } } } },
+			responses: {
+				201: { description: "Input appended to immutable history.", content: { "application/json": { schema: { type: "object", additionalProperties: false, required: ["outcome", "inputEntryId"], properties: { outcome: { type: "string", enum: [ConversationComputerParticipantInputOutcomes.Accepted] }, inputEntryId: { type: "string", format: "uuid" } } } } } },
+				200: { description: "Exact idempotent input retry returned its existing history entry.", content: { "application/json": { schema: { type: "object", additionalProperties: false, required: ["outcome", "inputEntryId"], properties: { outcome: { type: "string", enum: [ConversationComputerParticipantInputOutcomes.Idempotent] }, inputEntryId: { type: "string", format: "uuid" } } } } } },
+				400: { description: "Malformed input id or text." },
+				401: { description: "Authentication required." },
+				404: { description: "Conversation unavailable to this participant." },
+				503: { description: "ConversationComputer input authority unavailable." },
+			},
 		},
 	},
 	// Retry increases the attempt counter on the SAME run rather than creating a second one, which

--- a/libs/backend/server/conversations/main/src/self-conversation-socket.ts
+++ b/libs/backend/server/conversations/main/src/self-conversation-socket.ts
@@ -4,7 +4,7 @@ import type { Duplex } from "node:stream";
 import { WebSocket, WebSocketServer } from "ws";
 import { z } from "zod";
 
-import { ___ParticipantInputBlocksSchema } from "@opencrane/models/conversations";
+import { ConversationSocketFrameKinds, ___ParticipantInputBlocksSchema } from "@opencrane/models/conversations";
 import { __DecodeConversationProjectionCursor, __StreamConversationProjection, ConversationProjectionOutcomes, type ConversationProjectionDependencies, type ConversationProjectionSink } from "@opencrane/backend/conversations/projection";
 
 import { ConversationAuthorityOutcomes, ConversationWriteDenialReasons } from "./types/conversation-authority-result.types";
@@ -22,22 +22,33 @@ type _ConversationSocketSelection = {
 	readonly cursor: string | null;
 };
 
-/** Validates participant message submissions and rejects every other browser command. */
-const _CommandSchema = z.object({
-	type: z.literal("conversation.message.submit"),
+/** Validates direct and group participant message submissions. */
+const _MessageCommandSchema = z.object({
+	type: z.literal(ConversationSocketFrameKinds.MessageSubmit),
 	requestId: z.string().uuid(),
 	idempotencyKey: z.string().trim().min(1).max(128),
 	blocks: ___ParticipantInputBlocksSchema,
 	agentTarget: z.object({ agentServiceId: z.string().trim().min(1).max(128) }).strict().optional(),
 }).strict();
 
+/** Validates one AgentSession text input before it reaches immutable ConversationComputer history. */
+const _ComputerInputCommandSchema = z.object({
+	type: z.literal(ConversationSocketFrameKinds.ComputerInputSubmit),
+	requestId: z.string().uuid(),
+	inputId: z.string().uuid(),
+	text: z.string().trim().min(1).max(64 * 1024),
+}).strict();
+
+/** Accepts exactly the two public submission frames that their separate authorities own. */
+const _CommandSchema = z.discriminatedUnion("type", [_MessageCommandSchema, _ComputerInputCommandSchema]);
+
 /**
- * Builds a WebSocket endpoint for one participant's conversation projection and message submissions.
+ * Builds a WebSocket endpoint for one participant's projection and input submissions.
  *
  * The HTTP listener receives every upgrade, so this boundary rejects unrelated paths before `ws`
- * takes a socket. It authenticates the request, then passes that caller to the replay and message
- * authorities; a message frame cannot choose a participant or conversation. `attach` may be called
- * once; `close` asks active sockets to reconnect while the process drains.
+ * takes a socket. It authenticates the request, then passes that caller to the replay, direct/group
+ * message, and AgentSession input authorities; no frame can choose a participant or conversation.
+ * `attach` may be called once; `close` asks active sockets to reconnect while the process drains.
  *
  * Called by: `_CreatePrismaSelfConversationSocketServer`, composed by `apps/opencrane/src/index.ts`.
  *
@@ -168,7 +179,7 @@ async function _UpgradeConversation(socketServer: WebSocketServer, dependencies:
 	}
 }
 
-/** Run the projection tail and receive idempotent participant messages on one authenticated socket. */
+/** Runs one projection tail and serializes its caller's direct/group messages or AgentSession input. */
 async function _ServeConversationSocket(socket: WebSocket, dependencies: SelfConversationSocketDependencies, caller: ConversationCaller, conversationId: string, cursor: ReturnType<typeof __DecodeConversationProjectionCursor>): Promise<void>
 {
 	const abort = new AbortController();
@@ -187,7 +198,7 @@ async function _ServeConversationSocket(socket: WebSocket, dependencies: SelfCon
 
 		commands = commands.then(function _Submit()
 		{
-			return _SubmitMessage(socket, dependencies, caller, conversationId, data.toString());
+			return __SubmitSelfConversationSocketCommand(socket, dependencies, caller, conversationId, data.toString());
 		});
 	});
 	try
@@ -224,31 +235,53 @@ function _ProjectionOptions(dependencies: SelfConversationSocketDependencies): C
 	return { ...required, interrupts: dependencies.interrupts };
 }
 
-/** Submit a parsed participant command and answer only its caller with a correlation id. */
-async function _SubmitMessage(socket: WebSocket, dependencies: SelfConversationSocketDependencies, caller: ConversationCaller, conversationId: string, raw: string): Promise<void>
+/**
+ * Submits one validated participant frame and returns its correlated result to that socket only.
+ *
+ * Called by: `_ServeConversationSocket` and the socket-command contract test.
+ */
+export async function __SubmitSelfConversationSocketCommand(socket: WebSocket, dependencies: SelfConversationSocketDependencies, caller: ConversationCaller, conversationId: string, raw: string): Promise<void>
 {
 	const command = _CommandSchema.safeParse(_Json(raw));
 	if (!command.success)
 	{
-		_Send(socket, { type: "conversation.message.rejected", requestId: _RequestId(raw), error: "invalid_conversation_message" });
+		_Send(socket, { type: ConversationSocketFrameKinds.MessageRejected, requestId: _RequestId(raw), error: "invalid_conversation_message" });
 		return;
 	}
 
 	try
 	{
-		const result = await dependencies.authority.submitMessage(caller, conversationId, command.data);
-		if (result.outcome === ConversationAuthorityOutcomes.Denied)
+		if (command.data.type === ConversationSocketFrameKinds.MessageSubmit)
 		{
-			_Send(socket, { type: "conversation.message.rejected", requestId: command.data.requestId, error: result.reason });
+			const result = await dependencies.authority.submitMessage(caller, conversationId, command.data);
+			if (result.outcome === ConversationAuthorityOutcomes.Denied)
+			{
+				_Send(socket, { type: ConversationSocketFrameKinds.MessageRejected, requestId: command.data.requestId, error: result.reason });
+				return;
+			}
+
+			_Send(socket, { type: ConversationSocketFrameKinds.MessageAccepted, requestId: command.data.requestId, outcome: result.outcome });
 			return;
 		}
 
-		_Send(socket, { type: "conversation.message.accepted", requestId: command.data.requestId, outcome: result.outcome });
+		if (dependencies.computerInputs === null)
+		{
+			_Send(socket, { type: ConversationSocketFrameKinds.ComputerInputRejected, requestId: command.data.requestId, error: "conversation_computer_unavailable" });
+			return;
+		}
+		const result = await dependencies.computerInputs.admit(caller, conversationId, { inputId: command.data.inputId, text: command.data.text });
+		if (result === null)
+		{
+			_Send(socket, { type: ConversationSocketFrameKinds.ComputerInputRejected, requestId: command.data.requestId, error: "conversation_unavailable" });
+			return;
+		}
+		_Send(socket, { type: ConversationSocketFrameKinds.ComputerInputAccepted, requestId: command.data.requestId, outcome: result.outcome, inputEntryId: result.inputEntryId });
 	}
 	catch (error)
 	{
-		dependencies.logger.error({ err: error, operation: "conversation.socket.message.submit", siloId: caller.siloId }, "Conversation socket message submission failed");
-		_Send(socket, { type: "conversation.message.rejected", requestId: command.data.requestId, error: ConversationWriteDenialReasons.PersistenceUnavailable });
+		dependencies.logger.error({ err: error, operation: "conversation.socket.command.submit", siloId: caller.siloId }, "Conversation socket command submission failed");
+		const type = command.data.type === ConversationSocketFrameKinds.MessageSubmit ? ConversationSocketFrameKinds.MessageRejected : ConversationSocketFrameKinds.ComputerInputRejected;
+		_Send(socket, { type, requestId: command.data.requestId, error: ConversationWriteDenialReasons.PersistenceUnavailable });
 	}
 }
 

--- a/libs/backend/server/conversations/main/src/self-conversation-socket.types.ts
+++ b/libs/backend/server/conversations/main/src/self-conversation-socket.types.ts
@@ -6,6 +6,7 @@ import type { Logger } from "pino";
 import type { ConversationReplayUnitOfWork } from "./replay-reader.types";
 import type { ConversationCaller } from "./types/conversation-caller.types";
 import type { ConversationUnitOfWork } from "./types/conversation-unit-of-work.types";
+import type { ConversationComputerParticipantInputAdmission } from "./conversation-computers/conversation-computer-participant-input-admission";
 
 /**
  * Authenticates an HTTP upgrade before the socket server takes ownership of its connection.
@@ -54,8 +55,10 @@ export interface SelfConversationSocketDependencies
 {
 	/** Restores an authenticated participant before accepting an upgrade. */
 	readonly authenticator: SelfConversationSocketAuthenticator;
-	/** Admits participant messages with the same mode and idempotency checks as the HTTP API. */
+	/** Admits direct and group messages with the same idempotency checks as the HTTP API. */
 	readonly authority: ConversationUnitOfWork;
+	/** Admits AgentSession text through immutable history; null rejects it rather than using `authority`. */
+	readonly computerInputs: Pick<ConversationComputerParticipantInputAdmission, "admit"> | null;
 	/** Re-reads authorized timeline rows for the current socket cursor. */
 	readonly repository: ConversationReplayUnitOfWork;
 	/** Supplies current approval and elicitation overlays when enabled. */

--- a/libs/backend/server/conversations/main/src/self-conversations.router.ts
+++ b/libs/backend/server/conversations/main/src/self-conversations.router.ts
@@ -3,10 +3,14 @@ import type { Logger } from "pino";
 import { z } from "zod";
 
 import { ___ParticipantInputBlocksSchema } from "@opencrane/models/conversations";
+import { ConversationComputerParticipantInputOutcomes } from "./conversation-computers/conversation-computer-participant-input-authority.types";
 
 import { _ConversationCreationRequestSchema } from "./validators/conversation-creation.validator";
 import { AgentThreadReadDenialReasons, ConversationAuthorityOutcomes, ConversationWriteDenialReasons, type ConversationWriteDenial } from "./types/conversation-authority-result.types";
 import type { SelfConversationsRouterDependencies } from "./self-conversations.router.types";
+
+/** Bounded text input for a ConversationComputer-owned agent session. */
+const _ComputerInputSchema = z.object({ inputId: z.string().uuid(), text: z.string().trim().min(1).max(64 * 1024) }).strict();
 
 /** Bounded idempotent participant message body. */
 const _MessageSchema = z.object({
@@ -33,8 +37,8 @@ const _RunRetrySchema = z.object({ expectedAttempt: z.number().int().min(1) }).s
 
 /**
  * Build the HTTP routes a signed-in user uses for their own conversations: read the creation
- * directory, list, create, open, open an Agent thread, mark one read, post a message, retry a run,
- * archive, close.
+ * directory, list, create, open, open an Agent thread, mark one read, post direct/group message or
+ * AgentSession input, retry a run, archive, close.
  *
  * The router owns three jobs and nothing else. It derives the caller from the session (never
  * from the path or body, so there is no route for reading someone else's conversations), checks
@@ -68,7 +72,11 @@ export function __CreateSelfConversationsRouter(dependencies: SelfConversationsR
 	router.get("/directory", async function _Directory(request: Request, response: Response)
 	{
 		const caller = dependencies.resolveCaller(request);
-		if (caller === null) { response.status(401).json({ error: "conversation_authentication_required" }); return; }
+		if (caller === null)
+		{
+			response.status(401).json({ error: "conversation_authentication_required" });
+			return;
+		}
 		try
 		{
 			response.status(200).json({ directory: await dependencies.authority.directory(caller) });
@@ -83,7 +91,11 @@ export function __CreateSelfConversationsRouter(dependencies: SelfConversationsR
 	router.get("/", async function _List(request: Request, response: Response)
 	{
 		const caller = dependencies.resolveCaller(request);
-		if (caller === null) { response.status(401).json({ error: "conversation_authentication_required" }); return; }
+		if (caller === null)
+		{
+			response.status(401).json({ error: "conversation_authentication_required" });
+			return;
+		}
 		try
 		{
 			const conversations = await dependencies.authority.list(caller, request.query["includeArchived"] === "true");
@@ -191,6 +203,44 @@ export function __CreateSelfConversationsRouter(dependencies: SelfConversationsR
 		catch (err)
 		{
 			_log(dependencies.logger, err, "conversation.message.submit", caller.siloId);
+			response.status(503).json({ error: "persistence_unavailable" });
+		}
+	});
+
+	/** Write AgentSession input through its immutable history authority rather than AgentRun admission. */
+	router.post("/:conversationId/input", async function _SubmitComputerInput(request: Request, response: Response)
+	{
+		const caller = dependencies.resolveCaller(request);
+		if (caller === null)
+		{
+			response.status(401).json({ error: "conversation_authentication_required" });
+			return;
+		}
+		const conversationId = _parameter(request.params["conversationId"]);
+		const parsed = _ComputerInputSchema.safeParse(request.body);
+		if (conversationId === null || !parsed.success)
+		{
+			response.status(400).json({ error: "invalid_conversation_input" });
+			return;
+		}
+		if (dependencies.computerInputs === null)
+		{
+			response.status(503).json({ error: "conversation_computer_unavailable" });
+			return;
+		}
+		try
+		{
+			const result = await dependencies.computerInputs.admit(caller, conversationId, parsed.data);
+			if (result === null)
+			{
+				response.status(404).json({ error: "conversation_unavailable" });
+				return;
+			}
+			response.status(result.outcome === ConversationComputerParticipantInputOutcomes.Accepted ? 201 : 200).json(result);
+		}
+		catch (err)
+		{
+			_log(dependencies.logger, err, "conversation.computer.input", caller.siloId);
 			response.status(503).json({ error: "persistence_unavailable" });
 		}
 	});

--- a/libs/backend/server/conversations/main/src/self-conversations.router.types.ts
+++ b/libs/backend/server/conversations/main/src/self-conversations.router.types.ts
@@ -3,6 +3,7 @@ import type { Logger } from "pino";
 
 import type { ConversationCaller } from "./types/conversation-caller.types";
 import type { ConversationUnitOfWork } from "./types/conversation-unit-of-work.types";
+import type { ConversationComputerParticipantInputAdmission } from "./conversation-computers/conversation-computer-participant-input-admission";
 
 /**
  * What `__CreateSelfConversationsRouter` needs. Built by
@@ -14,6 +15,8 @@ export interface SelfConversationsRouterDependencies
 	readonly resolveCaller: (request: Request) => ConversationCaller | null;
 	/** Does the actual work and owns authorisation; the router only translates its results into HTTP. */
 	readonly authority: ConversationUnitOfWork;
+	/** Admits AgentSession text into immutable history; null rejects it rather than using the message authority. */
+	readonly computerInputs: Pick<ConversationComputerParticipantInputAdmission, "admit"> | null;
 	/** Used only for unexpected failures and database-unavailable denials. Never receives message content or user identity. */
 	readonly logger: Logger;
 }

--- a/libs/frontend/state/conversation/adapter/README.md
+++ b/libs/frontend/state/conversation/adapter/README.md
@@ -13,7 +13,8 @@ Opening a conversation creates a same-origin WebSocket at
 `/api/v1/me/conversations/:conversationId/socket`. The browser sends its existing cookie session
 during the upgrade; the server restores that session, derives the caller and silo, and rechecks
 participant membership before accepting the connection. The socket returns structured snapshot and
-live AG-UI frames, then carries participant message commands and their idempotent acknowledgements.
+live AG-UI frames, then carries direct/group message commands or AgentSession text input and their
+idempotent acknowledgements. An AgentSession never uses the message command as a fallback.
 The adapter validates every complete projection frame with the shared AG-UI state package before
 publishing browser view state.
 The backend [conversation projection package](../../../../backend/conversations/projection/main/README.md)
@@ -39,7 +40,8 @@ frames fail closed, and access revocation purges the reduced projection.
 ## Public surface
 
 - `OpenCraneConversationEventStream` — cookie-session socket adapter that implements the separate
-  [`ConversationEventStream`](../stream/README.md) port and submits participant messages.
+  [`ConversationEventStream`](../stream/README.md) port. It uses the immutable ConversationComputer
+  input frame for AgentSession text and preserves the message frame for direct/group content.
 
 ## Boundary
 

--- a/libs/frontend/state/conversation/adapter/src/lib/__tests__/opencrane-conversation-event-stream.spec.ts
+++ b/libs/frontend/state/conversation/adapter/src/lib/__tests__/opencrane-conversation-event-stream.spec.ts
@@ -1,6 +1,7 @@
 import { EventType } from "@ag-ui/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { ConversationModes } from "@opencrane/models/conversations";
 import { AgUiRunStatuses } from "@opencrane/state/conversation/ag-ui";
 import { ConversationEventStreamMessageError, ConversationEventStreamStatuses } from "@opencrane/state/conversation/stream";
 
@@ -111,10 +112,27 @@ describe("OpenCraneConversationEventStream", function _Suite()
 		const stream = new OpenCraneConversationEventStream();
 		const tail = stream.stream({ conversationId: "conversation-1", signal: controller.signal });
 		await vi.waitFor(() => expect(_Socket.connections[0]?.readyState).toBe(_Socket.OPEN));
-		const submitted = stream.submit({ conversationId: "conversation-1", idempotencyKey: "retry-1", blocks: [{ id: "block-1", kind: "text", value: "hello" }] });
+		const submitted = stream.submit({ conversationId: "conversation-1", mode: ConversationModes.Direct, idempotencyKey: "retry-1", blocks: [{ id: "block-1", kind: "text", value: "hello" }] });
 		const command = JSON.parse(_Socket.connections[0]!.sent[0] ?? "{}") as { readonly requestId: string; readonly type: string };
 		expect(command.type).toBe("conversation.message.submit");
 		_Socket.connections[0]!.deliver(JSON.stringify({ type: "conversation.message.accepted", requestId: command.requestId, outcome: "accepted" }));
+		await expect(submitted).resolves.toBeUndefined();
+		controller.abort();
+		await tail;
+	});
+
+	it("submits AgentSession input through the immutable ConversationComputer frame", async function _SubmitsComputerInput()
+	{
+		vi.stubGlobal("location", { origin: "https://testv4.dev.opencrane.ai" });
+		vi.stubGlobal("WebSocket", _Socket);
+		const controller = new AbortController();
+		const stream = new OpenCraneConversationEventStream();
+		const tail = stream.stream({ conversationId: "conversation-1", signal: controller.signal });
+		await vi.waitFor(() => expect(_Socket.connections[0]?.readyState).toBe(_Socket.OPEN));
+		const submitted = stream.submit({ conversationId: "conversation-1", mode: ConversationModes.AgentSession, idempotencyKey: "f8b48e77-9e1c-4dac-8e24-fac21e751ef5", blocks: [{ id: "block-1", kind: "text", value: "hello" }] });
+		const command = JSON.parse(_Socket.connections[0]!.sent[0] ?? "{}") as { readonly requestId: string; readonly type: string; readonly inputId: string; readonly text: string };
+		expect(command).toMatchObject({ type: "conversation.computer.input.submit", inputId: "f8b48e77-9e1c-4dac-8e24-fac21e751ef5", text: "hello" });
+		_Socket.connections[0]!.deliver(JSON.stringify({ type: "conversation.computer.input.accepted", requestId: command.requestId, outcome: "accepted", inputEntryId: command.inputId }));
 		await expect(submitted).resolves.toBeUndefined();
 		controller.abort();
 		await tail;

--- a/libs/frontend/state/conversation/adapter/src/lib/opencrane-conversation-event-stream.ts
+++ b/libs/frontend/state/conversation/adapter/src/lib/opencrane-conversation-event-stream.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
 
+import { ConversationModes, ConversationSocketFrameKinds, MessageContentBlockKinds } from "@opencrane/models/conversations";
 import { __AgUiResumeCursor, __CreateAgUiStreamState, __DecodeAgUiSocketRecord, __ReduceAgUiStream, __RevokeAgUiStreamAccess, type AgUiStreamState } from "@opencrane/state/conversation/ag-ui";
 import { ConversationEventStreamMessageError, ConversationEventStreamStatuses, type ConversationEventStream, type ConversationEventStreamUpdate, type StreamConversationEventsCommand, type SubmitConversationEventStreamMessageCommand } from "@opencrane/state/conversation/stream";
 
@@ -107,7 +108,7 @@ export class OpenCraneConversationEventStream implements ConversationEventStream
 		{
 			const timeout = setTimeout(() => this._rejectMessage(requestId), _MESSAGE_ACKNOWLEDGEMENT_TIMEOUT_MILLISECONDS);
 			this._pendingMessages.set(requestId, { socket, resolve, reject, timeout });
-			try { socket.send(JSON.stringify({ type: "conversation.message.submit", requestId, idempotencyKey: command.idempotencyKey, blocks: command.blocks })); }
+			try { socket.send(JSON.stringify(_SubmissionFrame(command, requestId))); }
 			catch { this._rejectMessage(requestId); }
 		});
 	}
@@ -208,9 +209,22 @@ function _HandleMessageAcknowledgement(raw: string, pendingMessages: ReadonlyMap
 	if (pending === undefined) return true;
 	clearTimeout(pending.timeout);
 	(pendingMessages as Map<string, PendingMessage>).delete(requestId);
-	if (value["type"] === "conversation.message.accepted") pending.resolve();
-	else pending.reject(new ConversationEventStreamMessageError(typeof value["error"] === "string" ? value["error"] : undefined));
+	if (value["type"] === ConversationSocketFrameKinds.MessageAccepted || value["type"] === ConversationSocketFrameKinds.ComputerInputAccepted)
+		pending.resolve();
+	else
+		pending.reject(new ConversationEventStreamMessageError(typeof value["error"] === "string" ? value["error"] : undefined));
 	return true;
+}
+
+/** Selects the immutable Computer contract for AgentSession input and leaves direct and group blocks unchanged. */
+function _SubmissionFrame(command: SubmitConversationEventStreamMessageCommand, requestId: string): Record<string, unknown>
+{
+	if (command.mode !== ConversationModes.AgentSession)
+		return { type: ConversationSocketFrameKinds.MessageSubmit, requestId, idempotencyKey: command.idempotencyKey, blocks: command.blocks };
+	const block = command.blocks[0];
+	if (command.blocks.length !== 1 || block?.kind !== MessageContentBlockKinds.Text)
+		throw new ConversationEventStreamMessageError("Agent sessions accept one text input.");
+	return { type: ConversationSocketFrameKinds.ComputerInputSubmit, requestId, inputId: command.idempotencyKey, text: block.value };
 }
 
 /** Recognize the server's transport heartbeat without feeding it to the AG-UI decoder. */

--- a/libs/frontend/state/conversation/stream/src/lib/conversation-event-stream.types.ts
+++ b/libs/frontend/state/conversation/stream/src/lib/conversation-event-stream.types.ts
@@ -1,4 +1,5 @@
 import type { AgUiStreamState } from "@opencrane/state/conversation/ag-ui";
+import type { ConversationModes } from "@opencrane/models/conversations";
 
 /**
  * Reports where a conversation stream is in its lifecycle so browser state can distinguish a
@@ -72,6 +73,8 @@ export interface SubmitConversationEventStreamMessageCommand
 {
 	/** Conversation selected by the active event stream. */
 	readonly conversationId: string;
+	/** Chooses the mode-owned public command frame without trusting a server-side default. */
+	readonly mode: ConversationModes;
 	/** Retry key the server uses to deduplicate uncertain submissions. */
 	readonly idempotencyKey: string;
 	/** Display-safe participant blocks retained unchanged for an exact retry. */

--- a/libs/frontend/state/conversation/workspace/adapter/src/lib/__tests__/opencrane-conversation-workspace.gateway.spec.ts
+++ b/libs/frontend/state/conversation/workspace/adapter/src/lib/__tests__/opencrane-conversation-workspace.gateway.spec.ts
@@ -2,6 +2,7 @@ import { Injector, runInInjectionContext } from "@angular/core";
 import { describe, expect, it, vi } from "vitest";
 
 import { ControlPlaneApiService } from "@opencrane/core";
+import { ConversationModes } from "@opencrane/models/conversations";
 import { ConversationEventStreamMessageError, type ConversationEventStream } from "@opencrane/state/conversation/stream";
 import { CONVERSATION_WORKSPACE_EVENT_STREAM, ConversationWorkspaceGatewayErrorKinds } from "@opencrane/state/conversation/workspace";
 
@@ -20,14 +21,14 @@ describe("OpenCraneConversationWorkspaceGateway", function _Suite()
 	{
 		const submit = vi.fn().mockResolvedValue(undefined);
 		const stream = { stream: vi.fn(), submit } as unknown as ConversationEventStream;
-		await expect(_Gateway(stream).send({ conversationId: "conversation-1", idempotencyKey: "retry-1", blocks: [{ id: "block-1", kind: "text", value: "hello" }] })).resolves.toBeUndefined();
-		expect(submit).toHaveBeenCalledWith({ conversationId: "conversation-1", idempotencyKey: "retry-1", blocks: [{ id: "block-1", kind: "text", value: "hello" }] });
+		await expect(_Gateway(stream).send({ conversationId: "conversation-1", mode: ConversationModes.AgentSession, idempotencyKey: "retry-1", blocks: [{ id: "block-1", kind: "text", value: "hello" }] })).resolves.toBeUndefined();
+		expect(submit).toHaveBeenCalledWith({ conversationId: "conversation-1", mode: ConversationModes.AgentSession, idempotencyKey: "retry-1", blocks: [{ id: "block-1", kind: "text", value: "hello" }] });
 	});
 
 	it("maps a transport-proven access loss to the workspace authority error", async function _MapsAccessLoss()
 	{
 		const submit = vi.fn().mockRejectedValue(new ConversationEventStreamMessageError("conversation_unavailable"));
 		const stream = { stream: vi.fn(), submit } as unknown as ConversationEventStream;
-		await expect(_Gateway(stream).send({ conversationId: "conversation-1", idempotencyKey: "retry-1", blocks: [{ id: "block-1", kind: "text", value: "hello" }] })).rejects.toMatchObject({ kind: ConversationWorkspaceGatewayErrorKinds.AccessChanged });
+		await expect(_Gateway(stream).send({ conversationId: "conversation-1", mode: ConversationModes.AgentSession, idempotencyKey: "retry-1", blocks: [{ id: "block-1", kind: "text", value: "hello" }] })).rejects.toMatchObject({ kind: ConversationWorkspaceGatewayErrorKinds.AccessChanged });
 	});
 });

--- a/libs/frontend/state/conversation/workspace/adapter/src/lib/opencrane-conversation-workspace.gateway.ts
+++ b/libs/frontend/state/conversation/workspace/adapter/src/lib/opencrane-conversation-workspace.gateway.ts
@@ -103,7 +103,7 @@ export class OpenCraneConversationWorkspaceGateway implements ConversationWorksp
 	public async send(command: SubmitConversationMessageCommand): Promise<void>
 	{
 		const blocks = command.blocks.map(function _Block(block) { return { ...block }; });
-		try { await this._eventStream.submit({ conversationId: command.conversationId, idempotencyKey: command.idempotencyKey, blocks }); }
+		try { await this._eventStream.submit({ conversationId: command.conversationId, mode: command.mode, idempotencyKey: command.idempotencyKey, blocks }); }
 		catch (error)
 		{
 			if (!(error instanceof ConversationEventStreamMessageError)) throw _InvalidResponse();

--- a/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.store.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.store.ts
@@ -267,9 +267,10 @@ export class ConversationWorkspaceStore
 	{
 		const selected = this._selected();
 		const text = this._draft().trim();
-		if (selected === null || (text.length === 0 && assetIds.length === 0) || !this._CanSend(assetIds.length > 0)) return false;
+		if (selected === null || (text.length === 0 && assetIds.length === 0) || (selected.mode === ConversationModes.AgentSession && assetIds.length > 0) || !this._CanSend(assetIds.length > 0))
+			return false;
 		const generation = this._generation;
-		const command = this._PendingMessageCommand(selected.id, text, assetIds);
+		const command = this._PendingMessageCommand(selected.id, selected.mode, text, assetIds);
 		this._sending.set(true);
 		this._error.set(null);
 		try
@@ -426,12 +427,13 @@ export class ConversationWorkspaceStore
 	}
 
 	/** Reuse the exact pending command, or freeze a fresh command from the current composer. */
-	private _PendingMessageCommand(conversationId: string, text: string, assetIds: readonly string[]): SubmitConversationMessageCommand
+	private _PendingMessageCommand(conversationId: string, mode: ConversationModes, text: string, assetIds: readonly string[]): SubmitConversationMessageCommand
 	{
-		if (this._pendingMessage !== null && _PendingMessageMatches(this._pendingMessage, conversationId, text, assetIds)) return this._pendingMessage;
+		if (this._pendingMessage !== null && _PendingMessageMatches(this._pendingMessage, conversationId, mode, text, assetIds))
+			return this._pendingMessage;
 		const textBlocks: readonly SubmitConversationMessageBlock[] = text.length === 0 ? [] : [{ id: globalThis.crypto.randomUUID(), kind: MessageContentBlockKinds.Text, value: text }];
 		const assetBlocks: readonly SubmitConversationMessageBlock[] = assetIds.map(function _AssetBlock(assetId) { return { id: globalThis.crypto.randomUUID(), kind: MessageContentBlockKinds.Artifact, value: assetId }; });
-		const command: SubmitConversationMessageCommand = { conversationId, idempotencyKey: globalThis.crypto.randomUUID(), blocks: [...textBlocks, ...assetBlocks] };
+		const command: SubmitConversationMessageCommand = { conversationId, mode, idempotencyKey: globalThis.crypto.randomUUID(), blocks: [...textBlocks, ...assetBlocks] };
 		this._pendingMessage = command;
 		return command;
 	}
@@ -464,9 +466,12 @@ export class ConversationWorkspaceStore
 }
 
 /** Check whether the current composer still exactly matches a command retained for an ambiguous retry. */
-function _PendingMessageMatches(command: SubmitConversationMessageCommand, conversationId: string, text: string, assetIds: readonly string[]): boolean
+function _PendingMessageMatches(command: SubmitConversationMessageCommand, conversationId: string, mode: ConversationModes, text: string, assetIds: readonly string[]): boolean
 {
-	if (command.conversationId !== conversationId) return false;
+	if (command.conversationId !== conversationId)
+		return false;
+	if (command.mode !== mode)
+		return false;
 	const expected = [...(text.length === 0 ? [] : [{ kind: MessageContentBlockKinds.Text, value: text }]), ...assetIds.map(function _AssetInput(assetId) { return { kind: MessageContentBlockKinds.Artifact, value: assetId }; })];
 	return command.blocks.length === expected.length && command.blocks.every(function _SameInput(block, index) { return block.kind === expected[index]?.kind && block.value === expected[index]?.value; });
 }

--- a/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.types.ts
+++ b/libs/frontend/state/conversation/workspace/src/lib/conversation-workspace.types.ts
@@ -256,6 +256,8 @@ export interface SubmitConversationMessageCommand
 {
 	/** Selected conversation that owns every referenced asset. */
 	readonly conversationId: string;
+	/** Immutable mode that selects the public transport's input contract. */
+	readonly mode: ConversationModes;
 	/** Client command coordinate reused only for an exact retry. */
 	readonly idempotencyKey: string;
 	/** Stable text and asset blocks reused byte-for-byte for an exact retry. */

--- a/libs/models/conversations/main/src/__tests__/conversation-command.test.ts
+++ b/libs/models/conversations/main/src/__tests__/conversation-command.test.ts
@@ -44,8 +44,9 @@ function _expectedOpenDecision(mode: ConversationModes, kind: ConversationComman
 
 	if (kind === ConversationCommandKinds.SubmitMessage)
 	{
-		const action = mode === ConversationModes.AgentSession ? ConversationCommandActions.AdmitAgentRun : ConversationCommandActions.AdmitOrdinaryMessage;
-		return { allowed: true, action };
+		if (mode === ConversationModes.AgentSession)
+			return { allowed: false, reason: ConversationCommandDenialReasons.CommandNotSupportedByMode };
+		return { allowed: true, action: ConversationCommandActions.AdmitOrdinaryMessage };
 	}
 
 	if (mode === ConversationModes.AgentSession)

--- a/libs/models/conversations/main/src/conversation-command.ts
+++ b/libs/models/conversations/main/src/conversation-command.ts
@@ -20,12 +20,6 @@ function _deny(reason: ConversationCommandDenialReasons): ConversationCommandDec
 	return { allowed: false, reason };
 }
 
-/** Routes agent-session input through run admission. */
-function _admitAgentRun(): ConversationCommandDecision
-{
-	return _allow(ConversationCommandActions.AdmitAgentRun);
-}
-
 /** Routes direct or group input through ordinary message admission. */
 function _admitOrdinaryMessage(): ConversationCommandDecision
 {
@@ -66,9 +60,9 @@ function _targetActiveRun(context: ConversationCommandContext): ConversationComm
 	return _allow(ConversationCommandActions.TargetActiveRun);
 }
 
-/** Exhaustive agent-session strategy: all input remains under run authority. */
+/** Exhaustive agent-session strategy: immutable ConversationComputer history owns new input. */
 const _AGENT_SESSION_STRATEGY: _ModeCommandStrategy = {
-	[ConversationCommandKinds.SubmitMessage]: _admitAgentRun,
+	[ConversationCommandKinds.SubmitMessage]: _denyUnsupportedModeCommand,
 	[ConversationCommandKinds.SteerRun]: _targetActiveRun,
 	[ConversationCommandKinds.AnswerElicitation]: _targetActiveRun,
 	[ConversationCommandKinds.Close]: _closeConversation,

--- a/libs/models/conversations/main/src/conversation-command.types.ts
+++ b/libs/models/conversations/main/src/conversation-command.types.ts
@@ -26,14 +26,35 @@ export enum ConversationCommandKinds
  */
 export enum ConversationCommandActions
 {
-	/** Route participant input through governed run admission. */
-	AdmitAgentRun = "admit_agent_run",
 	/** Persist an ordinary message without creating a synthetic run. */
 	AdmitOrdinaryMessage = "admit_ordinary_message",
 	/** Forward steering or elicitation to the exact currently active run. */
 	TargetActiveRun = "target_active_run",
 	/** Apply the only legal open-to-closed lifecycle transition. */
 	CloseConversation = "close_conversation",
+}
+
+/**
+ * Frames exchanged by the browser conversation socket for participant submissions.
+ *
+ * The browser adapter and server transport branch on these serialized values, so they are a
+ * closed wire contract. Renaming a member breaks active clients but does not change stored data.
+ * A frame selects a transport handler; it never grants conversation access by itself.
+ */
+export enum ConversationSocketFrameKinds
+{
+	/** Carries a direct or group participant message to the ordinary message authority. */
+	MessageSubmit = "conversation.message.submit",
+	/** Acknowledges an ordinary message append or idempotent retry. */
+	MessageAccepted = "conversation.message.accepted",
+	/** Refuses an ordinary message before it can enter a conversation. */
+	MessageRejected = "conversation.message.rejected",
+	/** Carries one AgentSession text body to immutable ConversationComputer history. */
+	ComputerInputSubmit = "conversation.computer.input.submit",
+	/** Acknowledges an immutable AgentSession input append or idempotent retry. */
+	ComputerInputAccepted = "conversation.computer.input.accepted",
+	/** Refuses an AgentSession input before it can enter immutable history. */
+	ComputerInputRejected = "conversation.computer.input.rejected",
 }
 
 /**


### PR DESCRIPTION
## Summary

- remove the retired AgentSession `SubmitMessage -> run admission -> relational message` writer and its command action
- add the dedicated authenticated `POST /me/conversations/:conversationId/input` contract, plus distinct ConversationComputer socket frames
- compose immutable-history participant admission when the mounted release supplies a ConversationComputer profile and payload keyring; otherwise both transports fail closed
- carry the selected conversation mode through the browser stream so AgentSession uses Computer input while direct and group conversations retain their existing message authority

## Cutover boundary

This is the one-way public AgentSession-input cutover. An AgentSession cannot fall back to `/messages` or the legacy message socket frame after this change. Direct and group conversations deliberately keep their current message path until their common HistoryStore authority replacement. The surviving group `@agent` child-thread bootstrap is not represented as converted here; its legacy run-owned transaction is the next explicitly bounded replacement checkpoint, not a fallback from the new AgentSession transport.

## Review order

#783 → #784 → #785 → #786 → #787 → #788 → #789 → #790 → #791 → #792 → #793 → #794 → #795 → #796 → #797 → #798 → #799 → #800 → #801 → #802 → #803 → #804 → #805 → #806 → #807 → #808 → #810 → #811 → #812 → #813 → #814 → #815 → #816 → #817 → #818 → #819 → #821 → #822 → #823

## Validation

- `npx nx run-many -t lint -p backend-server-conversations,models-conversations,frontend-conversation-adapter,frontend-conversation-stream-state,frontend-conversation-workspace-state,frontend-conversation-workspace-adapter,opencrane --skipNxCache --parallel=3`
- focused backend socket, router, OpenAPI, and message-admission tests (18 passed; local loopback suite run outside the sandbox)
- focused browser adapter and workspace tests (30 passed)
- `npm run check:module-growth -- --diff feat/issue-759-mount-computer-input`
- `npm run check:prisma-boundaries -- --diff feat/issue-759-mount-computer-input`
- `scripts/agent-style-check.sh --diff feat/issue-759-mount-computer-input`
- independent correctness/security review, post-rewrite residue gate, and final comments gate