### PR TITLE
✨ Discover pending requests for a selected conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
 
 ### Added
 
+- **Authenticated clients can discover pending input for one selected conversation.** The read
+  returns at most fifty unexpired requests assigned to the current participant after active
+  membership, conversation participation and central read permission are checked. It exposes no
+  protected purpose payload, credentials or resume material. The approval card, live notification
+  trigger and informed tool-action disclosure remain unfinished.
+
 - **People can distinguish tool progress from an assistant's final answer in recent personal activity.**
   The activity view shows queued, running, result-received and needs-attention tool phases while
   preserving the separate run status. Reads check the current personal owner and run permission;

--- a/libs/backend/agents/execution/elicitation/main/README.md
+++ b/libs/backend/agents/execution/elicitation/main/README.md
@@ -29,6 +29,8 @@ the generic elicitation result.
 
 - `PrismaElicitationUnitOfWork` — starts serializable transactions for browser responses, request
   reads, and personal-memory permission checks.
+- `_CreateSelfElicitationRouter` — lists up to fifty current requests for one readable conversation,
+  reads a named request, and submits one typed response through session-derived ownership.
 - `PrismaRuntimeElicitationUnitOfWork` — opens runtime proposals and expires due requests on the
   dispatch transaction that already holds the run lock; it never nests another transaction.
 - `PersonalMemoryPermissionAuthority` — opens and verifies the exact execution-user receipt without reading or consuming remembered content.

--- a/libs/backend/agents/execution/elicitation/main/src/__tests__/prisma-elicitation-unit-of-work.test.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/__tests__/prisma-elicitation-unit-of-work.test.ts
@@ -412,6 +412,26 @@ describe("PrismaElicitationUnitOfWork", function _Suite()
 		expect(transaction.conversationParticipant.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: expect.objectContaining({ conversation: { siloId: "silo-1" } }) }));
 	});
 
+	it("lists only current requests assigned to the admitted conversation participant", async function _ListsOpenOwned()
+	{
+		const transaction = { ..._Access(), elicitationRequest: { findMany: vi.fn().mockResolvedValue([_Request()]) } };
+		await expect(_Unit(transaction).listOpenOwned("silo-1", "conversation-1", "user-1", NOW)).resolves.toEqual([expect.objectContaining({ requestId: "request-1", conversationId: "conversation-1", assignedParticipantId: "user-1", state: "requested" })]);
+		expect(_productAuthorization.canRead).toHaveBeenCalledWith("silo-1", "user-1", "conversation-1", NOW);
+		expect(transaction.elicitationRequest.findMany).toHaveBeenCalledWith({
+			where: { siloId: "silo-1", conversationId: "conversation-1", assignedParticipantId: "user-1", state: ElicitationRequestState.Requested, expiresAt: { gt: NOW }, assignedParticipant: { accessEndedPosition: null } },
+			orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+			take: 50,
+		});
+	});
+
+	it("does not inspect requests when central conversation read is denied", async function _DeniesUnreadableConversation()
+	{
+		_productAuthorization.canRead.mockResolvedValue(false);
+		const transaction = { ..._Access(), elicitationRequest: { findMany: vi.fn() } };
+		await expect(_Unit(transaction).listOpenOwned("silo-1", "conversation-1", "user-1", NOW)).resolves.toEqual([]);
+		expect(transaction.elicitationRequest.findMany).not.toHaveBeenCalled();
+	});
+
 	it("denies child open, response, and activity after immediate-parent access ends", async function _DeniesRevokedParent()
 	{
 		const access = { orgMembership: { count: vi.fn().mockResolvedValue(1) }, conversationParticipant: { findFirst: vi.fn().mockResolvedValue(null) } };

--- a/libs/backend/agents/execution/elicitation/main/src/__tests__/self-elicitation.router.test.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/__tests__/self-elicitation.router.test.ts
@@ -36,6 +36,33 @@ function _App(dependencies: SelfElicitationRouterDependencies)
 
 describe("__CreateSelfElicitationRouter", function _Suite()
 {
+	it("lists only through session-derived conversation ownership", async function _ListsOpen()
+	{
+		const listOpenOwned = vi.fn().mockResolvedValue([{ requestId: "request-1" }]);
+		const dependencies = _Dependencies({ elicitations: _Elicitations({ listOpenOwned }) });
+		const response = await request(_App(dependencies)).get("/api/v1/me/conversations/conversation-1/elicitations?subjectId=forged&limit=1000");
+		expect(response.status).toBe(200);
+		expect(response.body).toEqual({ elicitations: [{ requestId: "request-1" }] });
+		expect(listOpenOwned).toHaveBeenCalledWith("silo-1", "conversation-1", "user-1", new Date("2026-08-11T10:00:00.000Z"));
+	});
+
+	it("rejects an invalid selected conversation before listing", async function _RejectsInvalidConversation()
+	{
+		const dependencies = _Dependencies();
+		const response = await request(_App(dependencies)).get("/api/v1/me/conversations/%20/elicitations");
+		expect(response.status).toBe(400);
+		expect(dependencies.elicitations.listOpenOwned).not.toHaveBeenCalled();
+	});
+
+	it("maps an unavailable pending read without exposing internal error detail", async function _MapsPendingReadFailure()
+	{
+		const dependencies = _Dependencies({ elicitations: _Elicitations({ listOpenOwned: vi.fn().mockRejectedValue(new Error("database detail")) }) });
+		const response = await request(_App(dependencies)).get("/api/v1/me/conversations/conversation-1/elicitations");
+		expect(response.status).toBe(503);
+		expect(response.body).toEqual({ error: "elicitation_read_unavailable" });
+		expect(dependencies.logger.error).toHaveBeenCalledWith(expect.objectContaining({ operation: "elicitation.list_open", siloId: "silo-1" }), "Open elicitation read failed");
+	});
+
 	it("reads only through session-derived ownership", async function _Reads()
 	{
 		const elicitation = { requestId: "request-1" } as never;
@@ -81,6 +108,7 @@ describe("__CreateSelfElicitationRouter", function _Suite()
 	it("requires a browser session for reads and answers", async function _RequiresSession()
 	{
 		const dependencies = _Dependencies({ resolveCaller: function _Missing() { return null; } });
+		expect((await request(_App(dependencies)).get("/api/v1/me/conversations/conversation-1/elicitations")).status).toBe(401);
 		expect((await request(_App(dependencies)).get("/api/v1/me/conversations/conversation-1/elicitations/request-1")).status).toBe(401);
 		expect((await request(_App(dependencies)).post("/api/v1/me/conversations/conversation-1/elicitations/request-1/responses").send({})).status).toBe(401);
 	});

--- a/libs/backend/agents/execution/elicitation/main/src/openapi.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/openapi.ts
@@ -42,6 +42,21 @@ export const _ElicitationOpenapiPaths = {
 			},
 		},
 	},
+	"/me/conversations/{conversationId}/elicitations": {
+		get: {
+			operationId: "listMyOpenConversationElicitations",
+			summary: "List pending participant-input requests",
+			description: "Returns at most fifty unexpired requests assigned to the authenticated participant in the selected readable conversation. Protected purpose payloads, credentials, and resume material are never returned.",
+			tags: ["Conversations"],
+			parameters: _ConversationParameters(),
+			responses: {
+				200: { description: "Current owned requests in oldest-first order.", content: { "application/json": { schema: { type: "object", additionalProperties: false, required: ["elicitations"], properties: { elicitations: { type: "array", maxItems: 50, items: _ELICITATION_SCHEMA } } } } } },
+				400: _Error("The selected conversation coordinate is invalid."),
+				401: _Error("No authenticated browser session owns the request list."),
+				503: _Error("The elicitation authority is temporarily unavailable."),
+			},
+		},
+	},
 	"/me/conversations/{conversationId}/elicitations/{requestId}": {
 		get: {
 			operationId: "getMyConversationElicitation",
@@ -83,9 +98,15 @@ export const _ElicitationOpenapiPaths = {
 function _Parameters()
 {
 	return [
-		{ name: "conversationId", in: "path", required: true, schema: { type: "string" }, description: "Conversation containing the request." },
+		..._ConversationParameters(),
 		{ name: "requestId", in: "path", required: true, schema: { type: "string" }, description: "Opaque elicitation identifier." },
 	] as const;
+}
+
+/** Selected conversation path coordinate shared by list, read, and response operations. */
+function _ConversationParameters()
+{
+	return [{ name: "conversationId", in: "path", required: true, schema: { type: "string" }, description: "Conversation containing the request." }] as const;
 }
 
 /** Build one bounded error response schema. */

--- a/libs/backend/agents/execution/elicitation/main/src/self-elicitation.router.ts
+++ b/libs/backend/agents/execution/elicitation/main/src/self-elicitation.router.ts
@@ -8,6 +8,28 @@ import type { SelfElicitationCaller, SelfElicitationRouterDependencies } from ".
 export function __CreateSelfElicitationRouter(dependencies: SelfElicitationRouterDependencies): Router
 {
 	const router = Router();
+	router.get("/:conversationId/elicitations", async function _ListOpen(request: Request, response: Response)
+	{
+		const caller = _RequireCaller(request, response, dependencies);
+		const conversationId = _ConversationId(request);
+		if (caller === null)
+			return;
+		if (conversationId === null)
+		{
+			_Respond(response, 400, "invalid_elicitation_coordinates");
+			return;
+		}
+		try
+		{
+			const elicitations = await dependencies.elicitations.listOpenOwned(caller.siloId, conversationId, caller.subjectId, dependencies.clock.now());
+			response.status(200).json({ elicitations });
+		}
+		catch (err)
+		{
+			dependencies.logger.error({ err, operation: "elicitation.list_open", siloId: caller.siloId }, "Open elicitation read failed");
+			_Respond(response, 503, "elicitation_read_unavailable");
+		}
+	});
 	router.get("/:conversationId/elicitations/:requestId", async function _Read(request: Request, response: Response)
 	{
 		const caller = _RequireCaller(request, response, dependencies);
@@ -84,12 +106,19 @@ function _RequireCaller(request: Request, response: Response, dependencies: Self
 	return caller;
 }
 
+/** Parse the selected non-empty conversation coordinate. */
+function _ConversationId(request: Request): string | null
+{
+	const conversationId = request.params["conversationId"];
+	return typeof conversationId === "string" && conversationId.trim().length > 0 ? conversationId : null;
+}
+
 /** Parse two non-empty path coordinates. */
 function _Coordinates(request: Request): { readonly conversationId: string; readonly requestId: string } | null
 {
-	const conversationId = request.params["conversationId"];
+	const conversationId = _ConversationId(request);
 	const requestId = request.params["requestId"];
-	return typeof conversationId === "string" && conversationId.trim().length > 0 && typeof requestId === "string" && requestId.trim().length > 0 ? { conversationId, requestId } : null;
+	return conversationId !== null && typeof requestId === "string" && requestId.trim().length > 0 ? { conversationId, requestId } : null;
 }
 
 /** Parse an optional bounded Activity page size. */

--- a/libs/contracts/src/generated/api.ts
+++ b/libs/contracts/src/generated/api.ts
@@ -566,6 +566,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/me/conversations/{conversationId}/elicitations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List pending participant-input requests
+         * @description Returns at most fifty unexpired requests assigned to the authenticated participant in the selected readable conversation. Protected purpose payloads, credentials, and resume material are never returned.
+         */
+        get: operations["listMyOpenConversationElicitations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/me/conversations/{conversationId}/elicitations/{requestId}": {
         parameters: {
             query?: never;
@@ -4262,6 +4282,115 @@ export interface operations {
                 };
             };
             /** @description The elicitation Activity index is temporarily unavailable. */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    listMyOpenConversationElicitations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Conversation containing the request. */
+                conversationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current owned requests in oldest-first order. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        elicitations: {
+                            /** @constant */
+                            version: "opencrane.elicitation.v1";
+                            requestId: string;
+                            conversationId: string;
+                            runId: string;
+                            attempt: number;
+                            assignedParticipantId: string;
+                            /** @enum {string} */
+                            purpose: "runtime_input" | "tool_approval" | "personal_memory_permission" | "a2ui_action";
+                            /** @enum {string} */
+                            state: "requested" | "answered" | "declined" | "expired" | "cancelled";
+                            body: {
+                                /** @constant */
+                                kind: "approval";
+                                prompt: string;
+                                action: string;
+                                target: string;
+                                dataUse: string;
+                                externalSystem?: string;
+                                consequence: string;
+                                cost?: string;
+                            } | {
+                                /** @constant */
+                                kind: "single_choice";
+                                prompt: string;
+                                choices: {
+                                    value: string;
+                                    label: string;
+                                    description?: string;
+                                }[];
+                            } | {
+                                /** @constant */
+                                kind: "multiple_choice";
+                                prompt: string;
+                                choices: {
+                                    value: string;
+                                    label: string;
+                                    description?: string;
+                                }[];
+                                minimumSelections: number;
+                                maximumSelections: number;
+                            } | {
+                                /** @constant */
+                                kind: "free_text";
+                                prompt: string;
+                                maximumLength: number;
+                                allowEmpty: boolean;
+                            };
+                            requiresStepUp: boolean;
+                            /** Format: date-time */
+                            requestedAt: string;
+                            /** Format: date-time */
+                            expiresAt: string;
+                            /** Format: date-time */
+                            resolvedAt?: string;
+                            safeReason?: string;
+                        }[];
+                    };
+                };
+            };
+            /** @description The selected conversation coordinate is invalid. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description No authenticated browser session owns the request list. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description The elicitation authority is temporarily unavailable. */
             503: {
                 headers: {
                     [name: string]: unknown;

--- a/libs/frontend/state/conversation/elicitation/README.md
+++ b/libs/frontend/state/conversation/elicitation/README.md
@@ -19,7 +19,8 @@ grants no access and does not copy an answer into this state package.
 ## Public surface
 
 - `ConversationElicitationStore` — component-scoped command, draft, step-up, and reconciliation state.
-- `OpenCraneConversationElicitationGateway` — generated-client adapter for request, response, and Activity reads.
+- `OpenCraneConversationElicitationGateway` — generated-client adapter for selected-conversation
+  pending lists, named request reads, responses, and Activity reads.
 - `__MapElicitationActivity` and `__MapToolActivity` — pure canonical-reference mappers.
 - `ConversationActivityKinds`, `ConversationActivityRow`, and `RunToolProgressPhases` — the derived row vocabulary and public tool-phase categories used by the Activity feature.
 

--- a/libs/frontend/state/conversation/elicitation/src/lib/__tests__/conversation-elicitation.store.spec.ts
+++ b/libs/frontend/state/conversation/elicitation/src/lib/__tests__/conversation-elicitation.store.spec.ts
@@ -22,7 +22,7 @@ function _Elicitation(): ConversationElicitation
 /** Create a generated-port double for the component-scoped store. */
 function _Gateway(): ConversationElicitationGateway
 {
-	return { read: vi.fn().mockResolvedValue(_Elicitation()), respond: vi.fn(), listActivity: vi.fn() };
+	return { listOpen: vi.fn().mockResolvedValue([]), read: vi.fn().mockResolvedValue(_Elicitation()), respond: vi.fn(), listActivity: vi.fn() };
 }
 
 beforeAll(function _InitializeAngularTesting()

--- a/libs/frontend/state/conversation/elicitation/src/lib/__tests__/opencrane-conversation-elicitation.gateway.spec.ts
+++ b/libs/frontend/state/conversation/elicitation/src/lib/__tests__/opencrane-conversation-elicitation.gateway.spec.ts
@@ -1,0 +1,58 @@
+import { Injector, runInInjectionContext } from "@angular/core";
+import { describe, expect, it, vi } from "vitest";
+
+import { ControlPlaneApiService } from "@opencrane/core";
+import { CONVERSATION_ELICITATION_VERSION, ElicitationBodyKinds, ElicitationPurposes, ElicitationRequestStates } from "@opencrane/contracts";
+
+import { OpenCraneConversationElicitationGateway } from "../opencrane-conversation-elicitation.gateway";
+
+const _ELICITATION = {
+	version: CONVERSATION_ELICITATION_VERSION,
+	requestId: "request-1",
+	conversationId: "conversation-1",
+	runId: "run-1",
+	attempt: 1,
+	assignedParticipantId: "user-1",
+	purpose: ElicitationPurposes.RuntimeInput,
+	state: ElicitationRequestStates.Requested,
+	body: { kind: ElicitationBodyKinds.FreeText, prompt: "Which option should I use?", maximumLength: 200, allowEmpty: false },
+	requiresStepUp: false,
+	requestedAt: "2026-08-11T08:00:00.000Z",
+	expiresAt: "2026-08-11T09:00:00.000Z",
+};
+
+/** Construct the adapter with a controlled generated client. */
+function _Gateway(client: object): OpenCraneConversationElicitationGateway
+{
+	const injector = Injector.create({ providers: [{ provide: ControlPlaneApiService, useValue: { client } }] });
+	return runInInjectionContext(injector, function _Create() { return new OpenCraneConversationElicitationGateway(); });
+}
+
+describe("OpenCraneConversationElicitationGateway", function _Suite()
+{
+	it("lists validated pending requests for the selected conversation", async function _ListsOpen()
+	{
+		const GET = vi.fn().mockResolvedValue({ data: { elicitations: [_ELICITATION] }, error: undefined, response: { ok: true, status: 200 } });
+		const elicitations = await _Gateway({ GET }).listOpen("conversation-1");
+		expect(GET).toHaveBeenCalledWith("/me/conversations/{conversationId}/elicitations", { params: { path: { conversationId: "conversation-1" } } });
+		expect(elicitations).toEqual([_ELICITATION]);
+	});
+
+	it("rejects a malformed request before it enters browser state", async function _RejectsMalformedRequest()
+	{
+		const GET = vi.fn().mockResolvedValue({ data: { elicitations: [{ ..._ELICITATION, assignedParticipantId: "" }] }, error: undefined, response: { ok: true, status: 200 } });
+		await expect(_Gateway({ GET }).listOpen("conversation-1")).rejects.toThrow("elicitation response has invalid coordinates");
+	});
+
+	it("rejects a response above the server-owned list bound", async function _RejectsOversizedList()
+	{
+		const GET = vi.fn().mockResolvedValue({ data: { elicitations: Array.from({ length: 51 }, function _Request() { return _ELICITATION; }) }, error: undefined, response: { ok: true, status: 200 } });
+		await expect(_Gateway({ GET }).listOpen("conversation-1")).rejects.toThrow("open elicitation list exceeds its response bound");
+	});
+
+	it("rejects a request projected from another conversation", async function _RejectsMismatchedConversation()
+	{
+		const GET = vi.fn().mockResolvedValue({ data: { elicitations: [{ ..._ELICITATION, conversationId: "conversation-2" }] }, error: undefined, response: { ok: true, status: 200 } });
+		await expect(_Gateway({ GET }).listOpen("conversation-1")).rejects.toThrow("open elicitation list does not match the selected conversation");
+	});
+});

--- a/libs/frontend/state/conversation/elicitation/src/lib/elicitation-gateway.types.ts
+++ b/libs/frontend/state/conversation/elicitation/src/lib/elicitation-gateway.types.ts
@@ -6,6 +6,8 @@ export type GeneratedElicitationSubmission = paths["/me/conversations/{conversat
 /** Signed-in browser port for generic participant input. */
 export interface ConversationElicitationGateway
 {
+	/** List at most fifty current requests assigned to the caller in one readable conversation. */
+	listOpen(conversationId: string): Promise<readonly ConversationElicitation[]>;
 	/** Read one exact active-participant request. */
 	read(conversationId: string, requestId: string): Promise<ConversationElicitation>;
 	/** Submit one typed idempotent response. */

--- a/libs/frontend/state/conversation/elicitation/src/lib/opencrane-conversation-elicitation.gateway.ts
+++ b/libs/frontend/state/conversation/elicitation/src/lib/opencrane-conversation-elicitation.gateway.ts
@@ -18,6 +18,20 @@ export class OpenCraneConversationElicitationGateway implements ConversationElic
 	private readonly _api = inject(ControlPlaneApiService);
 
 	/** @inheritdoc */
+	public async listOpen(conversationId: string): Promise<readonly ConversationElicitation[]>
+	{
+		const { data, error, response } = await this._api.client.GET("/me/conversations/{conversationId}/elicitations", { params: { path: { conversationId } } });
+		if (error !== undefined || !response.ok || data === undefined)
+			throw _Error(response.status, error);
+		if (!Array.isArray(data.elicitations) || data.elicitations.length > 50)
+			throw new TypeError("open elicitation list exceeds its response bound");
+		const elicitations = data.elicitations.map(__ParseConversationElicitation);
+		if (elicitations.some(function _BelongsToAnotherConversation(elicitation) { return elicitation.conversationId !== conversationId; }))
+			throw new TypeError("open elicitation list does not match the selected conversation");
+		return elicitations;
+	}
+
+	/** @inheritdoc */
 	public async read(conversationId: string, requestId: string): Promise<ConversationElicitation>
 	{
 		const { data, error, response } = await this._api.client.GET("/me/conversations/{conversationId}/elicitations/{requestId}", { params: { path: { conversationId, requestId } } });

--- a/plan.md
+++ b/plan.md
@@ -467,6 +467,9 @@ ESLint boundaries, agent style, Prisma boundaries and module growth pass. The fi
 name pre-existing response-outcome comparisons; no warning names added code. Independent integrated
 review and architecture post-review pass with no findings.
 
+CI caught a missing website OpenAPI snapshot after the typed client was generated. The website
+snapshot is now synchronized with the same emitted schema, and the documentation build passes.
+
 ### Testv5 access repair — preserve existing data
 
 Fresh owner sign-in succeeds. The remaining onboarding denial is `service_not_ready`: the exact

--- a/plan.md
+++ b/plan.md
@@ -449,6 +449,24 @@ integration and OpenCrane lint also passed after stacking onto #852. Independent
 architecture post-review passed. These are source and integration checks; no live remote-provider,
 hosted-MCP or fresh-install qualification is claimed here.
 
+### Selected-conversation elicitation discovery — source validated, review passed
+
+The authenticated browser API can list up to fifty current requests assigned to the caller in one
+selected conversation. The existing elicitation authority checks active membership, current
+participation and central Conversation/Read permission before returning the browser-safe request
+projections. The Activity index and named request read remain separate capabilities.
+
+This slice does not mount the existing elicitation card or add a polling, queue or scheduling path.
+An authoritative live trigger and exact human-readable tool, action and safe-argument disclosure
+remain required before the product can claim a visible informed-approval journey. Remote-provider
+metadata and live provider qualification remain separate work.
+
+Validation evidence: elicitation authority (`50`), frontend elicitation state (`8`) and shared
+contracts (`122`) tests pass. All three focused TypeScript lint targets, generated-client replay,
+ESLint boundaries, agent style, Prisma boundaries and module growth pass. The five style warnings
+name pre-existing response-outcome comparisons; no warning names added code. Independent integrated
+review and architecture post-review pass with no findings.
+
 ### Testv5 access repair — preserve existing data
 
 Fresh owner sign-in succeeds. The remaining onboarding denial is `service_not_ready`: the exact
@@ -464,9 +482,14 @@ actual composition tests (5) and fresh PostgreSQL repair tests (5) pass. The SQL
 Edit denial, audit rollback, exhausted source comparisons and concurrent conversation creation;
 the existing onboarding transaction retries conflicts and refuses a service that becomes used.
 Relevant type checks, the server build, style, boundaries and module-growth checks pass. Independent
-review and architecture post-review pass. Publication and a separately authorized live repair
-remain open. No live database, deployment, identities, conversation history or stored files have
-been changed.
+review and architecture post-review pass. The source is published in draft #855 at
+`26ffbf65447a96e9f928754af5c81eab475010bc`. The minimal deployment candidate
+`a198ff2431511a55673f2c137a42b861d03c8247` is stacked directly on the deployed server source.
+Normal CI run `34478251765` passed and published server image digest
+`4e259a6ef71086513d611973e4e97754671902553b6f35bce2550d4e81d90c50`. Read-only preservation
+inspection and the final read-only preflight pass. Explicit approval for the live installation
+remains pending, and no live database, deployment, identities, conversation history or stored files
+have been changed.
 
 The live PostgreSQL release metadata and deployed server manifest carry different baseline digests.
 This is an unresolved provenance problem; the readiness schema was read successfully and the

--- a/website/public/openapi.json
+++ b/website/public/openapi.json
@@ -4973,6 +4973,307 @@
         }
       }
     },
+    "/me/conversations/{conversationId}/elicitations": {
+      "get": {
+        "operationId": "listMyOpenConversationElicitations",
+        "summary": "List pending participant-input requests",
+        "description": "Returns at most fifty unexpired requests assigned to the authenticated participant in the selected readable conversation. Protected purpose payloads, credentials, and resume material are never returned.",
+        "tags": [
+          "Conversations"
+        ],
+        "parameters": [
+          {
+            "name": "conversationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Conversation containing the request."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Current owned requests in oldest-first order.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "elicitations"
+                  ],
+                  "properties": {
+                    "elicitations": {
+                      "type": "array",
+                      "maxItems": 50,
+                      "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                          "version",
+                          "requestId",
+                          "conversationId",
+                          "runId",
+                          "attempt",
+                          "assignedParticipantId",
+                          "purpose",
+                          "state",
+                          "body",
+                          "requiresStepUp",
+                          "requestedAt",
+                          "expiresAt"
+                        ],
+                        "properties": {
+                          "version": {
+                            "const": "opencrane.elicitation.v1"
+                          },
+                          "requestId": {
+                            "type": "string"
+                          },
+                          "conversationId": {
+                            "type": "string"
+                          },
+                          "runId": {
+                            "type": "string"
+                          },
+                          "attempt": {
+                            "type": "integer",
+                            "minimum": 1
+                          },
+                          "assignedParticipantId": {
+                            "type": "string"
+                          },
+                          "purpose": {
+                            "type": "string",
+                            "enum": [
+                              "runtime_input",
+                              "tool_approval",
+                              "personal_memory_permission",
+                              "a2ui_action"
+                            ]
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "requested",
+                              "answered",
+                              "declined",
+                              "expired",
+                              "cancelled"
+                            ]
+                          },
+                          "body": {
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "kind",
+                                  "prompt",
+                                  "action",
+                                  "target",
+                                  "dataUse",
+                                  "consequence"
+                                ],
+                                "properties": {
+                                  "kind": {
+                                    "const": "approval"
+                                  },
+                                  "prompt": {
+                                    "type": "string"
+                                  },
+                                  "action": {
+                                    "type": "string"
+                                  },
+                                  "target": {
+                                    "type": "string"
+                                  },
+                                  "dataUse": {
+                                    "type": "string"
+                                  },
+                                  "externalSystem": {
+                                    "type": "string"
+                                  },
+                                  "consequence": {
+                                    "type": "string"
+                                  },
+                                  "cost": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "kind",
+                                  "prompt",
+                                  "choices"
+                                ],
+                                "properties": {
+                                  "kind": {
+                                    "const": "single_choice"
+                                  },
+                                  "prompt": {
+                                    "type": "string"
+                                  },
+                                  "choices": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "value",
+                                        "label"
+                                      ],
+                                      "properties": {
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "description": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "kind",
+                                  "prompt",
+                                  "choices",
+                                  "minimumSelections",
+                                  "maximumSelections"
+                                ],
+                                "properties": {
+                                  "kind": {
+                                    "const": "multiple_choice"
+                                  },
+                                  "prompt": {
+                                    "type": "string"
+                                  },
+                                  "choices": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "required": [
+                                        "value",
+                                        "label"
+                                      ],
+                                      "properties": {
+                                        "value": {
+                                          "type": "string"
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "description": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "minimumSelections": {
+                                    "type": "integer"
+                                  },
+                                  "maximumSelections": {
+                                    "type": "integer"
+                                  }
+                                }
+                              },
+                              {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": [
+                                  "kind",
+                                  "prompt",
+                                  "maximumLength",
+                                  "allowEmpty"
+                                ],
+                                "properties": {
+                                  "kind": {
+                                    "const": "free_text"
+                                  },
+                                  "prompt": {
+                                    "type": "string"
+                                  },
+                                  "maximumLength": {
+                                    "type": "integer"
+                                  },
+                                  "allowEmpty": {
+                                    "type": "boolean"
+                                  }
+                                }
+                              }
+                            ]
+                          },
+                          "requiresStepUp": {
+                            "type": "boolean"
+                          },
+                          "requestedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "expiresAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "resolvedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "safeReason": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The selected conversation coordinate is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No authenticated browser session owns the request list.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "The elicitation authority is temporarily unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/me/conversations/{conversationId}/elicitations/{requestId}": {
       "get": {
         "operationId": "getMyConversationElicitation",


### PR DESCRIPTION
Clients can now retrieve pending requests assigned to the signed-in person for one selected conversation. The existing elicitation authority returns up to 50 open, unexpired requests in oldest-first order after checking current membership, participation and central Conversation/Read permission. A denied read returns an empty list.

The existing self-elicitation router exposes the read, and the existing frontend gateway uses the generated API client. It validates every returned projection, the response bound and its conversation coordinates. Silo and subject come from the verified session. The response uses the existing browser-safe projection and excludes protected purpose payloads and resume material.

The global Activity index and read-by-ID route remain useful for their existing purposes. This slice adds no data model, queue, scheduler, polling loop, store or UI component. The approval card remains unmounted: live notification of a newly created request and clear, frozen action details are separate work required for the complete visible approval journey.

Validation completed:

- Nx tests: backend elicitation 50, frontend elicitation state 8 and contracts 122 passed.
- Changed-package type checks/lint passed; generated API replay and website build passed. Both the generated client and website OpenAPI snapshot are synchronized.
- Style reported 0 errors; its 5 warnings are unchanged response-outcome comparisons outside this added read path and were reviewed. Prisma/dependency boundaries, module growth and diff checks passed.
- All gateway implementations and typed test doubles were checked for the new method; the existing store test double was updated.
- Architecture preflight/post-review and mandatory independent review passed with no findings.

CI validation at `b9b362f0ed7ceeef6212f1c4ef1c799e69243913` passed in [run 34482381043](https://github.com/elewa-git/opencrane/actions/runs/34482381043): affected build/test/lint, database authority, KurrentDB, API/client, Storybook, image smokes and stack ancestry. Image publication was still running at the recorded check; k3d was intentionally skipped.

Owning backend/frontend READMEs, `plan.md` and `CHANGELOG.md` describe this read capability and the remaining UI work. The plan also records PR #855's passing repair validation and minimal testv5 candidate. No testv5 deployment or live approval journey is claimed.

## Review order

1. PR #831 — member access and revocation.
2. PR #843 — library and component decomposition.
3. PR #849 — Absurd conversation turn progression.
4. PR #850 — company tool selection.
5. PR #851 — recent personal tool activity.
6. PR #852 — standard MCP requests and streamed responses.
7. PR #853 — durable personal tool approval.
8. PR #854 — memory provider coordinates.
9. PR #855 — unused personal assistant profile repair (direct base).
10. PR #856 — conversation-scoped pending request discovery (this PR).
