### PR TITLE
Qualify the pinned memory provider before enabling personal memory

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,6 +78,7 @@ jobs:
       has_deployables: ${{ steps.affected.outputs.has_deployables }}
       image_smokes: ${{ steps.affected.outputs.image_smokes }}
       has_image_smokes: ${{ steps.affected.outputs.has_image_smokes }}
+      cognee_memory_contract_required: ${{ steps.affected.outputs.cognee_memory_contract_required }}
       develop_smoke_images: ${{ steps.affected.outputs.develop_smoke_images }}
       develop_smoke_projects: ${{ steps.affected.outputs.develop_smoke_projects }}
       api_contract_changed: ${{ steps.affected.outputs.api_contract_changed }}
@@ -675,11 +676,50 @@ jobs:
           IMAGE_SMOKE_PROJECT: ${{ matrix.project }}
         run: npx nx run "$IMAGE_SMOKE_PROJECT:image-smoke"
 
+  cognee_memory_contract:
+    name: Cognee memory provider contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    needs: prepare
+    if: needs.prepare.outputs.cognee_memory_contract_required == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Restore node_modules
+        id: node-modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}
+
+      - name: Install provider-contract dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Prove the pinned memory provider contract
+        env:
+          NX_DAEMON: 'false'
+        run: npm exec -- nx run cognee:memory-contract
+
+      - name: Preserve provider qualification evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cognee-memory-contract-${{ github.run_attempt }}
+          path: .nx/test-results/cognee-memory-contract
+          if-no-files-found: error
+          retention-days: 14
+
   build-and-push:
     name: Build and publish affected images
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: [prepare, test, database, history_store, api_contract, storybook_visual, develop_smoke, image_smoke]
+    needs: [prepare, test, database, history_store, api_contract, storybook_visual, develop_smoke, image_smoke, cognee_memory_contract]
     # Manual publication bypasses failed validation only when the operator repeats this workflow's SHA.
     # The exact match prevents approval for one commit from publishing a different commit.
     if: >-
@@ -696,7 +736,8 @@ jobs:
           (needs.api_contract.result == 'success' || needs.api_contract.result == 'skipped') &&
           needs.storybook_visual.result == 'success' &&
           (needs.develop_smoke.result == 'success' || needs.develop_smoke.result == 'skipped') &&
-          (needs.image_smoke.result == 'success' || needs.image_smoke.result == 'skipped')))
+          (needs.image_smoke.result == 'success' || needs.image_smoke.result == 'skipped') &&
+          (needs.cognee_memory_contract.result == 'success' || needs.cognee_memory_contract.result == 'skipped')))
       }}
     permissions:
       contents: read
@@ -768,7 +809,7 @@ jobs:
     name: Publish develop smoke image (${{ matrix.project }})
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    needs: [prepare, test, database, history_store, api_contract, storybook_visual, develop_smoke, image_smoke, build-and-push]
+    needs: [prepare, test, database, history_store, api_contract, storybook_visual, develop_smoke, image_smoke, cognee_memory_contract, build-and-push]
     if: >-
       ${{
         always() &&
@@ -781,6 +822,7 @@ jobs:
         needs.storybook_visual.result == 'success' &&
         needs.develop_smoke.result == 'success' &&
         (needs.image_smoke.result == 'success' || needs.image_smoke.result == 'skipped') &&
+        (needs.cognee_memory_contract.result == 'success' || needs.cognee_memory_contract.result == 'skipped') &&
         (needs['build-and-push'].result == 'success' || needs['build-and-push'].result == 'skipped')
       }}
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The 0.11 baseline remains under review; this is not a release or a completed MVP
 
 ### Added
 
+- **Operators can qualify the pinned Cognee image against the memory-provider contract before publication.** The uncached `cognee:memory-contract` target runs disposable synthetic datasets with a deterministic local model and embedding stub on an internal Docker network, checking isolation, source and document identity, lost-response and restart recovery, indexing and deletion; selected CI retains the evidence and gates image publication. Personal memory writes and Remember, Recall, Correct and Forget journeys remain unfinished.
+
 - **People can stop their own current personal-assistant turn from the conversation.** Stop checks
   current access, saves the selected turn and prevents further model or tool work. Pending approvals
   close when cancellation wins; an answer already committed remains successful. Work already sent

--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -104,6 +104,9 @@ The negative control tests the current configuration, with dataset partitioning 
 disabled. The positive candidate enables both: Cognee requires authentication when partitioning is
 enabled. It registers a synthetic account in disposable storage and signs in again after restart;
 the test token stays in process memory and never enters evidence files.
+Authenticated search must identify the exact requested dataset in its response envelope. The
+negative control uses the provider's separate flat response shape; neither parser accepts the
+other mode or silently selects from several datasets.
 A passing provider proof is required before changing the deployment default or enabling personal
 memory writes. An empty result cannot stand in for an
 unavailable provider, a lost response cannot authorize another write, and a chunk identifier cannot

--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -100,9 +100,12 @@ port. The harness removes only its own containers, network and temporary storage
 The pinned image reports `1.2.1-local`: Cognee appends this suffix when it reads the version from its
 source checkout. Qualification requires that exact value and the reviewed module hashes.
 
-The test compares dataset partitioning enabled and disabled while Cognee HTTP login remains disabled.
-These are disposable test configurations. A passing provider proof is required before changing the
-deployment default or enabling personal memory writes. An empty result cannot stand in for an
+The negative control tests the current configuration, with dataset partitioning and HTTP login
+disabled. The positive candidate enables both: Cognee requires authentication when partitioning is
+enabled. It registers a synthetic account in disposable storage and signs in again after restart;
+the test token stays in process memory and never enters evidence files.
+A passing provider proof is required before changing the deployment default or enabling personal
+memory writes. An empty result cannot stand in for an
 unavailable provider, a lost response cannot authorize another write, and a chunk identifier cannot
 stand in for the owning document during deletion.
 

--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -97,6 +97,8 @@ a deterministic model/embedding stub on a private Docker network. It records the
 version and source hashes before checking dataset isolation, document identity, recovery after a lost
 response, restart, indexing and deletion. The driver uses container DNS without publishing a host
 port. The harness removes only its own containers, network and temporary storage.
+The pinned image reports `1.2.1-local`: Cognee appends this suffix when it reads the version from its
+source checkout. Qualification requires that exact value and the reviewed module hashes.
 
 The test compares dataset partitioning enabled and disabled while Cognee HTTP login remains disabled.
 These are disposable test configurations. A passing provider proof is required before changing the

--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -112,6 +112,12 @@ memory writes. An empty result cannot stand in for an
 unavailable provider, a lost response cannot authorize another write, and a chunk identifier cannot
 stand in for the owning document during deletion.
 
+The pinned 1.2.1 image currently fails the last-reference erasure check: it removes retrieval and
+dataset visibility but retains the original uploaded file. Its authenticated candidate passes
+isolation and restart recovery; that does not qualify deletion or enable personal memory. Keep the
+failed evidence and test assertion until a separately reviewed provider image passes the complete
+contract, including interrupted-deletion recovery and local file ownership.
+
 CI selects this uncached target whenever the existing image-smoke selection includes Cognee. A
 selected run fails if Docker or a required provider proof is unavailable. Logs and a machine-readable
 result are retained under `.nx/test-results/cognee-memory-contract` and uploaded by the workflow.

--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -37,7 +37,8 @@ offline image smoke. No runtime network exception hides either failure.
 - `deploy/Dockerfile` builds the OpenCrane-owned Cognee image.
 - `helm/` provides `opencrane.cognee.resources`, the named-template library composed by the silo
   chart.
-- `project.json` registers the container, contract-test, offline image-smoke, and Helm-lint targets.
+- `project.json` registers the container, fast contract tests, offline image smoke, memory-provider
+  qualification, and Helm-lint targets.
 
 There is no importable application code.
 
@@ -87,6 +88,26 @@ fallback.
 - `sharedPlatform.litellm.mode` must remain `instance`.
 - Cognee's own login middleware stays disabled because the authenticated gateway and NetworkPolicy
   own access to this private Service.
+
+## Provider qualification
+
+Run `npm exec -- nx run cognee:memory-contract` on the CI Docker runner to test the pinned image's
+memory behavior with synthetic facts. The target builds the app-owned image, then runs Cognee and
+a deterministic model/embedding stub on a private Docker network. It records the installed provider
+version and source hashes before checking dataset isolation, document identity, recovery after a lost
+response, restart, indexing and deletion. The driver uses container DNS without publishing a host
+port. The harness removes only its own containers, network and temporary storage.
+
+The test compares dataset partitioning enabled and disabled while Cognee HTTP login remains disabled.
+These are disposable test configurations. A passing provider proof is required before changing the
+deployment default or enabling personal memory writes. An empty result cannot stand in for an
+unavailable provider, a lost response cannot authorize another write, and a chunk identifier cannot
+stand in for the owning document during deletion.
+
+CI selects this uncached target whenever the existing image-smoke selection includes Cognee. A
+selected run fails if Docker or a required provider proof is unavailable. Logs and a machine-readable
+result are retained under `.nx/test-results/cognee-memory-contract` and uploaded by the workflow.
+The ordinary `cognee:test` target stays fast and does not require Docker.
 
 ## See also
 

--- a/apps/_infra/cognee/project.json
+++ b/apps/_infra/cognee/project.json
@@ -10,7 +10,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "options": { "command": "bash apps/_infra/cognee/tests/image-contract.sh && bash apps/_infra/cognee/tests/image-policy-contract.sh && PYTHONPYCACHEPREFIX=.nx/python python3 -m unittest discover -s apps/_infra/cognee/tests/fixtures -p test_provider_auth.py" }
+      "options": { "command": "bash apps/_infra/cognee/tests/image-contract.sh && bash apps/_infra/cognee/tests/image-policy-contract.sh && PYTHONPYCACHEPREFIX=.nx/python python3 -m unittest discover -s apps/_infra/cognee/tests/fixtures -p 'test_provider_*.py'" }
     },
     "container": {
       "executor": "nx:run-commands",

--- a/apps/_infra/cognee/project.json
+++ b/apps/_infra/cognee/project.json
@@ -10,7 +10,7 @@
     },
     "test": {
       "executor": "nx:run-commands",
-      "options": { "command": "bash apps/_infra/cognee/tests/image-contract.sh && bash apps/_infra/cognee/tests/image-policy-contract.sh" }
+      "options": { "command": "bash apps/_infra/cognee/tests/image-contract.sh && bash apps/_infra/cognee/tests/image-policy-contract.sh && PYTHONPYCACHEPREFIX=.nx/python python3 -m unittest discover -s apps/_infra/cognee/tests/fixtures -p test_provider_auth.py" }
     },
     "container": {
       "executor": "nx:run-commands",

--- a/apps/_infra/cognee/project.json
+++ b/apps/_infra/cognee/project.json
@@ -6,7 +6,7 @@
   "targets": {
     "lint": {
       "executor": "nx:run-commands",
-      "options": { "command": "bash -n apps/_infra/cognee/deploy/image-policy.sh apps/_infra/cognee/tests/image-contract.sh apps/_infra/cognee/tests/image-policy-contract.sh apps/_infra/cognee/tests/image-smoke.sh" }
+      "options": { "command": "for script in apps/_infra/cognee/deploy/*.sh apps/_infra/cognee/tests/*.sh; do bash -n \"$script\" || exit; done && PYTHONPYCACHEPREFIX=.nx/python python3 -m compileall -q apps/_infra/cognee/tests/fixtures" }
     },
     "test": {
       "executor": "nx:run-commands",
@@ -25,6 +25,14 @@
     "image-smoke": {
       "executor": "nx:run-commands",
       "options": { "command": "bash apps/_infra/cognee/tests/image-smoke.sh", "cwd": "." }
+    },
+    "memory-contract": {
+      "executor": "nx:run-commands",
+      "cache": false,
+      "options": {
+        "command": "docker build --platform linux/amd64 -t opencrane-cognee:memory-contract -f apps/_infra/cognee/deploy/Dockerfile . && bash apps/_infra/cognee/tests/memory-contract.sh opencrane-cognee:memory-contract",
+        "cwd": "."
+      }
     },
     "helm-lint": {
       "executor": "nx:run-commands",

--- a/apps/_infra/cognee/tests/fixtures/commit_then_drop_proxy.py
+++ b/apps/_infra/cognee/tests/fixtures/commit_then_drop_proxy.py
@@ -43,6 +43,9 @@ class _Handler(BaseHTTPRequestHandler):
             "content-type": self.headers.get("content-type", "application/octet-stream"),
             "content-length": str(len(payload)),
         }
+        authorization = self.headers.get("authorization")
+        if authorization is not None:
+            forwarded_headers["authorization"] = authorization
         connection.request("POST", self.path, body=payload, headers=forwarded_headers)
         response = connection.getresponse()
         response.read()

--- a/apps/_infra/cognee/tests/fixtures/commit_then_drop_proxy.py
+++ b/apps/_infra/cognee/tests/fixtures/commit_then_drop_proxy.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Forward one add request, consume its successful response, and drop the caller connection."""
+
+import http.client
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Drop responses only after the upstream provider has completed them."""
+
+    server_version = "OpenCraneCommitThenDrop/1"
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            body = b'{"status":"ok"}'
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_error(404)
+
+    def do_POST(self) -> None:
+        if self.path != "/api/v1/add":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("content-length", "0"))
+        payload = self.rfile.read(length)
+        connection = http.client.HTTPConnection(
+            os.environ.get("UPSTREAM_HOST", "cognee"),
+            int(os.environ.get("UPSTREAM_PORT", "8000")),
+            timeout=300,
+        )
+        forwarded_headers = {
+            "accept": "application/json",
+            "content-type": self.headers.get("content-type", "application/octet-stream"),
+            "content-length": str(len(payload)),
+        }
+        connection.request("POST", self.path, body=payload, headers=forwarded_headers)
+        response = connection.getresponse()
+        response.read()
+        status = response.status
+        connection.close()
+        if status < 200 or status >= 300:
+            self.send_error(502)
+            return
+        record = {"method": "POST", "path": self.path, "upstreamStatus": status, "responseDropped": True}
+        with Path(os.environ["DROP_METADATA_LOG"]).open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(record, sort_keys=True) + "\n")
+        self.close_connection = True
+
+
+def main() -> None:
+    os.umask(0o077)
+    server = ThreadingHTTPServer(("0.0.0.0", int(os.environ.get("DROP_PORT", "8091"))), _Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/_infra/cognee/tests/fixtures/evidence_summary.py
+++ b/apps/_infra/cognee/tests/fixtures/evidence_summary.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Combine the provider contract's independently written evidence into one receipt."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--image-inspect", required=True)
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--negative", required=True)
+    parser.add_argument("--positive-initial", required=True)
+    parser.add_argument("--positive", required=True)
+    parser.add_argument("--stub-log", required=True)
+    parser.add_argument("--drop-log", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--failure-status", type=int)
+    parser.add_argument("--failed-case")
+    return parser.parse_args()
+
+
+def _read_json(path: str):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _read_json_lines(path: str) -> list[dict]:
+    source = Path(path)
+    if not source.exists():
+        return []
+    values = []
+    for line_number, line in enumerate(source.read_text(encoding="utf-8").splitlines(), start=1):
+        if not line:
+            continue
+        try:
+            values.append(json.loads(line))
+        except json.JSONDecodeError:
+            values.append({"outcome": "invalid-json-line", "lineNumber": line_number})
+    return values
+
+
+def _optional_json(path: str):
+    source = Path(path)
+    if not source.exists():
+        return None
+    try:
+        return _read_json(path)
+    except json.JSONDecodeError:
+        return {"outcome": "invalid-json"}
+
+
+def main() -> None:
+    args = _arguments()
+    if args.failure_status is not None:
+        receipt = {
+            "outcome": "fail",
+            "failedCase": args.failed_case,
+            "exitStatus": args.failure_status,
+            "image": {
+                "requestedReference": args.image,
+                "inspection": _optional_json(args.image_inspect),
+            },
+            "source": _optional_json(args.source),
+            "negativeControl": _optional_json(args.negative),
+            "qualifiedCandidateInitial": _optional_json(args.positive_initial),
+            "qualifiedCandidate": _optional_json(args.positive),
+            "stubRequests": _read_json_lines(args.stub_log),
+            "commitThenDrop": _read_json_lines(args.drop_log),
+        }
+        Path(args.output).write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(f"CASE {args.failed_case} FAIL status={args.failure_status}")
+        return
+    image_inspect = _read_json(args.image_inspect)
+    if not isinstance(image_inspect, list) or len(image_inspect) != 1:
+        raise AssertionError("Docker image inspection did not return exactly one image")
+    image = image_inspect[0]
+    receipt = {
+        "outcome": "pass",
+        "image": {
+            "requestedReference": args.image,
+            "id": image.get("Id"),
+            "repoDigests": image.get("RepoDigests", []),
+        },
+        "source": _read_json(args.source),
+        "negativeControl": _read_json(args.negative),
+        "qualifiedCandidateInitial": _read_json(args.positive_initial),
+        "qualifiedCandidate": _read_json(args.positive),
+        "stubRequests": _read_json_lines(args.stub_log),
+        "commitThenDrop": _read_json_lines(args.drop_log),
+    }
+    if len(receipt["commitThenDrop"]) != 1:
+        raise AssertionError("Commit-then-drop proxy did not record exactly one committed add")
+    Path(args.output).write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print("CASE machine_readable_evidence_receipt PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/_infra/cognee/tests/fixtures/expected-source-hashes.json
+++ b/apps/_infra/cognee/tests/fixtures/expected-source-hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.1",
+  "version": "1.2.1-local",
   "modules": {
     "cognee.api.v1.datasets.datasets": "75ff6b78baedd292ec0d3b941295c6e064ce138bc0f2b3e6d00291bb4a6ebfe4",
     "cognee.api.v1.datasets.routers.get_datasets_router": "5b2fc117c3a051d797032b283b28f00e2e031b044e53eb0f9daab2ed711eac57",

--- a/apps/_infra/cognee/tests/fixtures/expected-source-hashes.json
+++ b/apps/_infra/cognee/tests/fixtures/expected-source-hashes.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.2.1",
+  "modules": {
+    "cognee.api.v1.datasets.datasets": "75ff6b78baedd292ec0d3b941295c6e064ce138bc0f2b3e6d00291bb4a6ebfe4",
+    "cognee.api.v1.datasets.routers.get_datasets_router": "5b2fc117c3a051d797032b283b28f00e2e031b044e53eb0f9daab2ed711eac57",
+    "cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter": "138fb2e0badafe633692619771cd69b550ffbd67fd5f58dbfc4e0b8de05906d9",
+    "cognee.infrastructure.loaders.core.text_loader": "d9ad0d98f4498bae6067c7a53d6470bdf98b53bf2d4ccbb975327185ce7b896e",
+    "cognee.modules.chunking.TextChunker": "43a6ac5e9f132374c67f0d2527a22657d1546854f0adafddd39cc190d08c4c0c",
+    "cognee.modules.data.methods.get_unique_data_id": "82d8dc8b21b151722c6d72330a36f7671be0b09d2a9452c1a1e964f5285ccd3c",
+    "cognee.modules.data.models.Data": "af3d18f88ec85b4098e841bbdb6ecf97736925998538542653143d4750951af7",
+    "cognee.modules.graph.methods.delete_data_nodes_and_edges": "51d664fb69a5c280fd85025f9430536424202958be77a6c09704254ef915c3fc",
+    "cognee.modules.ingestion.save_data_to_file": "3c64136ddbff3e7f3fc5e1315bc49b922390e731fdc4958c4ba04c6847eb40ed",
+    "cognee.modules.retrieval.chunks_retriever": "7cb62960a65e39915a21a2b1a72e6dff89fa1dd4be65c18a9cd252bb2d328525",
+    "cognee.modules.search.methods.get_search_type_retriever_instance": "351dc564339b84e17efa3bbc3186f12e548bf7976cc485cc5b4697c21585ff2b",
+    "cognee.modules.search.methods.search": "12b71778370c71c99148e7db4281a212ddfb2c6192f926b56399e61d8caf85fd",
+    "cognee.tasks.ingestion.data_item_to_text_file": "55eb748c3f10ed775c115817621f6230e5cbf2c5f9f51a49fb37218a90dce6a4",
+    "cognee.tasks.ingestion.ingest_data": "3c4c4c98de77589a23053f77c3f2cbb35a980e8c7645d131ab0a5ee22d8046ab"
+  }
+}

--- a/apps/_infra/cognee/tests/fixtures/openai_stub.py
+++ b/apps/_infra/cognee/tests/fixtures/openai_stub.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Serve deterministic OpenAI-compatible chat and embeddings without recording content."""
+
+import hashlib
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+
+def _resolve_reference(reference: str, root_schema: dict[str, Any]) -> dict[str, Any]:
+    if not reference.startswith("#/"):
+        raise AssertionError(f"The deterministic stub cannot resolve schema reference {reference}")
+    value: Any = root_schema
+    for segment in reference[2:].split("/"):
+        if not isinstance(value, dict) or segment not in value:
+            raise AssertionError(f"The deterministic stub cannot resolve schema reference {reference}")
+        value = value[segment]
+    if not isinstance(value, dict):
+        raise AssertionError(f"Schema reference does not resolve to an object: {reference}")
+    return value
+
+
+def _minimal_value(
+    schema: dict[str, Any], name: str = "value", root_schema: dict[str, Any] | None = None
+) -> Any:
+    root = schema if root_schema is None else root_schema
+    if "$ref" in schema:
+        return _minimal_value(_resolve_reference(str(schema["$ref"]), root), name, root)
+    if "const" in schema:
+        return schema["const"]
+    if "enum" in schema and schema["enum"]:
+        return schema["enum"][0]
+    if "allOf" in schema and schema["allOf"]:
+        values = [_minimal_value(part, name, root) for part in schema["allOf"]]
+        if all(isinstance(value, dict) for value in values):
+            merged = {}
+            for value in values:
+                merged.update(value)
+            return merged
+        return values[0]
+    for alternative in schema.get("anyOf", schema.get("oneOf", [])):
+        if alternative.get("type") != "null":
+            return _minimal_value(alternative, name, root)
+    schema_type = schema.get("type")
+    if schema_type == "object" or "properties" in schema:
+        properties = schema.get("properties", {})
+        required = schema.get("required", [])
+        return {
+            key: _minimal_value(properties.get(key, {}), key, root)
+            for key in required
+        }
+    if schema_type == "array":
+        return []
+    if schema_type == "integer":
+        return max(0, int(schema.get("minimum", 0)))
+    if schema_type == "number":
+        return max(0.0, float(schema.get("minimum", 0.0)))
+    if schema_type == "boolean":
+        return False
+    return name
+
+
+def _embedding(text: str, dimensions: int) -> list[float]:
+    vector = [0.0] * dimensions
+    lowered = text.lower()
+    if "isolation query" in lowered or "foreign-decoy" in lowered:
+        vector[0] = 1.0
+        return vector
+    if "authorized-memory" in lowered:
+        vector[0] = 0.8
+        if dimensions > 1:
+            vector[1] = 0.6
+        return vector
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    for index in range(dimensions):
+        vector[index] = (digest[index % len(digest)] / 255.0) - 0.5
+    return vector
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Handle only the OpenAI endpoints used by the provider contract."""
+
+    server_version = "OpenCraneMemoryContractStub/1"
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _write_metadata(self, model: str, item_count: int, status: int) -> None:
+        entry = {
+            "method": self.command,
+            "path": self.path,
+            "model": model,
+            "itemCount": item_count,
+            "status": status,
+        }
+        log_path = Path(os.environ["STUB_METADATA_LOG"])
+        with log_path.open("a", encoding="utf-8") as stream:
+            stream.write(json.dumps(entry, sort_keys=True) + "\n")
+
+    def _reply(self, payload: dict[str, Any], status: int = 200) -> None:
+        encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            self._reply({"status": "ok"})
+            return
+        self._reply({"error": "not_found"}, 404)
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length", "0"))
+        try:
+            body = json.loads(self.rfile.read(length))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self._reply({"error": "invalid_json"}, 400)
+            return
+        model = str(body.get("model", ""))
+        if self.path.endswith("/embeddings"):
+            values = body.get("input", [])
+            inputs = values if isinstance(values, list) else [values]
+            dimensions = int(body.get("dimensions", os.environ.get("STUB_DIMENSIONS", "1536")))
+            data = [
+                {"object": "embedding", "index": index, "embedding": _embedding(str(value), dimensions)}
+                for index, value in enumerate(inputs)
+            ]
+            self._write_metadata(model, len(inputs), 200)
+            self._reply(
+                {
+                    "object": "list",
+                    "model": model,
+                    "data": data,
+                    "usage": {"prompt_tokens": len(inputs), "total_tokens": len(inputs)},
+                }
+            )
+            return
+        if self.path.endswith("/chat/completions"):
+            response_format = body.get("response_format", {})
+            schema = response_format.get("json_schema", {}).get("schema", {})
+            content = json.dumps(_minimal_value(schema)) if schema else "{}"
+            messages = body.get("messages", [])
+            self._write_metadata(model, len(messages) if isinstance(messages, list) else 0, 200)
+            message: dict[str, Any] = {"role": "assistant", "content": content}
+            tools = body.get("tools", [])
+            if isinstance(tools, list) and tools:
+                function = tools[0].get("function", {})
+                parameters = function.get("parameters", {})
+                arguments = json.dumps(_minimal_value(parameters))
+                message = {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_memory_contract",
+                            "type": "function",
+                            "function": {"name": function.get("name", "respond"), "arguments": arguments},
+                        }
+                    ],
+                }
+            self._reply(
+                {
+                    "id": "chatcmpl-memory-contract",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": message,
+                            "finish_reason": "tool_calls" if tools else "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                }
+            )
+            return
+        self._reply({"error": "not_found"}, 404)
+
+
+def main() -> None:
+    os.umask(0o077)
+    port = int(os.environ.get("STUB_PORT", "8090"))
+    server = ThreadingHTTPServer(("0.0.0.0", port), _Handler)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/_infra/cognee/tests/fixtures/provider_api.py
+++ b/apps/_infra/cognee/tests/fixtures/provider_api.py
@@ -7,6 +7,7 @@ import mimetypes
 import uuid
 from typing import Any
 from urllib import error, request
+from urllib.parse import urlencode
 
 
 class ProviderResponseError(RuntimeError):
@@ -21,8 +22,9 @@ class ProviderResponseError(RuntimeError):
 class ProviderApi:
     """Call the exact Cognee dataset, ingestion, search, and deletion routes under test."""
 
-    def __init__(self, base_url: str):
+    def __init__(self, base_url: str, access_token: str | None = None):
         self.base_url = base_url.rstrip("/")
+        self._access_token = access_token
 
     def _request(
         self,
@@ -34,6 +36,8 @@ class ProviderApi:
         accepted: tuple[int, ...] = (200,),
     ) -> bytes:
         headers = {"accept": "application/json"}
+        if self._access_token is not None:
+            headers["authorization"] = f"Bearer {self._access_token}"
         if content_type is not None:
             headers["content-type"] = content_type
         command = request.Request(
@@ -49,6 +53,28 @@ class ProviderApi:
         if status not in accepted:
             raise ProviderResponseError(status, path, body)
         return body
+
+    def authenticate(self, email: str, password: str, register: bool) -> None:
+        """Create the synthetic user when requested, then retain its bearer only in memory."""
+        if register:
+            self.json(
+                "POST",
+                "/api/v1/auth/register",
+                {"email": email, "password": password},
+                accepted=(201,),
+            )
+        payload = urlencode({"username": email, "password": password}).encode("utf-8")
+        body = self._request(
+            "POST",
+            "/api/v1/auth/login",
+            payload,
+            "application/x-www-form-urlencoded",
+        )
+        response = json.loads(body)
+        access_token = response.get("access_token") if isinstance(response, dict) else None
+        if not isinstance(access_token, str) or not access_token:
+            raise AssertionError("Provider login did not return an access token")
+        self._access_token = access_token
 
     def json(
         self,
@@ -112,7 +138,7 @@ class ProviderApi:
             f"--{boundary}--\r\n".encode(),
         ]
         payload = b"".join(pieces)
-        endpoint = self if base_url is None else ProviderApi(base_url)
+        endpoint = self if base_url is None else ProviderApi(base_url, self._access_token)
         body = endpoint._request(
             "POST",
             "/api/v1/add",
@@ -142,16 +168,19 @@ class ProviderApi:
             ]
         )
         connection = http.client.HTTPConnection(proxy_host, proxy_port, timeout=310)
+        headers = {
+            "accept": "application/json",
+            "content-type": f"multipart/form-data; boundary={boundary}",
+            "content-length": str(len(payload)),
+        }
+        if self._access_token is not None:
+            headers["authorization"] = f"Bearer {self._access_token}"
         try:
             connection.request(
                 "POST",
                 "/api/v1/add",
                 body=payload,
-                headers={
-                    "accept": "application/json",
-                    "content-type": f"multipart/form-data; boundary={boundary}",
-                    "content-length": str(len(payload)),
-                },
+                headers=headers,
             )
             response = connection.getresponse()
             response.read()

--- a/apps/_infra/cognee/tests/fixtures/provider_api.py
+++ b/apps/_infra/cognee/tests/fixtures/provider_api.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Small HTTP client for the pinned Cognee provider qualification test."""
+
+import http.client
+import json
+import mimetypes
+import uuid
+from typing import Any
+from urllib import error, request
+
+
+class ProviderResponseError(RuntimeError):
+    """Report a provider response that does not satisfy the requested status."""
+
+    def __init__(self, status: int, path: str, body: bytes):
+        summary = body[:300].decode("utf-8", errors="replace")
+        super().__init__(f"Provider returned HTTP {status} for {path}: {summary}")
+        self.status = status
+
+
+class ProviderApi:
+    """Call the exact Cognee dataset, ingestion, search, and deletion routes under test."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip("/")
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: bytes | None = None,
+        content_type: str | None = None,
+        timeout: int = 300,
+        accepted: tuple[int, ...] = (200,),
+    ) -> bytes:
+        headers = {"accept": "application/json"}
+        if content_type is not None:
+            headers["content-type"] = content_type
+        command = request.Request(
+            f"{self.base_url}{path}", data=payload, headers=headers, method=method
+        )
+        try:
+            with request.urlopen(command, timeout=timeout) as response:
+                body = response.read()
+                status = response.status
+        except error.HTTPError as failure:
+            body = failure.read()
+            status = failure.code
+        if status not in accepted:
+            raise ProviderResponseError(status, path, body)
+        return body
+
+    def json(
+        self,
+        method: str,
+        path: str,
+        value: Any | None = None,
+        timeout: int = 300,
+        accepted: tuple[int, ...] = (200,),
+    ) -> Any:
+        payload = None
+        content_type = None
+        if value is not None:
+            payload = json.dumps(value, separators=(",", ":")).encode("utf-8")
+            content_type = "application/json"
+        body = self._request(method, path, payload, content_type, timeout, accepted)
+        return None if not body else json.loads(body)
+
+    def create_dataset(self, name: str) -> dict[str, Any]:
+        value = self.json("POST", "/api/v1/datasets", {"name": name})
+        if not isinstance(value, dict) or not isinstance(value.get("id"), str):
+            raise AssertionError("Dataset creation did not return an id")
+        return value
+
+    def list_data(self, dataset_id: str) -> list[dict[str, Any]]:
+        value = self.json("GET", f"/api/v1/datasets/{dataset_id}/data")
+        if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+            raise AssertionError("Dataset data response is not a list of objects")
+        return value
+
+    def raw(self, dataset_id: str, document_id: str) -> bytes:
+        return self._request(
+            "GET", f"/api/v1/datasets/{dataset_id}/data/{document_id}/raw"
+        )
+
+    def assert_raw_absent(self, dataset_id: str, document_id: str) -> None:
+        try:
+            self._request("GET", f"/api/v1/datasets/{dataset_id}/data/{document_id}/raw")
+        except ProviderResponseError as failure:
+            if failure.status == 404:
+                return
+            raise AssertionError(
+                f"Raw source absence returned HTTP {failure.status} instead of 404"
+            ) from failure
+        raise AssertionError("Raw source remains available after deletion")
+
+    def add(self, dataset_id: str, filename: str, content: bytes, base_url: str | None = None) -> Any:
+        boundary = f"opencrane-memory-contract-{uuid.uuid4().hex}"
+        content_type = mimetypes.guess_type(filename)[0] or "text/plain"
+        pieces = [
+            f"--{boundary}\r\n".encode(),
+            (
+                f'Content-Disposition: form-data; name="data"; filename="{filename}"\r\n'
+                f"Content-Type: {content_type}\r\n\r\n"
+            ).encode(),
+            content,
+            b"\r\n",
+            f"--{boundary}\r\n".encode(),
+            b'Content-Disposition: form-data; name="datasetId"\r\n\r\n',
+            dataset_id.encode(),
+            b"\r\n",
+            f"--{boundary}--\r\n".encode(),
+        ]
+        payload = b"".join(pieces)
+        endpoint = self if base_url is None else ProviderApi(base_url)
+        body = endpoint._request(
+            "POST",
+            "/api/v1/add",
+            payload,
+            f"multipart/form-data; boundary={boundary}",
+        )
+        return None if not body else json.loads(body)
+
+    def add_and_expect_dropped_response(
+        self, proxy_host: str, proxy_port: int, dataset_id: str, filename: str, content: bytes
+    ) -> None:
+        boundary = f"opencrane-memory-contract-{uuid.uuid4().hex}"
+        payload = b"".join(
+            [
+                f"--{boundary}\r\n".encode(),
+                (
+                    f'Content-Disposition: form-data; name="data"; filename="{filename}"\r\n'
+                    "Content-Type: text/plain\r\n\r\n"
+                ).encode(),
+                content,
+                b"\r\n",
+                f"--{boundary}\r\n".encode(),
+                b'Content-Disposition: form-data; name="datasetId"\r\n\r\n',
+                dataset_id.encode(),
+                b"\r\n",
+                f"--{boundary}--\r\n".encode(),
+            ]
+        )
+        connection = http.client.HTTPConnection(proxy_host, proxy_port, timeout=310)
+        try:
+            connection.request(
+                "POST",
+                "/api/v1/add",
+                body=payload,
+                headers={
+                    "accept": "application/json",
+                    "content-type": f"multipart/form-data; boundary={boundary}",
+                    "content-length": str(len(payload)),
+                },
+            )
+            response = connection.getresponse()
+            response.read()
+        except (http.client.RemoteDisconnected, ConnectionResetError):
+            return
+        finally:
+            connection.close()
+        raise AssertionError("Commit-then-drop proxy returned a response to the caller")
+
+    def cognify(self, dataset_id: str) -> Any:
+        return self.json(
+            "POST",
+            "/api/v1/cognify",
+            {"dataset_ids": [dataset_id], "run_in_background": False, "chunk_size": 128},
+            timeout=600,
+        )
+
+    def search(self, dataset_id: str, query_text: str, top_k: int = 10) -> list[dict[str, Any]]:
+        value = self.json(
+            "POST",
+            "/api/v1/search",
+            {
+                "search_type": "CHUNKS",
+                "dataset_ids": [dataset_id],
+                "query": query_text,
+                "top_k": top_k,
+            },
+            timeout=300,
+        )
+        if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+            raise AssertionError("CHUNKS response is not a list of objects")
+        return value
+
+    def delete(self, dataset_id: str, document_id: str) -> None:
+        self._request(
+            "DELETE",
+            f"/api/v1/datasets/{dataset_id}/data/{document_id}",
+            accepted=(200, 204),
+        )
+
+    def graph(self, dataset_id: str) -> Any:
+        return self.json("GET", f"/api/v1/datasets/{dataset_id}/graph")

--- a/apps/_infra/cognee/tests/fixtures/provider_api.py
+++ b/apps/_infra/cognee/tests/fixtures/provider_api.py
@@ -10,6 +10,26 @@ from urllib import error, request
 from urllib.parse import urlencode
 
 
+def _parse_chunks_response(
+    value: Any, dataset_id: str, dataset_enveloped: bool
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
+        raise AssertionError("CHUNKS response is not a list of objects")
+    if not dataset_enveloped:
+        if any("dataset_id" in item or "search_result" in item for item in value):
+            raise AssertionError("ACL-disabled CHUNKS response unexpectedly contains a dataset envelope")
+        return value
+    if len(value) != 1:
+        raise AssertionError("ACL-enabled CHUNKS response must contain exactly one dataset envelope")
+    envelope = value[0]
+    if envelope.get("dataset_id") != dataset_id:
+        raise AssertionError("ACL-enabled CHUNKS response identifies a different dataset")
+    chunks = envelope.get("search_result")
+    if not isinstance(chunks, list) or not all(isinstance(item, dict) for item in chunks):
+        raise AssertionError("ACL-enabled CHUNKS dataset result is not a list of objects")
+    return chunks
+
+
 class ProviderResponseError(RuntimeError):
     """Report a provider response that does not satisfy the requested status."""
 
@@ -25,6 +45,7 @@ class ProviderApi:
     def __init__(self, base_url: str, access_token: str | None = None):
         self.base_url = base_url.rstrip("/")
         self._access_token = access_token
+        self._dataset_enveloped_search = False
 
     def _request(
         self,
@@ -75,6 +96,7 @@ class ProviderApi:
         if not isinstance(access_token, str) or not access_token:
             raise AssertionError("Provider login did not return an access token")
         self._access_token = access_token
+        self._dataset_enveloped_search = True
 
     def json(
         self,
@@ -210,9 +232,7 @@ class ProviderApi:
             },
             timeout=300,
         )
-        if not isinstance(value, list) or not all(isinstance(item, dict) for item in value):
-            raise AssertionError("CHUNKS response is not a list of objects")
-        return value
+        return _parse_chunks_response(value, dataset_id, self._dataset_enveloped_search)
 
     def delete(self, dataset_id: str, document_id: str) -> None:
         self._request(

--- a/apps/_infra/cognee/tests/fixtures/provider_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/provider_contract.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Orchestrate the pinned Cognee memory provider qualification cases."""
+
+import argparse
+import json
+from pathlib import Path
+
+from provider_api import ProviderApi
+from provider_identity_contract import prepare_identity, recover_identity
+from provider_isolation_contract import prepare_isolation
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--phase", choices=("initial", "recovery"), required=True)
+    parser.add_argument("--mode", choices=("acl-disabled", "acl-enabled"), required=True)
+    parser.add_argument("--namespace", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--state", required=True)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8000")
+    parser.add_argument("--drop-proxy", default="drop-proxy:8091")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _arguments()
+    api = ProviderApi(args.base_url)
+    output_path = Path(args.output)
+    state_path = Path(args.state)
+    try:
+        if args.phase == "initial":
+            evidence = prepare_isolation(api, args.namespace, args.mode)
+            if args.mode == "acl-enabled":
+                evidence = prepare_identity(api, evidence, args.drop_proxy)
+            state_path.write_text(
+                json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+            )
+        else:
+            if args.mode != "acl-enabled":
+                raise AssertionError("Recovery phase is only valid for the ACL-enabled candidate")
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            evidence = recover_identity(api, state)
+    except Exception as failure:
+        evidence = {
+            "outcome": "fail",
+            "phase": args.phase,
+            "mode": args.mode,
+            "failureType": type(failure).__name__,
+            "message": str(failure),
+        }
+        output_path.write_text(
+            json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        raise
+    output_path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/_infra/cognee/tests/fixtures/provider_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/provider_contract.py
@@ -10,6 +10,10 @@ from provider_identity_contract import prepare_identity, recover_identity
 from provider_isolation_contract import prepare_isolation
 
 
+SYNTHETIC_USER_EMAIL = "opencrane-memory-contract@example.com"
+SYNTHETIC_USER_PASSWORD = "test-only-memory-contract-password"
+
+
 def _arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--phase", choices=("initial", "recovery"), required=True)
@@ -28,6 +32,12 @@ def main() -> None:
     output_path = Path(args.output)
     state_path = Path(args.state)
     try:
+        if args.mode == "acl-enabled":
+            api.authenticate(
+                SYNTHETIC_USER_EMAIL,
+                SYNTHETIC_USER_PASSWORD,
+                register=args.phase == "initial",
+            )
         if args.phase == "initial":
             evidence = prepare_isolation(api, args.namespace, args.mode)
             if args.mode == "acl-enabled":

--- a/apps/_infra/cognee/tests/fixtures/provider_identity_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/provider_identity_contract.py
@@ -1,0 +1,166 @@
+"""Prove Cognee recovery, membership deletion, and stored-byte identity semantics."""
+
+import uuid
+from typing import Any
+
+from provider_api import ProviderApi
+from provider_isolation_contract import (
+    AUTHORIZED,
+    QUERY,
+    assert_graph_contains,
+    assert_graph_excludes,
+    chunk_coordinates,
+    digest,
+    document_id,
+    documents_for,
+    graph_snapshot,
+    local_storage_paths,
+    member_by_digest,
+    report_case,
+)
+
+
+RECOVERY = (
+    "recovery-document survives a committed response that the caller never receives. " * 30
+).encode()
+CHANGED = (
+    "changed-content uses the same upload filename but represents another durable source. " * 20
+).encode()
+
+
+def prepare_identity(
+    api: ProviderApi, state: dict[str, Any], drop_proxy: str
+) -> dict[str, Any]:
+    dataset_id = state["authorizedDatasetId"]
+    source_id = state["authorizedDocumentId"]
+    before_replay = [document_id(item) for item in api.list_data(dataset_id)]
+    api.add(dataset_id, "authorized.txt", AUTHORIZED)
+    after_replay = [document_id(item) for item in api.list_data(dataset_id)]
+    if after_replay != before_replay or after_replay.count(source_id) != 1:
+        raise AssertionError("Same-content replay created a second dataset member")
+    if api.raw(dataset_id, source_id) != AUTHORIZED:
+        raise AssertionError("Raw source differs from the complete uploaded document")
+    report_case("same_content_document_identity_is_stable")
+
+    api.add(dataset_id, "authorized.txt", CHANGED)
+    changed_id = document_id(member_by_digest(api, dataset_id, CHANGED))
+    if changed_id == source_id:
+        raise AssertionError("Changed content silently overwrote the prior document identity")
+    if api.raw(dataset_id, source_id) != AUTHORIZED:
+        raise AssertionError("Changed-content upload modified the prior raw source")
+    report_case("same_filename_changed_content_creates_distinct_document_identity")
+
+    proxy_host, proxy_port = drop_proxy.rsplit(":", 1)
+    api.add_and_expect_dropped_response(
+        proxy_host, int(proxy_port), dataset_id, "recovery.txt", RECOVERY
+    )
+    report_case("committed_add_response_is_dropped_after_provider_success")
+    return {**state, "changedDocumentId": changed_id, "recoveryDigest": digest(RECOVERY)}
+
+
+def recover_identity(api: ProviderApi, state: dict[str, Any]) -> dict[str, Any]:
+    authorized_id = state["authorizedDatasetId"]
+    foreign_id = state["foreignDatasetId"]
+    authorized_document_id = state["authorizedDocumentId"]
+    recovery_document_id = document_id(member_by_digest(api, authorized_id, RECOVERY))
+    state["recoveryDocumentId"] = recovery_document_id
+    report_case("ambiguous_add_first_adopts_unique_member_and_full_digest_after_restart")
+
+    api.add(authorized_id, "recovery.txt", RECOVERY)
+    if document_id(member_by_digest(api, authorized_id, RECOVERY)) != recovery_document_id:
+        raise AssertionError("Controlled replay changed the recovered document identity")
+    report_case("controlled_same_content_replay_does_not_duplicate_document")
+    api.cognify(authorized_id)
+    recovery_results = api.search(authorized_id, "recovery-document", top_k=10)
+    recovery_chunks = documents_for(recovery_results, recovery_document_id)
+    if not recovery_chunks:
+        raise AssertionError("Recovered document did not become searchable after restart")
+    report_case("recovered_document_reaches_searchable_index_after_restart")
+
+    foreign_baseline = graph_snapshot(api, foreign_id)
+    if foreign_baseline != state["foreignGraphBaseline"]:
+        raise AssertionError("Provider restart changed the prior foreign dataset graph")
+    api.add(foreign_id, "authorized.txt", AUTHORIZED)
+    api.cognify(foreign_id)
+    shared_member = member_by_digest(api, foreign_id, AUTHORIZED)
+    shared_document_id = document_id(shared_member)
+    if shared_document_id != authorized_document_id:
+        raise AssertionError("Identical source did not retain its Data identity across datasets")
+    shared_chunks = documents_for(
+        api.search(foreign_id, "authorized-memory", top_k=20), shared_document_id
+    )
+    if len(set(shared_chunks)) < 2:
+        raise AssertionError("Shared dataset membership did not retain the document chunks")
+    assert_graph_contains(api, foreign_id, [shared_document_id, *shared_chunks])
+    foreign_augmented = graph_snapshot(api, foreign_id)
+    source_graph_delta = sorted(set(foreign_augmented) - set(foreign_baseline))
+    if not source_graph_delta:
+        raise AssertionError("Cognify produced no source-specific graph delta")
+    if not set(foreign_baseline).issubset(foreign_augmented):
+        raise AssertionError("Cognify removed prior foreign dataset graph content")
+    storage_paths = local_storage_paths(AUTHORIZED)
+    if not storage_paths:
+        raise AssertionError("Provider storage contains no complete source bytes before deletion")
+    report_case("identical_source_identity_is_shared_across_dataset_memberships")
+
+    unknown_id = str(uuid.uuid4())
+    api.delete(authorized_id, unknown_id)
+    if api.raw(authorized_id, authorized_document_id) != AUTHORIZED:
+        raise AssertionError("Deleting an unknown coordinate changed a known document")
+    report_case("unknown_delete_success_is_not_treated_as_known_document_erasure")
+
+    api.delete(authorized_id, authorized_document_id)
+    api.assert_raw_absent(authorized_id, authorized_document_id)
+    if any(document_id(item) == authorized_document_id for item in api.list_data(authorized_id)):
+        raise AssertionError("Deleted document remains listed in the source dataset")
+    if api.raw(foreign_id, authorized_document_id) != AUTHORIZED:
+        raise AssertionError("Deleting one membership changed the other dataset's source")
+    assert_graph_excludes(
+        api, authorized_id, [authorized_document_id, *state["authorizedChunkIds"]]
+    )
+    remaining_documents = [
+        chunk_coordinates(result)[1] for result in api.search(authorized_id, QUERY, top_k=20)
+    ]
+    if authorized_document_id in remaining_documents:
+        raise AssertionError("Deleted document remains visible in source dataset vector search")
+    retained_documents = [
+        chunk_coordinates(result)[1]
+        for result in api.search(foreign_id, "authorized-memory", top_k=20)
+    ]
+    if shared_document_id not in retained_documents:
+        raise AssertionError("Shared document disappeared from retained dataset vector search")
+    assert_graph_contains(api, foreign_id, [shared_document_id, *shared_chunks])
+    report_case("exact_delete_removes_source_graph_and_vector_visibility")
+    report_case("shared_document_survives_other_dataset_membership_delete")
+
+    api.delete(foreign_id, shared_document_id)
+    api.assert_raw_absent(foreign_id, shared_document_id)
+    if any(document_id(item) == shared_document_id for item in api.list_data(foreign_id)):
+        raise AssertionError("Last membership deletion left the Data row listed")
+    assert_graph_excludes(api, foreign_id, [shared_document_id, *shared_chunks])
+    final_documents = [
+        chunk_coordinates(result)[1]
+        for result in api.search(foreign_id, "authorized-memory", top_k=20)
+    ]
+    if shared_document_id in final_documents:
+        raise AssertionError("Last membership deletion left vector chunks searchable")
+    if graph_snapshot(api, foreign_id) != foreign_baseline:
+        raise AssertionError("Delete did not remove the source graph delta and preserve prior graph")
+    remaining_paths = local_storage_paths(AUTHORIZED)
+    if remaining_paths:
+        raise AssertionError(f"Last membership deletion left provider source bytes: {remaining_paths}")
+    report_case("last_membership_delete_removes_source_bytes_document_chunks_and_graph")
+
+    for source_id in (state["changedDocumentId"], recovery_document_id):
+        api.delete(authorized_id, source_id)
+        api.assert_raw_absent(authorized_id, source_id)
+    report_case("remaining_disposable_documents_delete_by_exact_coordinate")
+    return {
+        **state,
+        "recoveryChunkIds": recovery_chunks,
+        "sharedChunkIds": sorted(set(shared_chunks)),
+        "sharedDocumentId": shared_document_id,
+        "sourceStoragePathsRemoved": storage_paths,
+        "sourceGraphDelta": source_graph_delta,
+        "unknownDeleteId": unknown_id,
+    }

--- a/apps/_infra/cognee/tests/fixtures/provider_isolation_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/provider_isolation_contract.py
@@ -1,0 +1,159 @@
+"""Prove Cognee dataset isolation and stable document/chunk identity."""
+
+import hashlib
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+
+from provider_api import ProviderApi
+
+
+QUERY = "isolation query"
+AUTHORIZED = (
+    "authorized-memory stores the blue crane migration note. " * 80
+    + "\n\nOnly this dataset contains the approved source."
+).encode()
+FOREIGN = (
+    "foreign-decoy isolation query must outrank the approved source globally. " * 80
+    + "\n\nThis record belongs only to the other dataset."
+).encode()
+
+
+def digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def document_id(item: dict[str, Any]) -> str:
+    value = item.get("id")
+    if not isinstance(value, str):
+        raise AssertionError("Dataset member has no document id")
+    uuid.UUID(value)
+    return value
+
+
+def chunk_coordinates(result: dict[str, Any]) -> tuple[str, str]:
+    chunk_id = result.get("id")
+    source_id = result.get("document_id")
+    text = result.get("text")
+    if not isinstance(chunk_id, str) or not isinstance(source_id, str) or not isinstance(text, str):
+        raise AssertionError("CHUNKS result does not expose id, document_id, and text")
+    uuid.UUID(chunk_id)
+    uuid.UUID(source_id)
+    if chunk_id == source_id:
+        raise AssertionError("Cognee returned a document id as its chunk id")
+    return chunk_id, source_id
+
+
+def member_by_digest(api: ProviderApi, dataset_id: str, expected: bytes) -> dict[str, Any]:
+    expected_digest = digest(expected)
+    matches = []
+    for member in api.list_data(dataset_id):
+        source_id = document_id(member)
+        if digest(api.raw(dataset_id, source_id)) == expected_digest:
+            matches.append(member)
+    if len(matches) != 1:
+        raise AssertionError(
+            f"Expected one dataset member with digest {expected_digest}, received {len(matches)}"
+        )
+    return matches[0]
+
+
+def report_case(name: str) -> None:
+    print(f"CASE {name} PASS")
+
+
+def local_storage_paths(content: bytes) -> list[str]:
+    root = Path(os.environ["DATA_ROOT_DIRECTORY"])
+    expected_digest = digest(content)
+    paths = []
+    for path in root.rglob("*"):
+        is_candidate = path.is_file() and path.stat().st_size == len(content)
+        if is_candidate and digest(path.read_bytes()) == expected_digest:
+            paths.append(str(path))
+    return sorted(set(paths))
+
+
+def documents_for(results: list[dict[str, Any]], source_id: str) -> list[str]:
+    return [chunk for chunk, document in map(chunk_coordinates, results) if document == source_id]
+
+
+def graph_snapshot(api: ProviderApi, dataset_id: str) -> list[str]:
+    graph = api.graph(dataset_id)
+    if not isinstance(graph, dict):
+        raise AssertionError("Dataset graph response is not an object")
+    nodes = graph.get("nodes")
+    edges = graph.get("edges")
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        raise AssertionError("Dataset graph response does not contain node and edge lists")
+    if not all(isinstance(item, dict) for item in [*nodes, *edges]):
+        raise AssertionError("Dataset graph contains a non-object node or edge")
+    canonical = [f"node:{json.dumps(node, sort_keys=True)}" for node in nodes]
+    canonical.extend(f"edge:{json.dumps(edge, sort_keys=True)}" for edge in edges)
+    return sorted(hashlib.sha256(item.encode("utf-8")).hexdigest() for item in canonical)
+
+
+def assert_graph_contains(api: ProviderApi, dataset_id: str, coordinates: list[str]) -> None:
+    graph_text = json.dumps(api.graph(dataset_id), sort_keys=True)
+    if not any(coordinate in graph_text for coordinate in coordinates):
+        raise AssertionError("Dataset graph has no document or chunk baseline for the stored source")
+
+
+def assert_graph_excludes(api: ProviderApi, dataset_id: str, coordinates: list[str]) -> None:
+    graph_text = json.dumps(api.graph(dataset_id), sort_keys=True)
+    if any(coordinate in graph_text for coordinate in coordinates):
+        raise AssertionError("Deleted source remains visible in the dataset graph")
+
+
+def prepare_isolation(api: ProviderApi, namespace: str, mode: str) -> dict[str, Any]:
+    authorized_id = str(api.create_dataset(f"{namespace}-{mode}-authorized")["id"])
+    foreign_id = str(api.create_dataset(f"{namespace}-{mode}-foreign")["id"])
+    if graph_snapshot(api, authorized_id) or graph_snapshot(api, foreign_id):
+        raise AssertionError("New disposable dataset has graph content before ingestion")
+    api.add(authorized_id, "authorized.txt", AUTHORIZED)
+    api.add(foreign_id, "foreign.txt", FOREIGN)
+    api.cognify(authorized_id)
+    api.cognify(foreign_id)
+    authorized_document_id = document_id(member_by_digest(api, authorized_id, AUTHORIZED))
+    foreign_document_id = document_id(member_by_digest(api, foreign_id, FOREIGN))
+    foreign_graph_baseline = graph_snapshot(api, foreign_id)
+    if not foreign_graph_baseline:
+        raise AssertionError("Foreign source did not produce a nonempty graph baseline")
+    results = api.search(authorized_id, QUERY, top_k=1)
+    if len(results) != 1:
+        raise AssertionError(f"Isolation query returned {len(results)} results instead of one")
+    chunk_id, recalled_document_id = chunk_coordinates(results[0])
+    if mode == "acl-disabled":
+        if recalled_document_id != foreign_document_id or recalled_document_id == authorized_document_id:
+            raise AssertionError("ACL-disabled negative control did not expose the foreign chunk")
+        report_case("acl_disabled_negative_control_detects_cross_dataset_chunk")
+        return {
+            "mode": mode,
+            "authorizedDatasetId": authorized_id,
+            "foreignDatasetId": foreign_id,
+            "foreignDocumentId": foreign_document_id,
+            "recalledDocumentId": recalled_document_id,
+            "chunkId": chunk_id,
+        }
+    if recalled_document_id != authorized_document_id:
+        raise AssertionError("ACL-enabled search returned a document outside the requested dataset")
+    report_case("acl_enabled_chunks_are_dataset_scoped_and_useful")
+    authorized_chunks = documents_for(
+        api.search(authorized_id, "authorized-memory", top_k=20), authorized_document_id
+    )
+    if len(set(authorized_chunks)) < 2:
+        raise AssertionError("Long source did not produce at least two distinct document chunks")
+    assert_graph_contains(api, authorized_id, [authorized_document_id, *authorized_chunks])
+    report_case("document_has_distinct_multi_chunk_and_graph_baseline")
+    return {
+        "mode": mode,
+        "authorizedDatasetId": authorized_id,
+        "foreignDatasetId": foreign_id,
+        "authorizedDocumentId": authorized_document_id,
+        "foreignDocumentId": foreign_document_id,
+        "authorizedDigest": digest(AUTHORIZED),
+        "initialChunkId": chunk_id,
+        "authorizedChunkIds": sorted(set(authorized_chunks)),
+        "foreignGraphBaseline": foreign_graph_baseline,
+    }

--- a/apps/_infra/cognee/tests/fixtures/source_evidence.py
+++ b/apps/_infra/cognee/tests/fixtures/source_evidence.py
@@ -5,6 +5,7 @@ import argparse
 import hashlib
 import importlib.util
 import json
+import shutil
 from pathlib import Path
 
 import cognee
@@ -28,29 +29,50 @@ def main() -> None:
     args = _arguments()
     expected = json.loads(Path(args.expected).read_text(encoding="utf-8"))
     actual_version = getattr(cognee, "__version__", None)
+    mismatches = []
     if actual_version != expected["version"]:
-        raise AssertionError(
+        mismatches.append(
             f"Cognee version differs: expected {expected['version']}, received {actual_version}"
         )
 
+    snapshot_directory = Path(args.output).parent / "source-modules"
+    if snapshot_directory.exists():
+        shutil.rmtree(snapshot_directory)
+    snapshot_directory.mkdir()
     modules = {}
     for module_name, expected_digest in expected["modules"].items():
-        path = _module_path(module_name)
-        actual_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        try:
+            path = _module_path(module_name)
+        except (AssertionError, ImportError, ValueError) as error:
+            modules[module_name] = {"error": str(error)}
+            mismatches.append(f"Cognee module is unavailable: {module_name}: {error}")
+            continue
+        source = path.read_bytes()
+        actual_digest = hashlib.sha256(source).hexdigest()
+        snapshot = snapshot_directory / f"{module_name}.py"
+        snapshot.write_bytes(source)
         if actual_digest != expected_digest:
-            raise AssertionError(
+            mismatches.append(
                 f"Cognee source differs for {module_name}: "
                 f"expected {expected_digest}, received {actual_digest}"
             )
-        modules[module_name] = {"path": str(path), "sha256": actual_digest}
+        modules[module_name] = {
+            "path": str(path), "sha256": actual_digest, "snapshot": snapshot.name
+        }
 
-    evidence = {"cogneeVersion": actual_version, "modules": modules}
+    evidence = {
+        "cogneeVersion": actual_version,
+        "modules": modules,
+        "mismatches": mismatches,
+    }
     Path(args.output).write_text(
         json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
     print(f"EVIDENCE cognee_version={actual_version}")
     for module_name, value in modules.items():
-        print(f"EVIDENCE module={module_name} sha256={value['sha256']}")
+        print(f"EVIDENCE module={module_name} sha256={value.get('sha256', 'unavailable')}")
+    if mismatches:
+        raise AssertionError("\n".join(mismatches))
     print("CASE source_module_attestation PASS")
 
 

--- a/apps/_infra/cognee/tests/fixtures/source_evidence.py
+++ b/apps/_infra/cognee/tests/fixtures/source_evidence.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Verify the Cognee package and consequential provider modules inside the tested image."""
+
+import argparse
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import cognee
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--expected", required=True)
+    parser.add_argument("--output", required=True)
+    return parser.parse_args()
+
+
+def _module_path(module_name: str) -> Path:
+    spec = importlib.util.find_spec(module_name)
+    if spec is None or spec.origin is None:
+        raise AssertionError(f"Cognee module is unavailable: {module_name}")
+    return Path(spec.origin)
+
+
+def main() -> None:
+    args = _arguments()
+    expected = json.loads(Path(args.expected).read_text(encoding="utf-8"))
+    actual_version = getattr(cognee, "__version__", None)
+    if actual_version != expected["version"]:
+        raise AssertionError(
+            f"Cognee version differs: expected {expected['version']}, received {actual_version}"
+        )
+
+    modules = {}
+    for module_name, expected_digest in expected["modules"].items():
+        path = _module_path(module_name)
+        actual_digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        if actual_digest != expected_digest:
+            raise AssertionError(
+                f"Cognee source differs for {module_name}: "
+                f"expected {expected_digest}, received {actual_digest}"
+            )
+        modules[module_name] = {"path": str(path), "sha256": actual_digest}
+
+    evidence = {"cogneeVersion": actual_version, "modules": modules}
+    Path(args.output).write_text(
+        json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(f"EVIDENCE cognee_version={actual_version}")
+    for module_name, value in modules.items():
+        print(f"EVIDENCE module={module_name} sha256={value['sha256']}")
+    print("CASE source_module_attestation PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/_infra/cognee/tests/fixtures/test_provider_auth.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_auth.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Verify the disposable provider client and response-drop proxy authentication boundary."""
+
+import json
+import os
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+from commit_then_drop_proxy import _Handler as DropProxyHandler
+from provider_api import ProviderApi
+
+
+class _ProviderHandler(BaseHTTPRequestHandler):
+    requests: list[tuple[str, str, str | None]] = []
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    def _record(self) -> None:
+        self.requests.append((self.command, self.path, self.headers.get("authorization")))
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("content-length", "0"))
+        self.rfile.read(length)
+        self._record()
+        if self.path == "/api/v1/auth/register":
+            self._respond(201, {"id": "synthetic-user"})
+            return
+        if self.path == "/api/v1/auth/login":
+            self._respond(200, {"access_token": "test-bearer", "token_type": "bearer"})
+            return
+        if self.path in ("/api/v1/datasets", "/api/v1/add"):
+            if self.headers.get("authorization") != "Bearer test-bearer":
+                self._respond(401, {"detail": "Unauthorized"})
+                return
+            self._respond(200, {"id": "dataset"})
+            return
+        self._respond(404, {"detail": "Not found"})
+
+    def _respond(self, status: int, value: dict[str, str]) -> None:
+        body = json.dumps(value).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def _serve(handler: type[BaseHTTPRequestHandler]) -> tuple[ThreadingHTTPServer, threading.Thread]:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, thread
+
+
+class ProviderAuthenticationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        _ProviderHandler.requests = []
+
+    def test_register_login_and_authenticated_request_keep_token_in_memory(self) -> None:
+        server, thread = _serve(_ProviderHandler)
+        try:
+            api = ProviderApi(f"http://127.0.0.1:{server.server_port}")
+            api.authenticate("synthetic@example.com", "test-password", register=True)
+            api.create_dataset("isolated")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+        self.assertEqual(
+            _ProviderHandler.requests,
+            [
+                ("POST", "/api/v1/auth/register", None),
+                ("POST", "/api/v1/auth/login", None),
+                ("POST", "/api/v1/datasets", "Bearer test-bearer"),
+            ],
+        )
+
+    def test_recovery_login_does_not_register_again(self) -> None:
+        server, thread = _serve(_ProviderHandler)
+        try:
+            api = ProviderApi(f"http://127.0.0.1:{server.server_port}")
+            api.authenticate("synthetic@example.com", "test-password", register=False)
+            api.create_dataset("recovered")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+        self.assertEqual(
+            [path for _, path, _ in _ProviderHandler.requests],
+            ["/api/v1/auth/login", "/api/v1/datasets"],
+        )
+
+    def test_drop_proxy_forwards_bearer_without_recording_it(self) -> None:
+        upstream, upstream_thread = _serve(_ProviderHandler)
+        with tempfile.TemporaryDirectory() as directory:
+            metadata = Path(directory) / "drop.jsonl"
+            previous = {
+                name: os.environ.get(name)
+                for name in ("UPSTREAM_HOST", "UPSTREAM_PORT", "DROP_METADATA_LOG")
+            }
+            os.environ["UPSTREAM_HOST"] = "127.0.0.1"
+            os.environ["UPSTREAM_PORT"] = str(upstream.server_port)
+            os.environ["DROP_METADATA_LOG"] = str(metadata)
+            proxy, proxy_thread = _serve(DropProxyHandler)
+            try:
+                api = ProviderApi("http://unused", "test-bearer")
+                api.add_and_expect_dropped_response(
+                    "127.0.0.1", proxy.server_port, "dataset", "source.txt", b"source"
+                )
+            finally:
+                proxy.shutdown()
+                proxy.server_close()
+                proxy_thread.join()
+                upstream.shutdown()
+                upstream.server_close()
+                upstream_thread.join()
+                for name, value in previous.items():
+                    if value is None:
+                        os.environ.pop(name, None)
+                    else:
+                        os.environ[name] = value
+
+            record = json.loads(metadata.read_text(encoding="utf-8"))
+            self.assertEqual(
+                record,
+                {
+                    "method": "POST",
+                    "path": "/api/v1/add",
+                    "responseDropped": True,
+                    "upstreamStatus": 200,
+                },
+            )
+            self.assertNotIn("test-bearer", metadata.read_text(encoding="utf-8"))
+        self.assertEqual(_ProviderHandler.requests[-1][2], "Bearer test-bearer")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/_infra/cognee/tests/fixtures/test_provider_search.py
+++ b/apps/_infra/cognee/tests/fixtures/test_provider_search.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Verify strict mode-specific parsing of Cognee CHUNKS search responses."""
+
+import unittest
+
+from provider_api import _parse_chunks_response
+
+
+DATASET_ID = "dataset-one"
+CHUNK = {"id": "chunk-one", "document_id": "document-one", "text": "content"}
+
+
+class ProviderSearchResponseTest(unittest.TestCase):
+    def test_acl_disabled_accepts_only_the_flat_chunk_array(self) -> None:
+        self.assertEqual(_parse_chunks_response([CHUNK], DATASET_ID, False), [CHUNK])
+        with self.assertRaisesRegex(AssertionError, "unexpectedly contains a dataset envelope"):
+            _parse_chunks_response(
+                [{"dataset_id": DATASET_ID, "search_result": [CHUNK]}], DATASET_ID, False
+            )
+
+    def test_acl_enabled_accepts_the_exact_requested_dataset_envelope(self) -> None:
+        response = [
+            {
+                "dataset_id": DATASET_ID,
+                "dataset_name": "authorized",
+                "dataset_tenant_id": "tenant-one",
+                "search_result": [CHUNK],
+            }
+        ]
+        self.assertEqual(_parse_chunks_response(response, DATASET_ID, True), [CHUNK])
+
+    def test_acl_enabled_rejects_a_wrong_or_missing_dataset_identity(self) -> None:
+        for envelope in (
+            {"dataset_id": "dataset-two", "search_result": [CHUNK]},
+            {"search_result": [CHUNK]},
+        ):
+            with self.subTest(envelope=envelope):
+                with self.assertRaisesRegex(AssertionError, "different dataset"):
+                    _parse_chunks_response([envelope], DATASET_ID, True)
+
+    def test_acl_enabled_rejects_missing_or_extra_dataset_envelopes(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "exactly one dataset envelope"):
+            _parse_chunks_response([], DATASET_ID, True)
+        with self.assertRaisesRegex(AssertionError, "exactly one dataset envelope"):
+            _parse_chunks_response(
+                [
+                    {"dataset_id": DATASET_ID, "search_result": [CHUNK]},
+                    {"dataset_id": "dataset-two", "search_result": [CHUNK]},
+                ],
+                DATASET_ID,
+                True,
+            )
+
+    def test_acl_enabled_rejects_malformed_envelope_results(self) -> None:
+        for result in (None, {}, ["not-a-chunk"]):
+            with self.subTest(result=result):
+                with self.assertRaisesRegex(AssertionError, "dataset result is not a list"):
+                    _parse_chunks_response(
+                        [{"dataset_id": DATASET_ID, "search_result": result}], DATASET_ID, True
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/_infra/cognee/tests/memory-contract.sh
+++ b/apps/_infra/cognee/tests/memory-contract.sh
@@ -128,6 +128,7 @@ _start_cognee()
   local container="$1"
   local volume="$2"
   local access_control="$3"
+  local require_authentication="$4"
   docker run -d \
     --name "$container" \
     --network "$network" \
@@ -138,7 +139,7 @@ _start_cognee()
     --env HOST=0.0.0.0 \
     --env PORT=8000 \
     --env "ENABLE_BACKEND_ACCESS_CONTROL=$access_control" \
-    --env REQUIRE_AUTHENTICATION=false \
+    --env "REQUIRE_AUTHENTICATION=$require_authentication" \
     --env DATA_ROOT_DIRECTORY=/cognee-data/data_storage \
     --env SYSTEM_ROOT_DIRECTORY=/cognee-data/cognee_system \
     --env LLM_PROVIDER=openai \
@@ -155,7 +156,7 @@ _start_cognee()
 }
 
 current_case="acl_disabled_negative_control"
-_start_cognee "$negative" "$negative_volume" false
+_start_cognee "$negative" "$negative_volume" false false
 docker exec "$negative" python /contract/provider_contract.py \
   --phase initial \
   --mode acl-disabled \
@@ -168,7 +169,7 @@ docker logs "$negative" >"$output_dir/acl-disabled-provider.log" 2>&1
 docker rm -f "$negative" >/dev/null
 
 current_case="acl_enabled_initial_contract"
-_start_cognee "$positive" "$positive_volume" true
+_start_cognee "$positive" "$positive_volume" true true
 docker run -d \
   --name "$proxy" \
   --network "$network" \
@@ -196,7 +197,7 @@ docker exec "$positive" python /contract/provider_contract.py \
 docker logs "$positive" >"$output_dir/acl-enabled-before-restart.log" 2>&1
 docker rm -f "$positive" >/dev/null
 current_case="acl_enabled_restart_recovery_and_deletion"
-_start_cognee "$positive" "$positive_volume" true
+_start_cognee "$positive" "$positive_volume" true true
 docker exec "$positive" python /contract/provider_contract.py \
   --phase recovery \
   --mode acl-enabled \

--- a/apps/_infra/cognee/tests/memory-contract.sh
+++ b/apps/_infra/cognee/tests/memory-contract.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+umask 077
+
+if [[ "$#" -ne 1 || -z "$1" ]]; then
+  echo "usage: memory-contract.sh <locally-available-image-reference>" >&2
+  exit 2
+fi
+
+readonly image="$1"
+readonly root_dir="$(git rev-parse --show-toplevel)"
+readonly fixture_dir="$root_dir/apps/_infra/cognee/tests/fixtures"
+readonly requested_output_dir="${OUTPUT_DIR:-$root_dir/.nx/test-results/cognee-memory-contract}"
+mkdir -p "$requested_output_dir"
+readonly output_dir="$(cd "$requested_output_dir" && pwd)"
+readonly run_suffix="${GITHUB_RUN_ID:-local}-$$-$RANDOM"
+readonly network="opencrane-memory-contract-$run_suffix"
+readonly stub="opencrane-memory-stub-$run_suffix"
+readonly proxy="opencrane-memory-drop-$run_suffix"
+readonly negative="opencrane-cognee-negative-$run_suffix"
+readonly positive="opencrane-cognee-positive-$run_suffix"
+readonly negative_volume="opencrane-cognee-negative-$run_suffix"
+readonly positive_volume="opencrane-cognee-positive-$run_suffix"
+current_case="initialize"
+
+rm -f \
+  "$output_dir/evidence.json" \
+  "$output_dir/source-evidence.json" \
+  "$output_dir/negative-control.json" \
+  "$output_dir/positive-initial.json" \
+  "$output_dir/positive-recovery.json" \
+  "$output_dir/positive-state.json" \
+  "$output_dir/negative-state.json" \
+  "$output_dir/stub-requests.jsonl" \
+  "$output_dir/commit-then-drop.jsonl"
+
+_capture_logs()
+{
+  local container
+  for container in "$stub" "$proxy" "$negative" "$positive"; do
+    if docker container inspect "$container" >/dev/null 2>&1; then
+      docker logs "$container" >"$output_dir/$container.log" 2>&1 || true
+    fi
+  done
+}
+
+_cleanup()
+{
+  local status="$?"
+  _capture_logs
+  if [[ "$status" -ne 0 ]]; then
+    set +e
+    python3 "$fixture_dir/evidence_summary.py" \
+      --image "$image" \
+      --image-inspect "$output_dir/image-inspect.json" \
+      --source "$output_dir/source-evidence.json" \
+      --negative "$output_dir/negative-control.json" \
+      --positive-initial "$output_dir/positive-initial.json" \
+      --positive "$output_dir/positive-recovery.json" \
+      --stub-log "$output_dir/stub-requests.jsonl" \
+      --drop-log "$output_dir/commit-then-drop.jsonl" \
+      --output "$output_dir/evidence.json" \
+      --failure-status "$status" \
+      --failed-case "$current_case" \
+      >"$output_dir/evidence-summary.log" 2>&1
+    set -e
+  fi
+  docker rm -f "$stub" "$proxy" "$negative" "$positive" >/dev/null 2>&1 || true
+  docker volume rm "$negative_volume" "$positive_volume" >/dev/null 2>&1 || true
+  docker network rm "$network" >/dev/null 2>&1 || true
+  exit "$status"
+}
+trap _cleanup EXIT INT TERM
+
+command -v docker >/dev/null
+current_case="docker_daemon_and_image_available"
+docker info >/dev/null
+docker image inspect "$image" >"$output_dir/image-inspect.json"
+current_case="source_module_attestation"
+docker run --rm \
+  --network none \
+  --mount "type=bind,source=$fixture_dir,target=/contract,readonly" \
+  --mount "type=bind,source=$output_dir,target=/contract-output" \
+  --entrypoint python \
+  "$image" /contract/source_evidence.py \
+  --expected /contract/expected-source-hashes.json \
+  --output /contract-output/source-evidence.json \
+  | tee "$output_dir/source-evidence.log"
+docker network create --internal "$network" >/dev/null
+docker volume create "$negative_volume" >/dev/null
+docker volume create "$positive_volume" >/dev/null
+: >"$output_dir/stub-requests.jsonl"
+: >"$output_dir/commit-then-drop.jsonl"
+
+docker run -d \
+  --name "$stub" \
+  --network "$network" \
+  --network-alias openai-stub \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+  --mount "type=bind,source=$fixture_dir,target=/contract,readonly" \
+  --mount "type=bind,source=$output_dir,target=/contract-output" \
+  --env STUB_METADATA_LOG=/contract-output/stub-requests.jsonl \
+  --env STUB_DIMENSIONS=1536 \
+  --entrypoint python \
+  "$image" /contract/openai_stub.py >/dev/null
+
+_wait_for_url()
+{
+  local container="$1"
+  local url="$2"
+  local attempt
+  for attempt in $(seq 1 90); do
+    if docker exec "$container" python -c "import urllib.request; urllib.request.urlopen('$url', timeout=2).read()" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "bounded readiness failed for $container at $url" >&2
+  return 1
+}
+
+_wait_for_url "$stub" "http://127.0.0.1:8090/health"
+
+_start_cognee()
+{
+  local container="$1"
+  local volume="$2"
+  local access_control="$3"
+  docker run -d \
+    --name "$container" \
+    --network "$network" \
+    --network-alias cognee \
+    --mount "type=volume,source=$volume,target=/cognee-data" \
+    --mount "type=bind,source=$fixture_dir,target=/contract,readonly" \
+    --mount "type=bind,source=$output_dir,target=/contract-output" \
+    --env HOST=0.0.0.0 \
+    --env PORT=8000 \
+    --env "ENABLE_BACKEND_ACCESS_CONTROL=$access_control" \
+    --env REQUIRE_AUTHENTICATION=false \
+    --env DATA_ROOT_DIRECTORY=/cognee-data/data_storage \
+    --env SYSTEM_ROOT_DIRECTORY=/cognee-data/cognee_system \
+    --env LLM_PROVIDER=openai \
+    --env LLM_MODEL=openai/gpt-4o-mini \
+    --env LLM_ENDPOINT=http://openai-stub:8090/v1 \
+    --env LLM_API_KEY=test-only-memory-contract \
+    --env EMBEDDING_PROVIDER=openai_compatible \
+    --env EMBEDDING_MODEL=text-embedding-3-small \
+    --env EMBEDDING_DIMENSIONS=1536 \
+    --env EMBEDDING_ENDPOINT=http://openai-stub:8090/v1 \
+    --env EMBEDDING_API_KEY=test-only-memory-contract \
+    "$image" >/dev/null
+  _wait_for_url "$container" "http://127.0.0.1:8000/openapi.json"
+}
+
+current_case="acl_disabled_negative_control"
+_start_cognee "$negative" "$negative_volume" false
+docker exec "$negative" python /contract/provider_contract.py \
+  --phase initial \
+  --mode acl-disabled \
+  --namespace "$run_suffix" \
+  --base-url http://cognee:8000 \
+  --state /contract-output/negative-state.json \
+  --output /contract-output/negative-control.json \
+  | tee "$output_dir/negative-control.log"
+docker logs "$negative" >"$output_dir/acl-disabled-provider.log" 2>&1
+docker rm -f "$negative" >/dev/null
+
+current_case="acl_enabled_initial_contract"
+_start_cognee "$positive" "$positive_volume" true
+docker run -d \
+  --name "$proxy" \
+  --network "$network" \
+  --network-alias drop-proxy \
+  --read-only \
+  --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+  --mount "type=bind,source=$fixture_dir,target=/contract,readonly" \
+  --mount "type=bind,source=$output_dir,target=/contract-output" \
+  --env UPSTREAM_HOST=cognee \
+  --env UPSTREAM_PORT=8000 \
+  --env DROP_METADATA_LOG=/contract-output/commit-then-drop.jsonl \
+  --entrypoint python \
+  "$image" /contract/commit_then_drop_proxy.py >/dev/null
+_wait_for_url "$proxy" "http://127.0.0.1:8091/health"
+
+docker exec "$positive" python /contract/provider_contract.py \
+  --phase initial \
+  --mode acl-enabled \
+  --namespace "$run_suffix" \
+  --base-url http://cognee:8000 \
+  --state /contract-output/positive-state.json \
+  --output /contract-output/positive-initial.json \
+  | tee "$output_dir/positive-initial.log"
+
+docker logs "$positive" >"$output_dir/acl-enabled-before-restart.log" 2>&1
+docker rm -f "$positive" >/dev/null
+current_case="acl_enabled_restart_recovery_and_deletion"
+_start_cognee "$positive" "$positive_volume" true
+docker exec "$positive" python /contract/provider_contract.py \
+  --phase recovery \
+  --mode acl-enabled \
+  --namespace "$run_suffix" \
+  --base-url http://cognee:8000 \
+  --state /contract-output/positive-state.json \
+  --output /contract-output/positive-recovery.json \
+  | tee "$output_dir/positive-recovery.log"
+
+current_case="machine_readable_evidence_receipt"
+python3 "$fixture_dir/evidence_summary.py" \
+  --image "$image" \
+  --image-inspect "$output_dir/image-inspect.json" \
+  --source "$output_dir/source-evidence.json" \
+  --negative "$output_dir/negative-control.json" \
+  --positive-initial "$output_dir/positive-initial.json" \
+  --positive "$output_dir/positive-recovery.json" \
+  --stub-log "$output_dir/stub-requests.jsonl" \
+  --drop-log "$output_dir/commit-then-drop.jsonl" \
+  --output "$output_dir/evidence.json" \
+  | tee "$output_dir/evidence-summary.log"
+
+echo "Cognee memory provider contract: PASS"

--- a/plan.md
+++ b/plan.md
@@ -67,6 +67,11 @@ It must prove dataset isolation and useful recall, exact document/source identit
 committed response is lost, restart/index convergence and deletion boundaries. Selected CI cannot
 skip missing Docker or missing proof. The existing image-smoke selection owns the job condition and
 normal publication waits for its result. Implementation and provider qualification are in progress.
+Draft [#863](https://github.com/elewa-git/opencrane/pull/863) records the reviewed source at
+`5fdbd56e7b8260054da296372915111720275182`. Its first image run `34597141363` built successfully
+but stopped before semantic tests: the container label says `1.2.1`, while the loaded package reports
+`1.2.1-local`. Attestation now retains all inspected module hashes and source snapshots before
+rejecting mismatches. Expected hashes remain unchanged until that exact source is reviewed.
 Personal Remember, Recall, Correct and Forget remain unavailable until this evidence and their
 subsequent product slices are complete. Local container VMs are not started for this work.
 

--- a/plan.md
+++ b/plan.md
@@ -5,7 +5,8 @@
 Draft #858 is fully green at `3cb899d68c851bfb0073c42933fc77fba3fe0e17`:
 CI run `34578065587` includes the real KurrentDB lost-response recovery case, database authority,
 build/test/lint, API generation, all 169 Storybook behavior tests, Linux visual checks, and server/UI
-image publication. The complete PR stack check passes. No testv5 deployment is implied.
+image builds. The complete PR stack check passes. This pull-request workflow does not publish images
+or deploy testv5.
 
 Draft [#862](https://github.com/elewa-git/opencrane/pull/862) starts directly from that exact commit
 on `feat/0.12-conversation-work-cancellation`. Its first published commit is
@@ -29,8 +30,11 @@ smokes. Both new Target/NoTarget selection races pass against real KurrentDB. On
 fixture reused the wrong command digest; the reviewed correction recomputes it for that request.
 The generated website API reference is now synced. All 12 unique Linux renders from that exact
 commit (artifact `10195948833`) passed independent visual review and were copied byte-for-byte into
-the references. A fresh CI run must confirm these test and reference corrections; production code
-is unchanged.
+the references. Final CI run `34592580306` is fully green on
+`6536ac318d375685a2771c4156b9954a7971e2ce`: affected build/test/lint for 79 projects, all database
+authority suites, real Kurrent proofs, generated API, all 174 Storybook tests, three Linux visual
+checks and seven image builds pass. This pull-request run does not publish images. Production code
+is unchanged by the CI corrections; the live PR stack also passes.
 
 Architecture and independent reviews cover the final source; all raised findings are resolved.
 Database tests use an isolated local PostgreSQL instance, not testv5. Personal controls are the first UI journey; controls
@@ -41,6 +45,30 @@ Company-tool approval implementation and remote MCP activation retain their reco
 blocks. The testv5 repair still preserves all current data and awaits deployment approval. Its
 strengthened wrapper passed independent review and a fresh read-only inspection of image, baseline
 and volume coordinates. No install, database reset or test-data deletion occurred.
+
+### Next slice: qualify the pinned memory provider
+
+The memory slice starts directly above #862 at `6536ac318d375685a2771c4156b9954a7971e2ce` on
+`feat/0.12-memory-provider-contract`. Architecture preflight passes for test-only qualification under
+the existing Cognee app and CI workflow. No application adapter, memory write path or deployment
+configuration is changed in this slice.
+
+The source audit found that Cognee 1.2.1 CHUNKS retrieval does not apply the requested dataset when
+backend access control is disabled. The current chart disables that switch. The inspected source
+also separates chunk and document identity and provides no operation-idempotent HTTP Add contract.
+These findings require proof against the exact image; a matching version label alone is insufficient.
+The inspected last-reference deletion removes the processed source but can retain the original
+upload. Official Cognee 1.5.4 contains a fix for that ordinary case; its different ingestion/schema
+and path handling require separate qualification before selecting it as a replacement.
+
+The dedicated uncached `cognee:memory-contract` target runs two disposable provider configurations,
+synthetic datasets and a deterministic local model/embedding stub on an internal Docker network.
+It must prove dataset isolation and useful recall, exact document/source identity, recovery after a
+committed response is lost, restart/index convergence and deletion boundaries. Selected CI cannot
+skip missing Docker or missing proof. The existing image-smoke selection owns the job condition and
+normal publication waits for its result. Implementation and provider qualification are in progress.
+Personal Remember, Recall, Correct and Forget remain unavailable until this evidence and their
+subsequent product slices are complete. Local container VMs are not started for this work.
 
 ## Delivery priorities — 2026-09-10
 
@@ -96,8 +124,8 @@ remain separate gates.
 | --- | --- | --- | --- |
 | 1 | T1 — real tool retrieval | A permitted real record reaches an answer in personal and company-child chats; remote MCP connections and hosted MCP execution have qualified journeys. Results survive reload and restart without repeated dispatch. | IN PROGRESS: company tool selection and participant terminal-result history are implemented and result-history CI passes. Standard remote connection activation awaits its recorded approval, then one real integration and the required hosted MCP slice follow. |
 | 2 | T2 — approved external actions | A person reviews an exact action and arguments; one approval permits that effect once. Denial, expiry, changed arguments and revoked authority prevent it. | IN PROGRESS: personal approval, expiry, durable resume and visible decision controls are implemented in draft #857. Company approver/connection binding and real action qualification remain. |
-| 3 | M1 — long-term memory | Explicit remember, cross-conversation recall, correction and forget work with consent and isolated datasets. | Verify the pinned gateway's recall/deletion identity and recoverable correction before enabling writes. |
-| 4 | U1 — visible work controls | People can follow waiting, running and terminal work, make supported decisions and cancel eligible work after refresh. | IN PROGRESS: requester-only personal Stop and durable cleanup pass source review and local validation; complete draft #862 CI and qualify the live journey. Other-participant controls remain a separate actor-policy decision. |
+| 3 | M1 — long-term memory | Explicit remember, cross-conversation recall, correction and forget work with consent and isolated datasets. | IN PROGRESS: qualify the pinned provider's isolation, identity, restart and deletion contracts on disposable CI data before implementing personal dataset provisioning and explicit Remember. |
+| 4 | U1 — visible work controls | People can follow waiting, running and terminal work, make supported decisions and cancel eligible work after refresh. | IN PROGRESS: requester-only personal Stop and durable cleanup pass independent review and exact-head CI in draft #862; qualify the live journey. Other-participant controls remain a separate actor-policy decision. |
 | 5 | U2 — rich interaction | Durable choices, free text, structured results and A2UI remain usable and accessible after refresh. | Complete the existing server-issued interaction and presentation contracts. |
 | 6 | F1 — documents and generated files | A scanned document can inform an answer, and a generated file remains downloadable by its authorized audience. | Connect existing upload/scan, model input and artifact finalisation owners. |
 | 7 | D1 — autonomous delegation | A bounded child works with explicit context and narrower authority, then returns one durable result. | Follow [#845](https://github.com/elewa-git/opencrane/issues/845): root budgets, depth/fan-out, cancellation and result brokering. |

--- a/plan.md
+++ b/plan.md
@@ -77,6 +77,12 @@ hash matches the reviewed 1.2.1 source. The only mismatch is the version suffix.
 reader appends `-local` when reading its source checkout, so the fixture now requires the observed
 exact value `1.2.1-local`. No source hash or semantic requirement is relaxed; the next run can reach
 the provider behavior tests.
+Run `34598301881` passed source attestation and the ACL-disabled negative control, reproducing
+cross-dataset retrieval. The positive case stopped at HTTP 401: Cognee requires authentication when
+backend access control is enabled. The harness now qualifies that candidate with an explicit
+synthetic test-account login, repeated after restart, without retaining tokens in evidence. This
+does not change chart defaults, gateway authentication or production credentials. Positive
+isolation, recovery and deletion remain unproved until that authenticated case runs.
 Personal Remember, Recall, Correct and Forget remain unavailable until this evidence and their
 subsequent product slices are complete. Local container VMs are not started for this work.
 

--- a/plan.md
+++ b/plan.md
@@ -87,8 +87,15 @@ Run `34599650427` passed attestation, synthetic login, dataset creation and inge
 a harness parsing error: authenticated CHUNKS search returns a dataset envelope. The fixture now
 requires exactly the requested dataset envelope in that mode and keeps the ACL-disabled flat
 response separate. Eight fast provider tests cover authentication, proxy forwarding and malformed
-or foreign-dataset search responses. Positive isolation, recovery and deletion still require the
-next exact-image run; successful HTTP calls alone do not prove them.
+or foreign-dataset search responses.
+The exact-image run `34600864382` at `5902fb82109ebba2b357dba44bb42b787b9e0dd9` then passed
+authenticated dataset isolation, useful multi-chunk recall, document identity, committed-response
+loss, restart recovery and shared-reference preservation. Final-reference deletion failed: API,
+raw-route, graph and vector visibility disappeared, but the original uploaded file remained under
+the provider's data root. The retained artifact records this as a provider guarantee failure, not
+a harness error. The current image does not qualify for Forget; keep the failing assertion and
+publication gate. A separate whole-provider candidate must prove erasure, local path ownership and
+recovery after an interrupted deletion before memory mutation can be enabled.
 Personal Remember, Recall, Correct and Forget remain unavailable until this evidence and their
 subsequent product slices are complete. Local container VMs are not started for this work.
 
@@ -460,8 +467,9 @@ their own completion track; they are not silently bundled into the first tool PR
 | A1 — membership revocation and closed-work proof | IMPLEMENTED, IN REVIEW — standalone administrators can remove another non-Owner member through Settings. The server suspends the existing membership, protects Owner/self removal and rechecks current authority on retries. Workspace access loss clears retained private content and rejects delayed results. Focused unit checks and all 123 browser checks pass; five real PostgreSQL cases join the CI gate. The real-account removal and closed-work journey remains to qualify live. Fleet removal remains unsupported. |
 | T1 — first permitted tool retrieval | IN PROGRESS — the server's one-tool continuation is implemented and now progresses through Absurd in #849. Company tool assignment is the first active follow-up. Connection activation, a real integration and participant result evidence remain required. |
 | T2 | IN PROGRESS: personal approval and durable resume pass local integration; company approval and real external-action qualification remain. |
-| U1 | IN PROGRESS: requester-only personal Stop passes source review and local validation; CI and live qualification remain distinct gates. |
-| M1, U2, F1, D1, S1, A2, T3 | PLANNED in the exact priority order above, with separate acceptance for each journey. |
+| U1 | IN PROGRESS: requester-only personal Stop passes source review and exact-head CI in #862; live qualification and wider participant controls remain separate. |
+| M1 | IN PROGRESS: #863 qualifies the exact provider image. Isolation and restart recovery pass in the authenticated candidate, but final-reference deletion leaves original source bytes; provider repair and product memory journeys remain. |
+| U2, F1, D1, S1, A2, T3 | PLANNED in the exact priority order above, with separate acceptance for each journey. |
 | Q1 — operational acceptance | CONTINUOUS — source checks and CI do not replace fresh-install or real-account acceptance. |
 
 The 10 September priority order supersedes the earlier overnight sequencing and morning handoff.

--- a/plan.md
+++ b/plan.md
@@ -83,6 +83,12 @@ backend access control is enabled. The harness now qualifies that candidate with
 synthetic test-account login, repeated after restart, without retaining tokens in evidence. This
 does not change chart defaults, gateway authentication or production credentials. Positive
 isolation, recovery and deletion remain unproved until that authenticated case runs.
+Run `34599650427` passed attestation, synthetic login, dataset creation and ingestion, then exposed
+a harness parsing error: authenticated CHUNKS search returns a dataset envelope. The fixture now
+requires exactly the requested dataset envelope in that mode and keeps the ACL-disabled flat
+response separate. Eight fast provider tests cover authentication, proxy forwarding and malformed
+or foreign-dataset search responses. Positive isolation, recovery and deletion still require the
+next exact-image run; successful HTTP calls alone do not prove them.
 Personal Remember, Recall, Correct and Forget remain unavailable until this evidence and their
 subsequent product slices are complete. Local container VMs are not started for this work.
 

--- a/plan.md
+++ b/plan.md
@@ -72,6 +72,11 @@ Draft [#863](https://github.com/elewa-git/opencrane/pull/863) records the review
 but stopped before semantic tests: the container label says `1.2.1`, while the loaded package reports
 `1.2.1-local`. Attestation now retains all inspected module hashes and source snapshots before
 rejecting mismatches. Expected hashes remain unchanged until that exact source is reviewed.
+The second image run `34597761277` captured all 14 named modules: every source byte and expected
+hash matches the reviewed 1.2.1 source. The only mismatch is the version suffix. Upstream's version
+reader appends `-local` when reading its source checkout, so the fixture now requires the observed
+exact value `1.2.1-local`. No source hash or semantic requirement is relaxed; the next run can reach
+the provider behavior tests.
 Personal Remember, Recall, Correct and Forget remain unavailable until this evidence and their
 subsequent product slices are complete. Local container VMs are not started for this work.
 

--- a/scripts/__tests__/affected-deployables.test.mjs
+++ b/scripts/__tests__/affected-deployables.test.mjs
@@ -10,6 +10,7 @@ import { parse } from "yaml";
 import {
 	selectAffectedDeployables,
 	selectApiContractChanged,
+	selectCogneeMemoryContractRequired,
 	selectDevelopSmokeImages,
 	selectDevelopSmokeInputsChanged,
 	selectDevelopSmokeProjects,
@@ -242,6 +243,48 @@ test("selects affected image smokes unless manual qualification expands to every
 	);
 });
 
+test("selects Cognee provider qualification through the existing image-smoke decision", function _SelectsMemoryContract()
+{
+	const all = ["cognee", "mcp-executor"];
+	for (const [affected, manual, required] of [
+		[["cognee"], "", true],
+		[["mcp-executor"], "", false],
+		[[], "image-smoke", true],
+		[[], "all", true],
+		[[], "k3d", false],
+		[[], "none", false],
+	])
+	{
+		assert.equal(selectCogneeMemoryContractRequired(selectImageSmokeProjects(affected, all, manual)), required);
+	}
+});
+
+test("requires an uncached Docker memory proof before normal publication", function _ProtectsMemoryContract()
+{
+	const workflow = parse(_Workflow());
+	const provider = workflow.jobs.cognee_memory_contract;
+	assert.equal(provider.needs, "prepare");
+	assert.equal(provider.if, "needs.prepare.outputs.cognee_memory_contract_required == 'true'");
+	assert.equal(provider["continue-on-error"], undefined);
+	const execution = provider.steps.find(function _Execution(step) { return step.run?.includes("cognee:memory-contract"); });
+	assert.equal(execution.run, "npm exec -- nx run cognee:memory-contract");
+	assert.equal(execution["continue-on-error"], undefined);
+	const evidence = provider.steps.find(function _Evidence(step) { return step.uses === "actions/upload-artifact@v4"; });
+	assert.equal(evidence.if, "always()");
+	assert.equal(evidence.with.path, ".nx/test-results/cognee-memory-contract");
+	assert.equal(evidence.with["if-no-files-found"], "error");
+	for (const name of ["build-and-push", "publish-develop-smoke-images"])
+	{
+		const job = workflow.jobs[name];
+		assert.ok(job.needs.includes("cognee_memory_contract"));
+		assert.match(job.if, /needs\.cognee_memory_contract\.result == 'success' \|\| needs\.cognee_memory_contract\.result == 'skipped'/u);
+	}
+	const projectPath = fileURLToPath(new URL("../../apps/_infra/cognee/project.json", import.meta.url));
+	const project = JSON.parse(readFileSync(projectPath, "utf8"));
+	assert.equal(project.targets["memory-contract"].cache, false);
+	assert.doesNotMatch(project.targets.test.options.command, /memory-contract|docker/u);
+});
+
 test("uses all affected projects for contract verification and changed files for guard fixtures", function _SelectsPipelineInputs()
 {
 	const fixture = _Fixture();
@@ -344,7 +387,7 @@ test("keeps heavyweight remote qualification ahead of image publication", functi
 	assert.match(workflow, /run: \.\/apps\/_infra\/deploy-k8s\/platform\/tests\/develop-smoke\.sh/u);
 	assert.match(workflow, /inputs\.heavy_qualification == 'k3d'/u);
 	assert.match(workflow, /inputs\.heavy_qualification == 'all'/u);
-	assert.match(workflow, /needs: \[prepare, test, database, history_store, api_contract, storybook_visual, develop_smoke, image_smoke\]/u);
+	assert.match(workflow, /needs: \[prepare, test, database, history_store, api_contract, storybook_visual, develop_smoke, image_smoke, cognee_memory_contract\]/u);
 	assert.match(workflow, /needs\.history_store\.result == 'success'/u);
 	assert.match(developSmokeJob[0], /needs: prepare/u);
 	assert.match(developSmokeJob[0], /needs\.prepare\.outputs\.develop_smoke_can_skip != 'true'/u);

--- a/scripts/affected-deployables.core.mjs
+++ b/scripts/affected-deployables.core.mjs
@@ -155,6 +155,18 @@ export function selectImageSmokeProjects(affectedProjects, allProjects, heavyQua
 		.map(function _MatrixEntry(project) { return { project }; });
 }
 
+/**
+ * Requires provider qualification whenever the existing image-smoke selection includes Cognee.
+ *
+ * Called by: the affected-deployable selector before emitting the CI job condition.
+ * @param {{ project: string }[]} imageSmokes Already selected image-smoke owners.
+ * @returns {boolean} Whether the pinned Cognee image must prove its memory contract.
+ */
+export function selectCogneeMemoryContractRequired(imageSmokes)
+{
+	return imageSmokes.some(function _Cognee(entry) { return entry.project === "cognee"; });
+}
+
 /** Determines whether an affected project can change the generated API contract. */
 export function selectApiContractChanged(affectedProjects)
 {

--- a/scripts/affected-deployables.mjs
+++ b/scripts/affected-deployables.mjs
@@ -6,6 +6,7 @@ import { appendFileSync } from "node:fs";
 import {
   selectAffectedDeployables,
   selectApiContractChanged,
+  selectCogneeMemoryContractRequired,
   selectDevelopSmokeImages,
   selectDevelopSmokeInputsChanged,
   selectDevelopSmokeProjects,
@@ -99,6 +100,7 @@ _output("deployables", JSON.stringify({ include: deployables }));
 _output("has_deployables", String(deployables.length > 0));
 _output("image_smokes", JSON.stringify({ include: imageSmokes }));
 _output("has_image_smokes", String(imageSmokes.length > 0));
+_output("cognee_memory_contract_required", String(selectCogneeMemoryContractRequired(imageSmokes)));
 _output("develop_smoke_images", JSON.stringify({ include: developSmokeImages }));
 _output("develop_smoke_projects", developSmokeProjects.join(","));
 _output("affected_container_projects", affectedContainerProjects.join(","));


### PR DESCRIPTION
Personal memory needs proof that the pinned provider isolates datasets, preserves document identity after a lost response and restart, and deletes the last reference completely. The current provider's cached source exposes isolation and source-file deletion concerns; this draft adds an executable gate before any personal memory write path is enabled.

The existing Cognee app owns an uncached `memory-contract` Nx target. It runs the pinned image with synthetic data and deterministic local model/embedding responses on an internal Docker network, with no host ports or live services. It compares the current configuration with dataset partitioning disabled against an authenticated candidate with partitioning enabled. The candidate uses a disposable synthetic account, repeats login after restart, and keeps tokens out of evidence. It verifies installed source hashes and exercises indexing, chunk/document identity, committed-response loss, restart adoption, shared references and deletion. A selected CI run must retain evidence and pass before normal image publication proceeds.

Runtime adapters, chart defaults, IAM, catalog ownership and memory activation are unchanged. Absurd remains the durable workflow owner, the memory gateway remains the provider boundary, and Cognee remains the owner of stored memory content. Remember, Recall, Correct and Forget still need their product implementation and qualification.

## Validation

- Focused Cognee Nx lint and fast tests, including eight Python authentication, proxy and strict search-response tests; shell syntax and Python compilation.
- All 23 affected-deployable selector/workflow tests.
- Repository boundary checks, release versioning, workload ownership and its negative tests.
- Style, Prisma ownership, module-growth and whitespace checks.
- Architecture preflight/post-review and independent review PASS, including the revised graph-deletion proof and structured failure receipt. Initial source: `5fdbd56e7`. Subsequent attestation/authentication fixes and the strict search-parser correction at `5902fb82109ebba2b357dba44bb42b787b9e0dd9` received bounded independent review; Cognee test/lint passed on that correction.
- Exact-image CI verified all 14 inspected source modules byte-for-byte and the expected `1.2.1-local` version. Run `34598301881` reproduced cross-dataset retrieval in the ACL-disabled negative control. The strict authenticated search parser is independently reviewed and regression-tested.
- [Run `34600864382`](https://github.com/elewa-git/opencrane/actions/runs/34600864382) at `5902fb82109ebba2b357dba44bb42b787b9e0dd9` passed authenticated dataset isolation, useful multi-chunk recall, original/changed document identity, committed-response loss, restart adoption and shared-reference preservation.
- **Provider qualification failed at final-reference erasure.** API/raw-route, graph and vector visibility disappeared, but the original uploaded source file remained under the provider data root. This matches the attested provider defect. The assertion and publication gate remain intact; this draft is not ready to merge. A separate provider candidate needs full qualification, local path-ownership and interrupted-deletion recovery proof before personal memory activation.
- No Docker daemon is available locally, and no local container VM was started. The qualification used only disposable CI containers and synthetic content.

Testv5/live qualification remains a separate gate. This change does not deploy, inspect credentials, enable personal memory, or delete testv5 data. Pull-request image jobs build images; they do not publish them.

## Review order

1. PR #831
2. PR #843
3. PR #849
4. PR #850
5. PR #851
6. PR #852
7. PR #853
8. PR #854
9. PR #855
10. PR #856
11. PR #857
12. PR #858
13. PR #862
14. PR #863 (this PR), directly based on `feat/0.12-conversation-work-cancellation` at `6536ac318d375685a2771c4156b9954a7971e2ce`.

## Independent work

No predecessor is absorbed or closed. PRs #772, #840, #859, #860, #861 and #864 remain independent of this stack.
