### PR TITLE
Fix memory candidate qualification harness

### DIFF
--- a/apps/_infra/cognee/README.md
+++ b/apps/_infra/cognee/README.md
@@ -135,6 +135,11 @@ text. Use them to distinguish missing document association from a search-ranking
 search response cannot enumerate every chunk belonging to a document. This evidence does not relax
 the candidate's existing assertions or qualify the provider by itself.
 
+The candidate harness disables Cognee's automatic session feedback. These storage tests send fixed
+synthetic queries and require vector search to receive them unchanged; model-driven query rewriting
+is outside this provider qualification. The useful-retrieval, dataset, graph, restart and deletion
+assertions remain required.
+
 The candidate changes dataset and native-database behavior, so its qualification must include the
 full provider journey and deletion recovery. A successful ordinary delete alone does not establish
 safe local file ownership or recovery after an interrupted cleanup. Selecting a production image,

--- a/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_deletion_contract.py
+++ b/apps/_infra/cognee/tests/fixtures/v1_5_4/provider_deletion_contract.py
@@ -74,7 +74,7 @@ async def _path_safety_probes() -> dict[str, Any]:
     """Invoke the installed cleanup helper with only its count query stubbed."""
 
     from cognee.infrastructure.databases.relational.sqlalchemy.SqlAlchemyAdapter import (
-        SqlAlchemyAdapter,
+        SQLAlchemyAdapter,
     )
 
     data_root = Path(os.environ["DATA_ROOT_DIRECTORY"]).resolve()
@@ -92,7 +92,7 @@ async def _path_safety_probes() -> dict[str, Any]:
     symlink_path.symlink_to(outside_directory, target_is_directory=True)
 
     adapter = _NoReferenceAdapter()
-    cleanup = SqlAlchemyAdapter.remove_data_file_if_unreferenced
+    cleanup = SQLAlchemyAdapter.remove_data_file_if_unreferenced
     managed_location = managed_file.as_uri()
     sibling_location = outside_file.as_uri()
     traversal_location = (
@@ -124,7 +124,7 @@ async def _path_safety_probes() -> dict[str, Any]:
 
         return {
             "scope": (
-                "Exact installed SqlAlchemyAdapter.remove_data_file_if_unreferenced and "
+                "Exact installed SQLAlchemyAdapter.remove_data_file_if_unreferenced and "
                 "LocalFileStorage path resolution; only the relational count query returned zero."
             ),
             "managedLocation": managed_location,

--- a/apps/_infra/cognee/tests/memory-contract-1.5.4.sh
+++ b/apps/_infra/cognee/tests/memory-contract-1.5.4.sh
@@ -205,6 +205,7 @@ _start_cognee()
   local volume="$2"
   local access_control="$3"
   local require_authentication="$4"
+  # This storage contract sends fixed queries, so vector search must receive them unchanged.
   docker run -d \
     --name "$container" \
     --network "$network" \
@@ -216,6 +217,7 @@ _start_cognee()
     --env PORT=8000 \
     --env "ENABLE_BACKEND_ACCESS_CONTROL=$access_control" \
     --env "REQUIRE_AUTHENTICATION=$require_authentication" \
+    --env AUTO_FEEDBACK=false \
     --env DATA_ROOT_DIRECTORY=/cognee-storage/data \
     --env SYSTEM_ROOT_DIRECTORY=/cognee-storage/system \
     --env LLM_PROVIDER=openai \

--- a/plan.md
+++ b/plan.md
@@ -874,3 +874,12 @@ fresh-install or release qualification.
 
 Version-to-version upgrades return with an explicit MVP upgrade contract. Until then, preserve one
 clean baseline and delete superseded code in its owning replacement slice; use git for history.
+
+### Memory candidate path-safety harness correction — 2026-09-12
+
+The exact #870 head `6a12061dd5265c99433f929b015bdc0eef076c33` reached the path-safety phase in
+run `34687912613`, then stopped before those assertions with an import error. The installed and
+source-attested class is `SQLAlchemyAdapter`; the fixture imported `SqlAlchemyAdapter`. The fixture
+now uses the exact installed class name. Path ownership, interrupted deletion and all earlier
+provider assertions remain required. This is a harness correction, not provider qualification or
+permission to enable personal memory. The production 1.2.1 deletion failure remains unchanged.

--- a/plan.md
+++ b/plan.md
@@ -252,9 +252,10 @@ passes and independent source review passes. Exact-head CI run `34681268225` at
 graph contains 12 chunks for its distinct document, while its scoped CHUNKS response returns 20
 coordinates and none for that document. Follow-up confirms the fixture query was replaced by the
 synthetic model's literal `query_to_answer` during automatic feedback preparation. That ranked
-response does not prove missing vectors or a provider retrieval defect. The next correction must
-keep the requested query stable in the disposable harness and rerun the unchanged useful-retrieval
-and deletion gates. The candidate remains unqualified; deletion checks have not been reached.
+response does not prove missing vectors or a provider retrieval defect. The candidate harness now
+disables that query rewriting so its fixed synthetic query reaches vector search unchanged. Every
+useful-retrieval, isolation, restart and deletion assertion remains unchanged; the corrected harness
+still needs exact-image CI. The candidate remains unqualified; deletion checks have not been reached.
 
 The candidate keeps a separate disposable lifecycle because its non-root storage, evidence volume
 and additional restart differ from 1.2.1; API, stub, proxy, attestation and summary helpers remain


### PR DESCRIPTION
The Cognee 1.5.4 qualification fixture asked vector search for `authorized-memory`, but automatic session feedback replaced it with the deterministic model stub's literal `query_to_answer`. That changed ranking and prevented the existing useful-retrieval assertion from testing the intended document.

The shared disposable test-container startup now sets `AUTO_FEEDBACK=false`, keeping the synthetic storage query unchanged across initial runs and restarts. All dataset, graph, useful-retrieval, response-loss, restart, shared-reference, byte-erasure, path-ownership and interrupted-deletion assertions remain unchanged. Production image/configuration, pinned provider source, credentials and memory availability are unchanged.

The next exact-image run reached path-safety qualification and exposed a fixture import typo: the attested provider defines `SQLAlchemyAdapter`, while the fixture imported `SqlAlchemyAdapter`. The fixture now invokes the correctly named installed class. No provider assertion is removed or weakened.

## Review order

#831 → #843 → #849 → #850 → #851 → #852 → #853 → #854 → #855 → #856 → #857 → #858 → #862 → #863 → #867 → #868 → #869 → #870.

Direct base: `feat/0.12-conversation-pdf-input` at `8c534445f93dcc7168c06a6f8d1dbec4f459bcde`. This PR contains only the incremental memory qualification correction. No predecessor is absorbed or closed.

## Independent work

#772, #840, #859, #860 and #861 remain independent; #864 → #865 remains a separate chain.

## Validation

- `bash -n apps/_infra/cognee/tests/memory-contract-1.5.4.sh` passes.
- `cognee:test` passes: 23 Python fixture tests and the existing image-contract, image-policy and fake-Docker smoke checks.
- `cognee:lint` and whitespace checks pass.
- Independent source review covers query stability and the exact installed cleanup-class import. The fixture keeps the same managed-path, traversal, sibling, symlink and interrupted-deletion assertions.
- The exact-image `cognee:memory-contract-1-5-4` CI run remains required. A local unit pass does not prove that the provider consumed the setting or meets its retrieval/deletion guarantees.

## Remaining qualification

The candidate remains unqualified until the unchanged useful-retrieval, isolation, restart, deletion, path-containment and interruption gates pass against the exact image. Remember, Recall, Correct and Forget remain subsequent product work.

Testv5/live qualification remains separate. This change performs no deployment, credential inspection, live model/tool call, provider activation or testv5 data change.
