### PR TITLE
✨ Enable company assistant tool selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,12 +47,12 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
   `POST /api/v1/organization/company-assistant` selects its model and the people allowed to invoke
   it. Setup retries preserve the existing assistant and do not restore revoked grants.
 
-- **Conversation workloads can store a proposed tool call without dispatching it.** The private
-  route accepts one frozen tool revision and validated arguments, checks current permission and
-  preserves the same proposal across retries. Connecting it to model execution and durable
-  conversation results remains in development.
-  A durable reservation prevents unresolved tool work from being accepted as a final answer.
-  Exact proposal retries are supported; automatic recovery of an abandoned reservation is pending.
+- **Administrators can select the company assistant's tools through the API.** Each changed
+  selection publishes an immutable configuration and exact permissions for the assistant's own
+  identity. Stale edits conflict, unchanged selections still check current permission, and removing
+  a tool prevents later dispatch through the old revision. Edits preserve the original model
+  allowance; new assistants permit two model requests for one tool result and a final answer.
+  Credential activation, a management screen and live retrieval qualification remain unfinished.
 
 - **People can use agent-session conversations whose complete history survives server and executor
   restarts.** Immutable KurrentDB streams preserve ordered messages and computer lifecycle events,

--- a/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-dispatch-authority.test.ts
+++ b/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-dispatch-authority.test.ts
@@ -19,10 +19,10 @@ const _NOW = new Date("2026-09-09T00:00:00.000Z");
 const _MEMBERSHIP = { kind: ExecutionSubjectMembershipKinds.Standalone, principalId: "principal-1", siloId: "silo-1", issuer: "https://issuer.test", subjectId: "user-1", membershipId: "membership-1", membershipUpdatedAt: new Date(_NOW.getTime() - 2_000).toISOString(), observedAt: _NOW.toISOString(), trustedUntil: new Date(_NOW.getTime() + 60_000).toISOString() } as const;
 
 /** Build persisted grants consumed by the real central authority, rather than mocking allow decisions. */
-function _Grant(kind: ProductAuthorizationResourceKinds, id: string, action: ProductAuthorizationActions)
+function _Grant(kind: ProductAuthorizationResourceKinds, id: string, action: ProductAuthorizationActions, principalId = "principal-1")
 {
 	const capability = __ProductAuthorizationCapability(kind, action)!;
-	return { id: `grant-${kind}-${action}`, siloId: "silo-1", subjectKind: "Principal", subjectPrincipalId: "principal-1", subjectGroupId: null, boundaryKind: "Personal", boundaryPrincipalId: "principal-1", boundaryGroupId: null, boundaryCoverage: "Exact", catalogId: capability.catalog.catalogId, catalogRevision: capability.catalog.revision, catalogDigest: capability.catalog.digest, capabilityId: capability.capabilityId, resourceKind: kind, resourceId: id, effect: "Allow", priority: 0, validFrom: new Date(0), expiresAt: null as Date | null, revokedAt: null as Date | null };
+	return { id: `grant-${principalId}-${kind}-${action}`, siloId: "silo-1", subjectKind: "Principal", subjectPrincipalId: principalId, subjectGroupId: null, boundaryKind: "Personal", boundaryPrincipalId: principalId, boundaryGroupId: null, boundaryCoverage: "Exact", catalogId: capability.catalog.catalogId, catalogRevision: capability.catalog.revision, catalogDigest: capability.catalog.digest, capabilityId: capability.capabilityId, resourceKind: kind, resourceId: id, effect: "Allow", priority: 0, validFrom: new Date(0), expiresAt: null as Date | null, revokedAt: null as Date | null };
 }
 
 /** Exercise real service, membership, authorization and MCP assignment owners over mutable database rows. */
@@ -67,7 +67,42 @@ function _Fixture()
 	const config = { mode: FleetMembershipDeploymentModes.Standalone, siloId: "silo-1", trustedOidcIssuer: "https://issuer.test", maximumStalenessMs: 5_000 } as const;
 	const dependencies = { ..._CreateConversationToolDispatchDependencies({} as never, config), identities, computers };
 	const authority = new PrismaConversationToolDispatchAuthority(transaction as never, dependencies);
-	return { authority, dependencies, transaction, invocation, subject, identityHead, computer, grants, membership, identities, computers };
+	return { authority, dependencies, transaction, invocation, subject, identityHead, computer, grants, membership, principal, identities, computers };
+}
+
+/** Keep company and human grants separate while exercising the real managed evidence owner. */
+function _ManagedFixture()
+{
+	const f = _Fixture();
+	const subject = { ...f.subject, principalId: "managed-1", identity: { ...f.subject.identity, principalId: "managed-1" }, membership: { kind: ExecutionSubjectMembershipKinds.Managed, principalId: "managed-1", siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", agentRevisionDigest: `sha256:${"a".repeat(64)}`, decisionEvidenceId: "managed-evidence", trustedUntil: _MEMBERSHIP.trustedUntil } } as const;
+	const identity = { ...f.identityHead.identity, kind: "managed", principalId: "managed-1" };
+	f.identities.load.mockResolvedValue({ ...f.identityHead, identity });
+	f.transaction.agentRun.findFirst.mockResolvedValue({ conversationId: "conversation-1", executionSubject: subject, inputSnapshotDigest: `sha256:${"e".repeat(64)}` });
+	const service = { id: "service-1", principalId: "managed-1", name: "Company assistant", workloadProfile: {}, activeRevisionId: "revision-1", activeRevision: { id: "revision-1", siloId: "silo-1", agentServiceId: "service-1", state: "Published", digest: `sha256:${"a".repeat(64)}`, personaRevisionId: null, modelDefinitionId: "model-1", budget: { maxDurationMs: 60_000 }, skillAssignments: [], mcpToolAssignments: [{ toolRevisionId: "tool-1" }], boundaryAttachments: [] } };
+	const managedPrincipal = { ...f.principal, id: "managed-1", subject: "company-assistant", provenance: PrincipalProvenance.Internal };
+	const managedToolGrant = _Grant(ProductAuthorizationResourceKinds.McpToolRevision, "tool-1", ProductAuthorizationActions.Invoke, "managed-1");
+	f.grants.push(_Grant(ProductAuthorizationResourceKinds.ModelDefinition, "model-1", ProductAuthorizationActions.Use, "managed-1"), managedToolGrant);
+	const transaction = { ...f.transaction, agentService: { findFirst: vi.fn().mockResolvedValue(service) }, principal: {
+		findFirst: vi.fn(async function _PrincipalById(query: { where: { id: string } })
+		{
+			if (query.where.id === "managed-1")
+				return managedPrincipal;
+			if (query.where.id === f.principal.id)
+				return f.principal;
+			return null;
+		}),
+		findUnique: vi.fn(async function _PrincipalByScope(query: { where: { id_siloId: { id: string } } })
+		{
+			if (query.where.id_siloId.id === "managed-1")
+				return managedPrincipal;
+			if (query.where.id_siloId.id === f.principal.id)
+				return f.principal;
+			return null;
+		}),
+	}, authorizationGrant: { findMany: vi.fn(async function _GrantsForSubjects(query: { where: { OR: { subjectPrincipalId?: string }[] } }) { return f.grants.filter(grant => query.where.OR.some(subject => subject.subjectPrincipalId === grant.subjectPrincipalId)); }) } };
+	const invocation = { ...f.invocation, authorizationEvidence: { ...f.invocation.authorizationEvidence, executionSubject: subject } } as ToolInvocationRecord;
+	const authority = new PrismaConversationToolDispatchAuthority(transaction as never, f.dependencies);
+	return { ...f, authority, invocation, transaction, service, managedToolGrant };
 }
 
 afterEach(function _ResetClock() { vi.useRealTimers(); });
@@ -190,20 +225,33 @@ describe("current conversation tool dispatch authority", function _Suite()
 		await expect(f.authority.admitUntil(f.invocation, _NOW, _WORKLOAD)).resolves.toBeNull();
 	});
 
-	it("preserves the managed revision owner's current exclusion of tool assignments", async function _ManagedToolsRemainUnavailable()
+	it("admits an assigned company tool through the assistant's own principal", async function _ManagedToolAdmission()
 	{
-		const f = _Fixture();
-		const subject = { ...f.subject, principalId: "managed-1", identity: { ...f.subject.identity, principalId: "managed-1" } };
-		const identity = { ...f.identityHead.identity, kind: "managed", principalId: "managed-1" };
-		f.identities.load.mockResolvedValue({ ...f.identityHead, identity });
-		f.transaction.agentRun.findFirst.mockResolvedValue({ conversationId: "conversation-1", executionSubject: subject });
-		const service = { id: "service-1", principalId: "managed-1", name: "Company assistant", workloadProfile: {}, activeRevisionId: "revision-1", activeRevision: { id: "revision-1", siloId: "silo-1", agentServiceId: "service-1", state: "Published", digest: `sha256:${"a".repeat(64)}`, personaRevisionId: null, modelDefinitionId: "model-1", budget: { maxDurationMs: 60_000 }, skillAssignments: [], mcpToolAssignments: [{ toolRevisionId: "tool-1" }], boundaryAttachments: [] } };
-		const transaction = { ...f.transaction, agentService: { findFirst: vi.fn().mockResolvedValue(service) } };
-		const invocation = { ...f.invocation, authorizationEvidence: { ...f.invocation.authorizationEvidence, executionSubject: subject } } as ToolInvocationRecord;
-		const authority = new PrismaConversationToolDispatchAuthority(transaction as never, f.dependencies);
-		await expect(authority.admitUntil(invocation, _NOW, _WORKLOAD)).resolves.toBeNull();
-		expect(transaction.agentService.findFirst).toHaveBeenCalledOnce();
-		expect(f.transaction.auditDecision.create).not.toHaveBeenCalled();
+		const f = _ManagedFixture();
+		await expect(f.authority.admitUntil(f.invocation, _NOW, _WORKLOAD)).resolves.toBe(_NOW.getTime() + 5_000);
+		expect(f.transaction.agentService.findFirst).toHaveBeenCalledOnce();
+		expect(f.transaction.authorizationGrant.findMany).toHaveBeenLastCalledWith(expect.objectContaining({ where: { siloId: "silo-1", OR: [{ subjectKind: "Principal", subjectPrincipalId: "managed-1", subjectGroupId: null }] } }));
+		expect(f.transaction.auditDecision.create).toHaveBeenLastCalledWith({ data: expect.objectContaining({ actorKind: "Workload", actorId: _WORKLOAD.podUid, resourceKind: ProductAuthorizationResourceKinds.McpToolRevision, resourceId: "tool-1" }) });
+	});
+
+	it("does not borrow the human tool grant after the company grant is revoked", async function _ManagedGrantRevoked()
+	{
+		const f = _ManagedFixture();
+		f.managedToolGrant.revokedAt = _NOW;
+		expect(f.grants[2]!.revokedAt).toBeNull();
+		await expect(f.authority.admitUntil(f.invocation, _NOW, _WORKLOAD)).resolves.toBeNull();
+	});
+
+	it.each(["revision", "requester", "assignment"])("denies company dispatch after current %s changes", async function _ManagedCurrentAuthority(change)
+	{
+		const f = _ManagedFixture();
+		if (change === "revision")
+			f.service.activeRevisionId = "revision-2";
+		else if (change === "requester")
+			f.membership.status = OrgMemberStatus.Suspended;
+		else
+			f.transaction.agentRevisionMcpToolAssignment.findFirst.mockResolvedValue(null);
+		await expect(f.authority.admitUntil(f.invocation, _NOW, _WORKLOAD)).resolves.toBeNull();
 	});
 
 });

--- a/docs/agents/prisma-boundary-policy.json
+++ b/docs/agents/prisma-boundary-policy.json
@@ -1048,6 +1048,22 @@
 					{
 						"adapter": "PrismaAgentRevisionWriterRepository",
 						"importPath": "../../revisions/db/prisma-agent-revision-writer"
+					},
+					{
+						"adapter": "PrismaCompanyAssistantToolsRepository",
+						"importPath": "./prisma-company-assistant-tools"
+					}
+				]
+			},
+			{
+				"path": "libs/backend/server/agents/agent-services/main/src/company-assistants/db/prisma-company-assistant-tools.ts",
+				"adapter": "PrismaCompanyAssistantToolsRepository",
+				"contract": "CompanyAssistantToolsRepository",
+				"contractImportPath": "../company-assistant-provisioning.types",
+				"constructs": [
+					{
+						"adapter": "PrismaAgentRevisionWriterRepository",
+						"importPath": "../../revisions/db/prisma-agent-revision-writer"
 					}
 				]
 			},

--- a/docs/design/mvp-delivery-plan.md
+++ b/docs/design/mvp-delivery-plan.md
@@ -1,165 +1,140 @@
 # Deliver useful assistant work
 
-OpenCrane gives employees and teams assistants that can use company knowledge and tools under
-company control. The conversation baseline proves that people can join, approve personal settings,
-receive answers, collaborate in a group and review a company assistant's response. The next product
-step is to complete useful work and make returning to that work dependable.
+OpenCrane gives employees and teams assistants that use company knowledge and tools under company
+control. Personal and group text journeys already have implementation and live evidence. The next
+step is useful work with real records, explicit decisions, durable results and understandable controls.
 
-This plan covers all remaining gaps identified on 2026-09-08. The user authorized planning and
-overnight execution, with intermittent commits and reviewable PRs. It does not claim that the
-whole MVP can be delivered in one night. `plan.md` owns current status, `plan-done.md` owns completed
-tracks, and the deployment ledger owns live evidence.
+This plan records the user's priority order accepted on 10 September 2026. It supersedes the earlier
+overnight sequencing. `plan.md` owns current execution status, `plan-done.md` records completed tracks,
+and the deployment ledger records live evidence. A track may require several incremental PRs; the
+whole MVP is not one implementation or qualification claim.
 
-## Release outcomes
+## Priority order and acceptance
 
-| Milestone | Outcome | Required evidence |
-| --- | --- | --- |
-| Finish the 0.11 review baseline | People can onboard and use durable personal and group text chats. | Replay-contract CI is repaired; retain the existing live journey and recovery evidence. Review remains on #826. |
-| First follow-up PR | People can return to their assistant without losing login or completed activity. | Server replacement preserves a valid login, completed personal runs appear for their owner, and other people cannot read them. |
-| 0.12.0 | An assistant retrieves permitted company data and completes a human-approved action. | One real integration works through personal and company-child chats; activity, approval, cancellation, retry, result and current access remain correct after interruption. |
-| Remaining MVP tracks | People can use memory, files, delegation, scheduled work and understandable administration. | Each track below has its own complete user journey and negative/recovery proof. Assign later version numbers when its release scope is selected. |
+Dependencies below are concrete contracts. A small prerequisite lands with the feature that needs it:
+tool configuration is part of retrieval, and the exact approval presenter is part of approved actions.
+Complete administration, rich interaction and action recovery keep their later positions.
 
-0.12 uses the current conversation/computer ownership. PostgreSQL remains the authorization
-authority, KurrentDB stores history, and Agent Sandbox owns Pods. Reuse the memory gateway and
-durable tool invocation/executor owners. Pre-MVP installations use a clean baseline; schema changes
-regenerate and verify that baseline. A release number does not add an upgrade or migration layer.
-
-## Small PRs and their acceptance
-
-Each row is a bounded implementation slice. Split a row further when its review would combine
-independent ownership or unrelated risks. A dependency means a required contract, shared file or
-actual authority prerequisite; it is not a reason to serialize independent implementation.
-
-| ID | User outcome and implementation boundary | Depends on | Acceptance |
+| Priority / ID | User outcome and owner | Required contract | Completion evidence |
 | --- | --- | --- | --- |
-| C0 | Stable replay-contract CI. Own the replay test clock, preserve production deadlines. | Existing #826 | Deterministic timeout/sleep assertions; current `deploy-k8s:test` passes on Linux CI. |
-| R1 | Login survives server replacement. Extend the existing session owner and storage; remove the process-local store as an authority. | C0 for branch handoff | A fresh sign-in remains valid after a server replacement and across two server instances; logout, expiry and membership loss still deny access. Stored session secrets are protected and expiry cleanup is bounded. |
-| R2 | Completed personal work is visible. Create the verified personal owner’s exact run-read grant during admission; preserve current read authorization. | Current run contracts; coordinate any shared R1 files | A completed run appears to its owner with correct conversation/status links; another employee and another silo cannot discover it. Do not grant broader rights merely to make a list nonempty. |
-| A1 | Administrators can remove access and people cannot reopen revoked work. Extend existing membership/participant operations and their current UI owner. | R1 for live session continuity; current authority contract | A real member is removed through the product, subsequent reads/actions fail, selected private history/drafts clear, reconnect and late responses cannot restore them, and closed work stays closed. |
-| T1 | An assistant retrieves one permitted record and explains it. Connect compiled tool definitions to the conversation runtime, a run/lease-bound tool proposal/result contract and the existing MCP invocation owner. | C0; define shared contract before consumers | One installed read-only integration returns real data in both personal and company-child chats. Current grants, frozen tool revisions, credentials and budgets are checked. Retry/restart preserves invocation identity; tool activity/result and the final answer survive reload. |
-| T2 | People approve a precise external change. Connect the existing approval and effect-admission owners to T1 and the conversation UI. | T1; A1 before live revocation acceptance | The person reviews the exact target and arguments. Approval is bound to that action, denial executes nothing, changed arguments need a new decision, and a company assistant does not inherit private human credentials. |
-| T3 | Interrupted actions remain understandable. Complete cancellation, durable completion and uncertain-outcome handling in the same invocation owner. | T1 and T2 | Cancellation fences future effects; stale leases cannot execute; retry does not duplicate a write. A provider timeout after submission is shown as uncertain until reconciled, never as fabricated success or an automatic unsafe retry. |
-| U1 | People can follow and control assistant work. Extend the existing workspace event mapping and approved UI components. | T1 contract; T2/T3 states before final proof | Show proposed/running/waiting/failed/cancelled/completed work, approval details and result links. Reload and SSE resume preserve the state. Accessible approval, choice and free-text interactions use server-issued contracts. |
-| M1 | An employee explicitly remembers, corrects and forgets information. Complete dataset provisioning and the existing memory gateway/catalog path. | Current identity contracts; T1 only if memory uses the tool proposal path | Remember a fact, recall it in another conversation, correct it, then forget it. Dataset selection comes from admitted authority; provenance, consent and sensitivity are visible. Another employee, silo or unentitled group cannot recall it. New runs capture the authorized dataset; immutable old snapshots are not patched. |
-| F1 | People attach documents and receive durable files. Complete existing artifact upload, scan, model-input and output-finalization owners. | Current artifact contracts; T1 when generation uses tools | Upload an allowed document, answer using its contents, create a downloadable result, then reload/retry/close the conversation. Infected or unscanned content stays unavailable; unauthorized readers and stale workers cannot retrieve or finalize it. |
-| D1 | An assistant delegates a bounded task and receives the result. Compose existing child admission, reservation and completion ownership with a model-visible spawn operation. | T1 and T3; F1 or M1 only when delegated context includes those resources | One child uses explicitly selected authorized context, narrower capabilities and bounded depth/fan-out/spend. Its terminal result returns once; parent cancellation propagates. Siblings cannot read each other and child failures remain visible. Prove one level before recursive cases. |
-| S1 | Teams schedule useful work. Restore scheduling/trigger execution against the current identity, admission and lease contracts. | T3; D1 only for workflows that delegate | One scheduled company task runs with current authority. Pause/resume, overlap policy, retry, cancellation and missed triggers have explicit outcomes. Removing its permission prevents the next effect. Retired runtime routes remain deleted. |
-| A2 | Administrators configure assistants, integrations and spending in the product. Extend existing protected APIs and settings owners. | Relevant capability contracts from T1/T2/M1/S1 | A company operator configures one agent, provider/model, tool grant and budget, reviews effective access and usage, and revokes the grant. Ordinary employees cannot perform those changes or view secrets. Figures are actual recorded usage, with unknown cost stated explicitly. |
-| Q1 | The complete product recovers predictably under normal failures. Maintain focused operational proofs throughout delivery. | Run as each capability lands; final acceptance after selected tracks | Prove fresh-install readiness, cold computer startup, controller/consumer failure, provider failure, long-history cost, access changes, backup recovery and usage accounting on exact qualified images. Separate measured recovery intervals from user-visible outage and repair-deploy timings. |
+| 1 / T1 | Retrieve real company information and explain it. Agent services own assignment; input assembly freezes definitions; conversation turns and MCP own invocation/results. | Current company or personal identity, exact tool revision, authorized connection custody, saved run budget and existing tool dispatch. | One real read-only record is retrieved in personal and company-child chats. The answer and durable result remain after reload/restart. Wrong silo, withdrawn tool, revoked grant, stale lease/generation and unavailable credentials fail closed. Recovery cannot repeat dispatch or refresh the continuation allowance. |
+| 2 / T2 | Review and approve a precise external change. IAM owns the decision and effect admission; elicitation owns the participant interaction; MCP owns execution. | T1 dispatch and connection binding; an authorized human approver, exact saved arguments and current permission at execution. | Show target, arguments/changed fields, consequences and connection owner before approval. One approval permits one exact effect. Reject, cancel, expiry, changed arguments, revoked membership/grant/connection and stale attempts prevent dispatch. A timeout after submission is durably uncertain and is never blindly retried. |
+| 3 / M1 | Remember, recall, correct and forget information across conversations. The memory gateway owns fact content; the personal catalog owns metadata, consent and provenance. | Verified gateway-native dataset and stable deletion identity frozen in admitted authority; recoverable correction. | Remember a fact, recall it in a new conversation, correct it and forget it. Show consent/provenance/sensitivity. Other employees, silos and unentitled groups cannot recall it. Failed corrections/deletions can finish safely after restart. Never infer the dataset from a subject ID or rewrite an old run snapshot. |
+| 4 / U1 | Follow and control assistant work. Existing conversation events, workspace stores and reusable components own the experience. | Durable activity/result events and the supported decision/cancellation contracts from T1/T2. | Proposed, running, waiting, failed, cancelled and completed work survives reload and SSE resume. Relevant decisions, result links and cancellation are accessible on desktop and narrow screens. Current access governs every read; projections never authorize work. |
+| 5 / U2 | Use rich choices, forms and results in a conversation. Existing elicitation, A2UI and approved presenters own interaction. | Server-issued interaction identity, permitted audience, expiry and durable accepted responses. | Single/multiple choice, free text and structured results remain accessible after refresh. Stale, duplicate, modified and unauthorized submissions fail safely. Reuse component states, behavioural tests and visual fixtures rather than embedding complex interaction in routed pages. |
+| 6 / F1 | Read documents and receive generated files. Artifact upload, quarantine/scan, input compilation and finalisation retain their owners. | Current artifact grants and scan result; model-readable content and lease-bound output finalisation. | Upload an allowed document, answer from its content, produce a downloadable file and reopen it after reload/closure. Unscanned/infected content stays unavailable. Other users and stale workers cannot read or finalise the artifact. |
+| 7 / D1 | Delegate a bounded task to another assistant. Existing child admission, lineage, reservations and completion own the work. | T1 tool dispatch, current delegation grants, narrowed context/capabilities, root budget and cancellation. Memory/files are prerequisites only when selected context uses them. | A selected authorized child returns one terminal result or explicit failure. Prove depth/fan-out/concurrency/spend limits, sibling isolation, cancellation propagation, restart and target revocation. The child never implicitly inherits private tools, memory, files or credentials. |
+| 8 / S1 | Create and manage scheduled work from a conversation. Existing managed definitions, admission and Absurd own durable firing. | Reviewed immutable routine, timezone/destination, current authority for each firing, overlap/missed-run policy and bounded retry. | Confirm a routine and its next firing; prove scheduled execution, run now, pause/resume, revision and retirement. Duplicate sweeps/restarts cannot repeat a firing. Revocation prevents the next protected effect; results/refusals remain linked to the exact routine. |
+| 9 / A2 | Administer the company through the product. Existing protected APIs and settings owners remain authoritative. | The capability contracts introduced by T1/T2/M1/S1 and current membership/permission checks. | Configure one agent, connection, provider/model, tool selection and budget; inspect effective access/audit and actual recorded usage; revoke access. Employees cannot make admin changes or inspect secrets. Unknown costs are stated as unknown. |
+| 10 / T3 | Resolve interrupted or uncertain actions. The invocation owner preserves receipts; protected user/operator controls request reconciliation and supported repair. | Durable exact effect identity, provider receipts/status lookup and a provider-specific safe retry contract. | Reconcile an uncertain effect without duplicating it, explain cancellation races, preserve every attempt and resolution, and expose supported safe retry or explicit manual resolution. Reload/restart does not erase uncertainty or invent success. |
 
-For T1, begin with one already installed, authorized read-only integration. If none is suitable,
-record the missing test integration and prepare the internal contract and deterministic tests;
-do not install a marketplace or invent credentials. T2's live effect must use a dedicated test
-record/system with existing authorization. Real customer messages or writes require their own
-explicit authorization. The runtime proposes work; it never becomes the authority that approves it.
+Every track includes the safety required for its first useful journey. Full recovery is tenth;
+idempotency, current authority, lease/generation fencing, bounded retries and honest failure states
+are required from the first effect. Delegation and schedules do not depend on the whole recovery UI.
 
-The MCP public task API is caller-owned and does not supply the conversation run binding. Do not
-impersonate a human through that API to avoid adding the required run/lease-bound admission. The
-current lifecycle reporter validates fences but does not persist participant history; T1 must
-connect real tool activity/results to KurrentDB rather than treating log output as conversation proof.
+[#844](https://github.com/elewa-git/opencrane/issues/844) is the umbrella for the read-to-write journey,
+including its controls and eventual recovery. Its full acceptance spans T1, T2, U1 and T3.
+[#845](https://github.com/elewa-git/opencrane/issues/845) owns delegation completion, building on the
+child-run foundations in #320. [#848](https://github.com/elewa-git/opencrane/issues/848) owns
+conversational routines, superseding removed scheduling routes from #332.
 
-Long-term memory and autonomous delegation are not prerequisites for the first useful tool action.
-The existing #320 issue is closed but retains unfinished and obsolete runtime wording; refresh or
-replace its delivery issue before D1, using ADR 0016 as the current architecture. A closed issue or
-an old implementation narrative is not evidence of live functionality.
+## First execution wave: real tool retrieval
 
-## Source-grounded follow-through
+The review stack is `develop` → #831 (member access) → #843 (library/component decomposition)
+→ #849 (Absurd turns) → the company-tool selection follow-up. The first slice starts from immutable
+base `b4f275b3f090e9387a1b0de658968700c0b7ad04` on `feat/0.12-real-tool-retrieval`.
+Recheck live ancestry before publishing each PR; do not duplicate an open predecessor's patch.
 
-The internal T1 continuation in [#830](https://github.com/elewa-git/opencrane/pull/830) passes CI at
-`ada28f1f7`. Finish its user journey by assigning an explicitly permitted tool to a company
-assistant, installing a dedicated authorised test integration, and exposing the tool's progress
-and result. The existing company-assistant revision writer can own tool assignment; configuration
-must not inherit a requesting employee's private credentials. Credential activation still needs
-its own explicit contract. The current test installation has no suitable integration.
+1. **Enable company tool selection.** Port the existing unmerged company-tools work into
+   `agent-services/main/src/company-assistants`, `revisions` and `execution-evidence`. GET/PUT uses
+   current Administer/Assign decisions, immutable successor revisions, exact company-owned grants
+   and an expected active revision. Preserve model/persona/skill attachments and the original saved
+   budget. Only newly provisioned assistants receive the two-call policy. Fix nested Prisma
+   assignments to inherit their parent service. Qualify transaction rollback, concurrent editors,
+   removed/revoked grants and the separate company/human authority through unit and real SQL tests.
+2. **Establish one working connection.** Inventory the authorized test environment and select a
+   dedicated read-only integration and record. The current installation contract records
+   `NeedsCredential` or `SharedKey` but provides no credential activation command. Define personal
+   versus company ownership, authorized activation/reconnection and execution binding through the
+   existing credential owner. A shared-key label alone is not connectivity proof. Keep secrets out
+   of chat, workflow input and the ConversationComputer Pod. Missing setup produces an explicit
+   content-free waiting state.
+3. **Keep the retrieved evidence with the conversation.** Use the existing invocation result and
+   history boundary to expose a minimal durable tool result/activity reference to authorized
+   participants. The current lifecycle hook wakes Absurd but does not append participant history.
+   This is the evidence needed to trust the first retrieval; comprehensive controls remain U1.
+4. **Prove the real journey.** Retrieve the chosen record in personal and company-child chats, then
+   reload and replace a server without duplicating dispatch, refreshing allowance or losing the
+   answer/result. Exercise wrong-silo access, revoked company versus retained human grants, stale
+   lease/generation and unavailable connection. Record exact candidate, configured integration and
+   observed result separately from source tests and CI.
 
-M1 preflight found that the pinned memory service's chunk recall path does not establish dataset
-isolation and that its result identifiers cannot be treated as deletion handles. Keep personal
-memory disabled until the gateway proves two-dataset isolation, stable record identity and safe
-forget/correction recovery. A dataset UUID alone is not that proof.
+Architecture preflight passes for slice 1 using existing packages. A read-only integration selection
+is still needed for live acceptance. Source implementation can continue while that choice is pending.
+No connector credentials, installed integration inventory or live cluster state are assumed by this plan.
 
-F1 should extend the existing conversation-asset upload, quarantine, scan and download owners.
-Document contents still need a model-input path, and generated files need current-authority
-finalisation. Remove stale output-ticket descriptions when this slice opens; retired runtime
-routes are not an implementation template.
+## Next wave: approved external actions
 
-## Owners and parallel waves
+The current model selector and tool proposal reject approval-required tools, and the proposal intent
+always records `approvalRequired: false`. Connect those paths to the existing IAM deferred-approval
+owner. It already saves reviewed arguments, schema, action identity, expiry and the decision; use that
+saved request at execution instead of accepting a new payload from the browser.
 
-| Lane | Ownership | First useful assignment |
-| --- | --- | --- |
-| Reliability | Existing authentication/session and personal activity packages; corresponding schema only if required | R1 and R2, with independent discovery and one coordinator for shared contracts |
-| Actions | Conversation-computer runtime, conversation turn transport, MCP invocation boundary and their contracts | T1 preflight, then one retrieval journey |
-| Workspace | Existing Angular workspace/settings stores, mappers and approved components | U1 contract mapping; A1 product operation after authority preflight |
-| Memory | Memory gateway client, personal memory catalog and shared memory contracts | M1 source-grounded preflight; no direct Cognee calls outside the gateway |
-| Operations and review | Owning deploy/test scripts, CI evidence, scoped independent review | C0, then Q1 for each landed capability |
-| Documentation | Package READMEs, website guides/status, plan and changelog | Explain the user outcome and mark code, CI and live evidence separately in each slice |
+Extend the existing approval body and presenter to show the exact target, changed fields/arguments,
+consequences and selected connection owner. The current generic label and revision identifier do not
+suffice for a real external action. Resolve the entitled human participant explicitly for a company
+assistant: the executing service Principal is not automatically the approver. This minimal presenter
+belongs in T2 even though general rich interaction is fifth.
 
-Start C0 and the plan together. After C0 lands, create the R1/R2 follow-up review surface. T1
-contract discovery can run alongside reliability work; its runtime, server and UI consumers start
-only after the shared contract is settled. M1, F1 and A2 discovery can proceed independently once
-there is worker capacity. D1 and S1 wait for their actual action/cancellation dependencies.
+Use a dedicated fake-provider fixture for deterministic decision, tampering, revocation and ambiguity
+tests, then one authorized real write for acceptance. A submitted request or approval click is not
+proof that the provider completed the change. Broad provider-specific reconciliation remains T3.
 
-Every implementation worker receives explicit file ownership and the current immutable base. One
-coordinator owns branch changes, commits and shared planning files. Workers never revert another
-lane. Reuse completed agents when capacity is exhausted; if no independent reviewer is available,
-leave the review pending and continue safe independent work rather than declaring self-review done.
+## Ownership and delivery gates
 
-## Overnight execution: 8–9 September 2026
+Absurd owns durable progression, checkpoints, waiting and restart selection of saved steps.
+AgentSandbox owns the isolated execution environment under current lease and generation coordinates.
+The server owns model authority, credentials, budgets, tool permission, model calls, continuation and
+conversation output. KurrentDB stores immutable history; PostgreSQL remains the current authorization
+authority; the memory gateway owns long-term fact access. Do not add another scheduler, queue, outbox,
+broker, credential store or Pod model scheduler. Replaced code is deleted completely.
 
-Work begins on 8 September in Nairobi and checkpoints at **08:00 EAT on 9 September**
-(`2026-09-09T05:00:00Z`). Continuation checks every fifteen minutes use the current task and this
-plan. They recover work between working turns; active runs continue directly between ready slices.
+For every coherent slice:
 
-1. Repair C0 on #826; record focused validation, independent review and the exact CI run. Keep
-   previously qualified application evidence attached to its source; a test-only fix does not
-   require repeating the live backup drills.
-2. Create the immediate follow-up branch from the reviewed parent and record its immutable base.
-   While #826 is open, target its branch; if it has merged, use `develop` and prove the ancestry.
-3. Execute R1/R2 and the ready T1 work in bounded slices, using independent lanes where their files
-   do not overlap. Continue through the ordered backlog as dependencies and available time allow.
-4. At each gate, run focused Nx checks, required boundaries and risk-scoped independent review.
-   Push each coherent reviewed slice. Keep its PR incremental and explain the review order.
-5. For a real blocker, record the exact evidence and dependency, then continue another ready lane.
-   Do not spend the night repeatedly checking an unchanged queue or redoing a green proof.
-6. Before the morning boundary, finish or checkpoint the active slice. At or after 08:00 EAT,
-   begin no new implementation slice: record commits, PRs, CI, live proof, unresolved findings and
-   the next exact action, report here, and pause the overnight schedule. A late wake produces the
-   handoff instead of silently extending the run.
+1. Select one user outcome and immutable review base. Read the owning code and package docs; run
+   architecture preflight when responsibility/trust boundaries or package cohesion change.
+2. Use independent implementation lanes with explicit file ownership. Preserve thin apps, capability
+   folders, focused authority methods and reusable frontend components/stores. Component-manager
+   pre/post applies to frontend changes. Consequential comments explain the contract in human language.
+3. Run the relevant Nx tests, lint/type checks and build, plus required authorization, Prisma,
+   workflow, app composition, dependency, style and module-growth checks. Real transaction/race claims
+   require SQL tests. Reuse green evidence for unchanged code.
+4. Run architecture post-review where required and the mandatory independent review against the
+   exact base and source overlay. Resolve Critical/High findings, then update package docs, plan and
+   functional changelog with the actual implemented capability and remaining proof.
+5. Commit/push and open one incremental draft PR, state review order and exact validation, and
+   inspect live ancestry. Merge, release tagging and testv5 deployment/qualification remain separate
+   gates. Keep source completion, published CI and real user acceptance as separate statuses.
 
-The desired morning result is a repaired baseline, a reviewable continuity follow-up and concrete
-progress toward the first governed action, with every other MVP track planned. Progress depends
-on review, CI and external test availability; none of these targets are a promise that all MVP
-features will be complete by morning.
+## Continuous qualification
 
-## Delivery boundaries and evidence
+Login continuity (R1) and member-access revocation (A1) retain their outstanding fresh-install and
+real-account proofs. They are foundations alongside these priorities. Q1 adds each newly implemented
+journey to full installation acceptance: sign-in, onboarding, personal/group answers, reconnect,
+closed/revoked work, cross-silo denial, provider failure, backup/restore, usage and operator recovery.
+No critical journey is called complete from a unit test, healthy Pod or successful dispatch alone.
 
-- Commits, pushes and PRs are authorized by this task. Merging and release tags remain separate
-  actions. Keep root version 0.11.0 until the 0.12 release baseline is intentionally opened; update
-  version and manifest together then, not once per change.
-- Read current `AGENTS.md`, the selected row and its owning contracts. Apply architecture review
-  to changed trust/responsibility boundaries, deletion review to replaced mechanisms, and one
-  integrated independent review to each required slice. Preserve the current local Stop hooks.
-- Run tasks with `npx nx`. Use one relevant local test/build cycle per unchanged slice; reserve
-  container-backed authority, image and cluster proofs for Actions. Never start a local VM or
-  container runtime for validation.
-- Use existing dedicated testv5 Zitadel/provider credentials only through their intended services.
-  Keep credentials, test passwords and private payloads outside Git and logs. Preserve ignored
-  `keys/` fixtures and unrelated untracked `.codex`, `.agents` and screenshots.
-- Cluster mutations use app-owned scripts only. No raw Kubernetes/Helm/SQL writes, serving-volume
-  replacement, silo teardown or repeat of the rejected additional snapshot restore is included in
-  the overnight run. Prepare a reviewable plan for any newly necessary destructive operation.
-- Avoid new infrastructure, generic plugin frameworks and broad abstractions until a concrete
-  user journey needs them. Reuse and extend the current owners; delete superseded paths.
-- On each push/PR change and hourly checkpoint, refresh exact live ancestry. Capture committed,
-  staged, unstaged and untracked overlays separately. CI results name their SHA and run URL;
-  deployment results name immutable images; live acceptance names the tested journey and fixture.
-- Keep routine scheduled runs quiet. Notify on a material delivery, failure requiring attention,
-  blocked decision or the morning handoff. Do not send messages to external people.
+Testv5/live qualification is a separate gate. Record immutable source/images, configuration, actors,
+negative probes and observed outcome in the deploy ledger. Use app-owned deployment scripts for
+any authorized cluster mutation. Pre-MVP installations retain one clean baseline with no migration
+or compatibility scaffolding. Release scope and tags require their own explicit selection.
 
-## Later product expansion
+## Later work
 
-Mini-app previews/publication and internal CodeService follow the useful-assistant MVP tracks.
-Internal Git, broad marketplaces, additional compute tiers and warm-pool optimization are not
-overnight prerequisites. Select those scopes from measured user demand and latency/cost evidence.
+Published applications, mini-app previews, internal CodeService and general code work are deferred
+until after the ten priorities. Internal Git, broad marketplaces, warm pooling and extra compute tiers
+are not prerequisites. Optional external-agent protocol compatibility does not transfer server
+model/tool authority or durable ownership to external agents.
 
 See also: [Active plan](../../plan.md), [product contract](personal-agent-platform-product-contract.md),
 [workspace stories](../user-stories/workspace-and-conversations.md),

--- a/docs/design/mvp-delivery-plan.md
+++ b/docs/design/mvp-delivery-plan.md
@@ -41,7 +41,7 @@ conversational routines, superseding removed scheduling routes from #332.
 ## First execution wave: real tool retrieval
 
 The review stack is `develop` → #831 (member access) → #843 (library/component decomposition)
-→ #849 (Absurd turns) → the company-tool selection follow-up. The first slice starts from immutable
+→ #849 (Absurd turns) → [#850](https://github.com/elewa-git/opencrane/pull/850) (company tool selection). The first slice starts from immutable
 base `b4f275b3f090e9387a1b0de658968700c0b7ad04` on `feat/0.12-real-tool-retrieval`.
 Recheck live ancestry before publishing each PR; do not duplicate an open predecessor's patch.
 

--- a/libs/backend/agents/personal/configuration/main/src/__tests__/prisma-personal-configuration-materialization.test.ts
+++ b/libs/backend/agents/personal/configuration/main/src/__tests__/prisma-personal-configuration-materialization.test.ts
@@ -191,7 +191,7 @@ describe("Prisma-backed personal configuration materialization", function _Mater
 					}],
 				},
 				mcpToolAssignments: {
-					create: [{ toolRevisionId: "mcp-tool-revision-1", agentServiceId: "service-1", siloId: "silo-1" }],
+					create: [{ toolRevisionId: "mcp-tool-revision-1", siloId: "silo-1" }],
 				},
 				boundaryAttachments: {
 					create: [{

--- a/libs/backend/server/agents/agent-services/main/README.md
+++ b/libs/backend/server/agents/agent-services/main/README.md
@@ -4,13 +4,29 @@
 
 ## What it owns
 
-The source tree separates `company-assistants/`, `personal-agents/`, `revisions/` and
-`execution-evidence/`. Each owner keeps its persistence adapters under `db/` and tests under
-`__tests__/`, so changing publication does not require searching a shared database folder.
-
 This package owns immutable `AgentService` revisions, personal-assistant configuration, and explicit
-setup of one company assistant per silo. The company assistant can be selected for a group child
+setup and tool selection for one company assistant per silo, the organisation's isolated data boundary.
+The company assistant can be selected for a group child
 conversation once its published revision, identity, model permission and the caller's access are ready.
+
+```
+ administrator or approved personal configuration
+                      │ selected model and capabilities
+                      ▼
+ ┌──────────────────────────────────────────┐
+ │ agent-services ◄── HERE                  │
+ │ publish an immutable revision and grants │
+ └──────────────────────────────────────────┘
+                      │ exact revision and current permission evidence
+                      ▼
+ conversations → admit work through the workflow contract
+```
+
+**In this flow:** [personal configuration](../../../../agents/personal/configuration/main/README.md) ·
+[conversations](../../../conversations/main/README.md) · [workflow contract](../../../infra/workflows/contract/README.md).
+
+The source tree separates `company-assistants/`, `personal-agents/`, `revisions/` and
+`execution-evidence/`. Each owner keeps persistence adapters under `db/` and tests under `__tests__/`.
 
 A personal service is created during onboarding with one published revision. Later persona or model
 selection changes append and publish another immutable revision rather than editing history. The
@@ -28,8 +44,9 @@ active, its requested revision is still published and active, current deployment
 requester, and the central authority permits invocation and every frozen revision boundary. The
 result is immutable decision evidence for one run; it is not a reusable grant.
 
-A company assistant acts through its own stable Internal Principal. Its evidence binds the current
-service, published revision and model-use decision. The requesting human has separate Fleet or Standalone
+A company assistant acts through its own stable Internal Principal, a saved identity for the service.
+Its evidence binds the current service, published revision, exact tool selection and model-use decision.
+The requesting human has separate Fleet or Standalone
 membership evidence and must currently be allowed to invoke the service. Internal Principals do not
 need a fabricated fleet membership assertion: PostgreSQL service authority and checked identity
 history supply their current binding. Neither evidence form grants access by itself. Both service repositories delegate human membership
@@ -42,8 +59,10 @@ creating a child conversation and when admitting a run. Human Invoke decisions r
 the requesting Principal ID. Runtime Pod identity belongs to later workload decisions.
 
 The first company revision has no persona, skills, tools, memory or knowledge-boundary assignments.
-Its deployment-owned profile and budget use a selected model. Admission rejects extended revisions
-until those capabilities have a supported company policy.
+An administrator can then assign exact MCP (Model Context Protocol) tool revisions. New company
+assistants permit at most two model requests under one saved 32,000-token, two-minute turn budget.
+Tool edits preserve the saved budget. Admission still rejects persona, skill and boundary
+assignments until those capabilities have a supported company policy.
 
 ## Public surface
 
@@ -67,7 +86,8 @@ until those capabilities have a supported company policy.
   admissions. Child creation separately records human Invoke and company Model Use decisions after
   the same current service, identity, profile and membership checks.
 - `PrismaCompanyAssistantProvisioningUnitOfWork` and `_CreateCompanyAssistantProvisioningRouter`
-  provide explicit administrator setup, including checked identity establishment after commit.
+  provide administrator setup and exact tool selection, including checked identity establishment
+  after the setup commit.
 
 The app supplies transaction-scoped dependencies for admission and revision changes. Company setup
 owns its Serializable transaction and retries up to three unique-create or serialization conflicts.
@@ -93,6 +113,34 @@ The response returns `created: true` and the public assistant reference after id
 An existing assistant returns `created: false`: changed choices are not applied, revoked grants are
 not restored, and paused or retired services are not revived. A failed identity append can be retried
 from the committed service and first revision; suspended or revoked identities remain unavailable.
+
+### Company assistant tools
+
+Read `GET /api/v1/organization/company-assistant/tools`, then replace the selection with `PUT` to
+the same path. Supply `expectedActiveRevisionId` from the read and up to 32 unique `toolRevisionIds`;
+`[]` removes all assignments. Both responses contain `agentServiceId`, `activeRevisionId` and sorted
+`toolRevisionIds`. This remains an administrator API without a management screen.
+
+GET checks current Organization Administer. PUT records that decision and Assign for every selected
+tool, even when the selection is unchanged. Each tool must belong to this silo and a Ready revision
+of an Active, Published server. An unchanged selection creates no revision and restores no grants.
+A changed selection publishes an immutable successor while preserving the model, budget, prompt
+policy and other revision content.
+
+Publication and the assistant's exact tool Use/Invoke grants commit together. Reconciliation changes
+only grants owned by this company-assistant configuration; it leaves other managers, human grants
+and model grants alone. Removing an assignment prevents later dispatch through the superseded
+revision. It cannot undo an external effect that has already started.
+
+A stale expected revision returns `409`, even when the submitted selection matches the saved one.
+After an uncertain response, GET the current selection before editing again. The transaction helper
+retries only proven rollbacks, up to three attempts; it does not replay an unknown commit outcome.
+Tool edits never rewrite the assistant's identity history or replenish its model budget.
+
+Assignment does not install an integration or activate company credentials, and it does not borrow
+the requesting employee's private permissions or credentials. Run admission freezes the selected
+tool definitions and checks current Use; dispatch rechecks Invoke, revision assignment and human
+membership. Participant-visible tool results remain unfinished, and live retrieval is unqualified.
 
 ## Dependency direction
 

--- a/libs/backend/server/agents/agent-services/main/project.json
+++ b/libs/backend/server/agents/agent-services/main/project.json
@@ -6,6 +6,7 @@
   "tags": ["type:lib", "layer:backend", "scope:agent-services"],
   "targets": {
     "lint": { "executor": "nx:run-commands", "options": { "command": "tsc -p tsconfig.json --noEmit", "cwd": "libs/backend/server/agents/agent-services/main" } },
-    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run", "cwd": "libs/backend/server/agents/agent-services/main" } }
+    "test": { "executor": "nx:run-commands", "options": { "command": "vitest run --exclude '**/*.sql.test.ts'", "cwd": "libs/backend/server/agents/agent-services/main" } },
+    "test:sql": { "executor": "nx:run-commands", "options": { "command": "vitest run src/company-assistants/db/__tests__/company-assistant-tools.sql.test.ts", "cwd": "libs/backend/server/agents/agent-services/main" } }
   }
 }

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/__tests__/company-assistant-composition.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/__tests__/company-assistant-composition.test.ts
@@ -1,0 +1,56 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentIdentityHistory } from "@opencrane/backend/server/iam/identity";
+import { PrismaAuthorizationAuthority, PrismaManagedAuthorizationGrantRepository } from "@opencrane/backend/server/iam/authorization";
+import { PROMPT_COMPILER_VERSION } from "@opencrane/contracts";
+import { AuthorizationDecisionOutcomes } from "@opencrane/models/authorization";
+
+import { _CreateCompanyAssistantComposition } from "../company-assistant-composition";
+
+/** Restores the isolated database/history ports after the real route and publication composition runs. */
+afterEach(function _Restore() { vi.restoreAllMocks(); });
+
+describe("company assistant application composition", function _Suite()
+{
+	it("publishes a fresh two-call revision without increasing its total token or time ceilings", async function _PublishesToolCapableBudget()
+	{
+		vi.spyOn(PrismaAuthorizationAuthority.prototype, "admitPrincipal").mockResolvedValue({ outcome: AuthorizationDecisionOutcomes.Allow, evidence: { decisionDigest: "sha256:allowed" } } as never);
+		vi.spyOn(PrismaManagedAuthorizationGrantRepository.prototype, "reconcileManagedResourceGrants").mockResolvedValue(1);
+		vi.spyOn(AgentIdentityHistory.prototype, "load").mockResolvedValue(null);
+		vi.spyOn(AgentIdentityHistory.prototype, "loadActive").mockResolvedValue({ identity: { kind: "managed" } } as never);
+		let committed = false;
+		const append = vi.spyOn(AgentIdentityHistory.prototype, "append").mockImplementation(async function _AfterCommit()
+		{
+			expect(committed).toBe(true);
+			return {} as never;
+		});
+		const transaction = {
+			principal: { findMany: vi.fn().mockResolvedValue([{ id: "admin", subject: "admin-subject" }]), create: vi.fn().mockResolvedValue({}) },
+			orgMembership: { findMany: vi.fn().mockResolvedValue([{ subject: "admin-subject" }]) },
+			agentService: { findFirst: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({}), update: vi.fn().mockResolvedValue({}) },
+			agentRevision: { create: vi.fn().mockResolvedValue({}), update: vi.fn().mockResolvedValue({}) },
+		};
+		const prisma = { $transaction: vi.fn().mockImplementation(async function _Commit(operation)
+		{
+			const result = await operation(transaction);
+			committed = true;
+			return result;
+		}) };
+		const app = express();
+		app.use(express.json());
+		app.use(function _Authenticated(request, _response, next)
+		{
+			request.session = { authUser: { authenticatedAt: new Date().toISOString() } } as never;
+			request.authenticatedPrincipal = { principalId: "admin", siloId: "acme", issuer: "https://identity.example", subject: "admin-subject" };
+			next();
+		});
+		app.use(_CreateCompanyAssistantComposition(prisma as never, {} as never, { profileName: "company-test-profile" }, { warn: vi.fn() } as never));
+		const response = await request(app).post("/").set("Host", "acme.opencrane.test").send({ name: "Company assistant", modelDefinitionId: "model-1", invokerPrincipalIds: ["admin"] }).expect(201);
+		expect(response.body.created).toBe(true);
+		expect(transaction.agentRevision.create).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ data: expect.objectContaining({ budget: { maxTurns: 2, maxTokens: 32_000, maxDurationMs: 120_000 }, promptPolicyVersion: PROMPT_COMPILER_VERSION, mcpToolAssignments: { create: [] } }) }));
+		expect(transaction.agentService.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ workloadProfile: "company-test-profile" }) }));
+		expect(append).toHaveBeenCalledTimes(1);
+	});
+});

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/__tests__/company-assistant-provisioning.router.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/__tests__/company-assistant-provisioning.router.test.ts
@@ -3,7 +3,7 @@ import request from "supertest";
 import { describe, expect, it, vi } from "vitest";
 
 import { _CreateCompanyAssistantProvisioningRouter } from "../company-assistant-provisioning.router";
-import { CompanyAssistantProvisioningDenied } from "../db/prisma-company-assistant-provisioning";
+import { CompanyAssistantProvisioningDenied, CompanyAssistantToolsConflict, CompanyAssistantToolsUnavailable } from "../company-assistant.errors";
 
 const _BODY = { name: "Company assistant", modelDefinitionId: "model-1", invokerPrincipalIds: ["human-1"] };
 const _CALLER = { siloId: "silo-1", principalId: "admin" };
@@ -12,10 +12,12 @@ const _CALLER = { siloId: "silo-1", principalId: "admin" };
 function _Fixture(authenticated = true)
 {
 	const provision = vi.fn().mockResolvedValue({ created: true, agentServiceId: "company", name: "Company assistant", principalId: "private-principal", identityEventId: "private-event" });
+	const getTools = vi.fn().mockResolvedValue({ agentServiceId: "company", activeRevisionId: "revision-1", toolRevisionIds: ["tool-1"] });
+	const setTools = vi.fn().mockResolvedValue({ agentServiceId: "company", activeRevisionId: "revision-2", toolRevisionIds: ["tool-2"] });
 	const app = express();
 	app.use(express.json());
-	app.use(_CreateCompanyAssistantProvisioningRouter({ provision }, () => authenticated ? _CALLER : null, { warn: vi.fn() }));
-	return { app, provision };
+	app.use(_CreateCompanyAssistantProvisioningRouter({ provision, getTools, setTools }, () => authenticated ? _CALLER : null, { warn: vi.fn() }));
+	return { app, provision, getTools, setTools };
 }
 
 describe("company assistant provisioning HTTP contract", function _Suite()
@@ -51,5 +53,70 @@ describe("company assistant provisioning HTTP contract", function _Suite()
 		expect(response.body).toEqual({ created: false, assistant: { agentServiceId: "company", displayName: "Original name" } });
 		f.provision.mockRejectedValue(new CompanyAssistantProvisioningDenied());
 		expect((await request(f.app).post("/").send(_BODY).expect(403)).body).toEqual({ error: "company_assistant_setup_denied" });
+	});
+});
+
+
+describe("company assistant tool assignment HTTP contract", function _ToolsSuite()
+{
+	it("reads and replaces only the trusted caller's exact selection", async function _UsesCaller()
+	{
+		const f = _Fixture();
+		const current = await request(f.app).get("/tools").expect(200);
+		expect(current.body).toEqual({ agentServiceId: "company", activeRevisionId: "revision-1", toolRevisionIds: ["tool-1"] });
+		expect(current.headers["cache-control"]).toBe("no-store");
+		expect(f.getTools).toHaveBeenCalledExactlyOnceWith(_CALLER);
+		const body = { expectedActiveRevisionId: "revision-1", toolRevisionIds: ["tool-2"] };
+		const replaced = await request(f.app).put("/tools").send(body).expect(200);
+		expect(replaced.body).toEqual({ agentServiceId: "company", activeRevisionId: "revision-2", toolRevisionIds: ["tool-2"] });
+		expect(replaced.headers["cache-control"]).toBe("no-store");
+		expect(f.setTools).toHaveBeenCalledExactlyOnceWith(_CALLER, body);
+	});
+
+	it.each([
+		{ toolRevisionIds: [] }, { expectedActiveRevisionId: " ", toolRevisionIds: [] },
+		{ expectedActiveRevisionId: "revision-1", toolRevisionIds: ["duplicate", "duplicate"] },
+		{ expectedActiveRevisionId: "revision-1", toolRevisionIds: [" tool"] },
+		{ expectedActiveRevisionId: "revision-1", toolRevisionIds: Array.from({ length: 33 }, (_, index) => `tool-${index}`) },
+		{ expectedActiveRevisionId: "revision-1", toolRevisionIds: [], principalId: "human" },
+		{ expectedActiveRevisionId: "revision-1", toolRevisionIds: [], credential: "private" },
+	])("rejects malformed, oversized or authority-bearing input %j", async function _Rejects(body)
+	{
+		const f = _Fixture();
+		await request(f.app).put("/tools").send(body).expect(400);
+		expect(f.setTools).not.toHaveBeenCalled();
+	});
+
+	it("accepts an empty selection and preserves conflict as a refresh requirement", async function _ClearsAndConflicts()
+	{
+		const f = _Fixture();
+		const body = { expectedActiveRevisionId: "revision-1", toolRevisionIds: [] };
+		await request(f.app).put("/tools").send(body).expect(200);
+		expect(f.setTools).toHaveBeenCalledExactlyOnceWith(_CALLER, body);
+		f.setTools.mockRejectedValue(new CompanyAssistantToolsConflict());
+		expect((await request(f.app).put("/tools").send(body).expect(409)).body).toEqual({ error: "company_assistant_revision_changed" });
+	});
+
+	it("requires authentication before reading or replacing tools", async function _RequiresCaller()
+	{
+		const f = _Fixture(false);
+		await request(f.app).get("/tools").expect(401);
+		await request(f.app).put("/tools").send({ expectedActiveRevisionId: "revision-1", toolRevisionIds: [] }).expect(401);
+		expect(f.getTools).not.toHaveBeenCalled();
+		expect(f.setTools).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ error: new CompanyAssistantProvisioningDenied(), status: 403 },
+		{ error: new CompanyAssistantToolsUnavailable(), status: 404 },
+		{ error: new Error("private dependency details"), status: 503 },
+	])("conceals refused or unavailable authority at status $status", async function _Conceals({ error, status })
+	{
+		const f = _Fixture();
+		f.getTools.mockRejectedValue(error);
+		f.setTools.mockRejectedValue(error);
+		const read = await request(f.app).get("/tools").expect(status);
+		const write = await request(f.app).put("/tools").send({ expectedActiveRevisionId: "revision-1", toolRevisionIds: [] }).expect(status);
+		expect(JSON.stringify([read.body, write.body])).not.toContain(error.message);
 	});
 });

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-composition.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-composition.ts
@@ -14,8 +14,8 @@ import type { Logger } from "@opencrane/backend/observability";
  * Composes the administrator's company assistant setup under the deployed computer profile.
  *
  * Called by: public route composition after browser authentication is installed.
- * The first shared assistant performs one bounded text turn per request. Its service owner rejects
- * personal memory, skills and tool assignments until those paths have their own product proof.
+ * New assistants reserve two model calls for one permitted tool result and one final answer.
+ * Tool edits preserve each saved revision budget; personal memory and skills remain unavailable.
  * @see PrismaCompanyAssistantProvisioningUnitOfWork for current permission checks and recoverable creation.
  */
 export function _CreateCompanyAssistantComposition(prisma: PrismaClient, history: HistoryStore, profile: { readonly profileName: string }, logger: Logger): Router
@@ -23,7 +23,7 @@ export function _CreateCompanyAssistantComposition(prisma: PrismaClient, history
 	const authority = new PrismaCompanyAssistantProvisioningUnitOfWork(prisma, {
 		workloadProfile: profile.profileName,
 		promptPolicyVersion: PROMPT_COMPILER_VERSION,
-		budget: { maxTurns: 1, maxTokens: 32_000, maxDurationMs: 120_000 },
+		budget: { maxTurns: 2, maxTokens: 32_000, maxDurationMs: 120_000 },
 	}, new AgentIdentityHistory(history));
 	return _CreateCompanyAssistantProvisioningRouter(authority, function _ResolveAdministrator(request)
 	{

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-permissions.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-permissions.ts
@@ -1,0 +1,21 @@
+import type { AuthorizationAuthority, ManagedAuthorizationGrantSpec } from "@opencrane/backend/server/iam/authorization";
+import { AuthorizationBoundaryCoverages, AuthorizationBoundaryKinds, AuthorizationDecisionOutcomes, AuthorizationSubjectKinds, __ProductAuthorizationCapability, type ProductAuthorizationActions, type ProductAuthorizationResourceLocator } from "@opencrane/models/authorization";
+
+import { CompanyAssistantProvisioningDenied } from "./company-assistant.errors";
+
+/** Requires recorded central authority before publishing durable assistant authority. */
+export async function _AdmitCompanyAssistantChange(authorization: AuthorizationAuthority, caller: { readonly siloId: string; readonly principalId: string }, resource: ProductAuthorizationResourceLocator, action: ProductAuthorizationActions, argumentsDigest: `sha256:${string}`, now: Date): Promise<void>
+{
+	const decision = await authorization.admitPrincipal({ ...caller, actorKind: "user", actorId: caller.principalId, resource, action, argumentsDigest, nowEpochMs: now.getTime() });
+	if (decision.outcome !== AuthorizationDecisionOutcomes.Allow || decision.evidence === null)
+		throw new CompanyAssistantProvisioningDenied();
+}
+
+/** Derives one exact grant for selected human invokers or the assistant's own model and tool use. */
+export function _CompanyAssistantGrant(principalId: string, createdByPrincipalId: string, resource: ProductAuthorizationResourceLocator, action: ProductAuthorizationActions): ManagedAuthorizationGrantSpec
+{
+	const capability = __ProductAuthorizationCapability(resource.kind, action);
+	if (capability === null)
+		throw new CompanyAssistantProvisioningDenied();
+	return { subject: { kind: AuthorizationSubjectKinds.Principal, principalId }, boundary: { kind: AuthorizationBoundaryKinds.Personal, principalId }, boundaryCoverage: AuthorizationBoundaryCoverages.Exact, capability, resource, priority: 0, createdByPrincipalId };
+}

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-provisioning.router.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-provisioning.router.ts
@@ -2,19 +2,63 @@ import { Router } from "express";
 import type { Logger } from "@opencrane/backend/observability";
 
 import type { CompanyAssistantProvisioningAuthority, CompanyAssistantProvisioningCallerResolver } from "./company-assistant-provisioning.types";
-import { ___CompanyAssistantProvisioningSchema } from "./company-assistant-provisioning.validator";
-import { CompanyAssistantProvisioningDenied } from "./db/prisma-company-assistant-provisioning";
+import { ___CompanyAssistantProvisioningSchema, ___CompanyAssistantToolsSchema } from "./company-assistant-provisioning.validator";
+import { CompanyAssistantProvisioningDenied, CompanyAssistantToolsConflict, CompanyAssistantToolsUnavailable } from "./company-assistant.errors";
 
 /**
- * Creates the explicit operator setup route for the company's first shared assistant.
+ * Creates the operator routes for company assistant setup and exact tool assignment.
  *
  * Called by: application routing at `/api/v1/organization/company-assistant`.
- * The domain authority checks administrator and model permission and owns all persistence.
+ * The domain authority checks current administrator and selected-resource permissions and owns persistence.
  * @see PrismaCompanyAssistantProvisioningUnitOfWork for publication and history retry ordering.
  */
 export function _CreateCompanyAssistantProvisioningRouter(authority: CompanyAssistantProvisioningAuthority, resolveCaller: CompanyAssistantProvisioningCallerResolver, logger: Pick<Logger, "warn">): Router
 {
 	const router = Router();
+	router.route("/tools").get(async function _GetTools(request, response)
+	{
+		response.set("Cache-Control", "no-store");
+		const caller = resolveCaller(request);
+		if (caller === null)
+			return void response.status(401).json({ error: "unauthorized" });
+		try
+		{
+			response.json(await authority.getTools(caller));
+		}
+		catch (error)
+		{
+			if (error instanceof CompanyAssistantProvisioningDenied)
+				return void response.status(403).json({ error: "company_assistant_tools_denied" });
+			if (error instanceof CompanyAssistantToolsUnavailable)
+				return void response.status(404).json({ error: "company_assistant_unavailable" });
+			logger.warn({ err: new Error("Company assistant tool selection read failed"), siloId: caller.siloId }, "Company assistant tools unavailable");
+			response.status(503).json({ error: "company_assistant_tools_unavailable" });
+		}
+	}).put(async function _SetTools(request, response)
+	{
+		response.set("Cache-Control", "no-store");
+		const caller = resolveCaller(request);
+		if (caller === null)
+			return void response.status(401).json({ error: "unauthorized" });
+		const parsed = ___CompanyAssistantToolsSchema.safeParse(request.body);
+		if (!parsed.success)
+			return void response.status(400).json({ error: "invalid_request" });
+		try
+		{
+			response.json(await authority.setTools(caller, parsed.data));
+		}
+		catch (error)
+		{
+			if (error instanceof CompanyAssistantProvisioningDenied)
+				return void response.status(403).json({ error: "company_assistant_tools_denied" });
+			if (error instanceof CompanyAssistantToolsConflict)
+				return void response.status(409).json({ error: "company_assistant_revision_changed" });
+			if (error instanceof CompanyAssistantToolsUnavailable)
+				return void response.status(404).json({ error: "company_assistant_unavailable" });
+			logger.warn({ err: new Error("Company assistant tool assignment failed"), siloId: caller.siloId }, "Company assistant tools unavailable");
+			response.status(503).json({ error: "company_assistant_tools_unavailable" });
+		}
+	});
 	router.post("/", async function _Provision(request, response)
 	{
 		response.set("Cache-Control", "no-store");

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-provisioning.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-provisioning.types.ts
@@ -15,12 +15,45 @@ export type CompanyAssistantProvisioningCallerResolver = (request: Request) => C
 export interface CompanyAssistantProvisioningAuthority
 {
 	provision(caller: CompanyAssistantProvisioningCaller, command: CompanyAssistantProvisioningCommand): Promise<CompanyAssistantProvisioningResult>;
+	/** Reads the current assignment after checking the administrator's current permission. */
+	getTools(caller: CompanyAssistantProvisioningCaller): Promise<CompanyAssistantToolsSelection>;
+	/** Publishes a successor only when the caller still names the active source revision. */
+	setTools(caller: CompanyAssistantProvisioningCaller, command: CompanyAssistantToolsCommand): Promise<CompanyAssistantToolsSelection>;
 }
 
 /** Publishes PostgreSQL authority in an existing transaction without performing external history writes. */
-export interface CompanyAssistantProvisioningRepository
+export interface CompanyAssistantProvisioningRepository extends CompanyAssistantToolsRepository
 {
 	provision(caller: CompanyAssistantProvisioningCaller, command: CompanyAssistantProvisioningCommand, now: Date): Promise<CompanyAssistantProvisioningResult>;
+}
+
+/** Reads or replaces tool assignments using the caller's existing database transaction. */
+export interface CompanyAssistantToolsRepository
+{
+	/** Reads a current assignment without recording an effect admission. */
+	getTools(caller: CompanyAssistantProvisioningCaller, now: Date): Promise<CompanyAssistantToolsSelection>;
+	/** Records assignment authority and publishes the revision and grants in this transaction. */
+	setTools(caller: CompanyAssistantProvisioningCaller, command: CompanyAssistantToolsCommand, now: Date): Promise<CompanyAssistantToolsSelection>;
+}
+
+/** Replaces the company's complete tool selection against one observed active revision. */
+export interface CompanyAssistantToolsCommand
+{
+	/** Names the active revision observed by GET; stale requests must refresh before another edit. */
+	readonly expectedActiveRevisionId: string;
+	/** Names at most 32 unique immutable tool revisions; an empty list removes every assignment. */
+	readonly toolRevisionIds: readonly string[];
+}
+
+/** Returns the authoritative current selection without credentials or private execution coordinates. */
+export interface CompanyAssistantToolsSelection
+{
+	/** Identifies the silo's stable company assistant. */
+	readonly agentServiceId: string;
+	/** Identifies the immutable revision that owns this selection. */
+	readonly activeRevisionId: string;
+	/** Lists exact selected tool revisions in canonical order. */
+	readonly toolRevisionIds: readonly string[];
 }
 
 /** Carries the explicit administrator choices for the silo's first company assistant. */

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-provisioning.validator.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant-provisioning.validator.ts
@@ -1,8 +1,16 @@
 import { z } from "zod";
 
+import type { CompanyAssistantToolsCommand } from "./company-assistant-provisioning.types";
+
 /** Validates explicit setup choices while rejecting identity, execution policy and duplicate grant targets. */
 export const ___CompanyAssistantProvisioningSchema = z.object({
 	name: z.string().min(1).max(120).refine(value => value === value.trim() && value.length > 0),
 	modelDefinitionId: z.string().min(1).max(200).refine(value => value === value.trim() && value.length > 0),
 	invokerPrincipalIds: z.array(z.string().min(1).max(200).refine(value => value === value.trim() && value.length > 0)).min(1).max(100).refine(values => new Set(values).size === values.length),
+}).strict();
+
+/** Bounds a complete tool replacement and rejects identity, credential and execution-policy input. */
+export const ___CompanyAssistantToolsSchema: z.ZodType<CompanyAssistantToolsCommand> = z.object({
+	expectedActiveRevisionId: z.string().min(1).max(200).refine(value => value === value.trim()),
+	toolRevisionIds: z.array(z.string().min(1).max(200).refine(value => value === value.trim())).max(32).refine(values => new Set(values).size === values.length),
 }).strict();

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant.errors.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/company-assistant.errors.ts
@@ -1,0 +1,21 @@
+/** Stops provisioning without exposing the administrator's grants or other members' identities. */
+export class CompanyAssistantProvisioningDenied extends Error
+{
+	/** Supplies one rollback error for invalid choices or refused authority. */
+	public constructor() { super("Company assistant provisioning was not authorized or available"); }
+}
+
+/** Requires a fresh selection read after the active revision changes. */
+export class CompanyAssistantToolsConflict extends Error
+{
+	/** Rejects stale edits without suggesting that replacement choices were committed. */
+	public constructor() { super("Company assistant active revision changed"); }
+}
+
+/** Conceals unavailable company service coordinates after administrator authorization. */
+export class CompanyAssistantToolsUnavailable extends Error
+{
+	/** Reports that no active published company assistant can be edited. */
+	public constructor() { super("Company assistant is unavailable"); }
+}
+

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/db/__tests__/company-assistant-tools.sql.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/db/__tests__/company-assistant-tools.sql.test.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "node:crypto";
+import { AgentRevisionState, McpApprovalStatus, McpServerRevisionState, McpServerStatus, McpServerTransport, ModelRoutingScope, OciImageValidationState, OrgMemberStatus, OrgRole, PrincipalProvenance, Prisma, PrismaClient } from "@prisma/client";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { PrismaManagedAuthorizationGrantRepository, PrismaOrganizationAdminGrantBootstrapRepository } from "@opencrane/backend/server/iam/authorization";
+import { AuthorizationBoundaryCoverages, AuthorizationBoundaryKinds, AuthorizationSubjectKinds, ProductAuthorizationActions, ProductAuthorizationResourceKinds, __ProductAuthorizationCapability, type ProductAuthorizationResourceLocator } from "@opencrane/models/authorization";
+import { ___DigestCanonicalJson } from "@opencrane/util";
+
+import { CompanyAssistantProvisioningDenied, CompanyAssistantToolsConflict } from "../../company-assistant.errors";
+import { PrismaCompanyAssistantProvisioningRepository } from "../prisma-company-assistant-provisioning";
+import { PrismaCompanyAssistantProvisioningUnitOfWork } from "../prisma-company-assistant-provisioning-unit-of-work";
+
+const _First = new PrismaClient();
+const _Second = new PrismaClient();
+const _POLICY = { workloadProfile: "company", promptPolicyVersion: "sql-company-tools-v1", budget: { maxTurns: 2, maxTokens: 4096, maxDurationMs: 60_000 } };
+
+/** Seeds exact grants through the production managed writer and the installed capability catalogue. */
+async function _Grants(transaction: Prisma.TransactionClient, siloId: string, principalId: string, resource: ProductAuthorizationResourceLocator, actions: readonly ProductAuthorizationActions[], managerId = "company-tools-sql-admin")
+{
+	const grants = actions.map(function _Grant(action)
+	{
+		const capability = __ProductAuthorizationCapability(resource.kind, action);
+		if (capability === null)
+			throw new Error("Company tool SQL proof requires the installed product catalogue");
+		return { subject: { kind: AuthorizationSubjectKinds.Principal, principalId }, boundary: { kind: AuthorizationBoundaryKinds.Personal, principalId }, boundaryCoverage: AuthorizationBoundaryCoverages.Exact, capability, resource, priority: 0, createdByPrincipalId: principalId } as const;
+	});
+	const writer = new PrismaManagedAuthorizationGrantRepository(transaction);
+	await writer.reconcileManagedResourceGrants({ siloId, managerId, resource, grants, now: new Date() });
+}
+
+/** Freezes a credential-free discovered tool using the trigger-valid OCI sequence shared by SQL suites. */
+async function _Tool(transaction: Prisma.TransactionClient, siloId: string, principalId: string)
+{
+	const serverId = randomUUID();
+	const validationId = randomUUID();
+	const revisionId = randomUUID();
+	const toolId = randomUUID();
+	const digest = ___DigestCanonicalJson(toolId);
+	const image = `registry.example.test/company-tool-proof/image@${digest}`;
+	const now = new Date();
+	await transaction.mcpServer.create({ data: { id: serverId, siloId, name: serverId, endpoint: image, transport: McpServerTransport.OciImage, status: McpServerStatus.Active, approvalStatus: McpApprovalStatus.Published } });
+	await transaction.ociImageValidation.create({ data: { id: validationId, siloId, artifactId: randomUUID(), artifactRevisionId: randomUUID(), contentAddress: digest, byteLength: 1, mediaType: "application/vnd.oci.image.layout.v1+tar", submissionKeyDigest: digest, submissionDigest: digest, state: OciImageValidationState.Imported, indexDigest: digest, imageManifestDigest: digest, configDigest: digest, registryReference: image, createdByPrincipalId: principalId, completedAt: now } });
+	await transaction.mcpServerRevision.create({ data: { id: revisionId, siloId, mcpServerId: serverId, ociImageValidationId: validationId, revision: 1, registryReference: image } });
+	const schema = { type: "object", properties: {}, additionalProperties: false };
+	await transaction.mcpToolRevision.create({ data: { id: toolId, siloId, serverRevisionId: revisionId, name: "records.read", inputSchema: schema, inputSchemaDigest: ___DigestCanonicalJson(schema) } });
+	await transaction.mcpServerRevision.update({ where: { id: revisionId }, data: { state: McpServerRevisionState.Ready, protocolVersion: "2026-07-28", completedAt: now } });
+	await _Grants(transaction, siloId, principalId, { kind: ProductAuthorizationResourceKinds.McpToolRevision, id: toolId }, [ProductAuthorizationActions.Assign, ProductAuthorizationActions.Use]);
+	return { serverId, revisionId, toolId };
+}
+
+/** Creates only isolated authority rows; immutable revisions and audits remain in the disposable Actions database. */
+async function _Fixture()
+{
+	const siloId = `company-tools-sql-${randomUUID()}`;
+	return _First.$transaction(async function _Seed(transaction)
+	{
+		const principalId = randomUUID();
+		const modelId = randomUUID();
+		const membershipId = randomUUID();
+		const caller = { siloId, principalId };
+		await transaction.principal.create({ data: { id: principalId, siloId, issuer: "https://company-tools-sql.example", subject: principalId, provenance: PrincipalProvenance.External } });
+		await transaction.orgMembership.create({ data: { id: membershipId, clusterTenant: siloId, subject: principalId, role: OrgRole.Admin, status: OrgMemberStatus.Active } });
+		const bootstrap = new PrismaOrganizationAdminGrantBootstrapRepository(transaction);
+		await bootstrap.reconcileOrganizationAdminGrant({ ...caller, subject: principalId, now: new Date() });
+		await transaction.modelDefinition.create({ data: { id: modelId, siloId, scope: ModelRoutingScope.Global, publicModelName: modelId, litellmModelId: `litellm-${modelId}`, upstreamModel: modelId } });
+		await _Grants(transaction, siloId, principalId, { kind: ProductAuthorizationResourceKinds.ModelDefinition, id: modelId }, [ProductAuthorizationActions.Use]);
+		const firstTool = await _Tool(transaction, siloId, principalId);
+		const secondTool = await _Tool(transaction, siloId, principalId);
+		const repository = new PrismaCompanyAssistantProvisioningRepository(transaction, _POLICY);
+		const assistant = await repository.provision(caller, { name: "SQL company assistant", modelDefinitionId: modelId, invokerPrincipalIds: [principalId] }, new Date());
+		return { caller, membershipId, firstTool, secondTool, assistant };
+	}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, timeout: 20_000 });
+}
+
+/** Uses the production transaction owner; tool commands must never read or write identity history. */
+function _Authority(prisma: PrismaClient)
+{
+	const identities = { async load(): Promise<never> { throw new Error("Tool assignment read identity history"); }, async append(): Promise<never> { throw new Error("Tool assignment wrote identity history"); }, async loadActive(): Promise<never> { throw new Error("Tool assignment read active identity"); } };
+	return new PrismaCompanyAssistantProvisioningUnitOfWork(prisma, _POLICY, identities);
+}
+
+describe("company assistant tool assignment on the fresh PostgreSQL baseline", function _Suite()
+{
+	beforeAll(async function _Connect()
+	{
+		if (!process.env.DATABASE_URL)
+			throw new Error("Company tool SQL proof requires DATABASE_URL and the fresh target baseline");
+		await Promise.all([_First.$connect(), _Second.$connect()]);
+	});
+	afterAll(async function _Disconnect() { await Promise.all([_First.$disconnect(), _Second.$disconnect()]); });
+
+	it("publishes immutable successors and removes only its manager's old own-principal tool grants", async function _ExactReplacement()
+	{
+		const f = await _Fixture();
+		const authority = _Authority(_First);
+		const first = await authority.setTools(f.caller, { expectedActiveRevisionId: f.assistant.agentRevisionId, toolRevisionIds: [f.firstTool.toolId] });
+		const original = await _Second.agentRevision.findUniqueOrThrow({ where: { id: f.assistant.agentRevisionId }, include: { mcpToolAssignments: true } });
+		expect(original.mcpToolAssignments).toEqual([]);
+		await _Second.$transaction(async function _OtherManager(transaction)
+		{
+			await _Grants(transaction, f.caller.siloId, f.assistant.principalId, { kind: ProductAuthorizationResourceKinds.McpToolRevision, id: f.firstTool.toolId }, [ProductAuthorizationActions.Use], "independent-manager");
+		});
+		const second = await authority.setTools(f.caller, { expectedActiveRevisionId: first.activeRevisionId, toolRevisionIds: [f.secondTool.toolId] });
+		const managerId = `company-assistant:${f.assistant.agentServiceId}`;
+		const current = await _Second.authorizationGrant.findMany({ where: { siloId: f.caller.siloId, managerId, resourceKind: ProductAuthorizationResourceKinds.McpToolRevision, revokedAt: null } });
+		expect(current.map(grant => [grant.subjectPrincipalId, grant.resourceId, grant.capabilityId]).sort()).toEqual(["mcp-tool-revision:invoke", "mcp-tool-revision:use"].map(capability => [f.assistant.principalId, f.secondTool.toolId, capability]));
+		expect(await _Second.authorizationGrant.count({ where: { siloId: f.caller.siloId, resourceId: f.firstTool.toolId, managerId: "independent-manager", revokedAt: null } })).toBe(1);
+		expect(await _Second.authorizationGrant.count({ where: { siloId: f.caller.siloId, resourceId: f.firstTool.toolId, subjectPrincipalId: f.caller.principalId, revokedAt: null } })).toBe(2);
+		const revision = await _Second.agentRevision.findUniqueOrThrow({ where: { id: second.activeRevisionId } });
+		expect(revision).toMatchObject({ parentRevisionId: first.activeRevisionId, state: AgentRevisionState.Published, modelDefinitionId: original.modelDefinitionId, budget: original.budget, promptPolicyVersion: original.promptPolicyVersion, personaRevisionId: null });
+		const noOp = await _Authority(_Second).setTools(f.caller, { expectedActiveRevisionId: second.activeRevisionId, toolRevisionIds: [f.secondTool.toolId] });
+		expect(noOp).toEqual(second);
+		expect(await _Second.agentRevision.count({ where: { agentServiceId: f.assistant.agentServiceId } })).toBe(3);
+		await expect(authority.setTools(f.caller, { expectedActiveRevisionId: first.activeRevisionId, toolRevisionIds: [f.secondTool.toolId] })).rejects.toBeInstanceOf(CompanyAssistantToolsConflict);
+		await expect(authority.getTools(f.caller)).resolves.toEqual(second);
+	});
+
+	it("allows only one successor when independent servers replace the same observed revision", async function _ConcurrentReplacement()
+	{
+		const f = await _Fixture();
+		const results = await Promise.allSettled([
+			_Authority(_First).setTools(f.caller, { expectedActiveRevisionId: f.assistant.agentRevisionId, toolRevisionIds: [f.firstTool.toolId] }),
+			_Authority(_Second).setTools(f.caller, { expectedActiveRevisionId: f.assistant.agentRevisionId, toolRevisionIds: [f.secondTool.toolId] }),
+		]);
+		expect(results.filter(result => result.status === "fulfilled")).toHaveLength(1);
+		const rejected = results.find(result => result.status === "rejected");
+		expect(rejected?.status === "rejected" && rejected.reason instanceof CompanyAssistantToolsConflict).toBe(true);
+		const current = await _Authority(_Second).getTools(f.caller);
+		expect(await _Second.agentRevision.count({ where: { agentServiceId: f.assistant.agentServiceId } })).toBe(2);
+		const grants = await _Second.authorizationGrant.findMany({ where: { siloId: f.caller.siloId, managerId: `company-assistant:${f.assistant.agentServiceId}`, resourceKind: ProductAuthorizationResourceKinds.McpToolRevision, revokedAt: null } });
+		expect(grants).toHaveLength(2);
+		expect(grants.every(grant => current.toolRevisionIds.includes(grant.resourceId!))).toBe(true);
+	});
+
+	it("rolls back successor publication and all tool grants when the active-pointer comparison loses", async function _CasRollback()
+	{
+		const f = await _Fixture();
+		const extension = Prisma.defineExtension({ query: { agentService: { async updateMany({ args, query })
+		{
+			await query(args);
+			return { count: 0 };
+		} } } });
+		const client = _First.$extends(extension) as unknown as PrismaClient;
+		await expect(_Authority(client).setTools(f.caller, { expectedActiveRevisionId: f.assistant.agentRevisionId, toolRevisionIds: [f.firstTool.toolId] })).rejects.toBeInstanceOf(CompanyAssistantToolsConflict);
+		expect(await _Second.agentRevision.count({ where: { agentServiceId: f.assistant.agentServiceId } })).toBe(1);
+		expect(await _Second.authorizationGrant.count({ where: { siloId: f.caller.siloId, managerId: `company-assistant:${f.assistant.agentServiceId}`, resourceKind: ProductAuthorizationResourceKinds.McpToolRevision } })).toBe(0);
+		await expect(_Authority(_Second).getTools(f.caller)).resolves.toMatchObject({ activeRevisionId: f.assistant.agentRevisionId, toolRevisionIds: [] });
+	});
+
+	it("refuses missing Assign and a removed administrator despite retained grants", async function _CurrentPermissions()
+	{
+		const f = await _Fixture();
+		await _Second.authorizationGrant.updateMany({ where: { siloId: f.caller.siloId, subjectPrincipalId: f.caller.principalId, resourceId: f.firstTool.toolId, capabilityId: "mcp-tool-revision:assign" }, data: { revokedAt: new Date() } });
+		const command = { expectedActiveRevisionId: f.assistant.agentRevisionId, toolRevisionIds: [f.firstTool.toolId] };
+		await expect(_Authority(_First).setTools(f.caller, command)).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		await _Second.orgMembership.update({ where: { id: f.membershipId }, data: { status: OrgMemberStatus.Suspended } });
+		await expect(_Authority(_First).getTools(f.caller)).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		await expect(_Authority(_First).setTools(f.caller, { ...command, toolRevisionIds: [f.secondTool.toolId] })).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		expect(await _Second.agentRevision.count({ where: { agentServiceId: f.assistant.agentServiceId } })).toBe(1);
+	});
+
+	it("refuses a foreign tool and a server whose publication was withdrawn", async function _UnavailableTools()
+	{
+		const f = await _Fixture();
+		const other = await _Fixture();
+		await expect(_Authority(_First).setTools(f.caller, { expectedActiveRevisionId: f.assistant.agentRevisionId, toolRevisionIds: [other.firstTool.toolId] })).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		await _Second.mcpServer.update({ where: { id: f.firstTool.serverId }, data: { approvalStatus: McpApprovalStatus.Disabled } });
+		await expect(_Authority(_First).setTools(f.caller, { expectedActiveRevisionId: f.assistant.agentRevisionId, toolRevisionIds: [f.firstTool.toolId] })).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		expect(await _Second.agentRevision.count({ where: { agentServiceId: f.assistant.agentServiceId } })).toBe(1);
+	});
+});

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/db/__tests__/prisma-company-assistant-provisioning-unit-of-work.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/db/__tests__/prisma-company-assistant-provisioning-unit-of-work.test.ts
@@ -24,7 +24,7 @@ describe("PrismaCompanyAssistantProvisioningUnitOfWork", function _Suite()
 		}), append: vi.fn(), loadActive: vi.fn().mockResolvedValue({ identity: { kind: "managed" } }) };
 		const authority = new PrismaCompanyAssistantProvisioningUnitOfWork({ $transaction } as never, _POLICY, identities as never);
 		await expect(authority.provision(_CALLER, _COMMAND)).resolves.toEqual(_RESULT);
-		expect($transaction).toHaveBeenCalledWith(expect.any(Function), { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+		expect($transaction).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ isolationLevel: Prisma.TransactionIsolationLevel.Serializable }));
 		expect(identities.load).toHaveBeenCalledTimes(1);
 		expect(identities.append).not.toHaveBeenCalled();
 	});
@@ -36,6 +36,46 @@ describe("PrismaCompanyAssistantProvisioningUnitOfWork", function _Suite()
 		const authority = new PrismaCompanyAssistantProvisioningUnitOfWork({ $transaction } as never, _POLICY, identities as never);
 		await expect(authority.provision(_CALLER, _COMMAND)).rejects.toThrow();
 		expect($transaction).toHaveBeenCalledTimes(3);
+		expect(identities.load).not.toHaveBeenCalled();
+		expect(identities.append).not.toHaveBeenCalled();
+	});
+});
+
+describe("company assistant tool assignment transaction boundary", function _ToolsSuite()
+{
+	it.each(["P2002", "P2034"])("rechecks current assignment authority after a proven %s rollback without identity writes", async function _RetriesAssignment(code)
+	{
+		const selection = { agentServiceId: "company", activeRevisionId: "revision-2", toolRevisionIds: ["tool-1"] };
+		const setTools = vi.spyOn(PrismaCompanyAssistantProvisioningRepository.prototype, "setTools").mockRejectedValueOnce(new Prisma.PrismaClientKnownRequestError("rolled back", { code, clientVersion: "test" })).mockResolvedValue(selection);
+		const $transaction = vi.fn().mockImplementation(async operation => await operation({}));
+		const identities = { load: vi.fn(), append: vi.fn(), loadActive: vi.fn() };
+		const authority = new PrismaCompanyAssistantProvisioningUnitOfWork({ $transaction } as never, _POLICY, identities as never);
+		const command = { expectedActiveRevisionId: "revision-1", toolRevisionIds: ["tool-1"] };
+		await expect(authority.setTools(_CALLER, command)).resolves.toEqual(selection);
+		expect(setTools).toHaveBeenCalledTimes(2);
+		expect($transaction).toHaveBeenCalledWith(expect.any(Function), expect.objectContaining({ isolationLevel: Prisma.TransactionIsolationLevel.Serializable }));
+		expect(identities.load).not.toHaveBeenCalled();
+		expect(identities.append).not.toHaveBeenCalled();
+	});
+
+	it("does not replay an uncertain commit and uses GET to read the authoritative current selection", async function _DoesNotReplayUncertainCommit()
+	{
+		const command = { expectedActiveRevisionId: "revision-1", toolRevisionIds: ["tool-1"] };
+		const selection = { agentServiceId: "company", activeRevisionId: "revision-2", toolRevisionIds: ["tool-1"] };
+		const setTools = vi.spyOn(PrismaCompanyAssistantProvisioningRepository.prototype, "setTools").mockResolvedValue(selection);
+		const getTools = vi.spyOn(PrismaCompanyAssistantProvisioningRepository.prototype, "getTools").mockResolvedValue(selection);
+		const $transaction = vi.fn().mockImplementationOnce(async function _Uncertain(operation)
+		{
+			await operation({});
+			throw new Error("commit response lost");
+		}).mockImplementation(async operation => await operation({}));
+		const identities = { load: vi.fn(), append: vi.fn(), loadActive: vi.fn() };
+		const authority = new PrismaCompanyAssistantProvisioningUnitOfWork({ $transaction } as never, _POLICY, identities as never);
+		await expect(authority.setTools(_CALLER, command)).rejects.toThrow("commit response lost");
+		expect(setTools).toHaveBeenCalledTimes(1);
+		expect($transaction).toHaveBeenCalledTimes(1);
+		await expect(authority.getTools(_CALLER)).resolves.toEqual(selection);
+		expect(getTools).toHaveBeenCalledExactlyOnceWith(_CALLER, expect.any(Date));
 		expect(identities.load).not.toHaveBeenCalled();
 		expect(identities.append).not.toHaveBeenCalled();
 	});

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/db/__tests__/prisma-company-assistant-tools.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/db/__tests__/prisma-company-assistant-tools.test.ts
@@ -1,0 +1,170 @@
+import { AgentRevisionState, AgentServiceKind, AgentServiceState, AuthorizationBoundaryCoverage, AuthorizationBoundaryKind, McpApprovalStatus, McpServerRevisionState, McpServerStatus, PrincipalProvenance } from "@prisma/client";
+import { AuthorizationDecisionOutcomes, ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
+import { describe, expect, it, vi } from "vitest";
+
+import { __CompanyAssistantServiceId } from "../../managed-agent-identity";
+import { CompanyAssistantProvisioningDenied, CompanyAssistantToolsConflict, CompanyAssistantToolsUnavailable } from "../../company-assistant.errors";
+import { PrismaCompanyAssistantToolsRepository } from "../prisma-company-assistant-tools";
+
+const _NOW = new Date("2026-09-09T03:00:00.000Z");
+const _CALLER = { siloId: "silo-1", principalId: "admin" };
+const _SERVICE_ID = __CompanyAssistantServiceId(_CALLER.siloId);
+const _POLICY = { workloadProfile: "company", promptPolicyVersion: "1", budget: { maxTurns: 2, maxTokens: 4096, maxDurationMs: 60_000 } };
+const _COMMAND = { expectedActiveRevisionId: "revision-1", toolRevisionIds: ["tool-retained", "tool-new"] };
+
+/** Keeps source content distinct from replacement tools so accidental content loss is observable. */
+function _Fixture()
+{
+	const source = {
+		id: "revision-1", siloId: _CALLER.siloId, agentServiceId: _SERVICE_ID, revision: 1,
+		state: AgentRevisionState.Published, publishedAt: _NOW, promptPolicyVersion: "policy-original",
+		personaRevisionId: "persona-original", modelDefinitionId: "model-original", budget: _POLICY.budget,
+		skillAssignments: [{ skillId: "skill-original", skillRevisionId: "skill-revision-original" }],
+		mcpToolAssignments: [{ toolRevisionId: "tool-retained" }, { toolRevisionId: "tool-old" }],
+		boundaryAttachments: [{ boundaryKind: AuthorizationBoundaryKind.Group, boundaryGroupId: "group-original", boundaryPrincipalId: null, boundaryCoverage: AuthorizationBoundaryCoverage.Descendants }],
+	};
+	const service = { id: _SERVICE_ID, principalId: "company-principal", activeRevisionId: source.id, activeRevision: source };
+	const transaction = {
+		agentService: { findFirst: vi.fn().mockResolvedValue(service), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+		agentRevision: { create: vi.fn().mockResolvedValue({}), update: vi.fn().mockResolvedValue({}) },
+		mcpToolRevision: { findMany: vi.fn().mockResolvedValue(_COMMAND.toolRevisionIds.map(id => ({ id }))) },
+	};
+	const decidePrincipal = vi.fn().mockResolvedValue({ outcome: AuthorizationDecisionOutcomes.Allow });
+	const admitPrincipal = vi.fn().mockResolvedValue({ outcome: AuthorizationDecisionOutcomes.Allow, evidence: { decisionDigest: "sha256:allowed" } });
+	const reconcileManagedResourceGrants = vi.fn().mockResolvedValue(1);
+	const repository = new PrismaCompanyAssistantToolsRepository(transaction as never, { decidePrincipal, admitPrincipal } as never, { reconcileManagedResourceGrants });
+	return { repository, transaction, source, service, decidePrincipal, admitPrincipal, reconcileManagedResourceGrants };
+}
+
+describe("company assistant tool assignment persistence", function _Suite()
+{
+	it("reads current tools through a pure current Administer decision before touching the company service", async function _ReadsCurrent()
+	{
+		const f = _Fixture();
+		await expect(f.repository.getTools(_CALLER, _NOW)).resolves.toEqual({ agentServiceId: _SERVICE_ID, activeRevisionId: "revision-1", toolRevisionIds: ["tool-old", "tool-retained"] });
+		expect(f.decidePrincipal).toHaveBeenCalledExactlyOnceWith({ ..._CALLER, resource: { kind: ProductAuthorizationResourceKinds.Organization, id: _CALLER.siloId }, action: ProductAuthorizationActions.Administer, nowEpochMs: _NOW.getTime() });
+		expect(f.admitPrincipal).not.toHaveBeenCalled();
+		expect(f.transaction.agentService.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: { id: _SERVICE_ID, siloId: _CALLER.siloId, kind: AgentServiceKind.Managed, state: AgentServiceState.Active, principal: { is: { siloId: _CALLER.siloId, provenance: PrincipalProvenance.Internal } } } }));
+		f.transaction.agentService.findFirst.mockClear();
+		f.decidePrincipal.mockResolvedValue({ outcome: AuthorizationDecisionOutcomes.Deny });
+		await expect(f.repository.getTools(_CALLER, _NOW)).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		expect(f.transaction.agentService.findFirst).not.toHaveBeenCalled();
+	});
+
+	it("copies all other immutable content and reconciles only old and selected tool resources for its own principal", async function _Replaces()
+	{
+		const f = _Fixture();
+		const original = structuredClone(f.source);
+		const result = await f.repository.setTools(_CALLER, _COMMAND, _NOW);
+		expect(result).toEqual({ agentServiceId: _SERVICE_ID, activeRevisionId: expect.any(String), toolRevisionIds: ["tool-new", "tool-retained"] });
+		expect(result.activeRevisionId).not.toBe(f.source.id);
+		expect(f.source).toEqual(original);
+		expect(f.admitPrincipal.mock.calls.map(call => [call[0].resource, call[0].action])).toEqual([
+			[{ kind: ProductAuthorizationResourceKinds.Organization, id: _CALLER.siloId }, ProductAuthorizationActions.Administer],
+			[{ kind: ProductAuthorizationResourceKinds.McpToolRevision, id: "tool-new" }, ProductAuthorizationActions.Assign],
+			[{ kind: ProductAuthorizationResourceKinds.McpToolRevision, id: "tool-retained" }, ProductAuthorizationActions.Assign],
+		]);
+		expect(f.transaction.agentRevision.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({
+			id: result.activeRevisionId, revision: 2, parentRevision: { connect: { id_siloId: { id: "revision-1", siloId: _CALLER.siloId } } },
+			promptPolicyVersion: "policy-original", personaRevisionId: "persona-original", modelDefinition: { connect: { id_siloId: { id: "model-original", siloId: _CALLER.siloId } } }, budget: _POLICY.budget,
+			skillAssignments: { create: [{ skillId: "skill-original", skillRevisionId: "skill-revision-original" }] },
+			boundaryAttachments: { create: [{ siloId: _CALLER.siloId, boundaryKind: AuthorizationBoundaryKind.Group, boundaryGroupId: "group-original", boundaryCoverage: AuthorizationBoundaryCoverage.Descendants }] },
+			mcpToolAssignments: { create: ["tool-new", "tool-retained"].map(toolRevisionId => ({ toolRevisionId, siloId: _CALLER.siloId })) },
+		}) }));
+		const reconciled = f.reconcileManagedResourceGrants.mock.calls.map(call => call[0]);
+		expect(reconciled.map(call => call.resource.id)).toEqual(["tool-new", "tool-old", "tool-retained"]);
+		for (const call of reconciled)
+		{
+			expect(call).toMatchObject({ siloId: _CALLER.siloId, managerId: `company-assistant:${_SERVICE_ID}`, resource: { kind: ProductAuthorizationResourceKinds.McpToolRevision }, now: _NOW });
+			if (call.resource.id === "tool-old")
+				expect(call.grants).toEqual([]);
+			else
+				expect(call.grants).toEqual(["use", "invoke"].map(action => expect.objectContaining({ subject: { kind: "principal", principalId: "company-principal" }, boundary: { kind: "personal", principalId: "company-principal" }, boundaryCoverage: "exact", capability: expect.objectContaining({ capabilityId: `mcp-tool-revision:${action}` }) })));
+		}
+		expect(f.transaction.agentService.updateMany).toHaveBeenCalledExactlyOnceWith({ where: { id: _SERVICE_ID, siloId: _CALLER.siloId, kind: AgentServiceKind.Managed, state: AgentServiceState.Active, activeRevisionId: "revision-1" }, data: { activeRevisionId: result.activeRevisionId, updatedAt: _NOW } });
+		expect(f.transaction.agentRevision.update).toHaveBeenCalledExactlyOnceWith({ where: { id_siloId: { id: result.activeRevisionId, siloId: _CALLER.siloId } }, data: { state: AgentRevisionState.Published, publishedAt: _NOW } });
+	});
+
+	it("validates exact same-silo ready tool revisions on active published servers before any revision write", async function _RequiresPublishedTools()
+	{
+		const f = _Fixture();
+		f.transaction.mcpToolRevision.findMany.mockResolvedValue([]);
+		await expect(f.repository.setTools(_CALLER, _COMMAND, _NOW)).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		expect(f.transaction.mcpToolRevision.findMany).toHaveBeenCalledExactlyOnceWith({ where: { id: { in: ["tool-new", "tool-retained"] }, siloId: _CALLER.siloId, serverRevision: { is: { siloId: _CALLER.siloId, state: McpServerRevisionState.Ready, server: { is: { siloId: _CALLER.siloId, status: McpServerStatus.Active, approvalStatus: McpApprovalStatus.Published } } } } }, select: { id: true } });
+		expect(f.transaction.agentRevision.create).not.toHaveBeenCalled();
+		expect(f.reconcileManagedResourceGrants).not.toHaveBeenCalled();
+	});
+
+	it.each([1, 2, 3])("denies decision %s without revision or grant changes", async function _RequiresPermission(index)
+	{
+		const f = _Fixture();
+		f.admitPrincipal.mockReset().mockResolvedValue({ outcome: AuthorizationDecisionOutcomes.Deny, evidence: null });
+		for (let decision = 1; decision < index; decision += 1)
+			f.admitPrincipal.mockResolvedValueOnce({ outcome: AuthorizationDecisionOutcomes.Allow, evidence: { decisionDigest: "sha256:allowed" } });
+		await expect(f.repository.setTools(_CALLER, _COMMAND, _NOW)).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		expect(f.transaction.agentRevision.create).not.toHaveBeenCalled();
+		expect(f.reconcileManagedResourceGrants).not.toHaveBeenCalled();
+	});
+
+	it("refuses an allowed assignment decision when its durable evidence is missing", async function _RequiresAdmissionEvidence()
+	{
+		const f = _Fixture();
+		f.admitPrincipal.mockResolvedValueOnce({ outcome: AuthorizationDecisionOutcomes.Allow, evidence: { decisionDigest: "sha256:admin" } }).mockResolvedValueOnce({ outcome: AuthorizationDecisionOutcomes.Allow, evidence: null });
+		await expect(f.repository.setTools(_CALLER, _COMMAND, _NOW)).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+		expect(f.transaction.agentRevision.create).not.toHaveBeenCalled();
+		expect(f.reconcileManagedResourceGrants).not.toHaveBeenCalled();
+	});
+
+	it("requires fresh permissions for a current same-set no-op without restoring grants", async function _NoOp()
+	{
+		const f = _Fixture();
+		const command = { expectedActiveRevisionId: "revision-1", toolRevisionIds: ["tool-retained", "tool-old"] };
+		f.transaction.mcpToolRevision.findMany.mockResolvedValue(command.toolRevisionIds.map(id => ({ id })));
+		await expect(f.repository.setTools(_CALLER, command, _NOW)).resolves.toEqual({ agentServiceId: _SERVICE_ID, activeRevisionId: "revision-1", toolRevisionIds: ["tool-old", "tool-retained"] });
+		expect(f.admitPrincipal).toHaveBeenCalledTimes(3);
+		expect(f.transaction.agentRevision.create).not.toHaveBeenCalled();
+		expect(f.reconcileManagedResourceGrants).not.toHaveBeenCalled();
+		f.admitPrincipal.mockResolvedValue({ outcome: AuthorizationDecisionOutcomes.Deny, evidence: null });
+		await expect(f.repository.setTools(_CALLER, command, _NOW)).rejects.toBeInstanceOf(CompanyAssistantProvisioningDenied);
+	});
+
+	it("rejects stale same-set retries before equality and permits GET to return the authoritative successor", async function _RejectsUncertainRetry()
+	{
+		const f = _Fixture();
+		await expect(f.repository.setTools(_CALLER, { expectedActiveRevisionId: "previous-revision", toolRevisionIds: ["tool-old", "tool-retained"] }, _NOW)).rejects.toBeInstanceOf(CompanyAssistantToolsConflict);
+		expect(f.transaction.agentRevision.create).not.toHaveBeenCalled();
+		expect(f.reconcileManagedResourceGrants).not.toHaveBeenCalled();
+		await expect(f.repository.getTools(_CALLER, _NOW)).resolves.toMatchObject({ activeRevisionId: "revision-1", toolRevisionIds: ["tool-old", "tool-retained"] });
+	});
+
+	it("removes every old tool grant when the selected set is empty", async function _RemovesAll()
+	{
+		const f = _Fixture();
+		f.transaction.mcpToolRevision.findMany.mockResolvedValue([]);
+		await expect(f.repository.setTools(_CALLER, { expectedActiveRevisionId: "revision-1", toolRevisionIds: [] }, _NOW)).resolves.toMatchObject({ toolRevisionIds: [] });
+		expect(f.reconcileManagedResourceGrants.mock.calls.map(call => [call[0].resource.id, call[0].grants])).toEqual([["tool-old", []], ["tool-retained", []]]);
+	});
+
+	it("throws a transaction rollback error when the active pointer compare-and-swap loses", async function _RollsBackCas()
+	{
+		const f = _Fixture();
+		f.transaction.agentService.updateMany.mockResolvedValue({ count: 0 });
+		await expect(f.repository.setTools(_CALLER, _COMMAND, _NOW)).rejects.toBeInstanceOf(CompanyAssistantToolsConflict);
+	});
+
+	it.each([null, { activeRevisionId: "other" }, { principalId: null }, { activeRevision: null }])("refuses unavailable or mismatched service authority %j", async function _RequiresCurrentService(patch)
+	{
+		const f = _Fixture();
+		f.transaction.agentService.findFirst.mockResolvedValue(patch === null ? null : { ...f.service, ...patch });
+		await expect(f.repository.setTools(_CALLER, _COMMAND, _NOW)).rejects.toBeInstanceOf(CompanyAssistantToolsUnavailable);
+		expect(f.transaction.agentRevision.create).not.toHaveBeenCalled();
+	});
+
+	it.each([{ state: AgentRevisionState.Draft }, { publishedAt: null }, { siloId: "foreign" }, { agentServiceId: "foreign" }])("refuses unpublished or substituted source content %j", async function _RequiresPublishedSource(patch)
+	{
+		const f = _Fixture();
+		f.transaction.agentService.findFirst.mockResolvedValue({ ...f.service, activeRevision: { ...f.source, ...patch } });
+		await expect(f.repository.setTools(_CALLER, _COMMAND, _NOW)).rejects.toBeInstanceOf(CompanyAssistantToolsUnavailable);
+		expect(f.transaction.agentRevision.create).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/db/__tests__/prisma-managed-agent-conversation-resolver.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/db/__tests__/prisma-managed-agent-conversation-resolver.test.ts
@@ -17,7 +17,7 @@ afterEach(function _Restore() { vi.restoreAllMocks(); });
 /** Supplies separate current service, identity, human assertion and grant authorities. */
 function _Fixture()
 {
-	vi.spyOn(PrismaManagedExecutionEvidenceRepository.prototype, "loadCurrent").mockResolvedValue({ agentServiceId: _SERVICE, agentRevisionId: "revision-1", agentRevisionDigest: "sha256:revision", principalId: "company-principal", name: "Company", workloadProfile: "company", modelDefinitionId: "model-1", budget: { maxDurationMs: 60_000 } });
+	vi.spyOn(PrismaManagedExecutionEvidenceRepository.prototype, "loadCurrent").mockResolvedValue({ agentServiceId: _SERVICE, agentRevisionId: "revision-1", agentRevisionDigest: "sha256:revision", principalId: "company-principal", name: "Company", workloadProfile: "company", modelDefinitionId: "model-1", mcpToolRevisionIds: [], budget: { maxDurationMs: 60_000 } });
 	const membership = vi.spyOn(PrismaManagedExecutionEvidenceRepository.prototype, "verifyRequesterMembership").mockResolvedValue({ kind: "fleet", revision: 7 } as never);
 	const admit = vi.spyOn(PrismaAuthorizationAuthority.prototype, "admitPrincipal");
 	const decide = vi.spyOn(PrismaAuthorizationAuthority.prototype, "decidePrincipal");
@@ -106,7 +106,7 @@ describe("managed run admission through the central audit writer", function _Sui
 	function _RunFixture()
 	{
 		const f = _Fixture();
-		const revision = { agentServiceId: _SERVICE, agentRevisionId: "revision-1", agentRevisionDigest: `sha256:${"a".repeat(64)}`, principalId: "company-principal", name: "Company", workloadProfile: "company", modelDefinitionId: "model-1", budget: { maxDurationMs: 60_000 } };
+		const revision = { agentServiceId: _SERVICE, agentRevisionId: "revision-1", agentRevisionDigest: `sha256:${"a".repeat(64)}`, principalId: "company-principal", name: "Company", workloadProfile: "company", modelDefinitionId: "model-1", mcpToolRevisionIds: [], budget: { maxDurationMs: 60_000 } };
 		const human = { kind: "fleet", principalId: "human-1", siloId: "silo-1", decisionEvidenceId: "human-assertion", revision: 7, assertionId: "human-assertion", payloadDigest: `sha256:${"b".repeat(64)}`, trustedUntil: new Date(6_000).toISOString() };
 		const repository = { loadCurrent: vi.fn().mockResolvedValue(revision), verifyRequesterMembership: vi.fn().mockResolvedValue(human) };
 		const command = { identity: { schemaVersion: 1, kind: "managed", id: __ManagedAgentIdentityId(_SERVICE), siloId: "silo-1", agentServiceId: _SERVICE, principalId: "company-principal", name: "Company", avatarArtifactRevisionId: null, state: AgentIdentityStates.Active, createdByPrincipalId: "human-1", createdAt: new Date(1_000).toISOString() } as const, requesterPrincipalId: "human-1", agentRevisionId: "revision-1" };

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/db/prisma-company-assistant-provisioning-unit-of-work.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/db/prisma-company-assistant-provisioning-unit-of-work.ts
@@ -1,46 +1,51 @@
-import { Prisma, type PrismaClient } from "@prisma/client";
+import type { PrismaClient } from "@prisma/client";
 import type { AgentIdentityHistory } from "@opencrane/backend/server/iam/identity";
+import { ___RunInPrismaUnitOfWork, type PrismaUnitOfWorkIsolationLevel } from "@opencrane/backend/server/infra/prisma-unit-of-work";
 
 import { __EnsureCompanyAssistantIdentity } from "../company-assistant-identity";
-import type { CompanyAssistantProvisioningAuthority, CompanyAssistantProvisioningCaller, CompanyAssistantProvisioningCommand, CompanyAssistantProvisioningPolicy, CompanyAssistantProvisioningResult } from "../company-assistant-provisioning.types";
+import type { CompanyAssistantProvisioningAuthority, CompanyAssistantProvisioningCaller, CompanyAssistantProvisioningCommand, CompanyAssistantProvisioningPolicy, CompanyAssistantProvisioningRepository, CompanyAssistantProvisioningResult, CompanyAssistantToolsCommand, CompanyAssistantToolsSelection } from "../company-assistant-provisioning.types";
 import { PrismaCompanyAssistantProvisioningRepository } from "./prisma-company-assistant-provisioning";
 
 /**
- * Retries PostgreSQL creation races and establishes Kurrent identity only after a successful commit.
+ * Commits company setup or tool edits and establishes identity only after the setup transaction.
  *
- * Called by: the administrator setup router through CompanyAssistantProvisioningAuthority.
- * A later HTTP retry resumes a failed identity append from the same durable service and first revision.
- * @see __EnsureCompanyAssistantIdentity for active-state preservation on retries.
+ * Called by: the public company assistant router. Proven rollback conflicts receive at most three
+ * fresh transactions; uncertain outcomes are returned to the caller without replaying a write.
+ * @see __EnsureCompanyAssistantIdentity for active-state preservation on setup retries.
  */
 export class PrismaCompanyAssistantProvisioningUnitOfWork implements CompanyAssistantProvisioningAuthority
 {
 	/** Receives application-owned database, execution policy and checked history dependencies. */
 	public constructor(private readonly prisma: PrismaClient, private readonly policy: CompanyAssistantProvisioningPolicy, private readonly identities: Pick<AgentIdentityHistory, "load" | "append" | "loadActive">) {}
 
+	/** Reads the current authorized selection without touching the stable identity history. */
+	public getTools(caller: CompanyAssistantProvisioningCaller): Promise<CompanyAssistantToolsSelection>
+	{
+		return this._WithRepository(repository => repository.getTools(caller, new Date()), "ReadCommitted", 1);
+	}
+
+	/** Repeats only proven full rollbacks; an uncertain commit must be resolved through a fresh GET. */
+	public setTools(caller: CompanyAssistantProvisioningCaller, command: CompanyAssistantToolsCommand): Promise<CompanyAssistantToolsSelection>
+	{
+		return this._WithRepository(repository => repository.setTools(caller, command, new Date()), "Serializable", 3);
+	}
+
 	/** Publishes once and returns only after the committed company identity is active. */
 	public async provision(caller: CompanyAssistantProvisioningCaller, command: CompanyAssistantProvisioningCommand): Promise<CompanyAssistantProvisioningResult>
 	{
-		let result: CompanyAssistantProvisioningResult | null = null;
-		const policy = this.policy;
-		for (let attempt = 0; attempt < 3; attempt += 1)
-		{
-			try
-			{
-				result = await this.prisma.$transaction(async function _Provision(transaction: Prisma.TransactionClient)
-				{
-					return new PrismaCompanyAssistantProvisioningRepository(transaction, policy).provision(caller, command, new Date());
-				}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
-				break;
-			}
-			catch (error)
-			{
-				if (attempt === 2 || !(error instanceof Prisma.PrismaClientKnownRequestError) || !["P2002", "P2034"].includes(error.code))
-					throw error;
-			}
-		}
-		if (result === null)
-			throw new Error("Company assistant provisioning did not commit");
+		const result = await this._WithRepository(repository => repository.provision(caller, command, new Date()), "Serializable", 3);
 		await __EnsureCompanyAssistantIdentity(this.identities, result);
 		return result;
+	}
+
+	/** Binds each complete operation to one fresh transaction and the shared proven-rollback policy. */
+	private _WithRepository<Result>(operation: (repository: CompanyAssistantProvisioningRepository) => Promise<Result>, isolationLevel: PrismaUnitOfWorkIsolationLevel, attemptLimit: number): Promise<Result>
+	{
+		const policy = this.policy;
+		return ___RunInPrismaUnitOfWork(this.prisma, async function _Run(transaction)
+		{
+			const repository = new PrismaCompanyAssistantProvisioningRepository(transaction, policy);
+			return operation(repository);
+		}, { isolationLevel, attemptLimit, operation: "company assistant" });
 	}
 }

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/db/prisma-company-assistant-provisioning.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/db/prisma-company-assistant-provisioning.ts
@@ -1,25 +1,22 @@
 import { randomUUID } from "node:crypto";
 import { AgentRevisionState, AgentServiceKind, AgentServiceState, OrgMemberStatus, PrincipalProvenance, type Prisma } from "@prisma/client";
-import { PrismaAuthorizationAuthority, PrismaManagedAuthorizationGrantRepository, type AuthorizationAuthority, type ManagedAuthorizationGrantRepository, type ManagedAuthorizationGrantSpec } from "@opencrane/backend/server/iam/authorization";
-import { AuthorizationBoundaryCoverages, AuthorizationBoundaryKinds, AuthorizationDecisionOutcomes, AuthorizationSubjectKinds, ProductAuthorizationActions, ProductAuthorizationResourceKinds, __ProductAuthorizationCapability, type ProductAuthorizationResourceLocator } from "@opencrane/models/authorization";
+import { PrismaAuthorizationAuthority, PrismaManagedAuthorizationGrantRepository, type AuthorizationAuthority, type ManagedAuthorizationGrantRepository } from "@opencrane/backend/server/iam/authorization";
+import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
 import { ___DigestCanonicalJson } from "@opencrane/util";
 
-import type { CompanyAssistantProvisioningCommand, CompanyAssistantProvisioningPolicy, CompanyAssistantProvisioningRepository, CompanyAssistantProvisioningResult } from "../company-assistant-provisioning.types";
+import type { CompanyAssistantProvisioningCaller, CompanyAssistantProvisioningCommand, CompanyAssistantProvisioningPolicy, CompanyAssistantProvisioningRepository, CompanyAssistantProvisioningResult, CompanyAssistantToolsCommand, CompanyAssistantToolsRepository, CompanyAssistantToolsSelection } from "../company-assistant-provisioning.types";
+import { CompanyAssistantProvisioningDenied } from "../company-assistant.errors";
+import { _AdmitCompanyAssistantChange, _CompanyAssistantGrant } from "../company-assistant-permissions";
+import { PrismaCompanyAssistantToolsRepository } from "./prisma-company-assistant-tools";
 import { __CompanyAssistantServiceId, __ManagedAgentIdentityId } from "../managed-agent-identity";
+import type { AgentRevisionWriterRepository } from "../../revisions/db/prisma-agent-revision-writer.types";
 import { PrismaAgentRevisionWriterRepository } from "../../revisions/db/prisma-agent-revision-writer";
 
-/** Stops provisioning without exposing the administrator's grants or other members' identities. */
-export class CompanyAssistantProvisioningDenied extends Error
-{
-	/** Supplies one rollback error for invalid choices or refused authority. */
-	public constructor() { super("Company assistant provisioning was not authorized or available"); }
-}
-
 /**
- * Publishes the silo's one company assistant and its exact initial grants in the caller's transaction.
+ * Publishes the silo's company assistant and its exact initial or replacement tool grants.
  *
  * Called by: the administrator setup composition, inside a Serializable transaction that retries
- * unique-create races. Existing assistants are returned without changing their grants or state.
+ * unique-create races. Setup retries leave existing choices unchanged; setTools owns explicit edits.
  * Kurrent identity establishment follows commit through __EnsureCompanyAssistantIdentity.
  * @see CompanyAssistantProvisioningCommand for the explicit administrator choices.
  */
@@ -27,12 +24,29 @@ export class PrismaCompanyAssistantProvisioningRepository implements CompanyAssi
 {
 	private readonly authorization: AuthorizationAuthority;
 	private readonly grants: ManagedAuthorizationGrantRepository;
+	private readonly revisions: AgentRevisionWriterRepository;
+	/** Shares this transaction and its central permission ports across tool reads and edits. */
+	private readonly tools: CompanyAssistantToolsRepository;
 
 	/** Binds all PostgreSQL writes and decisions to the same transaction. */
 	public constructor(private readonly transaction: Prisma.TransactionClient, private readonly policy: CompanyAssistantProvisioningPolicy, authorization?: AuthorizationAuthority, grants?: ManagedAuthorizationGrantRepository)
 	{
 		this.authorization = authorization ?? new PrismaAuthorizationAuthority(this.transaction);
 		this.grants = grants ?? new PrismaManagedAuthorizationGrantRepository(this.transaction);
+		this.revisions = new PrismaAgentRevisionWriterRepository(this.transaction);
+		this.tools = new PrismaCompanyAssistantToolsRepository(this.transaction, this.authorization, this.grants);
+	}
+
+	/** Reads only the company's current selected tools through the same transaction-bound authority. */
+	public getTools(caller: CompanyAssistantProvisioningCaller, now: Date): Promise<CompanyAssistantToolsSelection>
+	{
+		return this.tools.getTools(caller, now);
+	}
+
+	/** Delegates immutable tool replacement without changing setup or stable identity history. */
+	public setTools(caller: CompanyAssistantProvisioningCaller, command: CompanyAssistantToolsCommand, now: Date): Promise<CompanyAssistantToolsSelection>
+	{
+		return this.tools.setTools(caller, command, now);
 	}
 
 	/** Commits the first choices only; an existing result never means replacement choices were applied. */
@@ -40,7 +54,7 @@ export class PrismaCompanyAssistantProvisioningRepository implements CompanyAssi
 	{
 		const serviceId = __CompanyAssistantServiceId(caller.siloId);
 		const argumentsDigest = ___DigestCanonicalJson({ serviceId, name: command.name, modelDefinitionId: command.modelDefinitionId, invokerPrincipalIds: [...command.invokerPrincipalIds].sort() });
-		await this._Admit(caller, { kind: ProductAuthorizationResourceKinds.Organization, id: caller.siloId }, ProductAuthorizationActions.Administer, argumentsDigest, now);
+		await _AdmitCompanyAssistantChange(this.authorization, caller, { kind: ProductAuthorizationResourceKinds.Organization, id: caller.siloId }, ProductAuthorizationActions.Administer, argumentsDigest, now);
 		const existing = await this.transaction.agentService.findFirst({ where: { id: serviceId, siloId: caller.siloId }, include: { principal: true, revisions: { where: { revision: 1 } } } });
 		if (existing !== null)
 		{
@@ -50,16 +64,16 @@ export class PrismaCompanyAssistantProvisioningRepository implements CompanyAssi
 			return { created: false, siloId: caller.siloId, agentServiceId: serviceId, agentRevisionId: existing.activeRevisionId, principalId: existing.principal.id, agentIdentityId: __ManagedAgentIdentityId(serviceId), name: existing.name, createdAt: existing.createdAt.toISOString(), createdByPrincipalId: first.authoredBy, identityEventId: first.id };
 		}
 		await this._ValidateChoices(caller.siloId, command);
-		await this._Admit(caller, { kind: ProductAuthorizationResourceKinds.ModelDefinition, id: command.modelDefinitionId }, ProductAuthorizationActions.Use, argumentsDigest, now);
+		await _AdmitCompanyAssistantChange(this.authorization, caller, { kind: ProductAuthorizationResourceKinds.ModelDefinition, id: command.modelDefinitionId }, ProductAuthorizationActions.Use, argumentsDigest, now);
 		const principalId = randomUUID();
 		const revisionId = randomUUID();
 		await this.transaction.principal.create({ data: { id: principalId, siloId: caller.siloId, issuer: "urn:opencrane:agent-service", subject: serviceId, provenance: PrincipalProvenance.Internal, email: null, displayName: command.name, createdAt: now } });
 		await this.transaction.agentService.create({ data: { id: serviceId, siloId: caller.siloId, kind: AgentServiceKind.Managed, name: command.name, principalId, workloadProfile: this.policy.workloadProfile, state: AgentServiceState.Draft, createdAt: now } });
-		await new PrismaAgentRevisionWriterRepository(this.transaction).createDraft({ agentRevisionId: revisionId, siloId: caller.siloId, agentServiceId: serviceId, revision: 1, parentRevisionId: null, sourceRevisionId: null, content: { promptPolicyVersion: this.policy.promptPolicyVersion, personaRevisionId: null, modelDefinitionId: command.modelDefinitionId, budget: this.policy.budget, skills: [], mcpToolRevisionIds: [], boundaryAttachments: [] }, changeMessage: "Administrator provisioned the company assistant", authoredBy: caller.principalId, createdAt: now });
+		await this.revisions.createDraft({ agentRevisionId: revisionId, siloId: caller.siloId, agentServiceId: serviceId, revision: 1, parentRevisionId: null, sourceRevisionId: null, content: { promptPolicyVersion: this.policy.promptPolicyVersion, personaRevisionId: null, modelDefinitionId: command.modelDefinitionId, budget: this.policy.budget, skills: [], mcpToolRevisionIds: [], boundaryAttachments: [] }, changeMessage: "Administrator provisioned the company assistant", authoredBy: caller.principalId, createdAt: now });
 		const service = { kind: ProductAuthorizationResourceKinds.AgentService, id: serviceId };
 		const model = { kind: ProductAuthorizationResourceKinds.ModelDefinition, id: command.modelDefinitionId };
-		await this.grants.reconcileManagedResourceGrants({ siloId: caller.siloId, managerId: `company-assistant:${serviceId}`, resource: service, now, grants: command.invokerPrincipalIds.flatMap(principal => [ProductAuthorizationActions.Discover, ProductAuthorizationActions.Read, ProductAuthorizationActions.Invoke].map(action => _Grant(principal, caller.principalId, service, action))) });
-		await this.grants.reconcileManagedResourceGrants({ siloId: caller.siloId, managerId: `company-assistant:${serviceId}`, resource: model, now, grants: [_Grant(principalId, caller.principalId, model, ProductAuthorizationActions.Use)] });
+		await this.grants.reconcileManagedResourceGrants({ siloId: caller.siloId, managerId: `company-assistant:${serviceId}`, resource: service, now, grants: command.invokerPrincipalIds.flatMap(principal => [ProductAuthorizationActions.Discover, ProductAuthorizationActions.Read, ProductAuthorizationActions.Invoke].map(action => _CompanyAssistantGrant(principal, caller.principalId, service, action))) });
+		await this.grants.reconcileManagedResourceGrants({ siloId: caller.siloId, managerId: `company-assistant:${serviceId}`, resource: model, now, grants: [_CompanyAssistantGrant(principalId, caller.principalId, model, ProductAuthorizationActions.Use)] });
 		await this.transaction.agentRevision.update({ where: { id: revisionId }, data: { state: AgentRevisionState.Published, publishedAt: now } });
 		await this.transaction.agentService.update({ where: { id: serviceId }, data: { state: AgentServiceState.Active, activeRevisionId: revisionId } });
 		return { created: true, siloId: caller.siloId, agentServiceId: serviceId, agentRevisionId: revisionId, principalId, agentIdentityId: __ManagedAgentIdentityId(serviceId), name: command.name, createdAt: now.toISOString(), createdByPrincipalId: caller.principalId, identityEventId: revisionId };
@@ -77,21 +91,4 @@ export class PrismaCompanyAssistantProvisioningRepository implements CompanyAssi
 		if (principals.some(principal => !memberships.some(member => member.subject === principal.subject)))
 			throw new CompanyAssistantProvisioningDenied();
 	}
-
-	/** Requires recorded central authority before publishing durable assistant authority. */
-	private async _Admit(caller: { readonly siloId: string; readonly principalId: string }, resource: ProductAuthorizationResourceLocator, action: ProductAuthorizationActions, argumentsDigest: `sha256:${string}`, now: Date): Promise<void>
-	{
-		const decision = await this.authorization.admitPrincipal({ ...caller, actorKind: "user", actorId: caller.principalId, resource, action, argumentsDigest, nowEpochMs: now.getTime() });
-		if (decision.outcome !== AuthorizationDecisionOutcomes.Allow || decision.evidence === null)
-			throw new CompanyAssistantProvisioningDenied();
-	}
-}
-
-/** Derives one exact grant from the administrator's selected humans or the assistant's own model use. */
-function _Grant(principalId: string, createdByPrincipalId: string, resource: ProductAuthorizationResourceLocator, action: ProductAuthorizationActions): ManagedAuthorizationGrantSpec
-{
-	const capability = __ProductAuthorizationCapability(resource.kind, action);
-	if (capability === null)
-		throw new CompanyAssistantProvisioningDenied();
-	return { subject: { kind: AuthorizationSubjectKinds.Principal, principalId }, boundary: { kind: AuthorizationBoundaryKinds.Personal, principalId }, boundaryCoverage: AuthorizationBoundaryCoverages.Exact, capability, resource, priority: 0, createdByPrincipalId };
 }

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/db/prisma-company-assistant-tools.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/db/prisma-company-assistant-tools.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "node:crypto";
+import { AgentRevisionState, AgentServiceKind, AgentServiceState, McpApprovalStatus, McpServerRevisionState, McpServerStatus, PrincipalProvenance, type Prisma } from "@prisma/client";
+import type { AuthorizationAuthority, ManagedAuthorizationGrantRepository } from "@opencrane/backend/server/iam/authorization";
+import { AuthorizationDecisionOutcomes, ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
+import { ___DigestCanonicalJson } from "@opencrane/util";
+
+import type { CompanyAssistantProvisioningCaller, CompanyAssistantToolsCommand, CompanyAssistantToolsRepository, CompanyAssistantToolsSelection } from "../company-assistant-provisioning.types";
+import { ___CompanyAssistantToolsSchema } from "../company-assistant-provisioning.validator";
+import { CompanyAssistantProvisioningDenied, CompanyAssistantToolsConflict, CompanyAssistantToolsUnavailable } from "../company-assistant.errors";
+import { _AdmitCompanyAssistantChange, _CompanyAssistantGrant } from "../company-assistant-permissions";
+import { __CompanyAssistantServiceId } from "../managed-agent-identity";
+import { _AGENT_REVISION_INCLUDE, _AgentRevisionContentFromRow, PrismaAgentRevisionWriterRepository } from "../../revisions/db/prisma-agent-revision-writer";
+
+/**
+ * Replaces the company's selected tools without changing its identity or saved execution budget.
+ *
+ * Called by: the company assistant repository inside the caller's transaction. Replacements use
+ * serializable isolation: authorization evidence, the successor, and its own grants commit together.
+ * The active revision comparison rejects stale edits and causes every losing write to roll back.
+ * Grant reconciliation visits tool IDs in sorted order before the final service update, so concurrent
+ * edits acquire those resource locks in the same order. The outer transaction retries proven rollbacks.
+ */
+export class PrismaCompanyAssistantToolsRepository implements CompanyAssistantToolsRepository
+{
+	/** Uses the caller's transaction and central authorization ports; it never opens its own transaction. */
+	public constructor(private readonly transaction: Prisma.TransactionClient, private readonly authorization: AuthorizationAuthority, private readonly grants: ManagedAuthorizationGrantRepository) {}
+
+	/** Reads current assignment eligibility without recording an effect admission or revealing credentials. */
+	public async getTools(caller: CompanyAssistantProvisioningCaller, now: Date): Promise<CompanyAssistantToolsSelection>
+	{
+		const decision = await this.authorization.decidePrincipal({ ...caller, resource: { kind: ProductAuthorizationResourceKinds.Organization, id: caller.siloId }, action: ProductAuthorizationActions.Administer, nowEpochMs: now.getTime() });
+		if (decision.outcome !== AuthorizationDecisionOutcomes.Allow)
+			throw new CompanyAssistantProvisioningDenied();
+		const service = await this._CurrentCompany(caller.siloId);
+		return { agentServiceId: service.id, activeRevisionId: service.activeRevision.id, toolRevisionIds: service.activeRevision.mcpToolAssignments.map(assignment => assignment.toolRevisionId).sort() };
+	}
+
+	/**
+	 * Publishes an immutable replacement and the exact grants for its own principal in the caller's transaction.
+	 * A stale expected revision always conflicts, including a retry after an uncertain successful commit.
+	 * An unchanged selection still requires current administrator permission and permission to assign each tool.
+	 */
+	public async setTools(caller: CompanyAssistantProvisioningCaller, command: CompanyAssistantToolsCommand, now: Date): Promise<CompanyAssistantToolsSelection>
+	{
+		// 1. Bind the administrator decision to this exact selection before reading or changing it.
+		if (!___CompanyAssistantToolsSchema.safeParse(command).success)
+			throw new CompanyAssistantProvisioningDenied();
+		const toolRevisionIds = [...command.toolRevisionIds].sort();
+		const argumentsDigest = ___DigestCanonicalJson({ agentServiceId: __CompanyAssistantServiceId(caller.siloId), expectedActiveRevisionId: command.expectedActiveRevisionId, toolRevisionIds });
+		await _AdmitCompanyAssistantChange(this.authorization, caller, { kind: ProductAuthorizationResourceKinds.Organization, id: caller.siloId }, ProductAuthorizationActions.Administer, argumentsDigest, now);
+		const service = await this._CurrentCompany(caller.siloId);
+		const source = service.activeRevision;
+		if (source.id !== command.expectedActiveRevisionId)
+			throw new CompanyAssistantToolsConflict();
+		// 2. Even an unchanged selection must still contain available tools the caller may assign.
+		const tools = await this.transaction.mcpToolRevision.findMany({ where: { id: { in: toolRevisionIds }, siloId: caller.siloId, serverRevision: { is: { siloId: caller.siloId, state: McpServerRevisionState.Ready, server: { is: { siloId: caller.siloId, status: McpServerStatus.Active, approvalStatus: McpApprovalStatus.Published } } } } }, select: { id: true } });
+		if (tools.length !== toolRevisionIds.length)
+			throw new CompanyAssistantProvisioningDenied();
+		for (const toolRevisionId of toolRevisionIds)
+			await _AdmitCompanyAssistantChange(this.authorization, caller, { kind: ProductAuthorizationResourceKinds.McpToolRevision, id: toolRevisionId }, ProductAuthorizationActions.Assign, argumentsDigest, now);
+		const previousToolIds = source.mcpToolAssignments.map(assignment => assignment.toolRevisionId).sort();
+		if (previousToolIds.length === toolRevisionIds.length && previousToolIds.every((id, index) => id === toolRevisionIds[index]))
+			return { agentServiceId: service.id, activeRevisionId: source.id, toolRevisionIds };
+		// 3. Copy the saved policy and budget, then reconcile only this assistant's managed grants.
+		const revisionId = randomUUID();
+		await new PrismaAgentRevisionWriterRepository(this.transaction).createDraft({ agentRevisionId: revisionId, siloId: caller.siloId, agentServiceId: service.id, revision: source.revision + 1, parentRevisionId: source.id, sourceRevisionId: null, content: { ..._AgentRevisionContentFromRow(source), mcpToolRevisionIds: toolRevisionIds }, changeMessage: "Administrator replaced company assistant tool assignments", authoredBy: caller.principalId, createdAt: now });
+		for (const toolRevisionId of [...new Set([...previousToolIds, ...toolRevisionIds])].sort())
+		{
+			const resource = { kind: ProductAuthorizationResourceKinds.McpToolRevision, id: toolRevisionId };
+			const grants = toolRevisionIds.includes(toolRevisionId) ? [ProductAuthorizationActions.Use, ProductAuthorizationActions.Invoke].map(action => _CompanyAssistantGrant(service.principalId, caller.principalId, resource, action)) : [];
+			await this.grants.reconcileManagedResourceGrants({ siloId: caller.siloId, managerId: `company-assistant:${service.id}`, resource, now, grants });
+		}
+		// 4. Publish and move the active pointer together; a lost comparison rolls back every write.
+		await this.transaction.agentRevision.update({ where: { id_siloId: { id: revisionId, siloId: caller.siloId } }, data: { state: AgentRevisionState.Published, publishedAt: now } });
+		const updated = await this.transaction.agentService.updateMany({ where: { id: service.id, siloId: caller.siloId, kind: AgentServiceKind.Managed, state: AgentServiceState.Active, activeRevisionId: source.id }, data: { activeRevisionId: revisionId, updatedAt: now } });
+		if (updated.count !== 1)
+			throw new CompanyAssistantToolsConflict();
+		return { agentServiceId: service.id, activeRevisionId: revisionId, toolRevisionIds };
+	}
+
+	/** Loads the company assistant with its internal principal and currently published revision. */
+	private async _CurrentCompany(siloId: string)
+	{
+		const service = await this.transaction.agentService.findFirst({ where: { id: __CompanyAssistantServiceId(siloId), siloId, kind: AgentServiceKind.Managed, state: AgentServiceState.Active, principal: { is: { siloId, provenance: PrincipalProvenance.Internal } } }, include: { activeRevision: { include: _AGENT_REVISION_INCLUDE } } });
+		const revision = service?.activeRevision;
+		if (service === null || service.principalId === null || revision === null || revision === undefined || service.activeRevisionId !== revision.id || revision.siloId !== siloId || revision.agentServiceId !== service.id || revision.state !== AgentRevisionState.Published || revision.publishedAt === null)
+			throw new CompanyAssistantToolsUnavailable();
+		return { ...service, principalId: service.principalId, activeRevision: revision };
+	}
+}

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/managed-agent.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/managed-agent.types.ts
@@ -3,28 +3,45 @@ import type { HumanMembershipEvidenceConfig } from "@opencrane/backend/server/ia
 import type { ExecutionSubjectHumanMembershipEvidence } from "@opencrane/models/agents";
 import type { JsonValue } from "@opencrane/util";
 
-/** Contains the active company assistant and its first, deliberately unextended execution policy. */
+/** Contains the active company assistant's published model, tool selection and execution limits. */
 export interface ManagedAgentRevisionEvidence
 {
+	/** Identifies the company service whose published revision is used. */
 	readonly agentServiceId: string;
+	/** Identifies the published revision admitted for this request. */
 	readonly agentRevisionId: string;
+	/** Binds the evidence to the contents of the published revision. */
 	readonly agentRevisionDigest: string;
+	/** Identifies the assistant's own principal for permission checks. */
 	readonly principalId: string;
+	/** Supplies the assistant's display name. */
 	readonly name: string;
+	/** Selects the deployed isolated execution profile. */
 	readonly workloadProfile: string;
+	/** Selects the model whose permission belongs to the assistant. */
 	readonly modelDefinitionId: string;
+	/** Lists the assigned tool revisions included in the run's effective contract digest. */
+	readonly mcpToolRevisionIds: readonly string[];
+	/** Carries the published call, token and duration limits. */
 	readonly budget: JsonValue;
 }
 
 /** Supplies the exact managed identity and published profile a child conversation may freeze. */
 export interface ManagedAgentConversationCandidate
 {
+	/** Identifies the company service whose published revision is used. */
 	readonly agentServiceId: string;
+	/** Identifies the published revision admitted for this request. */
 	readonly agentRevisionId: string;
+	/** Identifies the assistant in identity history. */
 	readonly agentIdentityId: string;
+	/** Identifies the assistant's own principal for permission checks. */
 	readonly principalId: string;
+	/** Supplies the assistant's display name. */
 	readonly name: string;
+	/** Selects the deployed isolated execution profile. */
 	readonly workloadProfile: string;
+	/** Identifies the published execution profile revision. */
 	readonly profileRevisionId: string;
 }
 
@@ -44,15 +61,21 @@ export interface CurrentManagedAgentConversation
 /** Supplies deployment-owned history, membership verification and published computer profiles. */
 export interface ManagedAgentConversationDependencies
 {
+	/** Loads the current identity from its history. */
 	readonly identityHistory: Pick<AgentIdentityHistory, "load">;
+	/** Selects how the requesting human's membership is verified. */
 	readonly membershipConfig: HumanMembershipEvidenceConfig;
+	/** Lists the execution profiles installed by this deployment. */
 	readonly profiles: readonly { readonly workloadProfile: string; readonly profileRevisionId: string }[];
+	/** Supplies trusted server time when the caller needs a fixed admission time. */
 	readonly nowEpochMs?: () => number;
 }
 
 /** Reads current managed service authority and independently verifies the human requester's membership. */
 export interface ManagedExecutionEvidenceRepository
 {
+	/** Returns the currently published company revision, or null when it cannot execute. */
 	loadCurrent(siloId: string, agentServiceId: string): Promise<ManagedAgentRevisionEvidence | null>;
+	/** Returns current human membership, or null when its authority has ended or expired. */
 	verifyRequesterMembership(siloId: string, principalId: string, nowEpochMs: number): Promise<ExecutionSubjectHumanMembershipEvidence | null>;
 }

--- a/libs/backend/server/agents/agent-services/main/src/company-assistants/openapi.ts
+++ b/libs/backend/server/agents/agent-services/main/src/company-assistants/openapi.ts
@@ -1,8 +1,24 @@
 /** Describes the reviewed company assistant setup result without exposing internal execution coordinates. */
 const _ResultSchema = { type: "object", additionalProperties: false, required: ["created", "assistant"], properties: { created: { type: "boolean" }, assistant: { type: "object", additionalProperties: false, required: ["agentServiceId", "displayName"], properties: { agentServiceId: { type: "string" }, displayName: { type: "string" } } } } } as const;
 
+/** Returns one authoritative active revision and its exact immutable tool selection. */
+const _ToolsSchema = { type: "object", additionalProperties: false, required: ["agentServiceId", "activeRevisionId", "toolRevisionIds"], properties: { agentServiceId: { type: "string" }, activeRevisionId: { type: "string" }, toolRevisionIds: { type: "array", uniqueItems: true, items: { type: "string" } } } } as const;
+
 /** Public operator setup paths composed into the application OpenAPI registry. */
 export const _CompanyAssistantOpenapiPaths = {
+	"/organization/company-assistant/tools": {
+		get: {
+			operationId: "getCompanyAssistantTools", summary: "Read the company assistant's current tool selection", tags: ["Organization assistants"],
+			description: "Requires current Organization Administer. Returns the exact active immutable revision and sorted tool revision IDs. This read does not record effect admission or supply external credentials.",
+			responses: { 200: { description: "Current selection.", content: { "application/json": { schema: _ToolsSchema } } }, 401: { description: "Authentication required." }, 403: { description: "Current administrator permission denied." }, 404: { description: "Active published company assistant unavailable." }, 503: { description: "Selection dependency unavailable." } },
+		},
+		put: {
+			operationId: "setCompanyAssistantTools", summary: "Replace the company assistant's tool selection", tags: ["Organization assistants"],
+			description: "Requires current Organization Administer and Assign on every selected same-silo ready tool revision of an active published server. Publishes an immutable successor and reconciles only the company's own Use/Invoke grants for removed and selected tools. A current unchanged selection is a no-op after fresh authorization. A stale expected revision always returns 409, including a retry after an uncertain successful commit; GET the authoritative selection before editing again. Empty selection removes all tools. This API creates no install or external credential binding and cannot borrow human private credentials.",
+			requestBody: { required: true, content: { "application/json": { schema: { type: "object", additionalProperties: false, required: ["expectedActiveRevisionId", "toolRevisionIds"], properties: { expectedActiveRevisionId: { type: "string", minLength: 1, maxLength: 200, pattern: "^\\S(?:.*\\S)?$" }, toolRevisionIds: { type: "array", maxItems: 32, uniqueItems: true, items: { type: "string", minLength: 1, maxLength: 200, pattern: "^\\S(?:.*\\S)?$" } } } } } } },
+			responses: { 200: { description: "Committed successor or unchanged current selection.", content: { "application/json": { schema: _ToolsSchema } } }, 400: { description: "Invalid tool selection." }, 401: { description: "Authentication required." }, 403: { description: "Current assignment permission or selected tool unavailable." }, 404: { description: "Active published company assistant unavailable." }, 409: { description: "Active revision changed; read current selection before another edit." }, 503: { description: "Assignment dependency unavailable; a failed response may follow a commit, so read current selection." } },
+		},
+	},
 	"/organization/company-assistant": { post: {
 		operationId: "provisionCompanyAssistant", summary: "Provision the company's first shared assistant", tags: ["Organization assistants"],
 		description: "Requires current Organization Administer and selected Model Use. Select current human Principal IDs explicitly. Once a company assistant exists, this call returns created:false and leaves its name, policy, grants and lifecycle unchanged. Retrying can finish identity establishment after a committed setup; it cannot revive a suspended or revoked identity.",

--- a/libs/backend/server/agents/agent-services/main/src/execution-evidence/__tests__/managed-execution-evidence.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/execution-evidence/__tests__/managed-execution-evidence.test.ts
@@ -10,7 +10,7 @@ const _IDENTITY = { schemaVersion: 1, kind: "managed", id: "company-identity", s
 /** Supplies independent current company authority and human fleet evidence. */
 function _Fixture()
 {
-	const revision = { agentServiceId: "company-service", agentRevisionId: "revision-1", agentRevisionDigest: "sha256:revision", principalId: "company-principal", name: "Company assistant", workloadProfile: "company", modelDefinitionId: "model-1", budget: { maxDurationMs: 10_000 } };
+	const revision = { agentServiceId: "company-service", agentRevisionId: "revision-1", agentRevisionDigest: "sha256:revision", principalId: "company-principal", name: "Company assistant", workloadProfile: "company", modelDefinitionId: "model-1", mcpToolRevisionIds: ["tool-1"], budget: { maxDurationMs: 10_000 } };
 	const human = { kind: "fleet", principalId: "human-1", siloId: "silo-1", decisionEvidenceId: "human-assertion", revision: 7, assertionId: "human-assertion", payloadDigest: "sha256:human", trustedUntil: new Date(6_000).toISOString() };
 	const repository = { loadCurrent: vi.fn().mockResolvedValue(revision), verifyRequesterMembership: vi.fn().mockResolvedValue(human) };
 	const admitPrincipal = vi.fn().mockResolvedValueOnce({ outcome: AuthorizationDecisionOutcomes.Allow, evidence: { decisionDigest: "sha256:invoke" } }).mockResolvedValue({ outcome: AuthorizationDecisionOutcomes.Allow, evidence: { decisionDigest: "sha256:model" } });
@@ -30,6 +30,20 @@ describe("ManagedExecutionEvidenceAuthority", function _Suite()
 		expect(f.admitPrincipal).toHaveBeenNthCalledWith(1, expect.objectContaining({ principalId: "human-1", action: ProductAuthorizationActions.Invoke, membershipRevision: 7 }));
 		expect(f.admitPrincipal).toHaveBeenNthCalledWith(2, expect.objectContaining({ principalId: "company-principal", action: ProductAuthorizationActions.Use, resource: { kind: ProductAuthorizationResourceKinds.ModelDefinition, id: "model-1" } }));
 		expect(f.admitPrincipal.mock.calls[1]?.[0]).not.toHaveProperty("membershipRevision");
+	});
+
+	it("binds the exact tool selection into the effective contract digest", async function _BindsTools()
+	{
+		const first = _Fixture();
+		const second = _Fixture();
+		second.repository.loadCurrent.mockResolvedValue({ ...second.revision, mcpToolRevisionIds: ["tool-2"] });
+		const firstResult = await first.authority.load(first.command, first.transaction as never);
+		const secondResult = await second.authority.load(second.command, second.transaction as never);
+		expect(firstResult.outcome).toBe("loaded");
+		expect(secondResult.outcome).toBe("loaded");
+		if (firstResult.outcome !== "loaded" || secondResult.outcome !== "loaded")
+			throw new Error("Expected current company execution evidence");
+		expect(firstResult.value.capability.effectiveContractDigest).not.toBe(secondResult.value.capability.effectiveContractDigest);
 	});
 
 	it.each([null, { agentRevisionId: "revision-2" }, { principalId: "other" }, { budget: [] }])("rejects changed current company authority %j before any grant admission", async function _RejectsCurrent(patch)

--- a/libs/backend/server/agents/agent-services/main/src/execution-evidence/db/__tests__/prisma-managed-execution-evidence-repository.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/execution-evidence/db/__tests__/prisma-managed-execution-evidence-repository.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { PrismaManagedExecutionEvidenceRepository } from "../prisma-managed-execution-evidence-repository";
 
-/** Supplies the smallest published company revision; every extension must be refused explicitly. */
+/** Supplies the smallest published company revision; unsupported extensions remain refused explicitly. */
 function _Row()
 {
 	return { id: "service-1", principalId: "company-principal", name: "Company", workloadProfile: "company", activeRevisionId: "revision-1", activeRevision: { id: "revision-1", siloId: "silo-1", agentServiceId: "service-1", state: AgentRevisionState.Published, digest: "sha256:revision", personaRevisionId: null, modelDefinitionId: "model-1", budget: { maxDurationMs: 60_000 }, skillAssignments: [], mcpToolAssignments: [], boundaryAttachments: [] } };
@@ -19,8 +19,16 @@ describe("PrismaManagedExecutionEvidenceRepository", function _Suite()
 		expect(findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: { id: "service-1", siloId: "silo-1", kind: AgentServiceKind.Managed, state: AgentServiceState.Active, principal: { is: { siloId: "silo-1", provenance: PrincipalProvenance.Internal } } } }));
 	});
 
+	it("returns assigned MCP tool revisions in stable order for the company principal", async function _LoadsTools()
+	{
+		const row = _Row();
+		const findFirst = vi.fn().mockResolvedValue({ ...row, activeRevision: { ...row.activeRevision, mcpToolAssignments: [{ toolRevisionId: "tool-z" }, { toolRevisionId: "tool-a" }] } });
+		const repository = new PrismaManagedExecutionEvidenceRepository({ agentService: { findFirst } } as never, {} as never);
+		await expect(repository.loadCurrent("silo-1", "service-1")).resolves.toMatchObject({ principalId: "company-principal", mcpToolRevisionIds: ["tool-a", "tool-z"] });
+	});
+
 	it.each([
-		{ state: AgentRevisionState.Draft }, { id: "other-revision" }, { siloId: "other-silo" }, { agentServiceId: "other-service" }, { personaRevisionId: "personal-persona" }, { skillAssignments: [{ skillId: "skill" }] }, { mcpToolAssignments: [{ toolRevisionId: "tool" }] }, { boundaryAttachments: [{ id: "memory-boundary" }] },
+		{ state: AgentRevisionState.Draft }, { id: "other-revision" }, { siloId: "other-silo" }, { agentServiceId: "other-service" }, { personaRevisionId: "personal-persona" }, { skillAssignments: [{ skillId: "skill" }] }, { boundaryAttachments: [{ id: "memory-boundary" }] },
 	])("rejects an unpublished, substituted or extended revision %j", async function _RejectsRevision(patch)
 	{
 		const row = _Row();

--- a/libs/backend/server/agents/agent-services/main/src/execution-evidence/db/prisma-managed-execution-evidence-repository.ts
+++ b/libs/backend/server/agents/agent-services/main/src/execution-evidence/db/prisma-managed-execution-evidence-repository.ts
@@ -12,7 +12,7 @@ export class PrismaManagedExecutionEvidenceRepository implements ManagedExecutio
 	/** Binds all mutable authority reads to the transaction that admits the child or its run. */
 	public constructor(private readonly transaction: Prisma.TransactionClient, private readonly membership: HumanMembershipEvidenceConfig) {}
 
-	/** Rejects inactive or extended revisions before a company assistant can acquire conversation authority. */
+	/** Requires an active published revision and refuses unsupported persona, skill and boundary assignments. */
 	public async loadCurrent(siloId: string, agentServiceId: string): Promise<ManagedAgentRevisionEvidence | null>
 	{
 		const service = await this.transaction.agentService.findFirst({
@@ -23,9 +23,9 @@ export class PrismaManagedExecutionEvidenceRepository implements ManagedExecutio
 		if (service === null || service.principalId === null || revision === null || revision === undefined
 			|| service.activeRevisionId !== revision.id || revision.siloId !== siloId || revision.agentServiceId !== agentServiceId
 			|| revision.state !== AgentRevisionState.Published || revision.personaRevisionId !== null
-			|| revision.skillAssignments.length !== 0 || revision.mcpToolAssignments.length !== 0 || revision.boundaryAttachments.length !== 0)
+			|| revision.skillAssignments.length !== 0 || revision.boundaryAttachments.length !== 0)
 			return null;
-		return { agentServiceId: service.id, agentRevisionId: revision.id, agentRevisionDigest: revision.digest, principalId: service.principalId, name: service.name, workloadProfile: service.workloadProfile, modelDefinitionId: revision.modelDefinitionId, budget: revision.budget as JsonValue };
+		return { agentServiceId: service.id, agentRevisionId: revision.id, agentRevisionDigest: revision.digest, principalId: service.principalId, name: service.name, workloadProfile: service.workloadProfile, modelDefinitionId: revision.modelDefinitionId, mcpToolRevisionIds: revision.mcpToolAssignments.map(assignment => assignment.toolRevisionId).sort(), budget: revision.budget as JsonValue };
 	}
 
 	/** Delegates human membership to the deployment-selected IAM authority. */

--- a/libs/backend/server/agents/agent-services/main/src/index.ts
+++ b/libs/backend/server/agents/agent-services/main/src/index.ts
@@ -1,5 +1,6 @@
 export { PrismaAgentRevisionModelSelectionRepository } from "./revisions/db/prisma-agent-revision-model-selection";
-export { PrismaCompanyAssistantProvisioningRepository, CompanyAssistantProvisioningDenied } from "./company-assistants/db/prisma-company-assistant-provisioning";
+export { PrismaCompanyAssistantProvisioningRepository } from "./company-assistants/db/prisma-company-assistant-provisioning";
+export { CompanyAssistantProvisioningDenied } from "./company-assistants/company-assistant.errors";
 export { PrismaCompanyAssistantProvisioningUnitOfWork } from "./company-assistants/db/prisma-company-assistant-provisioning-unit-of-work";
 export { _CreateCompanyAssistantProvisioningRouter } from "./company-assistants/company-assistant-provisioning.router";
 export { _CompanyAssistantOpenapiPaths } from "./company-assistants/openapi";

--- a/libs/backend/server/agents/agent-services/main/src/revisions/db/prisma-agent-revision-writer.ts
+++ b/libs/backend/server/agents/agent-services/main/src/revisions/db/prisma-agent-revision-writer.ts
@@ -1,7 +1,6 @@
 import { AgentRevisionState, AuthorizationBoundaryCoverage, AuthorizationBoundaryKind, Prisma } from "@prisma/client";
 
-import { __DigestAgentRevisionContent } from "@opencrane/models/agents";
-import { RevisionBoundaryCoverages, RevisionBoundaryKinds, type AgentBudget, type AgentRevisionContent, type RevisionBoundaryAttachment } from "@opencrane/models/agents";
+import { __DigestAgentRevisionContent, RevisionBoundaryCoverages, RevisionBoundaryKinds, type AgentBudget, type AgentRevisionContent, type RevisionBoundaryAttachment } from "@opencrane/models/agents";
 
 import type { AgentRevisionWriterRepository, CreateAgentRevisionWithinTransactionCommand } from "./prisma-agent-revision-writer.types";
 
@@ -86,9 +85,10 @@ function _RevisionCreateData(command: CreateAgentRevisionWithinTransactionComman
 			}),
 		},
 		mcpToolAssignments: {
-			create: command.content.mcpToolRevisionIds.map(function _MapMcpTool(toolRevisionId)
+			// Prisma takes the revision and service coordinates from the enclosing revision create.
+			create: command.content.mcpToolRevisionIds.map(function _MapMcpTool(toolRevisionId): Prisma.AgentRevisionMcpToolAssignmentUncheckedCreateWithoutAgentRevisionInput
 			{
-				return { toolRevisionId, agentServiceId: command.agentServiceId, siloId: command.siloId };
+				return { toolRevisionId, siloId: command.siloId };
 			}),
 		},
 		boundaryAttachments: {

--- a/libs/backend/server/gateways/mcp/main/README.md
+++ b/libs/backend/server/gateways/mcp/main/README.md
@@ -69,8 +69,11 @@ duration. PostgreSQL checks the paired invocation claim and preserves its absolu
 the MCP write is delayed; the returned command uses that saved expiry.
 
 History reads happen before the claim inside its bounded SQL transaction, while provider I/O stays
-after commit. The history read does not create a cross-store lock. Conversation model requests,
-result resumption and participant-visible tool history remain unfinished.
+after commit. The history read does not create a cross-store lock. The conversation server now
+owns model requests and result resumption: its Absurd workflow waits for the exact terminal tool
+result and may reserve one text-only continuation within the original remaining allowance. The
+ConversationComputer Pod does not schedule that work. Participant-visible tool history, company
+credential activation and a complete live retrieval journey remain unfinished.
 
 An installed server can then run a tool through a public task. The task keeps its state, input,
 result, and failure in the database, so a server restart does not repeat the tool call.
@@ -113,6 +116,12 @@ Individual users browse the approved directory and install servers they may use.
 servers, the same response lists tools from the newest Ready server revision, including the frozen
 input schema and digest an agent author must save. The API never returns credentials and never
 labels an install connected before a real connection exists.
+
+Company tool selection belongs to [agent services](../../../agents/agent-services/main/README.md).
+Its administrator API publishes exact assignments and grants for the assistant's own Principal,
+the service's saved identity. It does not create a connection or transfer a person's credentials.
+The install states `NeedsCredential` and `SharedKey` describe configuration; neither proves that
+credential activation or a provider call has succeeded.
 
 ## Rules
 

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -1476,6 +1476,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/organization/company-assistant/tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Read the company assistant's current tool selection
+         * @description Requires current Organization Administer. Returns the exact active immutable revision and sorted tool revision IDs. This read does not record effect admission or supply external credentials.
+         */
+        get: operations["getCompanyAssistantTools"];
+        /**
+         * Replace the company assistant's tool selection
+         * @description Requires current Organization Administer and Assign on every selected same-silo ready tool revision of an active published server. Publishes an immutable successor and reconciles only the company's own Use/Invoke grants for removed and selected tools. A current unchanged selection is a no-op after fresh authorization. A stale expected revision always returns 409, including a retry after an uncertain successful commit; GET the authoritative selection before editing again. Empty selection removes all tools. This API creates no install or external credential binding and cannot borrow human private credentials.
+         */
+        put: operations["setCompanyAssistantTools"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/organization/company-assistant": {
         parameters: {
             query?: never;
@@ -8111,6 +8135,131 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["Error"];
                 };
+            };
+        };
+    };
+    getCompanyAssistantTools: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current selection. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        agentServiceId: string;
+                        activeRevisionId: string;
+                        toolRevisionIds: string[];
+                    };
+                };
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Current administrator permission denied. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Active published company assistant unavailable. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Selection dependency unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    setCompanyAssistantTools: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    expectedActiveRevisionId: string;
+                    toolRevisionIds: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Committed successor or unchanged current selection. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        agentServiceId: string;
+                        activeRevisionId: string;
+                        toolRevisionIds: string[];
+                    };
+                };
+            };
+            /** @description Invalid tool selection. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Current assignment permission or selected tool unavailable. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Active published company assistant unavailable. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Active revision changed; read current selection before another edit. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Assignment dependency unavailable; a failed response may follow a commit, so read current selection. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/plan.md
+++ b/plan.md
@@ -1,8 +1,67 @@
 # OpenCrane — Active Plan
 
+## Delivery priorities — 2026-09-10
+
+The user selected this order. Each track delivers a useful journey through the existing owners;
+published applications and code work are deferred. Narrow prerequisites, such as a connection setup
+API or the approval needed for one action, land with the first capability that needs them. Full
+administration and action recovery retain their places below.
+
+| Priority | Track | Completion means | Current next step |
+| --- | --- | --- | --- |
+| 1 | T1 — real tool retrieval | A permitted real record reaches an answer in personal and company-child chats; the result survives reload and restart without repeated dispatch. | IN PROGRESS: company tool selection is implemented and locally verified; connection activation, participant result evidence and one real integration remain. |
+| 2 | T2 — approved external actions | A person reviews an exact action and arguments; one approval permits that effect once. Denial, expiry, changed arguments and revoked authority prevent it. | Reuse IAM deferred approval and elicitation; connect approval-required model tools and disclose the exact external target and connection owner. |
+| 3 | M1 — long-term memory | Explicit remember, cross-conversation recall, correction and forget work with consent and isolated datasets. | Verify the pinned gateway's recall/deletion identity and recoverable correction before enabling writes. |
+| 4 | U1 — visible work controls | People can follow waiting, running and terminal work, make supported decisions and cancel eligible work after refresh. | Reuse conversation events, stores and approved components; preserve current access on reconnect. |
+| 5 | U2 — rich interaction | Durable choices, free text, structured results and A2UI remain usable and accessible after refresh. | Complete the existing server-issued interaction and presentation contracts. |
+| 6 | F1 — documents and generated files | A scanned document can inform an answer, and a generated file remains downloadable by its authorized audience. | Connect existing upload/scan, model input and artifact finalisation owners. |
+| 7 | D1 — autonomous delegation | A bounded child works with explicit context and narrower authority, then returns one durable result. | Follow [#845](https://github.com/elewa-git/opencrane/issues/845): root budgets, depth/fan-out, cancellation and result brokering. |
+| 8 | S1 — scheduled work | A reviewed routine fires under current authority with explicit overlap, retry and missed-run policy. | Follow [#848](https://github.com/elewa-git/opencrane/issues/848) through Absurd and existing admission. |
+| 9 | A2 — complete administration | Operators configure agents, connections, models, permissions and budgets, and inspect effective access and actual usage. | Complete protected settings over the owners established by the earlier tracks. |
+| 10 | T3 — action recovery | People and operators can reconcile uncertain effects, inspect cancellation races and perform supported safe retries. | Add provider-specific reconciliation and repair controls over durable invocation evidence. |
+
+Every earlier track includes its required current-authority checks, bounded retries, lease/generation
+fencing and honest failure state. Priority 10 is the complete recovery experience; it is not a reason
+to defer duplicate-effect prevention. [#844](https://github.com/elewa-git/opencrane/issues/844) spans
+retrieval, approval, controls and recovery; its full acceptance closes only when those slices pass.
+The [delivery plan](docs/design/mvp-delivery-plan.md) records owners and acceptance for each slice.
+
+### First execution slice: company tool selection
+
+Implemented on `feat/0.12-real-tool-retrieval`, directly above
+[#849](https://github.com/elewa-git/opencrane/pull/849), with immutable review base
+`b4f275b3f090e9387a1b0de658968700c0b7ad04`. Reuse the earlier company-tools implementation and
+adapt it to #843's capability folders; do not reopen its obsolete flattened implementation.
+Architecture preflight passes for the existing agent-services, revision and execution-evidence owners.
+
+An administrator reads and replaces the assistant's exact tool selection through the API. One
+transaction publishes an immutable successor revision and its service-owned grants, with current
+Administer/Assign checks and a comparison against the expected active revision. Tool edits preserve
+the saved model budget. New company assistants receive the two-call limit needed for one tool result
+and one final answer. Dispatch continues to use the company identity; a person's private permissions
+or credentials cannot substitute for it.
+
+Source work can proceed independently of live setup. Credential activation is absent from the current
+MCP installation contract; an installed or SharedKey-labelled server is not proof of a working
+connection. T1 remains open until authorized connection custody/activation, a dedicated read-only
+integration and durable participant result evidence are proven. Full work controls remain priority 4.
+No integration or live cluster state has been inspected in this execution slice.
+
+Validation on this slice: 127 agent-services, 65 personal-configuration, 113 execution-inputs,
+95 contracts and 30 dispatch tests pass, plus five real PostgreSQL tests on the exact fresh baseline.
+The disposable database was stopped after qualification. Backend/contracts type checks and server
+build pass; generated API contracts and website schema are synchronized. Architecture preflight,
+architecture post-review and independent source review pass. Prisma, authorization, workflow,
+workload composition, domain, dependency, release, style and module-growth checks pass.
+The website build passes, including the generated API pages. This slice is ready for its incremental
+draft PR; CI and testv5/live acceptance remain separate evidence. The next source slice owns
+connection activation and its execution binding.
+
+
 ## Absurd-owned conversation turn progression - 2026-09-09
 
-In progress as a direct follow-up to [#843](https://github.com/elewa-git/opencrane/pull/843).
+Implemented in [#849](https://github.com/elewa-git/opencrane/pull/849), directly above
+[#843](https://github.com/elewa-git/opencrane/pull/843), at `b4f275b3f`.
 Conversation activation saves one `conversation-computer-turn` task through the existing Absurd
 transaction boundary. The server workflow selects and advances durable model, optional tool-result,
 continuation and output state; the Agent Sandbox Pod retains only its lease-fenced workspace,
@@ -12,7 +71,8 @@ deleted rather than retained as compatibility routes.
 The change must preserve one original model dispatch and one permitted text-only continuation under
 the original remaining allowance across process restarts. Terminal tool evidence wakes the exact
 saved workflow in the same transaction. Stale leases, generations and ended authority fail closed.
-Local validation, architecture post-review, independent review and draft PR creation remain required.
+Local validation, architecture post-review and independent review pass. The draft PR, CI and image
+publication are complete; the change remains unmerged.
 Fresh testv5 installation and live journey qualification remain a separate gate. Visible tool
 progress, approval controls and user-facing recovery controls remain later slices.
 
@@ -50,7 +110,9 @@ while the company controls access, data, and spending. MVP means an employee can
 assistant, get useful work done, and collaborate in a group without understanding the runtime.
 
 The current review order is `develop` → [#831](https://github.com/elewa-git/opencrane/pull/831)
-→ [#843](https://github.com/elewa-git/opencrane/pull/843). The merged conversation history and
+→ [#843](https://github.com/elewa-git/opencrane/pull/843)
+→ [#849](https://github.com/elewa-git/opencrane/pull/849) → the T1 company-tool selection follow-up.
+The merged conversation history and
 computer baseline is implemented; it is not yet a live-qualified MVP. [ADR 0016](docs/adr/0016-conversation-history-and-computers.md) supersedes the
 older run-owned runtime and relational transcript descriptions in historical plans.
 
@@ -124,16 +186,14 @@ their own completion track; they are not silently bundled into the first tool PR
 | R2 — visible personal activity | ✅ COMPLETE in [#829](https://github.com/elewa-git/opencrane/pull/829). UI `6692b2e59` and server `e50cdcc5b` are installed on testv5. Linux CI and publication pass. Two employees see their completed work, open its saved answer by keyboard, refresh without starting work, and recover activity after reload. Narrow-screen focus and cross-employee API isolation pass. See [completed work](plan-done.md) and the [deploy ledger](docs/agents/deploy-ledger.md). |
 | R1 — reliable login | IMPLEMENTED, CI GREEN at `44fd8f328` — encrypted PostgreSQL sessions, fixed deadlines, revision-checked saves and logout markers. All 52 auth tests and [CI](https://github.com/elewa-git/opencrane/actions/runs/34274625541) pass, including all seven SQL targets on fresh PostgreSQL and six real-client session proofs. Fresh-install live qualification remains pending; testv5 retains the earlier database baseline. |
 | A1 — membership revocation and closed-work proof | IMPLEMENTED, IN REVIEW — standalone administrators can remove another non-Owner member through Settings. The server suspends the existing membership, protects Owner/self removal and rechecks current authority on retries. Workspace access loss clears retained private content and rejects delayed results. Focused unit checks and all 123 browser checks pass; five real PostgreSQL cases join the CI gate. The real-account removal and closed-work journey remains to qualify live. Fleet removal remains unsupported. |
-| T1 — first permitted tool retrieval | INTERNAL CONTINUATION IMPLEMENTED in [#830](https://github.com/elewa-git/opencrane/pull/830), `ada28f1f7`; [CI](https://github.com/elewa-git/opencrane/actions/runs/34303700943) passes all seven SQL targets, 25 real KurrentDB cases, affected builds/tests and image validation. One permitted tool can feed one final model answer using the frozen run and remaining budget. Images are not published or installed. Real integration acceptance, company-assistant tool assignment and participant-visible tool progress remain unfinished; the live installed integration list is empty. |
-| T2/T3/U1 — approved actions and visible recovery | DEPENDS ON T1 — exact approval, cancellation, uncertain outcomes, retries and accessible workspace controls. |
-| M1/F1 — explicit memory and durable files | PREFLIGHT COMPLETE — memory needs a verified dataset-scoped recall/deletion contract and recoverable correction before writes are enabled. Existing upload/quarantine/scan owners can support files; document content is not yet connected to model input and assistant-generated file finalisation remains unfinished. Keep each journey independent. |
-| D1/S1 — autonomous delegation and shared schedules | DEPENDS ON ACTION CONTRACTS — bounded authority, budgets, cancellation and durable results. |
-| A2/Q1 — administration and operational acceptance | PLANNED THROUGHOUT — extend protected product surfaces and prove each newly landed journey. |
+| T1 — first permitted tool retrieval | IN PROGRESS — the server's one-tool continuation is implemented and now progresses through Absurd in #849. Company tool assignment is the first active follow-up. Connection activation, a real integration and participant result evidence remain required. |
+| T2, M1, U1, U2, F1, D1, S1, A2, T3 | PLANNED in the exact priority order above, with separate acceptance for each journey. |
+| Q1 — operational acceptance | CONTINUOUS — source checks and CI do not replace fresh-install or real-account acceptance. |
 
-The overnight run on 8–9 September continues these slices in dependency order and hands off at
-08:00 Nairobi time. It commits and pushes reviewed progress, maintains incremental PRs and records
-blockers without treating the whole MVP as a one-night promise. See the delivery plan for the
-morning checkpoint and operating boundaries.
+The 10 September priority order supersedes the earlier overnight sequencing and morning handoff.
+Execute bounded, independently reviewed slices on the live stack and record implementation, CI and
+live evidence separately. Deployment, release tags and the full testv5 qualification remain separate
+gates; no overnight automation is created by this plan.
 
 ## Extend the proven text journeys
 
@@ -154,7 +214,7 @@ ADR 0016, then projects the child and commits its first message with activation.
 creation becomes Ready. The company assistant uses its own managed identity and model permission;
 the human requester's current membership and invocation permission remain separate requirements.
 Runtime subagents
-([#320](https://github.com/elewa-git/opencrane/issues/320)) require explicit parent-run delegation,
+([#845](https://github.com/elewa-git/opencrane/issues/845), building on #320) require explicit parent-run delegation,
 budget, cancellation and result ownership and remain later work. Neither journey may silently
 inherit a person's private tools or memory.
 
@@ -182,7 +242,7 @@ tracks, not instructions to rebuild everything named here:
 - **Shared scheduled work:** restore supported managed scheduling and trigger execution against
   current identity and lease contracts; prove pause, resume, overlap, retry and cancellation. Removed
   0.10 execution routes are not a compatibility path. See
-  [#332](https://github.com/elewa-git/opencrane/issues/332).
+  [#848](https://github.com/elewa-git/opencrane/issues/848), building on the retired #332 work.
 - **Company administration:** finish membership, effective access, agent/tool configuration, audit,
   model/provider selection, budget and spending screens over the existing protected APIs. See
   [#224](https://github.com/elewa-git/opencrane/issues/224) and
@@ -230,7 +290,7 @@ the [deploy ledger](docs/agents/deploy-ledger.md).
 ## Later work
 
 - [#765](https://github.com/elewa-git/opencrane/issues/765): Git-backed project source, isolated
-  builds, immutable published artifacts and PreviewApps after the conversation baseline.
+  builds, immutable published artifacts, PreviewApps and code work after the ten priorities above.
 - Warm pooling, extra compute tiers and scale optimization wait for measured latency and cost.
 - A generic plugin framework waits for two concrete consumers that need the same extension contract.
 - [#513](https://github.com/elewa-git/opencrane/issues/513): evaluate provider-native model tracing

--- a/plan.md
+++ b/plan.md
@@ -28,7 +28,8 @@ The [delivery plan](docs/design/mvp-delivery-plan.md) records owners and accepta
 
 ### First execution slice: company tool selection
 
-Implemented on `feat/0.12-real-tool-retrieval`, directly above
+Implemented in draft [#850](https://github.com/elewa-git/opencrane/pull/850) on
+`feat/0.12-real-tool-retrieval`, directly above
 [#849](https://github.com/elewa-git/opencrane/pull/849), with immutable review base
 `b4f275b3f090e9387a1b0de658968700c0b7ad04`. Reuse the earlier company-tools implementation and
 adapt it to #843's capability folders; do not reopen its obsolete flattened implementation.
@@ -53,9 +54,9 @@ The disposable database was stopped after qualification. Backend/contracts type 
 build pass; generated API contracts and website schema are synchronized. Architecture preflight,
 architecture post-review and independent source review pass. Prisma, authorization, workflow,
 workload composition, domain, dependency, release, style and module-growth checks pass.
-The website build passes, including the generated API pages. This slice is ready for its incremental
-draft PR; CI and testv5/live acceptance remain separate evidence. The next source slice owns
-connection activation and its execution binding.
+The website build passes, including the generated API pages. Commit `376380280` is pushed and
+reviewable in draft #850. CI and testv5/live acceptance remain separate evidence. The next source
+slice owns connection activation and its execution binding.
 
 
 ## Absurd-owned conversation turn progression - 2026-09-09
@@ -111,7 +112,8 @@ assistant, get useful work done, and collaborate in a group without understandin
 
 The current review order is `develop` → [#831](https://github.com/elewa-git/opencrane/pull/831)
 → [#843](https://github.com/elewa-git/opencrane/pull/843)
-→ [#849](https://github.com/elewa-git/opencrane/pull/849) → the T1 company-tool selection follow-up.
+→ [#849](https://github.com/elewa-git/opencrane/pull/849)
+→ [#850](https://github.com/elewa-git/opencrane/pull/850) for T1 company-tool selection.
 The merged conversation history and
 computer baseline is implemented; it is not yet a live-qualified MVP. [ADR 0016](docs/adr/0016-conversation-history-and-computers.md) supersedes the
 older run-owned runtime and relational transcript descriptions in historical plans.

--- a/website/guide/first-agent.md
+++ b/website/guide/first-agent.md
@@ -1,13 +1,13 @@
 # Set up the company assistant
 
-A company assistant helps colleagues in a [chat linked to their group](/guide/child-runs).
-It has its own identity and model permission. It does not inherit the administrator's private
-assistant, memory or tools.
+A **company assistant** helps colleagues in a [chat linked to their group](/guide/child-runs).
+This page covers administrator setup, employee access and selection of the tools it may use.
 
 ::: info Current scope
-The 0.11 review baseline supports one explicitly provisioned company assistant per organisation,
-with text answers and follow-up questions. Setup currently uses the authenticated administrator
-API. Scheduling, automatic triggers, tools and delegation between assistants remain future work.
+The review branch supports one company assistant per organisation, with text answers, follow-up
+questions and exact tool selection through the authenticated administrator API. There is no
+management screen yet. Company credential activation and a complete live retrieval journey remain
+unfinished. See [development status](/guide/status) for the current implementation and live evidence.
 :::
 
 ## Choose who can use it
@@ -16,10 +16,12 @@ The administrator selects a name, an existing model definition and the exact cur
 principals who may use the assistant. The administrator needs permission to administer the
 organisation and use that model. Employees receive permission to discover, read and invoke the
 assistant; the assistant receives its own permission to use the selected model.
+It has its own identity and does not inherit the administrator's private assistant, memory or tools.
 
-The deployment supplies the computer profile and execution limits. The first company assistant
-uses one model turn per request, with ceilings of 32,000 completion tokens and two minutes. Those per-request
-limits are separate from company spending controls.
+The deployment supplies the computer profile and execution limits. Newly created company assistants
+permit at most two model requests, so one tool result can inform a final answer, within one shared
+turn allowance of 32,000 completion tokens and two minutes. These limits are separate from company spending
+controls. Editing an existing assistant's tools preserves its original allowance.
 
 ## Create it through the API
 
@@ -44,12 +46,51 @@ A suspended or retired assistant is never reopened by repeating setup. Manage ac
 company's existing permission controls. Check the [API reference](/reference/api) for the exact
 request schema and failure responses.
 
+## Choose its tools
+
+Read `GET /api/v1/organization/company-assistant/tools`, then send the complete desired selection
+to `PUT /api/v1/organization/company-assistant/tools`:
+
+```json
+{
+  "expectedActiveRevisionId": "revision-returned-by-the-read",
+  "toolRevisionIds": ["ready-tool-revision-id"]
+}
+```
+
+The response identifies the assistant, its active configuration revision and the selected tools.
+Select up to 32 unique tool revisions; an empty list removes all assignments. You need permission
+to administer the organisation and assign each selected tool. Every tool must belong to your
+organisation and a ready revision of an active, published server. An unchanged selection still
+checks those permissions and does not restore revoked grants.
+
+A changed selection creates an immutable revision: the previous configuration remains recorded.
+Use the returned `activeRevisionId` for your next edit. If you receive `409`, another edit has changed
+the active revision; read the configuration again before replacing it. After an uncertain response,
+also read the current configuration instead of assuming the edit failed.
+
+The assistant receives its own Use and Invoke permissions for the exact selected tools. Removing
+a tool withdraws the grants managed by this configuration and prevents further dispatch through
+the old revision. It cannot undo an external action already started. Assignment does not raise the
+model limit: an existing one-request configuration cannot make a second request to answer from a
+tool result.
+
+::: warning Assignment is not a connected integration
+This API selects tools and permissions; it does not install an integration or activate credentials.
+The assistant never falls back to an employee's private credentials. A dedicated integration still
+needs live retrieval proof. The current continuation supports one tool that needs no approval;
+approved external changes and visible tool progress remain unfinished.
+:::
+
+→ [Prepare a company integration](/guide/tools).
+
 ## Try it with colleagues
 
 An allowed employee opens a group, writes a request and chooses **Ask company assistant**. Check
 that the child chat produces an answer, survives refresh, and allows a person to review and share
-a result back. Include an employee without permission in your access tests. These complete
-journeys still need live qualification for the current review baseline.
+a result back. Include an employee without permission in your access tests. The earlier text-only
+journey passed in testv5; repeat it for the candidate being installed. Tool assignment does not
+establish the separate live retrieval proof.
 
 > See also: [Ask an assistant in a group](/guide/child-runs) ·
 > [Personal-assistant setup](/guide/persona) · [Access controls](/guide/permissions)

--- a/website/guide/status.md
+++ b/website/guide/status.md
@@ -12,8 +12,9 @@ baseline and follow-up PRs from remaining product work and live verification.
 | Durable conversations | Creation, posting and history reads, including ordinary direct/group messages and personal assistant conversations. History is stored in KurrentDB. All three modes distinguish a new chat from a retried creation command. |
 | Recognizable chats | Member display names in the participant picker and direct/group chat titles, with generic text for missing names. |
 | Live conversation updates | Bounded, resumable browser events with current access checks. Revocation clears the selected history and draft, and late responses cannot restore them. The event stream supplies message history and live changes; computer inspection refreshes separately. |
-| Personal model turns | Approved persona instructions and conversation history feed a bounded text request. The server keeps model input and keys and saves the answer for restart. Text checkpoint `378a755b6` has passed full CI; live qualification of that replacement remains outstanding. New runs explicitly exclude personal memory while provisioning and recall remain unfinished. |
+| Personal model turns | Approved persona instructions and conversation history feed a bounded request. The server keeps model input and keys and saves the answer for restart. Absurd advances the turn through model work and at most one permitted tool result and text-only continuation. Live qualification of this replacement remains outstanding. New runs explicitly exclude personal memory while provisioning and recall remain unfinished. |
 | Company assistant in groups | Explicit assistant selection on an own group message, recoverable child creation, fixed audience, current parent and child access checks, follow-up answers, and human-reviewed sharing back. Administrator setup uses the API. |
+| Company assistant tool selection | Administrators read and replace exact tools through the API. Changes create immutable revisions and grants for the assistant's own identity; stale edits conflict. Edits preserve the original budget. Connection activation, the management screen and live retrieval proof remain unfinished. |
 | Computer inspection | Workspace file, diff and browser discovery routes. Commands, page creation, screenshots and preview actions remain denied until their concrete effect admissions are connected. |
 | Computer recovery | Retrying failed starts, renewing or replacing active computers, and saving and restoring workspaces. |
 | History operations | Scheduled backups, restore tooling and health checks. A scheduled file-copy restore recovered completed personal/group chats, removed a later message and allowed new group messages and an assistant answer. Scheduled volume snapshots are ready; restoring them remains unqualified. |
@@ -24,57 +25,48 @@ current review work and its evidence.
 
 ## Still to complete
 
-- **Useful work across tools:** the internal continuation in [PR #830](https://github.com/elewa-git/opencrane/pull/830)
-  can use one permitted tool result in a final assistant answer. CI passes; this change is not yet
-  installed. A stacked follow-up moves durable turn progression from the conversation Pod into the
-  existing Absurd workflow boundary; its CI and live qualification remain pending. A real
-  integration, company-assistant tool assignment, visible tool progress and
-  human-approved changes still need their complete product journeys.
-- **Recovery controls:** when a model response cannot be recovered, preserve the pending run and
-  show the person what happened and what they can do next. The current server keeps the spent
-  request reservation and does not send another paid request. That restraint is implemented in
-  source; the user-facing recovery controls remain unfinished.
-- **Personal memory:** complete remembering, recalling, correcting and forgetting information
-  across conversations.
-- **Shared work:** restore supported managed-agent scheduling and triggered execution, and complete
-  delegation between assistants.
-- **Inputs and outputs:** complete the user journeys for attachments, generated files and their
-  recovery across refresh, retry and conversation closure.
-- **Administration:** complete the product surfaces for permissions, activity and cost without
-  requiring an employee to understand internal execution concepts. The follow-up implementation
-  gives people read access to each new personal run when it starts. Two new testv5 runs now appear
-  in their owners' activity API and remain invisible to the other employee. The follow-up UI adds
-  recent status, refresh and links to loaded answers. Fresh browser checks now pass for both
-  employees, including keyboard navigation, narrow screens and recovery after reload.
-  Existing older runs receive no backfill. Revoked access is checked on every read. Another follow-up
-  adds standalone member removal and clears retained workspace content after access loss. Owner
-  and self-removal are protected; Fleet removal is unavailable. This work is under review and
-  remains unqualified live. See [Remove a company member](/guide/permissions#remove-a-company-member).
-- **Login continuity:** preserve authenticated sessions across server replacement and support
-  multiple servers consistently. The follow-up implements encrypted PostgreSQL sessions with
-  fixed expiry and logout protection. CI and fresh PostgreSQL tests pass; fresh-install live
-  qualification remains pending. The current
-  testv5 server uses process-local sessions and requires a new sign-in after replacement.
+The active delivery order is:
+
+1. **Real tool retrieval:** connect and qualify a dedicated company integration so a permitted
+   record informs an answer and its result survives reload and restart. Internal continuation and
+   [company tool assignment](/guide/first-agent#choose-its-tools) are implemented; credential
+   activation and participant-visible result evidence remain unfinished.
+2. **Approved external actions:** let a person review the exact action, target and arguments before
+   one approval permits that action once. Changed arguments, expiry or revoked access must stop it.
+3. **Long-term memory:** complete remembering, recalling, correcting and forgetting information
+   across conversations, with consent and isolated personal and company datasets.
+4. **Visible work controls:** show waiting, running and finished work, required decisions and
+   supported cancellation. Recent personal activity is implemented; tool progress and controls
+   still need their complete journey.
+5. **Rich interaction:** complete durable choices, free-text questions and structured results that
+   remain accessible after refresh.
+6. **Documents and generated files:** complete attachment-to-answer and generated-file journeys,
+   including access checks and recovery across refresh, retry and conversation closure.
+7. **Autonomous delegation:** let an assistant delegate bounded work with explicit context,
+   narrower permissions and one recorded result.
+8. **Scheduled work:** let people review recurring work that checks current authority each time
+   it runs, with clear handling of overlaps, missed runs and retries.
+9. **Complete administration:** finish agent, connection, model, permission and spending controls.
+   Standalone member removal and browser clearing after access loss are implemented in review;
+   the real-account journey remains unqualified. See [Remove a company member](/guide/permissions#remove-a-company-member).
+10. **Action recovery:** explain uncertain outcomes and provide supported reconciliation and safe
+    retry controls. The server already preserves a spent model request without dispatching it again;
+    the full recovery experience remains unfinished.
+
+Login continuity also needs fresh-install live qualification. Encrypted PostgreSQL sessions with
+fixed expiry and logout protection are implemented and pass CI and fresh PostgreSQL tests.
 
 Durable application source, builds and published apps are later work. Temporary computer previews
 do not publish an application.
 
 Answer recovery saves the exact prepared answer before posting it, so a restart can recognise its
-original content and timestamp. Text checkpoint `378a755b6` in
-[#830](https://github.com/elewa-git/opencrane/pull/830) passes
-[full CI](https://github.com/elewa-git/opencrane/actions/runs/34300559935), including all seven fresh
-PostgreSQL targets and 24 real KurrentDB cases (seven conversation and 17 adapter, excluding skips).
-Its corrected PR metadata also passes
-[topology CI](https://github.com/elewa-git/opencrane/actions/runs/34301556387).
-
-The continuation implementation at `ada28f1f7` in PR #830 passes
-[full CI](https://github.com/elewa-git/opencrane/actions/runs/34303700943). Independent review also
-passes. Live qualification remains pending.
-Both paths preserve a spent request when its response is unavailable, without paid redispatch. A continuation uses the original key and subtracts the entire first token reservation
-before reserving its final request. LiteLLM and provider-internal retries have not been qualified as
-exactly-once execution. The answer-recovery, tool-handoff, Absurd orchestration and continuation changes
-have not been rolled out to testv5. T1 retrieval, T2/T3 approved actions and U1 visible recovery remain
-open delivery work.
+original content and timestamp. The Absurd implementation in
+[#849](https://github.com/elewa-git/opencrane/pull/849) passes CI and independent review; its live
+testv5 qualification remains separate. The conversation Pod no longer schedules model work.
+An unavailable response stays recorded without paid redispatch, and a continuation uses the original
+key and remaining call and token allowance. Provider-internal retries have not been qualified as
+exactly-once execution. Company tool assignment enables the next retrieval step; it does not prove
+that a live integration is connected or that the complete tool journey is ready.
 
 ## Proven in the test installation
 

--- a/website/guide/tools.md
+++ b/website/guide/tools.md
@@ -6,13 +6,12 @@ integrations.
 
 ::: info Current scope
 The catalogue, immutable package import and governed MCP execution services are implemented.
-The continuation implementation lets the first model request select one frozen tool that requires
-no approval. The server retains the declaration privately, checks the exact result and may request
-a final text answer using the same key and remaining original allowance. This implementation in
-PR #830 awaits CI and live qualification. Company assistant revisions still exclude tool
-assignments, and testv5 has no installed integration for a complete retrieval proof. Installing a
-tool alone does not make this journey available. Approvals, visible tool progress and recovery
-controls remain unfinished. See [development status](/guide/status).
+The server can select one frozen tool that needs no approval, retain its result privately and make
+at most one final text request within the original remaining allowance. Absurd durably advances
+this work. Administrators can [assign exact tools to the company assistant](/guide/first-agent#choose-its-tools)
+through the API. Credential activation and a complete live retrieval proof remain unfinished.
+Installing or assigning a tool alone does not establish a working connection. Approvals, visible
+tool progress and recovery controls remain unfinished. See [development status](/guide/status).
 :::
 
 ## Prepare an integration
@@ -21,17 +20,18 @@ Administrators use the authenticated `/api/v1/mcp` surface to browse, install an
 definitions. Consult the [API reference](/reference/api) for current payloads and the
 [OCI MCP guide](/integrators/oci-mcp-runtime) for the supported package format.
 
-Decide which tools are needed, who may use them, and which actions require approval. Registration
-alone does not grant access.
+Decide which tools are needed, who may use them, which company connection owns their credentials,
+and which actions require approval. Registration alone does not grant access. An install labelled
+`shared-key` does not prove that company credentials are configured or that a provider call works.
 
 ## The intended action journey
 
-When the conversation integration is complete, an assistant will propose a tool call. OpenCrane
-will check its permissions, request approval when required, execute the admitted action and return
-a recorded result. The assistant will not approve its own action.
+The implemented continuation can propose one tool call that needs no approval, check current
+permissions, execute it and use its recorded result in an answer. A tool that requires human
+approval still needs the review-and-execution journey. The assistant will not approve its own action.
 
 Revocation changes later permission decisions. It does not erase a record of an action that
 already completed.
 
 > See also: [Access controls](/guide/permissions) · [Review activity](/guide/audit) ·
-> [Governed packages](/integrators/governed-packages)
+> [Company assistant](/guide/first-agent) · [Governed packages](/integrators/governed-packages)

--- a/website/public/openapi.json
+++ b/website/public/openapi.json
@@ -12845,6 +12845,154 @@
         }
       }
     },
+    "/organization/company-assistant/tools": {
+      "get": {
+        "operationId": "getCompanyAssistantTools",
+        "summary": "Read the company assistant's current tool selection",
+        "tags": [
+          "Organization assistants"
+        ],
+        "description": "Requires current Organization Administer. Returns the exact active immutable revision and sorted tool revision IDs. This read does not record effect admission or supply external credentials.",
+        "responses": {
+          "200": {
+            "description": "Current selection.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "agentServiceId",
+                    "activeRevisionId",
+                    "toolRevisionIds"
+                  ],
+                  "properties": {
+                    "agentServiceId": {
+                      "type": "string"
+                    },
+                    "activeRevisionId": {
+                      "type": "string"
+                    },
+                    "toolRevisionIds": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Current administrator permission denied."
+          },
+          "404": {
+            "description": "Active published company assistant unavailable."
+          },
+          "503": {
+            "description": "Selection dependency unavailable."
+          }
+        }
+      },
+      "put": {
+        "operationId": "setCompanyAssistantTools",
+        "summary": "Replace the company assistant's tool selection",
+        "tags": [
+          "Organization assistants"
+        ],
+        "description": "Requires current Organization Administer and Assign on every selected same-silo ready tool revision of an active published server. Publishes an immutable successor and reconciles only the company's own Use/Invoke grants for removed and selected tools. A current unchanged selection is a no-op after fresh authorization. A stale expected revision always returns 409, including a retry after an uncertain successful commit; GET the authoritative selection before editing again. Empty selection removes all tools. This API creates no install or external credential binding and cannot borrow human private credentials.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "expectedActiveRevisionId",
+                  "toolRevisionIds"
+                ],
+                "properties": {
+                  "expectedActiveRevisionId": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "pattern": "^\\S(?:.*\\S)?$"
+                  },
+                  "toolRevisionIds": {
+                    "type": "array",
+                    "maxItems": 32,
+                    "uniqueItems": true,
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 200,
+                      "pattern": "^\\S(?:.*\\S)?$"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Committed successor or unchanged current selection.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "agentServiceId",
+                    "activeRevisionId",
+                    "toolRevisionIds"
+                  ],
+                  "properties": {
+                    "agentServiceId": {
+                      "type": "string"
+                    },
+                    "activeRevisionId": {
+                      "type": "string"
+                    },
+                    "toolRevisionIds": {
+                      "type": "array",
+                      "uniqueItems": true,
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tool selection."
+          },
+          "401": {
+            "description": "Authentication required."
+          },
+          "403": {
+            "description": "Current assignment permission or selected tool unavailable."
+          },
+          "404": {
+            "description": "Active published company assistant unavailable."
+          },
+          "409": {
+            "description": "Active revision changed; read current selection before another edit."
+          },
+          "503": {
+            "description": "Assignment dependency unavailable; a failed response may follow a commit, so read current selection."
+          }
+        }
+      }
+    },
     "/organization/company-assistant": {
       "post": {
         "operationId": "provisionCompanyAssistant",


### PR DESCRIPTION
Company assistants currently have no tool assignments, and managed execution rejects revisions that contain tools. This change lets an administrator read and replace the exact tool selection through `GET/PUT /api/v1/organization/company-assistant/tools`, so permitted company tools can reach the existing server-owned retrieval loop.

Each changed selection publishes an immutable successor and exact Use/Invoke grants for the assistant's own Principal in one Serializable transaction. Administer and Assign decisions must have durable evidence; unchanged selections still recheck current permission. Stale revisions conflict, and an uncertain successful update is resolved with a fresh GET. Edits preserve saved model/persona/skill configuration and budget. Only newly provisioned assistants receive the two-call policy for one tool result and a final answer. Nested Prisma assignments inherit the parent service identity.

This ports the earlier unpublished company-tools work into the capability folders from #843. It is the first implementation slice of the user's priority order: retrieval, approved actions, memory, visible controls, rich interaction, files, delegation, schedules, administration, then action recovery. Published applications and code work remain later. Relates to #844; it does not complete that issue.

## Review order

1. #831 — current member access and revocation.
2. #843 — library and component decomposition.
3. #849 — Absurd-owned conversation progression.
4. #850 — company tool assignment and managed retrieval evidence.

Direct base: `feat/absurd-conversation-turn-workflow`, immutable review base `b4f275b3f090e9387a1b0de658968700c0b7ad04`. The former #830 tool continuation is already in this ancestry. Review the incremental diff above its direct parent.

## Responsibilities

Absurd retains durable progression, waiting and restart recovery. AgentSandbox retains lease/generation-fenced isolated execution. The server retains model authority, credentials, budgets, tool permissions, invocation, continuation and conversation output. Company tool selection stays in agent-services; the app remains declarative composition. No new queue, scheduler, private model route or Pod orchestration is added. The old flattened source layout and replaced inline permission helpers are not retained as compatibility paths.

## Validation completed

- `nx run backend-server-agent-services:test`: 127 tests.
- `nx run backend-agents-personal-configuration:test`: 65 tests.
- `nx run backend-agents-execution-inputs:test`: 113 tests.
- `nx run contracts:test`: 95 tests.
- Targeted `opencrane:test` conversation-tool-dispatch-authority suite: 30 tests, including revoked company grant versus retained human grant.
- `nx run backend-server-agent-services:test:sql`: 5 tests on isolated PostgreSQL 17.11 using the exact current fresh baseline. Proves immutable publication, concurrent editors, rollback, current membership/Assign denial and unavailable tool rejection. Baseline SHA-256: `44f9d722ceb6c0d3de41bf16435741bec81fbb9c3b40cb72dc3c59c21a722e29`. Disposable server stopped afterwards.
- Nx lint/type checks: agent-services, personal-configuration, execution-inputs, contracts and opencrane. Nx builds: opencrane and website.
- Generated contracts and website OpenAPI synchronized through existing generation targets.
- Full ESLint dependency boundaries; Prisma, authorization enforcement, workflow, workload/app composition, agent-domain and release-versioning checks pass.
- Style: 14 production files, zero errors/warnings. Module growth: zero errors/review candidates. `git diff --check` passes.
- Architecture preflight and post-review PASS; mandatory independent review PASS with no remaining findings. Production source matches the reviewed content manifest.
- Live PR stack integrity PASS before publication; rechecked after opening.

The website build succeeds with relative `/api/v1` base-URL warnings.

## Remaining acceptance

This enables assignment; it does not establish a working provider connection. Credential activation, minimal participant-visible tool-result evidence and a chosen real read-only integration still complete T1. Broad tool controls, approval UX and action recovery remain their planned slices. Testv5/live qualification remains a separate gate. No deployment, real external action or release tag is included, and CI on this new head is still pending.
