### PR TITLE
Add durable personal tool approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
   allowance; new assistants permit two model requests for one tool result and a final answer.
   Credential activation, a management screen and live retrieval qualification remain unfinished.
 
+- **Personal assistants can wait for their owner's approval before calling a tool.** A decision
+  applies to the saved arguments and original run allowance. Approved work resumes after a restart
+  without repeating the call; denial, expiry, lost access or changed arguments prevent execution.
+  Live remote-provider and hosted-MCP qualification remain separate.
+
 - **People can use agent-session conversations whose complete history survives server and executor
   restarts.** Immutable KurrentDB streams preserve ordered messages and computer lifecycle events,
   while the authenticated web workspace reads and posts through the same typed backend conversation

--- a/apps/opencrane/package.json
+++ b/apps/opencrane/package.json
@@ -117,6 +117,7 @@
           "commands": [
             "sh ../../scripts/run-postgres-authority-tests.sh prisma/tests/authorization-active-grant-uniqueness.sql prisma/tests/phase-d-authority-integration.sql prisma/tests/skill-authoring-validation-authority.sql",
             "vitest run src/bootstrap/conversations/__tests__/conversation-tool-proposal.sql.test.ts",
+            "vitest run src/bootstrap/conversations/__tests__/conversation-tool-approval.sql.test.ts",
             "vitest run src/bootstrap/conversations/__tests__/conversation-tool-result.sql.test.ts"
           ],
           "parallel": false

--- a/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-approval.sql.test.ts
+++ b/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-approval.sql.test.ts
@@ -1,0 +1,200 @@
+import { randomUUID } from "node:crypto";
+
+import { AgentRunState, ToolInvocationState, ToolResultDeliveryState, PrismaClient } from "@prisma/client";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { PrismaElicitationRepository, PrismaElicitationUnitOfWork } from "@opencrane/backend/agents/execution/elicitation";
+import { ElicitationBodyKinds, CONVERSATION_COMPUTER_PROJECTED_TOKEN_AUDIENCE } from "@opencrane/contracts";
+import { __FakeWorkflowEngine } from "@opencrane/backend/server/infra/workflows/testing";
+import { PrismaConversationComputerTurnWorkflowEventRepository, PrismaConversationToolProposalUnitOfWork, PrismaConversationToolResultsUnitOfWork, _RegisterConversationComputerTurnWorkflow, CONVERSATION_COMPUTER_TURN_TASK } from "@opencrane/backend/server/conversations";
+import { ToolInvocationEventTypes } from "@opencrane/backend/server/iam/authorization";
+import type { IWorkflowTaskReceipt, IWorkflowEngine } from "@opencrane/backend/server/infra/workflows/contract";
+
+import { _ToolHandoffSqlRuntime, _WaitPastSqlDeadline } from "./conversation-tool-handoff.sql-fixture";
+import { _SeedConversationToolProposalSqlFixture } from "./conversation-tool-proposal.sql-fixture";
+
+const _First = new PrismaClient();
+const _Runtimes = new Set<ReturnType<typeof _ToolHandoffSqlRuntime>>();
+const _WORKLOAD = { subject: "system:serviceaccount:computers:computer", audience: CONVERSATION_COMPUTER_PROJECTED_TOKEN_AUDIENCE, namespace: "computers", serviceAccountName: "computer", workloadKind: "pod", workloadUid: "computer-pod-1", podUid: "computer-pod-1" } as const;
+
+describe("saved personal approval through the conversation workflow on PostgreSQL", function _Suite()
+{
+	beforeAll(async function _Connect()
+	{
+		if (!process.env.DATABASE_URL)
+			throw new Error("The approval SQL proof requires DATABASE_URL and the fresh target baseline");
+		await _First.$connect();
+	});
+	afterEach(async function _FinishControllers() { for (const runtime of _Runtimes) await runtime.register(); _Runtimes.clear(); });
+	afterAll(async function _Disconnect() { await _First.$disconnect(); });
+
+	it("waits for the exact owner, dispatches once, saves the result and consumes one continuation", async function _ApprovedJourney()
+	{
+		const f = await _SeedConversationToolProposalSqlFixture({ approvalRequired: true });
+		const runtime = _ToolHandoffSqlRuntime(_First, f);
+		_Runtimes.add(runtime);
+		const workflows = new __FakeWorkflowEngine();
+		const emitted: string[] = [];
+		const taskAliases = new Map<string, { readonly taskId: string; readonly taskName: string; readonly idempotencyKey: string }>();
+		const eventPort = _EventPort(workflows, emitted, taskAliases);
+		const approvalExpiry = (transaction: unknown, command: { readonly runId: string; readonly attempt: number; readonly now: Date }) => new PrismaElicitationRepository(transaction as never, new PrismaConversationComputerTurnWorkflowEventRepository(transaction as never, eventPort)).expireDue(command).then(() => undefined);
+		const proposalOwner = new PrismaConversationToolProposalUnitOfWork(_First, f.dependencies, runtime.admission, approvalExpiry);
+		let advanceCount = 0;
+		let resultReader: PrismaConversationToolResultsUnitOfWork | null = null;
+		const authority = {
+			start: async function _Start() { return f.turn; },
+			advance: async function _Advance()
+			{
+				advanceCount++;
+				const invocation = await _First.toolInvocation.findFirst({ where: { runId: f.runId } });
+				if (invocation === null)
+				{
+					await proposalOwner.admit(f.turn, f.candidate, f.proposal, _WORKLOAD);
+					const opened = await _First.toolInvocation.findFirstOrThrow({ where: { runId: f.runId } });
+					return { outcome: "tool_pending" as const, toolInvocationId: opened.toolInvocationId, waitFor: "approval" as const, waitUntilEpochMs: (await _First.approvalRequest.findFirstOrThrow({ where: { runId: f.runId } })).expiresAt.getTime() };
+				}
+				if (invocation.state === ToolInvocationState.AwaitingApproval)
+					return { outcome: "tool_pending" as const, toolInvocationId: invocation.toolInvocationId, waitFor: "approval" as const, waitUntilEpochMs: (await _First.approvalRequest.findFirstOrThrow({ where: { runId: f.runId } })).expiresAt.getTime() };
+				if (invocation.state === ToolInvocationState.Ready)
+				{
+					if (await _First.mcpRuntimeExecution.findUnique({ where: { toolInvocationId: invocation.id } }) === null)
+						await proposalOwner.admit(f.turn, f.candidate, f.proposal, _WORKLOAD);
+					return { outcome: "tool_pending" as const, toolInvocationId: invocation.toolInvocationId, waitFor: "result" as const };
+				}
+				if (invocation.state !== ToolInvocationState.Succeeded)
+					return { outcome: "tool_pending" as const, toolInvocationId: invocation.toolInvocationId, waitFor: "result" as const };
+				const delivery = await _First.toolResultDelivery.findUniqueOrThrow({ where: { toolInvocationId: invocation.id } });
+				const storedTurn = _ResultTurn(f, invocation.toolInvocationId, invocation.requestFingerprint, delivery.payloadDigest);
+				resultReader = _ResultReader(f, invocation, delivery.payloadDigest);
+				const result = await resultReader!.consume(storedTurn as never, _WORKLOAD);
+				expect(result.outcome).toBe("available");
+				return { outcome: "completed" as const };
+			},
+		};
+		_RegisterConversationComputerTurnWorkflow(workflows, { authority: authority as never, receipts: { bind: async function _Bind() { return true; } }, siloId: f.siloId });
+		const activationEventId = randomUUID();
+		const task = await workflows.spawn({ client: {} }, { taskName: CONVERSATION_COMPUTER_TURN_TASK.taskName, idempotencyKey: activationEventId, input: { siloId: f.siloId, computerId: f.turn.computerId, leaseId: f.turn.lease.leaseId, leaseGeneration: f.turn.lease.leaseGeneration, activationEventId, causationId: f.turn.latestPendingEntryId, causationPosition: f.turn.latestPendingEntryPosition } });
+		const persistedTask = { ...task, taskId: randomUUID() };
+		taskAliases.set(persistedTask.taskId, task);
+		await _First.agentRun.update({ where: { id: f.runId }, data: { workflowTaskId: persistedTask.taskId, workflowTaskName: persistedTask.taskName, workflowTaskKey: persistedTask.idempotencyKey } });
+		const running = workflows._DrainPendingTasks();
+		await _Eventually(async function _ApprovalOpened() { return (await _First.approvalRequest.findFirst({ where: { runId: f.runId } })) !== null; });
+		const invocationBefore = await _First.toolInvocation.findFirstOrThrow({ where: { runId: f.runId } });
+		expect(invocationBefore.state).toBe(ToolInvocationState.AwaitingApproval);
+		expect(await _First.mcpRuntimeExecution.count({ where: { siloId: f.siloId } })).toBe(0);
+		const approval = await _First.approvalRequest.findFirstOrThrow({ where: { runId: f.runId } });
+		const elicitation = new PrismaElicitationUnitOfWork(_First, function _WakeFactory(transaction) { return new PrismaConversationComputerTurnWorkflowEventRepository(transaction as never, eventPort); });
+		await expect(elicitation.respond({ siloId: f.siloId, conversationId: f.turn.binding.conversationId, requestId: approval.elicitationRequestId!, subjectId: f.principalId, verifiedStepUpAt: new Date(), submission: { idempotencyKey: `approve-${f.runId}`, response: { kind: ElicitationBodyKinds.Approval, approved: true } }, now: new Date() })).resolves.toMatchObject({ outcome: "accepted" });
+		await _Eventually(async function _Ready() { return (await _First.toolInvocation.findFirstOrThrow({ where: { runId: f.runId } })).state === ToolInvocationState.Ready; });
+		expect(await _First.mcpRuntimeExecution.count({ where: { siloId: f.siloId } })).toBe(0);
+		const registered = await _EventuallyValue(async function _Registered() { return runtime.register(); });
+		if (registered === null)
+			throw new Error("MCP execution was not admitted after owner approval");
+		await workflows.cancel(task);
+		await running;
+		const restarted = new __FakeWorkflowEngine();
+		const restartedAliases = new Map<string, { readonly taskId: string; readonly taskName: string; readonly idempotencyKey: string }>();
+		const restartedEventPort = _EventPort(restarted, emitted, restartedAliases);
+		_RegisterConversationComputerTurnWorkflow(restarted, { authority: authority as never, receipts: { bind: async function _Bind() { return true; } }, siloId: f.siloId });
+		const restartedActivationEventId = activationEventId;
+		const restartedTask = await restarted.spawn({ client: {} }, { taskName: CONVERSATION_COMPUTER_TURN_TASK.taskName, idempotencyKey: restartedActivationEventId, input: { siloId: f.siloId, computerId: f.turn.computerId, leaseId: f.turn.lease.leaseId, leaseGeneration: f.turn.lease.leaseGeneration, activationEventId: restartedActivationEventId, causationId: f.turn.latestPendingEntryId, causationPosition: f.turn.latestPendingEntryPosition } });
+		restartedAliases.set(persistedTask.taskId, restartedTask);
+		const restartedRunning = restarted._DrainPendingTasks();
+		await _Eventually(async function _RestartWaiting() { return (await _First.toolInvocation.findFirstOrThrow({ where: { runId: f.runId } })).state === ToolInvocationState.Ready; });
+		const command = await runtime.authority.claimCompanion(registered.identity, registered.executionReference);
+		if (command === null || typeof command === "string" || command.kind !== "invocation")
+			throw new Error("Expected the real invocation claim");
+		await expect(runtime.authority.completeCompanion(registered.identity, { executionReference: registered.executionReference, podUid: registered.identity.podUid, executionId: command.executionId, claimFence: command.claimFence, completion: { kind: command.kind, result: { isError: false, content: [{ type: "text", text: "approved SQL result" }] } } })).resolves.toBe("completed");
+		await _Eventually(async function _ExecutionSaved() { return (await _First.mcpRuntimeExecution.count({ where: { siloId: f.siloId } })) === 1; });
+		const invocationAfter = await _First.toolInvocation.findFirstOrThrow({ where: { runId: f.runId } });
+		await new PrismaConversationComputerTurnWorkflowEventRepository(_First as never, restartedEventPort).emit({ runId: f.runId, attempt: 1, eventType: ToolInvocationEventTypes.Completed, payload: { toolInvocationId: invocationAfter.toolInvocationId } });
+		await restartedRunning;
+		expect(advanceCount).toBe(4);
+		expect(emitted).toEqual([`tool-approval:${invocationAfter.toolInvocationId}`, `tool-result:${invocationAfter.toolInvocationId}`]);
+		expect(invocationAfter.id).not.toBe(invocationAfter.toolInvocationId);
+		expect(await _First.mcpRuntimeExecution.count({ where: { siloId: f.siloId } })).toBe(1);
+		expect(await _First.toolInvocation.count({ where: { runId: f.runId } })).toBe(1);
+		expect(await _First.toolResultDelivery.count({ where: { toolInvocationId: invocationAfter.id, state: ToolResultDeliveryState.Consumed } })).toBe(1);
+		await expect(resultReader!.consume(_ResultTurn(f, invocationAfter.toolInvocationId, invocationAfter.requestFingerprint, (await _First.toolResultDelivery.findUniqueOrThrow({ where: { toolInvocationId: invocationAfter.id } })).payloadDigest) as never, _WORKLOAD)).resolves.toMatchObject({ outcome: "available" });
+		expect(await _First.toolResultDelivery.count({ where: { toolInvocationId: invocationAfter.id, state: ToolResultDeliveryState.Consumed } })).toBe(1);
+		expect((await _First.runInputSnapshot.findFirstOrThrow({ where: { runId: f.runId } })).budgetPolicy).toMatchObject({ maxToolInvocations: 1 });
+	});
+
+	it("expires an unanswered approval into one saved terminal result without dispatch", async function _ExpiredJourney()
+	{
+		const f = await _SeedConversationToolProposalSqlFixture({ approvalRequired: true, runLifetimeMs: 1_500 });
+		const runtime = _ToolHandoffSqlRuntime(_First, f);
+		_Runtimes.add(runtime);
+		const owner = new PrismaConversationToolProposalUnitOfWork(_First, f.dependencies, runtime.admission, async function _ApprovalExpiry(transaction, command) { await new PrismaElicitationRepository(transaction as never).expireDue(command); });
+		const opened = await owner.admit(f.turn, f.candidate, f.proposal, _WORKLOAD);
+		const pending = await _First.toolInvocation.findFirstOrThrow({ where: { runId: f.runId } });
+		expect(opened.proposalId).toBe(pending.toolInvocationId);
+		expect(pending.id).not.toBe(pending.toolInvocationId);
+		expect(pending.state).toBe(ToolInvocationState.AwaitingApproval);
+		expect(await _First.mcpRuntimeExecution.count({ where: { siloId: f.siloId } })).toBe(0);
+		await _WaitPastSqlDeadline(_First, f.candidate.compiledInput.budget.wallClockDeadlineEpochMs!);
+		await new PrismaElicitationRepository(_First as never).expireDue({ runId: f.runId, attempt: 1, now: new Date() });
+		await expect(owner.admit(f.turn, f.candidate, f.proposal, _WORKLOAD)).resolves.toMatchObject({ proposalId: pending.toolInvocationId });
+		const expired = await _First.toolInvocation.findUniqueOrThrow({ where: { id: pending.id } });
+		expect(expired.state).toBe(ToolInvocationState.Failed);
+		expect(expired.failureCode).toBe("approval_expired");
+		expect(await _First.agentRun.findUniqueOrThrow({ where: { id: f.runId } })).toMatchObject({ state: AgentRunState.Running });
+		expect(await _First.mcpRuntimeExecution.count({ where: { siloId: f.siloId } })).toBe(0);
+		expect(await _First.toolResultDelivery.count({ where: { toolInvocationId: pending.id, state: ToolResultDeliveryState.Pending } })).toBe(1);
+	});
+
+	it("denies the saved approval before runtime admission", async function _DeniedJourney()
+	{
+		const f = await _SeedConversationToolProposalSqlFixture({ approvalRequired: true });
+		const runtime = _ToolHandoffSqlRuntime(_First, f);
+		_Runtimes.add(runtime);
+		const owner = new PrismaConversationToolProposalUnitOfWork(_First, f.dependencies, runtime.admission, async function _ApprovalExpiry(transaction, command) { await new PrismaElicitationRepository(transaction as never).expireDue(command); });
+		await owner.admit(f.turn, f.candidate, f.proposal, _WORKLOAD);
+		const pending = await _First.toolInvocation.findFirstOrThrow({ where: { runId: f.runId } });
+		const approval = await _First.approvalRequest.findFirstOrThrow({ where: { runId: f.runId } });
+		const elicitation = new PrismaElicitationUnitOfWork(_First);
+		await expect(elicitation.respond({ siloId: f.siloId, conversationId: f.turn.binding.conversationId, requestId: approval.elicitationRequestId!, subjectId: f.principalId, verifiedStepUpAt: new Date(), submission: { idempotencyKey: `deny-${f.runId}`, response: { kind: ElicitationBodyKinds.Approval, approved: false } }, now: new Date() })).resolves.toMatchObject({ outcome: "accepted" });
+		const denied = await _First.toolInvocation.findUniqueOrThrow({ where: { id: pending.id } });
+		expect(denied).toMatchObject({ state: ToolInvocationState.Failed, failureCode: "approval_denied" });
+		expect(await _First.mcpRuntimeExecution.count({ where: { siloId: f.siloId } })).toBe(0);
+		expect(await _First.toolResultDelivery.count({ where: { toolInvocationId: pending.id, state: ToolResultDeliveryState.Pending } })).toBe(1);
+	});
+});
+
+async function _Eventually(check: () => Promise<boolean>): Promise<void>
+{
+	for (let attempt = 0; attempt < 100; attempt++)
+	{
+		if (await check())
+			return;
+		await new Promise(resolve => setTimeout(resolve, 10));
+	}
+	throw new Error("SQL approval fixture did not reach its expected durable state");
+}
+
+async function _EventuallyValue<TValue>(read: () => Promise<TValue | null>): Promise<TValue>
+{
+	let value: TValue | null = null;
+	await _Eventually(async function _Read() { value = await read(); return value !== null; });
+	return value!;
+}
+
+function _EventPort(workflows: __FakeWorkflowEngine, emitted: string[], taskAliases: ReadonlyMap<string, { readonly taskId: string; readonly taskName: string; readonly idempotencyKey: string }>): Pick<IWorkflowEngine, "emitEventInTransaction">
+{
+	return { emitEventInTransaction: async function _Emit(transaction: unknown, task: IWorkflowTaskReceipt, event: { readonly eventName: string; readonly payload: unknown })
+	{
+		emitted.push(event.eventName);
+		return workflows.emitEventInTransaction(transaction as never, taskAliases.get(task.taskId) ?? task, event as never);
+	} } as Pick<IWorkflowEngine, "emitEventInTransaction">;
+}
+
+function _ResultReader(f: Awaited<ReturnType<typeof _SeedConversationToolProposalSqlFixture>>, invocation: { readonly toolInvocationId: string; readonly requestFingerprint: string }, resultDigest: string): PrismaConversationToolResultsUnitOfWork
+{
+	return new PrismaConversationToolResultsUnitOfWork(_First, f.siloId, { load: async function _Load() { return _ResultTurn(f, invocation.toolInvocationId, invocation.requestFingerprint, resultDigest); } } as never, { admit: async function _Admit() {} }, f.dependencies);
+}
+
+function _ResultTurn(f: Awaited<ReturnType<typeof _SeedConversationToolProposalSqlFixture>>, proposalId: string, requestFingerprint: string, resultDigest: string): unknown
+{
+	const deadline = f.candidate.compiledInput.budget.wallClockDeadlineEpochMs!;
+	return { ...f.turn, modelReservation: { ordinal: 1 as const, tools: "select", compiledInputDigest: f.turn.compile.digest, invocationFence: "model-fence", requestDigest: "sha256:request", maxCompletionTokens: 128, authorityExpiresAtEpochMs: deadline, dispatchDeadlineEpochMs: deadline }, toolSelection: { proposalId, requestFingerprint, payloadRef: "payload-ref", ciphertextDigest: "sha256:cipher" }, continuationReservation: resultDigest === "sha256:cipher" ? null : { ordinal: 2 as const, tools: "none", compiledInputDigest: f.turn.compile.digest, invocationFence: "continuation-fence", requestDigest: "sha256:continuation", maxCompletionTokens: 128, authorityExpiresAtEpochMs: deadline, dispatchDeadlineEpochMs: deadline, continuation: { payloadRef: "continuation-ref", ciphertextDigest: resultDigest }, proposalId, resultDigest } };
+}

--- a/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-proposal.sql-fixture.ts
+++ b/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-proposal.sql-fixture.ts
@@ -18,7 +18,7 @@ import { _CreateConversationToolDispatchDependencies } from "../../workflows/mcp
  * Immutable rows remain in the disposable CI database until its normal teardown. This helper
  * never disables constraints, deletes product history or connects to a Kubernetes database.
  */
-export async function _SeedConversationToolProposalSqlFixture(options: { readonly runLifetimeMs?: number; readonly trustLifetimeMs?: number; readonly currentLeaseLifetimeMs?: number; readonly currentMembershipLifetimeMs?: number } = {})
+export async function _SeedConversationToolProposalSqlFixture(options: { readonly runLifetimeMs?: number; readonly trustLifetimeMs?: number; readonly currentLeaseLifetimeMs?: number; readonly currentMembershipLifetimeMs?: number; readonly approvalRequired?: boolean } = {})
 {
 	const prefix = `tool-proof-${randomUUID()}`;
 	const id = (suffix: string) => `${prefix}-${suffix}`;
@@ -44,7 +44,7 @@ export async function _SeedConversationToolProposalSqlFixture(options: { readonl
 		requester: { membership, siloId, requesterPrincipalId: principalId, requestIdempotencyKey: id("request"), authenticatedAt: now.toISOString() },
 		admission: { authorizingPrincipalId: principalId, decisionEvidenceId: id("admission-evidence"), admittedAt: now.toISOString() } });
 	const schema = { type: "object", required: ["query"], properties: { query: { type: "string" } }, additionalProperties: false };
-	const tool = { name: "records.read", toolRevisionId: id("tool"), description: "Read a dedicated test record", requiresApproval: false, parametersSchema: schema, parametersSchemaDigest: ___DigestCanonicalJson(schema) };
+	const tool = { name: "records.read", toolRevisionId: id("tool"), description: "Read a dedicated test record", requiresApproval: options.approvalRequired === true, parametersSchema: schema, parametersSchemaDigest: ___DigestCanonicalJson(schema) };
 	const budgetPolicy = { maxModelTurns: 2, maxCompletionTokens: 1_024, maxToolInvocations: 1, wallClockDeadlineEpochMs: now.getTime() + (options.runLifetimeMs ?? 240_000) };
 	const snapshot: RunInputSnapshot = { runId, attempt: 1, siloId, agentServiceId, agentRevisionId, snapshotVersion: 1, conversationId, messageIds: [], personaRevisionId: id("persona"), preferenceFactIds: [], artifactRevisionIds: [], skillRevisionIds: [], memoryQueryPolicy: {}, mcpTools: [{ toolRevisionId: tool.toolRevisionId, name: tool.name, description: tool.description, inputSchema: schema, inputSchemaDigest: tool.parametersSchemaDigest }], modelRoute: { alias: modelId, modelDefinitionId: modelId, litellmModelId: `litellm-${modelId}`, maxOutputTokens: 512, generatedOutputCapabilities: [] }, budgetPolicy, executionSubject: subject, promptCompilerVersion: "tool-proof-v1", digest: "", compiledAt: now.toISOString() };
 	const snapshotDigest = __DigestRunInputSnapshot(snapshot);
@@ -72,6 +72,7 @@ export async function _SeedConversationToolProposalSqlFixture(options: { readonl
 		await setup.query("UPDATE agent_services SET state='active', active_revision_id=$2 WHERE id=$1", [agentServiceId, agentRevisionId]);
 		await setup.query("SELECT pg_temp.seed_agent_conversation($1, $2, $3)", [conversationId, siloId, agentServiceId]);
 		await setup.query("SELECT pg_temp.seed_participant($1, $2)", [conversationId, principalId]);
+		await setup.query("INSERT INTO conversation_computer_active_leases (computer_id, silo_id, conversation_id, agent_identity_id, lease_id, lease_generation, expires_at, updated_at) VALUES ($1, $2, $3, $4, $5, 1, $6, $7)", [computerId, siloId, conversationId, agentIdentityId, lease.leaseId, leaseExpiresAt, now]);
 		await setup.query("INSERT INTO agent_runs (id, silo_id, agent_service_id, agent_revision_id, conversation_id, trigger, agent_identity_id, principal_id, execution_subject, request_idempotency_key, input_snapshot_digest) VALUES ($1, $2, $3, $4, $5, 'interactive', $6, $7, $8::jsonb, $9, $10)", [runId, siloId, agentServiceId, agentRevisionId, conversationId, agentIdentityId, principalId, JSON.stringify(subject), id("request"), snapshotDigest]);
 		await setup.query("INSERT INTO run_input_snapshots (id, run_id, attempt, snapshot_version, silo_id, agent_service_id, agent_revision_id, agent_identity_id, principal_id, execution_subject, conversation_id, model_route, mcp_tools, memory_query_policy, budget_policy, prompt_compiler_version, input_digest, created_at, persona_revision_id) VALUES ($1, $2, 1, 1, $3, $4, $5, $6, $7, $8::jsonb, $9, $10::jsonb, $11::jsonb, '{}'::jsonb, $12::jsonb, 'tool-proof-v1', $13, $14, $15)", [id("snapshot"), runId, siloId, agentServiceId, agentRevisionId, agentIdentityId, principalId, JSON.stringify(subject), conversationId, JSON.stringify(snapshot.modelRoute), JSON.stringify(snapshot.mcpTools), JSON.stringify(budgetPolicy), snapshotDigest, now, id("persona")]);
 		await setup.query("SET CONSTRAINTS ALL IMMEDIATE");

--- a/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-proposal.sql.test.ts
+++ b/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-proposal.sql.test.ts
@@ -31,7 +31,7 @@ function _Runtime(client: PrismaClient, fixture: Awaited<ReturnType<typeof _Seed
 /** Compose the same atomic admission port used by the application. */
 function _Owner(client: PrismaClient, fixture: Awaited<ReturnType<typeof _SeedConversationToolProposalSqlFixture>>)
 {
-	return new PrismaConversationToolProposalUnitOfWork(client, fixture.dependencies, _Runtime(client, fixture).admission);
+	return new PrismaConversationToolProposalUnitOfWork(client, fixture.dependencies, _Runtime(client, fixture).admission, async function _ApprovalExpiry() {});
 }
 
 /** Hold the first two count reads until both transactions have observed the unreserved slot. */
@@ -107,7 +107,7 @@ describe("conversation tool proposal admission on fresh PostgreSQL", function _S
 		let created = 0;
 		const client = _First.$extends({ query: { toolInvocation: { async create({ args, query }) { const row = await query(args); created++; return row; } } } });
 		const dependencies = { ...f.dependencies, computers: { load: async function _RevokedComputer() { return null; } } };
-		const owner = new PrismaConversationToolProposalUnitOfWork(client as unknown as PrismaClient, dependencies, _Runtime(_First, f).admission);
+		const owner = new PrismaConversationToolProposalUnitOfWork(client as unknown as PrismaClient, dependencies, _Runtime(_First, f).admission, async function _ApprovalExpiry() {});
 		const auditsBefore = await _Second.auditDecision.count({ where: { siloId: f.siloId } });
 		await expect(owner.admit(f.turn, f.candidate, f.proposal, _WORKLOAD)).rejects.toThrow("conversation_tool_proposal_denied");
 		expect(created).toBe(1);

--- a/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-result.sql.test.ts
+++ b/apps/opencrane/src/bootstrap/conversations/__tests__/conversation-tool-result.sql.test.ts
@@ -89,7 +89,7 @@ async function _Completed(reserve = true)
 	const fixture = await _SeedConversationToolProposalSqlFixture();
 	const runtime = _ToolHandoffSqlRuntime(_First, fixture);
 	_Runtimes.add(runtime);
-	await new PrismaConversationToolProposalUnitOfWork(_First, fixture.dependencies, runtime.admission).admit(fixture.turn, fixture.candidate, fixture.proposal, _AUDITED_WORKLOAD);
+	await new PrismaConversationToolProposalUnitOfWork(_First, fixture.dependencies, runtime.admission, async function _ApprovalExpiry() {}).admit(fixture.turn, fixture.candidate, fixture.proposal, _AUDITED_WORKLOAD);
 	const registered = (await runtime.register())!;
 	const command = await runtime.authority.claimCompanion(registered.identity, registered.executionReference);
 	if (command === null || typeof command === "string" || command.kind !== "invocation")

--- a/apps/opencrane/src/bootstrap/conversations/conversation-computer-workflow-composition.ts
+++ b/apps/opencrane/src/bootstrap/conversations/conversation-computer-workflow-composition.ts
@@ -1,6 +1,7 @@
 import type * as k8s from "@kubernetes/client-node";
+import { PrismaElicitationRepository } from "@opencrane/backend/agents/execution/elicitation";
 import { PrismaConversationRunLifecycleUnitOfWork } from "@opencrane/backend/agents/execution/runs";
-import { PrismaConversationToolProposalUnitOfWork, PrismaConversationToolResultsUnitOfWork, PrismaConversationModelCustodyUnitOfWork, ConversationComputerTurnWriterFactory, ActiveConversationComputerTurnCandidateResolver, ConversationComputerTurnAuthorityService, KeyedConversationComputerReviewCredentialDeriver, KurrentConversationComputerTurnStore, PrismaConversationComputerCredentialUnitOfWork, PrismaConversationComputerTurnUnitOfWork, PrismaConversationComputerTurnWorkflowReceiptBinder, _CreateConversationComputerReviewCredentialRouter, _RegisterConversationComputerTurnWorkflow, type ConversationComputerRunAdmissionPort, type ConversationToolProposalRuntimeAdmission } from "@opencrane/backend/server/conversations";
+import { PrismaConversationToolProposalUnitOfWork, PrismaConversationToolResultsUnitOfWork, PrismaConversationModelCustodyUnitOfWork, ConversationComputerTurnWriterFactory, ActiveConversationComputerTurnCandidateResolver, ConversationComputerTurnAuthorityService, KeyedConversationComputerReviewCredentialDeriver, KurrentConversationComputerTurnStore, PrismaConversationComputerCredentialUnitOfWork, PrismaConversationComputerTurnUnitOfWork, PrismaConversationComputerTurnWorkflowReceiptBinder, PrismaConversationComputerTurnWorkflowEventRepository, _CreateConversationComputerReviewCredentialRouter, _RegisterConversationComputerTurnWorkflow, type ConversationComputerRunAdmissionPort, type ConversationToolProposalRuntimeAdmission } from "@opencrane/backend/server/conversations";
 import { ConversationComputerHistory } from "@opencrane/backend/server/conversations/computers";
 import { AesGcmConversationPrivatePayloadCipher, _ReadConversationPrivatePayloadKeyring } from "@opencrane/backend/server/conversations/history";
 import { __RequestConversationModel, _IssueAttemptLiteLlmKey, _RevokeAttemptLiteLlmKey, _RevokeAttemptLiteLlmKeyByAlias } from "@opencrane/backend/server/gateways/model-routing";
@@ -8,7 +9,7 @@ import { _CreateHumanMembershipEvidenceConfig } from "@opencrane/backend/server/
 import { AgentSandboxPodBindingAdapter } from "@opencrane/backend/server/infra/agent-sandbox";
 import { type HistoryStore } from "@opencrane/backend/server/infra/history-store";
 import { _CreateConversationComputerTokenReviewer } from "@opencrane/backend/server/infra/workload-identity";
-import { type PrismaClient } from "@prisma/client";
+import { Prisma, type PrismaClient } from "@prisma/client";
 import { type AgentSandboxReleaseProfileConfig } from "../configuration/config.types";
 import { _log } from "../process/log";
 import { _CreateConversationToolDispatchDependencies } from "../workflows/mcp-runtime-composition";
@@ -24,7 +25,11 @@ export function _CreateConversationComputerWorkflowComposition(prisma: PrismaCli
 	const credentials = new PrismaConversationComputerCredentialUnitOfWork(prisma, cipher, { issue: _IssueAttemptLiteLlmKey, revoke: _RevokeAttemptLiteLlmKey, revokeByAlias: _RevokeAttemptLiteLlmKeyByAlias }, siloId);
 	const turnStore = new KurrentConversationComputerTurnStore(history);
 	const toolDependencies = _CreateConversationToolDispatchDependencies(history, _CreateHumanMembershipEvidenceConfig());
-	const toolProposals = new PrismaConversationToolProposalUnitOfWork(prisma, toolDependencies, runtimeAdmission);
+	async function _ExpireApproval(transaction: unknown, command: { readonly runId: string; readonly attempt: number; readonly now: Date }): Promise<void>
+	{
+		await new PrismaElicitationRepository(transaction as Prisma.TransactionClient, new PrismaConversationComputerTurnWorkflowEventRepository(transaction as Prisma.TransactionClient, workflows)).expireDue(command);
+	}
+	const toolProposals = new PrismaConversationToolProposalUnitOfWork(prisma, toolDependencies, runtimeAdmission, _ExpireApproval);
 	const toolResults = new PrismaConversationToolResultsUnitOfWork(prisma, siloId, turnStore, candidates, toolDependencies);
 	const writers = new ConversationComputerTurnWriterFactory(history, turnStore, candidates, toolResults);
 	const modelCustody = new PrismaConversationModelCustodyUnitOfWork(prisma, cipher);

--- a/apps/opencrane/src/bootstrap/http/routes.ts
+++ b/apps/opencrane/src/bootstrap/http/routes.ts
@@ -1,6 +1,6 @@
 import { _CreateResourceShareCallerResolver } from "@opencrane/backend/server/iam/grants";
 import { Router, type Express, type Request } from "express";
-import type { PrismaClient } from "@prisma/client";
+import type { Prisma, PrismaClient } from "@prisma/client";
 import type * as k8s from "@kubernetes/client-node";
 
 import { aiBudgetRouter, tokenUsageRouter } from "@opencrane/backend/server/reporting/spend";
@@ -25,6 +25,7 @@ import { _CreateConversationHistoryComposition } from "../conversations/conversa
 import { _ReadConversationPrivatePayloadKeyring } from "@opencrane/backend/server/conversations/history";
 import { _ConversationComputerReviewAuthority, _CreateConversationComputerReviewRouter, KeyedConversationComputerReviewCredentialDeriver, PrismaConversationMetadataReader } from "@opencrane/backend/server/conversations";
 import { ConversationComputerHistory } from "@opencrane/backend/server/conversations/computers";
+import { PrismaConversationComputerTurnWorkflowEventRepository } from "@opencrane/backend/server/conversations";
 import type { HistoryStore } from "@opencrane/backend/server/infra/history-store";
 import { _ResolveSkillAuthoringValidationCaller, PrismaSkillAuthoringValidationSubmissionUnitOfWork, _CreateSkillCatalogueRouter, __CreateSkillAuthoringValidationSubmissionRouter } from "@opencrane/backend/server/agents/skills";
 import { _ResolveRequestPrincipal } from "@opencrane/backend/server/infra/auth";
@@ -84,7 +85,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, artifactScan
 		{ method: "use", path: "/api/v1/me/conversations", handler: __CreateConversationAssetRouter({ resolveCaller: _ResolveConversationAssetCaller, authority: _CreateConversationAssetAuthority(prisma, process.env, artifactScannerEnabled), logger: _log }) },
 		..._OptionalRoute("/api/v1/me/conversations", conversationHistory),
 		..._OptionalRoute("/api/v1/me/conversations", computerReview),
-		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfElicitationRouter(prisma, _log) },
+		{ method: "use", path: "/api/v1/me/conversations", handler: _CreateSelfElicitationRouter(prisma, _log, transaction => new PrismaConversationComputerTurnWorkflowEventRepository(transaction as Prisma.TransactionClient, mcpWorkflows.execution)) },
 		{ method: "use", path: "/api/v1/me/activity", handler: _CreateSelfElicitationActivityRouter(prisma, _log) },
 	];
 	const gatewayRoutes: readonly RouteMount[] = [

--- a/libs/backend/agents/execution/elicitation/main/README.md
+++ b/libs/backend/agents/execution/elicitation/main/README.md
@@ -41,6 +41,11 @@ The package owns request, response-attempt, result-delivery, and one-use memory-
 Tool approval keeps its own audit row, and runtime, browser, and A2UI payloads cannot select the
 respondent, dataset, or protected action.
 
+For a personal approval, the assigned participant answers the server-issued request. IAM changes
+the invocation to ready or failed inside that response transaction, and an injected wake port emits
+the existing saved-turn event only after the final pending input is gone. The wake port belongs to
+conversation composition, so this package does not create a scheduler or dispatch a tool.
+
 Runtime protocol code passes its existing transaction into `PrismaRuntimeElicitationUnitOfWork`.
 That unit constructs one repository from the same transaction and reuses it for the callback. This
 keeps the run lock, request change, candidate acceptance, and expiry decision in one commit without

--- a/libs/backend/agents/execution/elicitation/main/src/__tests__/prisma-elicitation-unit-of-work.test.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/__tests__/prisma-elicitation-unit-of-work.test.ts
@@ -1,4 +1,4 @@
-import { AgentRunState, ElicitationPurpose, ElicitationRequestState, ExternalActionClaimKind, PersonalMemoryPermissionReceiptState, Prisma, ToolInvocationState } from "@prisma/client";
+import { AgentRunState, ApprovalRequestState, ElicitationPurpose, ElicitationRequestState, ExternalActionClaimKind, PersonalMemoryPermissionReceiptState, Prisma, ToolInvocationState } from "@prisma/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const _productAuthorization = vi.hoisted(function _ProductAuthorization()
@@ -6,25 +6,37 @@ const _productAuthorization = vi.hoisted(function _ProductAuthorization()
 	return { canRead: vi.fn().mockResolvedValue(true), filterReadable: vi.fn(async function _All(_siloId: string, _subjectId: string, ids: readonly string[]) { return new Set(ids); }), admitResponse: vi.fn().mockResolvedValue(true) };
 });
 
+const _deferredAuthorization = vi.hoisted(function _DeferredAuthorization()
+{
+	return { decide: vi.fn().mockResolvedValue({ outcome: "approved" }), expire: vi.fn().mockResolvedValue(undefined) };
+});
+
 vi.mock("../elicitation-product-authorization", function _MockProductAuthorization()
 {
 	return { PrismaElicitationProductAuthorizationRepository: class { canReadConversation = _productAuthorization.canRead; filterReadableConversationIds = _productAuthorization.filterReadable; admitResponse = _productAuthorization.admitResponse; } };
+});
+
+vi.mock("@opencrane/backend/server/iam/authorization", async function _MockAuthorization(importOriginal)
+{
+	const original = await importOriginal<typeof import("@opencrane/backend/server/iam/authorization")>();
+	return { ...original, __DecideDeferredToolRequest: _deferredAuthorization.decide, __ExpireDeferredToolApprovalBatch: _deferredAuthorization.expire };
 });
 
 import { __DigestCanonicalJson, ExternalActionClaimKinds, ExternalActionRecoveryModes, ToolInvocationStates, type ToolInvocationAuthorizationEvidence, type ToolInvocationClaim, type ToolInvocationRecord } from "@opencrane/backend/server/iam/authorization";
 import { ElicitationBodyKinds, ElicitationPurposes, type RunInputSnapshot } from "@opencrane/contracts";
 import { ExecutionSubjectMembershipKinds, PERSONAL_MEMORY_RECALL_TOOL_REVISION } from "@opencrane/models/agents";
 
-import { PrismaElicitationUnitOfWork } from "../prisma-elicitation-unit-of-work";
+import { PrismaElicitationRepository, PrismaElicitationUnitOfWork } from "../prisma-elicitation-unit-of-work";
+import type { ElicitationRunWakePort } from "../elicitation.types";
 import { PrismaRuntimeElicitationUnitOfWork } from "../prisma-runtime-elicitation-unit-of-work";
 import { _BuildMemoryPermissionPayload } from "../purposes/personal-memory/personal-memory-permission-payload";
 
 const NOW = new Date("2026-08-11T10:00:00.000Z");
 
 /** Bind one transaction double to the process-owned unit-of-work boundary. */
-function _Unit(transaction: object): PrismaElicitationUnitOfWork
+function _Unit(transaction: object, wake: ElicitationRunWakePort | null = null): PrismaElicitationUnitOfWork
 {
-	return new PrismaElicitationUnitOfWork({ $transaction: vi.fn(async function _Transaction(operation) { return operation(transaction); }) } as never);
+	return new PrismaElicitationUnitOfWork({ $transaction: vi.fn(async function _Transaction(operation) { return operation(transaction); }) } as never, wake === null ? null : function _WakeFactory() { return wake; });
 }
 
 /** Active membership and current parent-coupled participant access. */
@@ -47,7 +59,7 @@ function _ResponseTransaction(request = _Request())
 		elicitationRequest: { findUnique: vi.fn().mockResolvedValue(request), updateMany: vi.fn().mockResolvedValue({ count: 1 }), count: vi.fn().mockResolvedValue(0) },
 		elicitationResponseAttempt: { findUnique: vi.fn().mockResolvedValue(null), create: vi.fn().mockResolvedValue({ id: "attempt-1" }) },
 		agentRun: { findUnique: vi.fn().mockResolvedValue({ id: "run-1", attempt: 2, state: AgentRunState.WaitingForInput }), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
-		approvalRequest: { findUnique: vi.fn(), count: vi.fn().mockResolvedValue(0) },
+		approvalRequest: { findUnique: vi.fn(), findMany: vi.fn().mockResolvedValue([]), count: vi.fn().mockResolvedValue(0) },
 		elicitationResultDelivery: { create: vi.fn().mockResolvedValue({ id: "delivery-1" }) },
 		personalMemoryPermissionReceipt: { create: vi.fn().mockResolvedValue({ id: "receipt-1" }) },
 		toolInvocation: { findUnique: vi.fn(), updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
@@ -188,6 +200,74 @@ describe("PrismaElicitationUnitOfWork", function _Suite()
 		expect(transaction.elicitationResultDelivery.create).toHaveBeenCalledTimes(1);
 		expect(transaction.elicitationResponseAttempt.create).toHaveBeenCalledTimes(1);
 		expect(transaction.agentRun.updateMany).toHaveBeenCalledTimes(1);
+	});
+
+	it("resumes the saved turn after the exact owner approves a tool", async function _WakesApprovedTool()
+	{
+		const request = _Request({ purpose: ElicitationPurpose.ToolApproval, bodyKind: "Approval", body: { kind: ElicitationBodyKinds.Approval, prompt: "Allow this action?", action: "Update a record", target: "remote record", dataUse: "Send the reviewed arguments", consequence: "The remote record changes" } });
+		const transaction = _ResponseTransaction(request);
+		const invocationRowId = "invocation-row-1";
+		const publicInvocationId = "public-invocation-1";
+		transaction.approvalRequest.findUnique.mockResolvedValue({ id: "approval-1", siloId: "silo-1", reviewedToolArguments: { recordId: "record-1" }, toolInvocationRowId: invocationRowId });
+		transaction.approvalRequest.findMany.mockResolvedValue([{ id: "approval-1", toolInvocationRowId: invocationRowId, state: ApprovalRequestState.Approved }]);
+		transaction.toolInvocation.findUnique.mockResolvedValue(_MemoryInvocation({ id: invocationRowId, toolInvocationId: publicInvocationId }));
+		const wake = { wake: vi.fn().mockResolvedValue(undefined) };
+
+		await expect(_Unit(transaction, wake).respond({ siloId: "silo-1", conversationId: "conversation-1", requestId: "request-1", subjectId: "user-1", verifiedStepUpAt: null, submission: { idempotencyKey: "retry-approval", response: { kind: ElicitationBodyKinds.Approval, approved: true } }, now: NOW })).resolves.toMatchObject({ outcome: "accepted", projection: { state: "answered" } });
+		expect(_deferredAuthorization.decide).toHaveBeenCalledWith(transaction, expect.objectContaining({ approvalRequestId: "approval-1", reviewerSubjectId: "user-1", decidedBy: "user-1", arguments: { recordId: "record-1" } }));
+		expect(wake.wake).toHaveBeenCalledOnce();
+		expect(wake.wake).toHaveBeenCalledWith("run-1", 2, publicInvocationId);
+	});
+
+	it("wakes a decided tool approval when a generic request resolves last", async function _WakesEarlierApprovedTool()
+	{
+		const transaction = _ResponseTransaction();
+		const invocationRowId = "invocation-row-approved";
+		const publicInvocationId = "public-invocation-approved";
+		transaction.approvalRequest.findMany.mockResolvedValue([{ id: "approval-approved", toolInvocationRowId: invocationRowId, state: ApprovalRequestState.Approved }]);
+		transaction.toolInvocation.findUnique.mockResolvedValue(_MemoryInvocation({ id: invocationRowId, toolInvocationId: publicInvocationId }));
+		const wake = { wake: vi.fn().mockResolvedValue(undefined) };
+
+		await expect(_Unit(transaction, wake).respond({ siloId: "silo-1", conversationId: "conversation-1", requestId: "request-1", subjectId: "user-1", verifiedStepUpAt: null, submission: { idempotencyKey: "generic-last-approved", response: { kind: ElicitationBodyKinds.FreeText, text: "Done" } }, now: NOW })).resolves.toMatchObject({ outcome: "accepted" });
+		expect(transaction.approvalRequest.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: { runId: "run-1", attempt: 2, state: { in: [ApprovalRequestState.Approved, ApprovalRequestState.Denied, ApprovalRequestState.Expired] } } }));
+		expect(wake.wake).toHaveBeenCalledExactlyOnceWith("run-1", 2, publicInvocationId);
+	});
+
+	it("wakes the public invocation after an approval request expires", async function _WakesExpiredTool()
+	{
+		const request = _Request({ purpose: ElicitationPurpose.ToolApproval, bodyKind: "Approval", body: { kind: ElicitationBodyKinds.Approval, prompt: "Allow this action?", action: "Update a record", target: "remote record", dataUse: "Send the reviewed arguments", consequence: "The remote record changes" }, expiresAt: new Date("2026-08-11T09:59:00.000Z") });
+		const invocationRowId = "invocation-row-1";
+		const publicInvocationId = "public-invocation-1";
+		let runState: AgentRunState = AgentRunState.WaitingForInput;
+		const transaction = {
+			elicitationRequest: { findMany: vi.fn().mockResolvedValue([request]), updateMany: vi.fn().mockResolvedValue({ count: 1 }), count: vi.fn().mockResolvedValue(0) },
+			approvalRequest: { findUnique: vi.fn().mockResolvedValue({ toolInvocationRowId: invocationRowId }), findMany: vi.fn().mockResolvedValue([{ id: "approval-1", toolInvocationRowId: invocationRowId, state: ApprovalRequestState.Expired }]), count: vi.fn().mockResolvedValue(0) },
+			agentRun: { findUnique: vi.fn().mockImplementation(async function _Run() { return { id: "run-1", attempt: 2, state: runState }; }), updateMany: vi.fn().mockImplementation(async function _Resume() { runState = AgentRunState.Running; return { count: 1 }; }) },
+			toolInvocation: { findUnique: vi.fn().mockResolvedValue(_MemoryInvocation({ id: invocationRowId, toolInvocationId: publicInvocationId })) },
+		} as const;
+		const wake = { wake: vi.fn().mockResolvedValue(undefined) };
+
+		await expect(new PrismaElicitationRepository(transaction as never, wake).expireDue({ runId: "run-1", attempt: 2, now: NOW })).resolves.toEqual({ expiredCount: 1, resumed: true });
+		expect(wake.wake).toHaveBeenCalledWith("run-1", 2, publicInvocationId);
+	});
+
+	it("wakes an expired tool approval when a generic request expires last", async function _WakesEarlierExpiredTool()
+	{
+		const request = _Request({ expiresAt: new Date("2026-08-11T09:59:00.000Z") });
+		const invocationRowId = "invocation-row-expired";
+		const publicInvocationId = "public-invocation-expired";
+		let runState: AgentRunState = AgentRunState.WaitingForInput;
+		const transaction = {
+			elicitationRequest: { findMany: vi.fn().mockResolvedValue([request]), updateMany: vi.fn().mockResolvedValue({ count: 1 }), count: vi.fn().mockResolvedValue(0) },
+			approvalRequest: { findMany: vi.fn().mockResolvedValue([{ id: "approval-expired", toolInvocationRowId: invocationRowId, state: ApprovalRequestState.Expired }]), count: vi.fn().mockResolvedValue(0) },
+			elicitationResultDelivery: { create: vi.fn().mockResolvedValue({ id: "delivery-1" }) },
+			agentRun: { findUnique: vi.fn().mockImplementation(async function _Run() { return { id: "run-1", attempt: 2, state: runState }; }), updateMany: vi.fn().mockImplementation(async function _Resume() { runState = AgentRunState.Running; return { count: 1 }; }) },
+			toolInvocation: { findUnique: vi.fn().mockResolvedValue(_MemoryInvocation({ id: invocationRowId, toolInvocationId: publicInvocationId })) },
+		} as const;
+		const wake = { wake: vi.fn().mockResolvedValue(undefined) };
+
+		await expect(new PrismaElicitationRepository(transaction as never, wake).expireDue({ runId: "run-1", attempt: 2, now: NOW })).resolves.toEqual({ expiredCount: 1, resumed: true });
+		expect(wake.wake).toHaveBeenCalledExactlyOnceWith("run-1", 2, publicInvocationId);
 	});
 
 	it.each(["input", "approval"])("keeps the run paused after a response while another %s remains pending", async function _pendingResponse(kind)

--- a/libs/backend/agents/execution/elicitation/main/src/elicitation.types.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/elicitation.types.ts
@@ -103,6 +103,16 @@ export interface ElicitationUnitOfWork extends SelfElicitationQueryRepository
 	respond(command: RespondToElicitationCommand): Promise<RespondToElicitationResult>;
 }
 
+/** Wakes the already-bound conversation turn after approval or expiry changes tool readiness. */
+export interface ElicitationRunWakePort
+{
+	/** Emit the existing approval-readiness event for the saved conversation turn task. */
+	wake(runId: string, attempt: number, toolInvocationId: string): Promise<void>;
+}
+
+/** Builds a transaction-bound wake port without letting elicitation own workflow infrastructure. */
+export type ElicitationRunWakeFactory = (transaction: object) => ElicitationRunWakePort;
+
 /** Trusted server command for expiring every due request on one waiting run attempt. */
 export interface ExpireElicitationBatchCommand
 {

--- a/libs/backend/agents/execution/elicitation/main/src/index.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/index.ts
@@ -1,6 +1,6 @@
-export { PrismaElicitationUnitOfWork } from "./prisma-elicitation-unit-of-work";
+export { PrismaElicitationRepository, PrismaElicitationUnitOfWork } from "./prisma-elicitation-unit-of-work";
 export { PrismaRuntimeElicitationUnitOfWork } from "./prisma-runtime-elicitation-unit-of-work";
 export { _ElicitationOpenapiPaths } from "./openapi";
 export { _CreateSelfElicitationActivityRouter, _CreateSelfElicitationRouter } from "./prisma-self-elicitation.router";
 export { PersonalMemoryPermissionVerificationOutcomes } from "./elicitation.types";
-export type { ExpireElicitationBatchCommand, ExpireElicitationBatchResult, OpenElicitationCommand, PersonalMemoryPermissionAuthority, PersonalMemoryPermissionVerificationResult, RuntimeElicitationUnitOfWork } from "./elicitation.types";
+export type { ElicitationRunWakeFactory, ElicitationRunWakePort, ExpireElicitationBatchCommand, ExpireElicitationBatchResult, OpenElicitationCommand, PersonalMemoryPermissionAuthority, PersonalMemoryPermissionVerificationResult, RuntimeElicitationUnitOfWork } from "./elicitation.types";

--- a/libs/backend/agents/execution/elicitation/main/src/prisma-elicitation-unit-of-work.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/prisma-elicitation-unit-of-work.ts
@@ -1,7 +1,7 @@
 import { AgentRunState, ApprovalRequestState, ElicitationBodyKind, ElicitationPurpose, ElicitationRequestState, OrgMemberStatus, Prisma, type PrismaClient } from "@prisma/client";
 
 import { ___DoWithTrace } from "@opencrane/backend/observability";
-import { __DigestCanonicalJson, type ToolInvocationClaim, type ToolInvocationRecord } from "@opencrane/backend/server/iam/authorization";
+import { __DigestCanonicalJson, __FindToolInvocationInTransaction, type ToolInvocationClaim, type ToolInvocationRecord } from "@opencrane/backend/server/iam/authorization";
 import { ElicitationBodyKinds, ElicitationPurposes, ElicitationRequestStates, type ConversationElicitation, type ElicitationBody, type RunInputSnapshot } from "@opencrane/contracts";
 import type { JsonValue } from "@opencrane/util";
 
@@ -15,7 +15,7 @@ import { PrismaToolApprovalPurposeAuthority } from "./purposes/tool-approval/pri
 import { PrismaA2uiActionPurposeAuthority } from "./purposes/a2ui-action/prisma-a2ui-action-purpose";
 import { PrismaPersonalMemoryPermissionPurposeAuthority } from "./purposes/personal-memory/prisma-personal-memory-permission-purpose";
 import { _Projection, _ProjectionAt, _PublicPurpose, _PublicState } from "./elicitation-prisma-mapping";
-import type { ElicitationRepository, ElicitationUnitOfWork, ExpireElicitationBatchCommand, ExpireElicitationBatchResult, OpenElicitationCommand, PersonalMemoryPermissionAuthority, PersonalMemoryPermissionVerificationResult, RespondToElicitationCommand, RespondToElicitationResult } from "./elicitation.types";
+import type { ElicitationRepository, ElicitationRunWakeFactory, ElicitationRunWakePort, ElicitationUnitOfWork, ExpireElicitationBatchCommand, ExpireElicitationBatchResult, OpenElicitationCommand, PersonalMemoryPermissionAuthority, PersonalMemoryPermissionVerificationResult, RespondToElicitationCommand, RespondToElicitationResult } from "./elicitation.types";
 
 /** Prisma repository bound to exactly one serializable elicitation transaction. */
 export class PrismaElicitationRepository implements ElicitationRepository
@@ -28,11 +28,14 @@ export class PrismaElicitationRepository implements ElicitationRepository
 	private readonly _productAuthorization: ElicitationProductAuthorization;
 	/** Selects the transaction-bound implementation for every saved purpose. */
 	private readonly _purposeStrategies: ElicitationPurposeStrategies;
+	/** Optional workflow wake owned by application composition. */
+	private readonly _wake: ElicitationRunWakePort | null;
 
 	/** Bind all request, response, purpose, and resume operations to one transaction. */
-	constructor(transaction: Prisma.TransactionClient)
+	constructor(transaction: Prisma.TransactionClient, wake: ElicitationRunWakePort | null = null)
 	{
 		this._transaction = transaction;
+		this._wake = wake;
 		this._memoryPermission = new PrismaPersonalMemoryPermissionPurposeAuthority(this._transaction);
 		this._productAuthorization = new PrismaElicitationProductAuthorizationRepository(this._transaction);
 		this._purposeStrategies = {
@@ -129,10 +132,13 @@ export class PrismaElicitationRepository implements ElicitationRepository
 		let approvalRequestId: string | null = null;
 		if (request.purpose === ElicitationPurpose.ToolApproval)
 		{
-			const approval = await transaction.approvalRequest.findUnique({ where: { elicitationRequestId: request.id }, select: { id: true } });
+			const approval = await transaction.approvalRequest.findUnique({ where: { elicitationRequestId: request.id }, select: { id: true, toolInvocationRowId: true } });
 			if (approval === null)
 				return { outcome: "unauthorized" };
 			approvalRequestId = approval.id;
+			const invocation = await __FindToolInvocationInTransaction(transaction, approval.toolInvocationRowId);
+			if (invocation === null || invocation.runId !== request.runId || invocation.attempt !== request.attempt)
+				return { outcome: "unauthorized" };
 		}
 		if (!await this._productAuthorization.admitResponse(command.siloId, command.subjectId, command.conversationId, approvalRequestId, command.submission.response as unknown as JsonValue, command.now))
 			return { outcome: "unauthorized" };
@@ -151,6 +157,7 @@ export class PrismaElicitationRepository implements ElicitationRepository
 			const resumed = await transaction.agentRun.updateMany({ where: { id: request.runId, attempt: request.attempt, state: AgentRunState.WaitingForInput }, data: { state: AgentRunState.Running } });
 			if (resumed.count !== 1)
 				throw new Error("elicitation response lost its waiting run fence");
+			await this._wakeDecidedToolApprovals(request.runId, request.attempt);
 		}
 		return { outcome: "accepted", projection: { requestId: request.id, state: publicState, idempotent: false, resolvedAt: command.now.toISOString() } };
 	}
@@ -247,6 +254,24 @@ export class PrismaElicitationRepository implements ElicitationRepository
 		const resumed = await this._transaction.agentRun.updateMany({ where: { id: request.runId, attempt: request.attempt, state: AgentRunState.WaitingForInput }, data: { state: AgentRunState.Running } });
 		if (resumed.count !== 1)
 			throw new Error("elicitation expiry lost its waiting run fence");
+		await this._wakeDecidedToolApprovals(request.runId, request.attempt);
+	}
+
+	/** Wake every terminal tool approval when the last input releases the run. */
+	private async _wakeDecidedToolApprovals(runId: string, attempt: number): Promise<void>
+	{
+		if (this._wake === null)
+			return;
+		const approvals = await this._transaction.approvalRequest.findMany({ where: { runId, attempt, state: { in: [ApprovalRequestState.Approved, ApprovalRequestState.Denied, ApprovalRequestState.Expired] } }, select: { toolInvocationRowId: true }, orderBy: { id: "asc" } });
+		const invocationIds = new Set<string>();
+		for (const approval of approvals)
+		{
+			const invocation = await __FindToolInvocationInTransaction(this._transaction, approval.toolInvocationRowId);
+			if (invocation !== null && invocation.runId === runId && invocation.attempt === attempt)
+				invocationIds.add(invocation.toolInvocationId);
+		}
+		for (const invocationId of invocationIds)
+			await this._wake.wake(runId, attempt, invocationId);
 	}
 }
 
@@ -264,11 +289,14 @@ export class PrismaElicitationUnitOfWork implements ElicitationUnitOfWork, Perso
 {
 	/** Canonical client used only to begin transactions. */
 	private readonly _prisma: PrismaClient;
+	/** Application-owned workflow wake factory bound inside each response transaction. */
+	private readonly _wakeFactory: ElicitationRunWakeFactory | null;
 
 	/** Bind the transaction owner to product persistence. */
-	constructor(prisma: PrismaClient)
+	constructor(prisma: PrismaClient, wakeFactory: ElicitationRunWakeFactory | null = null)
 	{
 		this._prisma = prisma;
+		this._wakeFactory = wakeFactory;
 	}
 
 	/** Open one request atomically. */
@@ -323,9 +351,10 @@ export class PrismaElicitationUnitOfWork implements ElicitationUnitOfWork, Perso
 	/** Construct exactly one transaction-bound repository. */
 	private async _execute<TResult>(work: (repository: ElicitationRepository) => Promise<TResult>): Promise<TResult>
 	{
+		const unit = this;
 		return this._prisma.$transaction(async function _Transaction(transaction): Promise<TResult>
 		{
-			const repository = new PrismaElicitationRepository(transaction);
+			const repository = new PrismaElicitationRepository(transaction, unit._wakeFactory === null ? null : unit._wakeFactory(transaction));
 			return work(repository);
 		}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
 	}

--- a/libs/backend/agents/execution/elicitation/main/src/prisma-self-elicitation.router.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/prisma-self-elicitation.router.ts
@@ -6,6 +6,7 @@ import { _ResolveRequestPrincipal } from "@opencrane/backend/server/infra/auth";
 
 import { PrismaElicitationUnitOfWork } from "./prisma-elicitation-unit-of-work";
 import { __CreateSelfElicitationActivityRouter, __CreateSelfElicitationRouter } from "./self-elicitation.router";
+import type { ElicitationRunWakeFactory } from "./elicitation.types";
 import type { SelfElicitationCaller } from "./self-elicitation.router.types";
 
 /** Map trusted browser-session facts into the elicitation caller contract. */
@@ -16,9 +17,9 @@ function _ResolveCaller(request: Parameters<typeof _ResolveRequestPrincipal>[0])
 }
 
 /** Compose the Prisma-backed self elicitation API. */
-export function _CreateSelfElicitationRouter(prisma: PrismaClient, logger: Logger): Router
+export function _CreateSelfElicitationRouter(prisma: PrismaClient, logger: Logger, wakeFactory: ElicitationRunWakeFactory | null = null): Router
 {
-	return __CreateSelfElicitationRouter({ resolveCaller: _ResolveCaller, elicitations: new PrismaElicitationUnitOfWork(prisma), clock: { now(): Date { return new Date(); } }, logger });
+	return __CreateSelfElicitationRouter({ resolveCaller: _ResolveCaller, elicitations: new PrismaElicitationUnitOfWork(prisma, wakeFactory), clock: { now(): Date { return new Date(); } }, logger });
 }
 
 /** Compose the Prisma-backed derived Activity index. */

--- a/libs/backend/agents/execution/inputs/main/README.md
+++ b/libs/backend/agents/execution/inputs/main/README.md
@@ -155,6 +155,10 @@ It receives canonical conversation messages through `VerifiedConversationPromptM
 so it has no relational transcript path. Missing rows, changed schemas, foreign model coordinates,
 inactive parents, and unsupported generated-output capabilities fail compilation closed.
 
+Approval-gated definitions remain available to personal model selection as declarative proposals.
+Managed company runs remove them from the compiled offer until an entitled human resolver and
+connection authority are bound; the compiler never turns a tool definition into permission to run it.
+
 ## Boundary
 
 Consumed by the OpenCrane bootstrap and conversation execution path. The conversation admission owner composes

--- a/libs/backend/agents/execution/inputs/main/src/prompt/__tests__/prisma-prompt-compiler-repository.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prompt/__tests__/prisma-prompt-compiler-repository.test.ts
@@ -1,9 +1,16 @@
+import { ExecutionSubjectMembershipKinds } from "@opencrane/models/agents";
 import { describe, expect, it, vi } from "vitest";
 
 import { PROMPT_COMPILER_VERSION } from "@opencrane/contracts";
 import { ___DigestCanonicalJson } from "@opencrane/util";
 
 import { PrismaPromptCompilerRepository, PrismaPromptCompilerUnitOfWork } from "../prisma-prompt-compiler-repository";
+
+/** Builds the verified personal execution subject required by the compiler boundary. */
+function _executionSubject()
+{
+	return { schemaVersion: 1, siloId: "silo-1", agentIdentityId: "identity-1", principalId: "principal-1", identity: { agentIdentityId: "identity-1", principalId: "principal-1", siloId: "silo-1", headRevision: "0", headDigest: `sha256:${"a".repeat(64)}`, decisionEvidenceId: "identity-decision-1", verifiedAt: "2026-09-06T00:00:00.000Z" }, membership: { kind: ExecutionSubjectMembershipKinds.Fleet, principalId: "principal-1", siloId: "silo-1", revision: 1, assertionId: "membership-1", payloadDigest: `sha256:${"b".repeat(64)}`, decisionEvidenceId: "membership-decision-1", trustedUntil: "2099-01-01T00:00:00.000Z" }, capability: { agentIdentityId: "identity-1", computerId: "computer-1", capabilitySetDigest: `sha256:${"c".repeat(64)}`, effectiveContractDigest: `sha256:${"d".repeat(64)}`, decisionEvidenceId: "capability-decision-1", decidedAt: "2026-09-06T00:00:00.000Z" }, runScope: { siloId: "silo-1", runId: "run-1", attempt: 1, agentServiceId: "service-1", agentRevisionId: "revision-1" }, computerScope: { siloId: "silo-1", computerId: "computer-1", leaseId: "lease-1", leaseGeneration: 1 }, requester: { siloId: "silo-1", requesterPrincipalId: "principal-1", requestIdempotencyKey: "request-1", authenticatedAt: "2026-09-06T00:00:00.000Z", membership: { kind: ExecutionSubjectMembershipKinds.Fleet, principalId: "principal-1", siloId: "silo-1", revision: 1, assertionId: "requester-membership-1", payloadDigest: `sha256:${"b".repeat(64)}`, decisionEvidenceId: "requester-decision-1", trustedUntil: "2099-01-01T00:00:00.000Z" } }, admission: { authorizingPrincipalId: "principal-1", decisionEvidenceId: "admission-decision-1", admittedAt: "2026-09-06T00:00:00.000Z" } } as const;
+}
 
 /** Build the narrow transaction doubles used by immutable prompt repository tests. */
 function _Transaction()
@@ -27,7 +34,7 @@ describe("PrismaPromptCompilerRepository", function _PrismaPromptCompilerReposit
 		const messages = { loadMessages: vi.fn().mockResolvedValue([]) };
 		const createMessages = vi.fn().mockReturnValue(messages);
 		const compiler = new PrismaPromptCompilerUnitOfWork(prisma as never, createMessages);
-		const snapshot = { runId: "run-1", attempt: 1, siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", snapshotVersion: 1, conversationId: null, messageIds: [], personaRevisionId: null, preferenceFactIds: [], artifactRevisionIds: [], skillRevisionIds: [], memoryQueryPolicy: {}, mcpTools: [], modelRoute: { alias: "tenant-model", modelDefinitionId: "model-1", litellmModelId: "deployment-1", maxOutputTokens: 4096, generatedOutputCapabilities: ["image_png"] }, budgetPolicy: { maxCompletionTokens: 256000, maxCostUsdMicros: 100, maxToolInvocations: 1, wallClockDeadlineEpochMs: 2_000_000_000_000 }, executionSubject: {} as never, promptCompilerVersion: PROMPT_COMPILER_VERSION, digest: `sha256:${"a".repeat(64)}`, compiledAt: "2026-09-06T00:00:00.000Z" };
+		const snapshot = { runId: "run-1", attempt: 1, siloId: "silo-1", agentServiceId: "service-1", agentRevisionId: "revision-1", snapshotVersion: 1, conversationId: null, messageIds: [], personaRevisionId: null, preferenceFactIds: [], artifactRevisionIds: [], skillRevisionIds: [], memoryQueryPolicy: {}, mcpTools: [], modelRoute: { alias: "tenant-model", modelDefinitionId: "model-1", litellmModelId: "deployment-1", maxOutputTokens: 4096, generatedOutputCapabilities: ["image_png"] }, budgetPolicy: { maxCompletionTokens: 256000, maxCostUsdMicros: 100, maxToolInvocations: 1, wallClockDeadlineEpochMs: 2_000_000_000_000 }, executionSubject: _executionSubject(), promptCompilerVersion: PROMPT_COMPILER_VERSION, digest: `sha256:${"a".repeat(64)}`, compiledAt: "2026-09-06T00:00:00.000Z" };
 
 		await expect(compiler.compile(snapshot, 1)).resolves.toEqual(expect.objectContaining({ runId: "run-1", messages: [], model: expect.objectContaining({ modelAlias: "tenant-model", maxOutputTokens: 4096 }), budget: expect.objectContaining({ maxCompletionTokens: 256000 }) }));
 		expect(createMessages).toHaveBeenCalledWith(transaction);

--- a/libs/backend/agents/execution/inputs/main/src/prompt/__tests__/prompt-compiler.test.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prompt/__tests__/prompt-compiler.test.ts
@@ -96,6 +96,15 @@ describe("__CompileRunInput", function _describeCompiler()
 		expect(compiled.tools.map(function _name(t): string { return t.name; })).toEqual(["alpha", "zulu"]);
 	});
 
+	it("does not offer approval-gated tools to a managed assistant", async function _HidesCompanyApprovals()
+	{
+		const subject = _executionSubject();
+		const managed = { ...subject, principalId: "company-principal", identity: { ...subject.identity, principalId: "company-principal" }, membership: { kind: ExecutionSubjectMembershipKinds.Managed, principalId: "company-principal", siloId: subject.siloId, agentServiceId: "svc-1", agentRevisionId: "rev-1", agentRevisionDigest: "sha256:revision", decisionEvidenceId: "sha256:decision", trustedUntil: "2099-01-01T00:00:00.000Z" } } as const;
+		const compiled = await __CompileRunInput(_snapshot({ executionSubject: managed }), 1, _repositories());
+
+		expect(compiled.tools.map(function _name(t): string { return t.name; })).toEqual(["zulu"]);
+	});
+
 	it("passes exact immutable MCP tool revisions to the tool-definition port", async function _PassesMcpToolRevisions()
 	{
 		let received: RunInputSnapshot["mcpTools"] | null = null;

--- a/libs/backend/agents/execution/inputs/main/src/prompt/prompt-compiler.ts
+++ b/libs/backend/agents/execution/inputs/main/src/prompt/prompt-compiler.ts
@@ -1,6 +1,7 @@
 import { PROMPT_COMPILER_VERSION } from "@opencrane/contracts";
 import type { CompiledBudget, CompiledRunInput, CompiledToolDefinition, RunInputSnapshot } from "@opencrane/contracts";
 import { ___DoWithTrace } from "@opencrane/backend/observability";
+import { ExecutionSubjectMembershipKinds } from "@opencrane/models/agents";
 import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 
 import type { PromptCompilerRepositories } from "./prompt-compiler.types";
@@ -85,7 +86,10 @@ async function _compileVerified(snapshot: RunInputSnapshot, attempt: number, rep
 	// 2. Look up every record the compiled input needs.
 	const personaInstructions = await repositories.loadPersonaInstructions(snapshot.personaRevisionId);
 	const messages = await repositories.loadMessages(snapshot.messageIds);
-	const tools = _orderTools(await repositories.loadToolDefinitions(snapshot.mcpTools));
+	const resolvedTools = _orderTools(await repositories.loadToolDefinitions(snapshot.mcpTools));
+	const tools = snapshot.executionSubject.membership.kind === ExecutionSubjectMembershipKinds.Managed
+		? resolvedTools.filter(tool => !tool.requiresApproval)
+		: resolvedTools;
 	const artifactSummaries = await repositories.loadArtifactSummaries([...snapshot.artifactRevisionIds].sort());
 	const skillSummaries = await repositories.loadSkillSummaries([...snapshot.skillRevisionIds].sort());
 	const model = await repositories.resolveModelRoute(snapshot.siloId, snapshot.modelRoute);

--- a/libs/backend/server/conversations/main/README.md
+++ b/libs/backend/server/conversations/main/README.md
@@ -79,6 +79,13 @@ The dispatch coordinator delegates saved run and budget evidence, current comput
 conversation access to their owners. It does not decide the invocation lifecycle; central IAM owns
 those state transitions. A terminal result remains readable only while its original authority holds.
 
+Approval-gated personal proposals preserve the frozen arguments, schema and run allowance in the
+existing invocation slot, then pause the run in `WaitingForInput` through deferred IAM approval.
+Only the exact current run owner may answer its elicitation. Approval marks the invocation ready and
+wakes the saved Absurd turn task; denial, expiry or stale authority produces no MCP dispatch and
+wakes the same continuation to record the terminal outcome. Managed company approval tools remain
+unavailable at model selection and proposal preparation until an entitled human resolver is bound.
+
 The turn store atomically commits the exact answer receipt and participant-visible history event. Absurd
 owns durable deadlines, waits, restart recovery and selection of the next saved step. A new
 physical append rechecks the workload lease, generation, Pod, history position, selected result digest and authority deadline through

--- a/libs/backend/server/conversations/main/src/computers/tools/proposal/__tests__/conversation-tool-proposal-evidence.test.ts
+++ b/libs/backend/server/conversations/main/src/computers/tools/proposal/__tests__/conversation-tool-proposal-evidence.test.ts
@@ -70,6 +70,7 @@ describe("proposal run and slot evidence", function _suite()
 	it("reads the running attempt and saved snapshot using their complete identity coordinates", async function _boundReads()
 	{
 		const f = _fixture();
+		f.proposal = { ...f.proposal, tool: { ...f.proposal.tool, requiresApproval: true } };
 		await expect(f.reader.load(f.turn, f.candidate, f.proposal)).resolves.toEqual({ subject: f.subject, agentRevisionId: "revision-1" });
 		expect(f.transaction.agentRun.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: {
 			id: "run-1", attempt: 1, siloId: "silo-1", state: AgentRunState.Running,
@@ -125,9 +126,10 @@ describe("proposal permission evidence", function _evidence()
 	{
 		const f = _fixture();
 		const run = { subject: f.subject, agentRevisionId: "revision-1" };
+		const proposal = { ...f.proposal, tool: { ...f.proposal.tool, requiresApproval: true } };
 		const coordinate = { resource: { kind: ProductAuthorizationResourceKinds.McpToolRevision, id: "tool-1" }, action: ProductAuthorizationActions.Invoke } as const;
-		const first = _CreateConversationToolProposalIntent(f.turn, run, f.proposal, coordinate, ___DigestCanonicalJson("first-decision"));
-		const next = _CreateConversationToolProposalIntent(f.turn, run, f.proposal, coordinate, ___DigestCanonicalJson("next-decision"));
+		const first = _CreateConversationToolProposalIntent(f.turn, run, proposal, coordinate, ___DigestCanonicalJson("first-decision"));
+		const next = _CreateConversationToolProposalIntent(f.turn, run, proposal, coordinate, ___DigestCanonicalJson("next-decision"));
 		expect(next.requestFingerprint).toBe(first.requestFingerprint);
 		expect(next.requestIdentity).toEqual(first.requestIdentity);
 		expect(next.authorizationEvidence.evidenceDigest).not.toBe(first.authorizationEvidence.evidenceDigest);
@@ -135,5 +137,6 @@ describe("proposal permission evidence", function _evidence()
 		expect(evidenceDigest).toBe(___DigestCanonicalJson({ ...binding, agentRevisionId: first.agentRevisionId, runId: first.runId, attempt: first.attempt, argumentsDigest: first.argumentsDigest } as unknown as JsonValue));
 		expect(first.authorizationEvidence.executionSubject).toBe(f.subject);
 		expect(first.authorizationEvidence.coordinates).toEqual([coordinate]);
+		expect(first.approvalRequired).toBe(true);
 	});
 });

--- a/libs/backend/server/conversations/main/src/computers/tools/proposal/__tests__/conversation-tool-proposal.test.ts
+++ b/libs/backend/server/conversations/main/src/computers/tools/proposal/__tests__/conversation-tool-proposal.test.ts
@@ -44,12 +44,12 @@ describe("one frozen conversation tool proposal", function _Suite()
 		expect(next.proposalId).toBe(original.proposalId);
 		expect(next.requestFingerprint).not.toBe(original.requestFingerprint);
 	});
-	it("rejects a tool outside the compiled set, changed schema and approval-required work", function _ExactTool()
+	it("rejects a tool outside the compiled set and changed schema while retaining approval metadata", function _ExactTool()
 	{
 		const f = _Fixture();
 		expect(() => _PrepareConversationToolProposal(f.turn, f.candidate, { ...f.proposal, toolRevisionId: "other" })).toThrow("invalid");
 		f.tool.requiresApproval = true;
-		expect(() => _PrepareConversationToolProposal(f.turn, f.candidate, f.proposal)).toThrow("invalid");
+		expect(_PrepareConversationToolProposal(f.turn, f.candidate, f.proposal).tool.requiresApproval).toBe(true);
 		f.tool.requiresApproval = false;
 		f.tool.parametersSchemaDigest = `sha256:${"0".repeat(64)}`;
 		expect(() => _PrepareConversationToolProposal(f.turn, f.candidate, f.proposal)).toThrow("invalid");

--- a/libs/backend/server/conversations/main/src/computers/tools/proposal/__tests__/prisma-conversation-tool-proposal.test.ts
+++ b/libs/backend/server/conversations/main/src/computers/tools/proposal/__tests__/prisma-conversation-tool-proposal.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ConversationToolProposalOutcomes } from "@opencrane/contracts";
+import { ___DigestCanonicalJson } from "@opencrane/util";
+
+import { PrismaConversationToolProposalRepository } from "../prisma-conversation-tool-proposal";
+import { _PrepareConversationToolProposal } from "../conversation-tool-proposal";
+
+const _run = vi.hoisted(function _Run()
+{
+	return { subject: { principalId: "user-1", membership: { kind: "fleet" }, capability: { capabilitySetDigest: "sha256:capability" } }, agentRevisionId: "revision-1" };
+});
+
+const _invocation = vi.hoisted(function _Invocation()
+{
+	return { id: "invocation-row-1", toolInvocationId: "public-invocation-1", state: "ready", revision: 2, requestFingerprint: "fingerprint" };
+});
+
+const _admitUntil = vi.hoisted(function _AdmitUntil()
+{
+	return vi.fn().mockResolvedValue(4_000_000_000_000);
+});
+
+vi.mock("../prisma-conversation-tool-proposal-run-reader", function _RunReader()
+{
+	return { PrismaConversationToolProposalRunRepository: class { load = vi.fn().mockResolvedValue(_run); } };
+});
+
+vi.mock("../prisma-conversation-tool-proposal-preparation", function _Preparation()
+{
+	return { PrismaConversationToolProposalPreparationAuthority: class { admit = vi.fn().mockResolvedValue({ outcome: "idempotent", invocation: _invocation }); } };
+});
+
+vi.mock("../../dispatch/prisma-conversation-tool-dispatch-authority", function _Dispatch()
+{
+	return { PrismaConversationToolDispatchAuthority: class { admitUntil = _admitUntil; } };
+});
+
+function _Fixture()
+{
+	const schema = { type: "object", additionalProperties: false, required: ["recordId"], properties: { recordId: { type: "string" } } };
+	const turn = { bootstrapId: "bootstrap-1", siloId: "silo-1", computerId: "computer-1", lease: { leaseId: "lease-1", leaseGeneration: 1, sandboxClaimId: "claim-1" }, binding: { conversationId: "conversation-1", agentIdentityId: "identity-1", agentServiceId: "service-1", expectedRevision: 2n }, compile: { runId: "run-1", attempt: 1, digest: "sha256:compiled" }, outputSourceCommandId: null } as any;
+	const candidate = { ...turn, credentialExpiresAt: "2099-01-01T00:00:00.000Z", compiledInput: { promptCompilerVersion: "proof-v1", runId: "run-1", attempt: 1, digest: "sha256:compiled", instructions: "", messages: [], tools: [{ name: "records.update", toolRevisionId: "tool-1", description: "Update a record", requiresApproval: true, parametersSchema: schema, parametersSchemaDigest: ___DigestCanonicalJson(schema) }], model: { modelAlias: "proof", maxOutputTokens: 512, generatedOutputCapabilities: [] }, budget: { maxModelTurns: 2, maxCompletionTokens: 1_024, maxCostUsdMicros: null, wallClockDeadlineEpochMs: Date.now() + 60_000, maxToolInvocations: 1 } } } as any;
+	const proposal = _PrepareConversationToolProposal(turn, candidate, { bootstrapId: turn.bootstrapId, toolRevisionId: "tool-1", arguments: { recordId: "record-1" } });
+	return { turn, candidate, proposal };
+}
+
+async function _ApprovalExpiry(): Promise<void> {}
+
+describe("conversation approval proposal replay", function _Suite()
+{
+	it("admits the existing Ready invocation so the saved result can be read", async function _ReadyReplay()
+	{
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-11T10:00:00.000Z"));
+		const f = _Fixture();
+		expect(f.candidate.compiledInput.budget.wallClockDeadlineEpochMs).toBeGreaterThan(Date.now());
+		const runtimeAdmission = vi.fn().mockResolvedValue(true);
+		const repository = new PrismaConversationToolProposalRepository({} as never, {} as never, runtimeAdmission, _ApprovalExpiry);
+
+		await expect(repository.admit(f.turn, f.candidate, f.proposal, { audience: "conversation", namespace: "computers", serviceAccountName: "computer", workloadKind: "pod", workloadUid: "pod-1", podUid: "pod-1" })).resolves.toEqual({ proposalId: "public-invocation-1", outcome: ConversationToolProposalOutcomes.Existing });
+		expect(_admitUntil).toHaveBeenCalledOnce();
+		expect(runtimeAdmission).toHaveBeenCalledWith({}, "invocation-row-1");
+	});
+
+	it("returns an existing terminal invocation without creating runtime work", async function _TerminalReplay()
+	{
+		const f = _Fixture();
+		_invocation.state = "failed";
+		const runtimeAdmission = vi.fn().mockResolvedValue(true);
+		const repository = new PrismaConversationToolProposalRepository({} as never, {} as never, runtimeAdmission, _ApprovalExpiry);
+
+		await expect(repository.admit(f.turn, f.candidate, f.proposal, { audience: "conversation", namespace: "computers", serviceAccountName: "computer", workloadKind: "pod", workloadUid: "pod-1", podUid: "pod-1" })).resolves.toEqual({ proposalId: "public-invocation-1", outcome: ConversationToolProposalOutcomes.Existing });
+		expect(runtimeAdmission).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/conversations/main/src/computers/tools/proposal/conversation-tool-proposal-intent.ts
+++ b/libs/backend/server/conversations/main/src/computers/tools/proposal/conversation-tool-proposal-intent.ts
@@ -49,7 +49,7 @@ export function _CreateConversationToolProposalIntent(turn: FrozenConversationCo
 		arguments: proposal.arguments,
 		argumentsDigest: proposal.argumentsDigest,
 		requestFingerprint: proposal.requestFingerprint,
-		approvalRequired: false,
+		approvalRequired: proposal.tool.requiresApproval,
 		recoveryMode: ExternalActionRecoveryModes.Manual,
 		recoveryKey: null,
 	};

--- a/libs/backend/server/conversations/main/src/computers/tools/proposal/conversation-tool-proposal.ts
+++ b/libs/backend/server/conversations/main/src/computers/tools/proposal/conversation-tool-proposal.ts
@@ -21,11 +21,11 @@ export function _PrepareConversationToolProposal(turn: FrozenConversationCompute
 	const tool = input.tools.find(item => item.toolRevisionId === proposal.toolRevisionId);
 	if (turn.outputSourceCommandId !== null || proposal.bootstrapId !== turn.bootstrapId || input.digest !== turn.compile.digest
 		|| input.runId !== turn.compile.runId || input.attempt !== turn.compile.attempt || candidate.binding.expectedRevision !== turn.binding.expectedRevision
-		|| tool === undefined || tool.requiresApproval || ___DigestCanonicalJson(tool.parametersSchema) !== tool.parametersSchemaDigest
+		|| tool === undefined || ___DigestCanonicalJson(tool.parametersSchema) !== tool.parametersSchemaDigest
 		|| !__ValidateDeferredToolArguments(tool.parametersSchema, proposal.arguments))
 		throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Invalid);
 	const deadline = input.budget.wallClockDeadlineEpochMs;
-	if (deadline === null || !Number.isSafeInteger(deadline) || deadline <= Date.now()
+	if (deadline === null || !Number.isSafeInteger(deadline) || (deadline <= Date.now() && !tool.requiresApproval)
 		|| (input.budget.maxToolInvocations !== null && (!Number.isSafeInteger(input.budget.maxToolInvocations) || input.budget.maxToolInvocations < 1)))
 		throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Denied);
 	const hex = createHash("sha256").update(JSON.stringify(["conversation-tool-proposal", turn.compile.runId, turn.compile.attempt, 1])).digest("hex");

--- a/libs/backend/server/conversations/main/src/computers/tools/proposal/conversation-tool-proposal.types.ts
+++ b/libs/backend/server/conversations/main/src/computers/tools/proposal/conversation-tool-proposal.types.ts
@@ -13,6 +13,9 @@ export interface ConversationToolProposalAdmission
 /** Create existing executor work in the proposal's transaction; never open another transaction or call a provider. */
 export type ConversationToolProposalRuntimeAdmission = (transaction: unknown, invocationRowId: string) => Promise<boolean>;
 
+/** Expires linked approval and elicitation rows in the caller's proposal transaction. */
+export type ConversationToolApprovalExpiry = (transaction: unknown, command: { readonly runId: string; readonly attempt: number; readonly now: Date }) => Promise<void>;
+
 /** Server-derived immutable facts passed into the proposal's transactional admission owner. */
 export interface PreparedConversationToolProposal
 {

--- a/libs/backend/server/conversations/main/src/computers/tools/proposal/prisma-conversation-tool-proposal.ts
+++ b/libs/backend/server/conversations/main/src/computers/tools/proposal/prisma-conversation-tool-proposal.ts
@@ -2,14 +2,15 @@ import { Prisma, type PrismaClient } from "@prisma/client";
 
 import { ConversationToolProposalOutcomes, type ConversationToolProposal, type ConversationToolProposalReceipt } from "@opencrane/contracts";
 import { ___DoWithTrace } from "@opencrane/backend/observability";
-import { __PrepareToolInvocationInTransaction, ToolInvocationAdmissionOutcomes, ToolInvocationStates, type ProductAuthorizationWorkloadContext } from "@opencrane/backend/server/iam/authorization";
+import { __OpenDeferredToolApprovalInTransaction, __PrepareToolInvocationInTransaction, ToolInvocationAdmissionOutcomes, ToolInvocationStates, type ProductAuthorizationWorkloadContext } from "@opencrane/backend/server/iam/authorization";
+import { ExecutionSubjectMembershipKinds } from "@opencrane/models/agents";
 import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
 
 import type { ConversationComputerTurnCandidate, FrozenConversationComputerTurn } from "../../turns/conversation-computer-turn.types";
 import type { ConversationToolDispatchDependencies } from "../dispatch/conversation-tool-dispatch.types";
 import { ConversationToolProposalRefusal } from "./conversation-tool-proposal-refusal";
 import { _PrepareConversationToolProposal } from "./conversation-tool-proposal";
-import { ConversationToolProposalRefusals, type ConversationToolProposalAdmission, type PreparedConversationToolProposal, type ConversationToolProposalRepository, type ConversationToolProposalRuntimeAdmission } from "./conversation-tool-proposal.types";
+import { ConversationToolProposalRefusals, type ConversationToolApprovalExpiry, type ConversationToolProposalAdmission, type PreparedConversationToolProposal, type ConversationToolProposalRepository, type ConversationToolProposalRuntimeAdmission } from "./conversation-tool-proposal.types";
 import { PrismaConversationToolDispatchAuthority } from "../dispatch/prisma-conversation-tool-dispatch-authority";
 import { PrismaConversationToolProposalRunRepository } from "./prisma-conversation-tool-proposal-run-reader";
 import { PrismaConversationToolProposalPreparationAuthority } from "./prisma-conversation-tool-proposal-preparation";
@@ -24,24 +25,75 @@ import { PrismaConversationToolProposalPreparationAuthority } from "./prisma-con
 export class PrismaConversationToolProposalRepository implements ConversationToolProposalRepository
 {
 	/** Bind all invocation writes and permission decisions to this transaction. */
-	public constructor(private readonly transaction: Prisma.TransactionClient, private readonly dependencies: ConversationToolDispatchDependencies, private readonly runtimeAdmission: ConversationToolProposalRuntimeAdmission) {}
+	public constructor(private readonly transaction: Prisma.TransactionClient, private readonly dependencies: ConversationToolDispatchDependencies, private readonly runtimeAdmission: ConversationToolProposalRuntimeAdmission, private readonly approvalExpiry: ConversationToolApprovalExpiry) {}
 
 	/** Save the proposal or reuse the identical saved call, checking access before executor admission. */
 	public async admit(turn: FrozenConversationComputerTurn, candidate: ConversationComputerTurnCandidate, proposal: PreparedConversationToolProposal, workload: ProductAuthorizationWorkloadContext): Promise<ConversationToolProposalReceipt>
 	{
+		const now = new Date();
+		if (proposal.tool.requiresApproval && Math.min(candidate.compiledInput.budget.wallClockDeadlineEpochMs ?? Number.POSITIVE_INFINITY, Date.parse(candidate.credentialExpiresAt)) <= now.getTime())
+			await this.approvalExpiry(this.transaction, { runId: turn.compile.runId, attempt: turn.compile.attempt, now });
 		const reader = new PrismaConversationToolProposalRunRepository(this.transaction);
 		const run = await reader.load(turn, candidate, proposal);
+		if (proposal.tool.requiresApproval && run.subject.membership.kind === ExecutionSubjectMembershipKinds.Managed)
+			throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Denied);
 		const preparation = new PrismaConversationToolProposalPreparationAuthority(this.transaction);
 		const result = await preparation.admit(turn, run, proposal, workload);
+		if (proposal.tool.requiresApproval && (result.invocation.state === ToolInvocationStates.Failed || result.invocation.state === ToolInvocationStates.Succeeded))
+			return { proposalId: result.invocation.toolInvocationId, outcome: ConversationToolProposalOutcomes.Existing };
 		// Recheck access after the tentative insert; a refusal must roll back that insert too.
 		const authority = new PrismaConversationToolDispatchAuthority(this.transaction, this.dependencies);
 		const admittedUntil = await authority.admitUntil(result.invocation, new Date(), workload);
 		if (admittedUntil === null
 			|| candidate.compiledInput.budget.wallClockDeadlineEpochMs! <= Date.now()
 			|| Date.parse(candidate.credentialExpiresAt) <= Date.now())
+				throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Denied);
+		const invocation = result.invocation.state === ToolInvocationStates.Preparing
+			? await __PrepareToolInvocationInTransaction(this.transaction, result.invocation.id, result.invocation.revision, new Date(Math.max(now.getTime(), result.invocation.nextPreparationAttemptAt.getTime())))
+			: result.invocation;
+		if (invocation === null)
 			throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Denied);
-		if (result.invocation.state === ToolInvocationStates.Preparing)
-			await __PrepareToolInvocationInTransaction(this.transaction, result.invocation.id, result.invocation.revision, new Date());
+		if (proposal.tool.requiresApproval)
+		{
+			if (invocation.state === ToolInvocationStates.Ready)
+			{
+				const runtimeAdmitted = await this.runtimeAdmission(this.transaction, invocation.id);
+				if (!runtimeAdmitted
+					|| candidate.compiledInput.budget.wallClockDeadlineEpochMs! <= Date.now()
+					|| Date.parse(candidate.credentialExpiresAt) <= Date.now())
+					throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Denied);
+				return { proposalId: invocation.toolInvocationId, outcome: ConversationToolProposalOutcomes.Existing };
+			}
+			if (invocation.state === ToolInvocationStates.Failed)
+				return { proposalId: invocation.toolInvocationId, outcome: ConversationToolProposalOutcomes.Existing };
+			if (invocation.state !== ToolInvocationStates.AwaitingApproval)
+				throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Denied);
+			const deadline = candidate.compiledInput.budget.wallClockDeadlineEpochMs;
+			const expiresAtEpochMs = Math.min(deadline ?? Number.POSITIVE_INFINITY, Date.parse(candidate.credentialExpiresAt));
+			if (!Number.isSafeInteger(expiresAtEpochMs) || expiresAtEpochMs <= now.getTime())
+				throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Denied);
+			const opened = await __OpenDeferredToolApprovalInTransaction(this.transaction, {
+				interruptId: invocation.toolInvocationId,
+				runId: turn.compile.runId,
+				attempt: turn.compile.attempt,
+				toolInvocationId: invocation.toolInvocationId,
+				toolRevisionId: proposal.tool.toolRevisionId,
+				arguments: proposal.arguments,
+				argumentsDigest: proposal.argumentsDigest,
+				parametersSchema: proposal.tool.parametersSchema,
+				parametersSchemaDigest: proposal.tool.parametersSchemaDigest,
+				capabilitySetDigest: run.subject.capability.capabilitySetDigest,
+				invocationId: invocation.id,
+				now,
+				expiresAt: new Date(expiresAtEpochMs),
+			});
+			if (!opened)
+				throw new ConversationToolProposalRefusal(ConversationToolProposalRefusals.Denied);
+			return {
+				proposalId: result.invocation.toolInvocationId,
+				outcome: result.outcome === ToolInvocationAdmissionOutcomes.Admitted ? ConversationToolProposalOutcomes.Recorded : ConversationToolProposalOutcomes.Existing,
+			};
+		}
 		const runtimeAdmitted = await this.runtimeAdmission(this.transaction, result.invocation.id);
 		if (!runtimeAdmitted
 			|| candidate.compiledInput.budget.wallClockDeadlineEpochMs! <= Date.now()
@@ -58,7 +110,7 @@ export class PrismaConversationToolProposalRepository implements ConversationToo
 export class PrismaConversationToolProposalUnitOfWork implements ConversationToolProposalAdmission
 {
 	/** Supply current permission checks and an executor admission callback that shares the transaction. */
-	public constructor(private readonly prisma: PrismaClient, private readonly dependencies: ConversationToolDispatchDependencies, private readonly runtimeAdmission: ConversationToolProposalRuntimeAdmission) {}
+	public constructor(private readonly prisma: PrismaClient, private readonly dependencies: ConversationToolDispatchDependencies, private readonly runtimeAdmission: ConversationToolProposalRuntimeAdmission, private readonly approvalExpiry: ConversationToolApprovalExpiry) {}
 
 	/** Validate the proposal once; retry the complete transaction only when PostgreSQL proves it rolled back. */
 	public admit(turn: FrozenConversationComputerTurn, candidate: ConversationComputerTurnCandidate, proposal: ConversationToolProposal, workload: ProductAuthorizationWorkloadContext): Promise<ConversationToolProposalReceipt>
@@ -67,11 +119,12 @@ export class PrismaConversationToolProposalUnitOfWork implements ConversationToo
 		const dependencies = this.dependencies;
 		const prisma = this.prisma;
 		const runtimeAdmission = this.runtimeAdmission;
+		const approvalExpiry = this.approvalExpiry;
 		return ___DoWithTrace("conversation.tool_proposal.admit", {}, async function _ProposalAdmission()
 		{
 			return ___RunInPrismaUnitOfWork(prisma, async function _Admit(transaction)
 			{
-				const repository = new PrismaConversationToolProposalRepository(transaction, dependencies, runtimeAdmission);
+				const repository = new PrismaConversationToolProposalRepository(transaction, dependencies, runtimeAdmission, approvalExpiry);
 				return repository.admit(turn, candidate, prepared, workload);
 			}, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable, operation: "conversation tool proposal", attemptLimit: 3, timeout: 10_000 });
 		});

--- a/libs/backend/server/conversations/main/src/computers/tools/results/prisma-conversation-tool-results.ts
+++ b/libs/backend/server/conversations/main/src/computers/tools/results/prisma-conversation-tool-results.ts
@@ -2,7 +2,7 @@ import { Prisma, type PrismaClient } from "@prisma/client";
 
 import { CONVERSATION_COMPUTER_PROJECTED_TOKEN_AUDIENCE } from "@opencrane/contracts";
 import { ___DoWithTrace } from "@opencrane/backend/observability";
-import { __ConsumeRunToolResultInTransaction, __ReadRunToolResultInTransaction, RunToolResultReadOutcomes } from "@opencrane/backend/server/iam/authorization";
+import { __ConsumeRunToolResultInTransaction, __ReadRunToolResultInTransaction, RunToolResultPendingKinds, RunToolResultReadOutcomes } from "@opencrane/backend/server/iam/authorization";
 import { ___RunInPrismaUnitOfWork } from "@opencrane/backend/server/infra/prisma-unit-of-work";
 import type { RuntimeWorkloadIdentity } from "@opencrane/backend/server/infra/workload-identity";
 import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
@@ -58,7 +58,12 @@ export class PrismaConversationToolResultsRepository implements ConversationComp
 		const command = { siloId: turn.siloId, runId: turn.compile.runId, attempt: turn.compile.attempt, toolInvocationId: selection.proposalId, runtimeInstanceId: turn.computerId, commandId: turn.bootstrapId, requestFingerprint: selection.requestFingerprint };
 		let result = await __ReadRunToolResultInTransaction(this.transaction, command);
 		if (result.outcome !== RunToolResultReadOutcomes.Available)
-			return { outcome: result.outcome === RunToolResultReadOutcomes.Pending && !consume ? ConversationComputerToolResultOutcomes.Pending : ConversationComputerToolResultOutcomes.Unavailable };
+		{
+			if (result.outcome !== RunToolResultReadOutcomes.Pending || consume)
+				return { outcome: ConversationComputerToolResultOutcomes.Unavailable };
+			const waitFor = result.pendingKind === RunToolResultPendingKinds.Approval ? "approval" : "result";
+			return { outcome: ConversationComputerToolResultOutcomes.Pending, waitFor, waitUntilEpochMs: result.pendingUntilEpochMs };
+		}
 		const reservation = turn.continuationReservation;
 		if (reservation !== null && (reservation.proposalId !== selection.proposalId || reservation.resultDigest !== result.payloadDigest))
 			return { outcome: ConversationComputerToolResultOutcomes.Unavailable };

--- a/libs/backend/server/conversations/main/src/computers/turns/__tests__/conversation-tool-continuation.test.ts
+++ b/libs/backend/server/conversations/main/src/computers/turns/__tests__/conversation-tool-continuation.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ConversationModelResponseKinds, ConversationModelToolModes } from "@opencrane/contracts";
+import { ConversationModelResponseKinds, ConversationModelToolModes, ConversationToolProposalOutcomes } from "@opencrane/contracts";
+import { ___DigestCanonicalJson } from "@opencrane/util";
 
 import { _ToolContinuationHarness } from "./conversation-tool-continuation.fixture";
+import { ConversationComputerToolResultOutcomes } from "../conversation-computer-continuation.types";
 
 afterEach(() => { vi.restoreAllMocks(); });
 
@@ -115,6 +117,51 @@ describe("one governed tool and its model continuation", function _Continuation(
 		expect(await f.restart().advance(f.step)).toEqual({ outcome: "completed" });
 		expect(f.credentials.issueOnce).toHaveBeenCalledOnce();
 		expect(f.toolFlags.executions).toBe(1);
+	});
+
+	it("pauses an approval proposal, admits exactly once after the owner decision, and replays safely", async function _ApprovalReplay()
+	{
+		const f = await _ToolContinuationHarness();
+		Object.assign(f.candidate.compiledInput.tools[0], { requiresApproval: true });
+		let decision: "awaiting" | "ready" = "awaiting";
+		f.proposals.admit.mockImplementation(async function _Admit(turn)
+		{
+			if (decision === "ready")
+				f.toolFlags.executions++;
+			return { proposalId: turn.toolSelection!.proposalId, outcome: ConversationToolProposalOutcomes.Existing };
+		});
+		f.results.read.mockImplementation(async function _Read(turn)
+		{
+			if (decision === "awaiting")
+				return { outcome: ConversationComputerToolResultOutcomes.Pending, waitFor: "approval", waitUntilEpochMs: Date.now() + 60_000 } as const;
+			const payload = { toolInvocationId: turn.toolSelection!.proposalId, outcome: "succeeded" as const, result: { record: "private-result" } };
+			return { outcome: ConversationComputerToolResultOutcomes.Available, payload, payloadDigest: ___DigestCanonicalJson(payload), notAfterEpochMs: Date.now() + 60_000 } as const;
+		});
+
+		expect(await f.authority.advance(f.step)).toMatchObject({ outcome: "tool_pending", waitFor: "approval" });
+		expect(f.toolFlags.executions).toBe(0);
+		decision = "ready";
+		expect(await f.restart().advance(f.step)).toEqual({ outcome: "completed" });
+		expect(f.toolFlags.executions).toBe(1);
+		expect(f.model.request).toHaveBeenCalledTimes(2);
+		expect(await f.restart().advance(f.step)).toEqual({ outcome: "completed" });
+		expect(f.toolFlags.executions).toBe(1);
+	});
+
+	it("leaves a denied approval terminal without admitting an external executor", async function _DeniedApproval()
+	{
+		const f = await _ToolContinuationHarness();
+		Object.assign(f.candidate.compiledInput.tools[0], { requiresApproval: true });
+		let denied = false;
+		f.proposals.admit.mockResolvedValue({ proposalId: f.call.id, outcome: ConversationToolProposalOutcomes.Existing });
+		f.results.read.mockImplementation(async function _Read()
+		{
+			return denied ? { outcome: ConversationComputerToolResultOutcomes.Unavailable } as const : { outcome: ConversationComputerToolResultOutcomes.Pending, waitFor: "approval" } as const;
+		});
+		expect(await f.authority.advance(f.step)).toMatchObject({ outcome: "tool_pending", waitFor: "approval" });
+		denied = true;
+		expect(await f.restart().advance(f.step)).toEqual({ outcome: "authority_ended" });
+		expect(f.toolFlags.executions).toBe(0);
 	});
 
 	it("recovers exact continuation custody after its response is lost before reservation", async function _ContinuationCustody()

--- a/libs/backend/server/conversations/main/src/computers/turns/conversation-computer-continuation.types.ts
+++ b/libs/backend/server/conversations/main/src/computers/turns/conversation-computer-continuation.types.ts
@@ -104,7 +104,7 @@ export enum ConversationComputerToolResultOutcomes
 
 /** Supplies only validated result content after the same transaction checks current authority. */
 export type ConversationComputerToolResult =
-	| { readonly outcome: ConversationComputerToolResultOutcomes.Pending | ConversationComputerToolResultOutcomes.Unavailable }
+	| { readonly outcome: ConversationComputerToolResultOutcomes.Pending | ConversationComputerToolResultOutcomes.Unavailable; readonly waitFor?: "approval" | "result"; readonly waitUntilEpochMs?: number }
 	| { readonly outcome: ConversationComputerToolResultOutcomes.Available; readonly payload: ToolResultDeliveryPayload; readonly payloadDigest: string; readonly notAfterEpochMs: number };
 
 /**

--- a/libs/backend/server/conversations/main/src/computers/turns/conversation-computer-model-flow.ts
+++ b/libs/backend/server/conversations/main/src/computers/turns/conversation-computer-model-flow.ts
@@ -61,7 +61,7 @@ async function _ContinueTool(turn: FrozenConversationComputerTurn, declaration: 
 	await dependencies.toolProposals.admit(selected, currentExecution.candidate, proposal.command, { audience: CONVERSATION_COMPUTER_PROJECTED_TOKEN_AUDIENCE, namespace: workload.namespace, serviceAccountName: workload.serviceAccountName, workloadKind: "pod", workloadUid: workload.podUid, podUid: workload.podUid });
 	const result = await dependencies.toolResults.read(selected, workload);
 	if (result.outcome === ConversationComputerToolResultOutcomes.Pending)
-		return { outcome: "tool_pending", toolInvocationId: selection.proposalId };
+		return { outcome: "tool_pending", toolInvocationId: selection.proposalId, waitFor: result.waitFor, waitUntilEpochMs: result.waitUntilEpochMs };
 	if (result.outcome !== ConversationComputerToolResultOutcomes.Available)
 		return { outcome: "authority_ended" };
 	const pair = ___ConversationModelContinuationSchema.parse({ call: declaration.call, resultContent: ___CanonicalizeJson(result.payload) });
@@ -95,7 +95,7 @@ async function _ContinueTool(turn: FrozenConversationComputerTurn, declaration: 
 /** Select one unambiguous frozen definition, then reuse the existing schema and budget validator. */
 function _Proposal(turn: FrozenConversationComputerTurn, candidate: ConversationComputerTurnCandidate, call: ConversationModelToolCall)
 {
-	const matching = candidate.compiledInput.tools.filter(tool => tool.name === call.name && !tool.requiresApproval);
+	const matching = candidate.compiledInput.tools.filter(tool => tool.name === call.name);
 	if (matching.length !== 1)
 		throw new Error("Conversation model selected an unavailable or ambiguous tool");
 	const command = ___ParseAndValidateJson(call.arguments, "Conversation tool arguments", argumentsValue => ___ConversationToolProposalSchema.parse({ bootstrapId: turn.bootstrapId, toolRevisionId: matching[0]!.toolRevisionId, arguments: argumentsValue }));
@@ -123,7 +123,7 @@ function _FirstReservation(turn: FrozenConversationComputerTurn, candidate: Conv
 	if (ceilings.some(value => value !== null && (!Number.isSafeInteger(value) || value <= 0)) || input.budget.maxModelTurns === null || !Number.isSafeInteger(input.budget.maxModelTurns) || input.budget.maxModelTurns < 1 || limits.length === 0 || !Number.isSafeInteger(authorityExpiresAtEpochMs) || authorityExpiresAtEpochMs <= Date.now())
 		throw new Error("Conversation model request has no remaining frozen allowance");
 	const total = input.budget.maxCompletionTokens ?? Math.min(...limits) * 2;
-	const maySelect = input.budget.maxModelTurns >= 2 && total >= 2 && Number.isSafeInteger(total) && (input.budget.maxToolInvocations === null || Number.isSafeInteger(input.budget.maxToolInvocations) && input.budget.maxToolInvocations >= 1) && input.tools.some(tool => !tool.requiresApproval);
+	const maySelect = input.budget.maxModelTurns >= 2 && total >= 2 && Number.isSafeInteger(total) && (input.budget.maxToolInvocations === null || Number.isSafeInteger(input.budget.maxToolInvocations) && input.budget.maxToolInvocations >= 1) && input.tools.length > 0;
 	const tools = maySelect ? ConversationModelToolModes.Select : ConversationModelToolModes.None;
 	const maxCompletionTokens = maySelect ? Math.min(...limits, Math.floor(total / 2)) : Math.min(...limits);
 	const facts = { ordinal: 1 as const, tools, compiledInputDigest: turn.compile.digest, maxCompletionTokens, authorityExpiresAtEpochMs, dispatchDeadlineEpochMs: Math.min(authorityExpiresAtEpochMs, Date.now() + 25_000) };

--- a/libs/backend/server/conversations/main/src/computers/turns/conversation-computer-model.types.ts
+++ b/libs/backend/server/conversations/main/src/computers/turns/conversation-computer-model.types.ts
@@ -3,7 +3,7 @@ import type { ConversationModelRequest, ConversationModelResponse, ConversationM
 export type ConversationComputerModelProgress =
 	| { readonly outcome: "completed" | "response_unavailable" | "authority_ended" | "retry" }
 	| { readonly outcome: "model_pending"; readonly notBeforeEpochMs: number; readonly ordinal: 1 | 2 }
-	| { readonly outcome: "tool_pending"; readonly toolInvocationId: string };
+	| { readonly outcome: "tool_pending"; readonly toolInvocationId: string; readonly waitFor?: "approval" | "result"; readonly waitUntilEpochMs?: number };
 
 /**
  * Records the consumed request allowance in revision 1 of the turn stream, without prompt or key.

--- a/libs/backend/server/conversations/main/src/computers/turns/workflow/__tests__/conversation-computer-turn-workflow.test.ts
+++ b/libs/backend/server/conversations/main/src/computers/turns/workflow/__tests__/conversation-computer-turn-workflow.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { IWorkflowTaskContext, IWorkflowTaskDefinition } from "@opencrane/backend/server/infra/workflows/contract";
+import { __FakeWorkflowEngine } from "@opencrane/backend/server/infra/workflows/testing";
 import { CONVERSATION_COMPUTER_TURN_TASK } from "../conversation-computer-turn-task";
 import type { ConversationComputerTurnTaskInput } from "../conversation-computer-turn-workflow.types";
 import { _RegisterConversationComputerTurnWorkflow } from "../conversation-computer-turn-workflow";
@@ -40,6 +41,53 @@ describe("conversation computer turn workflow", function _Suite()
 		const fixture = _Fixture([{ outcome: "tool_pending", toolInvocationId: "tool-1" }, { outcome: "completed" }]);
 		await expect(fixture.definition.run(fixture.context, _INPUT)).resolves.toEqual({ outcome: "completed", turnId: "turn-1" });
 		expect(fixture.context.waitForEvent).toHaveBeenCalledExactlyOnceWith("tool-result:tool-1");
+		expect(fixture.authority.advance).toHaveBeenCalledTimes(2);
+	});
+
+	it("waits on the separate approval event before terminal result delivery", async function _ApprovalWake()
+	{
+		const fixture = _Fixture([{ outcome: "tool_pending", toolInvocationId: "tool-1", waitFor: "approval" }, { outcome: "completed" }]);
+		await expect(fixture.definition.run(fixture.context, _INPUT)).resolves.toEqual({ outcome: "completed", turnId: "turn-1" });
+		expect(fixture.context.waitForEvent).toHaveBeenCalledExactlyOnceWith("tool-approval:tool-1");
+		expect(fixture.authority.advance).toHaveBeenCalledTimes(2);
+	});
+
+	it("resumes a saved approval through the workflow engine and admits one executor on replay", async function _ApprovalEngineJourney()
+	{
+		const execution = new __FakeWorkflowEngine();
+		const state = { approved: false, advances: 0, executions: 0 };
+		const authority = {
+			start: vi.fn().mockResolvedValue(_TURN),
+			advance: vi.fn(async function _Advance()
+			{
+				state.advances++;
+				if (!state.approved)
+					return { outcome: "tool_pending" as const, toolInvocationId: "tool-approval", waitFor: "approval" as const };
+				state.executions++;
+				return { outcome: "completed" as const };
+			}),
+		};
+		_RegisterConversationComputerTurnWorkflow(execution, { authority, receipts: { bind: vi.fn().mockResolvedValue(true) }, siloId: "silo-1" });
+		const task = await execution.spawn({ client: {} }, { taskName: CONVERSATION_COMPUTER_TURN_TASK.taskName, idempotencyKey: _TASK.idempotencyKey, input: _INPUT });
+		const running = execution._DrainPendingTasks();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(state.advances).toBe(1);
+		state.approved = true;
+		await execution.emitEvent(task, { eventName: "tool-approval:tool-approval", payload: { owner: "user-1" } });
+		await running;
+		expect(state.executions).toBe(1);
+		await execution._DrainPendingTasks();
+		expect(state.executions).toBe(1);
+	});
+
+	it("re-enters the saved turn when its approval wait reaches the durable deadline", async function _ApprovalTimeout()
+	{
+		const fixture = _Fixture([{ outcome: "tool_pending", toolInvocationId: "tool-1", waitFor: "approval", waitUntilEpochMs: Date.now() + 30_000 }, { outcome: "completed" }]);
+		const waitForEvent = fixture.context.waitForEvent as unknown as ReturnType<typeof vi.fn>;
+		waitForEvent.mockResolvedValueOnce({ eventName: "tool-approval:tool-1", payload: null, timedOut: true });
+		await expect(fixture.definition.run(fixture.context, _INPUT)).resolves.toEqual({ outcome: "completed", turnId: "turn-1" });
+		expect(fixture.context.waitForEvent).toHaveBeenCalledWith("tool-approval:tool-1", { timeoutAt: expect.any(Date) });
 		expect(fixture.authority.advance).toHaveBeenCalledTimes(2);
 	});
 

--- a/libs/backend/server/conversations/main/src/computers/turns/workflow/__tests__/prisma-conversation-computer-turn-workflow-events.test.ts
+++ b/libs/backend/server/conversations/main/src/computers/turns/workflow/__tests__/prisma-conversation-computer-turn-workflow-events.test.ts
@@ -75,4 +75,20 @@ describe("Prisma conversation computer turn workflow events", function _Suite()
 
 		expect(emitEventInTransaction).not.toHaveBeenCalled();
 	});
+
+	it("wakes the exact saved turn after an approval decision", async function _ApprovalWake()
+	{
+		const transaction = _Transaction();
+		const emitEventInTransaction = vi.fn().mockResolvedValue({ eventId: "event-approval" });
+		const repository = new PrismaConversationComputerTurnWorkflowEventRepository(transaction, { emitEventInTransaction });
+
+		await repository.wake("run-1", 2, "call-approval");
+
+		expect(transaction.agentRun.findUnique).toHaveBeenCalledWith({ where: { id_attempt: { id: "run-1", attempt: 2 } }, select: { workflowTaskId: true, workflowTaskName: true, workflowTaskKey: true } });
+		expect(emitEventInTransaction).toHaveBeenCalledWith(
+			{ client: transaction },
+			{ taskId: "task-1", taskName: CONVERSATION_COMPUTER_TURN_TASK.taskName, idempotencyKey: "activation-1" },
+			{ eventName: "tool-approval:call-approval", payload: { runId: "run-1", attempt: 2, toolInvocationId: "call-approval" } },
+		);
+	});
 });

--- a/libs/backend/server/conversations/main/src/computers/turns/workflow/conversation-computer-turn-workflow.ts
+++ b/libs/backend/server/conversations/main/src/computers/turns/workflow/conversation-computer-turn-workflow.ts
@@ -52,8 +52,15 @@ export function _RegisterConversationComputerTurnWorkflow(workflows: IWorkflowEn
 						await context.sleepUntil(new Date(progress.notBeforeEpochMs), `model-${progress.ordinal}-deadline`);
 						break;
 					case "tool_pending":
-						await context.waitForEvent(_ToolResultEventName(progress.toolInvocationId));
+					{
+						const approvalWait = progress.waitFor === "approval" && progress.waitUntilEpochMs !== undefined ? { timeoutAt: new Date(progress.waitUntilEpochMs) } : undefined;
+						const eventName = progress.waitFor === "approval" ? _ToolApprovalEventName(progress.toolInvocationId) : _ToolResultEventName(progress.toolInvocationId);
+						if (approvalWait === undefined)
+							await context.waitForEvent(eventName);
+						else
+							await context.waitForEvent(eventName, approvalWait);
 						break;
+					}
 					case "retry":
 						recoveryCycle += 1;
 						await context.sleepUntil(new Date(Date.now() + _TURN_RETRY_MILLISECONDS), `recovery-${recoveryCycle}`);
@@ -69,6 +76,14 @@ export function _ToolResultEventName(toolInvocationId: string): string
 	if (toolInvocationId.trim().length === 0)
 		throw new Error("Conversation turn tool event requires an invocation id");
 	return `tool-result:${toolInvocationId}`;
+}
+
+/** Names the separate wake emitted when an owner changes a deferred invocation's readiness. */
+export function _ToolApprovalEventName(toolInvocationId: string): string
+{
+	if (toolInvocationId.trim().length === 0)
+		throw new Error("Conversation turn approval event requires an invocation id");
+	return `tool-approval:${toolInvocationId}`;
 }
 
 /** Reject a task that crossed its declared receipt, silo or immutable activation coordinates. */

--- a/libs/backend/server/conversations/main/src/computers/turns/workflow/prisma-conversation-computer-turn-workflow-events.ts
+++ b/libs/backend/server/conversations/main/src/computers/turns/workflow/prisma-conversation-computer-turn-workflow-events.ts
@@ -3,7 +3,7 @@ import { ToolInvocationEventTypes, type ToolInvocationLifecycleEvent } from "@op
 import type { IWorkflowEngine, IWorkflowTaskReceipt } from "@opencrane/backend/server/infra/workflows/contract";
 
 import { CONVERSATION_COMPUTER_TURN_TASK } from "./conversation-computer-turn-task";
-import { _ToolResultEventName } from "./conversation-computer-turn-workflow";
+import { _ToolApprovalEventName, _ToolResultEventName } from "./conversation-computer-turn-workflow";
 import type { ConversationComputerTurnWorkflowEventRepository } from "./conversation-computer-turn-workflow-receipt.types";
 
 /** Delivers a terminal tool observation to its saved conversation workflow in the result transaction. */
@@ -24,6 +24,20 @@ export class PrismaConversationComputerTurnWorkflowEventRepository implements Co
 			{ client: this.transaction },
 			task,
 			{ eventName: _ToolResultEventName(event.payload.toolInvocationId), payload: { runId: event.runId, attempt: event.attempt, toolInvocationId: event.payload.toolInvocationId, eventType: event.eventType } },
+		);
+	}
+
+	/** Wake the exact saved turn after an approval decision changes its invocation readiness. */
+	public async wake(runId: string, attempt: number, toolInvocationId: string): Promise<void>
+	{
+		const run = await this.transaction.agentRun.findUnique({ where: { id_attempt: { id: runId, attempt } }, select: { workflowTaskId: true, workflowTaskName: true, workflowTaskKey: true } });
+		const task = _TaskReceipt(run);
+		if (task === null)
+			return;
+		await this.workflows.emitEventInTransaction(
+			{ client: this.transaction },
+			task,
+			{ eventName: _ToolApprovalEventName(toolInvocationId), payload: { runId, attempt, toolInvocationId } },
 		);
 	}
 }

--- a/libs/backend/server/conversations/main/src/index.ts
+++ b/libs/backend/server/conversations/main/src/index.ts
@@ -75,9 +75,9 @@ export type { ConversationToolDispatchAuthority, ConversationToolDispatchDepende
 export { PrismaConversationToolProposalUnitOfWork, PrismaConversationToolProposalRepository } from "./computers/tools/proposal/prisma-conversation-tool-proposal";
 export { ConversationToolProposalRefusal } from "./computers/tools/proposal/conversation-tool-proposal-refusal";
 export { ConversationToolProposalRefusals } from "./computers/tools/proposal/conversation-tool-proposal.types";
-export type { ConversationToolProposalAdmission, ConversationToolProposalRuntimeAdmission } from "./computers/tools/proposal/conversation-tool-proposal.types";
+export type { ConversationToolApprovalExpiry, ConversationToolProposalAdmission, ConversationToolProposalRuntimeAdmission } from "./computers/tools/proposal/conversation-tool-proposal.types";
 export type { ConversationComputerModelReservation, ConversationComputerModelTransport } from "./computers/turns/conversation-computer-model.types";
 export { CONVERSATION_COMPUTER_TURN_TASK } from "./computers/turns/workflow/conversation-computer-turn-task";
 export { PrismaConversationComputerTurnWorkflowReceiptBinder } from "./computers/turns/workflow/prisma-conversation-computer-turn-workflow-receipt-binder";
-export { _RegisterConversationComputerTurnWorkflow, _ToolResultEventName } from "./computers/turns/workflow/conversation-computer-turn-workflow";
+export { _RegisterConversationComputerTurnWorkflow, _ToolApprovalEventName, _ToolResultEventName } from "./computers/turns/workflow/conversation-computer-turn-workflow";
 export { PrismaConversationComputerTurnWorkflowEventRepository } from "./computers/turns/workflow/prisma-conversation-computer-turn-workflow-events";

--- a/libs/backend/server/gateways/model-routing/main/README.md
+++ b/libs/backend/server/gateways/model-routing/main/README.md
@@ -97,11 +97,13 @@ derived from their governed Global resource, so a late first POST cannot create 
   one frozen completion ceiling must exist. The request aborts by the earliest supplied deadline,
   compiled run deadline or 25 seconds, including time spent reading the body.
 
-The first request can offer the frozen tools that need no approval. Names must be unique and legal,
-with parameters matching their saved schema digests. The model may return text or propose exactly
-one offered tool. The shared declaration retains the provider call id, original argument string
-and accompanying text. Arguments must contain a bounded JSON object; the conversation and IAM
-owners still validate the actual schema and current permission before any execution.
+The first request can offer every frozen tool definition, including tools that need owner approval.
+Names must be unique and legal, with parameters matching their saved schema digests. The model may
+return text or propose exactly one offered tool. The shared declaration retains the provider call
+id, original argument string and accompanying text. Arguments must contain a bounded JSON object;
+the conversation and IAM owners still validate the actual schema and current permission before any
+execution. Managed company runs filter approval-gated tools before model selection until an entitled
+human resolver exists; personal runs can park the exact proposal in deferred approval.
 
 A continuation supplies that saved declaration and its authorized result. The adapter appends an
 assistant tool-call message and a tool-result message with the same provider call id after the

--- a/libs/backend/server/gateways/model-routing/main/src/__tests__/conversation-model.test.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/__tests__/conversation-model.test.ts
@@ -337,14 +337,14 @@ function _toolAnswer(call = _toolCall()): Record<string, unknown>
 
 describe("one selected tool and its paired continuation", function _toolExchange()
 {
-	it("offers only frozen nonapproval definitions and accepts one exact original declaration", async function _firstCall()
+	it("offers every frozen definition and accepts one exact original declaration", async function _firstCall()
 	{
 		const call = _toolCall({ content: "  Looking it up.\n" });
 		const fetchMock = vi.fn().mockResolvedValue(_response(_toolAnswer(call)));
 		vi.stubGlobal("fetch", fetchMock);
 		await expect(__RequestConversationModel(_selection([_tool(), _tool({ name: "write_file", requiresApproval: true })]))).resolves.toEqual({ kind: ConversationModelResponseKinds.Tool, call });
 		const body = JSON.parse(String(fetchMock.mock.calls[0]?.[1].body));
-		expect(body.tools).toEqual([{ type: "function", function: { name: "read_file", description: "Read a file.", parameters: _tool().parametersSchema } }]);
+		expect(body.tools).toEqual([_tool(), _tool({ name: "write_file", requiresApproval: true })].map(tool => ({ type: "function", function: { name: tool.name, description: tool.description, parameters: tool.parametersSchema } })));
 		expect(body).toMatchObject({ tool_choice: "auto", parallel_tool_calls: false, n: 1, stream: false });
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		expect(_telemetry.fields).toEqual([{}]);
@@ -382,7 +382,7 @@ describe("one selected tool and its paired continuation", function _toolExchange
 	});
 
 	it.each([
-		[], [_tool({ requiresApproval: true })], [_tool(), _tool()], [_tool(), _tool({ requiresApproval: true })],
+		[], [_tool(), _tool()],
 		[_tool({ name: "not.legal" })], [_tool({ parametersSchemaDigest: "sha256:changed" })],
 		[_tool({ parametersSchema: [] })], [_tool({ description: "\ud800" })],
 	].map(tools => ({ tools })))("rejects unusable frozen offer %# before dispatch", async function _badOffer({ tools })
@@ -391,6 +391,15 @@ describe("one selected tool and its paired continuation", function _toolExchange
 		vi.stubGlobal("fetch", fetchMock);
 		await expect(__RequestConversationModel(_selection(tools))).rejects.toMatchObject({ code: ConversationModelFailureCodes.InvalidRequest });
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("accepts an approval-gated saved continuation", async function _approvalContinuation()
+	{
+		const input = _selection([_tool({ requiresApproval: true })]);
+		const fetchMock = vi.fn().mockResolvedValue(_response());
+		vi.stubGlobal("fetch", fetchMock);
+		await expect(__RequestConversationModel({ ...input, tools: ConversationModelToolModes.None, continuation: { call: _toolCall(), resultContent: "approved result" } })).resolves.toMatchObject({ kind: ConversationModelResponseKinds.Text });
+		expect(fetchMock).toHaveBeenCalledOnce();
 	});
 
 	it.each([
@@ -428,7 +437,7 @@ describe("one selected tool and its paired continuation", function _toolExchange
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it.each(["approval", "unknown", "changed-schema", "select", "oversized", "unicode"])("rejects unusable continuation %s before dispatch", async function _badContinuation(kind)
+	it.each(["unknown", "changed-schema", "select", "oversized", "unicode"])("rejects unusable continuation %s before dispatch", async function _badContinuation(kind)
 	{
 		const input = _selection([_tool({ requiresApproval: kind === "approval", parametersSchemaDigest: kind === "changed-schema" ? "bad" : _tool().parametersSchemaDigest })]);
 		let resultContent = "result";

--- a/libs/backend/server/gateways/model-routing/main/src/core/conversation-model.validator.ts
+++ b/libs/backend/server/gateways/model-routing/main/src/core/conversation-model.validator.ts
@@ -34,8 +34,6 @@ function _offeredTools(tools: readonly CompiledToolDefinition[]): readonly Compi
 		if (!tool || typeof tool.name !== "string" || !/^[A-Za-z0-9_-]{1,64}$/u.test(tool.name) || names.has(tool.name) || typeof tool.requiresApproval !== "boolean")
 			throw new ConversationModelError(ConversationModelFailureCodes.InvalidRequest);
 		names.add(tool.name);
-		if (tool.requiresApproval)
-			continue;
 		if (typeof tool.description !== "string" || !_isRecord(tool.parametersSchema) || ___DigestCanonicalJson(tool.parametersSchema) !== tool.parametersSchemaDigest)
 			throw new ConversationModelError(ConversationModelFailureCodes.InvalidRequest);
 		offered.push(tool);

--- a/libs/backend/server/iam/authorization/main/README.md
+++ b/libs/backend/server/iam/authorization/main/README.md
@@ -74,7 +74,7 @@ the ordinary exact boundary-matching rules.
   grant on the retiring coordinates inside the owning product transaction.
 - `PrismaManagedShareRevocationRepository` soft-revokes the exact manager-owned grant linked from
   an explicit resource-share relation; it cannot create, list, or revoke arbitrary grants.
-- `__DecideDeferredToolRequest`, `__OpenDeferredToolApproval`,
+- `__DecideDeferredToolRequest`, `__OpenDeferredToolApproval`, `__OpenDeferredToolApprovalInTransaction`,
   `__CreatePrismaMcpToolInvocationParticipantFactory`, and their lifecycle contracts own durable human approval and
   provider-effect recovery for tool calls. A deferred approval opens only when the run and admitted
   invocation carry the same immutable execution subject, including the active conversation-computer

--- a/libs/backend/server/iam/authorization/main/src/approvals/__tests__/prisma-deferred-tool-approval-opener.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/approvals/__tests__/prisma-deferred-tool-approval-opener.test.ts
@@ -7,7 +7,7 @@ vi.mock("../../grants/persistence/prisma-managed-authorization-grant-repository"
 	return { __ReconcileManagedAuthorizationGrantsInTransaction: vi.fn().mockResolvedValue(2) };
 });
 
-import { __OpenDeferredToolApproval } from "../persistence/prisma-deferred-tool-approval-opener";
+import { __OpenDeferredToolApproval, __OpenDeferredToolApprovalInTransaction } from "../persistence/prisma-deferred-tool-approval-opener";
 import { __DigestCanonicalJson } from "../../authority/canonical-json-digest";
 
 /** Current immutable execution subject for the live conversation-computer lease. */
@@ -60,6 +60,14 @@ function _LiveTransaction()
 
 describe("Prisma deferred-tool approval opener", function _describeOpener()
 {
+	it("opens directly in the caller transaction without a nested transaction", async function _opensInCallerTransaction()
+	{
+		const transaction = _LiveTransaction();
+
+		await expect(__OpenDeferredToolApprovalInTransaction(transaction as unknown as Prisma.TransactionClient, _Command())).resolves.toBe(true);
+		expect(transaction.approvalRequest.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ toolInvocationRowId: "invocation-1", reviewedToolArguments: { calendarId: "primary" } }) }));
+	});
+
 	it("creates the approval inside the caller-owned transaction", async function _createsApproval()
 	{
 		const transaction = _LiveTransaction();

--- a/libs/backend/server/iam/authorization/main/src/approvals/persistence/prisma-deferred-tool-approval-opener.ts
+++ b/libs/backend/server/iam/authorization/main/src/approvals/persistence/prisma-deferred-tool-approval-opener.ts
@@ -64,6 +64,42 @@ export async function __OpenDeferredToolApproval(prisma: PrismaClient, command: 
 	return unitOfWork.open(command);
 }
 
+/** Open one approval inside an existing caller-owned transaction without creating a nested transaction. */
+export async function __OpenDeferredToolApprovalInTransaction(transaction: Prisma.TransactionClient, command: OpenDeferredToolApprovalCommand): Promise<boolean>
+{
+	const argumentsDigest = __DigestCanonicalJson(command.arguments);
+	const parametersSchemaDigest = __DigestCanonicalJson(command.parametersSchema);
+	if (argumentsDigest !== command.argumentsDigest || parametersSchemaDigest !== command.parametersSchemaDigest || !__ValidateDeferredToolArguments(command.parametersSchema, command.arguments))
+	{
+		await __MarkToolInvocationApprovalRejectedInTransaction(transaction, command.invocationId, command.now, "approval_arguments_invalid");
+		return false;
+	}
+	const projection = __ProjectDeferredToolApproval(command.parametersSchema, command.arguments);
+	const result = await __DeferToolRequest(transaction, {
+		interruptId: command.interruptId,
+		runId: command.runId,
+		attempt: command.attempt,
+		toolInvocationRowId: command.invocationId,
+		toolRevisionId: command.toolRevisionId,
+		reviewedArguments: command.arguments,
+		argumentsDigest: command.argumentsDigest,
+		reviewedParametersSchema: command.parametersSchema,
+		reviewedParametersSchemaDigest: parametersSchemaDigest,
+		safeProposedArguments: projection.proposedArguments,
+		responseSchema: projection.responseSchema,
+		actionDigest: __DigestCanonicalJson({ runId: command.runId, attempt: command.attempt, toolInvocationId: command.toolInvocationId, toolRevisionId: command.toolRevisionId, argumentsDigest: command.argumentsDigest }),
+		effectivePolicyDigest: command.capabilitySetDigest,
+		approverPolicyRevision: "mcp-server-requires-approval",
+		now: command.now,
+		expiresAt: command.expiresAt,
+	});
+	if (result.outcome !== DeferToolRequestOutcomes.Unavailable)
+		return true;
+	if (!await __MarkToolInvocationApprovalRejectedInTransaction(transaction, command.invocationId, command.now, "approval_unavailable"))
+		throw new Error("deferred approval lost its awaiting-approval invocation fence");
+	return false;
+}
+
 /** Opens one approval and cleans up when the transaction throws without revealing whether it committed. */
 class PrismaDeferredToolApprovalOpenUnitOfWork implements DeferredToolApprovalOpenUnitOfWork
 {

--- a/libs/backend/server/iam/authorization/main/src/index.ts
+++ b/libs/backend/server/iam/authorization/main/src/index.ts
@@ -20,10 +20,10 @@ export { DeferredToolApprovalLifecycleActions, DeferredToolApprovalLifecycleEven
 export type { DeferredToolApprovalLifecycleInput } from "./approvals/deferred-tool-approval-lifecycle.types";
 export { DeferToolRequestOutcomes } from "./approvals/deferred-tool-approval-open.types";
 export type { DeferToolRequestCommand, DeferToolRequestResult, OpenDeferredToolApprovalCommand } from "./approvals/deferred-tool-approval-open.types";
-export { __OpenDeferredToolApproval } from "./approvals/persistence/prisma-deferred-tool-approval-opener";
-export { __AdmitPreparingToolInvocationInTransaction, __PrepareToolInvocationInTransaction, __ReadRunToolProgressInTransaction, __ReadRunToolResultInTransaction, __ConsumeRunToolResultInTransaction } from "./tool-invocations/persistence/tool-invocation-transaction";
+export { __OpenDeferredToolApproval, __OpenDeferredToolApprovalInTransaction } from "./approvals/persistence/prisma-deferred-tool-approval-opener";
+export { __AdmitPreparingToolInvocationInTransaction, __FindToolInvocationInTransaction, __PrepareToolInvocationInTransaction, __ReadRunToolProgressInTransaction, __ReadRunToolResultInTransaction, __ConsumeRunToolResultInTransaction } from "./tool-invocations/persistence/tool-invocation-transaction";
 export type { ReadRunToolProgressCommand, RunToolProgressRepository } from "./tool-invocations/progress";
-export { RunToolResultReadOutcomes } from "./tool-invocations/run-tool-result-delivery.types";
+export { RunToolResultPendingKinds, RunToolResultReadOutcomes } from "./tool-invocations/run-tool-result-delivery.types";
 export type { ConsumeRunToolResultCommand, ReadRunToolResultCommand, ReadRunToolResultResult } from "./tool-invocations/run-tool-result-delivery.types";
 export { PrismaToolInvocationElicitationRepository } from "./tool-invocations/persistence/prisma-tool-invocation-elicitation-repository";
 export { __CreatePrismaMcpToolInvocationParticipantFactory } from "./tool-invocations/persistence/prisma-mcp-tool-invocation-participant";

--- a/libs/backend/server/iam/authorization/main/src/tool-invocations/__tests__/run-tool-result-delivery.test.ts
+++ b/libs/backend/server/iam/authorization/main/src/tool-invocations/__tests__/run-tool-result-delivery.test.ts
@@ -3,7 +3,7 @@ import { ___DigestCanonicalJson, type JsonValue } from "@opencrane/util";
 import { describe, expect, it, vi } from "vitest";
 
 import { PrismaToolInvocationRepository } from "../persistence/prisma-tool-invocation-repository";
-import { RunToolResultReadOutcomes, type ReadRunToolResultCommand } from "../run-tool-result-delivery.types";
+import { RunToolResultPendingKinds, RunToolResultReadOutcomes, type ReadRunToolResultCommand } from "../run-tool-result-delivery.types";
 import { ExternalActionClaimKinds } from "../tool-invocation-lifecycle.types";
 import { __ConsumeRunToolResultInTransaction, __ReadRunToolResultInTransaction } from "../persistence/tool-invocation-transaction";
 import type { ToolResultDeliveryPayload } from "../tool-invocation.types";
@@ -46,7 +46,7 @@ describe("__ReadRunToolResultInTransaction", function _resultReader()
 		const fixture = _reader(row);
 		const result = await __ReadRunToolResultInTransaction(fixture.transaction, _COMMAND);
 		expect(result).toMatchObject({ outcome: RunToolResultReadOutcomes.Available, invocation: { id: row.id, toolInvocationId: _COMMAND.toolInvocationId }, payload: row.resultDelivery.payload, payloadDigest: row.resultDelivery.payloadDigest, consumed: false });
-		expect(fixture.findFirst).toHaveBeenCalledExactlyOnceWith({ where: { ..._COMMAND, mcpTaskId: null, run: { is: { id: _COMMAND.runId, siloId: _COMMAND.siloId, attempt: _COMMAND.attempt, state: AgentRunState.Running } } }, include: { run: { select: { id: true, siloId: true, attempt: true, state: true } }, resultDelivery: true } });
+		expect(fixture.findFirst).toHaveBeenCalledExactlyOnceWith({ where: { ..._COMMAND, mcpTaskId: null, run: { is: { id: _COMMAND.runId, siloId: _COMMAND.siloId, attempt: _COMMAND.attempt, state: { in: [AgentRunState.Running, AgentRunState.WaitingForInput] } } } }, include: { run: { select: { id: true, siloId: true, attempt: true, state: true } }, resultDelivery: true } });
 		expect(row.resultDelivery.state).toBe(ToolResultDeliveryState.Pending);
 		expect(row.resultDelivery.consumedAt).toBeNull();
 	});
@@ -81,6 +81,15 @@ describe("__ReadRunToolResultInTransaction", function _resultReader()
 	{
 		const row = { ..._row(), state, result: null, completedAt: null, resultDelivery: null };
 		await expect(__ReadRunToolResultInTransaction(_reader(row).transaction, _COMMAND)).resolves.toEqual({ outcome: RunToolResultReadOutcomes.Pending });
+	});
+
+	it("retains the approval deadline for the conversation workflow timeout", async function _ApprovalDeadline()
+	{
+		const row = { ..._row(), state: ToolInvocationState.AwaitingApproval, result: null, completedAt: null, resultDelivery: null, run: { ..._row().run, state: AgentRunState.WaitingForInput } };
+		const findFirst = vi.fn().mockResolvedValueOnce(row).mockResolvedValueOnce({ expiresAt: new Date(_NOW.getTime() + 30_000) });
+		const transaction = { toolInvocation: { findFirst }, approvalRequest: { findFirst } } as unknown as Prisma.TransactionClient;
+
+		await expect(__ReadRunToolResultInTransaction(transaction, _COMMAND)).resolves.toEqual({ outcome: RunToolResultReadOutcomes.Pending, pendingKind: RunToolResultPendingKinds.Approval, pendingUntilEpochMs: _NOW.getTime() + 30_000 });
 	});
 
 	it("keeps an ambiguous provider outcome unavailable instead of inventing a result", async function _recoveryRequired()

--- a/libs/backend/server/iam/authorization/main/src/tool-invocations/persistence/prisma-run-tool-result-delivery-repository.ts
+++ b/libs/backend/server/iam/authorization/main/src/tool-invocations/persistence/prisma-run-tool-result-delivery-repository.ts
@@ -1,7 +1,7 @@
-import { AgentRunState, ToolInvocationState, ToolResultDeliveryState, type Prisma } from "@prisma/client";
+import { AgentRunState, ApprovalRequestState, ToolInvocationState, ToolResultDeliveryState, type Prisma } from "@prisma/client";
 
 import { _ToolInvocationRecord } from "../tool-invocation-persistence-mapping";
-import { RunToolResultReadOutcomes, type ConsumeRunToolResultCommand, type ReadRunToolResultCommand, type ReadRunToolResultResult, type RunToolResultDeliveryRepository } from "../run-tool-result-delivery.types";
+import { RunToolResultPendingKinds, RunToolResultReadOutcomes, type ConsumeRunToolResultCommand, type ReadRunToolResultCommand, type ReadRunToolResultResult, type RunToolResultDeliveryRepository } from "../run-tool-result-delivery.types";
 import { _CopyReadRunToolResultCommand, _ReadExactRunToolResultPayload } from "../run-tool-result-delivery.validator";
 import type { ToolInvocationRecord } from "../tool-invocation.types";
 
@@ -35,19 +35,27 @@ export class PrismaRunToolResultDeliveryRepository implements RunToolResultDeliv
 		if (coordinates === null)
 			return { outcome: RunToolResultReadOutcomes.Unavailable };
 		const row = await this.transaction.toolInvocation.findFirst({
-			where: { ...coordinates, mcpTaskId: null, run: { is: { id: coordinates.runId, siloId: coordinates.siloId, attempt: coordinates.attempt, state: AgentRunState.Running } } },
+			where: { ...coordinates, mcpTaskId: null, run: { is: { id: coordinates.runId, siloId: coordinates.siloId, attempt: coordinates.attempt, state: { in: [AgentRunState.Running, AgentRunState.WaitingForInput] } } } },
 			include: { run: { select: { id: true, siloId: true, attempt: true, state: true } }, resultDelivery: true },
 		});
 		if (row === null || row.mcpTaskId !== null || row.siloId !== coordinates.siloId || row.runId !== coordinates.runId || row.attempt !== coordinates.attempt
 			|| row.toolInvocationId !== coordinates.toolInvocationId || row.runtimeInstanceId !== coordinates.runtimeInstanceId || row.commandId !== coordinates.commandId || row.requestFingerprint !== coordinates.requestFingerprint
-			|| row.run === null || row.run.id !== coordinates.runId || row.run.siloId !== coordinates.siloId || row.run.attempt !== coordinates.attempt || row.run.state !== AgentRunState.Running)
+			|| row.run === null || row.run.id !== coordinates.runId || row.run.siloId !== coordinates.siloId || row.run.attempt !== coordinates.attempt
+			|| row.run.state !== AgentRunState.Running && !(row.run.state === AgentRunState.WaitingForInput && row.state === ToolInvocationState.AwaitingApproval))
 			return { outcome: RunToolResultReadOutcomes.Unavailable };
 		const delivery = row.resultDelivery;
 		if (row.state !== ToolInvocationState.Succeeded && row.state !== ToolInvocationState.Failed)
 		{
 			const pendingStates: readonly ToolInvocationState[] = [ToolInvocationState.Preparing, ToolInvocationState.AwaitingApproval, ToolInvocationState.Ready, ToolInvocationState.Claimed, ToolInvocationState.Reconciling];
 			const pending = delivery === null && row.completedAt === null && row.result === null && pendingStates.includes(row.state);
-			return { outcome: pending ? RunToolResultReadOutcomes.Pending : RunToolResultReadOutcomes.Unavailable };
+			if (!pending)
+				return { outcome: RunToolResultReadOutcomes.Unavailable };
+			const approval = row.state === ToolInvocationState.AwaitingApproval && this.transaction.approvalRequest !== undefined
+				? await this.transaction.approvalRequest.findFirst({ where: { toolInvocationRowId: row.id, state: ApprovalRequestState.Pending }, select: { expiresAt: true } })
+				: null;
+			return approval === null || approval === undefined
+				? { outcome: RunToolResultReadOutcomes.Pending }
+				: { outcome: RunToolResultReadOutcomes.Pending, pendingKind: RunToolResultPendingKinds.Approval, pendingUntilEpochMs: approval.expiresAt.getTime() };
 		}
 		if (delivery === null || delivery.toolInvocationId !== row.id || !(row.completedAt instanceof Date) || !Number.isFinite(row.completedAt.getTime())
 			|| row.claimKind !== null || row.claimExpiresAt !== null

--- a/libs/backend/server/iam/authorization/main/src/tool-invocations/run-tool-result-delivery.types.ts
+++ b/libs/backend/server/iam/authorization/main/src/tool-invocations/run-tool-result-delivery.types.ts
@@ -41,9 +41,18 @@ export enum RunToolResultReadOutcomes
 	Unavailable = "unavailable",
 }
 
+/** Identifies the durable wake that can make a pending invocation progress. */
+export enum RunToolResultPendingKinds
+{
+	/** An owner decision must move the invocation to Ready or Failed. */
+	Approval = "approval",
+	/** An executor result event must complete the already-admitted invocation. */
+	Execution = "execution",
+}
+
 /** Keeps result content out of pending or unavailable outcomes. */
 export type ReadRunToolResultResult =
-	| { readonly outcome: RunToolResultReadOutcomes.Pending | RunToolResultReadOutcomes.Unavailable }
+	| { readonly outcome: RunToolResultReadOutcomes.Pending | RunToolResultReadOutcomes.Unavailable; readonly pendingKind?: RunToolResultPendingKinds; readonly pendingUntilEpochMs?: number }
 	| {
 		/** Confirms storage integrity, not permission to disclose or dispatch. */
 		readonly outcome: RunToolResultReadOutcomes.Available;

--- a/libs/backend/server/infra/workflows/contract/src/workflow-engine.types.ts
+++ b/libs/backend/server/infra/workflows/contract/src/workflow-engine.types.ts
@@ -130,13 +130,23 @@ export interface IWorkflowTaskQueueAuthority
 }
 
 /** One application event delivered to a task. */
-export interface IWorkflowTaskEvent<TPayload>
-{
-	/** Event name the receiving task waits for. */
-	readonly eventName: string;
-	/** Application-owned event data; this contract does not prescribe its schema. */
-	readonly payload: TPayload;
-}
+export type IWorkflowTaskEvent<TPayload> =
+	| {
+		/** Event name the receiving task waits for. */
+		readonly eventName: string;
+		/** Application-owned event data; this contract does not prescribe its schema. */
+		readonly payload: TPayload;
+		/** A delivered event is never a timeout. */
+		readonly timedOut?: false;
+	}
+	| {
+		/** Event name whose durable wait reached its deadline. */
+		readonly eventName: string;
+		/** A timed-out wait has no application payload. */
+		readonly payload: null;
+		/** Discriminates timeout from a delivered event. */
+		readonly timedOut: true;
+	};
 
 /** Receipt for an event accepted for a specific task. */
 export interface IWorkflowTaskEventReceipt
@@ -205,7 +215,7 @@ export interface IWorkflowTaskContext
 	/** Run one named operation so an engine can resume it without repeating a completed effect. */
 	checkpoint<TResult>(step: IWorkflowCheckpointStep, operation: IWorkflowCheckpointOperation<TResult>): Promise<TResult>;
 	/** Wait until an event with this name is delivered to the current task. */
-	waitForEvent<TPayload>(eventName: string): Promise<IWorkflowTaskEvent<TPayload>>;
+	waitForEvent<TPayload>(eventName: string, options?: { readonly timeoutAt?: Date }): Promise<IWorkflowTaskEvent<TPayload>>;
 	/** Admit a child task that belongs to the current task's workflow engine. */
 	spawnChild<TInput>(task: IWorkflowTaskSpawn<TInput>): Promise<IWorkflowTaskReceipt>;
 	/** Wait for a child task receipt and return the result produced by its handler. */

--- a/libs/backend/server/infra/workflows/guard/src/workflow-guard.ts
+++ b/libs/backend/server/infra/workflows/guard/src/workflow-guard.ts
@@ -313,9 +313,9 @@ class _WorkflowTaskContext implements IWorkflowTaskContext
 	}
 
 	/** Receives an event after rejecting any credential-shaped fields from its saved payload. */
-	async waitForEvent<TPayload>(eventName: string): Promise<IWorkflowTaskEvent<TPayload>>
+	async waitForEvent<TPayload>(eventName: string, options: { readonly timeoutAt?: Date } = {}): Promise<IWorkflowTaskEvent<TPayload>>
 	{
-		const event = await this.context.waitForEvent<TPayload>(eventName);
+		const event = await this.context.waitForEvent<TPayload>(eventName, options);
 		_AssertPersistableWorkflowPayload(event.payload);
 		return event;
 	}

--- a/libs/backend/server/infra/workflows/infra_absurd/src/__tests__/absurd-task-context.test.ts
+++ b/libs/backend/server/infra/workflows/infra_absurd/src/__tests__/absurd-task-context.test.ts
@@ -1,0 +1,53 @@
+import { TimeoutError, type TaskContext } from "absurd-sdk";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { WorkflowError } from "@opencrane/backend/server/infra/workflows/contract";
+
+import { _AbsurdTaskContext } from "../absurd-task-context";
+
+const _TASK = { taskId: "task-1", taskName: "approval", idempotencyKey: "approval-1" } as const;
+
+/** Creates the adapter around the one SDK method exercised by these tests. */
+function _Context(awaitEvent: ReturnType<typeof vi.fn>): _AbsurdTaskContext
+{
+	return new _AbsurdTaskContext({ awaitEvent } as unknown as TaskContext, _TASK, 1, {} as never);
+}
+
+describe("Absurd task event waits", function _Suite()
+{
+	afterEach(function _RestoreClock()
+	{
+		vi.useRealTimers();
+	});
+
+	it("returns a delivered event without adding a timeout", async function _Delivered()
+	{
+		const awaitEvent = vi.fn().mockResolvedValue({ approved: true });
+		await expect(_Context(awaitEvent).waitForEvent("tool-approval:invoke-1")).resolves.toEqual({ eventName: "tool-approval:invoke-1", payload: { approved: true } });
+		expect(awaitEvent).toHaveBeenCalledExactlyOnceWith("opencrane-task:task-1:event:tool-approval:invoke-1", undefined);
+	});
+
+	it("rounds a future absolute deadline up to the SDK timeout in seconds", async function _FutureDeadline()
+	{
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-09-10T10:00:00.000Z"));
+		const awaitEvent = vi.fn().mockResolvedValue("approved");
+		await _Context(awaitEvent).waitForEvent("approval", { timeoutAt: new Date("2026-09-10T10:00:01.001Z") });
+		expect(awaitEvent).toHaveBeenCalledExactlyOnceWith("opencrane-task:task-1:event:approval", { timeout: 2 });
+	});
+
+	it("projects the pinned SDK timeout without an application payload", async function _Timeout()
+	{
+		const awaitEvent = vi.fn().mockRejectedValue(new TimeoutError("event wait expired"));
+		await expect(_Context(awaitEvent).waitForEvent("approval")).resolves.toEqual({ eventName: "approval", payload: null, timedOut: true });
+	});
+
+	it.each([new Date("invalid"), new Date("2026-09-10T09:59:59.999Z")])("rejects invalid or past deadlines before calling the SDK", async function _InvalidDeadline(timeoutAt)
+	{
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-09-10T10:00:00.000Z"));
+		const awaitEvent = vi.fn();
+		await expect(_Context(awaitEvent).waitForEvent("approval", { timeoutAt })).rejects.toBeInstanceOf(WorkflowError);
+		expect(awaitEvent).not.toHaveBeenCalled();
+	});
+});

--- a/libs/backend/server/infra/workflows/infra_absurd/src/absurd-task-context.ts
+++ b/libs/backend/server/infra/workflows/infra_absurd/src/absurd-task-context.ts
@@ -1,4 +1,4 @@
-import { CancelledTask, SuspendTask, type TaskContext } from "absurd-sdk";
+import { CancelledTask, SuspendTask, TimeoutError, type TaskContext } from "absurd-sdk";
 
 import { WorkflowError, WorkflowTaskCancelledError } from "@opencrane/backend/server/infra/workflows/contract";
 import type { IWorkflowCheckpointOperation, IWorkflowCheckpointStep, IWorkflowTaskContext, IWorkflowTaskEvent, IWorkflowTaskReceipt, IWorkflowTaskSpawn } from "@opencrane/backend/server/infra/workflows/contract";
@@ -85,17 +85,22 @@ export class _AbsurdTaskContext implements IWorkflowTaskContext
 	}
 
 	/** Suspend durably until this task receives its private event name. */
-	async waitForEvent<TPayload>(eventName: string): Promise<IWorkflowTaskEvent<TPayload>>
+	async waitForEvent<TPayload>(eventName: string, options: { readonly timeoutAt?: Date } = {}): Promise<IWorkflowTaskEvent<TPayload>>
 	{
 		const acceptedName = _RequiredString("eventName", eventName);
+		const timeoutMilliseconds = options.timeoutAt === undefined ? null : options.timeoutAt.getTime() - Date.now();
+		if (timeoutMilliseconds !== null && (!Number.isFinite(timeoutMilliseconds) || timeoutMilliseconds < 0))
+			throw new WorkflowError("event wait timeout must be a future Date");
 		try
 		{
-			const payload = await this.context.awaitEvent(_AbsurdTaskEventName(this.task.taskId, acceptedName));
+			const payload = await this.context.awaitEvent(_AbsurdTaskEventName(this.task.taskId, acceptedName), timeoutMilliseconds === null ? undefined : { timeout: Math.ceil(timeoutMilliseconds / 1_000) });
 			return { eventName: acceptedName, payload: payload as unknown as TPayload };
 		}
 		catch (error)
 		{
-			return _NormalizeContextError(this.task.taskId, error);
+			if (error instanceof TimeoutError)
+				return { eventName: acceptedName, payload: null, timedOut: true };
+			throw _NormalizeContextError(this.task.taskId, error);
 		}
 	}
 

--- a/libs/backend/server/infra/workflows/testing/src/__tests__/workflow-engine-contract.ts
+++ b/libs/backend/server/infra/workflows/testing/src/__tests__/workflow-engine-contract.ts
@@ -46,6 +46,8 @@ export function __TestWorkflowEngineContract(name: string, createHarness: IWorkf
 			harness.execution.register(_Task("contract-context", async function _RunContext(context)
 			{
 				const event = await context.waitForEvent<{ readonly value: string }>("approved");
+				if (event.timedOut)
+					throw new Error("contract test expected a delivered event");
 				const child = await context.spawnChild({ taskName: "contract-child", idempotencyKey: "child-1", input: { value: event.payload.value } });
 				const childResult = await context.awaitChild<string>(child);
 				return context.checkpoint({ stepName: "persist-result" }, async function _SaveResult()

--- a/libs/backend/server/infra/workflows/testing/src/fake-workflow-engine.ts
+++ b/libs/backend/server/infra/workflows/testing/src/fake-workflow-engine.ts
@@ -191,7 +191,7 @@ export class __FakeWorkflowEngine implements IWorkflowEngine, IWorkflowWorkerRun
 				self._AssertNotCancelled(record);
 				return operation();
 			},
-			async waitForEvent<TPayload>(eventName: string): Promise<IWorkflowTaskEvent<TPayload>>
+			async waitForEvent<TPayload>(eventName: string, _options: { readonly timeoutAt?: Date } = {}): Promise<IWorkflowTaskEvent<TPayload>>
 			{
 				self._AssertNotCancelled(record);
 				const queuedEvents = self.eventsByTask.get(record.receipt.taskId) ?? [];

--- a/libs/contracts/README.md
+++ b/libs/contracts/README.md
@@ -85,8 +85,9 @@ a tool's identity, arguments or result.
   immutable history and generation-fenced computer vocabulary shared by server and browser.
 - `ConversationToolProposal`, `___ConversationToolProposalSchema` and
   `ConversationToolProposalReceipt` — the private workload request for one frozen tool revision
-  and bounded JSON arguments. It accepts no caller-selected identity or approval. A receipt
-  confirms storage only; it contains no provider result or execution claim.
+  and bounded JSON arguments. It accepts no caller-selected identity; its approval requirement is
+  copied from the frozen tool definition and remains a proposal until server-owned IAM decides it.
+  A receipt confirms storage only; it contains no provider result or execution claim.
 - `___ConversationComputerSchema` validates the existing public computer shape, lease generation,
   and checkpoint metadata without admitting private extensions. Readers still bind its conversation
   coordinate to the authenticated request.

--- a/libs/contracts/src/conversations/conversation-model.types.ts
+++ b/libs/contracts/src/conversations/conversation-model.types.ts
@@ -9,7 +9,7 @@ export enum ConversationModelToolModes
 {
 	/** Requests text without sending tool definitions; a returned tool call must be rejected. */
 	None = "none",
-	/** Offers frozen tools that need no approval; the response may select at most one. */
+	/** Offers frozen tools; the response may select at most one and approval-gated calls remain proposals. */
 	Select = "select",
 }
 

--- a/plan.md
+++ b/plan.md
@@ -19,7 +19,7 @@ lanes while the common protocol work proceeds.
 | Priority | Track | Completion means | Current next step |
 | --- | --- | --- | --- |
 | 1 | T1 — real tool retrieval | A permitted real record reaches an answer in personal and company-child chats; remote MCP connections and hosted MCP execution have qualified journeys. Results survive reload and restart without repeated dispatch. | IN PROGRESS: company tool selection is implemented and locally verified; standard remote connection activation, participant result evidence and one real integration come first, followed by the required hosted MCP slice. |
-| 2 | T2 — approved external actions | A person reviews an exact action and arguments; one approval permits that effect once. Denial, expiry, changed arguments and revoked authority prevent it. | Reuse IAM deferred approval and elicitation; connect approval-required model tools and disclose the exact external target and connection owner. |
+| 2 | T2 — approved external actions | A person reviews an exact action and arguments; one approval permits that effect once. Denial, expiry, changed arguments and revoked authority prevent it. | IN PROGRESS: personal approval, expiry and durable resume are locally proven. Bind the company approver and disclose the exact connection owner and external target before qualifying a real action. |
 | 3 | M1 — long-term memory | Explicit remember, cross-conversation recall, correction and forget work with consent and isolated datasets. | Verify the pinned gateway's recall/deletion identity and recoverable correction before enabling writes. |
 | 4 | U1 — visible work controls | People can follow waiting, running and terminal work, make supported decisions and cancel eligible work after refresh. | Reuse conversation events, stores and approved components; preserve current access on reconnect. |
 | 5 | U2 — rich interaction | Durable choices, free text, structured results and A2UI remain usable and accessible after refresh. | Complete the existing server-issued interaction and presentation contracts. |
@@ -315,7 +315,8 @@ their own completion track; they are not silently bundled into the first tool PR
 | R1 — reliable login | IMPLEMENTED, CI GREEN at `44fd8f328` — encrypted PostgreSQL sessions, fixed deadlines, revision-checked saves and logout markers. All 52 auth tests and [CI](https://github.com/elewa-git/opencrane/actions/runs/34274625541) pass, including all seven SQL targets on fresh PostgreSQL and six real-client session proofs. Fresh-install live qualification remains pending; testv5 retains the earlier database baseline. |
 | A1 — membership revocation and closed-work proof | IMPLEMENTED, IN REVIEW — standalone administrators can remove another non-Owner member through Settings. The server suspends the existing membership, protects Owner/self removal and rechecks current authority on retries. Workspace access loss clears retained private content and rejects delayed results. Focused unit checks and all 123 browser checks pass; five real PostgreSQL cases join the CI gate. The real-account removal and closed-work journey remains to qualify live. Fleet removal remains unsupported. |
 | T1 — first permitted tool retrieval | IN PROGRESS — the server's one-tool continuation is implemented and now progresses through Absurd in #849. Company tool assignment is the first active follow-up. Connection activation, a real integration and participant result evidence remain required. |
-| T2, M1, U1, U2, F1, D1, S1, A2, T3 | PLANNED in the exact priority order above, with separate acceptance for each journey. |
+| T2 | IN PROGRESS: personal approval and durable resume pass local integration; company approval and real external-action qualification remain. |
+| M1, U1, U2, F1, D1, S1, A2, T3 | PLANNED in the exact priority order above, with separate acceptance for each journey. |
 | Q1 — operational acceptance | CONTINUOUS — source checks and CI do not replace fresh-install or real-account acceptance. |
 
 The 10 September priority order supersedes the earlier overnight sequencing and morning handoff.
@@ -414,6 +415,29 @@ snapshot restore was rejected before execution by automatic approval review; no 
 time is claimed.
 Cluster changes use the authorized app-owned scripts; exact inputs, incidents and proof belong in
 the [deploy ledger](docs/agents/deploy-ledger.md).
+
+### Personal approval slice — implementation and local integration complete
+
+This owned slice is stacked on PR #852 at `abeed031373f8461b97f3a7ae6997e61c3348a5e` and keeps approval-gated
+personal tools in the existing model/proposal loop. The model receives frozen definitions; a personal
+proposal preserves its arguments, schema digests and original run allowance, records a deferred IAM
+request assigned to the run's exact `Principal.subject`, and pauses the saved Absurd turn in
+`WaitingForInput`. An owner decision marks the invocation ready or terminally failed, then wakes the
+existing turn event so restart and duplicate admission reuse the same invocation without another MCP
+dispatch. Expiry, stale fencing and changed arguments fail closed.
+
+Managed company approval tools remain filtered at model selection and rejected before proposal
+preparation because the entitled human resolver and connection authority are not yet bound. The
+remote credential/connection schema therefore remains an integration boundary for the next slice;
+this personal approval path does not claim a live remote effect.
+
+Validation evidence: the final disposable PostgreSQL run passes proposal (`17`), approval (`3`),
+result (`4`) and all authority SQL checks after the mixed-batch wake repair. Full conversation coverage (`467`) passed, full
+elicitation coverage (`45`) passed with permitted HTTP listeners, IAM coverage (`243`) passed,
+OpenCrane lint and build passed, and Absurd adapter coverage (`33`) plus lint passed. PostgreSQL
+integration and OpenCrane lint also passed after stacking onto #852. Independent review and
+architecture post-review passed. These are source and integration checks; no live remote-provider,
+hosted-MCP or fresh-install qualification is claimed here.
 
 ## Later work
 


### PR DESCRIPTION
Personal assistants can now propose a tool that requires their owner's approval, wait durably for the decision, and resume the original invocation. The decision covers the saved arguments and original allowance. Denial, expiry, changed arguments and lost authority prevent execution; replay reuses saved work without another tool dispatch.

This draft is stacked directly on #852 (`feat/0.12-mcp-protocol-conformance`).

The existing elicitation transaction records the decision and wakes the saved Absurd turn using the public invocation ID. Approval and result events have separate names so an approval cannot consume the result wake. The last response in a mixed input batch wakes every terminal tool approval. Absurd retains the original deadline and handles timeout explicitly. IAM owns permission and decision evidence; the server owns model selection, arguments, budgets and continuation; the existing MCP runtime retains its execution fences.

Company approval tools remain unavailable until the entitled approver and connection authority are bound. This slice does not add a queue, scheduler, outbox, compatibility path or new live integration.

Validation completed:

- Disposable PostgreSQL through `nx run opencrane:test:sql`: all authority SQL checks, 17 proposal tests, 3 approval tests and 4 result tests passed, including a fresh rerun after rebasing onto #852. The fixture uses real Prisma repositories and workflow definition with a fake workflow engine and turn store.
- Nx tests: conversations 467, elicitation 45, IAM 243 and Absurd adapter 33 passed. Coverage includes owner decisions, mixed input batches, expiry, duplicate resume, a single consumed result and the preserved continuation allowance.
- OpenCrane type check and build passed; type check was repeated after the rebase. Changed package lint passed.
- Dependency, Prisma, workflow, IAM, workload ownership, agent-domain and release-versioning checks passed. Style: 0 errors and 0 warnings. Module growth: 0 errors; both reported candidates received a responsibility review.
- Architecture preflight/post-review and mandatory independent review passed. The clean rebase changed no implementation; `git range-diff` showed only plan context movement. Live PR-stack integrity passed before publication.

Owning package READMEs, `plan.md` and `CHANGELOG.md` describe the new behavior and remaining work. Testv5/live qualification remains a separate gate; no remote-provider effect, hosted-MCP qualification, company approval journey or fresh installation is claimed. Visible approval controls and recovery controls remain follow-up work.

## Review order

1. PR #831 — member access and revocation.
2. PR #843 — library and component decomposition.
3. PR #849 — Absurd conversation turn progression.
4. PR #850 — company tool selection.
5. PR #851 — recent personal tool activity.
6. PR #852 — standard MCP requests and streamed responses (direct base).
7. PR #853 — durable personal tool approval (this PR).
