### PR TITLE
Require conversation infrastructure for every silo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@ The [development status](website/guide/status.md) separates implemented work fro
 
 ### Fixed
 
+- **Operators cannot install an incomplete conversation silo under any tenant name.** Installation
+  requires KurrentDB history and Agent Sandbox execution; a disabled or incomplete profile stops
+  before silo changes or successful install preflight. Immutable images, TLS, bootstrap and service
+  credentials, and approved runtime prerequisites remain required.
+
 - **Browser login can survive server replacement and requests reaching different servers.** The
   follow-up stores encrypted sessions in PostgreSQL, preserves fixed expiry and prevents delayed
   saves from undoing logout. Fresh PostgreSQL CI passes. It requires the matching fresh baseline;

--- a/apps/_infra/deploy-k8s/README.md
+++ b/apps/_infra/deploy-k8s/README.md
@@ -9,8 +9,8 @@
 ## What it owns
 
 This is the **install root** for one **silo** — one customer's isolated slice of OpenCrane. The
-trusted services run in the release namespace; conversation computers run in
-two restricted sibling namespaces owned by the same release. Nothing is shared with other customers. Everything else under `apps/` ships a small
+trusted services run in the release namespace; the release's Agent Sandbox profile fixes where
+conversation computers run and which network paths they can use. Nothing is shared with other customers. Everything else under `apps/` ships a small
 Helm chart; this app is the **umbrella chart** (`opencrane-silo`) that pulls those deployment
 contracts together into one release, plus `deploy.sh`, the entrypoint that installs and upgrades it.
 
@@ -60,14 +60,13 @@ against the checked-out in-repo `file://` sources. The commit is the version aut
 `Chart.lock` and `charts/` outputs are derived packaging, not release inputs.
 
 The artifact preprocessor runs in its own PSA-restricted sibling namespace with a fixed zero-RBAC
-identity, bounded scratch, and no ArtifactStore route. The `conversation-computer` image runs in
-two fixed warm Deployments rather than one Job per attempt. Each generic Pod has only DNS and
-same-silo OpenCrane reachability. An admitted run claims one Pod once; that fixed profile additionally
-admits the exact controller binding path and same-silo LiteLLM. The release owns both namespaces,
-their zero-RBAC ServiceAccount, default-deny and profile-specific standard `NetworkPolicy` objects,
-and a release-scoped admission policy that permits only the exact generic-to-claimed label change or
-discard. Aggregate quotas bound each Deployment, its Pods, CPU, and memory. The admission boundary
-requires Kubernetes 1.30+.
+identity, bounded scratch, and no ArtifactStore route. Conversation computers start from a
+release-owned `SandboxTemplate` and a zero-replica `SandboxWarmPool`. OpenCrane admits each claim
+with its computer lease and generation; the external Agent Sandbox controller creates and deletes
+the Pod. The profile fixes the image digest, RuntimeClass, service account and resource limits.
+Release-owned claim admission keeps the computer identity and lease generation fixed, while
+`NetworkPolicy` allows the computer to reach DNS and the private OpenCrane server. The server owns
+model requests. These admission checks require Kubernetes 1.30+.
 
 ## Public surface
 
@@ -122,14 +121,20 @@ package imports it.
   `<release>-skill-authoring`, so different silos never share its Helm-owned namespace.
 - `--release` — optional only as a restatement of the silo identity. The wrapper derives and
   enforces `opencrane-<cluster-tenant>` so all Helm-owned namespaces stay inside one release.
-- `testv5` — the first 0.11 target silo additionally requires immutable KurrentDB and bootstrap
-  image digests; immutable TLS, administrator, operations, and `opencrane-history` service
-  Secrets; the ready Agent Sandbox controller with extensions enabled; and each Sandbox,
-  SandboxClaim, SandboxTemplate, and SandboxWarmPool CRD served and stored as `v1beta1`. The
-  deploy script rejects a missing Secret key, a different service username, or a CRD that does not
-  meet both API conditions before it changes the silo.
+- Every silo requires the complete conversation profile: KurrentDB history and Agent Sandbox
+  execution. `deploy.sh` enables both after checking immutable history, bootstrap and computer
+  image digests; immutable TLS, administrator, operations and `opencrane-history` service Secrets;
+  the ready Agent Sandbox controller with extensions enabled; an approved `gvisor` RuntimeClass;
+  and each Sandbox, SandboxClaim, SandboxTemplate and SandboxWarmPool custom resource definition
+  (CRD) served and stored as `v1beta1`. A missing Secret key, a different service username or an
+  unsupported CRD version stops installation before the silo changes.
+- `historyStore.kurrentdb.enabled=false` and `agentSandbox.enabled=false` are generic Helm-rendering
+  defaults for component checks. They do not describe a supported silo installation. The shared
+  deploy engine rejects disabled or incomplete conversation configuration before installation or
+  successful install preflight, including calls that bypass `deploy.sh`. Separate credential,
+  prerequisite and recovery commands remain available before a complete install profile exists.
 - `platform/provision-kurrentdb-bootstrap-secrets.sh` — creates the namespace-local immutable TLS,
-  administrator, operations, and `opencrane-history` Secrets for one fresh testv5 silo. Reruns
+  administrator, operations, and `opencrane-history` Secrets for a fresh silo. Reruns
   validate the existing authorities and never rotate them.
 - `--kurrentdb-replay-parked` — replays the installed silo's parked computer activations through a
   separate bounded Job derived from its verified KurrentDB bootstrap template. It leaves the

--- a/apps/_infra/deploy-k8s/deploy.sh
+++ b/apps/_infra/deploy-k8s/deploy.sh
@@ -4,7 +4,7 @@
 #
 # A thin profile over the shared install core (k8s-deploy.sh). It installs ONE
 # per-ClusterTenant silo — the dedicated stack a single ClusterTenant runs on shared
-# nodes: its own operator + channel proxy + LiteLLM + Cognee + opencrane-ui,
+# nodes: its own OpenCrane server, conversation history, computers, LiteLLM, Cognee and browser,
 # per-CT networking, and one app-owned PostgreSQL server with isolated logical databases
 # and credentials for OpenCrane and LiteLLM.
 #
@@ -44,7 +44,7 @@
 # the disposable local k3d smoke.
 #
 # Prereqs: kubectl, helm, the cluster-wide controllers, and the PostgreSQL credentials
-# Secrets already present in the target namespace. testv5 also requires a ready Agent Sandbox
+# Secrets already present in the target namespace. Every silo requires a ready Agent Sandbox
 # controller with its extensions; each Sandbox, SandboxClaim, SandboxTemplate, and SandboxWarmPool
 # CRD serving and storing v1beta1; the gvisor RuntimeClass; and KurrentDB TLS keys (tls.crt,
 # tls.key, ca.crt), administrator and operations password keys, and an `opencrane-history`
@@ -144,86 +144,85 @@ EXPECTED_RELEASE="opencrane-${CLUSTER_TENANT}"
 [[ -n "$RELEASE" ]] || RELEASE="$EXPECTED_RELEASE"
 [[ "$RELEASE" == "$EXPECTED_RELEASE" ]] || { err "--release must be '$EXPECTED_RELEASE' for ClusterTenant '$CLUSTER_TENANT'."; exit 1; }
 
-if [[ "$CLUSTER_TENANT" == "testv5" ]]; then
-  command -v jq >/dev/null 2>&1 || { err "jq is required to validate the testv5 Agent Sandbox controller."; exit 1; }
-  [[ "$KURRENTDB_IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || { err "testv5 requires --kurrentdb-image-digest with an immutable sha256 digest."; exit 1; }
-  [[ "$KURRENTDB_TLS_SECRET" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { err "testv5 requires --kurrentdb-tls-secret."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_ADMIN_SECRET" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { err "testv5 requires --kurrentdb-bootstrap-admin-secret."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_OPS_SECRET" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { err "testv5 requires --kurrentdb-bootstrap-ops-secret."; exit 1; }
-  [[ "$KURRENTDB_SERVICE_CREDENTIAL_SECRET" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { err "testv5 requires --kurrentdb-service-credential-secret."; exit 1; }
-  [[ -n "$KURRENTDB_BOOTSTRAP_IMAGE_REPOSITORY" ]] || { err "testv5 requires --kurrentdb-bootstrap-image-repository for the purpose-built bootstrap image."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || { err "testv5 requires --kurrentdb-bootstrap-image-digest with an immutable sha256 digest."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_IMAGE_PULL_POLICY" =~ ^(Always|IfNotPresent|Never)$ ]] || { err "testv5 requires --kurrentdb-bootstrap-image-pull-policy (Always, IfNotPresent, or Never)."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_CPU_REQUEST" =~ ^[1-9][0-9]*m?$ ]] || { err "testv5 requires --kurrentdb-bootstrap-cpu-request."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_MEMORY_REQUEST" =~ ^[1-9][0-9]*(Ki|Mi|Gi)$ ]] || { err "testv5 requires --kurrentdb-bootstrap-memory-request."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_CPU_LIMIT" =~ ^[1-9][0-9]*m?$ ]] || { err "testv5 requires --kurrentdb-bootstrap-cpu-limit."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_MEMORY_LIMIT" =~ ^[1-9][0-9]*(Ki|Mi|Gi)$ ]] || { err "testv5 requires --kurrentdb-bootstrap-memory-limit."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_ACTIVE_DEADLINE_SECONDS" =~ ^[1-9][0-9]*$ ]] || { err "testv5 requires --kurrentdb-bootstrap-active-deadline-seconds."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_BACKOFF_LIMIT" =~ ^[0-9]+$ ]] || { err "testv5 requires --kurrentdb-bootstrap-backoff-limit."; exit 1; }
-  [[ "$KURRENTDB_BOOTSTRAP_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { err "testv5 requires --kurrentdb-bootstrap-timeout-seconds."; exit 1; }
-  [[ "$AGENT_SANDBOX_IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || { err "testv5 requires --agent-sandbox-image-digest with an immutable sha256 digest."; exit 1; }
-  [[ "$AGENT_SANDBOX_IMAGE_PULL_POLICY" =~ ^(Always|IfNotPresent|Never)$ ]] || { err "testv5 requires --agent-sandbox-image-pull-policy (Always, IfNotPresent, or Never)."; exit 1; }
-  for crd in sandboxes.agents.x-k8s.io sandboxclaims.extensions.agents.x-k8s.io sandboxtemplates.extensions.agents.x-k8s.io sandboxwarmpools.extensions.agents.x-k8s.io; do
-    kubectl get crd "$crd" >/dev/null 2>&1 || { err "testv5 requires the Kubernetes Agent Sandbox CRD '$crd'."; exit 1; }
-    AGENT_SANDBOX_V1BETA1_STATE="$(kubectl get crd "$crd" -o 'jsonpath={range .spec.versions[?(@.name=="v1beta1")]}{.served}:{.storage}{end}')"
-    [[ "$AGENT_SANDBOX_V1BETA1_STATE" == "true:true" ]] || { err "testv5 requires Agent Sandbox CRD '$crd' to serve and store v1beta1 resources."; exit 1; }
-  done
-  AGENT_SANDBOX_IMAGE="$(kubectl get deployment agent-sandbox-controller --namespace agent-sandbox-system -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)"
-  [[ "$AGENT_SANDBOX_IMAGE" == *@sha256:* ]] || { err "testv5 requires the Agent Sandbox controller to use an immutable image digest."; exit 1; }
-  AGENT_SANDBOX_DEPLOYMENT="$(kubectl get deployment agent-sandbox-controller --namespace agent-sandbox-system -o json 2>/dev/null)" || { err "testv5 could not read the Agent Sandbox controller Deployment."; exit 1; }
-  jq -e '.spec.template.spec.containers[0].args | type == "array" and any(.[]; . == "--extensions")' >/dev/null 2>&1 <<<"$AGENT_SANDBOX_DEPLOYMENT" || { err "testv5 requires the Agent Sandbox extensions reconciler."; exit 1; }
-  kubectl rollout status deployment/agent-sandbox-controller --namespace agent-sandbox-system --timeout=120s >/dev/null || { err "testv5 requires a Ready Agent Sandbox controller."; exit 1; }
-  kubectl get sandboxwarmpools.extensions.agents.x-k8s.io --all-namespaces >/dev/null 2>&1 || { err "testv5 requires the Agent Sandbox extensions API to respond."; exit 1; }
-  kubectl get runtimeclass gvisor >/dev/null 2>&1 || { err "testv5 requires the approved gvisor RuntimeClass."; exit 1; }
-  kubectl get secret "$KURRENTDB_TLS_SECRET" --namespace "$NAMESPACE" >/dev/null 2>&1 || { err "testv5 KurrentDB TLS Secret '$KURRENTDB_TLS_SECRET' does not exist in namespace '$NAMESPACE'."; exit 1; }
-  kubectl get secret "$KURRENTDB_BOOTSTRAP_ADMIN_SECRET" --namespace "$NAMESPACE" >/dev/null 2>&1 || { err "testv5 KurrentDB bootstrap Secret '$KURRENTDB_BOOTSTRAP_ADMIN_SECRET' does not exist in namespace '$NAMESPACE'."; exit 1; }
-  kubectl get secret "$KURRENTDB_BOOTSTRAP_OPS_SECRET" --namespace "$NAMESPACE" >/dev/null 2>&1 || { err "testv5 KurrentDB bootstrap operations Secret '$KURRENTDB_BOOTSTRAP_OPS_SECRET' does not exist in namespace '$NAMESPACE'."; exit 1; }
-  kubectl get secret "$KURRENTDB_SERVICE_CREDENTIAL_SECRET" --namespace "$NAMESPACE" >/dev/null 2>&1 || { err "testv5 KurrentDB service credential Secret '$KURRENTDB_SERVICE_CREDENTIAL_SECRET' does not exist in namespace '$NAMESPACE'."; exit 1; }
-  for required_immutable_secret in "$KURRENTDB_TLS_SECRET" "$KURRENTDB_BOOTSTRAP_ADMIN_SECRET" "$KURRENTDB_BOOTSTRAP_OPS_SECRET" "$KURRENTDB_SERVICE_CREDENTIAL_SECRET"; do
-    [[ "$(kubectl get secret "$required_immutable_secret" --namespace "$NAMESPACE" -o jsonpath='{.immutable}')" == "true" ]] || { err "testv5 KurrentDB Secret '$required_immutable_secret' must set immutable: true."; exit 1; }
-  done
-  for required_tls_key in tls.crt tls.key ca.crt; do
-    [[ -n "$(kubectl get secret "$KURRENTDB_TLS_SECRET" --namespace "$NAMESPACE" -o "go-template={{ index .data \"$required_tls_key\" }}")" ]] || { err "testv5 KurrentDB TLS Secret '$KURRENTDB_TLS_SECRET' requires key '$required_tls_key'."; exit 1; }
-  done
-  [[ -n "$(kubectl get secret "$KURRENTDB_BOOTSTRAP_ADMIN_SECRET" --namespace "$NAMESPACE" -o 'go-template={{ index .data "password" }}')" ]] || { err "testv5 KurrentDB bootstrap Secret '$KURRENTDB_BOOTSTRAP_ADMIN_SECRET' requires key 'password'."; exit 1; }
-  [[ -n "$(kubectl get secret "$KURRENTDB_BOOTSTRAP_OPS_SECRET" --namespace "$NAMESPACE" -o 'go-template={{ index .data "password" }}')" ]] || { err "testv5 KurrentDB bootstrap operations Secret '$KURRENTDB_BOOTSTRAP_OPS_SECRET' requires key 'password'."; exit 1; }
-  for required_service_key in username password; do
-    [[ -n "$(kubectl get secret "$KURRENTDB_SERVICE_CREDENTIAL_SECRET" --namespace "$NAMESPACE" -o "go-template={{ index .data \"$required_service_key\" }}")" ]] || { err "testv5 KurrentDB service credential Secret '$KURRENTDB_SERVICE_CREDENTIAL_SECRET' requires key '$required_service_key'."; exit 1; }
-  done
-  KURRENTDB_SERVICE_USERNAME="$(kubectl get secret "$KURRENTDB_SERVICE_CREDENTIAL_SECRET" --namespace "$NAMESPACE" -o 'jsonpath={.data.username}' | base64 -d)"
-  [[ "$KURRENTDB_SERVICE_USERNAME" == "opencrane-history" ]] || { err "testv5 KurrentDB service credential Secret '$KURRENTDB_SERVICE_CREDENTIAL_SECRET' must use username 'opencrane-history'."; exit 1; }
-  PASSTHROUGH+=(
-    --set "historyStore.kurrentdb.enabled=true"
-    --set-string "historyStore.kurrentdb.image.digest=$KURRENTDB_IMAGE_DIGEST"
-    --set-string "historyStore.kurrentdb.tls.existingSecret=$KURRENTDB_TLS_SECRET"
-    --set-string "historyStore.kurrentdb.bootstrapAdmin.existingSecret=$KURRENTDB_BOOTSTRAP_ADMIN_SECRET"
-    --set-string "historyStore.kurrentdb.bootstrapOps.existingSecret=$KURRENTDB_BOOTSTRAP_OPS_SECRET"
-    --set-string "historyStore.kurrentdb.serviceCredential.existingSecret=$KURRENTDB_SERVICE_CREDENTIAL_SECRET"
-    --set-string "historyStore.kurrentdb.bootstrap.image.repository=$KURRENTDB_BOOTSTRAP_IMAGE_REPOSITORY"
-    --set-string "historyStore.kurrentdb.bootstrap.image.digest=$KURRENTDB_BOOTSTRAP_IMAGE_DIGEST"
-    --set-string "historyStore.kurrentdb.bootstrap.image.pullPolicy=$KURRENTDB_BOOTSTRAP_IMAGE_PULL_POLICY"
-    --set-string "historyStore.kurrentdb.bootstrap.resources.requests.cpu=$KURRENTDB_BOOTSTRAP_CPU_REQUEST"
-    --set-string "historyStore.kurrentdb.bootstrap.resources.requests.memory=$KURRENTDB_BOOTSTRAP_MEMORY_REQUEST"
-    --set-string "historyStore.kurrentdb.bootstrap.resources.limits.cpu=$KURRENTDB_BOOTSTRAP_CPU_LIMIT"
-    --set-string "historyStore.kurrentdb.bootstrap.resources.limits.memory=$KURRENTDB_BOOTSTRAP_MEMORY_LIMIT"
-    --set "historyStore.kurrentdb.bootstrap.activeDeadlineSeconds=$KURRENTDB_BOOTSTRAP_ACTIVE_DEADLINE_SECONDS"
-    --set "historyStore.kurrentdb.bootstrap.backoffLimit=$KURRENTDB_BOOTSTRAP_BACKOFF_LIMIT"
-    --set "historyStore.kurrentdb.bootstrap.timeoutSeconds=$KURRENTDB_BOOTSTRAP_TIMEOUT_SECONDS"
-    --set "agentSandbox.enabled=true"
-    --set-string "agentSandbox.namespace=$NAMESPACE"
-    --set-string "agentSandbox.runtimeClassName=gvisor"
-    --set-string "agentSandbox.serviceAccountName=${RELEASE}-agent-sandbox"
-    --set-string "agentSandbox.profiles[0].name=developer"
-    --set-string "agentSandbox.profiles[0].poolName=developer-pool"
-    --set "agentSandbox.profiles[0].warmReplicas=0"
-    --set-string "agentSandbox.profiles[0].image.repository=$AGENT_SANDBOX_IMAGE_REPOSITORY"
-    --set-string "agentSandbox.profiles[0].image.digest=$AGENT_SANDBOX_IMAGE_DIGEST"
-    --set-string "agentSandbox.profiles[0].image.pullPolicy=$AGENT_SANDBOX_IMAGE_PULL_POLICY"
-    --set-string "agentSandbox.profiles[0].resources.requests.cpu=100m"
-    --set-string "agentSandbox.profiles[0].resources.requests.memory=128Mi"
-    --set-string "agentSandbox.profiles[0].resources.limits.cpu=500m"
-    --set-string "agentSandbox.profiles[0].resources.limits.memory=512Mi")
-fi
+# Every silo needs conversation history and an admitted computer profile before installation.
+command -v jq >/dev/null 2>&1 || { err "jq is required to validate the Agent Sandbox controller."; exit 1; }
+[[ "$KURRENTDB_IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || { err "Conversation deployment requires --kurrentdb-image-digest with an immutable sha256 digest."; exit 1; }
+[[ "$KURRENTDB_TLS_SECRET" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { err "Conversation deployment requires --kurrentdb-tls-secret."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_ADMIN_SECRET" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-admin-secret."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_OPS_SECRET" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-ops-secret."; exit 1; }
+[[ "$KURRENTDB_SERVICE_CREDENTIAL_SECRET" =~ ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ ]] || { err "Conversation deployment requires --kurrentdb-service-credential-secret."; exit 1; }
+[[ -n "$KURRENTDB_BOOTSTRAP_IMAGE_REPOSITORY" ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-image-repository for the purpose-built bootstrap image."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-image-digest with an immutable sha256 digest."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_IMAGE_PULL_POLICY" =~ ^(Always|IfNotPresent|Never)$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-image-pull-policy (Always, IfNotPresent, or Never)."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_CPU_REQUEST" =~ ^[1-9][0-9]*m?$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-cpu-request."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_MEMORY_REQUEST" =~ ^[1-9][0-9]*(Ki|Mi|Gi)$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-memory-request."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_CPU_LIMIT" =~ ^[1-9][0-9]*m?$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-cpu-limit."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_MEMORY_LIMIT" =~ ^[1-9][0-9]*(Ki|Mi|Gi)$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-memory-limit."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_ACTIVE_DEADLINE_SECONDS" =~ ^[1-9][0-9]*$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-active-deadline-seconds."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_BACKOFF_LIMIT" =~ ^[0-9]+$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-backoff-limit."; exit 1; }
+[[ "$KURRENTDB_BOOTSTRAP_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { err "Conversation deployment requires --kurrentdb-bootstrap-timeout-seconds."; exit 1; }
+[[ "$AGENT_SANDBOX_IMAGE_DIGEST" =~ ^sha256:[a-f0-9]{64}$ ]] || { err "Conversation deployment requires --agent-sandbox-image-digest with an immutable sha256 digest."; exit 1; }
+[[ "$AGENT_SANDBOX_IMAGE_PULL_POLICY" =~ ^(Always|IfNotPresent|Never)$ ]] || { err "Conversation deployment requires --agent-sandbox-image-pull-policy (Always, IfNotPresent, or Never)."; exit 1; }
+for crd in sandboxes.agents.x-k8s.io sandboxclaims.extensions.agents.x-k8s.io sandboxtemplates.extensions.agents.x-k8s.io sandboxwarmpools.extensions.agents.x-k8s.io; do
+  kubectl get crd "$crd" >/dev/null 2>&1 || { err "Conversation deployment requires the Kubernetes Agent Sandbox CRD '$crd'."; exit 1; }
+  AGENT_SANDBOX_V1BETA1_STATE="$(kubectl get crd "$crd" -o 'jsonpath={range .spec.versions[?(@.name=="v1beta1")]}{.served}:{.storage}{end}')"
+  [[ "$AGENT_SANDBOX_V1BETA1_STATE" == "true:true" ]] || { err "Conversation deployment requires Agent Sandbox CRD '$crd' to serve and store v1beta1 resources."; exit 1; }
+done
+AGENT_SANDBOX_IMAGE="$(kubectl get deployment agent-sandbox-controller --namespace agent-sandbox-system -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null)"
+[[ "$AGENT_SANDBOX_IMAGE" == *@sha256:* ]] || { err "Conversation deployment requires the Agent Sandbox controller to use an immutable image digest."; exit 1; }
+AGENT_SANDBOX_DEPLOYMENT="$(kubectl get deployment agent-sandbox-controller --namespace agent-sandbox-system -o json 2>/dev/null)" || { err "Conversation deployment could not read the Agent Sandbox controller Deployment."; exit 1; }
+jq -e '.spec.template.spec.containers[0].args | type == "array" and any(.[]; . == "--extensions")' >/dev/null 2>&1 <<<"$AGENT_SANDBOX_DEPLOYMENT" || { err "Conversation deployment requires the Agent Sandbox extensions reconciler."; exit 1; }
+kubectl rollout status deployment/agent-sandbox-controller --namespace agent-sandbox-system --timeout=120s >/dev/null || { err "Conversation deployment requires a Ready Agent Sandbox controller."; exit 1; }
+kubectl get sandboxwarmpools.extensions.agents.x-k8s.io --all-namespaces >/dev/null 2>&1 || { err "Conversation deployment requires the Agent Sandbox extensions API to respond."; exit 1; }
+kubectl get runtimeclass gvisor >/dev/null 2>&1 || { err "Conversation deployment requires the approved gvisor RuntimeClass."; exit 1; }
+kubectl get secret "$KURRENTDB_TLS_SECRET" --namespace "$NAMESPACE" >/dev/null 2>&1 || { err "KurrentDB TLS Secret '$KURRENTDB_TLS_SECRET' does not exist in namespace '$NAMESPACE'."; exit 1; }
+kubectl get secret "$KURRENTDB_BOOTSTRAP_ADMIN_SECRET" --namespace "$NAMESPACE" >/dev/null 2>&1 || { err "KurrentDB bootstrap Secret '$KURRENTDB_BOOTSTRAP_ADMIN_SECRET' does not exist in namespace '$NAMESPACE'."; exit 1; }
+kubectl get secret "$KURRENTDB_BOOTSTRAP_OPS_SECRET" --namespace "$NAMESPACE" >/dev/null 2>&1 || { err "KurrentDB bootstrap operations Secret '$KURRENTDB_BOOTSTRAP_OPS_SECRET' does not exist in namespace '$NAMESPACE'."; exit 1; }
+kubectl get secret "$KURRENTDB_SERVICE_CREDENTIAL_SECRET" --namespace "$NAMESPACE" >/dev/null 2>&1 || { err "KurrentDB service credential Secret '$KURRENTDB_SERVICE_CREDENTIAL_SECRET' does not exist in namespace '$NAMESPACE'."; exit 1; }
+for required_immutable_secret in "$KURRENTDB_TLS_SECRET" "$KURRENTDB_BOOTSTRAP_ADMIN_SECRET" "$KURRENTDB_BOOTSTRAP_OPS_SECRET" "$KURRENTDB_SERVICE_CREDENTIAL_SECRET"; do
+  [[ "$(kubectl get secret "$required_immutable_secret" --namespace "$NAMESPACE" -o jsonpath='{.immutable}')" == "true" ]] || { err "KurrentDB Secret '$required_immutable_secret' must set immutable: true."; exit 1; }
+done
+for required_tls_key in tls.crt tls.key ca.crt; do
+  [[ -n "$(kubectl get secret "$KURRENTDB_TLS_SECRET" --namespace "$NAMESPACE" -o "go-template={{ index .data \"$required_tls_key\" }}")" ]] || { err "KurrentDB TLS Secret '$KURRENTDB_TLS_SECRET' requires key '$required_tls_key'."; exit 1; }
+done
+[[ -n "$(kubectl get secret "$KURRENTDB_BOOTSTRAP_ADMIN_SECRET" --namespace "$NAMESPACE" -o 'go-template={{ index .data "password" }}')" ]] || { err "KurrentDB bootstrap Secret '$KURRENTDB_BOOTSTRAP_ADMIN_SECRET' requires key 'password'."; exit 1; }
+[[ -n "$(kubectl get secret "$KURRENTDB_BOOTSTRAP_OPS_SECRET" --namespace "$NAMESPACE" -o 'go-template={{ index .data "password" }}')" ]] || { err "KurrentDB bootstrap operations Secret '$KURRENTDB_BOOTSTRAP_OPS_SECRET' requires key 'password'."; exit 1; }
+for required_service_key in username password; do
+  [[ -n "$(kubectl get secret "$KURRENTDB_SERVICE_CREDENTIAL_SECRET" --namespace "$NAMESPACE" -o "go-template={{ index .data \"$required_service_key\" }}")" ]] || { err "KurrentDB service credential Secret '$KURRENTDB_SERVICE_CREDENTIAL_SECRET' requires key '$required_service_key'."; exit 1; }
+done
+KURRENTDB_SERVICE_USERNAME="$(kubectl get secret "$KURRENTDB_SERVICE_CREDENTIAL_SECRET" --namespace "$NAMESPACE" -o 'jsonpath={.data.username}' | base64 -d)"
+[[ "$KURRENTDB_SERVICE_USERNAME" == "opencrane-history" ]] || { err "KurrentDB service credential Secret '$KURRENTDB_SERVICE_CREDENTIAL_SECRET' must use username 'opencrane-history'."; exit 1; }
+PASSTHROUGH+=(
+  --set "historyStore.kurrentdb.enabled=true"
+  --set-string "historyStore.kurrentdb.image.digest=$KURRENTDB_IMAGE_DIGEST"
+  --set-string "historyStore.kurrentdb.tls.existingSecret=$KURRENTDB_TLS_SECRET"
+  --set-string "historyStore.kurrentdb.bootstrapAdmin.existingSecret=$KURRENTDB_BOOTSTRAP_ADMIN_SECRET"
+  --set-string "historyStore.kurrentdb.bootstrapOps.existingSecret=$KURRENTDB_BOOTSTRAP_OPS_SECRET"
+  --set-string "historyStore.kurrentdb.serviceCredential.existingSecret=$KURRENTDB_SERVICE_CREDENTIAL_SECRET"
+  --set-string "historyStore.kurrentdb.bootstrap.image.repository=$KURRENTDB_BOOTSTRAP_IMAGE_REPOSITORY"
+  --set-string "historyStore.kurrentdb.bootstrap.image.digest=$KURRENTDB_BOOTSTRAP_IMAGE_DIGEST"
+  --set-string "historyStore.kurrentdb.bootstrap.image.pullPolicy=$KURRENTDB_BOOTSTRAP_IMAGE_PULL_POLICY"
+  --set-string "historyStore.kurrentdb.bootstrap.resources.requests.cpu=$KURRENTDB_BOOTSTRAP_CPU_REQUEST"
+  --set-string "historyStore.kurrentdb.bootstrap.resources.requests.memory=$KURRENTDB_BOOTSTRAP_MEMORY_REQUEST"
+  --set-string "historyStore.kurrentdb.bootstrap.resources.limits.cpu=$KURRENTDB_BOOTSTRAP_CPU_LIMIT"
+  --set-string "historyStore.kurrentdb.bootstrap.resources.limits.memory=$KURRENTDB_BOOTSTRAP_MEMORY_LIMIT"
+  --set "historyStore.kurrentdb.bootstrap.activeDeadlineSeconds=$KURRENTDB_BOOTSTRAP_ACTIVE_DEADLINE_SECONDS"
+  --set "historyStore.kurrentdb.bootstrap.backoffLimit=$KURRENTDB_BOOTSTRAP_BACKOFF_LIMIT"
+  --set "historyStore.kurrentdb.bootstrap.timeoutSeconds=$KURRENTDB_BOOTSTRAP_TIMEOUT_SECONDS"
+  --set "agentSandbox.enabled=true"
+  --set-string "agentSandbox.namespace=$NAMESPACE"
+  --set-string "agentSandbox.runtimeClassName=gvisor"
+  --set-string "agentSandbox.serviceAccountName=${RELEASE}-agent-sandbox"
+  --set-string "agentSandbox.profiles[0].name=developer"
+  --set-string "agentSandbox.profiles[0].poolName=developer-pool"
+  --set "agentSandbox.profiles[0].warmReplicas=0"
+  --set-string "agentSandbox.profiles[0].image.repository=$AGENT_SANDBOX_IMAGE_REPOSITORY"
+  --set-string "agentSandbox.profiles[0].image.digest=$AGENT_SANDBOX_IMAGE_DIGEST"
+  --set-string "agentSandbox.profiles[0].image.pullPolicy=$AGENT_SANDBOX_IMAGE_PULL_POLICY"
+  --set-string "agentSandbox.profiles[0].resources.requests.cpu=100m"
+  --set-string "agentSandbox.profiles[0].resources.requests.memory=128Mi"
+  --set-string "agentSandbox.profiles[0].resources.limits.cpu=500m"
+  --set-string "agentSandbox.profiles[0].resources.limits.memory=512Mi")
 
 # Human APIs are fail-closed without OIDC. Require the exact org client rather than deploying an
 # intentionally inaccessible or tokenless development setup.

--- a/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
+++ b/apps/_infra/deploy-k8s/platform/k8s-deploy.sh
@@ -83,9 +83,9 @@
 # limited to a disposable `.test` install that deliberately uses local imported tags.
 #
 # Raw Helm-arg passthrough: --helm-arg ARG (or OPENCRANE_HELM_EXTRA_ARGS='ARG1 ARG2 …')
-# appends verbatim arguments to the final helm upgrade invocation. Useful for sanctioned
-# one-time fixes like --take-ownership (e.g. when a Certificate loses ownership across versions).
-# Repeatable: --helm-arg --take-ownership --helm-arg --force-fields-order.
+# accepts Helm value flags and supported release controls such as --take-ownership. Target,
+# schema-validation and post-renderer overrides are rejected before installation so the final
+# release uses the validated profile. Repeatable: --helm-arg --take-ownership --helm-arg --force-conflicts.
 #
 # --base-domain is the platform BASE domain (e.g. dev.opencrane.ai). It is
 # a first-class, VALIDATED install input (lowercase FQDN, ≥2 labels) that drives a single
@@ -173,6 +173,7 @@ source "$SCRIPT_DIR/database-release-finalization.sh"
 source "$SCRIPT_DIR/kurrentdb-restore.sh"
 source "$SCRIPT_DIR/kurrentdb-bootstrap.sh"
 source "$SCRIPT_DIR/kurrentdb-replay.sh"
+source "$SCRIPT_DIR/required-conversation-profile.sh"
 CHART_DIR="${OPENCRANE_CHART_DIR:-}"
 if [[ -z "$CHART_DIR" ]]; then
   echo "[k8s-deploy] OPENCRANE_CHART_DIR is unset. Run a role wrapper deploy.sh — the fleet-platform chart's deploy.sh (now in WeOwnAI) or apps/_infra/deploy-k8s/deploy.sh — not k8s-deploy.sh directly." >&2
@@ -517,6 +518,28 @@ _resolve_release_images
 resolve_qualified_workflow_image_digests || exit $?
 preflight_qualified_release_tag_images || exit $?
 
+# Conversation resources are required by every real silo. Validate the same value sources and
+# preservation mode before preflight can succeed or installation publishes its first ConfigMap.
+# The KurrentDB snapshot Job needs these only in volumeSnapshot mode; the chart ignores them otherwise.
+_load_kubernetes_api_helm_args historyStore.kurrentdb.backup.volumeSnapshot "KurrentDB backup"
+KURRENTDB_BACKUP_KUBERNETES_API_ARGS=("${KUBERNETES_API_HELM_ARGS[@]}")
+CONVERSATION_PROFILE_ARGS=("${KURRENTDB_BACKUP_KUBERNETES_API_ARGS[@]}")
+[[ -n "$VALUES_FILE" ]] && CONVERSATION_PROFILE_ARGS+=(--values "$VALUES_FILE")
+if [[ ${#EXTRA_SET[@]} -gt 0 ]]; then
+  CONVERSATION_PROFILE_ARGS+=("${EXTRA_SET[@]}")
+fi
+if [[ ${#EXTRA_HELM_ARGS[@]} -gt 0 ]]; then
+  CONVERSATION_PROFILE_ARGS+=("${EXTRA_HELM_ARGS[@]}")
+fi
+if [[ -n "$REUSE_VALUES" ]]; then
+  CONVERSATION_PROFILE_ARGS+=(--reuse-values)
+elif [[ -n "$RESET_VALUES" ]]; then
+  CONVERSATION_PROFILE_ARGS+=(--reset-values)
+elif helm status "$RELEASE" -n "$NAMESPACE" >/dev/null 2>&1; then
+  CONVERSATION_PROFILE_ARGS+=(--reset-then-reuse-values)
+fi
+require_conversation_deployment_profile "${CONVERSATION_PROFILE_ARGS[@]}" || exit $?
+
 # --preflight runs before any cluster mutation and accumulates every failure in PF_FAILS, so the
 # operator can repair the environment once. It reads cloud and cluster state but never mutates it.
 _run_preflight() {
@@ -761,9 +784,6 @@ _load_kubernetes_api_helm_args memoryGateway "memory gateway"
 MEMORY_GATEWAY_KUBERNETES_API_ARGS=("${KUBERNETES_API_HELM_ARGS[@]}")
 _load_kubernetes_api_helm_args agentController "agent controller"
 AGENT_CONTROLLER_KUBERNETES_API_ARGS=("${KUBERNETES_API_HELM_ARGS[@]}")
-# The KurrentDB snapshot Job needs these only in volumeSnapshot mode; the chart ignores them otherwise.
-_load_kubernetes_api_helm_args historyStore.kurrentdb.backup.volumeSnapshot "KurrentDB backup"
-KURRENTDB_BACKUP_KUBERNETES_API_ARGS=("${KUBERNETES_API_HELM_ARGS[@]}")
 
 _copy_cnpg_uri_secret() {
   local source_secret="$1"

--- a/apps/_infra/deploy-k8s/platform/required-conversation-profile.sh
+++ b/apps/_infra/deploy-k8s/platform/required-conversation-profile.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Validates deployment inputs with Helm's existing value merging, schemas, and app-owned templates.
+# The core calls this after maintenance exits and before preflight success or a cluster write.
+require_conversation_deployment_profile()
+(
+  set -euo pipefail
+  umask 077
+  local fixture argument
+  local validation_args=(--namespace "$NAMESPACE")
+  fixture="$(mktemp -d)" || return $?
+  trap 'rm -rf -- "$fixture"' EXIT
+  mkdir -p "$fixture/chart/templates" "$fixture/chart/charts" || return $?
+
+  # These library charts own the conversation resource contracts. Other workloads need Secrets
+  # produced later in installation, so this render deliberately evaluates these two owners alone.
+  sed '/^dependencies:/,$d' "$CHART_DIR/Chart.yaml" >"$fixture/chart/Chart.yaml" || return $?
+  cp "$CHART_DIR/values.yaml" "$fixture/chart/values.yaml" || return $?
+  cp "$CHART_DIR"/charts/k8s-platform-*.tgz \
+    "$CHART_DIR"/charts/opencrane-kurrentdb-*.tgz \
+    "$CHART_DIR"/charts/opencrane-agent-sandbox-*.tgz "$fixture/chart/charts/" || return $?
+  jq '.properties |= with_entries(select(.key == "historyStore" or .key == "agentSandbox"))
+      | del(.allOf)
+      | .required = ["historyStore", "agentSandbox"]
+      | .properties.historyStore.required = ["kurrentdb"]
+      | .properties.historyStore.properties.kurrentdb.required += ["enabled"]
+      | .properties.historyStore.properties.kurrentdb.properties.enabled = {"const": true}
+      | .properties.agentSandbox.properties.enabled.const = true' \
+    "$CHART_DIR/values.schema.json" >"$fixture/chart/values.schema.json" || return $?
+  cat >"$fixture/chart/templates/required-conversation.yaml" <<'TEMPLATE' || return $?
+{{- if not (regexMatch "^sha256:[a-f0-9]{64}$" .Values.historyStore.kurrentdb.image.digest) -}}
+{{- fail "historyStore.kurrentdb.image.digest must be an immutable sha256 digest for deployment" -}}
+{{- end -}}
+{{ include "opencrane.kurrentdb.resources" . }}
+---
+{{ include "opencrane.agentSandbox.resources" . }}
+TEMPLATE
+
+  # Value flags retain Helm's own precedence, including raw --set-json/--set-file/--set-literal.
+  # Reject options which could change the target, disable validation, or transform the manifests.
+  while (( $# > 0 )); do
+    argument="$1"
+    shift
+    case "$argument" in
+      --values|-f|--set|--set-string|--set-json|--set-file|--set-literal|--timeout|--history-max|--description|--labels)
+        if (( $# == 0 )); then
+          err "A Helm passthrough option is missing its value."
+          return 1
+        fi
+        validation_args+=("$argument" "$1")
+        shift
+        ;;
+      --values=*|-f?*|--set=*|--set-string=*|--set-json=*|--set-file=*|--set-literal=*|--timeout=*|--history-max=*|--description=*|--labels=*|--wait|--wait=*|--wait-for-jobs|--take-ownership|--force-conflicts|--force-replace|--cleanup-on-fail|--rollback-on-failure|--reuse-values|--reuse-values=true|--reuse-values=false|--reset-values|--reset-values=true|--reset-values=false|--reset-then-reuse-values|--reset-then-reuse-values=true|--reset-then-reuse-values=false)
+        validation_args+=("$argument")
+        ;;
+      *)
+        err "Unsupported Helm passthrough option. Use deployment flags for target and validation settings."
+        return 1
+        ;;
+    esac
+  done
+
+  # Helm reads the existing release itself, so --reuse-values keeps its old chart defaults and
+  # --reset-then-reuse-values refreshes them exactly as in the final upgrade. Server dry-run reads
+  # the actual Kubernetes capabilities and Secret lookups without persisting release resources.
+  # Redirect all output because a profile or a Helm schema error can contain operator secrets.
+  if ! helm upgrade --install "$RELEASE" "$fixture/chart" \
+    "${validation_args[@]}" --dry-run=server --hide-secret --no-hooks \
+    --disable-openapi-validation >/dev/null 2>&1; then
+    err "Conversation deployment inputs failed Helm validation: historyStore.kurrentdb.enabled and agentSandbox.enabled must be true; supply complete immutable images, Secret references, and an approved sandbox profile. Also check the target release is readable."
+    return 1
+  fi
+)

--- a/apps/_infra/deploy-k8s/platform/tests/required-conversation-profile-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/required-conversation-profile-contract.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../../.." && pwd)"
+CORE="$ROOT_DIR/apps/_infra/deploy-k8s/platform/k8s-deploy.sh"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/current-chart-sources.sh"
+source "$ROOT_DIR/apps/_infra/deploy-k8s/platform/required-conversation-profile.sh"
+TEST_DIRECTORY="$(mktemp -d)"
+trap 'cleanup_current_chart_sources; rm -rf -- "$TEST_DIRECTORY"' EXIT
+REAL_HELM="$(command -v helm)"
+export REAL_HELM TEST_DIRECTORY
+prepare_current_chart_sources
+CHART_DIR="$(current_chart_sources_dir)"
+RELEASE=opencrane-acme
+NAMESPACE=opencrane-acme
+DIGEST="sha256:$(printf '%064d' 1)"
+cat >"$TEST_DIRECTORY/complete.yaml" <<VALUES
+historyStore:
+  kurrentdb:
+    enabled: true
+    image:
+      digest: $DIGEST
+    tls:
+      existingSecret: ledger-tls
+    bootstrapAdmin:
+      existingSecret: ledger-admin
+    bootstrapOps:
+      existingSecret: ledger-ops
+    serviceCredential:
+      existingSecret: ledger-service
+    bootstrap:
+      image:
+        repository: registry.example/bootstrap
+        digest: $DIGEST
+agentSandbox:
+  enabled: true
+  namespace: opencrane-acme
+  runtimeClassName: approved-runc
+  serviceAccountName: conversation-sandbox
+  profiles:
+    - name: developer
+      poolName: developer-pool
+      warmReplicas: 0
+      image:
+        repository: registry.example/computer
+        digest: $DIGEST
+        pullPolicy: IfNotPresent
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+VALUES
+printf 'historyStore:\n  kurrentdb:\n    enabled: false\n' >"$TEST_DIRECTORY/disabled.yaml"
+printf 'false' >"$TEST_DIRECTORY/disabled.txt"
+
+err() { printf '%s\n' "$*" >&2; }
+# Exercise the real Helm templates without requiring a cluster. Record preservation flags as
+# arguments; their release-merging implementation remains Helm's responsibility in production.
+helm()
+{
+  local verb="$1" release chart argument mode="" dry_run=0
+  local render_args=()
+  shift
+  case "$verb" in
+    dependency) "$REAL_HELM" dependency "$@" ;;
+    status) [[ "${TEST_RELEASE_EXISTS:-0}" == 1 ]] ;;
+    get) printf '{}\n' ;;
+    upgrade)
+      [[ "$1" == --install ]] || return 99
+      release="$2"
+      chart="$3"
+      shift 3
+      while (( $# > 0 )); do
+        argument="$1"
+        shift
+        case "$argument" in
+          --dry-run=server) dry_run=1 ;;
+          --hide-secret|--no-hooks|--disable-openapi-validation) ;;
+          --reuse-values|--reset-values|--reset-then-reuse-values) mode="$argument" ;;
+          *) render_args+=("$argument") ;;
+        esac
+      done
+      if [[ "$dry_run" != 1 ]]; then
+        printf 'MUTATION helm upgrade\n' >>"$TEST_DIRECTORY/calls"
+        return 99
+      fi
+      printf 'validate %s\n' "$mode" >>"$TEST_DIRECTORY/calls"
+      "$REAL_HELM" template "$release" "$chart" --kube-version 1.35.0 "${render_args[@]}"
+      ;;
+    *) printf 'Unexpected Helm call: %s\n' "$verb" >&2; return 99 ;;
+  esac
+}
+export -f helm
+expect_rejected()
+{
+  if require_conversation_deployment_profile "$@" >"$TEST_DIRECTORY/rejected" 2>&1; then
+    printf 'Invalid conversation deployment inputs were accepted.\n' >&2
+    exit 1
+  fi
+}
+
+require_conversation_deployment_profile --values "$TEST_DIRECTORY/complete.yaml" || exit 1
+expect_rejected
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set historyStore.kurrentdb.enabled=false
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set agentSandbox.enabled=false
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-string agentSandbox.enabled=false
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-string historyStore.kurrentdb.image.digest=
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-string historyStore.kurrentdb.tls.existingSecret=
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-string historyStore.kurrentdb.bootstrap.image.digest=
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-json 'agentSandbox.profiles=[]'
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-string 'agentSandbox.profiles[0].image.digest='
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --values "$TEST_DIRECTORY/disabled.yaml"
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-literal historyStore.kurrentdb.enabled=false
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-file "historyStore.kurrentdb.enabled=$TEST_DIRECTORY/disabled.txt"
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-json 'historyStore.kurrentdb.enabled=false'
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set historyStore.kurrentdb.enabled=false --set-json 'historyStore.kurrentdb.enabled=true'
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --skip-schema-validation
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --namespace another-silo
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --post-renderer arbitrary-command
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --dry-run=none
+require_conversation_deployment_profile --values "$TEST_DIRECTORY/disabled.yaml" --values "$TEST_DIRECTORY/complete.yaml" || exit 1
+require_conversation_deployment_profile --values "$TEST_DIRECTORY/complete.yaml" --reset-values || exit 1
+require_conversation_deployment_profile --values "$TEST_DIRECTORY/complete.yaml" --reuse-values || exit 1
+require_conversation_deployment_profile --values "$TEST_DIRECTORY/complete.yaml" --reset-then-reuse-values || exit 1
+for mode in --reset-values --reuse-values --reset-then-reuse-values; do
+  grep -Fq -- "validate $mode" "$TEST_DIRECTORY/calls" || exit 1
+done
+
+# Invalid schema input can appear in Helm diagnostics. The deployment prints a fixed diagnostic.
+expect_rejected --values "$TEST_DIRECTORY/complete.yaml" --set-string 'agentSandbox.profiles[0].image.digest=private-test-marker'
+if grep -Fq private-test-marker "$TEST_DIRECTORY/rejected"; then
+  printf 'Helm validation exposed a supplied value.\n' >&2
+  exit 1
+fi
+
+kubectl()
+{
+  printf 'kubectl %s\n' "$*" >>"$TEST_DIRECTORY/calls"
+  case "$1" in
+    cluster-info) return 0 ;;
+    config) printf 'contract-cluster\n'; return 0 ;;
+    get) ;;
+    *) printf 'MUTATION kubectl\n' >>"$TEST_DIRECTORY/calls"; return 99 ;;
+  esac
+  case "$*" in
+    *"service kubernetes"*"clusterIP"*) printf '10.43.0.1' ;;
+    *"service kubernetes"*"port"*) printf '443' ;;
+    *"endpoints kubernetes"*"ports"*) printf '6443' ;;
+    *"endpoints kubernetes"*"addresses"*) printf '172.18.0.2\n' ;;
+    *storageclass*) printf 'true' ;;
+    *"get ds"*) printf 'daemonset.apps/cilium\n' ;;
+    *"get secret"*".type"*) printf 'kubernetes.io/basic-auth' ;;
+    *"get secret opencrane-bootstrap"*".data.username"*) printf opencrane | base64 ;;
+    *"get secret litellm-bootstrap"*".data.username"*) printf litellm | base64 ;;
+    *"get secret admin-bootstrap"*".data.username"*) printf opencrane_database_admin | base64 ;;
+    *"get secret"*".data.password"*) printf contract-password | base64 ;;
+  esac
+}
+skopeo() { printf 'sha256:%064d\n' 1; }
+export -f kubectl skopeo
+CORE_ARGS=(--cluster-tenant acme --release opencrane-acme --namespace opencrane-acme
+  --release-version "$(jq -r .version "$ROOT_DIR/package.json")"
+  --image-tag sha-1234567 --opencrane-ui-digest "$DIGEST" --cognee-digest "$DIGEST"
+  --postgres-credentials-secret opencrane-bootstrap
+  --litellm-postgres-credentials-secret litellm-bootstrap
+  --postgres-admin-credentials-secret admin-bootstrap)
+export OPENCRANE_CHART_DIR="$ROOT_DIR/apps/_infra/deploy-k8s"
+bash "$CORE" "${CORE_ARGS[@]}" --values "$TEST_DIRECTORY/complete.yaml" --preflight >"$TEST_DIRECTORY/core-output" 2>&1 || { cat "$TEST_DIRECTORY/core-output" >&2; exit 1; }
+# This proves an arbitrary silo and an approved non-gvisor profile can pass direct-core preflight.
+grep -Fq 'Preflight: all checks passed.' "$TEST_DIRECTORY/core-output" || exit 1
+for action in --preflight install; do
+  action_args=("${CORE_ARGS[@]}")
+  [[ "$action" == install ]] || action_args+=("$action")
+  for input in missing disabled raw-disabled; do
+    input_args=(--storage-class contract-storage)
+    case "$input" in
+      disabled) input_args=(--values "$TEST_DIRECTORY/complete.yaml" --set historyStore.kurrentdb.enabled=false) ;;
+      raw-disabled) input_args=(--values "$TEST_DIRECTORY/complete.yaml" --helm-arg --set-json --helm-arg 'agentSandbox.enabled=false') ;;
+    esac
+    if bash "$CORE" "${action_args[@]}" "${input_args[@]}" >"$TEST_DIRECTORY/core-output" 2>&1; then
+      printf 'Direct core accepted %s inputs during %s.\n' "$input" "$action" >&2
+      exit 1
+    fi
+    grep -Fq 'Conversation deployment inputs failed Helm validation' "$TEST_DIRECTORY/core-output" || exit 1
+  done
+done
+if grep -Fq MUTATION "$TEST_DIRECTORY/calls"; then
+  printf 'Conversation preflight or invalid inputs reached a cluster mutation.\n' >&2
+  exit 1
+fi
+printf 'required conversation profile contract: PASS\n'

--- a/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/run-helm-contracts.sh
@@ -18,6 +18,7 @@ for contract in \
   current-chart-sources-contract.sh \
   provision-contract.sh \
   preflight-cni-contract.sh \
+  required-conversation-profile-contract.sh \
   kubernetes-api-helm-args-contract.sh \
   pooler-deploy-contract.sh \
   postgres-release-contract.sh \

--- a/apps/_infra/deploy-k8s/platform/tests/silo-deploy-profile-contract.sh
+++ b/apps/_infra/deploy-k8s/platform/tests/silo-deploy-profile-contract.sh
@@ -25,11 +25,11 @@ grep -Fq -- '--kurrentdb-bootstrap-image-repository' "$DEPLOY_SCRIPT"
 grep -Fq -- '--kurrentdb-bootstrap-image-digest' "$DEPLOY_SCRIPT"
 grep -Fq -- '--agent-sandbox-image-repository' "$DEPLOY_SCRIPT"
 grep -Fq -- '--agent-sandbox-image-digest' "$DEPLOY_SCRIPT"
-grep -Fq -- 'testv5 requires the Kubernetes Agent Sandbox CRD' "$DEPLOY_SCRIPT"
-grep -Fq -- 'testv5 requires the Agent Sandbox controller to use an immutable image digest' "$DEPLOY_SCRIPT"
-grep -Fq -- 'testv5 requires the Agent Sandbox extensions reconciler' "$DEPLOY_SCRIPT"
-grep -Fq -- 'testv5 requires a Ready Agent Sandbox controller' "$DEPLOY_SCRIPT"
-grep -Fq -- 'testv5 requires the approved gvisor RuntimeClass' "$DEPLOY_SCRIPT"
+grep -Fq -- 'Conversation deployment requires the Kubernetes Agent Sandbox CRD' "$DEPLOY_SCRIPT"
+grep -Fq -- 'Conversation deployment requires the Agent Sandbox controller to use an immutable image digest' "$DEPLOY_SCRIPT"
+grep -Fq -- 'Conversation deployment requires the Agent Sandbox extensions reconciler' "$DEPLOY_SCRIPT"
+grep -Fq -- 'Conversation deployment requires a Ready Agent Sandbox controller' "$DEPLOY_SCRIPT"
+grep -Fq -- 'Conversation deployment requires the approved gvisor RuntimeClass' "$DEPLOY_SCRIPT"
 grep -Fq -- "requires key '\$required_tls_key'" "$DEPLOY_SCRIPT"
 grep -Fq -- "requires key 'password'" "$DEPLOY_SCRIPT"
 grep -Fq -- "must set immutable: true" "$DEPLOY_SCRIPT"
@@ -115,13 +115,13 @@ grep -Fq -- '--set-string "opencrane-skill-authoring.skillAuthoring.namespace=$S
 grep -Fq -- '--set-string "opencrane-mcp-executor.mcpExecutor.namespace=$MCP_EXECUTOR_NAMESPACE"' "$DEPLOY_CORE"
 grep -Fq -- 'EXPECTED_RELEASE="opencrane-${CLUSTER_TENANT}"' "$DEPLOY_SCRIPT"
 grep -Fq -- '--release "$RELEASE"' "$DEPLOY_SCRIPT"
-extra_args_line="$(grep -nF '[[ ${#EXTRA_HELM_ARGS[@]} -gt 0 ]]' "$DEPLOY_CORE" | cut -d: -f1)"
+extra_args_line="$(grep -nF '[[ ${#EXTRA_HELM_ARGS[@]} -gt 0 ]] && helm_args+=' "$DEPLOY_CORE" | cut -d: -f1)"
 skill_namespace_line="$(grep -nF -- '--set-string "opencrane-skill-authoring.skillAuthoring.namespace=$SKILL_AUTHORING_NAMESPACE"' "$DEPLOY_CORE" | cut -d: -f1)"
-(( skill_namespace_line > extra_args_line ))
+(( skill_namespace_line > extra_args_line )) || exit 1
 grep -Fq -- 'resolve_cluster_tenant_crd_install' "$DEPLOY_CORE"
 grep -Fq -- '--set "crds.install=$CRDS_INSTALL"' "$DEPLOY_CORE"
 crd_install_line="$(grep -nF -- '--set "crds.install=$CRDS_INSTALL"' "$DEPLOY_CORE" | cut -d: -f1)"
-(( crd_install_line > extra_args_line ))
+(( crd_install_line > extra_args_line )) || exit 1
 grep -Fq -- '--opencrane-ui-digest) CONTROL_PLANE_SPA_DIGEST="$2"' "$DEPLOY_CORE"
 grep -Fq -- '--cognee-digest) COGNEE_DIGEST="$2"' "$DEPLOY_CORE"
 grep -Fq -- 'clustertenantManager.cognee.image.digest // empty' "$DEPLOY_CORE"
@@ -148,8 +148,8 @@ grep -Fq -- 'kubectl logs "job/$job_name"' "$DEPLOY_CORE"
   bootstrap_wait_test_dir="$(mktemp -d)"
   trap 'rm -rf "$bootstrap_wait_test_dir"' EXIT
   eval "$(sed -n '/^wait_for_final_kurrentdb_bootstrap_job_if_present()$/,/^}/p' "$DEPLOY_CORE")"
-  RELEASE=opencrane-testv5
-  NAMESPACE=opencrane-testv5
+  RELEASE=opencrane-acme
+  NAMESPACE=opencrane-acme
   TIMEOUT=7
   unset SECONDS
   err() { printf '%s\n' "$*" >&2; }
@@ -214,7 +214,7 @@ grep -Fq -- 'kubectl logs "job/$job_name"' "$DEPLOY_CORE"
     fi
     if [[ "$bootstrap_wait_case" == failed || "$bootstrap_wait_case" == failure-target || "$bootstrap_wait_case" == running-failed ]]; then
       grep -Fq 'reported terminal failure' "$bootstrap_wait_test_dir/output" || exit 1
-      grep -Fq 'logs job/opencrane-testv5-kurrentdb-bootstrap' "$bootstrap_wait_test_dir/calls" || exit 1
+      grep -Fq 'logs job/opencrane-acme-kurrentdb-bootstrap' "$bootstrap_wait_test_dir/calls" || exit 1
     fi
     if [[ "$bootstrap_wait_case" == running ]]; then
       [[ "$(tr '\n' ' ' <"$bootstrap_wait_test_dir/sleeps")" == '2 2 2 1 ' ]] || exit 1
@@ -252,7 +252,7 @@ grep -Fq -- 'kubectl logs "job/$job_name"' "$DEPLOY_CORE"
   {
     printf '%s\n' "$*" >>"$bootstrap_wait_test_dir/final-calls"
     case "$1 $2" in
-      'get deployment/opencrane-testv5-opencrane-server') printf '%s\n' deployment.apps/opencrane-testv5-opencrane-server ;;
+      'get deployment/opencrane-acme-opencrane-server') printf '%s\n' deployment.apps/opencrane-acme-opencrane-server ;;
       'rollout status') return "$server_exit" ;;
       *) echo "Unexpected finalization command: $*" >&2; return 99 ;;
     esac
@@ -284,7 +284,7 @@ grep -Fq -- 'kubectl logs "job/$job_name"' "$DEPLOY_CORE"
     elif [[ "$final_wait_case" == consumer-failure ]]; then
       [[ "$(cat "$bootstrap_wait_test_dir/final-calls")" == $'bootstrap\nconsumers' ]] || exit 1
     else
-      grep -Fq 'rollout status deployment/opencrane-testv5-opencrane-server -n opencrane-testv5 --timeout=7s' "$bootstrap_wait_test_dir/final-calls" || exit 1
+      grep -Fq 'rollout status deployment/opencrane-acme-opencrane-server -n opencrane-acme --timeout=7s' "$bootstrap_wait_test_dir/final-calls" || exit 1
     fi
     if [[ "$final_wait_case" == success || "$final_wait_case" == fresh-success ]]; then
       [[ "$(tail -n 1 "$bootstrap_wait_test_dir/final-calls")" == verify ]] || exit 1
@@ -469,29 +469,18 @@ exit 0
 EOF
 chmod +x "$wrapper_test_dir/platform/k8s-deploy.sh" "$wrapper_test_dir/bin/kubectl"
 wrapper_args_file="$wrapper_test_dir/args"
-PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" MISSING_KURRENTDB_SECRET_KEY=absent-key \
+# A new tenant must not reach the engine without the conversation configuration.
+if PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" \
   bash "$wrapper_test_dir/deploy.sh" \
-    --base-domain dev.opencrane.ai \
-    --cluster-tenant testv4 \
-    --acme-email operator@example.com \
-    --first-user-email owner@example.com \
-    --oidc-issuer-url https://issuer.example.com/ \
-    --oidc-client-id test-client >/dev/null
-wrapper_args="$(tr '\n' ' ' <"$wrapper_args_file")"
-[[ "$wrapper_args" == *"--namespace opencrane-testv4 --release opencrane-testv4"* ]]
-[[ "$wrapper_args" == *"--cluster-tenant testv4"* ]]
-set +e
-PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" WRAPPER_CORE_EXIT_CODE=47 \
-  bash "$wrapper_test_dir/deploy.sh" \
-    --base-domain dev.opencrane.ai \
-    --cluster-tenant testv4 \
-    --acme-email operator@example.com \
-    --first-user-email owner@example.com \
-    --oidc-issuer-url https://issuer.example.com/ \
-    --oidc-client-id test-client >/dev/null
-wrapper_status="$?"
-set -e
-[[ "$wrapper_status" -eq 47 ]]
+    --base-domain dev.opencrane.ai --cluster-tenant acme \
+    --acme-email operator@example.com --first-user-email owner@example.com \
+    --oidc-issuer-url https://issuer.example.com/ --oidc-client-id test-client \
+    >/dev/null 2>"$wrapper_test_dir/missing-profile.error"; then
+  echo "silo wrapper accepted missing conversation configuration" >&2
+  exit 1
+fi
+grep -Fq 'requires --kurrentdb-image-digest' "$wrapper_test_dir/missing-profile.error"
+[[ ! -e "$wrapper_args_file" ]] || { echo 'Incomplete configuration reached the deploy core.' >&2; exit 1; }
 if PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" \
   bash "$wrapper_test_dir/deploy.sh" \
     --base-domain dev.opencrane.ai \
@@ -536,7 +525,7 @@ cat >"$wrapper_test_dir/agent-sandbox-ready.json" <<'EOF'
 EOF
 cp "$wrapper_test_dir/agent-sandbox-ready.json" "$AGENT_SANDBOX_DEPLOYMENT_FIXTURE"
 
-testv5_required_args=(
+conversation_required_args=(
   --kurrentdb-image-digest sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   --kurrentdb-tls-secret kurrentdb-tls
   --kurrentdb-bootstrap-admin-secret kurrentdb-bootstrap
@@ -555,29 +544,52 @@ testv5_required_args=(
   --agent-sandbox-image-repository registry.invalid/opencrane-conversation-computer
   --agent-sandbox-image-digest sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
   --agent-sandbox-image-pull-policy IfNotPresent)
+# Tenant names do not select capabilities; both ordinary and historical names receive the profile.
+for tenant in acme testv5; do
+  PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" MISSING_KURRENTDB_SECRET_KEY=absent-key \
+    bash "$wrapper_test_dir/deploy.sh" \
+      --base-domain dev.opencrane.ai --cluster-tenant "$tenant" \
+      --acme-email operator@example.com --first-user-email owner@example.com \
+      --oidc-issuer-url https://issuer.example.com/ --oidc-client-id test-client \
+      "${conversation_required_args[@]}" >/dev/null
+  wrapper_args="$(tr '\n' ' ' <"$wrapper_args_file")"
+  [[ "$wrapper_args" == *"--namespace opencrane-$tenant --release opencrane-$tenant"* ]]
+  [[ "$wrapper_args" == *'historyStore.kurrentdb.enabled=true'* ]]
+  [[ "$wrapper_args" == *'agentSandbox.enabled=true'* ]]
+done
+set +e
+PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" WRAPPER_CORE_EXIT_CODE=47 MISSING_KURRENTDB_SECRET_KEY=absent-key \
+  bash "$wrapper_test_dir/deploy.sh" \
+    --base-domain dev.opencrane.ai --cluster-tenant acme \
+    --acme-email operator@example.com --first-user-email owner@example.com \
+    --oidc-issuer-url https://issuer.example.com/ --oidc-client-id test-client \
+    "${conversation_required_args[@]}" >/dev/null
+wrapper_status="$?"
+set -e
+[[ "$wrapper_status" -eq 47 ]]
 PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" MISSING_KURRENTDB_SECRET_KEY=absent-key \
   bash "$wrapper_test_dir/deploy.sh" \
     --base-domain dev.opencrane.ai \
-    --cluster-tenant testv5 \
+    --cluster-tenant acme \
     --acme-email operator@example.com \
     --first-user-email owner@example.com \
     --oidc-issuer-url https://issuer.example.com/ \
     --oidc-client-id test-client \
-    "${testv5_required_args[@]}" >/dev/null
-testv5_forwarded_args="$(tr '\n' ' ' <"$wrapper_args_file")"
-[[ "$testv5_forwarded_args" == *'historyStore.kurrentdb.bootstrapOps.existingSecret=kurrentdb-bootstrap-ops'* ]]
-[[ "$testv5_forwarded_args" == *'historyStore.kurrentdb.serviceCredential.existingSecret=kurrentdb-history-service'* ]]
-[[ "$testv5_forwarded_args" == *'historyStore.kurrentdb.bootstrap.image.repository=registry.invalid/opencrane-kurrentdb-bootstrap'* ]]
-[[ "$testv5_forwarded_args" == *'historyStore.kurrentdb.bootstrap.image.digest=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'* ]]
-[[ "$testv5_forwarded_args" == *'historyStore.kurrentdb.bootstrap.backoffLimit=0'* ]]
-[[ "$testv5_forwarded_args" == *'agentSandbox.enabled=true'* ]]
-[[ "$testv5_forwarded_args" == *'agentSandbox.namespace=opencrane-testv5'* ]]
-[[ "$testv5_forwarded_args" == *'agentSandbox.runtimeClassName=gvisor'* ]]
-[[ "$testv5_forwarded_args" == *'agentSandbox.serviceAccountName=opencrane-testv5-agent-sandbox'* ]]
-[[ "$testv5_forwarded_args" == *'agentSandbox.profiles[0].name=developer'* ]]
-[[ "$testv5_forwarded_args" == *'agentSandbox.profiles[0].poolName=developer-pool'* ]]
-[[ "$testv5_forwarded_args" == *'agentSandbox.profiles[0].warmReplicas=0'* ]]
-[[ "$testv5_forwarded_args" == *'agentSandbox.profiles[0].image.digest=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'* ]]
+    "${conversation_required_args[@]}" >/dev/null
+conversation_forwarded_args="$(tr '\n' ' ' <"$wrapper_args_file")"
+[[ "$conversation_forwarded_args" == *'historyStore.kurrentdb.bootstrapOps.existingSecret=kurrentdb-bootstrap-ops'* ]]
+[[ "$conversation_forwarded_args" == *'historyStore.kurrentdb.serviceCredential.existingSecret=kurrentdb-history-service'* ]]
+[[ "$conversation_forwarded_args" == *'historyStore.kurrentdb.bootstrap.image.repository=registry.invalid/opencrane-kurrentdb-bootstrap'* ]]
+[[ "$conversation_forwarded_args" == *'historyStore.kurrentdb.bootstrap.image.digest=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'* ]]
+[[ "$conversation_forwarded_args" == *'historyStore.kurrentdb.bootstrap.backoffLimit=0'* ]]
+[[ "$conversation_forwarded_args" == *'agentSandbox.enabled=true'* ]]
+[[ "$conversation_forwarded_args" == *'agentSandbox.namespace=opencrane-acme'* ]]
+[[ "$conversation_forwarded_args" == *'agentSandbox.runtimeClassName=gvisor'* ]]
+[[ "$conversation_forwarded_args" == *'agentSandbox.serviceAccountName=opencrane-acme-agent-sandbox'* ]]
+[[ "$conversation_forwarded_args" == *'agentSandbox.profiles[0].name=developer'* ]]
+[[ "$conversation_forwarded_args" == *'agentSandbox.profiles[0].poolName=developer-pool'* ]]
+[[ "$conversation_forwarded_args" == *'agentSandbox.profiles[0].warmReplicas=0'* ]]
+[[ "$conversation_forwarded_args" == *'agentSandbox.profiles[0].image.digest=sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'* ]]
 
 # The actual wrapper accepts the exact argument in Deployment JSON, never substrings or scalar text.
 for mutation in \
@@ -596,11 +608,11 @@ for mutation in \
   rm -f "$wrapper_args_file"
   if PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" MISSING_KURRENTDB_SECRET_KEY=absent-key \
     bash "$wrapper_test_dir/deploy.sh" \
-      --base-domain dev.opencrane.ai --cluster-tenant testv5 \
+      --base-domain dev.opencrane.ai --cluster-tenant acme \
       --acme-email operator@example.com --first-user-email owner@example.com \
       --oidc-issuer-url https://issuer.example.com/ --oidc-client-id test-client \
-      "${testv5_required_args[@]}" >/dev/null 2>"$wrapper_test_dir/extensions.error"; then
-    echo "testv5 accepted invalid Sandbox arguments: $mutation" >&2
+      "${conversation_required_args[@]}" >/dev/null 2>"$wrapper_test_dir/extensions.error"; then
+    echo "acme accepted invalid Sandbox arguments: $mutation" >&2
     exit 1
   fi
   grep -Fq 'requires the Agent Sandbox extensions reconciler' "$wrapper_test_dir/extensions.error"
@@ -609,77 +621,77 @@ done
 cp "$wrapper_test_dir/agent-sandbox-ready.json" "$AGENT_SANDBOX_DEPLOYMENT_FIXTURE"
 if PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" AGENT_SANDBOX_READ_FAILURE=true \
   bash "$wrapper_test_dir/deploy.sh" \
-    --base-domain dev.opencrane.ai --cluster-tenant testv5 \
+    --base-domain dev.opencrane.ai --cluster-tenant acme \
     --acme-email operator@example.com --first-user-email owner@example.com \
     --oidc-issuer-url https://issuer.example.com/ --oidc-client-id test-client \
-    "${testv5_required_args[@]}" >/dev/null 2>"$wrapper_test_dir/extensions-read.error"; then
-  echo 'testv5 ignored a failed Sandbox Deployment read.' >&2
+    "${conversation_required_args[@]}" >/dev/null 2>"$wrapper_test_dir/extensions-read.error"; then
+  echo 'acme ignored a failed Sandbox Deployment read.' >&2
   exit 1
 fi
 grep -Fq 'could not read the Agent Sandbox controller Deployment' "$wrapper_test_dir/extensions-read.error"
 [[ ! -e "$wrapper_args_file" ]] || { echo 'A failed Sandbox read reached the deploy core.' >&2; exit 1; }
 
-testv5_immutable_error_file="$wrapper_test_dir/testv5-kurrentdb-immutable.error"
+conversation_immutable_error_file="$wrapper_test_dir/acme-kurrentdb-immutable.error"
 if PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" MISSING_KURRENTDB_SECRET_KEY=absent-key KURRENTDB_SECRET_IMMUTABLE=false \
   bash "$wrapper_test_dir/deploy.sh" \
     --base-domain dev.opencrane.ai \
-    --cluster-tenant testv5 \
+    --cluster-tenant acme \
     --acme-email operator@example.com \
     --first-user-email owner@example.com \
     --oidc-issuer-url https://issuer.example.com/ \
     --oidc-client-id test-client \
-    "${testv5_required_args[@]}" > /dev/null 2>"$testv5_immutable_error_file"; then
-  echo "testv5 accepted a mutable KurrentDB Secret" >&2
+    "${conversation_required_args[@]}" > /dev/null 2>"$conversation_immutable_error_file"; then
+  echo "acme accepted a mutable KurrentDB Secret" >&2
   exit 1
 fi
-grep -Fq 'must set immutable: true' "$testv5_immutable_error_file"
+grep -Fq 'must set immutable: true' "$conversation_immutable_error_file"
 
-testv5_service_username_error_file="$wrapper_test_dir/testv5-kurrentdb-service-username.error"
+conversation_service_username_error_file="$wrapper_test_dir/acme-kurrentdb-service-username.error"
 if PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" MISSING_KURRENTDB_SECRET_KEY=absent-key KURRENTDB_SERVICE_USERNAME_BASE64=b3RoZXItdXNlcg== \
   bash "$wrapper_test_dir/deploy.sh" \
     --base-domain dev.opencrane.ai \
-    --cluster-tenant testv5 \
+    --cluster-tenant acme \
     --acme-email operator@example.com \
     --first-user-email owner@example.com \
     --oidc-issuer-url https://issuer.example.com/ \
     --oidc-client-id test-client \
-    "${testv5_required_args[@]}" > /dev/null 2>"$testv5_service_username_error_file"; then
-  echo "testv5 accepted a KurrentDB service credential for another username" >&2
+    "${conversation_required_args[@]}" > /dev/null 2>"$conversation_service_username_error_file"; then
+  echo "acme accepted a KurrentDB service credential for another username" >&2
   exit 1
 fi
-grep -Fq "must use username 'opencrane-history'" "$testv5_service_username_error_file"
+grep -Fq "must use username 'opencrane-history'" "$conversation_service_username_error_file"
 
 for missing_kurrentdb_secret_key in tls.crt tls.key ca.crt password username; do
-  testv5_error_file="$wrapper_test_dir/testv5-$missing_kurrentdb_secret_key.error"
+  conversation_error_file="$wrapper_test_dir/acme-$missing_kurrentdb_secret_key.error"
   if PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" MISSING_KURRENTDB_SECRET_KEY="$missing_kurrentdb_secret_key" \
     bash "$wrapper_test_dir/deploy.sh" \
       --base-domain dev.opencrane.ai \
-      --cluster-tenant testv5 \
+      --cluster-tenant acme \
       --acme-email operator@example.com \
       --first-user-email owner@example.com \
       --oidc-issuer-url https://issuer.example.com/ \
       --oidc-client-id test-client \
-      "${testv5_required_args[@]}" > /dev/null 2>"$testv5_error_file"; then
-    echo "testv5 accepted KurrentDB Secret without '$missing_kurrentdb_secret_key'" >&2
+      "${conversation_required_args[@]}" > /dev/null 2>"$conversation_error_file"; then
+    echo "acme accepted KurrentDB Secret without '$missing_kurrentdb_secret_key'" >&2
     exit 1
   fi
-  grep -Fq "requires key '$missing_kurrentdb_secret_key'" "$testv5_error_file"
+  grep -Fq "requires key '$missing_kurrentdb_secret_key'" "$conversation_error_file"
 done
 
-testv5_version_error_file="$wrapper_test_dir/testv5-agent-sandbox-version.error"
+conversation_version_error_file="$wrapper_test_dir/acme-agent-sandbox-version.error"
 if PATH="$wrapper_test_dir/bin:$PATH" WRAPPER_ARGS_FILE="$wrapper_args_file" AGENT_SANDBOX_V1BETA1_STATE='true:false' \
   bash "$wrapper_test_dir/deploy.sh" \
     --base-domain dev.opencrane.ai \
-    --cluster-tenant testv5 \
+    --cluster-tenant acme \
     --acme-email operator@example.com \
     --first-user-email owner@example.com \
     --oidc-issuer-url https://issuer.example.com/ \
     --oidc-client-id test-client \
-    "${testv5_required_args[@]}" > /dev/null 2>"$testv5_version_error_file"; then
-  echo "testv5 accepted an Agent Sandbox CRD without v1beta1 storage" >&2
+    "${conversation_required_args[@]}" > /dev/null 2>"$conversation_version_error_file"; then
+  echo "acme accepted an Agent Sandbox CRD without v1beta1 storage" >&2
   exit 1
 fi
-grep -Fq "to serve and store v1beta1 resources" "$testv5_version_error_file"
+grep -Fq "to serve and store v1beta1 resources" "$conversation_version_error_file"
 
 provider_secret_calls=()
 kubectl()

--- a/apps/_infra/deploy-k8s/values.yaml
+++ b/apps/_infra/deploy-k8s/values.yaml
@@ -104,10 +104,12 @@ sharedPlatform:
       #    Required when mode=shared.
       secretStoreName: ""
 
-# -- Private KurrentDB event ledger. The testv5 deploy path enables it after the KurrentDB and
-# bootstrap image digests, TLS material, and administrator, operations, and service Secrets pass preflight.
+# -- Stores conversation history in the private KurrentDB event ledger. Every silo deploy enables
+# it after the image digests, TLS material, and administrator, operations, and service Secrets pass preflight.
 historyStore:
   kurrentdb:
+    # -- Keeps generic Helm rendering available for component checks. Supported silo installs require
+    # this value to be true; the deploy engine rejects a disabled conversation profile before installation.
     enabled: false
     # -- Exact DNS resolver hosts (/32 IPv4 or /128 IPv6) for bootstrap and snapshot Jobs.
     # Add cluster or node-local resolver addresses when the CNI cannot match kube-dns Pods.
@@ -226,6 +228,8 @@ historyStore:
 # -- Defines release-scoped profiles for the external Kubernetes Agent Sandbox v1beta1 controller.
 # The chart creates profiles and claim admission only; it never installs the controller or CRDs.
 agentSandbox:
+  # -- Keeps generic Helm rendering available for component checks. Every supported silo install
+  # enables this profile after checking its immutable image and approved controller/runtime prerequisites.
   enabled: false
   # -- Maximum lifetime of one server-issued conversation-computer lease.
   leaseTtlSeconds: 3600

--- a/plan.md
+++ b/plan.md
@@ -89,6 +89,7 @@ their own completion track; they are not silently bundled into the first tool PR
 | F1 — documents and durable output | SOURCE GAP IDENTIFIED — reuse uploads/scanning but connect authorized document content to immutable model input. Generated-file finalization and complete recovery remain open. |
 | D1/S1 — delegation and schedules | PLANNED — depend on bounded action, cancellation and durable result contracts. |
 | A2/Q1 — administration and operational acceptance | PLANNED THROUGHOUT — configuration APIs are incremental; product controls and full journey/recovery qualification remain. |
+| Q1 — required conversation install profile | IMPLEMENTED — every supported silo install requires KurrentDB history and Agent Sandbox execution; generic Helm render defaults remain available for component checks. Full CI and live installation qualification remain pending. |
 
 The [dated overnight handoff](docs/design/overnight-delivery-2026-09-09.md) records commits, review
 surfaces, exact CI/live boundaries and the next concrete actions.

--- a/website/operators/deployment-configuration.md
+++ b/website/operators/deployment-configuration.md
@@ -92,14 +92,23 @@ membership and permission checks, and refreshing evidence cannot extend an alrea
 
 ## Conversation execution profile
 
-Generic defaults disable `historyStore.kurrentdb` and `agentSandbox`. The current wrapper enables
-and checks the conversation profile for the named `testv5` target. Other tenant names require an
-explicitly reviewed values profile and the same prerequisites; do not rename a real tenant to
-select development defaults.
+Every supported silo installation requires KurrentDB conversation history and an Agent Sandbox
+execution profile. `deploy.sh` enables and checks both for every tenant name. The shared deploy
+engine also rejects a disabled or incomplete profile before installing or reporting successful
+install preflight, so calling the engine directly preserves the same requirement.
 
-For `testv5`, the wrapper reads these additional environment variables (equivalent CLI flags are
-listed in the source). Store the non-secret configuration in your environment profile and supply
-only Secret names here:
+The generic Helm defaults keep `historyStore.kurrentdb.enabled` and `agentSandbox.enabled` false
+so individual chart components can be rendered and checked without a complete installation
+profile. Those defaults do not define a reduced silo mode. Credential preparation, shared
+prerequisite provisioning and recovery commands remain separate from install admission.
+
+Use the deployment flags to select the target. Raw `--helm-arg` passthrough accepts Helm value
+flags and supported release controls, but rejects target, schema-validation and post-renderer
+overrides that could change the validated installation.
+
+For every silo, the wrapper reads these additional environment variables (equivalent CLI flags
+are listed in the source). Store the non-secret configuration in your environment profile and
+supply only Secret names here:
 
 | Inputs | Variables |
 |---|---|


### PR DESCRIPTION
A fresh tenant could install the server without conversation history or computers because the wrapper enabled KurrentDB and Agent Sandbox only for `testv5`. Every silo now receives the same prerequisite checks and complete conversation profile. The shared engine rejects disabled or incomplete effective configuration before install preflight succeeds or installation writes begin, including direct engine calls.

The gate uses Helm's own value merging and the existing app-owned schemas/templates, including values files, setters and reused release settings. It rejects raw target, schema-validation and post-renderer overrides. Recovery commands remain available before install admission. Generic chart defaults remain disabled for component rendering; they are not a supported reduced installation. The plan, package README, operator guide and changelog explain that distinction.

## Validation

- Independent review of all 11 changed files: PASS against immutable base `06de306fe033fecb8d73c1909a1d8c1fada8fa90`.
- Deployment contract suite completed; a final correction to an existing ordering assertion passed its focused wrapper rerun. The new engine contract uses real Helm rendering with mocked release/cluster reads and proves valid ordinary-tenant profiles, disabled/incomplete refusal before mutation, value precedence and reuse flag forwarding.
- Nx Helm lint and website build pass. Boundary lint, workload ownership and negative checks, release manifest, style/Prisma boundaries and whitespace checks pass. Module growth has no errors; the existing large deploy engine was independently reviewed.
- Local Bash is macOS 3.2; Linux CI remains authoritative. Core validation checks configured inputs; the wrapper checks physical Secrets and controller readiness. Live release reuse and fresh installation were not exercised. No cluster deployment, release tag or website publication is included.

## Review order

1. [#826](https://github.com/elewa-git/opencrane/pull/826) establishes the conversation/computer baseline.
2. [#829](https://github.com/elewa-git/opencrane/pull/829) adds login continuity and personal activity.
3. [#830](https://github.com/elewa-git/opencrane/pull/830) connects one permitted tool continuation.
4. [#832](https://github.com/elewa-git/opencrane/pull/832) adds company-tool assignment.
5. [#833](https://github.com/elewa-git/opencrane/pull/833) adds personal tool progress.
6. [#834](https://github.com/elewa-git/opencrane/pull/834) documents the product, architecture and delivery contract; this PR's immutable base is `06de306fe033fecb8d73c1909a1d8c1fada8fa90`.
7. [#836](https://github.com/elewa-git/opencrane/pull/836) makes the conversation deployment profile mandatory for every silo.

## Independent work

[PR #831](https://github.com/elewa-git/opencrane/pull/831) independently owns member removal and is not included in this branch. No predecessors are absorbed or closed.
