### PR TITLE
🐛 Repair unused personal assistant execution profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ follows [Keep a Changelog](https://keepachangelog.com/); the project uses
 ## [Unreleased]
 
 Personal and group-assistant text journeys and recent personal activity have passed integration
-CI and live testv5 checks.
+CI and earlier live testv5 checks. Current testv5 onboarding is blocked by an unused personal
+assistant's outdated computer profile; its data-preserving repair remains under qualification.
 The 0.11 baseline remains under review; this is not a release or a completed MVP.
 
 ### Added
@@ -126,6 +127,10 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
   only rebuildable transaction projections.
 
 ### Fixed
+
+- **Completed setup can recover an unused personal assistant whose computer profile is no longer configured.**
+  The repair keeps setup answers, identity and revision history, requires current edit permission,
+  and refuses any assistant with prior conversations or runs. Live qualification remains separate.
 
 - **Browser login can survive server replacement and requests reaching different servers.** The
   follow-up stores encrypted sessions in PostgreSQL, preserves fixed expiry and prevents delayed

--- a/apps/opencrane/package.json
+++ b/apps/opencrane/package.json
@@ -118,7 +118,8 @@
             "sh ../../scripts/run-postgres-authority-tests.sh prisma/tests/authorization-active-grant-uniqueness.sql prisma/tests/phase-d-authority-integration.sql prisma/tests/skill-authoring-validation-authority.sql",
             "vitest run src/bootstrap/conversations/__tests__/conversation-tool-proposal.sql.test.ts",
             "vitest run src/bootstrap/conversations/__tests__/conversation-tool-approval.sql.test.ts",
-            "vitest run src/bootstrap/conversations/__tests__/conversation-tool-result.sql.test.ts"
+            "vitest run src/bootstrap/conversations/__tests__/conversation-tool-result.sql.test.ts",
+            "vitest run src/bootstrap/onboarding/__tests__/personal-agent-profile-repair.sql.test.ts"
           ],
           "parallel": false
         },

--- a/apps/opencrane/src/bootstrap/http/__tests__/user-onboarding-personal-agent-composition.test.ts
+++ b/apps/opencrane/src/bootstrap/http/__tests__/user-onboarding-personal-agent-composition.test.ts
@@ -1,9 +1,10 @@
 import express from "express";
 import request from "supertest";
 import { AgentRevisionState, AgentServiceKind, AgentServiceState, ModelRoutingScope, PersonaRevisionState, PrincipalProvenance, UserOnboardingCompletionProvenance, UserOnboardingState, type PrismaClient } from "@prisma/client";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Logger } from "@opencrane/backend/observability";
+import { PersonalAgentBootstrapConflict, PrismaPersonalAgentBootstrapRepository, type PersonalAgentBootstrapCommand } from "@opencrane/backend/server/agents/agent-services";
 import { PRODUCT_AUTHORIZATION_CATALOG_DIGEST, PRODUCT_AUTHORIZATION_CATALOG_ID, PRODUCT_AUTHORIZATION_CATALOG_REVISION } from "@opencrane/models/authorization";
 
 import { _CreateUserOnboardingComposition } from "@opencrane/backend/server/agents/onboarding";
@@ -268,7 +269,7 @@ function _App(fixture: ReturnType<typeof _PrismaFixture>)
 		if (fields.err !== undefined)
 			fixture.errors.push(fields.err);
 	}) } as unknown as Logger;
-	const composition = _CreateUserOnboardingComposition(fixture.prisma, logger, function _ResolveOwner() { return _OWNER; }, "developer");
+	const composition = _CreateUserOnboardingComposition(fixture.prisma, logger, function _ResolveOwner() { return _OWNER; }, "developer", ["developer"]);
 	const app = express();
 	app.use(express.json());
 	app.use("/api/v1/me/onboarding", composition.router);
@@ -277,10 +278,12 @@ function _App(fixture: ReturnType<typeof _PrismaFixture>)
 
 describe("personal Agent onboarding app composition", function _PersonalAgentCompositionSuite()
 {
+	afterEach(function _RestoreRepositoryMethods() { vi.restoreAllMocks(); });
+
 	it("refuses missing deployment profile configuration before creating the router", function _MissingProfile()
 	{
 		const fixture = _PrismaFixture(true);
-		expect(function _Compose() { return _CreateUserOnboardingComposition(fixture.prisma, {} as Logger, function _ResolveOwner() { return _OWNER; }, ""); }).toThrow("configured conversation-computer profile");
+		expect(function _Compose() { return _CreateUserOnboardingComposition(fixture.prisma, {} as Logger, function _ResolveOwner() { return _OWNER; }, "", []); }).toThrow("configured conversation-computer profile");
 		expect(fixture.attempts()).toBe(0);
 	});
 
@@ -302,5 +305,34 @@ describe("personal Agent onboarding app composition", function _PersonalAgentCom
 		await request(_App(fixture)).post("/api/v1/me/onboarding/chat/conclude").send({}).expect(503);
 		expect(fixture.state()).toMatchObject({ onboardingState: UserOnboardingState.BootstrapChatInProgress, completionProvenance: null, agentService: null, agentRevision: null, auditCount: 0, authorizationGrants: [_AgentServiceCollectionGrant()] });
 		expect(fixture.attempts()).toBe(3);
+	});
+
+	it("retries an agent-service comparison only after rolling back its staged writes", async function _RetriesAgentComparison()
+	{
+		const fixture = _PrismaFixture(true);
+		const original = PrismaPersonalAgentBootstrapRepository.prototype.ensureReady;
+		const preparation = vi.spyOn(PrismaPersonalAgentBootstrapRepository.prototype, "ensureReady").mockImplementationOnce(async function _LoseFirstComparison(this: PrismaPersonalAgentBootstrapRepository, command: PersonalAgentBootstrapCommand)
+		{
+			await original.call(this, command);
+			throw new PersonalAgentBootstrapConflict();
+		});
+		await request(_App(fixture)).post("/api/v1/me/onboarding/chat/conclude").send({}).expect(200);
+		expect(preparation.mock.calls.map(function _ReadinessKind(call) { return call[0].readinessKind; })).toEqual(["completion", "completion", "repair"]);
+		expect(fixture.state()).toMatchObject({ onboardingState: UserOnboardingState.Completed, auditCount: 6, agentService: { id: _ONBOARDING_ID, workloadProfile: "developer" } });
+		expect(fixture.state().authorizationGrants).toHaveLength(19);
+	});
+
+	it("returns unavailable after three agent-service conflicts without committing audit or Agent writes", async function _ExhaustsAgentComparisons()
+	{
+		const fixture = _PrismaFixture(true);
+		const original = PrismaPersonalAgentBootstrapRepository.prototype.ensureReady;
+		const preparation = vi.spyOn(PrismaPersonalAgentBootstrapRepository.prototype, "ensureReady").mockImplementation(async function _LoseEveryComparison(this: PrismaPersonalAgentBootstrapRepository, command: PersonalAgentBootstrapCommand)
+		{
+			await original.call(this, command);
+			throw new PersonalAgentBootstrapConflict();
+		});
+		await request(_App(fixture)).post("/api/v1/me/onboarding/chat/conclude").send({}).expect(503);
+		expect(preparation).toHaveBeenCalledTimes(3);
+		expect(fixture.state()).toMatchObject({ onboardingState: UserOnboardingState.BootstrapChatInProgress, completionProvenance: null, agentService: null, agentRevision: null, auditCount: 0, authorizationGrants: [_AgentServiceCollectionGrant()] });
 	});
 });

--- a/apps/opencrane/src/bootstrap/http/routes.ts
+++ b/apps/opencrane/src/bootstrap/http/routes.ts
@@ -60,7 +60,7 @@ export function _RegisterRoutes(app: Express, prisma: PrismaClient, artifactScan
 {
 	if (agentSandboxReleaseProfile === undefined)
 		throw new Error("Product routes require the configured conversation-computer profile");
-	const onboarding = _CreateUserOnboardingComposition(prisma, _log, _ResolveUserOnboardingOwner, agentSandboxReleaseProfile.profileName);
+	const onboarding = _CreateUserOnboardingComposition(prisma, _log, _ResolveUserOnboardingOwner, agentSandboxReleaseProfile.profileName, [agentSandboxReleaseProfile.profileName]);
 	const conversationHistory = historyStore === undefined || conversationPrivatePayloadKeyringPath === undefined ? null : _CreateConversationHistoryComposition(prisma, historyStore, conversationPrivatePayloadKeyringPath, agentSandboxReleaseProfile, mcpWorkflows.execution);
 	const computerReviewAuthority = historyStore === undefined || conversationPrivatePayloadKeyringPath === undefined ? null : new _ConversationComputerReviewAuthority(new PrismaConversationMetadataReader(prisma), new ConversationComputerHistory(historyStore), KeyedConversationComputerReviewCredentialDeriver.fromKeyring(_ReadConversationPrivatePayloadKeyring(conversationPrivatePayloadKeyringPath)));
 	const computerReview = computerReviewAuthority === null ? null : _CreateConversationComputerReviewRouter({ authority: computerReviewAuthority, sandboxNamespace: agentSandboxReleaseProfile.namespace, logger: _log }, _ResolveRequestPrincipal);

--- a/apps/opencrane/src/bootstrap/onboarding/__tests__/personal-agent-profile-repair.sql-fixture.ts
+++ b/apps/opencrane/src/bootstrap/onboarding/__tests__/personal-agent-profile-repair.sql-fixture.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import { Client } from "pg";
+
+import { ProductAuthorizationActions, ProductAuthorizationResourceKinds, __ProductAuthorizationCapability } from "@opencrane/models/authorization";
+import { ___DigestCanonicalJson } from "@opencrane/util";
+
+/** Values retained by the SQL proof after the fixture transaction commits. */
+export interface PersonalAgentProfileRepairSqlFixture
+{
+	readonly siloId: string;
+	readonly principalId: string;
+	readonly onboardingId: string;
+	readonly agentServiceId: string;
+	readonly agentRevisionId: string;
+	readonly personaProfileId: string;
+	readonly personaRevisionId: string;
+	readonly sourceWorkloadProfile: string;
+	readonly targetWorkloadProfile: string;
+}
+
+/** Seed one completed onboarding whose deterministic personal service has never admitted work. */
+export async function _SeedPersonalAgentProfileRepairSqlFixture(options: { readonly agentServiceEditEffect?: "allow" | "deny" } = {}): Promise<PersonalAgentProfileRepairSqlFixture>
+{
+	const prefix = `profile-repair-${randomUUID()}`;
+	const id = (suffix: string) => `${prefix}-${suffix}`;
+	const siloId = id("silo");
+	const principalId = id("principal");
+	const onboardingId = id("onboarding");
+	const agentRevisionId = id("agent-revision");
+	const modelDefinitionId = id("model");
+	const now = new Date();
+	const setup = new Client({ connectionString: process.env.DATABASE_URL });
+	await setup.connect();
+	try
+	{
+		await setup.query(await readFile(new URL("../../../../../../scripts/sql/authority-fixtures.sql", import.meta.url), "utf8"));
+		await setup.query("BEGIN");
+		await setup.query("SELECT pg_temp.seed_silo_model($1, $2)", [siloId, modelDefinitionId]);
+		await setup.query("SELECT pg_temp.seed_external_user($1, $2)", [siloId, principalId]);
+		await setup.query("INSERT INTO org_memberships (id, cluster_tenant, subject, role, status, updated_at) VALUES ($1, $2, $3, 'member', 'active', $4)", [id("membership"), siloId, principalId, now]);
+		const persona = await _SeedApprovedPersona(setup, id, siloId, principalId, now);
+		await _SeedCompletedOnboarding(setup, id, { onboardingId, siloId, principalId, persona }, now);
+		await setup.query("INSERT INTO agent_services (id, silo_id, kind, name, workload_profile, updated_at) VALUES ($1, $2, 'personal', 'Profile repair assistant', 'retired-personal', $3)", [onboardingId, siloId, now]);
+		await setup.query("INSERT INTO agent_revisions (id, silo_id, agent_service_id, revision, digest, prompt_policy_version, model_definition_id, budget, authored_by, persona_revision_id) VALUES ($1, $2, $3, 1, $4, 'profile-repair-v1', $5, '{}'::jsonb, $6, $7)", [agentRevisionId, siloId, onboardingId, ___DigestCanonicalJson(agentRevisionId), modelDefinitionId, principalId, persona.personaRevisionId]);
+		await setup.query("UPDATE agent_revisions SET state='published', published_at=$2 WHERE id=$1", [agentRevisionId, now]);
+		await setup.query("UPDATE agent_services SET state='active', active_revision_id=$2 WHERE id=$1", [onboardingId, agentRevisionId]);
+		await _SeedGrant(setup, id("agent-service-edit-grant"), siloId, principalId, `personal-agent-owner-access:${principalId}`, ProductAuthorizationResourceKinds.AgentService, onboardingId, ProductAuthorizationActions.Edit, options.agentServiceEditEffect ?? "allow");
+		await _SeedGrant(setup, id("conversation-create-grant"), siloId, principalId, id("conversation-grant-manager"), ProductAuthorizationResourceKinds.ConversationCollection, siloId, ProductAuthorizationActions.Create, "allow");
+		await setup.query("COMMIT");
+		return { siloId, principalId, onboardingId, agentServiceId: onboardingId, agentRevisionId, personaProfileId: persona.personaProfileId, personaRevisionId: persona.personaRevisionId, sourceWorkloadProfile: "retired-personal", targetWorkloadProfile: "personal-default" };
+	}
+	catch (error)
+	{
+		await setup.query("ROLLBACK");
+		throw error;
+	}
+	finally
+	{
+		await setup.end();
+	}
+}
+
+/** Build one approved active persona from the immutable baseline definitions. */
+async function _SeedApprovedPersona(setup: Client, id: (suffix: string) => string, siloId: string, principalId: string, now: Date): Promise<{ readonly personaProfileId: string; readonly personaRevisionId: string; readonly interviewId: string }>
+{
+	const personaProfileId = id("persona-profile");
+	const personaRevisionId = id("persona-revision");
+	const interviewId = id("interview");
+	const scoringDigest = "sha256:dd84a619e9a465cce882e63e523946502a325dd5b0dcb56fd7d33da6fd072af9";
+	const templateDigest = "sha256:8cf1b0a5180d7e1176efe7ebc857c1c2775ff0b3cd8591d07a3a42dc3c936efe";
+	const interpolationDigest = "sha256:3fe36e4967254849da2aa91b474510633bdc8c896a67febc24494b708a77f1d6";
+	const questions = ["q1-decision-speed", "q2-response-preference", "q3-feedback-preference", "q4-meeting-energy", "q5-new-ideas", "q6-risk-appetite", "q7-suggestion-cadence", "q8-challenge-preference", "q9-relationship-model", "q10-tone-preference"];
+	const answerIds = questions.map((_question, index) => id(`persona-answer-${index + 1}`));
+	const choiceIds = questions.map((question, index) => `${question}:${index === 8 ? "b" : "a"}`);
+	await setup.query("INSERT INTO persona_profiles (id, silo_id, user_id, updated_at) VALUES ($1, $2, $3, $4)", [personaProfileId, siloId, principalId, now]);
+	await setup.query("INSERT INTO persona_interviews (id, persona_profile_id, user_id, question_set_id, question_set_version, scoring_policy_id, scoring_policy_version, interpolation_map_id, interpolation_map_version) VALUES ($1, $2, $3, 'personal-agent-onboarding', 1, 'personal-agent-scoring', 1, 'personal-agent-interpolation', 1)", [interviewId, personaProfileId, principalId]);
+	for (const [index, question] of questions.entries())
+		await setup.query("INSERT INTO persona_interview_answers (id, interview_id, question_set_id, question_set_version, question_id, choice_id) VALUES ($1, $2, 'personal-agent-onboarding', 1, $3, $4)", [answerIds[index], interviewId, question, index === 8 ? "b" : "a"]);
+	await setup.query("UPDATE persona_interviews SET state='completed', completed_at=$2 WHERE id=$1", [interviewId, now]);
+	await setup.query("INSERT INTO persona_interview_scores (interview_id, scoring_policy_id, scoring_policy_version, scoring_policy_digest, ordered_answer_ids, ordered_choice_ids, red, yellow, green, blue, colour_total, explorer, guardian, openness_total, primary_candidates, secondary_candidates, modifier_candidates) VALUES ($1, 'personal-agent-scoring', 1, $2, $3::text[], $4::text[], 21, 6, 0, 5, 32, 7, 0, 7, ARRAY['Red']::\"PersonaColour\"[], ARRAY['Yellow']::\"PersonaColour\"[], ARRAY['Explorer']::\"PersonaOpennessModifier\"[])", [interviewId, scoringDigest, answerIds, choiceIds]);
+	const evidence = { orderedAnswerIds: answerIds, orderedChoiceIds: choiceIds, colours: { red: 21, yellow: 6, green: 0, blue: 5, total: 32 }, openness: { explorer: 7, guardian: 0, total: 7 }, tieResolutions: [], primary: "red", secondary: "yellow", modifier: "explorer" };
+	await setup.query("INSERT INTO persona_revisions (id, persona_profile_id, revision, soul_template_id, soul_template_version, soul_template_digest, interview_id, scoring_policy_id, scoring_policy_version, scoring_policy_digest, interpolation_map_id, interpolation_map_version, interpolation_map_digest, scoring_evidence, primary_colour, secondary_colour, modifier, compiled_instructions, authored_by) VALUES ($1, $2, 1, 'commander-explorer', 1, $3, $4, 'personal-agent-scoring', 1, $5, 'personal-agent-interpolation', 1, $6, $7::jsonb, 'Red', 'Yellow', 'Explorer', '# Compiled profile repair persona', $8)", [personaRevisionId, personaProfileId, templateDigest, interviewId, scoringDigest, interpolationDigest, JSON.stringify(evidence), principalId]);
+	for (const [index, category] of [[1, "Response"], [2, "Feedback"], [7, "Challenge"]] as const)
+		await setup.query("INSERT INTO persona_insights (id, persona_revision_id, category, statement, interview_id, question_set_id, question_set_version, question_id, answer_id) VALUES ($1, $2, $3, 'Profile repair fixture preference', $4, 'personal-agent-onboarding', 1, $5, $6)", [id(`persona-insight-${index}`), personaRevisionId, category, interviewId, questions[index], answerIds[index]]);
+	await setup.query("UPDATE persona_revisions SET state='approved', approved_by=$2, approved_at=$3 WHERE id=$1", [personaRevisionId, principalId, now]);
+	await setup.query("UPDATE persona_profiles SET active_revision_id=$2 WHERE id=$1", [personaProfileId, personaRevisionId]);
+	return { personaProfileId, personaRevisionId, interviewId };
+}
+
+/** Advance one trigger-valid onboarding through its exact three-answer completion sequence. */
+async function _SeedCompletedOnboarding(setup: Client, id: (suffix: string) => string, fixture: { readonly onboardingId: string; readonly siloId: string; readonly principalId: string; readonly persona: { readonly personaRevisionId: string; readonly interviewId: string } }, now: Date): Promise<void>
+{
+	const content = await setup.query<{ readonly id: string; readonly digest: string }>("SELECT id, digest FROM user_onboarding_bootstrap_content_revisions WHERE id='bootstrap-commander-v1'");
+	const revision = content.rows[0];
+	if (content.rows.length !== 1 || revision === undefined)
+		throw new Error("Profile repair fixture requires the commander onboarding content revision");
+	const conversationId = id("bootstrap-conversation");
+	await setup.query("INSERT INTO user_onboardings (id, silo_id, user_id, workflow_version, updated_at) VALUES ($1, $2, $3, 1, $4)", [fixture.onboardingId, fixture.siloId, fixture.principalId, now]);
+	await setup.query("UPDATE user_onboardings SET state='survey_in_progress', persona_interview_id=$2, survey_started_at=$3 WHERE id=$1", [fixture.onboardingId, fixture.persona.interviewId, now]);
+	await setup.query("UPDATE user_onboardings SET state='bootstrap_chat_pending', persona_revision_id=$2 WHERE id=$1", [fixture.onboardingId, fixture.persona.personaRevisionId]);
+	await setup.query("INSERT INTO user_onboarding_bootstrap_conversations (id, onboarding_id, silo_id, user_id, persona_revision_id, persona_display_name, persona_archetype, content_revision_id, content_digest, started_at) VALUES ($1, $2, $3, $4, $5, 'Profile repair assistant', 'commander', $6, $7, $8)", [conversationId, fixture.onboardingId, fixture.siloId, fixture.principalId, fixture.persona.personaRevisionId, revision.id, revision.digest, now]);
+	await setup.query("UPDATE user_onboardings SET state='bootstrap_chat_in_progress', bootstrap_conversation_id=$2, bootstrap_content_revision_id=$3, bootstrap_content_digest=$4 WHERE id=$1", [fixture.onboardingId, conversationId, revision.id, revision.digest]);
+	for (const ordinal of [1, 2, 3])
+		await setup.query("INSERT INTO user_onboarding_bootstrap_answers (id, conversation_id, ordinal, question_ordinal, text, idempotency_key, answered_at) VALUES ($1, $2, $3, $3, $4, $5, $6)", [id(`bootstrap-answer-${ordinal}`), conversationId, ordinal, `Answer ${ordinal}`, id(`bootstrap-answer-key-${ordinal}`), now]);
+	await setup.query("UPDATE user_onboardings SET state='completed', completion_provenance='bootstrap_concluded', completed_at=$2 WHERE id=$1", [fixture.onboardingId, now]);
+}
+
+/** Give the fixture owner one exact product capability through the real catalogue revision. */
+async function _SeedGrant(setup: Client, grantId: string, siloId: string, principalId: string, managerId: string, resourceKind: ProductAuthorizationResourceKinds, resourceId: string, action: ProductAuthorizationActions, effect: "allow" | "deny"): Promise<void>
+{
+	const capability = __ProductAuthorizationCapability(resourceKind, action);
+	if (capability === null)
+		throw new Error(`Profile repair fixture lacks ${resourceKind}:${action}`);
+	await setup.query("INSERT INTO authorization_grants (id, silo_id, subject_kind, subject_principal_id, boundary_kind, boundary_principal_id, boundary_coverage, manager_id, catalog_id, catalog_revision, catalog_digest, capability_id, resource_kind, resource_id, effect, priority, created_by) SELECT $1, $2, 'principal', $3, 'personal', $3, 'exact', $4, catalog_id, revision, digest, $5, $6, $7, $8, 0, $3 FROM capability_catalog_revisions WHERE catalog_id=$9 AND revision=$10", [grantId, siloId, principalId, managerId, capability.capabilityId, resourceKind, resourceId, effect, capability.catalog.catalogId, capability.catalog.revision]);
+}

--- a/apps/opencrane/src/bootstrap/onboarding/__tests__/personal-agent-profile-repair.sql.test.ts
+++ b/apps/opencrane/src/bootstrap/onboarding/__tests__/personal-agent-profile-repair.sql.test.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "node:crypto";
+
+import { Prisma, PrismaClient } from "@prisma/client";
+import express from "express";
+import request from "supertest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { Logger } from "@opencrane/backend/observability";
+import { _CreateUserOnboardingComposition } from "@opencrane/backend/server/agents/onboarding";
+import { PrismaAgentSessionCreationUnitOfWork } from "@opencrane/backend/server/conversations";
+import type { HistoryAppend, HistoryAtomicAppend, HistoryRecordedEvent, HistoryStore } from "@opencrane/backend/server/infra/history-store";
+import { ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
+import { ___DigestCanonicalJson } from "@opencrane/util";
+
+import { _SeedPersonalAgentProfileRepairSqlFixture, type PersonalAgentProfileRepairSqlFixture } from "./personal-agent-profile-repair.sql-fixture";
+
+/** Independent connections expose committed rows and Serializable retry behavior. */
+const _First = new PrismaClient();
+/** The competing process never shares transaction state with the repair owner. */
+const _Second = new PrismaClient();
+
+/** Mount the public app composition that owns the onboarding transaction and cross-domain adapter. */
+function _App(client: PrismaClient, fixture: PersonalAgentProfileRepairSqlFixture, configuredProfiles: readonly string[] = [fixture.targetWorkloadProfile])
+{
+	const logger = { debug: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+	const composition = _CreateUserOnboardingComposition(client, logger, function _Owner() { return { siloId: fixture.siloId, subjectId: fixture.principalId }; }, fixture.targetWorkloadProfile, configuredProfiles);
+	const app = express();
+	app.use("/api/v1/me/onboarding", composition.router);
+	return app;
+}
+
+/** Keep enough immutable history behavior to prove whether session creation crossed its append edge. */
+function _History()
+{
+	const streams = new Map<string, HistoryRecordedEvent[]>();
+	const append = vi.fn(async function _Append(command: HistoryAppend)
+	{
+		const events = _AppendEvents(streams, command);
+		return { streamName: command.streamName, revision: BigInt(events.length - 1) };
+	});
+	const appendAtomic = vi.fn(async function _AppendAtomic(command: HistoryAtomicAppend)
+	{
+		for (const expected of command.expectedHeads)
+		{
+			const current = streams.get(expected.streamName)?.length ?? 0;
+			if (current !== 0)
+				throw new Error("Profile repair history fixture received a stale creation append");
+		}
+		return command.appends.map(function _Commit(item)
+		{
+			const events = _AppendEvents(streams, item);
+			return { streamName: item.streamName, revision: BigInt(events.length - 1) };
+		});
+	});
+	const store: Pick<HistoryStore, "append" | "appendAtomic" | "readHead" | "readStream"> = {
+		append,
+		appendAtomic,
+		async readHead(streamName) { return { streamName, revision: streams.has(streamName) ? BigInt(streams.get(streamName)!.length - 1) : null }; },
+		async *readStream(request) { for (const event of streams.get(request.streamName) ?? []) yield event; },
+	};
+	return { store, append, appendAtomic };
+}
+
+/** Store one append in the in-memory provider while retaining the real event envelope. */
+function _AppendEvents(streams: Map<string, HistoryRecordedEvent[]>, command: HistoryAppend): HistoryRecordedEvent[]
+{
+	const current = streams.get(command.streamName) ?? [];
+	const committed = command.events.map(function _Recorded(event, index): HistoryRecordedEvent
+	{
+		return { ...event, streamName: command.streamName, revision: BigInt(current.length + index), recordedAt: new Date() };
+	});
+	const events = [...current, ...committed];
+	streams.set(command.streamName, events);
+	return events;
+}
+
+/** Read the exact service fields that a repair must preserve. */
+function _ServiceIdentity(client: PrismaClient, serviceId: string)
+{
+	return client.agentService.findUniqueOrThrow({ where: { id: serviceId }, select: { id: true, siloId: true, kind: true, name: true, state: true, activeRevisionId: true, principalId: true } });
+}
+
+describe("unused personal-agent workload-profile repair on fresh PostgreSQL", function _Suite()
+{
+	beforeAll(async function _Connect()
+	{
+		if (!process.env.DATABASE_URL)
+			throw new Error("The personal-agent profile repair SQL proof requires DATABASE_URL and the fresh target baseline");
+		await Promise.all([_First.$connect(), _Second.$connect()]);
+	});
+	afterAll(async function _Disconnect() { await Promise.all([_First.$disconnect(), _Second.$disconnect()]); });
+
+	it("repairs one unused deterministic service before the first session append", async function _RepairAndCreateSession()
+	{
+		const fixture = await _SeedPersonalAgentProfileRepairSqlFixture();
+		const caller = { siloId: fixture.siloId, subjectId: fixture.principalId, principalId: fixture.principalId };
+		const beforeService = await _ServiceIdentity(_Second, fixture.agentServiceId);
+		const beforeRevision = await _Second.agentRevision.findUniqueOrThrow({ where: { id: fixture.agentRevisionId } });
+		const beforePersona = await _Second.personaProfile.findUniqueOrThrow({ where: { id: fixture.personaProfileId } });
+		expect(await _Second.conversation.count({ where: { agentServiceId: fixture.agentServiceId } })).toBe(0);
+		expect(await _Second.agentRun.count({ where: { agentServiceId: fixture.agentServiceId } })).toBe(0);
+
+		const history = _History();
+		const sessions = new PrismaAgentSessionCreationUnitOfWork(_First, history.store, [{ workloadProfile: fixture.targetWorkloadProfile, profileRevisionId: `sha256:${"d".repeat(64)}` }]);
+		const sessionKey = randomUUID();
+		await expect(sessions.resolve(caller, fixture.agentServiceId, sessionKey)).resolves.toBeNull();
+		expect(history.append).not.toHaveBeenCalled();
+		expect(history.appendAtomic).not.toHaveBeenCalled();
+
+		const readiness = await request(_App(_First, fixture)).get("/api/v1/me/onboarding");
+		expect(readiness.status, JSON.stringify(readiness.body)).toBe(200);
+		expect(readiness.body).toMatchObject({ state: "completed" });
+		const repaired = await _Second.agentService.findUniqueOrThrow({ where: { id: fixture.agentServiceId } });
+		expect(repaired.workloadProfile).toBe(fixture.targetWorkloadProfile);
+		expect(await _ServiceIdentity(_Second, fixture.agentServiceId)).toEqual(beforeService);
+		expect(await _Second.agentRevision.findUniqueOrThrow({ where: { id: fixture.agentRevisionId } })).toEqual(beforeRevision);
+		expect(await _Second.personaProfile.findUniqueOrThrow({ where: { id: fixture.personaProfileId } })).toEqual(beforePersona);
+		expect(await _Second.agentRevision.count({ where: { agentServiceId: fixture.agentServiceId } })).toBe(1);
+
+		const audit = await _Second.auditDecision.findFirstOrThrow({ where: { siloId: fixture.siloId, resourceKind: ProductAuthorizationResourceKinds.AgentService, resourceId: fixture.agentServiceId, action: ProductAuthorizationActions.Edit } });
+		expect(audit).toMatchObject({ actorKind: "User", actorId: fixture.principalId, outcome: "Allow", reasonCode: "winning_allow" });
+		expect(audit.argumentsDigest).toBe(___DigestCanonicalJson({ onboardingId: fixture.onboardingId, readinessKind: "repair", agentServiceId: fixture.agentServiceId, agentRevisionId: fixture.agentRevisionId, sourceWorkloadProfile: fixture.sourceWorkloadProfile, targetWorkloadProfile: fixture.targetWorkloadProfile }));
+
+		await expect(sessions.resolve(caller, fixture.agentServiceId, sessionKey)).resolves.toMatch(/^[0-9a-f-]{36}$/u);
+		expect(history.append).toHaveBeenCalledTimes(1);
+		expect(history.appendAtomic).toHaveBeenCalledTimes(1);
+		const created = await _Second.conversation.findFirstOrThrow({ where: { siloId: fixture.siloId, agentServiceId: fixture.agentServiceId } });
+		expect(created.computerProfileRevisionId).toBe(`sha256:${"d".repeat(64)}`);
+	});
+
+	it("keeps an old profile that remains configured", async function _ConfiguredOldProfile()
+	{
+		const fixture = await _SeedPersonalAgentProfileRepairSqlFixture();
+		await request(_App(_First, fixture, [fixture.targetWorkloadProfile, fixture.sourceWorkloadProfile])).get("/api/v1/me/onboarding").expect(503);
+		expect((await _Second.agentService.findUniqueOrThrow({ where: { id: fixture.agentServiceId } })).workloadProfile).toBe(fixture.sourceWorkloadProfile);
+		expect(await _Second.auditDecision.count({ where: { siloId: fixture.siloId } })).toBe(0);
+	});
+
+	it("rolls the central denial decision back without changing the service", async function _DeniedRepair()
+	{
+		const fixture = await _SeedPersonalAgentProfileRepairSqlFixture({ agentServiceEditEffect: "deny" });
+		const beforeService = await _ServiceIdentity(_Second, fixture.agentServiceId);
+		await request(_App(_First, fixture)).get("/api/v1/me/onboarding").expect(503);
+		expect(await _ServiceIdentity(_Second, fixture.agentServiceId)).toEqual(beforeService);
+		expect((await _Second.agentService.findUniqueOrThrow({ where: { id: fixture.agentServiceId } })).workloadProfile).toBe(fixture.sourceWorkloadProfile);
+		expect(await _Second.auditDecision.count({ where: { siloId: fixture.siloId, resourceKind: ProductAuthorizationResourceKinds.AgentService, resourceId: fixture.agentServiceId, action: ProductAuthorizationActions.Edit } })).toBe(0);
+	});
+
+	it("rolls back authorization and the profile update when the final CAS reports no winner", async function _LostComparison()
+	{
+		const fixture = await _SeedPersonalAgentProfileRepairSqlFixture();
+		let intercepted = 0;
+		const client = _First.$extends({ query: { agentService: { async updateMany({ args, query })
+		{
+			if (args.data.workloadProfile === fixture.targetWorkloadProfile)
+			{
+				const changed = await query(args);
+				intercepted += changed.count;
+				return { count: 0 };
+			}
+			return query(args);
+		} } } }) as unknown as PrismaClient;
+		await request(_App(client, fixture)).get("/api/v1/me/onboarding").expect(503);
+		expect(intercepted).toBe(3);
+		expect((await _Second.agentService.findUniqueOrThrow({ where: { id: fixture.agentServiceId } })).workloadProfile).toBe(fixture.sourceWorkloadProfile);
+		expect(await _Second.auditDecision.count({ where: { siloId: fixture.siloId } })).toBe(0);
+	});
+
+	it("retries a serialization conflict and then refuses the concurrently used service", async function _ConcurrentUse()
+	{
+		const fixture = await _SeedPersonalAgentProfileRepairSqlFixture();
+		let repairReads = 0;
+		let releaseRead!: () => void;
+		let releaseReference!: () => void;
+		const readObserved = new Promise<void>(resolve => { releaseRead = resolve; });
+		const referenceCommitted = new Promise<void>(resolve => { releaseReference = resolve; });
+		const client = _First.$extends({ query: { agentService: { async findFirst({ args, query })
+		{
+			const service = await query(args);
+			if (args.where !== undefined && "conversations" in args.where)
+			{
+				repairReads += 1;
+				if (repairReads === 1)
+				{
+					releaseRead();
+					await referenceCommitted;
+				}
+			}
+			return service;
+		} } } }) as unknown as PrismaClient;
+		const repair = request(_App(client, fixture)).get("/api/v1/me/onboarding").then(function _Response(response) { return response; });
+		await readObserved;
+		const history = _History();
+		const sessions = new PrismaAgentSessionCreationUnitOfWork(_Second, history.store, [{ workloadProfile: fixture.sourceWorkloadProfile, profileRevisionId: `sha256:${"e".repeat(64)}` }]);
+		await expect(sessions.resolve({ siloId: fixture.siloId, subjectId: fixture.principalId, principalId: fixture.principalId }, fixture.agentServiceId, randomUUID())).resolves.toMatch(/^[0-9a-f-]{36}$/u);
+		releaseReference();
+		expect((await repair).status).toBe(503);
+		expect(repairReads).toBeGreaterThanOrEqual(2);
+		expect((await _Second.agentService.findUniqueOrThrow({ where: { id: fixture.agentServiceId } })).workloadProfile).toBe(fixture.sourceWorkloadProfile);
+		expect(await _Second.conversation.count({ where: { agentServiceId: fixture.agentServiceId } })).toBe(1);
+		expect(await _Second.auditDecision.count({ where: { siloId: fixture.siloId, resourceKind: ProductAuthorizationResourceKinds.AgentService, resourceId: fixture.agentServiceId, action: ProductAuthorizationActions.Edit } })).toBe(0);
+	});
+});

--- a/libs/backend/agents/personal/configuration/main/src/__tests__/prisma-personal-configuration-materialization.test.ts
+++ b/libs/backend/agents/personal/configuration/main/src/__tests__/prisma-personal-configuration-materialization.test.ts
@@ -64,6 +64,7 @@ function _Materializer(prisma: never, logger?: never): _PersonalConfigurationMat
 			admitInitialPublication: vi.fn().mockResolvedValue(undefined),
 			admitRevisionSelection: vi.fn().mockResolvedValue(undefined),
 			admitRevisionPublication: vi.fn().mockResolvedValue(undefined),
+			admitUnusedProfileChange: vi.fn().mockResolvedValue(undefined),
 		};
 	}), logger);
 }

--- a/libs/backend/server/agents/agent-services/main/README.md
+++ b/libs/backend/server/agents/agent-services/main/README.md
@@ -33,11 +33,19 @@ selection changes append and publish another immutable revision rather than edit
 repositories re-read the exact source revision, enforce silo and ownership coordinates, record
 central authorization decisions, and update the active revision in their caller's transaction.
 
-The app supplies the deployment's conversation-computer profile when composing personal-agent
-bootstrap. Initial publication stores that name, and readiness requires an existing service to
-match it. An absent profile prevents startup; a mismatched stored profile is refused without
-rewriting the service. The product's initial revision policy supplies budgets and prompt policy,
-while the deployment selects which computer can run it.
+The app supplies the selected conversation-computer profile and the complete list accepted by
+session admission. Initial publication stores the selected name. Completed-onboarding repair can
+correct a mismatched name only on the exact deterministic personal service, with its current
+approved persona and published revision, when it has no conversations or runs and the old name is
+absent from that complete list. Session creation rejects that old name before writing history.
+The central authority must allow the owner's Edit decision, and the source profile, revision and
+absence of prior use must still match when the update occurs. Both names enter the audit digest.
+
+The correction preserves the service, revision, persona and identity. Its Edit decision uses current
+grants; a denial leaves the profile unchanged. It cannot cancel work or alter computer leases.
+A service with any prior use or a still-configured old profile remains unavailable for this repair.
+The product's initial revision policy supplies budgets
+and prompt policy, while the deployment selects which computer can run it.
 
 The package also owns personal execution evidence. Admission proves that the personal service is
 active, its requested revision is still published and active, current deployment-selected human membership proves the

--- a/libs/backend/server/agents/agent-services/main/src/index.ts
+++ b/libs/backend/server/agents/agent-services/main/src/index.ts
@@ -21,10 +21,11 @@ export type { RuntimeAgentEffectEligibility, RuntimeAgentEffectEligibilityComman
 export { AgentRevisionPersonaSelectionMaterializationCodes } from "./revisions/agent-revision-persona-selection.types";
 export { PrismaPersonalAgentBootstrapRepository } from "./personal-agents/db/prisma-personal-agent-bootstrap-repository";
 export { PersonalAgentProductEffectDenied, PrismaPersonalAgentProductEffectsAuthority } from "./personal-agents/db/prisma-personal-agent-product-effects";
-export type { PersonalAgentProductEffects } from "./personal-agents/personal-agent-product-effects.types";
+export type { AdmitUnusedPersonalAgentProfileChangeCommand, PersonalAgentProductEffects } from "./personal-agents/personal-agent-product-effects.types";
+export { PersonalAgentBootstrapConflict } from "./personal-agents/personal-agent-bootstrap-conflict";
 export { InitialPersonalAgentDefaultModelResolutionStatuses } from "./personal-agents/initial-personal-agent-publication.types";
 export type { InitialPersonalAgentDefaultModelResolver } from "./personal-agents/initial-personal-agent-publication.types";
-export { PersonalAgentBootstrapStatuses } from "./personal-agents/personal-agent-bootstrap.types";
+export { PersonalAgentBootstrapStatuses, type PersonalAgentBootstrapCommand, type PersonalAgentBootstrapRepository, type PersonalAgentBootstrapResult } from "./personal-agents/personal-agent-bootstrap.types";
 export { __ExecutionCapabilityEvidence } from "./execution-evidence/execution-capability-evidence";
 export type { ExecutionCapabilityEvidence, ExecutionCapabilityEvidenceInput } from "./execution-evidence/execution-capability-evidence.types";
 export { PrismaPersonalExecutionEvidenceRepository } from "./execution-evidence/db/prisma-personal-execution-evidence-repository";

--- a/libs/backend/server/agents/agent-services/main/src/personal-agents/db/__tests__/prisma-initial-personal-agent-publication.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/personal-agents/db/__tests__/prisma-initial-personal-agent-publication.test.ts
@@ -32,6 +32,7 @@ function _ProductEffects()
 		admitInitialPublication: vi.fn().mockResolvedValue(undefined),
 		admitRevisionSelection: vi.fn().mockResolvedValue(undefined),
 		admitRevisionPublication: vi.fn().mockResolvedValue(undefined),
+		admitUnusedProfileChange: vi.fn().mockResolvedValue(undefined),
 	};
 }
 

--- a/libs/backend/server/agents/agent-services/main/src/personal-agents/db/__tests__/prisma-personal-agent-bootstrap-repository.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/personal-agents/db/__tests__/prisma-personal-agent-bootstrap-repository.test.ts
@@ -56,6 +56,26 @@ function _Transaction()
 	};
 }
 
+/** Creates a deterministic active service whose profile can be changed by the repair CAS. */
+function _RepairTransaction()
+{
+	const transaction = _Transaction();
+	const service = {
+		id: _COMMAND.onboardingId,
+		siloId: _COMMAND.siloId,
+		kind: "Personal",
+		state: "Active",
+		activeRevisionId: "revision-existing",
+		workloadProfile: "legacy-profile",
+		activeRevision: { personaRevisionId: _COMMAND.onboardingPersonaRevisionId, modelDefinitionId: "model-1" },
+	};
+	transaction.agentService.findMany.mockImplementation(async function _ReadMatchingServices() { return [service]; });
+	transaction.agentService.findUnique.mockImplementation(async function _ReadDeterministicService() { return service; });
+	transaction.agentService.findFirst.mockResolvedValue({ id: service.id, activeRevisionId: service.activeRevisionId, workloadProfile: service.workloadProfile, conversations: [], runs: [] });
+	transaction.agentService.updateMany.mockImplementation(async function _RepairProfile() { service.workloadProfile = "developer"; return { count: 1 }; });
+	return { transaction, service };
+}
+
 /** Resolves the configured default for tests that reach initial publication. */
 const _DEFAULT_MODEL_RESOLVER: InitialPersonalAgentDefaultModelResolver = {
 	async resolve()
@@ -74,13 +94,14 @@ function _ProductEffects()
 		admitInitialPublication: vi.fn().mockResolvedValue(undefined),
 		admitRevisionSelection: vi.fn().mockResolvedValue(undefined),
 		admitRevisionPublication: vi.fn().mockResolvedValue(undefined),
+		admitUnusedProfileChange: vi.fn().mockResolvedValue(undefined),
 	};
 }
 
 /** Constructs the repository without widening production code to a test-only client shape. */
-function _Repository(transaction: ReturnType<typeof _Transaction>, productEffects: ReturnType<typeof _ProductEffects> = _ProductEffects()): PrismaPersonalAgentBootstrapRepository
+function _Repository(transaction: ReturnType<typeof _Transaction>, productEffects: ReturnType<typeof _ProductEffects> = _ProductEffects(), configuredWorkloadProfiles: readonly string[] = ["developer"]): PrismaPersonalAgentBootstrapRepository
 {
-	return new PrismaPersonalAgentBootstrapRepository(transaction as unknown as Prisma.TransactionClient, _DEFAULT_MODEL_RESOLVER, "developer", productEffects);
+	return new PrismaPersonalAgentBootstrapRepository(transaction as unknown as Prisma.TransactionClient, _DEFAULT_MODEL_RESOLVER, "developer", configuredWorkloadProfiles, productEffects);
 }
 
 describe("Prisma personal-agent bootstrap repository", function _Suite()
@@ -88,7 +109,14 @@ describe("Prisma personal-agent bootstrap repository", function _Suite()
 	it.each(["", " ", " developer"])("rejects unusable configured profile %j before any authority read", function _InvalidProfile(profile)
 	{
 		const transaction = _Transaction();
-		expect(function _Construct() { return new PrismaPersonalAgentBootstrapRepository(transaction as never, _DEFAULT_MODEL_RESOLVER, profile, _ProductEffects()); }).toThrow("configured workload profile");
+		expect(function _Construct() { return new PrismaPersonalAgentBootstrapRepository(transaction as never, _DEFAULT_MODEL_RESOLVER, profile, ["developer"], _ProductEffects()); }).toThrow("configured workload profile");
+		expect(transaction.personaRevision.findUnique).not.toHaveBeenCalled();
+	});
+
+	it.each([{ configuredWorkloadProfiles: [] }, { configuredWorkloadProfiles: [""] }, { configuredWorkloadProfiles: ["developer", "developer"] }])("rejects malformed configured profile registry %j before any authority read", function _InvalidProfileRegistry({ configuredWorkloadProfiles }: { readonly configuredWorkloadProfiles: readonly string[] })
+	{
+		const transaction = _Transaction();
+		expect(function _Construct() { return new PrismaPersonalAgentBootstrapRepository(transaction as never, _DEFAULT_MODEL_RESOLVER, "developer", configuredWorkloadProfiles, _ProductEffects()); }).toThrow("configured workload profile");
 		expect(transaction.personaRevision.findUnique).not.toHaveBeenCalled();
 	});
 
@@ -126,6 +154,93 @@ describe("Prisma personal-agent bootstrap repository", function _Suite()
 		expect(transaction.agentService.create).not.toHaveBeenCalled();
 		expect(transaction.agentRevision.create).not.toHaveBeenCalled();
 		expect(transaction.auditDecision.create).not.toHaveBeenCalled();
+	});
+
+	it("repairs an unused deterministic service in place while preserving identity and revision", async function _RepairsUnusedService()
+	{
+		const fake = _RepairTransaction();
+		const productEffects = _ProductEffects();
+
+		await expect(_Repository(fake.transaction, productEffects).ensureReady({ ..._COMMAND, readinessKind: "repair" })).resolves.toEqual({ status: PersonalAgentBootstrapStatuses.Ready, agentServiceId: _COMMAND.onboardingId, agentRevisionId: "revision-existing", created: false, revised: false });
+		expect(productEffects.admitUnusedProfileChange).toHaveBeenCalledWith({ caller: { siloId: _COMMAND.siloId, subjectId: _COMMAND.subjectId, principalId: "principal-a" }, onboardingId: _COMMAND.onboardingId, agentServiceId: _COMMAND.onboardingId, agentRevisionId: "revision-existing", sourceWorkloadProfile: "legacy-profile", targetWorkloadProfile: "developer", now: _COMMAND.provisionedAt });
+		expect(fake.transaction.agentService.updateMany).toHaveBeenCalledWith({ where: { id: _COMMAND.onboardingId, siloId: _COMMAND.siloId, kind: "Personal", state: "Active", activeRevisionId: "revision-existing", workloadProfile: "legacy-profile", conversations: { none: {} }, runs: { none: {} } }, data: { workloadProfile: "developer", updatedAt: _COMMAND.provisionedAt } });
+		expect(productEffects.admitUnusedProfileChange.mock.invocationCallOrder[0]).toBeLessThan(fake.transaction.agentService.updateMany.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER);
+		expect(fake.transaction.agentRevision.create).not.toHaveBeenCalled();
+		expect(fake.transaction.agentRevision.update).not.toHaveBeenCalled();
+		expect(fake.transaction.auditDecision.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects a repair when the old profile remains in the complete configured registry", async function _RejectsRetainedProfile()
+	{
+		const fake = _RepairTransaction();
+		const productEffects = _ProductEffects();
+
+		await expect(_Repository(fake.transaction, productEffects, ["legacy-profile", "developer"]).ensureReady({ ..._COMMAND, readinessKind: "repair" })).resolves.toEqual({ status: PersonalAgentBootstrapStatuses.Denied, reason: PersonalAgentBootstrapDenialReasons.ServiceNotReady });
+		expect(productEffects.admitUnusedProfileChange).not.toHaveBeenCalled();
+		expect(fake.transaction.agentService.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("makes a profile repair replay idempotent without a second authority decision", async function _ReplaysRepair()
+	{
+		const fake = _RepairTransaction();
+		const productEffects = _ProductEffects();
+		const repository = _Repository(fake.transaction, productEffects);
+
+		await expect(repository.ensureReady({ ..._COMMAND, readinessKind: "repair" })).resolves.toMatchObject({ status: PersonalAgentBootstrapStatuses.Ready, agentServiceId: _COMMAND.onboardingId, agentRevisionId: "revision-existing" });
+		await expect(repository.ensureReady({ ..._COMMAND, readinessKind: "repair" })).resolves.toMatchObject({ status: PersonalAgentBootstrapStatuses.Ready, agentServiceId: _COMMAND.onboardingId, agentRevisionId: "revision-existing" });
+		expect(productEffects.admitUnusedProfileChange).toHaveBeenCalledOnce();
+		expect(fake.transaction.agentService.updateMany).toHaveBeenCalledOnce();
+		expect(fake.transaction.agentRevision.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects a completed onboarding mismatch and a repair on a non-deterministic service", async function _RejectsNonRepairableProfiles()
+	{
+		const completed = _Transaction();
+		const completedService = { id: _COMMAND.onboardingId, activeRevisionId: "revision-existing", workloadProfile: "legacy-profile", activeRevision: { personaRevisionId: _COMMAND.onboardingPersonaRevisionId, modelDefinitionId: "model-1" } };
+		completed.agentService.findMany.mockResolvedValue([completedService]);
+		completed.agentService.findUnique.mockResolvedValue({ ...completedService, siloId: _COMMAND.siloId, kind: "Personal", state: "Active" });
+		await expect(_Repository(completed).ensureReady(_COMMAND)).resolves.toEqual({ status: PersonalAgentBootstrapStatuses.Denied, reason: PersonalAgentBootstrapDenialReasons.ServiceNotReady });
+		expect(completed.agentService.updateMany).not.toHaveBeenCalled();
+
+		const nonDeterministic = _Transaction();
+		nonDeterministic.agentService.findMany.mockResolvedValue([completedService]);
+		await expect(_Repository(nonDeterministic).ensureReady({ ..._COMMAND, readinessKind: "repair" })).resolves.toEqual({ status: PersonalAgentBootstrapStatuses.Denied, reason: PersonalAgentBootstrapDenialReasons.ServiceNotReady });
+		expect(nonDeterministic.agentService.updateMany).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ label: "used", findFirstResult: null },
+		{ label: "stale source", findFirstResult: null },
+	])("rejects a $label deterministic repair before central admission", async function _RejectsUsedOrStale({ label, findFirstResult })
+	{
+		const fake = _RepairTransaction();
+		const productEffects = _ProductEffects();
+		fake.transaction.agentService.findFirst.mockResolvedValue(findFirstResult);
+
+		await expect(_Repository(fake.transaction, productEffects).ensureReady({ ..._COMMAND, readinessKind: "repair" })).resolves.toEqual({ status: PersonalAgentBootstrapStatuses.Denied, reason: PersonalAgentBootstrapDenialReasons.ServiceNotReady });
+		expect(productEffects.admitUnusedProfileChange).not.toHaveBeenCalled();
+		expect(fake.transaction.agentService.updateMany).not.toHaveBeenCalled();
+		if (label === "used")
+			expect(fake.transaction.agentService.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ conversations: { none: {} }, runs: { none: {} } }) }));
+	});
+
+	it("propagates a denied profile-effect decision before changing the service", async function _RejectsAuthorization()
+	{
+		const fake = _RepairTransaction();
+		const productEffects = _ProductEffects();
+		productEffects.admitUnusedProfileChange.mockRejectedValue(new Error("authorization unavailable"));
+
+		await expect(_Repository(fake.transaction, productEffects).ensureReady({ ..._COMMAND, readinessKind: "repair" })).rejects.toThrow("authorization unavailable");
+		expect(fake.transaction.agentService.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("fails the repair when the service compare-and-swap loses its source", async function _RejectsCasLoss()
+	{
+		const fake = _RepairTransaction();
+		fake.transaction.agentService.updateMany.mockResolvedValue({ count: 0 });
+
+		await expect(_Repository(fake.transaction).ensureReady({ ..._COMMAND, readinessKind: "repair" })).rejects.toThrow("lost its source comparison");
+		expect(fake.transaction.agentService.updateMany).toHaveBeenCalledOnce();
 	});
 
 	it("adopts one earlier ready personal service when the deterministic identity is unused", async function _ExistingPersonalService()

--- a/libs/backend/server/agents/agent-services/main/src/personal-agents/db/__tests__/prisma-personal-agent-product-effects.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/personal-agents/db/__tests__/prisma-personal-agent-product-effects.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { AuthorizationAuthority, ManagedAuthorizationGrantRepository } from "@opencrane/backend/server/iam/authorization";
 import { AuthorizationDecisionOutcomes, AuthorizationSubjectKinds, ProductAuthorizationActions, ProductAuthorizationResourceKinds } from "@opencrane/models/authorization";
+import { ___DigestCanonicalJson } from "@opencrane/util";
 
 import { PersonalAgentSelectedResourceKinds } from "../../personal-agent-product-effects.types";
 import { PrismaPersonalAgentProductEffectsAuthority } from "../prisma-personal-agent-product-effects";
@@ -57,6 +58,29 @@ describe("PrismaPersonalAgentProductEffectsAuthority", function _ProductEffectsS
 		const effects = new PrismaPersonalAgentProductEffectsAuthority(dependencies.transaction, dependencies.authorization, dependencies.managedGrants);
 
 		await expect(effects.admitRevisionSelection({ caller: _CALLER, source: _RESOURCES, target: { ..._RESOURCES, agentRevisionId: "revision-3", modelDefinitionId: "model-2" }, now: new Date("2026-08-29T08:00:00.000Z"), selectedResource: PersonalAgentSelectedResourceKinds.Model, argumentsValue: { modelAlias: "careful-model" } })).rejects.toThrow("not authorized");
+	});
+
+	it("admits an unused profile repair with an exact source/target digest and no grant reconciliation", async function _AdmitsUnusedProfileRepair()
+	{
+		const dependencies = _Dependencies();
+		const effects = new PrismaPersonalAgentProductEffectsAuthority(dependencies.transaction, dependencies.authorization, dependencies.managedGrants);
+		const now = new Date("2026-08-29T08:00:00.000Z");
+		const sourceWorkloadProfile = "legacy-profile";
+		const targetWorkloadProfile = "developer";
+
+		await effects.admitUnusedProfileChange({ caller: _CALLER, onboardingId: "onboarding-1", agentServiceId: _RESOURCES.agentServiceId, agentRevisionId: _RESOURCES.agentRevisionId, sourceWorkloadProfile, targetWorkloadProfile, now });
+
+		expect(dependencies.managedGrants.reconcileManagedResourceGrants).not.toHaveBeenCalled();
+		expect(dependencies.authorization.admitPrincipal).toHaveBeenCalledWith(expect.objectContaining({ siloId: _CALLER.siloId, principalId: _CALLER.principalId, actorKind: "user", actorId: _CALLER.principalId, resource: { kind: ProductAuthorizationResourceKinds.AgentService, id: _RESOURCES.agentServiceId }, action: ProductAuthorizationActions.Edit, argumentsDigest: ___DigestCanonicalJson({ onboardingId: "onboarding-1", readinessKind: "repair", agentServiceId: _RESOURCES.agentServiceId, agentRevisionId: _RESOURCES.agentRevisionId, sourceWorkloadProfile, targetWorkloadProfile }), nowEpochMs: now.getTime() }));
+	});
+
+	it("propagates central denial for an unused profile repair without restoring grants", async function _RejectsUnusedProfileRepair()
+	{
+		const dependencies = _Dependencies(AuthorizationDecisionOutcomes.Deny);
+		const effects = new PrismaPersonalAgentProductEffectsAuthority(dependencies.transaction, dependencies.authorization, dependencies.managedGrants);
+
+		await expect(effects.admitUnusedProfileChange({ caller: _CALLER, onboardingId: "onboarding-1", agentServiceId: _RESOURCES.agentServiceId, agentRevisionId: _RESOURCES.agentRevisionId, sourceWorkloadProfile: "legacy-profile", targetWorkloadProfile: "developer", now: new Date("2026-08-29T08:00:00.000Z") })).rejects.toThrow("not authorized");
+		expect(dependencies.managedGrants.reconcileManagedResourceGrants).not.toHaveBeenCalled();
 	});
 
 	it("keeps two personal owners isolated when their revisions share one ModelDefinition", async function _IsolatesSharedModel()

--- a/libs/backend/server/agents/agent-services/main/src/personal-agents/db/prisma-personal-agent-bootstrap-repository.ts
+++ b/libs/backend/server/agents/agent-services/main/src/personal-agents/db/prisma-personal-agent-bootstrap-repository.ts
@@ -1,6 +1,7 @@
 import { AgentRevisionState, AgentServiceKind, AgentServiceState, PersonaRevisionState, type Prisma } from "@prisma/client";
 
 import type { InitialPersonalAgentDefaultModelResolver } from "../initial-personal-agent-publication.types";
+import { PersonalAgentBootstrapConflict } from "../personal-agent-bootstrap-conflict";
 import { AgentRevisionPersonaSelectionMaterializationCodes } from "../../revisions/agent-revision-persona-selection.types";
 import { PersonalAgentBootstrapDenialReasons, PersonalAgentBootstrapStatuses, type DeniedPersonalAgentBootstrapResult, type PersonalAgentBootstrapCommand, type PersonalAgentBootstrapRepository, type PersonalAgentBootstrapResult, type ReadyPersonalAgentBootstrapResult } from "../personal-agent-bootstrap.types";
 import type { PersonalAgentProductCaller, PersonalAgentProductEffects } from "../personal-agent-product-effects.types";
@@ -89,16 +90,22 @@ export class PrismaPersonalAgentBootstrapRepository implements PersonalAgentBoot
 	private readonly productEffects: PersonalAgentProductEffects;
 	/** Deployment-selected profile required by new and existing personal services. */
 	private readonly workloadProfile: string;
+	/** Complete admission profile names, copied so a caller cannot change them during a repair. */
+	private readonly configuredWorkloadProfiles: ReadonlySet<string>;
 
 	/** Creates the personal-agent strategy inside an existing Serializable transaction. */
-	constructor(transaction: Prisma.TransactionClient, defaultModelResolver: InitialPersonalAgentDefaultModelResolver, workloadProfile: string, productEffects: PersonalAgentProductEffects | null = null)
+	constructor(transaction: Prisma.TransactionClient, defaultModelResolver: InitialPersonalAgentDefaultModelResolver, workloadProfile: string, configuredWorkloadProfiles: readonly string[], productEffects: PersonalAgentProductEffects | null = null)
 	{
 		if (workloadProfile.trim().length === 0 || workloadProfile.trim() !== workloadProfile)
 			throw new Error("Personal agent bootstrap requires a configured workload profile");
+		const profiles = new Set(configuredWorkloadProfiles);
+		if (profiles.size === 0 || profiles.size !== configuredWorkloadProfiles.length || !profiles.has(workloadProfile) || configuredWorkloadProfiles.some(function _InvalidProfile(profile) { return profile.trim().length === 0 || profile.trim() !== profile; }))
+			throw new Error("Personal agent bootstrap requires the complete configured workload profiles");
 		this.transaction = transaction;
 		this.defaultModelResolver = defaultModelResolver;
 		this.productEffects = productEffects ?? new PrismaPersonalAgentProductEffectsAuthority(transaction);
 		this.workloadProfile = workloadProfile;
+		this.configuredWorkloadProfiles = profiles;
 	}
 
 	/**
@@ -145,14 +152,17 @@ export class PrismaPersonalAgentBootstrapRepository implements PersonalAgentBoot
 			{
 				return _Denied(PersonalAgentBootstrapDenialReasons.ServiceIdentityConflict);
 			}
-			if (matching.length !== 1 || matching[0]?.id !== deterministic.id || deterministic.state !== AgentServiceState.Active || deterministic.activeRevisionId === null || deterministic.activeRevision?.personaRevisionId === null || deterministic.workloadProfile !== this.workloadProfile)
+			if (matching.length !== 1 || matching[0]?.id !== deterministic.id || deterministic.state !== AgentServiceState.Active || deterministic.activeRevisionId === null || deterministic.activeRevision?.personaRevisionId === null)
 			{
 				return _Denied(PersonalAgentBootstrapDenialReasons.ServiceNotReady);
 			}
 			const activeRevision = deterministic.activeRevision;
 			if (activeRevision === null || activeRevision.personaRevisionId === null)
 				return _Denied(PersonalAgentBootstrapDenialReasons.ServiceNotReady);
-			return this._EnsureCurrentPersona(command, persona, { id: deterministic.id, activeRevisionId: deterministic.activeRevisionId, workloadProfile: deterministic.workloadProfile, personaRevisionId: activeRevision.personaRevisionId, modelDefinitionId: activeRevision.modelDefinitionId }, caller);
+			const service = { id: deterministic.id, activeRevisionId: deterministic.activeRevisionId, workloadProfile: deterministic.workloadProfile, personaRevisionId: activeRevision.personaRevisionId, modelDefinitionId: activeRevision.modelDefinitionId };
+			if (service.workloadProfile !== this.workloadProfile && !await this._RepairUnusedProfile(command, persona, service, caller))
+				return _Denied(PersonalAgentBootstrapDenialReasons.ServiceNotReady);
+			return this._EnsureCurrentPersona(command, persona, { ...service, workloadProfile: this.workloadProfile }, caller);
 		}
 		if (matching.length === 1)
 		{
@@ -167,6 +177,31 @@ export class PrismaPersonalAgentBootstrapRepository implements PersonalAgentBoot
 		// 4. Delegate initial publication after bootstrap has proved that no service exists.
 		const publicationRepository = new PrismaInitialPersonalAgentPublicationRepository(this.transaction, this.defaultModelResolver, this.workloadProfile, this.productEffects);
 		return publicationRepository.publish(command, persona, caller);
+	}
+
+	/**
+	 * Correct a completed onboarding's unused service when its old profile cannot admit sessions.
+	 *
+	 * Session creation checks the same complete profile list before appending history. Requiring the
+	 * old name to be absent closes that creation path while this Serializable transaction proves no
+	 * conversation or run exists. A configured old profile or any prior use requires a separate
+	 * lifecycle operation; this repair never changes existing computer leases or execution evidence.
+	 * Authorization and the exact profile comparison commit together. Losing the comparison throws
+	 * so onboarding rolls back the decision and every other write in this attempt.
+	 */
+	private async _RepairUnusedProfile(command: PersonalAgentBootstrapCommand, persona: _ApprovedPersona, service: _ReadyPersonalService, caller: PersonalAgentProductCaller): Promise<boolean>
+	{
+		if (command.readinessKind !== "repair" || service.id !== command.onboardingId || service.personaRevisionId !== persona.id || !this.configuredWorkloadProfiles.has(this.workloadProfile) || this.configuredWorkloadProfiles.has(service.workloadProfile))
+			return false;
+		const where = { id: service.id, siloId: command.siloId, kind: AgentServiceKind.Personal, state: AgentServiceState.Active, activeRevisionId: service.activeRevisionId, workloadProfile: service.workloadProfile, conversations: { none: {} }, runs: { none: {} } };
+		const unused = await this.transaction.agentService.findFirst({ where, select: { id: true } });
+		if (unused === null)
+			return false;
+		await this.productEffects.admitUnusedProfileChange({ caller, onboardingId: command.onboardingId, agentServiceId: service.id, agentRevisionId: service.activeRevisionId, sourceWorkloadProfile: service.workloadProfile, targetWorkloadProfile: this.workloadProfile, now: command.provisionedAt });
+		const changed = await this.transaction.agentService.updateMany({ where, data: { workloadProfile: this.workloadProfile, updatedAt: command.provisionedAt } });
+		if (changed.count !== 1)
+			throw new PersonalAgentBootstrapConflict();
+		return true;
 	}
 
 	/** Reconcile one existing service to the owner's current approved persona without replacing it. */

--- a/libs/backend/server/agents/agent-services/main/src/personal-agents/db/prisma-personal-agent-product-effects.ts
+++ b/libs/backend/server/agents/agent-services/main/src/personal-agents/db/prisma-personal-agent-product-effects.ts
@@ -4,7 +4,7 @@ import { PrismaAuthorizationAuthority, PrismaManagedAuthorizationGrantRepository
 import { AuthorizationBoundaryCoverages, AuthorizationBoundaryKinds, AuthorizationDecisionOutcomes, AuthorizationSubjectKinds, ProductAuthorizationActions, ProductAuthorizationResourceKinds, __ProductAuthorizationCapability, type ProductAuthorizationResourceLocator } from "@opencrane/models/authorization";
 import { ___DigestCanonicalJson } from "@opencrane/util";
 
-import { PersonalAgentSelectedResourceKinds, type AdmitInitialPersonalAgentPublicationCommand, type AdmitPersonalAgentRevisionSelectionCommand, type PersonalAgentCurrentResources, type PersonalAgentProductCaller, type PersonalAgentProductEffects } from "../personal-agent-product-effects.types";
+import { PersonalAgentSelectedResourceKinds, type AdmitInitialPersonalAgentPublicationCommand, type AdmitPersonalAgentRevisionSelectionCommand, type AdmitUnusedPersonalAgentProfileChangeCommand, type PersonalAgentCurrentResources, type PersonalAgentProductCaller, type PersonalAgentProductEffects } from "../personal-agent-product-effects.types";
 
 /** Prefixes grants derived from one durable personal-agent owner and its revision relations. */
 const _PERSONAL_AGENT_OWNER_GRANT_MANAGER_ID = "personal-agent-owner-access";
@@ -110,6 +110,13 @@ export class PrismaPersonalAgentProductEffectsAuthority implements PersonalAgent
 		const argumentsDigest = ___DigestCanonicalJson(command.argumentsValue);
 		await this._Admit(command.caller, { kind: ProductAuthorizationResourceKinds.AgentRevision, id: command.target.agentRevisionId }, ProductAuthorizationActions.Edit, argumentsDigest, command.now);
 		await this._Admit(command.caller, { kind: ProductAuthorizationResourceKinds.AgentRevision, id: command.target.agentRevisionId }, ProductAuthorizationActions.Publish, argumentsDigest, command.now);
+	}
+
+	/** @inheritdoc */
+	async admitUnusedProfileChange(command: AdmitUnusedPersonalAgentProfileChangeCommand): Promise<void>
+	{
+		const argumentsDigest = ___DigestCanonicalJson({ onboardingId: command.onboardingId, readinessKind: "repair", agentServiceId: command.agentServiceId, agentRevisionId: command.agentRevisionId, sourceWorkloadProfile: command.sourceWorkloadProfile, targetWorkloadProfile: command.targetWorkloadProfile });
+		await this._Admit(command.caller, { kind: ProductAuthorizationResourceKinds.AgentService, id: command.agentServiceId }, ProductAuthorizationActions.Edit, argumentsDigest, command.now);
 	}
 
 	/** Writes the complete owner grant set for one exact resource. */

--- a/libs/backend/server/agents/agent-services/main/src/personal-agents/personal-agent-bootstrap-conflict.ts
+++ b/libs/backend/server/agents/agent-services/main/src/personal-agents/personal-agent-bootstrap-conflict.ts
@@ -1,0 +1,10 @@
+/** A personal-agent comparison lost; the owning transaction must roll back before retrying. */
+export class PersonalAgentBootstrapConflict extends Error
+{
+	/** Describe the lost comparison without exposing user or deployment coordinates. */
+	constructor()
+	{
+		super("unused personal agent profile repair lost its source comparison");
+		this.name = PersonalAgentBootstrapConflict.name;
+	}
+}

--- a/libs/backend/server/agents/agent-services/main/src/personal-agents/personal-agent-product-effects.types.ts
+++ b/libs/backend/server/agents/agent-services/main/src/personal-agents/personal-agent-product-effects.types.ts
@@ -61,6 +61,25 @@ export interface AdmitPersonalAgentRevisionSelectionCommand
 	readonly selectedResource: PersonalAgentSelectedResourceKinds;
 }
 
+/** Exact configuration correction for a personal service that has never admitted work. */
+export interface AdmitUnusedPersonalAgentProfileChangeCommand
+{
+	/** Authenticated owner whose central Edit permission must still be allowed. */
+	readonly caller: PersonalAgentProductCaller;
+	/** Completed onboarding that owns the deterministic service. */
+	readonly onboardingId: string;
+	/** Stable service whose profile changes without replacing its identity. */
+	readonly agentServiceId: string;
+	/** Published revision that must remain current throughout the correction. */
+	readonly agentRevisionId: string;
+	/** Saved profile that is no longer configured for session admission. */
+	readonly sourceWorkloadProfile: string;
+	/** Deployment-selected profile used by future session admission. */
+	readonly targetWorkloadProfile: string;
+	/** Trusted instant used for authorization and the service update. */
+	readonly now: Date;
+}
+
 /** Central product-effect adapter used inside personal-agent Serializable transactions. */
 export interface PersonalAgentProductEffects
 {
@@ -76,4 +95,6 @@ export interface PersonalAgentProductEffects
 	admitRevisionSelection(command: AdmitPersonalAgentRevisionSelectionCommand): Promise<void>;
 	/** Projects exact successor grants and admits publication after its row exists. */
 	admitRevisionPublication(command: AdmitPersonalAgentRevisionSelectionCommand): Promise<void>;
+	/** Admits one unused-service correction without restoring any owner grants. */
+	admitUnusedProfileChange(command: AdmitUnusedPersonalAgentProfileChangeCommand): Promise<void>;
 }

--- a/libs/backend/server/agents/agent-services/main/src/revisions/db/__tests__/prisma-agent-revision-persona-selection.test.ts
+++ b/libs/backend/server/agents/agent-services/main/src/revisions/db/__tests__/prisma-agent-revision-persona-selection.test.ts
@@ -82,6 +82,7 @@ function _ProductEffects()
 		admitInitialPublication: vi.fn().mockResolvedValue(undefined),
 		admitRevisionSelection: vi.fn().mockResolvedValue(undefined),
 		admitRevisionPublication: vi.fn().mockResolvedValue(undefined),
+		admitUnusedProfileChange: vi.fn().mockResolvedValue(undefined),
 	};
 }
 

--- a/libs/backend/server/agents/onboarding/main/README.md
+++ b/libs/backend/server/agents/onboarding/main/README.md
@@ -5,8 +5,9 @@
 ## What it owns
 
 `src/composition/` connects persona evidence, initial model selection and personal-agent readiness
-inside the existing onboarding completion transaction. The app only supplies the deployment profile,
-caller resolver and logger; `src/http/` supplies the verified-session owner resolver.
+inside the existing onboarding completion transaction. The app supplies the selected deployment
+profile, the complete profile list used by session admission, the caller resolver and logger;
+`src/http/` supplies the verified-session owner resolver.
 
 This package owns the server-tracked workflow that routes one authenticated person through persona
 survey and bootstrap chat before the main product. Authentication supplies the silo and stable OIDC
@@ -28,6 +29,11 @@ The package owns the survey hand-off and first guided exchange end to end:
 8. Repair older `bootstrap_concluded` rows idempotently on the next onboarding read. Repair keeps an
    existing owned personal service when present; creation uses the onboarding identifier as the
    deterministic identity only when no service exists.
+
+If that deterministic service has never admitted a conversation or run, agent-services may correct
+an old profile that is no longer configured. The owner's central Edit decision and the exact source
+comparison commit in this same transaction. The correction preserves onboarding answers, persona,
+identity and revision history. Any prior use or a still-configured old profile prevents this repair.
 
 ```text
  authenticated session       persona evidence authority

--- a/libs/backend/server/agents/onboarding/main/src/composition/user-onboarding-composition.ts
+++ b/libs/backend/server/agents/onboarding/main/src/composition/user-onboarding-composition.ts
@@ -1,7 +1,7 @@
 import type { Prisma } from "@prisma/client";
 
 import { _CreatePersonaWorkflowEvidenceRepository, PersonaWorkflowColours, type PersonaOnboardingCaller, type PersonaOnboardingWorkflowPort, type PersonaWorkflowEvidenceRepository } from "@opencrane/backend/agents/personal/personas";
-import { InitialPersonalAgentDefaultModelResolutionStatuses, PersonalAgentBootstrapStatuses, PrismaPersonalAgentBootstrapRepository, PrismaPersonalAgentProductEffectsAuthority, type InitialPersonalAgentDefaultModelResolver } from "@opencrane/backend/server/agents/agent-services";
+import { InitialPersonalAgentDefaultModelResolutionStatuses, PersonalAgentBootstrapConflict, PersonalAgentBootstrapStatuses, PrismaPersonalAgentBootstrapRepository, PrismaPersonalAgentProductEffectsAuthority, type InitialPersonalAgentDefaultModelResolver, type PersonalAgentBootstrapCommand, type PersonalAgentBootstrapRepository, type PersonalAgentBootstrapResult } from "@opencrane/backend/server/agents/agent-services";
 import { DefaultModelDefinitionResolutionStatuses, PrismaDefaultModelDefinitionResolverRepository } from "@opencrane/backend/server/gateways/model-routing";
 import type { Logger } from "@opencrane/backend/observability";
 import type { UserOnboardingOwner, UserOnboardingPersonaEvidencePort } from "../user-onboarding.types";
@@ -13,6 +13,7 @@ import { __UserOnboardingAuthority } from "../user-onboarding-authority";
 import { __UserOnboardingChatAuthority } from "../user-onboarding-chat-authority";
 import { _CreateUserOnboardingRepository } from "../prisma-user-onboarding-repository";
 import { PrismaUserOnboardingCompletionUnitOfWork } from "../prisma-user-onboarding-completion-unit-of-work";
+import { UserOnboardingCompletionConflict } from "../user-onboarding-completion";
 
 import type { UserOnboardingRouteComposition } from "./user-onboarding-composition.types";
 
@@ -22,30 +23,31 @@ type UserOnboardingPrismaClient = Parameters<typeof _CreateUserOnboardingReposit
 /**
  * Compose the owner-only onboarding router with the deployment's conversation-computer profile.
  * @param workloadProfile Profile name from the same release configuration used for conversations.
+ * @param configuredWorkloadProfiles Complete profile names accepted by session admission.
  * @throws When the configured profile is empty or contains surrounding whitespace.
  */
-export function _CreateUserOnboardingComposition(prisma: UserOnboardingPrismaClient, logger: Logger, resolveOwner: UserOnboardingOwnerResolver, workloadProfile: string): UserOnboardingRouteComposition
+export function _CreateUserOnboardingComposition(prisma: UserOnboardingPrismaClient, logger: Logger, resolveOwner: UserOnboardingOwnerResolver, workloadProfile: string, configuredWorkloadProfiles: readonly string[]): UserOnboardingRouteComposition
 {
 	if (workloadProfile.trim().length === 0 || workloadProfile.trim() !== workloadProfile)
 		throw new Error("Onboarding requires the configured conversation-computer profile");
 	const repository = _CreateUserOnboardingRepository(prisma);
 	const personaEvidence = _CreateUserOnboardingPersonaEvidence(_CreatePersonaWorkflowEvidenceRepository(prisma));
-	const completion = new PrismaUserOnboardingCompletionUnitOfWork(prisma, function _PersonalAgent(transaction) { return _CreatePersonalAgentBootstrap(transaction, logger, workloadProfile); });
+	const completion = new PrismaUserOnboardingCompletionUnitOfWork(prisma, function _PersonalAgent(transaction) { return _CreatePersonalAgentBootstrap(transaction, logger, workloadProfile, configuredWorkloadProfiles); });
 	const authority = new __UserOnboardingAuthority(repository, personaEvidence, 1, completion);
 	const chatAuthority = new __UserOnboardingChatAuthority(authority, repository, personaEvidence, completion);
 	return { router: __CreateUserOnboardingRouter({ authority, chatAuthority, resolveOwner, logger }), personaWorkflow: _CreatePersonaOnboardingWorkflow(authority) };
 }
 
 /** Adapt agent-services' richer result to onboarding's narrow cross-domain readiness port. */
-function _CreatePersonalAgentBootstrap(transaction: Prisma.TransactionClient, logger: Logger, workloadProfile: string): UserOnboardingPersonalAgentBootstrapPort
+function _CreatePersonalAgentBootstrap(transaction: Prisma.TransactionClient, logger: Logger, workloadProfile: string, configuredWorkloadProfiles: readonly string[]): UserOnboardingPersonalAgentBootstrapPort
 {
 	const defaultModelResolver = _CreateInitialPersonalAgentDefaultModelResolver(transaction);
 	const productEffects = new PrismaPersonalAgentProductEffectsAuthority(transaction);
-	const repository = new PrismaPersonalAgentBootstrapRepository(transaction, defaultModelResolver, workloadProfile, productEffects);
+	const repository = new PrismaPersonalAgentBootstrapRepository(transaction, defaultModelResolver, workloadProfile, configuredWorkloadProfiles, productEffects);
 	return {
 		async ensureReady(command)
 		{
-			const result = await repository.ensureReady(command);
+			const result = await _PreparePersonalAgent(repository, command);
 			if (result.status === PersonalAgentBootstrapStatuses.Ready)
 			{
 				const fields = { operation: "user_onboarding.personal_agent_ready_attempt", siloId: command.siloId, subjectId: command.subjectId, onboardingId: command.onboardingId, agentServiceId: result.agentServiceId, agentRevisionId: result.agentRevisionId, created: result.created, revised: result.revised };
@@ -56,6 +58,21 @@ function _CreatePersonalAgentBootstrap(transaction: Prisma.TransactionClient, lo
 			return { status: UserOnboardingPersonalAgentBootstrapStatuses.Denied };
 		},
 	};
+}
+
+/** Translate an agent comparison conflict into the onboarding owner's rollback and retry signal. */
+async function _PreparePersonalAgent(repository: PersonalAgentBootstrapRepository, command: PersonalAgentBootstrapCommand): Promise<PersonalAgentBootstrapResult>
+{
+	try
+	{
+		return await repository.ensureReady(command);
+	}
+	catch (error)
+	{
+		if (error instanceof PersonalAgentBootstrapConflict)
+			throw new UserOnboardingCompletionConflict();
+		throw error;
+	}
 }
 
 /** Adapt model-routing's result vocabulary into agent-services' narrow initial-publication port. */

--- a/plan.md
+++ b/plan.md
@@ -449,6 +449,33 @@ integration and OpenCrane lint also passed after stacking onto #852. Independent
 architecture post-review passed. These are source and integration checks; no live remote-provider,
 hosted-MCP or fresh-install qualification is claimed here.
 
+### Testv5 access repair — preserve existing data
+
+Fresh owner sign-in succeeds. The remaining onboarding denial is `service_not_ready`: the exact
+personal service still names `personal-default`, while the current server admits `developer`.
+Read-only inspection found no conversations, runs, computer leases, child requests or tool claims
+for that service. Its owner, approved persona and completed onboarding evidence are valid.
+
+The user requires all current test data to be preserved. Architecture preflight permits a narrow
+completed-onboarding correction only for that unused deterministic service, with an unconfigured
+old profile, current central Edit permission, and a transaction-bound source comparison. Used
+services and retained profiles remain denied. Agent-services tests (140), onboarding tests (49),
+actual composition tests (5) and fresh PostgreSQL repair tests (5) pass. The SQL proof covers current
+Edit denial, audit rollback, exhausted source comparisons and concurrent conversation creation;
+the existing onboarding transaction retries conflicts and refuses a service that becomes used.
+Relevant type checks, the server build, style, boundaries and module-growth checks pass. Independent
+review and architecture post-review pass. Publication and a separately authorized live repair
+remain open. No live database, deployment, identities, conversation history or stored files have
+been changed.
+
+The live PostgreSQL release metadata and deployed server manifest carry different baseline digests.
+This is an unresolved provenance problem; the readiness schema was read successfully and the
+profile mismatch, not a demonstrated missing table or column, caused this denial.
+The deployment candidate applies only this repair to the current server source. The existing
+installer reconciles PostgreSQL Helm values but preserves the existing cluster's baseline binding;
+it does not apply the source baseline to that database. This development repair cannot count as
+fresh-install or release qualification.
+
 ## Later work
 
 - [#765](https://github.com/elewa-git/opencrane/issues/765): Git-backed project source, isolated


### PR DESCRIPTION
Completed onboarding can recover an unused personal assistant when its saved execution profile is no longer configured. Testv5's owner can authenticate, but readiness currently rejects the saved `personal-default` profile because the server admits `developer`. This change corrects that narrow case while preserving the existing service, revision, persona, setup answers and identity.

Repair requires the deterministic personal service, its current approved persona and published revision, no conversations or runs, an old profile absent from the complete admission registry, and the owner's current central `AgentService/Edit` permission. The source profile, revision and absence of use must still match at the update. The authorization decision and update commit together. A conflicting update enters onboarding's existing bounded transaction retry; concurrent conversation creation makes the repair refuse the now-used service.

No schema, release manifest, migration, route, workflow or deployment configuration changes. This does not provide a general profile-change operation. The existing session boundary rejects an unconfigured profile before appending conversation history.

Validation completed:

- Nx tests: agent-services 140, onboarding 49 and actual app composition 5 passed.
- Personal-configuration's dependent type check and 65 tests passed after CI found and we corrected its missing test-double method. The correction changes one test fixture; production behavior is unchanged. Final source head is `26ffbf65447a96e9f928754af5c81eab475010bc`.
- Fresh PostgreSQL through `nx run opencrane:test:sql`: all three authority SQL files, 17 proposal tests, 3 approval tests, 4 result tests and 5 repair tests passed on final SHA `a11bba62b5d823260651ca971c0345fb413009f8`. The repair proof uses real Prisma repositories, central authorization and the public onboarding composition. It covers the exact Edit audit digest, denial rollback, retained old profiles, all three failed source comparisons, and a concurrent actual session creation that forces serialization recovery and preserves the winning conversation.
- Nx lint/type checks for agent-services, onboarding and OpenCrane passed; OpenCrane build passed.
- Dependency and Prisma boundaries, workflow guard, authorization enforcement, workload ownership, agent-domain boundaries and release-versioning checks passed, including the existing negative boundary fixtures.
- Style: 0 errors and 0 warnings. Module growth: 7 production files, 0 errors and 0 review candidates.
- Architecture preflight/post-review and mandatory independent review passed. The rebase onto #854 is identical according to `git range-diff`.

Owning package READMEs, `plan.md` and `CHANGELOG.md` describe the behavior and remaining qualification. The user requires all current testv5 data to be preserved. No live database, deployment, identities, history or stored files have been changed. A separate deployment candidate applies only this repair to testv5's current server source. Testv5/live qualification remains a separately authorized gate; the live baseline provenance discrepancy remains unresolved and this repair does not count as fresh-install or release qualification.

The minimal deployment candidate is commit `a198ff2431511a55673f2c137a42b861d03c8247` on `feat/testv5-profile-hotfix`, built on deployed server source `e50cdcc5b0f383943ee00407c43224696e68747c`. Independent review confirmed equivalent repair behavior in that older package layout. Its fresh PostgreSQL authority suites and 5 repair tests, 112 app tests, 103 agent-services tests, 49 onboarding tests, 65 personal-configuration tests, type checks, build, style and boundary checks pass. Its baseline, release manifest, Helm and deploy sources are unchanged. This PR remains the single source review; the candidate branch is for the server artifact and has no duplicate PR. [Normal server-image validation/publication](https://github.com/elewa-git/opencrane/actions/runs/34478251765) passed without an override and published `ghcr.io/elewa-git/opencrane-server:sha-a198ff2431511a55673f2c137a42b861d03c8247` at digest `sha256:4e259a6ef71086513d611973e4e97754671902553b6f35bce2550d4e81d90c50`. No deployment is authorized or claimed.

## Review order

1. PR #831 — member access and revocation.
2. PR #843 — library and component decomposition.
3. PR #849 — Absurd conversation turn progression.
4. PR #850 — company tool selection.
5. PR #851 — recent personal tool activity.
6. PR #852 — standard MCP requests and streamed responses.
7. PR #853 — durable personal tool approval.
8. PR #854 — memory provider coordinates (direct base).
9. PR #855 — repair unused personal assistant execution profiles (this PR).
